### PR TITLE
workload/schemachange: screen for errors in operations

### DIFF
--- a/pkg/workload/schemachange/error_screening.go
+++ b/pkg/workload/schemachange/error_screening.go
@@ -91,3 +91,68 @@ func tableHasDependencies(tx *pgx.Tx, tableName *tree.TableName) (bool, error) {
        )
 	`, tableName.Object(), tableName.Schema())
 }
+
+func columnIsDependedOn(tx *pgx.Tx, tableName *tree.TableName, columnName string) (bool, error) {
+	// To see if a column is depended on, the ordinal_position of the column is looked up in
+	// information_schema.columns. Then, this position is used to see if that column has view dependencies
+	// or foreign key dependencies which would be stored in crdb_internal.forward_dependencies and
+	// pg_catalog.pg_constraint respectively.
+	//
+	// crdb_internal.forward_dependencies.dependedonby_details is an array of ordinal positions
+	// stored as a list of numbers in a string, so SQL functions are used to parse these values
+	// into arrays. unnest is used to flatten rows with this column of array type into multiple rows,
+	// so performing unions and joins is easier.
+	return scanBool(tx, `SELECT EXISTS(
+		SELECT source.column_id
+			FROM (
+			   SELECT DISTINCT column_id
+			     FROM (
+			           SELECT unnest(
+			                   string_to_array(
+			                    rtrim(
+			                     ltrim(
+			                      fd.dependedonby_details,
+			                      'Columns: ['
+			                     ),
+			                     ']'
+			                    ),
+			                    ' '
+			                   )::INT8[]
+			                  ) AS column_id
+			             FROM crdb_internal.forward_dependencies
+			                   AS fd
+			            WHERE fd.descriptor_id
+			                  = $1::REGCLASS
+			          )
+			   UNION  (
+			           SELECT unnest(confkey) AS column_id
+			             FROM pg_catalog.pg_constraint
+			            WHERE confrelid = $1::REGCLASS
+			          )
+			 ) AS cons
+			 INNER JOIN (
+			   SELECT ordinal_position AS column_id
+			     FROM information_schema.columns
+			    WHERE table_schema = $2
+			      AND table_name = $3
+			      AND column_name = $4
+			  ) AS source ON source.column_id = cons.column_id
+)`, tableName.String(), tableName.Schema(), tableName.Object(), columnName)
+}
+
+func colIsPrimaryKey(tx *pgx.Tx, tableName *tree.TableName, columnName string) (bool, error) {
+	return scanBool(tx, `
+	SELECT EXISTS(
+				SELECT column_name
+				  FROM information_schema.table_constraints AS c
+				  JOIN information_schema.constraint_column_usage
+								AS ccu ON ccu.table_name = c.table_name
+				      AND ccu.table_schema = c.table_schema
+				      AND ccu.constraint_name = c.constraint_name
+				 WHERE c.table_schema = $1
+				   AND c.table_name = $2
+				   AND ccu.column_name = $3
+				   AND c.constraint_type = 'PRIMARY KEY'
+       );
+	`, tableName.Schema(), tableName.Object(), columnName)
+}

--- a/pkg/workload/schemachange/error_screening.go
+++ b/pkg/workload/schemachange/error_screening.go
@@ -74,3 +74,20 @@ func schemaExists(tx *pgx.Tx, schemaName string) (bool, error) {
    WHERE schema_name = $1
 	)`, schemaName)
 }
+
+func tableHasDependencies(tx *pgx.Tx, tableName *tree.TableName) (bool, error) {
+	return scanBool(tx, `
+	SELECT EXISTS(
+        SELECT fd.descriptor_name
+          FROM crdb_internal.forward_dependencies AS fd
+         WHERE fd.descriptor_id
+               = (
+                    SELECT c.oid
+                      FROM pg_catalog.pg_class AS c
+                      JOIN pg_catalog.pg_namespace AS ns ON
+                            ns.oid = c.relnamespace
+                     WHERE c.relname = $1 AND ns.nspname = $2
+                )
+       )
+	`, tableName.Object(), tableName.Schema())
+}

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -87,6 +87,7 @@ var opsWithExecErrorScreening = map[opType]bool{
 	createTableAs: true,
 	createView:    true,
 	createEnum:    true,
+	createSchema:  true,
 
 	dropColumn:        true,
 	dropColumnDefault: true,
@@ -1432,9 +1433,18 @@ func (og *operationGenerator) createSchema(tx *pgx.Tx) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	ifNotExists := og.randIntn(2) == 0
+
+	schemaExists, err := schemaExists(tx, schemaName)
+	if err != nil {
+		return "", err
+	}
+	if schemaExists && !ifNotExists {
+		og.expectedExecErrors.add(pgcode.DuplicateSchema)
+	}
 
 	// TODO(jayshrivastava): Support authorization
-	stmt := rowenc.MakeSchemaName(og.randIntn(2) == 0, schemaName, security.RootUserName())
+	stmt := rowenc.MakeSchemaName(ifNotExists, schemaName, security.RootUserName())
 	return tree.Serialize(stmt), nil
 }
 

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -92,6 +92,7 @@ var opsWithExecErrorScreening = map[opType]bool{
 	dropColumn:        true,
 	dropColumnDefault: true,
 	dropColumnNotNull: true,
+	dropSchema:        true,
 
 	renameColumn: true,
 	renameTable:  true,
@@ -1473,6 +1474,16 @@ func (og *operationGenerator) dropSchema(tx *pgx.Tx) (string, error) {
 	if err != nil {
 		return "", err
 	}
+
+	schemaExists, err := schemaExists(tx, schemaName)
+	if err != nil {
+		return "", err
+	}
+	codesWithConditions{
+		{pgcode.UndefinedSchema, !schemaExists},
+		{pgcode.InvalidSchemaName, schemaName == tree.PublicSchema},
+	}.add(og.expectedExecErrors)
+
 	return fmt.Sprintf(`DROP SCHEMA "%s" CASCADE`, schemaName), nil
 }
 

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -81,6 +81,7 @@ var opsWithExecErrorScreening = map[opType]bool{
 
 	dropColumn:        true,
 	dropColumnDefault: true,
+	dropColumnNotNull: true,
 
 	renameTable: true,
 	renameView:  true,
@@ -695,9 +696,33 @@ func (og *operationGenerator) dropColumnNotNull(tx *pgx.Tx) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	tableExists, err := tableExists(tx, tableName)
+	if err != nil {
+		return "", err
+	}
+	if !tableExists {
+		og.expectedExecErrors.add(pgcode.UndefinedTable)
+		return fmt.Sprintf(`ALTER TABLE %s ALTER COLUMN "IrrelevantColumnName" DROP NOT NULL`, tableName), nil
+	}
 	columnName, err := og.randColumn(tx, *tableName, og.pctExisting(true))
 	if err != nil {
 		return "", err
+	}
+	columnExists, err := columnExistsOnTable(tx, tableName, columnName)
+	if err != nil {
+		return "", err
+	}
+	colIsPrimaryKey, err := colIsPrimaryKey(tx, tableName, columnName)
+	if err != nil {
+		return "", err
+	}
+
+	codesWithConditions{
+		{pgcode.UndefinedColumn, !columnExists},
+		{pgcode.InvalidTableDefinition, colIsPrimaryKey},
+	}.add(og.expectedExecErrors)
+	if !columnExists {
+		og.expectedExecErrors.add(pgcode.UndefinedColumn)
 	}
 	return fmt.Sprintf(`ALTER TABLE %s ALTER COLUMN "%s" DROP NOT NULL`, tableName, columnName), nil
 }


### PR DESCRIPTION
workload/schemachange: screen for errors in operations

These changes add error screening for the following (https://github.com/cockroachdb/cockroach/issues/56119):
- createEnum op
- createSchema op
- dropColumn op
- dropColumnDefault op
- dropColumnNotNull op
- dropSchema op
- renameColumn op
- renameTable op
- renameView op

Also, errors caused by schema changes after writes in the same txn are handled (https://github.com/cockroachdb/cockroach/issues/56230)

It also resolves a bug related to ambiguity in column names that was caused by views/tables referencing the same columns (https://github.com/cockroachdb/cockroach/issues/56235). 
