### PR TITLE
workload/tpcc: add flag to replicate static columns

### DIFF
--- a/pkg/workload/tpcc/ddls.go
+++ b/pkg/workload/tpcc/ddls.go
@@ -21,61 +21,71 @@ import (
 const (
 	// WAREHOUSE table.
 	tpccWarehouseSchema = `(
-		w_id        integer   not null primary key,
-		w_name      varchar(10),
-		w_street_1  varchar(20),
-		w_street_2  varchar(20),
-		w_city      varchar(20),
-		w_state     char(2),
-		w_zip       char(9),
-		w_tax       decimal(4,4),
-		w_ytd       decimal(12,2)
-	)`
+		w_id        integer       not null primary key,
+		w_name      varchar(10)   not null,
+		w_street_1  varchar(20)   not null,
+		w_street_2  varchar(20)   not null,
+		w_city      varchar(20)   not null,
+		w_state     char(2)       not null,
+		w_zip       char(9)       not null,
+		w_tax       decimal(4,4)  not null,
+		w_ytd       decimal(12,2) not null`
+	tpccWarehouseColumnFamiliesSuffix = `, 
+		family      f1 (w_id, w_name, w_street_1, w_street_2, w_city, w_state, w_zip, w_ytd),
+		family      f2 (w_tax)`
 
 	// DISTRICT table.
 	tpccDistrictSchemaBase = `(
 		d_id         integer       not null,
 		d_w_id       integer       not null,
-		d_name       varchar(10),
-		d_street_1   varchar(20),
-		d_street_2   varchar(20),
-		d_city       varchar(20),
-		d_state      char(2),
-		d_zip        char(9),
-		d_tax        decimal(4,4),
-		d_ytd        decimal(12,2),
-		d_next_o_id  integer,
-		primary key (d_w_id, d_id)
-	)`
+		d_name       varchar(10)   not null,
+		d_street_1   varchar(20)   not null,
+		d_street_2   varchar(20)   not null,
+		d_city       varchar(20)   not null,
+		d_state      char(2)       not null,
+		d_zip        char(9)       not null,
+		d_tax        decimal(4,4)  not null,
+		d_ytd        decimal(12,2) not null,
+		d_next_o_id  integer       not null,
+		primary key  (d_w_id, d_id)`
+	tpccDistrictColumnFamiliesSuffix = `,
+		family       static    (d_w_id, d_id, d_name, d_street_1, d_street_2, d_city, d_state, d_zip),
+		family       dynamic_1 (d_ytd),
+		family       dynamic_2 (d_next_o_id, d_tax)`
 	tpccDistrictSchemaInterleaveSuffix = `
 		interleave in parent warehouse (d_w_id)`
 
 	// CUSTOMER table.
 	tpccCustomerSchemaBase = `(
-		c_id           integer        not null,
-		c_d_id         integer        not null,
-		c_w_id         integer        not null,
-		c_first        varchar(16),
-		c_middle       char(2),
-		c_last         varchar(16),
-		c_street_1     varchar(20),
-		c_street_2     varchar(20),
-		c_city         varchar(20),
-		c_state        char(2),
-		c_zip          char(9),
-		c_phone        char(16),
-		c_since        timestamp,
-		c_credit       char(2),
-		c_credit_lim   decimal(12,2),
-		c_discount     decimal(4,4),
-		c_balance      decimal(12,2),
-		c_ytd_payment  decimal(12,2),
-		c_payment_cnt  integer,
-		c_delivery_cnt integer,
-		c_data         varchar(500),
-		primary key (c_w_id, c_d_id, c_id),
-		index customer_idx (c_w_id, c_d_id, c_last, c_first)
-	)`
+		c_id           integer       not null,
+		c_d_id         integer       not null,
+		c_w_id         integer       not null,
+		c_first        varchar(16)   not null,
+		c_middle       char(2)       not null,
+		c_last         varchar(16)   not null,
+		c_street_1     varchar(20)   not null,
+		c_street_2     varchar(20)   not null,
+		c_city         varchar(20)   not null,
+		c_state        char(2)       not null,
+		c_zip          char(9)       not null,
+		c_phone        char(16)      not null,
+		c_since        timestamp     not null,
+		c_credit       char(2)       not null,
+		c_credit_lim   decimal(12,2) not null,
+		c_discount     decimal(4,4)  not null,
+		c_balance      decimal(12,2) not null,
+		c_ytd_payment  decimal(12,2) not null,
+		c_payment_cnt  integer       not null,
+		c_delivery_cnt integer       not null,
+		c_data         varchar(500)  not null,
+		primary key        (c_w_id, c_d_id, c_id),
+		index customer_idx (c_w_id, c_d_id, c_last, c_first)`
+	tpccCustomerColumnFamiliesSuffix = `, 
+		family static      (
+			c_id, c_d_id, c_w_id, c_first, c_middle, c_last, c_street_1, c_street_2,
+			c_city, c_state, c_zip, c_phone, c_since, c_credit, c_credit_lim, c_discount
+		),
+		family dynamic (c_balance, c_ytd_payment, c_payment_cnt, c_data, c_delivery_cnt)`
 	tpccCustomerSchemaInterleaveSuffix = `
 		interleave in parent district (c_w_id, c_d_id)`
 
@@ -176,14 +186,22 @@ const (
 		index order_line_stock_fk_idx (ol_supply_w_id, ol_i_id)`
 	tpccOrderLineSchemaInterleaveSuffix = `
 		interleave in parent "order" (ol_w_id, ol_d_id, ol_o_id)`
+
+	endSchema = "\n\t)"
 )
 
 func maybeAddFkSuffix(fks bool, base, suffix string) string {
-	const endSchema = "\n\t)"
 	if !fks {
 		return base + endSchema
 	}
 	return base + "," + suffix + endSchema
+}
+
+func maybeAddColumnFamiliesSuffix(separateColumnFamilies bool, base, suffix string) string {
+	if !separateColumnFamilies {
+		return base + endSchema
+	}
+	return base + suffix + endSchema
 }
 
 func maybeAddInterleaveSuffix(interleave bool, base, suffix string) string {


### PR DESCRIPTION
This commit adds a new flag, `--replicate-static-columns` (defaulted to
false). When set, the workload runner will create replicated indexes
containing all the static columns from the `district`, `warehouse` and
`item` tables.

These replicated indexes allow for local (within the zone or rack)
lookups on all those static columns.

Release note: None
