### PR TITLE
server: clarify a logging message

### DIFF
--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -771,7 +771,7 @@ func (s *sqlServer) preStart(
 		return errors.Wrap(err, "ensuring SQL migrations")
 	}
 
-	log.Infof(ctx, "done ensuring all necessary migrations have run")
+	log.Infof(ctx, "done ensuring all necessary startup migrations have run")
 
 	// Start the sqlLivenessProvider after we've run the SQL migrations that it
 	// relies on. Jobs used by sqlmigrations can't rely on having the


### PR DESCRIPTION
We'll want to eventually distinguish between sqlmigrations (only run at
start up) and general purpose (and possibly long-running) migrations.
We'll introduce the latter in another other PR (#56107), within a new
pkg/migration.

Release note: None