### PR TITLE
*: s/Version.Unstable/Version.Internal

### DIFF
--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -85,9 +85,9 @@ const (
 // with comments describing what backwards-incompatible features were
 // introduced.
 //
-// A roachpb.Version has the colloquial form MAJOR.MINOR[.PATCH][-UNSTABLE],
-// where the PATCH and UNSTABLE components can be omitted if zero. Keep in mind
-// that a version with an unstable component, like 1.1-2, represents a version
+// A roachpb.Version has the colloquial form MAJOR.MINOR[.PATCH][-INTERNAL],
+// where the PATCH and INTERNAL components can be omitted if zero. Keep in mind
+// that a version with an internal component, like 1.1-2, represents a version
 // that was developed AFTER v1.1 was released and is not slated for release
 // until the next stable version (either 1.2-0 or 2.0-0). Patch releases, like
 // 1.1.2, do not have associated migrations.
@@ -110,7 +110,7 @@ var versionsSingleton = keyedVersions([]keyedVersion{
 		// It enables use of updated fields in ChangeReplicasTrigger that will
 		// support atomic replication changes.
 		Key:     VersionAtomicChangeReplicasTrigger,
-		Version: roachpb.Version{Major: 19, Minor: 1, Unstable: 8},
+		Version: roachpb.Version{Major: 19, Minor: 1, Internal: 8},
 	},
 	{
 		// VersionAtomicChangeReplicas is https://github.com/cockroachdb/cockroach/pull/39936.
@@ -121,12 +121,12 @@ var versionsSingleton = keyedVersions([]keyedVersion{
 		// no atomic replication changes will be scheduled when it is set to
 		// 'false').
 		Key:     VersionAtomicChangeReplicas,
-		Version: roachpb.Version{Major: 19, Minor: 1, Unstable: 9},
+		Version: roachpb.Version{Major: 19, Minor: 1, Internal: 9},
 	},
 	{
 		// VersionPartitionedBackup is https://github.com/cockroachdb/cockroach/pull/39250.
 		Key:     VersionPartitionedBackup,
-		Version: roachpb.Version{Major: 19, Minor: 1, Unstable: 11},
+		Version: roachpb.Version{Major: 19, Minor: 1, Internal: 11},
 	},
 	{
 		// Version19_2 is CockroachDB v19.2. It's used for all v19.2.x patch releases.
@@ -136,7 +136,7 @@ var versionsSingleton = keyedVersions([]keyedVersion{
 	{
 		// VersionStart20_1 demarcates work towards CockroachDB v20.1.
 		Key:     VersionStart20_1,
-		Version: roachpb.Version{Major: 19, Minor: 2, Unstable: 1},
+		Version: roachpb.Version{Major: 19, Minor: 2, Internal: 1},
 	},
 	{
 		// VersionContainsEstimatesCounter is https://github.com/cockroachdb/cockroach/pull/37583.
@@ -155,7 +155,7 @@ var versionsSingleton = keyedVersions([]keyedVersion{
 		// behavior for ContainsEstimates=1 and the additive behavior for
 		// anything else.
 		Key:     VersionContainsEstimatesCounter,
-		Version: roachpb.Version{Major: 19, Minor: 2, Unstable: 2},
+		Version: roachpb.Version{Major: 19, Minor: 2, Internal: 2},
 	},
 	{
 		// VersionChangeReplicasDemotion enables the use of voter demotions
@@ -189,14 +189,14 @@ var versionsSingleton = keyedVersions([]keyedVersion{
 		// configuration change in their logs, the group won't lose availability
 		// when the leader instead crashes while removing the learner.
 		Key:     VersionChangeReplicasDemotion,
-		Version: roachpb.Version{Major: 19, Minor: 2, Unstable: 3},
+		Version: roachpb.Version{Major: 19, Minor: 2, Internal: 3},
 	},
 	{
 		// VersionSecondaryIndexColumnFamilies is https://github.com/cockroachdb/cockroach/pull/42073.
 		//
 		// It allows secondary indexes to respect table level column family definitions.
 		Key:     VersionSecondaryIndexColumnFamilies,
-		Version: roachpb.Version{Major: 19, Minor: 2, Unstable: 4},
+		Version: roachpb.Version{Major: 19, Minor: 2, Internal: 4},
 	},
 	{
 		// VersionNamespaceTableWithSchemas is https://github.com/cockroachdb/cockroach/pull/41977
@@ -205,7 +205,7 @@ var versionsSingleton = keyedVersions([]keyedVersion{
 		// added parentSchemaID column. In addition to the new column, the table is
 		// no longer in the system config range -- implying it is no longer gossiped.
 		Key:     VersionNamespaceTableWithSchemas,
-		Version: roachpb.Version{Major: 19, Minor: 2, Unstable: 5},
+		Version: roachpb.Version{Major: 19, Minor: 2, Internal: 5},
 	},
 	{
 		// VersionProtectedTimestamps introduces the system tables for the protected
@@ -215,14 +215,14 @@ var versionsSingleton = keyedVersions([]keyedVersion{
 		// system.protected_ts_records tables are part of the system bootstap
 		// schema.
 		Key:     VersionProtectedTimestamps,
-		Version: roachpb.Version{Major: 19, Minor: 2, Unstable: 6},
+		Version: roachpb.Version{Major: 19, Minor: 2, Internal: 6},
 	},
 	{
 		// VersionPrimaryKeyChanges is https://github.com/cockroachdb/cockroach/pull/42462
 		//
 		// It allows online primary key changes of tables.
 		Key:     VersionPrimaryKeyChanges,
-		Version: roachpb.Version{Major: 19, Minor: 2, Unstable: 7},
+		Version: roachpb.Version{Major: 19, Minor: 2, Internal: 7},
 	},
 	{
 		// VersionAuthLocalAndTrustRejectMethods introduces the HBA rule
@@ -233,14 +233,14 @@ var versionsSingleton = keyedVersions([]keyedVersion{
 		// introduced while previous-version nodes are still running, as
 		// this would block any new SQL client.
 		Key:     VersionAuthLocalAndTrustRejectMethods,
-		Version: roachpb.Version{Major: 19, Minor: 2, Unstable: 8},
+		Version: roachpb.Version{Major: 19, Minor: 2, Internal: 8},
 	},
 	{
 		// VersionPrimaryKeyColumnsOutOfFamilyZero allows for primary key columns
 		// to exist in column families other than 0, in order to prepare for
 		// primary key changes that move primary key columns to different families.
 		Key:     VersionPrimaryKeyColumnsOutOfFamilyZero,
-		Version: roachpb.Version{Major: 19, Minor: 2, Unstable: 9},
+		Version: roachpb.Version{Major: 19, Minor: 2, Internal: 9},
 	},
 	{
 		// VersionNoExplicitForeignKeyIndexIDs is https://github.com/cockroachdb/cockroach/pull/43332.
@@ -249,7 +249,7 @@ var versionsSingleton = keyedVersions([]keyedVersion{
 		// key constraints, and instead allows all places that need these IDs to select
 		// an appropriate index to uphold the foreign key relationship.
 		Key:     VersionNoExplicitForeignKeyIndexIDs,
-		Version: roachpb.Version{Major: 19, Minor: 2, Unstable: 11},
+		Version: roachpb.Version{Major: 19, Minor: 2, Internal: 11},
 	},
 	{
 		// VersionHashShardedIndexes is https://github.com/cockroachdb/cockroach/pull/42922
@@ -258,7 +258,7 @@ var versionsSingleton = keyedVersions([]keyedVersion{
 		// shard column, computed from the set of index columns, and prefix the index's
 		// ranges with said shard column.
 		Key:     VersionHashShardedIndexes,
-		Version: roachpb.Version{Major: 19, Minor: 2, Unstable: 12},
+		Version: roachpb.Version{Major: 19, Minor: 2, Internal: 12},
 	},
 	{
 		// VersionCreateRolePrivilege is https://github.com/cockroachdb/cockroach/pull/44232.
@@ -266,7 +266,7 @@ var versionsSingleton = keyedVersions([]keyedVersion{
 		// It represents adding role management via CREATEROLE privilege.
 		// Added new column in system.users table to track hasCreateRole.
 		Key:     VersionCreateRolePrivilege,
-		Version: roachpb.Version{Major: 19, Minor: 2, Unstable: 13},
+		Version: roachpb.Version{Major: 19, Minor: 2, Internal: 13},
 	},
 	{
 		// VersionStatementDiagnosticsSystemTables introduces the system tables for
@@ -275,7 +275,7 @@ var versionsSingleton = keyedVersions([]keyedVersion{
 		// system.statement_diagnostics and system.statement_bundle_chunks tables
 		// are part of the system bootstap schema.
 		Key:     VersionStatementDiagnosticsSystemTables,
-		Version: roachpb.Version{Major: 19, Minor: 2, Unstable: 14},
+		Version: roachpb.Version{Major: 19, Minor: 2, Internal: 14},
 	},
 	{
 		// VersionSchemaChangeJob is https://github.com/cockroachdb/cockroach/pull/45870.
@@ -283,14 +283,14 @@ var versionsSingleton = keyedVersions([]keyedVersion{
 		// From this version on, schema changes are run as jobs instead of being
 		// scheduled by the SchemaChangeManager.
 		Key:     VersionSchemaChangeJob,
-		Version: roachpb.Version{Major: 19, Minor: 2, Unstable: 15},
+		Version: roachpb.Version{Major: 19, Minor: 2, Internal: 15},
 	},
 	{
 		// VersionSavepoints enables the use of SQL savepoints, whereby
 		// the ignored seqnum list can become populated in transaction
 		// records.
 		Key:     VersionSavepoints,
-		Version: roachpb.Version{Major: 19, Minor: 2, Unstable: 16},
+		Version: roachpb.Version{Major: 19, Minor: 2, Internal: 16},
 	},
 	{
 		// Version20_1 is CockroachDB v20.1. It's used for all v20.1.x patch releases.
@@ -300,18 +300,18 @@ var versionsSingleton = keyedVersions([]keyedVersion{
 	{
 		// VersionStart20_2 demarcates work towards CockroachDB v20.2.
 		Key:     VersionStart20_2,
-		Version: roachpb.Version{Major: 20, Minor: 1, Unstable: 1},
+		Version: roachpb.Version{Major: 20, Minor: 1, Internal: 1},
 	},
 	{
 
 		// VersionGeospatialType enables the use of Geospatial features.
 		Key:     VersionGeospatialType,
-		Version: roachpb.Version{Major: 20, Minor: 1, Unstable: 2},
+		Version: roachpb.Version{Major: 20, Minor: 1, Internal: 2},
 	},
 	{
 		// VersionEnums enables the use of ENUM types.
 		Key:     VersionEnums,
-		Version: roachpb.Version{Major: 20, Minor: 1, Unstable: 3},
+		Version: roachpb.Version{Major: 20, Minor: 1, Internal: 3},
 	},
 	{
 
@@ -321,79 +321,79 @@ var versionsSingleton = keyedVersions([]keyedVersion{
 		// schema lease subsystem. Nodes which start with this version finalized
 		// will not pass gossip to the SQL layer.
 		Key:     VersionRangefeedLeases,
-		Version: roachpb.Version{Major: 20, Minor: 1, Unstable: 4},
+		Version: roachpb.Version{Major: 20, Minor: 1, Internal: 4},
 	},
 	{
 		// VersionAlterColumnTypeGeneral enables the use of alter column type for
 		// conversions that require the column data to be rewritten.
 		Key:     VersionAlterColumnTypeGeneral,
-		Version: roachpb.Version{Major: 20, Minor: 1, Unstable: 5},
+		Version: roachpb.Version{Major: 20, Minor: 1, Internal: 5},
 	},
 	{
 		// VersionAlterSystemJobsTable is a version which modified system.jobs table.
 		Key:     VersionAlterSystemJobsAddCreatedByColumns,
-		Version: roachpb.Version{Major: 20, Minor: 1, Unstable: 6},
+		Version: roachpb.Version{Major: 20, Minor: 1, Internal: 6},
 	},
 	{
 		// VersionAddScheduledJobsTable is a version which adds system.scheduled_jobs table.
 		Key:     VersionAddScheduledJobsTable,
-		Version: roachpb.Version{Major: 20, Minor: 1, Unstable: 7},
+		Version: roachpb.Version{Major: 20, Minor: 1, Internal: 7},
 	},
 	{
 		// VersionUserDefinedSchemas enables the creation of user defined schemas.
 		Key:     VersionUserDefinedSchemas,
-		Version: roachpb.Version{Major: 20, Minor: 1, Unstable: 8},
+		Version: roachpb.Version{Major: 20, Minor: 1, Internal: 8},
 	},
 	{
 		// VersionNoOriginFKIndexes allows for foreign keys to no longer need
 		// indexes on the origin side of the relationship.
 		Key:     VersionNoOriginFKIndexes,
-		Version: roachpb.Version{Major: 20, Minor: 1, Unstable: 9},
+		Version: roachpb.Version{Major: 20, Minor: 1, Internal: 9},
 	},
 	{
 		// VersionClientRangeInfosOnBatchResponse moves the response RangeInfos from
 		// individual response headers to the batch header.
 		Key:     VersionClientRangeInfosOnBatchResponse,
-		Version: roachpb.Version{Major: 20, Minor: 1, Unstable: 10},
+		Version: roachpb.Version{Major: 20, Minor: 1, Internal: 10},
 	},
 	{
 		// VersionNodeMembershipStatus gates the usage of the MembershipStatus
 		// enum in the Liveness proto. See comment on proto definition for more
 		// details.
 		Key:     VersionNodeMembershipStatus,
-		Version: roachpb.Version{Major: 20, Minor: 1, Unstable: 11},
+		Version: roachpb.Version{Major: 20, Minor: 1, Internal: 11},
 	},
 	{
 		// VersionRangeStatsRespHasDesc adds the RangeStatsResponse.RangeInfo field.
 		Key:     VersionRangeStatsRespHasDesc,
-		Version: roachpb.Version{Major: 20, Minor: 1, Unstable: 12},
+		Version: roachpb.Version{Major: 20, Minor: 1, Internal: 12},
 	},
 	{
 		// VersionMinPasswordLength adds the server.user_login.min_password_length setting.
 		Key:     VersionMinPasswordLength,
-		Version: roachpb.Version{Major: 20, Minor: 1, Unstable: 13},
+		Version: roachpb.Version{Major: 20, Minor: 1, Internal: 13},
 	},
 	{
 		// VersionAbortSpanBytes adds a field to MVCCStats
 		// (MVCCStats.AbortSpanBytes) that tracks the size of a
 		// range's abort span.
 		Key:     VersionAbortSpanBytes,
-		Version: roachpb.Version{Major: 20, Minor: 1, Unstable: 14},
+		Version: roachpb.Version{Major: 20, Minor: 1, Internal: 14},
 	},
 	{
 		// VersionAlterSystemJobsTableAddLeaseColumn is a version which modified system.jobs table.
 		Key:     VersionAlterSystemJobsAddSqllivenessColumnsAddNewSystemSqllivenessTable,
-		Version: roachpb.Version{Major: 20, Minor: 1, Unstable: 15},
+		Version: roachpb.Version{Major: 20, Minor: 1, Internal: 15},
 	},
 	{
 		// VersionMaterializedViews enables the use of materialized views.
 		Key:     VersionMaterializedViews,
-		Version: roachpb.Version{Major: 20, Minor: 1, Unstable: 16},
+		Version: roachpb.Version{Major: 20, Minor: 1, Internal: 16},
 	},
 	{
 		// VersionBox2DType enables the use of the box2d type.
 		Key:     VersionBox2DType,
-		Version: roachpb.Version{Major: 20, Minor: 1, Unstable: 17},
+		Version: roachpb.Version{Major: 20, Minor: 1, Internal: 17},
 	},
 	{
 		// VersionLeasedDatabasedDescriptors enables leased database descriptors.
@@ -401,12 +401,12 @@ var versionsSingleton = keyedVersions([]keyedVersion{
 		// usages of this version gate have been removed, this version remains to
 		// gate a few miscellaneous database descriptor changes.
 		Key:     VersionLeasedDatabaseDescriptors,
-		Version: roachpb.Version{Major: 20, Minor: 1, Unstable: 18},
+		Version: roachpb.Version{Major: 20, Minor: 1, Internal: 18},
 	},
 	{
 		// VersionUpdateScheduledJobsSchema drops schedule_changes and adds schedule_status.
 		Key:     VersionUpdateScheduledJobsSchema,
-		Version: roachpb.Version{Major: 20, Minor: 1, Unstable: 19},
+		Version: roachpb.Version{Major: 20, Minor: 1, Internal: 19},
 	},
 	{
 		// VersionCreateLoginPrivilege is when CREATELOGIN/NOCREATELOGIN
@@ -415,13 +415,13 @@ var versionsSingleton = keyedVersions([]keyedVersion{
 		// It represents adding authn principal management via CREATELOGIN
 		// role option.
 		Key:     VersionCreateLoginPrivilege,
-		Version: roachpb.Version{Major: 20, Minor: 1, Unstable: 20},
+		Version: roachpb.Version{Major: 20, Minor: 1, Internal: 20},
 	},
 	{
 		// VersionHBAForNonTLS is when the 'hostssl' and 'hostnossl' HBA
 		// configs are introduced.
 		Key:     VersionHBAForNonTLS,
-		Version: roachpb.Version{Major: 20, Minor: 1, Unstable: 21},
+		Version: roachpb.Version{Major: 20, Minor: 1, Internal: 21},
 	},
 	{
 		// Version20_2 is CockroachDB v20.2. It's used for all v20.2.x patch releases.
@@ -431,13 +431,13 @@ var versionsSingleton = keyedVersions([]keyedVersion{
 	{
 		// VersionStart21_1 demarcates work towards CockroachDB v21.1.
 		Key:     VersionStart21_1,
-		Version: roachpb.Version{Major: 20, Minor: 2, Unstable: 1},
+		Version: roachpb.Version{Major: 20, Minor: 2, Internal: 1},
 	},
 	{
 		// VersionEmptyArraysInInvertedIndexes is when empty arrays are added to
 		// array inverted indexes.
 		Key:     VersionEmptyArraysInInvertedIndexes,
-		Version: roachpb.Version{Major: 20, Minor: 2, Unstable: 2},
+		Version: roachpb.Version{Major: 20, Minor: 2, Internal: 2},
 	},
 
 	// Add new versions here (step two of two).

--- a/pkg/clusterversion/setting.go
+++ b/pkg/clusterversion/setting.go
@@ -69,7 +69,7 @@ func registerClusterVersionSetting() *clusterVersionSetting {
 	s.VersionSetting = settings.MakeVersionSetting(s)
 	settings.RegisterVersionSetting(
 		KeyVersionSetting,
-		"set the active cluster version in the format '<major>.<minor>'", // hide optional `-<unstable>,
+		"set the active cluster version in the format '<major>.<minor>'", // hide optional `-<internal>,
 		&s.VersionSetting)
 	s.SetVisibility(settings.Public)
 	s.SetReportable(true)

--- a/pkg/cmd/roachtest/versionupgrade.go
+++ b/pkg/cmd/roachtest/versionupgrade.go
@@ -250,7 +250,7 @@ func (u *versionUpgradeTest) uploadVersion(
 }
 
 // binaryVersion returns the binary running on the (one-indexed) node.
-// NB: version means major.minor[-unstable]; the patch level isn't returned. For example, a binary
+// NB: version means major.minor[-internal]; the patch level isn't returned. For example, a binary
 // of version 19.2.4 will return 19.2.
 func (u *versionUpgradeTest) binaryVersion(ctx context.Context, t *test, i int) roachpb.Version {
 	db := u.conn(ctx, t, i)
@@ -274,7 +274,7 @@ func (u *versionUpgradeTest) binaryVersion(ctx context.Context, t *test, i int) 
 // binaryVersion returns the cluster version active on the (one-indexed) node. Note that the
 // returned value might become stale due to the cluster auto-upgrading in the background plus
 // gossip asynchronicity.
-// NB: cluster versions are always major.minor[-unstable]; there isn't a patch level.
+// NB: cluster versions are always major.minor[-internal]; there isn't a patch level.
 func (u *versionUpgradeTest) clusterVersion(ctx context.Context, t *test, i int) roachpb.Version {
 	db := u.conn(ctx, t, i)
 

--- a/pkg/kv/kvserver/stores_test.go
+++ b/pkg/kv/kvserver/stores_test.go
@@ -375,8 +375,8 @@ func TestClusterVersionWriteSynthesize(t *testing.T) {
 
 	ls0.AddStore(stores[0])
 
-	versionA := roachpb.Version{Major: 1, Minor: 0, Unstable: 1} // 1.0-1
-	versionB := roachpb.Version{Major: 1, Minor: 0, Unstable: 2} // 1.0-2
+	versionA := roachpb.Version{Major: 1, Minor: 0, Internal: 1} // 1.0-1
+	versionB := roachpb.Version{Major: 1, Minor: 0, Internal: 2} // 1.0-2
 
 	// Verify that the initial read of an empty store synthesizes v1.0-0. This
 	// is the code path that runs after starting the 1.1 binary for the first
@@ -477,7 +477,7 @@ func TestStoresClusterVersionIncompatible(t *testing.T) {
 
 	ctx := context.Background()
 
-	vOneDashOne := roachpb.Version{Major: 1, Unstable: 1}
+	vOneDashOne := roachpb.Version{Major: 1, Internal: 1}
 	vOne := roachpb.Version{Major: 1}
 
 	type testCase struct {

--- a/pkg/roachpb/metadata.pb.go
+++ b/pkg/roachpb/metadata.pb.go
@@ -110,7 +110,7 @@ func (x *ReplicaType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (ReplicaType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_0c98cdbced5f2e8b, []int{0}
+	return fileDescriptor_metadata_86ec0afcbf251d96, []int{0}
 }
 
 // Attributes specifies a list of arbitrary strings describing
@@ -122,7 +122,7 @@ type Attributes struct {
 func (m *Attributes) Reset()      { *m = Attributes{} }
 func (*Attributes) ProtoMessage() {}
 func (*Attributes) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_0c98cdbced5f2e8b, []int{0}
+	return fileDescriptor_metadata_86ec0afcbf251d96, []int{0}
 }
 func (m *Attributes) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -156,7 +156,7 @@ type ReplicationTarget struct {
 func (m *ReplicationTarget) Reset()      { *m = ReplicationTarget{} }
 func (*ReplicationTarget) ProtoMessage() {}
 func (*ReplicationTarget) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_0c98cdbced5f2e8b, []int{1}
+	return fileDescriptor_metadata_86ec0afcbf251d96, []int{1}
 }
 func (m *ReplicationTarget) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -201,7 +201,7 @@ type ReplicaDescriptor struct {
 func (m *ReplicaDescriptor) Reset()      { *m = ReplicaDescriptor{} }
 func (*ReplicaDescriptor) ProtoMessage() {}
 func (*ReplicaDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_0c98cdbced5f2e8b, []int{2}
+	return fileDescriptor_metadata_86ec0afcbf251d96, []int{2}
 }
 func (m *ReplicaDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -236,7 +236,7 @@ func (m *ReplicaIdent) Reset()         { *m = ReplicaIdent{} }
 func (m *ReplicaIdent) String() string { return proto.CompactTextString(m) }
 func (*ReplicaIdent) ProtoMessage()    {}
 func (*ReplicaIdent) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_0c98cdbced5f2e8b, []int{3}
+	return fileDescriptor_metadata_86ec0afcbf251d96, []int{3}
 }
 func (m *ReplicaIdent) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -380,7 +380,7 @@ type RangeDescriptor struct {
 func (m *RangeDescriptor) Reset()      { *m = RangeDescriptor{} }
 func (*RangeDescriptor) ProtoMessage() {}
 func (*RangeDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_0c98cdbced5f2e8b, []int{4}
+	return fileDescriptor_metadata_86ec0afcbf251d96, []int{4}
 }
 func (m *RangeDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -419,7 +419,7 @@ type Percentiles struct {
 func (m *Percentiles) Reset()      { *m = Percentiles{} }
 func (*Percentiles) ProtoMessage() {}
 func (*Percentiles) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_0c98cdbced5f2e8b, []int{5}
+	return fileDescriptor_metadata_86ec0afcbf251d96, []int{5}
 }
 func (m *Percentiles) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -481,7 +481,7 @@ type StoreCapacity struct {
 func (m *StoreCapacity) Reset()      { *m = StoreCapacity{} }
 func (*StoreCapacity) ProtoMessage() {}
 func (*StoreCapacity) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_0c98cdbced5f2e8b, []int{6}
+	return fileDescriptor_metadata_86ec0afcbf251d96, []int{6}
 }
 func (m *StoreCapacity) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -526,7 +526,7 @@ func (m *NodeDescriptor) Reset()         { *m = NodeDescriptor{} }
 func (m *NodeDescriptor) String() string { return proto.CompactTextString(m) }
 func (*NodeDescriptor) ProtoMessage()    {}
 func (*NodeDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_0c98cdbced5f2e8b, []int{7}
+	return fileDescriptor_metadata_86ec0afcbf251d96, []int{7}
 }
 func (m *NodeDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -562,7 +562,7 @@ func (m *LocalityAddress) Reset()         { *m = LocalityAddress{} }
 func (m *LocalityAddress) String() string { return proto.CompactTextString(m) }
 func (*LocalityAddress) ProtoMessage()    {}
 func (*LocalityAddress) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_0c98cdbced5f2e8b, []int{8}
+	return fileDescriptor_metadata_86ec0afcbf251d96, []int{8}
 }
 func (m *LocalityAddress) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -600,7 +600,7 @@ func (m *StoreDescriptor) Reset()         { *m = StoreDescriptor{} }
 func (m *StoreDescriptor) String() string { return proto.CompactTextString(m) }
 func (*StoreDescriptor) ProtoMessage()    {}
 func (*StoreDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_0c98cdbced5f2e8b, []int{9}
+	return fileDescriptor_metadata_86ec0afcbf251d96, []int{9}
 }
 func (m *StoreDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -637,7 +637,7 @@ func (m *StoreDeadReplicas) Reset()         { *m = StoreDeadReplicas{} }
 func (m *StoreDeadReplicas) String() string { return proto.CompactTextString(m) }
 func (*StoreDeadReplicas) ProtoMessage()    {}
 func (*StoreDeadReplicas) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_0c98cdbced5f2e8b, []int{10}
+	return fileDescriptor_metadata_86ec0afcbf251d96, []int{10}
 }
 func (m *StoreDeadReplicas) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -671,7 +671,7 @@ type Locality struct {
 func (m *Locality) Reset()      { *m = Locality{} }
 func (*Locality) ProtoMessage() {}
 func (*Locality) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_0c98cdbced5f2e8b, []int{11}
+	return fileDescriptor_metadata_86ec0afcbf251d96, []int{11}
 }
 func (m *Locality) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -707,7 +707,7 @@ type Tier struct {
 func (m *Tier) Reset()      { *m = Tier{} }
 func (*Tier) ProtoMessage() {}
 func (*Tier) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_0c98cdbced5f2e8b, []int{12}
+	return fileDescriptor_metadata_86ec0afcbf251d96, []int{12}
 }
 func (m *Tier) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -737,16 +737,17 @@ type Version struct {
 	Minor int32 `protobuf:"varint,2,opt,name=minor_val,json=minorVal" json:"minor_val"`
 	// Note that patch is a placeholder and will always be zero.
 	Patch int32 `protobuf:"varint,3,opt,name=patch" json:"patch"`
-	// The unstable version is used to migrate during development.
-	// Users of stable, public releases will only use binaries
-	// with unstable set to 0.
-	Unstable int32 `protobuf:"varint,4,opt,name=unstable" json:"unstable"`
+	// The internal version is used to introduce migrations during the development
+	// cycle. They are subversions that are never the end versions of a release,
+	// i.e. users of stable, public release will only use binaries with the
+	// internal version set to 0.
+	Internal int32 `protobuf:"varint,4,opt,name=internal" json:"internal"`
 }
 
 func (m *Version) Reset()      { *m = Version{} }
 func (*Version) ProtoMessage() {}
 func (*Version) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_0c98cdbced5f2e8b, []int{13}
+	return fileDescriptor_metadata_86ec0afcbf251d96, []int{13}
 }
 func (m *Version) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1050,7 +1051,7 @@ func (this *Version) Equal(that interface{}) bool {
 	if this.Patch != that1.Patch {
 		return false
 	}
-	if this.Unstable != that1.Unstable {
+	if this.Internal != that1.Internal {
 		return false
 	}
 	return true
@@ -1624,7 +1625,7 @@ func (m *Version) MarshalTo(dAtA []byte) (int, error) {
 	i = encodeVarintMetadata(dAtA, i, uint64(m.Patch))
 	dAtA[i] = 0x20
 	i++
-	i = encodeVarintMetadata(dAtA, i, uint64(m.Unstable))
+	i = encodeVarintMetadata(dAtA, i, uint64(m.Internal))
 	return i, nil
 }
 
@@ -2015,7 +2016,7 @@ func (m *Version) Size() (n int) {
 	n += 1 + sovMetadata(uint64(m.Major))
 	n += 1 + sovMetadata(uint64(m.Minor))
 	n += 1 + sovMetadata(uint64(m.Patch))
-	n += 1 + sovMetadata(uint64(m.Unstable))
+	n += 1 + sovMetadata(uint64(m.Internal))
 	return n
 }
 
@@ -4014,9 +4015,9 @@ func (m *Version) Unmarshal(dAtA []byte) error {
 			}
 		case 4:
 			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Unstable", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field Internal", wireType)
 			}
-			m.Unstable = 0
+			m.Internal = 0
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
 					return ErrIntOverflowMetadata
@@ -4026,7 +4027,7 @@ func (m *Version) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.Unstable |= (int32(b) & 0x7F) << shift
+				m.Internal |= (int32(b) & 0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -4157,10 +4158,10 @@ var (
 	ErrIntOverflowMetadata   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("roachpb/metadata.proto", fileDescriptor_metadata_0c98cdbced5f2e8b) }
+func init() { proto.RegisterFile("roachpb/metadata.proto", fileDescriptor_metadata_86ec0afcbf251d96) }
 
-var fileDescriptor_metadata_0c98cdbced5f2e8b = []byte{
-	// 1427 bytes of a gzipped FileDescriptorProto
+var fileDescriptor_metadata_86ec0afcbf251d96 = []byte{
+	// 1425 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xbc, 0x56, 0xcd, 0x6f, 0x1b, 0x45,
 	0x14, 0xf7, 0xda, 0xeb, 0xd8, 0x7e, 0xce, 0x87, 0x3d, 0x82, 0xd6, 0x32, 0xc2, 0x76, 0x0d, 0x15,
 	0x69, 0x41, 0x49, 0x1a, 0x14, 0x55, 0x0d, 0x14, 0x29, 0x4e, 0xd2, 0x62, 0x9a, 0x2f, 0x36, 0x6e,
@@ -4241,14 +4242,14 @@ var fileDescriptor_metadata_0c98cdbced5f2e8b = []byte{
 	0x3b, 0x8c, 0xb6, 0x99, 0xb2, 0x44, 0x50, 0xca, 0xcb, 0xcf, 0x1a, 0x14, 0x54, 0xcb, 0x5f, 0x86,
 	0xd2, 0x00, 0x7f, 0xee, 0x53, 0xf3, 0x00, 0xbb, 0x32, 0x2f, 0x53, 0x32, 0x2f, 0xf9, 0x4d, 0x6e,
 	0x30, 0x8a, 0xc2, 0x7e, 0x07, 0xbb, 0x82, 0xeb, 0x78, 0x92, 0x9b, 0x3d, 0xc1, 0xe5, 0x06, 0xa3,
-	0x28, 0xec, 0x9c, 0x5b, 0x87, 0x7c, 0x80, 0x99, 0xb5, 0x3f, 0xb6, 0x31, 0x23, 0x88, 0x6f, 0xe6,
-	0xa1, 0x17, 0x32, 0xb1, 0x76, 0xd3, 0x9b, 0x32, 0x46, 0x93, 0x58, 0x2f, 0xbb, 0x50, 0x4e, 0xbd,
-	0x9c, 0xd1, 0x34, 0xc0, 0x9d, 0xed, 0xde, 0xba, 0x61, 0xde, 0xb8, 0xbd, 0xb1, 0x51, 0xc9, 0x20,
-	0x04, 0xd3, 0xd1, 0xef, 0xee, 0xd6, 0xea, 0xf6, 0x66, 0x77, 0xeb, 0x66, 0x25, 0x9b, 0x60, 0xdb,
-	0xb7, 0x7b, 0x37, 0xb7, 0x39, 0x96, 0x4b, 0xb0, 0xb5, 0xf5, 0xcd, 0xed, 0x1e, 0xc7, 0x74, 0x54,
-	0x86, 0xc2, 0xc6, 0xfa, 0x8a, 0xb1, 0xb5, 0x6e, 0x54, 0xb4, 0xba, 0xfe, 0xf5, 0x8f, 0x8d, 0x4c,
-	0xe7, 0xd2, 0xa3, 0xdf, 0x1a, 0x99, 0x47, 0x47, 0x0d, 0xed, 0xf1, 0x51, 0x43, 0x7b, 0x72, 0xd4,
-	0xd0, 0x7e, 0x3d, 0x6a, 0x68, 0xdf, 0x3d, 0x6d, 0x64, 0x1e, 0x3f, 0x6d, 0x64, 0x9e, 0x3c, 0x6d,
-	0x64, 0x3e, 0x2d, 0xc8, 0x6b, 0xfa, 0x3b, 0x00, 0x00, 0xff, 0xff, 0xf1, 0xbb, 0x1c, 0xba, 0xf7,
-	0x0d, 0x00, 0x00,
+	0x28, 0xec, 0x9c, 0x5b, 0x87, 0x7c, 0x80, 0x99, 0xb5, 0x3f, 0xb6, 0x31, 0x23, 0x88, 0x6f, 0x66,
+	0xf5, 0x04, 0x1b, 0xdb, 0x94, 0x31, 0x9a, 0xc4, 0x7a, 0xd9, 0x85, 0x72, 0xea, 0xe5, 0x8c, 0xa6,
+	0x01, 0xee, 0x6c, 0xf7, 0xd6, 0x0d, 0xf3, 0xc6, 0xed, 0x8d, 0x8d, 0x4a, 0x06, 0x21, 0x98, 0x8e,
+	0x7e, 0x77, 0xb7, 0x56, 0xb7, 0x37, 0xbb, 0x5b, 0x37, 0x2b, 0xd9, 0x04, 0xdb, 0xbe, 0xdd, 0xbb,
+	0xb9, 0xcd, 0xb1, 0x5c, 0x82, 0xad, 0xad, 0x6f, 0x6e, 0xf7, 0x38, 0xa6, 0xa3, 0x32, 0x14, 0x36,
+	0xd6, 0x57, 0x8c, 0xad, 0x75, 0xa3, 0xa2, 0xd5, 0xf5, 0xaf, 0x7f, 0x6c, 0x64, 0x3a, 0x97, 0x1e,
+	0xfd, 0xd6, 0xc8, 0x3c, 0x3a, 0x6a, 0x68, 0x8f, 0x8f, 0x1a, 0xda, 0x93, 0xa3, 0x86, 0xf6, 0xeb,
+	0x51, 0x43, 0xfb, 0xee, 0x69, 0x23, 0xf3, 0xf8, 0x69, 0x23, 0xf3, 0xe4, 0x69, 0x23, 0xf3, 0x69,
+	0x41, 0x5e, 0xd3, 0xdf, 0x01, 0x00, 0x00, 0xff, 0xff, 0x08, 0x52, 0x31, 0x35, 0xf7, 0x0d, 0x00,
+	0x00,
 }

--- a/pkg/roachpb/metadata.proto
+++ b/pkg/roachpb/metadata.proto
@@ -379,8 +379,9 @@ message Version {
   optional int32 minor_val = 2 [(gogoproto.nullable) = false, (gogoproto.customname) = "Minor"];
   // Note that patch is a placeholder and will always be zero.
   optional int32 patch = 3 [(gogoproto.nullable) = false];
-  // The unstable version is used to migrate during development.
-  // Users of stable, public releases will only use binaries
-  // with unstable set to 0.
-  optional int32 unstable = 4 [(gogoproto.nullable) = false];
+  // The internal version is used to introduce migrations during the development
+  // cycle. They are subversions that are never the end versions of a release,
+  // i.e. users of stable, public release will only use binaries with the
+  // internal version set to 0.
+  optional int32 internal = 4 [(gogoproto.nullable) = false];
 }

--- a/pkg/roachpb/version.go
+++ b/pkg/roachpb/version.go
@@ -35,9 +35,9 @@ func (v Version) Less(otherV Version) bool {
 	} else if v.Patch > otherV.Patch {
 		return false
 	}
-	if v.Unstable < otherV.Unstable {
+	if v.Internal < otherV.Internal {
 		return true
-	} else if v.Unstable > otherV.Unstable {
+	} else if v.Internal > otherV.Internal {
 		return false
 	}
 	return false
@@ -48,15 +48,15 @@ func (v Version) String() string { return redact.StringWithoutMarkers(v) }
 
 // SafeFormat implements the redact.SafeFormatter interface.
 func (v Version) SafeFormat(p redact.SafePrinter, _ rune) {
-	if v.Unstable == 0 {
+	if v.Internal == 0 {
 		p.Printf("%d.%d", v.Major, v.Minor)
 		return
 	}
-	p.Printf("%d.%d-%d", v.Major, v.Minor, v.Unstable)
+	p.Printf("%d.%d-%d", v.Major, v.Minor, v.Internal)
 }
 
 // ParseVersion parses a Version from a string of the form
-// "<major>.<minor>-<unstable>" where the "-<unstable>" is optional. We don't
+// "<major>.<minor>-<internal>" where the "-<internal>" is optional. We don't
 // use the Patch component, so it is always zero.
 func ParseVersion(s string) (Version, error) {
 	var c Version
@@ -85,7 +85,7 @@ func ParseVersion(s string) (Version, error) {
 
 	c.Major = int32(ints[0])
 	c.Minor = int32(ints[1])
-	c.Unstable = int32(ints[2])
+	c.Internal = int32(ints[2])
 
 	return c, nil
 }

--- a/pkg/roachpb/version_test.go
+++ b/pkg/roachpb/version_test.go
@@ -17,12 +17,12 @@ import (
 )
 
 func TestVersionLess(t *testing.T) {
-	v := func(major, minor, patch, unstable int32) Version {
+	v := func(major, minor, patch, internal int32) Version {
 		return Version{
 			Major:    major,
 			Minor:    minor,
 			Patch:    patch,
-			Unstable: unstable,
+			Internal: internal,
 		}
 	}
 	testData := []struct {

--- a/pkg/server/version_cluster_test.go
+++ b/pkg/server/version_cluster_test.go
@@ -132,7 +132,7 @@ func setupMixedCluster(
 // eg. prev(20.1) = 19.2, prev(19.2) = 19.1, prev(19.1) = 2.1,
 // prev(2.0) = 1.0, prev(2.1) == 2.0, prev(2.1-5) == 2.1.
 func prev(version roachpb.Version) roachpb.Version {
-	if version.Unstable != 0 {
+	if version.Internal != 0 {
 		return roachpb.Version{Major: version.Major, Minor: version.Minor}
 	}
 


### PR DESCRIPTION
We currently internal crdb versions to introduce backwards incompatible
migrations during the development cycle. These are subversions that are
never the end versions of a release, i.e. users of stable, public
release will only use binaries with the internal version tags set to 0.

It was previously named `Unstable`, and was proving to be a bit unwieldy
given our increase reliance on it in the forthcoming pkg/migration
(#56107). We rename it to something more appropriate here.

Release note: None