### PR TITLE
bazel: revert go1.13.14 pinning

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -19,7 +19,7 @@ http_archive(
 # Load the go dependencies and invoke them.
 load("@io_bazel_rules_go//go:deps.bzl", "go_rules_dependencies", "go_register_toolchains")
 go_rules_dependencies()
-go_register_toolchains(go_version="1.13.14")
+go_register_toolchains()
 
 # Load gazelle. This lets us auto-generate BUILD.bazel files throughout the
 # repo.


### PR DESCRIPTION
Bandaid to pre 1.14 issues: https://github.com/bazelbuild/bazel-gazelle/pull/767

Release note: None