### PR TITLE
sql: ban alter column type on view-depended cols

### DIFF
--- a/pkg/sql/alter_column_type.go
+++ b/pkg/sql/alter_column_type.go
@@ -62,6 +62,19 @@ func AlterColumnType(
 	cmds tree.AlterTableCmds,
 	tn *tree.TableName,
 ) error {
+	for _, tableRef := range tableDesc.DependedOnBy {
+		found := false
+		for _, colID := range tableRef.ColumnIDs {
+			if colID == col.ID {
+				found = true
+			}
+		}
+		if found {
+			return params.p.dependentViewError(
+				ctx, "column", col.Name, tableDesc.ParentID, tableRef.ID, "alter type of",
+			)
+		}
+	}
 
 	typ, err := tree.ResolveType(ctx, t.ToType, params.p.semaCtx.GetTypeResolver())
 	if err != nil {

--- a/pkg/sql/logictest/testdata/logic_test/alter_column_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_column_type
@@ -546,3 +546,20 @@ INSERT INTO t30 VALUES (e'a\\01');
 
 statement error pq: could not parse "a\\\\01" as type bytes: bytea encoded value ends with incomplete escape sequence
 ALTER TABLE t30 ALTER COLUMN x TYPE BYTES
+
+# Ensure that dependent views prevent column type modification.
+
+statement ok
+CREATE VIEW v AS SELECT x FROM t29
+
+statement error cannot alter type of column "x" because view "v" depends on it
+ALTER TABLE t29 ALTER COLUMN x TYPE INT2
+
+statement ok
+DROP VIEW v
+
+statement ok
+CREATE MATERIALIZED VIEW v AS SELECT x FROM t29
+
+statement error cannot alter type of column "x" because view "v" depends on it
+ALTER TABLE t29 ALTER COLUMN x TYPE INT2


### PR DESCRIPTION
Previously, it was legal to edit the column type of columns that were
depended on by views. This is not a good idea for various reasons, and
is not Postgres compatible to boot.

Now, it is illegal to alter the column type of columns that are depended
on views.

Closes #56166.

Release note (sql change): prevent column type modification of columns
that are depended on by views.