### PR TITLE
release-20.2: roachtest: add DROP DATABASE CASCADE at end of schemachange/random-load

### DIFF
--- a/pkg/cmd/roachtest/schemachange_random_load.go
+++ b/pkg/cmd/roachtest/schemachange_random_load.go
@@ -12,6 +12,7 @@ package main
 
 import (
 	"context"
+	gosql "database/sql"
 	"fmt"
 	"strings"
 )
@@ -75,6 +76,37 @@ func registerRandomLoadBenchSpec(r *testRegistry, b randomLoadBenchSpec) {
 }
 
 func runSchemaChangeRandomLoad(ctx context.Context, t *test, c *cluster, maxOps, concurrency int) {
+	validate := func(db *gosql.DB) {
+		var (
+			id           int
+			databaseName string
+			schemaName   string
+			objName      string
+			objError     string
+		)
+		numInvalidObjects := 0
+		rows, err := db.QueryContext(ctx, `SELECT id, database_name, schema_name, obj_name, error FROM crdb_internal.invalid_objects`)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for rows.Next() {
+			numInvalidObjects++
+			if err := rows.Scan(&id, &databaseName, &schemaName, &objName, &objError); err != nil {
+				t.Fatal(err)
+			}
+			t.logger().Errorf(
+				"invalid object found: id: %d, database_name: %s, schema_name: %s, obj_name: %s, error: %s",
+				id, databaseName, schemaName, objName, objError,
+			)
+		}
+		if err := rows.Err(); err != nil {
+			t.Fatal(err)
+		}
+		if numInvalidObjects > 0 {
+			t.Fatalf("found %d invalid objects", numInvalidObjects)
+		}
+	}
+
 	loadNode := c.Node(1)
 	roachNodes := c.Range(1, c.spec.NodeCount)
 	t.Status("copying binaries")
@@ -100,4 +132,25 @@ func runSchemaChangeRandomLoad(ctx context.Context, t *test, c *cluster, maxOps,
 	}
 	t.Status("running schemachange workload")
 	c.Run(ctx, loadNode, runCmd...)
+
+	// Drop the database to test the correctness of DROP DATABASE CASCADE, which
+	// has been a source of schema change bugs (mostly orphaned descriptors) in
+	// the past.
+	// TODO (lucy): When the workload supports multiple databases and running
+	// schema changes on them, we may want to push this into the post-run hook for
+	// the workload itself (if we even still want it, considering that the
+	// workload itself would be running DROP DATABASE CASCADE).
+
+	db := c.Conn(ctx, 1)
+	defer db.Close()
+
+	t.Status("performing validation after workload")
+	validate(db)
+	t.Status("dropping database")
+	_, err := db.ExecContext(ctx, `USE defaultdb; DROP DATABASE schemachange CASCADE;`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Status("performing validation after dropping database")
+	validate(db)
 }

--- a/pkg/cmd/roachtest/schemachange_random_load.go
+++ b/pkg/cmd/roachtest/schemachange_random_load.go
@@ -32,7 +32,7 @@ func registerSchemaChangeRandomLoad(r *testRegistry) {
 			maxOps := 5000
 			concurrency := 20
 			if local {
-				maxOps = 1000
+				maxOps = 200
 				concurrency = 2
 			}
 			runSchemaChangeRandomLoad(ctx, t, c, maxOps, concurrency)


### PR DESCRIPTION
Backport 2/2 commits from #55345.

/cc @cockroachdb/release

---

This commit adds a step at the end of schemachange/random-load to drop
the workload's database. This helps validate the correctness of DROP
DATABASE CASCADE in the presence of complex schemas.

Release note: None
