### PR TITLE
sql: clean up uses of Statement

### DIFF
--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -482,7 +482,7 @@ func (c *copyMachine) insertRows(ctx context.Context) (retErr error) {
 	c.rows = c.rows[:0]
 	c.rowsMemAcc.Clear(ctx)
 
-	c.p.stmt = &Statement{}
+	c.p.stmt = Statement{}
 	c.p.stmt.AST = &tree.Insert{
 		Table:   c.table,
 		Columns: c.columns,

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -671,7 +671,7 @@ func (p *PlanningCtx) flowSpecsToDiagram(
 	}
 	log.VEvent(ctx, 1, "creating plan diagram")
 	var stmtStr string
-	if p.planner != nil && p.planner.stmt != nil {
+	if p.planner != nil && p.planner.stmt.AST != nil {
 		stmtStr = p.planner.stmt.String()
 	}
 	diagram, err := execinfrapb.GeneratePlanDiagram(

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -347,7 +347,7 @@ func (dsp *DistSQLPlanner) Run(
 	if logPlanDiagram {
 		log.VEvent(ctx, 1, "creating plan diagram for logging")
 		var stmtStr string
-		if planCtx.planner != nil && planCtx.planner.stmt != nil {
+		if planCtx.planner != nil && planCtx.planner.stmt.AST != nil {
 			stmtStr = planCtx.planner.stmt.String()
 		}
 		_, url, err := execinfrapb.GeneratePlanDiagramURL(stmtStr, flows, false /* showInputTypes */)

--- a/pkg/sql/distsql_running_test.go
+++ b/pkg/sql/distsql_running_test.go
@@ -148,7 +148,7 @@ func TestDistSQLRunningInAbortedTxn(t *testing.T) {
 
 		// We need to re-plan every time, since close() below makes
 		// the plan unusable across retries.
-		p.stmt = &Statement{Statement: stmt}
+		p.stmt = makeStatement(stmt, ClusterWideID{})
 		if err := p.makeOptimizerPlan(ctx); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1178,15 +1178,15 @@ func (p *planner) isAsOf(ctx context.Context, stmt tree.Statement) (*hlc.Timesta
 	return &ts, err
 }
 
-// isSavepoint returns true if stmt is a SAVEPOINT statement.
-func isSavepoint(stmt Statement) bool {
-	_, isSavepoint := stmt.AST.(*tree.Savepoint)
+// isSavepoint returns true if ast is a SAVEPOINT statement.
+func isSavepoint(ast tree.Statement) bool {
+	_, isSavepoint := ast.(*tree.Savepoint)
 	return isSavepoint
 }
 
-// isSetTransaction returns true if stmt is a "SET TRANSACTION ..." statement.
-func isSetTransaction(stmt Statement) bool {
-	_, isSet := stmt.AST.(*tree.SetTransaction)
+// isSetTransaction returns true if ast is a "SET TRANSACTION ..." statement.
+func isSetTransaction(ast tree.Statement) bool {
+	_, isSet := ast.(*tree.SetTransaction)
 	return isSet
 }
 

--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -179,7 +179,7 @@ func (ex *connExecutor) recordStatementSummary(
 	// overhead latency: txn/retry management, error checking, etc
 	execOverhead := svcLat - processingLat
 
-	stmt := planner.stmt
+	stmt := &planner.stmt
 	flags := planner.curPlan.flags
 	if automaticRetryCount == 0 {
 		ex.updateOptCounters(flags)

--- a/pkg/sql/explain_tree_test.go
+++ b/pkg/sql/explain_tree_test.go
@@ -64,7 +64,7 @@ func TestPlanToTreeAndPlanToString(t *testing.T) {
 			defer cleanup()
 			p := internalPlanner.(*planner)
 
-			p.stmt = &Statement{Statement: stmt}
+			p.stmt = makeStatement(stmt, ClusterWideID{})
 			p.curPlan.savePlanString = true
 			p.curPlan.savePlanForStats = true
 			if err := p.makeOptimizerPlan(ctx); err != nil {

--- a/pkg/sql/export.go
+++ b/pkg/sql/export.go
@@ -142,7 +142,7 @@ func (ef *execFactory) ConstructExport(
 		}
 	}
 
-	exportID := ef.planner.stmt.queryID.String()
+	exportID := ef.planner.stmt.QueryID.String()
 	namePattern := fmt.Sprintf("export%s-%s", exportID, exportFilePatternDefault)
 
 	return &exportNode{

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -512,17 +512,22 @@ RESET application_name
 # reset to 0 between statements - a naive implementation could make
 # the counter increase forever, even between statements.
 #
+# TODO(radu): there should be a single fingerprint, with ::INTERVAL. The
+# different fingerprint on retries is caused by in-place mutation of the AST
+# (#22847).
+#
 query TIB
 SELECT key, max_retries, flags LIKE '!%' AS f
   FROM crdb_internal.node_statement_statistics
  WHERE application_name = 'test_max_retry'
 ORDER BY key, f
 ----
-CREATE SEQUENCE s                                           0  false
-DROP SEQUENCE s                                             0  false
-SELECT IF(nextval(_) < _, crdb_internal.force_retry(_), _)  2  false
-SELECT IF(nextval(_) < _, crdb_internal.force_retry(_), _)  1  true
-SET application_name = DEFAULT                              0  false
+CREATE SEQUENCE s                                                     0  false
+DROP SEQUENCE s                                                       0  false
+SELECT IF(nextval(_) < _, crdb_internal.force_retry(_), _)            2  false
+SELECT IF(nextval(_) < _, crdb_internal.force_retry(_), _)            1  true
+SELECT IF(nextval(_) < _, crdb_internal.force_retry(_::INTERVAL), _)  0  true
+SET application_name = DEFAULT                                        0  false
 
 
 # Testing split_enforced_until when truncating and dropping.

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal_tenant
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal_tenant
@@ -418,17 +418,23 @@ RESET application_name
 # reset to 0 between statements - a naive implementation could make
 # the counter increase forever, even between statements.
 #
+# TODO(radu): there should be a single fingerprint, with ::INTERVAL. The
+# different fingerprint on retries is caused by in-place mutation of the AST
+# (#22847).
+#
+
 query TIB
 SELECT key, max_retries, flags LIKE '!%' AS f
   FROM crdb_internal.node_statement_statistics
  WHERE application_name = 'test_max_retry'
 ORDER BY key, f
 ----
-CREATE SEQUENCE s                                           0  false
-DROP SEQUENCE s                                             0  false
-SELECT IF(nextval(_) < _, crdb_internal.force_retry(_), _)  2  false
-SELECT IF(nextval(_) < _, crdb_internal.force_retry(_), _)  1  true
-SET application_name = DEFAULT                              0  false
+CREATE SEQUENCE s                                                     0  false
+DROP SEQUENCE s                                                       0  false
+SELECT IF(nextval(_) < _, crdb_internal.force_retry(_), _)            2  false
+SELECT IF(nextval(_) < _, crdb_internal.force_retry(_), _)            1  true
+SELECT IF(nextval(_) < _, crdb_internal.force_retry(_::INTERVAL), _)  0  true
+SET application_name = DEFAULT                                        0  false
 
 query T
 SELECT crdb_internal.cluster_name()

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -46,12 +46,10 @@ var queryCacheEnabled = settings.RegisterBoolSetting(
 //  - AnonymizedStr
 //  - Memo (for reuse during exec, if appropriate).
 func (p *planner) prepareUsingOptimizer(ctx context.Context) (planFlags, error) {
-	stmt := p.stmt
+	stmt := &p.stmt
 
 	opc := &p.optPlanningCtx
 	opc.reset()
-
-	stmt.Prepared.AnonymizedStr = anonymizeStmt(stmt.AST)
 
 	switch stmt.AST.(type) {
 	case *tree.AlterIndex, *tree.AlterTable, *tree.AlterSequence,
@@ -207,7 +205,7 @@ func (p *planner) makeOptimizerPlan(ctx context.Context) error {
 		}
 		err := opc.runExecBuilder(
 			&p.curPlan,
-			p.stmt,
+			&p.stmt,
 			newDistSQLSpecExecFactory(p, planningMode),
 			execMemo,
 			p.EvalContext(),
@@ -242,7 +240,7 @@ func (p *planner) makeOptimizerPlan(ctx context.Context) error {
 				// execFactory.
 				err = opc.runExecBuilder(
 					&p.curPlan,
-					p.stmt,
+					&p.stmt,
 					newDistSQLSpecExecFactory(p, distSQLLocalOnlyPlanning),
 					execMemo,
 					p.EvalContext(),
@@ -263,7 +261,7 @@ func (p *planner) makeOptimizerPlan(ctx context.Context) error {
 	// If we got here, we did not create a plan above.
 	return opc.runExecBuilder(
 		&p.curPlan,
-		p.stmt,
+		&p.stmt,
 		newExecFactory(p),
 		execMemo,
 		p.EvalContext(),
@@ -558,7 +556,7 @@ func (opc *optPlanningCtx) runExecBuilder(
 		// planning process could in principle modify the AST, resulting in a
 		// different statement signature.
 		planTop.savePlanForStats = planTop.appStats.shouldSaveLogicalPlanDescription(
-			planTop.stmt,
+			planTop.stmt.AnonymizedStr,
 			allowAutoCommit,
 		)
 	}

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -137,8 +137,8 @@ type planner struct {
 	// a SQL session.
 	isInternalPlanner bool
 
-	// Reference to the corresponding sql Statement for this query.
-	stmt *Statement
+	// Corresponding Statement for this query.
+	stmt Statement
 
 	// Contexts for different stages of planning and execution.
 	semaCtx         tree.SemaContext
@@ -308,7 +308,7 @@ func newInternalPlanner(
 	p := &planner{execCfg: execCfg, alloc: &rowenc.DatumAlloc{}}
 
 	p.txn = txn
-	p.stmt = nil
+	p.stmt = Statement{}
 	p.cancelChecker = cancelchecker.NewCancelChecker(ctx)
 	p.isInternalPlanner = true
 

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -253,7 +253,7 @@ func (sc *SchemaChanger) backfillQueryIntoTable(
 		}
 
 		// Construct an optimized logical plan of the AS source stmt.
-		localPlanner.stmt = &Statement{Statement: stmt}
+		localPlanner.stmt = makeStatement(stmt, ClusterWideID{} /* queryID */)
 		localPlanner.optPlanningCtx.init(localPlanner)
 
 		localPlanner.runWithOptions(resolveFlags{skipCache: true}, func() {

--- a/pkg/sql/statement.go
+++ b/pkg/sql/statement.go
@@ -19,9 +19,10 @@ import (
 type Statement struct {
 	parser.Statement
 
-	ExpectedTypes colinfo.ResultColumns
 	AnonymizedStr string
-	queryID       ClusterWideID
+	QueryID       ClusterWideID
+
+	ExpectedTypes colinfo.ResultColumns
 
 	// Prepared is non-nil during the PREPARE phase, as well as during EXECUTE of
 	// a previously prepared statement. The Prepared statement can be modified
@@ -34,6 +35,24 @@ type Statement struct {
 	// Given that the PreparedStatement can be modified during planning, it is
 	// not safe for use on multiple threads.
 	Prepared *PreparedStatement
+}
+
+func makeStatement(parserStmt parser.Statement, queryID ClusterWideID) Statement {
+	return Statement{
+		Statement:     parserStmt,
+		AnonymizedStr: anonymizeStmt(parserStmt.AST),
+		QueryID:       queryID,
+	}
+}
+
+func makeStatementFromPrepared(prepared *PreparedStatement, queryID ClusterWideID) Statement {
+	return Statement{
+		Statement:     prepared.Statement,
+		Prepared:      prepared,
+		ExpectedTypes: prepared.Columns,
+		AnonymizedStr: prepared.AnonymizedStr,
+		QueryID:       queryID,
+	}
 }
 
 func (s Statement) String() string {

--- a/pkg/sql/testutils.go
+++ b/pkg/sql/testutils.go
@@ -114,7 +114,7 @@ func (dsp *DistSQLPlanner) Exec(
 		return err
 	}
 	p := localPlanner.(*planner)
-	p.stmt = &Statement{Statement: stmt}
+	p.stmt = makeStatement(stmt, ClusterWideID{} /* queryID */)
 	if err := p.makeOptimizerPlan(ctx); err != nil {
 		return err
 	}


### PR DESCRIPTION
This change cleans up the use of `sql.Statement` and reduces some
allocations. Specifically:

 - we create a  `Statement` lower in the stack (in `execStmtInOpenState`),
   and pass only what we need in the higher layers;

 - we change various functions to take a `tree.Statement` rather than
   an entire `Statement` when possible;

 - we move down the `withStatement` context allocation, so that it is
   avoided in the implicit transaction state transition;

 - we store a copy rather than a pointer to the Statement in the
   planner;

 - we avoid directly using `stmt` fields from `func()` declarations
   that escape;

 - we populate `Statement.AnonymizedStr` upfront. The anonymized
   string is always needed (to update statement stats).

```
name                               old time/op    new time/op    delta
EndToEnd/kv-read/EndToEnd             153µs ± 1%     154µs ± 2%    ~     (p=0.486 n=4+4)
EndToEnd/kv-read-no-prep/EndToEnd     216µs ± 1%     217µs ± 1%    ~     (p=0.886 n=4+4)
EndToEnd/kv-read-const/EndToEnd       111µs ± 1%     113µs ± 1%  +1.01%  (p=0.029 n=4+4)

name                               old alloc/op   new alloc/op   delta
EndToEnd/kv-read/EndToEnd            25.8kB ± 1%    25.5kB ± 1%    ~     (p=0.114 n=4+4)
EndToEnd/kv-read-no-prep/EndToEnd    32.2kB ± 1%    31.9kB ± 1%    ~     (p=0.686 n=4+4)
EndToEnd/kv-read-const/EndToEnd      21.0kB ± 1%    20.7kB ± 2%    ~     (p=0.200 n=4+4)

name                               old allocs/op  new allocs/op  delta
EndToEnd/kv-read/EndToEnd               252 ± 1%       250 ± 0%  -0.99%  (p=0.029 n=4+4)
EndToEnd/kv-read-no-prep/EndToEnd       332 ± 0%       330 ± 1%    ~     (p=0.229 n=4+4)
EndToEnd/kv-read-const/EndToEnd         214 ± 0%       212 ± 0%  -0.93%  (p=0.029 n=4+4)
```

Release note: None