### PR TITLE
flowinfra: fix and extend flow setup benchmark

### DIFF
--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -105,6 +105,7 @@ go_library(
         "//pkg/sql/rowenc",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
+        "//pkg/sql/sessiondatapb",
         "//pkg/sql/sqlliveness",
         "//pkg/sql/sqlliveness/slprovider",
         "//pkg/sql/sqlutil",

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -52,6 +52,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/querycache"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness/slprovider"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
@@ -810,7 +811,7 @@ func (s *sqlServer) preStart(
 			PlanHookMaker: func(opName string, txn *kv.Txn, user security.SQLUsername) (interface{}, func()) {
 				// This is a hack to get around a Go package dependency cycle. See comment
 				// in sql/jobs/registry.go on planHookMaker.
-				return sql.NewInternalPlanner(opName, txn, user, &sql.MemoryMetrics{}, s.execCfg)
+				return sql.NewInternalPlanner(opName, txn, user, &sql.MemoryMetrics{}, s.execCfg, sessiondatapb.SessionData{})
 			},
 		},
 		scheduledjobs.ProdJobSchedulerEnv,

--- a/pkg/sql/distsql_running_test.go
+++ b/pkg/sql/distsql_running_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -65,6 +66,7 @@ func TestDistSQLRunningInAbortedTxn(t *testing.T) {
 		security.RootUserName(),
 		&MemoryMetrics{},
 		&execCfg,
+		sessiondatapb.SessionData{},
 	)
 	defer cleanup()
 	p := internalPlanner.(*planner)

--- a/pkg/sql/explain_tree_test.go
+++ b/pkg/sql/explain_tree_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -60,6 +61,7 @@ func TestPlanToTreeAndPlanToString(t *testing.T) {
 				security.RootUserName(),
 				&MemoryMetrics{},
 				&execCfg,
+				sessiondatapb.SessionData{},
 			)
 			defer cleanup()
 			p := internalPlanner.(*planner)

--- a/pkg/sql/flowinfra/BUILD.bazel
+++ b/pkg/sql/flowinfra/BUILD.bazel
@@ -81,6 +81,7 @@ go_test(
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/rowenc",
         "//pkg/sql/sem/tree",
+        "//pkg/sql/sessiondatapb",
         "//pkg/sql/types",
         "//pkg/testutils",
         "//pkg/testutils/buildutil",

--- a/pkg/sql/flowinfra/flow_test.go
+++ b/pkg/sql/flowinfra/flow_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -38,31 +39,44 @@ func BenchmarkFlowSetup(b *testing.B) {
 
 	r := sqlutils.MakeSQLRunner(conn)
 	r.Exec(b, "CREATE DATABASE b; CREATE TABLE b.test (k INT);")
+	// Set the threshold to 0 so that we can control which engine is used for
+	// the query execution via the vectorize mode.
+	r.Exec(b, `SET CLUSTER SETTING sql.defaults.vectorize_row_count_threshold=0`)
 
 	execCfg := s.ExecutorConfig().(sql.ExecutorConfig)
 	dsp := execCfg.DistSQLPlanner
-	for _, distribute := range []bool{true, false} {
-		b.Run(fmt.Sprintf("distribute=%t", distribute), func(b *testing.B) {
-			b.RunParallel(func(pb *testing.PB) {
-				planner, cleanup := sql.NewInternalPlanner(
-					"test",
-					kv.NewTxn(ctx, s.DB(), s.NodeID()),
-					security.RootUserName(),
-					&sql.MemoryMetrics{},
-					&execCfg,
-				)
-				defer cleanup()
-				for pb.Next() {
-					if err := dsp.Exec(
-						ctx,
-						planner,
-						"SELECT k FROM b.test WHERE k=1",
-						distribute,
-					); err != nil {
-						b.Fatal(err)
-					}
+	for _, vectorize := range []bool{true, false} {
+		for _, distribute := range []bool{true, false} {
+			b.Run(fmt.Sprintf("vectorize=%t/distribute=%t", vectorize, distribute), func(b *testing.B) {
+				vectorizeMode := sessiondatapb.VectorizeOff
+				if vectorize {
+					vectorizeMode = sessiondatapb.VectorizeOn
 				}
+				b.RunParallel(func(pb *testing.PB) {
+					for pb.Next() {
+						// NB: planner cannot be reset and can only be used for
+						// a single statement, so we create a new one on every
+						// iteration.
+						planner, cleanup := sql.NewInternalPlanner(
+							"test",
+							kv.NewTxn(ctx, s.DB(), s.NodeID()),
+							security.RootUserName(),
+							&sql.MemoryMetrics{},
+							&execCfg,
+							sessiondatapb.SessionData{VectorizeMode: vectorizeMode},
+						)
+						defer cleanup()
+						if err := dsp.Exec(
+							ctx,
+							planner,
+							"SELECT k FROM b.test WHERE k=1",
+							distribute,
+						); err != nil {
+							b.Fatal(err)
+						}
+					}
+				})
 			})
-		})
+		}
 	}
 }

--- a/pkg/sql/job_exec_context.go
+++ b/pkg/sql/job_exec_context.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
 )
 
 // plannerJobExecContext is a wrapper to implement JobExecContext with a planner
@@ -29,7 +30,7 @@ type plannerJobExecContext struct {
 func MakeJobExecContext(
 	opName string, user security.SQLUsername, memMetrics *MemoryMetrics, execCfg *ExecutorConfig,
 ) (JobExecContext, func()) {
-	p, close := newInternalPlanner(opName, nil /*txn*/, user, memMetrics, execCfg)
+	p, close := newInternalPlanner(opName, nil /*txn*/, user, memMetrics, execCfg, sessiondatapb.SessionData{})
 	return &plannerJobExecContext{p: p}, close
 }
 

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -244,7 +244,7 @@ func (sc *SchemaChanger) backfillQueryIntoTable(
 
 		// Create an internal planner as the planner used to serve the user query
 		// would have committed by this point.
-		p, cleanup := NewInternalPlanner(desc, txn, security.RootUserName(), &MemoryMetrics{}, sc.execCfg)
+		p, cleanup := NewInternalPlanner(desc, txn, security.RootUserName(), &MemoryMetrics{}, sc.execCfg, sessiondatapb.SessionData{})
 		defer cleanup()
 		localPlanner := p.(*planner)
 		stmt, err := parser.ParseOne(query)

--- a/pkg/sql/values_test.go
+++ b/pkg/sql/values_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/bitarray"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -48,7 +49,7 @@ func makeTestPlanner() *planner {
 
 	// TODO(andrei): pass the cleanup along to the caller.
 	p, _ /* cleanup */ := newInternalPlanner(
-		"test", nil /* txn */, security.RootUserName(), &MemoryMetrics{}, &execCfg,
+		"test", nil /* txn */, security.RootUserName(), &MemoryMetrics{}, &execCfg, sessiondatapb.SessionData{},
 	)
 	return p
 }


### PR DESCRIPTION
Previously, the flow setup benchmark would fail because we reused the
same internal planner object multiple times, and this is not supported
(it would fail due to memory budget error). This is now fixed by
creating a new internal planner on every iteration.

Additionally, this commit extends the benchmark to try both the
vectorized and row-based flow setups.

Release note: None