### PR TITLE
sql,util: support encoding of JSON and Array inverted index spans for @>

### DIFF
--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -2029,6 +2029,17 @@ func (s Span) EqualValue(o Span) bool {
 	return s.Key.Equal(o.Key) && s.EndKey.Equal(o.EndKey)
 }
 
+// Compare returns an integer comparing two Spans lexicographically.
+// The result will be 0 if s==o, -1 if s starts before o or if the starts
+// are equal and s ends before o, and +1 otherwise.
+func (s Span) Compare(o Span) int {
+	cmp := bytes.Compare(s.Key, o.Key)
+	if cmp == 0 {
+		return bytes.Compare(s.EndKey, o.EndKey)
+	}
+	return cmp
+}
+
 // Overlaps returns true WLOG for span A and B iff:
 // 1. Both spans contain one key (just the start key) and they are equal; or
 // 2. The span with only one key is contained inside the other span; or

--- a/pkg/util/encoding/encoding.go
+++ b/pkg/util/encoding/encoding.go
@@ -941,6 +941,14 @@ func EncodeNotNullAscending(b []byte) []byte {
 	return append(b, encodedNotNull)
 }
 
+// EncodeJSONObjectSpanStartAscending encodes the first possible value for JSON
+// objects, which is \x00\xff. Non-objects (i.e., scalars and arrays) will
+// start with \x00\x01 or \x00\x03 (see AddJSONPathTerminator and
+// EncodeArrayAscending), so all objects will be ordered after them.
+func EncodeJSONObjectSpanStartAscending(b []byte) []byte {
+	return append(b, escape, escaped00)
+}
+
 // EncodeArrayAscending encodes a value used to signify membership of an array for JSON objects.
 func EncodeArrayAscending(b []byte) []byte {
 	return append(b, escape, escapedJSONArray)

--- a/pkg/util/json/BUILD.bazel
+++ b/pkg/util/json/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
     deps = [
         "//pkg/geo",
         "//pkg/geo/geopb",
+        "//pkg/roachpb",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/util/encoding",
@@ -39,8 +40,10 @@ go_test(
     deps = [
         "//pkg/sql/pgwire/pgerror",
         "//pkg/util/encoding",
+        "//pkg/util/randutil",
         "//pkg/util/timeutil",
         "//pkg/util/unique",
         "//vendor/github.com/cockroachdb/apd/v2:apd",
+        "//vendor/github.com/stretchr/testify/require",
     ],
 )

--- a/pkg/util/json/encoded.go
+++ b/pkg/util/json/encoded.go
@@ -17,6 +17,7 @@ import (
 	"strconv"
 	"unsafe"
 
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
 )
@@ -712,6 +713,16 @@ func (j *jsonEncoded) encodeInvertedIndexKeys(b []byte) ([][]byte, error) {
 		return nil, err
 	}
 	return decoded.encodeInvertedIndexKeys(b)
+}
+
+func (j *jsonEncoded) encodeContainingInvertedIndexSpans(
+	b []byte, isRoot, isObjectValue bool,
+) ([]roachpb.Spans, bool, error) {
+	decoded, err := j.decode()
+	if err != nil {
+		return nil, false, err
+	}
+	return decoded.encodeContainingInvertedIndexSpans(b, isRoot, isObjectValue)
 }
 
 // numInvertedIndexEntries implements the JSON interface.

--- a/pkg/util/unique/BUILD.bazel
+++ b/pkg/util/unique/BUILD.bazel
@@ -5,10 +5,12 @@ go_library(
     srcs = ["unique.go"],
     importpath = "github.com/cockroachdb/cockroach/pkg/util/unique",
     visibility = ["//visibility:public"],
+    deps = ["//pkg/roachpb"],
 )
 
 go_test(
     name = "unique_test",
     srcs = ["unique_test.go"],
     embed = [":unique"],
+    deps = ["//pkg/roachpb"],
 )

--- a/pkg/util/unique/unique.go
+++ b/pkg/util/unique/unique.go
@@ -14,6 +14,8 @@ import (
 	"bytes"
 	"reflect"
 	"sort"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 )
 
 // UniquifyByteSlices takes as input a slice of slices of bytes, and
@@ -31,6 +33,47 @@ func UniquifyByteSlices(slices [][]byte) [][]byte {
 	lastUniqueIdx := 0
 	for i := 1; i < len(slices); i++ {
 		if !bytes.Equal(slices[i], slices[lastUniqueIdx]) {
+			// We found a unique entry, at index i. The last unique entry in the array
+			// was at lastUniqueIdx, so set the entry after that one to our new unique
+			// entry, and bump lastUniqueIdx for the next loop iteration.
+			lastUniqueIdx++
+			slices[lastUniqueIdx] = slices[i]
+		}
+	}
+	slices = slices[:lastUniqueIdx+1]
+	return slices
+}
+
+// SortAndUniquifySpanSets takes as input a slice of Spans, and deduplicates
+// them using a sort and unique. It modifies the input slice in place and
+// returns it. The result will not contain any duplicates but it will be sorted
+// according to the following logic:
+// - Span set a (which has type roachpb.Spans) will be ordered before span set
+//   b if the first span in a that is not equal to the corresponding span in b
+//   (i.e., at the same position) is less than it (according to Span.Compare)
+//   or all corresponding spans are equal but there are fewer spans in a.
+// - Each span set will itself be sorted using Span.Compare.
+func SortAndUniquifySpanSets(slices []roachpb.Spans) []roachpb.Spans {
+	if len(slices) == 0 {
+		return slices
+	}
+
+	// First sort each slice individually.
+	for _, slice := range slices {
+		sort.Slice(slice, func(i int, j int) bool {
+			return slice[i].Compare(slice[j]) < 0
+		})
+	}
+
+	// Then sort all slices.
+	sort.Slice(slices, func(i int, j int) bool {
+		return compare(slices[i], slices[j]) < 0
+	})
+
+	// Then distinct.
+	lastUniqueIdx := 0
+	for i := 1; i < len(slices); i++ {
+		if compare(slices[i], slices[lastUniqueIdx]) != 0 {
 			// We found a unique entry, at index i. The last unique entry in the array
 			// was at lastUniqueIdx, so set the entry after that one to our new unique
 			// entry, and bump lastUniqueIdx for the next loop iteration.
@@ -107,4 +150,28 @@ func UniquifyAcrossSlices(
 		}
 	}
 	return lOut, rOut
+}
+
+// compare returns an integer comparing two Spans lexicographically.
+// - The result will be 0 if a==b.
+// - The result will be -1 if the first span in a that is not equal to the
+//   corresponding span in b (i.e., at the same position) is less than it
+//   (according to Span.Compare) or all corresponding spans are equal but
+//   there are fewer spans in a.
+// - The result will be +1 otherwise.
+// Assumes that each of the Spans are already sorted using Span.Compare.
+func compare(a, b roachpb.Spans) int {
+	for i := 0; i < len(a) && i < len(b); i++ {
+		cmp := a[i].Compare(b[i])
+		if cmp != 0 {
+			return cmp
+		}
+	}
+	if len(a) < len(b) {
+		return -1
+	}
+	if len(b) < len(a) {
+		return 1
+	}
+	return 0
 }

--- a/pkg/util/unique/unique_test.go
+++ b/pkg/util/unique/unique_test.go
@@ -12,9 +12,12 @@ package unique
 
 import (
 	"fmt"
+	"math/rand"
 	"reflect"
 	"strconv"
 	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 )
 
 func TestUniquifyByteSlices(t *testing.T) {
@@ -63,6 +66,77 @@ func TestUniquifyByteSlices(t *testing.T) {
 			}
 			if got := UniquifyByteSlices(input); !reflect.DeepEqual(got, expected) {
 				t.Errorf("UniquifyByteSlices() = %v, expected %v", got, expected)
+			}
+		})
+	}
+}
+
+func TestUniquifySpans(t *testing.T) {
+	tests := []struct {
+		input    [][][]string
+		expected [][][]string
+	}{
+		{
+			input:    [][][]string{{{"a", "b"}}, {{"a", "b"}}},
+			expected: [][][]string{{{"a", "b"}}},
+		},
+		{
+			input:    [][][]string{},
+			expected: [][][]string{},
+		},
+		{
+			input:    [][][]string{{{"a", "b"}}},
+			expected: [][][]string{{{"a", "b"}}},
+		},
+		{
+			input:    [][][]string{{{"a", "b"}}, {{"a", "b"}, {"c", "d"}}, {{"a", "b"}}},
+			expected: [][][]string{{{"a", "b"}}, {{"a", "b"}, {"c", "d"}}},
+		},
+		{
+			input:    [][][]string{{{"a", "b"}, {"c", "d"}}, {{"a", "b"}}},
+			expected: [][][]string{{{"a", "b"}}, {{"a", "b"}, {"c", "d"}}},
+		},
+		{
+			input:    [][][]string{{{"bar", "foo"}}, {{"bar", "foo"}}, {{"foobar", "foobaz"}}},
+			expected: [][][]string{{{"bar", "foo"}}, {{"foobar", "foobaz"}}},
+		},
+	}
+	for i, tt := range tests {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			// Add a random permutation within each span set.
+			for idx := range tt.input {
+				rand.Shuffle(len(tt.input[idx]), func(i, j int) {
+					tt.input[idx][i], tt.input[idx][j] = tt.input[idx][j], tt.input[idx][i]
+				})
+			}
+
+			// Add a random permutation at the top level.
+			rand.Shuffle(len(tt.input), func(i, j int) {
+				tt.input[i], tt.input[j] = tt.input[j], tt.input[i]
+			})
+
+			input := make([]roachpb.Spans, len(tt.input))
+			expected := make([]roachpb.Spans, len(tt.expected))
+			for i, spans := range tt.input {
+				input[i] = make(roachpb.Spans, len(spans))
+				for j := range spans {
+					input[i][j] = roachpb.Span{
+						Key:    roachpb.Key(spans[j][0]),
+						EndKey: roachpb.Key(spans[j][1]),
+					}
+				}
+			}
+			for i, spans := range tt.expected {
+				expected[i] = make(roachpb.Spans, len(spans))
+				for j := range spans {
+					expected[i][j] = roachpb.Span{
+						Key:    roachpb.Key(spans[j][0]),
+						EndKey: roachpb.Key(spans[j][1]),
+					}
+				}
+			}
+			if got := SortAndUniquifySpanSets(input); !reflect.DeepEqual(got, expected) {
+				t.Errorf("SortAndUniquifySpanSets() = %v, expected %v", got, expected)
 			}
 		})
 	}


### PR DESCRIPTION
This commit adds support for encoding spans of JSON and Array inverted
keys for the purpose of evaluating contains (`@>`) predicates. It ensures
that the resulting spans produce correct results for all possible inputs
to the contains (`@>`) predicate.

Release note: None