### PR TITLE
ui: databases page requires click to load table info

### DIFF
--- a/pkg/ui/src/views/databases/containers/databaseTables/databaseTables.styl
+++ b/pkg/ui/src/views/databases/containers/databaseTables/databaseTables.styl
@@ -8,6 +8,8 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+@require "~styl/base/palette.styl"
+
 .empty-state
   display flex
   justify-content center
@@ -22,3 +24,25 @@
   position relative
   top 3px
   right 2px
+
+.sort-table__cell a 
+  color: $text-color;
+  &:hover
+    color: $link-color;
+
+.table-name a
+  display flex
+  align-items center
+  width 100%
+  height 100%
+  svg
+    margin-right 11px
+  &:hover
+    path
+      fill $colors--primary-blue-3
+
+.database-summary-title
+  display flex
+
+.database-summary-load-button
+  margin-left 11px

--- a/pkg/ui/src/views/databases/containers/databases/index.tsx
+++ b/pkg/ui/src/views/databases/containers/databases/index.tsx
@@ -101,11 +101,11 @@ class DatabaseTablesList extends React.Component<DatabaseListProps> {
       <DatabaseListNav selected="tables" onChange={this.handleOnNavigationListChange}/>
       <div className="section databases">
         {
-          user.map(n => <DatabaseSummaryTables name={n} key={n} />)
+          user.map(n => <DatabaseSummaryTables name={n} key={n} updateOnLoad={false} />)
         }
         <hr />
         {
-          system.map(n => <DatabaseSummaryTables name={n} key={n} />)
+          system.map(n => <DatabaseSummaryTables name={n} key={n} updateOnLoad={false} />)
         }
         <NonTableSummary />
       </div>

--- a/pkg/ui/src/views/databases/data/tableInfo.tsx
+++ b/pkg/ui/src/views/databases/data/tableInfo.tsx
@@ -43,4 +43,8 @@ export class TableInfo {
           this.physicalSize = FixLong(stats.approximate_disk_bytes).toNumber();
       }
   }
+
+  public detailsAndStatsLoaded(): boolean {
+    return this.id !== undefined && this.physicalSize !== undefined;
+  }
 }


### PR DESCRIPTION
Currently, the databases page automatically loads stats and info
on all tables in all database simultaneously. This can cause heavy
load and contention on clusters with hundreds of tables and/or
databases.

This change introduces a quick fix to prevent the immediate problem
with the expectation that we will revisit the databases page for
a more thorough redesign in the near future.

This change adds a button next to each database in the
databases page titled "Load stats for all tables" which triggers
the queries to load table-specific stats for just that one database.
The tables will be loaded in sequence by converting the loading
loop to use async/await to ensure one query is executed at a time.

One problem this introduces is that the database stats summary
box on the right computes its data incrementally and will show
changing data as more tables load for a specific database. We have
chosen to not show the updated data until all table info has been
loaded for the given database.

Release note (admin ui change): Loading table-level stats requires
a button click per-database in order to prevent contention for
clusters with many databases and/or tables. In addition, the loading
of table data is staggered by table instead of triggered simultaneously
for all tables.