### PR TITLE
tracing: make Span.crdbSpan a pointer

### DIFF
--- a/pkg/util/tracing/shadow.go
+++ b/pkg/util/tracing/shadow.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
-	"github.com/cockroachdb/logtags"
 	lightstep "github.com/lightstep/lightstep-tracer-go"
 	opentracing "github.com/opentracing/opentracing-go"
 	zipkin "github.com/openzipkin-contrib/zipkin-go-opentracing"
@@ -76,55 +75,33 @@ func (st *shadowTracer) Close() {
 	st.manager.Close(st)
 }
 
-// otLogTagsOption is an opentracing.StartSpanOption that inserts the log
-// tags into newly created spans.
-type otLogTagsOption logtags.Buffer
-
-func (o *otLogTagsOption) Apply(opts *opentracing.StartSpanOptions) {
-	tags := (*logtags.Buffer)(o).Get()
-	if len(tags) == 0 {
-		return
-	}
-	if opts.Tags == nil {
-		opts.Tags = map[string]interface{}{}
-	}
-	for _, tag := range tags {
-		opts.Tags[tagName(tag.Key())] = tag.Value()
-	}
-}
-
-// linkShadowSpan creates and links a Shadow Span to the passed-in Span (i.e.
-// fills in s.shadowTr and s.shadowSpan). This should only be called when
-// shadow tracing is enabled.
+// makeShadowSpan creates an otSpan for construction of a Span.
+// This must be called with a non-nil shadowTr, which must have
+// been confirmed to be compatible with parentShadowCtx.
 //
-// The Shadow Span will have a parent if parentShadowCtx is not nil.
-// parentType is ignored if parentShadowCtx is nil.
-//
-// The tags (including logTags) from s are copied to the Shadow Span.
-func linkShadowSpan(
-	s *Span,
+// The span contained in `otSpan` will have a parent if parentShadowCtx
+// is not nil. parentType is ignored if parentShadowCtx is nil.
+func makeShadowSpan(
 	shadowTr *shadowTracer,
 	parentShadowCtx opentracing.SpanContext,
 	parentType opentracing.SpanReferenceType,
-) {
+	opName string,
+	startTime time.Time,
+) otSpan {
 	// Create the shadow lightstep Span.
-	var opts []opentracing.StartSpanOption
+	opts := make([]opentracing.StartSpanOption, 0, 2)
 	// Replicate the options, using the lightstep context in the reference.
-	opts = append(opts, opentracing.StartTime(s.crdb.startTime))
-	if s.crdb.logTags != nil {
-		opts = append(opts, (*otLogTagsOption)(s.crdb.logTags))
-	}
-	if s.crdb.mu.tags != nil {
-		opts = append(opts, s.crdb.mu.tags)
-	}
+	opts = append(opts, opentracing.StartTime(startTime))
 	if parentShadowCtx != nil {
 		opts = append(opts, opentracing.SpanReference{
 			Type:              parentType,
 			ReferencedContext: parentShadowCtx,
 		})
 	}
-	s.ot.shadowTr = shadowTr
-	s.ot.shadowSpan = shadowTr.StartSpan(s.crdb.operation, opts...)
+	return otSpan{
+		shadowTr:   shadowTr,
+		shadowSpan: shadowTr.StartSpan(opName, opts...),
+	}
 }
 
 func createLightStepTracer(token string) (shadowTracerManager, opentracing.Tracer) {

--- a/pkg/util/tracing/span_options.go
+++ b/pkg/util/tracing/span_options.go
@@ -30,7 +30,7 @@ type spanOptions struct {
 }
 
 func (opts *spanOptions) parentTraceID() uint64 {
-	if opts.Parent != nil {
+	if opts.Parent != nil && !opts.Parent.isNoop() {
 		return opts.Parent.crdb.traceID
 	} else if opts.RemoteParent != nil {
 		return opts.RemoteParent.traceID
@@ -39,7 +39,7 @@ func (opts *spanOptions) parentTraceID() uint64 {
 }
 
 func (opts *spanOptions) parentSpanID() uint64 {
-	if opts.Parent != nil {
+	if opts.Parent != nil && !opts.Parent.isNoop() {
 		return opts.Parent.crdb.spanID
 	} else if opts.RemoteParent != nil {
 		return opts.RemoteParent.spanID
@@ -49,7 +49,7 @@ func (opts *spanOptions) parentSpanID() uint64 {
 
 func (opts *spanOptions) recordingType() RecordingType {
 	var recordingType RecordingType
-	if opts.Parent != nil {
+	if opts.Parent != nil && !opts.Parent.isNoop() {
 		recordingType = opts.Parent.crdb.getRecordingType()
 	} else if opts.RemoteParent != nil {
 		recordingType = opts.RemoteParent.recordingType

--- a/pkg/util/tracing/tags.go
+++ b/pkg/util/tracing/tags.go
@@ -47,9 +47,18 @@ func RegisterTagRemapping(logTag, spanTag string) {
 	tagRemap[logTag] = spanTag
 }
 
-func tagName(logTag string) string {
-	if v, ok := tagRemap[logTag]; ok {
-		return v
+// setLogTags calls the provided function for each tag pair from the provided log tags.
+// It takes into account any prior calls to RegisterTagRemapping.
+func setLogTags(logTags []logtags.Tag, setTag func(remappedKey string, value *logtags.Tag)) {
+	tagName := func(logTag string) string {
+		if v, ok := tagRemap[logTag]; ok {
+			return v
+		}
+		return logTag
 	}
-	return logTag
+
+	for i := range logTags {
+		tag := &logTags[i]
+		setTag(tagName(tag.Key()), tag)
+	}
 }


### PR DESCRIPTION
A `Span` essentially fans out over any subset of the below:

- CRDB trace span
- net/trace span
- external opentracing-comatible tracer Span

The latter two are already pointers, which means that there is a
convenient check for their absence in tracing-internal code.

This wasn't true for crdbSpan, which has bitten me in the past.

Make things more idiomatic by using a pointer for this one, too.
As currently written, our tracer will always populate the crdbSpan
whenever net/trace or opentracing tracers are active. However,
there is no good reason to do that, and even if there were, it
should not reflect as a fundamental requirement in the code.

One nice outcome of this change is that the noopSpan is now
`&Span{tracer: t}`, and all fields except for the tracer are nil,
meaning that any bug around noop spans will quickly manifest as an NPE.
(One past bug involved erroneously assigning an operation name to the
noopSpan).

Other than a few clarification that resulted from the pointer change,
this commit also improves `startSpanGeneric` to avoid populating a
struct's internals after the initial assignment, a pattern which I
have found easier to get wrong. Now, all ingredients are held in
local variables, which are assigned to `crdbSpan` wholesale.

Release note: None
