### PR TITLE
liveness: introduce GetLivenessesFromKV

### DIFF
--- a/pkg/kv/kvserver/liveness/client_test.go
+++ b/pkg/kv/kvserver/liveness/client_test.go
@@ -13,6 +13,7 @@ package liveness_test
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -81,6 +82,60 @@ func TestNodeLivenessAppearsAtStart(t *testing.T) {
 			t.Fatalf("expected membership=active, got membership=%s", livenessRec.Membership)
 		}
 	}
+}
+
+// TestGetLivenessesFromKV verifies that fetching liveness records from KV
+// directly retrieves all the records we expect.
+func TestGetLivenessesFromKV(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	tc := testcluster.StartTestCluster(t, 3, base.TestClusterArgs{})
+	defer tc.Stopper().Stop(ctx)
+
+	// At this point StartTestCluster has waited for all nodes to become live.
+
+	// Verify that each servers sees the same set of liveness records in KV.
+	for i := 0; i < tc.NumServers(); i++ {
+		nodeID := tc.Server(i).NodeID()
+		nl := tc.Server(i).NodeLiveness().(*liveness.NodeLiveness)
+
+		if live, err := nl.IsLive(nodeID); err != nil {
+			t.Fatal(err)
+		} else if !live {
+			t.Fatalf("node %d not live", nodeID)
+		}
+
+		livenesses, err := nl.GetLivenessesFromKV(ctx)
+		assert.Nil(t, err)
+		assert.Equal(t, len(livenesses), tc.NumServers())
+
+		var nodeIDs []roachpb.NodeID
+		for _, liveness := range livenesses {
+			nodeIDs = append(nodeIDs, liveness.NodeID)
+
+			// We expect epoch=1 as nodes first create a liveness record at epoch=0,
+			// and then increment it during their first heartbeat.
+			if liveness.Epoch != 1 {
+				t.Fatalf("expected epoch=1, got epoch=%d", liveness.Epoch)
+			}
+			if !liveness.Membership.Active() {
+				t.Fatalf("expected membership=active, got membership=%s", liveness.Membership)
+			}
+		}
+
+		sort.Slice(nodeIDs, func(i, j int) bool {
+			return nodeIDs[i] < nodeIDs[j]
+		})
+		for i := range nodeIDs {
+			expNodeID := roachpb.NodeID(i + 1) // Node IDs are 1-indexed.
+			if nodeIDs[i] != expNodeID {
+				t.Fatalf("expected nodeID=%d, got %d", expNodeID, nodeIDs[i])
+			}
+		}
+	}
+
 }
 
 func TestNodeLivenessStatusMap(t *testing.T) {

--- a/pkg/sql/optionalnodeliveness/node_liveness.go
+++ b/pkg/sql/optionalnodeliveness/node_liveness.go
@@ -11,6 +11,8 @@
 package optionalnodeliveness
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
@@ -20,6 +22,7 @@ import (
 type Interface interface {
 	Self() (livenesspb.Liveness, bool)
 	GetLivenesses() []livenesspb.Liveness
+	GetLivenessesFromKV(ctx context.Context) ([]livenesspb.Liveness, error)
 	IsLive(roachpb.NodeID) (bool, error)
 }
 


### PR DESCRIPTION
Now that we always create a liveness record on start up (#53805), we can simply
fetch all records from KV when wanting an up-to-date view of all nodes that
have ever been a part of the cluster. We add a helper to do as much, which
we'll rely on when introducing long running migrations (#56107).

It's a bit unfortunate that we're further adding on to the liveness API without
changing the underlying look-aside cache structure, but the up-to-date records
from KV directly is the world we're hoping to start moving towards over time.
The TODO added in [1] outlines what the future holds.

We'll also expose the GetLivenessesFromKV API we introduced earlier to pkg/sql.
We'll rely on it when needing to plumb in the liveness instance into the
migration manager process (prototyped in #56107)

It should be noted that this will be a relatively meatier form of a dependency
on node liveness from pkg/sql than we have currently. Today the only uses are
in DistSQL planning and in jobs[2]. As it relates to our multi-tenancy work,
the real use of this API will happen only on the system tenant. System tenants
alone have the privilege to set cluster settings (or at least the version
setting specifically), which is what the migration manager will be wired into.

[1]: https://github.com/cockroachdb/cockroach/commit/d631239
[2]: https://github.com/cockroachdb/cockroach/pull/48795

Release note: None

---

First commit is from #56221, and can be ignored here.
