### PR TITLE
sql: do not display show last query statistics help message

### DIFF
--- a/pkg/sql/parser/help_test.go
+++ b/pkg/sql/parser/help_test.go
@@ -354,7 +354,6 @@ func TestContextualHelp(t *testing.T) {
 		{`SHOW SYNTAX ??`, `SHOW SYNTAX`},
 		{`SHOW SYNTAX 'foo' ??`, `SHOW SYNTAX`},
 		{`SHOW SAVEPOINT STATUS ??`, `SHOW SAVEPOINT`},
-		{`SHOW LAST QUERY STATISTICS ??`, `SHOW LAST QUERY STATISTICS`},
 
 		{`SHOW RANGE ??`, `SHOW RANGE`},
 

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -4363,7 +4363,7 @@ show_stmt:
 | show_users_stmt           // EXTEND WITH HELP: SHOW USERS
 | show_zone_stmt
 | SHOW error                // SHOW HELP: SHOW
-| show_last_query_stats_stmt // EXTEND WITH HELP: SHOW LAST QUERY STATISTICS
+| show_last_query_stats_stmt
 
 // Cursors are not yet supported by CockroachDB. CLOSE ALL is safe to no-op
 // since there will be no open cursors.
@@ -4947,9 +4947,6 @@ show_syntax_stmt:
   }
 | SHOW SYNTAX error // SHOW HELP: SHOW SYNTAX
 
-// %Help: SHOW LAST QUERY STATISTICS - display statistics for the last query issued
-// %Category: Misc
-// %Text: SHOW LAST QUERY STATISTICS
 show_last_query_stats_stmt:
   SHOW LAST QUERY STATISTICS
   {


### PR DESCRIPTION
`SHOW LAST QUERY STATISTICS` should not be used by users from the CLI
as it can lead to surprising behavior. This is because the CLI may
perform queries invisible to the user (eg. getting the current
database) and therefore `SHOW LAST QUERY STATISTICS` may not be timing
the user query. To that end, this is supposed to be an undocumented
feature only used by the CLI to display query timings. Unfortunately,
we generated help text for this query, making it possible for users to
discover this statement. This patch removes that help message.

Release note: None