### PR TITLE
release-20.1: sql: bugfix to fractional year interval parsing

### DIFF
--- a/pkg/sql/sem/tree/interval_test.go
+++ b/pkg/sql/sem/tree/interval_test.go
@@ -370,8 +370,13 @@ func TestPGIntervalSyntax(t *testing.T) {
 		{`1yr`, types.IntervalTypeMetadata{}, `1 year`, ``},
 		{`1yrs`, types.IntervalTypeMetadata{}, `1 year`, ``},
 		{`1.5y`, types.IntervalTypeMetadata{}, `1 year 6 mons`, ``},
-		{`1.1y`, types.IntervalTypeMetadata{}, `1 year 1 mon 6 days`, ``},
-		{`1.11y`, types.IntervalTypeMetadata{}, `1 year 1 mon 9 days 14:24:00`, ``},
+		{`1.1y`, types.IntervalTypeMetadata{}, `1 year 1 mon`, ``},
+		{`1.19y`, types.IntervalTypeMetadata{}, `1 year 2 mons`, ``},
+		{`1.11y`, types.IntervalTypeMetadata{}, `1 year 1 mon`, ``},
+		{`-1.5y`, types.IntervalTypeMetadata{}, `-1 years -6 mons`, ``},
+		{`-1.1y`, types.IntervalTypeMetadata{}, `-1 years -1 mons`, ``},
+		{`-1.19y`, types.IntervalTypeMetadata{}, `-1 years -2 mons`, ``},
+		{`-1.11y`, types.IntervalTypeMetadata{}, `-1 years -1 mons`, ``},
 
 		// Mixed unit/HH:MM:SS formats
 		{`1:2:3`, types.IntervalTypeMetadata{}, `01:02:03`, ``},


### PR DESCRIPTION
Backport 1/1 commits from #55230.

/cc @cockroachdb/release

---

Previously, parsing an interval with a fractional year would produce an
interval that was "too precise" compared to Postgres, which we aim to be
compatible with. Postgres truncates the precision of fractional years in
intervals to months; we did not.

This commit fixes the issue. For example, '1.1 year'::interval will
become '1 year 1 month' instead of a quantity with days and hours.

Closes #55226.

Release note (sql change): parsing intervals with fractional years now
produces intervals with no more precision than months, to match the
behavior of Postgres.
