### PR TITLE
build: fix Pebble nightly tests to really use Pebble master

### DIFF
--- a/build/teamcity-nightly-pebble.sh
+++ b/build/teamcity-nightly-pebble.sh
@@ -34,7 +34,7 @@ make bin/roachprod bin/roachtest
 
 rm -fr vendor/github.com/cockroachdb/pebble
 git clone https://github.com/cockroachdb/pebble vendor/github.com/cockroachdb/pebble
-GOOS=linux go build -o pebble.linux github.com/cockroachdb/pebble/cmd/pebble
+GOOS=linux go build -v -mod=vendor -o pebble.linux github.com/cockroachdb/pebble/cmd/pebble
 export PEBBLE_BIN=pebble.linux
 
 # NB: We specify "true" for the --cockroach and --workload binaries to


### PR DESCRIPTION
Fix the Pebble nightly tests to really use the Pebble master branch. The
script was attempting to do this, but the lack of `-mod=vendor` was
causing `go build` to instead use the version the module cache (i.e. the
version listed in `go.mod`).

Release note: None