### PR TITLE
release-19.2: sql: bugfix to fractional year interval parsing

### DIFF
--- a/pkg/sql/sem/tree/interval.go
+++ b/pkg/sql/sem/tree/interval.go
@@ -455,7 +455,11 @@ func parseDuration(s string) (duration.Duration, error) {
 			// A regular number followed by a unit, such as "9 day".
 			d = d.Add(unit.Mul(v))
 			if hasDecimal {
-				d = addFrac(d, unit, vp)
+				var err error
+				d, err = addFrac(d, unit, vp)
+				if err != nil {
+					return d, err
+				}
 			}
 			continue
 		}
@@ -537,14 +541,23 @@ func (l *intervalLexer) parseShortDuration(h int64, hasSign bool) (duration.Dura
 // given as second argument multiplied by the factor in the third
 // argument. For computing fractions there are 30 days to a month and
 // 24 hours to a day.
-func addFrac(d duration.Duration, unit duration.Duration, f float64) duration.Duration {
+func addFrac(d duration.Duration, unit duration.Duration, f float64) (duration.Duration, error) {
 	if unit.Months > 0 {
 		f = f * float64(unit.Months)
 		d.Months += int64(f)
-		f = math.Mod(f, 1) * 30
-		d.Days += int64(f)
-		f = math.Mod(f, 1) * 24
-		d.SetNanos(d.Nanos() + int64(float64(time.Hour.Nanoseconds())*f))
+		switch unit.Months {
+		case 1:
+			f = math.Mod(f, 1) * 30
+			d.Days += int64(f)
+			f = math.Mod(f, 1) * 24
+			d.SetNanos(d.Nanos() + int64(float64(time.Hour.Nanoseconds())*f))
+		case 12:
+			// Nothing to do: Postgres limits the precision of fractional years to
+			// months. Do not continue to add precision to the interval.
+			// See issue #55226 for more details on this.
+		default:
+			return duration.Duration{}, errors.AssertionFailedf("unhandled unit type %v", unit)
+		}
 	} else if unit.Days > 0 {
 		f = f * float64(unit.Days)
 		d.Days += int64(f)
@@ -553,7 +566,7 @@ func addFrac(d duration.Duration, unit duration.Duration, f float64) duration.Du
 	} else {
 		d.SetNanos(d.Nanos() + int64(float64(unit.Nanos())*f))
 	}
-	return d
+	return d, nil
 }
 
 // floatToNanos converts a fractional number representing nanoseconds to the

--- a/pkg/sql/sem/tree/interval_test.go
+++ b/pkg/sql/sem/tree/interval_test.go
@@ -291,8 +291,13 @@ func TestPGIntervalSyntax(t *testing.T) {
 		{`1yr`, `1 year`, ``},
 		{`1yrs`, `1 year`, ``},
 		{`1.5y`, `1 year 6 mons`, ``},
-		{`1.1y`, `1 year 1 mon 6 days`, ``},
-		{`1.11y`, `1 year 1 mon 9 days 14:24:00`, ``},
+		{`1.1y`, `1 year 1 mon`, ``},
+		{`1.19y`, `1 year 2 mons`, ``},
+		{`1.11y`, `1 year 1 mon`, ``},
+		{`-1.5y`, `-1 years -6 mons`, ``},
+		{`-1.1y`, `-1 years -1 mons`, ``},
+		{`-1.19y`, `-1 years -2 mons`, ``},
+		{`-1.11y`, `-1 years -1 mons`, ``},
 
 		// Mixed unit/HH:MM:SS formats
 		{`1:2:3`, `01:02:03`, ``},


### PR DESCRIPTION
Backport 1/1 commits from #55230.

/cc @cockroachdb/release

---

Previously, parsing an interval with a fractional year would produce an
interval that was "too precise" compared to Postgres, which we aim to be
compatible with. Postgres truncates the precision of fractional years in
intervals to months; we did not.

This commit fixes the issue. For example, '1.1 year'::interval will
become '1 year 1 month' instead of a quantity with days and hours.

Closes #55226.

Release note (sql change): parsing intervals with fractional years now
produces intervals with no more precision than months, to match the
behavior of Postgres.
