### PR TITLE
pkg/ccl/sqlproxyccl: support multiple outgoing TLS configs

### DIFF
--- a/pkg/ccl/sqlproxyccl/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/BUILD.bazel
@@ -26,13 +26,22 @@ go_library(
 go_test(
     name = "sqlproxyccl_test",
     srcs = [
+        "main_test.go",
         "proxy_test.go",
         "server_test.go",
     ],
     embed = [":sqlproxyccl"],
     deps = [
+        "//pkg/base",
+        "//pkg/ccl/utilccl",
+        "//pkg/security",
+        "//pkg/security/securitytest",
+        "//pkg/server",
+        "//pkg/testutils/serverutils",
         "//pkg/testutils/skip",
+        "//pkg/testutils/testcluster",
         "//pkg/util/leaktest",
+        "//pkg/util/randutil",
         "//vendor/github.com/cockroachdb/errors",
         "//vendor/github.com/jackc/pgx/v4:pgx",
         "//vendor/github.com/stretchr/testify/require",

--- a/pkg/ccl/sqlproxyccl/main_test.go
+++ b/pkg/ccl/sqlproxyccl/main_test.go
@@ -1,0 +1,33 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package sqlproxyccl
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+func TestMain(m *testing.M) {
+	defer utilccl.TestingEnableEnterprise()()
+	security.SetAssetLoader(securitytest.EmbeddedAssets)
+	randutil.SeedForTests()
+	serverutils.InitTestServerFactory(server.TestServerFactory)
+	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
+	os.Exit(m.Run())
+}
+
+//go:generate ../../util/leaktest/add-leaktest.sh *_test.go

--- a/pkg/ccl/sqlproxyccl/server_test.go
+++ b/pkg/ccl/sqlproxyccl/server_test.go
@@ -14,10 +14,12 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/stretchr/testify/require"
 )
 
 func TestHandleHealth(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	proxyServer := NewServer(Options{})
 
 	rw := httptest.NewRecorder()
@@ -33,6 +35,7 @@ func TestHandleHealth(t *testing.T) {
 }
 
 func TestHandleVars(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	proxyServer := NewServer(Options{})
 
 	rw := httptest.NewRecorder()


### PR DESCRIPTION
As a part of constraining the access of CockroachCloud superusers, the
CockroachCloud team would like to proxy SQL access to clusters through
sqlproxy (see CC-2865). Each cluster has its own TLS certificates, so
we need to be able to configure an outgoing TLS config per-cluster. This
commit updates the existing `OutgoingAddrFromParams` to return a
TLSConfig alongside the address.

Release note: none