### PR TITLE
sql: refactor code shared by diagnostics and EXPLAIN ANALYZE (DEBUG)

### DIFF
--- a/pkg/bench/ddl_analysis/ddl_analysis_bench.go
+++ b/pkg/bench/ddl_analysis/ddl_analysis_bench.go
@@ -44,10 +44,8 @@ func RunRoundTripBenchmark(b *testing.B, tests []RoundTripBenchTestCase) {
 		b.Run(tc.name, func(b *testing.B) {
 			var stmtToKvBatchRequests sync.Map
 
-			beforePlan := func(sp *tracing.Span, stmt string) {
+			beforePlan := func(trace tracing.Recording, stmt string) {
 				if _, ok := stmtToKvBatchRequests.Load(stmt); ok {
-					sp.Finish()
-					trace := sp.GetRecording()
 					count := countKvBatchRequestsInRecording(trace)
 					stmtToKvBatchRequests.Store(stmt, count)
 				}

--- a/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads_test.go
+++ b/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads_test.go
@@ -227,9 +227,9 @@ func TestFollowerReadsWithStaleDescriptor(t *testing.T) {
 							},
 						},
 						SQLExecutor: &sql.ExecutorTestingKnobs{
-							WithStatementTrace: func(sp *tracing.Span, stmt string) {
+							WithStatementTrace: func(trace tracing.Recording, stmt string) {
 								if stmt == historicalQuery {
-									recCh <- sp.GetRecording()
+									recCh <- trace
 								}
 							},
 						},

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -39,6 +39,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
+	"github.com/cockroachdb/cockroach/pkg/sql/stmtdiagnostics"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/cancelchecker"
@@ -1119,7 +1120,7 @@ type connExecutor struct {
 
 	// stmtDiagnosticsRecorder is used to track which queries need to have
 	// information collected.
-	stmtDiagnosticsRecorder StmtDiagnosticsRecorder
+	stmtDiagnosticsRecorder *stmtdiagnostics.Registry
 }
 
 // ctxHolder contains a connection's context and, while session tracing is

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -443,7 +443,7 @@ func (ex *connExecutor) execStmtInOpenState(
 		p.extendedEvalCtx.Context = ctx
 
 		defer func() {
-			ex.server.cfg.TestingKnobs.WithStatementTrace(sp, sql)
+			ex.server.cfg.TestingKnobs.WithStatementTrace(sp.GetRecording(), sql)
 		}()
 	}
 

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
+	"github.com/cockroachdb/cockroach/pkg/sql/stmtdiagnostics"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/cancelchecker"
@@ -341,7 +342,8 @@ func (ex *connExecutor) execStmtInOpenState(
 	p.noticeSender = res
 
 	var shouldCollectDiagnostics bool
-	var finishCollectionDiagnostics StmtDiagnosticsTraceFinishFunc
+	var diagRequestID stmtdiagnostics.RequestID
+	var finishCollectionDiagnostics func()
 
 	if explainBundle, ok := ast.(*tree.ExplainAnalyzeDebug); ok {
 		telemetry.Inc(sqltelemetry.ExplainAnalyzeDebugUseCounter)
@@ -364,10 +366,8 @@ func (ex *connExecutor) execStmtInOpenState(
 		// bundle.
 		p.discardRows = true
 	} else {
-		shouldCollectDiagnostics, finishCollectionDiagnostics = ex.stmtDiagnosticsRecorder.ShouldCollectDiagnostics(ctx, ast)
-		if shouldCollectDiagnostics {
-			telemetry.Inc(sqltelemetry.StatementDiagnosticsCollectedCounter)
-		}
+		shouldCollectDiagnostics, diagRequestID, finishCollectionDiagnostics =
+			ex.stmtDiagnosticsRecorder.ShouldCollectDiagnostics(ctx, stmt.AnonymizedStr)
 	}
 
 	if shouldCollectDiagnostics {
@@ -378,7 +378,7 @@ func (ex *connExecutor) execStmtInOpenState(
 		ctx, sp = tracing.StartSnowballTrace(ctx, tr, "traced statement")
 		// TODO(radu): consider removing this if/when #46164 is addressed.
 		p.extendedEvalCtx.Context = ctx
-		anonymizedStr := stmt.AnonymizedStr
+		fingerprint := stmt.AnonymizedStr
 		defer func() {
 			// Record the statement information that we've collected.
 			// Note that in case of implicit transactions, the trace contains the auto-commit too.
@@ -386,22 +386,22 @@ func (ex *connExecutor) execStmtInOpenState(
 			trace := sp.GetRecording()
 			ie := p.extendedEvalCtx.InternalExecutor.(*InternalExecutor)
 			placeholders := p.extendedEvalCtx.Placeholders
+			bundle := buildStatementBundle(
+				origCtx, ex.server.cfg.DB, ie, &p.curPlan, trace, placeholders,
+			)
+			bundle.insert(origCtx, fingerprint, ast, ex.server.cfg.StmtDiagnosticsRecorder, diagRequestID)
 			if finishCollectionDiagnostics != nil {
-				bundle, collectionErr := buildStatementBundle(
-					origCtx, ex.server.cfg.DB, ie, &p.curPlan, trace, placeholders,
-				)
-				finishCollectionDiagnostics(origCtx, bundle.trace, bundle.zip, collectionErr)
+				finishCollectionDiagnostics()
+				telemetry.Inc(sqltelemetry.StatementDiagnosticsCollectedCounter)
 			} else {
 				// Handle EXPLAIN ANALYZE (DEBUG).
-				// If there was a communication error, no point in setting any results.
+				// If there was a communication error already, no point in setting any results.
 				if retErr == nil {
-					retErr = setExplainBundleResult(
-						origCtx, res, ast, trace, &p.curPlan, placeholders, ie, ex.server.cfg,
-					)
+					retErr = setExplainBundleResult(origCtx, res, bundle, ex.server.cfg)
 				}
 			}
 
-			stmtStats, _ := ex.appStats.getStatsForStmt(anonymizedStr, ex.implicitTxn(), retErr, false)
+			stmtStats, _ := ex.appStats.getStatsForStmt(fingerprint, ex.implicitTxn(), retErr, false)
 			if stmtStats == nil {
 				return
 			}

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -743,40 +743,6 @@ func (cfg *ExecutorConfig) Organization() string {
 	return ClusterOrganization.Get(&cfg.Settings.SV)
 }
 
-// StmtDiagnosticsRecorder is the interface into *stmtdiagnostics.Registry to
-// record statement diagnostics.
-type StmtDiagnosticsRecorder interface {
-
-	// ShouldCollectDiagnostics checks whether any data should be collected for the
-	// given query, which is the case if the registry has a request for this
-	// statement's fingerprint; in this case ShouldCollectDiagnostics will not
-	// return true again on this note for the same diagnostics request.
-	//
-	// If data is to be collected, the returned finish() function must always be
-	// called once the data was collected. If collection fails, it can be called
-	// with a collectionErr.
-	ShouldCollectDiagnostics(ctx context.Context, ast tree.Statement) (
-		shouldCollect bool,
-		finish StmtDiagnosticsTraceFinishFunc,
-	)
-
-	// InsertStatementDiagnostics inserts a trace into system.statement_diagnostics.
-	//
-	// traceJSON is either DNull (when collectionErr should not be nil) or a *DJSON.
-	InsertStatementDiagnostics(ctx context.Context,
-		stmtFingerprint string,
-		stmt string,
-		traceJSON tree.Datum,
-		bundleZip []byte,
-	) (id int64, err error)
-}
-
-// StmtDiagnosticsTraceFinishFunc is the type of function returned from
-// ShouldCollectDiagnostics to report the outcome of a trace.
-type StmtDiagnosticsTraceFinishFunc = func(
-	ctx context.Context, traceJSON tree.Datum, bundle []byte, collectionErr error,
-)
-
 var _ base.ModuleTestingKnobs = &ExecutorTestingKnobs{}
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -844,7 +844,7 @@ type ExecutorTestingKnobs struct {
 
 	// WithStatementTrace is called after the statement is executed in
 	// execStmtInOpenState.
-	WithStatementTrace func(span *tracing.Span, stmt string)
+	WithStatementTrace func(trace tracing.Recording, stmt string)
 
 	// RunAfterSCJobsCacheLookup is called after the SchemaChangeJobCache is checked for
 	// a given table id.

--- a/pkg/sql/trace_test.go
+++ b/pkg/sql/trace_test.go
@@ -587,9 +587,9 @@ func TestTraceDistSQL(t *testing.T) {
 			UseDatabase: "test",
 			Knobs: base.TestingKnobs{
 				SQLExecutor: &sql.ExecutorTestingKnobs{
-					WithStatementTrace: func(sp *tracing.Span, stmt string) {
+					WithStatementTrace: func(trace tracing.Recording, stmt string) {
 						if stmt == countStmt {
-							recCh <- sp.GetRecording()
+							recCh <- trace
 						}
 					},
 				},


### PR DESCRIPTION
#### sql: pass recording to WithStatementTrace

Pass the recording instead of the span.

Release note: None

#### sql: refactor code shared by diagnostics and EXPLAIN ANALYZE (DEBUG)

There are two paths that result in a bundle being collected and inserted
into the diagnostics tables. Each path uses its own code to insert the
diagnostics bundle, which leads to unnecessary complication.

This change simplifies the stmtdiagnostics code to let the caller do
the insertion and streamlines the higher level code.

Release note: None