### PR TITLE
colflow, serverpb: add check for NodesResponse error

### DIFF
--- a/pkg/server/serverpb/status.go
+++ b/pkg/server/serverpb/status.go
@@ -94,7 +94,11 @@ func (lg *LatencyGetter) GetLatency(
 	if lg.latencyMap == nil {
 		lg.latencyMap = make(map[roachpb.NodeID]map[roachpb.NodeID]int64)
 	}
-	response, _ := ss.Nodes(ctx, &NodesRequest{})
+	response, err := ss.Nodes(ctx, &NodesRequest{})
+	if err != nil {
+		// When latency is 0, it is not shown on EXPLAIN ANALYZE diagrams.
+		return 0
+	}
 	for _, sendingNode := range response.Nodes {
 		sendingNodeID := sendingNode.Desc.NodeID
 		if lg.latencyMap[sendingNodeID] == nil {


### PR DESCRIPTION
When the node latency map (introduced in #55705) is updated, it makes a
NodesRequest and the returned NodesResponse is used to obtain the node
latencies. This commit adds an error check for this response so that a
nil pointer dereference doesn't occur.

ran `make stressrace TESTS=TestUncertaintyErrorIsReturned PKG=./pkg/sql/rowexec TESTTIMEOUT=5m STRESSFLAGS='-timeout 5m' 2>&1` for a couple minutes with no failures.

Fixes: #56255

Release note: None.