### PR TITLE
release-20.1: physicalplan: preevaluate subqueries on LocalExprs and always set LocalExprs

### DIFF
--- a/pkg/sql/colexec/execplan.go
+++ b/pkg/sql/colexec/execplan.go
@@ -1420,7 +1420,7 @@ func (r *postProcessResult) planFilterExpr(
 		ctx, evalCtx, helper.Expr, r.ColumnTypes, r.Op, acc,
 	)
 	if err != nil {
-		return errors.Wrapf(err, "unable to columnarize filter expression %q", filter.Expr)
+		return errors.Wrapf(err, "unable to columnarize filter expression %q", filter)
 	}
 	r.InternalMemUsage += selectionInternalMem
 	if len(filterColumnTypes) > len(r.ColumnTypes) {

--- a/pkg/sql/execinfrapb/data.go
+++ b/pkg/sql/execinfrapb/data.go
@@ -102,8 +102,9 @@ type Expression struct {
 	// (@1, @2, @3 ..) used for "input" variables.
 	Expr string
 
-	// LocalExpr is an unserialized field that's used to pass expressions to local
-	// flows without serializing/deserializing them.
+	// LocalExpr is an unserialized field that's used to pass expressions to
+	// the gateway node without serializing/deserializing them. It is always
+	// set in non-test setup.
 	LocalExpr tree.TypedExpr
 }
 
@@ -114,13 +115,13 @@ func (e *Expression) Empty() bool {
 
 // String implements the Stringer interface.
 func (e Expression) String() string {
+	if e.Expr != "" {
+		return e.Expr
+	}
 	if e.LocalExpr != nil {
 		ctx := tree.NewFmtCtx(tree.FmtCheckEquivalence)
 		ctx.FormatNode(e.LocalExpr)
 		return ctx.CloseAndGetString()
-	}
-	if e.Expr != "" {
-		return e.Expr
 	}
 	return "none"
 }

--- a/pkg/sql/physicalplan/expression.go
+++ b/pkg/sql/physicalplan/expression.go
@@ -14,8 +14,6 @@
 package physicalplan
 
 import (
-	"fmt"
-
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -80,39 +78,31 @@ func MakeExpression(
 		evalCtx: evalCtx,
 	}
 
-	outExpr := expr.(tree.Expr)
 	if ctx.EvaluateSubqueries() {
-		outExpr, _ = tree.WalkExpr(subqueryVisitor, expr)
+		outExpr, _ := tree.WalkExpr(subqueryVisitor, expr)
 		if subqueryVisitor.err != nil {
 			return execinfrapb.Expression{}, subqueryVisitor.err
 		}
 		expr = outExpr.(tree.TypedExpr)
 	}
 
+	if indexVarMap != nil {
+		// Remap our indexed vars.
+		expr = sqlbase.RemapIVarsInTypedExpr(expr, indexVarMap)
+	}
+	expression := execinfrapb.Expression{LocalExpr: expr}
 	if ctx.IsLocal() {
-		if indexVarMap != nil {
-			// Remap our indexed vars.
-			expr = sqlbase.RemapIVarsInTypedExpr(expr, indexVarMap)
-		}
-		return execinfrapb.Expression{LocalExpr: expr}, nil
+		return expression, nil
 	}
 
-	// We format the expression using the IndexedVar and Placeholder formatting interceptors.
+	// Since the plan is not fully local, serialize the expression.
 	fmtCtx := execinfrapb.ExprFmtCtxBase(evalCtx)
-	if indexVarMap != nil {
-		fmtCtx.SetIndexedVarFormat(func(ctx *tree.FmtCtx, idx int) {
-			remappedIdx := indexVarMap[idx]
-			if remappedIdx < 0 {
-				panic(fmt.Sprintf("unmapped index %d", idx))
-			}
-			ctx.Printf("@%d", remappedIdx+1)
-		})
-	}
-	fmtCtx.FormatNode(outExpr)
+	fmtCtx.FormatNode(expr)
 	if log.V(1) {
-		log.Infof(evalCtx.Ctx(), "Expr %s:\n%s", fmtCtx.String(), tree.ExprDebugString(outExpr))
+		log.Infof(evalCtx.Ctx(), "Expr %s:\n%s", fmtCtx.String(), tree.ExprDebugString(expr))
 	}
-	return execinfrapb.Expression{Expr: fmtCtx.CloseAndGetString()}, nil
+	expression.Expr = fmtCtx.CloseAndGetString()
+	return expression, nil
 }
 
 type evalAndReplaceSubqueryVisitor struct {

--- a/pkg/sql/physicalplan/physical_plan.go
+++ b/pkg/sql/physicalplan/physical_plan.go
@@ -650,14 +650,17 @@ func (p *PhysicalPlan) AddFilter(
 		return err
 	}
 	if !post.Filter.Empty() {
-		// Either Expr or LocalExpr will be set (not both).
-		if filter.Expr != "" {
-			filter.Expr = fmt.Sprintf("(%s) AND (%s)", post.Filter.Expr, filter.Expr)
-		} else if filter.LocalExpr != nil {
+		// LocalExpr is usually set, but it can be left nil in tests, so we
+		// need to perform the nil check.
+		if post.Filter.LocalExpr != nil && filter.LocalExpr != nil {
 			filter.LocalExpr = tree.NewTypedAndExpr(
 				post.Filter.LocalExpr,
 				filter.LocalExpr,
 			)
+		}
+		// Expr is set for all distributed plans (as well as in some tests).
+		if post.Filter.Expr != "" && filter.Expr != "" {
+			filter.Expr = fmt.Sprintf("(%s) AND (%s)", post.Filter.Expr, filter.Expr)
 		}
 	}
 	for _, pIdx := range p.ResultRouters {

--- a/pkg/sql/physicalplan/physical_plan_test.go
+++ b/pkg/sql/physicalplan/physical_plan_test.go
@@ -337,7 +337,16 @@ func TestProjectionAndRendering(t *testing.T) {
 
 		tc.action(&p)
 
-		if post := p.GetLastStagePost(); !reflect.DeepEqual(post, tc.expPost) {
+		post := p.GetLastStagePost()
+		// The actual planning always sets unserialized LocalExpr field on the
+		// expressions, however, we don't do that for the expected results. In
+		// order to be able to use the deep comparison below we manually unset
+		// that unserialized field.
+		post.Filter.LocalExpr = nil
+		for i := range post.RenderExprs {
+			post.RenderExprs[i].LocalExpr = nil
+		}
+		if !reflect.DeepEqual(post, tc.expPost) {
 			t.Errorf("%d: incorrect post:\n%s\nexpected:\n%s", testIdx, &post, &tc.expPost)
 		}
 		var resTypes []string

--- a/pkg/sql/rowexec/joinerbase.go
+++ b/pkg/sql/rowexec/joinerbase.go
@@ -63,7 +63,7 @@ func (jb *joinerBase) init(
 
 	if jb.joinType.IsSetOpJoin() {
 		if !onExpr.Empty() {
-			return errors.Errorf("expected empty onExpr, got %v", onExpr.Expr)
+			return errors.Errorf("expected empty onExpr, got %v", onExpr)
 		}
 	}
 


### PR DESCRIPTION
Backport 2/3 commits from #49891.

/cc @cockroachdb/release

I am backporting because it also fixes an error caused when performing comparison between collated strings.

---

**physicalplan: preevaluate subqueries on LocalExprs**

When the plan is local, we do not serialize expressions. Previously, in
such a case we would also not preevaluate the subqueries in the
expressions which made `EXPLAIN (VEC)` return unexpected plan (there
would `tree.Subquery` in the expression which we don't support in the
vectorized, so we would wrap the plan). Now we will preevalute the
subqueries before storing in the processor spec. AFAICT it affects only
this explain variant and nothing else.

Release note: None

**physicalplan: always store LocalExpr**

Previously, we would set either `LocalExpr` (unserialized expression,
only when we have the full plan on a single node) or `Expr` (serialized
expression, when we have distributed plan as well as in some tests).
However, we could be setting both and making best effort to reuse
unserialized `LocalExpr` on the gateway even if the plan is distributed.
And this commit adds such behavior.

Fixes: #49810.

Release note: None
