### PR TITLE
sql/rowexec: skip TestUncertaintyErrorIsReturned

### DIFF
--- a/pkg/sql/rowexec/processors_test.go
+++ b/pkg/sql/rowexec/processors_test.go
@@ -701,6 +701,7 @@ func TestDrainingProcessorSwallowsUncertaintyError(t *testing.T) {
 // in which an UncertaintyError is expected.
 func TestUncertaintyErrorIsReturned(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 56255, "flaky test")
 	defer log.Scope(t).Close(t)
 
 	const numNodes = 3


### PR DESCRIPTION
Refs: #56255

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes

Release note: None