### PR TITLE
[dnm,wip] server: reproduce double-allocation of store IDs

### DIFF
--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -307,6 +307,7 @@ go_test(
         "//pkg/util/timeutil",
         "//pkg/util/uuid",
         "//vendor/github.com/cockroachdb/errors",
+        "//vendor/github.com/dustin/go-humanize",
         "//vendor/github.com/gogo/protobuf/jsonpb",
         "//vendor/github.com/gogo/protobuf/proto",
         "//vendor/github.com/grpc-ecosystem/grpc-gateway/runtime",


### PR DESCRIPTION
We seem to be doing a few unsound things with how we allocate store IDs
(courtesy of yours truly). The changes made to a recently added test
stressing our multi-store behaviour demonstrates the bug.

    --- FAIL: TestAddNewStoresToExistingNodes (38.44s)
        multi_store_test.go:155: expected the 6th store to have storeID s6, found s5

Release note: None