### PR TITLE
bazel: Make TestTempDir work with external tools.

### DIFF
--- a/pkg/ccl/importccl/bench_test.go
+++ b/pkg/ccl/importccl/bench_test.go
@@ -47,7 +47,7 @@ func BenchmarkImportWorkload(b *testing.B) {
 	skip.WithIssue(b, 41932, "broken due to adding keys out-of-order to an sstable")
 	skip.UnderShort(b, "skipping long benchmark")
 
-	dir, cleanup := testutils.TestTempDir(b)
+	dir, cleanup := testutils.TempDir(b)
 	defer cleanup()
 
 	g := tpcc.FromWarehouses(1)

--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -1165,7 +1165,7 @@ func TestImportUserDefinedTypes(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
-	baseDir, cleanup := testutils.TestTempDir(t)
+	baseDir, cleanup := testutils.TempDir(t)
 	defer cleanup()
 	tc := testcluster.StartTestCluster(
 		t, 1, base.TestClusterArgs{ServerArgs: base.TestServerArgs{ExternalIODir: baseDir}})

--- a/pkg/testutils/bazel.go
+++ b/pkg/testutils/bazel.go
@@ -14,7 +14,6 @@ import (
 	"os"
 	"path"
 	"strings"
-	"testing"
 
 	"github.com/cockroachdb/errors"
 )
@@ -47,8 +46,8 @@ const testTmpDirEnv = "TEST_TMPDIR"
 // Name of the environment variable containing the bazel target path (//pkg/cmd/foo:bar).
 const testTargetEnv = "TEST_TARGET"
 
-// RunningUnderBazel returns true if the test is executed by bazel.
-func RunningUnderBazel() bool {
+// runningUnderBazel returns true if the test is executed by bazel.
+func runningUnderBazel() bool {
 	return os.Getenv(testSrcDirEnv) != ""
 }
 
@@ -74,15 +73,6 @@ func TestSrcDir() string {
 		return srcDir
 	}
 	return ""
-}
-
-// TestTempDir returns a temporary directory and a cleanup function for a test.
-func TestTempDir(t testing.TB) (string, func()) {
-	if RunningUnderBazel() {
-		// Bazel sets up private temp directories for each test.
-		return requireEnv(testTmpDirEnv), func() {}
-	}
-	return TempDir(t)
 }
 
 // bazeRelativeTargetPath returns relative path to the package
@@ -112,7 +102,7 @@ func bazelRelativeTargetPath() string {
 // containing test data files, given the relative (to the test) path components.
 //
 func TestDataPath(relative ...string) string {
-	if RunningUnderBazel() {
+	if runningUnderBazel() {
 		return path.Join(TestSrcDir(), requireEnv(testWorkspaceEnv), bazelRelativeTargetPath(),
 			path.Join(relative...))
 	}

--- a/pkg/testutils/dir.go
+++ b/pkg/testutils/dir.go
@@ -21,7 +21,18 @@ import (
 // TempDir creates a directory and a function to clean it up at the end of the
 // test.
 func TempDir(t testing.TB) (string, func()) {
-	dir, err := ioutil.TempDir("", fileutil.EscapeFilename(t.Name()))
+	tmpDir := ""
+	if runningUnderBazel() {
+		// Bazel sets up private temp directories for each test.
+		// Normally, this private temp directory will be cleaned up automatically.
+		// However, we do use external tools (such as stress) which re-execute the
+		// same test multiple times.  Bazel, on the other hand, does not know about
+		// this, and only creates this temporary directory once.  So, ensure we create
+		// a unique temporary directory underneath bazel TEST_TMPDIR.
+		tmpDir = requireEnv(testTmpDirEnv)
+	}
+
+	dir, err := ioutil.TempDir(tmpDir, fileutil.EscapeFilename(t.Name()))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Ensure TestTempDir works with external tools, s.a. stress, which
may execute the same test many times.

Release Notes: None