### PR TITLE
Revert "storage: add MakeEngineIterator and {Put,Clear}EngineKey"

### DIFF
--- a/pkg/ccl/storageccl/engineccl/batch_repr.go
+++ b/pkg/ccl/storageccl/engineccl/batch_repr.go
@@ -84,5 +84,5 @@ func VerifyBatchRepr(
 	}
 	defer iter.Close()
 
-	return storage.ComputeStatsForRange(iter, start.Key, end.Key, nowNanos)
+	return storage.ComputeStatsGo(iter, start.Key, end.Key, nowNanos)
 }

--- a/pkg/ccl/storageccl/import.go
+++ b/pkg/ccl/storageccl/import.go
@@ -142,8 +142,6 @@ func evalImport(ctx context.Context, cArgs batcheval.CommandArgs) (*roachpb.Impo
 	}
 	defer cArgs.EvalCtx.GetLimiters().ConcurrentImportRequests.Finish()
 
-	// The sstables only contain MVCC data and no intents, so using an MVCC
-	// iterator is sufficient.
 	var iters []storage.SimpleMVCCIterator
 	for _, file := range args.Files {
 		log.VEventf(ctx, 2, "import file %s %s", file.Path, args.Key)

--- a/pkg/ccl/workloadccl/format/sstable.go
+++ b/pkg/ccl/workloadccl/format/sstable.go
@@ -83,7 +83,7 @@ func ToSSTable(t workload.Table, tableID descpb.ID, ts time.Time) ([]byte, error
 		for kvBatch := range kvCh {
 			for _, kv := range kvBatch.KVs {
 				mvccKey := storage.MVCCKey{Timestamp: sstTS, Key: kv.Key}
-				if err := sw.PutMVCC(mvccKey, kv.Value.RawBytes); err != nil {
+				if err := sw.Put(mvccKey, kv.Value.RawBytes); err != nil {
 					return err
 				}
 			}

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -316,7 +316,7 @@ func runDebugRangeData(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	iter := rditer.NewReplicaEngineDataIterator(&desc, db, debugCtx.replicated)
+	iter := rditer.NewReplicaDataIterator(&desc, db, debugCtx.replicated, false /* seekEnd */)
 	defer iter.Close()
 	results := 0
 	for ; ; iter.Next() {
@@ -325,7 +325,10 @@ func runDebugRangeData(cmd *cobra.Command, args []string) error {
 		} else if !ok {
 			break
 		}
-		kvserver.PrintEngineKeyValue(iter.UnsafeKey(), iter.UnsafeValue())
+		kvserver.PrintKeyValue(storage.MVCCKeyValue{
+			Key:   iter.Key(),
+			Value: iter.Value(),
+		})
 		results++
 		if results == debugCtx.maxResults {
 			break
@@ -458,14 +461,9 @@ Decode and print a hexadecimal-encoded key-value pair.
 		isTS := bytes.HasPrefix(bs[0], keys.TimeseriesPrefix)
 		k, err := storage.DecodeMVCCKey(bs[0])
 		if err != nil {
-			// - Could be an EngineKey.
-			// - Older versions of the consistency checker give you diffs with a raw_key that
-			//   is already a roachpb.Key, so make a half-assed attempt to support both.
+			// Older versions of the consistency checker give you diffs with a raw_key that
+			// is already a roachpb.Key, so make a half-assed attempt to support both.
 			if !isTS {
-				if k, ok := storage.DecodeEngineKey(bs[0]); ok {
-					kvserver.PrintEngineKeyValue(k, bs[1])
-					return nil
-				}
 				fmt.Printf("unable to decode key: %v, assuming it's a roachpb.Key with fake timestamp;\n"+
 					"if the result below looks like garbage, then it likely is:\n\n", err)
 			}

--- a/pkg/kv/bulk/sst_batcher.go
+++ b/pkg/kv/bulk/sst_batcher.go
@@ -387,7 +387,7 @@ func AddSSTable(
 
 	var stats enginepb.MVCCStats
 	if (ms == enginepb.MVCCStats{}) {
-		stats, err = storage.ComputeStatsForRange(iter, start, end, now.UnixNano())
+		stats, err = storage.ComputeStatsGo(iter, start, end, now.UnixNano())
 		if err != nil {
 			return 0, errors.Wrapf(err, "computing stats for SST [%s, %s)", start, end)
 		}
@@ -437,7 +437,7 @@ func AddSSTable(
 						return err
 					}
 
-					right.stats, err = storage.ComputeStatsForRange(
+					right.stats, err = storage.ComputeStatsGo(
 						iter, right.start, right.end, now.UnixNano(),
 					)
 					if err != nil {

--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
@@ -32,8 +32,6 @@ func init() {
 }
 
 // EvalAddSSTable evaluates an AddSSTable command.
-// NB: These sstables do not contain intents/locks, so the code below only
-// needs to deal with MVCCKeys.
 func EvalAddSSTable(
 	ctx context.Context, readWriter storage.ReadWriter, cArgs CommandArgs, _ roachpb.Response,
 ) (result.Result, error) {
@@ -91,7 +89,7 @@ func EvalAddSSTable(
 	if args.MVCCStats == nil || verifyFastPath {
 		log.VEventf(ctx, 2, "computing MVCCStats for SSTable [%s,%s)", mvccStartKey.Key, mvccEndKey.Key)
 
-		computed, err := storage.ComputeStatsForRange(
+		computed, err := storage.ComputeStatsGo(
 			dataIter, mvccStartKey.Key, mvccEndKey.Key, h.Timestamp.WallTime)
 		if err != nil {
 			return result.Result{}, errors.Wrap(err, "computing SSTable MVCC stats")
@@ -181,6 +179,7 @@ func EvalAddSSTable(
 
 	ms.Add(stats)
 
+	// TODO(sumeer): use EngineIterator and replace the Put hack below.
 	if args.IngestAsWrites {
 		log.VEventf(ctx, 2, "ingesting SST (%d keys/%d bytes) via regular write batch", stats.KeyCount, len(args.Data))
 		dataIter.SeekGE(storage.MVCCKey{Key: keys.MinKey})

--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
@@ -392,7 +392,7 @@ func TestAddSSTableMVCCStats(t *testing.T) {
 			beforeStats := func() enginepb.MVCCStats {
 				iter := e.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{UpperBound: roachpb.KeyMax})
 				defer iter.Close()
-				beforeStats, err := storage.ComputeStatsForRange(iter, roachpb.KeyMin, roachpb.KeyMax, 10)
+				beforeStats, err := storage.ComputeStatsGo(iter, roachpb.KeyMin, roachpb.KeyMax, 10)
 				if err != nil {
 					t.Fatalf("%+v", err)
 				}
@@ -443,7 +443,7 @@ func TestAddSSTableMVCCStats(t *testing.T) {
 			afterStats := func() enginepb.MVCCStats {
 				iter := e.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{UpperBound: roachpb.KeyMax})
 				defer iter.Close()
-				afterStats, err := storage.ComputeStatsForRange(iter, roachpb.KeyMin, roachpb.KeyMax, 10)
+				afterStats, err := storage.ComputeStatsGo(iter, roachpb.KeyMin, roachpb.KeyMax, 10)
 				if err != nil {
 					t.Fatalf("%+v", err)
 				}
@@ -526,7 +526,7 @@ func TestAddSSTableDisallowShadowing(t *testing.T) {
 				}
 				defer dataIter.Close()
 
-				stats, err := storage.ComputeStatsForRange(dataIter, startKey, endKey, 0)
+				stats, err := storage.ComputeStatsGo(dataIter, startKey, endKey, 0)
 				if err != nil {
 					t.Fatalf("%+v", err)
 				}

--- a/pkg/kv/kvserver/batcheval/cmd_clear_range_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_clear_range_test.go
@@ -33,14 +33,37 @@ type wrappedBatch struct {
 	clearRangeCount int
 }
 
-func (wb *wrappedBatch) ClearEngineKey(key storage.EngineKey) error {
+// TODO(sbhola): narrow the calls where we increment counters to
+// make this test stricter.
+
+func (wb *wrappedBatch) ClearMVCC(key storage.MVCCKey) error {
 	wb.clearCount++
-	return wb.Batch.ClearEngineKey(key)
+	return wb.Batch.ClearMVCC(key)
+}
+
+func (wb *wrappedBatch) ClearUnversioned(key roachpb.Key) error {
+	wb.clearCount++
+	return wb.Batch.ClearUnversioned(key)
+}
+
+func (wb *wrappedBatch) ClearIntent(key roachpb.Key) error {
+	wb.clearCount++
+	return wb.Batch.ClearIntent(key)
+}
+
+func (wb *wrappedBatch) ClearRawRange(start, end roachpb.Key) error {
+	wb.clearRangeCount++
+	return wb.Batch.ClearRawRange(start, end)
 }
 
 func (wb *wrappedBatch) ClearMVCCRangeAndIntents(start, end roachpb.Key) error {
 	wb.clearRangeCount++
 	return wb.Batch.ClearMVCCRangeAndIntents(start, end)
+}
+
+func (wb *wrappedBatch) ClearMVCCRange(start, end storage.MVCCKey) error {
+	wb.clearRangeCount++
+	return wb.Batch.ClearMVCCRange(start, end)
 }
 
 // TestCmdClearRangeBytesThreshold verifies that clear range resorts to

--- a/pkg/kv/kvserver/batcheval/cmd_revert_range_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_revert_range_test.go
@@ -44,7 +44,7 @@ func getStats(t *testing.T, reader storage.Reader) enginepb.MVCCStats {
 	t.Helper()
 	iter := reader.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{UpperBound: roachpb.KeyMax})
 	defer iter.Close()
-	s, err := storage.ComputeStatsForRange(iter, roachpb.KeyMin, roachpb.KeyMax, 1100)
+	s, err := storage.ComputeStatsGo(iter, roachpb.KeyMin, roachpb.KeyMax, 1100)
 	if err != nil {
 		t.Fatalf("%+v", err)
 	}

--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -3116,7 +3116,7 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 		// Construct SST #1 through #3 as numbered above, but only ultimately
 		// keep the 3rd one.
 		keyRanges := rditer.MakeReplicatedKeyRanges(inSnap.State.Desc)
-		it := rditer.NewReplicaEngineDataIterator(inSnap.State.Desc, sendingEng, true /* replicatedOnly */)
+		it := rditer.NewReplicaDataIterator(inSnap.State.Desc, sendingEng, true /* replicatedOnly */, false /* seekEnd */)
 		defer it.Close()
 		// Write a range deletion tombstone to each of the SSTs then put in the
 		// kv entries from the sender of the snapshot.
@@ -3142,7 +3142,7 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 					expectedSSTs = append(expectedSSTs, sstFile.Data())
 					break
 				}
-				if err := sst.PutEngineKey(it.Key(), it.Value()); err != nil {
+				if err := sst.Put(it.Key(), it.Value()); err != nil {
 					return err
 				}
 			}

--- a/pkg/kv/kvserver/consistency_queue_test.go
+++ b/pkg/kv/kvserver/consistency_queue_test.go
@@ -442,7 +442,7 @@ func TestCheckConsistencyInconsistent(t *testing.T) {
 		iter := cpEng.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{UpperBound: []byte("\xff")})
 		defer iter.Close()
 
-		ms, err := storage.ComputeStatsForRange(iter, roachpb.KeyMin, roachpb.KeyMax, 0 /* nowNanos */)
+		ms, err := storage.ComputeStatsGo(iter, roachpb.KeyMin, roachpb.KeyMax, 0 /* nowNanos */)
 		assert.NoError(t, err)
 
 		assert.NotZero(t, ms.KeyBytes)

--- a/pkg/kv/kvserver/debug_print.go
+++ b/pkg/kv/kvserver/debug_print.go
@@ -86,7 +86,6 @@ func tryRangeDescriptor(kv storage.MVCCKeyValue) (string, error) {
 	return descStr(desc), nil
 }
 
-// tryIntent does not look at the key.
 func tryIntent(kv storage.MVCCKeyValue) (string, error) {
 	if len(kv.Value) == 0 {
 		return "", errors.New("empty")
@@ -374,21 +373,4 @@ func (s *stringifyWriteBatch) String() string {
 		return wbStr
 	}
 	return fmt.Sprintf("failed to stringify write batch (%x): %s", s.Data, err)
-}
-
-// PrintEngineKeyValue attempts to print the given key-value pair.
-func PrintEngineKeyValue(k storage.EngineKey, v []byte) {
-	if k.IsMVCCKey() {
-		if key, err := k.ToMVCCKey(); err == nil {
-			PrintKeyValue(storage.MVCCKeyValue{Key: key, Value: v})
-			return
-		}
-	}
-	var sb strings.Builder
-	fmt.Fprintf(&sb, "%s %x (%#x): ", k.Key, k.Version, k.Encode())
-	if out, err := tryIntent(storage.MVCCKeyValue{Value: v}); err == nil {
-		sb.WriteString(out)
-	} else {
-		fmt.Fprintf(&sb, "%x", v)
-	}
 }

--- a/pkg/kv/kvserver/gc/gc_iterator.go
+++ b/pkg/kv/kvserver/gc/gc_iterator.go
@@ -17,10 +17,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
 )
 
-// gcIterator wraps an rditer.ReplicaMVCCDataIterator which it reverse iterates for
+// gcIterator wraps an rditer.ReplicaDataIterator which it reverse iterates for
 // the purpose of discovering gc-able replicated data.
 type gcIterator struct {
-	it   *rditer.ReplicaMVCCDataIterator
+	it   *rditer.ReplicaDataIterator
 	done bool
 	err  error
 	buf  gcIteratorRingBuf
@@ -28,7 +28,7 @@ type gcIterator struct {
 
 func makeGCIterator(desc *roachpb.RangeDescriptor, snap storage.Reader) gcIterator {
 	return gcIterator{
-		it: rditer.NewReplicaMVCCDataIterator(desc, snap,
+		it: rditer.NewReplicaDataIterator(desc, snap,
 			true /* replicatedOnly */, true /* seekEnd */),
 	}
 }

--- a/pkg/kv/kvserver/gc/gc_old_test.go
+++ b/pkg/kv/kvserver/gc/gc_old_test.go
@@ -50,7 +50,7 @@ func runGCOld(
 	cleanupTxnIntentsAsyncFn CleanupTxnIntentsAsyncFunc,
 ) (Info, error) {
 
-	iter := rditer.NewReplicaMVCCDataIterator(desc, snap,
+	iter := rditer.NewReplicaDataIterator(desc, snap,
 		true /* replicatedOnly */, false /* seekEnd */)
 	defer iter.Close()
 

--- a/pkg/kv/kvserver/rditer/replica_data_iter.go
+++ b/pkg/kv/kvserver/rditer/replica_data_iter.go
@@ -17,55 +17,31 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
 )
 
-// KeyRange is a helper struct for the ReplicaMVCCDataIterator and
-// ReplicaEngineDataIterator.
+// KeyRange is a helper struct for the ReplicaDataIterator.
 // TODO(sumeer): change these to roachpb.Key since the timestamp is
-// always empty and the code below assumes that fact.
+// always empty.
 type KeyRange struct {
 	Start, End storage.MVCCKey
 }
 
-// ReplicaMVCCDataIterator provides a complete iteration over MVCC or unversioned
-// (which can be made to look like an MVCCKey) key / value
-// rows in a range, including system-local metadata and user data.
+// ReplicaDataIterator provides a complete iteration over all key / value
+// rows in a range, including all system-local metadata and user data.
 // The ranges keyRange slice specifies the key ranges which comprise
-// the range's data. This cannot be used to iterate over keys that are not
-// representable as MVCCKeys, except when such non-MVCCKeys are limited to
-// intents, which can be made to look like interleaved MVCCKeys. Most callers
-// want the real keys, and should use ReplicaEngineDataIterator.
+// all of the range's data.
 //
-// A ReplicaMVCCDataIterator provides a subset of the engine.MVCCIterator interface.
+// A ReplicaDataIterator provides a subset of the engine.MVCCIterator interface.
 //
-// TODO(tschottdorf): the API is awkward. By default, ReplicaMVCCDataIterator uses
+// TODO(tschottdorf): the API is awkward. By default, ReplicaDataIterator uses
 // a byte allocator which needs to be reset manually using `ResetAllocator`.
 // This is problematic as it requires of every user careful tracking of when
 // to call that method; some just never call it and pull the whole replica
 // into memory. Use of an allocator should be opt-in.
 //
-// TODO(sumeer): merge with ReplicaEngineDataIterator. We can use an EngineIterator
-// for MVCC key ranges and convert from EngineKey to MVCCKey.
-type ReplicaMVCCDataIterator struct {
+// TODO(sumeer): Should return EngineKeys, to handle separated lock table.
+type ReplicaDataIterator struct {
 	curIndex int
 	ranges   []KeyRange
 	it       storage.MVCCIterator
-	a        bufalloc.ByteAllocator
-}
-
-// ReplicaEngineDataIterator is like ReplicaMVCCDataIterator, but iterates
-// using the general EngineKeys. It provides a subset of the engine.EngineIterator
-// interface.
-//
-// TODO(tschottdorf): the API is awkward. By default, ReplicaMVCCDataIterator uses
-// a byte allocator which needs to be reset manually using `ResetAllocator`.
-// This is problematic as it requires of every user careful tracking of when
-// to call that method; some just never call it and pull the whole replica
-// into memory. Use of an allocator should be opt-in.
-type ReplicaEngineDataIterator struct {
-	curIndex int
-	ranges   []KeyRange
-	it       storage.EngineIterator
-	valid    bool
-	err      error
 	a        bufalloc.ByteAllocator
 }
 
@@ -138,19 +114,18 @@ func MakeUserKeyRange(d *roachpb.RangeDescriptor) KeyRange {
 	}
 }
 
-// NewReplicaMVCCDataIterator creates a ReplicaMVCCDataIterator for the given replica.
-// TODO(sumeer): narrow this interface since only gcIterator uses
-// ReplicaMVCCDataIterator.
-func NewReplicaMVCCDataIterator(
+// NewReplicaDataIterator creates a ReplicaDataIterator for the given replica.
+func NewReplicaDataIterator(
 	d *roachpb.RangeDescriptor, reader storage.Reader, replicatedOnly bool, seekEnd bool,
-) *ReplicaMVCCDataIterator {
+) *ReplicaDataIterator {
+	// TODO(sumeer): use an EngineIterator.
 	it := reader.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{UpperBound: d.EndKey.AsRawKey()})
 
 	rangeFunc := MakeAllKeyRanges
 	if replicatedOnly {
 		rangeFunc = MakeReplicatedKeyRanges
 	}
-	ri := &ReplicaMVCCDataIterator{
+	ri := &ReplicaDataIterator{
 		ranges: rangeFunc(d),
 		it:     it,
 	}
@@ -163,27 +138,27 @@ func NewReplicaMVCCDataIterator(
 }
 
 // seekStart seeks the iterator to the start of its data range.
-func (ri *ReplicaMVCCDataIterator) seekStart() {
+func (ri *ReplicaDataIterator) seekStart() {
 	ri.curIndex = 0
 	ri.it.SeekGE(ri.ranges[ri.curIndex].Start)
 	ri.advance()
 }
 
 // seekEnd seeks the iterator to the end of its data range.
-func (ri *ReplicaMVCCDataIterator) seekEnd() {
+func (ri *ReplicaDataIterator) seekEnd() {
 	ri.curIndex = len(ri.ranges) - 1
 	ri.it.SeekLT(ri.ranges[ri.curIndex].End)
 	ri.retreat()
 }
 
 // Close the underlying iterator.
-func (ri *ReplicaMVCCDataIterator) Close() {
+func (ri *ReplicaDataIterator) Close() {
 	ri.curIndex = len(ri.ranges)
 	ri.it.Close()
 }
 
 // Next advances to the next key in the iteration.
-func (ri *ReplicaMVCCDataIterator) Next() {
+func (ri *ReplicaDataIterator) Next() {
 	ri.it.Next()
 	ri.advance()
 }
@@ -191,7 +166,7 @@ func (ri *ReplicaMVCCDataIterator) Next() {
 // advance moves the iterator forward through the ranges until a valid
 // key is found or the iteration is done and the iterator becomes
 // invalid.
-func (ri *ReplicaMVCCDataIterator) advance() {
+func (ri *ReplicaDataIterator) advance() {
 	for {
 		if ok, _ := ri.Valid(); ok && ri.it.UnsafeKey().Less(ri.ranges[ri.curIndex].End) {
 			return
@@ -206,13 +181,13 @@ func (ri *ReplicaMVCCDataIterator) advance() {
 }
 
 // Prev advances the iterator one key backwards.
-func (ri *ReplicaMVCCDataIterator) Prev() {
+func (ri *ReplicaDataIterator) Prev() {
 	ri.it.Prev()
 	ri.retreat()
 }
 
 // retreat is the opposite of advance.
-func (ri *ReplicaMVCCDataIterator) retreat() {
+func (ri *ReplicaDataIterator) retreat() {
 	for {
 		if ok, _ := ri.Valid(); ok && ri.ranges[ri.curIndex].Start.Less(ri.it.UnsafeKey()) {
 			return
@@ -227,21 +202,21 @@ func (ri *ReplicaMVCCDataIterator) retreat() {
 }
 
 // Valid returns true if the iterator currently points to a valid value.
-func (ri *ReplicaMVCCDataIterator) Valid() (bool, error) {
+func (ri *ReplicaDataIterator) Valid() (bool, error) {
 	ok, err := ri.it.Valid()
 	ok = ok && ri.curIndex >= 0 && ri.curIndex < len(ri.ranges)
 	return ok, err
 }
 
 // Key returns the current key.
-func (ri *ReplicaMVCCDataIterator) Key() storage.MVCCKey {
+func (ri *ReplicaDataIterator) Key() storage.MVCCKey {
 	key := ri.it.UnsafeKey()
 	ri.a, key.Key = ri.a.Copy(key.Key, 0)
 	return key
 }
 
 // Value returns the current value.
-func (ri *ReplicaMVCCDataIterator) Value() []byte {
+func (ri *ReplicaDataIterator) Value() []byte {
 	value := ri.it.UnsafeValue()
 	ri.a, value = ri.a.Copy(value, 0)
 	return value
@@ -249,118 +224,17 @@ func (ri *ReplicaMVCCDataIterator) Value() []byte {
 
 // UnsafeKey returns the same value as Key, but the memory is invalidated on
 // the next call to {Next,Prev,Close}.
-func (ri *ReplicaMVCCDataIterator) UnsafeKey() storage.MVCCKey {
+func (ri *ReplicaDataIterator) UnsafeKey() storage.MVCCKey {
 	return ri.it.UnsafeKey()
 }
 
 // UnsafeValue returns the same value as Value, but the memory is invalidated on
 // the next call to {Next,Prev,Close}.
-func (ri *ReplicaMVCCDataIterator) UnsafeValue() []byte {
+func (ri *ReplicaDataIterator) UnsafeValue() []byte {
 	return ri.it.UnsafeValue()
 }
 
-// ResetAllocator resets the ReplicaMVCCDataIterator's internal byte allocator.
-func (ri *ReplicaMVCCDataIterator) ResetAllocator() {
+// ResetAllocator resets the ReplicaDataIterator's internal byte allocator.
+func (ri *ReplicaDataIterator) ResetAllocator() {
 	ri.a = nil
-}
-
-// NewReplicaEngineDataIterator creates a ReplicaEngineDataIterator for the given replica.
-func NewReplicaEngineDataIterator(
-	d *roachpb.RangeDescriptor, reader storage.Reader, replicatedOnly bool,
-) *ReplicaEngineDataIterator {
-	it := reader.NewEngineIterator(storage.IterOptions{UpperBound: d.EndKey.AsRawKey()})
-
-	rangeFunc := MakeAllKeyRanges
-	if replicatedOnly {
-		rangeFunc = MakeReplicatedKeyRanges
-	}
-	ri := &ReplicaEngineDataIterator{
-		ranges: rangeFunc(d),
-		it:     it,
-	}
-	ri.seekStart()
-	return ri
-}
-
-// seekStart seeks the iterator to the start of its data range.
-func (ri *ReplicaEngineDataIterator) seekStart() {
-	ri.curIndex = 0
-	ri.valid, ri.err = ri.it.SeekEngineKeyGE(storage.EngineKey{Key: ri.ranges[ri.curIndex].Start.Key})
-	ri.advance()
-}
-
-// Close the underlying iterator.
-func (ri *ReplicaEngineDataIterator) Close() {
-	ri.valid = false
-	ri.it.Close()
-}
-
-// Next advances to the next key in the iteration.
-func (ri *ReplicaEngineDataIterator) Next() {
-	ri.valid, ri.err = ri.it.NextEngineKey()
-	ri.advance()
-}
-
-// advance moves the iterator forward through the ranges until a valid
-// key is found or the iteration is done and the iterator becomes
-// invalid.
-func (ri *ReplicaEngineDataIterator) advance() {
-	for ri.valid {
-		var k storage.EngineKey
-		k, ri.err = ri.it.UnsafeEngineKey()
-		if ri.err != nil {
-			ri.valid = false
-			return
-		}
-		if k.Key.Compare(ri.ranges[ri.curIndex].End.Key) < 0 {
-			return
-		}
-		ri.curIndex++
-		if ri.curIndex < len(ri.ranges) {
-			ri.valid, ri.err = ri.it.SeekEngineKeyGE(
-				storage.EngineKey{Key: ri.ranges[ri.curIndex].Start.Key})
-		} else {
-			ri.valid = false
-			return
-		}
-	}
-}
-
-// Valid returns true if the iterator currently points to a valid value.
-func (ri *ReplicaEngineDataIterator) Valid() (bool, error) {
-	return ri.valid, ri.err
-}
-
-// Key returns the current key.
-// TODO(sumeer): only used in tests. Remove method and allocator.
-func (ri *ReplicaEngineDataIterator) Key() storage.EngineKey {
-	key := ri.UnsafeKey()
-	key, ri.a = key.CopyUsingAlloc(ri.a)
-	return key
-}
-
-// Value returns the current value.
-// TODO(sumeer): only used in tests. Remove method and allocator.
-func (ri *ReplicaEngineDataIterator) Value() []byte {
-	value := ri.it.UnsafeValue()
-	ri.a, value = ri.a.Copy(value, 0)
-	return value
-}
-
-// UnsafeKey returns the same value as Key, but the memory is invalidated on
-// the next call to {Next,Close}.
-func (ri *ReplicaEngineDataIterator) UnsafeKey() storage.EngineKey {
-	key, err := ri.it.UnsafeEngineKey()
-	if err != nil {
-		// If Valid(), we've already extracted an EngineKey earlier,
-		// when doing the key comparison, so this will not happen.
-		panic("method called on an invalid iter")
-	}
-	return key
-}
-
-// UnsafeValue returns the same value as Value, but the memory is invalidated on
-// the next call to {Next,Close}.
-func (ri *ReplicaEngineDataIterator) UnsafeValue() []byte {
-	return ri.it.UnsafeValue()
 }

--- a/pkg/kv/kvserver/rditer/replica_data_iter_test.go
+++ b/pkg/kv/kvserver/rditer/replica_data_iter_test.go
@@ -138,7 +138,7 @@ func verifyRDIter(
 			}, hlc.Timestamp{WallTime: 42})
 			readWriter = spanset.NewReadWriterAt(readWriter, &spans, hlc.Timestamp{WallTime: 42})
 		}
-		iter := NewReplicaMVCCDataIterator(desc, readWriter, replicatedOnly, reverse /* seekEnd */)
+		iter := NewReplicaDataIterator(desc, readWriter, replicatedOnly, reverse /* seekEnd */)
 		defer iter.Close()
 		i := 0
 		if reverse {
@@ -237,7 +237,7 @@ func TestReplicaDataIterator(t *testing.T) {
 
 	// Verify that the replicated-only iterator ignores unreplicated keys.
 	unreplicatedPrefix := keys.MakeRangeIDUnreplicatedPrefix(desc.RangeID)
-	iter := NewReplicaMVCCDataIterator(&desc, eng,
+	iter := NewReplicaDataIterator(&desc, eng,
 		true /* replicatedOnly */, false /* seekEnd */)
 	defer iter.Close()
 	for ; ; iter.Next() {

--- a/pkg/kv/kvserver/replica_consistency.go
+++ b/pkg/kv/kvserver/replica_consistency.go
@@ -633,13 +633,13 @@ func (r *Replica) sha512(
 	// all of the replicated key space.
 	if !statsOnly {
 		// TODO(sumeer): remember that this caller of MakeReplicatedKeyRanges does
-		// not want the lock table ranges since the iter has been constructed using
-		// MVCCKeyAndIntentsIterKind. By the time we have replicated locks
+		// not want the lock table ranges since it has already considered the
+		// intents earlier in this function. By the time we have replicated locks
 		// other than exclusive locks, we will probably not have any interleaved
-		// intents so we could stop using MVCCKeyAndIntentsIterKind and
+		// intents so we could stop using MVCCKeyAndIntentsIterKind above and
 		// consider all locks here.
 		for _, span := range rditer.MakeReplicatedKeyRanges(&desc) {
-			spanMS, err := storage.ComputeStatsForRange(
+			spanMS, err := storage.ComputeStatsGo(
 				iter, span.Start.Key, span.End.Key, 0 /* nowNanos */, visitor,
 			)
 			if err != nil {

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -6990,8 +6990,8 @@ func TestReplicaDestroy(t *testing.T) {
 		}
 	}()
 
-	iter := rditer.NewReplicaEngineDataIterator(tc.repl.Desc(), tc.repl.store.Engine(),
-		false /* replicatedOnly */)
+	iter := rditer.NewReplicaDataIterator(tc.repl.Desc(), tc.repl.store.Engine(),
+		false /* replicatedOnly */, false /* seekEnd */)
 	defer iter.Close()
 	if ok, err := iter.Valid(); err != nil {
 		t.Fatal(err)

--- a/pkg/kv/kvserver/spanset/batch.go
+++ b/pkg/kv/kvserver/spanset/batch.go
@@ -298,10 +298,6 @@ func (s spanSetReader) NewMVCCIterator(
 	return NewIteratorAt(s.r.NewMVCCIterator(iterKind, opts), s.spans, s.ts)
 }
 
-func (s spanSetReader) NewEngineIterator(opts storage.IterOptions) storage.EngineIterator {
-	panic("unsupported")
-}
-
 // GetDBEngine recursively searches for the underlying rocksDB engine.
 func GetDBEngine(reader storage.Reader, span roachpb.Span) storage.Reader {
 	switch v := reader.(type) {
@@ -371,10 +367,6 @@ func (s spanSetWriter) ClearIntent(key roachpb.Key) error {
 		return err
 	}
 	return s.w.ClearIntent(key)
-}
-
-func (s spanSetWriter) ClearEngineKey(key storage.EngineKey) error {
-	panic("unsupported")
 }
 
 func (s spanSetWriter) checkAllowedRange(start, end roachpb.Key) error {
@@ -452,10 +444,6 @@ func (s spanSetWriter) PutIntent(key roachpb.Key, value []byte) error {
 	return s.w.PutIntent(key, value)
 }
 
-func (s spanSetWriter) PutEngineKey(key storage.EngineKey, value []byte) error {
-	panic("unsupported")
-}
-
 func (s spanSetWriter) LogData(data []byte) error {
 	return s.w.LogData(data)
 }
@@ -512,8 +500,8 @@ type spanSetBatch struct {
 
 var _ storage.Batch = spanSetBatch{}
 
-func (s spanSetBatch) SingleClearEngineKey(key storage.EngineKey) error {
-	return s.b.SingleClearEngineKey(key)
+func (s spanSetBatch) SingleClearEngine(key storage.EngineKey) error {
+	return s.b.SingleClearEngine(key)
 }
 
 func (s spanSetBatch) Commit(sync bool) error {

--- a/pkg/kv/kvserver/stateloader/stateloader.go
+++ b/pkg/kv/kvserver/stateloader/stateloader.go
@@ -290,7 +290,7 @@ func (rsl StateLoader) SetRangeAppliedState(
 		RangeStats:        newMS.ToPersistentStats(),
 	}
 	// The RangeAppliedStateKey is not included in stats. This is also reflected
-	// in C.MVCCComputeStats and ComputeStatsForRange.
+	// in C.MVCCComputeStats and ComputeStatsGo.
 	ms := (*enginepb.MVCCStats)(nil)
 	return storage.MVCCPutProto(ctx, readWriter, ms, rsl.RangeAppliedStateKey(), hlc.Timestamp{}, nil, &as)
 }
@@ -400,7 +400,7 @@ func (rsl StateLoader) writeLegacyMVCCStatsInternal(
 	// enlarges the size of the struct itself. This is mostly fine - we persist
 	// MVCCStats under the RangeAppliedState key and don't account for the size of
 	// the MVCCStats struct itself when doing so (we ignore the RangeAppliedState key
-	// in ComputeStatsForRange). This would not therefore not cause replica state divergence
+	// in ComputeStatsGo). This would not therefore not cause replica state divergence
 	// in mixed version clusters (the enlarged struct does not contribute to a
 	// persisted stats difference on disk because we're not accounting for the size of
 	// the struct itself).

--- a/pkg/kv/kvserver/store_snapshot.go
+++ b/pkg/kv/kvserver/store_snapshot.go
@@ -162,7 +162,7 @@ func (msstw *multiSSTWriter) finalizeSST(ctx context.Context) error {
 	return nil
 }
 
-func (msstw *multiSSTWriter) Put(ctx context.Context, key storage.EngineKey, value []byte) error {
+func (msstw *multiSSTWriter) Put(ctx context.Context, key storage.MVCCKey, value []byte) error {
 	for msstw.keyRanges[msstw.currRange].End.Key.Compare(key.Key) <= 0 {
 		// Finish the current SST, write to the file, and move to the next key
 		// range.
@@ -176,7 +176,7 @@ func (msstw *multiSSTWriter) Put(ctx context.Context, key storage.EngineKey, val
 	if msstw.keyRanges[msstw.currRange].Start.Key.Compare(key.Key) > 0 {
 		return crdberrors.AssertionFailedf("client error: expected %s to fall in one of %s", key.Key, msstw.keyRanges)
 	}
-	if err := msstw.currSST.PutEngineKey(key, value); err != nil {
+	if err := msstw.currSST.Put(key, value); err != nil {
 		return errors.Wrap(err, "failed to put in sst")
 	}
 	return nil
@@ -246,7 +246,7 @@ func (kvSS *kvBatchSnapshotStrategy) Receive(
 				if batchReader.BatchType() != storage.BatchTypeValue {
 					return noSnap, crdberrors.AssertionFailedf("expected type %d, found type %d", storage.BatchTypeValue, batchReader.BatchType())
 				}
-				key, err := batchReader.EngineKey()
+				key, err := batchReader.MVCCKey()
 				if err != nil {
 					return noSnap, errors.Wrap(err, "failed to decode mvcc key")
 				}
@@ -334,13 +334,21 @@ func (kvSS *kvBatchSnapshotStrategy) Send(
 			break
 		}
 		kvs++
+		// TODO(sumeer): this is incorrect. We should be iterating using EngineIterator
+		// and Putting an EngineKey.
 		unsafeKey := iter.UnsafeKey()
 		unsafeValue := iter.UnsafeValue()
 		if b == nil {
 			b = kvSS.newBatch()
 		}
-		if err := b.PutEngineKey(unsafeKey, unsafeValue); err != nil {
-			return 0, err
+		if unsafeKey.Timestamp.IsEmpty() {
+			if err := b.PutUnversioned(unsafeKey.Key, unsafeValue); err != nil {
+				return 0, err
+			}
+		} else {
+			if err := b.PutMVCC(unsafeKey, unsafeValue); err != nil {
+				return 0, err
+			}
 		}
 
 		if bLen := int64(b.Len()); bLen >= kvSS.batchSize {

--- a/pkg/storage/batch.go
+++ b/pkg/storage/batch.go
@@ -275,15 +275,6 @@ func (r *RocksDBBatchReader) MVCCKey() (MVCCKey, error) {
 	return decodeMVCCKey(r.Key())
 }
 
-// EngineKey returns the EngineKey for the current batch entry.
-func (r *RocksDBBatchReader) EngineKey() (EngineKey, error) {
-	key, ok := DecodeEngineKey(r.Key())
-	if !ok {
-		return key, errors.Errorf("invalid encoded engine key: %x", r.Key())
-	}
-	return key, nil
-}
-
 // Value returns the value of the current batch entry. Value panics if the
 // BatchType is BatchTypeDeleted.
 func (r *RocksDBBatchReader) Value() []byte {

--- a/pkg/storage/batch_test.go
+++ b/pkg/storage/batch_test.go
@@ -98,7 +98,7 @@ func testBatchBasics(t *testing.T, writeOnly bool, commit func(e Engine, b Batch
 			if err := e.PutUnversioned(mvccKey("d").Key, []byte("before")); err != nil {
 				t.Fatal(err)
 			}
-			if err := b.SingleClearEngineKey(EngineKey{Key: mvccKey("d").Key}); err != nil {
+			if err := b.SingleClearEngine(EngineKey{Key: mvccKey("d").Key}); err != nil {
 				t.Fatal(err)
 			}
 
@@ -451,7 +451,7 @@ func TestBatchGet(t *testing.T) {
 			if err := b.PutUnversioned(mvccKey("d").Key, []byte("before")); err != nil {
 				t.Fatal(err)
 			}
-			if err := b.SingleClearEngineKey(EngineKey{Key: mvccKey("d").Key}); err != nil {
+			if err := b.SingleClearEngine(EngineKey{Key: mvccKey("d").Key}); err != nil {
 				t.Fatal(err)
 			}
 			if err := b.PutUnversioned(mvccKey("d").Key, []byte("after")); err != nil {
@@ -1010,7 +1010,7 @@ func TestBatchDistinctPanics(t *testing.T) {
 				func() { _ = batch.PutUnversioned(a.Key, nil) },
 				func() { _ = batch.Merge(a, nil) },
 				func() { _ = batch.ClearUnversioned(a.Key) },
-				func() { _ = batch.SingleClearEngineKey(EngineKey{Key: a.Key}) },
+				func() { _ = batch.SingleClearEngine(EngineKey{Key: a.Key}) },
 				func() { _ = batch.ApplyBatchRepr(nil, false) },
 				func() { _, _ = batch.MVCCGet(a) },
 				func() { _, _, _, _ = batch.MVCCGetProto(a, nil) },

--- a/pkg/storage/engine_key_test.go
+++ b/pkg/storage/engine_key_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
@@ -105,12 +104,6 @@ func TestMVCCAndEngineKeyEncodeDecode(t *testing.T) {
 			keyDecoded, err := eKeyDecoded.ToMVCCKey()
 			require.NoError(t, err)
 			require.Equal(t, test.key, keyDecoded)
-			b3 := EncodeKey(test.key)
-			require.Equal(t, b3, b1)
-			k3, ts, ok := enginepb.SplitMVCCKey(b3)
-			require.True(t, ok)
-			require.Equal(t, k3, []byte(test.key.Key))
-			require.Equal(t, ts, encodedTS)
 		})
 	}
 }

--- a/pkg/storage/mvcc_stats_test.go
+++ b/pkg/storage/mvcc_stats_test.go
@@ -1335,9 +1335,9 @@ var mvccStatsTests = []struct {
 		},
 	},
 	{
-		name: "ComputeStatsForRange",
+		name: "ComputeStatsGo",
 		fn: func(iter MVCCIterator, start, end roachpb.Key, nowNanos int64) (enginepb.MVCCStats, error) {
-			return ComputeStatsForRange(iter, start, end, nowNanos)
+			return ComputeStatsGo(iter, start, end, nowNanos)
 		},
 	},
 }

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -2580,7 +2580,7 @@ func computeStats(
 	t.Helper()
 	iter := reader.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{UpperBound: to})
 	defer iter.Close()
-	s, err := ComputeStatsForRange(iter, from, to, nowNanos)
+	s, err := ComputeStatsGo(iter, from, to, nowNanos)
 	if err != nil {
 		t.Fatalf("%+v", err)
 	}

--- a/pkg/storage/pebble_batch.go
+++ b/pkg/storage/pebble_batch.go
@@ -22,24 +22,15 @@ import (
 
 // Wrapper struct around a pebble.Batch.
 type pebbleBatch struct {
-	db    *pebble.DB
-	batch *pebble.Batch
-	buf   []byte
-	// The iterator reuse optimization in pebbleBatch is for servicing a
-	// BatchRequest, such that the iterators get reused across different
-	// requests in the batch.
-	// Reuse iterators for {normal,prefix} x {MVCCKey,EngineKey} iteration. We
-	// need separate iterators for EngineKey and MVCCKey iteration since
-	// iterators that make separated locks/intents look as interleaved need to
-	// use both simultaneously.
-	prefixIter       pebbleIterator
-	normalIter       pebbleIterator
-	prefixEngineIter pebbleIterator
-	normalEngineIter pebbleIterator
-	closed           bool
-	isDistinct       bool
-	distinctOpen     bool
-	parentBatch      *pebbleBatch
+	db           *pebble.DB
+	batch        *pebble.Batch
+	buf          []byte
+	prefixIter   pebbleIterator
+	normalIter   pebbleIterator
+	closed       bool
+	isDistinct   bool
+	distinctOpen bool
+	parentBatch  *pebbleBatch
 }
 
 var _ Batch = &pebbleBatch{}
@@ -67,16 +58,6 @@ func newPebbleBatch(db *pebble.DB, batch *pebble.Batch) *pebbleBatch {
 			upperBoundBuf: pb.normalIter.upperBoundBuf,
 			reusable:      true,
 		},
-		prefixEngineIter: pebbleIterator{
-			lowerBoundBuf: pb.prefixIter.lowerBoundBuf,
-			upperBoundBuf: pb.prefixIter.upperBoundBuf,
-			reusable:      true,
-		},
-		normalEngineIter: pebbleIterator{
-			lowerBoundBuf: pb.normalIter.lowerBoundBuf,
-			upperBoundBuf: pb.normalIter.upperBoundBuf,
-			reusable:      true,
-		},
 	}
 	return pb
 }
@@ -91,8 +72,6 @@ func (p *pebbleBatch) Close() {
 	// Destroy the iterators before closing the batch.
 	p.prefixIter.destroy()
 	p.normalIter.destroy()
-	p.prefixEngineIter.destroy()
-	p.normalEngineIter.destroy()
 
 	if !p.isDistinct {
 		_ = p.batch.Close()
@@ -234,39 +213,6 @@ func (p *pebbleBatch) NewMVCCIterator(iterKind MVCCIterKind, opts IterOptions) M
 	return iter
 }
 
-// NewEngineIterator implements the Batch interface.
-func (p *pebbleBatch) NewEngineIterator(opts IterOptions) EngineIterator {
-	if !opts.Prefix && len(opts.UpperBound) == 0 && len(opts.LowerBound) == 0 {
-		panic("iterator must set prefix or upper bound or lower bound")
-	}
-
-	if !p.batch.Indexed() && !p.isDistinct {
-		panic("write-only batch")
-	}
-	if p.distinctOpen {
-		panic("distinct batch open")
-	}
-
-	iter := &p.normalEngineIter
-	if opts.Prefix {
-		iter = &p.prefixEngineIter
-	}
-	if iter.inuse {
-		panic("iterator already in use")
-	}
-
-	if iter.iter != nil {
-		iter.setOptions(opts)
-	} else if p.batch.Indexed() {
-		iter.init(p.batch, opts)
-	} else {
-		iter.init(p.db, opts)
-	}
-
-	iter.inuse = true
-	return iter
-}
-
 // NewMVCCIterator implements the Batch interface.
 func (p *pebbleBatch) ApplyBatchRepr(repr []byte, sync bool) error {
 	if p.distinctOpen {
@@ -299,18 +245,6 @@ func (p *pebbleBatch) ClearIntent(key roachpb.Key) error {
 	return p.clear(MVCCKey{Key: key})
 }
 
-// ClearEngineKey implements the Batch interface.
-func (p *pebbleBatch) ClearEngineKey(key EngineKey) error {
-	if p.distinctOpen {
-		panic("distinct batch open")
-	}
-	if len(key.Key) == 0 {
-		return emptyKeyError()
-	}
-	p.buf = key.EncodeToBuf(p.buf[:0])
-	return p.batch.Delete(p.buf, nil)
-}
-
 func (p *pebbleBatch) clear(key MVCCKey) error {
 	if p.distinctOpen {
 		panic("distinct batch open")
@@ -323,8 +257,8 @@ func (p *pebbleBatch) clear(key MVCCKey) error {
 	return p.batch.Delete(p.buf, nil)
 }
 
-// SingleClearEngineKey implements the Batch interface.
-func (p *pebbleBatch) SingleClearEngineKey(key EngineKey) error {
+// SingleClearEngine implements the Batch interface.
+func (p *pebbleBatch) SingleClearEngine(key EngineKey) error {
 	if p.distinctOpen {
 		panic("distinct batch open")
 	}
@@ -420,19 +354,6 @@ func (p *pebbleBatch) PutUnversioned(key roachpb.Key, value []byte) error {
 // PutIntent implements the Batch interface.
 func (p *pebbleBatch) PutIntent(key roachpb.Key, value []byte) error {
 	return p.put(MVCCKey{Key: key}, value)
-}
-
-// PutEngineKey implements the Batch interface.
-func (p *pebbleBatch) PutEngineKey(key EngineKey, value []byte) error {
-	if p.distinctOpen {
-		panic("distinct batch open")
-	}
-	if len(key.Key) == 0 {
-		return emptyKeyError()
-	}
-
-	p.buf = key.EncodeToBuf(p.buf[:0])
-	return p.batch.Set(p.buf, value, nil)
 }
 
 func (p *pebbleBatch) put(key MVCCKey, value []byte) error {

--- a/pkg/storage/sst_writer.go
+++ b/pkg/storage/sst_writer.go
@@ -139,19 +139,6 @@ func (fw *SSTWriter) PutIntent(key roachpb.Key, value []byte) error {
 	return fw.put(MVCCKey{Key: key}, value)
 }
 
-// PutEngineKey implements the Writer interface.
-// An error is returned if it is not greater than any previously added entry
-// (according to the comparator configured during writer creation). `Close`
-// cannot have been called.
-func (fw *SSTWriter) PutEngineKey(key EngineKey, value []byte) error {
-	if fw.fw == nil {
-		return errors.New("cannot call Put on a closed writer")
-	}
-	fw.DataSize += int64(len(key.Key)) + int64(len(value))
-	fw.scratch = key.EncodeToBuf(fw.scratch[:0])
-	return fw.fw.Set(fw.scratch, value)
-}
-
 // put puts a kv entry into the sstable being built. An error is returned if it
 // is not greater than any previously added entry (according to the comparator
 // configured during writer creation). `Close` cannot have been called.
@@ -194,19 +181,6 @@ func (fw *SSTWriter) ClearUnversioned(key roachpb.Key) error {
 // called.
 func (fw *SSTWriter) ClearIntent(key roachpb.Key) error {
 	panic("ClearIntent is unsupported")
-}
-
-// ClearEngineKey implements the Writer interface. An error is returned if it is
-// not greater than any previous point key passed to this Writer (according to
-// the comparator configured during writer creation). `Close` cannot have been
-// called.
-func (fw *SSTWriter) ClearEngineKey(key EngineKey) error {
-	if fw.fw == nil {
-		return errors.New("cannot call Clear on a closed writer")
-	}
-	fw.scratch = key.EncodeToBuf(fw.scratch[:0])
-	fw.DataSize += int64(len(key.Key))
-	return fw.fw.Delete(fw.scratch)
 }
 
 // An error is returned if it is not greater than any previous point key


### PR DESCRIPTION
Causing regular failure, e.g. https://teamcity.cockroachdb.com//viewLog.html?buildId=2418871&buildTypeId=Cockroach_MergedExtendedCi

This reverts commit 3afaafd669c304cd694aba4f6ab77eba07ad5f92.

Release note: None