### PR TITLE
release-20.2: sql: in schema changer, wait for leases of referenced descriptors to update

### DIFF
--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -982,10 +982,11 @@ func WaitToUpdateLeases(ctx context.Context, leaseMgr *lease.Manager, descID des
 }
 
 // done finalizes the mutations (adds new cols/indexes to the table).
-// It ensures that all nodes are on the current (pre-update) version of the
-// schema.
+// It ensures that all nodes are on the current (pre-update) version of
+// sc.descID and that all nodes are on the new (post-update) version of
+// any other modified descriptors.
+//
 // It also kicks off GC jobs as needed.
-// Returns the updated descriptor.
 func (sc *SchemaChanger) done(ctx context.Context) error {
 
 	// Get the other tables whose foreign key backreferences need to be removed.
@@ -997,7 +998,9 @@ func (sc *SchemaChanger) done(ctx context.Context) error {
 	// descriptor updates are published.
 	var childJobs []*jobs.StartableJob
 	var didUpdate bool
-	err := sc.txn(ctx, func(ctx context.Context, txn *kv.Txn, descsCol *descs.Collection) error {
+	modified, err := sc.txnWithModified(ctx, func(
+		ctx context.Context, txn *kv.Txn, descsCol *descs.Collection,
+	) error {
 		childJobs = nil
 		fksByBackrefTable = make(map[descpb.ID][]*descpb.ConstraintToUpdate)
 		interleaveParents = make(map[descpb.ID]struct{})
@@ -1339,6 +1342,17 @@ func (sc *SchemaChanger) done(ctx context.Context) error {
 			log.Warningf(ctx, "starting job %d failed with error: %v", *job.ID(), err)
 		}
 		log.VEventf(ctx, 2, "started job %d", *job.ID())
+	}
+	// Wait for the modified versions of tables other than the table we're
+	// updating to have their leases updated.
+	for _, desc := range modified {
+		// sc.descID gets waited for above this call in sc.exec().
+		if desc.ID == sc.descID {
+			continue
+		}
+		if err := WaitToUpdateLeases(ctx, sc.leaseMgr, desc.ID); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -1903,12 +1917,28 @@ func (*SchemaChangerTestingKnobs) ModuleTestingKnobs() {}
 func (sc *SchemaChanger) txn(
 	ctx context.Context, f func(context.Context, *kv.Txn, *descs.Collection) error,
 ) error {
+	_, err := sc.txnWithModified(ctx, f)
+	return err
+}
+
+// txnWithModified is a convenient wrapper around descs.Txn() which additionally
+// returns the set of modified descriptors.
+func (sc *SchemaChanger) txnWithModified(
+	ctx context.Context, f func(context.Context, *kv.Txn, *descs.Collection) error,
+) (descsWithNewVersions []lease.IDVersion, _ error) {
 	ie := sc.ieFactory(ctx, newFakeSessionData())
-	return descs.Txn(ctx, sc.settings, sc.leaseMgr, ie, sc.db, func(
+	if err := descs.Txn(ctx, sc.settings, sc.leaseMgr, ie, sc.db, func(
 		ctx context.Context, txn *kv.Txn, descsCol *descs.Collection,
 	) error {
-		return f(ctx, txn, descsCol)
-	})
+		if err := f(ctx, txn, descsCol); err != nil {
+			return err
+		}
+		descsWithNewVersions = descsCol.GetDescriptorsWithNewVersion()
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return descsWithNewVersions, nil
 }
 
 // createSchemaChangeEvalCtx creates an extendedEvalContext() to be used for backfills.


### PR DESCRIPTION
Backport 1/1 commits from #54434.

/cc @cockroachdb/release

---

In 20.1 we moved the schema changer over to utilize the jobs infrastructure.
Prior to that change, after committing a sql transaction we'd kick off the
schema changer to run for the relevant mutations and then we'd wait for all
modified descriptors to have just one version (after the schema change). In
20.1 we decided for descriptors referenced in schema changes to also create
schema change jobs that have an InvalidMutationID which leads to the job
merely waiting for one version for that descriptor. Unfortunately, that
solution doesn't generally work. In particular, it doesn't work in cases
where we are add an fk constraint that we need to mark validated at the
end and it doesn't work in cases where we want to remove a type back
reference after dropping a column or when adding a type reference.

Realistically, when the schema change job ends up touching multiple
descriptors, we need to make sure we wait for the leases to update
for all of them.

You might think that this could lead directly to eliminating the
InvalidMutationID schema change jobs, but I'm not convinced that
that always follows and so I'm leaving that for later.

It turns out that I don't think the type portions of this represent
correctness problems as the type references just used for type DDLs but
I do think for tables it might be worse. At the very least it might mean
that query plans a tad longer to reflect fk relationships.

Fixes #52539.
Fixes #40200.

Release note (bug fix): Fixed a bug which allowed statements after a
schema change to fail to observe side-effects of that change on referenced
tables.
