### PR TITLE
cloud: update resource requests/limits in StatefulSet configs

### DIFF
--- a/cloud/kubernetes/bring-your-own-certs/cockroachdb-statefulset.yaml
+++ b/cloud/kubernetes/bring-your-own-certs/cockroachdb-statefulset.yaml
@@ -154,6 +154,17 @@ spec:
       - name: cockroachdb
         image: cockroachdb/cockroach:v20.1.8
         imagePullPolicy: IfNotPresent
+        # TODO: Change these to appropriate values for the hardware that you're running. You can see
+        # the resources that can be allocated on each of your Kubernetes nodes by running:
+        #   kubectl describe nodes
+        # Note that requests and limits should have identical values.
+        # resources:
+        #   requests:
+        #     cpu: "16"
+        #     memory: "8Gi"
+        #   limits:
+        #     cpu: "16"
+        #     memory: "8Gi" 
         ports:
         - containerPort: 26257
           name: grpc

--- a/cloud/kubernetes/cockroachdb-statefulset-secure.yaml
+++ b/cloud/kubernetes/cockroachdb-statefulset-secure.yaml
@@ -197,20 +197,16 @@ spec:
         image: cockroachdb/cockroach:v20.1.8
         imagePullPolicy: IfNotPresent
         # TODO: Change these to appropriate values for the hardware that you're running. You can see
-        # the amount of allocatable resources on each of your Kubernetes nodes by running:
+        # the resources that can be allocated on each of your Kubernetes nodes by running:
         #   kubectl describe nodes
+        # Note that requests and limits should have identical values.
         # resources:
         #   requests:
         #     cpu: "16"
         #     memory: "8Gi"
         #   limits:
-            # NOTE: Unless you have enabled the non-default Static CPU Management Policy
-            # and are using an integer number of CPUs, we don't recommend setting a CPU limit.
-            # See:
-            #   https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#static-policy
-            #   https://github.com/kubernetes/kubernetes/issues/51135
-            #   cpu: "16"
-            #   memory: "8Gi"
+        #     cpu: "16"
+        #     memory: "8Gi" 
         ports:
         - containerPort: 26257
           name: grpc

--- a/cloud/kubernetes/cockroachdb-statefulset.yaml
+++ b/cloud/kubernetes/cockroachdb-statefulset.yaml
@@ -100,20 +100,16 @@ spec:
         image: cockroachdb/cockroach:v20.1.8
         imagePullPolicy: IfNotPresent
         # TODO: Change these to appropriate values for the hardware that you're running. You can see
-        # the amount of allocatable resources on each of your Kubernetes nodes by running:
+        # the resources that can be allocated on each of your Kubernetes nodes by running:
         #   kubectl describe nodes
+        # Note that requests and limits should have identical values.
         # resources:
         #   requests:
         #     cpu: "16"
         #     memory: "8Gi"
         #   limits:
-            # NOTE: Unless you have enabled the non-default Static CPU Management Policy
-            # and are using an integer number of CPUs, we don't recommend setting a CPU limit.
-            # See:
-            #   https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#static-policy
-            #   https://github.com/kubernetes/kubernetes/issues/51135
-            #   cpu: "16"
-            #   memory: "8Gi" 
+        #     cpu: "16"
+        #     memory: "8Gi" 
         ports:
         - containerPort: 26257
           name: grpc

--- a/cloud/kubernetes/multiregion/eks/cockroachdb-statefulset-secure-eks.yaml
+++ b/cloud/kubernetes/multiregion/eks/cockroachdb-statefulset-secure-eks.yaml
@@ -186,17 +186,17 @@ spec:
       - name: cockroachdb
         image: cockroachdb/cockroach:v20.1.8
         imagePullPolicy: IfNotPresent
-        # TODO: Change these to appropriate values for the hardware that you're running. You can see the amount of allocatable resources on each of your Kubernetes nodes by running: kubectl describe nodes
+        # TODO: Change these to appropriate values for the hardware that you're running. You can see
+        # the resources that can be allocated on each of your Kubernetes nodes by running:
+        #   kubectl describe nodes
+        # Note that requests and limits should have identical values.
         # resources:
         #   requests:
         #     cpu: "16"
         #     memory: "8Gi"
-        #     NOTE: Unless you have enabled the non-default Static CPU Management Policy and are using an integer number of CPUs, we don't recommend setting a CPU limit. See:
-        #         https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#static-policy
-        #         https://github.com/kubernetes/kubernetes/issues/51135
         #   limits:
         #     cpu: "16"
-        #     memory: "8Gi"
+        #     memory: "8Gi" 
         ports:
         - containerPort: 26257
           name: grpc

--- a/cloud/kubernetes/performance/cockroachdb-statefulset-insecure.yaml
+++ b/cloud/kubernetes/performance/cockroachdb-statefulset-insecure.yaml
@@ -143,20 +143,16 @@ spec:
         image: cockroachdb/cockroach:v20.1.8
         imagePullPolicy: IfNotPresent
         # TODO: Change these to appropriate values for the hardware that you're running. You can see
-        # the amount of allocatable resources on each of your Kubernetes nodes by running:
+        # the resources that can be allocated on each of your Kubernetes nodes by running:
         #   kubectl describe nodes
-        resources:
-          requests:
-            cpu: "16"
-            memory: "8Gi"
-          limits:
-            # NOTE: Unless you have enabled the non-default Static CPU Management Policy
-            # and are using an integer number of CPUs, we don't recommend setting a CPU limit.
-            # See:
-            #   https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#static-policy
-            #   https://github.com/kubernetes/kubernetes/issues/51135
-            #cpu: "16"
-            memory: "8Gi"
+        # Note that requests and limits should have identical values.
+        # resources:
+        #   requests:
+        #     cpu: "16"
+        #     memory: "8Gi"
+        #   limits:
+        #     cpu: "16"
+        #     memory: "8Gi" 
         ports:
         - containerPort: 26257
           name: grpc

--- a/cloud/kubernetes/performance/cockroachdb-statefulset-secure.yaml
+++ b/cloud/kubernetes/performance/cockroachdb-statefulset-secure.yaml
@@ -234,20 +234,16 @@ spec:
         image: cockroachdb/cockroach:v20.1.8
         imagePullPolicy: IfNotPresent
         # TODO: Change these to appropriate values for the hardware that you're running. You can see
-        # the amount of allocatable resources on each of your Kubernetes nodes by running:
+        # the resources that can be allocated on each of your Kubernetes nodes by running:
         #   kubectl describe nodes
-        resources:
-          requests:
-            cpu: "16"
-            memory: "8Gi"
-          limits:
-            # NOTE: Unless you have enabled the non-default Static CPU Management Policy
-            # and are using an integer number of CPUs, we don't recommend setting a CPU limit.
-            # See:
-            #   https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#static-policy
-            #   https://github.com/kubernetes/kubernetes/issues/51135
-            #cpu: "16"
-            memory: "8Gi"
+        # Note that requests and limits should have identical values.
+        # resources:
+        #   requests:
+        #     cpu: "16"
+        #     memory: "8Gi"
+        #   limits:
+        #     cpu: "16"
+        #     memory: "8Gi" 
         ports:
         - containerPort: 26257
           name: grpc


### PR DESCRIPTION
Our various StatefulSet configs had a placeholder `resources.requests` block with guidelines that became outdated with #51471. The guidelines are now updated.

Thanks to @tim-o for pointing this out.

Release note: none