### PR TITLE
kvserver: use messages on NotLeaseholderErrors everywhere

### DIFF
--- a/pkg/kv/kvserver/replica_application_result.go
+++ b/pkg/kv/kvserver/replica_application_result.go
@@ -214,8 +214,8 @@ func (r *Replica) tryReproposeWithNewLeaseIndex(
 			r.mu.state.Lease,
 			r.store.StoreID(),
 			r.mu.state.Desc,
+			"reproposal failed due to closed timestamp",
 		)
-		err.CustomMsg = "reproposal failed due to closed timestamp"
 		return roachpb.NewError(err)
 	}
 	// Some tests check for this log message in the trace.

--- a/pkg/kv/kvserver/replica_application_state_machine.go
+++ b/pkg/kv/kvserver/replica_application_state_machine.go
@@ -261,10 +261,11 @@ func checkForcedErr(
 		// We return a NotLeaseHolderError so that the DistSender retries.
 		// NB: we set proposerStoreID to 0 because we don't know who proposed the
 		// Raft command. This is ok, as this is only used for debug information.
-		nlhe := newNotLeaseHolderError(replicaState.Lease, 0 /* proposerStoreID */, replicaState.Desc)
-		nlhe.CustomMsg = fmt.Sprintf(
-			"stale proposal: command was proposed under lease #%d but is being applied "+
-				"under lease: %s", raftCmd.ProposerLeaseSequence, replicaState.Lease)
+		nlhe := newNotLeaseHolderError(
+			replicaState.Lease, 0 /* proposerStoreID */, replicaState.Desc,
+			fmt.Sprintf(
+				"stale proposal: command was proposed under lease #%d but is being applied "+
+					"under lease: %s", raftCmd.ProposerLeaseSequence, replicaState.Lease))
 		return leaseIndex, proposalNoReevaluation, roachpb.NewError(nlhe)
 	}
 

--- a/pkg/kv/kvserver/replica_write.go
+++ b/pkg/kv/kvserver/replica_write.go
@@ -124,7 +124,8 @@ func (r *Replica) executeWriteBatch(
 	// manager.
 	if curLease, _ := r.GetLease(); curLease.Sequence > st.Lease.Sequence {
 		curLeaseCpy := curLease // avoid letting curLease escape
-		err := newNotLeaseHolderError(&curLeaseCpy, r.store.StoreID(), r.Desc())
+		err := newNotLeaseHolderError(&curLeaseCpy, r.store.StoreID(), r.Desc(),
+			"stale lease discovered before proposing")
 		log.VEventf(ctx, 2, "%s before proposing: %s", err, ba.Summary())
 		return nil, g, roachpb.NewError(err)
 	}

--- a/pkg/roachpb/errors.go
+++ b/pkg/roachpb/errors.go
@@ -407,12 +407,12 @@ func (e *NotLeaseHolderError) Type() ErrorDetailType {
 }
 
 func (e *NotLeaseHolderError) message(_ *Error) string {
-	const prefix = "[NotLeaseHolderError] "
-	if e.CustomMsg != "" {
-		return prefix + e.CustomMsg
-	}
 	var buf strings.Builder
-	buf.WriteString(prefix)
+	buf.WriteString("[NotLeaseHolderError] ")
+	if e.CustomMsg != "" {
+		buf.WriteString(e.CustomMsg)
+		buf.WriteString("; ")
+	}
 	fmt.Fprintf(&buf, "r%d: ", e.RangeID)
 	if e.Replica != (ReplicaDescriptor{}) {
 		fmt.Fprintf(&buf, "replica %s not lease holder; ", e.Replica)


### PR DESCRIPTION
NLHE permits custom messages in it, but the field was rarely used. This
patch makes every instance where we instantiate the error provide a
message, since this error comes from a wide variety of conditions.

Release note: None