### PR TITLE
release-20.2: changefeedccl: support skipping client-side TLS verification of Kafka

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -1891,6 +1891,12 @@ func TestChangefeedErrors(t *testing.T) {
 		`CREATE CHANGEFEED FOR foo INTO 'kafka://nope'`,
 	)
 
+	// Test that a well-formed URI gets as far as unavailable kafka error.
+	sqlDB.ExpectErr(
+		t, `client has run out of available brokers`,
+		`CREATE CHANGEFEED FOR foo INTO 'kafka://nope/?tls_enabled=true&insecure_tls_skip_verify=true'`,
+	)
+
 	// kafka_topic_prefix was referenced by an old version of the RFC, it's
 	// "topic_prefix" now.
 	sqlDB.ExpectErr(
@@ -1908,6 +1914,10 @@ func TestChangefeedErrors(t *testing.T) {
 	sqlDB.ExpectErr(
 		t, `param tls_enabled must be a bool`,
 		`CREATE CHANGEFEED FOR foo INTO $1`, `kafka://nope/?tls_enabled=foo`,
+	)
+	sqlDB.ExpectErr(
+		t, `param insecure_tls_skip_verify must be a bool`,
+		`CREATE CHANGEFEED FOR foo INTO $1`, `kafka://nope/?tls_enabled=true&insecure_tls_skip_verify=foo`,
 	)
 	sqlDB.ExpectErr(
 		t, `param ca_cert must be base 64 encoded`,

--- a/pkg/ccl/changefeedccl/changefeedbase/options.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options.go
@@ -82,6 +82,7 @@ const (
 	SinkParamFileSize         = `file_size`
 	SinkParamSchemaTopic      = `schema_topic`
 	SinkParamTLSEnabled       = `tls_enabled`
+	SinkParamSkipTLSVerify    = `insecure_tls_skip_verify`
 	SinkParamTopicPrefix      = `topic_prefix`
 	SinkSchemeBuffer          = ``
 	SinkSchemeExperimentalSQL = `experimental-sql`


### PR DESCRIPTION
Backport 1/1 commits from #56126.

/cc @cockroachdb/release

---
We currently force anyone authenticating using TLS to verify the response.
This is a blocker for some test integrations because the hosts provide mismatched certs.
This patch enables the insecure_tls_skip_verify param on sink URIs, which maps to
InsecureSkipVerify in our net client.

Release note (enterprise change): The insecure_tls_skip_verify query param may now be set
on changefeed sinks. This disables client-side validation of responses and should
be avoided if possible since it creates man-in-the-middle vulnerabilities.
