### PR TITLE
storage: add MakeEngineIterator and {Put,Clear}EngineKey

### DIFF
--- a/pkg/ccl/storageccl/engineccl/batch_repr.go
+++ b/pkg/ccl/storageccl/engineccl/batch_repr.go
@@ -84,5 +84,5 @@ func VerifyBatchRepr(
 	}
 	defer iter.Close()
 
-	return storage.ComputeStatsGo(iter, start.Key, end.Key, nowNanos)
+	return storage.ComputeStatsForRange(iter, start.Key, end.Key, nowNanos)
 }

--- a/pkg/ccl/storageccl/import.go
+++ b/pkg/ccl/storageccl/import.go
@@ -142,6 +142,8 @@ func evalImport(ctx context.Context, cArgs batcheval.CommandArgs) (*roachpb.Impo
 	}
 	defer cArgs.EvalCtx.GetLimiters().ConcurrentImportRequests.Finish()
 
+	// The sstables only contain MVCC data and no intents, so using an MVCC
+	// iterator is sufficient.
 	var iters []storage.SimpleMVCCIterator
 	for _, file := range args.Files {
 		log.VEventf(ctx, 2, "import file %s %s", file.Path, args.Key)

--- a/pkg/ccl/workloadccl/format/sstable.go
+++ b/pkg/ccl/workloadccl/format/sstable.go
@@ -83,7 +83,7 @@ func ToSSTable(t workload.Table, tableID descpb.ID, ts time.Time) ([]byte, error
 		for kvBatch := range kvCh {
 			for _, kv := range kvBatch.KVs {
 				mvccKey := storage.MVCCKey{Timestamp: sstTS, Key: kv.Key}
-				if err := sw.Put(mvccKey, kv.Value.RawBytes); err != nil {
+				if err := sw.PutMVCC(mvccKey, kv.Value.RawBytes); err != nil {
 					return err
 				}
 			}

--- a/pkg/kv/bulk/sst_batcher.go
+++ b/pkg/kv/bulk/sst_batcher.go
@@ -387,7 +387,7 @@ func AddSSTable(
 
 	var stats enginepb.MVCCStats
 	if (ms == enginepb.MVCCStats{}) {
-		stats, err = storage.ComputeStatsGo(iter, start, end, now.UnixNano())
+		stats, err = storage.ComputeStatsForRange(iter, start, end, now.UnixNano())
 		if err != nil {
 			return 0, errors.Wrapf(err, "computing stats for SST [%s, %s)", start, end)
 		}
@@ -437,7 +437,7 @@ func AddSSTable(
 						return err
 					}
 
-					right.stats, err = storage.ComputeStatsGo(
+					right.stats, err = storage.ComputeStatsForRange(
 						iter, right.start, right.end, now.UnixNano(),
 					)
 					if err != nil {

--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
@@ -392,7 +392,7 @@ func TestAddSSTableMVCCStats(t *testing.T) {
 			beforeStats := func() enginepb.MVCCStats {
 				iter := e.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{UpperBound: roachpb.KeyMax})
 				defer iter.Close()
-				beforeStats, err := storage.ComputeStatsGo(iter, roachpb.KeyMin, roachpb.KeyMax, 10)
+				beforeStats, err := storage.ComputeStatsForRange(iter, roachpb.KeyMin, roachpb.KeyMax, 10)
 				if err != nil {
 					t.Fatalf("%+v", err)
 				}
@@ -443,7 +443,7 @@ func TestAddSSTableMVCCStats(t *testing.T) {
 			afterStats := func() enginepb.MVCCStats {
 				iter := e.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{UpperBound: roachpb.KeyMax})
 				defer iter.Close()
-				afterStats, err := storage.ComputeStatsGo(iter, roachpb.KeyMin, roachpb.KeyMax, 10)
+				afterStats, err := storage.ComputeStatsForRange(iter, roachpb.KeyMin, roachpb.KeyMax, 10)
 				if err != nil {
 					t.Fatalf("%+v", err)
 				}
@@ -526,7 +526,7 @@ func TestAddSSTableDisallowShadowing(t *testing.T) {
 				}
 				defer dataIter.Close()
 
-				stats, err := storage.ComputeStatsGo(dataIter, startKey, endKey, 0)
+				stats, err := storage.ComputeStatsForRange(dataIter, startKey, endKey, 0)
 				if err != nil {
 					t.Fatalf("%+v", err)
 				}

--- a/pkg/kv/kvserver/batcheval/cmd_clear_range.go
+++ b/pkg/kv/kvserver/batcheval/cmd_clear_range.go
@@ -86,15 +86,19 @@ func ClearRange(
 	// instead of using a range tombstone (inefficient for small ranges).
 	if total := statsDelta.Total(); total < ClearRangeBytesThreshold {
 		log.VEventf(ctx, 2, "delta=%d < threshold=%d; using non-range clear", total, ClearRangeBytesThreshold)
-		if err := readWriter.MVCCIterate(from, to, storage.MVCCKeyAndIntentsIterKind, func(kv storage.MVCCKeyValue) error {
-			if kv.Key.Timestamp.IsEmpty() {
-				// It can be an intent or an inline MVCCMetadata -- we have no idea.
-				// TODO(sumeer): cannot clear separated intents in this manner. Write the iteration code
-				// here instead of using Reader.MVCCIterate.
-				return readWriter.ClearUnversioned(kv.Key.Key)
+		iter := readWriter.NewEngineIterator(storage.IterOptions{UpperBound: to})
+		valid, err := iter.SeekEngineKeyGE(storage.EngineKey{Key: from})
+		for ; valid; valid, err = iter.NextEngineKey() {
+			var k storage.EngineKey
+			if k, err = iter.UnsafeEngineKey(); err != nil {
+				break
 			}
-			return readWriter.ClearMVCC(kv.Key)
-		}); err != nil {
+			if err = readWriter.ClearEngineKey(k); err != nil {
+				return result.Result{}, err
+			}
+		}
+		iter.Close()
+		if err != nil {
 			return result.Result{}, err
 		}
 		return pd, nil

--- a/pkg/kv/kvserver/batcheval/cmd_clear_range_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_clear_range_test.go
@@ -33,37 +33,14 @@ type wrappedBatch struct {
 	clearRangeCount int
 }
 
-// TODO(sbhola): narrow the calls where we increment counters to
-// make this test stricter.
-
-func (wb *wrappedBatch) ClearMVCC(key storage.MVCCKey) error {
+func (wb *wrappedBatch) ClearEngineKey(key storage.EngineKey) error {
 	wb.clearCount++
-	return wb.Batch.ClearMVCC(key)
-}
-
-func (wb *wrappedBatch) ClearUnversioned(key roachpb.Key) error {
-	wb.clearCount++
-	return wb.Batch.ClearUnversioned(key)
-}
-
-func (wb *wrappedBatch) ClearIntent(key roachpb.Key) error {
-	wb.clearCount++
-	return wb.Batch.ClearIntent(key)
-}
-
-func (wb *wrappedBatch) ClearRawRange(start, end roachpb.Key) error {
-	wb.clearRangeCount++
-	return wb.Batch.ClearRawRange(start, end)
+	return wb.Batch.ClearEngineKey(key)
 }
 
 func (wb *wrappedBatch) ClearMVCCRangeAndIntents(start, end roachpb.Key) error {
 	wb.clearRangeCount++
 	return wb.Batch.ClearMVCCRangeAndIntents(start, end)
-}
-
-func (wb *wrappedBatch) ClearMVCCRange(start, end storage.MVCCKey) error {
-	wb.clearRangeCount++
-	return wb.Batch.ClearMVCCRange(start, end)
 }
 
 // TestCmdClearRangeBytesThreshold verifies that clear range resorts to

--- a/pkg/kv/kvserver/batcheval/cmd_revert_range_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_revert_range_test.go
@@ -44,7 +44,7 @@ func getStats(t *testing.T, reader storage.Reader) enginepb.MVCCStats {
 	t.Helper()
 	iter := reader.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{UpperBound: roachpb.KeyMax})
 	defer iter.Close()
-	s, err := storage.ComputeStatsGo(iter, roachpb.KeyMin, roachpb.KeyMax, 1100)
+	s, err := storage.ComputeStatsForRange(iter, roachpb.KeyMin, roachpb.KeyMax, 1100)
 	if err != nil {
 		t.Fatalf("%+v", err)
 	}

--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -3118,7 +3118,7 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 		// Construct SST #1 through #3 as numbered above, but only ultimately
 		// keep the 3rd one.
 		keyRanges := rditer.MakeReplicatedKeyRanges(inSnap.State.Desc)
-		it := rditer.NewReplicaDataIterator(inSnap.State.Desc, sendingEng, true /* replicatedOnly */, false /* seekEnd */)
+		it := rditer.NewReplicaEngineDataIterator(inSnap.State.Desc, sendingEng, true /* replicatedOnly */)
 		defer it.Close()
 		// Write a range deletion tombstone to each of the SSTs then put in the
 		// kv entries from the sender of the snapshot.
@@ -3144,7 +3144,7 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 					expectedSSTs = append(expectedSSTs, sstFile.Data())
 					break
 				}
-				if err := sst.Put(it.Key(), it.Value()); err != nil {
+				if err := sst.PutEngineKey(it.Key(), it.Value()); err != nil {
 					return err
 				}
 			}

--- a/pkg/kv/kvserver/consistency_queue_test.go
+++ b/pkg/kv/kvserver/consistency_queue_test.go
@@ -442,7 +442,7 @@ func TestCheckConsistencyInconsistent(t *testing.T) {
 		iter := cpEng.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{UpperBound: []byte("\xff")})
 		defer iter.Close()
 
-		ms, err := storage.ComputeStatsGo(iter, roachpb.KeyMin, roachpb.KeyMax, 0 /* nowNanos */)
+		ms, err := storage.ComputeStatsForRange(iter, roachpb.KeyMin, roachpb.KeyMax, 0 /* nowNanos */)
 		assert.NoError(t, err)
 
 		assert.NotZero(t, ms.KeyBytes)

--- a/pkg/kv/kvserver/debug_print.go
+++ b/pkg/kv/kvserver/debug_print.go
@@ -86,6 +86,7 @@ func tryRangeDescriptor(kv storage.MVCCKeyValue) (string, error) {
 	return descStr(desc), nil
 }
 
+// tryIntent does not look at the key.
 func tryIntent(kv storage.MVCCKeyValue) (string, error) {
 	if len(kv.Value) == 0 {
 		return "", errors.New("empty")
@@ -373,4 +374,21 @@ func (s *stringifyWriteBatch) String() string {
 		return wbStr
 	}
 	return fmt.Sprintf("failed to stringify write batch (%x): %s", s.Data, err)
+}
+
+// PrintEngineKeyValue attempts to print the given key-value pair.
+func PrintEngineKeyValue(k storage.EngineKey, v []byte) {
+	if k.IsMVCCKey() {
+		if key, err := k.ToMVCCKey(); err == nil {
+			PrintKeyValue(storage.MVCCKeyValue{Key: key, Value: v})
+			return
+		}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%s %x (%#x): ", k.Key, k.Version, k.Encode())
+	if out, err := tryIntent(storage.MVCCKeyValue{Value: v}); err == nil {
+		sb.WriteString(out)
+	} else {
+		fmt.Fprintf(&sb, "%x", v)
+	}
 }

--- a/pkg/kv/kvserver/gc/gc_iterator.go
+++ b/pkg/kv/kvserver/gc/gc_iterator.go
@@ -17,10 +17,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
 )
 
-// gcIterator wraps an rditer.ReplicaDataIterator which it reverse iterates for
+// gcIterator wraps an rditer.ReplicaMVCCDataIterator which it reverse iterates for
 // the purpose of discovering gc-able replicated data.
 type gcIterator struct {
-	it   *rditer.ReplicaDataIterator
+	it   *rditer.ReplicaMVCCDataIterator
 	done bool
 	err  error
 	buf  gcIteratorRingBuf
@@ -28,7 +28,7 @@ type gcIterator struct {
 
 func makeGCIterator(desc *roachpb.RangeDescriptor, snap storage.Reader) gcIterator {
 	return gcIterator{
-		it: rditer.NewReplicaDataIterator(desc, snap,
+		it: rditer.NewReplicaMVCCDataIterator(desc, snap,
 			true /* replicatedOnly */, true /* seekEnd */),
 	}
 }

--- a/pkg/kv/kvserver/gc/gc_old_test.go
+++ b/pkg/kv/kvserver/gc/gc_old_test.go
@@ -50,7 +50,7 @@ func runGCOld(
 	cleanupTxnIntentsAsyncFn CleanupTxnIntentsAsyncFunc,
 ) (Info, error) {
 
-	iter := rditer.NewReplicaDataIterator(desc, snap,
+	iter := rditer.NewReplicaMVCCDataIterator(desc, snap,
 		true /* replicatedOnly */, false /* seekEnd */)
 	defer iter.Close()
 

--- a/pkg/kv/kvserver/rditer/replica_data_iter.go
+++ b/pkg/kv/kvserver/rditer/replica_data_iter.go
@@ -17,31 +17,55 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
 )
 
-// KeyRange is a helper struct for the ReplicaDataIterator.
+// KeyRange is a helper struct for the ReplicaMVCCDataIterator and
+// ReplicaEngineDataIterator.
 // TODO(sumeer): change these to roachpb.Key since the timestamp is
-// always empty.
+// always empty and the code below assumes that fact.
 type KeyRange struct {
 	Start, End storage.MVCCKey
 }
 
-// ReplicaDataIterator provides a complete iteration over all key / value
-// rows in a range, including all system-local metadata and user data.
+// ReplicaMVCCDataIterator provides a complete iteration over MVCC or unversioned
+// (which can be made to look like an MVCCKey) key / value
+// rows in a range, including system-local metadata and user data.
 // The ranges keyRange slice specifies the key ranges which comprise
-// all of the range's data.
+// the range's data. This cannot be used to iterate over keys that are not
+// representable as MVCCKeys, except when such non-MVCCKeys are limited to
+// intents, which can be made to look like interleaved MVCCKeys. Most callers
+// want the real keys, and should use ReplicaEngineDataIterator.
 //
-// A ReplicaDataIterator provides a subset of the engine.MVCCIterator interface.
+// A ReplicaMVCCDataIterator provides a subset of the engine.MVCCIterator interface.
 //
-// TODO(tschottdorf): the API is awkward. By default, ReplicaDataIterator uses
+// TODO(tschottdorf): the API is awkward. By default, ReplicaMVCCDataIterator uses
 // a byte allocator which needs to be reset manually using `ResetAllocator`.
 // This is problematic as it requires of every user careful tracking of when
 // to call that method; some just never call it and pull the whole replica
 // into memory. Use of an allocator should be opt-in.
 //
-// TODO(sumeer): Should return EngineKeys, to handle separated lock table.
-type ReplicaDataIterator struct {
+// TODO(sumeer): merge with ReplicaEngineDataIterator. We can use an EngineIterator
+// for MVCC key ranges and convert from EngineKey to MVCCKey.
+type ReplicaMVCCDataIterator struct {
 	curIndex int
 	ranges   []KeyRange
 	it       storage.MVCCIterator
+	a        bufalloc.ByteAllocator
+}
+
+// ReplicaEngineDataIterator is like ReplicaMVCCDataIterator, but iterates
+// using the general EngineKeys. It provides a subset of the engine.EngineIterator
+// interface.
+//
+// TODO(tschottdorf): the API is awkward. By default, ReplicaMVCCDataIterator uses
+// a byte allocator which needs to be reset manually using `ResetAllocator`.
+// This is problematic as it requires of every user careful tracking of when
+// to call that method; some just never call it and pull the whole replica
+// into memory. Use of an allocator should be opt-in.
+type ReplicaEngineDataIterator struct {
+	curIndex int
+	ranges   []KeyRange
+	it       storage.EngineIterator
+	valid    bool
+	err      error
 	a        bufalloc.ByteAllocator
 }
 
@@ -114,18 +138,19 @@ func MakeUserKeyRange(d *roachpb.RangeDescriptor) KeyRange {
 	}
 }
 
-// NewReplicaDataIterator creates a ReplicaDataIterator for the given replica.
-func NewReplicaDataIterator(
+// NewReplicaMVCCDataIterator creates a ReplicaMVCCDataIterator for the given replica.
+// TODO(sumeer): narrow this interface since only gcIterator uses
+// ReplicaMVCCDataIterator.
+func NewReplicaMVCCDataIterator(
 	d *roachpb.RangeDescriptor, reader storage.Reader, replicatedOnly bool, seekEnd bool,
-) *ReplicaDataIterator {
-	// TODO(sumeer): use an EngineIterator.
+) *ReplicaMVCCDataIterator {
 	it := reader.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{UpperBound: d.EndKey.AsRawKey()})
 
 	rangeFunc := MakeAllKeyRanges
 	if replicatedOnly {
 		rangeFunc = MakeReplicatedKeyRanges
 	}
-	ri := &ReplicaDataIterator{
+	ri := &ReplicaMVCCDataIterator{
 		ranges: rangeFunc(d),
 		it:     it,
 	}
@@ -138,27 +163,27 @@ func NewReplicaDataIterator(
 }
 
 // seekStart seeks the iterator to the start of its data range.
-func (ri *ReplicaDataIterator) seekStart() {
+func (ri *ReplicaMVCCDataIterator) seekStart() {
 	ri.curIndex = 0
 	ri.it.SeekGE(ri.ranges[ri.curIndex].Start)
 	ri.advance()
 }
 
 // seekEnd seeks the iterator to the end of its data range.
-func (ri *ReplicaDataIterator) seekEnd() {
+func (ri *ReplicaMVCCDataIterator) seekEnd() {
 	ri.curIndex = len(ri.ranges) - 1
 	ri.it.SeekLT(ri.ranges[ri.curIndex].End)
 	ri.retreat()
 }
 
 // Close the underlying iterator.
-func (ri *ReplicaDataIterator) Close() {
+func (ri *ReplicaMVCCDataIterator) Close() {
 	ri.curIndex = len(ri.ranges)
 	ri.it.Close()
 }
 
 // Next advances to the next key in the iteration.
-func (ri *ReplicaDataIterator) Next() {
+func (ri *ReplicaMVCCDataIterator) Next() {
 	ri.it.Next()
 	ri.advance()
 }
@@ -166,7 +191,7 @@ func (ri *ReplicaDataIterator) Next() {
 // advance moves the iterator forward through the ranges until a valid
 // key is found or the iteration is done and the iterator becomes
 // invalid.
-func (ri *ReplicaDataIterator) advance() {
+func (ri *ReplicaMVCCDataIterator) advance() {
 	for {
 		if ok, _ := ri.Valid(); ok && ri.it.UnsafeKey().Less(ri.ranges[ri.curIndex].End) {
 			return
@@ -181,13 +206,13 @@ func (ri *ReplicaDataIterator) advance() {
 }
 
 // Prev advances the iterator one key backwards.
-func (ri *ReplicaDataIterator) Prev() {
+func (ri *ReplicaMVCCDataIterator) Prev() {
 	ri.it.Prev()
 	ri.retreat()
 }
 
 // retreat is the opposite of advance.
-func (ri *ReplicaDataIterator) retreat() {
+func (ri *ReplicaMVCCDataIterator) retreat() {
 	for {
 		if ok, _ := ri.Valid(); ok && ri.ranges[ri.curIndex].Start.Less(ri.it.UnsafeKey()) {
 			return
@@ -202,21 +227,21 @@ func (ri *ReplicaDataIterator) retreat() {
 }
 
 // Valid returns true if the iterator currently points to a valid value.
-func (ri *ReplicaDataIterator) Valid() (bool, error) {
+func (ri *ReplicaMVCCDataIterator) Valid() (bool, error) {
 	ok, err := ri.it.Valid()
 	ok = ok && ri.curIndex >= 0 && ri.curIndex < len(ri.ranges)
 	return ok, err
 }
 
 // Key returns the current key.
-func (ri *ReplicaDataIterator) Key() storage.MVCCKey {
+func (ri *ReplicaMVCCDataIterator) Key() storage.MVCCKey {
 	key := ri.it.UnsafeKey()
 	ri.a, key.Key = ri.a.Copy(key.Key, 0)
 	return key
 }
 
 // Value returns the current value.
-func (ri *ReplicaDataIterator) Value() []byte {
+func (ri *ReplicaMVCCDataIterator) Value() []byte {
 	value := ri.it.UnsafeValue()
 	ri.a, value = ri.a.Copy(value, 0)
 	return value
@@ -224,17 +249,118 @@ func (ri *ReplicaDataIterator) Value() []byte {
 
 // UnsafeKey returns the same value as Key, but the memory is invalidated on
 // the next call to {Next,Prev,Close}.
-func (ri *ReplicaDataIterator) UnsafeKey() storage.MVCCKey {
+func (ri *ReplicaMVCCDataIterator) UnsafeKey() storage.MVCCKey {
 	return ri.it.UnsafeKey()
 }
 
 // UnsafeValue returns the same value as Value, but the memory is invalidated on
 // the next call to {Next,Prev,Close}.
-func (ri *ReplicaDataIterator) UnsafeValue() []byte {
+func (ri *ReplicaMVCCDataIterator) UnsafeValue() []byte {
 	return ri.it.UnsafeValue()
 }
 
-// ResetAllocator resets the ReplicaDataIterator's internal byte allocator.
-func (ri *ReplicaDataIterator) ResetAllocator() {
+// ResetAllocator resets the ReplicaMVCCDataIterator's internal byte allocator.
+func (ri *ReplicaMVCCDataIterator) ResetAllocator() {
 	ri.a = nil
+}
+
+// NewReplicaEngineDataIterator creates a ReplicaEngineDataIterator for the given replica.
+func NewReplicaEngineDataIterator(
+	d *roachpb.RangeDescriptor, reader storage.Reader, replicatedOnly bool,
+) *ReplicaEngineDataIterator {
+	it := reader.NewEngineIterator(storage.IterOptions{UpperBound: d.EndKey.AsRawKey()})
+
+	rangeFunc := MakeAllKeyRanges
+	if replicatedOnly {
+		rangeFunc = MakeReplicatedKeyRanges
+	}
+	ri := &ReplicaEngineDataIterator{
+		ranges: rangeFunc(d),
+		it:     it,
+	}
+	ri.seekStart()
+	return ri
+}
+
+// seekStart seeks the iterator to the start of its data range.
+func (ri *ReplicaEngineDataIterator) seekStart() {
+	ri.curIndex = 0
+	ri.valid, ri.err = ri.it.SeekEngineKeyGE(storage.EngineKey{Key: ri.ranges[ri.curIndex].Start.Key})
+	ri.advance()
+}
+
+// Close the underlying iterator.
+func (ri *ReplicaEngineDataIterator) Close() {
+	ri.valid = false
+	ri.it.Close()
+}
+
+// Next advances to the next key in the iteration.
+func (ri *ReplicaEngineDataIterator) Next() {
+	ri.valid, ri.err = ri.it.NextEngineKey()
+	ri.advance()
+}
+
+// advance moves the iterator forward through the ranges until a valid
+// key is found or the iteration is done and the iterator becomes
+// invalid.
+func (ri *ReplicaEngineDataIterator) advance() {
+	for ri.valid {
+		var k storage.EngineKey
+		k, ri.err = ri.it.UnsafeEngineKey()
+		if ri.err != nil {
+			ri.valid = false
+			return
+		}
+		if k.Key.Compare(ri.ranges[ri.curIndex].End.Key) < 0 {
+			return
+		}
+		ri.curIndex++
+		if ri.curIndex < len(ri.ranges) {
+			ri.valid, ri.err = ri.it.SeekEngineKeyGE(
+				storage.EngineKey{Key: ri.ranges[ri.curIndex].Start.Key})
+		} else {
+			ri.valid = false
+			return
+		}
+	}
+}
+
+// Valid returns true if the iterator currently points to a valid value.
+func (ri *ReplicaEngineDataIterator) Valid() (bool, error) {
+	return ri.valid, ri.err
+}
+
+// Key returns the current key.
+// TODO(sumeer): only used in tests. Remove method and allocator.
+func (ri *ReplicaEngineDataIterator) Key() storage.EngineKey {
+	key := ri.UnsafeKey()
+	key, ri.a = key.CopyUsingAlloc(ri.a)
+	return key
+}
+
+// Value returns the current value.
+// TODO(sumeer): only used in tests. Remove method and allocator.
+func (ri *ReplicaEngineDataIterator) Value() []byte {
+	value := ri.it.UnsafeValue()
+	ri.a, value = ri.a.Copy(value, 0)
+	return value
+}
+
+// UnsafeKey returns the same value as Key, but the memory is invalidated on
+// the next call to {Next,Close}.
+func (ri *ReplicaEngineDataIterator) UnsafeKey() storage.EngineKey {
+	key, err := ri.it.UnsafeEngineKey()
+	if err != nil {
+		// If Valid(), we've already extracted an EngineKey earlier,
+		// when doing the key comparison, so this will not happen.
+		panic("method called on an invalid iter")
+	}
+	return key
+}
+
+// UnsafeValue returns the same value as Value, but the memory is invalidated on
+// the next call to {Next,Close}.
+func (ri *ReplicaEngineDataIterator) UnsafeValue() []byte {
+	return ri.it.UnsafeValue()
 }

--- a/pkg/kv/kvserver/rditer/replica_data_iter_test.go
+++ b/pkg/kv/kvserver/rditer/replica_data_iter_test.go
@@ -138,7 +138,7 @@ func verifyRDIter(
 			}, hlc.Timestamp{WallTime: 42})
 			readWriter = spanset.NewReadWriterAt(readWriter, &spans, hlc.Timestamp{WallTime: 42})
 		}
-		iter := NewReplicaDataIterator(desc, readWriter, replicatedOnly, reverse /* seekEnd */)
+		iter := NewReplicaMVCCDataIterator(desc, readWriter, replicatedOnly, reverse /* seekEnd */)
 		defer iter.Close()
 		i := 0
 		if reverse {
@@ -237,7 +237,7 @@ func TestReplicaDataIterator(t *testing.T) {
 
 	// Verify that the replicated-only iterator ignores unreplicated keys.
 	unreplicatedPrefix := keys.MakeRangeIDUnreplicatedPrefix(desc.RangeID)
-	iter := NewReplicaDataIterator(&desc, eng,
+	iter := NewReplicaMVCCDataIterator(&desc, eng,
 		true /* replicatedOnly */, false /* seekEnd */)
 	defer iter.Close()
 	for ; ; iter.Next() {

--- a/pkg/kv/kvserver/replica_consistency.go
+++ b/pkg/kv/kvserver/replica_consistency.go
@@ -633,13 +633,13 @@ func (r *Replica) sha512(
 	// all of the replicated key space.
 	if !statsOnly {
 		// TODO(sumeer): remember that this caller of MakeReplicatedKeyRanges does
-		// not want the lock table ranges since it has already considered the
-		// intents earlier in this function. By the time we have replicated locks
+		// not want the lock table ranges since the iter has been constructed using
+		// MVCCKeyAndIntentsIterKind. By the time we have replicated locks
 		// other than exclusive locks, we will probably not have any interleaved
-		// intents so we could stop using MVCCKeyAndIntentsIterKind above and
+		// intents so we could stop using MVCCKeyAndIntentsIterKind and
 		// consider all locks here.
 		for _, span := range rditer.MakeReplicatedKeyRanges(&desc) {
-			spanMS, err := storage.ComputeStatsGo(
+			spanMS, err := storage.ComputeStatsForRange(
 				iter, span.Start.Key, span.End.Key, 0 /* nowNanos */, visitor,
 			)
 			if err != nil {

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -6998,8 +6998,8 @@ func TestReplicaDestroy(t *testing.T) {
 		}
 	}()
 
-	iter := rditer.NewReplicaDataIterator(tc.repl.Desc(), tc.repl.store.Engine(),
-		false /* replicatedOnly */, false /* seekEnd */)
+	iter := rditer.NewReplicaEngineDataIterator(tc.repl.Desc(), tc.repl.store.Engine(),
+		false /* replicatedOnly */)
 	defer iter.Close()
 	if ok, err := iter.Valid(); err != nil {
 		t.Fatal(err)

--- a/pkg/kv/kvserver/spanset/batch.go
+++ b/pkg/kv/kvserver/spanset/batch.go
@@ -18,7 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 )
 
-// MVCCIterator wraps an engine.MVCCIterator and ensures that it can
+// MVCCIterator wraps an storage.MVCCIterator and ensures that it can
 // only be used to access spans in a SpanSet.
 type MVCCIterator struct {
 	i     storage.MVCCIterator
@@ -55,17 +55,17 @@ func NewIteratorAt(iter storage.MVCCIterator, spans *SpanSet, ts hlc.Timestamp) 
 	return &MVCCIterator{i: iter, spans: spans, ts: ts}
 }
 
-// Close is part of the engine.MVCCIterator interface.
+// Close is part of the storage.MVCCIterator interface.
 func (i *MVCCIterator) Close() {
 	i.i.Close()
 }
 
-// Iterator returns the underlying engine.MVCCIterator.
+// Iterator returns the underlying storage.MVCCIterator.
 func (i *MVCCIterator) Iterator() storage.MVCCIterator {
 	return i.i
 }
 
-// Valid is part of the engine.MVCCIterator interface.
+// Valid is part of the storage.MVCCIterator interface.
 func (i *MVCCIterator) Valid() (bool, error) {
 	if i.err != nil {
 		return false, i.err
@@ -77,13 +77,13 @@ func (i *MVCCIterator) Valid() (bool, error) {
 	return ok && !i.invalid, nil
 }
 
-// SeekGE is part of the engine.MVCCIterator interface.
+// SeekGE is part of the storage.MVCCIterator interface.
 func (i *MVCCIterator) SeekGE(key storage.MVCCKey) {
 	i.i.SeekGE(key)
 	i.checkAllowed(roachpb.Span{Key: key.Key}, true)
 }
 
-// SeekLT is part of the engine.MVCCIterator interface.
+// SeekLT is part of the storage.MVCCIterator interface.
 func (i *MVCCIterator) SeekLT(key storage.MVCCKey) {
 	i.i.SeekLT(key)
 	// CheckAllowed{At} supports the span representation of [,key), which
@@ -91,19 +91,19 @@ func (i *MVCCIterator) SeekLT(key storage.MVCCKey) {
 	i.checkAllowed(roachpb.Span{EndKey: key.Key}, true)
 }
 
-// Next is part of the engine.MVCCIterator interface.
+// Next is part of the storage.MVCCIterator interface.
 func (i *MVCCIterator) Next() {
 	i.i.Next()
 	i.checkAllowed(roachpb.Span{Key: i.UnsafeKey().Key}, false)
 }
 
-// Prev is part of the engine.MVCCIterator interface.
+// Prev is part of the storage.MVCCIterator interface.
 func (i *MVCCIterator) Prev() {
 	i.i.Prev()
 	i.checkAllowed(roachpb.Span{Key: i.UnsafeKey().Key}, false)
 }
 
-// NextKey is part of the engine.MVCCIterator interface.
+// NextKey is part of the storage.MVCCIterator interface.
 func (i *MVCCIterator) NextKey() {
 	i.i.NextKey()
 	i.checkAllowed(roachpb.Span{Key: i.UnsafeKey().Key}, false)
@@ -131,37 +131,37 @@ func (i *MVCCIterator) checkAllowed(span roachpb.Span, errIfDisallowed bool) {
 	}
 }
 
-// Key is part of the engine.MVCCIterator interface.
+// Key is part of the storage.MVCCIterator interface.
 func (i *MVCCIterator) Key() storage.MVCCKey {
 	return i.i.Key()
 }
 
-// Value is part of the engine.MVCCIterator interface.
+// Value is part of the storage.MVCCIterator interface.
 func (i *MVCCIterator) Value() []byte {
 	return i.i.Value()
 }
 
-// ValueProto is part of the engine.MVCCIterator interface.
+// ValueProto is part of the storage.MVCCIterator interface.
 func (i *MVCCIterator) ValueProto(msg protoutil.Message) error {
 	return i.i.ValueProto(msg)
 }
 
-// UnsafeKey is part of the engine.MVCCIterator interface.
+// UnsafeKey is part of the storage.MVCCIterator interface.
 func (i *MVCCIterator) UnsafeKey() storage.MVCCKey {
 	return i.i.UnsafeKey()
 }
 
-// UnsafeRawKey is part of the engine.MVCCIterator interface.
+// UnsafeRawKey is part of the storage.MVCCIterator interface.
 func (i *MVCCIterator) UnsafeRawKey() []byte {
 	return i.i.UnsafeRawKey()
 }
 
-// UnsafeValue is part of the engine.MVCCIterator interface.
+// UnsafeValue is part of the storage.MVCCIterator interface.
 func (i *MVCCIterator) UnsafeValue() []byte {
 	return i.i.UnsafeValue()
 }
 
-// ComputeStats is part of the engine.MVCCIterator interface.
+// ComputeStats is part of the storage.MVCCIterator interface.
 func (i *MVCCIterator) ComputeStats(
 	start, end roachpb.Key, nowNanos int64,
 ) (enginepb.MVCCStats, error) {
@@ -177,7 +177,7 @@ func (i *MVCCIterator) ComputeStats(
 	return i.i.ComputeStats(start, end, nowNanos)
 }
 
-// FindSplitKey is part of the engine.MVCCIterator interface.
+// FindSplitKey is part of the storage.MVCCIterator interface.
 func (i *MVCCIterator) FindSplitKey(
 	start, end, minSplitKey roachpb.Key, targetSize int64,
 ) (storage.MVCCKey, error) {
@@ -193,26 +193,117 @@ func (i *MVCCIterator) FindSplitKey(
 	return i.i.FindSplitKey(start, end, minSplitKey, targetSize)
 }
 
-// CheckForKeyCollisions is part of the engine.MVCCIterator interface.
+// CheckForKeyCollisions is part of the storage.MVCCIterator interface.
 func (i *MVCCIterator) CheckForKeyCollisions(
 	sstData []byte, start, end roachpb.Key,
 ) (enginepb.MVCCStats, error) {
 	return i.i.CheckForKeyCollisions(sstData, start, end)
 }
 
-// SetUpperBound is part of the engine.MVCCIterator interface.
+// SetUpperBound is part of the storage.MVCCIterator interface.
 func (i *MVCCIterator) SetUpperBound(key roachpb.Key) {
 	i.i.SetUpperBound(key)
 }
 
-// Stats is part of the engine.MVCCIterator interface.
+// Stats is part of the storage.MVCCIterator interface.
 func (i *MVCCIterator) Stats() storage.IteratorStats {
 	return i.i.Stats()
 }
 
-// SupportsPrev is part of the engine.MVCCIterator interface.
+// SupportsPrev is part of the storage.MVCCIterator interface.
 func (i *MVCCIterator) SupportsPrev() bool {
 	return i.i.SupportsPrev()
+}
+
+// EngineIterator wraps a storage.EngineIterator and ensures that it can
+// only be used to access spans in a SpanSet.
+type EngineIterator struct {
+	i     storage.EngineIterator
+	spans *SpanSet
+}
+
+// Close is part of the storage.EngineIterator interface.
+func (i *EngineIterator) Close() {
+	i.i.Close()
+}
+
+// SeekEngineKeyGE is part of the storage.EngineIterator interface.
+func (i *EngineIterator) SeekEngineKeyGE(key storage.EngineKey) (valid bool, err error) {
+	valid, err = i.i.SeekEngineKeyGE(key)
+	if !valid {
+		return valid, err
+	}
+	if err = i.spans.CheckAllowed(SpanReadOnly, roachpb.Span{Key: key.Key}); err != nil {
+		return false, err
+	}
+	return valid, err
+}
+
+// SeekEngineKeyLT is part of the storage.EngineIterator interface.
+func (i *EngineIterator) SeekEngineKeyLT(key storage.EngineKey) (valid bool, err error) {
+	valid, err = i.i.SeekEngineKeyLT(key)
+	if !valid {
+		return valid, err
+	}
+	if err = i.spans.CheckAllowed(SpanReadOnly, roachpb.Span{EndKey: key.Key}); err != nil {
+		return false, err
+	}
+	return valid, err
+}
+
+// NextEngineKey is part of the storage.EngineIterator interface.
+func (i *EngineIterator) NextEngineKey() (valid bool, err error) {
+	valid, err = i.i.NextEngineKey()
+	if !valid {
+		return valid, err
+	}
+	return i.checkKeyAllowed()
+}
+
+// PrevEngineKey is part of the storage.EngineIterator interface.
+func (i *EngineIterator) PrevEngineKey() (valid bool, err error) {
+	valid, err = i.i.PrevEngineKey()
+	if !valid {
+		return valid, err
+	}
+	return i.checkKeyAllowed()
+}
+
+func (i *EngineIterator) checkKeyAllowed() (valid bool, err error) {
+	key, err := i.i.UnsafeEngineKey()
+	if err != nil {
+		return false, err
+	}
+	if err = i.spans.CheckAllowed(SpanReadOnly, roachpb.Span{Key: key.Key}); err != nil {
+		// Invalid, but no error.
+		return false, nil // nolint:returnerrcheck
+	}
+	return true, nil
+}
+
+// UnsafeEngineKey is part of the storage.EngineIterator interface.
+func (i *EngineIterator) UnsafeEngineKey() (storage.EngineKey, error) {
+	return i.i.UnsafeEngineKey()
+}
+
+// UnsafeValue is part of the storage.EngineIterator interface.
+func (i *EngineIterator) UnsafeValue() []byte {
+	return i.i.UnsafeValue()
+}
+
+// EngineKey is part of the storage.EngineIterator interface.
+func (i *EngineIterator) EngineKey() (storage.EngineKey, error) {
+	return i.i.EngineKey()
+}
+
+// Value is part of the storage.EngineIterator interface.
+func (i *EngineIterator) Value() []byte {
+	return i.i.Value()
+}
+
+// SetUpperBound is part of the storage.EngineIterator interface.
+func (i *EngineIterator) SetUpperBound(key roachpb.Key) {
+	i.i.SetUpperBound(key)
 }
 
 type spanSetReader struct {
@@ -298,6 +389,16 @@ func (s spanSetReader) NewMVCCIterator(
 	return NewIteratorAt(s.r.NewMVCCIterator(iterKind, opts), s.spans, s.ts)
 }
 
+func (s spanSetReader) NewEngineIterator(opts storage.IterOptions) storage.EngineIterator {
+	if !s.spansOnly {
+		panic("cannot do timestamp checking for EngineIterator")
+	}
+	return &EngineIterator{
+		i:     s.r.NewEngineIterator(opts),
+		spans: s.spans,
+	}
+}
+
 // GetDBEngine recursively searches for the underlying rocksDB engine.
 func GetDBEngine(reader storage.Reader, span roachpb.Span) storage.Reader {
 	switch v := reader.(type) {
@@ -367,6 +468,16 @@ func (s spanSetWriter) ClearIntent(key roachpb.Key) error {
 		return err
 	}
 	return s.w.ClearIntent(key)
+}
+
+func (s spanSetWriter) ClearEngineKey(key storage.EngineKey) error {
+	if !s.spansOnly {
+		panic("cannot do timestamp checking for clearing EngineKey")
+	}
+	if err := s.spans.CheckAllowed(SpanReadWrite, roachpb.Span{Key: key.Key}); err != nil {
+		return err
+	}
+	return s.w.ClearEngineKey(key)
 }
 
 func (s spanSetWriter) checkAllowedRange(start, end roachpb.Key) error {
@@ -444,6 +555,16 @@ func (s spanSetWriter) PutIntent(key roachpb.Key, value []byte) error {
 	return s.w.PutIntent(key, value)
 }
 
+func (s spanSetWriter) PutEngineKey(key storage.EngineKey, value []byte) error {
+	if !s.spansOnly {
+		panic("cannot do timestamp checking for putting EngineKey")
+	}
+	if err := s.spans.CheckAllowed(SpanReadWrite, roachpb.Span{Key: key.Key}); err != nil {
+		return err
+	}
+	return s.w.PutEngineKey(key, value)
+}
+
 func (s spanSetWriter) LogData(data []byte) error {
 	return s.w.LogData(data)
 }
@@ -500,8 +621,8 @@ type spanSetBatch struct {
 
 var _ storage.Batch = spanSetBatch{}
 
-func (s spanSetBatch) SingleClearEngine(key storage.EngineKey) error {
-	return s.b.SingleClearEngine(key)
+func (s spanSetBatch) SingleClearEngineKey(key storage.EngineKey) error {
+	return s.b.SingleClearEngineKey(key)
 }
 
 func (s spanSetBatch) Commit(sync bool) error {

--- a/pkg/kv/kvserver/stateloader/stateloader.go
+++ b/pkg/kv/kvserver/stateloader/stateloader.go
@@ -290,7 +290,7 @@ func (rsl StateLoader) SetRangeAppliedState(
 		RangeStats:        newMS.ToPersistentStats(),
 	}
 	// The RangeAppliedStateKey is not included in stats. This is also reflected
-	// in C.MVCCComputeStats and ComputeStatsGo.
+	// in C.MVCCComputeStats and ComputeStatsForRange.
 	ms := (*enginepb.MVCCStats)(nil)
 	return storage.MVCCPutProto(ctx, readWriter, ms, rsl.RangeAppliedStateKey(), hlc.Timestamp{}, nil, &as)
 }
@@ -400,7 +400,7 @@ func (rsl StateLoader) writeLegacyMVCCStatsInternal(
 	// enlarges the size of the struct itself. This is mostly fine - we persist
 	// MVCCStats under the RangeAppliedState key and don't account for the size of
 	// the MVCCStats struct itself when doing so (we ignore the RangeAppliedState key
-	// in ComputeStatsGo). This would not therefore not cause replica state divergence
+	// in ComputeStatsForRange). This would not therefore not cause replica state divergence
 	// in mixed version clusters (the enlarged struct does not contribute to a
 	// persisted stats difference on disk because we're not accounting for the size of
 	// the struct itself).

--- a/pkg/storage/batch.go
+++ b/pkg/storage/batch.go
@@ -275,6 +275,15 @@ func (r *RocksDBBatchReader) MVCCKey() (MVCCKey, error) {
 	return decodeMVCCKey(r.Key())
 }
 
+// EngineKey returns the EngineKey for the current batch entry.
+func (r *RocksDBBatchReader) EngineKey() (EngineKey, error) {
+	key, ok := DecodeEngineKey(r.Key())
+	if !ok {
+		return key, errors.Errorf("invalid encoded engine key: %x", r.Key())
+	}
+	return key, nil
+}
+
 // Value returns the value of the current batch entry. Value panics if the
 // BatchType is BatchTypeDeleted.
 func (r *RocksDBBatchReader) Value() []byte {

--- a/pkg/storage/batch_test.go
+++ b/pkg/storage/batch_test.go
@@ -98,7 +98,7 @@ func testBatchBasics(t *testing.T, writeOnly bool, commit func(e Engine, b Batch
 			if err := e.PutUnversioned(mvccKey("d").Key, []byte("before")); err != nil {
 				t.Fatal(err)
 			}
-			if err := b.SingleClearEngine(EngineKey{Key: mvccKey("d").Key}); err != nil {
+			if err := b.SingleClearEngineKey(EngineKey{Key: mvccKey("d").Key}); err != nil {
 				t.Fatal(err)
 			}
 
@@ -451,7 +451,7 @@ func TestBatchGet(t *testing.T) {
 			if err := b.PutUnversioned(mvccKey("d").Key, []byte("before")); err != nil {
 				t.Fatal(err)
 			}
-			if err := b.SingleClearEngine(EngineKey{Key: mvccKey("d").Key}); err != nil {
+			if err := b.SingleClearEngineKey(EngineKey{Key: mvccKey("d").Key}); err != nil {
 				t.Fatal(err)
 			}
 			if err := b.PutUnversioned(mvccKey("d").Key, []byte("after")); err != nil {
@@ -1010,7 +1010,7 @@ func TestBatchDistinctPanics(t *testing.T) {
 				func() { _ = batch.PutUnversioned(a.Key, nil) },
 				func() { _ = batch.Merge(a, nil) },
 				func() { _ = batch.ClearUnversioned(a.Key) },
-				func() { _ = batch.SingleClearEngine(EngineKey{Key: a.Key}) },
+				func() { _ = batch.SingleClearEngineKey(EngineKey{Key: a.Key}) },
 				func() { _ = batch.ApplyBatchRepr(nil, false) },
 				func() { _, _ = batch.MVCCGet(a) },
 				func() { _, _, _, _ = batch.MVCCGetProto(a, nil) },

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -136,35 +136,39 @@ type MVCCIterator interface {
 
 // EngineIterator is an iterator over key-value pairs where the key is
 // an EngineKey.
-//lint:ignore U1001 unused
 type EngineIterator interface {
 	// Close frees up resources held by the iterator.
 	Close()
-	// SeekGE advances the iterator to the first key in the engine which
-	// is >= the provided key.
-	SeekGE(key EngineKey) (valid bool, err error)
-	// SeekLT advances the iterator to the first key in the engine which
-	// is < the provided key.
-	SeekLT(key EngineKey) (valid bool, err error)
-	// Next advances the iterator to the next key/value in the
-	// iteration. After this call, valid will be true if the
-	// iterator was not originally positioned at the last key.
-	Next() (valid bool, err error)
-	// Prev moves the iterator backward to the previous key/value
-	// in the iteration. After this call, valid will be true if the
-	// iterator was not originally positioned at the first key.
-	Prev() (valid bool, err error)
-	// UnsafeKey returns the same value as Key, but the memory is invalidated on
-	// the next call to {Next,NextKey,Prev,SeekGE,SeekLT,Close}.
+	// SeekEngineKeyGE advances the iterator to the first key in the engine
+	// which is >= the provided key.
+	SeekEngineKeyGE(key EngineKey) (valid bool, err error)
+	// SeekEngineKeyLT advances the iterator to the first key in the engine
+	// which is < the provided key.
+	SeekEngineKeyLT(key EngineKey) (valid bool, err error)
+	// NextEngineKey advances the iterator to the next key/value in the
+	// iteration. After this call, valid will be true if the iterator was not
+	// originally positioned at the last key. Note that unlike
+	// MVCCIterator.NextKey, this method does not skip other versions with the
+	// same EngineKey.Key.
+	// TODO(sumeer): change MVCCIterator.Next() to match the
+	// return values, change all its callers, and rename this
+	// to Next().
+	NextEngineKey() (valid bool, err error)
+	// PrevEngineKey moves the iterator backward to the previous key/value in
+	// the iteration. After this call, valid will be true if the iterator was
+	// not originally positioned at the first key.
+	PrevEngineKey() (valid bool, err error)
+	// UnsafeEngineKey returns the same value as Key, but the memory is
+	// invalidated on the next call to {Next,NextKey,Prev,SeekGE,SeekLT,Close}.
 	// REQUIRES: latest positioning function returned valid=true.
-	UnsafeKey() EngineKey
+	UnsafeEngineKey() (EngineKey, error)
 	// UnsafeValue returns the same value as Value, but the memory is
 	// invalidated on the next call to {Next,NextKey,Prev,SeekGE,SeekLT,Close}.
 	// REQUIRES: latest positioning function returned valid=true.
 	UnsafeValue() []byte
-	// Key returns the current key.
+	// EngineKey returns the current key.
 	// REQUIRES: latest positioning function returned valid=true.
-	Key() EngineKey
+	EngineKey() (EngineKey, error)
 	// Value returns the current value as a byte slice.
 	// REQUIRES: latest positioning function returned valid=true.
 	Value() []byte
@@ -288,6 +292,10 @@ type Reader interface {
 	// engine. The caller must invoke MVCCIterator.Close() when finished
 	// with the iterator to free resources.
 	NewMVCCIterator(iterKind MVCCIterKind, opts IterOptions) MVCCIterator
+	// NewEngineIterator returns a new instance of an EngineIterator over this
+	// engine. The caller must invoke EngineIterator.Close() when finished
+	// with the iterator to free resources.
+	NewEngineIterator(opts IterOptions) EngineIterator
 }
 
 // Writer is the write interface to an engine's data.
@@ -325,6 +333,13 @@ type Writer interface {
 	//
 	// It is safe to modify the contents of the arguments after it returns.
 	ClearIntent(key roachpb.Key) error
+	// ClearEngineKey removes the item from the db with the given EngineKey.
+	// Note that clear actually removes entries from the storage engine. This is
+	// a general-purpose and low-level method that should be used sparingly,
+	// only when the other Clear* methods are not applicable.
+	//
+	// It is safe to modify the contents of the arguments after it returns.
+	ClearEngineKey(key EngineKey) error
 
 	// ClearRawRange removes a set of entries, from start (inclusive) to end
 	// (exclusive). It can be applied to a range consisting of MVCCKeys or the
@@ -410,6 +425,12 @@ type Writer interface {
 	//
 	// It is safe to modify the contents of the arguments after Put returns.
 	PutIntent(key roachpb.Key, value []byte) error
+	// PutEngineKey sets the given key to the value provided. This is a
+	// general-purpose and low-level method that should be used sparingly,
+	// only when the other Put* methods are not applicable.
+	//
+	// It is safe to modify the contents of the arguments after Put returns.
+	PutEngineKey(key EngineKey, value []byte) error
 
 	// LogData adds the specified data to the RocksDB WAL. The data is
 	// uninterpreted by RocksDB (i.e. not added to the memtable or sstables).
@@ -535,7 +556,7 @@ type Engine interface {
 // Batch is the interface for batch specific operations.
 type Batch interface {
 	ReadWriter
-	// SingleClearEngine removes the most recent write to the item from the db
+	// SingleClearEngineKey removes the most recent write to the item from the db
 	// with the given key. Whether older writes of the item will come back
 	// to life if not also removed with SingleClear is undefined. See the
 	// following:
@@ -549,7 +570,7 @@ type Batch interface {
 	// TODO(sumeer): try to remove it from this exported interface.
 	//
 	// It is safe to modify the contents of the arguments after it returns.
-	SingleClearEngine(key EngineKey) error
+	SingleClearEngineKey(key EngineKey) error
 	// Commit atomically applies any batched updates to the underlying
 	// engine. This is a noop unless the batch was created via NewBatch(). If
 	// sync is true, the batch is synchronously committed to disk.
@@ -720,10 +741,11 @@ func WriteSyncNoop(ctx context.Context, eng Engine) error {
 }
 
 // ClearRangeWithHeuristic clears the keys from start (inclusive) to end
-// (exclusive). Depending on the number of keys, it will either use ClearRange
-// or ClearIterRange.
+// (exclusive). Depending on the number of keys, it will either use ClearRawRange
+// or clear individual keys. It works with EngineKeys, so don't expect it to
+// find and clear separated intents if [start, end) refers to MVCC key space.
 func ClearRangeWithHeuristic(reader Reader, writer Writer, start, end roachpb.Key) error {
-	iter := reader.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{UpperBound: end})
+	iter := reader.NewEngineIterator(IterOptions{UpperBound: end})
 	defer iter.Close()
 
 	// It is expensive for there to be many range deletion tombstones in the same
@@ -731,43 +753,45 @@ func ClearRangeWithHeuristic(reader Reader, writer Writer, start, end roachpb.Ke
 	// sstable is accessed. So we avoid using range deletion unless there is some
 	// minimum number of keys. The value here was pulled out of thin air. It might
 	// be better to make this dependent on the size of the data being deleted. Or
-	// perhaps we should fix RocksDB to handle large numbers of tombstones in an
+	// perhaps we should fix Pebble to handle large numbers of tombstones in an
 	// sstable better. Note that we are referring to storage-level tombstones here,
 	// and not MVCC tombstones.
 	const clearRangeMinKeys = 64
 	// Peek into the range to see whether it's large enough to justify
-	// ClearRange. Note that the work done here is bounded by
+	// ClearRawRange. Note that the work done here is bounded by
 	// clearRangeMinKeys, so it will be fairly cheap even for large
 	// ranges.
 	//
-	// TODO(bdarnell): Move this into ClearIterRange so we don't have
-	// to do this scan twice.
+	// TODO(sumeer): Could add the iterated keys to the batch, so we don't have
+	// to do the scan again. If there are too many keys, this will mean a mix of
+	// point tombstones and range tombstone.
 	count := 0
-	iter.SeekGE(MakeMVCCMetadataKey(start))
-	for {
-		valid, err := iter.Valid()
-		if err != nil {
-			return err
-		}
-		if !valid {
-			break
-		}
+	valid, err := iter.SeekEngineKeyGE(EngineKey{Key: start})
+	for valid {
 		count++
 		if count > clearRangeMinKeys {
 			break
 		}
-		iter.Next()
-	}
-	var err error
-	if count > clearRangeMinKeys {
-		err = writer.ClearRawRange(start, end)
-	} else {
-		err = writer.ClearIterRange(iter, start, end)
+		valid, err = iter.NextEngineKey()
 	}
 	if err != nil {
 		return err
 	}
-	return nil
+	if count > clearRangeMinKeys {
+		return writer.ClearRawRange(start, end)
+	}
+	valid, err = iter.SeekEngineKeyGE(EngineKey{Key: start})
+	for valid {
+		var k EngineKey
+		if k, err = iter.UnsafeEngineKey(); err != nil {
+			break
+		}
+		if err = writer.ClearEngineKey(k); err != nil {
+			break
+		}
+		valid, err = iter.NextEngineKey()
+	}
+	return err
 }
 
 var ingestDelayL0Threshold = settings.RegisterIntSetting(

--- a/pkg/storage/engine_key.go
+++ b/pkg/storage/engine_key.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 )
@@ -51,7 +52,7 @@ func (k EngineKey) Format(f fmt.State, c rune) {
 }
 
 // Encoding:
-// Key + \x00 (sentinel) [+ Version + <byte representing length of Version>]
+// Key + \x00 (sentinel) [+ Version + <byte representing length of Version + 1>]
 //
 // The motivation for the sentinel is that we configure the underlying storage
 // engine (Pebble) with a Split function that can be used for constructing
@@ -62,6 +63,32 @@ const (
 	sentinelLen            = 1
 	suffixEncodedLengthLen = 1
 )
+
+// Copy makes a copy of the key.
+func (k EngineKey) Copy() EngineKey {
+	buf := make([]byte, len(k.Key)+len(k.Version))
+	return k.copyUsingSizedBuf(buf)
+}
+
+// CopyUsingAlloc makes a copy of the key using the given allocator.
+func (k EngineKey) CopyUsingAlloc(
+	alloc bufalloc.ByteAllocator,
+) (EngineKey, bufalloc.ByteAllocator) {
+	var buf []byte
+	alloc, buf = alloc.Alloc(len(k.Key)+len(k.Version), 0)
+	return k.copyUsingSizedBuf(buf), alloc
+}
+
+func (k EngineKey) copyUsingSizedBuf(buf []byte) EngineKey {
+	copy(buf, k.Key)
+	k.Key = buf[:len(k.Key)]
+	if len(k.Version) > 0 {
+		versionCopy := buf[len(k.Key):]
+		copy(versionCopy, k.Version)
+		k.Version = versionCopy
+	}
+	return k
+}
 
 // EncodedLen returns the encoded length of k.
 func (k EngineKey) EncodedLen() int {
@@ -97,7 +124,11 @@ func (k EngineKey) EncodeToBuf(buf []byte) []byte {
 func (k EngineKey) encodeToSizedBuf(buf []byte) {
 	copy(buf, k.Key)
 	pos := len(k.Key)
-	suffixLen := len(k.Version)
+	// The length of the suffix is the full encoded length (len(buf)) minus the
+	// length of the key minus the length of the sentinel. Note that the
+	// suffixLen is 0 when Version is empty, and when Version is non-empty, it
+	// is len(Version)+1. That is, it includes the length byte at the end.
+	suffixLen := len(buf) - pos - 1
 	if suffixLen > 0 {
 		buf[pos] = 0
 		pos += sentinelLen
@@ -163,13 +194,11 @@ func DecodeEngineKey(b []byte) (key EngineKey, ok bool) {
 	if len(b) == 0 {
 		return EngineKey{}, false
 	}
-	// Last byte is the version length.
+	// Last byte is the version length + 1 when there is a version,
+	// else it is 0.
 	versionLen := int(b[len(b)-1])
 	// keyPartEnd points to the sentinel byte.
-	keyPartEnd := len(b) - 1
-	if versionLen > 0 {
-		keyPartEnd = len(b) - 1 - versionLen - 1
-	}
+	keyPartEnd := len(b) - 1 - versionLen
 	if keyPartEnd < 0 {
 		return EngineKey{}, false
 	}

--- a/pkg/storage/engine_key_test.go
+++ b/pkg/storage/engine_key_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
@@ -104,6 +105,12 @@ func TestMVCCAndEngineKeyEncodeDecode(t *testing.T) {
 			keyDecoded, err := eKeyDecoded.ToMVCCKey()
 			require.NoError(t, err)
 			require.Equal(t, test.key, keyDecoded)
+			b3 := EncodeKey(test.key)
+			require.Equal(t, b3, b1)
+			k3, ts, ok := enginepb.SplitMVCCKey(b3)
+			require.True(t, ok)
+			require.Equal(t, k3, []byte(test.key.Key))
+			require.Equal(t, ts, encodedTS)
 		})
 	}
 }

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -3360,7 +3360,7 @@ func MVCCGarbageCollect(
 		}
 
 		// For GCBytesAge, this requires keeping track of the previous key's
-		// timestamp (prevNanos). See ComputeStatsGo for a more easily digested
+		// timestamp (prevNanos). See ComputeStatsForRange for a more easily digested
 		// and better commented version of this logic. The below block will set
 		// prevNanos to the appropriate value and position the iterator at the
 		// first garbage version.
@@ -3584,19 +3584,13 @@ func willOverflow(a, b int64) bool {
 	return math.MinInt64-b > a
 }
 
-// ComputeStatsGo scans the underlying engine from start to end keys and
+// ComputeStatsForRange scans the underlying engine from start to end keys and
 // computes stats counters based on the values. This method is used after a
 // range is split to recompute stats for each subrange. The start key is always
 // adjusted to avoid counting local keys in the event stats are being recomputed
 // for the first range (i.e. the one with start key == KeyMin). The nowNanos arg
 // specifies the wall time in nanoseconds since the epoch and is used to compute
 // the total age of all intents.
-//
-// Most codepaths will be computing stats on a RocksDB iterator, which is
-// implemented in c++, so iter.ComputeStats will save several cgo calls per kv
-// processed. (Plus, on equal footing, the c++ implementation is slightly
-// faster.) ComputeStatsGo is here for codepaths that have a pure-go
-// implementation of SimpleMVCCIterator.
 //
 // When optional callbacks are specified, they are invoked for each physical
 // key-value pair (i.e. not for implicit meta records), and iteration is aborted
@@ -3605,7 +3599,7 @@ func willOverflow(a, b int64) bool {
 // Callbacks must copy any data they intend to hold on to.
 //
 // This implementation must match engine/db.cc:MVCCComputeStatsInternal.
-func ComputeStatsGo(
+func ComputeStatsForRange(
 	iter SimpleMVCCIterator,
 	start, end roachpb.Key,
 	nowNanos int64,

--- a/pkg/storage/mvcc_stats_test.go
+++ b/pkg/storage/mvcc_stats_test.go
@@ -1335,9 +1335,9 @@ var mvccStatsTests = []struct {
 		},
 	},
 	{
-		name: "ComputeStatsGo",
+		name: "ComputeStatsForRange",
 		fn: func(iter MVCCIterator, start, end roachpb.Key, nowNanos int64) (enginepb.MVCCStats, error) {
-			return ComputeStatsGo(iter, start, end, nowNanos)
+			return ComputeStatsForRange(iter, start, end, nowNanos)
 		},
 	},
 }

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -2580,7 +2580,7 @@ func computeStats(
 	t.Helper()
 	iter := reader.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{UpperBound: to})
 	defer iter.Close()
-	s, err := ComputeStatsGo(iter, from, to, nowNanos)
+	s, err := ComputeStatsForRange(iter, from, to, nowNanos)
 	if err != nil {
 		t.Fatalf("%+v", err)
 	}

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -724,6 +724,15 @@ func (p *Pebble) NewMVCCIterator(iterKind MVCCIterKind, opts IterOptions) MVCCIt
 	return iter
 }
 
+// NewEngineIterator implements the Engine interface.
+func (p *Pebble) NewEngineIterator(opts IterOptions) EngineIterator {
+	iter := newPebbleIterator(p.db, opts)
+	if iter == nil {
+		panic("couldn't create a new iterator")
+	}
+	return iter
+}
+
 // ApplyBatchRepr implements the Engine interface.
 func (p *Pebble) ApplyBatchRepr(repr []byte, sync bool) error {
 	// batch.SetRepr takes ownership of the underlying slice, so make a copy.
@@ -758,6 +767,14 @@ func (p *Pebble) ClearUnversioned(key roachpb.Key) error {
 // ClearIntent implements the Engine interface.
 func (p *Pebble) ClearIntent(key roachpb.Key) error {
 	return p.clear(MVCCKey{Key: key})
+}
+
+// ClearEngineKey implements the Engine interface.
+func (p *Pebble) ClearEngineKey(key EngineKey) error {
+	if len(key.Key) == 0 {
+		return emptyKeyError()
+	}
+	return p.db.Delete(key.Encode(), pebble.Sync)
 }
 
 func (p *Pebble) clear(key MVCCKey) error {
@@ -824,6 +841,14 @@ func (p *Pebble) PutUnversioned(key roachpb.Key, value []byte) error {
 // PutIntent implements the Engine interface.
 func (p *Pebble) PutIntent(key roachpb.Key, value []byte) error {
 	return p.put(MVCCKey{Key: key}, value)
+}
+
+// PutEngineKey implements the Engine interface.
+func (p *Pebble) PutEngineKey(key EngineKey, value []byte) error {
+	if len(key.Key) == 0 {
+		return emptyKeyError()
+	}
+	return p.db.Set(key.Encode(), value, pebble.Sync)
 }
 
 func (p *Pebble) put(key MVCCKey, value []byte) error {
@@ -1150,10 +1175,19 @@ func (p *Pebble) CreateCheckpoint(dir string) error {
 }
 
 type pebbleReadOnly struct {
-	parent     *Pebble
-	prefixIter pebbleIterator
-	normalIter pebbleIterator
-	closed     bool
+	parent *Pebble
+	// The iterator reuse optimization in pebbleReadOnly is for servicing a
+	// BatchRequest, such that the iterators get reused across different
+	// requests in the batch.
+	// Reuse iterators for {normal,prefix} x {MVCCKey,EngineKey} iteration. We
+	// need separate iterators for EngineKey and MVCCKey iteration since
+	// iterators that make separated locks/intents look as interleaved need to
+	// use both simultaneously.
+	prefixIter       pebbleIterator
+	normalIter       pebbleIterator
+	prefixEngineIter pebbleIterator
+	normalEngineIter pebbleIterator
+	closed           bool
 }
 
 var _ ReadWriter = &pebbleReadOnly{}
@@ -1165,6 +1199,8 @@ func (p *pebbleReadOnly) Close() {
 	p.closed = true
 	p.prefixIter.destroy()
 	p.normalIter.destroy()
+	p.prefixEngineIter.destroy()
+	p.normalEngineIter.destroy()
 }
 
 func (p *pebbleReadOnly) Closed() bool {
@@ -1207,6 +1243,7 @@ func (p *pebbleReadOnly) MVCCIterate(
 	return iterateOnReader(p, start, end, iterKind, f)
 }
 
+// NewMVCCIterator implements the Engine interface.
 func (p *pebbleReadOnly) NewMVCCIterator(iterKind MVCCIterKind, opts IterOptions) MVCCIterator {
 	if p.closed {
 		panic("using a closed pebbleReadOnly")
@@ -1220,6 +1257,31 @@ func (p *pebbleReadOnly) NewMVCCIterator(iterKind MVCCIterKind, opts IterOptions
 	iter := &p.normalIter
 	if opts.Prefix {
 		iter = &p.prefixIter
+	}
+	if iter.inuse {
+		panic("iterator already in use")
+	}
+
+	if iter.iter != nil {
+		iter.setOptions(opts)
+	} else {
+		iter.init(p.parent.db, opts)
+		iter.reusable = true
+	}
+
+	iter.inuse = true
+	return iter
+}
+
+// NewEngineIterator implements the Engine interface.
+func (p *pebbleReadOnly) NewEngineIterator(opts IterOptions) EngineIterator {
+	if p.closed {
+		panic("using a closed pebbleReadOnly")
+	}
+
+	iter := &p.normalEngineIter
+	if opts.Prefix {
+		iter = &p.prefixEngineIter
 	}
 	if iter.inuse {
 		panic("iterator already in use")
@@ -1256,6 +1318,10 @@ func (p *pebbleReadOnly) ClearIntent(key roachpb.Key) error {
 	panic("not implemented")
 }
 
+func (p *pebbleReadOnly) ClearEngineKey(key EngineKey) error {
+	panic("not implemented")
+}
+
 func (p *pebbleReadOnly) ClearRawRange(start, end roachpb.Key) error {
 	panic("not implemented")
 }
@@ -1285,6 +1351,10 @@ func (p *pebbleReadOnly) PutUnversioned(key roachpb.Key, value []byte) error {
 }
 
 func (p *pebbleReadOnly) PutIntent(key roachpb.Key, value []byte) error {
+	panic("not implemented")
+}
+
+func (p *pebbleReadOnly) PutEngineKey(key EngineKey, value []byte) error {
 	panic("not implemented")
 }
 
@@ -1378,6 +1448,11 @@ func (p *pebbleSnapshot) MVCCIterate(
 
 // NewMVCCIterator implements the Reader interface.
 func (p pebbleSnapshot) NewMVCCIterator(iterKind MVCCIterKind, opts IterOptions) MVCCIterator {
+	return newPebbleIterator(p.snapshot, opts)
+}
+
+// NewEngineIterator implements the Reader interface.
+func (p pebbleSnapshot) NewEngineIterator(opts IterOptions) EngineIterator {
 	return newPebbleIterator(p.snapshot, opts)
 }
 

--- a/pkg/storage/pebble_iterator.go
+++ b/pkg/storage/pebble_iterator.go
@@ -20,16 +20,18 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble"
 )
 
-// pebbleIterator is a wrapper around a pebble.MVCCIterator that implements the
-// MVCCIterator interface.
+// pebbleIterator is a wrapper around a pebble.Iterator that implements the
+// MVCCIterator and EngineIterator interfaces. A single pebbleIterator
+// should only be used in one of the two modes.
 type pebbleIterator struct {
 	// Underlying iterator for the DB.
 	iter    *pebble.Iterator
 	options pebble.IterOptions
-	// Reusable buffer for MVCC key encoding.
+	// Reusable buffer for MVCCKey or EngineKey encoding.
 	keyBuf []byte
 	// Buffers for copying iterator bounds to. Note that the underlying memory
 	// is not GCed upon Close(), to reduce the number of overall allocations. We
@@ -40,18 +42,19 @@ type pebbleIterator struct {
 	upperBoundBuf [2][]byte
 	curBuf        int
 	// Set to true to govern whether to call SeekPrefixGE or SeekGE. Skips
-	// SSTables based on MVCC key when true.
+	// SSTables based on MVCC/Engine key when true.
 	prefix bool
 	// If reusable is true, Close() does not actually close the underlying
 	// iterator, but simply marks it as not inuse. Used by pebbleReadOnly.
 	reusable bool
 	inuse    bool
 	// Stat tracking the number of sstables encountered during time-bound
-	// iteration.
+	// iteration. Only used for MVCCIterator.
 	timeBoundNumSSTables int
 }
 
 var _ MVCCIterator = &pebbleIterator{}
+var _ EngineIterator = &pebbleIterator{}
 
 var pebbleIterPool = sync.Pool{
 	New: func() interface{} {
@@ -60,7 +63,7 @@ var pebbleIterPool = sync.Pool{
 }
 
 // Instantiates a new Pebble iterator, or gets one from the pool.
-func newPebbleIterator(handle pebble.Reader, opts IterOptions) MVCCIterator {
+func newPebbleIterator(handle pebble.Reader, opts IterOptions) *pebbleIterator {
 	iter := pebbleIterPool.Get().(*pebbleIterator)
 	iter.init(handle, opts)
 	return iter
@@ -84,9 +87,11 @@ func (p *pebbleIterator) init(handle pebble.Reader, opts IterOptions) {
 
 	if opts.LowerBound != nil {
 		// This is the same as
-		// p.options.LowerBound = EncodeKeyToBuf(p.lowerBoundBuf[0][:0], MVCCKey{Key: opts.LowerBound}) .
-		// Since we are encoding zero-timestamp MVCC Keys anyway, we can just append
-		// the NUL byte instead of calling EncodeKey which will do the same thing.
+		// p.options.LowerBound = EncodeKeyToBuf(p.lowerBoundBuf[0][:0], MVCCKey{Key: opts.LowerBound})
+		// or EngineKey{Key: opts.LowerBound}.EncodeToBuf(...).
+		// Since we are encoding keys with an empty version anyway, we can just
+		// append the NUL byte instead of calling the above encode functions which
+		// will do the same thing.
 		p.lowerBoundBuf[0] = append(p.lowerBoundBuf[0][:0], opts.LowerBound...)
 		p.lowerBoundBuf[0] = append(p.lowerBoundBuf[0], 0x00)
 		p.options.LowerBound = p.lowerBoundBuf[0]
@@ -151,8 +156,10 @@ func (p *pebbleIterator) setOptions(opts IterOptions) {
 	if opts.LowerBound != nil {
 		// This is the same as
 		// p.options.LowerBound = EncodeKeyToBuf(p.lowerBoundBuf[i][:0], MVCCKey{Key: opts.LowerBound}) .
-		// Since we are encoding zero-timestamp MVCC Keys anyway, we can just append
-		// the NUL byte instead of calling EncodeKey which will do the same thing.
+		// or EngineKey{Key: opts.LowerBound}.EncodeToBuf(...).
+		// Since we are encoding keys with an empty version anyway, we can just
+		// append the NUL byte instead of calling the above encode functions which
+		// will do the same thing.
 		p.lowerBoundBuf[i] = append(p.lowerBoundBuf[i][:0], opts.LowerBound...)
 		p.lowerBoundBuf[i] = append(p.lowerBoundBuf[i], 0x00)
 		p.options.LowerBound = p.lowerBoundBuf[i]
@@ -192,9 +199,26 @@ func (p *pebbleIterator) SeekGE(key MVCCKey) {
 	}
 }
 
+// SeekEngineKeyGE implements the EngineIterator interface.
+func (p *pebbleIterator) SeekEngineKeyGE(key EngineKey) (valid bool, err error) {
+	p.keyBuf = key.EncodeToBuf(p.keyBuf[:0])
+	var ok bool
+	if p.prefix {
+		ok = p.iter.SeekPrefixGE(p.keyBuf)
+	} else {
+		ok = p.iter.SeekGE(p.keyBuf)
+	}
+	// NB: A Pebble Iterator always returns ok==false when an error is
+	// present.
+	if ok {
+		return true, nil
+	}
+	return false, p.iter.Error()
+}
+
 // Valid implements the MVCCIterator interface.
 func (p *pebbleIterator) Valid() (bool, error) {
-	// NB: A Pebble MVCCIterator always returns Valid()==false when an error is
+	// NB: A Pebble Iterator always returns Valid()==false when an error is
 	// present. If Valid() is true, there is no error.
 	if ok := p.iter.Valid(); ok {
 		return ok, nil
@@ -205,6 +229,17 @@ func (p *pebbleIterator) Valid() (bool, error) {
 // Next implements the MVCCIterator interface.
 func (p *pebbleIterator) Next() {
 	p.iter.Next()
+}
+
+// NextEngineKey implements the Engineterator interface.
+func (p *pebbleIterator) NextEngineKey() (valid bool, err error) {
+	ok := p.iter.Next()
+	// NB: A Pebble Iterator always returns ok==false when an error is
+	// present.
+	if ok {
+		return true, nil
+	}
+	return false, p.iter.Error()
 }
 
 // NextKey implements the MVCCIterator interface.
@@ -237,12 +272,21 @@ func (p *pebbleIterator) UnsafeKey() MVCCKey {
 	return mvccKey
 }
 
-// UnsafeRawKey returns the raw key from the underlying pebble.MVCCIterator.
+// UnsafeEngineKey implements the EngineIterator interface.
+func (p *pebbleIterator) UnsafeEngineKey() (EngineKey, error) {
+	engineKey, ok := DecodeEngineKey(p.iter.Key())
+	if !ok {
+		return engineKey, errors.Errorf("invalid encoded engine key: %x", p.iter.Key())
+	}
+	return engineKey, nil
+}
+
+// UnsafeRawKey returns the raw key from the underlying pebble.Iterator.
 func (p *pebbleIterator) UnsafeRawKey() []byte {
 	return p.iter.Key()
 }
 
-// UnsafeValue implements the MVCCIterator interface.
+// UnsafeValue implements the MVCCIterator and EngineIterator interfaces.
 func (p *pebbleIterator) UnsafeValue() []byte {
 	if valid, err := p.Valid(); err != nil || !valid {
 		return nil
@@ -256,9 +300,32 @@ func (p *pebbleIterator) SeekLT(key MVCCKey) {
 	p.iter.SeekLT(p.keyBuf)
 }
 
+// SeekEngineKeyLT implements the EngineIterator interface.
+func (p *pebbleIterator) SeekEngineKeyLT(key EngineKey) (valid bool, err error) {
+	p.keyBuf = key.EncodeToBuf(p.keyBuf[:0])
+	ok := p.iter.SeekLT(p.keyBuf)
+	// NB: A Pebble Iterator always returns ok==false when an error is
+	// present.
+	if ok {
+		return true, nil
+	}
+	return false, p.iter.Error()
+}
+
 // Prev implements the MVCCIterator interface.
 func (p *pebbleIterator) Prev() {
 	p.iter.Prev()
+}
+
+// PrevEngineKey implements the EngineIterator interface.
+func (p *pebbleIterator) PrevEngineKey() (valid bool, err error) {
+	ok := p.iter.Prev()
+	// NB: A Pebble Iterator always returns ok==false when an error is
+	// present.
+	if ok {
+		return true, nil
+	}
+	return false, p.iter.Error()
 }
 
 // Key implements the MVCCIterator interface.
@@ -270,7 +337,16 @@ func (p *pebbleIterator) Key() MVCCKey {
 	return key
 }
 
-// Value implements the MVCCIterator interface.
+// EngineKey implements the EngineIterator interface.
+func (p *pebbleIterator) EngineKey() (EngineKey, error) {
+	key, err := p.UnsafeEngineKey()
+	if err != nil {
+		return key, err
+	}
+	return key.Copy(), nil
+}
+
+// Value implements the MVCCIterator and EngineIterator interfaces.
 func (p *pebbleIterator) Value() []byte {
 	value := p.UnsafeValue()
 	valueCopy := make([]byte, len(value))
@@ -289,7 +365,7 @@ func (p *pebbleIterator) ValueProto(msg protoutil.Message) error {
 func (p *pebbleIterator) ComputeStats(
 	start, end roachpb.Key, nowNanos int64,
 ) (enginepb.MVCCStats, error) {
-	return ComputeStatsGo(p, start, end, nowNanos)
+	return ComputeStatsForRange(p, start, end, nowNanos)
 }
 
 // Go-only version of IsValidSplitKey. Checks if the specified key is in


### PR DESCRIPTION
- The EngineIterator interface is implemented by
  pebbleIterator. There are changes to method names
  in EngineIterator since Go does not allow method
  overloading.
- Callers that need to work with EngineKeys, since they will
  eventually need to see separated lock table keys in a
  non-interleaved manner, are switched to using the new
  interfaces.
- ReplicaDataIterator is split into ReplicaMVCCDataIterator
  and ReplicaEngineDataIterator. Only the gcIterator uses
  the former.
- Add PrintEngineKeyValue.
- There was a bug in EngineKey encoding that caused it to
  diverge from MVCCKey. This has been fixed and tests
  added.
- spanset wrappers implement these EngineKey methods for use
   in race tests.

Informs cockroachdb#41720

Release note: None