### PR TITLE
tracing: internally remove WithSeparateRecording

### DIFF
--- a/pkg/kv/kvserver/replica_application_decoder.go
+++ b/pkg/kv/kvserver/replica_application_decoder.go
@@ -150,7 +150,7 @@ func (d *replicaDecoder) createTracingSpans(ctx context.Context) {
 				log.Errorf(ctx, "unable to extract trace data from raft command: %s", err)
 			} else {
 				cmd.sp = d.r.AmbientContext.Tracer.StartSpan(
-					"raft application", tracing.WithRemoteParent(spanCtx), tracing.WithFollowsFrom())
+					"raft application", tracing.WithParentAndManualCollection(spanCtx), tracing.WithFollowsFrom())
 				cmd.ctx = tracing.ContextWithSpan(ctx, cmd.sp)
 			}
 		} else {

--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -297,7 +297,7 @@ func (p *pendingLeaseRequest) requestLeaseAsync(
 		// except that one does not currently support FollowsFrom relationships.
 		sp = tr.StartSpan(
 			opName,
-			tracing.WithParent(parentSp),
+			tracing.WithParentAndAutoCollection(parentSp),
 			tracing.WithFollowsFrom(),
 			tracing.WithCtxLogTags(parentCtx),
 		)

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -975,7 +975,7 @@ func (s *vectorizedFlowCreator) setupOutput(
 					DrainMetaCb: func(ctx context.Context) []execinfrapb.ProducerMetadata {
 						// Start a separate recording so that GetRecording will return
 						// the recordings for only the child spans containing stats.
-						ctx, span := tracing.ChildSpanSeparateRecording(ctx, "")
+						ctx, span := tracing.ChildSpanRemote(ctx, "")
 						finishVectorizedStatsCollectors(
 							ctx, flowCtx.ID, flowCtx.Cfg.TestingKnobs.DeterministicStats, vscs,
 						)

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -202,12 +202,12 @@ func (ds *ServerImpl) setupFlow(
 		// TODO(andrei): localState.IsLocal is not quite the right thing to use.
 		//  If that field is unset, we might still want to create a child span if
 		//  this flow is run synchronously.
-		sp = ds.Tracer.StartSpan(opName, tracing.WithParent(parentSpan), tracing.WithCtxLogTags(ctx))
+		sp = ds.Tracer.StartSpan(opName, tracing.WithParentAndAutoCollection(parentSpan), tracing.WithCtxLogTags(ctx))
 	} else {
 		// We use FollowsFrom because the flow's span outlives the SetupFlow request.
 		sp = ds.Tracer.StartSpan(
 			opName,
-			tracing.WithParent(parentSpan),
+			tracing.WithParentAndAutoCollection(parentSpan),
 			tracing.WithFollowsFrom(),
 			tracing.WithCtxLogTags(ctx),
 		)

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1516,7 +1516,7 @@ func (st *SessionTracing) StartTracing(
 		// Create a child span while recording.
 		sp = parentSp.Tracer().StartSpan(
 			opName,
-			tracing.WithParent(parentSp),
+			tracing.WithParentAndAutoCollection(parentSp),
 			tracing.WithCtxLogTags(connCtx),
 			tracing.WithForceRealSpan(),
 		)

--- a/pkg/sql/execinfra/processorsbase.go
+++ b/pkg/sql/execinfra/processorsbase.go
@@ -878,7 +878,7 @@ func (pb *ProcessorBase) AppendTrailingMeta(meta execinfrapb.ProducerMetadata) {
 // ProcessorSpan creates a child span for a processor (if we are doing any
 // tracing). The returned span needs to be finished using tracing.FinishSpan.
 func ProcessorSpan(ctx context.Context, name string) (context.Context, *tracing.Span) {
-	return tracing.ChildSpanSeparateRecording(ctx, name)
+	return tracing.ChildSpanRemote(ctx, name)
 }
 
 // StartInternal prepares the ProcessorBase for execution. It returns the

--- a/pkg/sql/explain_distsql.go
+++ b/pkg/sql/explain_distsql.go
@@ -169,7 +169,7 @@ func (n *explainDistSQLNode) startExec(params runParams) error {
 			tracer := parentSp.Tracer()
 			sp = tracer.StartSpan(
 				"explain-distsql", tracing.WithForceRealSpan(),
-				tracing.WithParent(parentSp),
+				tracing.WithParentAndAutoCollection(parentSp),
 				tracing.WithCtxLogTags(params.ctx))
 		} else {
 			tracer := params.extendedEvalCtx.ExecCfg.AmbientCtx.Tracer

--- a/pkg/sql/trace_test.go
+++ b/pkg/sql/trace_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -33,6 +34,9 @@ import (
 
 func TestTrace(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.UnderRace(t, "does too much work under race, see: "+
+		"https://github.com/cockroachdb/cockroach/pull/56343#issuecomment-733577377")
+
 	defer log.Scope(t).Close(t)
 
 	// These are always appended, even without the test specifying it.

--- a/pkg/sql/txn_state.go
+++ b/pkg/sql/txn_state.go
@@ -166,7 +166,7 @@ func (ts *txnState) resetForNewSQLTxn(
 		// Create a child span for this SQL txn.
 		sp = parentSp.Tracer().StartSpan(
 			opName,
-			tracing.WithParent(parentSp),
+			tracing.WithParentAndAutoCollection(parentSp),
 			tracing.WithCtxLogTags(connCtx),
 			tracing.WithForceRealSpan(),
 		)

--- a/pkg/util/tracing/grpc_interceptor.go
+++ b/pkg/util/tracing/grpc_interceptor.go
@@ -128,7 +128,7 @@ func ServerInterceptor(tracer *Tracer) grpc.UnaryServerInterceptor {
 		serverSpan := tracer.StartSpan(
 			info.FullMethod,
 			WithTags(gRPCComponentTag, ext.SpanKindRPCServer),
-			WithRemoteParent(spanMeta),
+			WithParentAndManualCollection(spanMeta),
 		)
 		defer serverSpan.Finish()
 
@@ -171,7 +171,7 @@ func StreamServerInterceptor(tracer *Tracer) grpc.StreamServerInterceptor {
 		serverSpan := tracer.StartSpan(
 			info.FullMethod,
 			WithTags(gRPCComponentTag, ext.SpanKindRPCServer),
-			WithRemoteParent(spanMeta),
+			WithParentAndManualCollection(spanMeta),
 		)
 		defer serverSpan.Finish()
 		ss = &tracingServerStream{
@@ -257,7 +257,7 @@ func ClientInterceptor(tracer *Tracer, init func(*Span)) grpc.UnaryClientInterce
 		}
 		clientSpan := tracer.StartSpan(
 			method,
-			WithParent(parent),
+			WithParentAndAutoCollection(parent),
 			WithTags(gRPCComponentTag, ext.SpanKindRPCClient),
 		)
 		init(clientSpan)
@@ -306,7 +306,7 @@ func StreamClientInterceptor(tracer *Tracer, init func(*Span)) grpc.StreamClient
 
 		clientSpan := tracer.StartSpan(
 			method,
-			WithParent(parent),
+			WithParentAndAutoCollection(parent),
 			WithTags(gRPCComponentTag, ext.SpanKindRPCClient),
 		)
 		init(clientSpan)

--- a/pkg/util/tracing/span.go
+++ b/pkg/util/tracing/span.go
@@ -213,14 +213,12 @@ func (s *Span) IsRecording() bool {
 // parent.
 // If separate recording is specified, the child is not registered with the
 // parent. Thus, the parent's recording will not include this child.
-func (s *crdbSpan) enableRecording(
-	parent *crdbSpan, recType RecordingType, separateRecording bool,
-) {
+func (s *crdbSpan) enableRecording(parent *crdbSpan, recType RecordingType) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	atomic.StoreInt32(&s.recording, 1)
 	s.mu.recording.recordingType = recType
-	if parent != nil && !separateRecording {
+	if parent != nil {
 		parent.addChild(s)
 	}
 	if recType == SnowballRecording {
@@ -257,7 +255,7 @@ func (s *Span) StartRecording(recType RecordingType) {
 	// If we're already recording (perhaps because the parent was recording when
 	// this Span was created), there's nothing to do.
 	if !s.crdb.isRecording() {
-		s.crdb.enableRecording(nil /* parent */, recType, false /* separateRecording */)
+		s.crdb.enableRecording(nil /* parent */, recType)
 	}
 }
 

--- a/pkg/util/tracing/span.go
+++ b/pkg/util/tracing/span.go
@@ -404,7 +404,7 @@ func (s *Span) Finish() {
 
 // Meta returns the information which needs to be propagated across
 // process boundaries in order to derive child spans from this Span.
-// This may return nil, which is a valid input to `WithRemoteParent`,
+// This may return nil, which is a valid input to `WithParentAndManualCollection`,
 // if the Span has been optimized out.
 func (s *Span) Meta() *SpanMeta {
 	var traceID uint64

--- a/pkg/util/tracing/span.go
+++ b/pkg/util/tracing/span.go
@@ -365,7 +365,7 @@ func (s *Span) IsBlackHole() bool {
 // or corresponds to a "no-op" Span. If this is true, any Span
 // derived from this context will be a "black hole Span".
 func (sc *SpanMeta) isNilOrNoop() bool {
-	return sc.recordingType == NoRecording && sc.shadowTracerType == ""
+	return sc == nil || (sc.recordingType == NoRecording && sc.shadowTracerType == "")
 }
 
 // SetSpanStats sets the stats on a Span. stats.Stats() will also be added to
@@ -436,6 +436,14 @@ func (s *Span) Meta() *SpanMeta {
 		shadowCtx = s.ot.shadowSpan.Context()
 	}
 
+	if traceID == 0 &&
+		spanID == 0 &&
+		shadowTrTyp == "" &&
+		shadowCtx == nil &&
+		recordingType == 0 &&
+		baggage == nil {
+		return nil
+	}
 	return &SpanMeta{
 		traceID:          traceID,
 		spanID:           spanID,

--- a/pkg/util/tracing/span_options.go
+++ b/pkg/util/tracing/span_options.go
@@ -47,7 +47,7 @@ func (opts *spanOptions) parentSpanID() uint64 {
 }
 
 func (opts *spanOptions) recordingType() RecordingType {
-	var recordingType RecordingType
+	recordingType := NoRecording
 	if opts.Parent != nil && !opts.Parent.isNoop() {
 		recordingType = opts.Parent.crdb.getRecordingType()
 	} else if opts.RemoteParent != nil {

--- a/pkg/util/tracing/span_options.go
+++ b/pkg/util/tracing/span_options.go
@@ -20,8 +20,8 @@ import (
 // field comment below are invoked as arguments to `Tracer.StartSpan`.
 // See the SpanOption interface for a synopsis.
 type spanOptions struct {
-	Parent        *Span                         // see WithParent
-	RemoteParent  *SpanMeta                     // see WithRemoteParent
+	Parent        *Span                         // see WithParentAndAutoCollection
+	RemoteParent  *SpanMeta                     // see WithParentAndManualCollection
 	RefType       opentracing.SpanReferenceType // see WithFollowsFrom
 	LogTags       *logtags.Buffer               // see WithLogTags
 	Tags          map[string]interface{}        // see WithTags
@@ -69,8 +69,8 @@ func (opts *spanOptions) shadowTrTyp() (string, bool) {
 // SpanOption is the interface satisfied by options to `Tracer.StartSpan`.
 // A synopsis of the options follows. For details, see their comments.
 //
-// - WithParent: create a child Span from a Span (local span).
-// - WithRemoteParent: create a child Span from a SpanMeta (remote span).
+// - WithParentAndAutoCollection: create a child Span from a Span.
+// - WithParentAndManualCollection: create a child Span from a SpanMeta.
 // - WithFollowsFrom: indicate that child may outlive parent.
 // - WithLogTags: populates the Span tags from a `logtags.Buffer`.
 // - WithCtxLogTags: like WithLogTags, but takes a `context.Context`.
@@ -80,17 +80,20 @@ type SpanOption interface {
 	apply(spanOptions) spanOptions
 }
 
-type parentOption Span
+type parentAndAutoCollectionOption Span
 
-// WithParent instructs StartSpan to create a child span referring to the
-// given local parent Span.
+// WithParentAndAutoCollection instructs StartSpan to create a child Span
+// from a parent Span.
 //
-// Children of local parents inherit the parent's log tags, and will
-// share their recording with the parent (unless WithSeparateRecording is
-// used). They will also start recording if the parent is recording at
-// the time of child instantiation. If the parent span is not recording,
-// the child could be a "noop span" (depending on whether the Tracer is
-// configured to trace to an external tracing system) which does not support
+// The child inherits the parent's log tags. The data collected in the
+// child trace will be retrieved automatically when the parent's data is
+// retrieved, meaning that the caller has no obligation (and in fact
+// must not) manually propagate the recording to the parent Span.
+//
+// The child will start recording if the parent is recording at the time
+// of child instantiation. If the parent span is not recording, the child
+// could be a "noop span" (depending on whether the Tracer is configured
+// to trace to an external tracing system) which does not support
 // recording, unless the WithForceRealSpan option is passed to StartSpan.
 //
 // By default, children are derived using a ChildOf relationship,
@@ -98,29 +101,47 @@ type parentOption Span
 // wait for the child to Finish(). If this expectation does not hold,
 // WithFollowsFrom should be added to the StartSpan invocation.
 //
-// When no local Span is available, WithRemoteParent should be used.
-func WithParent(sp *Span) SpanOption {
-	return (*parentOption)(sp)
+// When the parent Span is not available at the caller,
+// WithParentAndManualCollection should be used, which incurs an
+// obligation to manually propagate the trace data to the parent Span.
+func WithParentAndAutoCollection(sp *Span) SpanOption {
+	return (*parentAndAutoCollectionOption)(sp)
 }
 
-func (p *parentOption) apply(opts spanOptions) spanOptions {
+func (p *parentAndAutoCollectionOption) apply(opts spanOptions) spanOptions {
 	opts.Parent = (*Span)(p)
 	return opts
 }
 
-type remoteParentOption SpanMeta
+type parentAndManualCollectionOption SpanMeta
 
-// WithRemoteParent instructs StartSpan to create child span descending
-// from a parent described via SpanMeta. Since no local parent is
-// available (in contrast to WithParent), this Span will not share a
-// recording with any other Span. The caller must collect the resulting
-// Span's recording and propagate it back towards the root of the trace
-// via ImportRemoteSpans.
-func WithRemoteParent(parent *SpanMeta) SpanOption {
-	return (*remoteParentOption)(parent)
+// WithParentAndManualCollection instructs StartSpan to create a
+// child span descending from a parent described via a SpanMeta. In
+// contrast with WithParentAndAutoCollection, the caller must call
+// `Span.GetRecording` when finishing the returned Span, and propagate the
+// result to the parent Span by calling `Span.ImportRemoteSpans` on it.
+//
+// The canonical use case for this is around RPC boundaries, where a
+// server handling a request wants to create a child span descending
+// from a parent on a remote machine.
+//
+// node 1                     (network)          node 2
+// --------------------------------------------------------------------------
+// Span.Meta()               ----------> sp2 := Tracer.StartSpan(
+//                                       		WithParentAndManualCollection(.))
+//                                       doSomething(sp2)
+//                                       sp2.Finish()
+// Span.ImportRemoteSpans(.) <---------- sp2.GetRecording()
+//
+// By default, the child span is derived using a ChildOf relationship,
+// which corresponds to the expectation that the parent span will
+// wait for the child to Finish(). If this expectation does not hold,
+// WithFollowsFrom should be added to the StartSpan invocation.
+func WithParentAndManualCollection(parent *SpanMeta) SpanOption {
+	return (*parentAndManualCollectionOption)(parent)
 }
 
-func (p *remoteParentOption) apply(opts spanOptions) spanOptions {
+func (p *parentAndManualCollectionOption) apply(opts spanOptions) spanOptions {
 	opts.RemoteParent = (*SpanMeta)(p)
 	return opts
 }
@@ -149,7 +170,7 @@ func (o tagsOption) apply(opts spanOptions) spanOptions {
 type followsFromOpt struct{}
 
 // WithFollowsFrom instructs StartSpan to use a FollowsFrom relationship
-// should a child span be created (i.e. should WithParent or WithRemoteParent
+// should a child span be created (i.e. should WithParentAndAutoCollection or WithParentAndManualCollection
 // be supplied as well). A WithFollowsFrom child is expected to, in the common
 // case, outlive the parent span (for example: asynchronous cleanup work),
 // whereas a "regular" child span is not (i.e. the parent span typically

--- a/pkg/util/tracing/span_test.go
+++ b/pkg/util/tracing/span_test.go
@@ -11,6 +11,7 @@
 package tracing
 
 import (
+	"context"
 	"regexp"
 	"strings"
 	"testing"
@@ -180,4 +181,20 @@ Span grandchild:
     === operation:grandchild sb:1
 `
 	require.Equal(t, exp, recToStrippedString(childRec))
+}
+
+func TestChildSpan(t *testing.T) {
+	tr := NewTracer()
+	// Set up non-recording span.
+	sp := tr.StartSpan("foo", WithForceRealSpan())
+	ctx := ContextWithSpan(context.Background(), sp)
+	// Since the parent span was not recording, we would expect the
+	// noop span back. However - we don't, we get our inputs instead.
+	// This is a performance optimization; there is a to-do in
+	// childSpan asking for its removal, but for now it's here to stay.
+	{
+		newCtx, newSp := ChildSpan(ctx, "foo")
+		require.Equal(t, ctx, newCtx)
+		require.Equal(t, sp, newSp)
+	}
 }

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -209,9 +209,13 @@ func (t *Tracer) startSpanGeneric(opName string, opts spanOptions) *Span {
 		}
 	}
 
-	// If tracing is disabled, avoid overhead and return a noop Span.
+	// Avoid creating a real span when possible. If tracing is globally
+	// enabled, we always need to create spans. If the incoming
+	// span is recording (which implies that there is a parent) then
+	// we also have to create a real child. Additionally, if the
+	// caller explicitly asked for a real span they need to get one.
+	// In all other cases, a noop span will do.
 	if !t.AlwaysTrace() &&
-		opts.parentTraceID() == 0 &&
 		opts.recordingType() == NoRecording &&
 		!opts.ForceRealSpan {
 		return t.noopSpan
@@ -574,6 +578,11 @@ func childSpan(ctx context.Context, opName string, remote bool) (context.Context
 	if newSpan.isNoop() {
 		// Optimization: if we end up with a noop, return the inputs
 		// to avoid ContextWithSpan call below.
+		//
+		// TODO(tbg): this is unsound. We are returning the incoming
+		// context which may have a Span that could later start recording.
+		// So in effect that span may capture parts of two goroutines
+		// accidentally.
 		return ctx, sp
 	}
 	return ContextWithSpan(ctx, newSpan), newSpan

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -157,7 +157,7 @@ func (t *Tracer) getShadowTracer() *shadowTracer {
 	return (*shadowTracer)(atomic.LoadPointer(&t.shadowTracer))
 }
 
-// StartSpan starts a Span. See spanOptions for details.
+// StartSpan starts a Span. See SpanOption for details.
 func (t *Tracer) StartSpan(operationName string, os ...SpanOption) *Span {
 	// Fast paths to avoid the allocation of StartSpanOptions below when tracing
 	// is disabled: if we have no options or a single SpanReference (the common

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -162,20 +162,22 @@ func (t *Tracer) StartSpan(operationName string, os ...SpanOption) *Span {
 	// Fast paths to avoid the allocation of StartSpanOptions below when tracing
 	// is disabled: if we have no options or a single SpanReference (the common
 	// case) with a black hole span, return a noop Span now.
-	if len(os) == 1 {
-		switch o := os[0].(type) {
-		case *parentOption:
-			if (*Span)(o).IsBlackHole() {
-				return t.noopSpan
-			}
-		case *remoteParentOption:
-			if (*SpanMeta)(o).isNilOrNoop() {
-				return t.noopSpan
+	if !t.AlwaysTrace() {
+		if len(os) == 1 {
+			switch o := os[0].(type) {
+			case *parentOption:
+				if (*Span)(o).IsBlackHole() {
+					return t.noopSpan
+				}
+			case *remoteParentOption:
+				if (*SpanMeta)(o).isNilOrNoop() {
+					return t.noopSpan
+				}
 			}
 		}
-	}
-	if len(os) == 0 && !t.AlwaysTrace() {
-		return t.noopSpan
+		if len(os) == 0 {
+			return t.noopSpan
+		}
 	}
 
 	// NB: apply takes and returns a value to avoid forcing

--- a/pkg/util/tracing/tracer_test.go
+++ b/pkg/util/tracing/tracer_test.go
@@ -144,7 +144,7 @@ func TestStartChildSpan(t *testing.T) {
 
 	sp1 = tr.StartSpan("parent", WithForceRealSpan())
 	sp1.StartRecording(SingleNodeRecording)
-	sp2 = tr.StartSpan("child", WithParent(sp1), WithSeparateRecording())
+	sp2 = tr.StartSpan("child", WithRemoteParent(sp1.Meta()))
 	sp2.Finish()
 	sp1.Finish()
 	if err := TestingCheckRecordedSpans(sp1.GetRecording(), `

--- a/pkg/util/tracing/tracer_test.go
+++ b/pkg/util/tracing/tracer_test.go
@@ -27,10 +27,10 @@ func TestStartSpanAlwaysTrace(t *testing.T) {
 	require.True(t, tr.AlwaysTrace())
 	nilMeta := tr.noopSpan.Meta()
 	require.Nil(t, nilMeta)
-	sp := tr.StartSpan("foo", WithRemoteParent(nilMeta))
+	sp := tr.StartSpan("foo", WithParentAndManualCollection(nilMeta))
 	require.False(t, sp.IsBlackHole())
 	require.False(t, sp.isNoop())
-	sp = tr.StartSpan("foo", WithParent(tr.noopSpan))
+	sp = tr.StartSpan("foo", WithParentAndAutoCollection(tr.noopSpan))
 	require.False(t, sp.IsBlackHole())
 	require.False(t, sp.isNoop())
 }
@@ -44,7 +44,7 @@ func TestTracerRecording(t *testing.T) {
 	}
 	noop1.LogKV("hello", "void")
 
-	noop2 := tr.StartSpan("noop2", WithRemoteParent(noop1.Meta()))
+	noop2 := tr.StartSpan("noop2", WithParentAndManualCollection(noop1.Meta()))
 	if !noop2.isNoop() {
 		t.Error("expected noop child Span")
 	}
@@ -60,7 +60,7 @@ func TestTracerRecording(t *testing.T) {
 	}
 
 	// Unless recording is actually started, child spans are still noop.
-	noop3 := tr.StartSpan("noop3", WithRemoteParent(s1.Meta()))
+	noop3 := tr.StartSpan("noop3", WithParentAndManualCollection(s1.Meta()))
 	if !noop3.isNoop() {
 		t.Error("expected noop child Span")
 	}
@@ -69,7 +69,7 @@ func TestTracerRecording(t *testing.T) {
 	s1.LogKV("x", 1)
 	s1.StartRecording(SingleNodeRecording)
 	s1.LogKV("x", 2)
-	s2 := tr.StartSpan("b", WithParent(s1))
+	s2 := tr.StartSpan("b", WithParentAndAutoCollection(s1))
 	if s2.IsBlackHole() {
 		t.Error("recording Span should not be black hole")
 	}
@@ -94,7 +94,7 @@ func TestTracerRecording(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s3 := tr.StartSpan("c", WithParent(s2))
+	s3 := tr.StartSpan("c", WithParentAndAutoCollection(s2))
 	s3.LogKV("x", 4)
 	s3.SetTag("tag", "val")
 
@@ -148,7 +148,7 @@ func TestStartChildSpan(t *testing.T) {
 	tr := NewTracer()
 	sp1 := tr.StartSpan("parent", WithForceRealSpan())
 	sp1.StartRecording(SingleNodeRecording)
-	sp2 := tr.StartSpan("child", WithParent(sp1))
+	sp2 := tr.StartSpan("child", WithParentAndAutoCollection(sp1))
 	sp2.Finish()
 	sp1.Finish()
 	if err := TestingCheckRecordedSpans(sp1.GetRecording(), `
@@ -160,7 +160,7 @@ func TestStartChildSpan(t *testing.T) {
 
 	sp1 = tr.StartSpan("parent", WithForceRealSpan())
 	sp1.StartRecording(SingleNodeRecording)
-	sp2 = tr.StartSpan("child", WithRemoteParent(sp1.Meta()))
+	sp2 = tr.StartSpan("child", WithParentAndManualCollection(sp1.Meta()))
 	sp2.Finish()
 	sp1.Finish()
 	if err := TestingCheckRecordedSpans(sp1.GetRecording(), `
@@ -176,7 +176,7 @@ func TestStartChildSpan(t *testing.T) {
 
 	sp1 = tr.StartSpan("parent", WithForceRealSpan())
 	sp1.StartRecording(SingleNodeRecording)
-	sp2 = tr.StartSpan("child", WithParent(sp1),
+	sp2 = tr.StartSpan("child", WithParentAndAutoCollection(sp1),
 		WithLogTags(logtags.SingleTagBuffer("key", "val")))
 	sp2.Finish()
 	sp1.Finish()
@@ -214,7 +214,7 @@ func TestTracerInjectExtract(t *testing.T) {
 	if !wireContext.isNilOrNoop() {
 		t.Errorf("expected noop context: %v", wireContext)
 	}
-	noop2 := tr2.StartSpan("remote op", WithRemoteParent(wireContext))
+	noop2 := tr2.StartSpan("remote op", WithParentAndManualCollection(wireContext))
 	if !noop2.isNoop() {
 		t.Fatalf("expected noop Span: %+v", noop2)
 	}
@@ -236,7 +236,7 @@ func TestTracerInjectExtract(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	s2 := tr2.StartSpan("remote op", WithRemoteParent(wireContext))
+	s2 := tr2.StartSpan("remote op", WithParentAndManualCollection(wireContext))
 
 	// Compare TraceIDs
 	trace1 := s1.Meta().traceID
@@ -310,7 +310,7 @@ func TestLightstepContext(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s2 := tr.StartSpan("child", WithRemoteParent(wireContext))
+	s2 := tr.StartSpan("child", WithParentAndManualCollection(wireContext))
 	s2Ctx := s2.ot.shadowSpan.Context()
 
 	// Verify that the baggage is correct in both the tracer context and in the

--- a/pkg/util/tracing/tracer_test.go
+++ b/pkg/util/tracing/tracer_test.go
@@ -25,7 +25,9 @@ func TestStartSpanAlwaysTrace(t *testing.T) {
 	tr := NewTracer()
 	tr._useNetTrace = 1
 	require.True(t, tr.AlwaysTrace())
-	sp := tr.StartSpan("foo", WithRemoteParent(nil))
+	nilMeta := tr.noopSpan.Meta()
+	require.Nil(t, nilMeta)
+	sp := tr.StartSpan("foo", WithRemoteParent(nilMeta))
 	require.False(t, sp.IsBlackHole())
 	require.False(t, sp.isNoop())
 	sp = tr.StartSpan("foo", WithParent(tr.noopSpan))

--- a/pkg/util/tracing/tracer_test.go
+++ b/pkg/util/tracing/tracer_test.go
@@ -19,6 +19,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestStartSpanAlwaysTrace(t *testing.T) {
+	// Regression test: if tracing is on, don't erroneously return a noopSpan
+	// due to optimizations in StartSpan.
+	tr := NewTracer()
+	tr._useNetTrace = 1
+	require.True(t, tr.AlwaysTrace())
+	sp := tr.StartSpan("foo", WithRemoteParent(nil))
+	require.False(t, sp.IsBlackHole())
+	require.False(t, sp.isNoop())
+	sp = tr.StartSpan("foo", WithParent(tr.noopSpan))
+	require.False(t, sp.IsBlackHole())
+	require.False(t, sp.isNoop())
+}
+
 func TestTracerRecording(t *testing.T) {
 	tr := NewTracer()
 


### PR DESCRIPTION
- tracing: improve a comment
- tracing: internally remove WithSeparateRecording
- tracing: don't erroneously return a noopSpan
- tracing: return nil *SpanMeta
