### PR TITLE
cli - Modify cockroach demo to allow for add node

### DIFF
--- a/pkg/cli/interactive_tests/test_demo_global.tcl.disabled
+++ b/pkg/cli/interactive_tests/test_demo_global.tcl.disabled
@@ -1,11 +1,12 @@
 #! /usr/bin/env expect -f
 
+# This testcase is disabled until #56264 is resolved
 source [file join [file dirname $argv0] common.tcl]
 
 start_test "Check --global flag runs as expected"
 
 # Start a demo with --global set
-spawn $argv demo movr --global
+spawn $argv demo movr --nodes 9 --global
 
 # Ensure db is movr.
 eexpect "movr>"

--- a/pkg/cli/interactive_tests/test_demo_node_cmds.tcl
+++ b/pkg/cli/interactive_tests/test_demo_node_cmds.tcl
@@ -76,6 +76,39 @@ eexpect "5 |  false   |      false      | active"
 send "\\demo recommission 4\r"
 eexpect "can only recommission a decommissioning node"
 
+send "\\demo add blah\r"
+eexpect "internal server error: tier must be in the form \"key=value\" not \"blah\""
+
+send "\\demo add region=ca-central,zone=a\r"
+eexpect "node 6 has been added with locality \"region=ca-central,zone=a\""
+
+send "show regions;\r"
+eexpect "ca-central | \{a\}"
+eexpect "us-east1   | \{b,c,d\}"
+eexpect "us-west1   | \{a,b\}"
+
+# We use kv_node_status here because gossip_liveness is timing dependant.
+send "select node_id, locality from crdb_internal.kv_node_status;\r"
+eexpect "1 | region=us-east1,az=b"
+eexpect "2 | region=us-east1,az=c"
+eexpect "3 | region=us-east1,az=d"
+eexpect "4 | region=us-west1,az=a"
+eexpect "5 | region=us-west1,az=b"
+eexpect "6 | region=ca-central,zone=a"
+
+# Shut down the newly created node.
+send "\\demo shutdown 6\r"
+eexpect "node 6 has been shutdown"
+
+# By now the node should have stabalized in gossip which allows us to query the more detailed information there.
+send "select node_id, draining, decommissioning, membership from crdb_internal.gossip_liveness ORDER BY node_id;\r"
+eexpect "1 |  false   |      false      | active"
+eexpect "2 |  false   |      false      | active"
+eexpect "3 |  false   |      false      | active"
+eexpect "4 |  false   |      true       | decommissioned"
+eexpect "5 |  false   |      false      | active"
+eexpect "6 |   true   |      false      | active"
+
 interrupt
 eexpect eof
 end_test

--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -98,6 +98,7 @@ Commands specific to the demo shell (EXPERIMENTAL):
   \demo restart <nodeid>       restart a stopped demo node.
   \demo decommission <nodeid>  decommission a node.
   \demo recommission <nodeid>  recommission a node.
+  \demo add <locality>         add a node (locality specified as "region=<region>,zone=<zone>").
 `
 
 	defaultPromptPattern = "%n@%M/%/%x>"
@@ -531,6 +532,13 @@ func (c *cliState) handleDemo(cmd []string, nextState, errState cliStateEnum) cl
 		return c.invalidSyntax(errState, `\demo can only be run with cockroach demo`)
 	}
 
+	// The \demo command has one of three patterns:
+	//
+	//	- A lone command (currently, only ls)
+	//	- A command followed by a string (add followed by locality string)
+	//	- A command followed by a node number (shutdown, restart, decommission, recommission)
+	//
+	// We parse these commands separately, in the following blocks.
 	if len(cmd) == 1 && cmd[0] == "ls" {
 		demoCtx.transientCluster.listDemoNodes(os.Stdout, false /* justOne */)
 		return nextState
@@ -540,6 +548,40 @@ func (c *cliState) handleDemo(cmd []string, nextState, errState cliStateEnum) cl
 		return c.invalidSyntax(errState, `\demo expects 2 parameters`)
 	}
 
+	// Special case the add command it takes a string instead of a node number.
+	if cmd[0] == "add" {
+		return c.handleDemoAddNode(cmd, nextState, errState)
+	}
+
+	// If we've made it down here, we're handling the remaining demo node commands.
+	return c.handleDemoNodeCommands(cmd, nextState, errState)
+}
+
+// handleDemoAddNode handles the `add` node command in demo.
+func (c *cliState) handleDemoAddNode(cmd []string, nextState, errState cliStateEnum) cliStateEnum {
+	if cmd[0] != "add" {
+		return c.internalServerError(errState, fmt.Errorf("bad call to handleDemoAddNode"))
+	}
+
+	if demoCtx.simulateLatency {
+		fmt.Printf("add command is not supported in --global configurations")
+		return nextState
+	}
+
+	if err := demoCtx.transientCluster.AddNode(cmd[1]); err != nil {
+		return c.internalServerError(errState, err)
+	}
+	addedNodeID := len(demoCtx.transientCluster.servers)
+	fmt.Printf("node %v has been added with locality \"%s\"\n",
+		addedNodeID, demoCtx.localities[addedNodeID-1].String())
+	return nextState
+}
+
+// handleDemoNodeCommands handles the node commands in demo (with the exception of `add` which is handled
+// with handleDemoAddNode.
+func (c *cliState) handleDemoNodeCommands(
+	cmd []string, nextState, errState cliStateEnum,
+) cliStateEnum {
 	nodeID, err := strconv.ParseInt(cmd[1], 10, 32)
 	if err != nil {
 		return c.invalidSyntax(

--- a/pkg/sql/logictest/testdata/logic_test/multiregion
+++ b/pkg/sql/logictest/testdata/logic_test/multiregion
@@ -3,7 +3,7 @@
 query TT colnames
 SHOW REGIONS
 ----
-region  availability_zones
+region  zones
 test1   {test1-az1,test1-az2,test1-az3}
 test2   {test2-az1,test2-az2,test2-az3}
 test3   {test3-az1,test3-az2,test3-az3}


### PR DESCRIPTION
Commit `cea1bfe`: cli - Modify cockroach demo to allow for add node

Previously, cockroach demo allowed you to start a 9 node cluster, but
once activated, it was not possible to add nodes to the cluster.  This
commits adds the ability to add nodes to a running demo cluster.

The main motivation for this change is to more easily test multi-region
clusters.

Release note (cli change): `cockroach demo` now allows for nodes to be
added using the `\demo` client-side command.  This works in both single
node and multi-node configurations (e.g. when started with `--nodes int`
or `--geo-partitioned-replicas`).

---

Commit `8dd0f48`: sql: Change SHOW REGIONS to pull from kv_node_status table

Previously the SHOW REGIONS statement pulled data from the
`crdb_internal.gossip_nodes` table.  The problem with this table however,
is that it isn't a consistent and reliable source of information.  For
example, nodes remain in the gossip table for 24 hours after they've
been shutdown and decommissioned.  Additionally, nodes may not be
present in the `gossip_nodes` table immediately after they've been added
to the cluster.  To fix these issues, SHOW REGIONS will now pull data
from the `crdb_internal.kv_node_status` table, to which nodes are added when they are
first started, and removed when they are decommissioned.

This commit fixes #56332.

Release note (sql change): SHOW REGIONS has changed the column name for
availability zones to `zones` from `availability_zones`.  This was
agreed upon with the TLs and PMs for multi-region simplification.