### PR TITLE
sql: fix collated string typing to ignore hyphens/case

### DIFF
--- a/pkg/sql/lex/BUILD.bazel
+++ b/pkg/sql/lex/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//pkg/sql/sessiondatapb",
         "//pkg/util/stringencoding",
         "//vendor/github.com/cockroachdb/errors",
+        "//vendor/golang.org/x/text/language",
     ],
 )
 

--- a/pkg/sql/lex/encode.go
+++ b/pkg/sql/lex/encode.go
@@ -23,6 +23,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/hex"
+	"unicode"
 	"unicode/utf8"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/lexbase"
@@ -31,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
 	"github.com/cockroachdb/cockroach/pkg/util/stringencoding"
 	"github.com/cockroachdb/errors"
+	"golang.org/x/text/language"
 )
 
 var mustQuoteMap = map[byte]bool{
@@ -112,6 +114,10 @@ func EncodeSQLStringWithFlags(buf *bytes.Buffer, in string, flags lexbase.Encode
 // need to be quoted, and they are considered equivalent to dash characters by
 // the CLDR standard: http://cldr.unicode.org/.
 func EncodeLocaleName(buf *bytes.Buffer, s string) {
+	// If possible, try to normalize the case of the locale name.
+	if normalized, err := language.Parse(s); err == nil {
+		s = normalized.String()
+	}
 	for i, n := 0, len(s); i < n; i++ {
 		ch := s[i]
 		if ch == '-' {
@@ -120,6 +126,33 @@ func EncodeLocaleName(buf *bytes.Buffer, s string) {
 			buf.WriteByte(ch)
 		}
 	}
+}
+
+// LocaleNamesAreEqual checks for equality of two locale names. The comparison
+// is case-insensitive and treats '-' and '_' as the same.
+func LocaleNamesAreEqual(a, b string) bool {
+	if a == b {
+		return true
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i, n := 0, len(a); i < n; i++ {
+		ai, bi := a[i], b[i]
+		if ai == bi {
+			continue
+		}
+		if ai == '-' && bi == '_' {
+			continue
+		}
+		if ai == '_' && bi == '-' {
+			continue
+		}
+		if unicode.ToLower(rune(ai)) != unicode.ToLower(rune(bi)) {
+			return false
+		}
+	}
+	return true
 }
 
 // EncodeSQLBytes encodes the SQL byte array in 'in' to buf, to a

--- a/pkg/sql/logictest/testdata/logic_test/collatedstring
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring
@@ -7,10 +7,10 @@ SELECT 'A' COLLATE en = 'a'
 statement error pq: unsupported comparison operator: <collatedstring{en}> = <collatedstring{de}>
 SELECT 'A' COLLATE en = 'a' COLLATE de
 
-statement error pq: unsupported comparison operator: \('a' COLLATE en_u_ks_level1\) IN \('A' COLLATE en_u_ks_level1, 'b' COLLATE en\): expected 'b' COLLATE en to be of type collatedstring{en_u_ks_level1}, found type collatedstring{en}
+statement error pq: unsupported comparison operator: \('a' COLLATE en_u_ks_level1\) IN \('A' COLLATE en_u_ks_level1, 'b' COLLATE en\): expected 'b' COLLATE en to be of type collatedstring\{en_u_ks_level1\}, found type collatedstring\{en\}
 SELECT ('a' COLLATE en_u_ks_level1) IN ('A' COLLATE en_u_ks_level1, 'b' COLLATE en)
 
-statement error pq: tuples \('a' COLLATE en_u_ks_level1, 'a' COLLATE en\), \('A' COLLATE en, 'B' COLLATE en\) are not comparable at index 1: unsupported comparison operator: <collatedstring{en_u_ks_level1}> < <collatedstring{en}
+statement error pq: tuples \('a' COLLATE en_u_ks_level1, 'a' COLLATE en\), \('A' COLLATE en, 'B' COLLATE en\) are not comparable at index 1: unsupported comparison operator: <collatedstring\{en_u_ks_level1\}> < <collatedstring\{en\}>
 SELECT ('a' COLLATE en_u_ks_level1, 'a' COLLATE en) < ('A' COLLATE en, 'B' COLLATE en)
 
 
@@ -356,9 +356,9 @@ SHOW CREATE TABLE quoted_coll
 quoted_coll  CREATE TABLE public.quoted_coll (
              a STRING COLLATE en NULL,
              b STRING COLLATE en_US NULL,
-             c STRING COLLATE en_Us NULL DEFAULT 'c':::STRING COLLATE en_us,
+             c STRING COLLATE en_US NULL DEFAULT 'c':::STRING COLLATE en_US,
              d STRING COLLATE en_u_ks_level1 NULL DEFAULT 'd':::STRING COLLATE en_u_ks_level1,
-             e STRING COLLATE en_us NULL AS (a COLLATE en_us) STORED,
+             e STRING COLLATE en_US NULL AS (a COLLATE en_US) STORED,
              FAMILY "primary" (a, b, c, d, e, rowid)
 )
 
@@ -427,3 +427,50 @@ default_collation       default
 no_collation_str        default
 no_collation_str_array  default
 rowid                   NULL
+
+# Regression test for collated string lowercase and hyphen/underscore equality.
+subtest nocase_strings
+
+statement ok
+CREATE TABLE nocase_strings (s STRING COLLATE "en-US-u-ks-level2");
+
+statement ok
+INSERT INTO nocase_strings VALUES ('Aaa' COLLATE "en-US-u-ks-level2"), ('Bbb' COLLATE "en-US-u-ks-level2");
+
+query T
+SELECT s FROM nocase_strings WHERE s = ('bbb' COLLATE "en-US-u-ks-level2")
+----
+Bbb
+
+query T
+SELECT s FROM nocase_strings WHERE s = ('bbb' COLLATE "en-us-u-ks-level2")
+----
+Bbb
+
+query T
+SELECT s FROM nocase_strings WHERE s = ('bbb' COLLATE "en_US_u_ks_level2")
+----
+Bbb
+
+statement ok
+CREATE TABLE collation_name_case (s STRING COLLATE en_us_u_ks_level2);
+
+query TT
+SHOW CREATE TABLE collation_name_case
+----
+collation_name_case   CREATE TABLE public.collation_name_case (
+                      s STRING COLLATE en_US_u_ks_level2 NULL,
+                      FAMILY "primary" (s, rowid)
+)
+
+statement error invalid locale en-US-u-ks-le"vel2: language: tag is not well-formed
+CREATE TABLE nocase_strings (s STRING COLLATE "en-US-u-ks-le""vel2");
+
+statement error syntax error: invalid locale en-US-u-ks-le: language: tag is not well-formed
+CREATE TABLE nocase_strings (s STRING COLLATE "en-US-u-ks-le"vel2");
+
+statement error invalid locale en-us-u-ks-l"evel2: language: tag is not well-formed
+SELECT s FROM nocase_strings WHERE s = ('bbb' COLLATE "en-us-u-ks-l""evel2")
+
+statement error at or near "evel2": syntax error
+SELECT s FROM nocase_strings WHERE s = ('bbb' COLLATE "en-us-u-ks-l"evel2")

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -1402,52 +1402,52 @@ SELECT table_name, column_name, data_type, crdb_sql_type, udt_catalog, udt_schem
 FROM information_schema.columns
 WHERE table_schema = 'public' AND table_name = 'data_types'
 ----
-table_name  column_name  data_type                    crdb_sql_type            udt_catalog  udt_schema  udt_name      collation_catalog  collation_schema  collation_name
-data_types  a            bigint                       INT8                     test         pg_catalog  int8          NULL               NULL              NULL
-data_types  a2           smallint                     INT2                     test         pg_catalog  int2          NULL               NULL              NULL
-data_types  a4           integer                      INT4                     test         pg_catalog  int4          NULL               NULL              NULL
-data_types  a8           bigint                       INT8                     test         pg_catalog  int8          NULL               NULL              NULL
-data_types  b            double precision             FLOAT8                   test         pg_catalog  float8        NULL               NULL              NULL
-data_types  b4           real                         FLOAT4                   test         pg_catalog  float4        NULL               NULL              NULL
-data_types  br           real                         FLOAT4                   test         pg_catalog  float4        NULL               NULL              NULL
-data_types  c            numeric                      DECIMAL                  test         pg_catalog  numeric       NULL               NULL              NULL
-data_types  cp           numeric                      DECIMAL(3)               test         pg_catalog  numeric       NULL               NULL              NULL
-data_types  cps          numeric                      DECIMAL(3,2)             test         pg_catalog  numeric       NULL               NULL              NULL
-data_types  d            text                         STRING                   test         pg_catalog  text          NULL               NULL              NULL
-data_types  dl           text                         STRING COLLATE en        test         pg_catalog  text          test               pg_catalog        en
-data_types  dc           character                    CHAR                     test         pg_catalog  bpchar        NULL               NULL              NULL
-data_types  dc2          character                    CHAR(2)                  test         pg_catalog  bpchar        NULL               NULL              NULL
-data_types  dv           character varying            VARCHAR                  test         pg_catalog  varchar       NULL               NULL              NULL
-data_types  dv2          character varying            VARCHAR(2)               test         pg_catalog  varchar       NULL               NULL              NULL
-data_types  dq           "char"                       "char"                   test         pg_catalog  char          NULL               NULL              NULL
-data_types  e            bytea                        BYTES                    test         pg_catalog  bytea         NULL               NULL              NULL
-data_types  f            timestamp without time zone  TIMESTAMP                test         pg_catalog  timestamp     NULL               NULL              NULL
-data_types  f6           timestamp without time zone  TIMESTAMP(6)             test         pg_catalog  timestamp     NULL               NULL              NULL
-data_types  g            timestamp with time zone     TIMESTAMPTZ              test         pg_catalog  timestamptz   NULL               NULL              NULL
-data_types  g6           timestamp with time zone     TIMESTAMPTZ(6)           test         pg_catalog  timestamptz   NULL               NULL              NULL
-data_types  h            bit                          BIT                      test         pg_catalog  bit           NULL               NULL              NULL
-data_types  h2           bit                          BIT(2)                   test         pg_catalog  bit           NULL               NULL              NULL
-data_types  hv           bit varying                  VARBIT                   test         pg_catalog  varbit        NULL               NULL              NULL
-data_types  hv2          bit varying                  VARBIT(2)                test         pg_catalog  varbit        NULL               NULL              NULL
-data_types  i            interval                     INTERVAL                 test         pg_catalog  interval      NULL               NULL              NULL
-data_types  j            boolean                      BOOL                     test         pg_catalog  bool          NULL               NULL              NULL
-data_types  k            oid                          OID                      test         pg_catalog  oid           NULL               NULL              NULL
-data_types  k2           regclass                     REGCLASS                 test         pg_catalog  regclass      NULL               NULL              NULL
-data_types  k3           regnamespace                 REGNAMESPACE             test         pg_catalog  regnamespace  NULL               NULL              NULL
-data_types  k4           regproc                      REGPROC                  test         pg_catalog  regproc       NULL               NULL              NULL
-data_types  k5           regprocedure                 REGPROCEDURE             test         pg_catalog  regprocedure  NULL               NULL              NULL
-data_types  k6           regtype                      REGTYPE                  test         pg_catalog  regtype       NULL               NULL              NULL
-data_types  l            uuid                         UUID                     test         pg_catalog  uuid          NULL               NULL              NULL
-data_types  m            ARRAY                        INT2[]                   test         pg_catalog  _int2         NULL               NULL              NULL
-data_types  m2           ARRAY                        STRING[]                 test         pg_catalog  _text         NULL               NULL              NULL
-data_types  m3           ARRAY                        DECIMAL(3,2)[]           test         pg_catalog  _numeric      NULL               NULL              NULL
-data_types  m4           ARRAY                        VARCHAR(2)[] COLLATE en  test         pg_catalog  _varchar      NULL               NULL              NULL
-data_types  n            inet                         INET                     test         pg_catalog  inet          NULL               NULL              NULL
-data_types  o            time without time zone       TIME                     test         pg_catalog  time          NULL               NULL              NULL
-data_types  o6           time without time zone       TIME(6)                  test         pg_catalog  time          NULL               NULL              NULL
-data_types  p            jsonb                        JSONB                    test         pg_catalog  jsonb         NULL               NULL              NULL
-data_types  q            name                         NAME                     test         pg_catalog  name          NULL               NULL              NULL
-data_types  rowid        bigint                       INT8                     test         pg_catalog  int8          NULL               NULL              NULL
+table_name  column_name  data_type                    crdb_sql_type              udt_catalog  udt_schema  udt_name      collation_catalog  collation_schema  collation_name
+data_types  a            bigint                       INT8                       test         pg_catalog  int8          NULL               NULL              NULL
+data_types  a2           smallint                     INT2                       test         pg_catalog  int2          NULL               NULL              NULL
+data_types  a4           integer                      INT4                       test         pg_catalog  int4          NULL               NULL              NULL
+data_types  a8           bigint                       INT8                       test         pg_catalog  int8          NULL               NULL              NULL
+data_types  b            double precision             FLOAT8                     test         pg_catalog  float8        NULL               NULL              NULL
+data_types  b4           real                         FLOAT4                     test         pg_catalog  float4        NULL               NULL              NULL
+data_types  br           real                         FLOAT4                     test         pg_catalog  float4        NULL               NULL              NULL
+data_types  c            numeric                      DECIMAL                    test         pg_catalog  numeric       NULL               NULL              NULL
+data_types  cp           numeric                      DECIMAL(3)                 test         pg_catalog  numeric       NULL               NULL              NULL
+data_types  cps          numeric                      DECIMAL(3,2)               test         pg_catalog  numeric       NULL               NULL              NULL
+data_types  d            text                         STRING                     test         pg_catalog  text          NULL               NULL              NULL
+data_types  dl           text                         STRING COLLATE en          test         pg_catalog  text          test               pg_catalog        en
+data_types  dc           character                    CHAR                       test         pg_catalog  bpchar        NULL               NULL              NULL
+data_types  dc2          character                    CHAR(2)                    test         pg_catalog  bpchar        NULL               NULL              NULL
+data_types  dv           character varying            VARCHAR                    test         pg_catalog  varchar       NULL               NULL              NULL
+data_types  dv2          character varying            VARCHAR(2)                 test         pg_catalog  varchar       NULL               NULL              NULL
+data_types  dq           "char"                       "char"                     test         pg_catalog  char          NULL               NULL              NULL
+data_types  e            bytea                        BYTES                      test         pg_catalog  bytea         NULL               NULL              NULL
+data_types  f            timestamp without time zone  TIMESTAMP                  test         pg_catalog  timestamp     NULL               NULL              NULL
+data_types  f6           timestamp without time zone  TIMESTAMP(6)               test         pg_catalog  timestamp     NULL               NULL              NULL
+data_types  g            timestamp with time zone     TIMESTAMPTZ                test         pg_catalog  timestamptz   NULL               NULL              NULL
+data_types  g6           timestamp with time zone     TIMESTAMPTZ(6)             test         pg_catalog  timestamptz   NULL               NULL              NULL
+data_types  h            bit                          BIT                        test         pg_catalog  bit           NULL               NULL              NULL
+data_types  h2           bit                          BIT(2)                     test         pg_catalog  bit           NULL               NULL              NULL
+data_types  hv           bit varying                  VARBIT                     test         pg_catalog  varbit        NULL               NULL              NULL
+data_types  hv2          bit varying                  VARBIT(2)                  test         pg_catalog  varbit        NULL               NULL              NULL
+data_types  i            interval                     INTERVAL                   test         pg_catalog  interval      NULL               NULL              NULL
+data_types  j            boolean                      BOOL                       test         pg_catalog  bool          NULL               NULL              NULL
+data_types  k            oid                          OID                        test         pg_catalog  oid           NULL               NULL              NULL
+data_types  k2           regclass                     REGCLASS                   test         pg_catalog  regclass      NULL               NULL              NULL
+data_types  k3           regnamespace                 REGNAMESPACE               test         pg_catalog  regnamespace  NULL               NULL              NULL
+data_types  k4           regproc                      REGPROC                    test         pg_catalog  regproc       NULL               NULL              NULL
+data_types  k5           regprocedure                 REGPROCEDURE               test         pg_catalog  regprocedure  NULL               NULL              NULL
+data_types  k6           regtype                      REGTYPE                    test         pg_catalog  regtype       NULL               NULL              NULL
+data_types  l            uuid                         UUID                       test         pg_catalog  uuid          NULL               NULL              NULL
+data_types  m            ARRAY                        INT2[]                     test         pg_catalog  _int2         NULL               NULL              NULL
+data_types  m2           ARRAY                        STRING[]                   test         pg_catalog  _text         NULL               NULL              NULL
+data_types  m3           ARRAY                        DECIMAL(3,2)[]             test         pg_catalog  _numeric      NULL               NULL              NULL
+data_types  m4           ARRAY                        VARCHAR(2)[] COLLATE en    test         pg_catalog  _varchar      NULL               NULL              NULL
+data_types  n            inet                         INET                       test         pg_catalog  inet          NULL               NULL              NULL
+data_types  o            time without time zone       TIME                       test         pg_catalog  time          NULL               NULL              NULL
+data_types  o6           time without time zone       TIME(6)                    test         pg_catalog  time          NULL               NULL              NULL
+data_types  p            jsonb                        JSONB                      test         pg_catalog  jsonb         NULL               NULL              NULL
+data_types  q            name                         NAME                       test         pg_catalog  name          NULL               NULL              NULL
+data_types  rowid        bigint                       INT8                       test         pg_catalog  int8          NULL               NULL              NULL
 
 statement ok
 DROP TABLE data_types

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -339,7 +339,7 @@ func TestParse(t *testing.T) {
 		{`CREATE TABLE a (b STRING COLLATE de)`},
 		{`CREATE TABLE a (b STRING(3) COLLATE de)`},
 		{`CREATE TABLE a (b STRING[] COLLATE de)`},
-		{`CREATE TABLE a (b STRING(3)[] COLLATE de)`},
+		{`CREATE TABLE a (b STRING(3)[] COLLATE en_US)`},
 
 		{`CREATE TABLE a (LIKE b)`},
 		{`CREATE TABLE a (LIKE b, c INT8)`},
@@ -2754,6 +2754,10 @@ SKIP_MISSING_FOREIGN_KEYS, SKIP_MISSING_SEQUENCES, SKIP_MISSING_SEQUENCE_OWNERS,
 		{`REVOKE ALL PRIVILEGES ON SCHEMA foo FROM root`, `REVOKE ALL ON SCHEMA foo FROM root`},
 		{`REVOKE ALL PRIVILEGES ON SCHEMA foo.bar FROM root`, `REVOKE ALL ON SCHEMA foo.bar FROM root`},
 		{`REVOKE ALL PRIVILEGES ON SCHEMA a.b, c.d FROM root`, `REVOKE ALL ON SCHEMA a.b, c.d FROM root`},
+
+		// Check rules for normalizing collation names.
+		{`CREATE TABLE a (b STRING COLLATE "en-us")`, `CREATE TABLE a (b STRING COLLATE en_US)`},
+		{`CREATE TABLE a (b STRING COLLATE en_us)`, `CREATE TABLE a (b STRING COLLATE en_US)`},
 	}
 	for _, d := range testData {
 		t.Run(d.sql, func(t *testing.T) {

--- a/pkg/sql/sem/tree/alter_table.go
+++ b/pkg/sql/sem/tree/alter_table.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
+	"github.com/cockroachdb/cockroach/pkg/sql/lex"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 )
 
@@ -238,7 +239,7 @@ func (node *AlterTableAlterColumnType) Format(ctx *FmtCtx) {
 	ctx.WriteString(node.ToType.SQLString())
 	if len(node.Collation) > 0 {
 		ctx.WriteString(" COLLATE ")
-		ctx.WriteString(node.Collation)
+		lex.EncodeLocaleName(&ctx.Buffer, node.Collation)
 	}
 	if node.Using != nil {
 		ctx.WriteString(" USING ")

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -1290,7 +1290,7 @@ func (d *DCollatedString) Compare(ctx *EvalContext, other Datum) int {
 		return 1
 	}
 	v, ok := UnwrapDatum(ctx, other).(*DCollatedString)
-	if !ok || d.Locale != v.Locale {
+	if !ok || !d.ResolvedType().Equivalent(other.ResolvedType()) {
 		panic(makeUnsupportedComparisonMessage(d, other))
 	}
 	return bytes.Compare(d.Key, v.Key)

--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -1758,8 +1758,12 @@ func (t *T) Equivalent(other *T) bool {
 
 	switch t.Family() {
 	case CollatedStringFamily:
-		if t.Locale() != "" && other.Locale() != "" && t.Locale() != other.Locale() {
-			return false
+		// CockroachDB differs from Postgres by comparing collation names
+		// case-insensitively and equating hyphens/underscores.
+		if t.Locale() != "" && other.Locale() != "" {
+			if !lex.LocaleNamesAreEqual(t.Locale(), other.Locale()) {
+				return false
+			}
 		}
 
 	case TupleFamily:


### PR DESCRIPTION
Our documentation says that "Collation names are case-insensitive, and
hyphens and underscores are interchangeable."
https://www.cockroachlabs.com/docs/stable/collate.html#details

However, we did not implement this correctly.

Furthermore, there was a bug where even if the same collation name was
used the whole time, we would fail to round trip it correctly because
when serializing the CollateExpr, quotes are not used around the
collation name. We can't use quotes because tools (like TypeORM) cannot
parse quoted collation names. Instead we now normalize the name using
language.Parse().

fixes #56335 

Release note (bug fix): Fix typing of collated strings so that collation
names are case-insensitive and hyphens/underscores are interchangeable.