### PR TITLE
sql: reorganize EXPLAIN ANALYZE, consolidate schema of EXPLAIN variants

### DIFF
--- a/pkg/sql/catalog/colinfo/result_columns.go
+++ b/pkg/sql/catalog/colinfo/result_columns.go
@@ -146,8 +146,7 @@ func (r ResultColumns) String(printTypes bool, showHidden bool) string {
 	return f.CloseAndGetString()
 }
 
-// ExplainPlanColumns are the result columns of an EXPLAIN (PLAN) ...
-// statement.
+// ExplainPlanColumns are the result columns of various EXPLAIN variants.
 var ExplainPlanColumns = ResultColumns{
 	{Name: "info", Typ: types.String},
 }
@@ -158,24 +157,6 @@ var ExplainDistSQLColumns = ResultColumns{
 	{Name: "automatic", Typ: types.Bool},
 	{Name: "url", Typ: types.String},
 	{Name: "json", Typ: types.String, Hidden: true},
-}
-
-// ExplainOptColumns are the result columns of an
-// EXPLAIN (OPT) statement.
-var ExplainOptColumns = ResultColumns{
-	{Name: "text", Typ: types.String},
-}
-
-// ExplainVecColumns are the result columns of an
-// EXPLAIN (VEC) statement.
-var ExplainVecColumns = ResultColumns{
-	{Name: "text", Typ: types.String},
-}
-
-// ExplainAnalyzeDebugColumns are the result columns of an
-// EXPLAIN ANALYZE (DEBUG) statement.
-var ExplainAnalyzeDebugColumns = ResultColumns{
-	{Name: "text", Typ: types.String},
 }
 
 // ShowTraceColumns are the result columns of a SHOW [KV] TRACE statement.

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -341,11 +341,11 @@ func (ex *connExecutor) execStmtInOpenState(
 	p.noticeSender = res
 	ih := &p.instrumentation
 
-	if explainBundle, ok := ast.(*tree.ExplainAnalyzeDebug); ok {
+	if explain, ok := ast.(*tree.ExplainAnalyze); ok && explain.Mode == tree.ExplainDebug {
 		telemetry.Inc(sqltelemetry.ExplainAnalyzeDebugUseCounter)
 		ih.SetOutputMode(explainAnalyzeDebugOutput)
 		// Strip off the explain node to execute the inner statement.
-		stmt.AST = explainBundle.Statement
+		stmt.AST = explain.Statement
 		ast = stmt.AST
 		// TODO(radu): should we trim the "EXPLAIN ANALYZE (DEBUG)" part from
 		// stmt.SQL?

--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -734,14 +734,14 @@ func (e *distSQLSpecExecFactory) ConstructExplainOpt(
 }
 
 func (e *distSQLSpecExecFactory) ConstructExplain(
-	options *tree.ExplainOptions, stmtType tree.StatementType, plan exec.Plan,
+	options *tree.ExplainOptions, analyze bool, stmtType tree.StatementType, plan exec.Plan,
 ) (exec.Node, error) {
 	// TODO(yuzefovich): make sure to return the same nice error in some
 	// variants of EXPLAIN when subqueries are present as we do in the old path.
 	// TODO(yuzefovich): make sure that local plan nodes that create
 	// distributed jobs are shown as "distributed". See distSQLExplainable.
 	p := plan.(*planComponents)
-	explain, err := constructExplainDistSQLOrVecNode(options, stmtType, p, e.planner)
+	explain, err := constructExplainDistSQLOrVecNode(options, analyze, stmtType, p, e.planner)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/exec_factory_util.go
+++ b/pkg/sql/exec_factory_util.go
@@ -107,10 +107,12 @@ func makeScanColumnsConfig(table cat.Table, cols exec.TableColumnOrdinalSet) sca
 }
 
 func constructExplainDistSQLOrVecNode(
-	options *tree.ExplainOptions, stmtType tree.StatementType, p *planComponents, planner *planner,
+	options *tree.ExplainOptions,
+	analyze bool,
+	stmtType tree.StatementType,
+	p *planComponents,
+	planner *planner,
 ) (exec.Node, error) {
-	analyzeSet := options.Flags[tree.ExplainFlagAnalyze]
-
 	if options.Flags[tree.ExplainFlagEnv] {
 		return nil, errors.New("ENV only supported with (OPT) option")
 	}
@@ -120,7 +122,7 @@ func constructExplainDistSQLOrVecNode(
 		return &explainDistSQLNode{
 			options:  options,
 			plan:     *p,
-			analyze:  analyzeSet,
+			analyze:  analyze,
 			stmtType: stmtType,
 		}, nil
 

--- a/pkg/sql/explain_bundle.go
+++ b/pkg/sql/explain_bundle.go
@@ -46,7 +46,7 @@ func setExplainBundleResult(
 	bundle diagnosticsBundle,
 	execCfg *ExecutorConfig,
 ) error {
-	res.ResetStmtType(&tree.ExplainAnalyzeDebug{})
+	res.ResetStmtType(&tree.ExplainAnalyze{})
 	res.SetColumns(ctx, colinfo.ExplainAnalyzeDebugColumns)
 
 	var text []string

--- a/pkg/sql/explain_bundle.go
+++ b/pkg/sql/explain_bundle.go
@@ -47,7 +47,7 @@ func setExplainBundleResult(
 	execCfg *ExecutorConfig,
 ) error {
 	res.ResetStmtType(&tree.ExplainAnalyze{})
-	res.SetColumns(ctx, colinfo.ExplainAnalyzeDebugColumns)
+	res.SetColumns(ctx, colinfo.ExplainPlanColumns)
 
 	var text []string
 	if bundle.collectionErr != nil {

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -31,11 +31,11 @@ import (
 // explainPlanNode implements EXPLAIN (PLAN); it produces the output of
 // EXPLAIN given an explain.Plan.
 type explainPlanNode struct {
+	optColumnsSlot
+
 	flags explain.Flags
 	plan  *explain.Plan
 	run   explainPlanNodeRun
-
-	columns colinfo.ResultColumns
 }
 
 type explainPlanNodeRun struct {
@@ -50,7 +50,7 @@ func (e *explainPlanNode) startExec(params runParams) error {
 	if err := emitExplain(ob, params.p.ExecCfg().Codec, e.plan, distribution, willVectorize); err != nil {
 		return err
 	}
-	v := params.p.newContainerValuesNode(e.columns, 0)
+	v := params.p.newContainerValuesNode(colinfo.ExplainPlanColumns, 0)
 	rows := ob.BuildStringRows()
 	datums := make([]tree.DString, len(rows))
 	for i, row := range rows {

--- a/pkg/sql/logictest/testdata/logic_test/prepare
+++ b/pkg/sql/logictest/testdata/logic_test/prepare
@@ -1156,11 +1156,11 @@ PREPARE e AS OPT PLAN '
     )
     [
       (Options "opt,verbose")
-      (ColList [ (NewColumn "text" "string") ])
+      (ColList [ (NewColumn "info" "string") ])
       (Props (MinPhysProps))
     ]
   )
-  (Presentation "text")
+  (Presentation "info")
   (NoOrdering)
 )'
 

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -329,7 +329,7 @@ ALTER TABLE c INJECT STATISTICS '[
 # vectorize=experimental_always, but we check that the vectorized plan contains
 # a wrapped joinReader processor.
 query B
-SELECT count(*) > 0 FROM [EXPLAIN (VEC) SELECT c.a FROM c JOIN d ON d.b = c.b] WHERE text LIKE '%rowexec.joinReader%'
+SELECT count(*) > 0 FROM [EXPLAIN (VEC) SELECT c.a FROM c JOIN d ON d.b = c.b] WHERE info LIKE '%rowexec.joinReader%'
 ----
 true
 

--- a/pkg/sql/opt/exec/execbuilder/statement.go
+++ b/pkg/sql/opt/exec/execbuilder/statement.go
@@ -140,7 +140,7 @@ func (b *Builder) buildExplain(explain *memo.ExplainExpr) (execPlan, error) {
 	if err != nil {
 		return execPlan{}, err
 	}
-	node, err := b.factory.ConstructExplain(&explain.Options, explain.StmtType, plan)
+	node, err := b.factory.ConstructExplain(&explain.Options, explain.Analyze, explain.StmtType, plan)
 	if err != nil {
 		return execPlan{}, err
 	}

--- a/pkg/sql/opt/exec/explain/result_columns.go
+++ b/pkg/sql/opt/exec/explain/result_columns.go
@@ -169,7 +169,7 @@ func getResultColumns(
 		case tree.ExplainDistSQL:
 			return colinfo.ExplainDistSQLColumns, nil
 		case tree.ExplainVec:
-			return colinfo.ExplainVecColumns, nil
+			return colinfo.ExplainPlanColumns, nil
 		default:
 			return nil, errors.AssertionFailedf("unknown explain mode %v", o.Mode)
 		}
@@ -178,7 +178,7 @@ func getResultColumns(
 		return colinfo.ExplainPlanColumns, nil
 
 	case explainOptOp:
-		return colinfo.ExplainOptColumns, nil
+		return colinfo.ExplainPlanColumns, nil
 
 	case showTraceOp:
 		if args.(*showTraceArgs).Compact {

--- a/pkg/sql/opt/exec/factory.opt
+++ b/pkg/sql/opt/exec/factory.opt
@@ -325,6 +325,7 @@ define ExplainOpt {
 # Explain implements EXPLAIN, showing information about the given plan.
 define Explain {
     Options *tree.ExplainOptions
+    Analyze bool
     StmtType tree.StatementType
     Plan exec.Plan
 }

--- a/pkg/sql/opt/ops/statement.opt
+++ b/pkg/sql/opt/ops/statement.opt
@@ -68,6 +68,11 @@ define ExplainPrivate {
     # Options contains settings that control the output of the explain statement.
     Options ExplainOptions
 
+    # Analyze indicates if this is an EXPLAIN ANALYZE.
+    # TODO(radu): remove this onse ANALYZE Is only implemented as a top-level
+    # statement.
+    Analyze bool
+
     # ColList stores the column IDs for the explain columns.
     ColList ColList
 

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -291,6 +291,9 @@ func (b *Builder) buildStmt(
 	case *tree.Explain:
 		return b.buildExplain(stmt, inScope)
 
+	case *tree.ExplainAnalyze:
+		return b.buildExplainAnalyze(stmt, inScope)
+
 	case *tree.ShowTraceForSession:
 		return b.buildShowTrace(stmt, inScope)
 
@@ -317,10 +320,6 @@ func (b *Builder) buildStmt(
 
 	case *tree.Export:
 		return b.buildExport(stmt, inScope)
-
-	case *tree.ExplainAnalyzeDebug:
-		// This statement should have been handled by the executor.
-		panic(errors.Errorf("%s can only be used as a top-level statement", stmt.StatementTag()))
 
 	default:
 		// See if this statement can be rewritten to another statement using the

--- a/pkg/sql/opt/optbuilder/explain.go
+++ b/pkg/sql/opt/optbuilder/explain.go
@@ -47,11 +47,11 @@ func (b *Builder) buildExplain(explain *tree.Explain, inScope *scope) (outScope 
 		} else {
 			telemetry.Inc(sqltelemetry.ExplainOptUseCounter)
 		}
-		cols = colinfo.ExplainOptColumns
+		cols = colinfo.ExplainPlanColumns
 
 	case tree.ExplainVec:
 		telemetry.Inc(sqltelemetry.ExplainVecUseCounter)
-		cols = colinfo.ExplainVecColumns
+		cols = colinfo.ExplainPlanColumns
 
 	default:
 		panic(errors.Errorf("EXPLAIN mode %s not supported", explain.Mode))

--- a/pkg/sql/opt/optbuilder/explain.go
+++ b/pkg/sql/opt/optbuilder/explain.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
+	"github.com/cockroachdb/errors"
 )
 
 func (b *Builder) buildExplain(explain *tree.Explain, inScope *scope) (outScope *scope) {
@@ -37,16 +38,7 @@ func (b *Builder) buildExplain(explain *tree.Explain, inScope *scope) (outScope 
 		cols = colinfo.ExplainPlanColumns
 
 	case tree.ExplainDistSQL:
-		analyze := explain.Flags[tree.ExplainFlagAnalyze]
-		if analyze {
-			telemetry.Inc(sqltelemetry.ExplainAnalyzeUseCounter)
-		} else {
-			telemetry.Inc(sqltelemetry.ExplainDistSQLUseCounter)
-		}
-		if analyze && tree.IsStmtParallelized(explain.Statement) {
-			panic(pgerror.Newf(pgcode.FeatureNotSupported,
-				"EXPLAIN ANALYZE does not support RETURNING NOTHING statements"))
-		}
+		telemetry.Inc(sqltelemetry.ExplainDistSQLUseCounter)
 		cols = colinfo.ExplainDistSQLColumns
 
 	case tree.ExplainOpt:
@@ -62,14 +54,55 @@ func (b *Builder) buildExplain(explain *tree.Explain, inScope *scope) (outScope 
 		cols = colinfo.ExplainVecColumns
 
 	default:
-		panic(pgerror.Newf(pgcode.FeatureNotSupported,
-			"EXPLAIN ANALYZE does not support RETURNING NOTHING statements"))
+		panic(errors.Errorf("EXPLAIN mode %s not supported", explain.Mode))
 	}
 	b.synthesizeResultColumns(outScope, cols)
 
 	input := stmtScope.expr.(memo.RelExpr)
 	private := memo.ExplainPrivate{
 		Options:  explain.ExplainOptions,
+		Analyze:  false,
+		ColList:  colsToColList(outScope.cols),
+		Props:    stmtScope.makePhysicalProps(),
+		StmtType: explain.Statement.StatementType(),
+	}
+	outScope.expr = b.factory.ConstructExplain(input, &private)
+	return outScope
+}
+
+func (b *Builder) buildExplainAnalyze(
+	explain *tree.ExplainAnalyze, inScope *scope,
+) (outScope *scope) {
+	if explain.Mode == tree.ExplainDebug {
+		// This statement should have been handled by the executor.
+		panic(errors.New("EXPLAIN ANALYZE (DEBUG) can only be used as a top-level statement"))
+	}
+	if explain.Mode != tree.ExplainDistSQL {
+		panic(errors.Errorf("EXPLAIN ANALYZE mode %s not supported", explain.Mode))
+	}
+	if tree.IsStmtParallelized(explain.Statement) {
+		panic(pgerror.Newf(pgcode.FeatureNotSupported,
+			"EXPLAIN ANALYZE does not support RETURNING NOTHING statements"))
+	}
+
+	// TODO(radu): eventually, all ANALYZE modes should be supported and handled
+	// only as top-level statements.
+
+	b.pushWithFrame()
+	// We don't allow the statement under Explain to reference outer columns, so we
+	// pass a "blank" scope rather than inScope.
+	stmtScope := b.buildStmtAtRoot(explain.Statement, nil /* desiredTypes */, b.allocScope())
+
+	b.popWithFrame(stmtScope)
+	outScope = inScope.push()
+
+	telemetry.Inc(sqltelemetry.ExplainAnalyzeUseCounter)
+	b.synthesizeResultColumns(outScope, colinfo.ExplainDistSQLColumns)
+
+	input := stmtScope.expr.(memo.RelExpr)
+	private := memo.ExplainPrivate{
+		Options:  explain.ExplainOptions,
+		Analyze:  true,
 		ColList:  colsToColList(outScope.cols),
 		Props:    stmtScope.makePhysicalProps(),
 		StmtType: explain.Statement.StatementType(),

--- a/pkg/sql/opt/xform/testdata/rules/partitioned
+++ b/pkg/sql/opt/xform/testdata/rules/partitioned
@@ -33,7 +33,7 @@ EXPLAIN (OPT, VERBOSE)
   val = 1
 ----
 explain
- ├── columns: text:6
+ ├── columns: info:6
  ├── mode: opt, verbose
  └── select
       ├── columns: planet:1!null region:2!null subregion:3!null val:4!null

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1116,9 +1116,9 @@ func (ef *execFactory) ConstructExplainOpt(
 
 // ConstructExplain is part of the exec.Factory interface.
 func (ef *execFactory) ConstructExplain(
-	options *tree.ExplainOptions, stmtType tree.StatementType, plan exec.Plan,
+	options *tree.ExplainOptions, analyze bool, stmtType tree.StatementType, plan exec.Plan,
 ) (exec.Node, error) {
-	return constructExplainDistSQLOrVecNode(options, stmtType, plan.(*planComponents), ef.planner)
+	return constructExplainDistSQLOrVecNode(options, analyze, stmtType, plan.(*planComponents), ef.planner)
 }
 
 // ConstructShowTrace is part of the exec.Factory interface.

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1085,7 +1085,7 @@ func (ef *execFactory) showEnv(plan string, envOpts exec.ExplainEnvData) (exec.N
 		return nil, err
 	}
 	return &valuesNode{
-		columns:          colinfo.ExplainOptColumns,
+		columns:          append(colinfo.ResultColumns(nil), colinfo.ExplainPlanColumns...),
 		tuples:           [][]tree.TypedExpr{{tree.NewDString(url.String())}},
 		specifiedInQuery: true,
 	}, nil
@@ -1108,7 +1108,7 @@ func (ef *execFactory) ConstructExplainOpt(
 	}
 
 	return &valuesNode{
-		columns:          colinfo.ExplainOptColumns,
+		columns:          append(colinfo.ResultColumns(nil), colinfo.ExplainPlanColumns...),
 		tuples:           rows,
 		specifiedInQuery: true,
 	}, nil
@@ -1824,7 +1824,6 @@ func (ef *execFactory) ConstructExplainPlan(
 		flags: flags,
 		plan:  plan.(*explain.Plan),
 	}
-	n.columns = colinfo.ExplainPlanColumns
 	return n, nil
 }
 

--- a/pkg/sql/parser/testdata/errors
+++ b/pkg/sql/parser/testdata/errors
@@ -568,7 +568,7 @@ EXPLAIN (DEBUG) SELECT 1
 error
 EXPLAIN (PLAN, DEBUG) SELECT 1
 ----
-at or near "EOF": syntax error: DEBUG flag can only be used with EXPLAIN ANALYZE
+at or near "EOF": syntax error: cannot set EXPLAIN mode more than once: DEBUG
 DETAIL: source SQL:
 EXPLAIN (PLAN, DEBUG) SELECT 1
                               ^

--- a/pkg/sql/plan_columns.go
+++ b/pkg/sql/plan_columns.go
@@ -61,8 +61,6 @@ func getPlanColumns(plan planNode, mut bool) colinfo.ResultColumns {
 		return n.columns
 	case *virtualTableNode:
 		return n.columns
-	case *explainPlanNode:
-		return n.columns
 	case *windowNode:
 		return n.columns
 	case *showTraceNode:
@@ -101,8 +99,10 @@ func getPlanColumns(plan planNode, mut bool) colinfo.ResultColumns {
 		return n.getColumns(mut, colinfo.ScrubColumns)
 	case *explainDistSQLNode:
 		return n.getColumns(mut, colinfo.ExplainDistSQLColumns)
+	case *explainPlanNode:
+		return n.getColumns(mut, colinfo.ExplainPlanColumns)
 	case *explainVecNode:
-		return n.getColumns(mut, colinfo.ExplainVecColumns)
+		return n.getColumns(mut, colinfo.ExplainPlanColumns)
 	case *relocateNode:
 		return n.getColumns(mut, colinfo.AlterTableRelocateColumns)
 	case *scatterNode:

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -85,7 +85,7 @@ func (p *planner) prepareUsingOptimizer(ctx context.Context) (planFlags, error) 
 			if len(p.semaCtx.Placeholders.Types) != 0 {
 				return 0, errors.Errorf("%s does not support placeholders", stmt.AST.StatementTag())
 			}
-			stmt.Prepared.Columns = colinfo.ExplainAnalyzeDebugColumns
+			stmt.Prepared.Columns = colinfo.ExplainPlanColumns
 			return opc.flags, nil
 		}
 	}

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -50,7 +50,7 @@ func (p *planner) prepareUsingOptimizer(ctx context.Context) (planFlags, error) 
 	opc := &p.optPlanningCtx
 	opc.reset()
 
-	switch stmt.AST.(type) {
+	switch n := stmt.AST.(type) {
 	case *tree.AlterIndex, *tree.AlterTable, *tree.AlterSequence,
 		*tree.Analyze,
 		*tree.BeginTransaction,
@@ -78,14 +78,16 @@ func (p *planner) prepareUsingOptimizer(ctx context.Context) (planFlags, error) 
 		// descriptors and such).
 		return opc.flags, nil
 
-	case *tree.ExplainAnalyzeDebug:
-		// This statement returns result columns but does not support placeholders,
-		// and we don't want to do anything during prepare.
-		if len(p.semaCtx.Placeholders.Types) != 0 {
-			return 0, errors.Errorf("%s does not support placeholders", stmt.AST.StatementTag())
+	case *tree.ExplainAnalyze:
+		if n.Mode == tree.ExplainDebug {
+			// This statement returns result columns but does not support placeholders,
+			// and we don't want to do anything during prepare.
+			if len(p.semaCtx.Placeholders.Types) != 0 {
+				return 0, errors.Errorf("%s does not support placeholders", stmt.AST.StatementTag())
+			}
+			stmt.Prepared.Columns = colinfo.ExplainAnalyzeDebugColumns
+			return opc.flags, nil
 		}
-		stmt.Prepared.Columns = colinfo.ExplainAnalyzeDebugColumns
-		return opc.flags, nil
 	}
 
 	if opc.useCache {

--- a/pkg/sql/sem/tree/explain.go
+++ b/pkg/sql/sem/tree/explain.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/util/pretty"
 	"github.com/cockroachdb/errors"
 )
 
@@ -24,6 +25,13 @@ type Explain struct {
 	ExplainOptions
 
 	// Statement is the statement being EXPLAINed.
+	Statement Statement
+}
+
+// ExplainAnalyze represents an EXPLAIN ANALYZE statement.
+type ExplainAnalyze struct {
+	ExplainOptions
+
 	Statement Statement
 }
 
@@ -56,6 +64,10 @@ const (
 	// query would be run in "auto" vectorized mode.
 	ExplainVec
 
+	// ExplainDebug generates a statement diagnostics bundle; only used with
+	// EXPLAIN ANALYZE.
+	ExplainDebug
+
 	numExplainModes = iota
 )
 
@@ -64,6 +76,7 @@ var explainModeStrings = [...]string{
 	ExplainDistSQL: "DISTSQL",
 	ExplainOpt:     "OPT",
 	ExplainVec:     "VEC",
+	ExplainDebug:   "DEBUG",
 }
 
 var explainModeStringMap = func() map[string]ExplainMode {
@@ -88,20 +101,16 @@ type ExplainFlag uint8
 const (
 	ExplainFlagVerbose ExplainFlag = 1 + iota
 	ExplainFlagTypes
-	ExplainFlagAnalyze
 	ExplainFlagEnv
 	ExplainFlagCatalog
-	ExplainFlagDebug
 	numExplainFlags = iota
 )
 
 var explainFlagStrings = [...]string{
 	ExplainFlagVerbose: "VERBOSE",
 	ExplainFlagTypes:   "TYPES",
-	ExplainFlagAnalyze: "ANALYZE",
 	ExplainFlagEnv:     "ENV",
 	ExplainFlagCatalog: "CATALOG",
-	ExplainFlagDebug:   "DEBUG",
 }
 
 var explainFlagStringMap = func() map[string]ExplainFlag {
@@ -122,21 +131,14 @@ func (f ExplainFlag) String() string {
 // Format implements the NodeFormatter interface.
 func (node *Explain) Format(ctx *FmtCtx) {
 	ctx.WriteString("EXPLAIN ")
-	showMode := node.Mode != ExplainPlan
-	// ANALYZE is a special case because it is a statement implemented as an
-	// option to EXPLAIN.
-	if node.Flags[ExplainFlagAnalyze] {
-		ctx.WriteString("ANALYZE ")
-		showMode = true
-	}
 	wroteFlag := false
-	if showMode {
+	if node.Mode != ExplainPlan {
 		fmt.Fprintf(ctx, "(%s", node.Mode)
 		wroteFlag = true
 	}
 
 	for f := ExplainFlag(1); f <= numExplainFlags; f++ {
-		if f != ExplainFlagAnalyze && node.Flags[f] {
+		if node.Flags[f] {
 			if !wroteFlag {
 				ctx.WriteString("(")
 				wroteFlag = true
@@ -152,26 +154,67 @@ func (node *Explain) Format(ctx *FmtCtx) {
 	ctx.FormatNode(node.Statement)
 }
 
-// ExplainAnalyzeDebug represents an EXPLAIN ANALYZE (DEBUG) statement. It is a
-// different node type than Explain to allow easier special treatment in the SQL
-// layer.
-type ExplainAnalyzeDebug struct {
-	Statement Statement
+// doc is part of the docer interface.
+func (node *Explain) doc(p *PrettyCfg) pretty.Doc {
+	d := pretty.Keyword("EXPLAIN")
+	var opts []pretty.Doc
+	if node.Mode != ExplainPlan {
+		opts = append(opts, pretty.Keyword(node.Mode.String()))
+	}
+	for f := ExplainFlag(1); f <= numExplainFlags; f++ {
+		if node.Flags[f] {
+			opts = append(opts, pretty.Keyword(f.String()))
+		}
+	}
+	if len(opts) > 0 {
+		d = pretty.ConcatSpace(
+			d,
+			p.bracket("(", p.commaSeparated(opts...), ")"),
+		)
+	}
+	return p.nestUnder(d, p.Doc(node.Statement))
 }
 
 // Format implements the NodeFormatter interface.
-func (node *ExplainAnalyzeDebug) Format(ctx *FmtCtx) {
-	ctx.WriteString("EXPLAIN ANALYZE (DEBUG) ")
+func (node *ExplainAnalyze) Format(ctx *FmtCtx) {
+	fmt.Fprintf(ctx, "EXPLAIN ANALYZE (%s", node.Mode)
+
+	for f := ExplainFlag(1); f <= numExplainFlags; f++ {
+		if node.Flags[f] {
+			fmt.Fprintf(ctx, ", %s", f.String())
+		}
+	}
+	ctx.WriteString(") ")
 	ctx.FormatNode(node.Statement)
 }
 
-// MakeExplain parses the EXPLAIN option strings and generates an explain
-// statement.
+// doc is part of the docer interface.
+func (node *ExplainAnalyze) doc(p *PrettyCfg) pretty.Doc {
+	d := pretty.Keyword("EXPLAIN ANALYZE")
+	var opts []pretty.Doc
+	opts = append(opts, pretty.Keyword(node.Mode.String()))
+	for f := ExplainFlag(1); f <= numExplainFlags; f++ {
+		if node.Flags[f] {
+			opts = append(opts, pretty.Keyword(f.String()))
+		}
+	}
+	if len(opts) > 0 {
+		d = pretty.ConcatSpace(
+			d,
+			p.bracket("(", p.commaSeparated(opts...), ")"),
+		)
+	}
+	return p.nestUnder(d, p.Doc(node.Statement))
+}
+
+// MakeExplain parses the EXPLAIN option strings and generates an Explain
+// or ExplainAnalyze statement.
 func MakeExplain(options []string, stmt Statement) (Statement, error) {
 	for i := range options {
 		options[i] = strings.ToUpper(options[i])
 	}
 	var opts ExplainOptions
+	var analyze bool
 	for _, opt := range options {
 		opt = strings.ToUpper(opt)
 		if m, ok := explainModeStringMap[opt]; ok {
@@ -181,13 +224,16 @@ func MakeExplain(options []string, stmt Statement) (Statement, error) {
 			opts.Mode = m
 			continue
 		}
+		if opt == "ANALYZE" {
+			analyze = true
+			continue
+		}
 		flag, ok := explainFlagStringMap[opt]
 		if !ok {
 			return nil, pgerror.Newf(pgcode.Syntax, "unsupported EXPLAIN option: %s", opt)
 		}
 		opts.Flags[flag] = true
 	}
-	analyze := opts.Flags[ExplainFlagAnalyze]
 	if opts.Mode == 0 {
 		if analyze {
 			// ANALYZE implies DISTSQL.
@@ -196,22 +242,21 @@ func MakeExplain(options []string, stmt Statement) (Statement, error) {
 			// Default mode is ExplainPlan.
 			opts.Mode = ExplainPlan
 		}
-	} else if analyze && opts.Mode != ExplainDistSQL {
-		return nil, pgerror.Newf(pgcode.Syntax, "EXPLAIN ANALYZE cannot be used with %s", opts.Mode)
 	}
 
-	if opts.Flags[ExplainFlagDebug] {
-		if !analyze {
-			return nil, pgerror.Newf(pgcode.Syntax, "DEBUG flag can only be used with EXPLAIN ANALYZE")
+	if analyze {
+		if opts.Mode != ExplainDistSQL && opts.Mode != ExplainDebug {
+			return nil, pgerror.Newf(pgcode.Syntax, "EXPLAIN ANALYZE cannot be used with %s", opts.Mode)
 		}
-		if len(options) != 2 {
-			return nil, pgerror.Newf(pgcode.Syntax,
-				"EXPLAIN ANALYZE (DEBUG) cannot be used in conjunction with other flags",
-			)
-		}
-		return &ExplainAnalyzeDebug{Statement: stmt}, nil
+		return &ExplainAnalyze{
+			ExplainOptions: opts,
+			Statement:      stmt,
+		}, nil
 	}
 
+	if opts.Mode == ExplainDebug {
+		return nil, pgerror.Newf(pgcode.Syntax, "DEBUG flag can only be used with EXPLAIN ANALYZE")
+	}
 	return &Explain{
 		ExplainOptions: opts,
 		Statement:      stmt,

--- a/pkg/sql/sem/tree/explain.go
+++ b/pkg/sql/sem/tree/explain.go
@@ -32,6 +32,7 @@ type Explain struct {
 type ExplainAnalyze struct {
 	ExplainOptions
 
+	// Statement is the statement being EXPLAINed.
 	Statement Statement
 }
 

--- a/pkg/sql/sem/tree/pretty.go
+++ b/pkg/sql/sem/tree/pretty.go
@@ -2089,44 +2089,6 @@ func (node *Export) doc(p *PrettyCfg) pretty.Doc {
 	return p.rlTable(items...)
 }
 
-func (node *Explain) doc(p *PrettyCfg) pretty.Doc {
-	d := pretty.Keyword("EXPLAIN")
-	showMode := node.Mode != ExplainPlan
-	// ANALYZE is a special case because it is a statement implemented as an
-	// option to EXPLAIN.
-	if node.Flags[ExplainFlagAnalyze] {
-		d = pretty.ConcatSpace(d, pretty.Keyword("ANALYZE"))
-		showMode = true
-	}
-	var opts []pretty.Doc
-	if showMode {
-		opts = append(opts, pretty.Keyword(node.Mode.String()))
-	}
-	for f := ExplainFlag(1); f <= numExplainFlags; f++ {
-		if f != ExplainFlagAnalyze && node.Flags[f] {
-			opts = append(opts, pretty.Keyword(f.String()))
-		}
-	}
-	if len(opts) > 0 {
-		d = pretty.ConcatSpace(
-			d,
-			p.bracket("(", p.commaSeparated(opts...), ")"),
-		)
-	}
-	return p.nestUnder(d, p.Doc(node.Statement))
-}
-
-func (node *ExplainAnalyzeDebug) doc(p *PrettyCfg) pretty.Doc {
-	d := pretty.ConcatSpace(
-		pretty.ConcatSpace(
-			pretty.Keyword("EXPLAIN"),
-			pretty.Keyword("ANALYZE"),
-		),
-		p.bracket("(", pretty.Keyword("DEBUG"), ")"),
-	)
-	return p.nestUnder(d, p.Doc(node.Statement))
-}
-
 func (node *NotExpr) doc(p *PrettyCfg) pretty.Doc {
 	return p.nestUnder(
 		pretty.Keyword("NOT"),

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -555,10 +555,10 @@ func (*Explain) StatementType() StatementType { return Rows }
 func (*Explain) StatementTag() string { return "EXPLAIN" }
 
 // StatementType implements the Statement interface.
-func (*ExplainAnalyzeDebug) StatementType() StatementType { return Rows }
+func (*ExplainAnalyze) StatementType() StatementType { return Rows }
 
 // StatementTag returns a short string identifying the type of statement.
-func (*ExplainAnalyzeDebug) StatementTag() string { return "EXPLAIN ANALYZE (DEBUG)" }
+func (*ExplainAnalyze) StatementTag() string { return "EXPLAIN ANALYZE" }
 
 // StatementType implements the Statement interface.
 func (*Export) StatementType() StatementType { return Rows }
@@ -1118,7 +1118,7 @@ func (n *DropView) String() string                       { return AsString(n) }
 func (n *DropRole) String() string                       { return AsString(n) }
 func (n *Execute) String() string                        { return AsString(n) }
 func (n *Explain) String() string                        { return AsString(n) }
-func (n *ExplainAnalyzeDebug) String() string            { return AsString(n) }
+func (n *ExplainAnalyze) String() string                 { return AsString(n) }
 func (n *Export) String() string                         { return AsString(n) }
 func (n *Grant) String() string                          { return AsString(n) }
 func (n *GrantRole) String() string                      { return AsString(n) }

--- a/pkg/sql/sem/tree/walk.go
+++ b/pkg/sql/sem/tree/walk.go
@@ -855,13 +855,13 @@ func (stmt *Explain) walkStmt(v Visitor) Statement {
 }
 
 // copyNode makes a copy of this Statement without recursing in any child Statements.
-func (stmt *ExplainAnalyzeDebug) copyNode() *ExplainAnalyzeDebug {
+func (stmt *ExplainAnalyze) copyNode() *ExplainAnalyze {
 	stmtCopy := *stmt
 	return &stmtCopy
 }
 
 // walkStmt is part of the walkableStmt interface.
-func (stmt *ExplainAnalyzeDebug) walkStmt(v Visitor) Statement {
+func (stmt *ExplainAnalyze) walkStmt(v Visitor) Statement {
 	s, changed := walkStmt(v, stmt.Statement)
 	if changed {
 		stmt = stmt.copyNode()

--- a/pkg/sql/values.go
+++ b/pkg/sql/values.go
@@ -24,6 +24,7 @@ import (
 )
 
 type valuesNode struct {
+	// Note: the columns can be renamed in place (see planMutableColumns).
 	columns colinfo.ResultColumns
 	tuples  [][]tree.TypedExpr
 


### PR DESCRIPTION
#### sql: reorganize EXPLAIN ANALYZE

This change reorganizes the AST representation for EXPLAIN ANALYZE. We
currently have a separate node for EXPLAIN ANALYZE (DEBUG) but other
EXPLAIN ANALYZE variants use the same tree node as EXPLAIN. The main
reason for this distinction is that the latter is executed very
differently, only supported as a top-level statement.

This change removes the special node for EXPLAIN ANALYZE (DEBUG) and
adds an `ExplainAnalyze` node for all ANALYZE variants. Eventually all
ANALYZE variants will only be supported as top-level statements.

As part of this change, DEBUG is changed from a flag to a mode (which
more closely matches its usage).

Release note: None

#### sql: consolidate schema of EXPLAIN variants

We now have a bunch of EXPLAIN variants that return a single text
column. Consolidate them so they all use the same ResultColumns.

Release note: None
