### PR TITLE
hlc: introduce synthetic flag on timestamps

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -824,7 +824,7 @@ func backupPlanHook(
 				keys.MinKey,
 				p.User(),
 				func(span covering.Range, start, end hlc.Timestamp) error {
-					if (start == hlc.Timestamp{}) {
+					if start.IsEmpty() {
 						newSpans = append(newSpans, roachpb.Span{Key: span.Start, EndKey: span.End})
 						return nil
 					}

--- a/pkg/ccl/changefeedccl/cdctest/validator.go
+++ b/pkg/ccl/changefeedccl/cdctest/validator.go
@@ -467,7 +467,7 @@ func (v *fingerprintValidator) NoteResolved(partition string, resolved hlc.Times
 		// we fingerprint at `updated.Prev()` since we want to catch cases where one or
 		// more row updates are missed. For example: If k1 was written at t1, t2, t3 and
 		// the update for t2 was missed.
-		if v.previousRowUpdateTs != (hlc.Timestamp{}) && v.previousRowUpdateTs.Less(row.updated) {
+		if !v.previousRowUpdateTs.IsEmpty() && v.previousRowUpdateTs.Less(row.updated) {
 			if err := v.fingerprint(row.updated.Prev()); err != nil {
 				return err
 			}

--- a/pkg/ccl/changefeedccl/changefeed.go
+++ b/pkg/ccl/changefeedccl/changefeed.go
@@ -199,7 +199,7 @@ func kvsToRows(
 				}
 				schemaTimestamp := kv.Value.Timestamp
 				prevSchemaTimestamp := schemaTimestamp
-				if backfillTs := input.BackfillTimestamp(); backfillTs != (hlc.Timestamp{}) {
+				if backfillTs := input.BackfillTimestamp(); !backfillTs.IsEmpty() {
 					schemaTimestamp = backfillTs
 					prevSchemaTimestamp = schemaTimestamp.Prev()
 				}

--- a/pkg/ccl/changefeedccl/changefeed_dist.go
+++ b/pkg/ccl/changefeedccl/changefeed_dist.go
@@ -80,7 +80,7 @@ func distChangefeedFlow(
 	// based on whether we should perform an initial scan.
 	{
 		h := progress.GetHighWater()
-		noHighWater := (h == nil || *h == (hlc.Timestamp{}))
+		noHighWater := (h == nil || h.IsEmpty())
 		// We want to set the highWater and thus avoid an initial scan if either
 		// this is a cursor and there was no request for one, or we don't have a
 		// cursor but we have a request to not have an initial scan.
@@ -92,7 +92,7 @@ func distChangefeedFlow(
 
 	spansTS := details.StatementTime
 	var initialHighWater hlc.Timestamp
-	if h := progress.GetHighWater(); h != nil && *h != (hlc.Timestamp{}) {
+	if h := progress.GetHighWater(); h != nil && !h.IsEmpty() {
 		initialHighWater = *h
 		// If we have a high-water set, use it to compute the spans, since the
 		// ones at the statement time may have been garbage collected by now.

--- a/pkg/ccl/changefeedccl/kvfeed/buffer.go
+++ b/pkg/ccl/changefeedccl/kvfeed/buffer.go
@@ -126,7 +126,7 @@ func (b *Event) Timestamp() hlc.Timestamp {
 	case ResolvedEvent:
 		return b.resolved.Timestamp
 	case KVEvent:
-		if b.backfillTimestamp != (hlc.Timestamp{}) {
+		if !b.backfillTimestamp.IsEmpty() {
 			return b.backfillTimestamp
 		}
 		return b.kv.Value.Timestamp

--- a/pkg/ccl/changefeedccl/kvfeed/buffer.go
+++ b/pkg/ccl/changefeedccl/kvfeed/buffer.go
@@ -211,6 +211,7 @@ var memBufferColTypes = []*types.T{
 	types.Bytes, // span.EndKey
 	types.Int,   // ts.WallTime
 	types.Int,   // ts.Logical
+	types.Int,   // ts.Flags
 }
 
 // memBuffer is an in-memory buffer for changed KV and Resolved timestamp
@@ -266,6 +267,7 @@ func (b *memBuffer) AddKV(
 		tree.DNull,
 		b.allocMu.a.NewDInt(tree.DInt(kv.Value.Timestamp.WallTime)),
 		b.allocMu.a.NewDInt(tree.DInt(kv.Value.Timestamp.Logical)),
+		b.allocMu.a.NewDInt(tree.DInt(kv.Value.Timestamp.Flags)),
 	}
 	b.allocMu.Unlock()
 	return b.addRow(ctx, row)
@@ -284,6 +286,7 @@ func (b *memBuffer) AddResolved(
 		b.allocMu.a.NewDBytes(tree.DBytes(span.EndKey)),
 		b.allocMu.a.NewDInt(tree.DInt(ts.WallTime)),
 		b.allocMu.a.NewDInt(tree.DInt(ts.Logical)),
+		b.allocMu.a.NewDInt(tree.DInt(ts.Flags)),
 	}
 	b.allocMu.Unlock()
 	return b.addRow(ctx, row)
@@ -300,6 +303,7 @@ func (b *memBuffer) Get(ctx context.Context) (Event, error) {
 	ts := hlc.Timestamp{
 		WallTime: int64(*row[5].(*tree.DInt)),
 		Logical:  int32(*row[6].(*tree.DInt)),
+		Flags:    uint32(*row[7].(*tree.DInt)),
 	}
 	if row[2] != tree.DNull {
 		e.prevVal = roachpb.Value{

--- a/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
+++ b/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
@@ -362,7 +362,7 @@ func copyFromSourceToSinkUntilTableEvent(
 					return false, false
 				}
 				frontier.Forward(resolved.Span, boundaryResolvedTimestamp)
-				return true, frontier.Frontier() == boundaryResolvedTimestamp
+				return true, frontier.Frontier().EqOrdering(boundaryResolvedTimestamp)
 			default:
 				log.Fatal(ctx, "unknown event type")
 				return false, false

--- a/pkg/ccl/changefeedccl/schemafeed/schema_feed.go
+++ b/pkg/ccl/changefeedccl/schemafeed/schema_feed.go
@@ -369,7 +369,7 @@ func (tf *SchemaFeed) waitForTS(ctx context.Context, ts hlc.Timestamp) error {
 	tf.mu.Lock()
 	highWater := tf.mu.highWater
 	var err error
-	if tf.mu.errTS != (hlc.Timestamp{}) && tf.mu.errTS.LessEq(ts) {
+	if !tf.mu.errTS.IsEmpty() && tf.mu.errTS.LessEq(ts) {
 		err = tf.mu.err
 	}
 	fastPath := err != nil || ts.LessEq(highWater)
@@ -437,7 +437,7 @@ func (tf *SchemaFeed) adjustTimestamps(startTS, endTS hlc.Timestamp, validateErr
 
 	if validateErr != nil {
 		// don't care about startTS in the invalid case
-		if tf.mu.errTS == (hlc.Timestamp{}) || endTS.Less(tf.mu.errTS) {
+		if tf.mu.errTS.IsEmpty() || endTS.Less(tf.mu.errTS) {
 			tf.mu.errTS = endTS
 			tf.mu.err = validateErr
 			newWaiters := make([]tableHistoryWaiter, 0, len(tf.mu.waiters))

--- a/pkg/ccl/storageccl/export_test.go
+++ b/pkg/ccl/storageccl/export_test.go
@@ -581,11 +581,7 @@ func TestRandomKeyAndTimestampExport(t *testing.T) {
 		}
 		batch.Close()
 
-		sort.Slice(timestamps, func(i, j int) bool {
-			return (timestamps[i].WallTime < timestamps[j].WallTime) ||
-				(timestamps[i].WallTime == timestamps[j].WallTime &&
-					timestamps[i].Logical < timestamps[j].Logical)
-		})
+		sort.Slice(timestamps, func(i, j int) bool { return timestamps[i].Less(timestamps[j]) })
 		return keys, timestamps
 	}
 

--- a/pkg/ccl/storageccl/import.go
+++ b/pkg/ccl/storageccl/import.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
-	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
@@ -220,7 +219,7 @@ func evalImport(ctx context.Context, cArgs batcheval.CommandArgs) (*roachpb.Impo
 			break
 		}
 
-		if args.EndTime != (hlc.Timestamp{}) {
+		if !args.EndTime.IsEmpty() {
 			// TODO(dan): If we have to skip past a lot of versions to find the
 			// latest one before args.EndTime, then this could be slow.
 			if args.EndTime.Less(iter.UnsafeKey().Timestamp) {

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -349,7 +349,7 @@ func loadRangeDescriptor(
 ) (roachpb.RangeDescriptor, error) {
 	var desc roachpb.RangeDescriptor
 	handleKV := func(kv storage.MVCCKeyValue) error {
-		if kv.Key.Timestamp == (hlc.Timestamp{}) {
+		if kv.Key.Timestamp.IsEmpty() {
 			// We only want values, not MVCCMetadata.
 			return nil
 		}

--- a/pkg/jobs/helpers.go
+++ b/pkg/jobs/helpers.go
@@ -54,7 +54,7 @@ func NewFakeNodeLiveness(nodeCount int) *FakeNodeLiveness {
 		nodeID := roachpb.NodeID(i + 1)
 		nl.mu.livenessMap[nodeID] = &livenesspb.Liveness{
 			Epoch:      1,
-			Expiration: hlc.LegacyTimestamp(hlc.MaxTimestamp),
+			Expiration: hlc.MaxTimestamp.ToLegacyTimestamp(),
 			NodeID:     nodeID,
 		}
 	}
@@ -113,7 +113,7 @@ func (nl *FakeNodeLiveness) FakeIncrementEpoch(id roachpb.NodeID) {
 func (nl *FakeNodeLiveness) FakeSetExpiration(id roachpb.NodeID, ts hlc.Timestamp) {
 	nl.mu.Lock()
 	defer nl.mu.Unlock()
-	nl.mu.livenessMap[id].Expiration = hlc.LegacyTimestamp(ts)
+	nl.mu.livenessMap[id].Expiration = ts.ToLegacyTimestamp()
 }
 
 // ResetConstructors resets the registered Resumer constructors.

--- a/pkg/jobs/jobs_test.go
+++ b/pkg/jobs/jobs_test.go
@@ -1499,7 +1499,7 @@ func TestShowJobs(t *testing.T) {
 			progress := &jobspb.Progress{
 				ModifiedMicros: in.modified.UnixNano() / time.Microsecond.Nanoseconds(),
 			}
-			if in.highWater != (hlc.Timestamp{}) {
+			if !in.highWater.IsEmpty() {
 				progress.Progress = &jobspb.Progress_HighWater{
 					HighWater: &in.highWater,
 				}

--- a/pkg/keys/constants.go
+++ b/pkg/keys/constants.go
@@ -64,9 +64,6 @@ var (
 	// metadata is identified by one of the suffixes listed below, along
 	// with potentially additional encoded key info, for instance in the
 	// case of AbortSpan entry.
-	//
-	// NOTE: LocalRangeIDPrefix must be kept in sync with the value
-	// in storage/engine/rocksdb/db.cc.
 	LocalRangeIDPrefix = roachpb.RKey(makeKey(localPrefix, roachpb.Key("i")))
 	// LocalRangeIDReplicatedInfix is the post-Range ID specifier for all Raft
 	// replicated per-range data. By appending this after the Range ID, these
@@ -135,9 +132,6 @@ var (
 	// specific sort of per-range metadata is identified by one of the
 	// suffixes listed below, along with potentially additional encoded
 	// key info, such as the txn ID in the case of a transaction record.
-	//
-	// NOTE: LocalRangePrefix must be kept in sync with the value in
-	// storage/engine/rocksdb/db.cc.
 	LocalRangePrefix = roachpb.Key(makeKey(localPrefix, roachpb.RKey("k")))
 	LocalRangeMax    = LocalRangePrefix.PrefixEnd()
 	// LocalQueueLastProcessedSuffix is the suffix for replica queue state keys.
@@ -152,8 +146,6 @@ var (
 	LocalRangeDescriptorSuffix = roachpb.RKey("rdsc")
 	// LocalTransactionSuffix specifies the key suffix for
 	// transaction records. The additional detail is the transaction id.
-	// NOTE: if this value changes, it must be updated in C++
-	// (storage/engine/rocksdb/db.cc).
 	LocalTransactionSuffix = roachpb.RKey("txn-")
 
 	// 4. Lock table keys

--- a/pkg/kv/client_test.go
+++ b/pkg/kv/client_test.go
@@ -338,7 +338,7 @@ func TestClientGetAndPut(t *testing.T) {
 	if !bytes.Equal(value, gr.ValueBytes()) {
 		t.Errorf("expected values equal; %s != %s", value, gr.ValueBytes())
 	}
-	if gr.Value.Timestamp == (hlc.Timestamp{}) {
+	if gr.Value.Timestamp.IsEmpty() {
 		t.Fatalf("expected non-zero timestamp; got empty")
 	}
 }
@@ -361,7 +361,7 @@ func TestClientPutInline(t *testing.T) {
 	if !bytes.Equal(value, gr.ValueBytes()) {
 		t.Errorf("expected values equal; %s != %s", value, gr.ValueBytes())
 	}
-	if ts := gr.Value.Timestamp; ts != (hlc.Timestamp{}) {
+	if ts := gr.Value.Timestamp; !ts.IsEmpty() {
 		t.Fatalf("expected zero timestamp; got %s", ts)
 	}
 }

--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -574,7 +574,7 @@ func (ds *DistSender) initAndVerifyBatch(
 
 	// In the event that timestamp isn't set and read consistency isn't
 	// required, set the timestamp using the local clock.
-	if ba.ReadConsistency != roachpb.CONSISTENT && ba.Timestamp == (hlc.Timestamp{}) {
+	if ba.ReadConsistency != roachpb.CONSISTENT && ba.Timestamp.IsEmpty() {
 		ba.Timestamp = ds.clock.Now()
 	}
 
@@ -1954,10 +1954,10 @@ func (ds *DistSender) sendToReplicas(
 			// If the reply contains a timestamp, update the local HLC with it.
 			if br.Error != nil {
 				log.VErrEventf(ctx, 2, "%v", br.Error)
-				if br.Error.Now != (hlc.Timestamp{}) {
+				if !br.Error.Now.IsEmpty() {
 					ds.clock.Update(br.Error.Now)
 				}
-			} else if br.Now != (hlc.Timestamp{}) {
+			} else if !br.Now.IsEmpty() {
 				ds.clock.Update(br.Now)
 			}
 

--- a/pkg/kv/kvclient/kvcoord/split_test.go
+++ b/pkg/kv/kvclient/kvcoord/split_test.go
@@ -290,7 +290,7 @@ func TestRangeSplitsStickyBit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if (desc.GetStickyBit() == hlc.Timestamp{}) {
+	if desc.GetStickyBit().IsEmpty() {
 		t.Fatal("Sticky bit not set after splitting")
 	}
 
@@ -309,7 +309,7 @@ func TestRangeSplitsStickyBit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if (desc.GetStickyBit() == hlc.Timestamp{}) {
+	if desc.GetStickyBit().IsEmpty() {
 		t.Fatal("Sticky bit not set after splitting")
 	}
 }

--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
@@ -634,7 +634,7 @@ func RunCommitTrigger(
 	}
 	if sbt := ct.GetStickyBitTrigger(); sbt != nil {
 		newDesc := *rec.Desc()
-		if sbt.StickyBit != (hlc.Timestamp{}) {
+		if !sbt.StickyBit.IsEmpty() {
 			newDesc.StickyBit = &sbt.StickyBit
 		} else {
 			newDesc.StickyBit = nil
@@ -945,7 +945,7 @@ func splitTriggerHelper(
 		if err != nil {
 			return enginepb.MVCCStats{}, result.Result{}, errors.Wrap(err, "unable to load GCThreshold")
 		}
-		if (*gcThreshold == hlc.Timestamp{}) {
+		if gcThreshold.IsEmpty() {
 			log.VEventf(ctx, 1, "LHS's GCThreshold of split is not set")
 		}
 

--- a/pkg/kv/kvserver/below_raft_protos_test.go
+++ b/pkg/kv/kvserver/below_raft_protos_test.go
@@ -66,7 +66,7 @@ var belowRaftGoldenProtos = map[reflect.Type]fixture{
 			return m
 		},
 		emptySum:     7551962144604783939,
-		populatedSum: 12720006657210437557,
+		populatedSum: 5737658018003400959,
 	},
 	reflect.TypeOf(&enginepb.RangeAppliedState{}): {
 		populatedConstructor: func(r *rand.Rand) protoutil.Message {
@@ -124,7 +124,7 @@ var belowRaftGoldenProtos = map[reflect.Type]fixture{
 			return enginepb.NewPopulatedMVCCMetadataSubsetForMergeSerialization(r, false)
 		},
 		emptySum:     14695981039346656037,
-		populatedSum: 7432412240713840291,
+		populatedSum: 834545685817460463,
 	},
 }
 

--- a/pkg/kv/kvserver/client_metrics_test.go
+++ b/pkg/kv/kvserver/client_metrics_test.go
@@ -386,7 +386,7 @@ func TestStoreMaxBehindNanosOnlyTracksEpochBasedLeases(t *testing.T) {
 	testutils.SucceedsSoon(t, func() error {
 		_, metaRepl := getFirstStoreReplica(t, tc.Server(1), keys.Meta2Prefix)
 		l, _ := metaRepl.GetLease()
-		if l.Start == (hlc.Timestamp{}) {
+		if l.Start.IsEmpty() {
 			return errors.Errorf("don't have a lease for meta1 yet: %v %v", l, meta2Repl1)
 		}
 		sinceExpBasedLeaseStart := timeutil.Since(timeutil.Unix(0, l.Start.WallTime))

--- a/pkg/kv/kvserver/client_split_test.go
+++ b/pkg/kv/kvserver/client_split_test.go
@@ -1771,7 +1771,7 @@ func TestStoreSplitTimestampCacheDifferentLeaseHolder(t *testing.T) {
 	}
 
 	// Verify that the txn's safe timestamp was set.
-	if txnOld.TestingCloneTxn().ReadTimestamp == (hlc.Timestamp{}) {
+	if txnOld.TestingCloneTxn().ReadTimestamp.IsEmpty() {
 		t.Fatal("expected non-zero refreshed timestamp")
 	}
 

--- a/pkg/kv/kvserver/debug_print.go
+++ b/pkg/kv/kvserver/debug_print.go
@@ -235,7 +235,7 @@ func tryTxn(kv storage.MVCCKeyValue) (string, error) {
 }
 
 func tryRangeIDKey(kv storage.MVCCKeyValue) (string, error) {
-	if kv.Key.Timestamp != (hlc.Timestamp{}) {
+	if !kv.Key.Timestamp.IsEmpty() {
 		return "", fmt.Errorf("range ID keys shouldn't have timestamps: %s", kv.Key)
 	}
 	_, _, suffix, _, err := keys.DecodeRangeIDKey(kv.Key.Key)

--- a/pkg/kv/kvserver/gc/data_distribution_test.go
+++ b/pkg/kv/kvserver/gc/data_distribution_test.go
@@ -57,10 +57,10 @@ func (ds dataDistribution) setupTest(
 		} else {
 			// TODO(ajwerner): Decide if using MVCCPut is worth it.
 			ts := kv.Key.Timestamp
-			if txn.ReadTimestamp == (hlc.Timestamp{}) {
+			if txn.ReadTimestamp.IsEmpty() {
 				txn.ReadTimestamp = ts
 			}
-			if txn.WriteTimestamp == (hlc.Timestamp{}) {
+			if txn.WriteTimestamp.IsEmpty() {
 				txn.WriteTimestamp = ts
 			}
 			err := storage.MVCCPut(ctx, eng, &ms, kv.Key.Key, ts,

--- a/pkg/kv/kvserver/gc/gc.go
+++ b/pkg/kv/kvserver/gc/gc.go
@@ -250,7 +250,7 @@ func processReplicatedKeyRange(
 		if meta.Txn != nil {
 			// Keep track of intent to resolve if older than the intent
 			// expiration threshold.
-			if hlc.Timestamp(meta.Timestamp).Less(intentExp) {
+			if meta.Timestamp.ToTimestamp().Less(intentExp) {
 				txnID := meta.Txn.ID
 				if _, ok := txnMap[txnID]; !ok {
 					txnMap[txnID] = &roachpb.Transaction{

--- a/pkg/kv/kvserver/gc/gc_old_test.go
+++ b/pkg/kv/kvserver/gc/gc_old_test.go
@@ -125,7 +125,7 @@ func runGCOld(
 					startIdx = 2
 				}
 				// See if any values may be GC'd.
-				if idx, gcTS := gc.Filter(keys[startIdx:], vals[startIdx:]); gcTS != (hlc.Timestamp{}) {
+				if idx, gcTS := gc.Filter(keys[startIdx:], vals[startIdx:]); !gcTS.IsEmpty() {
 					// Batch keys after the total size of version keys exceeds
 					// the threshold limit. This avoids sending potentially large
 					// GC requests through Raft. Iterate through the keys in reverse

--- a/pkg/kv/kvserver/gc/gc_old_test.go
+++ b/pkg/kv/kvserver/gc/gc_old_test.go
@@ -101,7 +101,7 @@ func runGCOld(
 				if meta.Txn != nil {
 					// Keep track of intent to resolve if older than the intent
 					// expiration threshold.
-					if hlc.Timestamp(meta.Timestamp).Less(intentExp) {
+					if meta.Timestamp.ToTimestamp().Less(intentExp) {
 						txnID := meta.Txn.ID
 						if _, ok := txnMap[txnID]; !ok {
 							txnMap[txnID] = &roachpb.Transaction{

--- a/pkg/kv/kvserver/gc_queue.go
+++ b/pkg/kv/kvserver/gc_queue.go
@@ -281,7 +281,7 @@ func makeGCQueueScoreImpl(
 ) gcQueueScore {
 	ms.Forward(now.WallTime)
 	var r gcQueueScore
-	if (gcThreshold != hlc.Timestamp{}) {
+	if !gcThreshold.IsEmpty() {
 		r.LikelyLastGC = time.Duration(now.WallTime - gcThreshold.Add(r.TTL.Nanoseconds(), 0).WallTime)
 	}
 

--- a/pkg/kv/kvserver/liveness/liveness.go
+++ b/pkg/kv/kvserver/liveness/liveness.go
@@ -825,8 +825,7 @@ func (nl *NodeLiveness) heartbeatInternal(
 	// [*]: see TODO below about how errNodeAlreadyLive handling does not
 	//      enforce this guarantee.
 	beforeQueueTS := nl.clock.Now()
-	minExpiration := hlc.LegacyTimestamp(
-		beforeQueueTS.Add(nl.livenessThreshold.Nanoseconds(), 0))
+	minExpiration := beforeQueueTS.Add(nl.livenessThreshold.Nanoseconds(), 0).ToLegacyTimestamp()
 
 	// Before queueing, record the heartbeat as in-flight.
 	nl.metrics.HeartbeatsInFlight.Inc(1)
@@ -873,8 +872,7 @@ func (nl *NodeLiveness) heartbeatInternal(
 	// Grab a new clock reading to compute the new expiration time,
 	// since we may have queued on the semaphore for a while.
 	afterQueueTS := nl.clock.Now()
-	newLiveness.Expiration = hlc.LegacyTimestamp(
-		afterQueueTS.Add(nl.livenessThreshold.Nanoseconds(), 0))
+	newLiveness.Expiration = afterQueueTS.Add(nl.livenessThreshold.Nanoseconds(), 0).ToLegacyTimestamp()
 	// This guards against the system clock moving backwards. As long
 	// as the cockroach process is running, checks inside hlc.Clock
 	// will ensure that the clock never moves backwards, but these

--- a/pkg/kv/kvserver/liveness/liveness_test.go
+++ b/pkg/kv/kvserver/liveness/liveness_test.go
@@ -43,7 +43,7 @@ func TestShouldReplaceLiveness(t *testing.T) {
 	l := func(epo int64, expiration hlc.Timestamp, draining bool, membership string) Record {
 		liveness := livenesspb.Liveness{
 			Epoch:      epo,
-			Expiration: hlc.LegacyTimestamp(expiration),
+			Expiration: expiration.ToLegacyTimestamp(),
 			Draining:   draining,
 			Membership: toMembershipStatus(membership),
 		}

--- a/pkg/kv/kvserver/liveness/livenesspb/liveness.go
+++ b/pkg/kv/kvserver/liveness/livenesspb/liveness.go
@@ -53,7 +53,7 @@ func (l *Liveness) Compare(o Liveness) int {
 		}
 		return +1
 	}
-	if l.Expiration != o.Expiration {
+	if !l.Expiration.EqOrdering(o.Expiration) {
 		if l.Expiration.Less(o.Expiration) {
 			return -1
 		}

--- a/pkg/kv/kvserver/log.go
+++ b/pkg/kv/kvserver/log.go
@@ -214,7 +214,7 @@ func (s *Store) logChange(
 // *are* the first action in a transaction, and we must elect to use the store's
 // physical time instead.
 func selectEventTimestamp(s *Store, input hlc.Timestamp) time.Time {
-	if input == (hlc.Timestamp{}) {
+	if input.IsEmpty() {
 		return s.Clock().PhysicalTime()
 	}
 	return input.GoTime()

--- a/pkg/kv/kvserver/node_liveness_test.go
+++ b/pkg/kv/kvserver/node_liveness_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
-	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -196,7 +195,7 @@ func TestRedundantNodeLivenessHeartbeatsAvoided(t *testing.T) {
 			livenessAfter, found := nl.Self()
 			assert.True(t, found)
 			exp := livenessAfter.Expiration
-			minExp := hlc.LegacyTimestamp(before.Add(nlActive.Nanoseconds(), 0))
+			minExp := before.Add(nlActive.Nanoseconds(), 0).ToLegacyTimestamp()
 			if exp.Less(minExp) {
 				return errors.Errorf("expected min expiration %v, found %v", minExp, exp)
 			}
@@ -958,7 +957,7 @@ func TestNodeLivenessDecommissionAbsent(t *testing.T) {
 	if err := mtc.dbs[0].CPut(ctx, keys.NodeLivenessKey(goneNodeID), &livenesspb.Liveness{
 		NodeID:     goneNodeID,
 		Epoch:      1,
-		Expiration: hlc.LegacyTimestamp(mtc.clock().Now()),
+		Expiration: mtc.clock().Now().ToLegacyTimestamp(),
 		Membership: livenesspb.MembershipStatus_ACTIVE,
 	}, nil); err != nil {
 		t.Fatal(err)

--- a/pkg/kv/kvserver/protectedts/ptstorage/BUILD.bazel
+++ b/pkg/kv/kvserver/protectedts/ptstorage/BUILD.bazel
@@ -20,7 +20,6 @@ go_library(
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
         "//pkg/sql/sqlutil",
-        "//pkg/util/hlc",
         "//pkg/util/log",
         "//pkg/util/protoutil",
         "//pkg/util/uuid",

--- a/pkg/kv/kvserver/protectedts/ptstorage/storage.go
+++ b/pkg/kv/kvserver/protectedts/ptstorage/storage.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
-	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
@@ -266,7 +265,7 @@ var (
 )
 
 func validateRecordForProtect(r *ptpb.Record) error {
-	if r.Timestamp == (hlc.Timestamp{}) {
+	if r.Timestamp.IsEmpty() {
 		return errZeroTimestamp
 	}
 	if r.ID == uuid.Nil {

--- a/pkg/kv/kvserver/queue.go
+++ b/pkg/kv/kvserver/queue.go
@@ -212,7 +212,7 @@ func isExpectedQueueError(err error) bool {
 // Returns a bool for whether to queue as well as a priority based
 // on how long it's been since last processed.
 func shouldQueueAgain(now, last hlc.Timestamp, minInterval time.Duration) (bool, float64) {
-	if minInterval == 0 || last == (hlc.Timestamp{}) {
+	if minInterval == 0 || last.IsEmpty() {
 		return true, 0
 	}
 	if diff := now.GoTime().Sub(last.GoTime()); diff >= minInterval {
@@ -220,7 +220,7 @@ func shouldQueueAgain(now, last hlc.Timestamp, minInterval time.Duration) (bool,
 		// If there's a non-zero last processed timestamp, adjust the
 		// priority by a multiple of how long it's been since the last
 		// time this replica was processed.
-		if last != (hlc.Timestamp{}) {
+		if !last.IsEmpty() {
 			priority = float64(diff.Nanoseconds()) / float64(minInterval.Nanoseconds())
 		}
 		return true, priority

--- a/pkg/kv/kvserver/rangefeed/processor.go
+++ b/pkg/kv/kvserver/rangefeed/processor.go
@@ -471,7 +471,7 @@ func (p *Processor) ForwardClosedTS(closedTS hlc.Timestamp) bool {
 	if p == nil {
 		return true
 	}
-	if closedTS == (hlc.Timestamp{}) {
+	if closedTS.IsEmpty() {
 		return true
 	}
 	return p.sendEvent(event{ct: closedTS}, p.EventChanTimeout)
@@ -538,7 +538,7 @@ func (p *Processor) consumeEvent(ctx context.Context, e *event) {
 	switch {
 	case len(e.ops) > 0:
 		p.consumeLogicalOps(ctx, e.ops)
-	case e.ct != hlc.Timestamp{}:
+	case !e.ct.IsEmpty():
 		p.forwardClosedTS(ctx, e.ct)
 	case e.initRTS:
 		p.initResolvedTS(ctx)

--- a/pkg/kv/kvserver/rangefeed/registry.go
+++ b/pkg/kv/kvserver/rangefeed/registry.go
@@ -348,7 +348,7 @@ func (r *registration) maybeRunCatchupScan() error {
 				// immediately after) the provisional key.
 				catchupIter.SeekGE(storage.MVCCKey{
 					Key:       unsafeKey.Key,
-					Timestamp: hlc.Timestamp(meta.Timestamp).Prev(),
+					Timestamp: meta.Timestamp.ToTimestamp().Prev(),
 				})
 				continue
 			}

--- a/pkg/kv/kvserver/rangefeed/resolved_timestamp.go
+++ b/pkg/kv/kvserver/rangefeed/resolved_timestamp.go
@@ -312,7 +312,7 @@ func (h unresolvedTxnHeap) Less(i, j int) bool {
 	// container/heap constructs a min-heap by default, so prioritize the txn
 	// with the smaller timestamp. Break ties by comparing IDs to establish a
 	// total order.
-	if h[i].timestamp == h[j].timestamp {
+	if h[i].timestamp.EqOrdering(h[j].timestamp) {
 		return bytes.Compare(h[i].txnID.GetBytes(), h[j].txnID.GetBytes()) < 0
 	}
 	return h[i].timestamp.Less(h[j].timestamp)

--- a/pkg/kv/kvserver/rangefeed/task_test.go
+++ b/pkg/kv/kvserver/rangefeed/task_test.go
@@ -105,7 +105,7 @@ func newTestIterator(kvs []storage.MVCCKeyValue) *testIterator {
 				}
 				expNextKey := storage.MVCCKey{
 					Key:       kv.Key.Key,
-					Timestamp: hlc.Timestamp(meta.Timestamp),
+					Timestamp: meta.Timestamp.ToTimestamp(),
 				}
 				if !kvs[i].Key.Equal(expNextKey) {
 					panic(missingErr)

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -172,7 +172,7 @@ func setStickyBit(desc *roachpb.RangeDescriptor, expiration hlc.Timestamp) {
 	// byte representation of setting the stickyBit to nil is different than
 	// setting it to hlc.Timestamp{}. This check ensures that CPuts would not
 	// fail on older versions.
-	if (expiration != hlc.Timestamp{}) {
+	if !expiration.IsEmpty() {
 		desc.StickyBit = &expiration
 	}
 }
@@ -462,7 +462,7 @@ func (r *Replica) adminUnsplitWithDescriptor(
 	// mixed version clusters that don't support StickyBit, all range descriptor
 	// sticky bits are guaranteed to be nil, so we can skip checking the cluster
 	// version.
-	if (desc.GetStickyBit() == hlc.Timestamp{}) {
+	if desc.GetStickyBit().IsEmpty() {
 		return reply, nil
 	}
 

--- a/pkg/kv/kvserver/replica_consistency.go
+++ b/pkg/kv/kvserver/replica_consistency.go
@@ -612,7 +612,7 @@ func (r *Replica) sha512(
 		if _, err := hasher.Write(unsafeKey.Key); err != nil {
 			return err
 		}
-		legacyTimestamp = hlc.LegacyTimestamp(unsafeKey.Timestamp)
+		legacyTimestamp = unsafeKey.Timestamp.ToLegacyTimestamp()
 		if size := legacyTimestamp.Size(); size > cap(timestampBuf) {
 			timestampBuf = make([]byte, size)
 		} else {

--- a/pkg/kv/kvserver/replica_consistency_diff.go
+++ b/pkg/kv/kvserver/replica_consistency_diff.go
@@ -113,9 +113,9 @@ func diffRange(l, r *roachpb.RaftSnapshotData) ReplicaSnapshotDiffSlice {
 			// Timestamp sorting is weird. Timestamp{} sorts first, the
 			// remainder sort in descending order. See storage/engine/doc.go.
 			if e.Timestamp != v.Timestamp {
-				if e.Timestamp == (hlc.Timestamp{}) {
+				if e.Timestamp.IsEmpty() {
 					addLeaseHolder()
-				} else if v.Timestamp == (hlc.Timestamp{}) {
+				} else if v.Timestamp.IsEmpty() {
 					addReplica()
 				} else if v.Timestamp.Less(e.Timestamp) {
 					addLeaseHolder()

--- a/pkg/kv/kvserver/replica_consistency_diff.go
+++ b/pkg/kv/kvserver/replica_consistency_diff.go
@@ -112,7 +112,7 @@ func diffRange(l, r *roachpb.RaftSnapshotData) ReplicaSnapshotDiffSlice {
 		case 0:
 			// Timestamp sorting is weird. Timestamp{} sorts first, the
 			// remainder sort in descending order. See storage/engine/doc.go.
-			if e.Timestamp != v.Timestamp {
+			if !e.Timestamp.EqOrdering(v.Timestamp) {
 				if e.Timestamp.IsEmpty() {
 					addLeaseHolder()
 				} else if v.Timestamp.IsEmpty() {

--- a/pkg/kv/kvserver/replica_destroy.go
+++ b/pkg/kv/kvserver/replica_destroy.go
@@ -243,7 +243,7 @@ func writeTombstoneKey(
 	tombstone := &roachpb.RangeTombstone{
 		NextReplicaID: nextReplicaID,
 	}
-	// "Blind" because ms == nil and timestamp == hlc.Timestamp{}.
+	// "Blind" because ms == nil and timestamp.IsEmpty().
 	return storage.MVCCBlindPutProto(ctx, writer, nil, tombstoneKey,
 		hlc.Timestamp{}, tombstone, nil)
 }

--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -726,7 +726,7 @@ func (r *Replica) evaluateProposal(
 	ba *roachpb.BatchRequest,
 	latchSpans *spanset.SpanSet,
 ) (*result.Result, bool, *roachpb.Error) {
-	if ba.Timestamp == (hlc.Timestamp{}) {
+	if ba.Timestamp.IsEmpty() {
 		return nil, false, roachpb.NewErrorf("can't propose Raft command with zero timestamp")
 	}
 

--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -563,7 +563,7 @@ func (r *Replica) leaseStatus(
 			status.State = kvserverpb.LeaseState_EXPIRED
 			return status
 		}
-		expiration = hlc.Timestamp(status.Liveness.Expiration)
+		expiration = status.Liveness.Expiration.ToTimestamp()
 	}
 	maxOffset := r.store.Clock().MaxOffset()
 	stasis := expiration.Add(-int64(maxOffset), 0)

--- a/pkg/kv/kvserver/replica_send.go
+++ b/pkg/kv/kvserver/replica_send.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/spanset"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/txnwait"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
@@ -644,7 +643,7 @@ func (r *Replica) executeAdminBatch(
 // TODO(tschottdorf): should check that request is contained in range and that
 // EndTxn only occurs at the very end.
 func (r *Replica) checkBatchRequest(ba *roachpb.BatchRequest, isReadOnly bool) error {
-	if ba.Timestamp == (hlc.Timestamp{}) {
+	if ba.Timestamp.IsEmpty() {
 		// For transactional requests, Store.Send sets the timestamp. For non-
 		// transactional requests, the client sets the timestamp. Either way, we
 		// need to have a timestamp at this point.

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -2931,7 +2931,7 @@ func TestReplicaTSCacheForwardsIntentTS(t *testing.T) {
 			} else if err := iter.ValueProto(&keyMeta); err != nil {
 				t.Fatalf("failed to unmarshal metadata for %q", mvccKey)
 			}
-			if tsNext := tsNew.Next(); hlc.Timestamp(keyMeta.Timestamp) != tsNext {
+			if tsNext := tsNew.Next(); keyMeta.Timestamp.ToTimestamp() != tsNext {
 				t.Errorf("timestamp not forwarded for %q intent: expected %s but got %s",
 					key, tsNext, keyMeta.Timestamp)
 			}

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -324,7 +324,7 @@ func (tc *testContext) Sender() kv.Sender {
 		if ba.RangeID == 0 {
 			ba.RangeID = 1
 		}
-		if ba.Timestamp == (hlc.Timestamp{}) {
+		if ba.Timestamp.IsEmpty() {
 			if err := ba.SetActiveTimestamp(tc.Clock().Now); err != nil {
 				tc.Fatal(err)
 			}

--- a/pkg/kv/kvserver/stateloader/initial.go
+++ b/pkg/kv/kvserver/stateloader/initial.go
@@ -70,7 +70,7 @@ func WriteInitialReplicaState(
 
 	if existingGCThreshold, err := rsl.LoadGCThreshold(ctx, readWriter); err != nil {
 		return enginepb.MVCCStats{}, errors.Wrap(err, "error reading GCThreshold")
-	} else if (*existingGCThreshold != hlc.Timestamp{}) {
+	} else if !existingGCThreshold.IsEmpty() {
 		log.Fatalf(ctx, "expected trivial GChreshold, but found %+v", existingGCThreshold)
 	}
 

--- a/pkg/kv/kvserver/stateloader/stateloader.go
+++ b/pkg/kv/kvserver/stateloader/stateloader.go
@@ -575,7 +575,7 @@ func (rsl StateLoader) SetRaftTruncatedState(
 	if (*truncState == roachpb.RaftTruncatedState{}) {
 		return errors.New("cannot persist empty RaftTruncatedState")
 	}
-	// "Blind" because ms == nil and timestamp == hlc.Timestamp{}.
+	// "Blind" because ms == nil and timestamp.IsEmpty().
 	return storage.MVCCBlindPutProto(
 		ctx,
 		writer,
@@ -605,7 +605,7 @@ func (rsl StateLoader) LoadHardState(
 func (rsl StateLoader) SetHardState(
 	ctx context.Context, writer storage.Writer, hs raftpb.HardState,
 ) error {
-	// "Blind" because ms == nil and timestamp == hlc.Timestamp{}.
+	// "Blind" because ms == nil and timestamp.IsEmpty().
 	return storage.MVCCBlindPutProto(
 		ctx,
 		writer,

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -1231,7 +1231,7 @@ func TestStoreAnnotateNow(t *testing.T) {
 				if pErr == nil {
 					t.Fatal("expected an error")
 				}
-				if pErr.Now == (hlc.Timestamp{}) {
+				if pErr.Now.IsEmpty() {
 					t.Fatal("timestamp not annotated on error")
 				}
 			}},
@@ -1240,7 +1240,7 @@ func TestStoreAnnotateNow(t *testing.T) {
 				if pErr != nil {
 					t.Fatal(pErr)
 				}
-				if pReply.Now == (hlc.Timestamp{}) {
+				if pReply.Now.IsEmpty() {
 					t.Fatal("timestamp not annotated on batch response")
 				}
 			}},

--- a/pkg/kv/kvserver/stores.go
+++ b/pkg/kv/kvserver/stores.go
@@ -106,7 +106,7 @@ func (ls *Stores) AddStore(s *Store) {
 	// all stores have the most recent values.
 	ls.mu.Lock()
 	defer ls.mu.Unlock()
-	if ls.mu.biLatestTS != (hlc.Timestamp{}) {
+	if !ls.mu.biLatestTS.IsEmpty() {
 		if err := ls.updateBootstrapInfoLocked(ls.mu.latestBI); err != nil {
 			ctx := ls.AnnotateCtx(context.TODO())
 			log.Errorf(ctx, "failed to update bootstrap info on newly added store: %+v", err)

--- a/pkg/roachpb/batch.go
+++ b/pkg/roachpb/batch.go
@@ -32,7 +32,7 @@ import (
 // timestamp is specified, nowFn is used to create and set one.
 func (ba *BatchRequest) SetActiveTimestamp(nowFn func() hlc.Timestamp) error {
 	if txn := ba.Txn; txn != nil {
-		if ba.Timestamp != (hlc.Timestamp{}) {
+		if !ba.Timestamp.IsEmpty() {
 			return errors.New("transactional request must not set batch timestamp")
 		}
 
@@ -47,7 +47,7 @@ func (ba *BatchRequest) SetActiveTimestamp(nowFn func() hlc.Timestamp) error {
 		ba.Timestamp = txn.ReadTimestamp
 	} else {
 		// When not transactional, allow empty timestamp and use nowFn instead
-		if ba.Timestamp == (hlc.Timestamp{}) {
+		if ba.Timestamp.IsEmpty() {
 			ba.Timestamp = nowFn()
 		}
 	}

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -918,7 +918,7 @@ func (t Transaction) Clone() *Transaction {
 
 // AssertInitialized crashes if the transaction is not initialized.
 func (t *Transaction) AssertInitialized(ctx context.Context) {
-	if t.ID == (uuid.UUID{}) || t.WriteTimestamp == (hlc.Timestamp{}) {
+	if t.ID == (uuid.UUID{}) || t.WriteTimestamp.IsEmpty() {
 		log.Fatalf(ctx, "uninitialized txn: %s", *t)
 	}
 }
@@ -1150,9 +1150,9 @@ func (t *Transaction) Update(o *Transaction) {
 	// On update, set lower bound timestamps to the minimum seen by either txn.
 	// These shouldn't differ unless one of them is empty, but we're careful
 	// anyway.
-	if t.MinTimestamp == (hlc.Timestamp{}) {
+	if t.MinTimestamp.IsEmpty() {
 		t.MinTimestamp = o.MinTimestamp
-	} else if o.MinTimestamp != (hlc.Timestamp{}) {
+	} else if !o.MinTimestamp.IsEmpty() {
 		t.MinTimestamp.Backward(o.MinTimestamp)
 	}
 
@@ -1935,11 +1935,11 @@ func equivalentTimestamps(a, b *hlc.Timestamp) bool {
 		if b == nil {
 			return true
 		}
-		if (*b == hlc.Timestamp{}) {
+		if b.IsEmpty() {
 			return true
 		}
 	} else if b == nil {
-		if (*a == hlc.Timestamp{}) {
+		if a.IsEmpty() {
 			return true
 		}
 	}

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -1098,7 +1098,7 @@ func (t *Transaction) Update(o *Transaction) {
 			// Nothing to do.
 		}
 
-		if t.ReadTimestamp.Equal(o.ReadTimestamp) {
+		if t.ReadTimestamp == o.ReadTimestamp {
 			// If neither of the transactions has a bumped ReadTimestamp, then the
 			// WriteTooOld flag is cumulative.
 			t.WriteTooOld = t.WriteTooOld || o.WriteTooOld

--- a/pkg/roachpb/data_test.go
+++ b/pkg/roachpb/data_test.go
@@ -46,6 +46,10 @@ func makeTS(walltime int64, logical int32) hlc.Timestamp {
 	}
 }
 
+func makeTSWithFlag(walltime int64, logical int32) hlc.Timestamp {
+	return makeTS(walltime, logical).SetFlag(hlc.TimestampFlag_SYNTHETIC)
+}
+
 // TestKeyNext tests that the method for creating lexicographic
 // successors to byte slices works as expected.
 func TestKeyNext(t *testing.T) {
@@ -457,17 +461,17 @@ var nonZeroTxn = Transaction{
 		Key:            Key("foo"),
 		ID:             uuid.MakeV4(),
 		Epoch:          2,
-		WriteTimestamp: makeTS(20, 21),
-		MinTimestamp:   makeTS(10, 11),
+		WriteTimestamp: makeTSWithFlag(20, 21),
+		MinTimestamp:   makeTSWithFlag(10, 11),
 		Priority:       957356782,
 		Sequence:       123,
 	},
 	Name:                 "name",
 	Status:               COMMITTED,
-	LastHeartbeat:        makeTS(1, 2),
-	ReadTimestamp:        makeTS(20, 22),
-	MaxTimestamp:         makeTS(40, 41),
-	ObservedTimestamps:   []ObservedTimestamp{{NodeID: 1, Timestamp: makeTS(1, 2)}},
+	LastHeartbeat:        makeTSWithFlag(1, 2),
+	ReadTimestamp:        makeTSWithFlag(20, 22),
+	MaxTimestamp:         makeTSWithFlag(40, 41),
+	ObservedTimestamps:   []ObservedTimestamp{{NodeID: 1, Timestamp: makeTSWithFlag(1, 2)}},
 	WriteTooOld:          true,
 	LockSpans:            []Span{{Key: []byte("a"), EndKey: []byte("b")}},
 	InFlightWrites:       []SequencedWrite{{Key: []byte("c"), Sequence: 1}},

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -1370,7 +1370,7 @@ func TestHealthAPI(t *testing.T) {
 	defer ts.nodeLiveness.PauseAllHeartbeatsForTest()()
 	self, ok := ts.nodeLiveness.Self()
 	assert.True(t, ok)
-	s.Clock().Update(hlc.Timestamp(self.Expiration).Add(1, 0))
+	s.Clock().Update(self.Expiration.ToTimestamp().Add(1, 0))
 
 	var resp serverpb.HealthResponse
 	testutils.SucceedsSoon(t, func() error {

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -2018,10 +2018,10 @@ func (ex *connExecutor) setTransactionModes(
 			"unknown isolation level: %s", errors.Safe(modes.Isolation))
 	}
 	rwMode := modes.ReadWriteMode
-	if modes.AsOf.Expr != nil && (asOfTs == hlc.Timestamp{}) {
+	if modes.AsOf.Expr != nil && asOfTs.IsEmpty() {
 		return errors.AssertionFailedf("expected an evaluated AS OF timestamp")
 	}
-	if (asOfTs != hlc.Timestamp{}) {
+	if !asOfTs.IsEmpty() {
 		ex.state.setHistoricalTimestamp(ex.Ctx(), asOfTs)
 		ex.state.sqlTimestamp = asOfTs.GoTime()
 		if rwMode == tree.UnspecifiedReadWriteMode {

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -56,7 +56,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
-	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
@@ -2553,7 +2552,7 @@ CREATE TABLE crdb_internal.ranges_no_leases (
 			}
 
 			splitEnforcedUntil := tree.DNull
-			if (desc.GetStickyBit() != hlc.Timestamp{}) {
+			if !desc.GetStickyBit().IsEmpty() {
 				splitEnforcedUntil = tree.TimestampToInexactDTimestamp(*desc.StickyBit)
 			}
 

--- a/pkg/sql/drop_index.go
+++ b/pkg/sql/drop_index.go
@@ -29,7 +29,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
-	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/errors"
 )
 
@@ -470,7 +469,7 @@ func (p *planner) dropIndexByName(
 					// We have to explicitly check that the range descriptor's start key
 					// lies within the span of the index since ScanMetaKVs returns all
 					// intersecting spans.
-					if (desc.GetStickyBit() != hlc.Timestamp{}) && span.Key.Compare(desc.StartKey.AsRawKey()) <= 0 {
+					if !desc.GetStickyBit().IsEmpty() && span.Key.Compare(desc.StartKey.AsRawKey()) <= 0 {
 						// Swallow "key is not the start of a range" errors because it would
 						// mean that the sticky bit was removed and merged concurrently. DROP
 						// INDEX should not fail because of this.

--- a/pkg/sql/drop_table.go
+++ b/pkg/sql/drop_table.go
@@ -26,7 +26,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
-	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 )
@@ -370,7 +369,7 @@ func (p *planner) unsplitRangesForTable(ctx context.Context, tableDesc *tabledes
 			if err := r.ValueProto(&desc); err != nil {
 				return err
 			}
-			if (desc.GetStickyBit() != hlc.Timestamp{}) {
+			if !desc.GetStickyBit().IsEmpty() {
 				// Swallow "key is not the start of a range" errors because it would mean
 				// that the sticky bit was removed and merged concurrently. DROP TABLE
 				// should not fail because of this.

--- a/pkg/sql/pgwire/testdata/pgtest/notice
+++ b/pkg/sql/pgwire/testdata/pgtest/notice
@@ -55,7 +55,7 @@ Query {"String": "DROP INDEX t_x_idx"}
 until crdb_only
 CommandComplete
 ----
-{"Severity":"NOTICE","Code":"00000","Message":"the data for dropped indexes is reclaimed asynchronously","Detail":"","Hint":"The reclamation delay can be customized in the zone configuration for the table.","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"drop_index.go","Line":520,"Routine":"dropIndexByName","UnknownFields":null}
+{"Severity":"NOTICE","Code":"00000","Message":"the data for dropped indexes is reclaimed asynchronously","Detail":"","Hint":"The reclamation delay can be customized in the zone configuration for the table.","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"drop_index.go","Line":519,"Routine":"dropIndexByName","UnknownFields":null}
 {"Type":"CommandComplete","CommandTag":"DROP INDEX"}
 
 until noncrdb_only

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -292,7 +292,7 @@ func newInternalPlanner(
 	var ts time.Time
 	if txn != nil {
 		readTimestamp := txn.ReadTimestamp()
-		if readTimestamp == (hlc.Timestamp{}) {
+		if readTimestamp.IsEmpty() {
 			panic("makeInternalPlanner called with a transaction without timestamps")
 		}
 		ts = readTimestamp.GoTime()

--- a/pkg/sql/sem/tree/as_of.go
+++ b/pkg/sql/sem/tree/as_of.go
@@ -132,7 +132,7 @@ func DatumToHLC(evalCtx *EvalContext, stmtTimestamp time.Time, d Datum) (hlc.Tim
 		return ts, convErr
 	}
 	zero := hlc.Timestamp{}
-	if ts == zero {
+	if ts.EqOrdering(zero) {
 		return ts, errors.Errorf("zero timestamp is invalid")
 	} else if ts.Less(zero) {
 		return ts, errors.Errorf("timestamp before 1970-01-01T00:00:00Z is invalid")

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3406,7 +3406,7 @@ func (ctx *EvalContext) GetStmtTimestamp() time.Time {
 // the evaluation context. The timestamp is guaranteed to be nonzero.
 func (ctx *EvalContext) GetClusterTimestamp() *DDecimal {
 	ts := ctx.Txn.CommitTimestamp()
-	if ts == (hlc.Timestamp{}) {
+	if ts.IsEmpty() {
 		panic(errors.AssertionFailedf("zero cluster timestamp in txn"))
 	}
 	return TimestampToDecimalDatum(ts)

--- a/pkg/sql/split.go
+++ b/pkg/sql/split.go
@@ -70,7 +70,7 @@ func (n *splitNode) Next(params runParams) (bool, error) {
 
 func (n *splitNode) Values() tree.Datums {
 	splitEnforcedUntil := tree.DNull
-	if (n.run.lastExpirationTime != hlc.Timestamp{}) {
+	if !n.run.lastExpirationTime.IsEmpty() {
 		splitEnforcedUntil = tree.TimestampToInexactDTimestamp(n.run.lastExpirationTime)
 	}
 	return tree.Datums{

--- a/pkg/sql/unsplit_test.go
+++ b/pkg/sql/unsplit_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
-	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
@@ -208,7 +207,7 @@ func TestUnsplitAt(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				if (rng.GetStickyBit() != hlc.Timestamp{}) {
+				if !rng.GetStickyBit().IsEmpty() {
 					t.Fatalf("%s: expected range sticky bit to be hlc.MinTimestamp, got %s", tt.unsplitStmt, rng.GetStickyBit())
 				}
 			}

--- a/pkg/storage/batch.go
+++ b/pkg/storage/batch.go
@@ -82,8 +82,6 @@ const (
 // The <wall_time> and <logical> portions of the key are encoded as 64 and
 // 32-bit big-endian integers. A custom RocksDB comparator is used to maintain
 // the desired ordering as these keys do not sort lexicographically correctly.
-// Note that the encoding of these keys needs to match up with the encoding in
-// rocksdb/db.cc:EncodeKey().
 //
 // TODO(bilal): This struct exists mostly as a historic artifact. Transition
 // the remaining few test uses of this struct over to pebble.Batch, and remove
@@ -121,8 +119,7 @@ func (b *RocksDBBatchBuilder) Put(key MVCCKey, value []byte) {
 	// deferredOp.Finish.
 }
 
-// EncodeKey encodes an engine.MVCC key into the RocksDB representation. This
-// encoding must match with the encoding in engine/db.cc:EncodeKey().
+// EncodeKey encodes an engine.MVCC key into the RocksDB representation.
 func EncodeKey(key MVCCKey) []byte {
 	keyLen := key.Len()
 	buf := make([]byte, keyLen)
@@ -131,7 +128,6 @@ func EncodeKey(key MVCCKey) []byte {
 }
 
 // EncodeKeyToBuf encodes an engine.MVCC key into the RocksDB representation.
-// This encoding must match with the encoding in engine/db.cc:EncodeKey().
 func EncodeKeyToBuf(buf []byte, key MVCCKey) []byte {
 	keyLen := key.Len()
 	if cap(buf) < keyLen {
@@ -172,8 +168,7 @@ func encodeTimestamp(ts hlc.Timestamp) []byte {
 	return encodedTS
 }
 
-// DecodeMVCCKey decodes an engine.MVCCKey from its serialized representation. This
-// decoding must match engine/db.cc:DecodeKey().
+// DecodeMVCCKey decodes an engine.MVCCKey from its serialized representation.
 func DecodeMVCCKey(encodedKey []byte) (MVCCKey, error) {
 	k, ts, err := enginepb.DecodeKey(encodedKey)
 	return MVCCKey{k, ts}, err

--- a/pkg/storage/batch_test.go
+++ b/pkg/storage/batch_test.go
@@ -1206,6 +1206,7 @@ func TestDecodeKey(t *testing.T) {
 		{Key: []byte("foo")},
 		{Key: []byte("foo"), Timestamp: hlc.Timestamp{WallTime: 1}},
 		{Key: []byte("foo"), Timestamp: hlc.Timestamp{WallTime: 1, Logical: 1}},
+		{Key: []byte("foo"), Timestamp: hlc.Timestamp{WallTime: 1, Logical: 1, Flags: 3}},
 	}
 	for _, test := range tests {
 		t.Run(test.String(), func(t *testing.T) {

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -80,7 +80,7 @@ type IteratorStats struct {
 // engine. It is used for iterating over the key space that can have multiple
 // versions, and if often also used (due to historical reasons) for iterating
 // over the key space that never has multiple versions (i.e.,
-// MVCCKey.Timestamp == hlc.Timestamp{}).
+// MVCCKey.Timestamp.IsEmpty()).
 //
 // MVCCIterator implementations are thread safe unless otherwise noted.
 type MVCCIterator interface {

--- a/pkg/storage/engine_key_test.go
+++ b/pkg/storage/engine_key_test.go
@@ -69,22 +69,30 @@ func TestMVCCAndEngineKeyEncodeDecode(t *testing.T) {
 	testCases := []struct {
 		key MVCCKey
 	}{
-		{key: MVCCKey{Key: roachpb.Key("foo"), Timestamp: hlc.Timestamp{WallTime: 99, Logical: 45}}},
-		{key: MVCCKey{Key: roachpb.Key("glue"), Timestamp: hlc.Timestamp{WallTime: 89999}}},
 		{key: MVCCKey{Key: roachpb.Key("a")}},
+		{key: MVCCKey{Key: roachpb.Key("glue"), Timestamp: hlc.Timestamp{WallTime: 89999}}},
+		{key: MVCCKey{Key: roachpb.Key("foo"), Timestamp: hlc.Timestamp{WallTime: 99, Logical: 45}}},
+		{key: MVCCKey{Key: roachpb.Key("flags"), Timestamp: hlc.Timestamp{WallTime: 99, Logical: 45, Flags: 3}}},
 	}
 	for _, test := range testCases {
 		t.Run("", func(t *testing.T) {
 			var encodedTS []byte
 			if !(test.key.Timestamp == hlc.Timestamp{}) {
-				if test.key.Timestamp.Logical == 0 {
-					encodedTS = make([]byte, 8)
+				var size int
+				if test.key.Timestamp.Flags != 0 {
+					size = 13
+				} else if test.key.Timestamp.Logical != 0 {
+					size = 12
 				} else {
-					encodedTS = make([]byte, 12)
+					size = 8
 				}
+				encodedTS = make([]byte, size)
 				binary.BigEndian.PutUint64(encodedTS, uint64(test.key.Timestamp.WallTime))
 				if test.key.Timestamp.Logical != 0 {
 					binary.BigEndian.PutUint32(encodedTS[8:], uint32(test.key.Timestamp.Logical))
+				}
+				if test.key.Timestamp.Flags != 0 {
+					encodedTS[12] = uint8(test.key.Timestamp.Flags)
 				}
 			}
 			eKey := EngineKey{Key: test.key.Key, Version: encodedTS}

--- a/pkg/storage/engine_key_test.go
+++ b/pkg/storage/engine_key_test.go
@@ -77,7 +77,7 @@ func TestMVCCAndEngineKeyEncodeDecode(t *testing.T) {
 	for _, test := range testCases {
 		t.Run("", func(t *testing.T) {
 			var encodedTS []byte
-			if !(test.key.Timestamp == hlc.Timestamp{}) {
+			if !test.key.Timestamp.IsEmpty() {
 				var size int
 				if test.key.Timestamp.Flags != 0 {
 					size = 13

--- a/pkg/storage/enginepb/decode.go
+++ b/pkg/storage/enginepb/decode.go
@@ -42,8 +42,7 @@ func SplitMVCCKey(mvccKey []byte) (key []byte, ts []byte, ok bool) {
 	return key, ts, true
 }
 
-// DecodeKey decodes an key/timestamp from its serialized representation. This
-// decoding must match libroach/encoding.cc:DecodeKey().
+// DecodeKey decodes an key/timestamp from its serialized representation.
 func DecodeKey(encodedKey []byte) (key []byte, timestamp hlc.Timestamp, _ error) {
 	key, ts, ok := SplitMVCCKey(encodedKey)
 	if !ok {
@@ -57,6 +56,10 @@ func DecodeKey(encodedKey []byte) (key []byte, timestamp hlc.Timestamp, _ error)
 	case 12:
 		timestamp.WallTime = int64(binary.BigEndian.Uint64(ts[0:8]))
 		timestamp.Logical = int32(binary.BigEndian.Uint32(ts[8:12]))
+	case 13:
+		timestamp.WallTime = int64(binary.BigEndian.Uint64(ts[0:8]))
+		timestamp.Logical = int32(binary.BigEndian.Uint32(ts[8:12]))
+		timestamp.Flags = uint32(ts[12])
 	default:
 		return nil, timestamp, errors.Errorf(
 			"invalid encoded mvcc key: %x bad timestamp %x", encodedKey, ts)

--- a/pkg/storage/enginepb/decode.go
+++ b/pkg/storage/enginepb/decode.go
@@ -25,7 +25,6 @@ import (
 // code out from abstract interfaces -- See #30114 and #30001.
 
 // SplitMVCCKey returns the key and timestamp components of an encoded MVCC key.
-// This decoding must match engine/db.cc:SplitKey().
 func SplitMVCCKey(mvccKey []byte) (key []byte, ts []byte, ok bool) {
 	if len(mvccKey) == 0 {
 		return nil, nil, false

--- a/pkg/storage/enginepb/mvcc_test.go
+++ b/pkg/storage/enginepb/mvcc_test.go
@@ -42,7 +42,7 @@ func TestFormatMVCCMetadata(t *testing.T) {
 	val3.SetString("baz")
 	meta := &enginepb.MVCCMetadata{
 		Txn:       tmeta,
-		Timestamp: hlc.LegacyTimestamp(ts),
+		Timestamp: ts.ToLegacyTimestamp(),
 		KeyBytes:  123,
 		ValBytes:  456,
 		RawBytes:  val1.RawBytes,

--- a/pkg/storage/metamorphic/operations.go
+++ b/pkg/storage/metamorphic/operations.go
@@ -1207,7 +1207,7 @@ var opGenerators = []opGenerator{
 				key := m.keyGenerator.parse(arg)
 				// Don't put anything at the 0 timestamp; the MVCC code expects
 				// MVCCMetadata at those values.
-				if key.Timestamp == (hlc.Timestamp{}) {
+				if key.Timestamp.IsEmpty() {
 					key.Timestamp = key.Timestamp.Next()
 				}
 				keys = append(keys, key)

--- a/pkg/storage/multi_iterator.go
+++ b/pkg/storage/multi_iterator.go
@@ -155,7 +155,7 @@ func (f *multiIterator) advance() {
 			// The iterator at iterIdx has the same key as the current best, add
 			// it to itersWithCurrentKey and check how the timestamps compare.
 			f.itersWithCurrentKey = append(f.itersWithCurrentKey, iterIdx)
-			if proposedMVCCKey.Timestamp == iterMVCCKey.Timestamp {
+			if proposedMVCCKey.Timestamp.EqOrdering(iterMVCCKey.Timestamp) {
 				// We have two exactly equal mvcc keys (both key and timestamps
 				// match). The one in the later iterator takes precedence and
 				// the one in the earlier iterator should be omitted from

--- a/pkg/storage/multi_iterator_test.go
+++ b/pkg/storage/multi_iterator_test.go
@@ -136,7 +136,7 @@ func TestMultiIterator(t *testing.T) {
 							break
 						}
 						output.Write(it.UnsafeKey().Key)
-						if it.UnsafeKey().Timestamp == (hlc.Timestamp{}) {
+						if it.UnsafeKey().Timestamp.IsEmpty() {
 							output.WriteRune('M')
 						} else {
 							output.WriteByte(byte(it.UnsafeKey().Timestamp.WallTime))

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -3598,8 +3598,6 @@ func willOverflow(a, b int64) bool {
 // on the first error returned from any of them.
 //
 // Callbacks must copy any data they intend to hold on to.
-//
-// This implementation must match engine/db.cc:MVCCComputeStatsInternal.
 func ComputeStatsForRange(
 	iter SimpleMVCCIterator,
 	start, end roachpb.Key,

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -111,7 +111,7 @@ func MakeMVCCMetadataKey(key roachpb.Key) MVCCKey {
 // Next returns the next key.
 func (k MVCCKey) Next() MVCCKey {
 	ts := k.Timestamp.Prev()
-	if ts == (hlc.Timestamp{}) {
+	if ts.IsEmpty() {
 		return MVCCKey{
 			Key: k.Key.Next(),
 		}
@@ -142,7 +142,7 @@ func (k MVCCKey) Equal(l MVCCKey) bool {
 
 // IsValue returns true iff the timestamp is non-zero.
 func (k MVCCKey) IsValue() bool {
-	return k.Timestamp != (hlc.Timestamp{})
+	return !k.Timestamp.IsEmpty()
 }
 
 // EncodedSize returns the size of the MVCCKey when encoded.
@@ -185,7 +185,7 @@ func (k MVCCKey) Len() int {
 	)
 
 	n := len(k.Key) + timestampEncodedLengthLen
-	if k.Timestamp != (hlc.Timestamp{}) {
+	if !k.Timestamp.IsEmpty() {
 		n += timestampSentinelLen + walltimeEncodedLen
 		if k.Timestamp.Logical != 0 || k.Timestamp.Flags != 0 {
 			n += logicalEncodedLen
@@ -1108,7 +1108,7 @@ func mvccGetInternal(
 		// would apply to.
 		seekKey.Timestamp = timestamp
 	}
-	if seekKey.Timestamp == (hlc.Timestamp{}) {
+	if seekKey.Timestamp.IsEmpty() {
 		return nil, ignoredIntent, safeValue, nil
 	}
 
@@ -1251,7 +1251,7 @@ func MVCCPut(
 	// If we're not tracking stats for the key and we're writing a non-versioned
 	// key we can utilize a blind put to avoid reading any existing value.
 	var iter MVCCIterator
-	blind := ms == nil && timestamp == (hlc.Timestamp{})
+	blind := ms == nil && timestamp.IsEmpty()
 	if !blind {
 		iter = rw.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{Prefix: true})
 		defer iter.Close()
@@ -1320,7 +1320,7 @@ func mvccPutUsingIter(
 ) error {
 	var rawBytes []byte
 	if valueFn == nil {
-		if value.Timestamp != (hlc.Timestamp{}) {
+		if !value.Timestamp.IsEmpty() {
 			return errors.Errorf("cannot have timestamp set in value on Put")
 		}
 		rawBytes = value.RawBytes
@@ -1557,7 +1557,7 @@ func mvccPutInternal(
 	}
 
 	// Verify we're not mixing inline and non-inline values.
-	putIsInline := timestamp == (hlc.Timestamp{})
+	putIsInline := timestamp.IsEmpty()
 	if ok && putIsInline != buf.meta.IsInline() {
 		return errors.Errorf("%q: put is inline=%t, but existing value is inline=%t",
 			metaKey, putIsInline, buf.meta.IsInline())
@@ -2183,7 +2183,7 @@ func MVCCMerge(
 	meta := &buf.meta
 	*meta = enginepb.MVCCMetadata{RawBytes: rawBytes}
 	// If non-zero, set the merge timestamp to provide some replay protection.
-	if timestamp != (hlc.Timestamp{}) {
+	if !timestamp.IsEmpty() {
 		buf.ts = timestamp.ToLegacyTimestamp()
 		meta.MergeTimestamp = &buf.ts
 	}

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -137,7 +137,7 @@ func (k MVCCKey) Less(l MVCCKey) bool {
 
 // Equal returns whether two keys are identical.
 func (k MVCCKey) Equal(l MVCCKey) bool {
-	return k.Key.Compare(l.Key) == 0 && k.Timestamp == l.Timestamp
+	return k.Key.Compare(l.Key) == 0 && k.Timestamp.EqOrdering(l.Timestamp)
 }
 
 // IsValue returns true iff the timestamp is non-zero.

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -1201,7 +1201,7 @@ func (b *putBuffer) marshalMeta(meta *enginepb.MVCCMetadata) (_ []byte, err erro
 func (b *putBuffer) putMeta(
 	writer Writer, key MVCCKey, meta *enginepb.MVCCMetadata, inlineMeta bool,
 ) (keyBytes, valBytes int64, err error) {
-	if meta.Txn != nil && !meta.Timestamp.Equal(meta.Txn.WriteTimestamp.ToLegacyTimestamp()) {
+	if meta.Txn != nil && meta.Timestamp.ToTimestamp() != meta.Txn.WriteTimestamp {
 		// The timestamps are supposed to be in sync. If they weren't, it wouldn't
 		// be clear for readers which one to use for what.
 		return 0, 0, errors.AssertionFailedf(
@@ -2851,6 +2851,7 @@ func mvccResolveWriteIntent(
 	if !ok || meta.Txn == nil || intent.Txn.ID != meta.Txn.ID {
 		return false, nil
 	}
+	metaTimestamp := meta.Timestamp.ToTimestamp()
 
 	// A commit with a newer epoch than the intent effectively means that we
 	// wrote this intent before an earlier retry, but didn't write it again
@@ -2873,7 +2874,8 @@ func mvccResolveWriteIntent(
 	// replays of intent resolution make this configuration a possibility. We
 	// treat such intents as uncommitted.
 	epochsMatch := meta.Txn.Epoch == intent.Txn.Epoch
-	timestampsValid := meta.Timestamp.ToTimestamp().LessEq(intent.Txn.WriteTimestamp)
+	timestampsValid := metaTimestamp.LessEq(intent.Txn.WriteTimestamp)
+	timestampChanged := metaTimestamp.Less(intent.Txn.WriteTimestamp)
 	commit := intent.Status == roachpb.COMMITTED && epochsMatch && timestampsValid
 
 	// Note the small difference to commit epoch handling here: We allow
@@ -2902,8 +2904,8 @@ func mvccResolveWriteIntent(
 	// TODO(tschottdorf): various epoch-related scenarios here deserve more
 	// testing.
 	inProgress := !intent.Status.IsFinalized() && meta.Txn.Epoch >= intent.Txn.Epoch
-	pushed := inProgress && meta.Timestamp.ToTimestamp().Less(intent.Txn.WriteTimestamp)
-	latestKey := MVCCKey{Key: intent.Key, Timestamp: meta.Timestamp.ToTimestamp()}
+	pushed := inProgress && timestampChanged
+	latestKey := MVCCKey{Key: intent.Key, Timestamp: metaTimestamp}
 
 	// Handle partial txn rollbacks. If the current txn sequence
 	// is part of a rolled back (ignored) seqnum range, we're going
@@ -2977,8 +2979,8 @@ func mvccResolveWriteIntent(
 		// If we're moving the intent's timestamp, adjust stats and
 		// rewrite it.
 		var prevValSize int64
-		if buf.newMeta.Timestamp != meta.Timestamp {
-			oldKey := MVCCKey{Key: intent.Key, Timestamp: meta.Timestamp.ToTimestamp()}
+		if timestampChanged {
+			oldKey := MVCCKey{Key: intent.Key, Timestamp: metaTimestamp}
 			newKey := MVCCKey{Key: intent.Key, Timestamp: newTimestamp}
 
 			// Rewrite the versioned value at the new timestamp.

--- a/pkg/storage/mvcc_incremental_iterator.go
+++ b/pkg/storage/mvcc_incremental_iterator.go
@@ -282,7 +282,7 @@ func (i *MVCCIncrementalIterator) advance() {
 			// They key is an MVCC value and note an intent.
 			// Intents are handled next.
 			i.meta.Reset()
-			i.meta.Timestamp = hlc.LegacyTimestamp(unsafeMetaKey.Timestamp)
+			i.meta.Timestamp = unsafeMetaKey.Timestamp.ToLegacyTimestamp()
 		} else {
 			// The key is a metakey (an intent), this is used later to see if the
 			// timestamp of this intent is within the incremental iterator's time
@@ -303,7 +303,7 @@ func (i *MVCCIncrementalIterator) advance() {
 			return
 		}
 
-		metaTimestamp := hlc.Timestamp(i.meta.Timestamp)
+		metaTimestamp := i.meta.Timestamp.ToTimestamp()
 		if i.meta.Txn != nil {
 			if i.startTime.Less(metaTimestamp) && metaTimestamp.LessEq(i.endTime) {
 				i.err = &roachpb.WriteIntentError{

--- a/pkg/storage/mvcc_stats_test.go
+++ b/pkg/storage/mvcc_stats_test.go
@@ -168,7 +168,7 @@ func TestMVCCStatsPutCommitMovesTimestamp(t *testing.T) {
 
 			mKeySize := int64(mvccKey(key).EncodedSize()) // 2
 			mValSize := int64((&enginepb.MVCCMetadata{    // 44
-				Timestamp: hlc.LegacyTimestamp(ts1),
+				Timestamp: ts1.ToLegacyTimestamp(),
 				Deleted:   false,
 				Txn:       &txn.TxnMeta,
 			}).Size())
@@ -248,7 +248,7 @@ func TestMVCCStatsPutPushMovesTimestamp(t *testing.T) {
 
 			mKeySize := int64(mvccKey(key).EncodedSize()) // 2
 			mValSize := int64((&enginepb.MVCCMetadata{    // 44
-				Timestamp: hlc.LegacyTimestamp(ts1),
+				Timestamp: ts1.ToLegacyTimestamp(),
 				Deleted:   false,
 				Txn:       &txn.TxnMeta,
 			}).Size())
@@ -335,14 +335,14 @@ func TestMVCCStatsDeleteMovesTimestamp(t *testing.T) {
 			require.EqualValues(t, mKeySize, 2)
 
 			mVal1Size := int64((&enginepb.MVCCMetadata{
-				Timestamp: hlc.LegacyTimestamp(ts1),
+				Timestamp: ts1.ToLegacyTimestamp(),
 				Deleted:   false,
 				Txn:       &txn.TxnMeta,
 			}).Size())
 			require.EqualValues(t, mVal1Size, 46)
 
 			m1ValSize := int64((&enginepb.MVCCMetadata{
-				Timestamp: hlc.LegacyTimestamp(ts2),
+				Timestamp: ts2.ToLegacyTimestamp(),
 				Deleted:   false,
 				Txn:       &txn.TxnMeta,
 			}).Size())
@@ -379,7 +379,7 @@ func TestMVCCStatsDeleteMovesTimestamp(t *testing.T) {
 			// sequence number. Also since there was a write previously on the same
 			// transaction, the IntentHistory will add a few bytes to the metadata.
 			m2ValSize := int64((&enginepb.MVCCMetadata{
-				Timestamp: hlc.LegacyTimestamp(ts2),
+				Timestamp: ts2.ToLegacyTimestamp(),
 				Txn:       &txn.TxnMeta,
 				IntentHistory: []enginepb.MVCCMetadata_SequencedIntent{
 					{Sequence: 0, Value: value.RawBytes},
@@ -449,14 +449,14 @@ func TestMVCCStatsPutMovesDeletionTimestamp(t *testing.T) {
 			require.EqualValues(t, mKeySize, 2)
 
 			mVal1Size := int64((&enginepb.MVCCMetadata{
-				Timestamp: hlc.LegacyTimestamp(ts1),
+				Timestamp: ts1.ToLegacyTimestamp(),
 				Deleted:   false,
 				Txn:       &txn.TxnMeta,
 			}).Size())
 			require.EqualValues(t, mVal1Size, 46)
 
 			m1ValSize := int64((&enginepb.MVCCMetadata{
-				Timestamp: hlc.LegacyTimestamp(ts2),
+				Timestamp: ts2.ToLegacyTimestamp(),
 				Deleted:   false,
 				Txn:       &txn.TxnMeta,
 			}).Size())
@@ -494,7 +494,7 @@ func TestMVCCStatsPutMovesDeletionTimestamp(t *testing.T) {
 			// sequence number. Also the value is larger because the previous intent on the
 			// transaction is recorded in the IntentHistory.
 			m2ValSize := int64((&enginepb.MVCCMetadata{
-				Timestamp: hlc.LegacyTimestamp(ts2),
+				Timestamp: ts2.ToLegacyTimestamp(),
 				Txn:       &txn.TxnMeta,
 				IntentHistory: []enginepb.MVCCMetadata_SequencedIntent{
 					{Sequence: 0, Value: []byte{}},
@@ -582,7 +582,7 @@ func TestMVCCStatsDelDelCommitMovesTimestamp(t *testing.T) {
 			}
 
 			mValSize := int64((&enginepb.MVCCMetadata{
-				Timestamp: hlc.LegacyTimestamp(ts1),
+				Timestamp: ts1.ToLegacyTimestamp(),
 				Deleted:   true,
 				Txn:       &txn.TxnMeta,
 			}).Size())
@@ -729,7 +729,7 @@ func TestMVCCStatsPutDelPutMovesTimestamp(t *testing.T) {
 			}
 
 			mValSize := int64((&enginepb.MVCCMetadata{
-				Timestamp: hlc.LegacyTimestamp(ts1),
+				Timestamp: ts1.ToLegacyTimestamp(),
 				Deleted:   true,
 				Txn:       &txn.TxnMeta,
 			}).Size())
@@ -758,7 +758,7 @@ func TestMVCCStatsPutDelPutMovesTimestamp(t *testing.T) {
 			// Annoyingly, the new meta value is actually a little larger thanks to the
 			// sequence number.
 			m2ValSize := int64((&enginepb.MVCCMetadata{
-				Timestamp: hlc.LegacyTimestamp(ts3),
+				Timestamp: ts3.ToLegacyTimestamp(),
 				Txn:       &txn.TxnMeta,
 			}).Size())
 
@@ -810,7 +810,7 @@ func TestMVCCStatsPutDelPutMovesTimestamp(t *testing.T) {
 				// Annoyingly, the new meta value is actually a little larger thanks to the
 				// sequence number.
 				m2ValSizeWithHistory := int64((&enginepb.MVCCMetadata{
-					Timestamp: hlc.LegacyTimestamp(ts3),
+					Timestamp: ts3.ToLegacyTimestamp(),
 					Txn:       &txn.TxnMeta,
 					IntentHistory: []enginepb.MVCCMetadata_SequencedIntent{
 						{Sequence: 0, Value: []byte{}},
@@ -948,7 +948,7 @@ func TestMVCCStatsPutIntentTimestampNotPutTimestamp(t *testing.T) {
 
 			mKeySize := int64(mvccKey(key).EncodedSize()) // 2
 			m1ValSize := int64((&enginepb.MVCCMetadata{   // 44
-				Timestamp: hlc.LegacyTimestamp(ts201),
+				Timestamp: ts201.ToLegacyTimestamp(),
 				Txn:       &txn.TxnMeta,
 			}).Size())
 			vKeySize := MVCCVersionTimestampSize   // 12
@@ -979,7 +979,7 @@ func TestMVCCStatsPutIntentTimestampNotPutTimestamp(t *testing.T) {
 			// Annoyingly, the new meta value is actually a little larger thanks to the
 			// sequence number.
 			m2ValSize := int64((&enginepb.MVCCMetadata{ // 46
-				Timestamp: hlc.LegacyTimestamp(ts201),
+				Timestamp: ts201.ToLegacyTimestamp(),
 				Txn:       &txn.TxnMeta,
 				IntentHistory: []enginepb.MVCCMetadata_SequencedIntent{
 					{Sequence: 0, Value: value.RawBytes},
@@ -1133,7 +1133,7 @@ func TestMVCCStatsTxnSysPutPut(t *testing.T) {
 			require.EqualValues(t, mKeySize, 11)
 
 			mValSize := int64((&enginepb.MVCCMetadata{
-				Timestamp: hlc.LegacyTimestamp(ts1),
+				Timestamp: ts1.ToLegacyTimestamp(),
 				Deleted:   false,
 				Txn:       &txn.TxnMeta,
 			}).Size())
@@ -1164,7 +1164,7 @@ func TestMVCCStatsTxnSysPutPut(t *testing.T) {
 			// The value also grows as the older value is part of the same
 			// transaction and so contributes to the intent history.
 			mVal2Size := int64((&enginepb.MVCCMetadata{
-				Timestamp: hlc.LegacyTimestamp(ts2),
+				Timestamp: ts2.ToLegacyTimestamp(),
 				Deleted:   false,
 				Txn:       &txn.TxnMeta,
 				IntentHistory: []enginepb.MVCCMetadata_SequencedIntent{
@@ -1222,7 +1222,7 @@ func TestMVCCStatsTxnSysPutAbort(t *testing.T) {
 			require.EqualValues(t, mKeySize, 11)
 
 			mValSize := int64((&enginepb.MVCCMetadata{
-				Timestamp: hlc.LegacyTimestamp(ts1),
+				Timestamp: ts1.ToLegacyTimestamp(),
 				Deleted:   false,
 				Txn:       &txn.TxnMeta,
 			}).Size())

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -1247,7 +1247,7 @@ func (p *pebbleReadOnly) NewMVCCIterator(iterKind MVCCIterKind, opts IterOptions
 		panic("using a closed pebbleReadOnly")
 	}
 
-	if opts.MinTimestampHint != (hlc.Timestamp{}) {
+	if !opts.MinTimestampHint.IsEmpty() {
 		// MVCCIterators that specify timestamp bounds cannot be cached.
 		return newPebbleIterator(p.parent.db, opts)
 	}

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -252,7 +252,7 @@ func (t *pebbleTimeBoundPropCollector) Finish(userProps map[string]string) error
 			return nil //nolint:returnerrcheck
 		}
 		if meta.Txn != nil {
-			ts := encodeTimestamp(hlc.Timestamp(meta.Timestamp))
+			ts := encodeTimestamp(meta.Timestamp.ToTimestamp())
 			t.updateBounds(ts)
 		}
 	}

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -75,8 +75,7 @@ func MVCCKeyCompare(a, b []byte) int {
 	bEnd := len(b) - 1
 	if aEnd < 0 || bEnd < 0 {
 		// This should never happen unless there is some sort of corruption of
-		// the keys. This is a little bizarre, but the behavior exactly matches
-		// engine/db.cc:DBComparator.
+		// the keys.
 		return bytes.Compare(a, b)
 	}
 
@@ -85,8 +84,7 @@ func MVCCKeyCompare(a, b []byte) int {
 	bSep := bEnd - int(b[bEnd])
 	if aSep < 0 || bSep < 0 {
 		// This should never happen unless there is some sort of corruption of
-		// the keys. This is a little bizarre, but the behavior exactly matches
-		// engine/db.cc:DBComparator.
+		// the keys.
 		return bytes.Compare(a, b)
 	}
 

--- a/pkg/storage/pebble_batch.go
+++ b/pkg/storage/pebble_batch.go
@@ -209,7 +209,7 @@ func (p *pebbleBatch) NewMVCCIterator(iterKind MVCCIterKind, opts IterOptions) M
 		panic("distinct batch open")
 	}
 
-	if opts.MinTimestampHint != (hlc.Timestamp{}) {
+	if !opts.MinTimestampHint.IsEmpty() {
 		// MVCCIterators that specify timestamp bounds cannot be cached.
 		return newPebbleIterator(p.batch, opts)
 	}

--- a/pkg/storage/pebble_iterator.go
+++ b/pkg/storage/pebble_iterator.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
-	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble"
@@ -103,7 +102,7 @@ func (p *pebbleIterator) init(handle pebble.Reader, opts IterOptions) {
 		p.options.UpperBound = p.upperBoundBuf[0]
 	}
 
-	if opts.MaxTimestampHint != (hlc.Timestamp{}) {
+	if !opts.MaxTimestampHint.IsEmpty() {
 		encodedMinTS := string(encodeTimestamp(opts.MinTimestampHint))
 		encodedMaxTS := string(encodeTimestamp(opts.MaxTimestampHint))
 		p.options.TableFilter = func(userProps map[string]string) bool {
@@ -127,7 +126,7 @@ func (p *pebbleIterator) init(handle pebble.Reader, opts IterOptions) {
 			}
 			return used
 		}
-	} else if opts.MinTimestampHint != (hlc.Timestamp{}) {
+	} else if !opts.MinTimestampHint.IsEmpty() {
 		panic("min timestamp hint set without max timestamp hint")
 	}
 
@@ -143,7 +142,7 @@ func (p *pebbleIterator) setOptions(opts IterOptions) {
 	// Overwrite any stale options from last time.
 	p.options = pebble.IterOptions{}
 
-	if opts.MinTimestampHint != (hlc.Timestamp{}) || opts.MaxTimestampHint != (hlc.Timestamp{}) {
+	if !opts.MinTimestampHint.IsEmpty() || !opts.MaxTimestampHint.IsEmpty() {
 		panic("iterator with timestamp hints cannot be reused")
 	}
 	if !opts.Prefix && len(opts.UpperBound) == 0 && len(opts.LowerBound) == 0 {

--- a/pkg/storage/pebble_mvcc_scanner.go
+++ b/pkg/storage/pebble_mvcc_scanner.go
@@ -284,7 +284,7 @@ func (p *pebbleMVCCScanner) uncertaintyError(ts hlc.Timestamp) bool {
 // Emit a tuple and return true if we have reason to believe iteration can
 // continue.
 func (p *pebbleMVCCScanner) getAndAdvance() bool {
-	if p.curKey.Timestamp != (hlc.Timestamp{}) {
+	if !p.curKey.Timestamp.IsEmpty() {
 		if p.curKey.Timestamp.LessEq(p.ts) {
 			// 1. Fast path: there is no intent and our read timestamp is newer than
 			// the most recent version's timestamp.
@@ -681,7 +681,7 @@ func (p *pebbleMVCCScanner) iterSeekReverse(key MVCCKey) bool {
 		return false
 	}
 
-	if p.curKey.Timestamp == (hlc.Timestamp{}) {
+	if p.curKey.Timestamp.IsEmpty() {
 		// We landed on an intent or inline value.
 		return true
 	}

--- a/pkg/storage/pebble_mvcc_scanner.go
+++ b/pkg/storage/pebble_mvcc_scanner.go
@@ -339,7 +339,7 @@ func (p *pebbleMVCCScanner) getAndAdvance() bool {
 		p.err = errors.Errorf("intent without transaction")
 		return false
 	}
-	metaTS := hlc.Timestamp(p.meta.Timestamp)
+	metaTS := p.meta.Timestamp.ToTimestamp()
 
 	// metaTS is the timestamp of an intent value, which we may or may
 	// not end up ignoring, depending on factors codified below. If we do ignore

--- a/pkg/util/hlc/BUILD.bazel
+++ b/pkg/util/hlc/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//pkg/util/timeutil",
         "//vendor/github.com/cockroachdb/errors",
         "//vendor/github.com/gogo/protobuf/proto",
+        "//vendor/google.golang.org/protobuf/proto",
     ],
 )
 

--- a/pkg/util/hlc/legacy_timestamp.proto
+++ b/pkg/util/hlc/legacy_timestamp.proto
@@ -30,4 +30,17 @@ message LegacyTimestamp {
   // skew)/(minimal ns between events) and nearly impossible to
   // overflow.
   optional int32 logical = 2 [(gogoproto.nullable) = false];
+  // A collection of bit flags that provide details about the timestamp
+  // and its meaning. The data type is a uint32, but the number of flags
+  // is limited to 8 so that the flags can be encoded into a single byte.
+  //
+  // Flags do not affect the sort order of Timestamps. However, they are
+  // considered when performing structural equality checks (e.g. using the
+  // == operator). Consider use of the EqOrdering method when testing for
+  // equality.
+  //
+  // The field is nullable so that it is not serialized when no flags are
+  // set. This ensures that the timestamp encoding does not change across
+  // nodes that are and are not aware of this field.
+  optional uint32 flags = 3;
 }

--- a/pkg/util/hlc/timestamp.go
+++ b/pkg/util/hlc/timestamp.go
@@ -15,11 +15,13 @@ import (
 	"math"
 	"regexp"
 	"strconv"
+	"strings"
 	"time"
 	"unsafe"
 
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
+	"google.golang.org/protobuf/proto"
 )
 
 // Timestamp constant values.
@@ -30,6 +32,16 @@ var (
 	MinTimestamp = Timestamp{WallTime: 0, Logical: 1}
 )
 
+// EqOrdering returns whether the receiver sorts equally to the parameter.
+//
+// This method is split from tests of structural equality (Equal and the equals
+// operator) because it does not consider differences in flags and only
+// considers whether the walltime and logical time differ between the
+// timestamps.
+func (t Timestamp) EqOrdering(s Timestamp) bool {
+	return t.WallTime == s.WallTime && t.Logical == s.Logical
+}
+
 // Less returns whether the receiver is less than the parameter.
 func (t Timestamp) Less(s Timestamp) bool {
 	return t.WallTime < s.WallTime || (t.WallTime == s.WallTime && t.Logical < s.Logical)
@@ -37,8 +49,19 @@ func (t Timestamp) Less(s Timestamp) bool {
 
 // LessEq returns whether the receiver is less than or equal to the parameter.
 func (t Timestamp) LessEq(s Timestamp) bool {
-	return t.Less(s) || t == s
+	return t.WallTime < s.WallTime || (t.WallTime == s.WallTime && t.Logical <= s.Logical)
 }
+
+var flagStrings = map[TimestampFlag]string{
+	TimestampFlag_SYNTHETIC: "syn",
+}
+var flagStringsInverted = func() map[string]TimestampFlag {
+	m := make(map[string]TimestampFlag)
+	for k, v := range flagStrings {
+		m[v] = k
+	}
+	return m
+}()
 
 // String implements the fmt.Formatter interface.
 func (t Timestamp) String() string {
@@ -89,6 +112,22 @@ func (t Timestamp) String() string {
 	}
 	buf = strconv.AppendInt(buf, int64(t.Logical), 10)
 
+	if t.Flags != 0 {
+		buf = append(buf, '[')
+		comma := false
+		for i := 0; i < 8; i++ {
+			f := TimestampFlag(1 << i)
+			if t.IsFlagSet(f) {
+				if comma {
+					buf = append(buf, ',')
+				}
+				comma = true
+				buf = append(buf, flagStrings[f]...)
+			}
+		}
+		buf = append(buf, ']')
+	}
+
 	return *(*string)(unsafe.Pointer(&buf))
 }
 
@@ -97,11 +136,12 @@ func (Timestamp) SafeValue() {}
 
 var (
 	timestampRegexp = regexp.MustCompile(
-		`^(?P<sign>-)?(?P<secs>\d{1,19})(\.(?P<nanos>\d{1,20}))?,(?P<logical>-?\d{1,10})$`)
+		`^(?P<sign>-)?(?P<secs>\d{1,19})(?:\.(?P<nanos>\d{1,20}))?,(?P<logical>-?\d{1,10})(?:\[(?P<flags>[\w,]+)\])?$`)
 	signSubexp    = 1
 	secsSubexp    = 2
-	nanosSubexp   = 4
-	logicalSubexp = 5
+	nanosSubexp   = 3
+	logicalSubexp = 4
+	flagsSubexp   = 5
 )
 
 // ParseTimestamp attempts to parse the string generated from
@@ -135,10 +175,27 @@ func ParseTimestamp(str string) (_ Timestamp, err error) {
 	if matches[signSubexp] == "-" {
 		wallTime *= -1
 	}
-	return Timestamp{
+	t := Timestamp{
 		WallTime: wallTime,
 		Logical:  int32(logical),
-	}, nil
+	}
+	if flagsMatch := matches[flagsSubexp]; flagsMatch != "" {
+		flagStrs := strings.Split(flagsMatch, ",")
+		for _, flagStr := range flagStrs {
+			if flagStr == "" {
+				return Timestamp{}, errors.Errorf("empty flag provided")
+			}
+			flagMatch, ok := flagStringsInverted[flagStr]
+			if !ok {
+				return Timestamp{}, errors.Errorf("unknown flag %q provided", flagStr)
+			}
+			if t.IsFlagSet(flagMatch) {
+				return Timestamp{}, errors.Errorf("duplicate flag %q provided", flagStr)
+			}
+			t = t.SetFlag(flagMatch)
+		}
+	}
+	return t, nil
 }
 
 // AsOfSystemTime returns a string to be used in an AS OF SYSTEM TIME query.
@@ -146,18 +203,14 @@ func (t Timestamp) AsOfSystemTime() string {
 	return fmt.Sprintf("%d.%010d", t.WallTime, t.Logical)
 }
 
-// Less returns whether the receiver is less than the parameter.
-func (t LegacyTimestamp) Less(s LegacyTimestamp) bool {
-	return Timestamp(t).Less(Timestamp(s))
-}
-
-func (t LegacyTimestamp) String() string {
-	return Timestamp(t).String()
-}
-
 // IsEmpty retruns true if t is an empty Timestamp.
 func (t Timestamp) IsEmpty() bool {
 	return t == Timestamp{}
+}
+
+// IsFlagSet returns whether the specified flag is set on the timestamp.
+func (t Timestamp) IsFlagSet(f TimestampFlag) bool {
+	return t.Flags&uint32(f) != 0
 }
 
 // Add returns a timestamp with the WallTime and Logical components increased.
@@ -166,7 +219,14 @@ func (t Timestamp) Add(wallTime int64, logical int32) Timestamp {
 	return Timestamp{
 		WallTime: t.WallTime + wallTime,
 		Logical:  t.Logical + logical,
+		Flags:    t.Flags,
 	}
+}
+
+// SetFlag returns a timestamp with the specified flag set.
+func (t Timestamp) SetFlag(f TimestampFlag) Timestamp {
+	t.Flags = t.Flags | uint32(f)
+	return t
 }
 
 // Clone return a new timestamp that has the same contents as the receiver.
@@ -182,11 +242,13 @@ func (t Timestamp) Next() Timestamp {
 		}
 		return Timestamp{
 			WallTime: t.WallTime + 1,
+			Flags:    t.Flags,
 		}
 	}
 	return Timestamp{
 		WallTime: t.WallTime,
 		Logical:  t.Logical + 1,
+		Flags:    t.Flags,
 	}
 }
 
@@ -196,11 +258,13 @@ func (t Timestamp) Prev() Timestamp {
 		return Timestamp{
 			WallTime: t.WallTime,
 			Logical:  t.Logical - 1,
+			Flags:    t.Flags,
 		}
 	} else if t.WallTime > 0 {
 		return Timestamp{
 			WallTime: t.WallTime - 1,
 			Logical:  math.MaxInt32,
+			Flags:    t.Flags,
 		}
 	}
 	panic("cannot take the previous value to a zero timestamp")
@@ -214,19 +278,23 @@ func (t Timestamp) FloorPrev() Timestamp {
 		return Timestamp{
 			WallTime: t.WallTime,
 			Logical:  t.Logical - 1,
+			Flags:    t.Flags,
 		}
 	} else if t.WallTime > 0 {
 		return Timestamp{
 			WallTime: t.WallTime - 1,
 			Logical:  0,
+			Flags:    t.Flags,
 		}
 	}
 	panic("cannot take the previous value to a zero timestamp")
 }
 
-// Forward updates the timestamp from the one given, if that moves it forwards
-// in time. Returns true if the timestamp was adjusted and false otherwise.
+// Forward replaces the receiver with the argument, if that moves it forwards in
+// time. Returns true if the timestamp was adjusted and false otherwise.
 func (t *Timestamp) Forward(s Timestamp) bool {
+	// TODO(nvanbenschoten): if the timestamps equal and either is
+	// non-synthetic, we can remove the synthetic bit.
 	if t.Less(s) {
 		*t = s
 		return true
@@ -234,9 +302,11 @@ func (t *Timestamp) Forward(s Timestamp) bool {
 	return false
 }
 
-// Backward updates the timestamp from the one given, if that moves it
-// backwards in time.
+// Backward replaces the receiver with the argument, if that moves it backwards
+// in time.
 func (t *Timestamp) Backward(s Timestamp) {
+	// TODO(nvanbenschoten): remove the synthetic bit from the older
+	// value if the younger one is non-synthetic.
 	if s.Less(*t) {
 		*t = s
 	}
@@ -245,4 +315,31 @@ func (t *Timestamp) Backward(s Timestamp) {
 // GoTime converts the timestamp to a time.Time.
 func (t Timestamp) GoTime() time.Time {
 	return timeutil.Unix(0, t.WallTime)
+}
+
+// ToLegacyTimestamp converts a Timestamp to a LegacyTimestamp.
+func (t Timestamp) ToLegacyTimestamp() LegacyTimestamp {
+	var flags *uint32
+	if t.Flags != 0 {
+		flags = proto.Uint32(t.Flags)
+	}
+	return LegacyTimestamp{WallTime: t.WallTime, Logical: t.Logical, Flags: flags}
+}
+
+// ToTimestamp converts a LegacyTimestamp to a Timestamp.
+func (t LegacyTimestamp) ToTimestamp() Timestamp {
+	var flags uint32
+	if t.Flags != nil {
+		flags = *t.Flags
+	}
+	return Timestamp{WallTime: t.WallTime, Logical: t.Logical, Flags: flags}
+}
+
+// Less returns whether the receiver is less than the parameter.
+func (t LegacyTimestamp) Less(s LegacyTimestamp) bool {
+	return t.ToTimestamp().Less(s.ToTimestamp())
+}
+
+func (t LegacyTimestamp) String() string {
+	return t.ToTimestamp().String()
 }

--- a/pkg/util/hlc/timestamp.go
+++ b/pkg/util/hlc/timestamp.go
@@ -335,6 +335,11 @@ func (t LegacyTimestamp) ToTimestamp() Timestamp {
 	return Timestamp{WallTime: t.WallTime, Logical: t.Logical, Flags: flags}
 }
 
+// EqOrdering returns whether the receiver sorts equally to the parameter.
+func (t LegacyTimestamp) EqOrdering(s LegacyTimestamp) bool {
+	return t.ToTimestamp().EqOrdering(s.ToTimestamp())
+}
+
 // Less returns whether the receiver is less than the parameter.
 func (t LegacyTimestamp) Less(s LegacyTimestamp) bool {
 	return t.ToTimestamp().Less(s.ToTimestamp())

--- a/pkg/util/hlc/timestamp.pb.go
+++ b/pkg/util/hlc/timestamp.pb.go
@@ -20,22 +20,67 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
 
+// TimestampFlag is used to provide extra classification for Timestamps.
+type TimestampFlag int32
+
+const (
+	TimestampFlag_UNKNOWN TimestampFlag = 0
+	// A synthetic timestamp is defined as a timestamp that makes no claim
+	// about the value of clocks in the system. While standard timestamps
+	// are pulled from HLC clocks and indicate that some node in the system
+	// has a clock with a reading equal to or above its value, a synthetic
+	// timestamp makes no such indication.
+	//
+	// Synthetic timestamps are central to non-blocking transactions, which
+	// write at "future timestamps". They are also used to disconnect some
+	// committed versions from observed timestamps, where they indicate that
+	// versions were moved from the timestamp at which they were originally
+	// written. Only synthetic timestamps require observing the full
+	// uncertainty interval, whereas readings off the leaseholders's clock
+	// can tighten it for non-synthetic versions.
+	TimestampFlag_SYNTHETIC TimestampFlag = 1
+)
+
+var TimestampFlag_name = map[int32]string{
+	0: "UNKNOWN",
+	1: "SYNTHETIC",
+}
+var TimestampFlag_value = map[string]int32{
+	"UNKNOWN":   0,
+	"SYNTHETIC": 1,
+}
+
+func (x TimestampFlag) String() string {
+	return proto.EnumName(TimestampFlag_name, int32(x))
+}
+func (TimestampFlag) EnumDescriptor() ([]byte, []int) {
+	return fileDescriptor_timestamp_7c076e9f3a1546ea, []int{0}
+}
+
 // Timestamp represents a state of the hybrid logical clock.
 type Timestamp struct {
 	// Holds a wall time, typically a unix epoch time expressed in
 	// nanoseconds.
 	WallTime int64 `protobuf:"varint,1,opt,name=wall_time,json=wallTime,proto3" json:"wall_time,omitempty"`
-	// The logical component captures causality for events whose wall
-	// times are equal. It is effectively bounded by (maximum clock
-	// skew)/(minimal ns between events) and nearly impossible to
-	// overflow.
+	// The logical component captures causality for events whose wall times
+	// are equal. It is effectively bounded by (maximum clock skew)/(minimal
+	// ns between events) and nearly impossible to overflow.
 	Logical int32 `protobuf:"varint,2,opt,name=logical,proto3" json:"logical,omitempty"`
+	// A collection of bit flags that provide details about the timestamp
+	// and its meaning. The data type is a uint32, but the number of flags
+	// is limited to 8 so that the flags can be encoded into a single byte.
+	//
+	// Flags do not affect the sort order of Timestamps. However, they are
+	// considered when performing structural equality checks (e.g. using the
+	// == operator). Consider use of the EqOrdering method when testing for
+	// equality.
+	Flags uint32 `protobuf:"varint,3,opt,name=flags,proto3" json:"flags,omitempty"`
 }
 
 func (m *Timestamp) Reset()      { *m = Timestamp{} }
 func (*Timestamp) ProtoMessage() {}
 func (*Timestamp) Descriptor() ([]byte, []int) {
-	return fileDescriptor_timestamp_7743fc20d6f93748, []int{0}
+	return fileDescriptor_timestamp_7c076e9f3a1546ea, []int{0}
 }
 func (m *Timestamp) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -62,6 +107,7 @@ var xxx_messageInfo_Timestamp proto.InternalMessageInfo
 
 func init() {
 	proto.RegisterType((*Timestamp)(nil), "cockroach.util.hlc.Timestamp")
+	proto.RegisterEnum("cockroach.util.hlc.TimestampFlag", TimestampFlag_name, TimestampFlag_value)
 }
 func (this *Timestamp) Equal(that interface{}) bool {
 	if that == nil {
@@ -86,6 +132,9 @@ func (this *Timestamp) Equal(that interface{}) bool {
 		return false
 	}
 	if this.Logical != that1.Logical {
+		return false
+	}
+	if this.Flags != that1.Flags {
 		return false
 	}
 	return true
@@ -115,6 +164,11 @@ func (m *Timestamp) MarshalTo(dAtA []byte) (int, error) {
 		i++
 		i = encodeVarintTimestamp(dAtA, i, uint64(m.Logical))
 	}
+	if m.Flags != 0 {
+		dAtA[i] = 0x18
+		i++
+		i = encodeVarintTimestamp(dAtA, i, uint64(m.Flags))
+	}
 	return i, nil
 }
 
@@ -137,6 +191,7 @@ func NewPopulatedTimestamp(r randyTimestamp, easy bool) *Timestamp {
 	if r.Intn(2) == 0 {
 		this.Logical *= -1
 	}
+	this.Flags = uint32(r.Uint32())
 	if !easy && r.Intn(10) != 0 {
 	}
 	return this
@@ -226,6 +281,9 @@ func (m *Timestamp) Size() (n int) {
 	if m.Logical != 0 {
 		n += 1 + sovTimestamp(uint64(m.Logical))
 	}
+	if m.Flags != 0 {
+		n += 1 + sovTimestamp(uint64(m.Flags))
+	}
 	return n
 }
 
@@ -305,6 +363,25 @@ func (m *Timestamp) Unmarshal(dAtA []byte) error {
 				b := dAtA[iNdEx]
 				iNdEx++
 				m.Logical |= (int32(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 3:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Flags", wireType)
+			}
+			m.Flags = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTimestamp
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Flags |= (uint32(b) & 0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -436,21 +513,25 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("util/hlc/timestamp.proto", fileDescriptor_timestamp_7743fc20d6f93748)
+	proto.RegisterFile("util/hlc/timestamp.proto", fileDescriptor_timestamp_7c076e9f3a1546ea)
 }
 
-var fileDescriptor_timestamp_7743fc20d6f93748 = []byte{
-	// 191 bytes of a gzipped FileDescriptorProto
+var fileDescriptor_timestamp_7c076e9f3a1546ea = []byte{
+	// 247 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x92, 0x28, 0x2d, 0xc9, 0xcc,
 	0xd1, 0xcf, 0xc8, 0x49, 0xd6, 0x2f, 0xc9, 0xcc, 0x4d, 0x2d, 0x2e, 0x49, 0xcc, 0x2d, 0xd0, 0x2b,
 	0x28, 0xca, 0x2f, 0xc9, 0x17, 0x12, 0x4a, 0xce, 0x4f, 0xce, 0x2e, 0xca, 0x4f, 0x4c, 0xce, 0xd0,
 	0x03, 0xa9, 0xd1, 0xcb, 0xc8, 0x49, 0x96, 0x12, 0x49, 0xcf, 0x4f, 0xcf, 0x07, 0x4b, 0xeb, 0x83,
-	0x58, 0x10, 0x95, 0x4a, 0x01, 0x5c, 0x9c, 0x21, 0x30, 0xcd, 0x42, 0xd2, 0x5c, 0x9c, 0xe5, 0x89,
+	0x58, 0x10, 0x95, 0x4a, 0x69, 0x5c, 0x9c, 0x21, 0x30, 0xcd, 0x42, 0xd2, 0x5c, 0x9c, 0xe5, 0x89,
 	0x39, 0x39, 0xf1, 0x20, 0xe3, 0x24, 0x18, 0x15, 0x18, 0x35, 0x98, 0x83, 0x38, 0x40, 0x02, 0x20,
 	0x15, 0x42, 0x12, 0x5c, 0xec, 0x39, 0xf9, 0xe9, 0x99, 0xc9, 0x89, 0x39, 0x12, 0x4c, 0x0a, 0x8c,
-	0x1a, 0xac, 0x41, 0x30, 0xae, 0x15, 0xcf, 0x8c, 0x05, 0xf2, 0x0c, 0x3b, 0x16, 0xc8, 0x33, 0xbe,
-	0x58, 0x20, 0xcf, 0xe8, 0xa4, 0x7a, 0xe2, 0xa1, 0x1c, 0xc3, 0x89, 0x47, 0x72, 0x8c, 0x17, 0x1e,
-	0xc9, 0x31, 0xde, 0x78, 0x24, 0xc7, 0xf8, 0xe0, 0x91, 0x1c, 0xe3, 0x84, 0xc7, 0x72, 0x0c, 0x17,
-	0x1e, 0xcb, 0x31, 0xdc, 0x78, 0x2c, 0xc7, 0x10, 0xc5, 0x9c, 0x91, 0x93, 0x9c, 0xc4, 0x06, 0xb6,
-	0xdf, 0x18, 0x10, 0x00, 0x00, 0xff, 0xff, 0x8a, 0xc4, 0x02, 0x06, 0xc5, 0x00, 0x00, 0x00,
+	0x1a, 0xac, 0x41, 0x30, 0xae, 0x90, 0x08, 0x17, 0x6b, 0x5a, 0x4e, 0x62, 0x7a, 0xb1, 0x04, 0xb3,
+	0x02, 0xa3, 0x06, 0x6f, 0x10, 0x84, 0x63, 0xc5, 0x33, 0x63, 0x81, 0x3c, 0xc3, 0x8e, 0x05, 0xf2,
+	0x8c, 0x2f, 0x16, 0xc8, 0x33, 0x6a, 0x69, 0x73, 0xf1, 0xc2, 0xed, 0x71, 0xcb, 0x49, 0x4c, 0x17,
+	0xe2, 0xe6, 0x62, 0x0f, 0xf5, 0xf3, 0xf6, 0xf3, 0x0f, 0xf7, 0x13, 0x60, 0x10, 0xe2, 0xe5, 0xe2,
+	0x0c, 0x8e, 0xf4, 0x0b, 0xf1, 0x70, 0x0d, 0xf1, 0x74, 0x16, 0x60, 0x74, 0x52, 0x3d, 0xf1, 0x50,
+	0x8e, 0xe1, 0xc4, 0x23, 0x39, 0xc6, 0x0b, 0x8f, 0xe4, 0x18, 0x6f, 0x3c, 0x92, 0x63, 0x7c, 0xf0,
+	0x48, 0x8e, 0x71, 0xc2, 0x63, 0x39, 0x86, 0x0b, 0x8f, 0xe5, 0x18, 0x6e, 0x3c, 0x96, 0x63, 0x88,
+	0x62, 0xce, 0xc8, 0x49, 0x4e, 0x62, 0x03, 0x7b, 0xc1, 0x18, 0x10, 0x00, 0x00, 0xff, 0xff, 0xf4,
+	0x8d, 0x21, 0xb8, 0x08, 0x01, 0x00, 0x00,
 }

--- a/pkg/util/hlc/timestamp.proto
+++ b/pkg/util/hlc/timestamp.proto
@@ -24,9 +24,39 @@ message Timestamp {
   // Holds a wall time, typically a unix epoch time expressed in
   // nanoseconds.
   int64 wall_time = 1;
-  // The logical component captures causality for events whose wall
-  // times are equal. It is effectively bounded by (maximum clock
-  // skew)/(minimal ns between events) and nearly impossible to
-  // overflow.
+  // The logical component captures causality for events whose wall times
+  // are equal. It is effectively bounded by (maximum clock skew)/(minimal
+  // ns between events) and nearly impossible to overflow.
   int32 logical = 2;
+  // A collection of bit flags that provide details about the timestamp
+  // and its meaning. The data type is a uint32, but the number of flags
+  // is limited to 8 so that the flags can be encoded into a single byte.
+  //
+  // Flags do not affect the sort order of Timestamps. However, they are
+  // considered when performing structural equality checks (e.g. using the
+  // == operator). Consider use of the EqOrdering method when testing for
+  // equality.
+  uint32 flags = 3;
+}
+
+// TimestampFlag is used to provide extra classification for Timestamps.
+enum TimestampFlag {
+  UNKNOWN = 0x00;
+  // A synthetic timestamp is defined as a timestamp that makes no claim
+  // about the value of clocks in the system. While standard timestamps
+  // are pulled from HLC clocks and indicate that some node in the system
+  // has a clock with a reading equal to or above its value, a synthetic
+  // timestamp makes no such indication.
+  //
+  // Synthetic timestamps are central to non-blocking transactions, which
+  // write at "future timestamps". They are also used to disconnect some
+  // committed versions from observed timestamps, where they indicate that
+  // versions were moved from the timestamp at which they were originally
+  // written. Only synthetic timestamps require observing the full
+  // uncertainty interval, whereas readings off the leaseholders's clock
+  // can tighten it for non-synthetic versions.
+  SYNTHETIC = 0x01;
+  // ... = 0x02;
+  // ... = 0x04;
+  // max = 0x80;
 }

--- a/pkg/util/span/frontier.go
+++ b/pkg/util/span/frontier.go
@@ -60,7 +60,7 @@ func (h frontierHeap) Len() int { return len(h) }
 
 // Less implements heap.Interface.
 func (h frontierHeap) Less(i, j int) bool {
-	if h[i].ts == h[j].ts {
+	if h[i].ts.EqOrdering(h[j].ts) {
 		return h[i].span.Key.Compare(h[j].span.Key) < 0
 	}
 	return h[i].ts.Less(h[j].ts)


### PR DESCRIPTION
Informs #52745.
Informs #36431.

This commit introduces an 8-bit `flags` field on the hlc timestamp struct. The flags are used to provide details about the timestamp and its meaning. They do not affect the sort order of Timestamps.

The commit then introduces the first flag: SYNTHETIC. As discussed in #52745, a synthetic timestamp is defined as a timestamp that makes no claim about the value of clocks in the system. While standard timestamps are pulled from HLC clocks and indicate that some node in the system has a clock with a reading equal to or above its value, a synthetic timestamp makes no such indication. By avoiding a connection to "real time", synthetic timestamps can be used to write values at a future time and to indicate that observed timestamps do not apply to such writes for the purposes of tracking causality between the write and its observers. Observed timestamps will be a critical part of implementing non-blocking transactions (#52745) and fixing the interaction between observed timestamps and transaction refreshing (#36431).

The original plan was to reserve the high-order bit in the logical portion of a timestamp as a "synthetic bit". This is how I began implementing things, but was turned off for a few reasons. First, it was fairly subtle and seemed too easy to get wrong. Using a separate field is more explicit and avoids a class of bugs. Second, I began to have serious concerns about how the synthetic bit would impact timestamp ordering. Every timestamp comparison would need to mask out the bit or risk being incorrect. This was even true of the LSM custom comparator. This seemed difficult to get right and seemed particularly concerning since we're planning on marking only some of a transaction's committed values as synthetic to fix #36431, so if we weren't careful, we could get atomicity violations. There were also minor backwards compatibility concerns.

But a separate field is more expensive in theory, so we need to be careful. However, it turns out that a separate field is mostly free in each case that we care about. In memory, the separate field is effectively free because the Timestamp struct was previously 12 bytes but was always padded out to 16 bytes when included as a field in any other struct. This means that the flags field is replacing existing padding. Over the wire, the field will not be included when zero and will use a varint encoding when not zero, so again, it is mostly free. In the engine key encoding, the field is also not included when zero, and takes up only 1 byte when non-zero, so it is mostly free.

----

First three commits from #56477.

@sumeerbhola I'm hoping you can take a look at the engine-level changes in the `introduce synthetic flag on timestamps` commit (4th commit as of the time of writing). I think the key encoding added here makes sense, but want to make sure you're on board. One possible concern is that we introduce a new 13-byte suffix, which means that combined with a 4-byte sequence number (see https://github.com/cockroachdb/cockroach/issues/41720#issuecomment-548780872), we'd collide with the 17 byte `engineKeyVersionLockTableLen`.

@tbg do you mind being the primary reviewer here? I think you know the most about the motivations for this change and will have a good sense of whether this is the best way to introduce additional state on timestamps.