### PR TITLE
workload/schemachange: improve error screening

### DIFF
--- a/pkg/workload/schemachange/error_screening.go
+++ b/pkg/workload/schemachange/error_screening.go
@@ -36,6 +36,15 @@ func viewExists(tx *pgx.Tx, tableName *tree.TableName) (bool, error) {
    )`, tableName.Schema(), tableName.Object())
 }
 
+func sequenceExists(tx *pgx.Tx, seqName *tree.TableName) (bool, error) {
+	return scanBool(tx, `SELECT EXISTS (
+	SELECT sequence_name
+    FROM information_schema.sequences
+   WHERE sequence_schema = $1
+     AND sequence_name = $2
+   )`, seqName.Schema(), seqName.Object())
+}
+
 func columnExistsOnTable(tx *pgx.Tx, tableName *tree.TableName, columnName string) (bool, error) {
 	return scanBool(tx, `SELECT EXISTS (
 	SELECT column_name

--- a/pkg/workload/schemachange/error_screening.go
+++ b/pkg/workload/schemachange/error_screening.go
@@ -165,3 +165,159 @@ func colIsPrimaryKey(tx *pgx.Tx, tableName *tree.TableName, columnName string) (
        );
 	`, tableName.Schema(), tableName.Object(), columnName)
 }
+
+// valuesViolateUniqueConstraints determines if any unique constraints (including primary constraints)
+// will be violated upon inserting the specified rows into the specified table.
+func violatesUniqueConstraints(
+	tx *pgx.Tx, tableName *tree.TableName, columns []string, rows [][]string,
+) (bool, error) {
+
+	if len(rows) == 0 {
+		return false, fmt.Errorf("violatesUniqueConstraints: no rows provided")
+	}
+
+	// Fetch unique constraints from the database. The format returned is an array of string arrays.
+	// Each string array is a group of column names for which a unique constraint exists.
+	constraints, err := scanStringArrayRows(tx, `
+	 SELECT DISTINCT array_agg(cols.column_name ORDER BY cols.column_name)
+					    FROM (
+					          SELECT d.oid,
+					                 d.table_name,
+					                 d.schema_name,
+					                 conname,
+					                 contype,
+					                 unnest(conkey) AS position
+					            FROM (
+					                  SELECT c.oid AS oid,
+					                         c.relname AS table_name,
+					                         ns.nspname AS schema_name
+					                    FROM pg_catalog.pg_class AS c
+					                    JOIN pg_catalog.pg_namespace AS ns ON
+					                          ns.oid = c.relnamespace
+					                   WHERE ns.nspname = $1
+					                     AND c.relname = $2
+					                 ) AS d
+					            JOIN (
+					                  SELECT conname, conkey, conrelid, contype
+					                    FROM pg_catalog.pg_constraint
+					                   WHERE contype = 'p' OR contype = 'u'
+					                 ) ON conrelid = d.oid
+					         ) AS cons
+					    JOIN (
+					          SELECT table_name,
+					                 table_schema,
+					                 column_name,
+					                 ordinal_position
+					            FROM information_schema.columns
+					         ) AS cols ON cons.schema_name = cols.table_schema
+					                  AND cols.table_name = cons.table_name
+					                  AND cols.ordinal_position = cons.position
+					GROUP BY cons.conname;
+`, tableName.Schema(), tableName.Object())
+	if err != nil {
+		return false, err
+	}
+
+	for _, constraint := range constraints {
+		// previousRows is used to check unique constraints among the values which
+		// will be inserted into the database.
+		previousRows := map[string]bool{}
+		for _, row := range rows {
+			violation, err := violatesUniqueConstraintsHelper(tx, tableName, columns, constraint, row, previousRows)
+			if err != nil {
+				return false, err
+			}
+			if violation {
+				return true, nil
+			}
+		}
+	}
+
+	return false, nil
+}
+
+func violatesUniqueConstraintsHelper(
+	tx *pgx.Tx,
+	tableName *tree.TableName,
+	columns []string,
+	constraint []string,
+	row []string,
+	previousRows map[string]bool,
+) (bool, error) {
+
+	// Put values to be inserted into a column name to value map to simplify lookups.
+	columnsToValues := map[string]string{}
+	for i := 0; i < len(columns); i++ {
+		columnsToValues[columns[i]] = row[i]
+	}
+
+	query := strings.Builder{}
+	query.WriteString(fmt.Sprintf(`SELECT EXISTS (
+			SELECT *
+				FROM %s
+       WHERE
+		`, tableName.String()))
+
+	atLeastOneNonNullValue := false
+	for _, column := range constraint {
+
+		// Null values are not checked because unique constraints do not apply to null values.
+		if columnsToValues[column] != "NULL" {
+			if atLeastOneNonNullValue {
+				query.WriteString(fmt.Sprintf(` AND %s = %s`, column, columnsToValues[column]))
+			} else {
+				query.WriteString(fmt.Sprintf(`%s = %s`, column, columnsToValues[column]))
+			}
+
+			atLeastOneNonNullValue = true
+		}
+	}
+	query.WriteString(")")
+
+	// If there are only null values being inserted for each of the constrained columns,
+	// then checking for uniqueness against other rows is not necessary.
+	if !atLeastOneNonNullValue {
+		return false, nil
+	}
+
+	queryString := query.String()
+
+	// Check for uniqueness against other rows to be inserted. For simplicity, the `SELECT EXISTS`
+	// query used to check for uniqueness against rows in the database can also
+	// be used as a unique key to check for uniqueness among rows to be inserted.
+	if _, duplicateEntry := previousRows[queryString]; duplicateEntry {
+		return true, nil
+	}
+	previousRows[queryString] = true
+
+	// Check for uniqueness against rows in the database.
+	exists, err := scanBool(tx, queryString)
+	if err != nil {
+		return false, err
+	}
+	if exists {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func scanStringArrayRows(tx *pgx.Tx, query string, args ...interface{}) ([][]string, error) {
+	rows, err := tx.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	results := [][]string{}
+	for rows.Next() {
+		var columnNames []string
+		err := rows.Scan(&columnNames)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, columnNames)
+	}
+
+	return results, err
+}

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -31,12 +31,13 @@ import (
 // seqNum may be shared across multiple instances of this, so it should only
 // be change atomically.
 type operationGeneratorParams struct {
-	seqNum          *int64
-	errorRate       int
-	enumPct         int
-	rng             *rand.Rand
-	ops             *deck
-	maxSourceTables int
+	seqNum             *int64
+	errorRate          int
+	enumPct            int
+	rng                *rand.Rand
+	ops                *deck
+	maxSourceTables    int
+	sequenceOwnedByPct int
 }
 
 // The OperationBuilder has the sole responsibility of generating ops
@@ -353,7 +354,40 @@ func (og *operationGenerator) createIndex(tx *pgx.Tx) (string, error) {
 }
 
 func (og *operationGenerator) createSequence(tx *pgx.Tx) (string, error) {
-	return fmt.Sprintf(`CREATE SEQUENCE "seq%d"`, og.newUniqueSeqNum()), nil
+	seqName, err := og.randSequence(tx, og.pctExisting(false), "")
+	if err != nil {
+		return "", err
+	}
+
+	ifNotExists := og.randIntn(2) == 0
+
+	var seqOptions tree.SequenceOptions
+	// Decide if the sequence should be owned by a column. If so, it can
+	// set using the tree.SeqOptOwnedBy sequence option.
+	if og.randIntn(100) < og.params.sequenceOwnedByPct {
+		table, err := og.randTable(tx, og.pctExisting(true), "")
+		if err != nil {
+			return "", err
+		}
+		column, err := og.randColumn(tx, *table, og.pctExisting(true))
+		if err != nil {
+			return "", err
+		}
+
+		seqOptions = append(
+			seqOptions,
+			tree.SequenceOption{
+				Name:          tree.SeqOptOwnedBy,
+				ColumnItemVal: &tree.ColumnItem{TableName: table.ToUnresolvedObjectName(), ColumnName: tree.Name(column)}},
+		)
+	}
+	createSeq := &tree.CreateSequence{
+		IfNotExists: ifNotExists,
+		Name:        *seqName,
+		Options:     seqOptions,
+	}
+
+	return tree.Serialize(createSeq), nil
 }
 
 func (og *operationGenerator) createTable(tx *pgx.Tx) (string, error) {
@@ -790,11 +824,16 @@ func (og *operationGenerator) dropIndex(tx *pgx.Tx) (string, error) {
 }
 
 func (og *operationGenerator) dropSequence(tx *pgx.Tx) (string, error) {
-	sequenceName, err := og.randSequence(tx, og.pctExisting(true))
+	sequenceName, err := og.randSequence(tx, og.pctExisting(true), "")
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf(`DROP SEQUENCE "%s"`, sequenceName), nil
+	ifExists := og.randIntn(2) == 0
+	dropSeq := &tree.DropSequence{
+		Names:    tree.TableNames{*sequenceName},
+		IfExists: ifExists,
+	}
+	return tree.Serialize(dropSeq), nil
 }
 
 func (og *operationGenerator) dropTable(tx *pgx.Tx) (string, error) {
@@ -928,17 +967,17 @@ func (og *operationGenerator) renameIndex(tx *pgx.Tx) (string, error) {
 }
 
 func (og *operationGenerator) renameSequence(tx *pgx.Tx) (string, error) {
-	srcSequenceName, err := og.randSequence(tx, og.pctExisting(true))
+	srcSequenceName, err := og.randSequence(tx, og.pctExisting(true), "")
 	if err != nil {
 		return "", err
 	}
 
-	destSequenceName, err := og.randSequence(tx, og.pctExisting(false))
+	destSequenceName, err := og.randSequence(tx, og.pctExisting(false), "")
 	if err != nil {
 		return "", err
 	}
 
-	return fmt.Sprintf(`ALTER SEQUENCE "%s" RENAME TO "%s"`, srcSequenceName, destSequenceName), nil
+	return fmt.Sprintf(`ALTER SEQUENCE %s RENAME TO %s`, srcSequenceName, destSequenceName), nil
 }
 
 func (og *operationGenerator) renameTable(tx *pgx.Tx) (string, error) {
@@ -1244,22 +1283,77 @@ ORDER BY random()
 	return name, nil
 }
 
-func (og *operationGenerator) randSequence(tx *pgx.Tx, pctExisting int) (string, error) {
+// randSequence returns a sequence qualified by a schema
+func (og *operationGenerator) randSequence(
+	tx *pgx.Tx, pctExisting int, desiredSchema string,
+) (*tree.TableName, error) {
+
+	if desiredSchema != "" {
+		if og.randIntn(100) >= pctExisting {
+			treeSeqName := tree.MakeTableNameFromPrefix(tree.ObjectNamePrefix{
+				SchemaName:     tree.Name(desiredSchema),
+				ExplicitSchema: true,
+			}, tree.Name(fmt.Sprintf("seq%d", og.newUniqueSeqNum())))
+			return &treeSeqName, nil
+		}
+		q := fmt.Sprintf(`
+   SELECT sequence_name
+     FROM [SHOW SEQUENCES]
+    WHERE sequence_name LIKE 'seq%%'
+			AND sequence_schema = '%s'
+ ORDER BY random()
+		LIMIT 1;
+		`, desiredSchema)
+
+		var seqName string
+		if err := tx.QueryRow(q).Scan(&seqName); err != nil {
+			treeSeqName := tree.MakeTableNameFromPrefix(tree.ObjectNamePrefix{}, "")
+			return &treeSeqName, err
+		}
+
+		treeSeqName := tree.MakeTableNameFromPrefix(tree.ObjectNamePrefix{
+			SchemaName:     tree.Name(desiredSchema),
+			ExplicitSchema: true,
+		}, tree.Name(seqName))
+		return &treeSeqName, nil
+	}
+
 	if og.randIntn(100) >= pctExisting {
-		return fmt.Sprintf(`seq%d`, og.newUniqueSeqNum()), nil
+		// Most of the time, this case is for creating sequences, so it
+		// is preferable that the schema exists.
+		randSchema, err := og.randSchema(tx, og.pctExisting(true))
+		if err != nil {
+			treeSeqName := tree.MakeTableNameFromPrefix(tree.ObjectNamePrefix{}, "")
+			return &treeSeqName, err
+		}
+		treeSeqName := tree.MakeTableNameFromPrefix(tree.ObjectNamePrefix{
+			SchemaName:     tree.Name(randSchema),
+			ExplicitSchema: true,
+		}, tree.Name(fmt.Sprintf("seq%d", og.newUniqueSeqNum())))
+		return &treeSeqName, nil
 	}
-	const q = `
-  SELECT sequence_name
-    FROM [SHOW SEQUENCES]
-   WHERE sequence_name LIKE 'seq%'
-ORDER BY random()
-   LIMIT 1;
-`
-	var name string
-	if err := tx.QueryRow(q).Scan(&name); err != nil {
-		return "", err
+
+	q := `
+   SELECT sequence_schema, sequence_name
+     FROM [SHOW SEQUENCES]
+    WHERE sequence_name LIKE 'seq%%'
+ ORDER BY random()
+		LIMIT 1;
+		`
+
+	var schemaName string
+	var seqName string
+	if err := tx.QueryRow(q).Scan(&schemaName, &seqName); err != nil {
+		treeTableName := tree.MakeTableNameFromPrefix(tree.ObjectNamePrefix{}, "")
+		return &treeTableName, err
 	}
-	return name, nil
+
+	treeSeqName := tree.MakeTableNameFromPrefix(tree.ObjectNamePrefix{
+		SchemaName:     tree.Name(schemaName),
+		ExplicitSchema: true,
+	}, tree.Name(seqName))
+	return &treeSeqName, nil
+
 }
 
 func (og *operationGenerator) randEnum(tx *pgx.Tx, pctExisting int) (tree.UnresolvedName, error) {

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -94,6 +94,7 @@ var opsWithExecErrorScreening = map[opType]bool{
 	dropColumn:        true,
 	dropColumnDefault: true,
 	dropColumnNotNull: true,
+	dropSequence:      true,
 	dropTable:         true,
 	dropView:          true,
 	dropSchema:        true,
@@ -883,6 +884,14 @@ func (og *operationGenerator) dropSequence(tx *pgx.Tx) (string, error) {
 	dropSeq := &tree.DropSequence{
 		Names:    tree.TableNames{*sequenceName},
 		IfExists: ifExists,
+	}
+
+	sequenceExists, err := sequenceExists(tx, sequenceName)
+	if err != nil {
+		return "", err
+	}
+	if !sequenceExists && !ifExists {
+		og.expectedExecErrors.add(pgcode.UndefinedTable)
 	}
 	return tree.Serialize(dropSeq), nil
 }

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -1318,7 +1318,7 @@ func (og *operationGenerator) randTable(
 		treeTableName := tree.MakeTableNameFromPrefix(tree.ObjectNamePrefix{
 			SchemaName:     tree.Name(desiredSchema),
 			ExplicitSchema: true,
-		}, tree.Name(fmt.Sprintf("table%d", og.newUniqueSeqNum())))
+		}, tree.Name(tableName))
 		return &treeTableName, nil
 	}
 

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -98,9 +98,10 @@ var opsWithExecErrorScreening = map[opType]bool{
 	dropView:          true,
 	dropSchema:        true,
 
-	renameColumn: true,
-	renameTable:  true,
-	renameView:   true,
+	renameColumn:   true,
+	renameSequence: true,
+	renameTable:    true,
+	renameView:     true,
 }
 
 func opScreensForExecErrors(op opType) bool {
@@ -1022,10 +1023,39 @@ func (og *operationGenerator) renameSequence(tx *pgx.Tx) (string, error) {
 		return "", err
 	}
 
-	destSequenceName, err := og.randSequence(tx, og.pctExisting(false), "")
+	// Decide whether or not to produce a 'cannot change schema of table with RENAME' error
+	desiredSchema := ""
+	if !og.produceError() {
+		desiredSchema = srcSequenceName.Schema()
+	}
+
+	destSequenceName, err := og.randSequence(tx, og.pctExisting(false), desiredSchema)
 	if err != nil {
 		return "", err
 	}
+
+	srcSequenceExists, err := sequenceExists(tx, srcSequenceName)
+	if err != nil {
+		return "", err
+	}
+
+	destSchemaExists, err := schemaExists(tx, destSequenceName.Schema())
+	if err != nil {
+		return "", err
+	}
+
+	destSequenceExists, err := sequenceExists(tx, destSequenceName)
+	if err != nil {
+		return "", err
+	}
+
+	srcEqualsDest := srcSequenceName.String() == destSequenceName.String()
+	codesWithConditions{
+		{code: pgcode.UndefinedTable, condition: !srcSequenceExists},
+		{code: pgcode.UndefinedSchema, condition: !destSchemaExists},
+		{code: pgcode.DuplicateRelation, condition: !srcEqualsDest && destSequenceExists},
+		{code: pgcode.InvalidName, condition: srcSequenceName.Schema() != destSequenceName.Schema()},
+	}.add(og.expectedExecErrors)
 
 	return fmt.Sprintf(`ALTER SEQUENCE %s RENAME TO %s`, srcSequenceName, destSequenceName), nil
 }

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -103,6 +103,8 @@ var opsWithExecErrorScreening = map[opType]bool{
 	renameSequence: true,
 	renameTable:    true,
 	renameView:     true,
+
+	insertRow: true,
 }
 
 func opScreensForExecErrors(op opType) bool {
@@ -1205,29 +1207,57 @@ func (og *operationGenerator) insertRow(tx *pgx.Tx) (string, error) {
 	if err != nil {
 		return "", errors.Wrapf(err, "error getting random table name")
 	}
+	tableExists, err := tableExists(tx, tableName)
+	if err != nil {
+		return "", err
+	}
+	if !tableExists {
+		og.expectedExecErrors.add(pgcode.UndefinedTable)
+		return fmt.Sprintf(
+			`INSERT INTO %s (IrrelevantColumnName) VALUES ("IrrelevantValue")`,
+			tableName,
+		), nil
+	}
 	cols, err := og.getTableColumns(tx, tableName.String())
 	if err != nil {
 		return "", errors.Wrapf(err, "error getting table columns for insert row")
 	}
 	colNames := []string{}
-	rows := []string{}
+	rows := [][]string{}
 	for _, col := range cols {
-		colNames = append(colNames, fmt.Sprintf(`"%s"`, col.name))
+		colNames = append(colNames, col.name)
 	}
-	numRows := og.randIntn(10) + 1
+	numRows := og.randIntn(3) + 1
 	for i := 0; i < numRows; i++ {
 		var row []string
 		for _, col := range cols {
 			d := rowenc.RandDatum(og.params.rng, col.typ, col.nullable)
 			row = append(row, tree.AsStringWithFlags(d, tree.FmtParsable))
 		}
-		rows = append(rows, fmt.Sprintf("(%s)", strings.Join(row, ",")))
+
+		rows = append(rows, row)
 	}
+
+	// Verify if the new row will violate unique constraints by checking the constraints and
+	// existing rows in the database.
+	uniqueConstraintViolation, err := violatesUniqueConstraints(tx, tableName, colNames, rows)
+	if err != nil {
+		return "", err
+	}
+	if uniqueConstraintViolation {
+		og.expectedExecErrors.add(pgcode.UniqueViolation)
+	}
+
+	formattedRows := []string{}
+	for _, row := range rows {
+		formattedRows = append(formattedRows, fmt.Sprintf("(%s)", strings.Join(row, ",")))
+	}
+
 	return fmt.Sprintf(
 		`INSERT INTO %s (%s) VALUES %s`,
 		tableName,
 		strings.Join(colNames, ","),
-		strings.Join(rows, ","),
+		strings.Join(formattedRows, ","),
 	), nil
 }
 
@@ -1287,8 +1317,10 @@ func (og *operationGenerator) getTableColumns(tx *pgx.Tx, tableName string) ([]c
 		if err != nil {
 			return nil, err
 		}
-		typNames = append(typNames, typName)
-		ret = append(ret, c)
+		if c.name != "rowid" {
+			typNames = append(typNames, typName)
+			ret = append(ret, c)
+		}
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err


### PR DESCRIPTION
workload/schemachange: improve error screening

Several ops will be updated to screen for errors (https://github.com/cockroachdb/cockroach/issues/56119):
- dropTable
- dropView
- createSequence
- renameSequence
- dropSequence
- insertRow

Sequences were also updated to have more interesting cases: non-existing sequences can randomly be returned and sequences can be owned by columns.

Furthermore, this change fixes a bug where non-existing tables were getting returned instead of existing ones.

Finally, error screening logic is updated to ignore transaction retry errors. This fixes one of the issues in https://github.com/cockroachdb/cockroach/issues/56230.