### PR TITLE
tabledesc: add validation for partial index predicates, check constraint expressions, and computed column expressions

### DIFF
--- a/pkg/sql/catalog/tabledesc/safe_format_test.go
+++ b/pkg/sql/catalog/tabledesc/safe_format_test.go
@@ -167,6 +167,7 @@ func TestSafeMessage(t *testing.T) {
 								Name:           "check_not_null",
 								Check: descpb.TableDescriptor_CheckConstraint{
 									Name:                "check_not_null",
+									Expr:                "j IS NOT NULL",
 									Validity:            descpb.ConstraintValidity_Unvalidated,
 									ColumnIDs:           []descpb.ColumnID{2},
 									IsNonNullConstraint: true,

--- a/pkg/sql/catalog/tabledesc/validate_test.go
+++ b/pkg/sql/catalog/tabledesc/validate_test.go
@@ -166,9 +166,7 @@ var validationMap = []struct {
 			"OwnsSequenceIds": {
 				status: todoIAmKnowinglyAddingTechDebt,
 				reason: "initial import: TODO(features): add validation"},
-			"ComputeExpr": {
-				status: todoIAmKnowinglyAddingTechDebt,
-				reason: "initial import: TODO(features): add validation"},
+			"ComputeExpr": {status: iSolemnlySwearThisFieldIsValidated},
 			"PGAttributeNum": {
 				status: todoIAmKnowinglyAddingTechDebt,
 				reason: "initial import: TODO(features): add validation"},

--- a/pkg/sql/catalog/tabledesc/validate_test.go
+++ b/pkg/sql/catalog/tabledesc/validate_test.go
@@ -148,9 +148,7 @@ var validationMap = []struct {
 			"Sharded":           {status: iSolemnlySwearThisFieldIsValidated},
 			"Disabled":          {status: thisFieldReferencesNoObjects},
 			"GeoConfig":         {status: thisFieldReferencesNoObjects},
-			"Predicate": {
-				status: todoIAmKnowinglyAddingTechDebt,
-				reason: "initial import: TODO(mgartner): add validation"},
+			"Predicate":         {status: iSolemnlySwearThisFieldIsValidated},
 		},
 	},
 	{

--- a/pkg/sql/catalog/tabledesc/validate_test.go
+++ b/pkg/sql/catalog/tabledesc/validate_test.go
@@ -83,9 +83,7 @@ var validationMap = []struct {
 			"FormatVersion": {status: thisFieldReferencesNoObjects},
 			"State":         {status: thisFieldReferencesNoObjects},
 			"OfflineReason": {status: thisFieldReferencesNoObjects},
-			"Checks": {
-				status: todoIAmKnowinglyAddingTechDebt,
-				reason: "initial import: TODO(features): add validation"},
+			"Checks":        {status: iSolemnlySwearThisFieldIsValidated},
 			"ViewQuery": {
 				status: todoIAmKnowinglyAddingTechDebt,
 				reason: "initial import: TODO(features): add validation"},


### PR DESCRIPTION
#### tabledesc: validate partial index predicate expressions

This commit adds validation to ensure that partial index predicate
expressions do not reference nonexistent columns.

I tested this validation ad-hoc by commenting-out code that renames
columns in partial index predicate expressions during an
`ALTER TABLE ... RENAME COLUMN` statement, and verifying that the
correct error was returned.

Fixes #51083

Release note: None

#### tabledesc: validate check constraint expressions

This commit adds validation for check constraints defined on a table
descriptor. The validation includes verifying that check constraints
exist in the table and that check constraint expressions do not
reference non-existent columns.

Informs #50854

Release note: None

#### tabledesc: move column validation into helper function

Release note: None

#### tabledesc: validate computed column expressions

This commit adds validation to ensure that computed column expressions
do not reference nonexistent columns.

I tested this validation ad-hoc by commenting-out code that renames
columns in computed column expressions during an
`ALTER TABLE ... RENAME COLUMN` statement, and verifying that the
correct error was returned.

Informs #50854

Release note: None
