### PR TITLE
opt: fix output columns for anti join in paired join

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/inverted_join_geospatial_explain
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_join_geospatial_explain
@@ -426,31 +426,35 @@ vectorized: true
 │ estimated row count: 997 (missing stats)
 │
 └── • project
-    │ columns: (lk, geom1, rk1)
+    │ columns: (lk, geom1)
     │ estimated row count: 997 (missing stats)
     │
-    └── • lookup join (anti)
-        │ columns: (lk, geom1, rk1, rk2, cont)
-        │ table: rtable@primary
-        │ equality: (rk1, rk2) = (rk1,rk2)
-        │ equality cols are key
-        │ pred: st_covers(geom1, geom)
+    └── • project
+        │ columns: (lk, geom1, rk1)
+        │ estimated row count: 1100 (missing stats)
         │
-        └── • project
+        └── • lookup join (anti)
             │ columns: (lk, geom1, rk1, rk2, cont)
-            │ estimated row count: 1111 (missing stats)
+            │ table: rtable@primary
+            │ equality: (rk1, rk2) = (rk1,rk2)
+            │ equality cols are key
+            │ pred: st_covers(geom1, geom)
             │
-            └── • inverted join (left outer)
-                │ columns: (lk, geom1, rk1, rk2, geom_inverted_key, cont)
-                │ table: rtable@geom_index
-                │ inverted expr: st_covers(geom1, geom_inverted_key)
-                │ on: (lk > 5) AND (rk1 > 12)
+            └── • project
+                │ columns: (lk, geom1, rk1, rk2, cont)
+                │ estimated row count: 1111 (missing stats)
                 │
-                └── • scan
-                      columns: (lk, geom1)
-                      estimated row count: 1000 (missing stats)
-                      table: ltable@primary
-                      spans: FULL SCAN
+                └── • inverted join (left outer)
+                    │ columns: (lk, geom1, rk1, rk2, geom_inverted_key, cont)
+                    │ table: rtable@geom_index
+                    │ inverted expr: st_covers(geom1, geom_inverted_key)
+                    │ on: (lk > 5) AND (rk1 > 12)
+                    │
+                    └── • scan
+                          columns: (lk, geom1)
+                          estimated row count: 1000 (missing stats)
+                          table: ltable@primary
+                          spans: FULL SCAN
 
 # Bounding box operations.
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -1502,9 +1502,11 @@ func (b *Builder) buildLookupJoin(join *memo.LookupJoinExpr) (execPlan, error) {
 
 	// Apply a post-projection if Cols doesn't contain all input columns.
 	//
-	// NB: For paired-joins, this is where the continuation column and the PK
-	// columns for the right side, which were part of the inputCols, are
-	// projected away.
+	// NB: For left outer paired-joins, this is where the continuation column and
+	// the PK columns for the right side, which were part of the inputCols, are
+	// projected away. (The GenerateInvertedJoins exploration rule has already
+	// done this for semi and anti paired-joins by adding a Project operator
+	// after the join).
 	if !inputCols.SubsetOf(join.Cols) {
 		outCols := join.Cols
 		if join.JoinType == opt.SemiJoinOp || join.JoinType == opt.AntiJoinOp {


### PR DESCRIPTION
Prior to this commit, the output columns of an anti join could incorrectly
include some of the columns from the right side if it was used as the second
join in a paired join.  This commit fixes the logic in the `GenerateInvertedJoins`
rule to add a `Project` expression that ensures that all right side columns are
projected away.

No release note is needed since this bug was introduced very recently and
is not included in any release.

Release note: None