### PR TITLE
sqlsmith: add schema-related operations

### DIFF
--- a/pkg/internal/sqlsmith/alter.go
+++ b/pkg/internal/sqlsmith/alter.go
@@ -21,6 +21,7 @@ var (
 	alters               = append(append(altersTableExistence, altersExistingTable...), altersTypeExistence...)
 	altersTableExistence = []statementWeight{
 		{10, makeCreateTable},
+		{2, makeCreateSchema},
 		{1, makeDropTable},
 	}
 	altersExistingTable = []statementWeight{
@@ -62,9 +63,20 @@ func makeAlter(s *Smither) (tree.Statement, bool) {
 	return nil, false
 }
 
+func makeCreateSchema(s *Smither) (tree.Statement, bool) {
+	return &tree.CreateSchema{
+		Schema: tree.ObjectNamePrefix{
+			SchemaName:     s.name("schema"),
+			ExplicitSchema: true,
+		},
+	}, true
+}
+
 func makeCreateTable(s *Smither) (tree.Statement, bool) {
 	table := rowenc.RandCreateTable(s.rnd, "", 0)
-	table.Table = tree.MakeUnqualifiedTableName(s.name("tab"))
+	schemaOrd := s.rnd.Intn(len(s.schemas))
+	schema := s.schemas[schemaOrd]
+	table.Table = tree.MakeTableNameWithSchema(tree.Name(s.dbName), schema.SchemaName, s.name("tab"))
 	return table, true
 }
 

--- a/pkg/internal/sqlsmith/schema.go
+++ b/pkg/internal/sqlsmith/schema.go
@@ -55,6 +55,10 @@ func (s *Smither) ReloadSchemas() error {
 	if err != nil {
 		return err
 	}
+	s.schemas, err = s.extractSchemas()
+	if err != nil {
+		return err
+	}
 	s.indexes, err = s.extractIndexes(s.tables)
 	s.columns = make(map[tree.TableName]map[tree.Name]*tree.ColumnTableDef)
 	for _, ref := range s.tables {
@@ -208,6 +212,31 @@ FROM
 	}, nil
 }
 
+type schemaRef struct {
+	SchemaName tree.Name
+}
+
+func (s *Smither) extractSchemas() ([]*schemaRef, error) {
+	rows, err := s.db.Query(`
+SELECT nspname FROM pg_catalog.pg_namespace
+WHERE nspname NOT IN ('crdb_internal', 'pg_catalog', 'pg_extension',
+		'information_schema')`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var ret []*schemaRef
+	for rows.Next() {
+		var schema tree.Name
+		if err := rows.Scan(&schema); err != nil {
+			return nil, err
+		}
+		ret = append(ret, &schemaRef{SchemaName: schema})
+	}
+	return ret, nil
+}
+
 func (s *Smither) extractTables() ([]*tableRef, error) {
 	rows, err := s.db.Query(`
 SELECT
@@ -222,7 +251,8 @@ SELECT
 FROM
 	information_schema.columns
 WHERE
-	table_schema = 'public'
+	table_schema NOT IN ('crdb_internal', 'pg_catalog', 'pg_extension',
+	                     'information_schema')
 ORDER BY
 	table_catalog, table_schema, table_name
 	`)
@@ -241,9 +271,6 @@ ORDER BY
 	var tables []*tableRef
 	var currentCols []*tree.ColumnTableDef
 	emit := func() error {
-		if lastSchema != "public" {
-			return nil
-		}
 		if len(currentCols) == 0 {
 			return fmt.Errorf("zero columns for %s.%s", lastCatalog, lastName)
 		}
@@ -255,8 +282,9 @@ ORDER BY
 				Type: col.Type,
 			})
 		}
+		tableName := tree.MakeTableNameWithSchema(lastCatalog, lastSchema, lastName)
 		tables = append(tables, &tableRef{
-			TableName: tree.NewTableName(lastCatalog, lastName),
+			TableName: &tableName,
 			Columns:   currentCols,
 		})
 		return nil
@@ -324,9 +352,13 @@ func (s *Smither) extractIndexes(
 		// sqlsmith.
 		rows, err := s.db.Query(fmt.Sprintf(`
 			SELECT
-			    index_name, column_name, storing, direction = 'ASC'
+			    si.index_name, column_name, storing, direction = 'ASC',
+          is_inverted
 			FROM
-			    [SHOW INDEXES FROM %s]
+			    [SHOW INDEXES FROM %s] si
+      JOIN crdb_internal.table_indexes ti
+           ON si.table_name = ti.descriptor_name
+           AND si.index_name = ti.index_name
 			WHERE
 			    column_name != 'rowid'
 			`, t.TableName))
@@ -335,15 +367,16 @@ func (s *Smither) extractIndexes(
 		}
 		for rows.Next() {
 			var idx, col tree.Name
-			var storing, ascending bool
-			if err := rows.Scan(&idx, &col, &storing, &ascending); err != nil {
+			var storing, ascending, inverted bool
+			if err := rows.Scan(&idx, &col, &storing, &ascending, &inverted); err != nil {
 				rows.Close()
 				return nil, err
 			}
 			if _, ok := indexes[idx]; !ok {
 				indexes[idx] = &tree.CreateIndex{
-					Name:  idx,
-					Table: *t.TableName,
+					Name:     idx,
+					Table:    *t.TableName,
+					Inverted: inverted,
 				}
 			}
 			create := indexes[idx]
@@ -359,25 +392,10 @@ func (s *Smither) extractIndexes(
 					Direction: dir,
 				})
 			}
-			row := s.db.QueryRow(fmt.Sprintf(`
-			SELECT
-			    is_inverted
-			FROM
-			    crdb_internal.table_indexes
-			WHERE
-			    descriptor_name = '%s' AND index_name = '%s'
-`, t.TableName.Table(), idx))
-			var isInverted bool
-			if err = row.Scan(&isInverted); err != nil {
-				// We got an error which likely indicates that 'is_inverted' column is
-				// not present in crdb_internal.table_indexes vtable (probably because
-				// we're running 19.2 version). We will use a heuristic to determine
-				// whether the index is inverted.
-				isInverted = strings.Contains(strings.ToLower(idx.String()), "jsonb")
-			}
-			indexes[idx].Inverted = isInverted
 		}
-		rows.Close()
+		if err := rows.Close(); err != nil {
+			return nil, err
+		}
 		if err := rows.Err(); err != nil {
 			return nil, err
 		}

--- a/pkg/internal/sqlsmith/sqlsmith.go
+++ b/pkg/internal/sqlsmith/sqlsmith.go
@@ -60,6 +60,8 @@ type Smither struct {
 	rnd              *rand.Rand
 	db               *gosql.DB
 	lock             syncutil.RWMutex
+	dbName           string
+	schemas          []*schemaRef
 	tables           []*tableRef
 	columns          map[tree.TableName]map[tree.Name]*tree.ColumnTableDef
 	indexes          map[tree.TableName]map[tree.Name]*tree.CreateIndex
@@ -128,6 +130,10 @@ func NewSmither(db *gosql.DB, rnd *rand.Rand, opts ...SmitherOption) (*Smither, 
 	s.scalarExprSampler = newWeightedScalarExprSampler(s.scalarExprWeights, rnd.Int63())
 	s.boolExprSampler = newWeightedScalarExprSampler(s.boolExprWeights, rnd.Int63())
 	s.enableBulkIO()
+	row := s.db.QueryRow("SELECT current_database()")
+	if err := row.Scan(&s.dbName); err != nil {
+		return nil, err
+	}
 	return s, s.ReloadSchemas()
 }
 


### PR DESCRIPTION
User-defined schemas are now supported in sqlsmith. UDSs will be
randomly generated, and new tables will be randomly included in the
available UDSs. Queries will select from any table, including those
inside of UDSs as well.

Closes #54961.

Release note: None