### PR TITLE
release-20.2: buitins,geomfn: bug fix in ST_Scale when factor, origin are empty points

### DIFF
--- a/pkg/geo/geomfn/affine_transforms.go
+++ b/pkg/geo/geomfn/affine_transforms.go
@@ -116,6 +116,7 @@ func translate(t geom.T, deltas []float64) (geom.T, error) {
 }
 
 // Scale returns a modified Geometry whose coordinates are multiplied by the factors.
+// REQUIRES: len(factors) >= 2.
 func Scale(g geo.Geometry, factors []float64) (geo.Geometry, error) {
 	var zFactor float64
 	if len(factors) > 2 {
@@ -132,7 +133,8 @@ func Scale(g geo.Geometry, factors []float64) (geo.Geometry, error) {
 	)
 }
 
-// ScaleRelativeToOrigin returns a modified Geometry whose coordinates are multiplied by the factors relative to the origin
+// ScaleRelativeToOrigin returns a modified Geometry whose coordinates are
+// multiplied by the factors relative to the origin.
 func ScaleRelativeToOrigin(
 	g geo.Geometry, factor geo.Geometry, origin geo.Geometry,
 ) (geo.Geometry, error) {
@@ -173,6 +175,13 @@ func ScaleRelativeToOrigin(
 		return geo.Geometry{}, errors.Wrap(err, "number of dimensions for the scaling factor and origin must be equal")
 	}
 
+	// This is inconsistent with PostGIS, which allows a POINT EMPTY, but whose
+	// behavior seems to depend on previous queries in the session, and not
+	// desirable to reproduce.
+	if len(originPointG.FlatCoords()) < 2 {
+		return geo.Geometry{}, errors.Newf("the origin must have at least 2 coordinates")
+	}
+
 	// Offset by the origin, scale, and translate it back to the origin.
 	offsetDeltas := make([]float64, 0, 3)
 	offsetDeltas = append(offsetDeltas, -originPointG.X(), -originPointG.Y())
@@ -184,11 +193,18 @@ func ScaleRelativeToOrigin(
 		return geo.Geometry{}, err
 	}
 
-	xFactor, yFactor := factorPointG.X(), factorPointG.Y()
-	var zFactor float64 = 1
-	if factorPointG.Layout().ZIndex() != -1 {
-		zFactor = factorPointG.Z()
+	var xFactor, yFactor, zFactor float64
+	zFactor = 1
+	if len(factorPointG.FlatCoords()) < 2 {
+		// POINT EMPTY results in factors of 0, similar to PostGIS.
+		xFactor, yFactor = 0, 0
+	} else {
+		xFactor, yFactor = factorPointG.X(), factorPointG.Y()
+		if factorPointG.Layout().ZIndex() != -1 {
+			zFactor = factorPointG.Z()
+		}
 	}
+
 	retT, err = affine(
 		retT,
 		AffineMatrix([][]float64{

--- a/pkg/geo/geomfn/affine_transforms_test.go
+++ b/pkg/geo/geomfn/affine_transforms_test.go
@@ -225,6 +225,13 @@ func TestScaleRelativeToOrigin(t *testing.T) {
 			origin:   geom.NewPointFlat(geom.XY, []float64{1, 1}),
 			expected: geom.NewPointEmpty(geom.XY),
 		},
+		{
+			desc:     "scale using an empty point as factor",
+			input:    geom.NewLineStringFlat(geom.XY, []float64{1, 1, 2, 2}),
+			factor:   geom.NewPointEmpty(geom.XY),
+			origin:   geom.NewPointFlat(geom.XY, []float64{1, 1}),
+			expected: geom.NewLineStringFlat(geom.XY, []float64{1, 1, 1, 1}),
+		},
 	}
 
 	for _, tc := range testCases {
@@ -324,6 +331,13 @@ func TestCollectionScaleRelativeToOrigin(t *testing.T) {
 			factor:      geom.NewPointFlat(geom.XY, []float64{2, 2}),
 			origin:      geom.NewLineStringFlat(geom.XY, []float64{1, 1, 1, 1}),
 			expectedErr: "the false origin must be a Point",
+		},
+		{
+			desc:        "scale using an empty point as origin",
+			input:       geom.NewLineStringFlat(geom.XY, []float64{1, 1, 2, 2}),
+			factor:      geom.NewPointFlat(geom.XY, []float64{2, 2}),
+			origin:      geom.NewPointEmpty(geom.XY),
+			expectedErr: "the origin must have at least 2 coordinates",
 		},
 	}
 

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -4796,27 +4796,28 @@ POLYGON ((-0.1 0, 1 0, 1 1, -0.1 1, -0.1 0))           POLYGON ((0.9 1, 2 1, 2 2
 POLYGON ((-1 0, 0 0, 0 1, -1 1, -1 0))                 POLYGON ((0 1, 1 1, 1 2, 0 2, 0 1))
 POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))                    POLYGON ((1 1, 2 1, 2 2, 1 2, 1 1))
 
-query TTTT
+query TTTTT
 SELECT
   ST_AsText(a.geom) d,
   ST_AsText(ST_Scale(a.geom, .5 , 2)),
   ST_AsText(ST_Scale(a.geom, 'Point(.25 3)')),
-  ST_AsText(ST_Scale(a.geom, 'Point(2 2)', 'Point(1 1)'))
+  ST_AsText(ST_Scale(a.geom, 'Point(2 2)', 'Point(1 1)')),
+  ST_AsText(ST_Scale(a.geom, 'POINT EMPTY'))
 FROM geom_operators_test a
 ORDER BY d ASC
 ----
-NULL                                                   NULL                                                   NULL                                                      NULL
-GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (0 0)))  GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (0 0)))  GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (0 0)))     GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (-1 -1)))
-GEOMETRYCOLLECTION EMPTY                               GEOMETRYCOLLECTION EMPTY                               GEOMETRYCOLLECTION EMPTY                                  GEOMETRYCOLLECTION EMPTY
-LINESTRING (-0.5 0.5, 0.5 0.5)                         LINESTRING (-0.25 1, 0.25 1)                           LINESTRING (-0.125 1.5, 0.125 1.5)                        LINESTRING (-2 0, 0 0)
-LINESTRING EMPTY                                       LINESTRING EMPTY                                       LINESTRING EMPTY                                          LINESTRING EMPTY
-POINT (-0.5 0.5)                                       POINT (-0.25 1)                                        POINT (-0.125 1.5)                                        POINT (-2 0)
-POINT (0.5 0.5)                                        POINT (0.25 1)                                         POINT (0.125 1.5)                                         POINT (0 0)
-POINT (5 5)                                            POINT (2.5 10)                                         POINT (1.25 15)                                           POINT (9 9)
-POINT EMPTY                                            POINT EMPTY                                            POINT EMPTY                                               POINT EMPTY
-POLYGON ((-0.1 0, 1 0, 1 1, -0.1 1, -0.1 0))           POLYGON ((-0.05 0, 0.5 0, 0.5 2, -0.05 2, -0.05 0))    POLYGON ((-0.025 0, 0.25 0, 0.25 3, -0.025 3, -0.025 0))  POLYGON ((-1.2 -1, 1 -1, 1 1, -1.2 1, -1.2 -1))
-POLYGON ((-1 0, 0 0, 0 1, -1 1, -1 0))                 POLYGON ((-0.5 0, 0 0, 0 2, -0.5 2, -0.5 0))           POLYGON ((-0.25 0, 0 0, 0 3, -0.25 3, -0.25 0))           POLYGON ((-3 -1, -1 -1, -1 1, -3 1, -3 -1))
-POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))                    POLYGON ((0 0, 0.5 0, 0.5 2, 0 2, 0 0))                POLYGON ((0 0, 0.25 0, 0.25 3, 0 3, 0 0))                 POLYGON ((-1 -1, 1 -1, 1 1, -1 1, -1 -1))
+NULL                                                   NULL                                                   NULL                                                      NULL                                                     NULL
+GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (0 0)))  GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (0 0)))  GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (0 0)))     GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (-1 -1)))  GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (0 0)))
+GEOMETRYCOLLECTION EMPTY                               GEOMETRYCOLLECTION EMPTY                               GEOMETRYCOLLECTION EMPTY                                  GEOMETRYCOLLECTION EMPTY                                 GEOMETRYCOLLECTION EMPTY
+LINESTRING (-0.5 0.5, 0.5 0.5)                         LINESTRING (-0.25 1, 0.25 1)                           LINESTRING (-0.125 1.5, 0.125 1.5)                        LINESTRING (-2 0, 0 0)                                   LINESTRING (0 0, 0 0)
+LINESTRING EMPTY                                       LINESTRING EMPTY                                       LINESTRING EMPTY                                          LINESTRING EMPTY                                         LINESTRING EMPTY
+POINT (-0.5 0.5)                                       POINT (-0.25 1)                                        POINT (-0.125 1.5)                                        POINT (-2 0)                                             POINT (0 0)
+POINT (0.5 0.5)                                        POINT (0.25 1)                                         POINT (0.125 1.5)                                         POINT (0 0)                                              POINT (0 0)
+POINT (5 5)                                            POINT (2.5 10)                                         POINT (1.25 15)                                           POINT (9 9)                                              POINT (0 0)
+POINT EMPTY                                            POINT EMPTY                                            POINT EMPTY                                               POINT EMPTY                                              POINT EMPTY
+POLYGON ((-0.1 0, 1 0, 1 1, -0.1 1, -0.1 0))           POLYGON ((-0.05 0, 0.5 0, 0.5 2, -0.05 2, -0.05 0))    POLYGON ((-0.025 0, 0.25 0, 0.25 3, -0.025 3, -0.025 0))  POLYGON ((-1.2 -1, 1 -1, 1 1, -1.2 1, -1.2 -1))          POLYGON ((0 0, 0 0, 0 0, 0 0, 0 0))
+POLYGON ((-1 0, 0 0, 0 1, -1 1, -1 0))                 POLYGON ((-0.5 0, 0 0, 0 2, -0.5 2, -0.5 0))           POLYGON ((-0.25 0, 0 0, 0 3, -0.25 3, -0.25 0))           POLYGON ((-3 -1, -1 -1, -1 1, -3 1, -3 -1))              POLYGON ((0 0, 0 0, 0 0, 0 0, 0 0))
+POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))                    POLYGON ((0 0, 0.5 0, 0.5 2, 0 2, 0 0))                POLYGON ((0 0, 0.25 0, 0.25 3, 0 3, 0 0))                 POLYGON ((-1 -1, 1 -1, 1 1, -1 1, -1 -1))                POLYGON ((0 0, 0 0, 0 0, 0 0, 0 0))
 
 query TT
 SELECT

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -4035,7 +4035,13 @@ The matrix transformation will be applied as follows for each coordinate:
 					return nil, errors.Newf("a Point must be used as the scaling factor")
 				}
 
-				ret, err := geomfn.Scale(g.Geometry, pointFactor.FlatCoords())
+				factors := pointFactor.FlatCoords()
+				if len(factors) < 2 {
+					// Scale by 0, and leave Z untouched (this matches the behavior of
+					// ScaleRelativeToOrigin).
+					factors = []float64{0, 0, 1}
+				}
+				ret, err := geomfn.Scale(g.Geometry, factors)
 				if err != nil {
 					return nil, err
 				}


### PR DESCRIPTION
Backport 1/1 commits from #54626.

/cc @cockroachdb/release

---

Resolves #56357 

Fixes #54603

Release note: None
