### PR TITLE
release-20.1: roachtest: use IMPORT for all TPC-C tests

### DIFF
--- a/pkg/cmd/roachtest/cancel.go
+++ b/pkg/cmd/roachtest/cancel.go
@@ -43,8 +43,7 @@ func registerCancel(r *testRegistry) {
 		m := newMonitor(ctx, c, c.All())
 		m.Go(func(ctx context.Context) error {
 			t.Status("importing TPCC fixture")
-			c.Run(ctx, c.Node(1), fmt.Sprintf(
-				"./workload fixtures load tpcc --warehouses=%d {pgurl:1}", warehouses))
+			c.Run(ctx, c.Node(1), tpccImportCmd(warehouses))
 
 			conn := c.Conn(ctx, 1)
 			defer conn.Close()

--- a/pkg/cmd/roachtest/drop.go
+++ b/pkg/cmd/roachtest/drop.go
@@ -37,8 +37,7 @@ func registerDrop(r *testRegistry) {
 		m := newMonitor(ctx, c, c.Range(1, nodes))
 		m.Go(func(ctx context.Context) error {
 			t.WorkerStatus("importing TPCC fixture")
-			c.Run(ctx, c.Node(1), fmt.Sprintf(
-				"./workload fixtures load tpcc --warehouses=%d --db tpcc {pgurl:1}", warehouses))
+			c.Run(ctx, c.Node(1), tpccImportCmd(warehouses))
 
 			// Don't open the DB connection until after the data has been imported.
 			// Otherwise the ALTER TABLE query below might fail to find the

--- a/pkg/cmd/roachtest/mixed_version_jobs.go
+++ b/pkg/cmd/roachtest/mixed_version_jobs.go
@@ -104,15 +104,10 @@ func (s *backgroundStepper) stop(ctx context.Context, t *test, u *versionUpgrade
 	}
 }
 
-func backgroundTPCCWorkload(t *test, warehouses int, tpccDB string) backgroundStepper {
+func backgroundTPCCWorkload(t *test, warehouses int) backgroundStepper {
 	return makeBackgroundStepper(func(ctx context.Context, u *versionUpgradeTest) error {
-		cmd := []string{
-			"./workload fixtures load tpcc",
-			fmt.Sprintf("--warehouses=%d", warehouses),
-			fmt.Sprintf("--db=%s", tpccDB),
-		}
 		// The workload has to run on one of the nodes of the cluster.
-		err := u.c.RunE(ctx, u.c.Node(1), cmd...)
+		err := u.c.RunE(ctx, u.c.Node(1), tpccImportCmd(warehouses))
 		if ctx.Err() != nil {
 			// If the context is canceled, that's probably why the workload returned
 			// so swallow error. (This is how the harness tells us to shut down the
@@ -220,7 +215,7 @@ func runJobsMixedVersions(
 	// `cockroach` will be used.
 	const mainVersion = ""
 	roachNodes := c.All()
-	backgroundTPCC := backgroundTPCCWorkload(t, warehouses, "tpcc")
+	backgroundTPCC := backgroundTPCCWorkload(t, warehouses)
 	resumeAllJobsAndWaitStep := makeResumeAllJobsAndWaitStep(10 * time.Second)
 	c.Put(ctx, workload, "./workload", c.Node(1))
 

--- a/pkg/cmd/roachtest/network.go
+++ b/pkg/cmd/roachtest/network.go
@@ -108,9 +108,7 @@ func runNetworkTPCC(ctx context.Context, t *test, origC *cluster, nodes int) {
 
 	const warehouses = 1
 	c.Start(ctx, t, serverNodes)
-	c.Run(ctx, workerNode, fmt.Sprintf(
-		`./workload fixtures load tpcc --warehouses=%d {pgurl:1}`, warehouses,
-	))
+	c.Run(ctx, c.Node(1), tpccImportCmd(warehouses))
 
 	db := c.Conn(ctx, 1)
 	defer db.Close()

--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -71,9 +71,9 @@ type tpccOptions struct {
 // specify pgurl to ensure that it is run on a node with a running cockroach
 // instance to ensure that the workload version matches the gateway version in a
 // mixed version cluster.
-func tpccImportCmd(t *test, warehouses int, extraArgs string) string {
+func tpccImportCmd(warehouses int, extraArgs ...string) string {
 	return fmt.Sprintf("./cockroach workload fixtures import tpcc --warehouses=%d %s",
-		warehouses, extraArgs)
+		warehouses, strings.Join(extraArgs, " "))
 }
 
 func setupTPCC(
@@ -125,7 +125,7 @@ func setupTPCC(
 		switch opts.SetupType {
 		case usingImport:
 			t.Status("loading fixture")
-			c.Run(ctx, crdbNodes[:1], tpccImportCmd(t, opts.Warehouses, opts.ExtraSetupArgs))
+			c.Run(ctx, crdbNodes[:1], tpccImportCmd(opts.Warehouses, opts.ExtraSetupArgs))
 		case usingInit:
 			t.Status("initializing tables")
 			extraArgs := opts.ExtraSetupArgs
@@ -639,7 +639,7 @@ func loadTPCCBench(
 	// Load the corresponding fixture.
 	t.l.Printf("restoring tpcc fixture\n")
 	waitForFullReplication(t, db)
-	cmd := tpccImportCmd(t, b.LoadWarehouses, loadArgs)
+	cmd := tpccImportCmd(b.LoadWarehouses, loadArgs)
 	if err := c.RunE(ctx, roachNodes[:1], cmd); err != nil {
 		return err
 	}


### PR DESCRIPTION
Backport 1/1 commits from #55982.

Fixes https://github.com/cockroachdb/cockroach/issues/56185.

/cc @cockroachdb/release

---

Fixes #55541.
Fixes #55580.

In #54880 and #55050, we switched to using IMPORT for most TPC-C tests,
instead of BACKUP, which requires fixtures to be regenerated whenever
we changed the workload. In this PR, we switch over the remaining uses
of `fixtures load tpcc` to `fixtures import tpcc` to avoid compatibility
issues on older release branches.
