### PR TITLE
release-20.1: cli: add support for BIT type in dump

### DIFF
--- a/pkg/cli/dump.go
+++ b/pkg/cli/dump.go
@@ -701,6 +701,11 @@ func dumpTableData(w io.Writer, conn *sqlConn, clusterTS string, bmd basicMetada
 							return err
 						}
 						d = tree.NewDOid(*i)
+					case types.BitFamily:
+						d, err = tree.ParseDBitArray(string(t))
+						if err != nil {
+							return err
+						}
 					default:
 						return errors.Errorf("unknown []byte type: %s, %v: %s", t, cols[si], md.columnTypes[cols[si]])
 					}


### PR DESCRIPTION
Backport 1/1 commits from #54984.

/cc @cockroachdb/release

---

This commit adds support for the BIT type in dump.

Release note (bug fix): Previously, dumps of tables with a BIT type
column would result in an error. This column type is now supported.
