### PR TITLE
release-20.1: protectedts/ptstorage: respect zero as disabling limits

### DIFF
--- a/pkg/kv/kvserver/protectedts/ptstorage/sql.go
+++ b/pkg/kv/kvserver/protectedts/ptstorage/sql.go
@@ -50,8 +50,8 @@ SELECT
     new_num_spans, 
     new_total_bytes,
     (
-       new_num_spans > $1
-       OR new_total_bytes > $2
+       ($1 > 0 AND new_num_spans > $1)
+       OR ($2 > 0 AND new_total_bytes > $2)
        OR EXISTS(SELECT * FROM system.protected_ts_records WHERE id = $4)
     ) AS failed
 FROM (

--- a/pkg/kv/kvserver/protectedts/ptstorage/storage_test.go
+++ b/pkg/kv/kvserver/protectedts/ptstorage/storage_test.go
@@ -157,6 +157,50 @@ var testCases = []testCase{
 		},
 	},
 	{
+		name: "Protect - unlimited bytes",
+		ops: []op{
+			protectOp{spans: tableSpans(42)},
+			funcOp(func(ctx context.Context, t *testing.T, tCtx *testContext) {
+				_, err := tCtx.tc.ServerConn(0).Exec("SET CLUSTER SETTING kv.protectedts.max_bytes = $1", 0)
+				require.NoError(t, err)
+			}),
+			protectOp{
+				spans: append(tableSpans(1, 2),
+					func() roachpb.Span {
+						s := tableSpan(3)
+						s.EndKey = append(s.EndKey, bytes.Repeat([]byte{'a'}, 2<<20 /* 2 MiB */)...)
+						return s
+					}()),
+			},
+			protectOp{
+				spans: tableSpans(1, 2),
+			},
+		},
+	},
+	{
+		name: "Protect - unlimited spans",
+		ops: []op{
+			protectOp{spans: tableSpans(42)},
+			funcOp(func(ctx context.Context, t *testing.T, tCtx *testContext) {
+				_, err := tCtx.tc.ServerConn(0).Exec("SET CLUSTER SETTING kv.protectedts.max_spans = $1", 0)
+				require.NoError(t, err)
+			}),
+			protectOp{
+				spans: func() []roachpb.Span {
+					const lotsOfSpans = 1 << 15
+					spans := make([]roachpb.Span, lotsOfSpans)
+					for i := 0; i < lotsOfSpans; i++ {
+						spans[i] = tableSpan(uint32(i))
+					}
+					return spans
+				}(),
+			},
+			protectOp{
+				spans: tableSpans(1, 2),
+			},
+		},
+	},
+	{
 		name: "GetRecord - does not exist",
 		ops: []op{
 			funcOp(func(ctx context.Context, t *testing.T, tCtx *testContext) {


### PR DESCRIPTION
Backport 1/1 commits from #54578.

/cc @cockroachdb/release

---

The comment on the settings said that zero disables the limits but that
was not respected.

Release note (bug fix): Fixed bug which did not respect disabling protected
timestamp settings with zero values.
