### PR TITLE
sql: add pgcode to `ALTER COLUMN SET DEFAULT` type error

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -921,7 +921,7 @@ func applyColumnMutation(
 				params.ctx, t.Default, colDatumType, "DEFAULT", &params.p.semaCtx, tree.VolatilityVolatile,
 			)
 			if err != nil {
-				return err
+				return pgerror.WithCandidateCode(err, pgcode.DatatypeMismatch)
 			}
 			s := tree.Serialize(expr)
 			col.DefaultExpr = &s

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -479,6 +479,9 @@ INSERT INTO add_default (a) VALUES (2)
 statement ok
 ALTER TABLE add_default ALTER COLUMN b SET DEFAULT 10
 
+statement error pgcode 42804 expected DEFAULT expression to have type int, but ''i'::STRING' has type string
+ALTER TABLE add_default ALTER COLUMN b SET DEFAULT 'i'::string
+
 statement ok
 INSERT INTO add_default (a) VALUES (3)
 

--- a/pkg/sql/logictest/testdata/logic_test/rename_index
+++ b/pkg/sql/logictest/testdata/logic_test/rename_index
@@ -48,7 +48,7 @@ ALTER INDEX users@foo RENAME TO bar
 statement error pgcode 42601 empty index name
 ALTER INDEX users@foo RENAME TO ""
 
-statement error index "ffo" does not exist
+statement error pgcode 42704 index "ffo" does not exist
 ALTER INDEX users@ffo RENAME TO ufo
 
 statement error index "ffo" does not exist

--- a/pkg/sql/rename_index.go
+++ b/pkg/sql/rename_index.go
@@ -52,7 +52,7 @@ func (p *planner) RenameIndex(ctx context.Context, n *tree.RenameIndex) (planNod
 			return newZeroNode(nil /* columns */), nil
 		}
 		// Index does not exist, but we want it to: error out.
-		return nil, err
+		return nil, pgerror.WithCandidateCode(err, pgcode.UndefinedObject)
 	}
 
 	if err := p.CheckPrivilege(ctx, tableDesc, privilege.CREATE); err != nil {


### PR DESCRIPTION
sql: add pgcode to `ALTER COLUMN SET DEFAULT` type error 

Previously, adding a default value of the wrong type to a
column would return an unclassifed error to the user. This change
resolves the issue by returning a pgcode.DatatypeMismatch (42804)
in the specified situation.

Closes: https://github.com/cockroachdb/cockroach/issues/56449

Release note (sql change): Added a pgcode (42804, DatatypeMismatch)
when adding a default value of the wrong type to a column.

---
sql: add pgcode to `ALTER INDEX ... RENAME TO` undefined index error

Previously, executing a statement to rename an undefined
index would result in an uncategorized error. This change fixes
this behaviour by returning a pgcode.UndefinedObject (42704)
error in the same situation.

Closes: #56465

Release note (sql change): Attempting to rename undefined index
will return a pgcode.UndefinedObject (42704) error intead of
an uncategorized error.