### PR TITLE
release-20.2: changefeedccl: add metrics for number of job failures and running feeds

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -585,6 +585,7 @@ func (cf *changeFrontier) Start(ctx context.Context) context.Context {
 	cf.metrics.mu.Lock()
 	cf.metricsID = cf.metrics.mu.id
 	cf.metrics.mu.id++
+	cf.metrics.Running.Inc(1)
 	cf.metrics.mu.Unlock()
 	// TODO(dan): It's very important that we de-register from the metric because
 	// if we orphan an entry in there, our monitoring will lie (say the changefeed
@@ -622,6 +623,9 @@ func (cf *changeFrontier) closeMetrics() {
 	// Delete this feed from the MaxBehindNanos metric so it's no longer
 	// considered by the gauge.
 	cf.metrics.mu.Lock()
+	if cf.metricsID > 0 {
+		cf.metrics.Running.Dec(1)
+	}
 	delete(cf.metrics.mu.resolved, cf.metricsID)
 	cf.metricsID = -1
 	cf.metrics.mu.Unlock()

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -659,6 +659,7 @@ func (b *changefeedResumer) OnFailOrCancel(ctx context.Context, planHookState in
 	) {
 		telemetry.Count(`changefeed.enterprise.cancel`)
 	} else {
+		phs.ExecCfg().JobRegistry.MetricsStruct().Changefeed.(*Metrics).Failures.Inc(1)
 		telemetry.Count(`changefeed.enterprise.fail`)
 	}
 	return nil

--- a/pkg/ccl/changefeedccl/metrics.go
+++ b/pkg/ccl/changefeedccl/metrics.go
@@ -101,6 +101,12 @@ var (
 		Measurement: "Errors",
 		Unit:        metric.Unit_COUNT,
 	}
+	metaChangefeedFailures = metric.Metadata{
+		Name:        "changefeed.failures",
+		Help:        "Total number of changefeed jobs which have failed",
+		Measurement: "Changefeed Jobs",
+		Unit:        metric.Unit_COUNT,
+	}
 
 	metaChangefeedProcessingNanos = metric.Metadata{
 		Name:        "changefeed.processing_nanos",
@@ -126,6 +132,12 @@ var (
 		Measurement: "Nanoseconds",
 		Unit:        metric.Unit_NANOSECONDS,
 	}
+	metaChangefeedRunning = metric.Metadata{
+		Name:        "changefeed.running",
+		Help:        "Number of currently running changefeeds, including sinkless",
+		Measurement: "Changefeeds",
+		Unit:        metric.Unit_COUNT,
+	}
 
 	// TODO(dan): This was intended to be a measure of the minimum distance of
 	// any changefeed ahead of its gc ttl threshold, but keeping that correct in
@@ -146,11 +158,14 @@ type Metrics struct {
 	EmittedBytes    *metric.Counter
 	Flushes         *metric.Counter
 	ErrorRetries    *metric.Counter
+	Failures        *metric.Counter
 
 	ProcessingNanos    *metric.Counter
 	TableMetadataNanos *metric.Counter
 	EmitNanos          *metric.Counter
 	FlushNanos         *metric.Counter
+
+	Running *metric.Gauge
 
 	mu struct {
 		syncutil.Mutex
@@ -171,14 +186,16 @@ func MakeMetrics(histogramWindow time.Duration) metric.Struct {
 		EmittedBytes:    metric.NewCounter(metaChangefeedEmittedBytes),
 		Flushes:         metric.NewCounter(metaChangefeedFlushes),
 		ErrorRetries:    metric.NewCounter(metaChangefeedErrorRetries),
+		Failures:        metric.NewCounter(metaChangefeedFailures),
 
 		ProcessingNanos:    metric.NewCounter(metaChangefeedProcessingNanos),
 		TableMetadataNanos: metric.NewCounter(metaChangefeedTableMetadataNanos),
 		EmitNanos:          metric.NewCounter(metaChangefeedEmitNanos),
 		FlushNanos:         metric.NewCounter(metaChangefeedFlushNanos),
+		Running:            metric.NewGauge(metaChangefeedRunning),
 	}
 	m.mu.resolved = make(map[int]hlc.Timestamp)
-
+	m.mu.id = 1 // start the first id at 1 so we can detect initialization
 	m.MaxBehindNanos = metric.NewFunctionalGauge(metaChangefeedMaxBehindNanos, func() int64 {
 		now := timeutil.Now()
 		var maxBehind time.Duration

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -1139,7 +1139,7 @@ func (r *Registry) stepThroughStateMachine(
 			// If the job has failed with any error different than canceled we
 			// mark it as Failed.
 			nextStatus := StatusFailed
-			if errors.Is(jobErr, errJobCanceled) {
+			if HasErrJobCanceled(jobErr) {
 				nextStatus = StatusCanceled
 			}
 			return r.stepThroughStateMachine(ctx, phs, resumer, resultsCh, job, nextStatus, jobErr)

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -1024,6 +1024,7 @@ var charts = []sectionDescription{
 				Title: "Errors",
 				Metrics: []string{
 					"changefeed.error_retries",
+					"changefeed.failures",
 				},
 			},
 			{
@@ -1048,6 +1049,12 @@ var charts = []sectionDescription{
 				Title: "Poll Request Time",
 				Metrics: []string{
 					"changefeed.poll_request_nanos",
+				},
+			},
+			{
+				Title: "Currently Running",
+				Metrics: []string{
+					"changefeed.running",
 				},
 			},
 			{


### PR DESCRIPTION
Backport 2/2 commits from #54381.

/cc @cockroachdb/release

---

This commit adds two new metrics:
1) changefeeds.running - gauge of the number of running CHANGEFEEDs both
     as jobs and sinkless
    
 2) changefeeds.failures - counter of the number of permanent failures of
    CHANGEFEED jobs.

Fixes #53130.
    
Release note (enterprise change): Added metrics to track the current number
of running CHANGEFEEDs and the number of failed CHANGEFEED jobs.

