### PR TITLE
release-20.2: importccl: deal with transaction restarts when rewriting new tables

### DIFF
--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -50,6 +50,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
@@ -1139,7 +1140,10 @@ func (r *importResumer) prepareTableDescsForIngestion(
 					hasExistingTables = true
 				} else {
 					newTablenameToIdx[table.Desc.Name] = i
-					newTableDescs = append(newTableDescs, table)
+					// Make a deep copy of the table descriptor so that rewrites do not
+					// partially clobber the descriptor stored in details.
+					newTableDescs = append(newTableDescs,
+						*protoutil.Clone(&table).(*jobspb.ImportDetails_Table))
 				}
 			}
 


### PR DESCRIPTION
Backport 1/1 commits from #54423.

/cc @cockroachdb/release

---

This one is subtle and a bit saddening. The problem was introduced in
https://github.com/cockroachdb/cockroach/pull/52238/files#diff-cbacddd1cbf61d8685733941d377ca0fR900

In that diff we create a shallow copy of the table descriptor when wrapping it
inside a (now) tabledesc.Mutable. This means that when we rewrite the
descriptors here we end up modifying IDs inside of structures stored in the
backing details table descriptor but we don't change the ID inside that
descriptor. In the face of a transaction restart, this leads to an ID mismatch
and ultimately a validation failure.

This commit fixes that bug by taking a deep copy of the descriptor.

Fixes #52703.

Release note (bug fix): Fixed a bug introduced in an alpha where imports
of tables with foreign keys can fail in rare circumstances.
