### PR TITLE
kv: immediately propagate WriteTooOld error from DeleteRange requests

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_test.go
@@ -786,3 +786,54 @@ func TestTxnWaitPolicies(t *testing.T) {
 		}
 	})
 }
+
+// TestTxnReturnsWriteTooOldErrorOnConflictingDeleteRange tests that if two
+// transactions issue delete range operations over the same keys, the later
+// transaction eagerly returns a WriteTooOld error instead of deferring the
+// error and temporarily leaking a non-serializable state through its ReturnKeys
+// field.
+func TestTxnReturnsWriteTooOldErrorOnConflictingDeleteRange(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+	s := createTestDB(t)
+	defer s.Stop()
+
+	// Write a value at key "a".
+	require.NoError(t, s.DB.Put(ctx, "a", "val"))
+
+	// Create two transactions.
+	txn1 := s.DB.NewTxn(ctx, "test txn 1")
+	txn2 := s.DB.NewTxn(ctx, "test txn 2")
+
+	// Both txns read the value.
+	kvs, err := txn1.Scan(ctx, "a", "b", 0)
+	require.NoError(t, err)
+	require.Len(t, kvs, 1)
+	require.Equal(t, roachpb.Key("a"), kvs[0].Key)
+
+	kvs, err = txn2.Scan(ctx, "a", "b", 0)
+	require.NoError(t, err)
+	require.Len(t, kvs, 1)
+	require.Equal(t, roachpb.Key("a"), kvs[0].Key)
+
+	// The first transaction deletes the value using a delete range operation.
+	b := txn1.NewBatch()
+	b.DelRange("a", "b", true /* returnKeys */)
+	require.NoError(t, txn1.Run(ctx, b))
+	require.Len(t, b.Results[0].Keys, 1)
+	require.Equal(t, roachpb.Key("a"), b.Results[0].Keys[0])
+
+	// The first transaction commits.
+	require.NoError(t, txn1.Commit(ctx))
+
+	// The second transaction attempts to delete the value using a delete range
+	// operation. This should immediately fail with a WriteTooOld error. It
+	// would be incorrect for this to be delayed and for 0 keys to be returned.
+	b = txn2.NewBatch()
+	b.DelRange("a", "b", true /* returnKeys */)
+	err = txn2.Run(ctx, b)
+	require.NotNil(t, err)
+	require.Regexp(t, "TransactionRetryWithProtoRefreshError: WriteTooOldError", err)
+	require.Len(t, b.Results[0].Keys, 0)
+}

--- a/pkg/kv/kvserver/replica_evaluate_test.go
+++ b/pkg/kv/kvserver/replica_evaluate_test.go
@@ -259,7 +259,7 @@ func TestEvaluateBatch(t *testing.T) {
 			// unreplicated lock should be acquired on each key that is scanned.
 			name: "scans with key locking",
 			setup: func(t *testing.T, d *data) {
-				writeABCDEF(t, d)
+				writeABCDEFAt(t, d, ts.Prev())
 				scanAD := scanArgsString("a", "d")
 				scanAD.KeyLocking = lock.Exclusive
 				d.ba.Add(scanAD)
@@ -281,7 +281,7 @@ func TestEvaluateBatch(t *testing.T) {
 			// Ditto in reverse.
 			name: "reverse scans with key locking",
 			setup: func(t *testing.T, d *data) {
-				writeABCDEF(t, d)
+				writeABCDEFAt(t, d, ts.Prev())
 				scanAD := revScanArgsString("a", "d")
 				scanAD.KeyLocking = lock.Exclusive
 				d.ba.Add(scanAD)
@@ -304,7 +304,7 @@ func TestEvaluateBatch(t *testing.T) {
 			// transaction set, so no locks should be acquired.
 			name: "scans with key locking without txn",
 			setup: func(t *testing.T, d *data) {
-				writeABCDEF(t, d)
+				writeABCDEFAt(t, d, ts.Prev())
 				scanAD := scanArgsString("a", "d")
 				scanAD.KeyLocking = lock.Exclusive
 				d.ba.Add(scanAD)
@@ -325,7 +325,7 @@ func TestEvaluateBatch(t *testing.T) {
 			// Ditto in reverse.
 			name: "reverse scans with key locking without txn",
 			setup: func(t *testing.T, d *data) {
-				writeABCDEF(t, d)
+				writeABCDEFAt(t, d, ts.Prev())
 				scanAD := revScanArgsString("a", "d")
 				scanAD.KeyLocking = lock.Exclusive
 				d.ba.Add(scanAD)
@@ -349,7 +349,7 @@ func TestEvaluateBatch(t *testing.T) {
 			// keys past the limit.
 			name: "scan with key locking and MaxSpanRequestKeys=3",
 			setup: func(t *testing.T, d *data) {
-				writeABCDEF(t, d)
+				writeABCDEFAt(t, d, ts.Prev())
 				scanAE := scanArgsString("a", "e")
 				scanAE.KeyLocking = lock.Exclusive
 				d.ba.Add(scanAE)
@@ -367,7 +367,7 @@ func TestEvaluateBatch(t *testing.T) {
 			// Ditto in reverse.
 			name: "reverse scan with key locking and MaxSpanRequestKeys=3",
 			setup: func(t *testing.T, d *data) {
-				writeABCDEF(t, d)
+				writeABCDEFAt(t, d, ts.Prev())
 				scanAE := revScanArgsString("a", "e")
 				scanAE.KeyLocking = lock.Exclusive
 				d.ba.Add(scanAE)
@@ -389,7 +389,7 @@ func TestEvaluateBatch(t *testing.T) {
 			// rows are scanner nor locks acquired.
 			name: "scans with key locking and MaxSpanRequestKeys=3",
 			setup: func(t *testing.T, d *data) {
-				writeABCDEF(t, d)
+				writeABCDEFAt(t, d, ts.Prev())
 				scanAE := scanArgsString("a", "e")
 				scanAE.KeyLocking = lock.Exclusive
 				d.ba.Add(scanAE)
@@ -410,7 +410,7 @@ func TestEvaluateBatch(t *testing.T) {
 			// Ditto in reverse.
 			name: "reverse scans with key locking and MaxSpanRequestKeys=3",
 			setup: func(t *testing.T, d *data) {
-				writeABCDEF(t, d)
+				writeABCDEFAt(t, d, ts.Prev())
 				scanAE := revScanArgsString("a", "e")
 				scanAE.KeyLocking = lock.Exclusive
 				d.ba.Add(scanAE)
@@ -433,7 +433,7 @@ func TestEvaluateBatch(t *testing.T) {
 			// past the limit.
 			name: "scan with key locking and TargetBytes=1",
 			setup: func(t *testing.T, d *data) {
-				writeABCDEF(t, d)
+				writeABCDEFAt(t, d, ts.Prev())
 				scanAE := scanArgsString("a", "e")
 				scanAE.KeyLocking = lock.Exclusive
 				d.ba.Add(scanAE)
@@ -451,7 +451,7 @@ func TestEvaluateBatch(t *testing.T) {
 			// Ditto in reverse.
 			name: "reverse scan with key locking and TargetBytes=1",
 			setup: func(t *testing.T, d *data) {
-				writeABCDEF(t, d)
+				writeABCDEFAt(t, d, ts.Prev())
 				scanAE := revScanArgsString("a", "e")
 				scanAE.KeyLocking = lock.Exclusive
 				d.ba.Add(scanAE)
@@ -472,7 +472,7 @@ func TestEvaluateBatch(t *testing.T) {
 			// are scanner nor locks acquired.
 			name: "scans with key locking and TargetBytes=1",
 			setup: func(t *testing.T, d *data) {
-				writeABCDEF(t, d)
+				writeABCDEFAt(t, d, ts.Prev())
 				scanAE := scanArgsString("a", "e")
 				scanAE.KeyLocking = lock.Exclusive
 				d.ba.Add(scanAE)
@@ -493,7 +493,7 @@ func TestEvaluateBatch(t *testing.T) {
 			// Ditto in reverse.
 			name: "reverse scans with key locking and TargetBytes=1",
 			setup: func(t *testing.T, d *data) {
-				writeABCDEF(t, d)
+				writeABCDEFAt(t, d, ts.Prev())
 				scanAE := revScanArgsString("a", "e")
 				scanAE.KeyLocking = lock.Exclusive
 				d.ba.Add(scanAE)
@@ -616,18 +616,27 @@ type testCase struct {
 }
 
 func writeABCDEF(t *testing.T, d *data) {
-	writeABCDEFIntents(t, d, nil /* txn */)
+	writeABCDEFAt(t, d, d.ba.Timestamp)
+}
+
+func writeABCDEFAt(t *testing.T, d *data, ts hlc.Timestamp) {
+	writeABCDEFWith(t, d.eng, ts, nil /* txn */)
 }
 
 func writeABCDEFIntents(t *testing.T, d *data, txn *roachpb.Transaction) {
+	writeABCDEFWith(t, d.eng, txn.WriteTimestamp, txn)
+}
+
+func writeABCDEFWith(t *testing.T, eng storage.Engine, ts hlc.Timestamp, txn *roachpb.Transaction) {
 	for _, k := range []string{"a", "b", "c", "d", "e", "f"} {
 		require.NoError(t, storage.MVCCPut(
-			context.Background(), d.eng, nil /* ms */, roachpb.Key(k), d.ba.Timestamp,
+			context.Background(), eng, nil /* ms */, roachpb.Key(k), ts,
 			roachpb.MakeValueFromString("value-"+k), txn))
 	}
 }
 
 func verifyScanResult(t *testing.T, r resp, keysPerResp ...[]string) {
+	t.Helper()
 	require.Nil(t, r.pErr)
 	require.NotNil(t, r.br)
 	require.Len(t, r.br.Responses, len(keysPerResp))
@@ -663,6 +672,7 @@ func verifyScanResult(t *testing.T, r resp, keysPerResp ...[]string) {
 }
 
 func verifyNumKeys(t *testing.T, r resp, keysPerResp ...int) {
+	t.Helper()
 	require.Nil(t, r.pErr)
 	require.NotNil(t, r.br)
 	require.Len(t, r.br.Responses, len(keysPerResp))
@@ -673,6 +683,7 @@ func verifyNumKeys(t *testing.T, r resp, keysPerResp ...int) {
 }
 
 func verifyResumeSpans(t *testing.T, r resp, resumeSpans ...string) {
+	t.Helper()
 	for i, span := range resumeSpans {
 		rs := r.br.Responses[i].GetInner().Header().ResumeSpan
 		if span == "" {
@@ -686,6 +697,7 @@ func verifyResumeSpans(t *testing.T, r resp, resumeSpans ...string) {
 }
 
 func verifyAcquiredLocks(t *testing.T, r resp, dur lock.Durability, lockedKeys ...string) {
+	t.Helper()
 	var foundLocked []string
 	for _, l := range r.res.Local.AcquiredLocks {
 		if l.Durability == dur {

--- a/pkg/roachpb/api.go
+++ b/pkg/roachpb/api.go
@@ -1189,14 +1189,15 @@ func (drr *DeleteRangeRequest) flags() int {
 	// This workaround does not preclude us from creating a separate
 	// "DeleteInlineRange" command at a later date.
 	if drr.Inline {
-		return isWrite | isRange | isAlone
+		return isRead | isWrite | isRange | isAlone
 	}
 	// DeleteRange updates the timestamp cache as it doesn't leave intents or
-	// tombstones for keys which don't yet exist, but still wants to prevent
-	// anybody from writing under it. Note that, even if we didn't update the ts
-	// cache, deletes of keys that exist would not be lost (since the DeleteRange
-	// leaves intents on those keys), but deletes of "empty space" would.
-	return isWrite | isTxn | isLocking | isIntentWrite | isRange | consultsTSCache | updatesTSCache | needsRefresh | canBackpressure
+	// tombstones for keys which don't yet exist or keys that already have
+	// tombstones on them, but still wants to prevent anybody from writing under
+	// it. Note that, even if we didn't update the ts cache, deletes of keys
+	// that exist would not be lost (since the DeleteRange leaves intents on
+	// those keys), but deletes of "empty space" would.
+	return isRead | isWrite | isTxn | isLocking | isIntentWrite | isRange | consultsTSCache | updatesTSCache | needsRefresh | canBackpressure
 }
 
 // Note that ClearRange commands cannot be part of a transaction as

--- a/pkg/roachpb/errors.pb.go
+++ b/pkg/roachpb/errors.pb.go
@@ -122,7 +122,7 @@ func (x *TransactionAbortedReason) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (TransactionAbortedReason) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_errors_7f973735b5f2ff97, []int{0}
+	return fileDescriptor_errors_1a1ac4f8ac3e0d62, []int{0}
 }
 
 // TransactionRetryReason specifies what caused a transaction retry.
@@ -173,7 +173,7 @@ func (x *TransactionRetryReason) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (TransactionRetryReason) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_errors_7f973735b5f2ff97, []int{1}
+	return fileDescriptor_errors_1a1ac4f8ac3e0d62, []int{1}
 }
 
 // TransactionRestart indicates how an error should be handled in a
@@ -224,7 +224,7 @@ func (x *TransactionRestart) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (TransactionRestart) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_errors_7f973735b5f2ff97, []int{2}
+	return fileDescriptor_errors_1a1ac4f8ac3e0d62, []int{2}
 }
 
 // Reason specifies what caused the error.
@@ -263,7 +263,7 @@ func (x *TransactionStatusError_Reason) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (TransactionStatusError_Reason) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_errors_7f973735b5f2ff97, []int{9, 0}
+	return fileDescriptor_errors_1a1ac4f8ac3e0d62, []int{9, 0}
 }
 
 // Reason specifies what caused the error.
@@ -319,7 +319,7 @@ func (x *RangeFeedRetryError_Reason) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (RangeFeedRetryError_Reason) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_errors_7f973735b5f2ff97, []int{27, 0}
+	return fileDescriptor_errors_1a1ac4f8ac3e0d62, []int{27, 0}
 }
 
 // A NotLeaseHolderError indicates that the current range is not the lease
@@ -350,7 +350,7 @@ func (m *NotLeaseHolderError) Reset()         { *m = NotLeaseHolderError{} }
 func (m *NotLeaseHolderError) String() string { return proto.CompactTextString(m) }
 func (*NotLeaseHolderError) ProtoMessage()    {}
 func (*NotLeaseHolderError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_7f973735b5f2ff97, []int{0}
+	return fileDescriptor_errors_1a1ac4f8ac3e0d62, []int{0}
 }
 func (m *NotLeaseHolderError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -385,7 +385,7 @@ func (m *NodeUnavailableError) Reset()         { *m = NodeUnavailableError{} }
 func (m *NodeUnavailableError) String() string { return proto.CompactTextString(m) }
 func (*NodeUnavailableError) ProtoMessage()    {}
 func (*NodeUnavailableError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_7f973735b5f2ff97, []int{1}
+	return fileDescriptor_errors_1a1ac4f8ac3e0d62, []int{1}
 }
 func (m *NodeUnavailableError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -419,7 +419,7 @@ func (m *UnsupportedRequestError) Reset()         { *m = UnsupportedRequestError
 func (m *UnsupportedRequestError) String() string { return proto.CompactTextString(m) }
 func (*UnsupportedRequestError) ProtoMessage()    {}
 func (*UnsupportedRequestError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_7f973735b5f2ff97, []int{2}
+	return fileDescriptor_errors_1a1ac4f8ac3e0d62, []int{2}
 }
 func (m *UnsupportedRequestError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -456,7 +456,7 @@ func (m *RangeNotFoundError) Reset()         { *m = RangeNotFoundError{} }
 func (m *RangeNotFoundError) String() string { return proto.CompactTextString(m) }
 func (*RangeNotFoundError) ProtoMessage()    {}
 func (*RangeNotFoundError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_7f973735b5f2ff97, []int{3}
+	return fileDescriptor_errors_1a1ac4f8ac3e0d62, []int{3}
 }
 func (m *RangeNotFoundError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -507,7 +507,7 @@ func (m *RangeKeyMismatchError) Reset()         { *m = RangeKeyMismatchError{} }
 func (m *RangeKeyMismatchError) String() string { return proto.CompactTextString(m) }
 func (*RangeKeyMismatchError) ProtoMessage()    {}
 func (*RangeKeyMismatchError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_7f973735b5f2ff97, []int{4}
+	return fileDescriptor_errors_1a1ac4f8ac3e0d62, []int{4}
 }
 func (m *RangeKeyMismatchError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -552,7 +552,7 @@ type ReadWithinUncertaintyIntervalError struct {
 func (m *ReadWithinUncertaintyIntervalError) Reset()      { *m = ReadWithinUncertaintyIntervalError{} }
 func (*ReadWithinUncertaintyIntervalError) ProtoMessage() {}
 func (*ReadWithinUncertaintyIntervalError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_7f973735b5f2ff97, []int{5}
+	return fileDescriptor_errors_1a1ac4f8ac3e0d62, []int{5}
 }
 func (m *ReadWithinUncertaintyIntervalError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -595,7 +595,7 @@ func (m *TransactionAbortedError) Reset()         { *m = TransactionAbortedError
 func (m *TransactionAbortedError) String() string { return proto.CompactTextString(m) }
 func (*TransactionAbortedError) ProtoMessage()    {}
 func (*TransactionAbortedError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_7f973735b5f2ff97, []int{6}
+	return fileDescriptor_errors_1a1ac4f8ac3e0d62, []int{6}
 }
 func (m *TransactionAbortedError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -631,7 +631,7 @@ func (m *TransactionPushError) Reset()         { *m = TransactionPushError{} }
 func (m *TransactionPushError) String() string { return proto.CompactTextString(m) }
 func (*TransactionPushError) ProtoMessage()    {}
 func (*TransactionPushError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_7f973735b5f2ff97, []int{7}
+	return fileDescriptor_errors_1a1ac4f8ac3e0d62, []int{7}
 }
 func (m *TransactionPushError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -667,7 +667,7 @@ func (m *TransactionRetryError) Reset()         { *m = TransactionRetryError{} }
 func (m *TransactionRetryError) String() string { return proto.CompactTextString(m) }
 func (*TransactionRetryError) ProtoMessage()    {}
 func (*TransactionRetryError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_7f973735b5f2ff97, []int{8}
+	return fileDescriptor_errors_1a1ac4f8ac3e0d62, []int{8}
 }
 func (m *TransactionRetryError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -707,7 +707,7 @@ func (m *TransactionStatusError) Reset()         { *m = TransactionStatusError{}
 func (m *TransactionStatusError) String() string { return proto.CompactTextString(m) }
 func (*TransactionStatusError) ProtoMessage()    {}
 func (*TransactionStatusError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_7f973735b5f2ff97, []int{9}
+	return fileDescriptor_errors_1a1ac4f8ac3e0d62, []int{9}
 }
 func (m *TransactionStatusError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -745,7 +745,7 @@ func (m *WriteIntentError) Reset()         { *m = WriteIntentError{} }
 func (m *WriteIntentError) String() string { return proto.CompactTextString(m) }
 func (*WriteIntentError) ProtoMessage()    {}
 func (*WriteIntentError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_7f973735b5f2ff97, []int{10}
+	return fileDescriptor_errors_1a1ac4f8ac3e0d62, []int{10}
 }
 func (m *WriteIntentError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -774,6 +774,13 @@ var xxx_messageInfo_WriteIntentError proto.InternalMessageInfo
 // value newer than its timestamp, making it impossible to rewrite
 // history. The write is instead done at actual timestamp, which is
 // the timestamp of the existing version+1.
+//
+// If a blind write request (see IsBlindWrite) returns a WriteTooOld
+// error during evaluation (in pkg/kvserver/batcheval), it must also
+// complete its work and return a valid result. This allows callers to
+// optionally defer the WriteTooOldError until later in the transaction
+// by instead bumping the transaction's write timestamp, setting the
+// transaction's WriteTooOld flag, and dropping the error.
 type WriteTooOldError struct {
 	Timestamp       hlc.Timestamp `protobuf:"bytes,1,opt,name=timestamp" json:"timestamp"`
 	ActualTimestamp hlc.Timestamp `protobuf:"bytes,2,opt,name=actual_timestamp,json=actualTimestamp" json:"actual_timestamp"`
@@ -783,7 +790,7 @@ func (m *WriteTooOldError) Reset()         { *m = WriteTooOldError{} }
 func (m *WriteTooOldError) String() string { return proto.CompactTextString(m) }
 func (*WriteTooOldError) ProtoMessage()    {}
 func (*WriteTooOldError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_7f973735b5f2ff97, []int{11}
+	return fileDescriptor_errors_1a1ac4f8ac3e0d62, []int{11}
 }
 func (m *WriteTooOldError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -819,7 +826,7 @@ func (m *OpRequiresTxnError) Reset()         { *m = OpRequiresTxnError{} }
 func (m *OpRequiresTxnError) String() string { return proto.CompactTextString(m) }
 func (*OpRequiresTxnError) ProtoMessage()    {}
 func (*OpRequiresTxnError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_7f973735b5f2ff97, []int{12}
+	return fileDescriptor_errors_1a1ac4f8ac3e0d62, []int{12}
 }
 func (m *OpRequiresTxnError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -856,7 +863,7 @@ func (m *ConditionFailedError) Reset()         { *m = ConditionFailedError{} }
 func (m *ConditionFailedError) String() string { return proto.CompactTextString(m) }
 func (*ConditionFailedError) ProtoMessage()    {}
 func (*ConditionFailedError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_7f973735b5f2ff97, []int{13}
+	return fileDescriptor_errors_1a1ac4f8ac3e0d62, []int{13}
 }
 func (m *ConditionFailedError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -893,7 +900,7 @@ func (m *LeaseRejectedError) Reset()         { *m = LeaseRejectedError{} }
 func (m *LeaseRejectedError) String() string { return proto.CompactTextString(m) }
 func (*LeaseRejectedError) ProtoMessage()    {}
 func (*LeaseRejectedError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_7f973735b5f2ff97, []int{14}
+	return fileDescriptor_errors_1a1ac4f8ac3e0d62, []int{14}
 }
 func (m *LeaseRejectedError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -931,7 +938,7 @@ func (m *AmbiguousResultError) Reset()         { *m = AmbiguousResultError{} }
 func (m *AmbiguousResultError) String() string { return proto.CompactTextString(m) }
 func (*AmbiguousResultError) ProtoMessage()    {}
 func (*AmbiguousResultError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_7f973735b5f2ff97, []int{15}
+	return fileDescriptor_errors_1a1ac4f8ac3e0d62, []int{15}
 }
 func (m *AmbiguousResultError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -965,7 +972,7 @@ func (m *RaftGroupDeletedError) Reset()         { *m = RaftGroupDeletedError{} }
 func (m *RaftGroupDeletedError) String() string { return proto.CompactTextString(m) }
 func (*RaftGroupDeletedError) ProtoMessage()    {}
 func (*RaftGroupDeletedError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_7f973735b5f2ff97, []int{16}
+	return fileDescriptor_errors_1a1ac4f8ac3e0d62, []int{16}
 }
 func (m *RaftGroupDeletedError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1003,7 +1010,7 @@ func (m *ReplicaCorruptionError) Reset()         { *m = ReplicaCorruptionError{}
 func (m *ReplicaCorruptionError) String() string { return proto.CompactTextString(m) }
 func (*ReplicaCorruptionError) ProtoMessage()    {}
 func (*ReplicaCorruptionError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_7f973735b5f2ff97, []int{17}
+	return fileDescriptor_errors_1a1ac4f8ac3e0d62, []int{17}
 }
 func (m *ReplicaCorruptionError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1040,7 +1047,7 @@ func (m *ReplicaTooOldError) Reset()         { *m = ReplicaTooOldError{} }
 func (m *ReplicaTooOldError) String() string { return proto.CompactTextString(m) }
 func (*ReplicaTooOldError) ProtoMessage()    {}
 func (*ReplicaTooOldError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_7f973735b5f2ff97, []int{18}
+	return fileDescriptor_errors_1a1ac4f8ac3e0d62, []int{18}
 }
 func (m *ReplicaTooOldError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1075,7 +1082,7 @@ func (m *StoreNotFoundError) Reset()         { *m = StoreNotFoundError{} }
 func (m *StoreNotFoundError) String() string { return proto.CompactTextString(m) }
 func (*StoreNotFoundError) ProtoMessage()    {}
 func (*StoreNotFoundError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_7f973735b5f2ff97, []int{19}
+	return fileDescriptor_errors_1a1ac4f8ac3e0d62, []int{19}
 }
 func (m *StoreNotFoundError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1120,7 +1127,7 @@ type UnhandledRetryableError struct {
 func (m *UnhandledRetryableError) Reset()      { *m = UnhandledRetryableError{} }
 func (*UnhandledRetryableError) ProtoMessage() {}
 func (*UnhandledRetryableError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_7f973735b5f2ff97, []int{20}
+	return fileDescriptor_errors_1a1ac4f8ac3e0d62, []int{20}
 }
 func (m *UnhandledRetryableError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1172,7 +1179,7 @@ func (m *TransactionRetryWithProtoRefreshError) Reset()         { *m = Transacti
 func (m *TransactionRetryWithProtoRefreshError) String() string { return proto.CompactTextString(m) }
 func (*TransactionRetryWithProtoRefreshError) ProtoMessage()    {}
 func (*TransactionRetryWithProtoRefreshError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_7f973735b5f2ff97, []int{21}
+	return fileDescriptor_errors_1a1ac4f8ac3e0d62, []int{21}
 }
 func (m *TransactionRetryWithProtoRefreshError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1210,7 +1217,7 @@ func (m *TxnAlreadyEncounteredErrorError) Reset()         { *m = TxnAlreadyEncou
 func (m *TxnAlreadyEncounteredErrorError) String() string { return proto.CompactTextString(m) }
 func (*TxnAlreadyEncounteredErrorError) ProtoMessage()    {}
 func (*TxnAlreadyEncounteredErrorError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_7f973735b5f2ff97, []int{22}
+	return fileDescriptor_errors_1a1ac4f8ac3e0d62, []int{22}
 }
 func (m *TxnAlreadyEncounteredErrorError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1247,7 +1254,7 @@ func (m *IntegerOverflowError) Reset()         { *m = IntegerOverflowError{} }
 func (m *IntegerOverflowError) String() string { return proto.CompactTextString(m) }
 func (*IntegerOverflowError) ProtoMessage()    {}
 func (*IntegerOverflowError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_7f973735b5f2ff97, []int{23}
+	return fileDescriptor_errors_1a1ac4f8ac3e0d62, []int{23}
 }
 func (m *IntegerOverflowError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1283,7 +1290,7 @@ func (m *BatchTimestampBeforeGCError) Reset()         { *m = BatchTimestampBefor
 func (m *BatchTimestampBeforeGCError) String() string { return proto.CompactTextString(m) }
 func (*BatchTimestampBeforeGCError) ProtoMessage()    {}
 func (*BatchTimestampBeforeGCError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_7f973735b5f2ff97, []int{24}
+	return fileDescriptor_errors_1a1ac4f8ac3e0d62, []int{24}
 }
 func (m *BatchTimestampBeforeGCError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1322,7 +1329,7 @@ func (m *IntentMissingError) Reset()         { *m = IntentMissingError{} }
 func (m *IntentMissingError) String() string { return proto.CompactTextString(m) }
 func (*IntentMissingError) ProtoMessage()    {}
 func (*IntentMissingError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_7f973735b5f2ff97, []int{25}
+	return fileDescriptor_errors_1a1ac4f8ac3e0d62, []int{25}
 }
 func (m *IntentMissingError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1359,7 +1366,7 @@ func (m *MergeInProgressError) Reset()         { *m = MergeInProgressError{} }
 func (m *MergeInProgressError) String() string { return proto.CompactTextString(m) }
 func (*MergeInProgressError) ProtoMessage()    {}
 func (*MergeInProgressError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_7f973735b5f2ff97, []int{26}
+	return fileDescriptor_errors_1a1ac4f8ac3e0d62, []int{26}
 }
 func (m *MergeInProgressError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1394,7 +1401,7 @@ func (m *RangeFeedRetryError) Reset()         { *m = RangeFeedRetryError{} }
 func (m *RangeFeedRetryError) String() string { return proto.CompactTextString(m) }
 func (*RangeFeedRetryError) ProtoMessage()    {}
 func (*RangeFeedRetryError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_7f973735b5f2ff97, []int{27}
+	return fileDescriptor_errors_1a1ac4f8ac3e0d62, []int{27}
 }
 func (m *RangeFeedRetryError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1433,7 +1440,7 @@ func (m *IndeterminateCommitError) Reset()         { *m = IndeterminateCommitErr
 func (m *IndeterminateCommitError) String() string { return proto.CompactTextString(m) }
 func (*IndeterminateCommitError) ProtoMessage()    {}
 func (*IndeterminateCommitError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_7f973735b5f2ff97, []int{28}
+	return fileDescriptor_errors_1a1ac4f8ac3e0d62, []int{28}
 }
 func (m *IndeterminateCommitError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1496,7 +1503,7 @@ func (m *ErrorDetail) Reset()         { *m = ErrorDetail{} }
 func (m *ErrorDetail) String() string { return proto.CompactTextString(m) }
 func (*ErrorDetail) ProtoMessage()    {}
 func (*ErrorDetail) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_7f973735b5f2ff97, []int{29}
+	return fileDescriptor_errors_1a1ac4f8ac3e0d62, []int{29}
 }
 func (m *ErrorDetail) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2423,7 +2430,7 @@ func (m *ErrPosition) Reset()         { *m = ErrPosition{} }
 func (m *ErrPosition) String() string { return proto.CompactTextString(m) }
 func (*ErrPosition) ProtoMessage()    {}
 func (*ErrPosition) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_7f973735b5f2ff97, []int{30}
+	return fileDescriptor_errors_1a1ac4f8ac3e0d62, []int{30}
 }
 func (m *ErrPosition) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2485,7 +2492,7 @@ type Error struct {
 func (m *Error) Reset()      { *m = Error{} }
 func (*Error) ProtoMessage() {}
 func (*Error) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_7f973735b5f2ff97, []int{31}
+	return fileDescriptor_errors_1a1ac4f8ac3e0d62, []int{31}
 }
 func (m *Error) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -8922,9 +8929,9 @@ var (
 	ErrIntOverflowErrors   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("roachpb/errors.proto", fileDescriptor_errors_7f973735b5f2ff97) }
+func init() { proto.RegisterFile("roachpb/errors.proto", fileDescriptor_errors_1a1ac4f8ac3e0d62) }
 
-var fileDescriptor_errors_7f973735b5f2ff97 = []byte{
+var fileDescriptor_errors_1a1ac4f8ac3e0d62 = []byte{
 	// 2954 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x9c, 0x59, 0xcb, 0x6f, 0x1b, 0xd7,
 	0xd5, 0xe7, 0x50, 0x94, 0x44, 0x1d, 0x3d, 0x3c, 0xbe, 0x96, 0xe5, 0x91, 0x1c, 0x53, 0xca, 0xd8,

--- a/pkg/roachpb/errors.proto
+++ b/pkg/roachpb/errors.proto
@@ -263,6 +263,13 @@ message WriteIntentError {
 // value newer than its timestamp, making it impossible to rewrite
 // history. The write is instead done at actual timestamp, which is
 // the timestamp of the existing version+1.
+//
+// If a blind write request (see IsBlindWrite) returns a WriteTooOld
+// error during evaluation (in pkg/kvserver/batcheval), it must also
+// complete its work and return a valid result. This allows callers to
+// optionally defer the WriteTooOldError until later in the transaction
+// by instead bumping the transaction's write timestamp, setting the
+// transaction's WriteTooOld flag, and dropping the error.
 message WriteTooOldError {
   optional util.hlc.Timestamp timestamp = 1 [(gogoproto.nullable) = false];
   optional util.hlc.Timestamp actual_timestamp = 2 [(gogoproto.nullable) = false];

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -2405,10 +2405,6 @@ func MVCCDeleteRange(
 	txn *roachpb.Transaction,
 	returnKeys bool,
 ) ([]roachpb.Key, *roachpb.Span, int64, error) {
-	// In order to detect the potential write intent by another concurrent
-	// transaction with a newer timestamp, we need to use the max timestamp for
-	// scan.
-	scanTs := hlc.MaxTimestamp
 	// In order for this operation to be idempotent when run transactionally, we
 	// need to perform the initial scan at the previous sequence number so that
 	// we don't see the result from equal or later sequences.
@@ -2418,35 +2414,31 @@ func MVCCDeleteRange(
 		prevSeqTxn.Sequence--
 		scanTxn = prevSeqTxn
 	}
-	res, err := MVCCScan(
-		ctx, rw, key, endKey, scanTs, MVCCScanOptions{Txn: scanTxn, MaxKeys: max})
+	res, err := MVCCScan(ctx, rw, key, endKey, timestamp, MVCCScanOptions{
+		FailOnMoreRecent: true, Txn: scanTxn, MaxKeys: max,
+	})
 	if err != nil {
 		return nil, nil, 0, err
 	}
 
 	buf := newPutBuffer()
+	defer buf.release()
 	iter := newMVCCIterator(rw, timestamp.IsEmpty(), IterOptions{Prefix: true})
-
-	for i := range res.KVs {
-		err = mvccPutInternal(
-			ctx, rw, iter, ms, res.KVs[i].Key, timestamp, nil, txn, buf, nil)
-		if err != nil {
-			break
-		}
-	}
-
-	iter.Close()
-	buf.release()
+	defer iter.Close()
 
 	var keys []roachpb.Key
-	if returnKeys && err == nil && len(res.KVs) > 0 {
-		keys = make([]roachpb.Key, len(res.KVs))
-		for i := range res.KVs {
-			keys[i] = res.KVs[i].Key
+	for i, kv := range res.KVs {
+		if err := mvccPutInternal(ctx, rw, iter, ms, kv.Key, timestamp, nil, txn, buf, nil); err != nil {
+			return nil, nil, 0, err
+		}
+		if returnKeys {
+			if i == 0 {
+				keys = make([]roachpb.Key, len(res.KVs))
+			}
+			keys[i] = kv.Key
 		}
 	}
-
-	return keys, res.ResumeSpan, res.NumKeys, err
+	return keys, res.ResumeSpan, res.NumKeys, nil
 }
 
 func mvccScanToBytes(

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -2648,12 +2648,11 @@ type MVCCScanResult struct {
 // non-transactional scans may be inconsistent.
 //
 // When scanning in "fail on more recent" mode, a WriteTooOldError will be
-// returned if the scan observes a version with a timestamp above the read
-// timestamp. If the scan observes multiple versions with timestamp above
+// returned if the scan observes a version with a timestamp at or above the read
+// timestamp. If the scan observes multiple versions with timestamp at or above
 // the read timestamp, the maximum will be returned in the WriteTooOldError.
-// Similarly, a WriteIntentError will be returned if the scan observes
-// another transaction's intent, even if it has a timestamp above the read
-// timestamp.
+// Similarly, a WriteIntentError will be returned if the scan observes another
+// transaction's intent, even if it has a timestamp above the read timestamp.
 func MVCCScan(
 	ctx context.Context,
 	reader Reader,

--- a/pkg/storage/testdata/mvcc_histories/delete_range
+++ b/pkg/storage/testdata/mvcc_histories/delete_range
@@ -1,0 +1,170 @@
+# Populate some values
+
+run ok
+with ts=44 v=abc
+  put  k=a
+  put  k=a/123
+  put  k=b
+  put  k=b/123
+  put  k=c
+  put  k=c/123
+  put  k=d
+  put  k=d/123
+----
+>> at end:
+data: "a"/0.000000044,0 -> /BYTES/abc
+data: "a/123"/0.000000044,0 -> /BYTES/abc
+data: "b"/0.000000044,0 -> /BYTES/abc
+data: "b/123"/0.000000044,0 -> /BYTES/abc
+data: "c"/0.000000044,0 -> /BYTES/abc
+data: "c/123"/0.000000044,0 -> /BYTES/abc
+data: "d"/0.000000044,0 -> /BYTES/abc
+data: "d/123"/0.000000044,0 -> /BYTES/abc
+
+
+# A simple non-txn that deletes a range of keys.
+## The delete tombstone is placed alongside each of the previous values, at the newer timestamp.
+
+run ok
+del_range k=a end=b ts=45
+----
+del_range: "a"-"b" -> deleted 2 key(s)
+>> at end:
+data: "a"/0.000000045,0 -> /<empty>
+data: "a"/0.000000044,0 -> /BYTES/abc
+data: "a/123"/0.000000045,0 -> /<empty>
+data: "a/123"/0.000000044,0 -> /BYTES/abc
+data: "b"/0.000000044,0 -> /BYTES/abc
+data: "b/123"/0.000000044,0 -> /BYTES/abc
+data: "c"/0.000000044,0 -> /BYTES/abc
+data: "c/123"/0.000000044,0 -> /BYTES/abc
+data: "d"/0.000000044,0 -> /BYTES/abc
+data: "d/123"/0.000000044,0 -> /BYTES/abc
+
+
+# A simple txn that deletes a range of keys.
+## The delete tombstone is placed alongside each of the previous values, at the newer timestamp.
+## The deleted keys are returned.
+
+run ok
+with t=A
+  txn_begin ts=46
+  del_range k=b end=c returnKeys
+  txn_remove
+----
+del_range: "b"-"c" -> deleted 2 key(s)
+del_range: returned "b"
+del_range: returned "b/123"
+>> at end:
+data: "a"/0.000000045,0 -> /<empty>
+data: "a"/0.000000044,0 -> /BYTES/abc
+data: "a/123"/0.000000045,0 -> /<empty>
+data: "a/123"/0.000000044,0 -> /BYTES/abc
+meta: "b"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000046,0 min=0,0 seq=0} ts=0.000000046,0 del=true klen=12 vlen=0
+data: "b"/0.000000046,0 -> /<empty>
+data: "b"/0.000000044,0 -> /BYTES/abc
+meta: "b/123"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000046,0 min=0,0 seq=0} ts=0.000000046,0 del=true klen=12 vlen=0
+data: "b/123"/0.000000046,0 -> /<empty>
+data: "b/123"/0.000000044,0 -> /BYTES/abc
+data: "c"/0.000000044,0 -> /BYTES/abc
+data: "c/123"/0.000000044,0 -> /BYTES/abc
+data: "d"/0.000000044,0 -> /BYTES/abc
+data: "d/123"/0.000000044,0 -> /BYTES/abc
+
+
+# A limited non-txn that deletes a range of keys.
+## Only up to two keys are deleted.
+## The deleted keys are returned.
+
+run ok
+del_range k=c end=z ts=47 max=2 returnKeys
+----
+del_range: "c"-"z" -> deleted 2 key(s)
+del_range: returned "c"
+del_range: returned "c/123"
+del_range: resume span ["d","z")
+>> at end:
+data: "a"/0.000000045,0 -> /<empty>
+data: "a"/0.000000044,0 -> /BYTES/abc
+data: "a/123"/0.000000045,0 -> /<empty>
+data: "a/123"/0.000000044,0 -> /BYTES/abc
+meta: "b"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000046,0 min=0,0 seq=0} ts=0.000000046,0 del=true klen=12 vlen=0
+data: "b"/0.000000046,0 -> /<empty>
+data: "b"/0.000000044,0 -> /BYTES/abc
+meta: "b/123"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000046,0 min=0,0 seq=0} ts=0.000000046,0 del=true klen=12 vlen=0
+data: "b/123"/0.000000046,0 -> /<empty>
+data: "b/123"/0.000000044,0 -> /BYTES/abc
+data: "c"/0.000000047,0 -> /<empty>
+data: "c"/0.000000044,0 -> /BYTES/abc
+data: "c/123"/0.000000047,0 -> /<empty>
+data: "c/123"/0.000000044,0 -> /BYTES/abc
+data: "d"/0.000000044,0 -> /BYTES/abc
+data: "d/123"/0.000000044,0 -> /BYTES/abc
+
+
+# A txn that performs a delete range at a lower timestamp returns a WriteTooOld error.
+
+run error
+with t=A
+  txn_begin ts=46
+  del_range k=c end=z returnKeys
+  txn_remove
+----
+>> at end:
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000046,0 min=0,0 seq=0} lock=true stat=PENDING rts=0.000000046,0 wto=false max=0,0
+data: "a"/0.000000045,0 -> /<empty>
+data: "a"/0.000000044,0 -> /BYTES/abc
+data: "a/123"/0.000000045,0 -> /<empty>
+data: "a/123"/0.000000044,0 -> /BYTES/abc
+meta: "b"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000046,0 min=0,0 seq=0} ts=0.000000046,0 del=true klen=12 vlen=0
+data: "b"/0.000000046,0 -> /<empty>
+data: "b"/0.000000044,0 -> /BYTES/abc
+meta: "b/123"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000046,0 min=0,0 seq=0} ts=0.000000046,0 del=true klen=12 vlen=0
+data: "b/123"/0.000000046,0 -> /<empty>
+data: "b/123"/0.000000044,0 -> /BYTES/abc
+data: "c"/0.000000047,0 -> /<empty>
+data: "c"/0.000000044,0 -> /BYTES/abc
+data: "c/123"/0.000000047,0 -> /<empty>
+data: "c/123"/0.000000044,0 -> /BYTES/abc
+data: "d"/0.000000044,0 -> /BYTES/abc
+data: "d/123"/0.000000044,0 -> /BYTES/abc
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write at timestamp 0.000000046,0 too old; wrote at 0.000000047,1
+
+run ok
+txn_remove t=A
+----
+>> at end:
+
+
+# A txn that performs a delete range at a higher timestamp does not place duplicate tombstones.
+
+run ok
+with t=A
+  txn_begin ts=48
+  del_range k=c end=z returnKeys
+  txn_remove
+----
+del_range: "c"-"z" -> deleted 2 key(s)
+del_range: returned "d"
+del_range: returned "d/123"
+>> at end:
+data: "a"/0.000000045,0 -> /<empty>
+data: "a"/0.000000044,0 -> /BYTES/abc
+data: "a/123"/0.000000045,0 -> /<empty>
+data: "a/123"/0.000000044,0 -> /BYTES/abc
+meta: "b"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000046,0 min=0,0 seq=0} ts=0.000000046,0 del=true klen=12 vlen=0
+data: "b"/0.000000046,0 -> /<empty>
+data: "b"/0.000000044,0 -> /BYTES/abc
+meta: "b/123"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000046,0 min=0,0 seq=0} ts=0.000000046,0 del=true klen=12 vlen=0
+data: "b/123"/0.000000046,0 -> /<empty>
+data: "b/123"/0.000000044,0 -> /BYTES/abc
+data: "c"/0.000000047,0 -> /<empty>
+data: "c"/0.000000044,0 -> /BYTES/abc
+data: "c/123"/0.000000047,0 -> /<empty>
+data: "c/123"/0.000000044,0 -> /BYTES/abc
+meta: "d"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000048,0 min=0,0 seq=0} ts=0.000000048,0 del=true klen=12 vlen=0
+data: "d"/0.000000048,0 -> /<empty>
+data: "d"/0.000000044,0 -> /BYTES/abc
+meta: "d/123"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000048,0 min=0,0 seq=0} ts=0.000000048,0 del=true klen=12 vlen=0
+data: "d/123"/0.000000048,0 -> /<empty>
+data: "d/123"/0.000000044,0 -> /BYTES/abc

--- a/pkg/storage/testdata/mvcc_histories/read_fail_on_more_recent
+++ b/pkg/storage/testdata/mvcc_histories/read_fail_on_more_recent
@@ -44,10 +44,11 @@ get k=k1 ts=10,0
 ----
 get: "k1" -> /BYTES/v @0.000000010,0
 
-run ok
+run error
 get k=k1 ts=10,0 failOnMoreRecent
 ----
-get: "k1" -> /BYTES/v @0.000000010,0
+get: "k1" -> <no data>
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write at timestamp 0.000000010,0 too old; wrote at 0.000000010,1
 
 run ok
 get k=k1 ts=11,0
@@ -75,10 +76,11 @@ scan k=k1 end=k2 ts=10,0
 ----
 scan: "k1" -> /BYTES/v @0.000000010,0
 
-run ok
+run error
 scan k=k1 end=k2 ts=10,0 failOnMoreRecent
 ----
-scan: "k1" -> /BYTES/v @0.000000010,0
+scan: "k1"-"k2" -> <no data>
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write at timestamp 0.000000010,0 too old; wrote at 0.000000010,1
 
 run ok
 scan k=k1 end=k2 ts=11,0
@@ -190,7 +192,7 @@ run error
 scan k=k1 end=k3 ts=10,0 failOnMoreRecent
 ----
 scan: "k1"-"k3" -> <no data>
-error: (*roachpb.WriteIntentError:) conflicting intents on "k2"
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write at timestamp 0.000000010,0 too old; wrote at 0.000000010,1
 
 run error
 scan k=k1 end=k3 ts=11,0


### PR DESCRIPTION
Fixes #56111.

This commit fixes a bug that allowed non-serializable state to leak from
the return value of a DeleteRange request. DeleteRange requests were not
returning WriteTooOld errors on conflicting tombstones at higher
timestamps, so they were allowing conflicting DELETEs to influence their
returned keys. This, in turn, was permitting cases where a DELETE's rows
updated return value would disagree with previously observed state in a
transaction.

Worse than this, I think there might have even been a bug with deferring
the WriteTooOld status from a DeleteRange request, because unlike most
MVCC operations, MVCCDeleteRange does not complete before returning a
WriteTooOldError. I think this means that it could have partially
succeeded and then returned a WriteTooOldError. If the write too old
status was deferred, this would result in the DeleteRange request
failing to delete some keys. This is why "blind-write" requests must
complete entirely even if they intend to return a WriteTooOldError (see
`mvccPutInternal`). We don't particularly like this behavior, but it's
been around for years.

The fix for this issue is twofold. First, this commit fixes
MVCCDeleteRange. It uses the relatively new `FailOnMoreRecent` flag in
its initial scan to ensure that a WriteTooOld error is returned even in
the presence of tombstones at equal or higher timestamps. This has the
side-effect of letting us get rid of some strange code added in ee80e3d
which scanned at MaxTimestamp. Second, this commit fixes DeleteRange
request by giving it the `isRead` flag. This ensures that the request is
never considered a blind-write and therefore never defers a "write too
old" status.

I intend to backport this to release-20.1 and release-20.2.

Release notes (bug fix): DELETE statements no longer have a chance of
returning an incorrect number of deleted rows in transactions that will
eventually need to restart due to contention.