### PR TITLE
sql: prevent crash on range scan on virtual index

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2769,3 +2769,14 @@ FROM
 WHERE
   n.nspname != 'pg_toast'
   AND (t.typrelid = 0 OR (SELECT c.relkind = 'c' FROM pg_catalog.pg_class AS c WHERE c.oid = t.typrelid))
+
+# Regression test for range constraints on virtual index scans. (#56440)
+query O
+SELECT oid FROM pg_type WHERE oid IN (19,20,24) ORDER BY oid
+----
+19
+20
+24
+
+statement ok
+SELECT * FROM pg_class WHERE oid = 10 OR oid BETWEEN 20 AND 30 OR oid = 40


### PR DESCRIPTION
Fixes #56440.

Previously, the database would panic when a user performed a range scan
against a virtual table that had a virtual index. For example, the
queries:

```
SELECT * FROM pg_catalog.pg_type WHERE oid IN (19, 20)
SELECT * FROM pg_catalog.pg_class WHERE oid BETWEEN 20 AND 50
```

would cause this crash, since both of those tables have virtual indexes
defined on their `oid` columns.

This crash is now corrected.

Release note (bug fix): prevent a crash, introduced in the 20.2 series,
caused by range scans over virtual tables with virtual indexes.