### PR TITLE
release-20.2: server: add license expiry time to prometheus metrics

### DIFF
--- a/pkg/base/license.go
+++ b/pkg/base/license.go
@@ -11,6 +11,9 @@
 package base
 
 import (
+	"context"
+	"time"
+
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
@@ -23,6 +26,17 @@ import (
 // This function is overridden by an init hook in CCL builds.
 var CheckEnterpriseEnabled = func(_ *cluster.Settings, _ uuid.UUID, org, feature string) error {
 	return errors.New("OSS binaries do not include enterprise features")
+}
+
+// TimeToEnterpriseLicenseExpiry returns a duration object that measures the time until
+// the currently set enterprise license expires starting from the 3rd argument
+// passed in.
+//
+// This function is overridden by an init hook in CCL builds
+var TimeToEnterpriseLicenseExpiry = func(
+	ctx context.Context, _ *cluster.Settings, _ time.Time,
+) (time.Duration, error) {
+	return 0, nil
 }
 
 // LicenseType returns what type of license the cluster is running with, or

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -1461,20 +1461,46 @@ func (s *statusServer) RaftDebug(
 
 type varsHandler struct {
 	metricSource metricMarshaler
+	st           *cluster.Settings
 }
 
 func (h varsHandler) handleVars(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
 	w.Header().Set(httputil.ContentTypeHeader, httputil.PlaintextContentType)
 	err := h.metricSource.PrintAsText(w)
 	if err != nil {
-		log.Errorf(r.Context(), "%v", err)
+		log.Errorf(ctx, "%v", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
+
+	h.appendLicenseExpiryMetric(ctx, w)
 	telemetry.Inc(telemetryPrometheusVars)
 }
 
+// appendLicenseExpiryMetric computes the seconds until the enterprise licence
+// expires on this clusters. the license expiry metric is computed on-demand
+// since it's not regularly computed as part of running the cluster unless
+// enterprise features are accessed.
+func (h varsHandler) appendLicenseExpiryMetric(ctx context.Context, w io.Writer) {
+	durationToExpiry, err := base.TimeToEnterpriseLicenseExpiry(ctx, h.st, timeutil.Now())
+	if err != nil {
+		log.Errorf(ctx, "unable to generate time to license expiry: %v", err)
+		return
+	}
+
+	secondsToExpiry := int64(durationToExpiry / time.Second)
+
+	_, err = w.Write([]byte(
+		fmt.Sprintf("seconds_until_enterprise_license_expiry %d\n", secondsToExpiry),
+	))
+	if err != nil {
+		log.Errorf(ctx, "problem writing license expiry metric: %v", err)
+	}
+}
+
 func (s *statusServer) handleVars(w http.ResponseWriter, r *http.Request) {
-	varsHandler{s.metricSource}.handleVars(w, r)
+	varsHandler{s.metricSource, s.st}.handleVars(w, r)
 }
 
 // Ranges returns range info for the specified node.

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -675,7 +675,7 @@ func StartTenant(
 				return
 			}
 		})
-		f := varsHandler{metricSource: args.recorder}.handleVars
+		f := varsHandler{metricSource: args.recorder, st: args.Settings}.handleVars
 		mux.Handle(statusVars, http.HandlerFunc(f))
 		_ = http.Serve(httpL, mux)
 	})


### PR DESCRIPTION
Backport 1/1 commits from #55565.

/cc @cockroachdb/release

---

This change adds a license expiry metric titled
`seconds_until_enterprise_license_expiry` which contains an integer number of
seconds until the enterprise license expires on the cluster (if one exists). If
no enterprise license is configured, this metric is not appended

This metric is computed on-demand since there is no periodic process that can
regularly update a timeseries for us.

This resolves #52794

Release note (api change): adds a new prometheus metric called
`seconds_until_license_expiry` that reports on the number of seconds until the
enterprise license on the cluster expires and 0 if there is no license. It will
return a negative number if the expiration is in the past.
