### PR TITLE
colflow: more minor optimizations and pooling on the read path

### DIFF
--- a/pkg/sql/colcontainer/diskqueue_test.go
+++ b/pkg/sql/colcontainer/diskqueue_test.go
@@ -97,12 +97,11 @@ func TestDiskQueue(t *testing.T) {
 					require.NoError(t, err)
 
 					// Verify that a directory was created.
-					directories, err := queueCfg.FS.List(queueCfg.Path)
+					directories, err := queueCfg.FS.List(queueCfg.GetPath(ctx))
 					require.NoError(t, err)
 					require.Equal(t, 1, len(directories))
 
 					// Run verification.
-					ctx := context.Background()
 					for {
 						b := op.Next(ctx)
 						require.NoError(t, q.Enqueue(ctx, b))
@@ -159,7 +158,7 @@ func TestDiskQueue(t *testing.T) {
 					require.NoError(t, q.Close(ctx))
 
 					// Verify no directories are left over.
-					directories, err = queueCfg.FS.List(queueCfg.Path)
+					directories, err = queueCfg.FS.List(queueCfg.GetPath(ctx))
 					require.NoError(t, err)
 					require.Equal(t, 0, len(directories))
 				})

--- a/pkg/sql/colexec/spilling_queue_test.go
+++ b/pkg/sql/colexec/spilling_queue_test.go
@@ -143,7 +143,7 @@ func TestSpillingQueue(t *testing.T) {
 			require.NoError(t, q.close(ctx))
 
 			// Verify no directories are left over.
-			directories, err := queueCfg.FS.List(queueCfg.Path)
+			directories, err := queueCfg.FS.List(queueCfg.GetPath(ctx))
 			require.NoError(t, err)
 			require.Equal(t, 0, len(directories))
 		}

--- a/pkg/sql/distsql/columnar_operators_test.go
+++ b/pkg/sql/distsql/columnar_operators_test.go
@@ -293,7 +293,7 @@ func TestAggregatorAgainstProcessor(t *testing.T) {
 						inputs:     []rowenc.EncDatumRows{rows},
 						pspec:      pspec,
 					}
-					if err := verifyColOperator(args); err != nil {
+					if err := verifyColOperator(t, args); err != nil {
 						if strings.Contains(err.Error(), "different errors returned") {
 							// Columnar and row-based aggregators are likely to hit
 							// different errors, and we will swallow those and move
@@ -395,7 +395,7 @@ func TestDistinctAgainstProcessor(t *testing.T) {
 						inputs:     []rowenc.EncDatumRows{rows},
 						pspec:      pspec,
 					}
-					if err := verifyColOperator(args); err != nil {
+					if err := verifyColOperator(t, args); err != nil {
 						fmt.Printf("--- seed = %d run = %d nCols = %d distinct cols = %v ordered cols = %v ---\n",
 							seed, run, nCols, distinctCols, orderedCols)
 						prettyPrintTypes(inputTypes, "t" /* tableName */)
@@ -468,7 +468,7 @@ func TestSorterAgainstProcessor(t *testing.T) {
 					if spillForced {
 						args.numForcedRepartitions = 2 + rng.Intn(3)
 					}
-					if err := verifyColOperator(args); err != nil {
+					if err := verifyColOperator(t, args); err != nil {
 						fmt.Printf("--- seed = %d spillForced = %t nCols = %d K = %d ---\n",
 							seed, spillForced, nCols, topK)
 						prettyPrintTypes(inputTypes, "t" /* tableName */)
@@ -543,7 +543,7 @@ func TestSortChunksAgainstProcessor(t *testing.T) {
 						pspec:          pspec,
 						forceDiskSpill: spillForced,
 					}
-					if err := verifyColOperator(args); err != nil {
+					if err := verifyColOperator(t, args); err != nil {
 						fmt.Printf("--- seed = %d spillForced = %t orderingCols = %v matchLen = %d run = %d ---\n",
 							seed, spillForced, orderingCols, matchLen, run)
 						prettyPrintTypes(inputTypes, "t" /* tableName */)
@@ -719,7 +719,7 @@ func TestHashJoinerAgainstProcessor(t *testing.T) {
 									}
 								}
 
-								if err := verifyColOperator(args); err != nil {
+								if err := verifyColOperator(t, args); err != nil {
 									fmt.Printf("--- spillForced = %t join type = %s onExpr = %q"+
 										" filter = %q seed = %d run = %d ---\n",
 										spillForced, testSpec.joinType.String(), onExpr.Expr, filter.Expr, seed, run)
@@ -932,7 +932,7 @@ func TestMergeJoinerAgainstProcessor(t *testing.T) {
 									args.colIdxsToCheckForEquality[i] = int(lOrderingCols[i].ColIdx)
 								}
 							}
-							if err := verifyColOperator(args); err != nil {
+							if err := verifyColOperator(t, args); err != nil {
 								fmt.Printf("--- join type = %s onExpr = %q filter = %q seed = %d run = %d ---\n",
 									testSpec.joinType.String(), onExpr.Expr, filter.Expr, seed, run)
 								fmt.Printf("--- left ordering = %v right ordering = %v ---\n", lOrderingCols, rOrderingCols)
@@ -1106,7 +1106,7 @@ func TestWindowFunctionsAgainstProcessor(t *testing.T) {
 						inputs:     []rowenc.EncDatumRows{rows},
 						pspec:      pspec,
 					}
-					if err := verifyColOperator(args); err != nil {
+					if err := verifyColOperator(t, args); err != nil {
 						fmt.Printf("seed = %d\n", seed)
 						prettyPrintTypes(inputTypes, "t" /* tableName */)
 						prettyPrintInput(rows, inputTypes, "t" /* tableName */)

--- a/pkg/sql/distsql/columnar_utils_test.go
+++ b/pkg/sql/distsql/columnar_utils_test.go
@@ -16,6 +16,7 @@ import (
 	"math"
 	"math/rand"
 	"strconv"
+	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
@@ -67,7 +68,7 @@ type verifyColOperatorArgs struct {
 
 // verifyColOperator passes inputs through both the processor defined by pspec
 // and the corresponding columnar operator and verifies that the results match.
-func verifyColOperator(args verifyColOperatorArgs) error {
+func verifyColOperator(t *testing.T, args verifyColOperatorArgs) error {
 	const floatPrecision = 0.0000001
 	rng := args.rng
 	if rng == nil {
@@ -137,8 +138,11 @@ func verifyColOperator(args verifyColOperatorArgs) error {
 		Spec:                args.pspec,
 		Inputs:              columnarizers,
 		StreamingMemAccount: &acc,
-		DiskQueueCfg:        colcontainer.DiskQueueCfg{FS: tempFS},
-		FDSemaphore:         colexecbase.NewTestingSemaphore(256),
+		DiskQueueCfg: colcontainer.DiskQueueCfg{
+			FS:      tempFS,
+			GetPath: func(context.Context) string { return "" },
+		},
+		FDSemaphore: colexecbase.NewTestingSemaphore(256),
 
 		// TODO(yuzefovich): adjust expression generator to not produce
 		// mixed-type timestamp-related expressions and then disallow the

--- a/pkg/testutils/colcontainerutils/diskqueuecfg.go
+++ b/pkg/testutils/colcontainerutils/diskqueuecfg.go
@@ -11,6 +11,7 @@
 package colcontainerutils
 
 import (
+	"context"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -55,7 +56,9 @@ func NewTestingDiskQueueCfg(t testing.TB, inMem bool) (colcontainer.DiskQueueCfg
 		}
 	}
 	cfg.FS = testingFS
-	cfg.Path = path
+	cfg.GetPath = func(context.Context) string {
+		return path
+	}
 
 	if err := cfg.EnsureDefaults(); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
**colflow: evaluate temp storage path lazily**

This commit makes the evaluation of the temp storage path in the
vectorized flow lazy which allows us to not create a uuid in case of
a local flow when the spilling to disk doesn't occur. This shows about
1% improvement on the micro benchmark of the flow setup. Additionally,
the directory creation is now done when its path is requested for the
first time which allows us to remove one callback from the config.

Release note: None

**colflow: more pooling of objects during the flow setup**

This commit keeps the references to several slices and a map that are
used during the flow setup which allows us to remove several
allocations.

Release note: None