### PR TITLE
server: name sqlmigrations.Manager vars more appropriately

### DIFF
--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -341,10 +341,10 @@ func (ts *TestServer) JobRegistry() interface{} {
 	return nil
 }
 
-// MigrationManager returns the *sqlmigrations.Manager as an interface{}.
-func (ts *TestServer) MigrationManager() interface{} {
+// SQLMigrationsManager returns the *sqlmigrations.Manager as an interface{}.
+func (ts *TestServer) SQLMigrationsManager() interface{} {
 	if ts != nil {
-		return ts.sqlServer.migMgr
+		return ts.sqlServer.sqlmigrationsMgr
 	}
 	return nil
 }

--- a/pkg/testutils/serverutils/test_server_shim.go
+++ b/pkg/testutils/serverutils/test_server_shim.go
@@ -112,8 +112,8 @@ type TestServerInterface interface {
 	// JobRegistry returns the *jobs.Registry as an interface{}.
 	JobRegistry() interface{}
 
-	// MigrationManager returns the *jobs.Registry as an interface{}.
-	MigrationManager() interface{}
+	// SQLMigrationsManager returns the *sqlmigrations.Manager as an interface{}.
+	SQLMigrationsManager() interface{}
 
 	// NodeLiveness exposes the NodeLiveness instance used by the TestServer as an
 	// interface{}.


### PR DESCRIPTION
We intend to use "migration manager" for the more general purpose
migration infrastructure we're introducing as part of long running
migrations.

Release note: None