### PR TITLE
settings,migration: disconnect cluster version from gossip

### DIFF
--- a/pkg/clusterversion/BUILD.bazel
+++ b/pkg/clusterversion/BUILD.bazel
@@ -18,7 +18,6 @@ go_library(
         "//pkg/settings",
         "//pkg/util/log",
         "//pkg/util/protoutil",
-        "//pkg/util/syncutil",
         "//vendor/github.com/cockroachdb/errors",
         "//vendor/github.com/cockroachdb/redact",
         "//vendor/github.com/gogo/protobuf/proto",

--- a/pkg/migration/BUILD.bazel
+++ b/pkg/migration/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "manager.go",
         "migrations.go",
+        "util.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/migration",
     visibility = ["//visibility:public"],
@@ -12,8 +13,12 @@ go_library(
         "//pkg/kv",
         "//pkg/kv/kvserver/liveness/livenesspb",
         "//pkg/roachpb",
+        "//pkg/rpc",
         "//pkg/rpc/nodedialer",
+        "//pkg/server/serverpb",
         "//pkg/sql",
+        "//pkg/util/log",
+        "//vendor/github.com/cockroachdb/errors",
         "//vendor/github.com/cockroachdb/logtags",
     ],
 )

--- a/pkg/migration/manager.go
+++ b/pkg/migration/manager.go
@@ -27,8 +27,12 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
+	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
 )
 
@@ -68,6 +72,101 @@ type Helper struct {
 	*Manager
 }
 
+// RequiredNodeIDs returns the node IDs for all nodes that are currently part of
+// the cluster (i.e. they haven't been decommissioned away). Migrations have the
+// pre-requisite that all required nodes are up and running so that we're able
+// to execute all relevant node-level operations on them. If any of the nodes
+// are found to be unavailable, an error is returned.
+func (h *Helper) RequiredNodeIDs(ctx context.Context) ([]roachpb.NodeID, error) {
+	var nodeIDs []roachpb.NodeID
+	ls, err := h.nl.GetLivenessesFromKV(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, l := range ls {
+		if l.Membership.Decommissioned() {
+			continue
+		}
+		live, err := h.nl.IsLive(l.NodeID)
+		if err != nil {
+			return nil, err
+		}
+		if !live {
+			return nil, errors.Newf("n%d required, but unavailable", l.NodeID)
+		}
+		nodeIDs = append(nodeIDs, l.NodeID)
+	}
+	return nodeIDs, nil
+}
+
+// EveryNode invokes the given closure (named by the informational parameter op)
+// across every node in the cluster. The mechanism for ensuring that we've done
+// so, while accounting for the possibility of new nodes being added to the
+// cluster in the interim, is provided by the following structure:
+//   (a) We'll retrieve the list of node IDs for all nodes in the system
+//   (b) For each node, we'll invoke the closure
+//   (c) We'll retrieve the list of node IDs again to account for the
+//       possibility of a new node being added during (b)
+//   (d) If there any discrepancies between the list retrieved in (a)
+//       and (c), we'll invoke the closure each node again
+//   (e) We'll continue to loop around until the node ID list stabilizes
+//
+// By the time EveryNode returns, we'll have thus invoked the closure against
+// every node in the cluster.
+//
+// To consider one example of how this primitive is used, let's consider our use
+// of it to bump the cluster version. After we return, given all nodes in the
+// cluster will have their cluster versions bumped, and future node additions
+// will observe the latest version (through the join RPC). This lets us author
+// migrations that can assume that a certain version gate has been enabled on
+// all nodes in the cluster, and will always be enabled for any new nodes in the
+// system.
+//
+// It may be possible however that right after we return, a new node may join.
+// This means that some migrations may have to be split up into two version
+// bumps: one that phases out the old version (i.e. stops creation of stale data
+// or behavior) and a clean-up version, which removes any vestiges of the stale
+// data/behavior, and which, when active, ensures that the old data has vanished
+// from the system. This is similar in spirit to how schema changes are split up
+// into multiple smaller steps that are carried out sequentially.
+func (h *Helper) EveryNode(
+	ctx context.Context, op string, fn func(context.Context, serverpb.MigrationClient) error,
+) error {
+	nodeIDs, err := h.RequiredNodeIDs(ctx)
+	if err != nil {
+		return err
+	}
+
+	for {
+		// TODO(irfansharif): We can/should send out these RPCs in parallel.
+		log.Infof(ctx, "executing op=%s on nodes=%s", op, nodeIDs)
+		for _, nodeID := range nodeIDs {
+			conn, err := h.dialer.Dial(ctx, nodeID, rpc.DefaultClass)
+			if err != nil {
+				return err
+			}
+			client := serverpb.NewMigrationClient(conn)
+			if err := fn(ctx, client); err != nil {
+				return err
+			}
+		}
+
+		curNodeIDs, err := h.RequiredNodeIDs(ctx)
+		if err != nil {
+			return err
+		}
+
+		if !identical(nodeIDs, curNodeIDs) {
+			nodeIDs = curNodeIDs
+			continue
+		}
+
+		break
+	}
+
+	return nil
+}
+
 // nodeLiveness is the subset of the interface satisfied by CRDB's node liveness
 // component that the migration manager relies upon.
 type nodeLiveness interface {
@@ -96,7 +195,7 @@ func NewManager(
 func (m *Manager) MigrateTo(ctx context.Context, targetV roachpb.Version) error {
 	// TODO(irfansharif): Should we inject every ctx here with specific labels
 	// for each migration, so they log distinctly?
-	_ = logtags.AddTag(ctx, "migration-mgr", nil)
+	ctx = logtags.AddTag(ctx, "migration-mgr", nil)
 
 	// TODO(irfansharif): We'll need to acquire a lease here and refresh it
 	// throughout during the migration to ensure mutual exclusion.
@@ -113,16 +212,68 @@ func (m *Manager) MigrateTo(ctx context.Context, targetV roachpb.Version) error 
 	// TODO(irfansharif): After determining the last completed migration, if
 	// any, we'll be want to assemble the list of remaining migrations to step
 	// through to get to targetV.
-	_ = targetV
-	var vs []roachpb.Version
+
+	// TODO(irfansharif): We'll need to introduce fence/noop versions in order
+	// for the infrastructure here to step through adjacent cluster versions.
+	// It's instructive to walk through how we expect a version migration from
+	// v21.1 to v21.2 to take place, and how we would behave in the presence of
+	// new v21.1 or v21.2 nodes being added to the cluster during.
+	//   - All nodes are running v21.1
+	//   - All nodes are rolled into v21.2 binaries, but with active cluster
+	//     version still as v21.1
+	//   - The first version bump will be into v21.2.0-1noop
+	//   - Validation for setting active cluster version to v21.2.0-1noop first
+	//     checks to see that all nodes are running v21.2 binaries
+	// Then concurrently:
+	//   - A new node is added to the cluster, but running binary v21.1
+	//   - We try bumping the cluster gates to v21.2.0-1noop
+	//
+	// If the v21.1 nodes manages to sneak in before the version bump, it's
+	// fine as the version bump is a no-op one. Any subsequent bumps (including
+	// the "actual" one bumping to v21.2.0) will fail during validation.
+	//
+	// If the v21.1 node is only added after v21.2.0-1noop is active, it won't
+	// be able to actually join the cluster (it'll be prevented by the join
+	// RPC).
+	//
+	// It would be nice to only contain this "fence" version tag within this
+	// package. Perhaps by defining yet another proto version type, but for
+	// pkg/migrations internal use only? I think the UX we want for engineers
+	// defining migrations is that they'd only care about introducing the next
+	// version key within pkg/clusterversion, and registering a corresponding
+	// migration for it here.
+	var vs = []roachpb.Version{targetV}
 
 	for _, version := range vs {
-		_ = &Helper{Manager: m}
-		// TODO(irfansharif): We'll want to out the version gate to every node
-		// in the cluster. Each node will want to persist the version, bump the
-		// local version gates, and then return. The migration associated with
-		// the specific version can then assume that every node in the cluster
-		// has the corresponding version activated.
+		h := &Helper{Manager: m}
+
+		// Push out the version gate to every node in the cluster. Each node
+		// will persist the version, bump the local version gates, and then
+		// return. The migration associated with the specific version can assume
+		// that every node in the cluster has the corresponding version
+		// activated.
+		{
+			// First sanity check that we'll actually be able to perform the
+			// cluster version bump, cluster-wide.
+			req := &serverpb.ValidateTargetClusterVersionRequest{Version: &version}
+			err := h.EveryNode(ctx, "validate-cv", func(ctx context.Context, client serverpb.MigrationClient) error {
+				_, err := client.ValidateTargetClusterVersion(ctx, req)
+				return err
+			})
+			if err != nil {
+				return err
+			}
+		}
+		{
+			req := &serverpb.BumpClusterVersionRequest{Version: &version}
+			err := h.EveryNode(ctx, "bump-cv", func(ctx context.Context, client serverpb.MigrationClient) error {
+				_, err := client.BumpClusterVersion(ctx, req)
+				return err
+			})
+			if err != nil {
+				return err
+			}
+		}
 
 		// TODO(irfansharif): We'll want to retrieve the right migration off of
 		// our registry of migrations, and execute it.

--- a/pkg/migration/util.go
+++ b/pkg/migration/util.go
@@ -1,0 +1,37 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package migration
+
+import (
+	"sort"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+)
+
+// identical returns whether or not two lists of node IDs are identical as sets.
+func identical(a, b []roachpb.NodeID) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	sort.Slice(a, func(i, j int) bool {
+		return a[i] < a[j]
+	})
+	sort.Slice(b, func(i, j int) bool {
+		return b[i] < b[j]
+	})
+
+	for i, v := range a {
+		if v != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/server/init.go
+++ b/pkg/server/init.go
@@ -241,11 +241,15 @@ func (s *initServer) ServeAndWait(
 			// version will be the bootstrap version (aka the binary version[1]),
 			// but the version setting does not know yet (it was initialized as
 			// BinaryMinSupportedVersion because the engines were all
-			// uninitialized). We *could* just let the server start, and it
-			// would populate system.settings, which is then gossiped, and then
-			// the callback would update the version, but we take this shortcut
-			// to avoid having every freshly bootstrapped cluster spend time at
-			// an old cluster version.
+			// uninitialized). Given that the bootstrap version was persisted to
+			// all the engines, it's now safe for us to bump the version setting
+			// itself and start operating at the latest cluster version.
+			//
+			// TODO(irfansharif): We're calling Initialize a second time here.
+			// There's no real reason to anymore, we can use
+			// SetActiveClusterVersion instead. This will let us make
+			// `Initialize` a bit stricter, which is a nice simplification to
+			// have.
 			//
 			// [1]: See the top-level comment in pkg/clusterversion to make
 			// sense of the many versions of ...versions.
@@ -255,6 +259,7 @@ func (s *initServer) ServeAndWait(
 
 			log.Infof(ctx, "cluster %s has been created", state.clusterID)
 			log.Infof(ctx, "allocated node ID: n%d (for self)", state.nodeID)
+			log.Infof(ctx, "active cluster version: %s", state.clusterVersion)
 
 			return state, true, nil
 		case result := <-joinCh:
@@ -277,13 +282,9 @@ func (s *initServer) ServeAndWait(
 
 			state := result.state
 
-			// TODO(irfansharif): We can try and initialize the the version
-			// setting to the active cluster version, in the same way we do when
-			// bootstrapping. We'd need to persis the cluster version to the
-			// engines here if we're looking to do so.
-
 			log.Infof(ctx, "joined cluster %s through join rpc", state.clusterID)
-			log.Infof(ctx, "received node ID %d", state.nodeID)
+			log.Infof(ctx, "received node ID: %d", state.nodeID)
+			log.Infof(ctx, "received cluster version: %s", state.clusterVersion)
 
 			return state, true, nil
 		case <-stopper.ShouldQuiesce():

--- a/pkg/settings/cluster/cluster_settings.go
+++ b/pkg/settings/cluster/cluster_settings.go
@@ -46,8 +46,10 @@ type Settings struct {
 	// is useful.
 	cpuProfiling int32 // atomic
 
-	// Version provides a read-only view to the active cluster version and this
-	// binary's version details.
+	// Version provides the interface through which which callers read/write to
+	// the active cluster version, and access this binary's version details.
+	// Setting the active cluster version has a very specific, intended usage
+	// pattern. Look towards the interface itself for more commentary.
 	Version clusterversion.Handle
 }
 


### PR DESCRIPTION
...in favor of direct RPCs to all nodes in the cluster. It uses the
building blocks we've added thus far to replace the use of gossip to
disseminate the cluster version. It does so by sending out individual
RPCs to each node in the cluster, informing them of a version bump, all
the while retaining the same guarantees provided by our (now previously)
gossip-backed mechanism. This is another in the series of PRs to
introduce long running migrations (#48843), pulled out of our original
prototype in #56107.

This diff has the following "pieces":
- We disconnect the version setting updates through gossip (by
  disconnecting the setting type within the updater process)
- We use the `Migration` service to send out RPCs to each node in the
  cluster, containing the payload that each node would otherwise receive
  through gossip. We do this by first introducing two primitives in
  pkg/migrations:
  - `RequiredNodes` retrieves a list of all nodes that are part of the
    cluster. It's powered by `pkg/../liveness`.
  - `EveryNode` is a shorthand that allows us to send out node-level
    migration RPCs to every node in the cluster.
  
  We combine these primitives with the RPCs introduced in #56476
  (`ValidateTargetClusterVersion`, `BumpClusterVersion`) to actually
  carry out the version bumps.
- We expand the `clusterversion.Handle` interface to allow setting the
  active version directly through it. We then make use of it in the
  implementation for `BumpClusterVersion`.
- Within `BumpClusterVersion`, we persists the cluster version received
  from the client node first, within `keys.StoreClusterVersionKey`, before
  bumping the version gate. This is a required invariant in the system
  in order for us to not regress our cluster version on restart. It was
  previously achieved by attaching callbacks on the version handle
  (`SetBeforeChange`).
- We no longer need the callbacks attached to gossip to persist cluster
  versions to disk. We're doing it as part of the `BumpClusterVersion`
  RPC. We remove them entirely.
- We use the active version provided by the join RPC to set the
  version setting directly (after having persisted it first). This too
  was previously achieved through gossip + the callback.

Release note: None

---

Only the last commit is of interest. All prior commits should be reviewed
across  #56476, #56474 and #56368.