### PR TITLE
release-20.2: auth: use HMAC to secure OIDC flow

### DIFF
--- a/pkg/server/authentication.go
+++ b/pkg/server/authentication.go
@@ -21,8 +21,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
@@ -63,15 +61,10 @@ func (c *noOIDCConfigured) GetOIDCConf() ui.OIDCUIConf {
 	}
 }
 
-func (c *noOIDCConfigured) ValidateOIDCState(state *serverpb.OIDCState) error {
-	return errors.New("OIDC is not enabled")
-}
-
 // OIDC is an interface that an OIDC-based authentication module should implement to integrate with
 // the rest of the node's functionality
 type OIDC interface {
 	ui.OIDCUI
-	ValidateOIDCState(state *serverpb.OIDCState) error
 }
 
 // ConfigureOIDC is a hook for the `oidcccl` library to add OIDC login support. It's called during
@@ -83,8 +76,6 @@ var ConfigureOIDC = func(
 	userLoginFromSSO func(ctx context.Context, username string) (*http.Cookie, error),
 	ambientCtx log.AmbientContext,
 	cluster uuid.UUID,
-	nodeDialer *nodedialer.Dialer,
-	nodeID roachpb.NodeID,
 ) (OIDC, error) {
 	return &noOIDCConfigured{}, nil
 }
@@ -180,17 +171,6 @@ var errWebAuthenticationFailure = status.Errorf(
 	codes.Unauthenticated,
 	"the provided credentials did not match any account on the server",
 )
-
-func (s *authenticationServer) ValidateOIDCState(
-	ctx context.Context, req *serverpb.ValidateOIDCStateRequest,
-) (*serverpb.ValidateOIDCStateResponse, error) {
-	err := s.server.oidc.ValidateOIDCState(req.State)
-	if err != nil {
-		return nil, err
-	}
-
-	return &serverpb.ValidateOIDCStateResponse{}, nil
-}
 
 // UserLoginFromSSO checks for the existence of a given username and if it exists,
 // creates a session for the username in the `web_sessions` table.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1572,7 +1572,7 @@ func (s *Server) Start(ctx context.Context) error {
 
 	// OIDC Configuration must happen prior to the UI Handler being defined below so that we have
 	// the system settings initialized for it to pick up from the oidcAuthenticationServer.
-	oidc, err := ConfigureOIDC(ctx, s.ClusterSettings(), &s.mux, s.authentication.UserLoginFromSSO, s.cfg.AmbientCtx, s.ClusterID(), s.nodeDialer, s.NodeID())
+	oidc, err := ConfigureOIDC(ctx, s.ClusterSettings(), &s.mux, s.authentication.UserLoginFromSSO, s.cfg.AmbientCtx, s.ClusterID())
 	if err != nil {
 		return err
 	}

--- a/pkg/server/serverpb/authentication.pb.go
+++ b/pkg/server/serverpb/authentication.pb.go
@@ -7,8 +7,6 @@ import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
 import math "math"
 
-import github_com_cockroachdb_cockroach_pkg_roachpb "github.com/cockroachdb/cockroach/pkg/roachpb"
-
 import (
 	context "context"
 	grpc "google.golang.org/grpc"
@@ -39,7 +37,7 @@ func (m *UserLoginRequest) Reset()         { *m = UserLoginRequest{} }
 func (m *UserLoginRequest) String() string { return proto.CompactTextString(m) }
 func (*UserLoginRequest) ProtoMessage()    {}
 func (*UserLoginRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_authentication_60086026974687e4, []int{0}
+	return fileDescriptor_authentication_2bd2c74a23e120dd, []int{0}
 }
 func (m *UserLoginRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -74,7 +72,7 @@ func (m *UserLoginResponse) Reset()         { *m = UserLoginResponse{} }
 func (m *UserLoginResponse) String() string { return proto.CompactTextString(m) }
 func (*UserLoginResponse) ProtoMessage()    {}
 func (*UserLoginResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_authentication_60086026974687e4, []int{1}
+	return fileDescriptor_authentication_2bd2c74a23e120dd, []int{1}
 }
 func (m *UserLoginResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -109,7 +107,7 @@ func (m *UserLogoutRequest) Reset()         { *m = UserLogoutRequest{} }
 func (m *UserLogoutRequest) String() string { return proto.CompactTextString(m) }
 func (*UserLogoutRequest) ProtoMessage()    {}
 func (*UserLogoutRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_authentication_60086026974687e4, []int{2}
+	return fileDescriptor_authentication_2bd2c74a23e120dd, []int{2}
 }
 func (m *UserLogoutRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -141,7 +139,7 @@ func (m *UserLogoutResponse) Reset()         { *m = UserLogoutResponse{} }
 func (m *UserLogoutResponse) String() string { return proto.CompactTextString(m) }
 func (*UserLogoutResponse) ProtoMessage()    {}
 func (*UserLogoutResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_authentication_60086026974687e4, []int{3}
+	return fileDescriptor_authentication_2bd2c74a23e120dd, []int{3}
 }
 func (m *UserLogoutResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -179,7 +177,7 @@ func (m *SessionCookie) Reset()         { *m = SessionCookie{} }
 func (m *SessionCookie) String() string { return proto.CompactTextString(m) }
 func (*SessionCookie) ProtoMessage()    {}
 func (*SessionCookie) Descriptor() ([]byte, []int) {
-	return fileDescriptor_authentication_60086026974687e4, []int{4}
+	return fileDescriptor_authentication_2bd2c74a23e120dd, []int{4}
 }
 func (m *SessionCookie) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -208,17 +206,17 @@ var xxx_messageInfo_SessionCookie proto.InternalMessageInfo
 // when the identity provider triggers our callback, it returns the same state message back to
 // us so that we can ensure that we're only processing responses that we originated.
 type OIDCState struct {
-	// ID of node that originated the OIDC session.
-	NodeID github_com_cockroachdb_cockroach_pkg_roachpb.NodeID `protobuf:"varint,1,opt,name=node_id,json=nodeId,proto3,casttype=github.com/cockroachdb/cockroach/pkg/roachpb.NodeID" json:"node_id,omitempty"`
-	// Random bytes that the originating node stores to validate the callback response.
-	Secret []byte `protobuf:"bytes,2,opt,name=secret,proto3" json:"secret,omitempty"`
+	// token is a random string that is sent over to the auth provider to be returned back
+	Token []byte `protobuf:"bytes,3,opt,name=token,proto3" json:"token,omitempty"`
+	// tokenMAC is an HMAC hash of the random `token` string using the client-side cookie as a key
+	TokenMAC []byte `protobuf:"bytes,4,opt,name=tokenMAC,proto3" json:"tokenMAC,omitempty"`
 }
 
 func (m *OIDCState) Reset()         { *m = OIDCState{} }
 func (m *OIDCState) String() string { return proto.CompactTextString(m) }
 func (*OIDCState) ProtoMessage()    {}
 func (*OIDCState) Descriptor() ([]byte, []int) {
-	return fileDescriptor_authentication_60086026974687e4, []int{5}
+	return fileDescriptor_authentication_2bd2c74a23e120dd, []int{5}
 }
 func (m *OIDCState) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -243,79 +241,6 @@ func (m *OIDCState) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_OIDCState proto.InternalMessageInfo
 
-// ValidateOIDCStateRequest is a message that one node sends to another to request
-// a state validation. When an OIDC identity provider triggers our callback URL it
-// sends back a serialized OIDCState (defined above). If the NodeID in that state
-// does not match the node we're processing the callback with, we will request a
-// validation from the appropriate node using this message.
-type ValidateOIDCStateRequest struct {
-	State *OIDCState `protobuf:"bytes,1,opt,name=state,proto3" json:"state,omitempty"`
-}
-
-func (m *ValidateOIDCStateRequest) Reset()         { *m = ValidateOIDCStateRequest{} }
-func (m *ValidateOIDCStateRequest) String() string { return proto.CompactTextString(m) }
-func (*ValidateOIDCStateRequest) ProtoMessage()    {}
-func (*ValidateOIDCStateRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_authentication_60086026974687e4, []int{6}
-}
-func (m *ValidateOIDCStateRequest) XXX_Unmarshal(b []byte) error {
-	return m.Unmarshal(b)
-}
-func (m *ValidateOIDCStateRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	b = b[:cap(b)]
-	n, err := m.MarshalTo(b)
-	if err != nil {
-		return nil, err
-	}
-	return b[:n], nil
-}
-func (dst *ValidateOIDCStateRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ValidateOIDCStateRequest.Merge(dst, src)
-}
-func (m *ValidateOIDCStateRequest) XXX_Size() int {
-	return m.Size()
-}
-func (m *ValidateOIDCStateRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_ValidateOIDCStateRequest.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_ValidateOIDCStateRequest proto.InternalMessageInfo
-
-// ValidateOIDCStateResponse simply tells us if a given state was considered valid
-// by the node. It will usually result in that state being cleared from the node's
-// cache and discarded to prevent reuse.
-type ValidateOIDCStateResponse struct {
-}
-
-func (m *ValidateOIDCStateResponse) Reset()         { *m = ValidateOIDCStateResponse{} }
-func (m *ValidateOIDCStateResponse) String() string { return proto.CompactTextString(m) }
-func (*ValidateOIDCStateResponse) ProtoMessage()    {}
-func (*ValidateOIDCStateResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_authentication_60086026974687e4, []int{7}
-}
-func (m *ValidateOIDCStateResponse) XXX_Unmarshal(b []byte) error {
-	return m.Unmarshal(b)
-}
-func (m *ValidateOIDCStateResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	b = b[:cap(b)]
-	n, err := m.MarshalTo(b)
-	if err != nil {
-		return nil, err
-	}
-	return b[:n], nil
-}
-func (dst *ValidateOIDCStateResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ValidateOIDCStateResponse.Merge(dst, src)
-}
-func (m *ValidateOIDCStateResponse) XXX_Size() int {
-	return m.Size()
-}
-func (m *ValidateOIDCStateResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_ValidateOIDCStateResponse.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_ValidateOIDCStateResponse proto.InternalMessageInfo
-
 func init() {
 	proto.RegisterType((*UserLoginRequest)(nil), "cockroach.server.serverpb.UserLoginRequest")
 	proto.RegisterType((*UserLoginResponse)(nil), "cockroach.server.serverpb.UserLoginResponse")
@@ -323,8 +248,6 @@ func init() {
 	proto.RegisterType((*UserLogoutResponse)(nil), "cockroach.server.serverpb.UserLogoutResponse")
 	proto.RegisterType((*SessionCookie)(nil), "cockroach.server.serverpb.SessionCookie")
 	proto.RegisterType((*OIDCState)(nil), "cockroach.server.serverpb.OIDCState")
-	proto.RegisterType((*ValidateOIDCStateRequest)(nil), "cockroach.server.serverpb.ValidateOIDCStateRequest")
-	proto.RegisterType((*ValidateOIDCStateResponse)(nil), "cockroach.server.serverpb.ValidateOIDCStateResponse")
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -341,13 +264,6 @@ const _ = grpc.SupportPackageIsVersion4
 type LogInClient interface {
 	// UserLogin is used to create a web authentication session.
 	UserLogin(ctx context.Context, in *UserLoginRequest, opts ...grpc.CallOption) (*UserLoginResponse, error)
-	// ValidateOIDCState is used for nodes to validate OIDC state that another node
-	// may have cached since auth requests can originate and be completed at any
-	// node in the cluster.
-	//
-	// This endpoint does not have an HTTP API since we only intend to use it for
-	// inter-node communication.
-	ValidateOIDCState(ctx context.Context, in *ValidateOIDCStateRequest, opts ...grpc.CallOption) (*ValidateOIDCStateResponse, error)
 }
 
 type logInClient struct {
@@ -367,26 +283,10 @@ func (c *logInClient) UserLogin(ctx context.Context, in *UserLoginRequest, opts 
 	return out, nil
 }
 
-func (c *logInClient) ValidateOIDCState(ctx context.Context, in *ValidateOIDCStateRequest, opts ...grpc.CallOption) (*ValidateOIDCStateResponse, error) {
-	out := new(ValidateOIDCStateResponse)
-	err := c.cc.Invoke(ctx, "/cockroach.server.serverpb.LogIn/ValidateOIDCState", in, out, opts...)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
-}
-
 // LogInServer is the server API for LogIn service.
 type LogInServer interface {
 	// UserLogin is used to create a web authentication session.
 	UserLogin(context.Context, *UserLoginRequest) (*UserLoginResponse, error)
-	// ValidateOIDCState is used for nodes to validate OIDC state that another node
-	// may have cached since auth requests can originate and be completed at any
-	// node in the cluster.
-	//
-	// This endpoint does not have an HTTP API since we only intend to use it for
-	// inter-node communication.
-	ValidateOIDCState(context.Context, *ValidateOIDCStateRequest) (*ValidateOIDCStateResponse, error)
 }
 
 func RegisterLogInServer(s *grpc.Server, srv LogInServer) {
@@ -411,24 +311,6 @@ func _LogIn_UserLogin_Handler(srv interface{}, ctx context.Context, dec func(int
 	return interceptor(ctx, in, info, handler)
 }
 
-func _LogIn_ValidateOIDCState_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(ValidateOIDCStateRequest)
-	if err := dec(in); err != nil {
-		return nil, err
-	}
-	if interceptor == nil {
-		return srv.(LogInServer).ValidateOIDCState(ctx, in)
-	}
-	info := &grpc.UnaryServerInfo{
-		Server:     srv,
-		FullMethod: "/cockroach.server.serverpb.LogIn/ValidateOIDCState",
-	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(LogInServer).ValidateOIDCState(ctx, req.(*ValidateOIDCStateRequest))
-	}
-	return interceptor(ctx, in, info, handler)
-}
-
 var _LogIn_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "cockroach.server.serverpb.LogIn",
 	HandlerType: (*LogInServer)(nil),
@@ -436,10 +318,6 @@ var _LogIn_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "UserLogin",
 			Handler:    _LogIn_UserLogin_Handler,
-		},
-		{
-			MethodName: "ValidateOIDCState",
-			Handler:    _LogIn_ValidateOIDCState_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
@@ -640,63 +518,18 @@ func (m *OIDCState) MarshalTo(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
-	if m.NodeID != 0 {
-		dAtA[i] = 0x8
+	if len(m.Token) > 0 {
+		dAtA[i] = 0x1a
 		i++
-		i = encodeVarintAuthentication(dAtA, i, uint64(m.NodeID))
+		i = encodeVarintAuthentication(dAtA, i, uint64(len(m.Token)))
+		i += copy(dAtA[i:], m.Token)
 	}
-	if len(m.Secret) > 0 {
-		dAtA[i] = 0x12
+	if len(m.TokenMAC) > 0 {
+		dAtA[i] = 0x22
 		i++
-		i = encodeVarintAuthentication(dAtA, i, uint64(len(m.Secret)))
-		i += copy(dAtA[i:], m.Secret)
+		i = encodeVarintAuthentication(dAtA, i, uint64(len(m.TokenMAC)))
+		i += copy(dAtA[i:], m.TokenMAC)
 	}
-	return i, nil
-}
-
-func (m *ValidateOIDCStateRequest) Marshal() (dAtA []byte, err error) {
-	size := m.Size()
-	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
-	if err != nil {
-		return nil, err
-	}
-	return dAtA[:n], nil
-}
-
-func (m *ValidateOIDCStateRequest) MarshalTo(dAtA []byte) (int, error) {
-	var i int
-	_ = i
-	var l int
-	_ = l
-	if m.State != nil {
-		dAtA[i] = 0xa
-		i++
-		i = encodeVarintAuthentication(dAtA, i, uint64(m.State.Size()))
-		n1, err := m.State.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n1
-	}
-	return i, nil
-}
-
-func (m *ValidateOIDCStateResponse) Marshal() (dAtA []byte, err error) {
-	size := m.Size()
-	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
-	if err != nil {
-		return nil, err
-	}
-	return dAtA[:n], nil
-}
-
-func (m *ValidateOIDCStateResponse) MarshalTo(dAtA []byte) (int, error) {
-	var i int
-	_ = i
-	var l int
-	_ = l
 	return i, nil
 }
 
@@ -775,35 +608,14 @@ func (m *OIDCState) Size() (n int) {
 	}
 	var l int
 	_ = l
-	if m.NodeID != 0 {
-		n += 1 + sovAuthentication(uint64(m.NodeID))
-	}
-	l = len(m.Secret)
+	l = len(m.Token)
 	if l > 0 {
 		n += 1 + l + sovAuthentication(uint64(l))
 	}
-	return n
-}
-
-func (m *ValidateOIDCStateRequest) Size() (n int) {
-	if m == nil {
-		return 0
-	}
-	var l int
-	_ = l
-	if m.State != nil {
-		l = m.State.Size()
+	l = len(m.TokenMAC)
+	if l > 0 {
 		n += 1 + l + sovAuthentication(uint64(l))
 	}
-	return n
-}
-
-func (m *ValidateOIDCStateResponse) Size() (n int) {
-	if m == nil {
-		return 0
-	}
-	var l int
-	_ = l
 	return n
 }
 
@@ -1207,28 +1019,9 @@ func (m *OIDCState) Unmarshal(dAtA []byte) error {
 			return fmt.Errorf("proto: OIDCState: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
-		case 1:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field NodeID", wireType)
-			}
-			m.NodeID = 0
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowAuthentication
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				m.NodeID |= (github_com_cockroachdb_cockroach_pkg_roachpb.NodeID(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-		case 2:
+		case 3:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Secret", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field Token", wireType)
 			}
 			var byteLen int
 			for shift := uint(0); ; shift += 7 {
@@ -1252,66 +1045,16 @@ func (m *OIDCState) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.Secret = append(m.Secret[:0], dAtA[iNdEx:postIndex]...)
-			if m.Secret == nil {
-				m.Secret = []byte{}
+			m.Token = append(m.Token[:0], dAtA[iNdEx:postIndex]...)
+			if m.Token == nil {
+				m.Token = []byte{}
 			}
 			iNdEx = postIndex
-		default:
-			iNdEx = preIndex
-			skippy, err := skipAuthentication(dAtA[iNdEx:])
-			if err != nil {
-				return err
-			}
-			if skippy < 0 {
-				return ErrInvalidLengthAuthentication
-			}
-			if (iNdEx + skippy) > l {
-				return io.ErrUnexpectedEOF
-			}
-			iNdEx += skippy
-		}
-	}
-
-	if iNdEx > l {
-		return io.ErrUnexpectedEOF
-	}
-	return nil
-}
-func (m *ValidateOIDCStateRequest) Unmarshal(dAtA []byte) error {
-	l := len(dAtA)
-	iNdEx := 0
-	for iNdEx < l {
-		preIndex := iNdEx
-		var wire uint64
-		for shift := uint(0); ; shift += 7 {
-			if shift >= 64 {
-				return ErrIntOverflowAuthentication
-			}
-			if iNdEx >= l {
-				return io.ErrUnexpectedEOF
-			}
-			b := dAtA[iNdEx]
-			iNdEx++
-			wire |= (uint64(b) & 0x7F) << shift
-			if b < 0x80 {
-				break
-			}
-		}
-		fieldNum := int32(wire >> 3)
-		wireType := int(wire & 0x7)
-		if wireType == 4 {
-			return fmt.Errorf("proto: ValidateOIDCStateRequest: wiretype end group for non-group")
-		}
-		if fieldNum <= 0 {
-			return fmt.Errorf("proto: ValidateOIDCStateRequest: illegal tag %d (wire type %d)", fieldNum, wire)
-		}
-		switch fieldNum {
-		case 1:
+		case 4:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field State", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field TokenMAC", wireType)
 			}
-			var msglen int
+			var byteLen int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
 					return ErrIntOverflowAuthentication
@@ -1321,75 +1064,23 @@ func (m *ValidateOIDCStateRequest) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				msglen |= (int(b) & 0x7F) << shift
+				byteLen |= (int(b) & 0x7F) << shift
 				if b < 0x80 {
 					break
 				}
 			}
-			if msglen < 0 {
+			if byteLen < 0 {
 				return ErrInvalidLengthAuthentication
 			}
-			postIndex := iNdEx + msglen
+			postIndex := iNdEx + byteLen
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.State == nil {
-				m.State = &OIDCState{}
-			}
-			if err := m.State.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
-				return err
+			m.TokenMAC = append(m.TokenMAC[:0], dAtA[iNdEx:postIndex]...)
+			if m.TokenMAC == nil {
+				m.TokenMAC = []byte{}
 			}
 			iNdEx = postIndex
-		default:
-			iNdEx = preIndex
-			skippy, err := skipAuthentication(dAtA[iNdEx:])
-			if err != nil {
-				return err
-			}
-			if skippy < 0 {
-				return ErrInvalidLengthAuthentication
-			}
-			if (iNdEx + skippy) > l {
-				return io.ErrUnexpectedEOF
-			}
-			iNdEx += skippy
-		}
-	}
-
-	if iNdEx > l {
-		return io.ErrUnexpectedEOF
-	}
-	return nil
-}
-func (m *ValidateOIDCStateResponse) Unmarshal(dAtA []byte) error {
-	l := len(dAtA)
-	iNdEx := 0
-	for iNdEx < l {
-		preIndex := iNdEx
-		var wire uint64
-		for shift := uint(0); ; shift += 7 {
-			if shift >= 64 {
-				return ErrIntOverflowAuthentication
-			}
-			if iNdEx >= l {
-				return io.ErrUnexpectedEOF
-			}
-			b := dAtA[iNdEx]
-			iNdEx++
-			wire |= (uint64(b) & 0x7F) << shift
-			if b < 0x80 {
-				break
-			}
-		}
-		fieldNum := int32(wire >> 3)
-		wireType := int(wire & 0x7)
-		if wireType == 4 {
-			return fmt.Errorf("proto: ValidateOIDCStateResponse: wiretype end group for non-group")
-		}
-		if fieldNum <= 0 {
-			return fmt.Errorf("proto: ValidateOIDCStateResponse: illegal tag %d (wire type %d)", fieldNum, wire)
-		}
-		switch fieldNum {
 		default:
 			iNdEx = preIndex
 			skippy, err := skipAuthentication(dAtA[iNdEx:])
@@ -1517,41 +1208,36 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("server/serverpb/authentication.proto", fileDescriptor_authentication_60086026974687e4)
+	proto.RegisterFile("server/serverpb/authentication.proto", fileDescriptor_authentication_2bd2c74a23e120dd)
 }
 
-var fileDescriptor_authentication_60086026974687e4 = []byte{
-	// 504 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x94, 0x53, 0x4d, 0x6f, 0xd3, 0x40,
-	0x10, 0x8d, 0x8d, 0xe2, 0x36, 0x53, 0x10, 0x64, 0xa9, 0xaa, 0xd4, 0x20, 0x07, 0x59, 0x3d, 0xa0,
-	0x02, 0xb6, 0x94, 0x70, 0xea, 0x05, 0x91, 0xe6, 0x12, 0x14, 0x51, 0x29, 0x15, 0x3d, 0xf4, 0x82,
-	0xd6, 0xf6, 0xca, 0x59, 0x25, 0xdd, 0x31, 0xde, 0x35, 0x08, 0x2e, 0x20, 0x04, 0x77, 0x24, 0xfe,
-	0x54, 0x8f, 0x95, 0xb8, 0xf4, 0x14, 0x81, 0xc3, 0xaf, 0xe0, 0x84, 0xfc, 0x91, 0x0f, 0x01, 0xa9,
-	0xc2, 0x29, 0xf3, 0xf1, 0xe6, 0xcd, 0xcb, 0x9b, 0x35, 0xec, 0x49, 0x16, 0xbf, 0x66, 0xb1, 0x5b,
-	0xfc, 0x44, 0x9e, 0x4b, 0x13, 0x35, 0x64, 0x42, 0x71, 0x9f, 0x2a, 0x8e, 0xc2, 0x89, 0x62, 0x54,
-	0x48, 0x76, 0x7d, 0xf4, 0x47, 0x31, 0x52, 0x7f, 0xe8, 0x14, 0x40, 0x67, 0x86, 0x37, 0xb7, 0x43,
-	0x0c, 0x31, 0x47, 0xb9, 0x59, 0x54, 0x0c, 0x98, 0x77, 0x43, 0xc4, 0x70, 0xcc, 0x5c, 0x1a, 0x71,
-	0x97, 0x0a, 0x81, 0x2a, 0x67, 0x93, 0x45, 0xd7, 0x7e, 0x06, 0xb7, 0x5e, 0x48, 0x16, 0xf7, 0x31,
-	0xe4, 0x62, 0xc0, 0x5e, 0x25, 0x4c, 0x2a, 0x62, 0xc2, 0x66, 0x22, 0x59, 0x2c, 0xe8, 0x19, 0x6b,
-	0x68, 0xf7, 0xb4, 0xfb, 0xb5, 0xc1, 0x3c, 0xcf, 0x7a, 0x11, 0x95, 0xf2, 0x0d, 0xc6, 0x41, 0x43,
-	0x2f, 0x7a, 0xb3, 0xdc, 0xbe, 0x0d, 0xf5, 0x25, 0x2e, 0x19, 0xa1, 0x90, 0x6c, 0xa9, 0x88, 0x89,
-	0x2a, 0x37, 0xd8, 0xdb, 0x40, 0x96, 0x8b, 0x25, 0xf4, 0x09, 0xdc, 0x38, 0x66, 0x52, 0x72, 0x14,
-	0x87, 0x88, 0x23, 0xce, 0xc8, 0x0e, 0xe8, 0x3c, 0xc8, 0x25, 0x5c, 0xeb, 0x18, 0xe9, 0xa4, 0xa9,
-	0xf7, 0xba, 0x03, 0x9d, 0x07, 0x64, 0x07, 0x0c, 0xc9, 0xfc, 0x98, 0xa9, 0x5c, 0xc2, 0xf5, 0x41,
-	0x99, 0xd9, 0xef, 0xa1, 0x76, 0xd4, 0xeb, 0x1e, 0x1e, 0x2b, 0xaa, 0x18, 0x39, 0x85, 0x0d, 0x81,
-	0x01, 0x7b, 0x59, 0x32, 0x54, 0x3b, 0x4f, 0xd3, 0x49, 0xd3, 0x78, 0x8e, 0x01, 0xeb, 0x75, 0x7f,
-	0x4d, 0x9a, 0xed, 0x90, 0xab, 0x61, 0xe2, 0x39, 0x3e, 0x9e, 0xb9, 0x73, 0x4b, 0x03, 0x6f, 0x11,
-	0xbb, 0xd1, 0x28, 0x74, 0xf3, 0x28, 0xf2, 0x9c, 0x62, 0x6c, 0x60, 0x64, 0x8c, 0xbd, 0xd5, 0x02,
-	0x4e, 0xa0, 0x71, 0x42, 0xc7, 0x3c, 0xa0, 0x8a, 0xcd, 0x85, 0xcc, 0x5c, 0x3d, 0x80, 0xaa, 0xcc,
-	0xf2, 0x5c, 0xcd, 0x56, 0x6b, 0xcf, 0x59, 0x79, 0x48, 0x67, 0x31, 0x5b, 0x8c, 0xd8, 0x77, 0x60,
-	0xf7, 0x1f, 0xbc, 0x85, 0x6d, 0xad, 0xcf, 0x3a, 0x54, 0xfb, 0x18, 0xf6, 0x04, 0x79, 0x0b, 0xb5,
-	0xf9, 0x01, 0xc8, 0x83, 0x2b, 0x16, 0xfc, 0x79, 0x72, 0xf3, 0xe1, 0x7a, 0xe0, 0xf2, 0x50, 0xf5,
-	0x8f, 0xdf, 0x7e, 0x7e, 0xd5, 0xb7, 0x6c, 0xc3, 0x1d, 0x67, 0xf5, 0x03, 0x6d, 0x9f, 0x7c, 0xd0,
-	0xa0, 0xfe, 0x97, 0x44, 0xd2, 0xbe, 0x82, 0x76, 0x95, 0x51, 0xe6, 0xe3, 0xff, 0x1b, 0x2a, 0x35,
-	0x55, 0x5a, 0x9f, 0x34, 0x30, 0xfa, 0x18, 0x1e, 0x25, 0x8a, 0xbc, 0x03, 0x58, 0xbc, 0x2f, 0xb2,
-	0xc6, 0x9f, 0x5b, 0xbc, 0x4d, 0xf3, 0xd1, 0x9a, 0xe8, 0x72, 0xef, 0xcd, 0xdc, 0x8b, 0x1a, 0xd9,
-	0xc8, 0xbc, 0xc0, 0x44, 0x75, 0xf6, 0xcf, 0x7f, 0x58, 0x95, 0xf3, 0xd4, 0xd2, 0x2e, 0x52, 0x4b,
-	0xbb, 0x4c, 0x2d, 0xed, 0x7b, 0x6a, 0x69, 0x5f, 0xa6, 0x56, 0xe5, 0x62, 0x6a, 0x55, 0x2e, 0xa7,
-	0x56, 0xe5, 0x74, 0x73, 0xc6, 0xe7, 0x19, 0xf9, 0x47, 0xd8, 0xfe, 0x1d, 0x00, 0x00, 0xff, 0xff,
-	0x40, 0x9f, 0xd2, 0xb7, 0xfb, 0x03, 0x00, 0x00,
+var fileDescriptor_authentication_2bd2c74a23e120dd = []byte{
+	// 421 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x52, 0xcf, 0x6b, 0xd4, 0x40,
+	0x18, 0xdd, 0xc9, 0x6e, 0xe3, 0xee, 0xa8, 0xb8, 0x1d, 0x97, 0xb2, 0x06, 0x19, 0x25, 0x78, 0x90,
+	0xaa, 0x09, 0xd4, 0x9b, 0x17, 0xb1, 0xdb, 0xcb, 0x2e, 0x2b, 0x85, 0x14, 0x2f, 0xde, 0xa6, 0xd9,
+	0x8f, 0x74, 0xd8, 0x3a, 0x5f, 0x9c, 0x99, 0x28, 0x7a, 0x2c, 0xfe, 0x01, 0x82, 0xff, 0x54, 0x8f,
+	0x05, 0x2f, 0x3d, 0x89, 0x66, 0xfd, 0x43, 0x24, 0x93, 0xec, 0x0f, 0x84, 0xc2, 0x9e, 0xf2, 0xbd,
+	0xef, 0xbd, 0xbc, 0xbc, 0xef, 0x11, 0xfa, 0xc4, 0x80, 0xfe, 0x04, 0x3a, 0xae, 0x1f, 0xf9, 0x69,
+	0x2c, 0x0a, 0x7b, 0x06, 0xca, 0xca, 0x54, 0x58, 0x89, 0x2a, 0xca, 0x35, 0x5a, 0x64, 0x0f, 0x52,
+	0x4c, 0xe7, 0x1a, 0x45, 0x7a, 0x16, 0xd5, 0xc2, 0x68, 0xa9, 0x0f, 0x06, 0x19, 0x66, 0xe8, 0x54,
+	0x71, 0x35, 0xd5, 0x2f, 0x04, 0x0f, 0x33, 0xc4, 0xec, 0x1c, 0x62, 0x91, 0xcb, 0x58, 0x28, 0x85,
+	0xd6, 0xb9, 0x99, 0x9a, 0x0d, 0x27, 0xb4, 0xff, 0xce, 0x80, 0x9e, 0x62, 0x26, 0x55, 0x02, 0x1f,
+	0x0b, 0x30, 0x96, 0x05, 0xb4, 0x5b, 0x18, 0xd0, 0x4a, 0x7c, 0x80, 0x21, 0x79, 0x4c, 0x9e, 0xf6,
+	0x92, 0x15, 0xae, 0xb8, 0x5c, 0x18, 0xf3, 0x19, 0xf5, 0x6c, 0xe8, 0xd5, 0xdc, 0x12, 0x87, 0xf7,
+	0xe9, 0xee, 0x86, 0x97, 0xc9, 0x51, 0x19, 0xd8, 0x58, 0x62, 0x61, 0x9b, 0x2f, 0x84, 0x03, 0xca,
+	0x36, 0x97, 0x8d, 0xf4, 0x35, 0xbd, 0x7b, 0x02, 0xc6, 0x48, 0x54, 0x23, 0xc4, 0xb9, 0x04, 0xb6,
+	0x47, 0x3d, 0x39, 0x73, 0x11, 0xda, 0x87, 0x7e, 0xf9, 0xeb, 0x91, 0x37, 0x3e, 0x4a, 0x3c, 0x39,
+	0x63, 0x7b, 0xd4, 0x37, 0x90, 0x6a, 0xb0, 0x2e, 0xc2, 0x9d, 0xa4, 0x41, 0xe1, 0x98, 0xf6, 0x8e,
+	0xc7, 0x47, 0xa3, 0x13, 0x2b, 0x2c, 0xb0, 0x01, 0xdd, 0xb1, 0x38, 0x07, 0x35, 0x6c, 0x3b, 0x4d,
+	0x0d, 0xaa, 0xfc, 0x6e, 0x78, 0xfb, 0x66, 0x34, 0xec, 0x38, 0x62, 0x85, 0x27, 0x9d, 0x2e, 0xe9,
+	0x7b, 0x93, 0x4e, 0xd7, 0xeb, 0xb7, 0x0f, 0x2e, 0x08, 0xdd, 0x99, 0x62, 0x36, 0x56, 0xec, 0x0b,
+	0xed, 0xad, 0xae, 0x62, 0xcf, 0xa2, 0x1b, 0xeb, 0x8f, 0xfe, 0xef, 0x31, 0x78, 0xbe, 0x9d, 0xb8,
+	0xb9, 0x7e, 0xf7, 0xe2, 0xe7, 0xdf, 0x1f, 0xde, 0xed, 0xd0, 0x8f, 0xcf, 0xab, 0xfd, 0x2b, 0xb2,
+	0x7f, 0xf0, 0x8d, 0x50, 0x7f, 0x8a, 0xd9, 0x71, 0x61, 0xd9, 0x57, 0x4a, 0xd7, 0x8d, 0xb1, 0x2d,
+	0x9c, 0xd7, 0x6d, 0x07, 0x2f, 0xb6, 0x54, 0x37, 0x41, 0xee, 0xb9, 0x20, 0x3d, 0x76, 0xab, 0x0a,
+	0x82, 0x85, 0x3d, 0xdc, 0xbf, 0xfc, 0xc3, 0x5b, 0x97, 0x25, 0x27, 0x57, 0x25, 0x27, 0xd7, 0x25,
+	0x27, 0xbf, 0x4b, 0x4e, 0xbe, 0x2f, 0x78, 0xeb, 0x6a, 0xc1, 0x5b, 0xd7, 0x0b, 0xde, 0x7a, 0xdf,
+	0x5d, 0xfa, 0x9d, 0xfa, 0xee, 0xb7, 0x7a, 0xf9, 0x2f, 0x00, 0x00, 0xff, 0xff, 0xab, 0x03, 0xf7,
+	0x60, 0xcd, 0x02, 0x00, 0x00,
 }

--- a/pkg/server/serverpb/authentication.proto
+++ b/pkg/server/serverpb/authentication.proto
@@ -54,29 +54,13 @@ message SessionCookie {
 // when the identity provider triggers our callback, it returns the same state message back to
 // us so that we can ensure that we're only processing responses that we originated.
 message OIDCState {
-	// ID of node that originated the OIDC session.
-	int32 node_id = 1 [
-		(gogoproto.customname) = "NodeID",
-		(gogoproto.casttype) =
-			"github.com/cockroachdb/cockroach/pkg/roachpb.NodeID"
-	];
-	// Random bytes that the originating node stores to validate the callback response.
-	bytes secret = 2;
+	reserved 1;
+	reserved 2;
+	// token is a random string that is sent over to the auth provider to be returned back
+	bytes token = 3;
+	// tokenMAC is an HMAC hash of the random `token` string using the client-side cookie as a key
+	bytes tokenMAC = 4;
 }
-
-// ValidateOIDCStateRequest is a message that one node sends to another to request
-// a state validation. When an OIDC identity provider triggers our callback URL it
-// sends back a serialized OIDCState (defined above). If the NodeID in that state
-// does not match the node we're processing the callback with, we will request a
-// validation from the appropriate node using this message.
-message ValidateOIDCStateRequest {
-	OIDCState state = 1;
-}
-
-// ValidateOIDCStateResponse simply tells us if a given state was considered valid
-// by the node. It will usually result in that state being cleared from the node's
-// cache and discarded to prevent reuse.
-message ValidateOIDCStateResponse {}
 
 // LogIn and LogOut are the GRPC APIs used to create web authentication sessions.
 // Intended for use over GRPC-Gateway, which identifies sessions using HTTP
@@ -93,14 +77,6 @@ service LogIn {
 			body: "*"
 		};
 	}
-
-	// ValidateOIDCState is used for nodes to validate OIDC state that another node
-	// may have cached since auth requests can originate and be completed at any
-	// node in the cluster.
-	//
-	// This endpoint does not have an HTTP API since we only intend to use it for
-	// inter-node communication.
-	rpc ValidateOIDCState(ValidateOIDCStateRequest) returns (ValidateOIDCStateResponse) {}
 }
 
 service LogOut {


### PR DESCRIPTION
Backport 1/1 commits from #55556.

/cc @cockroachdb/release

---

This change replaces existing server-side state validation logic
implemented for the OIDC flow with a stateless HMAC-based state
validation.

The goal is to ensure that we process requests that we initiated,
and also to bind the user's browser session to their auth request so
that one user can't process the callback for another user's auth request.

The HMAC-based method works as follows:

1. When the auth request is triggered, we generate 2 random byte arrays:
a secret key and a token. The secret key is stored in a browser cookie
at the client. The token is hashed using HMAC with the secret key and
the resulting hash and token pair are encoded into a protobuf and sent
along to the auth provider as the `state` param.

2. When the auth callback is triggered, we receive back the same encoded
protobuf we sent over, containing the token and the HMAC hash. We then
retrieve the secret key in the client's browser cookie. Then the secret
key and token are used to reconstruct the expected hash and check it
against the one in the state protobuf we just decoded.

If the hash matches we proceed with authentication, if it does not we
immediately fail.

This change makes it possible to validate the state in the query param
against the browser cookie without any server-side state or
communication between CRDB nodes.

Since the OIDC feature is experimental, this change also removes the
state validation RPC calls and protos. A consequence of this is that a
cluster in the process of upgrading will experience malfunction of the
OIDC-based login flow if the node that initiated the auth flow and the
one that handles the callback are running different versions that use
different state validation logic.

This change is part of #54619 

Release note (security update): This change modifies the state
validation for the OIDC login flow and replaces it with a stateless hash
validation of the state parameter with the browser cookie using HMAC.
