### PR TITLE
ccl/sqlproxyccl: don't set ServerName to address

### DIFF
--- a/pkg/ccl/sqlproxyccl/proxy.go
+++ b/pkg/ccl/sqlproxyccl/proxy.go
@@ -30,7 +30,8 @@ type Options struct {
 	// allow use of SNI. Should always return ("", nil).
 	BackendFromSNI func(serverName string) (addr string, conf *tls.Config, clientErr error)
 	// BackendFromParams returns the address and TLS config to use for
-	// the proxy -> backend connection.
+	// the proxy -> backend connection. The returned config must have
+	// an appropriate ServerName for the remote backend.
 	BackendFromParams func(map[string]string) (addr string, conf *tls.Config, clientErr error)
 
 	// If set, consulted to modify the parameters set by the frontend before
@@ -142,7 +143,6 @@ func (s *Server) Proxy(conn net.Conn) error {
 	}
 
 	outCfg := outgoingTLS.Clone()
-	outCfg.ServerName = outgoingAddr
 	crdbConn = tls.Client(crdbConn, outCfg)
 
 	if s.opts.ModifyRequestParams != nil {


### PR DESCRIPTION
Previously, the sqlproxy library would set the outgoing TLSConfig's
`ServerName` field to the outgoing address. This does not work if the
TLSConfig does not set InsecureSkipVerify and the outgoing address
specifies a port.

To fix this, this commit changes the sqlproxy to use the unmodified
TLSConfig and relies on the configured `BackendFromParams` func
returning a TLSConfig with a ServerName that matches the returned
outgoing address.

Release note: none