### PR TITLE
colconv: pin bazel generated code go dependency

### DIFF
--- a/pkg/sql/colconv/BUILD.bazel
+++ b/pkg/sql/colconv/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//pkg/col/coldataext",
         "//pkg/col/typeconv",
         "//pkg/sql/colexecbase/colexecerror",
+        "//pkg/sql/execinfra",  # keep
         "//pkg/sql/rowenc",
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",


### PR DESCRIPTION
In https://github.com/cockroachdb/cockroach/commit/a266317bf17 we added a dependency on pkg/sql/execinfra for one of the generated eg.go files. We'll want to tell bazel about it so it knows to pick it up.

Release note: None