### PR TITLE
release-20.1: sql: fix panic when showing histograms on all-null columns

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -540,3 +540,51 @@ ORDER BY statistics_name, column_names::STRING
 statistics_name  column_names  row_count  distinct_count  null_count  has_histogram
 arr_stats        {rowid}       4          4               0           true
 arr_stats_x      {x}           4          3               1           false
+
+# Regression test for #56356. Histograms on all-null columns should not cause
+# an error.
+statement ok
+CREATE TABLE all_null (k INT PRIMARY KEY, c INT);
+INSERT INTO all_null VALUES (1, NULL);
+CREATE STATISTICS s FROM all_null
+
+query T
+SELECT jsonb_pretty(COALESCE(json_agg(stat), '[]'))
+  FROM (
+SELECT json_array_elements(statistics) - 'created_at' AS stat
+FROM [SHOW STATISTICS USING JSON FOR TABLE all_null]
+)
+----
+[
+    {
+        "columns": [
+            "k"
+        ],
+        "distinct_count": 1,
+        "histo_buckets": [
+            {
+                "distinct_range": 0,
+                "num_eq": 1,
+                "num_range": 0,
+                "upper_bound": "1"
+            }
+        ],
+        "histo_col_type": "INT8",
+        "name": "s",
+        "null_count": 0,
+        "row_count": 1
+    },
+    {
+        "columns": [
+            "c"
+        ],
+        "distinct_count": 1,
+        "histo_col_type": "",
+        "name": "s",
+        "null_count": 1,
+        "row_count": 1
+    }
+]
+
+statement ok
+SELECT * FROM all_null WHERE c IS NOT NULL

--- a/pkg/sql/rowexec/sample_aggregator.go
+++ b/pkg/sql/rowexec/sample_aggregator.go
@@ -435,5 +435,5 @@ func (s *sampleAggregator) generateHistogram(
 			values = append(values, ed.Datum)
 		}
 	}
-	return stats.EquiDepthHistogram(evalCtx, values, numRows, distinctCount, maxBuckets)
+	return stats.EquiDepthHistogram(evalCtx, colType, values, numRows, distinctCount, maxBuckets)
 }

--- a/pkg/sql/stats/histogram.go
+++ b/pkg/sql/stats/histogram.go
@@ -42,11 +42,15 @@ var HistogramClusterMode = settings.RegisterPublicBoolSetting(
 // known number of distinct values (distinctCount) among the buckets, in
 // proportion with the number of rows in each bucket.
 func EquiDepthHistogram(
-	evalCtx *tree.EvalContext, samples tree.Datums, numRows, distinctCount int64, maxBuckets int,
+	evalCtx *tree.EvalContext,
+	colType *types.T,
+	samples tree.Datums,
+	numRows, distinctCount int64,
+	maxBuckets int,
 ) (HistogramData, error) {
 	numSamples := len(samples)
 	if numSamples == 0 {
-		return HistogramData{}, nil
+		return HistogramData{ColumnType: *colType}, nil
 	}
 	if maxBuckets < 2 {
 		return HistogramData{}, errors.Errorf("histogram requires at least two buckets")

--- a/pkg/sql/stats/json.go
+++ b/pkg/sql/stats/json.go
@@ -87,6 +87,10 @@ func (js *JSONStatistic) DecodeAndSetHistogram(datum tree.Datum) error {
 	if datum.ResolvedType().Family() != types.BytesFamily {
 		return fmt.Errorf("histogram datum type should be Bytes")
 	}
+	if len(*datum.(*tree.DBytes)) == 0 {
+		// This can happen if every value in the column is null.
+		return nil
+	}
 	h := &HistogramData{}
 	if err := protoutil.Unmarshal([]byte(*datum.(*tree.DBytes)), h); err != nil {
 		return err


### PR DESCRIPTION
Backport 1/1 commits from #56434.

/cc @cockroachdb/release

---

Prior to this commit, attempting to view statistics for a column in which
all values were null could cause the system to panic. This was because the
histogram data was empty, and we were trying to decode an empty byte string.
This commit fixes the panic by checking if the byte string is empty before
trying to decode it, and also ensuring that the column type for the histogram
is set even if there are no buckets.

Fixes #56356

Release note (bug fix): Fixed a panic that could occur when running
`SHOW STATISTICS USING JSON` for a table in which at least one of the columns
contained all null values.
