### PR TITLE
bazel: Move third party repositories to c-deps/REPOSITORIES.bzl

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -60,6 +60,12 @@ protobuf_deps()
 load("//:DEPS.bzl", "go_deps")
 go_deps()
 
+
+# Loading c-deps third party dependencies.
+load("//c-deps:REPOSITORIES.bzl", "c_deps")
+c_deps()
+
+
 # Load the bazel utility that lets us build C/C++ projects using cmake/make/etc.
 #
 # TODO(irfansharif): Point to an upstream SHA once it picks up Oliver's changes
@@ -71,45 +77,3 @@ git_repository(
 )
 load("@rules_foreign_cc//:workspace_definitions.bzl", "rules_foreign_cc_dependencies")
 rules_foreign_cc_dependencies()
-
-# Define the repositories for each of our c-dependencies. BUILD_ALL_CONTENT is
-# a shorthand to glob over all checked-in files.
-BUILD_ALL_CONTENT = """filegroup(name = "all", srcs = glob(["**"]), visibility = ["//visibility:public"])"""
-
-# Each of these c-dependencies map to one or more library definitions in the
-# top-level BUILD.bazel. Library definitions will list the following
-# definitions as sources. For certain libraries (like `libroachccl`), the
-# repository definitions are also listed as tool dependencies. This is because
-# building those libraries require certain checked out repositories being
-# placed relative to the source tree of the library itself.
-
-new_local_repository(
-    name = "libroach",
-    path = "c-deps/libroach",
-    build_file_content = BUILD_ALL_CONTENT,
-)
-
-new_local_repository(
-  name = "proj",
-  path = "c-deps/proj",
-  build_file_content = BUILD_ALL_CONTENT,
-)
-
-# For c-deps/protobuf, we elide a checked in generated file. Already generated
-# files are read-only in the bazel sandbox, so bazel is unable to regenerate
-# the same files, which the build process requires it to do so.
-BUILD_PROTOBUF_CONTENT = """filegroup(name = "all", srcs = glob(["**"], exclude=["src/google/protobuf/compiler/js/well_known_types_embed.cc"]), visibility = ["//visibility:public"])"""
-new_local_repository(
-   name = "protobuf",
-   path = "c-deps/protobuf",
-   build_file_content = BUILD_PROTOBUF_CONTENT,
-)
-
-# This is essentially the same above, we elide a generated file to avoid
-# permission issues when building jemalloc within the bazel sandbox.
-BUILD_JEMALLOC_CONTENT = """filegroup(name = "all", srcs = glob(["**"], exclude=["configure"]), visibility = ["//visibility:public"])"""
-new_local_repository(
-  name = "jemalloc",
-  path = "c-deps/jemalloc",
-  build_file_content = BUILD_JEMALLOC_CONTENT,
-)

--- a/c-deps/REPOSITORIES.bzl
+++ b/c-deps/REPOSITORIES.bzl
@@ -1,0 +1,44 @@
+# c-deps repository definitions.
+
+# Define the repositories for each of our c-dependencies. BUILD_ALL_CONTENT is
+# a shorthand to glob over all checked-in files.
+BUILD_ALL_CONTENT = """filegroup(name = "all", srcs = glob(["**"]), visibility = ["//visibility:public"])"""
+
+# Each of these c-dependencies map to one or more library definitions in the
+# top-level BUILD.bazel. Library definitions will list the following
+# definitions as sources. For certain libraries (like `libroachccl`), the
+# repository definitions are also listed as tool dependencies. This is because
+# building those libraries require certain checked out repositories being
+# placed relative to the source tree of the library itself.
+
+# For c-deps/protobuf, we elide a checked in generated file. Already generated
+# files are read-only in the bazel sandbox, so bazel is unable to regenerate
+# the same files, which the build process requires it to do so.
+BUILD_PROTOBUF_CONTENT = """filegroup(name = "all", srcs = glob(["**"], exclude=["src/google/protobuf/compiler/js/well_known_types_embed.cc"]), visibility = ["//visibility:public"])"""
+
+# This is essentially the same above, we elide a generated file to avoid
+# permission issues when building jemalloc within the bazel sandbox.
+BUILD_JEMALLOC_CONTENT = """filegroup(name = "all", srcs = glob(["**"], exclude=["configure"]), visibility = ["//visibility:public"])"""
+
+# We do need to add native as new_local_repository is defined in Bazel core.
+def c_deps():
+    native.new_local_repository(
+        name = "libroach",
+        path = "c-deps/libroach",
+        build_file_content = BUILD_ALL_CONTENT,
+    )
+    native.new_local_repository(
+        name = "proj",
+        path = "c-deps/proj",
+        build_file_content = BUILD_ALL_CONTENT,
+    )
+    native.new_local_repository(
+        name = "protobuf",
+        path = "c-deps/protobuf",
+        build_file_content = BUILD_PROTOBUF_CONTENT,
+    )
+    native.new_local_repository(
+        name = "jemalloc",
+        path = "c-deps/jemalloc",
+        build_file_content = BUILD_JEMALLOC_CONTENT,
+    )


### PR DESCRIPTION
bazel: Move third party repositories to c-deps/REPOSITORIES.bzl

This is one of the Bazel re-factoring that we are working on
and it is about to move third party repositories out of root WORKSPACE. 
fixes #56053

Best practices is to separate external dependencies and it also
hides the repo WORKSPACE from being used by other directories.

We are creating a new .bzl file inside c-deps with all the external dependencies
and then load then inside our root WORKSPACE

Release note: None