### PR TITLE
colexec: mark encoding type as safe to print

### DIFF
--- a/docs/generated/redact_safe.md
+++ b/docs/generated/redact_safe.md
@@ -48,3 +48,4 @@ pkg/util/log/redact.go | `reflect.TypeOf(complex128(0))`
 pkg/util/log/redact.go | `reflect.TypeOf(os.Interrupt)`
 pkg/util/log/redact.go | `reflect.TypeOf(time.Time{})`
 pkg/util/log/redact.go | `reflect.TypeOf(time.Duration(0))`
+pkg/util/log/redact.go | `reflect.TypeOf(encodingtype.T(0))`

--- a/pkg/util/encoding/BUILD.bazel
+++ b/pkg/util/encoding/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//pkg/geo/geopb",
         "//pkg/util/bitarray",
         "//pkg/util/duration",
+        "//pkg/util/encoding/encodingtype",
         "//pkg/util/ipaddr",
         "//pkg/util/protoutil",
         "//pkg/util/timeofday",

--- a/pkg/util/encoding/encoding.go
+++ b/pkg/util/encoding/encoding.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
 	"github.com/cockroachdb/cockroach/pkg/util/bitarray"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding/encodingtype"
 	"github.com/cockroachdb/cockroach/pkg/util/ipaddr"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeofday"
@@ -1548,7 +1549,7 @@ func DecodeBitArrayDescending(b []byte) ([]byte, bitarray.BitArray, error) {
 // Type represents the type of a value encoded by
 // Encode{Null,NotNull,Varint,Uvarint,Float,Bytes}.
 //go:generate stringer -type=Type
-type Type int
+type Type encodingtype.T
 
 // Type values.
 // TODO(dan, arjun): Make this into a proto enum.

--- a/pkg/util/encoding/encodingtype/BUILD.bazel
+++ b/pkg/util/encoding/encodingtype/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "encodingtype",
+    srcs = ["encoding_type.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/util/encoding/encodingtype",
+    visibility = ["//visibility:public"],
+)

--- a/pkg/util/encoding/encodingtype/encoding_type.go
+++ b/pkg/util/encoding/encodingtype/encoding_type.go
@@ -1,0 +1,16 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package encodingtype
+
+// T is declared in the encodingtype package so that it can be
+// registered as always safe to report, while avoiding an import
+// cycle.
+type T int

--- a/pkg/util/log/BUILD.bazel
+++ b/pkg/util/log/BUILD.bazel
@@ -43,6 +43,7 @@ go_library(
         "//pkg/settings",
         "//pkg/util",
         "//pkg/util/caller",
+        "//pkg/util/encoding/encodingtype",
         "//pkg/util/envutil",
         "//pkg/util/fileutil",
         "//pkg/util/log/logflags",

--- a/pkg/util/log/redact.go
+++ b/pkg/util/log/redact.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/util/encoding/encodingtype"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
 	"github.com/cockroachdb/redact"
@@ -117,6 +118,8 @@ func init() {
 	// Times and durations too.
 	redact.RegisterSafeType(reflect.TypeOf(time.Time{}))
 	redact.RegisterSafeType(reflect.TypeOf(time.Duration(0)))
+	// Encoded types should always be safe to report.
+	redact.RegisterSafeType(reflect.TypeOf(encodingtype.T(0)))
 }
 
 type redactablePackage struct {


### PR DESCRIPTION
This commit marks Type, which represents the type of an
encoded value, as safe to print so that in error messages
the encoding type is not redacted.

Fixes: #56225

Release note: None