### PR TITLE
backupccl: add feature flag support for BACKUP, RESTORE

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -13,6 +13,8 @@
 <tr><td><code>enterprise.license</code></td><td>string</td><td><code></code></td><td>the encoded cluster license</td></tr>
 <tr><td><code>external.graphite.endpoint</code></td><td>string</td><td><code></code></td><td>if nonempty, push server metrics to the Graphite or Carbon server at the specified host:port</td></tr>
 <tr><td><code>external.graphite.interval</code></td><td>duration</td><td><code>10s</code></td><td>the interval at which metrics are pushed to Graphite (if enabled)</td></tr>
+<tr><td><code>feature.backup.enabled</code></td><td>boolean</td><td><code>true</code></td><td>set to true to enable backups, false to disable; default is true</td></tr>
+<tr><td><code>feature.restore.enabled</code></td><td>boolean</td><td><code>true</code></td><td>set to true to enable restore, false to disable; default is true</td></tr>
 <tr><td><code>jobs.retention_time</code></td><td>duration</td><td><code>336h0m0s</code></td><td>the amount of time to retain records for completed jobs before</td></tr>
 <tr><td><code>kv.allocator.load_based_lease_rebalancing.enabled</code></td><td>boolean</td><td><code>true</code></td><td>set to enable rebalancing of range leases based on load and latency</td></tr>
 <tr><td><code>kv.allocator.load_based_rebalancing</code></td><td>enumeration</td><td><code>leases and replicas</code></td><td>whether to rebalance based on the distribution of QPS across stores [off = 0, leases = 1, leases and replicas = 2]</td></tr>

--- a/pkg/ccl/backupccl/BUILD.bazel
+++ b/pkg/ccl/backupccl/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "//pkg/ccl/storageccl",
         "//pkg/ccl/utilccl",
         "//pkg/clusterversion",
+        "//pkg/featureflag",
         "//pkg/gossip",
         "//pkg/jobs",
         "//pkg/jobs/jobspb",

--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
+	"github.com/cockroachdb/cockroach/pkg/featureflag"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobsprotectedts"
@@ -27,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
@@ -78,6 +80,12 @@ type backupKMSEnv struct {
 }
 
 var _ cloud.KMSEnv = &backupKMSEnv{}
+
+// featureBackupEnabled is used to enable and disable the BACKUP feature.
+var featureBackupEnabled = settings.RegisterPublicBoolSetting(
+	"feature.backup.enabled",
+	"set to true to enable backups, false to disable; default is true",
+	featureflag.FeatureFlagEnabledDefault)
 
 func (p *backupKMSEnv) ClusterSettings() *cluster.Settings {
 	return p.settings
@@ -499,6 +507,12 @@ func backupPlanHook(
 	backupStmt := getBackupStatement(stmt)
 	if backupStmt == nil {
 		return nil, nil, nil, false, nil
+	}
+
+	// Check whether feature backup is enabled or not.
+	if !featureBackupEnabled.Get(&p.ExecCfg().Settings.SV) {
+		return nil, nil, nil, false,
+			pgerror.Newf(pgcode.OperatorIntervention, "BACKUP feature was disabled by the database administrator")
 	}
 
 	var err error

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -17,12 +17,14 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/featureflag"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkeys"
@@ -67,6 +69,12 @@ const (
 	// cluster backups.
 	restoreTempSystemDB = "crdb_temp_system"
 )
+
+// featureRestoreEnabled is used to enable and disable the RESTORE feature.
+var featureRestoreEnabled = settings.RegisterPublicBoolSetting(
+	"feature.restore.enabled",
+	"set to true to enable restore, false to disable; default is true",
+	featureflag.FeatureFlagEnabledDefault)
 
 // rewriteViewQueryDBNames rewrites the passed table's ViewQuery replacing all
 // non-empty db qualifiers with `newDB`.
@@ -1174,6 +1182,12 @@ func restorePlanHook(
 	restoreStmt, ok := stmt.(*tree.Restore)
 	if !ok {
 		return nil, nil, nil, false, nil
+	}
+
+	// Check whether feature restore is enabled or not.
+	if !featureRestoreEnabled.Get(&p.ExecCfg().Settings.SV) {
+		return nil, nil, nil, false,
+			pgerror.Newf(pgcode.OperatorIntervention, "RESTORE feature was disabled by the database administrator")
 	}
 
 	fromFns := make([]func() ([]string, error), len(restoreStmt.From))

--- a/pkg/ccl/backupccl/testdata/backup-restore/feature-flags
+++ b/pkg/ccl/backupccl/testdata/backup-restore/feature-flags
@@ -1,0 +1,38 @@
+new-server name=s1
+----
+
+exec-sql
+CREATE DATABASE d;
+CREATE TABLE d.t (x INT);
+INSERT INTO d.t VALUES (1), (2), (3);
+----
+
+# Test running backup when BACKUP feature flag is disabled.
+exec-sql
+SET CLUSTER SETTING feature.backup.enabled = FALSE;
+BACKUP TO 'nodelocal://0/test-root/';
+----
+pq: BACKUP feature was disabled by the database administrator
+
+# Test running backup when feature flag is enabled.
+exec-sql
+SET CLUSTER SETTING feature.backup.enabled = TRUE;
+BACKUP TO 'nodelocal://0/test-root/';
+----
+
+exec-sql
+DROP TABLE d.t;
+----
+
+# Test running restore when feature flag is disabled.
+exec-sql
+SET CLUSTER SETTING feature.restore.enabled = FALSE;
+RESTORE TABLE d.t FROM 'nodelocal://0/test-root/';
+----
+pq: RESTORE feature was disabled by the database administrator
+
+# Test running restore when feature flag is enabled.
+exec-sql
+SET CLUSTER SETTING feature.restore.enabled = TRUE;
+RESTORE TABLE d.t FROM 'nodelocal://0/test-root/';
+----

--- a/pkg/featureflag/BUILD.bazel
+++ b/pkg/featureflag/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "featureflag",
+    srcs = ["feature_flags.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/featureflag",
+    visibility = ["//visibility:public"],
+)

--- a/pkg/featureflag/feature_flags.go
+++ b/pkg/featureflag/feature_flags.go
@@ -1,0 +1,14 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package featureflag
+
+// FeatureFlagEnabledDefault is used for the default value of all feature flag cluster settings.
+const FeatureFlagEnabledDefault = true


### PR DESCRIPTION
Follow-up to the RFC at #55778. This addresses the SRE use case mentioned in #51643 — instead of moving forward with a global denylist as the RFC indicated, we are prototyping feature flags via cluster settings to turn on/off requested features. The first part of the prototype will be done on `BACKUP` and `RESTORE` commands.

See [this doc](https://docs.google.com/document/d/1nZSdcK7YprL0P4TAuseY-mvlYnd82IaJ_ptAQDoWB6o/edit?) for further details. 

Note that the logic test under `ccl/backupccl/testdata/backup-restore/feature-flags` can be tested with the command `make test PKG=./pkg/ccl/backupccl TESTS='TestBackupRestoreDataDriven'`

— Commit message below — 

Adds a cluster setting to toggle a feature flag for the BACKUP and
RESTORE commands off and on. The feature is being introduced to
address a Cockroach Cloud SRE use case: needing to disable certain
categories of features in case of cluster failure.

Release note (enterprise change): Adds cluster settings to enable/
disable the BACKUP and RESTORE commands. If a user attempts to use
these features while they are disabled, an error indicating that
the database administrator has disabled the feature is surfaced.

Example usage for the database administrator:
SET CLUSTER SETTING feature.backup.enabled = FALSE;
SET CLUSTER SETTING feature.backup.enabled = TRUE;
SET CLUSTER SETTING feature.restore.enabled = FALSE;
SET CLUSTER SETTING feature.restore.enabled = TRUE;