### PR TITLE
settings: patch backwards incompatible short type identifier change

### DIFF
--- a/pkg/settings/registry.go
+++ b/pkg/settings/registry.go
@@ -144,7 +144,8 @@ var ReadableTypes = map[string]string{
 	"z": "byte size",
 	"d": "duration",
 	"e": "enumeration",
-	"v": "version",
+	// This is named "m" (instead of "v") for backwards compatibility reasons.
+	"m": "version",
 }
 
 // RedactedValue returns a string representation of the value for settings

--- a/pkg/settings/updater.go
+++ b/pkg/settings/updater.go
@@ -83,15 +83,7 @@ func (u updater) Set(key, rawValue string, vt string) error {
 
 	u.m[key] = struct{}{}
 
-	// TODO(irfansharif): Looks like we introduced a regression in #55994. In
-	// mixed-version clusters, when the 21.1 node attempts to refresh setting,
-	// it expects to find a type "v" for the version setting, but finds "m"
-	// already present in 20.2. We just so happen to be adding dedicated
-	// functionality for the version setting update process (not doing it
-	// through updater, as here, but instead using a dedicated RPC for it).
-	// Still, this is a bit unfortunate, and maybe merits reverting the type
-	// annotation diff.
-	if expected := d.Typ(); expected != "v" && vt != expected {
+	if expected := d.Typ(); vt != expected {
 		return errors.Errorf("setting '%s' defined as type %s, not %s", key, expected, vt)
 	}
 

--- a/pkg/settings/version.go
+++ b/pkg/settings/version.go
@@ -104,7 +104,8 @@ func (v *VersionSetting) SettingsListDefault() string {
 
 // Typ is part of the Setting interface.
 func (*VersionSetting) Typ() string {
-	return "v"
+	// This is named "m" (instead of "v") for backwards compatibility reasons.
+	return "m"
 }
 
 // String is part of the Setting interface.


### PR DESCRIPTION
We introduced a regression in #55994. In mixed-version clusters, when
the 21.1 node attempts to refresh settings, it expects to find a type
"v" for the version setting, but finds "m" already present in 20.2. We
revert the bits of #55994 that introduced this regression.

Release note (sql, cli change): In an earlier commit (3edd70ba, not part
of any release, yet) we introduced a regression by representing the
shortened form of the cluster version setting's type as "v", from an
earlier "m". It's now back to what it was. Specifically:
    - The `setting_type` column for `version` in `SHOW CLUSTER SETTINGS`
      will now show an "m" instead of a "v"
    - The `valueType` column for `version` in `system.settings` will now
      show an "m" instead of a "v"

---

First commit is from #56480.