### PR TITLE
vendor: go get honnef.co/go/tools@v0.0.1-2020.1.6

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -5,8 +5,8 @@ def go_deps():
         name = "co_honnef_go_tools",
         build_file_proto_mode = "disable_global",
         importpath = "honnef.co/go/tools",
-        sum = "h1:RFEMAhc9/Ej5KcaFZooS1PGYAhVl+CUxVj2gyKYGxKQ=",
-        version = "v0.0.0-20190530104931-1f0868a609b7",
+        sum = "h1:W18jzjh8mfPez+AwGLxmOImucz/IFjpNlrKVnaj2YVc=",
+        version = "v0.0.1-2020.1.6",
     )
     go_repository(
         name = "com_github_abourget_teamcity",
@@ -1117,6 +1117,14 @@ def go_deps():
         version = "v0.0.0-20190109223431-e84dfd68c163",
     )
     go_repository(
+        name = "com_github_google_renameio",
+        build_file_proto_mode = "disable",
+        importpath = "github.com/google/renameio",
+        sum = "h1:GOZbcHa3HfsPKPlmyPyN2KEohoMXOhdMbHrvbpl2QaA=",
+        version = "v0.1.0",
+    )
+
+    go_repository(
         name = "com_github_google_uuid",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/google/uuid",
@@ -2219,6 +2227,14 @@ def go_deps():
         version = "v1.2.0",
     )
     go_repository(
+        name = "com_github_rogpeppe_go_internal",
+        build_file_proto_mode = "disable",
+        importpath = "github.com/rogpeppe/go-internal",
+        sum = "h1:RR9dF3JtopPvtkroDZuVD7qquD0bnHlKSqaQhgwt8yk=",
+        version = "v1.3.0",
+    )
+
+    go_repository(
         name = "com_github_rs_xid",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/rs/xid",
@@ -2659,6 +2675,14 @@ def go_deps():
         sum = "h1:Ev7yu1/f6+d+b3pi5vPdRPc6nNtP1umSfcWiEfRqv6I=",
         version = "v1.0.25",
     )
+    go_repository(
+        name = "in_gopkg_errgo_v2",
+        build_file_proto_mode = "disable",
+        importpath = "gopkg.in/errgo.v2",
+        sum = "h1:0vLT13EuvQ0hNvakwLuFZ/jYrLp5F3kcWHXdRggjCE8=",
+        version = "v2.1.0",
+    )
+
     go_repository(
         name = "in_gopkg_fsnotify_v1",
         build_file_proto_mode = "disable_global",

--- a/go.mod
+++ b/go.mod
@@ -166,7 +166,7 @@ require (
 	gopkg.in/square/go-jose.v2 v2.5.1 // indirect
 	gopkg.in/yaml.v2 v2.3.0
 	gotest.tools v2.2.0+incompatible // indirect
-	honnef.co/go/tools v0.0.0-20190530104931-1f0868a609b7
+	honnef.co/go/tools v0.0.1-2020.1.6
 	vitess.io/vitess v0.0.0-00010101000000-000000000000
 )
 

--- a/go.sum
+++ b/go.sum
@@ -354,6 +354,7 @@ github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXi
 github.com/google/pprof v0.0.0-20181127221834-b4f47329b966/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190109223431-e84dfd68c163 h1:beB+Da4k9B1zmgag78k3k1Bx4L/fdWr5FwNa0f8RxmY=
 github.com/google/pprof v0.0.0-20190109223431-e84dfd68c163/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
+github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v0.0.0-20161128191214-064e2069ce9c/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
@@ -669,6 +670,7 @@ github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqn
 github.com/rcrowley/go-metrics v0.0.0-20190826022208-cac0b30c2563 h1:dY6ETXrvDG7Sa4vE8ZQG4yqWg6UnOcbqTAahkV813vQ=
 github.com/rcrowley/go-metrics v0.0.0-20190826022208-cac0b30c2563/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
+github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
 github.com/rs/zerolog v1.13.0/go.mod h1:YbFCdg8HfsridGWAh22vktObvhZbQsZXe4/zB0OKkWU=
 github.com/rs/zerolog v1.15.0/go.mod h1:xYTKnLHcpfU2225ny5qZjxnj9NvkumZYjJHlAThCjNc=
@@ -895,6 +897,7 @@ golang.org/x/tools v0.0.0-20190823170909-c4a336ef6a2f/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200207183749-b753a1ba74fa/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/tools v0.0.0-20200410194907-79a7a3126eef/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200509030707-2212a7e161a5 h1:MeC2gMlMdkd67dn17MEby3rGXRxZtWeiRXOnISfTQ74=
 golang.org/x/tools v0.0.0-20200509030707-2212a7e161a5/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200626171337-aa94e735be7f h1:JcoF/bowzCDI+MXu1yLqQGNO3ibqWsWq+Sk7pOT218w=
@@ -948,6 +951,7 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/cheggaaa/pb.v1 v1.0.25/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
+gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/go-playground/assert.v1 v1.2.1/go.mod h1:9RXL0bg/zibRAgZUYszZSwO/z8Y/a8bDuhia5mkpMnE=
@@ -979,6 +983,6 @@ gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
-honnef.co/go/tools v0.0.0-20190530104931-1f0868a609b7 h1:RFEMAhc9/Ej5KcaFZooS1PGYAhVl+CUxVj2gyKYGxKQ=
-honnef.co/go/tools v0.0.0-20190530104931-1f0868a609b7/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
+honnef.co/go/tools v0.0.1-2020.1.6 h1:W18jzjh8mfPez+AwGLxmOImucz/IFjpNlrKVnaj2YVc=
+honnef.co/go/tools v0.0.1-2020.1.6/go.mod h1:pyyisuGw24ruLjrr1ddx39WE0y9OooInRzEYLhQB2YY=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/pkg/acceptance/localcluster/cluster.go
+++ b/pkg/acceptance/localcluster/cluster.go
@@ -298,7 +298,7 @@ func (c *Cluster) makeNode(ctx context.Context, nodeIdx int, cfg NodeConfig) (*N
 		fmt.Sprintf("--http-port=%d", cfg.HTTPPort),
 		fmt.Sprintf("--store=%s", cfg.DataDir),
 		fmt.Sprintf("--listening-url-file=%s", n.listeningURLFile()),
-		fmt.Sprintf("--cache=256MiB"),
+		"--cache=256MiB",
 	}
 
 	if n.Cfg.LogDir != "" {

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -1175,7 +1175,7 @@ func TestEncryptedBackupRestoreSystemJobs(t *testing.T) {
 			sanitizedEncryptionOption = fmt.Sprintf("kms='%s'", sanitizedURI)
 		} else {
 			encryptionOption = "encryption_passphrase='abcdefg'"
-			sanitizedEncryptionOption = fmt.Sprintf("encryption_passphrase='redacted'")
+			sanitizedEncryptionOption = "encryption_passphrase='redacted'"
 		}
 
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
+++ b/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
@@ -185,7 +185,7 @@ CREATE TABLE data2.foo (a int);
 			switch table {
 			case systemschema.TableStatisticsTable.Name:
 				// createdAt and statisticsID are re-generated on RESTORE.
-				query := fmt.Sprintf("SELECT \"tableID\", name, \"columnIDs\", \"rowCount\" FROM system.table_statistics")
+				query := `SELECT "tableID", name, "columnIDs", "rowCount" FROM system.table_statistics`
 				verificationQueries[i] = query
 			case systemschema.SettingsTable.Name:
 				// We don't include the cluster version.
@@ -299,7 +299,7 @@ func TestIncrementalFullClusterBackup(t *testing.T) {
 	defer cleanupEmptyCluster()
 
 	sqlDB.Exec(t, `BACKUP TO $1`, LocalFoo)
-	sqlDB.Exec(t, fmt.Sprintf("CREATE USER maxroach1"))
+	sqlDB.Exec(t, "CREATE USER maxroach1")
 
 	sqlDB.Exec(t, `BACKUP TO $1 INCREMENTAL FROM $2`, incrementalBackupLocation, LocalFoo)
 	sqlDBRestore.Exec(t, `RESTORE FROM $1, $2`, LocalFoo, incrementalBackupLocation)

--- a/pkg/ccl/backupccl/restore_mid_schema_change_test.go
+++ b/pkg/ccl/backupccl/restore_mid_schema_change_test.go
@@ -213,9 +213,9 @@ func restoreMidSchemaChange(
 		require.NoError(t, err)
 
 		sqlDB.Exec(t, "USE defaultdb")
-		restoreQuery := fmt.Sprintf("RESTORE defaultdb.* from $1")
+		restoreQuery := "RESTORE defaultdb.* from $1"
 		if isClusterRestore {
-			restoreQuery = fmt.Sprintf("RESTORE from $1")
+			restoreQuery = "RESTORE from $1"
 		}
 		log.Infof(context.Background(), "%+v", sqlDB.QueryStr(t, "SHOW BACKUP $1", LocalFoo))
 		sqlDB.Exec(t, restoreQuery, LocalFoo)

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -49,7 +49,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
-	crdberrors "github.com/cockroachdb/errors"
 )
 
 func init() {
@@ -674,7 +673,7 @@ func (b *changefeedResumer) maybeCleanUpProtectedTimestamp(
 	}
 	if err := db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 		return pts.Release(ctx, txn, ptsID)
-	}); err != nil && !crdberrors.Is(err, protectedts.ErrNotExists) {
+	}); err != nil && !errors.Is(err, protectedts.ErrNotExists) {
 		// NB: The record should get cleaned up by the reconciliation loop.
 		// No good reason to cause more trouble by returning an error here.
 		// Log and move on.

--- a/pkg/cli/nodelocal_test.go
+++ b/pkg/cli/nodelocal_test.go
@@ -33,7 +33,7 @@ func Example_nodelocal() {
 	c.Run(fmt.Sprintf("nodelocal upload %s /test/file2.csv", file))
 	c.Run(fmt.Sprintf("nodelocal upload %s /test/file1.csv", file))
 	c.Run(fmt.Sprintf("nodelocal upload %s /test/../../file1.csv", file))
-	c.Run(fmt.Sprintf("nodelocal upload notexist.csv /test/file1.csv"))
+	c.Run("nodelocal upload notexist.csv /test/file1.csv")
 
 	// Output:
 	// nodelocal upload test.csv /test/file1.csv

--- a/pkg/cli/sql_util.go
+++ b/pkg/cli/sql_util.go
@@ -479,7 +479,7 @@ func (t sqlTxnShim) Rollback(context.Context) error {
 
 func (t sqlTxnShim) Exec(_ context.Context, query string, values ...interface{}) error {
 	if len(values) != 0 {
-		panic(fmt.Sprintf("sqlTxnShim.ExecContext must not be called with values"))
+		panic("sqlTxnShim.ExecContext must not be called with values")
 	}
 	return t.conn.Exec(query, nil)
 }

--- a/pkg/cli/userfiletable_test.go
+++ b/pkg/cli/userfiletable_test.go
@@ -46,7 +46,7 @@ func Example_userfile_upload() {
 	c.Run(fmt.Sprintf("userfile upload %s /test/../../file1.csv", file))
 	c.Run(fmt.Sprintf("userfile upload %s /test/./file1.csv", file))
 	c.Run(fmt.Sprintf("userfile upload %s test/file1.csv", file))
-	c.Run(fmt.Sprintf("userfile upload notexist.csv /test/file1.csv"))
+	c.Run("userfile upload notexist.csv /test/file1.csv")
 	c.Run(fmt.Sprintf("userfile upload %s /test/À.csv", file))
 	// Test fully qualified URI specifying db.schema.tablename_prefix.
 	c.Run(fmt.Sprintf("userfile upload %s userfile://defaultdb.public.foo/test/file1.csv", file))

--- a/pkg/cmd/allocsim/main.go
+++ b/pkg/cmd/allocsim/main.go
@@ -248,7 +248,7 @@ func (a *allocSim) rangeInfo() allocStats {
 				return
 			}
 			resp, err := status.Metrics(context.Background(), &serverpb.MetricsRequest{
-				NodeId: fmt.Sprintf("local"),
+				NodeId: "local",
 			})
 			if err != nil {
 				log.Fatalf(context.Background(), "%v", err)

--- a/pkg/cmd/github-pull-request-make/main.go
+++ b/pkg/cmd/github-pull-request-make/main.go
@@ -279,7 +279,7 @@ func main() {
 					fmt.Sprintf("PKG=./%s", name),
 					fmt.Sprintf("TESTS=%s", tests),
 					fmt.Sprintf("TESTTIMEOUT=%s", timeout),
-					fmt.Sprintf("GOTESTFLAGS=-json"), // allow TeamCity to parse failures
+					"GOTESTFLAGS=-json", // allow TeamCity to parse failures
 					fmt.Sprintf("STRESSFLAGS=-stderr -maxfails 1 -maxtime %s", duration),
 				)
 				cmd.Env = append(os.Environ(), "COCKROACH_NIGHTLY_STRESS=true")

--- a/pkg/cmd/roachprod/vm/azure/flags.go
+++ b/pkg/cmd/roachprod/vm/azure/flags.go
@@ -55,7 +55,7 @@ func (o *providerOpts) ConfigureCreateFlags(flags *pflag.FlagSet) {
 			strings.Join(defaultLocations, ",")))
 	flags.StringVar(&o.vnetName, ProviderName+"-vnet-name", "common",
 		"The name of the VNet to use")
-	flags.StringVar(&o.zone, ProviderName+"-availability-zone", "", fmt.Sprintf("Availability Zone to create VMs in"))
+	flags.StringVar(&o.zone, ProviderName+"-availability-zone", "", "Availability Zone to create VMs in")
 	flags.StringVar(&o.networkDiskType, ProviderName+"-network-disk-type", "premium-disk",
 		"type of network disk [premium-disk, ultra-disk]. only used if local-ssd is false")
 	flags.Int32Var(&o.networkDiskSize, ProviderName+"-volume-size", 500,

--- a/pkg/cmd/roachtest/cdc.go
+++ b/pkg/cmd/roachtest/cdc.go
@@ -482,7 +482,7 @@ func runCDCSchemaRegistry(ctx context.Context, t *test, c *cluster) {
 
 func registerCDC(r *testRegistry) {
 	r.Add(testSpec{
-		Name:    fmt.Sprintf("cdc/tpcc-1000"),
+		Name:    "cdc/tpcc-1000",
 		Owner:   OwnerCDC,
 		Cluster: makeClusterSpec(4, cpu(16)),
 		Run: func(ctx context.Context, t *test, c *cluster) {
@@ -496,7 +496,7 @@ func registerCDC(r *testRegistry) {
 		},
 	})
 	r.Add(testSpec{
-		Name:    fmt.Sprintf("cdc/initial-scan"),
+		Name:    "cdc/initial-scan",
 		Owner:   OwnerCDC,
 		Cluster: makeClusterSpec(4, cpu(16)),
 		Run: func(ctx context.Context, t *test, c *cluster) {
@@ -525,7 +525,7 @@ func registerCDC(r *testRegistry) {
 		},
 	})
 	r.Add(testSpec{
-		Name:    fmt.Sprintf("cdc/sink-chaos"),
+		Name:    "cdc/sink-chaos",
 		Owner:   `cdc`,
 		Cluster: makeClusterSpec(4, cpu(16)),
 		Run: func(ctx context.Context, t *test, c *cluster) {
@@ -540,7 +540,7 @@ func registerCDC(r *testRegistry) {
 		},
 	})
 	r.Add(testSpec{
-		Name:    fmt.Sprintf("cdc/crdb-chaos"),
+		Name:    "cdc/crdb-chaos",
 		Owner:   `cdc`,
 		Skip:    "#37716",
 		Cluster: makeClusterSpec(4, cpu(16)),
@@ -560,7 +560,7 @@ func registerCDC(r *testRegistry) {
 		},
 	})
 	r.Add(testSpec{
-		Name:  fmt.Sprintf("cdc/ledger"),
+		Name:  "cdc/ledger",
 		Owner: `cdc`,
 		// TODO(mrtracy): This workload is designed to be running on a 20CPU nodes,
 		// but this cannot be allocated without some sort of configuration outside

--- a/pkg/cmd/roachtest/gossip.go
+++ b/pkg/cmd/roachtest/gossip.go
@@ -117,7 +117,7 @@ SELECT string_agg(source_id::TEXT || ':' || target_id::TEXT, ',')
 	}
 
 	r.Add(testSpec{
-		Name:    fmt.Sprintf("gossip/chaos/nodes=9"),
+		Name:    "gossip/chaos/nodes=9",
 		Owner:   OwnerKV,
 		Cluster: makeClusterSpec(9),
 		Run: func(ctx context.Context, t *test, c *cluster) {

--- a/pkg/cmd/roachtest/hotspotsplits.go
+++ b/pkg/cmd/roachtest/hotspotsplits.go
@@ -50,7 +50,7 @@ func registerHotSpotSplits(r *testRegistry) {
 		})
 
 		m.Go(func() error {
-			t.Status(fmt.Sprintf("starting checks for range sizes"))
+			t.Status("starting checks for range sizes")
 			const sizeLimit = 3 * (1 << 29) // 3*512 MB (512 mb is default size)
 
 			db := c.Conn(ctx, 1)

--- a/pkg/cmd/roachtest/inconsistency.go
+++ b/pkg/cmd/roachtest/inconsistency.go
@@ -12,7 +12,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	_ "github.com/lib/pq"
@@ -20,7 +19,7 @@ import (
 
 func registerInconsistency(r *testRegistry) {
 	r.Add(testSpec{
-		Name:       fmt.Sprintf("inconsistency"),
+		Name:       "inconsistency",
 		Owner:      OwnerKV,
 		MinVersion: "v19.2.2", // https://github.com/cockroachdb/cockroach/pull/42149 is new in 19.2.2
 		Cluster:    makeClusterSpec(3),

--- a/pkg/cmd/roachtest/inverted_index.go
+++ b/pkg/cmd/roachtest/inverted_index.go
@@ -39,7 +39,7 @@ func runSchemaChangeInvertedIndex(ctx context.Context, t *test, c *cluster) {
 	c.Put(ctx, workload, "./workload", workloadNode)
 	c.Start(ctx, t, crdbNodes)
 
-	cmdInit := fmt.Sprintf("./workload init json {pgurl:1}")
+	cmdInit := "./workload init json {pgurl:1}"
 	c.Run(ctx, workloadNode, cmdInit)
 
 	// On a 4-node GCE cluster with the standard configuration, this generates ~10 million rows

--- a/pkg/cmd/roachtest/kv.go
+++ b/pkg/cmd/roachtest/kv.go
@@ -167,7 +167,7 @@ func registerKV(r *testRegistry) {
 			nameParts = append(nameParts, fmt.Sprintf("splt=%d", computeNumSplits(opts)))
 		}
 		if opts.sequential {
-			nameParts = append(nameParts, fmt.Sprintf("seq"))
+			nameParts = append(nameParts, "seq")
 		}
 
 		minVersion := "v2.0.0"

--- a/pkg/cmd/roachtest/restart.go
+++ b/pkg/cmd/roachtest/restart.go
@@ -84,7 +84,7 @@ func runRestart(ctx context.Context, t *test, c *cluster, downDuration time.Dura
 
 func registerRestart(r *testRegistry) {
 	r.Add(testSpec{
-		Name:    fmt.Sprintf("restart/down-for-2m"),
+		Name:    "restart/down-for-2m",
 		Owner:   OwnerKV,
 		Cluster: makeClusterSpec(3),
 		// "cockroach workload is only in 19.1+"

--- a/pkg/cmd/roachtest/split.go
+++ b/pkg/cmd/roachtest/split.go
@@ -198,7 +198,7 @@ func runLoadSplits(ctx context.Context, t *test, c *cluster, params splitParams)
 			params.concurrency, params.readPercent, params.spanPercent, extraFlags, c.spec.NodeCount,
 			params.waitDuration.String()))
 
-		t.Status(fmt.Sprintf("waiting for splits"))
+		t.Status("waiting for splits")
 		if rc := rangeCount(); rc < params.minimumRanges || rc > params.maximumRanges {
 			return errors.Errorf("kv.kv has %d ranges, expected between %d and %d splits",
 				rc, params.minimumRanges, params.maximumRanges)


### PR DESCRIPTION
This dependency was likely to be updated as a side effect of unrelated
bumps, and it would usually update to a buggy version (that found lots
of bogus unused definitions). Rip off the band aid and jump to a modern
version that seems to work just fine.

This commit also fixes the findings of the new version: duplicate
imports, and redundant `fmt.Sprintf`.

Release note: None
