### PR TITLE
roachtest: de-flake decommission/mixed-versions

### DIFF
--- a/pkg/cmd/roachtest/BUILD.bazel
+++ b/pkg/cmd/roachtest/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "cluster_init.go",
         "copy.go",
         "decommission.go",
+        "decommission_self.go",
         "disk_full.go",
         "disk_stall.go",
         "django.go",

--- a/pkg/cmd/roachtest/acceptance.go
+++ b/pkg/cmd/roachtest/acceptance.go
@@ -36,6 +36,15 @@ func registerAcceptance(r *testRegistry) {
 		{name: "build-analyze", fn: runBuildAnalyze},
 		{name: "cli/node-status", fn: runCLINodeStatus},
 		{name: "cluster-init", fn: runClusterInit},
+		{name: "decommission-self",
+			fn: runDecommissionSelf,
+			// Decommissioning self was observed to hang, though not in this test
+			// when run locally. More investigation is needed; there is a small
+			// chance that the original observation was in error. However, it
+			// seems likely that the problem exists even if it is rarely reproduced,
+			// so this test is skipped.
+			skip: "https://github.com/cockroachdb/cockroach/issues/56718",
+		},
 		{name: "event-log", fn: runEventLog},
 		{name: "gossip/peerings", fn: runGossipPeerings},
 		{name: "gossip/restart", fn: runGossipRestart},

--- a/pkg/cmd/roachtest/decommission_self.go
+++ b/pkg/cmd/roachtest/decommission_self.go
@@ -1,0 +1,38 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import "context"
+
+// runDecommissionSelf decommissions n2 through n2. This is an acceptance test.
+//
+// See https://github.com/cockroachdb/cockroach/issues/56718
+func runDecommissionSelf(ctx context.Context, t *test, c *cluster) {
+	// An empty string means that the cockroach binary specified by flag
+	// `cockroach` will be used.
+	const mainVersion = ""
+
+	allNodes := c.All()
+	u := newVersionUpgradeTest(c,
+		uploadVersion(allNodes, mainVersion),
+		startVersion(allNodes, mainVersion),
+		fullyDecommissionStep(2, 2, mainVersion),
+		func(ctx context.Context, t *test, u *versionUpgradeTest) {
+			// Stop n2 and exclude it from post-test consistency checks,
+			// as this node can't contact cluster any more and operations
+			// on it will hang.
+			u.c.Wipe(ctx, c.Node(2))
+		},
+		checkOneMembership(1, "decommissioned"),
+	)
+
+	u.run(ctx, t)
+}


### PR DESCRIPTION
The test was fully decommissioning and then recommissioning nodes, which
does no longer work now that the master branch is 21.1 and thus the
predecessor version in this test is 20.2, which does know about fully
decommissioning (decommission attempts run via 20.1 nodes never set
the status to fully decommissioned, so we got away with it so far).

Pare down the test so that it carries out one random partial and full
decommission cycle alongside a partial version upgrade, which is
reasonably all we can do unless we want to get into the business
of wiping and re-adding nodes to the cluster in this test, which
I don't think we do as it doesn't work well with the step-driven
format this test is using.

Fixes #55798.

Release note: None
