### PR TITLE
sql: encode multi-column inverted index keys

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index_multi_column
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index_multi_column
@@ -1,0 +1,132 @@
+# LogicTest: local
+
+statement ok
+SET experimental_enable_multi_column_inverted_indexes=true
+
+statement ok
+CREATE TABLE t (
+    k INT PRIMARY KEY,
+    i INT,
+    s STRING,
+    j JSON,
+    FAMILY (k, i, s, j),
+    INVERTED INDEX (i, j),
+    INVERTED INDEX (i, s, j)
+)
+
+query T kvtrace
+INSERT INTO t VALUES (1, 333, 'foo', '{"a": "b"}'::json)
+----
+CPut /Table/53/1/1/0 -> /TUPLE/2:2:Int/333/1:3:Bytes/foo/
+InitPut /Table/53/2/333/"a"/"b"/1/0 -> /BYTES/
+InitPut /Table/53/3/333/"foo"/"a"/"b"/1/0 -> /BYTES/
+
+# Don't insert duplicate values.
+query T kvtrace
+INSERT INTO t VALUES (2, 333, 'foo', '[7, 0, 7]'::json)
+----
+CPut /Table/53/1/2/0 -> /TUPLE/2:2:Int/333/1:3:Bytes/foo/
+InitPut /Table/53/2/333/Arr/0/2/0 -> /BYTES/
+InitPut /Table/53/2/333/Arr/7/2/0 -> /BYTES/
+InitPut /Table/53/3/333/"foo"/Arr/0/2/0 -> /BYTES/
+InitPut /Table/53/3/333/"foo"/Arr/7/2/0 -> /BYTES/
+
+query T kvtrace
+INSERT INTO t VALUES (3, 333, 'foo', '[{"a": "b"}, 3, {"a": "b"}]'::json)
+----
+CPut /Table/53/1/3/0 -> /TUPLE/2:2:Int/333/1:3:Bytes/foo/
+InitPut /Table/53/2/333/Arr/3/3/0 -> /BYTES/
+InitPut /Table/53/2/333/Arr/"a"/"b"/3/0 -> /BYTES/
+InitPut /Table/53/3/333/"foo"/Arr/3/3/0 -> /BYTES/
+InitPut /Table/53/3/333/"foo"/Arr/"a"/"b"/3/0 -> /BYTES/
+
+# Don't delete duplicate values.
+query T kvtrace
+DELETE FROM t WHERE k = 2
+----
+Scan /Table/53/1/2{-/#}
+Del /Table/53/2/333/Arr/0/2/0
+Del /Table/53/2/333/Arr/7/2/0
+Del /Table/53/3/333/"foo"/Arr/0/2/0
+Del /Table/53/3/333/"foo"/Arr/7/2/0
+Del /Table/53/1/2/0
+
+query T kvtrace
+DELETE FROM t WHERE k = 3
+----
+Scan /Table/53/1/3{-/#}
+Del /Table/53/2/333/Arr/3/3/0
+Del /Table/53/2/333/Arr/"a"/"b"/3/0
+Del /Table/53/3/333/"foo"/Arr/3/3/0
+Del /Table/53/3/333/"foo"/Arr/"a"/"b"/3/0
+Del /Table/53/1/3/0
+
+# Don't insert NULL values in the inverted column.
+query T kvtrace
+INSERT INTO t VALUES (4, 333, 'foo', NULL)
+----
+CPut /Table/53/1/4/0 -> /TUPLE/2:2:Int/333/1:3:Bytes/foo
+
+# Update away from NULL.
+query T kvtrace
+UPDATE t SET j = '[1]' WHERE k = 4
+----
+Scan /Table/53/1/4{-/#}
+Put /Table/53/1/4/0 -> /TUPLE/2:2:Int/333/1:3:Bytes/foo/
+InitPut /Table/53/2/333/Arr/1/4/0 -> /BYTES/
+InitPut /Table/53/3/333/"foo"/Arr/1/4/0 -> /BYTES/
+
+# Update back to NULL.
+query T kvtrace
+UPDATE t SET j = NULL WHERE k = 4
+----
+Scan /Table/53/1/4{-/#}
+Put /Table/53/1/4/0 -> /TUPLE/2:2:Int/333/1:3:Bytes/foo
+Del /Table/53/2/333/Arr/1/4/0
+Del /Table/53/3/333/"foo"/Arr/1/4/0
+
+# Deleting a NULL shouldn't remove anything from the inv idx.
+query T kvtrace
+DELETE FROM t WHERE k = 4
+----
+Scan /Table/53/1/4{-/#}
+Del /Table/53/1/4/0
+
+# Insert NULL non-inverted value.
+query T kvtrace
+INSERT INTO t VALUES (5, NULL, 'foo', '{"a": "b"}'::json)
+----
+CPut /Table/53/1/5/0 -> /TUPLE/3:3:Bytes/foo/
+InitPut /Table/53/2/NULL/"a"/"b"/5/0 -> /BYTES/
+InitPut /Table/53/3/NULL/"foo"/"a"/"b"/5/0 -> /BYTES/
+
+# Update away from NULL.
+query T kvtrace
+UPDATE t SET i = 333 WHERE k = 5
+----
+Scan /Table/53/1/5{-/#}
+Put /Table/53/1/5/0 -> /TUPLE/2:2:Int/333/1:3:Bytes/foo/
+Del /Table/53/2/NULL/"a"/"b"/5/0
+InitPut /Table/53/2/333/"a"/"b"/5/0 -> /BYTES/
+Del /Table/53/3/NULL/"foo"/"a"/"b"/5/0
+InitPut /Table/53/3/333/"foo"/"a"/"b"/5/0 -> /BYTES/
+
+# Update back to NULL.
+query T kvtrace
+UPDATE t SET i = NULL WHERE k = 5
+----
+Scan /Table/53/1/5{-/#}
+Put /Table/53/1/5/0 -> /TUPLE/3:3:Bytes/foo/
+Del /Table/53/2/333/"a"/"b"/5/0
+InitPut /Table/53/2/NULL/"a"/"b"/5/0 -> /BYTES/
+Del /Table/53/3/333/"foo"/"a"/"b"/5/0
+InitPut /Table/53/3/NULL/"foo"/"a"/"b"/5/0 -> /BYTES/
+
+# Delete row with NULL non-inverted row.
+query T kvtrace
+DELETE FROM t WHERE k = 5
+----
+Scan /Table/53/1/5{-/#}
+Del /Table/53/2/NULL/"a"/"b"/5/0
+Del /Table/53/3/NULL/"foo"/"a"/"b"/5/0
+Del /Table/53/1/5/0

--- a/pkg/sql/opt/norm/prune_cols_funcs.go
+++ b/pkg/sql/opt/norm/prune_cols_funcs.go
@@ -149,19 +149,24 @@ func neededMutationFetchCols(
 
 		// Make sure to consider indexes that are being added or dropped.
 		for i, n := 0, tabMeta.Table.DeletableIndexCount(); i < n; i++ {
-			indexCols := tabMeta.IndexColumns(i)
-
 			// If the columns being updated are not part of the index and the
 			// index is not a partial index, then the update does not require
 			// changes to the index. Partial indexes may be updated (even when a
 			// column in the index is not changing) when rows that were not
 			// previously in the index must be added to the index because they
 			// now satisfy the partial index predicate.
+			//
+			// Note that we use the set of index columns where the virtual
+			// columns have been mapped to their source columns. Virtual columns
+			// are never part of the updated columns. Updates to source columns
+			// trigger index changes.
+			//
 			// TODO(mgartner): Index columns are not necessary when neither the
 			// index columns nor the columns referenced in the partial index
 			// predicate are being updated. We should prune mutation fetch
 			// columns when this is the case, rather than always marking index
 			// columns of partial indexes as "needed".
+			indexCols := tabMeta.IndexColumnsMapVirtual(i)
 			_, isPartialIndex := tabMeta.Table.Index(i).Predicate()
 			if !indexCols.Intersects(updateCols) && !isPartialIndex {
 				continue

--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -55,6 +55,20 @@ CREATE TABLE partial_indexes (
 )
 ----
 
+exec-ddl
+CREATE TABLE multi_col_inv_idx (
+    a INT PRIMARY KEY,
+    b INT,
+    c STRING,
+    j JSON,
+    FAMILY (a),
+    FAMILY (b),
+    FAMILY (c),
+    FAMILY (j),
+    INVERTED INDEX (b, c, j)
+)
+----
+
 # --------------------------------------------------
 # PruneProjectCols
 # --------------------------------------------------
@@ -2046,6 +2060,37 @@ project
            │    └── fd: (7)-->(8-10)
            └── projections
                 └── c:9 + 1 [as=c_new:13, outer=(9), immutable]
+
+# Do not prune columns that are required for encoding a multi-column inverted
+# index.
+norm expect-not=PruneMutationFetchCols
+UPDATE multi_col_inv_idx SET j = '[1]' WHERE a = 1
+----
+update multi_col_inv_idx
+ ├── columns: <none>
+ ├── fetch columns: a:7 b:8 c:9 j:10
+ ├── update-mapping:
+ │    └── j_new:13 => j:4
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ └── project
+      ├── columns: j_new:13!null a:7!null b:8 c:9 j:10
+      ├── cardinality: [0 - 1]
+      ├── key: ()
+      ├── fd: ()-->(7-10,13)
+      ├── select
+      │    ├── columns: a:7!null b:8 c:9 j:10
+      │    ├── cardinality: [0 - 1]
+      │    ├── key: ()
+      │    ├── fd: ()-->(7-10)
+      │    ├── scan multi_col_inv_idx
+      │    │    ├── columns: a:7!null b:8 c:9 j:10
+      │    │    ├── key: (7)
+      │    │    └── fd: (7)-->(8-10)
+      │    └── filters
+      │         └── a:7 = 1 [outer=(7), constraints=(/7: [/1 - /1]; tight), fd=()-->(7)]
+      └── projections
+           └── '[1]' [as=j_new:13]
 
 # Prune unused upsert columns.
 norm expect=PruneMutationInputCols

--- a/pkg/sql/opt/table_meta.go
+++ b/pkg/sql/opt/table_meta.go
@@ -174,8 +174,8 @@ func (tm *TableMeta) clearAnnotations() {
 	}
 }
 
-// IndexColumns returns the metadata IDs for the set of columns in the given
-// index.
+// IndexColumns returns the metadata IDs for the set of table columns in the
+// given index.
 // TODO(justin): cache this value in the table metadata.
 func (tm *TableMeta) IndexColumns(indexOrd int) ColSet {
 	index := tm.Table.Index(indexOrd)
@@ -183,6 +183,24 @@ func (tm *TableMeta) IndexColumns(indexOrd int) ColSet {
 	var indexCols ColSet
 	for i, n := 0, index.ColumnCount(); i < n; i++ {
 		ord := index.Column(i).Ordinal()
+		indexCols.Add(tm.MetaID.ColumnID(ord))
+	}
+	return indexCols
+}
+
+// IndexColumnsMapVirtual returns the metadata IDs for the set of table columns
+// in the given index. Virtual inverted index columns are mapped to their source
+// column.
+func (tm *TableMeta) IndexColumnsMapVirtual(indexOrd int) ColSet {
+	index := tm.Table.Index(indexOrd)
+
+	var indexCols ColSet
+	for i, n := 0, index.ColumnCount(); i < n; i++ {
+		col := index.Column(i)
+		ord := col.Ordinal()
+		if col.Kind() == cat.VirtualInverted {
+			ord = col.InvertedSourceColumnOrdinal()
+		}
 		indexCols.Add(tm.MetaID.ColumnID(ord))
 	}
 	return indexCols

--- a/pkg/sql/rowenc/index_encoding.go
+++ b/pkg/sql/rowenc/index_encoding.go
@@ -130,11 +130,10 @@ func EncodePartialIndexKey(
 
 	// We know we will append to the key which will cause the capacity to grow so
 	// make it bigger from the get-go.
-	// Add twice the key prefix as an initial guess.
+	// Add the length of the key prefix as an initial guess.
 	// Add 3 bytes for every ancestor: table,index id + interleave sentinel.
 	// Add 2 bytes for every column value. An underestimate for all but low integers.
-	key = make([]byte, len(keyPrefix), 2*len(keyPrefix)+3*len(index.Interleave.Ancestors)+2*len(values))
-	copy(key, keyPrefix)
+	key = growKey(keyPrefix, len(keyPrefix)+3*len(index.Interleave.Ancestors)+2*len(values))
 
 	dirs := directions(index.ColumnDirections)
 
@@ -759,12 +758,28 @@ func EncodeInvertedIndexKeys(
 	values []tree.Datum,
 	keyPrefix []byte,
 ) (key [][]byte, err error) {
-	if len(index.ColumnIDs) > 1 {
-		return nil, errors.AssertionFailedf("trying to apply inverted index to more than one column")
+	numColumns := len(index.ColumnIDs)
+
+	// If the index is a multi-column inverted index, we encode the non-inverted
+	// columns in the key prefix.
+	if numColumns > 1 {
+		// Do not encode the last column, which is the inverted column, here. It
+		// is encoded below this block.
+		colIDs := index.ColumnIDs[:numColumns-1]
+		dirs := directions(index.ColumnDirections)
+
+		// Double the size of the key to make the imminent appends more
+		// efficient.
+		keyPrefix = growKey(keyPrefix, len(keyPrefix))
+
+		keyPrefix, _, err = EncodeColumns(colIDs, dirs, colMap, values, keyPrefix)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	var val tree.Datum
-	if i, ok := colMap[index.ColumnIDs[0]]; ok {
+	if i, ok := colMap[index.ColumnIDs[numColumns-1]]; ok {
 		val = values[i]
 	} else {
 		val = tree.DNull
@@ -1782,4 +1797,12 @@ func EncodeColumns(
 		}
 	}
 	return key, containsNull, nil
+}
+
+// growKey returns a new key with  the same contents as the given key and with
+// additionalCapacity more capacity.
+func growKey(key []byte, additionalCapacity int) []byte {
+	newKey := make([]byte, len(key), len(key)+additionalCapacity)
+	copy(newKey, key)
+	return newKey
 }


### PR DESCRIPTION
#### sql: encode multi-column inverted index keys

This commit adds support for encoding multi-column inverted index keys.
The values of the non-inverted columns are used to generate the prefix
for the inverted keys.

Release note: None

#### opt: do not prune multi-column inverted index columns during mutation

When a mutation updates an inverted column that is indexed by a
multi-column inverted index the non-inverted prefix columns must be
fetched in order to build the new index keys. Previously, the pruning
normalization rules would incorrectly prune these prefix columns. The
pruning rules only considered the columns of an index to be required to
fetch when one of the index columns was being mutated. The index columns
of an inverted index include the virtual inverted column, not the source
column. So, mutations to the source column did not prevent pruning
columns of indexes that included the source column's virtual inverted
column.

This commit changes the behavior of pruning such that index columns will
not be pruned if the source column of the index's virtual inverted
column is mutated.

Release note: None
