### PR TITLE
ui: fix Overview screen in OSS builds

### DIFF
--- a/pkg/ui/src/routes/visualization.tsx
+++ b/pkg/ui/src/routes/visualization.tsx
@@ -31,11 +31,13 @@ class NodesWrapper extends React.Component<{}, {}> {
 
 export default function createClusterOverviewRoutes(): JSX.Element {
   return (
-    <Route path="overview" component={ ClusterOverview } >
-      <Switch>
-        <Route exact path="/" component={() => <Redirect to="list" />}/>
-        <Route path="list" component={ NodesWrapper } />
-      </Switch>
+    <Route path="/overview">
+      <ClusterOverview>
+        <Switch>
+          <Redirect exact from="/overview" to="/overview/list" />
+          <Route path="/overview/list" component={ NodesWrapper } />
+        </Switch>
+      </ClusterOverview>
     </Route>
   );
 }


### PR DESCRIPTION
Previously, when using OSS builds (created with `make buildoss`), when
you loading the DB Console in your browser, you'd get "Page Not Found".
The route for the overview page was missing the leading '/'.  This bug
appears to have been introduced in
722c93252eb0199f23b395cabef1bd416534a441.

Release note (admin ui change): This fixes a bug where users of
the OSS builds of CockroachDB would see "Page Not Found" when loading
the Console.