### PR TITLE
sql: generate flow id upfront

### DIFF
--- a/pkg/ccl/backupccl/backup_processor_planning.go
+++ b/pkg/ccl/backupccl/backup_processor_planning.go
@@ -80,7 +80,7 @@ func distBackup(
 	if err != nil {
 		return err
 	}
-	p := sql.MakePhysicalPlan(gatewayNodeID)
+	p := sql.MakePhysicalPlan(planCtx, gatewayNodeID)
 
 	// Setup a one-stage plan with one proc per input spec.
 	corePlacement := make([]physicalplan.ProcessorCorePlacement, len(backupSpecs))

--- a/pkg/ccl/backupccl/restore_processor_planning.go
+++ b/pkg/ccl/backupccl/restore_processor_planning.go
@@ -105,7 +105,7 @@ func distRestore(
 	if err != nil {
 		return err
 	}
-	p := sql.MakePhysicalPlan(gatewayNodeID)
+	p := sql.MakePhysicalPlan(planCtx, gatewayNodeID)
 
 	// Plan SplitAndScatter in a round-robin fashion.
 	splitAndScatterStageID := p.NewStageOnNodes(nodes)

--- a/pkg/ccl/changefeedccl/changefeed_dist.go
+++ b/pkg/ccl/changefeedccl/changefeed_dist.go
@@ -157,7 +157,7 @@ func distChangefeedFlow(
 		UserProto:    execCtx.User().EncodeProto(),
 	}
 
-	p := sql.MakePhysicalPlan(gatewayNodeID)
+	p := sql.MakePhysicalPlan(planCtx, gatewayNodeID)
 	p.AddNoInputStage(corePlacement, execinfrapb.PostProcessSpec{}, changefeedResultTypes, execinfrapb.Ordering{})
 	p.AddSingleGroupStage(
 		gatewayNodeID,

--- a/pkg/sql/colflow/BUILD.bazel
+++ b/pkg/sql/colflow/BUILD.bazel
@@ -33,7 +33,6 @@ go_library(
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "//pkg/util/tracing",
-        "//pkg/util/uuid",
         "//vendor/github.com/cockroachdb/errors",
         "//vendor/github.com/cockroachdb/logtags",
         "//vendor/github.com/marusama/semaphore",

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -48,7 +48,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
-	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
 	"github.com/marusama/semaphore"
@@ -268,16 +267,8 @@ func (f *vectorizedFlow) getTempStoragePath(ctx context.Context) string {
 		return f.tempStorage.path
 	}
 	// We haven't created this flow's temporary directory yet, so we do so now.
-	// The directory name is the flow's ID in most cases apart from when the
-	// flow's ID is unset (in the case of local flows). In this case the
-	// directory will be prefixed with "local-flow" and a uuid is generated on
-	// the spot to provide a unique name.
-	var tempDirName string
-	if id := f.GetID(); id.Equal(uuid.Nil) {
-		tempDirName = "local-flow" + uuid.FastMakeV4().String()
-	} else {
-		tempDirName = id.String()
-	}
+	// The directory name is the flow's ID.
+	tempDirName := f.GetID().String()
 	f.tempStorage.path = filepath.Join(f.Cfg.TempStoragePath, tempDirName)
 	log.VEventf(ctx, 1, "flow %s spilled to disk, stack trace: %s", f.ID, util.GetSmallTrace(2))
 	if err := f.Cfg.TempFS.MkdirAll(f.tempStorage.path); err != nil {

--- a/pkg/sql/distsql_plan_backfill.go
+++ b/pkg/sql/distsql_plan_backfill.go
@@ -68,7 +68,7 @@ func (dsp *DistSQLPlanner) createBackfiller(
 		return PhysicalPlan{}, err
 	}
 
-	p := MakePhysicalPlan(dsp.gatewayNodeID)
+	p := MakePhysicalPlan(planCtx, dsp.gatewayNodeID)
 	p.ResultRouters = make([]physicalplan.ProcessorIdx, len(spanPartitions))
 	for i, sp := range spanPartitions {
 		ib := &execinfrapb.BackfillerSpec{}

--- a/pkg/sql/distsql_plan_csv.go
+++ b/pkg/sql/distsql_plan_csv.go
@@ -207,7 +207,7 @@ func DistIngest(
 	if err != nil {
 		return roachpb.BulkOpSummary{}, err
 	}
-	p := MakePhysicalPlan(gatewayNodeID)
+	p := MakePhysicalPlan(planCtx, gatewayNodeID)
 
 	// Setup a one-stage plan with one proc per input spec.
 	corePlacement := make([]physicalplan.ProcessorCorePlacement, len(inputSpecs))

--- a/pkg/sql/distsql_plan_scrub_physical.go
+++ b/pkg/sql/distsql_plan_scrub_physical.go
@@ -53,7 +53,7 @@ func (dsp *DistSQLPlanner) createScrubPhysicalCheck(
 		corePlacement[i].Core.TableReader = tr
 	}
 
-	p := MakePhysicalPlan(dsp.gatewayNodeID)
+	p := MakePhysicalPlan(planCtx, dsp.gatewayNodeID)
 	p.AddNoInputStage(corePlacement, execinfrapb.PostProcessSpec{}, rowexec.ScrubTypes, execinfrapb.Ordering{})
 	p.PlanToStreamColMap = identityMapInPlace(make([]int, len(rowexec.ScrubTypes)))
 

--- a/pkg/sql/physicalplan/aggregator_funcs_test.go
+++ b/pkg/sql/physicalplan/aggregator_funcs_test.go
@@ -67,7 +67,7 @@ func runTestFlow(
 		Version:           execinfra.Version,
 		LeafTxnInputState: &leafInputState,
 		Flow: execinfrapb.FlowSpec{
-			FlowID:     execinfrapb.FlowID{UUID: uuid.MakeV4()},
+			FlowID:     execinfrapb.FlowID{UUID: uuid.FastMakeV4()},
 			Processors: procs,
 		},
 	}

--- a/pkg/util/uuid/generator_test.go
+++ b/pkg/util/uuid/generator_test.go
@@ -322,22 +322,27 @@ func testNewV5DifferentNamespaces(t *testing.T) {
 }
 
 func BenchmarkGenerator(b *testing.B) {
-	b.Run("NewV1", func(b *testing.B) {
+	b.Run("V1", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			Must(NewV1())
 		}
 	})
-	b.Run("NewV3", func(b *testing.B) {
+	b.Run("V3", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			NewV3(NamespaceDNS, "www.example.com")
 		}
 	})
-	b.Run("NewV4", func(b *testing.B) {
+	b.Run("V4", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			Must(NewV4())
 		}
 	})
-	b.Run("NewV5", func(b *testing.B) {
+	b.Run("FastV4", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			FastMakeV4()
+		}
+	})
+	b.Run("V5", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			NewV5(NamespaceDNS, "www.example.com")
 		}


### PR DESCRIPTION
The distsql physical planner has special logic to avoid generating a
flow UUID if everything happens to be local (unless we are doing
EXPLAIN ANALYZE). The latter is especially questionable: we are
modifying the flow specs after planning, from the `saveFlows`
callback.

This change simplifies this to always generate an UUID upfront when we
create the `PlanningCtx`. We also switch from the crypto-rand fed
`MakeV4` (~1us in the benchmarks) to `FastMakeV4()` (~40ns).

Release note: None