### PR TITLE
sql: fix arrays in COPY FROM

### DIFF
--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -539,7 +539,7 @@ func (c *copyMachine) readTextTuple(ctx context.Context, line []byte) error {
 			types.UuidFamily:
 			s = decodeCopy(s)
 		}
-		d, err := rowenc.ParseDatumStringAsWithRawBytes(c.resultColumns[i].Typ, s, c.parsingEvalCtx)
+		d, _, err := tree.ParseAndRequireString(c.resultColumns[i].Typ, s, c.parsingEvalCtx)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
There was a regression where arrays in the '{...}' format no longer
worked when used with COPY FROM.

fixes #56593 

Release note (bug fix): Arrays in COPY FROM input data were causing a
parsing error. Now they are parsed and copied correctly.