### PR TITLE
geo: add limit to quad_segs for ST_Buffer, points for ST_Interpolate

### DIFF
--- a/pkg/geo/geo.go
+++ b/pkg/geo/geo.go
@@ -49,6 +49,9 @@ const (
 // while DWithinExclusive == (Distance < x).
 type FnExclusivity bool
 
+// MaxAllowedSplitPoints is the maximum number of points any spatial function may split to.
+const MaxAllowedSplitPoints = 65336
+
 const (
 	// FnExclusive indicates that the corresponding geo function should have
 	// exclusive semantics.

--- a/pkg/geo/geogfn/segmentize.go
+++ b/pkg/geo/geogfn/segmentize.go
@@ -43,11 +43,11 @@ func Segmentize(geography geo.Geography, segmentMaxLength float64) (geo.Geograph
 		// Convert segmentMaxLength to Angle with respect to earth sphere as
 		// further calculation is done considering segmentMaxLength as Angle.
 		segmentMaxAngle := segmentMaxLength / spheroid.SphereRadius
-		segGeometry, err := geosegmentize.SegmentizeGeom(geometry, segmentMaxAngle, segmentizeCoords)
+		ret, err := geosegmentize.Segmentize(geometry, segmentMaxAngle, segmentizeCoords)
 		if err != nil {
 			return geo.Geography{}, err
 		}
-		return geo.MakeGeographyFromGeomT(segGeometry)
+		return geo.MakeGeographyFromGeomT(ret)
 	}
 }
 
@@ -78,13 +78,13 @@ func segmentizeCoords(a geom.Coord, b geom.Coord, segmentMaxAngle float64) ([]fl
 	// numberOfSegmentsToCreate = 2^(ceil(log2(segmentMaxLength/distanceBetweenPoints))).
 	numberOfSegmentsToCreate := int(math.Pow(2, math.Ceil(math.Log2(chordAngleBetweenPoints/segmentMaxAngle))))
 	numPoints := 2 * (1 + numberOfSegmentsToCreate)
-	if numPoints > geosegmentize.MaxPoints {
+	if numPoints > geo.MaxAllowedSplitPoints {
 		return nil, errors.Newf(
 			"attempting to segmentize into too many coordinates; need %d points between %v and %v, max %d",
 			numPoints,
 			a,
 			b,
-			geosegmentize.MaxPoints,
+			geo.MaxAllowedSplitPoints,
 		)
 	}
 	allSegmentizedCoordinates := make([]float64, 0, numPoints)

--- a/pkg/geo/geogfn/segmentize_test.go
+++ b/pkg/geo/geogfn/segmentize_test.go
@@ -118,7 +118,11 @@ func TestSegmentize(t *testing.T) {
 	t.Run("many coordinates to segmentize", func(t *testing.T) {
 		g := geo.MustParseGeography("LINESTRING(0 0, 100 80)")
 		_, err := Segmentize(g, 0.001)
-		require.EqualError(t, err, "attempting to segmentize into too many coordinates; need 34359738370 points between [0 0] and [100 80], max 16336")
+		require.EqualError(
+			t,
+			err,
+			fmt.Sprintf("attempting to segmentize into too many coordinates; need 34359738370 points between [0 0] and [100 80], max %d", geo.MaxAllowedSplitPoints),
+		)
 	})
 }
 

--- a/pkg/geo/geomfn/buffer.go
+++ b/pkg/geo/geomfn/buffer.go
@@ -113,6 +113,13 @@ func ParseBufferParams(s string, distance float64) (BufferParams, float64, error
 
 // Buffer buffers a given Geometry by the supplied parameters.
 func Buffer(g geo.Geometry, params BufferParams, distance float64) (geo.Geometry, error) {
+	if params.p.QuadrantSegments > geo.MaxAllowedSplitPoints {
+		return geo.Geometry{}, errors.Newf(
+			"attempting to split buffered geometry into too many quadrant segments; requested %d quadrant segments, max %d",
+			params.p.QuadrantSegments,
+			geo.MaxAllowedSplitPoints,
+		)
+	}
 	bufferedGeom, err := geos.Buffer(g.EWKB(), params.p, distance)
 	if err != nil {
 		return geo.Geometry{}, err

--- a/pkg/geo/geomfn/linear_reference.go
+++ b/pkg/geo/geomfn/linear_reference.go
@@ -37,6 +37,13 @@ func LineInterpolatePoints(g geo.Geometry, fraction float64, repeat bool) (geo.G
 		lengthOfLineString := geomRepr.Length()
 		if repeat && fraction <= 0.5 && fraction != 0 {
 			numberOfInterpolatedPoints := int(1 / fraction)
+			if numberOfInterpolatedPoints > geo.MaxAllowedSplitPoints {
+				return geo.Geometry{}, errors.Newf(
+					"attempting to interpolate into too many points; requires %d points, max %d",
+					numberOfInterpolatedPoints,
+					geo.MaxAllowedSplitPoints,
+				)
+			}
 			interpolatedPoints := geom.NewMultiPoint(geom.XY).SetSRID(geomRepr.SRID())
 			for pointInserted := 1; pointInserted <= numberOfInterpolatedPoints; pointInserted++ {
 				pointEWKB, err := geos.InterpolateLine(g.EWKB(), float64(pointInserted)*fraction*lengthOfLineString)

--- a/pkg/geo/geomfn/linear_reference_test.go
+++ b/pkg/geo/geomfn/linear_reference_test.go
@@ -104,4 +104,18 @@ func TestLineInterpolatePoints(t *testing.T) {
 				})
 		}
 	}
+
+	t.Run("too many points when repeat=true", func(t *testing.T) {
+		g := geo.MustParseGeometry("LINESTRING(0 0, 100 100)")
+		_, err := LineInterpolatePoints(g, 0.000001, true)
+		require.EqualError(
+			t,
+			err,
+			fmt.Sprintf(
+				"attempting to interpolate into too many points; requires 1000000 points, max %d",
+				geo.MaxAllowedSplitPoints,
+			),
+		)
+	})
+
 }

--- a/pkg/geo/geomfn/segmentize.go
+++ b/pkg/geo/geomfn/segmentize.go
@@ -37,7 +37,7 @@ func Segmentize(g geo.Geometry, segmentMaxLength float64) (geo.Geometry, error) 
 		if segmentMaxLength <= 0 {
 			return geo.Geometry{}, errors.Newf("maximum segment length must be positive")
 		}
-		segGeometry, err := geosegmentize.SegmentizeGeom(geometry, segmentMaxLength, segmentizeCoords)
+		segGeometry, err := geosegmentize.Segmentize(geometry, segmentMaxLength, segmentizeCoords)
 		if err != nil {
 			return geo.Geometry{}, err
 		}
@@ -57,13 +57,13 @@ func segmentizeCoords(a geom.Coord, b geom.Coord, maxSegmentLength float64) ([]f
 	// in which given two coordinates will be divided.
 	numberOfSegmentsToCreate := int(math.Ceil(distanceBetweenPoints / maxSegmentLength))
 	numPoints := 2 * (1 + numberOfSegmentsToCreate)
-	if numPoints > geosegmentize.MaxPoints {
+	if numPoints > geo.MaxAllowedSplitPoints {
 		return nil, errors.Newf(
 			"attempting to segmentize into too many coordinates; need %d points between %v and %v, max %d",
 			numPoints,
 			a,
 			b,
-			geosegmentize.MaxPoints,
+			geo.MaxAllowedSplitPoints,
 		)
 	} // segmentFraction represent the fraction of length each segment
 	// has with respect to total length between two coordinates.

--- a/pkg/geo/geomfn/segmentize_test.go
+++ b/pkg/geo/geomfn/segmentize_test.go
@@ -188,6 +188,10 @@ func TestSegmentizeCoords(t *testing.T) {
 	t.Run("many coordinates to segmentize", func(t *testing.T) {
 		g := geo.MustParseGeometry("LINESTRING(0 0, 100 100)")
 		_, err := Segmentize(g, 0.001)
-		require.EqualError(t, err, "attempting to segmentize into too many coordinates; need 282846 points between [0 0] and [100 100], max 16336")
+		require.EqualError(
+			t,
+			err,
+			fmt.Sprintf("attempting to segmentize into too many coordinates; need 282846 points between [0 0] and [100 100], max %d", geo.MaxAllowedSplitPoints),
+		)
 	})
 }

--- a/pkg/geo/geosegmentize/geosegmentize.go
+++ b/pkg/geo/geosegmentize/geosegmentize.go
@@ -15,10 +15,7 @@ import (
 	"github.com/twpayne/go-geom"
 )
 
-// MaxPoints is the maximum number of points segmentize is allowed to generate.
-const MaxPoints = 16336
-
-// SegmentizeGeom returns a modified geom.T having no segment longer
+// Segmentize returns a modified geom.T having no segment longer
 // than the given maximum segment length.
 // segmentMaxAngleOrLength represents two different things depending
 // on the object, which is about to segmentize as in case of geography
@@ -28,7 +25,7 @@ const MaxPoints = 16336
 // us to segmentize given two-points. We have to specify segmentizeCoords
 // explicitly, as the algorithm for segmentization is significantly
 // different for geometry and geography.
-func SegmentizeGeom(
+func Segmentize(
 	geometry geom.T,
 	segmentMaxAngleOrLength float64,
 	segmentizeCoords func(geom.Coord, geom.Coord, float64) ([]float64, error),
@@ -57,7 +54,7 @@ func SegmentizeGeom(
 	case *geom.MultiLineString:
 		segMultiLine := geom.NewMultiLineString(geom.XY).SetSRID(geometry.SRID())
 		for lineIdx := 0; lineIdx < geometry.NumLineStrings(); lineIdx++ {
-			l, err := SegmentizeGeom(geometry.LineString(lineIdx), segmentMaxAngleOrLength, segmentizeCoords)
+			l, err := Segmentize(geometry.LineString(lineIdx), segmentMaxAngleOrLength, segmentizeCoords)
 			if err != nil {
 				return nil, err
 			}
@@ -85,7 +82,7 @@ func SegmentizeGeom(
 	case *geom.Polygon:
 		segPolygon := geom.NewPolygon(geom.XY).SetSRID(geometry.SRID())
 		for loopIdx := 0; loopIdx < geometry.NumLinearRings(); loopIdx++ {
-			l, err := SegmentizeGeom(geometry.LinearRing(loopIdx), segmentMaxAngleOrLength, segmentizeCoords)
+			l, err := Segmentize(geometry.LinearRing(loopIdx), segmentMaxAngleOrLength, segmentizeCoords)
 			if err != nil {
 				return nil, err
 			}
@@ -98,7 +95,7 @@ func SegmentizeGeom(
 	case *geom.MultiPolygon:
 		segMultiPolygon := geom.NewMultiPolygon(geom.XY).SetSRID(geometry.SRID())
 		for polygonIdx := 0; polygonIdx < geometry.NumPolygons(); polygonIdx++ {
-			p, err := SegmentizeGeom(geometry.Polygon(polygonIdx), segmentMaxAngleOrLength, segmentizeCoords)
+			p, err := Segmentize(geometry.Polygon(polygonIdx), segmentMaxAngleOrLength, segmentizeCoords)
 			if err != nil {
 				return nil, err
 			}
@@ -111,7 +108,7 @@ func SegmentizeGeom(
 	case *geom.GeometryCollection:
 		segGeomCollection := geom.NewGeometryCollection().SetSRID(geometry.SRID())
 		for geoIdx := 0; geoIdx < geometry.NumGeoms(); geoIdx++ {
-			g, err := SegmentizeGeom(geometry.Geom(geoIdx), segmentMaxAngleOrLength, segmentizeCoords)
+			g, err := Segmentize(geometry.Geom(geoIdx), segmentMaxAngleOrLength, segmentizeCoords)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
This prevents a CPU-locked database and also ensures RSG tests do not
die.

Release note (sql change): A maximum of 65336 quadrant segments is
allowed for ST_Buffer. This used to be unlimited.

Release note (sql change): A maximum of 65336 points can be interpolated
for repeat=true in ST_InterpolatePoints.

Release note (sql change): Segmentize allows up to 65336 points instead of
16336.