### PR TITLE
sql: prohibit ALTER TABLE SET DATA TYPE requiring conversion/validation

### DIFF
--- a/pkg/sql/alter_column_type.go
+++ b/pkg/sql/alter_column_type.go
@@ -157,6 +157,27 @@ func alterColumnTypeGeneral(
 	cmds tree.AlterTableCmds,
 	tn *tree.TableName,
 ) error {
+	// alterColumnTypeGeneralOld is temporarily disabled until #54844 is disabled.
+	// This keeps static lint from failing.
+	_ = alterColumnTypeGeneralOld
+	return unimplemented.NewWithIssuef(
+		54844,
+		"ALTER COLUMN TYPE from %v to %v is prohibited until v21.1",
+		col.Type,
+		toType,
+	)
+}
+
+func alterColumnTypeGeneralOld(
+	ctx context.Context,
+	tableDesc *tabledesc.Mutable,
+	col *descpb.ColumnDescriptor,
+	toType *types.T,
+	using tree.Expr,
+	params runParams,
+	cmds tree.AlterTableCmds,
+	tn *tree.TableName,
+) error {
 	// Make sure that all nodes in the cluster are able to perform
 	// general alter column type conversions.
 	if !params.p.ExecCfg().Settings.Version.IsActive(

--- a/pkg/sql/alter_column_type_test.go
+++ b/pkg/sql/alter_column_type_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -34,6 +35,7 @@ import (
 func TestInsertBeforeOldColumnIsDropped(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	skip.WithIssue(t, 54844)
 
 	params, _ := tests.CreateTestServerParams()
 	childJobStartNotification := make(chan struct{})
@@ -96,6 +98,7 @@ ALTER TABLE test ALTER COLUMN x TYPE STRING;`)
 func TestInsertBeforeOldColumnIsDroppedUsingExpr(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	skip.WithIssue(t, 54844)
 
 	params, _ := tests.CreateTestServerParams()
 	childJobStartNotification := make(chan struct{})
@@ -159,6 +162,7 @@ ALTER TABLE test ALTER COLUMN x TYPE BOOL USING (x > 0);`)
 func TestVisibilityDuringAlterColumnType(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	skip.WithIssue(t, 54844)
 
 	defer setTestJobsAdoptInterval()()
 
@@ -223,6 +227,7 @@ INSERT INTO t.test VALUES (1), (2), (3);
 func TestAlterColumnTypeFailureRollback(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	skip.WithIssue(t, 54844)
 
 	ctx := context.Background()
 	params, _ := tests.CreateTestServerParams()
@@ -257,6 +262,7 @@ func TestQueryIntToString(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	defer setTestJobsAdoptInterval()()
+	skip.WithIssue(t, 54844)
 
 	params, _ := tests.CreateTestServerParams()
 
@@ -283,6 +289,7 @@ ALTER TABLE t.test ALTER COLUMN y TYPE STRING;
 func TestSchemaChangeBeforeAlterColumnType(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	skip.WithIssue(t, 54844)
 
 	ctx := context.Background()
 
@@ -332,6 +339,7 @@ ALTER TABLE t.test ALTER COLUMN y TYPE STRING;`)
 func TestSchemaChangeWhileExecutingAlterColumnType(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	skip.WithIssue(t, 54844)
 
 	params, _ := tests.CreateTestServerParams()
 	childJobStartNotification := make(chan struct{})

--- a/pkg/sql/err_count_test.go
+++ b/pkg/sql/err_count_test.go
@@ -65,32 +65,6 @@ func TestErrorCounts(t *testing.T) {
 	}
 }
 
-func TestUnimplementedCounts(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-
-	telemetry.GetFeatureCounts(telemetry.Raw, telemetry.ResetCounts)
-
-	params, _ := tests.CreateTestServerParams()
-	s, db, _ := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop(context.Background())
-
-	if _, err := db.Exec(`
-CREATE TABLE t(x INT8); 
-SET enable_experimental_alter_column_type_general = true;
-BEGIN;
-`); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := db.Exec("ALTER TABLE t ALTER COLUMN x SET DATA TYPE STRING"); err == nil {
-		t.Fatal("expected error, got no error")
-	}
-
-	if telemetry.GetRawFeatureCounts()["unimplemented.#49351"] == 0 {
-		t.Fatal("expected unimplemented telemetry, got nothing")
-	}
-}
-
 func TestTransactionRetryErrorCounts(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)

--- a/pkg/sql/logictest/testdata/logic_test/alter_column_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_column_type
@@ -171,381 +171,382 @@ CREATE TABLE t1 (date string)
 statement ok
 INSERT INTO t1 VALUES ('hello')
 
-statement error pq: ALTER COLUMN TYPE from string to timestamp is only supported experimentally
+statement error unimplemented: ALTER COLUMN TYPE from string to timestamp is prohibited until v21.1
 ALTER TABLE t1 ALTER COLUMN date TYPE timestamp
 
 # After setting enable_experimental_alter_column_type_general, ALTER COLUMN TYPE should work.
 statement ok
 SET enable_experimental_alter_column_type_general = true
 
-statement error pq: parsing as type timestamp: could not parse "hello"
-ALTER TABLE t1 ALTER COLUMN date TYPE timestamp
-
-# Verify ALTER COLUMN TYPE from INT to STRING works correctly.
-statement ok
-CREATE TABLE t2 (id int)
-
-statement ok
-INSERT INTO t2 VALUES (1), (2), (3), (4)
-
-statement ok
-ALTER TABLE t2 ALTER COLUMN id TYPE STRING
-
-query TTBTTTB
-SHOW COLUMNS FROM t2
-----
-id     STRING  true   NULL            ·  {}         false
-rowid  INT8    false  unique_rowid()  ·  {primary}  true
-
-statement ok
-INSERT INTO t2 VALUES ('5')
-
-statement error pq: value type int doesn't match type string of column "id"
-INSERT INTO t2 VALUES (6)
-
-# Verify ALTER COLUMN TYPE from INT to STRING works correctly.
-# Column order should stay the same.
-statement ok
-CREATE TABLE t3 (id int, id2 int, id3 int)
-
-statement ok
-INSERT INTO t3 VALUES (1,1,1), (2,2,2), (3,3,3)
-
-statement ok
-ALTER TABLE t3 ALTER COLUMN id2 TYPE string
-
-query TTBTTTB
-SHOW COLUMNS FROM t3
-----
-id     INT8    true   NULL            ·  {}         false
-id2    STRING  true   NULL            ·  {}         false
-id3    INT8    true   NULL            ·  {}         false
-rowid  INT8    false  unique_rowid()  ·  {primary}  true
-
-statement ok
-INSERT INTO t3 VALUES (4,'4',4)
-
-query ITI
-SELECT * FROM t3 ORDER BY id
-----
-1  1  1
-2  2  2
-3  3  3
-4  4  4
-
-# Ensure ALTER COLUMN TYPE correctly changes the precision of TIMESTAMPTZ.
-statement ok
-CREATE TABLE t5 (x TIMESTAMPTZ(6));
-INSERT INTO t5 VALUES ('2016-01-25 10:10:10.555555-05:00');
-INSERT INTO t5 VALUES ('2016-01-26 10:10:10.555555-05:00');
-ALTER TABLE t5 ALTER COLUMN x TYPE TIMESTAMPTZ(3);
-INSERT INTO t5 VALUES ('2016-01-26 10:10:10.55-05:00');
-
-query T
-SELECT * FROM t5 ORDER BY x
-----
-2016-01-25 16:10:10.556 +0100 CET
-2016-01-26 16:10:10.55 +0100 CET
-2016-01-26 16:10:10.556 +0100 CET
-
-# Ensure column families stay the same.
-statement ok
-CREATE TABLE t6(id INT, id2 INT, FAMILY f1 (id), FAMILY f2 (id2));
-INSERT INTO t6 VALUES (1), (2), (3);
-ALTER TABLE t6 ALTER COLUMN id2 TYPE STRING;
-
-query TT
-SHOW CREATE TABLE t6
-----
-t6  CREATE TABLE public.t6 (
-    id INT8 NULL,
-    id2 STRING NULL,
-    FAMILY f1 (id, rowid),
-    FAMILY f2 (id2)
-)
-
-# Ensure default expressions are casted correctly.
-statement ok
-CREATE TABLE t7 (x INT DEFAULT 1, y INT);
-INSERT INTO t7 (y) VALUES (1), (2), (3);
-ALTER TABLE t7 ALTER COLUMN x TYPE DATE;
-INSERT INTO t7 (y) VALUES (4);
-
-query TI
-SELECT * FROM t7 ORDER BY y
-----
-1970-01-02 00:00:00 +0000 +0000  1
-1970-01-02 00:00:00 +0000 +0000  2
-1970-01-02 00:00:00 +0000 +0000  3
-1970-01-02 00:00:00 +0000 +0000  4
-
-# Ensure a runtime error correctly rolls back and the table is unchanged.
-statement ok
-CREATE TABLE t8 (x STRING)
-
-statement ok
-INSERT INTO t8 VALUES ('hello')
-
-statement error pq: could not parse "hello" as type int: strconv.ParseInt: parsing "hello": invalid syntax
-ALTER TABLE t8 ALTER COLUMN x TYPE INT
-
-query TT
-SHOW CREATE TABLE t8
-----
-t8  CREATE TABLE public.t8 (
-    x STRING NULL,
-    FAMILY "primary" (x, rowid)
-)
-
-# Ensure ALTER COLUMN TYPE is disallowed if column is part of primary key.
-statement ok
-CREATE TABLE t9 (x INT PRIMARY KEY)
-
-statement error pq: unimplemented: ALTER COLUMN TYPE requiring rewrite of on-disk data is currently not supported for columns that are part of an index
-ALTER TABLE t9 ALTER COLUMN x TYPE STRING
-
-# Ensure ALTER COLUMN TYPE is disallowed if column is part of an index.
-statement ok
-CREATE TABLE t10 (x INT, y INT, INDEX(x, y))
-
-statement error pq: unimplemented: ALTER COLUMN TYPE requiring rewrite of on-disk data is currently not supported for columns that are part of an index
-ALTER TABLE t10 ALTER COLUMN y TYPE STRING
-
-# Ensure ALTER COLUMN TYPE is disallowed if an expression was provided.
-statement ok
-CREATE TABLE t11 (x INT)
-
-# Ensure ALTER COLUMN TYPE is disallowed if the column has a constraint.
-statement ok
-CREATE TABLE t12 (x INT check (x > 0))
-
-statement error pq: unimplemented: ALTER COLUMN TYPE for a column that has a constraint is currently not supported
-ALTER TABLE t12 ALTER COLUMN x TYPE STRING
-
-# Ensure ALTER COLUMN TYPE works correctly for interleaved tables.
-statement ok
-CREATE TABLE t13 (x INT PRIMARY KEY, y INT);
-INSERT INTO t13 VALUES (1, 1), (2, 2);
-CREATE TABLE t14 (x INT, y INT, z STRING, PRIMARY KEY(y, x)) INTERLEAVE IN PARENT t13 (y);
-INSERT INTO t14 VALUES (1, 1, '1'), (2, 2, '2')
-
-# Ensure we can change the column type of an interleaved child if the
-# column is not part of the primary key.
-statement ok
-ALTER TABLE t14 ALTER COLUMN z TYPE INT
-
-query III
-SELECT x, y, z FROM t14 ORDER BY x
-----
-1  1  1
-2  2  2
-
-# Ensure we can change the column type of an interleaved parent if the
-# column is not part of the primary key.
-statement ok
-ALTER TABLE t13 ALTER COLUMN y TYPE STRING
-
-query IT
-SELECT x, y FROM t13 ORDER BY x
-----
-1  1
-2  2
-
-# Ensure we can change the column type of a column stored in a secondary index.
-statement ok
-CREATE TABLE t15 (x INT, y INT);
-CREATE INDEX ON t15 (x) STORING (y);
-INSERT INTO t15 VALUES (1, 1), (2, 2)
-
-statement ok
-ALTER TABLE t15 ALTER COLUMN y TYPE STRING;
-
-query IT
-SELECT x, y FROM t15 ORDER BY x
-----
-1  1
-2  2
-
-# Ensure ALTER COLUMN TYPE works for collated strings.
-statement ok
-CREATE TABLE t16 (x STRING);
-INSERT INTO t16 VALUES ('Backhaus'), ('Bär'), ('Baz');
-
-query T
-SELECT x FROM t16 ORDER BY x
-----
-Backhaus
-Baz
-Bär
-
-statement ok
-ALTER TABLE t16 ALTER COLUMN x TYPE STRING COLLATE de
-
-query T
-SELECT x FROM t16 ORDER BY x
-----
-Backhaus
-Bär
-Baz
-
-# Ensure ALTER COLUMN TYPE fails if the DEFAULT EXPR cannot be casted to the new type.
-statement ok
-CREATE TABLE t17 (x STRING DEFAULT 'HELLO');
-
-statement error pq: could not parse "HELLO" as type int: strconv.ParseInt: parsing "HELLO": invalid syntax
-ALTER TABLE t17 ALTER COLUMN x TYPE INT
-
-query TT colnames
-show create table t17
-----
-table_name  create_statement
-t17         CREATE TABLE public.t17 (
-            x STRING NULL DEFAULT 'HELLO':::STRING,
-            FAMILY "primary" (x, rowid)
-)
-
-# Ensure ALTER COLUMN TYPE fails if the column is part of an FK relationship.
-statement ok
-CREATE TABLE t18 (x INT NOT NULL PRIMARY KEY);
-CREATE TABLE t19 (y INT NOT NULL REFERENCES t18 (x), INDEX(y));
-
-statement error pq: unimplemented: ALTER COLUMN TYPE requiring rewrite of on-disk data is currently not supported for columns that are part of an index
-ALTER TABLE t18 ALTER COLUMN x TYPE STRING
-
-statement error pq: unimplemented: ALTER COLUMN TYPE for a column that has a constraint is currently not supported
-ALTER TABLE t19 ALTER COLUMN y TYPE STRING
-
-# Ensure ALTER COLUMN TYPE does not work inside a transaction.
-statement ok
-CREATE TABLE t20 (x INT);
-BEGIN
-
-statement error pq: unimplemented: ALTER COLUMN TYPE is not supported inside a transaction
-ALTER TABLE t20 ALTER COLUMN x TYPE STRING
-
-statement ok
-ROLLBACK
-
-# Ensure ALTER COLUMN TYPE cannot be used in combination with other ALTER TABLE commands.
-statement ok
-CREATE TABLE t21 (x INT);
-
-statement error pq: unimplemented: ALTER COLUMN TYPE cannot be used in combination with other ALTER TABLE commands
-ALTER TABLE t21 ALTER COLUMN x TYPE STRING, ALTER COLUMN x SET NOT NULL;
-
-statement ok
-CREATE TABLE t22 (x INT);
-
-statement error pq: unimplemented: ALTER COLUMN TYPE cannot be used in combination with other ALTER TABLE commands
-ALTER TABLE t22 ALTER COLUMN x SET NOT NULL, ALTER COLUMN x TYPE STRING;
-
-# Ensure ALTER COLUMN TYPE USING EXPRESSION works.
-statement ok
-CREATE TABLE t23 (x INT);
-INSERT INTO t23 VALUES (-3), (-2), (-1), (0), (1), (2), (3)
-
-statement ok
-ALTER TABLE t23 ALTER COLUMN x TYPE BOOL USING (x > 0)
-
-query B
-SELECT x FROM t23 ORDER BY x
-----
-false
-false
-false
-false
-true
-true
-true
-
-# Ensure ALTER COLUMN TYPE rolls back if is not applicable to value in the column.
-statement ok
-CREATE TABLE t24 (x STRING);
-INSERT INTO t24 VALUES ('1'), ('hello');
-
-statement error pq: could not parse "hello" as type int: strconv.ParseInt: parsing "hello": invalid syntax
-ALTER TABLE t24  ALTER COLUMN x TYPE INT USING (x::int + 5)
-
-query TT colnames
-show create table t24
-----
-table_name  create_statement
-t24         CREATE TABLE public.t24 (
-            x STRING NULL,
-            FAMILY "primary" (x, rowid)
-)
-
-# Ensure USING EXPRESSION rolls back if the USING EXPRESSION does not conform
-# to the new type of the column.
-statement ok
-CREATE TABLE t25 (x INT);
-INSERT INTO t25 VALUES (1);
-
-statement error pq: expected ALTER COLUMN TYPE USING EXPRESSION expression to have type string, but '\(x\)' has type int
-ALTER TABLE t25 ALTER COLUMN x TYPE STRING USING (x);
-
-statement ok
-CREATE TABLE t26 (x INT);
-CREATE TABLE t27 (x INT);
-
-# Ensure USING EXPRESSION cannot reference columns that do not exist in the
-# table being altered.
-statement error pq: column "y" does not exist
-ALTER TABLE t26 ALTER COLUMN x TYPE BOOL USING (y > 0);
-
-# Ensure USING EXPRESSION cannot reference other tables.
-statement error pq: no data source matches prefix: t26 in this context
-ALTER TABLE t27 ALTER COLUMN x TYPE BOOL USING (t26.x > 0);
-
-# Ensure USING EXPRESSION cannot reference columns with a database or column
-# specified.
-
-statement error pq: no data source matches prefix: db.schema.t in this context
-ALTER TABLE t27 ALTER COLUMN x TYPE STRING USING (db.schema.t.x::STRING)
-
-statement error pq: no data source matches prefix: schema.t in this context
-ALTER TABLE t27 ALTER COLUMN x TYPE STRING USING (schema.t.x::STRING)
-
-statement ok
-ALTER TABLE t27 ALTER COLUMN x TYPE STRING USING (x::STRING)
-
-# Ensure ALTER COLUMN TYPE ... USING EXPRESSION does not perform a no-op when
-# converting to the same type.
-statement ok
-CREATE TABLE t28(x INT);
-INSERT INTO t28 VALUES (1), (2), (3);
-ALTER TABLE t28 ALTER COLUMN x TYPE INT USING (x * 5)
-
-query I
-SELECT x FROM t28 ORDER BY x
-----
-5
-10
-15
+#statement error pq: parsing as type timestamp: could not parse "hello"
+#ALTER TABLE t1 ALTER COLUMN date TYPE timestamp
+#
+## Verify ALTER COLUMN TYPE from INT to STRING works correctly.
+#statement ok
+#CREATE TABLE t2 (id int)
+#
+#statement ok
+#INSERT INTO t2 VALUES (1), (2), (3), (4)
+#
+#statement ok
+#ALTER TABLE t2 ALTER COLUMN id TYPE STRING
+#
+#query TTBTTTB
+#SHOW COLUMNS FROM t2
+#----
+#id     STRING  true   NULL            ·  {}         false
+#rowid  INT8    false  unique_rowid()  ·  {primary}  true
+#
+#statement ok
+#INSERT INTO t2 VALUES ('5')
+#
+#statement error pq: value type int doesn't match type string of column "id"
+#INSERT INTO t2 VALUES (6)
+#
+## Verify ALTER COLUMN TYPE from INT to STRING works correctly.
+## Column order should stay the same.
+#statement ok
+#CREATE TABLE t3 (id int, id2 int, id3 int)
+#
+#statement ok
+#INSERT INTO t3 VALUES (1,1,1), (2,2,2), (3,3,3)
+#
+#statement ok
+#ALTER TABLE t3 ALTER COLUMN id2 TYPE string
+#
+#query TTBTTTB
+#SHOW COLUMNS FROM t3
+#----
+#id     INT8    true   NULL            ·  {}         false
+#id2    STRING  true   NULL            ·  {}         false
+#id3    INT8    true   NULL            ·  {}         false
+#rowid  INT8    false  unique_rowid()  ·  {primary}  true
+#
+#statement ok
+#INSERT INTO t3 VALUES (4,'4',4)
+#
+#query ITI
+#SELECT * FROM t3 ORDER BY id
+#----
+#1  1  1
+#2  2  2
+#3  3  3
+#4  4  4
+#
+## Ensure ALTER COLUMN TYPE correctly changes the precision of TIMESTAMPTZ.
+#statement ok
+#CREATE TABLE t5 (x TIMESTAMPTZ(6));
+#INSERT INTO t5 VALUES ('2016-01-25 10:10:10.555555-05:00');
+#INSERT INTO t5 VALUES ('2016-01-26 10:10:10.555555-05:00');
+#ALTER TABLE t5 ALTER COLUMN x TYPE TIMESTAMPTZ(3);
+#INSERT INTO t5 VALUES ('2016-01-26 10:10:10.55-05:00');
+#
+#query T
+#SELECT * FROM t5 ORDER BY x
+#----
+#2016-01-25 16:10:10.556 +0100 CET
+#2016-01-26 16:10:10.55 +0100 CET
+#2016-01-26 16:10:10.556 +0100 CET
+#
+## Ensure column families stay the same.
+#statement ok
+#CREATE TABLE t6(id INT, id2 INT, FAMILY f1 (id), FAMILY f2 (id2));
+#INSERT INTO t6 VALUES (1), (2), (3);
+#ALTER TABLE t6 ALTER COLUMN id2 TYPE STRING;
+#
+#query TT
+#SHOW CREATE TABLE t6
+#----
+#t6  CREATE TABLE public.t6 (
+#    id INT8 NULL,
+#    id2 STRING NULL,
+#    FAMILY f1 (id, rowid),
+#    FAMILY f2 (id2)
+#)
+#
+## Ensure default expressions are casted correctly.
+#statement ok
+#CREATE TABLE t7 (x INT DEFAULT 1, y INT);
+#INSERT INTO t7 (y) VALUES (1), (2), (3);
+#ALTER TABLE t7 ALTER COLUMN x TYPE DATE;
+#INSERT INTO t7 (y) VALUES (4);
+#
+#query TI
+#SELECT * FROM t7 ORDER BY y
+#----
+#1970-01-02 00:00:00 +0000 +0000  1
+#1970-01-02 00:00:00 +0000 +0000  2
+#1970-01-02 00:00:00 +0000 +0000  3
+#1970-01-02 00:00:00 +0000 +0000  4
+#
+## Ensure a runtime error correctly rolls back and the table is unchanged.
+#statement ok
+#CREATE TABLE t8 (x STRING)
+#
+#statement ok
+#INSERT INTO t8 VALUES ('hello')
+#
+#statement error pq: could not parse "hello" as type int: strconv.ParseInt: parsing "hello": invalid syntax
+#ALTER TABLE t8 ALTER COLUMN x TYPE INT
+#
+#query TT
+#SHOW CREATE TABLE t8
+#----
+#t8  CREATE TABLE public.t8 (
+#    x STRING NULL,
+#    FAMILY "primary" (x, rowid)
+#)
+#
+## Ensure ALTER COLUMN TYPE is disallowed if column is part of primary key.
+#statement ok
+#CREATE TABLE t9 (x INT PRIMARY KEY)
+#
+#statement error pq: unimplemented: ALTER COLUMN TYPE requiring rewrite of on-disk data is currently not supported for columns that are part of an index
+#ALTER TABLE t9 ALTER COLUMN x TYPE STRING
+#
+## Ensure ALTER COLUMN TYPE is disallowed if column is part of an index.
+#statement ok
+#CREATE TABLE t10 (x INT, y INT, INDEX(x, y))
+#
+#statement error pq: unimplemented: ALTER COLUMN TYPE requiring rewrite of on-disk data is currently not supported for columns that are part of an index
+#ALTER TABLE t10 ALTER COLUMN y TYPE STRING
+#
+## Ensure ALTER COLUMN TYPE is disallowed if an expression was provided.
+#statement ok
+#CREATE TABLE t11 (x INT)
+#
+## Ensure ALTER COLUMN TYPE is disallowed if the column has a constraint.
+#statement ok
+#CREATE TABLE t12 (x INT check (x > 0))
+#
+#statement error pq: unimplemented: ALTER COLUMN TYPE for a column that has a constraint is currently not supported
+#ALTER TABLE t12 ALTER COLUMN x TYPE STRING
+#
+## Ensure ALTER COLUMN TYPE works correctly for interleaved tables.
+#statement ok
+#CREATE TABLE t13 (x INT PRIMARY KEY, y INT);
+#INSERT INTO t13 VALUES (1, 1), (2, 2);
+#CREATE TABLE t14 (x INT, y INT, z STRING, PRIMARY KEY(y, x)) INTERLEAVE IN PARENT t13 (y);
+#INSERT INTO t14 VALUES (1, 1, '1'), (2, 2, '2')
+#
+## Ensure we can change the column type of an interleaved child if the
+## column is not part of the primary key.
+#statement ok
+#ALTER TABLE t14 ALTER COLUMN z TYPE INT
+#
+#query III
+#SELECT x, y, z FROM t14 ORDER BY x
+#----
+#1  1  1
+#2  2  2
+#
+## Ensure we can change the column type of an interleaved parent if the
+## column is not part of the primary key.
+#statement ok
+#ALTER TABLE t13 ALTER COLUMN y TYPE STRING
+#
+#query IT
+#SELECT x, y FROM t13 ORDER BY x
+#----
+#1  1
+#2  2
+#
+## Ensure we can change the column type of a column stored in a secondary index.
+#statement ok
+#CREATE TABLE t15 (x INT, y INT);
+#CREATE INDEX ON t15 (x) STORING (y);
+#INSERT INTO t15 VALUES (1, 1), (2, 2)
+#
+#statement ok
+#ALTER TABLE t15 ALTER COLUMN y TYPE STRING;
+#
+#query IT
+#SELECT x, y FROM t15 ORDER BY x
+#----
+#1  1
+#2  2
+#
+## Ensure ALTER COLUMN TYPE works for collated strings.
+#statement ok
+#CREATE TABLE t16 (x STRING);
+#INSERT INTO t16 VALUES ('Backhaus'), ('Bär'), ('Baz');
+#
+#query T
+#SELECT x FROM t16 ORDER BY x
+#----
+#Backhaus
+#Baz
+#Bär
+#
+#statement ok
+#ALTER TABLE t16 ALTER COLUMN x TYPE STRING COLLATE de
+#
+#query T
+#SELECT x FROM t16 ORDER BY x
+#----
+#Backhaus
+#Bär
+#Baz
+#
+## Ensure ALTER COLUMN TYPE fails if the DEFAULT EXPR cannot be casted to the new type.
+#statement ok
+#CREATE TABLE t17 (x STRING DEFAULT 'HELLO');
+#
+#statement error pq: could not parse "HELLO" as type int: strconv.ParseInt: parsing "HELLO": invalid syntax
+#ALTER TABLE t17 ALTER COLUMN x TYPE INT
+#
+#query TT colnames
+#show create table t17
+#----
+#table_name  create_statement
+#t17         CREATE TABLE public.t17 (
+#            x STRING NULL DEFAULT 'HELLO':::STRING,
+#            FAMILY "primary" (x, rowid)
+#)
+#
+## Ensure ALTER COLUMN TYPE fails if the column is part of an FK relationship.
+#statement ok
+#CREATE TABLE t18 (x INT NOT NULL PRIMARY KEY);
+#CREATE TABLE t19 (y INT NOT NULL REFERENCES t18 (x), INDEX(y));
+#
+#statement error pq: unimplemented: ALTER COLUMN TYPE requiring rewrite of on-disk data is currently not supported for columns that are part of an index
+#ALTER TABLE t18 ALTER COLUMN x TYPE STRING
+#
+#statement error pq: unimplemented: ALTER COLUMN TYPE for a column that has a constraint is currently not supported
+#ALTER TABLE t19 ALTER COLUMN y TYPE STRING
+#
+## Ensure ALTER COLUMN TYPE does not work inside a transaction.
+#statement ok
+#CREATE TABLE t20 (x INT);
+#BEGIN
+#
+#statement error pq: unimplemented: ALTER COLUMN TYPE is not supported inside a transaction
+#ALTER TABLE t20 ALTER COLUMN x TYPE STRING
+#
+#statement ok
+#ROLLBACK
+#
+## Ensure ALTER COLUMN TYPE cannot be used in combination with other ALTER TABLE commands.
+#statement ok
+#CREATE TABLE t21 (x INT);
+#
+#statement error pq: unimplemented: ALTER COLUMN TYPE cannot be used in combination with other ALTER TABLE commands
+#ALTER TABLE t21 ALTER COLUMN x TYPE STRING, ALTER COLUMN x SET NOT NULL;
+#
+#statement ok
+#CREATE TABLE t22 (x INT);
+#
+#statement error pq: unimplemented: ALTER COLUMN TYPE cannot be used in combination with other ALTER TABLE commands
+#ALTER TABLE t22 ALTER COLUMN x SET NOT NULL, ALTER COLUMN x TYPE STRING;
+#
+## Ensure ALTER COLUMN TYPE USING EXPRESSION works.
+#statement ok
+#CREATE TABLE t23 (x INT);
+#INSERT INTO t23 VALUES (-3), (-2), (-1), (0), (1), (2), (3)
+#
+#statement ok
+#ALTER TABLE t23 ALTER COLUMN x TYPE BOOL USING (x > 0)
+#
+#query B
+#SELECT x FROM t23 ORDER BY x
+#----
+#false
+#false
+#false
+#false
+#true
+#true
+#true
+#
+## Ensure ALTER COLUMN TYPE rolls back if is not applicable to value in the column.
+#statement ok
+#CREATE TABLE t24 (x STRING);
+#INSERT INTO t24 VALUES ('1'), ('hello');
+#
+#statement error pq: could not parse "hello" as type int: strconv.ParseInt: parsing "hello": invalid syntax
+#ALTER TABLE t24  ALTER COLUMN x TYPE INT USING (x::int + 5)
+#
+#query TT colnames
+#show create table t24
+#----
+#table_name  create_statement
+#t24         CREATE TABLE public.t24 (
+#            x STRING NULL,
+#            FAMILY "primary" (x, rowid)
+#)
+#
+## Ensure USING EXPRESSION rolls back if the USING EXPRESSION does not conform
+## to the new type of the column.
+#statement ok
+#CREATE TABLE t25 (x INT);
+#INSERT INTO t25 VALUES (1);
+#
+#statement error pq: expected ALTER COLUMN TYPE USING EXPRESSION expression to have type string, but '\(x\)' has type int
+#ALTER TABLE t25 ALTER COLUMN x TYPE STRING USING (x);
+#
+#statement ok
+#CREATE TABLE t26 (x INT);
+#CREATE TABLE t27 (x INT);
+#
+## Ensure USING EXPRESSION cannot reference columns that do not exist in the
+## table being altered.
+#statement error pq: column "y" does not exist
+#ALTER TABLE t26 ALTER COLUMN x TYPE BOOL USING (y > 0);
+#
+## Ensure USING EXPRESSION cannot reference other tables.
+#statement error pq: no data source matches prefix: t26 in this context
+#ALTER TABLE t27 ALTER COLUMN x TYPE BOOL USING (t26.x > 0);
+#
+## Ensure USING EXPRESSION cannot reference columns with a database or column
+## specified.
+#
+#statement error pq: no data source matches prefix: db.schema.t in this context
+#ALTER TABLE t27 ALTER COLUMN x TYPE STRING USING (db.schema.t.x::STRING)
+#
+#statement error pq: no data source matches prefix: schema.t in this context
+#ALTER TABLE t27 ALTER COLUMN x TYPE STRING USING (schema.t.x::STRING)
+#
+#statement ok
+#ALTER TABLE t27 ALTER COLUMN x TYPE STRING USING (x::STRING)
+#
+## Ensure ALTER COLUMN TYPE ... USING EXPRESSION does not perform a no-op when
+## converting to the same type.
+#statement ok
+#CREATE TABLE t28(x INT);
+#INSERT INTO t28 VALUES (1), (2), (3);
+#ALTER TABLE t28 ALTER COLUMN x TYPE INT USING (x * 5)
+#
+#query I
+#SELECT x FROM t28 ORDER BY x
+#----
+#5
+#10
+#15
 
 # Regression 50277, ensure ColumnConversionValidate type conversion doesn't
 # error before running the online schema change.
 statement ok
 CREATE TABLE t29 (x INT8);
-INSERT INTO t29 VALUES (1), (2), (3);
-ALTER TABLE t29 ALTER COLUMN x TYPE INT4;
 
-query I
-SELECT x FROM t29 ORDER BY x
-----
-1
-2
-3
-
-# ColumnConversionValidate should error out if the conversion is not valid.
-# STRING -> BYTES is a ColumnConversionValidate type conversion, it should
-# try the conversion and error out if the cast cannot be applied.
-statement ok
-CREATE TABLE t30 (x STRING);
-INSERT INTO t30 VALUES (e'a\\01');
-
-statement error pq: could not parse "a\\\\01" as type bytes: bytea encoded value ends with incomplete escape sequence
-ALTER TABLE t30 ALTER COLUMN x TYPE BYTES
+#INSERT INTO t29 VALUES (1), (2), (3);
+#ALTER TABLE t29 ALTER COLUMN x TYPE INT4;
+#
+#query I
+#SELECT x FROM t29 ORDER BY x
+#----
+#1
+#2
+#3
+#
+## ColumnConversionValidate should error out if the conversion is not valid.
+## STRING -> BYTES is a ColumnConversionValidate type conversion, it should
+## try the conversion and error out if the cast cannot be applied.
+#statement ok
+#CREATE TABLE t30 (x STRING);
+#INSERT INTO t30 VALUES (e'a\\01');
+#
+#statement error pq: could not parse "a\\\\01" as type bytes: bytea encoded value ends with incomplete escape sequence
+#ALTER TABLE t30 ALTER COLUMN x TYPE BYTES
 
 # Ensure that dependent views prevent column type modification.
 

--- a/pkg/sql/logictest/testdata/logic_test/drop_type
+++ b/pkg/sql/logictest/testdata/logic_test/drop_type
@@ -96,11 +96,12 @@ DROP TYPE t
 # Altering a column's type to a UDT should pick up the reference.
 statement ok
 CREATE TYPE t AS ENUM ('hello');
-ALTER TABLE t1 ADD COLUMN x STRING;
-ALTER TABLE t1 ALTER COLUMN x SET DATA TYPE t
 
-statement error pq: cannot drop type "t" because other objects \(\[test.public.t1\]\) still depend on it
-DROP TYPE t
+#ALTER TABLE t1 ADD COLUMN x STRING;
+#ALTER TABLE t1 ALTER COLUMN x SET DATA TYPE t
+#
+#statement error pq: cannot drop type "t" because other objects \(\[test.public.t1\]\) still depend on it
+#DROP TYPE t
 
 statement ok
 DROP TABLE t1

--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -991,77 +991,77 @@ statement error pq: foreign key violation: "enum_origin" row x='hello' has no ma
 ALTER TABLE enum_origin ADD FOREIGN KEY (x) REFERENCES enum_referenced (x)
 
 # Tests for ALTER COLUMN SET DATA TYPE.
-statement ok
-SET enable_experimental_alter_column_type_general = true;
-CREATE TABLE enum_data_type (x STRING);
-INSERT INTO enum_data_type VALUES ('hello'), ('howdy');
-ALTER TABLE enum_data_type ALTER COLUMN x SET DATA TYPE greeting;
-INSERT INTO enum_data_type VALUES ('hi')
+#statement ok
+#SET enable_experimental_alter_column_type_general = true;
+#CREATE TABLE enum_data_type (x STRING);
+#INSERT INTO enum_data_type VALUES ('hello'), ('howdy');
+#ALTER TABLE enum_data_type ALTER COLUMN x SET DATA TYPE greeting;
+#INSERT INTO enum_data_type VALUES ('hi')
+#
+#query T rowsort
+#SELECT * FROM enum_data_type
+#----
+#hello
+#howdy
+#hi
 
-query T rowsort
-SELECT * FROM enum_data_type
-----
-hello
-howdy
-hi
-
-statement ok
-DROP TABLE enum_data_type;
-CREATE TABLE enum_data_type (x greeting);
-INSERT INTO enum_data_type VALUES ('hello'), ('howdy')
-
-# Enum to the same enum is a noop.
-statement ok
-ALTER TABLE enum_data_type ALTER COLUMN x SET DATA TYPE greeting
-
-# Now, set it to string.
-statement ok
-ALTER TABLE enum_data_type ALTER COLUMN x SET DATA TYPE STRING
-
-query T rowsort
-SELECT * FROM enum_data_type
-----
-hello
-howdy
-
-# Convert an enum type into another with USING.
-statement ok
-DROP TABLE enum_data_type;
-CREATE TABLE enum_data_type (x greeting);
-INSERT INTO enum_data_type VALUES ('hello'), ('hi')
-
-statement ok
-ALTER TABLE enum_data_type ALTER COLUMN x SET DATA TYPE dbs USING
-  (CASE WHEN x = 'hello' THEN 'cockroach' ELSE 'postgres' END)
-
-query T rowsort
-SELECT * FROM enum_data_type
-----
-cockroach
-postgres
-
-# Test when the conversion of string -> enum should fail.
-statement ok
-DROP TABLE enum_data_type;
-CREATE TABLE enum_data_type (x STRING);
-INSERT INTO enum_data_type VALUES ('notagreeting')
-
-statement error pq: invalid input value for enum greeting: "notagreeting"
-ALTER TABLE enum_data_type ALTER COLUMN x SET DATA TYPE greeting
-
-statement ok
-ALTER TABLE enum_data_type
-  ALTER COLUMN x SET DATA TYPE greeting USING (CASE WHEN x = 'notagreeting' THEN 'hello' ELSE 'hi' END)
-
-query T
-SELECT * FROM enum_data_type
-----
-hello
-
-query T
-SELECT to_json('hello'::greeting)
-----
-"hello"
+#statement ok
+#DROP TABLE enum_data_type;
+#CREATE TABLE enum_data_type (x greeting);
+#INSERT INTO enum_data_type VALUES ('hello'), ('howdy')
+#
+## Enum to the same enum is a noop.
+#statement ok
+#ALTER TABLE enum_data_type ALTER COLUMN x SET DATA TYPE greeting
+#
+## Now, set it to string.
+#statement ok
+#ALTER TABLE enum_data_type ALTER COLUMN x SET DATA TYPE STRING
+#
+#query T rowsort
+#SELECT * FROM enum_data_type
+#----
+#hello
+#howdy
+#
+## Convert an enum type into another with USING.
+#statement ok
+#DROP TABLE enum_data_type;
+#CREATE TABLE enum_data_type (x greeting);
+#INSERT INTO enum_data_type VALUES ('hello'), ('hi')
+#
+#statement ok
+#ALTER TABLE enum_data_type ALTER COLUMN x SET DATA TYPE dbs USING
+#  (CASE WHEN x = 'hello' THEN 'cockroach' ELSE 'postgres' END)
+#
+#query T rowsort
+#SELECT * FROM enum_data_type
+#----
+#cockroach
+#postgres
+#
+## Test when the conversion of string -> enum should fail.
+#statement ok
+#DROP TABLE enum_data_type;
+#CREATE TABLE enum_data_type (x STRING);
+#INSERT INTO enum_data_type VALUES ('notagreeting')
+#
+#statement error pq: invalid input value for enum greeting: "notagreeting"
+#ALTER TABLE enum_data_type ALTER COLUMN x SET DATA TYPE greeting
+#
+#statement ok
+#ALTER TABLE enum_data_type
+#  ALTER COLUMN x SET DATA TYPE greeting USING (CASE WHEN x = 'notagreeting' THEN 'hello' ELSE 'hi' END)
+#
+#query T
+#SELECT * FROM enum_data_type
+#----
+#hello
+#
+#query T
+#SELECT to_json('hello'::greeting)
+#----
+#"hello"
 
 # Regression for #51474.
 statement ok

--- a/pkg/sql/pgwire/testdata/pgtest/row_description
+++ b/pkg/sql/pgwire/testdata/pgtest/row_description
@@ -300,66 +300,66 @@ ReadyForQuery
 {"Type":"CommandComplete","CommandTag":"SELECT 1"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
-send crdb_only
-Query {"String": "SET enable_experimental_alter_column_type_general = true"}
-----
-
-until crdb_only
-ReadyForQuery
-----
-{"Type":"CommandComplete","CommandTag":"SET"}
-{"Type":"ReadyForQuery","TxStatus":"I"}
-
-send crdb_only
-Query {"String": "ALTER TABLE tab3 ALTER COLUMN b TYPE STRING"}
-----
-
-send noncrdb_only
-Query {"String": "ALTER TABLE tab3 ALTER COLUMN b TYPE TEXT"}
-----
-
-until
-ReadyForQuery
-----
-{"Type":"CommandComplete","CommandTag":"ALTER TABLE"}
-{"Type":"ReadyForQuery","TxStatus":"I"}
-
-# Ensure that after alter column type, the TableAttributeNumber stays consistent.
-# TableAttributeNumber of column b should stay as 2.
-
-# 80 = ASCII 'P' for Portal
-send
-Parse {"Name": "s3", "Query": "SELECT b FROM tab3"}
-Bind {"DestinationPortal": "p3", "PreparedStatement": "s3"}
-Describe {"ObjectType": 80, "Name": "p3"}
-Execute {"Portal": "p3"}
-Sync
-----
-
-until
-BindComplete
-----
-{"Type":"ParseComplete"}
-{"Type":"BindComplete"}
-
-until noncrdb_only ignore_table_oids
-RowDescription
-----
-{"Type":"RowDescription","Fields":[{"Name":"b","TableOID":0,"TableAttributeNumber":2,"DataTypeOID":25,"DataTypeSize":-1,"TypeModifier":-1,"Format":0}]}
-
-until crdb_only
-RowDescription
-----
-{"Type":"RowDescription","Fields":[{"Name":"b","TableOID":55,"TableAttributeNumber":2,"DataTypeOID":25,"DataTypeSize":-1,"TypeModifier":-1,"Format":0}]}
-
-
-until
-DataRow
-----
-{"Type":"DataRow","Values":[{"text":"hello"}]}
-
-until
-ReadyForQuery
-----
-{"Type":"CommandComplete","CommandTag":"SELECT 1"}
-{"Type":"ReadyForQuery","TxStatus":"I"}
+#send crdb_only
+#Query {"String": "SET enable_experimental_alter_column_type_general = true"}
+#----
+#
+#until crdb_only
+#ReadyForQuery
+#----
+#{"Type":"CommandComplete","CommandTag":"SET"}
+#{"Type":"ReadyForQuery","TxStatus":"I"}
+#
+#send crdb_only
+#Query {"String": "ALTER TABLE tab3 ALTER COLUMN b TYPE STRING"}
+#----
+#
+#send noncrdb_only
+#Query {"String": "ALTER TABLE tab3 ALTER COLUMN b TYPE TEXT"}
+#----
+#
+#until
+#ReadyForQuery
+#----
+#{"Type":"CommandComplete","CommandTag":"ALTER TABLE"}
+#{"Type":"ReadyForQuery","TxStatus":"I"}
+#
+## Ensure that after alter column type, the TableAttributeNumber stays consistent.
+## TableAttributeNumber of column b should stay as 2.
+#
+## 80 = ASCII 'P' for Portal
+#send
+#Parse {"Name": "s3", "Query": "SELECT b FROM tab3"}
+#Bind {"DestinationPortal": "p3", "PreparedStatement": "s3"}
+#Describe {"ObjectType": 80, "Name": "p3"}
+#Execute {"Portal": "p3"}
+#Sync
+#----
+#
+#until
+#BindComplete
+#----
+#{"Type":"ParseComplete"}
+#{"Type":"BindComplete"}
+#
+#until noncrdb_only ignore_table_oids
+#RowDescription
+#----
+#{"Type":"RowDescription","Fields":[{"Name":"b","TableOID":0,"TableAttributeNumber":2,"DataTypeOID":25,"DataTypeSize":-1,"TypeModifier":-1,"Format":0}]}
+#
+#until crdb_only
+#RowDescription
+#----
+#{"Type":"RowDescription","Fields":[{"Name":"b","TableOID":55,"TableAttributeNumber":2,"DataTypeOID":25,"DataTypeSize":-1,"TypeModifier":-1,"Format":0}]}
+#
+#
+#until
+#DataRow
+#----
+#{"Type":"DataRow","Values":[{"text":"hello"}]}
+#
+#until
+#ReadyForQuery
+#----
+#{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+#{"Type":"ReadyForQuery","TxStatus":"I"}


### PR DESCRIPTION
Refs: #54844 

sql: prohibit ALTER TABLE SET DATA TYPE requiring conversion/validation

Performing the validation and conversion as we do today in ALTER TABLE
... SET DATA TYPE ... is broken as it does not perform certain precision
or width based checks correctly.

The fix for this is deemed risky, hence we are disabling the
functionality in v20.2. This commit is intended for backport only.

Release note (sql change): ALTER TABLE ... SET DATA TYPE ... is no
longer available for operations that involve conversion (e.g. string ->
timestamptz) or precision/width truncation (e.g. INT(4) -> INT(2)) due
to a bug in validation. These features are already gated by the session
variable `enable_experimental_alter_column_type_general` - setting this
session variable is now a no-op.
