### PR TITLE
release-20.2: backupccl: redact the schedule emitted on create schedule

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -305,14 +305,16 @@ func resolveOptionsForBackupJobDescription(
 	return newOpts, nil
 }
 
-func backupJobDescription(
-	p sql.PlanHookState,
+// GetRedactedBackupNode returns a copy of the argument `backup`, but with all
+// the secret information redacted.
+func GetRedactedBackupNode(
 	backup *tree.Backup,
 	to []string,
 	incrementalFrom []string,
 	kmsURIs []string,
 	resolvedSubdir string,
-) (string, error) {
+	hasBeenPlanned bool,
+) (*tree.Backup, error) {
 	b := &tree.Backup{
 		AsOf:    backup.AsOf,
 		Targets: backup.Targets,
@@ -327,14 +329,14 @@ func backupJobDescription(
 	// LATEST, where we are appending an incremental BACKUP.
 	// - For `BACKUP INTO x` this would be the sub-directory we have selected to
 	// write the BACKUP to.
-	if b.Nested {
+	if b.Nested && hasBeenPlanned {
 		b.Subdir = tree.NewDString(resolvedSubdir)
 	}
 
 	for _, t := range to {
 		sanitizedTo, err := cloudimpl.SanitizeExternalStorageURI(t, nil /* extraParams */)
 		if err != nil {
-			return "", err
+			return nil, err
 		}
 		b.To = append(b.To, tree.NewDString(sanitizedTo))
 	}
@@ -342,16 +344,32 @@ func backupJobDescription(
 	for _, from := range incrementalFrom {
 		sanitizedFrom, err := cloudimpl.SanitizeExternalStorageURI(from, nil /* extraParams */)
 		if err != nil {
-			return "", err
+			return nil, err
 		}
 		b.IncrementalFrom = append(b.IncrementalFrom, tree.NewDString(sanitizedFrom))
 	}
 
 	resolvedOpts, err := resolveOptionsForBackupJobDescription(backup.Options, kmsURIs)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	b.Options = resolvedOpts
+	return b, nil
+}
+
+func backupJobDescription(
+	p sql.PlanHookState,
+	backup *tree.Backup,
+	to []string,
+	incrementalFrom []string,
+	kmsURIs []string,
+	resolvedSubdir string,
+) (string, error) {
+	b, err := GetRedactedBackupNode(backup, to, incrementalFrom, kmsURIs, resolvedSubdir,
+		true /* hasBeenPlanned */)
+	if err != nil {
+		return "", err
+	}
 
 	ann := p.ExtendedEvalContext().Annotations
 	return tree.AsStringWithFQNames(b, ann), nil

--- a/pkg/ccl/backupccl/create_scheduled_backup.go
+++ b/pkg/ccl/backupccl/create_scheduled_backup.go
@@ -249,8 +249,9 @@ func doCreateBackupSchedules(
 	// Evaluate encryption KMS URIs if set.
 	// Only one of encryption passphrase and KMS URI should be set, but this check
 	// is done during backup planning so we do not need to worry about it here.
+	var kmsURIs []string
 	if eval.kmsURIs != nil {
-		kmsURIs, err := eval.kmsURIs()
+		kmsURIs, err = eval.kmsURIs()
 		if err != nil {
 			return errors.Wrapf(err, "failed to evaluate backup kms_uri")
 		}
@@ -344,7 +345,8 @@ func doCreateBackupSchedules(
 		if err := inc.Create(ctx, ex, p.ExtendedEvalContext().Txn); err != nil {
 			return err
 		}
-		if err := emitSchedule(inc, tree.AsString(backupNode), resultsCh); err != nil {
+		if err := emitSchedule(inc, backupNode, destinations, nil /* incrementalFrom */, kmsURIs,
+			resultsCh); err != nil {
 			return err
 		}
 		unpauseOnSuccessID = inc.ScheduleID()
@@ -352,7 +354,6 @@ func doCreateBackupSchedules(
 
 	// Create FULL backup schedule.
 	backupNode.AppendToLatest = false
-	fullBackupStmt := tree.AsString(backupNode)
 	full, err := makeBackupSchedule(
 		env, p.User(), scheduleLabel,
 		fullRecurrence, details, unpauseOnSuccessID, updateMetricOnSuccess, backupNode)
@@ -376,7 +377,8 @@ func doCreateBackupSchedules(
 		return err
 	}
 	collectScheduledBackupTelemetry(incRecurrence, firstRun, fullRecurrencePicked, details)
-	return emitSchedule(full, fullBackupStmt, resultsCh)
+	return emitSchedule(full, backupNode, destinations, nil /* incrementalFrom */, kmsURIs,
+		resultsCh)
 }
 
 // checkForExistingBackupsInCollection checks that there are no existing backups
@@ -467,7 +469,12 @@ func makeBackupSchedule(
 	return sj, nil
 }
 
-func emitSchedule(sj *jobs.ScheduledJob, backupStmt string, resultsCh chan<- tree.Datums) error {
+func emitSchedule(
+	sj *jobs.ScheduledJob,
+	backupNode *tree.Backup,
+	to, incrementalFrom, kmsURIs []string,
+	resultsCh chan<- tree.Datums,
+) error {
 	var nextRun tree.Datum
 	status := "ACTIVE"
 	if sj.IsPaused() {
@@ -484,13 +491,19 @@ func emitSchedule(sj *jobs.ScheduledJob, backupStmt string, resultsCh chan<- tre
 		nextRun = next
 	}
 
+	redactedBackupNode, err := GetRedactedBackupNode(backupNode, to, incrementalFrom, kmsURIs, "",
+		false /* hasBeenPlanned */)
+	if err != nil {
+		return err
+	}
+
 	resultsCh <- tree.Datums{
 		tree.NewDInt(tree.DInt(sj.ScheduleID())),
 		tree.NewDString(sj.ScheduleLabel()),
 		tree.NewDString(status),
 		nextRun,
 		tree.NewDString(sj.ScheduleExpr()),
-		tree.NewDString(backupStmt),
+		tree.NewDString(tree.AsString(redactedBackupNode)),
 	}
 	return nil
 }


### PR DESCRIPTION
Backport 1/1 commits from #56091.

/cc @cockroachdb/release

---

Redacts all the regular suspects when emitting the schedule created by
the user via `CREATE SCHEDULE`. It shares the same logic used to redact
before writing to the job description after the backup has been planned.

Release note: None
