### PR TITLE
cli: handle utf in show tables

### DIFF
--- a/pkg/cli/sql_util.go
+++ b/pkg/cli/sql_util.go
@@ -551,6 +551,7 @@ func (c *sqlConn) Close() {
 
 type sqlRowsI interface {
 	driver.RowsColumnTypeScanType
+	driver.RowsColumnTypeDatabaseTypeName
 	Result() driver.Result
 	Tag() string
 
@@ -618,6 +619,10 @@ func (r *sqlRows) NextResultSet() (bool, error) {
 
 func (r *sqlRows) ColumnTypeScanType(index int) reflect.Type {
 	return r.rows.ColumnTypeScanType(index)
+}
+
+func (r *sqlRows) ColumnTypeDatabaseTypeName(index int) string {
+	return r.rows.ColumnTypeDatabaseTypeName(index)
 }
 
 func makeSQLConn(url string) *sqlConn {
@@ -1087,6 +1092,12 @@ func getNextRowStrings(rows *sqlRows, showMoreChars bool) ([]string, error) {
 
 	rowStrings := make([]string, len(cols))
 	for i, v := range vals {
+		databaseType := rows.ColumnTypeDatabaseTypeName(i)
+		if databaseType == "NAME" {
+			if bytes, ok := v.([]byte); ok {
+				v = string(bytes)
+			}
+		}
 		rowStrings[i] = formatVal(v, showMoreChars, showMoreChars)
 	}
 	return rowStrings, nil


### PR DESCRIPTION
Fixes: https://github.com/cockroachdb/cockroach/issues/51459 - UTF table names in `SHOW TABLES`

CLI on master shows UTF table names as escaped codepoints instead of UTF chars. It's because table name  is stored in a `relname` column an internal NAME type. Internally it's handled by a `DName` type that is sent to CLI as a byte array. This byte array is rendered as is, without UTF handling. See [sql_utl.go](https://github.com/cockroachdb/cockroach/blob/master/pkg/cli/sql_util.go#L1124-L1158)

This PR adds casting `relname` to `string` to achieve proper UTF handling in the CLI.

Alternatively we could convert `DName` to `string` before converting it to `driver.Value`. I'm not sure where to do it. If it's a better way to go, I'd be grateful for some guidance.
