### PR TITLE
kv: remove assertion around QuotaPool and Raft window size config

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -413,9 +413,6 @@ func (cfg *RaftConfig) SetDefaults() {
 	if cfg.RaftProposalQuota > int64(cfg.RaftMaxUncommittedEntriesSize) {
 		panic("raft proposal quota should not be above max uncommitted entries size")
 	}
-	if cfg.RaftProposalQuota < int64(cfg.RaftMaxSizePerMsg)*int64(cfg.RaftMaxInflightMsgs) {
-		panic("raft proposal quota should not be below per-replica replication window size")
-	}
 }
 
 // RaftElectionTimeout returns the raft election timeout, as computed from the


### PR DESCRIPTION
This check was well intentioned when added, but seems misguided
in retrospect. There are valid reasons why someone might want to
configure limits to various dimensions of the Raft window size
in ways that, when combined, exceeds the total window size limit
(i.e. the quota pool size).