### PR TITLE
roachprod: dismiss signup banner for nodes started by roachprod

### DIFF
--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -80,7 +80,10 @@ var (
 	listMine          bool
 	clusterType       = "cockroach"
 	secure            = false
-	nodeEnv           = []string{"COCKROACH_ENABLE_RPC_COMPRESSION=false"}
+	nodeEnv           = []string{
+		"COCKROACH_ENABLE_RPC_COMPRESSION=false",
+		"COCKROACH_UI_RELEASE_NOTES_SIGNUP_DISMISSED=true",
+	}
 	nodeArgs          []string
 	tag               string
 	external          = false


### PR DESCRIPTION
Previously, when starting a node using roachprod, the db console
ui would display a release notes signup banner. This banner is not
useful for users of roachprod. We introduced a way to toggle this
via env var in cockroachdb#56437. This commit sets that
env var, COCKROACH_UI_RELEASE_NOTES_SIGNUP_DISMISSED=true for
`cockroach start*` commands issued from roachprod.

Resolves: cockroachdb#46998
See also: cockroachdb#56437

Release note: none