### PR TITLE
sql: use FastIntMap for column id -> idx maps

### DIFF
--- a/pkg/ccl/changefeedccl/avro.go
+++ b/pkg/ccl/changefeedccl/avro.go
@@ -401,7 +401,7 @@ func indexToAvroSchema(
 	}
 	colIdxByID := tableDesc.ColumnIdxMap()
 	for _, colID := range indexDesc.ColumnIDs {
-		colIdx, ok := colIdxByID[colID]
+		colIdx, ok := colIdxByID.Get(colID)
 		if !ok {
 			return nil, errors.Errorf(`unknown column id: %d`, colID)
 		}

--- a/pkg/ccl/changefeedccl/encoder.go
+++ b/pkg/ccl/changefeedccl/encoder.go
@@ -144,7 +144,7 @@ func (e *jsonEncoder) encodeKeyRaw(row encodeRow) ([]interface{}, error) {
 	colIdxByID := row.tableDesc.ColumnIdxMap()
 	jsonEntries := make([]interface{}, len(row.tableDesc.GetPrimaryIndex().ColumnIDs))
 	for i, colID := range row.tableDesc.GetPrimaryIndex().ColumnIDs {
-		idx, ok := colIdxByID[colID]
+		idx, ok := colIdxByID.Get(colID)
 		if !ok {
 			return nil, errors.Errorf(`unknown column id: %d`, colID)
 		}

--- a/pkg/ccl/changefeedccl/rowfetcher_cache.go
+++ b/pkg/ccl/changefeedccl/rowfetcher_cache.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/hydratedtables"
@@ -152,10 +153,10 @@ func (c *rowFetcherCache) RowFetcherForTableDesc(
 		return rf, nil
 	}
 	// TODO(dan): Allow for decoding a subset of the columns.
-	colIdxMap := make(map[descpb.ColumnID]int)
+	var colIdxMap catalog.TableColMap
 	var valNeededForCol util.FastIntSet
 	for colIdx := range tableDesc.Columns {
-		colIdxMap[tableDesc.Columns[colIdx].ID] = colIdx
+		colIdxMap.Set(tableDesc.Columns[colIdx].ID, colIdx)
 		valNeededForCol.Add(colIdx)
 	}
 

--- a/pkg/server/settingsworker.go
+++ b/pkg/server/settingsworker.go
@@ -79,7 +79,7 @@ func (s *Server) refreshSettings() {
 				}
 				colID := lastColID + descpb.ColumnID(colIDDiff)
 				lastColID = colID
-				if idx, ok := colIdxMap[colID]; ok {
+				if idx, ok := colIdxMap.Get(colID); ok {
 					res, bytes, err = rowenc.DecodeTableValue(a, tbl.Columns[idx].Type, bytes)
 					if err != nil {
 						return err

--- a/pkg/sql/backfill/BUILD.bazel
+++ b/pkg/sql/backfill/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//pkg/kv",
         "//pkg/roachpb",
+        "//pkg/sql/catalog",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/schemaexpr",
         "//pkg/sql/catalog/tabledesc",

--- a/pkg/sql/backfill/backfill.go
+++ b/pkg/sql/backfill/backfill.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemaexpr"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
@@ -378,7 +379,7 @@ type IndexBackfiller struct {
 
 	added []*descpb.IndexDescriptor
 	// colIdxMap maps ColumnIDs to indices into desc.Columns and desc.Mutations.
-	colIdxMap map[descpb.ColumnID]int
+	colIdxMap catalog.TableColMap
 
 	types   []*types.T
 	rowVals tree.Datums
@@ -442,7 +443,7 @@ func (ib *IndexBackfiller) InitForLocalUse(
 	// Add the columns referenced in the predicate to valNeededForCol so that
 	// columns necessary to evaluate the predicate expression are fetched.
 	predicateRefColIDs.ForEach(func(col descpb.ColumnID) {
-		valNeededForCol.Add(ib.colIdxMap[col])
+		valNeededForCol.Add(ib.colIdxMap.GetDefault(col))
 	})
 
 	return ib.init(evalCtx, predicates, valNeededForCol, desc, mon)
@@ -498,7 +499,7 @@ func (ib *IndexBackfiller) InitForDistributedUse(
 	// Add the columns referenced in the predicate to valNeededForCol so that
 	// columns necessary to evaluate the predicate expression are fetched.
 	predicateRefColIDs.ForEach(func(col descpb.ColumnID) {
-		valNeededForCol.Add(ib.colIdxMap[col])
+		valNeededForCol.Add(ib.colIdxMap.GetDefault(col))
 	})
 
 	return ib.init(evalCtx, predicates, valNeededForCol, desc, mon)
@@ -539,9 +540,8 @@ func (ib *IndexBackfiller) initCols(desc *tabledesc.Immutable) {
 	}
 
 	// Create a map of each column's ID to its ordinal.
-	ib.colIdxMap = make(map[descpb.ColumnID]int, len(ib.cols))
 	for i := range ib.cols {
-		ib.colIdxMap[ib.cols[i].ID] = i
+		ib.colIdxMap.Set(ib.cols[i].ID, i)
 	}
 }
 

--- a/pkg/sql/catalog/BUILD.bazel
+++ b/pkg/sql/catalog/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
         "desc_getter.go",
         "descriptor.go",
         "errors.go",
+        "table_col_map.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/catalog",
     visibility = ["//visibility:public"],

--- a/pkg/sql/catalog/descriptor.go
+++ b/pkg/sql/catalog/descriptor.go
@@ -130,12 +130,12 @@ type TableDescriptor interface {
 	FindColumnByName(name tree.Name) (*descpb.ColumnDescriptor, bool, error)
 	FindActiveColumnByID(id descpb.ColumnID) (*descpb.ColumnDescriptor, error)
 	FindColumnByID(id descpb.ColumnID) (*descpb.ColumnDescriptor, error)
-	ColumnIdxMap() map[descpb.ColumnID]int
+	ColumnIdxMap() TableColMap
 	GetColumnAtIdx(idx int) *descpb.ColumnDescriptor
 	AllNonDropColumns() []descpb.ColumnDescriptor
 	VisibleColumns() []descpb.ColumnDescriptor
 	ColumnsWithMutations(includeMutations bool) []descpb.ColumnDescriptor
-	ColumnIdxMapWithMutations(includeMutations bool) map[descpb.ColumnID]int
+	ColumnIdxMapWithMutations(includeMutations bool) TableColMap
 	DeletableColumns() []descpb.ColumnDescriptor
 
 	GetFamilies() []descpb.ColumnFamilyDescriptor

--- a/pkg/sql/catalog/schemaexpr/computed_exprs.go
+++ b/pkg/sql/catalog/schemaexpr/computed_exprs.go
@@ -11,6 +11,7 @@
 package schemaexpr
 
 import (
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -26,7 +27,7 @@ type RowIndexedVarContainer struct {
 	// original table, we need to store a mapping between them.
 
 	Cols    []descpb.ColumnDescriptor
-	Mapping map[descpb.ColumnID]int
+	Mapping catalog.TableColMap
 }
 
 var _ tree.IndexedVarContainer = &RowIndexedVarContainer{}
@@ -35,7 +36,7 @@ var _ tree.IndexedVarContainer = &RowIndexedVarContainer{}
 func (r *RowIndexedVarContainer) IndexedVarEval(
 	idx int, ctx *tree.EvalContext,
 ) (tree.Datum, error) {
-	rowIdx, ok := r.Mapping[r.Cols[idx].ID]
+	rowIdx, ok := r.Mapping.Get(r.Cols[idx].ID)
 	if !ok {
 		return tree.DNull, nil
 	}

--- a/pkg/sql/catalog/table_col_map.go
+++ b/pkg/sql/catalog/table_col_map.go
@@ -1,0 +1,52 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package catalog
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/util"
+)
+
+// TableColMap is a map from descpb.ColumnID to int. It is typically used to
+// store a mapping from column id to ordinal position within a row, but can be
+// used for any similar purpose.
+type TableColMap struct {
+	m util.FastIntMap
+}
+
+// Set maps a key to the given value.
+func (s *TableColMap) Set(col descpb.ColumnID, val int) { s.m.Set(int(col), val) }
+
+// Get returns the current value mapped to key, or ok=false if the
+// key is unmapped.
+func (s *TableColMap) Get(col descpb.ColumnID) (val int, ok bool) { return s.m.Get(int(col)) }
+
+// GetDefault returns the current value mapped to key, or 0 if the key is
+// unmapped.
+func (s *TableColMap) GetDefault(col descpb.ColumnID) (val int) { return s.m.GetDefault(int(col)) }
+
+// Len returns the number of keys in the map.
+func (s *TableColMap) Len() (val int) { return s.m.Len() }
+
+// ForEach calls the given function for each key/value pair in the map (in
+// arbitrary order).
+func (s *TableColMap) ForEach(f func(colID descpb.ColumnID, returnIndex int)) {
+	s.m.ForEach(func(k, v int) {
+		f(descpb.ColumnID(k), v)
+	})
+}
+
+// String prints out the contents of the map in the following format:
+//   map[key1:val1 key2:val2 ...]
+// The keys are in ascending order.
+func (s *TableColMap) String() string {
+	return s.m.String()
+}

--- a/pkg/sql/catalog/tabledesc/structured.go
+++ b/pkg/sql/catalog/tabledesc/structured.go
@@ -2585,25 +2585,25 @@ func (desc *Immutable) FindColumnMutationByName(name tree.Name) *descpb.Descript
 
 // ColumnIdxMap returns a map from Column ID to the ordinal position of that
 // column.
-func (desc *Immutable) ColumnIdxMap() map[descpb.ColumnID]int {
+func (desc *Immutable) ColumnIdxMap() catalog.TableColMap {
 	return desc.ColumnIdxMapWithMutations(false)
 }
 
 // ColumnIdxMapWithMutations returns a map from Column ID to the ordinal
 // position of that column, optionally including mutation columns if the input
 // bool is true.
-func (desc *Immutable) ColumnIdxMapWithMutations(mutations bool) map[descpb.ColumnID]int {
-	colIdxMap := make(map[descpb.ColumnID]int, len(desc.Columns))
+func (desc *Immutable) ColumnIdxMapWithMutations(mutations bool) catalog.TableColMap {
+	var colIdxMap catalog.TableColMap
 	for i := range desc.Columns {
 		id := desc.Columns[i].ID
-		colIdxMap[id] = i
+		colIdxMap.Set(id, i)
 	}
 	if mutations {
 		idx := len(desc.Columns)
 		for i := range desc.Mutations {
 			col := desc.Mutations[i].GetColumn()
 			if col != nil {
-				colIdxMap[col.ID] = idx
+				colIdxMap.Set(col.ID, idx)
 				idx++
 			}
 		}

--- a/pkg/sql/colfetcher/colbatch_scan.go
+++ b/pkg/sql/colfetcher/colbatch_scan.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
@@ -176,7 +177,7 @@ func NewColBatchScan(
 	}
 	for i := range sysColDescs {
 		typs = append(typs, sysColDescs[i].Type)
-		columnIdxMap[sysColDescs[i].ID] = len(columnIdxMap)
+		columnIdxMap.Set(sysColDescs[i].ID, columnIdxMap.Len())
 	}
 
 	semaCtx := tree.MakeSemaContext()
@@ -230,7 +231,7 @@ func initCRowFetcher(
 	fetcher *cFetcher,
 	desc *tabledesc.Immutable,
 	indexIdx int,
-	colIdxMap map[descpb.ColumnID]int,
+	colIdxMap catalog.TableColMap,
 	reverseScan bool,
 	valNeededForCol util.FastIntSet,
 	scanVisibility execinfrapb.ScanVisibility,

--- a/pkg/sql/distsql_plan_stats.go
+++ b/pkg/sql/distsql_plan_stats.go
@@ -112,7 +112,7 @@ func (dsp *DistSQLPlanner) createStatsPlan(
 			StatName:            s.name,
 		}
 		for i, colID := range s.columns {
-			colIdx, ok := scan.colIdxMap[colID]
+			colIdx, ok := scan.colIdxMap.Get(colID)
 			if !ok {
 				panic("necessary column not scanned")
 			}

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -110,7 +110,7 @@ func (r *insertRun) initRowContainer(params runParams, columns colinfo.ResultCol
 	colIDToRetIndex := r.ti.tableDesc().ColumnIdxMap()
 	r.rowIdxToTabColIdx = make([]int, len(r.insertCols))
 	for i, col := range r.insertCols {
-		if idx, ok := colIDToRetIndex[col.ID]; !ok {
+		if idx, ok := colIDToRetIndex.Get(col.ID); !ok {
 			// Column must be write only and not public.
 			r.rowIdxToTabColIdx[i] = -1
 		} else {

--- a/pkg/sql/insert_fast_path.go
+++ b/pkg/sql/insert_fast_path.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
@@ -90,7 +91,7 @@ type insertFastPathFKCheck struct {
 	tabDesc     *tabledesc.Immutable
 	idxDesc     *descpb.IndexDescriptor
 	keyPrefix   []byte
-	colMap      map[descpb.ColumnID]int
+	colMap      catalog.TableColMap
 	spanBuilder *span.Builder
 }
 
@@ -108,7 +109,6 @@ func (c *insertFastPathFKCheck) init(params runParams) error {
 			"%d FK cols, only %d cols in index", len(c.InsertCols), idx.numLaxKeyCols,
 		)
 	}
-	c.colMap = make(map[descpb.ColumnID]int, len(c.InsertCols))
 	for i, ord := range c.InsertCols {
 		var colID descpb.ColumnID
 		if i < len(c.idxDesc.ColumnIDs) {
@@ -117,7 +117,7 @@ func (c *insertFastPathFKCheck) init(params runParams) error {
 			colID = c.idxDesc.ExtraColumnIDs[i-len(c.idxDesc.ColumnIDs)]
 		}
 
-		c.colMap[colID] = int(ord)
+		c.colMap.Set(colID, int(ord))
 	}
 	return nil
 }

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemaexpr"
@@ -1338,10 +1339,10 @@ func (ef *execFactory) ConstructUpdate(
 
 	// updateColsIdx inverts the mapping of UpdateCols to FetchCols. See
 	// the explanatory comments in updateRun.
-	updateColsIdx := make(map[descpb.ColumnID]int, len(ru.UpdateCols))
+	var updateColsIdx catalog.TableColMap
 	for i := range ru.UpdateCols {
 		id := ru.UpdateCols[i].ID
-		updateColsIdx[id] = i
+		updateColsIdx.Set(id, i)
 	}
 
 	upd := updateNodePool.Get().(*updateNode)
@@ -1453,14 +1454,6 @@ func (ef *execFactory) ConstructUpsert(
 	// Truncate any FetchCols added by MakeUpdater. The optimizer has already
 	// computed a correct set that can sometimes be smaller.
 	ru.FetchCols = ru.FetchCols[:len(fetchColDescs)]
-
-	// updateColsIdx inverts the mapping of UpdateCols to FetchCols. See
-	// the explanatory comments in updateRun.
-	updateColsIdx := make(map[descpb.ColumnID]int, len(ru.UpdateCols))
-	for i := range ru.UpdateCols {
-		id := ru.UpdateCols[i].ID
-		updateColsIdx[id] = i
-	}
 
 	// Instantiate the upsert node.
 	ups := upsertNodePool.Get().(*upsertNode)

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -446,7 +446,7 @@ https://www.postgresql.org/docs/12/catalog-pg-attribute.html`,
 		return table.ForeachIndex(catalog.IndexOpts{}, func(index *descpb.IndexDescriptor, _ bool) error {
 			for _, colID := range index.ColumnIDs {
 				idxID := h.IndexOid(table.GetID(), index.ID)
-				column := table.GetColumnAtIdx(columnIdxMap[colID])
+				column := table.GetColumnAtIdx(columnIdxMap.GetDefault(colID))
 				if err := addColumn(column, idxID, column.GetPGAttributeNum()); err != nil {
 					return err
 				}

--- a/pkg/sql/row/BUILD.bazel
+++ b/pkg/sql/row/BUILD.bazel
@@ -73,6 +73,7 @@ go_test(
         "//pkg/security/securitytest",
         "//pkg/server",
         "//pkg/settings/cluster",
+        "//pkg/sql/catalog",
         "//pkg/sql/catalog/catalogkv",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/tabledesc",

--- a/pkg/sql/row/errors.go
+++ b/pkg/sql/row/errors.go
@@ -173,10 +173,10 @@ func DecodeRowInfo(
 	var valNeededForCol util.FastIntSet
 	valNeededForCol.AddRange(0, len(colIDs)-1)
 
-	colIdxMap := make(map[descpb.ColumnID]int, len(colIDs))
+	var colIdxMap catalog.TableColMap
 	cols := make([]descpb.ColumnDescriptor, len(colIDs))
 	for i, colID := range colIDs {
-		colIdxMap[colID] = i
+		colIdxMap.Set(colID, i)
 		col, err := tableDesc.FindColumnByID(colID)
 		if err != nil {
 			return nil, nil, nil, err

--- a/pkg/sql/row/fetcher.go
+++ b/pkg/sql/row/fetcher.go
@@ -88,7 +88,7 @@ type tableInfo struct {
 	neededValueCols int
 
 	// Map used to get the index for columns in cols.
-	colIdxMap map[descpb.ColumnID]int
+	colIdxMap catalog.TableColMap
 
 	// One value per column that is part of the key; each value is a column
 	// index (into cols); -1 if we don't need the value for that column.
@@ -151,7 +151,7 @@ type FetcherTableArgs struct {
 	Spans            roachpb.Spans
 	Desc             catalog.TableDescriptor
 	Index            *descpb.IndexDescriptor
-	ColIdxMap        map[descpb.ColumnID]int
+	ColIdxMap        catalog.TableColMap
 	IsSecondaryIndex bool
 	Cols             []descpb.ColumnDescriptor
 	// The indexes (0 to # of columns - 1) of the columns to return.
@@ -376,13 +376,14 @@ func (rf *Fetcher) Init(
 
 		// Scan through the entire columns map to see which columns are
 		// required.
-		for col, idx := range table.colIdxMap {
+		for _, col := range table.cols {
+			idx := table.colIdxMap.GetDefault(col.ID)
 			if tableArgs.ValNeededForCol.Contains(idx) {
 				// The idx-th column is required.
-				table.neededCols.Add(int(col))
+				table.neededCols.Add(int(col.ID))
 
 				// Set up any system column metadata, if this column is a system column.
-				switch colinfo.GetSystemColumnKindFromColumnID(col) {
+				switch colinfo.GetSystemColumnKindFromColumnID(col.ID) {
 				case descpb.SystemColumnKind_MVCCTIMESTAMP:
 					table.timestampOutputIdx = idx
 					rf.mvccDecodeStrategy = MVCCDecodingRequired
@@ -409,7 +410,7 @@ func (rf *Fetcher) Init(
 			table.indexColIdx = make([]int, nIndexCols)
 		}
 		for i, id := range indexColumnIDs {
-			colIdx, ok := table.colIdxMap[id]
+			colIdx, ok := table.colIdxMap.Get(id)
 			if ok {
 				table.indexColIdx[i] = colIdx
 				if table.neededCols.Contains(int(id)) {
@@ -1042,7 +1043,7 @@ func (rf *Fetcher) processKV(
 				}
 				for i, id := range table.index.ExtraColumnIDs {
 					if table.neededCols.Contains(int(id)) {
-						table.row[table.colIdxMap[id]] = table.extraVals[i]
+						table.row[table.colIdxMap.GetDefault(id)] = table.extraVals[i]
 					}
 				}
 				if rf.traceKV {
@@ -1105,7 +1106,7 @@ func (rf *Fetcher) processValueSingle(
 	}
 
 	if rf.traceKV || table.neededCols.Contains(int(colID)) {
-		if idx, ok := table.colIdxMap[colID]; ok {
+		if idx, ok := table.colIdxMap.Get(colID); ok {
 			if rf.traceKV {
 				prettyKey = fmt.Sprintf("%s/%s", prettyKey, table.desc.DeletableColumns()[idx].Name)
 			}
@@ -1179,7 +1180,7 @@ func (rf *Fetcher) processValueBytes(
 			}
 			continue
 		}
-		idx := table.colIdxMap[colID]
+		idx := table.colIdxMap.GetDefault(colID)
 
 		if rf.traceKV {
 			prettyKey = fmt.Sprintf("%s/%s", prettyKey, table.desc.DeletableColumns()[idx].Name)
@@ -1390,7 +1391,7 @@ func (rf *Fetcher) checkPrimaryIndexDatumEncodings(ctx context.Context) error {
 		}
 
 		for _, colID := range familySortedColumnIDs {
-			rowVal := table.row[table.colIdxMap[colID]]
+			rowVal := table.row[table.colIdxMap.GetDefault(colID)]
 			if rowVal.IsNull() {
 				// Column is not present.
 				continue
@@ -1480,7 +1481,7 @@ func (rf *Fetcher) checkKeyOrdering(ctx context.Context) error {
 	// is found, compare the values to ensure the ordering matches the column
 	// ordering.
 	for i, id := range rf.rowReadyTable.index.ColumnIDs {
-		idx := rf.rowReadyTable.colIdxMap[id]
+		idx := rf.rowReadyTable.colIdxMap.GetDefault(id)
 		result := rf.rowReadyTable.decodedRow[idx].Compare(&evalCtx, rf.rowReadyTable.lastDatums[idx])
 		expectedDirection := rf.rowReadyTable.index.ColumnDirections[i]
 		if rf.reverse && expectedDirection == descpb.IndexDescriptor_ASC {

--- a/pkg/sql/row/fetcher_mvcc_test.go
+++ b/pkg/sql/row/fetcher_mvcc_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
@@ -90,11 +91,11 @@ func TestRowFetcherMVCCMetadata(t *testing.T) {
 	childDesc := catalogkv.TestingGetImmutableTableDescriptor(kvDB, keys.SystemSQLCodec, `d`, `child`)
 	var args []row.FetcherTableArgs
 	for _, desc := range []*tabledesc.Immutable{parentDesc, childDesc} {
-		colIdxMap := make(map[descpb.ColumnID]int)
+		var colIdxMap catalog.TableColMap
 		var valNeededForCol util.FastIntSet
 		for colIdx := range desc.Columns {
 			id := desc.Columns[colIdx].ID
-			colIdxMap[id] = colIdx
+			colIdxMap.Set(id, colIdx)
 			valNeededForCol.Add(colIdx)
 		}
 		args = append(args, row.FetcherTableArgs{

--- a/pkg/sql/row/fk_spans.go
+++ b/pkg/sql/row/fk_spans.go
@@ -12,7 +12,7 @@ package row
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/span"
 )
@@ -20,7 +20,7 @@ import (
 // FKCheckSpan returns a span that can be scanned to ascertain existence of a
 // specific row in a given index.
 func FKCheckSpan(
-	s *span.Builder, values []tree.Datum, colMap map[descpb.ColumnID]int, numCols int,
+	s *span.Builder, values []tree.Datum, colMap catalog.TableColMap, numCols int,
 ) (roachpb.Span, error) {
 	span, containsNull, err := s.SpanFromDatumRow(values, numCols, colMap)
 	if err != nil {

--- a/pkg/sql/row/helper.go
+++ b/pkg/sql/row/helper.go
@@ -64,7 +64,7 @@ func newRowHelper(
 // encodeSecondaryIndexes. includeEmpty details whether the results should
 // include empty secondary index k/v pairs.
 func (rh *rowHelper) encodeIndexes(
-	colIDtoRowIndex map[descpb.ColumnID]int,
+	colIDtoRowIndex catalog.TableColMap,
 	values []tree.Datum,
 	ignoreIndexes util.FastIntSet,
 	includeEmpty bool,
@@ -82,7 +82,7 @@ func (rh *rowHelper) encodeIndexes(
 
 // encodePrimaryIndex encodes the primary index key.
 func (rh *rowHelper) encodePrimaryIndex(
-	colIDtoRowIndex map[descpb.ColumnID]int, values []tree.Datum,
+	colIDtoRowIndex catalog.TableColMap, values []tree.Datum,
 ) (primaryIndexKey []byte, err error) {
 	if rh.primaryIndexKeyPrefix == nil {
 		rh.primaryIndexKeyPrefix = rowenc.MakeIndexKeyPrefix(rh.Codec, rh.TableDesc,
@@ -105,7 +105,7 @@ func (rh *rowHelper) encodePrimaryIndex(
 // includeEmpty details whether the results should include empty secondary index
 // k/v pairs.
 func (rh *rowHelper) encodeSecondaryIndexes(
-	colIDtoRowIndex map[descpb.ColumnID]int,
+	colIDtoRowIndex catalog.TableColMap,
 	values []tree.Datum,
 	ignoreIndexes util.FastIntSet,
 	includeEmpty bool,

--- a/pkg/sql/row/inserter.go
+++ b/pkg/sql/row/inserter.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
@@ -29,7 +30,7 @@ import (
 type Inserter struct {
 	Helper                rowHelper
 	InsertCols            []descpb.ColumnDescriptor
-	InsertColIDtoRowIndex map[descpb.ColumnID]int
+	InsertColIDtoRowIndex catalog.TableColMap
 
 	// For allocation avoidance.
 	marshaled []roachpb.Value
@@ -57,7 +58,7 @@ func MakeInserter(
 	}
 
 	for i, col := range tableDesc.PrimaryIndex.ColumnIDs {
-		if _, ok := ri.InsertColIDtoRowIndex[col]; !ok {
+		if _, ok := ri.InsertColIDtoRowIndex.Get(col); !ok {
 			return Inserter{}, fmt.Errorf("missing %q primary key column", tableDesc.PrimaryIndex.ColumnNames[i])
 		}
 	}

--- a/pkg/sql/row/row_converter.go
+++ b/pkg/sql/row/row_converter.go
@@ -128,7 +128,7 @@ func GenerateInsertRow(
 			// columns, all the columns which could possibly be referenced *are*
 			// available.
 			col := computedColsLookup[i]
-			computeIdx := rowContainerForComputedVals.Mapping[col.ID]
+			computeIdx := rowContainerForComputedVals.Mapping.GetDefault(col.ID)
 			if !col.IsComputed() {
 				continue
 			}
@@ -161,7 +161,7 @@ func GenerateInsertRow(
 	// Check to see if NULL is being inserted into any non-nullable column.
 	for _, col := range tableDesc.WritableColumns() {
 		if !col.Nullable {
-			if i, ok := rowContainerForComputedVals.Mapping[col.ID]; !ok || rowVals[i] == tree.DNull {
+			if i, ok := rowContainerForComputedVals.Mapping.Get(col.ID); !ok || rowVals[i] == tree.DNull {
 				return nil, sqlerrors.NewNonNullViolationError(col.Name)
 			}
 		}
@@ -372,7 +372,7 @@ func NewDatumRowConverter(
 	for _, col := range c.tableDesc.Columns {
 		// We prefer to have the order of columns that will be sent into
 		// MakeComputedExprs to map that of Datums.
-		colsOrdered[ri.InsertColIDtoRowIndex[col.ID]] = col
+		colsOrdered[ri.InsertColIDtoRowIndex.GetDefault(col.ID)] = col
 	}
 	// Here, computeExprs will be nil if there's no computed column, or
 	// the list of computed expressions (including nil, for those columns

--- a/pkg/sql/row/updater.go
+++ b/pkg/sql/row/updater.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
@@ -32,9 +33,9 @@ type Updater struct {
 	Helper                rowHelper
 	DeleteHelper          *rowHelper
 	FetchCols             []descpb.ColumnDescriptor
-	FetchColIDtoRowIndex  map[descpb.ColumnID]int
+	FetchColIDtoRowIndex  catalog.TableColMap
 	UpdateCols            []descpb.ColumnDescriptor
-	UpdateColIDtoRowIndex map[descpb.ColumnID]int
+	UpdateColIDtoRowIndex catalog.TableColMap
 	primaryKeyColChange   bool
 
 	// rd and ri are used when the update this Updater is created for modifies
@@ -127,7 +128,7 @@ func MakeUpdater(
 			return true
 		}
 		return index.RunOverAllColumns(func(id descpb.ColumnID) error {
-			if _, ok := updateColIDtoRowIndex[id]; ok {
+			if _, ok := updateColIDtoRowIndex.Get(id); ok {
 				return returnTruePseudoError
 			}
 			return nil
@@ -193,12 +194,12 @@ func MakeUpdater(
 		// maybeAddCol adds the provided column to ru.FetchCols and
 		// ru.FetchColIDtoRowIndex if it isn't already present.
 		maybeAddCol := func(colID descpb.ColumnID) error {
-			if _, ok := ru.FetchColIDtoRowIndex[colID]; !ok {
+			if _, ok := ru.FetchColIDtoRowIndex.Get(colID); !ok {
 				col, _, err := tableDesc.FindReadableColumnByID(colID)
 				if err != nil {
 					return err
 				}
-				ru.FetchColIDtoRowIndex[col.ID] = len(ru.FetchCols)
+				ru.FetchColIDtoRowIndex.Set(col.ID, len(ru.FetchCols))
 				ru.FetchCols = append(ru.FetchCols, *col)
 			}
 			return nil
@@ -219,7 +220,7 @@ func MakeUpdater(
 			family := &tableDesc.Families[i]
 			familyBeingUpdated := false
 			for _, colID := range family.ColumnIDs {
-				if _, ok := ru.UpdateColIDtoRowIndex[colID]; ok {
+				if _, ok := ru.UpdateColIDtoRowIndex.Get(colID); ok {
 					familyBeingUpdated = true
 					break
 				}
@@ -310,7 +311,7 @@ func (ru *Updater) UpdateRow(
 	// Update the row values.
 	copy(ru.newValues, oldValues)
 	for i, updateCol := range ru.UpdateCols {
-		ru.newValues[ru.FetchColIDtoRowIndex[updateCol.ID]] = updateValues[i]
+		ru.newValues[ru.FetchColIDtoRowIndex.GetDefault(updateCol.ID)] = updateValues[i]
 	}
 
 	rowPrimaryKeyChanged := false

--- a/pkg/sql/rowenc/index_encoding.go
+++ b/pkg/sql/rowenc/index_encoding.go
@@ -63,7 +63,7 @@ func MakeIndexKeyPrefix(
 func EncodeIndexKey(
 	tableDesc catalog.TableDescriptor,
 	index *descpb.IndexDescriptor,
-	colMap map[descpb.ColumnID]int,
+	colMap catalog.TableColMap,
 	values []tree.Datum,
 	keyPrefix []byte,
 ) (key []byte, containsNull bool, err error) {
@@ -84,7 +84,7 @@ func EncodePartialIndexSpan(
 	tableDesc catalog.TableDescriptor,
 	index *descpb.IndexDescriptor,
 	numCols int,
-	colMap map[descpb.ColumnID]int,
+	colMap catalog.TableColMap,
 	values []tree.Datum,
 	keyPrefix []byte,
 ) (span roachpb.Span, containsNull bool, err error) {
@@ -113,7 +113,7 @@ func EncodePartialIndexKey(
 	tableDesc catalog.TableDescriptor,
 	index *descpb.IndexDescriptor,
 	numCols int,
-	colMap map[descpb.ColumnID]int,
+	colMap catalog.TableColMap,
 	values []tree.Datum,
 	keyPrefix []byte,
 ) (key []byte, containsNull bool, err error) {
@@ -258,15 +258,15 @@ func NeededColumnFamilyIDs(
 	var compositeCols util.FastIntSet
 	var extraCols util.FastIntSet
 	for _, columnID := range index.ColumnIDs {
-		columnOrdinal := colIdxMap[columnID]
+		columnOrdinal := colIdxMap.GetDefault(columnID)
 		indexedCols.Add(columnOrdinal)
 	}
 	for _, columnID := range index.CompositeColumnIDs {
-		columnOrdinal := colIdxMap[columnID]
+		columnOrdinal := colIdxMap.GetDefault(columnID)
 		compositeCols.Add(columnOrdinal)
 	}
 	for _, columnID := range index.ExtraColumnIDs {
-		columnOrdinal := colIdxMap[columnID]
+		columnOrdinal := colIdxMap.GetDefault(columnID)
 		extraCols.Add(columnOrdinal)
 	}
 
@@ -338,7 +338,7 @@ func NeededColumnFamilyIDs(
 				// Nothing left to check.
 				break
 			}
-			columnOrdinal := colIdxMap[columnID]
+			columnOrdinal := colIdxMap.GetDefault(columnID)
 			if nc.Contains(columnOrdinal) {
 				needed = true
 			}
@@ -482,9 +482,9 @@ func makeKeyFromEncDatums(
 // findColumnValue returns the value corresponding to the column. If
 // the column isn't present return a NULL value.
 func findColumnValue(
-	column descpb.ColumnID, colMap map[descpb.ColumnID]int, values []tree.Datum,
+	column descpb.ColumnID, colMap catalog.TableColMap, values []tree.Datum,
 ) tree.Datum {
-	if i, ok := colMap[column]; ok {
+	if i, ok := colMap.Get(column); ok {
 		// TODO(pmattis): Need to convert the values[i] value to the type
 		// expected by the column.
 		return values[i]
@@ -753,10 +753,7 @@ func (a byID) Less(i, j int) bool { return a[i].id < a[j].id }
 // concatenating keyPrefix with the encodings of the column in the
 // index.
 func EncodeInvertedIndexKeys(
-	index *descpb.IndexDescriptor,
-	colMap map[descpb.ColumnID]int,
-	values []tree.Datum,
-	keyPrefix []byte,
+	index *descpb.IndexDescriptor, colMap catalog.TableColMap, values []tree.Datum, keyPrefix []byte,
 ) (key [][]byte, err error) {
 	numColumns := len(index.ColumnIDs)
 
@@ -779,7 +776,7 @@ func EncodeInvertedIndexKeys(
 	}
 
 	var val tree.Datum
-	if i, ok := colMap[index.ColumnIDs[numColumns-1]]; ok {
+	if i, ok := colMap.Get(index.ColumnIDs[numColumns-1]); ok {
 		val = values[i]
 	} else {
 		val = tree.DNull
@@ -990,7 +987,7 @@ func EncodePrimaryIndex(
 	codec keys.SQLCodec,
 	tableDesc catalog.TableDescriptor,
 	index *descpb.IndexDescriptor,
-	colMap map[descpb.ColumnID]int,
+	colMap catalog.TableColMap,
 	values []tree.Datum,
 	includeEmpty bool,
 ) ([]IndexEntry, error) {
@@ -1042,7 +1039,7 @@ func EncodePrimaryIndex(
 				columnsToEncode = append(columnsToEncode, valueEncodedColumn{id: colID})
 				continue
 			}
-			if cdatum, ok := values[colMap[colID]].(tree.CompositeDatum); ok {
+			if cdatum, ok := values[colMap.GetDefault(colID)].(tree.CompositeDatum); ok {
 				if cdatum.IsComposite() {
 					columnsToEncode = append(columnsToEncode, valueEncodedColumn{id: colID, isComposite: true})
 					continue
@@ -1077,7 +1074,7 @@ func EncodeSecondaryIndex(
 	codec keys.SQLCodec,
 	tableDesc catalog.TableDescriptor,
 	secondaryIndex *descpb.IndexDescriptor,
-	colMap map[descpb.ColumnID]int,
+	colMap catalog.TableColMap,
 	values []tree.Datum,
 	includeEmpty bool,
 ) ([]IndexEntry, error) {
@@ -1179,7 +1176,7 @@ func EncodeSecondaryIndex(
 func encodeSecondaryIndexWithFamilies(
 	familyMap map[descpb.FamilyID][]valueEncodedColumn,
 	index *descpb.IndexDescriptor,
-	colMap map[descpb.ColumnID]int,
+	colMap catalog.TableColMap,
 	key []byte,
 	row []tree.Datum,
 	extraKeyCols []byte,
@@ -1259,7 +1256,7 @@ func encodeSecondaryIndexWithFamilies(
 // families were introduced onto secondary indexes.
 func encodeSecondaryIndexNoFamilies(
 	index *descpb.IndexDescriptor,
-	colMap map[descpb.ColumnID]int,
+	colMap catalog.TableColMap,
 	key []byte,
 	row []tree.Datum,
 	extraKeyCols []byte,
@@ -1308,7 +1305,7 @@ func encodeSecondaryIndexNoFamilies(
 // writeColumnValues writes the value encoded versions of the desired columns from the input
 // row of datums into the value byte slice.
 func writeColumnValues(
-	value []byte, colMap map[descpb.ColumnID]int, row []tree.Datum, columns []valueEncodedColumn,
+	value []byte, colMap catalog.TableColMap, row []tree.Datum, columns []valueEncodedColumn,
 ) ([]byte, error) {
 	var lastColID descpb.ColumnID
 	for _, col := range columns {
@@ -1339,7 +1336,7 @@ func EncodeSecondaryIndexes(
 	codec keys.SQLCodec,
 	tableDesc catalog.TableDescriptor,
 	indexes []*descpb.IndexDescriptor,
-	colMap map[descpb.ColumnID]int,
+	colMap catalog.TableColMap,
 	values []tree.Datum,
 	secondaryIndexEntries []IndexEntry,
 	includeEmpty bool,
@@ -1776,7 +1773,7 @@ func AdjustEndKeyForInterleave(
 func EncodeColumns(
 	columnIDs []descpb.ColumnID,
 	directions directions,
-	colMap map[descpb.ColumnID]int,
+	colMap catalog.TableColMap,
 	values []tree.Datum,
 	keyPrefix []byte,
 ) (key []byte, containsNull bool, err error) {

--- a/pkg/sql/rowenc/index_encoding_test.go
+++ b/pkg/sql/rowenc/index_encoding_test.go
@@ -51,17 +51,17 @@ type indexKeyTest struct {
 	secondaryValues      []tree.Datum // len must be at least secondaryInterleaveComponents+1
 }
 
-func makeTableDescForTest(test indexKeyTest) (*tabledesc.Immutable, map[descpb.ColumnID]int) {
+func makeTableDescForTest(test indexKeyTest) (*tabledesc.Immutable, catalog.TableColMap) {
 	primaryColumnIDs := make([]descpb.ColumnID, len(test.primaryValues))
 	secondaryColumnIDs := make([]descpb.ColumnID, len(test.secondaryValues))
 	columns := make([]descpb.ColumnDescriptor, len(test.primaryValues)+len(test.secondaryValues))
-	colMap := make(map[descpb.ColumnID]int, len(test.secondaryValues))
+	var colMap catalog.TableColMap
 	secondaryType := descpb.IndexDescriptor_FORWARD
 	for i := range columns {
 		columns[i] = descpb.ColumnDescriptor{
 			ID: descpb.ColumnID(i + 1),
 		}
-		colMap[columns[i].ID] = i
+		colMap.Set(columns[i].ID, i)
 		if i < len(test.primaryValues) {
 			columns[i].Type = test.primaryValues[i].ResolvedType()
 			primaryColumnIDs[i] = columns[i].ID
@@ -252,7 +252,7 @@ func TestIndexKey(t *testing.T) {
 			}
 
 			for j, value := range values {
-				testValue := testValues[colMap[index.ColumnIDs[j]]]
+				testValue := testValues[colMap.GetDefault(index.ColumnIDs[j])]
 				if value.Compare(evalCtx, testValue) != 0 {
 					t.Fatalf("%d: value %d got %q but expected %q", i, j, value, testValue)
 				}
@@ -1263,12 +1263,12 @@ func ExtractIndexKey(
 	}
 
 	// Encode the index key from its components.
-	colMap := make(map[descpb.ColumnID]int)
+	var colMap catalog.TableColMap
 	for i, columnID := range index.ColumnIDs {
-		colMap[columnID] = i
+		colMap.Set(columnID, i)
 	}
 	for i, columnID := range index.ExtraColumnIDs {
-		colMap[columnID] = i + len(index.ColumnIDs)
+		colMap.Set(columnID, i+len(index.ColumnIDs))
 	}
 	indexKeyPrefix := MakeIndexKeyPrefix(codec, tableDesc, tableDesc.GetPrimaryIndexID())
 

--- a/pkg/sql/rowenc/partition.go
+++ b/pkg/sql/rowenc/partition.go
@@ -159,9 +159,9 @@ func DecodePartitionTuple(
 	}
 
 	allDatums := append(prefixDatums, t.Datums...)
-	colMap := make(map[descpb.ColumnID]int, len(allDatums))
+	var colMap catalog.TableColMap
 	for i := range allDatums {
-		colMap[idxDesc.ColumnIDs[i]] = i
+		colMap.Set(idxDesc.ColumnIDs[i], i)
 	}
 
 	indexKeyPrefix := MakeIndexKeyPrefix(codec, tableDesc, idxDesc.ID)

--- a/pkg/sql/rowenc/testutils.go
+++ b/pkg/sql/rowenc/testutils.go
@@ -1019,9 +1019,9 @@ func TestingMakePrimaryIndexKey(
 	}
 	// Create the ColumnID to index in datums slice map needed by
 	// MakeIndexKeyPrefix.
-	colIDToRowIndex := make(map[descpb.ColumnID]int)
+	var colIDToRowIndex catalog.TableColMap
 	for i := range vals {
-		colIDToRowIndex[index.ColumnIDs[i]] = i
+		colIDToRowIndex.Set(index.ColumnIDs[i], i)
 	}
 
 	keyPrefix := MakeIndexKeyPrefix(keys.SystemSQLCodec, desc, index.ID)

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -15,6 +15,7 @@ import (
 	"sort"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
@@ -76,7 +77,7 @@ type joinReader struct {
 
 	desc             tabledesc.Immutable
 	index            *descpb.IndexDescriptor
-	colIdxMap        map[descpb.ColumnID]int
+	colIdxMap        catalog.TableColMap
 	maintainOrdering bool
 
 	// fetcher wraps the row.Fetcher used to perform lookups. This enables the
@@ -222,7 +223,7 @@ func newJoinReader(
 	}
 	for i := range sysColDescs {
 		columnTypes = append(columnTypes, sysColDescs[i].Type)
-		jr.colIdxMap[sysColDescs[i].ID] = len(jr.colIdxMap)
+		jr.colIdxMap.Set(sysColDescs[i].ID, jr.colIdxMap.Len())
 	}
 
 	var leftTypes []*types.T
@@ -274,7 +275,11 @@ func newJoinReader(
 	}
 
 	neededRightCols := jr.neededRightCols()
-	if isSecondary && !neededRightCols.SubsetOf(getIndexColSet(jr.index, jr.colIdxMap)) {
+	set, err := getIndexColSet(jr.index, jr.colIdxMap)
+	if err != nil {
+		return nil, err
+	}
+	if isSecondary && !neededRightCols.SubsetOf(set) {
 		return nil, errors.Errorf("joinreader index does not cover all columns")
 	}
 
@@ -388,19 +393,14 @@ func (jr *joinReader) initJoinReaderStrategy(
 
 // getIndexColSet returns a set of all column indices for the given index.
 func getIndexColSet(
-	index *descpb.IndexDescriptor, colIdxMap map[descpb.ColumnID]int,
-) util.FastIntSet {
+	index *descpb.IndexDescriptor, colIdxMap catalog.TableColMap,
+) (util.FastIntSet, error) {
 	cols := util.MakeFastIntSet()
 	err := index.RunOverAllColumns(func(id descpb.ColumnID) error {
-		cols.Add(colIdxMap[id])
+		cols.Add(colIdxMap.GetDefault(id))
 		return nil
 	})
-	if err != nil {
-		// This path should never be hit since the column function never returns an
-		// error.
-		panic(err)
-	}
-	return cols
+	return cols, err
 }
 
 // SetBatchSizeBytes sets the desired batch size. It should only be used in tests.

--- a/pkg/sql/rowexec/rowfetcher.go
+++ b/pkg/sql/rowexec/rowfetcher.go
@@ -63,7 +63,7 @@ func initRowFetcher(
 	fetcher *row.Fetcher,
 	desc *tabledesc.Immutable,
 	indexIdx int,
-	colIdxMap map[descpb.ColumnID]int,
+	colIdxMap catalog.TableColMap,
 	reverseScan bool,
 	valNeededForCol util.FastIntSet,
 	isCheck bool,

--- a/pkg/sql/rowexec/scrub_tablereader.go
+++ b/pkg/sql/rowexec/scrub_tablereader.go
@@ -15,6 +15,7 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
@@ -114,7 +115,7 @@ func newScrubTableReader(
 	} else {
 		colIdxMap := tr.tableDesc.ColumnIdxMap()
 		err := spec.Table.Indexes[spec.IndexIdx-1].RunOverAllColumns(func(id descpb.ColumnID) error {
-			neededColumns.Add(colIdxMap[id])
+			neededColumns.Add(colIdxMap.GetDefault(id))
 			return nil
 		})
 		if err != nil {
@@ -190,14 +191,14 @@ func (tr *scrubTableReader) generateScrubErrorRow(
 func (tr *scrubTableReader) prettyPrimaryKeyValues(
 	row rowenc.EncDatumRow, table *descpb.TableDescriptor,
 ) string {
-	colIdxMap := make(map[descpb.ColumnID]int, len(table.Columns))
+	var colIdxMap catalog.TableColMap
 	for i := range table.Columns {
 		id := table.Columns[i].ID
-		colIdxMap[id] = i
+		colIdxMap.Set(id, i)
 	}
-	colIDToRowIdxMap := make(map[descpb.ColumnID]int, len(table.Columns))
+	var colIDToRowIdxMap catalog.TableColMap
 	for rowIdx, colIdx := range tr.fetcherResultToColIdx {
-		colIDToRowIdxMap[tr.tableDesc.Columns[colIdx].ID] = rowIdx
+		colIDToRowIdxMap.Set(tr.tableDesc.Columns[colIdx].ID, rowIdx)
 	}
 	var primaryKeyValues bytes.Buffer
 	primaryKeyValues.WriteByte('(')
@@ -206,7 +207,7 @@ func (tr *scrubTableReader) prettyPrimaryKeyValues(
 			primaryKeyValues.WriteByte(',')
 		}
 		primaryKeyValues.WriteString(
-			row[colIDToRowIdxMap[id]].String(table.Columns[colIdxMap[id]].Type))
+			row[colIDToRowIdxMap.GetDefault(id)].String(table.Columns[colIdxMap.GetDefault(id)].Type))
 	}
 	primaryKeyValues.WriteByte(')')
 	return primaryKeyValues.String()

--- a/pkg/sql/rowexec/tablereader.go
+++ b/pkg/sql/rowexec/tablereader.go
@@ -103,7 +103,7 @@ func newTableReader(
 	}
 	for i := range sysColDescs {
 		resultTypes = append(resultTypes, sysColDescs[i].Type)
-		columnIdxMap[sysColDescs[i].ID] = len(columnIdxMap)
+		columnIdxMap.Set(sysColDescs[i].ID, columnIdxMap.Len())
 	}
 
 	tr.ignoreMisplannedRanges = flowCtx.Local

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
@@ -64,7 +65,7 @@ type scanNode struct {
 	resultColumns colinfo.ResultColumns
 
 	// Map used to get the index for columns in cols.
-	colIdxMap map[descpb.ColumnID]int
+	colIdxMap catalog.TableColMap
 
 	spans   []roachpb.Span
 	reverse bool
@@ -328,9 +329,8 @@ func (n *scanNode) initDescDefaults(colCfg scanColumnsConfig) error {
 
 	// Set up the rest of the scanNode.
 	n.resultColumns = colinfo.ResultColumnsFromColDescPtrs(n.desc.GetID(), n.cols)
-	n.colIdxMap = make(map[descpb.ColumnID]int, len(n.cols))
 	for i, c := range n.cols {
-		n.colIdxMap[c.ID] = i
+		n.colIdxMap.Set(c.ID, i)
 	}
 	return nil
 }

--- a/pkg/sql/scrub_physical.go
+++ b/pkg/sql/scrub_physical.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowcontainer"
@@ -66,10 +67,10 @@ func (o *physicalCheckOperation) Start(params runParams) error {
 	ctx := params.ctx
 	// Collect all of the columns, their types, and their IDs.
 	var columnIDs []tree.ColumnID
-	colIDToIdx := make(map[descpb.ColumnID]int, len(o.tableDesc.Columns))
+	var colIDToIdx catalog.TableColMap
 	columns := make([]*descpb.ColumnDescriptor, len(columnIDs))
 	for i := range o.tableDesc.Columns {
-		colIDToIdx[o.tableDesc.Columns[i].ID] = i
+		colIDToIdx.Set(o.tableDesc.Columns[i].ID, i)
 	}
 
 	// Collect all of the columns being scanned.
@@ -90,7 +91,7 @@ func (o *physicalCheckOperation) Start(params runParams) error {
 	}
 
 	for i := range columnIDs {
-		idx := colIDToIdx[descpb.ColumnID(columnIDs[i])]
+		idx := colIDToIdx.GetDefault(descpb.ColumnID(columnIDs[i]))
 		columns = append(columns, &o.tableDesc.Columns[idx])
 	}
 

--- a/pkg/sql/scrub_test.go
+++ b/pkg/sql/scrub_test.go
@@ -22,8 +22,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/scrub"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -62,9 +62,9 @@ INSERT INTO t."tEst" VALUES (10, 20);
 	tableDesc := catalogkv.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, "t", "tEst")
 	secondaryIndex := &tableDesc.Indexes[0]
 
-	colIDtoRowIndex := make(map[descpb.ColumnID]int)
-	colIDtoRowIndex[tableDesc.Columns[0].ID] = 0
-	colIDtoRowIndex[tableDesc.Columns[1].ID] = 1
+	var colIDtoRowIndex catalog.TableColMap
+	colIDtoRowIndex.Set(tableDesc.Columns[0].ID, 0)
+	colIDtoRowIndex.Set(tableDesc.Columns[1].ID, 1)
 
 	// Construct the secondary index key that is currently in the
 	// database.
@@ -131,9 +131,9 @@ CREATE INDEX secondary ON t.test (v);
 	tableDesc := catalogkv.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, "t", "test")
 	secondaryIndexDesc := &tableDesc.Indexes[0]
 
-	colIDtoRowIndex := make(map[descpb.ColumnID]int)
-	colIDtoRowIndex[tableDesc.Columns[0].ID] = 0
-	colIDtoRowIndex[tableDesc.Columns[1].ID] = 1
+	var colIDtoRowIndex catalog.TableColMap
+	colIDtoRowIndex.Set(tableDesc.Columns[0].ID, 0)
+	colIDtoRowIndex.Set(tableDesc.Columns[1].ID, 1)
 
 	// Construct datums and secondary k/v for our row values (k, v).
 	values := []tree.Datum{tree.NewDInt(10), tree.NewDInt(314)}
@@ -225,10 +225,10 @@ INSERT INTO t.test VALUES (10, 20, 1337);
 	tableDesc := catalogkv.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, "t", "test")
 	secondaryIndexDesc := &tableDesc.Indexes[0]
 
-	colIDtoRowIndex := make(map[descpb.ColumnID]int)
-	colIDtoRowIndex[tableDesc.Columns[0].ID] = 0
-	colIDtoRowIndex[tableDesc.Columns[1].ID] = 1
-	colIDtoRowIndex[tableDesc.Columns[2].ID] = 2
+	var colIDtoRowIndex catalog.TableColMap
+	colIDtoRowIndex.Set(tableDesc.Columns[0].ID, 0)
+	colIDtoRowIndex.Set(tableDesc.Columns[1].ID, 1)
+	colIDtoRowIndex.Set(tableDesc.Columns[2].ID, 2)
 
 	// Generate the existing secondary index key.
 	values := []tree.Datum{tree.NewDInt(10), tree.NewDInt(20), tree.NewDInt(1337)}
@@ -344,9 +344,9 @@ INSERT INTO t.test VALUES (10, 2);
 
 	tableDesc := catalogkv.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, "t", "test")
 
-	colIDtoRowIndex := make(map[descpb.ColumnID]int)
-	colIDtoRowIndex[tableDesc.Columns[0].ID] = 0
-	colIDtoRowIndex[tableDesc.Columns[1].ID] = 1
+	var colIDtoRowIndex catalog.TableColMap
+	colIDtoRowIndex.Set(tableDesc.Columns[0].ID, 0)
+	colIDtoRowIndex.Set(tableDesc.Columns[1].ID, 1)
 
 	// Create the primary index key.
 	values := []tree.Datum{tree.NewDInt(10), tree.NewDInt(2)}
@@ -447,9 +447,9 @@ func TestScrubFKConstraintFKMissing(t *testing.T) {
 	values := []tree.Datum{tree.NewDInt(10), tree.NewDInt(314)}
 	secondaryIndex := &tableDesc.Indexes[0]
 
-	colIDtoRowIndex := make(map[descpb.ColumnID]int)
-	colIDtoRowIndex[tableDesc.Columns[0].ID] = 0
-	colIDtoRowIndex[tableDesc.Columns[1].ID] = 1
+	var colIDtoRowIndex catalog.TableColMap
+	colIDtoRowIndex.Set(tableDesc.Columns[0].ID, 0)
+	colIDtoRowIndex.Set(tableDesc.Columns[1].ID, 1)
 
 	// Construct the secondary index key entry as it exists in the
 	// database.
@@ -585,9 +585,9 @@ INSERT INTO t.test VALUES (217, 314);
 	// Construct datums for our row values (k, v).
 	values := []tree.Datum{tree.NewDInt(217), tree.NewDInt(314)}
 
-	colIDtoRowIndex := make(map[descpb.ColumnID]int)
-	colIDtoRowIndex[tableDesc.Columns[0].ID] = 0
-	colIDtoRowIndex[tableDesc.Columns[1].ID] = 1
+	var colIDtoRowIndex catalog.TableColMap
+	colIDtoRowIndex.Set(tableDesc.Columns[0].ID, 0)
+	colIDtoRowIndex.Set(tableDesc.Columns[1].ID, 1)
 
 	// Create the primary index key
 	primaryIndexKeyPrefix := rowenc.MakeIndexKeyPrefix(
@@ -667,10 +667,10 @@ INSERT INTO t.test VALUES (217, 314, 1337);
 	// Construct datums for our row values (k, v, b).
 	values := []tree.Datum{tree.NewDInt(217), tree.NewDInt(314), tree.NewDInt(1337)}
 
-	colIDtoRowIndex := make(map[descpb.ColumnID]int)
-	colIDtoRowIndex[tableDesc.Columns[0].ID] = 0
-	colIDtoRowIndex[tableDesc.Columns[1].ID] = 1
-	colIDtoRowIndex[tableDesc.Columns[2].ID] = 2
+	var colIDtoRowIndex catalog.TableColMap
+	colIDtoRowIndex.Set(tableDesc.Columns[0].ID, 0)
+	colIDtoRowIndex.Set(tableDesc.Columns[1].ID, 1)
+	colIDtoRowIndex.Set(tableDesc.Columns[2].ID, 2)
 
 	// Create the primary index key
 	primaryIndexKeyPrefix := rowenc.MakeIndexKeyPrefix(
@@ -773,9 +773,9 @@ CREATE TABLE t.test (
 	// Construct datums for our row values (k, v1).
 	values := []tree.Datum{tree.NewDInt(217), tree.NewDInt(314)}
 
-	colIDtoRowIndex := make(map[descpb.ColumnID]int)
-	colIDtoRowIndex[tableDesc.Columns[0].ID] = 0
-	colIDtoRowIndex[tableDesc.Columns[1].ID] = 1
+	var colIDtoRowIndex catalog.TableColMap
+	colIDtoRowIndex.Set(tableDesc.Columns[0].ID, 0)
+	colIDtoRowIndex.Set(tableDesc.Columns[1].ID, 1)
 
 	// Create the primary index key
 	primaryIndexKeyPrefix := rowenc.MakeIndexKeyPrefix(
@@ -877,10 +877,10 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v1 INT, v2 INT);
 	// Construct datums for our row values (k, v1, v2).
 	values := []tree.Datum{tree.NewDInt(217), tree.NewDInt(314), tree.NewDInt(1337)}
 
-	colIDtoRowIndex := make(map[descpb.ColumnID]int)
-	colIDtoRowIndex[tableDesc.Columns[0].ID] = 0
-	colIDtoRowIndex[tableDesc.Columns[1].ID] = 1
-	colIDtoRowIndex[tableDesc.Columns[2].ID] = 2
+	var colIDtoRowIndex catalog.TableColMap
+	colIDtoRowIndex.Set(tableDesc.Columns[0].ID, 0)
+	colIDtoRowIndex.Set(tableDesc.Columns[1].ID, 1)
+	colIDtoRowIndex.Set(tableDesc.Columns[2].ID, 2)
 
 	// Create the primary index key
 	primaryIndexKeyPrefix := rowenc.MakeIndexKeyPrefix(

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -39,6 +39,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkeys"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -3651,9 +3652,9 @@ may increase either contention or retry errors, or both.`,
 
 				// Create a column id to row index map. In this case, each column ID
 				// just maps to the i'th ordinal.
-				colMap := make(map[descpb.ColumnID]int)
+				var colMap catalog.TableColMap
 				for i, id := range indexColIDs {
-					colMap[id] = i
+					colMap.Set(id, i)
 				}
 				// Finally, encode the index key using the provided datums.
 				keyPrefix := rowenc.MakeIndexKeyPrefix(ctx.Codec, tableDesc, indexDesc.ID)

--- a/pkg/sql/span/BUILD.bazel
+++ b/pkg/sql/span/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//pkg/keys",
         "//pkg/roachpb",
+        "//pkg/sql/catalog",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/tabledesc",
         "//pkg/sql/opt/constraint",

--- a/pkg/sql/span/span_builder.go
+++ b/pkg/sql/span/span_builder.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/constraint"
@@ -149,7 +150,7 @@ func (s *Builder) SpanFromEncDatums(
 // It also returns whether or not the input values contain a null value or not, which can be
 // used as input for CanSplitSpanIntoSeparateFamilies.
 func (s *Builder) SpanFromDatumRow(
-	values tree.Datums, prefixLen int, colMap map[descpb.ColumnID]int,
+	values tree.Datums, prefixLen int, colMap catalog.TableColMap,
 ) (_ roachpb.Span, containsNull bool, _ error) {
 	return rowenc.EncodePartialIndexSpan(s.table, s.index, prefixLen, colMap, values, s.KeyPrefix)
 }

--- a/pkg/sql/split.go
+++ b/pkg/sql/split.go
@@ -92,9 +92,9 @@ func getRowKey(
 	index *descpb.IndexDescriptor,
 	values []tree.Datum,
 ) ([]byte, error) {
-	colMap := make(map[descpb.ColumnID]int)
+	var colMap catalog.TableColMap
 	for i := range values {
-		colMap[index.ColumnIDs[i]] = i
+		colMap.Set(index.ColumnIDs[i], i)
 	}
 	prefix := rowenc.MakeIndexKeyPrefix(codec, tableDesc, index.ID)
 	key, _, err := rowenc.EncodePartialIndexKey(

--- a/pkg/sql/tablewriter_delete.go
+++ b/pkg/sql/tablewriter_delete.go
@@ -115,8 +115,9 @@ func (td *tableDeleter) deleteAllRowsScan(
 	}
 
 	var valNeededForCol util.FastIntSet
-	for _, idx := range td.rd.FetchColIDtoRowIndex {
-		valNeededForCol.Add(idx)
+	for i := range td.rd.FetchCols {
+		col := td.rd.FetchCols[i].ID
+		valNeededForCol.Add(td.rd.FetchColIDtoRowIndex.GetDefault(col))
 	}
 
 	var rf row.Fetcher
@@ -245,8 +246,9 @@ func (td *tableDeleter) deleteIndexScan(
 	}
 
 	var valNeededForCol util.FastIntSet
-	for _, idx := range td.rd.FetchColIDtoRowIndex {
-		valNeededForCol.Add(idx)
+	for i := range td.rd.FetchCols {
+		col := td.rd.FetchCols[i].ID
+		valNeededForCol.Add(td.rd.FetchColIDtoRowIndex.GetDefault(col))
 	}
 
 	var rf row.Fetcher

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"sync"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemaexpr"
@@ -104,7 +105,7 @@ type updateRun struct {
 	// updateColsIdx maps the order of the 2nd stage into the order of the 3rd stage.
 	// This provides the inverse mapping of sourceSlots.
 	//
-	updateColsIdx map[descpb.ColumnID]int
+	updateColsIdx catalog.TableColMap
 
 	// rowIdxToRetIdx is the mapping from the columns in ru.FetchCols to the
 	// columns in the resultRowBuffer. A value of -1 is used to indicate
@@ -255,7 +256,9 @@ func (u *updateNode) processSourceRow(params runParams, sourceVals tree.Datums) 
 		copy(u.run.iVarContainerForComputedCols.CurSourceRow, oldValues)
 		for i := range u.run.tu.ru.UpdateCols {
 			id := u.run.tu.ru.UpdateCols[i].ID
-			u.run.iVarContainerForComputedCols.CurSourceRow[u.run.tu.ru.FetchColIDtoRowIndex[id]] = u.run.updateValues[i]
+			idx := u.run.tu.ru.FetchColIDtoRowIndex.GetDefault(id)
+			u.run.iVarContainerForComputedCols.CurSourceRow[idx] = u.run.
+				updateValues[i]
 		}
 
 		// Now (re-)compute the computed columns.
@@ -268,7 +271,8 @@ func (u *updateNode) processSourceRow(params runParams, sourceVals tree.Datums) 
 				params.EvalContext().IVarContainer = nil
 				return errors.Wrapf(err, "computed column %s", tree.ErrString((*tree.Name)(&u.run.computedCols[i].Name)))
 			}
-			u.run.updateValues[u.run.updateColsIdx[u.run.computedCols[i].ID]] = d
+			idx := u.run.updateColsIdx.GetDefault(u.run.computedCols[i].ID)
+			u.run.updateValues[idx] = d
 		}
 		params.EvalContext().PopIVarContainer()
 	}

--- a/pkg/sql/virtual_schema.go
+++ b/pkg/sql/virtual_schema.go
@@ -533,7 +533,7 @@ func (e *virtualDefEntry) makeConstrainedRowsGenerator(
 	dbDesc *dbdesc.Immutable,
 	index *descpb.IndexDescriptor,
 	indexKeyDatums []tree.Datum,
-	columnIdxMap map[descpb.ColumnID]int,
+	columnIdxMap catalog.TableColMap,
 	idxConstraint *constraint.Constraint,
 	columns colinfo.ResultColumns,
 ) func(pusher rowPusher) error {
@@ -543,7 +543,7 @@ func (e *virtualDefEntry) makeConstrainedRowsGenerator(
 		addRowIfPassesFilter := func(idxConstraint *constraint.Constraint) func(datums ...tree.Datum) error {
 			return func(datums ...tree.Datum) error {
 				for i, id := range index.ColumnIDs {
-					indexKeyDatums[i] = datums[columnIdxMap[id]]
+					indexKeyDatums[i] = datums[columnIdxMap.GetDefault(id)]
 				}
 				// Construct a single key span out of the current row, so that
 				// we can test it for containment within the constraint span of the

--- a/pkg/util/fast_int_map.go
+++ b/pkg/util/fast_int_map.go
@@ -82,6 +82,16 @@ func (m FastIntMap) Get(key int) (value int, ok bool) {
 	return value, ok
 }
 
+// GetDefault returns the current value mapped to key, or 0 if the key is
+// unmapped.
+func (m FastIntMap) GetDefault(key int) (value int) {
+	value, ok := m.Get(key)
+	if !ok {
+		return 0
+	}
+	return value
+}
+
 // Len returns the number of keys in the map.
 func (m FastIntMap) Len() int {
 	if m.large != nil {


### PR DESCRIPTION
This commit replaces the use of map[ColumnID]int for maps of column id
to ordinal with the use of FastIntMap, to save on allocations in common
cases.

Closes #37801

Release note: None