### PR TITLE
sql: Create empty table pg_opclass to improve postgress compatibility

### DIFF
--- a/pkg/sql/catalog/catconstants/constants.go
+++ b/pkg/sql/catalog/catconstants/constants.go
@@ -130,6 +130,7 @@ const (
 	PgCatalogLocksTableID
 	PgCatalogMatViewsTableID
 	PgCatalogNamespaceTableID
+	PgCatalogOpclassTableID
 	PgCatalogOperatorTableID
 	PgCatalogPreparedStatementsTableID
 	PgCatalogPreparedXactsTableID

--- a/pkg/sql/logictest/testdata/logic_test/grant_table
+++ b/pkg/sql/logictest/testdata/logic_test/grant_table
@@ -278,6 +278,7 @@ test           pg_catalog          pg_language                        public   S
 test           pg_catalog          pg_locks                           public   SELECT
 test           pg_catalog          pg_matviews                        public   SELECT
 test           pg_catalog          pg_namespace                       public   SELECT
+test           pg_catalog          pg_opclass                         public   SELECT
 test           pg_catalog          pg_operator                        public   SELECT
 test           pg_catalog          pg_prepared_statements             public   SELECT
 test           pg_catalog          pg_prepared_xacts                  public   SELECT

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -315,6 +315,7 @@ pg_catalog          pg_language
 pg_catalog          pg_locks
 pg_catalog          pg_matviews
 pg_catalog          pg_namespace
+pg_catalog          pg_opclass
 pg_catalog          pg_operator
 pg_catalog          pg_prepared_statements
 pg_catalog          pg_prepared_xacts
@@ -469,6 +470,7 @@ pg_language
 pg_locks
 pg_matviews
 pg_namespace
+pg_opclass
 pg_operator
 pg_prepared_statements
 pg_prepared_xacts
@@ -642,6 +644,7 @@ system         pg_catalog          pg_language                        SYSTEM VIE
 system         pg_catalog          pg_locks                           SYSTEM VIEW  NO                  1
 system         pg_catalog          pg_matviews                        SYSTEM VIEW  NO                  1
 system         pg_catalog          pg_namespace                       SYSTEM VIEW  NO                  1
+system         pg_catalog          pg_opclass                         SYSTEM VIEW  NO                  1
 system         pg_catalog          pg_operator                        SYSTEM VIEW  NO                  1
 system         pg_catalog          pg_prepared_statements             SYSTEM VIEW  NO                  1
 system         pg_catalog          pg_prepared_xacts                  SYSTEM VIEW  NO                  1
@@ -1751,6 +1754,7 @@ NULL     public   system         pg_catalog          pg_language                
 NULL     public   system         pg_catalog          pg_locks                           SELECT          NULL          YES
 NULL     public   system         pg_catalog          pg_matviews                        SELECT          NULL          YES
 NULL     public   system         pg_catalog          pg_namespace                       SELECT          NULL          YES
+NULL     public   system         pg_catalog          pg_opclass                         SELECT          NULL          YES
 NULL     public   system         pg_catalog          pg_operator                        SELECT          NULL          YES
 NULL     public   system         pg_catalog          pg_prepared_statements             SELECT          NULL          YES
 NULL     public   system         pg_catalog          pg_prepared_xacts                  SELECT          NULL          YES
@@ -2130,6 +2134,7 @@ NULL     public   system         pg_catalog          pg_language                
 NULL     public   system         pg_catalog          pg_locks                           SELECT          NULL          YES
 NULL     public   system         pg_catalog          pg_matviews                        SELECT          NULL          YES
 NULL     public   system         pg_catalog          pg_namespace                       SELECT          NULL          YES
+NULL     public   system         pg_catalog          pg_opclass                         SELECT          NULL          YES
 NULL     public   system         pg_catalog          pg_operator                        SELECT          NULL          YES
 NULL     public   system         pg_catalog          pg_prepared_statements             SELECT          NULL          YES
 NULL     public   system         pg_catalog          pg_prepared_xacts                  SELECT          NULL          YES

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -46,6 +46,7 @@ pg_catalog  pg_language              table  NULL  NULL
 pg_catalog  pg_locks                 table  NULL  NULL
 pg_catalog  pg_matviews              table  NULL  NULL
 pg_catalog  pg_namespace             table  NULL  NULL
+pg_catalog  pg_opclass               table  NULL  NULL
 pg_catalog  pg_operator              table  NULL  NULL
 pg_catalog  pg_prepared_statements   table  NULL  NULL
 pg_catalog  pg_prepared_xacts        table  NULL  NULL
@@ -123,6 +124,7 @@ pg_catalog  pg_language              table  NULL  NULL
 pg_catalog  pg_locks                 table  NULL  NULL
 pg_catalog  pg_matviews              table  NULL  NULL
 pg_catalog  pg_namespace             table  NULL  NULL
+pg_catalog  pg_opclass               table  NULL  NULL
 pg_catalog  pg_operator              table  NULL  NULL
 pg_catalog  pg_prepared_statements   table  NULL  NULL
 pg_catalog  pg_prepared_xacts        table  NULL  NULL
@@ -1726,31 +1728,32 @@ objoid      classoid    objsubid  description
 4294967200  4294967219  0         locks held by active processes (empty - feature does not exist)
 4294967199  4294967219  0         available materialized views (empty - feature does not exist)
 4294967198  4294967219  0         available namespaces (incomplete; namespaces and databases are congruent in CockroachDB)
-4294967197  4294967219  0         operators (incomplete)
-4294967196  4294967219  0         prepared statements
-4294967195  4294967219  0         prepared transactions (empty - feature does not exist)
-4294967194  4294967219  0         built-in functions (incomplete)
-4294967193  4294967219  0         range types (empty - feature does not exist)
-4294967192  4294967219  0         rewrite rules (empty - feature does not exist)
-4294967191  4294967219  0         database roles
-4294967178  4294967219  0         security labels (empty - feature does not exist)
-4294967190  4294967219  0         security labels (empty)
-4294967189  4294967219  0         sequences (see also information_schema.sequences)
-4294967188  4294967219  0         session variables (incomplete)
-4294967187  4294967219  0         shared dependencies (empty - not implemented)
+4294967197  4294967219  0         opclass (empty - Operator classes not supported yet)
+4294967196  4294967219  0         operators (incomplete)
+4294967195  4294967219  0         prepared statements
+4294967194  4294967219  0         prepared transactions (empty - feature does not exist)
+4294967193  4294967219  0         built-in functions (incomplete)
+4294967192  4294967219  0         range types (empty - feature does not exist)
+4294967191  4294967219  0         rewrite rules (empty - feature does not exist)
+4294967190  4294967219  0         database roles
+4294967177  4294967219  0         security labels (empty - feature does not exist)
+4294967189  4294967219  0         security labels (empty)
+4294967188  4294967219  0         sequences (see also information_schema.sequences)
+4294967187  4294967219  0         session variables (incomplete)
+4294967186  4294967219  0         shared dependencies (empty - not implemented)
 4294967211  4294967219  0         shared object comments
-4294967177  4294967219  0         shared security labels (empty - feature not supported)
-4294967179  4294967219  0         backend access statistics (empty - monitoring works differently in CockroachDB)
-4294967184  4294967219  0         tables summary (see also information_schema.tables, pg_catalog.pg_class)
-4294967183  4294967219  0         available tablespaces (incomplete; concept inapplicable to CockroachDB)
-4294967182  4294967219  0         triggers (empty - feature does not exist)
-4294967181  4294967219  0         scalar types (incomplete)
-4294967186  4294967219  0         database users
-4294967185  4294967219  0         local to remote user mapping (empty - feature does not exist)
-4294967180  4294967219  0         view definitions (incomplete - see also information_schema.views)
-4294967175  4294967219  0         Shows all defined geography columns. Matches PostGIS' geography_columns functionality.
-4294967174  4294967219  0         Shows all defined geometry columns. Matches PostGIS' geometry_columns functionality.
-4294967173  4294967219  0         Shows all defined Spatial Reference Identifiers (SRIDs). Matches PostGIS' spatial_ref_sys table.
+4294967176  4294967219  0         shared security labels (empty - feature not supported)
+4294967178  4294967219  0         backend access statistics (empty - monitoring works differently in CockroachDB)
+4294967183  4294967219  0         tables summary (see also information_schema.tables, pg_catalog.pg_class)
+4294967182  4294967219  0         available tablespaces (incomplete; concept inapplicable to CockroachDB)
+4294967181  4294967219  0         triggers (empty - feature does not exist)
+4294967180  4294967219  0         scalar types (incomplete)
+4294967185  4294967219  0         database users
+4294967184  4294967219  0         local to remote user mapping (empty - feature does not exist)
+4294967179  4294967219  0         view definitions (incomplete - see also information_schema.views)
+4294967174  4294967219  0         Shows all defined geography columns. Matches PostGIS' geography_columns functionality.
+4294967173  4294967219  0         Shows all defined geometry columns. Matches PostGIS' geometry_columns functionality.
+4294967172  4294967219  0         Shows all defined Spatial Reference Identifiers (SRIDs). Matches PostGIS' spatial_ref_sys table.
 
 ## pg_catalog.pg_shdescription
 

--- a/pkg/sql/logictest/testdata/logic_test/table
+++ b/pkg/sql/logictest/testdata/logic_test/table
@@ -626,6 +626,7 @@ pg_language                        NULL
 pg_locks                           NULL
 pg_matviews                        NULL
 pg_namespace                       NULL
+pg_opclass                         NULL
 pg_operator                        NULL
 pg_prepared_statements             NULL
 pg_prepared_xacts                  NULL

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -235,6 +235,7 @@ var pgCatalog = virtualSchema{
 		catconstants.PgCatalogLocksTableID:               pgCatalogLocksTable,
 		catconstants.PgCatalogMatViewsTableID:            pgCatalogMatViewsTable,
 		catconstants.PgCatalogNamespaceTableID:           pgCatalogNamespaceTable,
+		catconstants.PgCatalogOpclassTableID:             pgCatalogOpclassTable,
 		catconstants.PgCatalogOperatorTableID:            pgCatalogOperatorTable,
 		catconstants.PgCatalogPreparedStatementsTableID:  pgCatalogPreparedStatementsTable,
 		catconstants.PgCatalogPreparedXactsTableID:       pgCatalogPreparedXactsTable,
@@ -1650,6 +1651,15 @@ var (
 	// Avoid unused warning for constants.
 	_ = postfixKind
 )
+
+var pgCatalogOpclassTable = virtualSchemaTable{
+	comment: `opclass (empty - Operator classes not supported yet)
+https://www.postgresql.org/docs/12/catalog-pg-opclass.html`,
+	schema: vtable.PGCatalogOpclass,
+	populate: func(ctx context.Context, p *planner, db *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
+		return nil
+	},
+}
 
 var pgCatalogOperatorTable = virtualSchemaTable{
 	comment: `operators (incomplete)

--- a/pkg/sql/vtable/pg_catalog.go
+++ b/pkg/sql/vtable/pg_catalog.go
@@ -495,6 +495,21 @@ CREATE TABLE pg_catalog.pg_namespace (
 	nspacl STRING[]
 )`
 
+// PGCatalogOpclass describes the schema of the pg_catalog.pg_opclass table.
+// https://www.postgresql.org/docs/12/catalog-pg-opclass.html
+const PGCatalogOpclass = `
+CREATE TABLE pg_catalog.pg_opclass (
+	oid OID,
+	opcmethod OID,
+	opcname NAME,
+	opcnamespace OID,
+	opcowner OID,
+	opcfamily OID,
+	opcintype OID,
+	opcdefault BOOL,
+	opckeytype OID
+)`
+
 // PGCatalogOperator describes the schema of the pg_catalog.pg_operator table.
 // https://www.postgresql.org/docs/9.5/catalog-pg-operator.html,
 const PGCatalogOperator = `


### PR DESCRIPTION
Previously, Performing a query against pg_opclass causes a failure on
Cockroach 0A000: unimplemented
This causes tools like Npgsql's reported in ticket 48729 breaks while
querying this table
To address this as operator classes are not supported yet, we enable
querying pg_opclass returning empty results

Release note (sql change): Create empty pg_catalog.pg_opclass table
to improve compatibility with Postgres