### PR TITLE
tls: avoid CVE-2020-28362 w/ go v1.14<1.14.2 or v1.15<1.15.5

### DIFF
--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"math"
 	"net"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -151,7 +152,7 @@ func NewServer(ctx *Context, opts ...ServerOption) *grpc.Server {
 		if err != nil {
 			panic(err)
 		}
-		grpcOpts = append(grpcOpts, grpc.Creds(credentials.NewTLS(tlsConfig)))
+		grpcOpts = append(grpcOpts, grpc.Creds(&protectCredentials{credentials.NewTLS(tlsConfig)}))
 	}
 
 	// These interceptors will be called in the order in which they appear, i.e.
@@ -678,7 +679,7 @@ func (ctx *Context) grpcDialOptions(
 		if err != nil {
 			return nil, err
 		}
-		dialOpts = append(dialOpts, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
+		dialOpts = append(dialOpts, grpc.WithTransportCredentials(&protectCredentials{credentials.NewTLS(tlsConfig)}))
 	}
 
 	// The limiting factor for lowering the max message size is the fact
@@ -748,6 +749,47 @@ func (ctx *Context) grpcDialOptions(
 		dialOpts = append(dialOpts, grpc.WithChainStreamInterceptor(streamInterceptors...))
 	}
 	return dialOpts, nil
+}
+
+type protectCredentials struct {
+	p credentials.TransportCredentials
+}
+
+var _ credentials.TransportCredentials = (*protectCredentials)(nil)
+
+func (p *protectCredentials) Info() credentials.ProtocolInfo    { return p.p.Info() }
+func (p *protectCredentials) OverrideServerName(s string) error { return p.p.OverrideServerName(s) }
+
+func (p *protectCredentials) ClientHandshake(
+	ctx context.Context, s string, c net.Conn,
+) (rc net.Conn, ra credentials.AuthInfo, resErr error) {
+	defer func() {
+		// This is to work around https://github.com/golang/go/issues/42554 until
+		// this build of CockroachDB is using Go 1.15.5.
+		if r := recover(); r != nil && strings.Contains(fmt.Sprint(r), "index out of range") {
+			resErr = errors.CombineErrors(resErr, errors.Newf("panic during key load: %v", r))
+		}
+	}()
+
+	return p.p.ClientHandshake(ctx, s, c)
+}
+
+func (p *protectCredentials) ServerHandshake(
+	c net.Conn,
+) (rc net.Conn, ra credentials.AuthInfo, resErr error) {
+	defer func() {
+		// This is to work around https://github.com/golang/go/issues/42554 until
+		// this build of CockroachDB is using Go 1.15.5.
+		if r := recover(); r != nil && strings.Contains(fmt.Sprint(r), "index out of range") {
+			resErr = errors.CombineErrors(resErr, errors.Newf("panic during key load: %v", r))
+		}
+	}()
+
+	return p.p.ServerHandshake(c)
+}
+
+func (p *protectCredentials) Clone() credentials.TransportCredentials {
+	return &protectCredentials{p.p.Clone()}
 }
 
 // growStackCodec wraps the default grpc/encoding/proto codec to detect

--- a/pkg/rpc/context_test.go
+++ b/pkg/rpc/context_test.go
@@ -83,7 +83,7 @@ func newTestServer(t testing.TB, ctx *Context, extraOpts ...grpc.ServerOption) *
 		t.Fatal(err)
 	}
 	opts := []grpc.ServerOption{
-		grpc.Creds(credentials.NewTLS(tlsConfig)),
+		grpc.Creds(&protectCredentials{credentials.NewTLS(tlsConfig)}),
 		grpc.StatsHandler(&ctx.stats),
 	}
 	opts = append(opts, extraOpts...)
@@ -561,7 +561,7 @@ func TestHeartbeatHealthTransport(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	s := grpc.NewServer(grpc.Creds(credentials.NewTLS(tlsConfig)))
+	s := grpc.NewServer(grpc.Creds(&protectCredentials{credentials.NewTLS(tlsConfig)}))
 	RegisterHeartbeatServer(s, &HeartbeatService{
 		clock:              clock,
 		remoteClockMonitor: serverCtx.RemoteClocks,

--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -13,6 +13,7 @@ package pgwire
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"io"
 	"net"
 	"strings"
@@ -761,6 +762,16 @@ func (s *Server) maybeUpgradeToSecureConn(
 		}
 		newConn = tls.Server(conn, tlsConfig)
 		newConnType = hba.ConnHostSSL
+
+		defer func() {
+			// This is to work around https://github.com/golang/go/issues/42554 until
+			// this build of CockroachDB is using Go 1.15.5.
+			if r := recover(); r != nil && strings.Contains(fmt.Sprint(r), "index out of range") {
+				serverErr = errors.CombineErrors(serverErr, errors.Newf("panic during key load: %v", r))
+				newConn = conn
+				conn.Close()
+			}
+		}()
 	}
 	s.metrics.BytesOutCount.Inc(int64(n))
 


### PR DESCRIPTION
NOTE: this patch exists for reference purpose only. No released version of
CockroachDB is affected (the bug only exists in Go 1.14/1.15, and
crdb up to and including v20.2 was built with Go 1.13).

This patch prevents a crash in CockroachDB when a client connects to
either the SQL or RPC port with a TLS client cert that tickles
CVE-2020-28362.

The HTTP port is not protected.

Release note: None