### PR TITLE
sql: use catalog.TableColSet instead of map[descpb.ColumnID]struct{}

### DIFF
--- a/pkg/ccl/importccl/read_import_avro.go
+++ b/pkg/ccl/importccl/read_import_avro.go
@@ -210,7 +210,7 @@ func (a *avroConsumer) FillDatums(
 	// Set any nil datums to DNull (in case native
 	// record didn't have the value set at all)
 	for i := range conv.Datums {
-		if _, isTargetCol := conv.IsTargetCol[i]; isTargetCol && conv.Datums[i] == nil {
+		if conv.TargetColOrds.Contains(i) && conv.Datums[i] == nil {
 			if a.strict {
 				return fmt.Errorf("field %s was not set in the avro import", conv.VisibleCols[i].Name)
 			}

--- a/pkg/ccl/importccl/read_import_csv.go
+++ b/pkg/ccl/importccl/read_import_csv.go
@@ -180,7 +180,7 @@ func (c *csvRowConsumer) FillDatums(
 	for i, field := range record {
 		// Skip over record entries corresponding to columns not in the target
 		// columns specified by the user.
-		if _, ok := conv.IsTargetCol[i]; !ok {
+		if !conv.TargetColOrds.Contains(i) {
 			continue
 		}
 

--- a/pkg/sql/backfill/backfill.go
+++ b/pkg/sql/backfill/backfill.go
@@ -465,7 +465,7 @@ func (ib *IndexBackfiller) InitForDistributedUse(
 
 	evalCtx := flowCtx.NewEvalCtx()
 	var predicates map[descpb.IndexID]tree.TypedExpr
-	var predicateRefColIDs schemaexpr.TableColSet
+	var predicateRefColIDs catalog.TableColSet
 
 	// Install type metadata in the target descriptors, as well as resolve any
 	// user defined types in partial index predicate expressions.

--- a/pkg/sql/catalog/BUILD.bazel
+++ b/pkg/sql/catalog/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "descriptor.go",
         "errors.go",
         "table_col_map.go",
+        "table_col_set.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/catalog",
     visibility = ["//visibility:public"],
@@ -34,6 +35,7 @@ go_test(
     srcs = [
         "dep_test.go",
         "descriptor_test.go",
+        "table_col_set_test.go",
     ],
     embed = [":catalog"],
     deps = [
@@ -42,6 +44,7 @@ go_test(
         "//pkg/sql/catalog/schemadesc",
         "//pkg/sql/catalog/tabledesc",
         "//pkg/testutils/buildutil",
+        "//pkg/util",
         "//pkg/util/leaktest",
         "//vendor/github.com/cockroachdb/redact",
         "//vendor/github.com/stretchr/testify/require",

--- a/pkg/sql/catalog/colinfo/column_resolver.go
+++ b/pkg/sql/catalog/colinfo/column_resolver.go
@@ -42,8 +42,8 @@ func ProcessTargetColumns(
 		return nil, nil
 	}
 
+	var colIDSet catalog.TableColSet
 	cols := make([]descpb.ColumnDescriptor, len(nameList))
-	colIDSet := make(map[descpb.ColumnID]struct{}, len(nameList))
 	for i, colName := range nameList {
 		var col *descpb.ColumnDescriptor
 		var err error
@@ -56,11 +56,11 @@ func ProcessTargetColumns(
 			return nil, err
 		}
 
-		if _, ok := colIDSet[col.ID]; ok {
+		if colIDSet.Contains(col.ID) {
 			return nil, pgerror.Newf(pgcode.Syntax,
 				"multiple assignments to the same column %q", &nameList[i])
 		}
-		colIDSet[col.ID] = struct{}{}
+		colIDSet.Add(col.ID)
 		cols[i] = *col
 	}
 

--- a/pkg/sql/catalog/schemaexpr/BUILD.bazel
+++ b/pkg/sql/catalog/schemaexpr/BUILD.bazel
@@ -13,7 +13,6 @@ go_library(
         "expr_filter.go",
         "partial_index.go",
         "select_name_resolution.go",
-        "table_col_set.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/catalog/schemaexpr",
     visibility = ["//visibility:public"],
@@ -28,7 +27,6 @@ go_library(
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
         "//pkg/sql/types",
-        "//pkg/util",
         "//vendor/github.com/cockroachdb/errors",
     ],
 )
@@ -40,7 +38,6 @@ go_test(
         "column_test.go",
         "expr_test.go",
         "partial_index_test.go",
-        "table_col_set_test.go",
         "testutils_test.go",
     ],
     embed = [":schemaexpr"],
@@ -53,6 +50,5 @@ go_test(
         "//pkg/sql/sem/builtins",
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",
-        "//pkg/util",
     ],
 )

--- a/pkg/sql/catalog/schemaexpr/column.go
+++ b/pkg/sql/catalog/schemaexpr/column.go
@@ -234,8 +234,8 @@ func (d *dummyColumn) ResolvedType() *types.T {
 // descriptor, replaceColumnVars errs with pgcode.UndefinedColumn.
 func replaceColumnVars(
 	desc catalog.TableDescriptor, rootExpr tree.Expr,
-) (tree.Expr, TableColSet, error) {
-	var colIDs TableColSet
+) (tree.Expr, catalog.TableColSet, error) {
+	var colIDs catalog.TableColSet
 
 	newExpr, err := tree.SimpleVisit(rootExpr, func(expr tree.Expr) (recurse bool, newExpr tree.Expr, err error) {
 		vBase, ok := expr.(tree.VarName)

--- a/pkg/sql/catalog/schemaexpr/computed_column.go
+++ b/pkg/sql/catalog/schemaexpr/computed_column.go
@@ -64,7 +64,7 @@ func (v *ComputedColumnValidator) Validate(d *tree.ColumnTableDef) error {
 		)
 	}
 
-	var depColIDs TableColSet
+	var depColIDs catalog.TableColSet
 	// First, check that no column in the expression is a computed column.
 	err := iterColDescriptors(v.desc, d.Computed.Expr, func(c *descpb.ColumnDescriptor) error {
 		if c.IsComputed() {

--- a/pkg/sql/catalog/schemaexpr/default_exprs.go
+++ b/pkg/sql/catalog/schemaexpr/default_exprs.go
@@ -90,9 +90,9 @@ func ProcessColumnSet(
 	tableDesc catalog.TableDescriptor,
 	inSet func(*descpb.ColumnDescriptor) bool,
 ) []descpb.ColumnDescriptor {
-	colIDSet := make(map[descpb.ColumnID]struct{}, len(cols))
+	var colIDSet catalog.TableColSet
 	for i := range cols {
-		colIDSet[cols[i].ID] = struct{}{}
+		colIDSet.Add(cols[i].ID)
 	}
 
 	// Add all public or columns in DELETE_AND_WRITE_ONLY state
@@ -101,8 +101,8 @@ func ProcessColumnSet(
 	for i := range writable {
 		col := &writable[i]
 		if inSet(col) {
-			if _, ok := colIDSet[col.ID]; !ok {
-				colIDSet[col.ID] = struct{}{}
+			if !colIDSet.Contains(col.ID) {
+				colIDSet.Add(col.ID)
 				cols = append(cols, *col)
 			}
 		}

--- a/pkg/sql/catalog/schemaexpr/expr.go
+++ b/pkg/sql/catalog/schemaexpr/expr.go
@@ -43,8 +43,8 @@ func DequalifyAndValidateExpr(
 	semaCtx *tree.SemaContext,
 	maxVolatility tree.Volatility,
 	tn *tree.TableName,
-) (string, TableColSet, error) {
-	var colIDs TableColSet
+) (string, catalog.TableColSet, error) {
+	var colIDs catalog.TableColSet
 	sourceInfo := colinfo.NewSourceInfoForSingleTable(
 		*tn, colinfo.ResultColumnsFromColDescs(
 			desc.GetID(),
@@ -80,8 +80,10 @@ func DequalifyAndValidateExpr(
 }
 
 // ExtractColumnIDs returns the set of column IDs within the given expression.
-func ExtractColumnIDs(desc catalog.TableDescriptor, rootExpr tree.Expr) (TableColSet, error) {
-	var colIDs TableColSet
+func ExtractColumnIDs(
+	desc catalog.TableDescriptor, rootExpr tree.Expr,
+) (catalog.TableColSet, error) {
+	var colIDs catalog.TableColSet
 
 	_, err := tree.SimpleVisit(rootExpr, func(expr tree.Expr) (recurse bool, newExpr tree.Expr, err error) {
 		vBase, ok := expr.(tree.VarName)

--- a/pkg/sql/catalog/schemaexpr/partial_index.go
+++ b/pkg/sql/catalog/schemaexpr/partial_index.go
@@ -92,7 +92,7 @@ func MakePartialIndexExprs(
 	tableDesc catalog.TableDescriptor,
 	evalCtx *tree.EvalContext,
 	semaCtx *tree.SemaContext,
-) (_ map[descpb.IndexID]tree.TypedExpr, refColIDs TableColSet, _ error) {
+) (_ map[descpb.IndexID]tree.TypedExpr, refColIDs catalog.TableColSet, _ error) {
 	// If none of the indexes are partial indexes, return early.
 	partialIndexCount := 0
 	for i := range indexes {

--- a/pkg/sql/catalog/table_col_set.go
+++ b/pkg/sql/catalog/table_col_set.go
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-package schemaexpr
+package catalog
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -46,9 +46,6 @@ func (s TableColSet) ForEach(f func(col descpb.ColumnID)) {
 	s.set.ForEach(func(i int) { f(descpb.ColumnID(i)) })
 }
 
-// UnionWith adds all the columns from rhs to this set.
-func (s *TableColSet) UnionWith(rhs TableColSet) { s.set.UnionWith(rhs.set) }
-
 // Ordered returns a slice with all the descpb.ColumnIDs in the set, in
 // increasing order.
 func (s TableColSet) Ordered() []descpb.ColumnID {
@@ -61,6 +58,9 @@ func (s TableColSet) Ordered() []descpb.ColumnID {
 	})
 	return result
 }
+
+// UnionWith adds all the columns from rhs to this set.
+func (s *TableColSet) UnionWith(rhs TableColSet) { s.set.UnionWith(rhs.set) }
 
 // String returns a list representation of elements. Sequential runs of positive
 // numbers are shown as ranges. For example, for the set {1, 2, 3  5, 6, 10},

--- a/pkg/sql/catalog/table_col_set.go
+++ b/pkg/sql/catalog/table_col_set.go
@@ -41,6 +41,13 @@ func (s TableColSet) Empty() bool { return s.set.Empty() }
 // Len returns the number of the columns in the set.
 func (s TableColSet) Len() int { return s.set.Len() }
 
+// Next returns the first value in the set which is >= startVal. If there is no
+// value, the second return value is false.
+func (s TableColSet) Next(startVal descpb.ColumnID) (descpb.ColumnID, bool) {
+	c, ok := s.set.Next(int(startVal))
+	return descpb.ColumnID(c), ok
+}
+
 // ForEach calls a function for each column in the set (in increasing order).
 func (s TableColSet) ForEach(f func(col descpb.ColumnID)) {
 	s.set.ForEach(func(i int) { f(descpb.ColumnID(i)) })

--- a/pkg/sql/catalog/table_col_set_test.go
+++ b/pkg/sql/catalog/table_col_set_test.go
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-package schemaexpr
+package catalog
 
 import (
 	"testing"

--- a/pkg/sql/distsql_plan_stats.go
+++ b/pkg/sql/distsql_plan_stats.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
@@ -25,7 +26,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/span"
 	"github.com/cockroachdb/cockroach/pkg/sql/stats"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
-	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
@@ -64,11 +64,11 @@ func (dsp *DistSQLPlanner) createStatsPlan(
 
 	// Calculate the set of columns we need to scan.
 	var colCfg scanColumnsConfig
-	var tableColSet util.FastIntSet
+	var tableColSet catalog.TableColSet
 	for _, s := range reqStats {
 		for _, c := range s.columns {
-			if !tableColSet.Contains(int(c)) {
-				tableColSet.Add(int(c))
+			if !tableColSet.Contains(c) {
+				tableColSet.Add(c)
 				colCfg.wantedColumns = append(colCfg.wantedColumns, tree.ColumnID(c))
 			}
 		}

--- a/pkg/sql/row/fetcher.go
+++ b/pkg/sql/row/fetcher.go
@@ -1397,7 +1397,7 @@ func (rf *Fetcher) checkPrimaryIndexDatumEncodings(ctx context.Context) error {
 				continue
 			}
 
-			if skip, err := rh.skipColumnInPK(colID, familyID, rowVal.Datum); err != nil {
+			if skip, err := rh.skipColumnInPK(colID, rowVal.Datum); err != nil {
 				return errors.NewAssertionErrorWithWrappedErrf(err, "unable to determine skip")
 			} else if skip {
 				continue

--- a/pkg/sql/row/updater.go
+++ b/pkg/sql/row/updater.go
@@ -91,14 +91,14 @@ func MakeUpdater(
 ) (Updater, error) {
 	updateColIDtoRowIndex := ColIDtoRowIndexFromCols(updateCols)
 
-	primaryIndexCols := make(map[descpb.ColumnID]struct{}, len(tableDesc.PrimaryIndex.ColumnIDs))
+	var primaryIndexCols catalog.TableColSet
 	for _, colID := range tableDesc.PrimaryIndex.ColumnIDs {
-		primaryIndexCols[colID] = struct{}{}
+		primaryIndexCols.Add(colID)
 	}
 
 	var primaryKeyColChange bool
 	for _, c := range updateCols {
-		if _, ok := primaryIndexCols[c.ID]; ok {
+		if primaryIndexCols.Contains(c.ID) {
 			primaryKeyColChange = true
 			break
 		}

--- a/pkg/sql/row/writer.go
+++ b/pkg/sql/row/writer.go
@@ -174,7 +174,7 @@ func prepareInsertOrUpdateBatch(
 				continue
 			}
 
-			if skip, err := helper.skipColumnInPK(colID, family.ID, values[idx]); err != nil {
+			if skip, err := helper.skipColumnInPK(colID, values[idx]); err != nil {
 				return nil, err
 			} else if skip {
 				continue

--- a/pkg/sql/rowenc/index_encoding.go
+++ b/pkg/sql/rowenc/index_encoding.go
@@ -1003,9 +1003,9 @@ func EncodePrimaryIndex(
 		return nil, err
 	}
 	// This information should be precomputed on the table descriptor.
-	indexedColumns := map[descpb.ColumnID]struct{}{}
+	var indexedColumns catalog.TableColSet
 	for _, colID := range index.ColumnIDs {
-		indexedColumns[colID] = struct{}{}
+		indexedColumns.Add(colID)
 	}
 	var entryValue []byte
 	indexEntries := make([]IndexEntry, 0, tableDesc.NumFamilies())
@@ -1041,7 +1041,7 @@ func EncodePrimaryIndex(
 		}
 
 		for _, colID := range family.ColumnIDs {
-			if _, ok := indexedColumns[colID]; !ok {
+			if !indexedColumns.Contains(colID) {
 				columnsToEncode = append(columnsToEncode, valueEncodedColumn{id: colID})
 				continue
 			}


### PR DESCRIPTION
#### sql: move TableColSet from schemaexpr package to catalog

The `TableColSet` type describes a set of columns of a table. This
commit moves the type to the `catalog` package because it its usage is
not specific to the functionality in the `schemaexpr` package.

Release note: None

#### sql: use catalog.TableColSet instead of map[descpb.ColumnID]struct{}

This commit converts all instances where a set of column IDs was
implemented with a `map[descpb.ColumnID]struct{}` with the more
efficient `catalog.TableColSet`, a wrapper around `util.FastIntSet`.

Release note: None
