### PR TITLE
sql: handle bool values for compat-only session vars

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/set
+++ b/pkg/sql/logictest/testdata/logic_test/set
@@ -421,3 +421,12 @@ SET TRANSACTION DEFERRABLE
 
 statement ok
 rollback
+
+statement ok
+SET standard_conforming_strings=true
+
+statement ok
+SET standard_conforming_strings='true'
+
+statement ok
+SET standard_conforming_strings='on'

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -1255,6 +1255,7 @@ func makeCompatBoolVar(varName string, displayValue, anyValAllowed bool) session
 			return err
 		},
 		GlobalDefault: func(sv *settings.Values) string { return displayValStr },
+		GetStringVal:  makePostgresBoolGetStringValFn(varName),
 	}
 }
 


### PR DESCRIPTION
Release note (bug fix): Some boolean session variables would only accept
string ("true" or "false") values. Now they accept unquoted true or
false values too.

fixes #56618 