### PR TITLE
sql/catalog/descs: cache resolved mutable descriptor objects upon res…

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -6645,15 +6645,15 @@ CREATE TYPE sc.typ AS ENUM ('hello');
 
 		sqlDB.ExpectErr(t, `database "d" is offline: restoring`, `USE d`)
 
-		sqlDB.ExpectErr(t, `target database or schema does not exist`, `SHOW TABLES FROM d`)
-		sqlDB.ExpectErr(t, `target database or schema does not exist`, `SHOW TABLES FROM d.sc`)
+		sqlDB.ExpectErr(t, `database "d" is offline: restoring`, `SHOW TABLES FROM d`)
+		sqlDB.ExpectErr(t, `database "d" is offline: restoring`, `SHOW TABLES FROM d.sc`)
 
-		sqlDB.ExpectErr(t, `relation "d.sc.tb" does not exist`, `SELECT * FROM d.sc.tb`)
-		sqlDB.ExpectErr(t, `relation "d.sc.tb" does not exist`, `ALTER TABLE d.sc.tb ADD COLUMN b INT`)
+		sqlDB.ExpectErr(t, `database "d" is offline: restoring`, `SELECT * FROM d.sc.tb`)
+		sqlDB.ExpectErr(t, `database "d" is offline: restoring`, `ALTER TABLE d.sc.tb ADD COLUMN b INT`)
 
-		sqlDB.ExpectErr(t, `type "d.sc.typ" does not exist`, `ALTER TYPE d.sc.typ RENAME TO typ2`)
+		sqlDB.ExpectErr(t, `database "d" is offline: restoring`, `ALTER TYPE d.sc.typ RENAME TO typ2`)
 
-		sqlDB.ExpectErr(t, `cannot create "d.sc.other" because the target database or schema does not exist`, `CREATE TABLE d.sc.other()`)
+		sqlDB.ExpectErr(t, `database "d" is offline: restoring`, `CREATE TABLE d.sc.other()`)
 
 		close(continueNotif)
 		require.NoError(t, g.Wait())
@@ -6683,6 +6683,7 @@ CREATE TYPE sc.typ AS ENUM ('hello');
 		sqlDB.Exec(t, `
 CREATE DATABASE d;
 USE d;
+CREATE TABLE tb (x INT);
 CREATE SCHEMA sc;
 CREATE TABLE sc.tb (x INT);
 CREATE TYPE sc.typ AS ENUM ('hello');
@@ -6714,8 +6715,11 @@ CREATE TYPE sc.typ AS ENUM ('hello');
 		schemaDesc := catalogkv.TestingGetSchemaDescriptor(kvDB, keys.SystemSQLCodec, dbDesc.GetID(), "sc")
 		require.Equal(t, descpb.DescriptorState_OFFLINE, schemaDesc.State)
 
-		tableDesc := catalogkv.TestingGetTableDescriptorFromSchema(kvDB, keys.SystemSQLCodec, "newdb", "sc", "tb")
-		require.Equal(t, descpb.DescriptorState_OFFLINE, tableDesc.State)
+		publicTableDesc := catalogkv.TestingGetTableDescriptorFromSchema(kvDB, keys.SystemSQLCodec, "newdb", "public", "tb")
+		require.Equal(t, descpb.DescriptorState_OFFLINE, publicTableDesc.State)
+
+		scTableDesc := catalogkv.TestingGetTableDescriptorFromSchema(kvDB, keys.SystemSQLCodec, "newdb", "sc", "tb")
+		require.Equal(t, descpb.DescriptorState_OFFLINE, scTableDesc.State)
 
 		typeDesc := catalogkv.TestingGetTypeDescriptorFromSchema(kvDB, keys.SystemSQLCodec, "newdb", "sc", "typ")
 		require.Equal(t, descpb.DescriptorState_OFFLINE, typeDesc.State)
@@ -6741,7 +6745,10 @@ CREATE TYPE sc.typ AS ENUM ('hello');
 			{"public", security.AdminRole},
 		})
 
-		sqlDB.ExpectErr(t, `target database or schema does not exist`, `SHOW TABLES FROM newdb.sc`)
+		sqlDB.ExpectErr(t, `schema "sc" is offline: restoring`, `SHOW TABLES FROM newdb.sc`)
+
+		sqlDB.ExpectErr(t, `relation "tb" is offline: restoring`, `SELECT * FROM newdb.tb`)
+		sqlDB.ExpectErr(t, `relation "tb" is offline: restoring`, `SELECT * FROM newdb.public.tb`)
 
 		sqlDB.ExpectErr(t, `schema "sc" is offline: restoring`, `SELECT * FROM newdb.sc.tb`)
 		sqlDB.ExpectErr(t, `schema "sc" is offline: restoring`, `SELECT * FROM sc.tb`)

--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -2978,7 +2978,7 @@ func TestImportIntoCSV(t *testing.T) {
 			<-importBodyFinished
 
 			err := sqlDB.DB.QueryRowContext(ctx, `SELECT 1 FROM t`).Scan(&unused)
-			if !testutils.IsError(err, "relation \"t\" does not exist") {
+			if !testutils.IsError(err, `relation "t" is offline: importing`) {
 				return err
 			}
 			return nil

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -357,14 +357,6 @@ func (sc *SchemaChanger) dropConstraints(
 		if err != nil {
 			return err
 		}
-		// TODO(ajwerner): The need to do this implies that we should cache all
-		// mutable descriptors inside of the collection when they are resolved
-		// such that all attempts to resolve a mutable descriptor from a
-		// collection will always give you the same exact pointer.
-		scTable.MaybeIncrementVersion()
-		if err := descsCol.AddUncommittedDescriptor(scTable); err != nil {
-			return err
-		}
 		b := txn.NewBatch()
 		for i := range constraints {
 			constraint := &constraints[i]
@@ -490,14 +482,7 @@ func (sc *SchemaChanger) addConstraints(
 		if err != nil {
 			return err
 		}
-		// TODO(ajwerner): The need to do this implies that we should cache all
-		// mutable descriptors inside of the collection when they are resolved
-		// such that all attempts to resolve a mutable descriptor from a
-		// collection will always give you the same exact pointer.
-		scTable.MaybeIncrementVersion()
-		if err := descsCol.AddUncommittedDescriptor(scTable); err != nil {
-			return err
-		}
+
 		b := txn.NewBatch()
 		for i := range constraints {
 			constraint := &constraints[i]

--- a/pkg/sql/catalog/descriptor.go
+++ b/pkg/sql/catalog/descriptor.go
@@ -16,6 +16,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -216,7 +218,9 @@ func FilterDescriptorState(desc Descriptor, flags tree.CommonLookupFlags) error 
 		}
 		return NewInactiveDescriptorError(err)
 	case desc.Adding():
-		return errTableAdding
+		// Only table descriptors can be in the adding state.
+		return pgerror.WithCandidateCode(newAddingTableError(desc.(TableDescriptor)),
+			pgcode.ObjectNotInPrerequisiteState)
 	default:
 		return nil
 	}

--- a/pkg/sql/catalog/descs/BUILD.bazel
+++ b/pkg/sql/catalog/descs/BUILD.bazel
@@ -58,6 +58,7 @@ go_test(
         "//pkg/security",
         "//pkg/security/securitytest",
         "//pkg/server",
+        "//pkg/sql/catalog/dbdesc",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/lease",
         "//pkg/sql/catalog/tabledesc",

--- a/pkg/sql/catalog/descs/collection_test.go
+++ b/pkg/sql/catalog/descs/collection_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/dbdesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
@@ -155,4 +156,168 @@ func TestTxnClearsCollectionOnRetry(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
+}
+
+// TestAddUncommittedDescriptorAndMutableResolution tests the collection to
+// ensure that subsequent resolution of mutable descriptors yields the same
+// object. It also ensures that immutable resolution only yields a modified
+// immutable descriptor after a modified version has been explicitly added
+// with AddUncommittedDescriptor.
+func TestAddUncommittedDescriptorAndMutableResolution(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{})
+	defer tc.Stopper().Stop(ctx)
+
+	s0 := tc.Server(0)
+	tdb := sqlutils.MakeSQLRunner(tc.ServerConn(0))
+	tdb.Exec(t, "CREATE DATABASE db")
+	tdb.Exec(t, "USE db")
+	tdb.Exec(t, "CREATE SCHEMA db.sc")
+	tdb.Exec(t, "CREATE TABLE db.sc.tab (i INT PRIMARY KEY)")
+	tdb.Exec(t, "CREATE TYPE db.sc.typ AS ENUM ('foo')")
+	lm := s0.LeaseManager().(*lease.Manager)
+	ie := s0.InternalExecutor().(sqlutil.InternalExecutor)
+	var dbID descpb.ID
+	t.Run("database descriptors", func(t *testing.T) {
+		require.NoError(t, descs.Txn(ctx, s0.ClusterSettings(), lm, ie, s0.DB(), func(
+			ctx context.Context, txn *kv.Txn, descriptors *descs.Collection,
+		) error {
+			flags := tree.DatabaseLookupFlags{}
+			flags.RequireMutable = true
+			flags.Required = true
+
+			db, err := descriptors.GetDatabaseByName(ctx, txn, "db", flags)
+			require.NoError(t, err)
+			dbID = db.GetID()
+
+			resolved, err := descriptors.GetDatabaseByName(ctx, txn, "db", flags)
+			require.NoError(t, err)
+
+			require.Same(t, db, resolved)
+
+			byID, err := descriptors.GetMutableDescriptorByID(ctx, db.GetID(), txn)
+			require.NoError(t, err)
+			require.Same(t, db, byID)
+
+			mut := db.(*dbdesc.Mutable)
+			mut.MaybeIncrementVersion()
+			mut.Schemas["foo"] = descpb.DatabaseDescriptor_SchemaInfo{ID: 2}
+
+			flags.RequireMutable = false
+
+			immByName, err := descriptors.GetDatabaseByName(ctx, txn, "db", flags)
+			require.NoError(t, err)
+			require.Equal(t, mut.OriginalVersion(), immByName.GetVersion())
+
+			immByID, err := descriptors.GetDatabaseVersionByID(ctx, txn, db.GetID(), flags)
+			require.NoError(t, err)
+			require.Same(t, immByName, immByID)
+
+			mut.Name = "new_name"
+			mut.SetDrainingNames([]descpb.NameInfo{{
+				Name: "db",
+			}})
+
+			// Try to get the database descriptor by the old name and fail.
+			failedToResolve, err := descriptors.GetDatabaseByName(ctx, txn, "db", flags)
+			require.Regexp(t, `database "db" does not exist`, err)
+			require.Nil(t, failedToResolve)
+
+			// Try to get the database descriptor by the new name and succeed but get
+			// the old version with the old name (this is bizarre but is the
+			// contract now).
+			immResolvedWithNewNameButHasOldName, err := descriptors.GetDatabaseByName(ctx, txn, "new_name", flags)
+			require.NoError(t, err)
+			require.Same(t, immByID, immResolvedWithNewNameButHasOldName)
+
+			require.NoError(t, descriptors.AddUncommittedDescriptor(mut))
+
+			immByNameAfter, err := descriptors.GetDatabaseByName(ctx, txn, "new_name", flags)
+			require.NoError(t, err)
+			require.Equal(t, db.GetVersion(), immByNameAfter.GetVersion())
+			require.Equal(t, mut.ImmutableCopy(), immByNameAfter)
+
+			immByIDAfter, err := descriptors.GetDatabaseVersionByID(ctx, txn, db.GetID(), flags)
+			require.NoError(t, err)
+			require.Same(t, immByNameAfter, immByIDAfter)
+
+			return nil
+		}))
+	})
+	t.Run("schema descriptors", func(t *testing.T) {
+		require.NoError(t, descs.Txn(ctx, s0.ClusterSettings(), lm, ie, s0.DB(), func(
+			ctx context.Context, txn *kv.Txn, descriptors *descs.Collection,
+		) error {
+			flags := tree.SchemaLookupFlags{}
+			flags.RequireMutable = true
+			flags.Required = true
+
+			ok, schema, err := descriptors.GetSchemaByName(ctx, txn, dbID, "sc", flags)
+			require.NoError(t, err)
+			require.True(t, ok)
+
+			ok, resolved, err := descriptors.GetSchemaByName(ctx, txn, dbID, "sc", flags)
+			require.NoError(t, err)
+			require.True(t, ok)
+
+			require.Same(t, schema.Desc, resolved.Desc)
+
+			byID, err := descriptors.GetMutableDescriptorByID(ctx, schema.ID, txn)
+			require.NoError(t, err)
+
+			require.Same(t, schema.Desc, byID)
+			return nil
+		}))
+	})
+	t.Run("table descriptors", func(t *testing.T) {
+		require.NoError(t, descs.Txn(ctx, s0.ClusterSettings(), lm, ie, s0.DB(), func(
+			ctx context.Context, txn *kv.Txn, descriptors *descs.Collection,
+		) error {
+			flags := tree.ObjectLookupFlags{}
+			flags.RequireMutable = true
+			flags.Required = true
+			tn := tree.MakeTableNameWithSchema("db", "sc", "tab")
+
+			tab, err := descriptors.GetTableByName(ctx, txn, &tn, flags)
+			require.NoError(t, err)
+
+			resolved, err := descriptors.GetTableByName(ctx, txn, &tn, flags)
+			require.NoError(t, err)
+
+			require.Same(t, tab, resolved)
+
+			byID, err := descriptors.GetMutableDescriptorByID(ctx, tab.GetID(), txn)
+			require.NoError(t, err)
+
+			require.Same(t, tab, byID)
+			return nil
+		}))
+	})
+	t.Run("type descriptors", func(t *testing.T) {
+		require.NoError(t, descs.Txn(ctx, s0.ClusterSettings(), lm, ie, s0.DB(), func(
+			ctx context.Context, txn *kv.Txn, descriptors *descs.Collection,
+		) error {
+			flags := tree.ObjectLookupFlags{}
+			flags.RequireMutable = true
+			flags.Required = true
+			tn := tree.MakeNewQualifiedTypeName("db", "sc", "typ")
+			typ, err := descriptors.GetTypeByName(ctx, txn, &tn, flags)
+			require.NoError(t, err)
+
+			resolved, err := descriptors.GetTypeByName(ctx, txn, &tn, flags)
+			require.NoError(t, err)
+
+			require.Same(t, typ, resolved)
+
+			byID, err := descriptors.GetMutableTypeVersionByID(ctx, txn, typ.GetID())
+			require.NoError(t, err)
+
+			require.Same(t, typ, byID)
+
+			return nil
+		}))
+	})
 }

--- a/pkg/sql/descriptor_mutation_test.go
+++ b/pkg/sql/descriptor_mutation_test.go
@@ -1228,7 +1228,7 @@ func TestAddingFKs(t *testing.T) {
 	// Client should not see the orders table.
 	if _, err := sqlDB.Exec(
 		`SELECT * FROM t.orders`,
-	); !testutils.IsError(err, `table is being added`) {
+	); !testutils.IsError(err, `table "\w+" is being added`) {
 		t.Fatal(err)
 	}
 }

--- a/pkg/sql/drop_view.go
+++ b/pkg/sql/drop_view.go
@@ -192,7 +192,8 @@ func (p *planner) dropViewImpl(
 	var cascadeDroppedViews []string
 
 	// Remove back-references from the tables/views this view depends on.
-	for _, depID := range viewDesc.DependsOn {
+	dependedOn := append([]descpb.ID(nil), viewDesc.DependsOn...)
+	for _, depID := range dependedOn {
 		dependencyDesc, err := p.Descriptors().GetMutableTableVersionByID(ctx, depID, p.txn)
 		if err != nil {
 			return cascadeDroppedViews,
@@ -215,7 +216,8 @@ func (p *planner) dropViewImpl(
 	viewDesc.DependsOn = nil
 
 	if behavior == tree.DropCascade {
-		for _, ref := range viewDesc.DependedOnBy {
+		dependedOnBy := append([]descpb.TableDescriptor_Reference(nil), viewDesc.DependedOnBy...)
+		for _, ref := range dependedOnBy {
 			dependentDesc, err := p.getViewDescForCascade(
 				ctx, viewDesc.TypeName(), viewDesc.Name, viewDesc.ParentID, ref.ID, behavior,
 			)

--- a/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
@@ -281,7 +281,7 @@ b  CREATE TABLE public.b (
 )
 
 # table b is not visible to the transaction #17949
-statement error pgcode 42P01 relation "b" does not exist
+statement error pgcode 55000 table "b" is being added
 INSERT INTO b VALUES (1);
 
 statement ok
@@ -299,7 +299,7 @@ statement count 3
 SELECT * FROM stock
 
 # index is only over data added in the transaction so the backfill occurs
-# within the trasaction.
+# within the transaction.
 statement ok
 CREATE INDEX idx_quantity ON stock (quantity)
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/sql_fn
+++ b/pkg/sql/opt/exec/execbuilder/testdata/sql_fn
@@ -223,8 +223,6 @@ vectorized: true
               columns: ()
               estimated row count: 10 (missing stats)
 
-# TODO(rytaft): Figure out why goem7 didn't get added even though the ALTER
-# TABLE statement is included in the EXPLAIN plan above.
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE my_spatial_table]
 ----
@@ -236,9 +234,10 @@ CREATE TABLE public.my_spatial_table (
    geom4 GEOMETRY(LINESTRING,4326) NULL,
    geom5 GEOMETRY(MULTIPOINT,4326) NULL,
    geom6 GEOMETRY(MULTILINESTRING,4326) NULL,
+   geom7 GEOMETRY(POINT,4326) NULL,
    geom8 GEOMETRY(POINT,4326) NULL,
    CONSTRAINT "primary" PRIMARY KEY (k ASC),
-   FAMILY "primary" (k, geom1, geom2, geom3, geom4, geom5, geom6, geom8)
+   FAMILY "primary" (k, geom1, geom2, geom3, geom4, geom5, geom6, geom7, geom8)
 )
 
 # In a WHERE clause.
@@ -265,11 +264,12 @@ CREATE TABLE public.my_spatial_table (
    geom4 GEOMETRY(LINESTRING,4326) NULL,
    geom5 GEOMETRY(MULTIPOINT,4326) NULL,
    geom6 GEOMETRY(MULTILINESTRING,4326) NULL,
+   geom7 GEOMETRY(POINT,4326) NULL,
    geom8 GEOMETRY(POINT,4326) NULL,
    geom9 GEOMETRY(GEOMETRY,4326) NULL,
    geom10 GEOMETRY(GEOMETRYCOLLECTION) NULL,
    CONSTRAINT "primary" PRIMARY KEY (k ASC),
-   FAMILY "primary" (k, geom1, geom2, geom3, geom4, geom5, geom6, geom8, geom9, geom10)
+   FAMILY "primary" (k, geom1, geom2, geom3, geom4, geom5, geom6, geom7, geom8, geom9, geom10)
 )
 
 # Regression test for #50296. Using AddGeometryColumn with NULL arguments must

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -6315,10 +6315,10 @@ func TestAddingTableResolution(t *testing.T) {
 	// In this test it gets stuck in the adding state.
 	sqlRun.Exec(t, `CREATE MATERIALIZED VIEW foo AS SELECT random(), generate_series FROM generate_series(1, 10);`)
 
-	sqlRun.ExpectErr(t, `pq: table is being added`, `SELECT * FROM foo`)
-	sqlRun.ExpectErr(t, `pq: relation "foo" does not exist`, `ALTER MATERIALIZED VIEW foo RENAME TO bar`)
+	sqlRun.ExpectErr(t, `pq: materialized view "foo" is being added`, `SELECT * FROM foo`)
+	sqlRun.ExpectErr(t, `pq: materialized view "foo" is being added`, `ALTER MATERIALIZED VIEW foo RENAME TO bar`)
 	// Regression test for #52829.
-	sqlRun.ExpectErr(t, `pq: relation "foo" does not exist`, `SHOW CREATE foo`)
+	sqlRun.ExpectErr(t, `pq: materialized view "foo" is being added`, `SHOW CREATE foo`)
 }
 
 // TestFailureToMarkCanceledReversalLeadsToCanceledStatus is a regression test

--- a/pkg/sql/sequence.go
+++ b/pkg/sql/sequence.go
@@ -534,7 +534,10 @@ func maybeAddSequenceDependencies(
 func (p *planner) dropSequencesOwnedByCol(
 	ctx context.Context, col *descpb.ColumnDescriptor, queueJob bool,
 ) error {
-	for _, sequenceID := range col.OwnsSequenceIds {
+	// Copy out the sequence IDs as the code to drop the sequence will reach
+	// back around and update the descriptor from underneath us.
+	ownsSequenceIDs := append([]descpb.ID(nil), col.OwnsSequenceIds...)
+	for _, sequenceID := range ownsSequenceIDs {
 		seqDesc, err := p.Descriptors().GetMutableTableVersionByID(ctx, sequenceID, p.txn)
 		// Special case error swallowing for #50781, which can cause a
 		// column to own sequences that do not exist.
@@ -551,6 +554,8 @@ func (p *planner) dropSequencesOwnedByCol(
 		}
 		jobDesc := fmt.Sprintf("removing sequence %q dependent on column %q which is being dropped",
 			seqDesc.Name, col.ColName())
+		// Note that this call will end up resolving and modifying the table
+		// descriptor.
 		if err := p.dropSequenceImpl(
 			ctx, seqDesc, queueJob, jobDesc, tree.DropRestrict,
 		); err != nil {


### PR DESCRIPTION
…olution

When resolving descriptors, the collection checks to see if an "uncommitted"
descriptor had been previously added. Such descriptors are added explicitly
by users with the `AddUncommittedDescriptor()` method. However, prior to this
PR, that method could only be called with a "modified" descriptor (one with an
incremented version) and thus was not called when a mutable descriptor is
resolved (only when it is added). This can be problematic as a mutable
descriptor may be resolved more than once during the execution of a statement
prior to the point where that descriptor is written to the database and added.

In some places, to deal with this, we would increment the version of the
descriptor and add it to the collection prior to performing any changes in
order to ensure that we'd get back the same in-memory object if the same
descriptor was subsequently resolved by name or ID. This was to fix bugs.
We've seen more bugs of this type lately (#56387).

The PR changes the behavior such that once you resolve a mutable descriptor
once, subsequent resolutions will return the same object. This should make
the behavior more obvious.

Release note: None