### PR TITLE
[WIP] backupccl: fix full cluster backup/restore behavior with temp objects

### DIFF
--- a/pkg/ccl/backupccl/targets.go
+++ b/pkg/ccl/backupccl/targets.go
@@ -771,6 +771,10 @@ func fullClusterTargets(
 				fullClusterDBs = append(fullClusterDBs, dbDesc)
 			}
 		case catalog.TableDescriptor:
+			// Skip temporary tables and sequences.
+			if desc.TableDesc().Temporary {
+				continue
+			}
 			if desc.GetParentID() == keys.SystemDatabaseID {
 				// Add only the system tables that we plan to include in a full cluster
 				// backup.
@@ -864,7 +868,7 @@ func selectTargets(
 	descriptorCoverage tree.DescriptorCoverage,
 	asOf hlc.Timestamp,
 ) ([]catalog.Descriptor, []catalog.DatabaseDescriptor, []descpb.TenantInfo, error) {
-	allDescs, lastBackupManifest := loadSQLDescsFromBackupsAtTime(backupManifests, asOf)
+	allDescs, _, lastBackupManifest := loadSQLDescsFromBackupsAtTime(backupManifests, asOf)
 
 	if descriptorCoverage == tree.AllDescriptors {
 		return fullClusterTargetsRestore(allDescs, lastBackupManifest)


### PR DESCRIPTION
Previously, a full cluster backup  would backup the table descriptors
related to temp objects, but not the pg_temp schema, since it does not
have a descriptor representation. After a full cluster restore any code
path which attempted to resolve the temp table desc would fail, since it
would not be able to find the parent schema ID.

This change does two things:
- Prevents full cluster backups from backing up temporary objects.

- Adds logic to full cluster restore to skip restoring temporary object
  descriptors. This alone is not sufficient as we may have jobs captured
by the full cluster backup referencing these temp objects. Thus, this
change also filters out such rows before restoring the system.jobs
table.

Informs: #56512

Release note: None