### PR TITLE
sql: fix cornercases with LIMIT and OFFSET

### DIFF
--- a/pkg/sql/colexec/external_sort_test.go
+++ b/pkg/sql/colexec/external_sort_test.go
@@ -89,7 +89,7 @@ func TestExternalSort(t *testing.T) {
 						// flow this will happen in a downstream materializer/outbox,
 						// since there is no way to tell an operator that Next won't be
 						// called again.
-						if tc.k == 0 || tc.k >= len(tc.tuples) {
+						if tc.k == 0 || tc.k >= uint64(len(tc.tuples)) {
 							semsToCheck = append(semsToCheck, sem)
 						}
 						// TODO(asubiotto): Pass in the testing.T of the caller to this
@@ -317,7 +317,7 @@ func createDiskBackedSorter(
 	typs []*types.T,
 	ordCols []execinfrapb.Ordering_Column,
 	matchLen int,
-	k int,
+	k uint64,
 	spillingCallbackFn func(),
 	numForcedRepartitions int,
 	delegateFDAcquisitions bool,
@@ -334,7 +334,7 @@ func createDiskBackedSorter(
 			Sorter: sorterSpec,
 		},
 		Post: execinfrapb.PostProcessSpec{
-			Limit: uint64(k),
+			Limit: k,
 		},
 		ResultTypes: typs,
 	}

--- a/pkg/sql/colexec/limit.go
+++ b/pkg/sql/colexec/limit.go
@@ -22,10 +22,10 @@ import (
 type limitOp struct {
 	oneInputCloserHelper
 
-	limit int
+	limit uint64
 
 	// seen is the number of tuples seen so far.
-	seen int
+	seen uint64
 	// done is true if the limit has been reached.
 	done bool
 }
@@ -34,7 +34,7 @@ var _ colexecbase.Operator = &limitOp{}
 var _ closableOperator = &limitOp{}
 
 // NewLimitOp returns a new limit operator with the given limit.
-func NewLimitOp(input colexecbase.Operator, limit int) colexecbase.Operator {
+func NewLimitOp(input colexecbase.Operator, limit uint64) colexecbase.Operator {
 	c := &limitOp{
 		oneInputCloserHelper: makeOneInputCloserHelper(input),
 		limit:                limit,
@@ -55,10 +55,10 @@ func (c *limitOp) Next(ctx context.Context) coldata.Batch {
 	if length == 0 {
 		return bat
 	}
-	newSeen := c.seen + length
+	newSeen := c.seen + uint64(length)
 	if newSeen >= c.limit {
 		c.done = true
-		bat.SetLength(c.limit - c.seen)
+		bat.SetLength(int(c.limit - c.seen))
 		return bat
 	}
 	c.seen = newSeen

--- a/pkg/sql/colexec/limit_test.go
+++ b/pkg/sql/colexec/limit_test.go
@@ -22,7 +22,7 @@ func TestLimit(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	tcs := []struct {
-		limit    int
+		limit    uint64
 		tuples   []tuple
 		expected []tuple
 	}{

--- a/pkg/sql/colexec/offset.go
+++ b/pkg/sql/colexec/offset.go
@@ -22,16 +22,16 @@ import (
 type offsetOp struct {
 	OneInputNode
 
-	offset int
+	offset uint64
 
 	// seen is the number of tuples seen so far.
-	seen int
+	seen uint64
 }
 
 var _ colexecbase.Operator = &offsetOp{}
 
 // NewOffsetOp returns a new offset operator with the given offset.
-func NewOffsetOp(input colexecbase.Operator, offset int) colexecbase.Operator {
+func NewOffsetOp(input colexecbase.Operator, offset uint64) colexecbase.Operator {
 	c := &offsetOp{
 		OneInputNode: NewOneInputNode(input),
 		offset:       offset,
@@ -51,14 +51,14 @@ func (c *offsetOp) Next(ctx context.Context) coldata.Batch {
 			return bat
 		}
 
-		c.seen += length
+		c.seen += uint64(length)
 
 		delta := c.seen - c.offset
 		// If the current batch encompasses the offset "boundary",
 		// add the elements after the boundary to the selection vector.
-		if delta > 0 && delta < length {
+		if delta > 0 && delta < uint64(length) {
 			sel := bat.Selection()
-			outputStartIdx := length - delta
+			outputStartIdx := length - int(delta)
 			if sel != nil {
 				copy(sel, sel[outputStartIdx:length])
 			} else {
@@ -68,7 +68,7 @@ func (c *offsetOp) Next(ctx context.Context) coldata.Batch {
 					sel[i] = outputStartIdx + i
 				}
 			}
-			bat.SetLength(delta)
+			bat.SetLength(int(delta))
 		}
 
 		if c.seen > c.offset {

--- a/pkg/sql/colexec/offset_test.go
+++ b/pkg/sql/colexec/offset_test.go
@@ -25,7 +25,7 @@ func TestOffset(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	tcs := []struct {
-		offset   int
+		offset   uint64
 		tuples   []tuple
 		expected []tuple
 	}{

--- a/pkg/sql/colexec/sort_test.go
+++ b/pkg/sql/colexec/sort_test.go
@@ -171,7 +171,7 @@ func TestSortRandomized(t *testing.T) {
 				}
 				runTests(t, []tuples{tups}, expected, orderedVerifier, func(input []colexecbase.Operator) (colexecbase.Operator, error) {
 					if topK {
-						return NewTopKSorter(testAllocator, input[0], typs[:nCols], ordCols, k), nil
+						return NewTopKSorter(testAllocator, input[0], typs[:nCols], ordCols, uint64(k)), nil
 					}
 					return NewSorter(testAllocator, input[0], typs[:nCols], ordCols)
 				})
@@ -281,7 +281,7 @@ func TestAllSpooler(t *testing.T) {
 func BenchmarkSort(b *testing.B) {
 	rng, _ := randutil.NewPseudoRand()
 	ctx := context.Background()
-	k := 128
+	k := uint64(128)
 
 	for _, nBatches := range []int{1 << 1, 1 << 4, 1 << 8} {
 		for _, nCols := range []int{1, 2, 4} {

--- a/pkg/sql/colexec/utils_test.go
+++ b/pkg/sql/colexec/utils_test.go
@@ -1566,7 +1566,7 @@ type sortTestCase struct {
 	typs        []*types.T
 	ordCols     []execinfrapb.Ordering_Column
 	matchLen    int
-	k           int
+	k           uint64
 }
 
 // Mock typing context for the typechecker.

--- a/pkg/sql/logictest/testdata/logic_test/limit
+++ b/pkg/sql/logictest/testdata/logic_test/limit
@@ -176,3 +176,146 @@ INSERT INTO t_47283 VALUES (1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6)
 query II
 SELECT * FROM (SELECT * FROM t_47283 ORDER BY k LIMIT 4) WHERE a > 5 LIMIT 1
 ----
+
+# Test various combinations of LIMIT and OFFSET with values coming from
+# subqueries, including values that can cause overflows.
+statement ok
+CREATE TABLE vals (k STRING PRIMARY KEY, v INT);
+INSERT INTO vals VALUES ('zero', 0), ('one', 1), ('large', 9223372036854775806), ('maxint64', 9223372036854775807);
+CREATE TABLE probe (a INT PRIMARY KEY);
+INSERT INTO probe VALUES (1), (2), (3), (4);
+
+# No offset.
+query I
+SELECT a FROM probe ORDER BY a LIMIT (SELECT v FROM vals WHERE k = 'zero');
+----
+
+query I
+SELECT a FROM probe ORDER BY a LIMIT (SELECT v FROM vals WHERE k = 'one');
+----
+1
+
+query I
+SELECT a FROM probe ORDER BY a LIMIT (SELECT v FROM vals WHERE k = 'large');
+----
+1
+2
+3
+4
+
+query I
+SELECT a FROM probe ORDER BY a LIMIT (SELECT v FROM vals WHERE k = 'maxint64');
+----
+1
+2
+3
+4
+
+# No limit.
+query I
+SELECT a FROM probe ORDER BY a OFFSET (SELECT v FROM vals WHERE k = 'zero');
+----
+1
+2
+3
+4
+
+query I
+SELECT a FROM probe ORDER BY a OFFSET (SELECT v FROM vals WHERE k = 'one');
+----
+2
+3
+4
+
+query I
+SELECT a FROM probe ORDER BY a OFFSET (SELECT v FROM vals WHERE k = 'large');
+----
+
+query I
+SELECT a FROM probe ORDER BY a OFFSET (SELECT v FROM vals WHERE k = 'maxint64');
+----
+
+
+# Offset zero.
+query I
+SELECT a FROM probe ORDER BY a LIMIT (SELECT v FROM vals WHERE k = 'zero') OFFSET (SELECT v FROM vals WHERE k = 'zero');
+----
+
+query I
+SELECT a FROM probe ORDER BY a LIMIT (SELECT v FROM vals WHERE k = 'one') OFFSET (SELECT v FROM vals WHERE k = 'zero');
+----
+1
+
+query I
+SELECT a FROM probe ORDER BY a LIMIT (SELECT v FROM vals WHERE k = 'large') OFFSET (SELECT v FROM vals WHERE k = 'zero');
+----
+1
+2
+3
+4
+
+query I
+SELECT a FROM probe ORDER BY a LIMIT (SELECT v FROM vals WHERE k = 'maxint64') OFFSET (SELECT v FROM vals WHERE k = 'zero');
+----
+1
+2
+3
+4
+
+# Offset one.
+query I
+SELECT a FROM probe ORDER BY a LIMIT (SELECT v FROM vals WHERE k = 'zero') OFFSET (SELECT v FROM vals WHERE k = 'one');
+----
+
+query I
+SELECT a FROM probe ORDER BY a LIMIT (SELECT v FROM vals WHERE k = 'one') OFFSET (SELECT v FROM vals WHERE k = 'one');
+----
+2
+
+query I
+SELECT a FROM probe ORDER BY a LIMIT (SELECT v FROM vals WHERE k = 'large') OFFSET (SELECT v FROM vals WHERE k = 'one');
+----
+2
+3
+4
+
+query I
+SELECT a FROM probe ORDER BY a LIMIT (SELECT v FROM vals WHERE k = 'maxint64') OFFSET (SELECT v FROM vals WHERE k = 'one');
+----
+2
+3
+4
+
+# Offset large.
+query I
+SELECT a FROM probe ORDER BY a LIMIT (SELECT v FROM vals WHERE k = 'zero') OFFSET (SELECT v FROM vals WHERE k = 'large');
+----
+
+query I
+SELECT a FROM probe ORDER BY a LIMIT (SELECT v FROM vals WHERE k = 'one') OFFSET (SELECT v FROM vals WHERE k = 'large');
+----
+
+query I
+SELECT a FROM probe ORDER BY a LIMIT (SELECT v FROM vals WHERE k = 'large') OFFSET (SELECT v FROM vals WHERE k = 'large');
+----
+
+query I
+SELECT a FROM probe ORDER BY a LIMIT (SELECT v FROM vals WHERE k = 'maxint64') OFFSET (SELECT v FROM vals WHERE k = 'large');
+----
+
+# Offset maxint64.
+query I
+SELECT a FROM probe ORDER BY a LIMIT (SELECT v FROM vals WHERE k = 'zero') OFFSET (SELECT v FROM vals WHERE k = 'maxint64');
+----
+
+query I
+SELECT a FROM probe ORDER BY a LIMIT (SELECT v FROM vals WHERE k = 'one') OFFSET (SELECT v FROM vals WHERE k = 'maxint64');
+----
+
+query I
+SELECT a FROM probe ORDER BY a LIMIT (SELECT v FROM vals WHERE k = 'large') OFFSET (SELECT v FROM vals WHERE k = 'maxint64');
+----
+
+query I
+SELECT a FROM probe ORDER BY a LIMIT (SELECT v FROM vals WHERE k = 'maxint64') OFFSET (SELECT v FROM vals WHERE k = 'maxint64');
+----

--- a/pkg/sql/physicalplan/BUILD.bazel
+++ b/pkg/sql/physicalplan/BUILD.bazel
@@ -20,7 +20,6 @@ go_library(
         "//pkg/rpc",
         "//pkg/settings/cluster",
         "//pkg/sql/catalog/colinfo",
-        "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/schemaexpr",
         "//pkg/sql/execinfra",
         "//pkg/sql/execinfrapb",

--- a/pkg/sql/rowexec/sorter.go
+++ b/pkg/sql/rowexec/sorter.go
@@ -186,14 +186,9 @@ func newSorter(
 	if post.Limit != 0 && post.Filter.Empty() {
 		// The sorter needs to produce Offset + Limit rows. The ProcOutputHelper
 		// will discard the first Offset ones.
-		// LIMIT and OFFSET should each never be greater than math.MaxInt64, the
-		// parser ensures this.
-		if post.Limit > math.MaxInt64 || post.Offset > math.MaxInt64 {
-			return nil, errors.AssertionFailedf(
-				"error creating sorter: limit %d offset %d too large",
-				errors.Safe(post.Limit), errors.Safe(post.Offset))
+		if post.Limit <= math.MaxUint64-post.Offset {
+			count = post.Limit + post.Offset
 		}
-		count = post.Limit + post.Offset
 	}
 
 	// Choose the optimal processor.

--- a/pkg/sql/rowexec/sorter_test.go
+++ b/pkg/sql/rowexec/sorter_test.go
@@ -382,14 +382,33 @@ func TestSortInvalidLimit(t *testing.T) {
 	spec := execinfrapb.SorterSpec{}
 
 	t.Run("KTooLarge", func(t *testing.T) {
+		ctx := context.Background()
+		st := cluster.MakeTestingClusterSettings()
+		evalCtx := tree.MakeTestingEvalContext(st)
+		defer evalCtx.Stop(ctx)
+		diskMonitor := execinfra.NewTestDiskMonitor(ctx, st)
+		defer diskMonitor.Stop(ctx)
+		flowCtx := execinfra.FlowCtx{
+			EvalCtx: &evalCtx,
+			Cfg: &execinfra.ServerConfig{
+				Settings:    st,
+				DiskMonitor: diskMonitor,
+			},
+		}
+
 		post := execinfrapb.PostProcessSpec{}
-		post.Limit = math.MaxInt64
-		post.Offset = math.MaxInt64 + 1
-		// All arguments apart from spec and post are not necessary.
-		if _, err := newSorter(
-			context.Background(), nil, 0, &spec, nil, &post, nil,
-		); !testutils.IsError(err, "too large") {
-			t.Fatalf("unexpected error %v, expected k too large", err)
+		post.Limit = math.MaxUint64 - 1000
+		post.Offset = 2000
+		in := distsqlutils.NewRowBuffer([]*types.T{types.Int}, rowenc.EncDatumRows{}, distsqlutils.RowBufferArgs{})
+		out := &distsqlutils.RowBuffer{}
+		proc, err := newSorter(
+			context.Background(), &flowCtx, 0, &spec, in, &post, out,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, sortAll := proc.(*sortAllProcessor); !sortAll {
+			t.Fatalf("expected *sortAllProcessor, got %T", proc)
 		}
 	})
 


### PR DESCRIPTION
We fix a few bugs around LIMIT and OFFSET, mostly around overflows. We
also remove the optimization in the distsql planner to return an empty
plan in some cases (this increases the testing surface and should
rarely be useful, as the optimizer can do this optimization when the
values are not subqueries).

Release note (bug fix): fixed internal errors related to very large
LIMIT and/or OFFSET values.