### PR TITLE
kv: use leaseholder's observed timestamp even for follower reads

### DIFF
--- a/pkg/kv/kvserver/observedts/BUILD.bazel
+++ b/pkg/kv/kvserver/observedts/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "observedts",
@@ -12,5 +12,18 @@ go_library(
         "//pkg/kv/kvserver/kvserverpb",
         "//pkg/roachpb",
         "//pkg/util/log",
+    ],
+)
+
+go_test(
+    name = "observedts_test",
+    srcs = ["limit_test.go"],
+    embed = [":observedts"],
+    deps = [
+        "//pkg/kv/kvserver/kvserverpb",
+        "//pkg/roachpb",
+        "//pkg/util/hlc",
+        "//pkg/util/leaktest",
+        "//vendor/github.com/stretchr/testify/require",
     ],
 )

--- a/pkg/kv/kvserver/observedts/limit_test.go
+++ b/pkg/kv/kvserver/observedts/limit_test.go
@@ -1,0 +1,117 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package observedts
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLimitTxnMaxTimestamp(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	txn := &roachpb.Transaction{
+		ReadTimestamp: hlc.Timestamp{WallTime: 10},
+		MaxTimestamp:  hlc.Timestamp{WallTime: 20},
+	}
+	txn.UpdateObservedTimestamp(1, hlc.Timestamp{WallTime: 15})
+	txnWithMaxTimestamp := func(ts hlc.Timestamp) *roachpb.Transaction {
+		txnClone := txn.Clone()
+		txnClone.MaxTimestamp = ts
+		return txnClone
+	}
+
+	repl1 := roachpb.ReplicaDescriptor{NodeID: 1}
+	repl2 := roachpb.ReplicaDescriptor{NodeID: 2}
+	lease := kvserverpb.LeaseStatus{
+		Lease: roachpb.Lease{Replica: repl1},
+		State: kvserverpb.LeaseState_VALID,
+	}
+
+	testCases := []struct {
+		name   string
+		txn    *roachpb.Transaction
+		lease  kvserverpb.LeaseStatus
+		expTxn *roachpb.Transaction
+	}{
+		{
+			name:   "no txn",
+			txn:    nil,
+			lease:  lease,
+			expTxn: nil,
+		},
+		{
+			name: "invalid lease",
+			txn:  txn,
+			lease: func() kvserverpb.LeaseStatus {
+				leaseClone := lease
+				leaseClone.State = kvserverpb.LeaseState_EXPIRED
+				return leaseClone
+			}(),
+			expTxn: txn,
+		},
+		{
+			name: "no observed timestamp",
+			txn:  txn,
+			lease: func() kvserverpb.LeaseStatus {
+				leaseClone := lease
+				leaseClone.Lease.Replica = repl2
+				return leaseClone
+			}(),
+			expTxn: txn,
+		},
+		{
+			name:   "valid lease",
+			txn:    txn,
+			lease:  lease,
+			expTxn: txnWithMaxTimestamp(hlc.Timestamp{WallTime: 15}),
+		},
+		{
+			name: "valid lease with start time above observed timestamp",
+			txn:  txn,
+			lease: func() kvserverpb.LeaseStatus {
+				leaseClone := lease
+				leaseClone.Lease.Start = hlc.Timestamp{WallTime: 18}
+				return leaseClone
+			}(),
+			expTxn: txnWithMaxTimestamp(hlc.Timestamp{WallTime: 18}),
+		},
+		{
+			name: "valid lease with start time above max timestamp",
+			txn:  txn,
+			lease: func() kvserverpb.LeaseStatus {
+				leaseClone := lease
+				leaseClone.Lease.Start = hlc.Timestamp{WallTime: 22}
+				return leaseClone
+			}(),
+			expTxn: txn,
+		},
+	}
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			// Copy txn to test that the transaction is not mutated.
+			var txnBefore *roachpb.Transaction
+			if test.txn != nil {
+				txnBefore = test.txn.Clone()
+			}
+
+			txnOut := LimitTxnMaxTimestamp(context.Background(), test.txn, test.lease)
+			require.Equal(t, test.expTxn, txnOut)
+			require.Equal(t, txnBefore, test.txn)
+		})
+	}
+}

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -719,7 +719,7 @@ func (r *Replica) descRLocked() *roachpb.RangeDescriptor {
 
 // NodeID returns the ID of the node this replica belongs to.
 func (r *Replica) NodeID() roachpb.NodeID {
-	return r.store.nodeDesc.NodeID
+	return r.store.NodeID()
 }
 
 // GetNodeLocality returns the locality of the node this replica belongs to.

--- a/pkg/kv/kvserver/replica_send.go
+++ b/pkg/kv/kvserver/replica_send.go
@@ -306,7 +306,7 @@ func (r *Replica) executeBatchWithConcurrencyRetries(
 			}
 		}
 		// Limit the transaction's maximum timestamp using observed timestamps.
-		observedts.LimitTxnMaxTimestamp(ctx, ba, status)
+		ba.Txn = observedts.LimitTxnMaxTimestamp(ctx, ba.Txn, status)
 
 		// Determine the maximal set of key spans that the batch will operate
 		// on. We only need to do this once and we make sure to do so after we

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -2260,6 +2260,9 @@ func (s *Store) RaftStatus(rangeID roachpb.RangeID) *raft.Status {
 // ClusterID accessor.
 func (s *Store) ClusterID() uuid.UUID { return s.Ident.ClusterID }
 
+// NodeID accessor.
+func (s *Store) NodeID() roachpb.NodeID { return s.Ident.NodeID }
+
 // StoreID accessor.
 func (s *Store) StoreID() roachpb.StoreID { return s.Ident.StoreID }
 

--- a/pkg/kv/kvserver/store_send.go
+++ b/pkg/kv/kvserver/store_send.go
@@ -108,7 +108,7 @@ func (s *Store) Send(
 			// can use it to shorten its uncertainty interval when it comes back to
 			// this node.
 			if pErr != nil {
-				pErr.OriginNode = ba.Replica.NodeID
+				pErr.OriginNode = s.NodeID()
 				if txn := pErr.GetTxn(); txn == nil {
 					pErr.SetTxn(ba.Txn)
 				}
@@ -150,9 +150,9 @@ func (s *Store) Send(
 		// updating the top end of our uncertainty timestamp would lead to a
 		// restart (at least in the absence of a prior observed timestamp from
 		// this node, in which case the following is a no-op).
-		if _, ok := ba.Txn.GetObservedTimestamp(ba.Replica.NodeID); !ok {
+		if _, ok := ba.Txn.GetObservedTimestamp(s.NodeID()); !ok {
 			txnClone := ba.Txn.Clone()
-			txnClone.UpdateObservedTimestamp(ba.Replica.NodeID, s.cfg.Clock.Now())
+			txnClone.UpdateObservedTimestamp(s.NodeID(), s.Clock().Now())
 			ba.Txn = txnClone
 		}
 	}


### PR DESCRIPTION
This commit addresses a longstanding TODO to rationalize the use of
observed timestamps during follower reads.

Before this change, we used to use observed timestamps pulled from the
follower node to limit a transaction's uncertainty interval, but this
was incorrect. An observed timestamp pulled from the follower node's
clock has no meaning for the purpose of reducing the transaction's
uncertainty interval. This is because there is no guarantee that at the
time of acquiring the observed timestamp from the follower node, the
leaseholder hadn't already served writes at higher timestamps than the
follower node's clock reflected.

However, if the transaction performing a follower read happens to have
an observed timestamp from the current leaseholder, this timestamp can
be used to reduce the transaction's uncertainty interval. Even though
the read is being served from a different replica in the range, the
observed timestamp still places a bound on the values in the range that
may have been written before the transaction began.

In the past, this was mostly innocuous because AOST txns don't have an
uncertainty interval and the follower read duration was so large that
very few "present time" transactions would ever perform follower reads.
Now that the follower read duration is lower and more and more present
time transactions will perform follower reads, this is more critical to
get right.

The change also reworks the observedts package's docs a little bit to
take advantage of section headers:
![localhost_8080_pkg_github com_cockroachdb_cockroach_pkg_kv_kvserver_observedts_](https://user-images.githubusercontent.com/5438456/99130331-0d3cfc00-25de-11eb-9f49-616bfed9fc55.png)
