### PR TITLE
sql: categorize pgcode.DuplicateRelation in `ALTER INDEX ... RENAME TO`

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/rename_index
+++ b/pkg/sql/logictest/testdata/logic_test/rename_index
@@ -42,7 +42,7 @@ users_dupe  foo         true        2             id           ASC        false 
 users_dupe  bar         false       1             id           ASC        false    false
 users_dupe  bar         false       2             name         ASC        false    false
 
-statement error index name "bar" already exists
+statement error pgcode 42P07 index name "bar" already exists
 ALTER INDEX users@foo RENAME TO bar
 
 statement error pgcode 42601 empty index name

--- a/pkg/sql/rename_index.go
+++ b/pkg/sql/rename_index.go
@@ -12,7 +12,6 @@ package sql
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -92,7 +91,7 @@ func (n *renameIndexNode) startExec(params runParams) error {
 	}
 
 	if _, _, err := tableDesc.FindIndexByName(string(n.n.NewName)); err == nil {
-		return fmt.Errorf("index name %q already exists", string(n.n.NewName))
+		return pgerror.Newf(pgcode.DuplicateRelation, "index name %q already exists", string(n.n.NewName))
 	}
 
 	if err := tableDesc.RenameIndexDescriptor(idx, string(n.n.NewName)); err != nil {


### PR DESCRIPTION
sql: categorize pgcode.DuplicateRelation in `ALTER INDEX ... RENAME TO`

Previously, renaming an index to a name that is being used for another index
returned an uncategorized error. This change will fix this behavior by returning
a pgcode.DuplicateRelation (42P07) instead.

Closes: https://github.com/cockroachdb/cockroach/issues/56677

Release note (sql change): Renaming an index to
a name that is already being used for another index will now return
a pgcode.DuplicateRelation (42P07) instead of an uncategorized error.