### PR TITLE
stopper: assert that stoppers don't leak

### DIFF
--- a/pkg/internal/client/requestbatcher/batcher_test.go
+++ b/pkg/internal/client/requestbatcher/batcher_test.go
@@ -548,10 +548,12 @@ func TestMaxKeysPerBatchReq(t *testing.T) {
 
 func TestPanicWithNilSender(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	stopper := stop.NewStopper()
+	defer stopper.Stop(context.Background())
 	defer func() {
 		if r := recover(); r == nil {
 			t.Fatalf("failed to panic with a nil Sender")
 		}
 	}()
-	New(Config{Stopper: stop.NewStopper()})
+	New(Config{Stopper: stopper})
 }

--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -3401,6 +3401,7 @@ func TestStoreRangeMergeDuringShutdown(t *testing.T) {
 		startWithSingleRange: true,
 	}
 	mtc.Start(t, 1)
+	defer mtc.Stop()
 	store := mtc.Store(0)
 	stopper := mtc.engineStoppers[0]
 

--- a/pkg/kv/kvserver/closedts/container/container_test.go
+++ b/pkg/kv/kvserver/closedts/container/container_test.go
@@ -123,6 +123,7 @@ func setupTwoNodeTest() (_ *TestContainer, _ *TestContainer, shutdown func()) {
 			defer wg.Done()
 			c2.Stopper.Stop(context.Background())
 		}()
+		wg.Wait()
 	}
 }
 

--- a/pkg/kv/kvserver/rangefeed/processor_test.go
+++ b/pkg/kv/kvserver/rangefeed/processor_test.go
@@ -432,7 +432,9 @@ func TestNilProcessor(t *testing.T) {
 
 	// The following should panic because they are not safe
 	// to call on a nil Processor.
-	require.Panics(t, func() { p.Start(stop.NewStopper(), nil) })
+	stopper := stop.NewStopper()
+	defer stopper.Stop(context.Background())
+	require.Panics(t, func() { p.Start(stopper, nil) })
 	require.Panics(t, func() { p.Register(roachpb.RSpan{}, hlc.Timestamp{}, nil, false, nil, nil) })
 }
 

--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -261,7 +261,9 @@ func TestDistSQLReceiverUpdatesCaches(t *testing.T) {
 
 	size := func() int64 { return 2 << 10 }
 	st := cluster.MakeTestingClusterSettings()
-	rangeCache := kvcoord.NewRangeDescriptorCache(st, nil /* db */, size, stop.NewStopper())
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+	rangeCache := kvcoord.NewRangeDescriptorCache(st, nil /* db */, size, stopper)
 	r := MakeDistSQLReceiver(
 		ctx, nil /* resultWriter */, tree.Rows,
 		rangeCache, nil /* txn */, nil /* updateClock */, &SessionTracing{})

--- a/pkg/util/leaktest/leaktest.go
+++ b/pkg/util/leaktest/leaktest.go
@@ -112,8 +112,6 @@ func AfterTest(t testing.TB) func() {
 			return
 		}
 
-		// TODO(tbg): make this call 't.Error' instead of 't.Logf' once there is
-		// enough Stopper discipline.
 		PrintLeakedStoppers(t)
 
 		// Loop, waiting for goroutines to shut down.

--- a/pkg/util/stop/stopper.go
+++ b/pkg/util/stop/stopper.go
@@ -95,7 +95,7 @@ func PrintLeakedStoppers(t testing.TB) {
 	trackedStoppers.Lock()
 	defer trackedStoppers.Unlock()
 	for _, tracked := range trackedStoppers.stoppers {
-		t.Logf("leaked stopper, created at:\n%s", tracked.createdAt)
+		t.Errorf("leaked stopper, created at:\n%s", tracked.createdAt)
 	}
 }
 

--- a/pkg/util/stop/stopper_test.go
+++ b/pkg/util/stop/stopper_test.go
@@ -346,6 +346,7 @@ func TestStopperRunTaskPanic(t *testing.T) {
 	s := stop.NewStopper(stop.OnPanic(func(v interface{}) {
 		ch <- v
 	}))
+	defer s.Stop(context.Background())
 	// If RunTask were not panic-safe, Stop() would deadlock.
 	type testFn func()
 	explode := func(context.Context) { panic(ch) }


### PR DESCRIPTION
Fixes #56697
Fixes #56696

Until now leaked stoppers were just reported in tests but did not
cause failures. This PR switches the check to cause errors instead.

Release note: None