### PR TITLE
util/hlc: add lock-free Clock.Update() fast path for old wall times

### DIFF
--- a/pkg/util/hlc/hlc_test.go
+++ b/pkg/util/hlc/hlc_test.go
@@ -13,7 +13,9 @@ package hlc
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"regexp"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -581,4 +583,51 @@ func TestLateStartForwardClockJump(t *testing.T) {
 	<-tickedCh
 	c.Now()
 
+}
+
+func BenchmarkUpdate(b *testing.B) {
+	b.StopTimer()
+
+	concurrency := 32    // number of concurrent updaters
+	updates := int(10e6) // total number of updates to perform
+	advanceChance := 0.2 // chance for each worker to advance time
+	advanceMax := 5      // max amount to advance time by per update
+
+	// We pre-generate random timestamps for each worker, to avoid it skewing
+	// the benchmark.
+	//
+	// This benchmark may not be entirely realistic, since each worker advances
+	// its own clock independent of other workers, which probably leads to
+	// having one front-runner. However, synchronizing them while running ends up
+	// benchmarking the contention of the benchmark synchronization rather than
+	// the HLC.
+	r := rand.New(rand.NewSource(34704832098))
+	timestamps := make([][]Timestamp, concurrency)
+	for w := 0; w < concurrency; w++ {
+		timestamps[w] = make([]Timestamp, updates/concurrency)
+		wallTime := 0
+		for i := 0; i < updates/concurrency; i++ {
+			if r.Float64() < advanceChance {
+				wallTime += r.Intn(advanceMax + 1)
+			}
+			timestamps[w][i] = Timestamp{WallTime: int64(wallTime)}
+		}
+	}
+
+	b.StartTimer()
+	for n := 0; n < b.N; n++ {
+		clock := NewClock(func() int64 { return 0 }, time.Second)
+		wg := sync.WaitGroup{}
+		for w := 0; w < concurrency; w++ {
+			w := w // make sure we don't close over the loop variable
+			wg.Add(1)
+			go func() {
+				for _, timestamp := range timestamps[w] {
+					clock.Update(timestamp)
+				}
+				wg.Done()
+			}()
+		}
+		wg.Wait()
+	}
 }


### PR DESCRIPTION
Clock.Update() is a significant source of contention under high
concurrency, since it always takes out an exclusive mutex lock. This
commit retains the mutex, but additionally updates `Timestamp.WallTime`
atomically while holding the lock. This allows a fast-path where the
incoming timestamp can be compared against the current wall time and
dropped if it's behind without taking out the mutex lock.

This also adds a micro-benchmark `BenchmarkUpdate`, which was used to
compare the old behavior (`Mutex`), the new behavior (`atomic`), and an
alternative implementation using a read-write mutex (`RWMutex`).
Although this is not likely to be realistic (see code comment), the
results show an order of magnitude improvement under high concurrency,
and a negligible (5%) penalty with no concurrency.

| Concurrency | 1     | 4     | 16    | 64    |
|-------------|-------|-------|-------|-------|
| `Mutex`     | 141ms | 353ms | 516ms | 522ms |
| `RWMutex`   | 326ms | 138ms | 95ms  | 80ms  |
| `atomic`    | 148ms | 111ms | 68ms  | 26ms  |

Release note (performance improvement): the hybrid logical clock used
to coordinate distributed operations now performs significantly better
under high contention with many concurrent updates from remote nodes.

Resolves #37279.