### PR TITLE
opt: use optional filters to constrain multi-column inverted indexes

### DIFF
--- a/pkg/sql/opt/invertedidx/geo.go
+++ b/pkg/sql/opt/invertedidx/geo.go
@@ -73,6 +73,7 @@ func TryConstrainGeoIndex(
 	evalCtx *tree.EvalContext,
 	factory *norm.Factory,
 	filters memo.FiltersExpr,
+	optionalFilters memo.FiltersExpr,
 	tabID opt.TableID,
 	index cat.Index,
 ) (
@@ -84,7 +85,7 @@ func TryConstrainGeoIndex(
 ) {
 	// Attempt to constrain the prefix columns, if there are any. If they cannot
 	// be constrained to single values, the index cannot be used.
-	constraint, filters, ok = constrainPrefixColumns(evalCtx, factory, filters, tabID, index)
+	constraint, filters, ok = constrainPrefixColumns(evalCtx, factory, filters, optionalFilters, tabID, index)
 	if !ok {
 		return nil, nil, nil, nil, false
 	}

--- a/pkg/sql/opt/invertedidx/geo_test.go
+++ b/pkg/sql/opt/invertedidx/geo_test.go
@@ -491,7 +491,7 @@ func TestTryConstrainGeoIndex(t *testing.T) {
 		// that is tested elsewhere. This is just testing that we are constraining
 		// the index when we expect to.
 		_, _, _, pfState, ok := invertedidx.TryConstrainGeoIndex(
-			evalCtx, &f, filters, tab, md.Table(tab).Index(tc.indexOrd),
+			evalCtx, &f, filters, nil /* optionalFilters */, tab, md.Table(tab).Index(tc.indexOrd),
 		)
 		if tc.ok != ok {
 			t.Fatalf("expected %v, got %v", tc.ok, ok)

--- a/pkg/sql/opt/invertedidx/inverted_index_expr.go
+++ b/pkg/sql/opt/invertedidx/inverted_index_expr.go
@@ -262,6 +262,7 @@ func constrainPrefixColumns(
 	evalCtx *tree.EvalContext,
 	factory *norm.Factory,
 	filters memo.FiltersExpr,
+	optionalFilters memo.FiltersExpr,
 	tabID opt.TableID,
 	index cat.Index,
 ) (constraint *constraint.Constraint, remainingFilters memo.FiltersExpr, ok bool) {
@@ -287,7 +288,7 @@ func constrainPrefixColumns(
 
 	var ic idxconstraint.Instance
 	ic.Init(
-		filters, nil, /* optionalFilters */
+		filters, optionalFilters,
 		prefixColumns, notNullCols, tabMeta.ComputedCols,
 		false /* isInverted */, evalCtx, factory,
 	)

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -3257,6 +3257,160 @@ select
  └── filters
       └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:4) [outer=(4), immutable, constraints=(/4: (/NULL - ])]
 
+exec-ddl
+CREATE TABLE mc (
+  k INT PRIMARY KEY,
+  a STRING NOT NULL,
+  b STRING NOT NULL,
+  c STRING AS (upper(a)) STORED,
+  geom GEOMETRY,
+  CHECK (b IN ('foo', 'bar', 'baz'))
+)
+----
+
+exec-ddl
+CREATE INVERTED INDEX mc_idx ON mc (b, geom)
+----
+
+# Constrain the first prefix column with a CHECK constraint.
+opt expect=GenerateInvertedIndexScans
+SELECT * FROM mc WHERE ST_CoveredBy('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))'::geometry, geom)
+----
+select
+ ├── columns: k:1!null a:2!null b:3!null c:4 geom:5!null
+ ├── immutable
+ ├── key: (1)
+ ├── fd: (1)-->(2-5)
+ ├── index-join mc
+ │    ├── columns: k:1!null a:2!null b:3!null c:4 geom:5
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-5)
+ │    └── inverted-filter
+ │         ├── columns: k:1!null
+ │         ├── inverted expression: /7
+ │         │    ├── tight: false
+ │         │    └── union spans
+ │         │         ├── ["B\xfd\x10\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x10\x00\x00\x00\x00\x00\x00\x00"]
+ │         │         ├── ["B\xfd\x11\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x11\x00\x00\x00\x00\x00\x00\x00"]
+ │         │         └── ["B\xfd\x14\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x14\x00\x00\x00\x00\x00\x00\x00"]
+ │         ├── pre-filterer expression
+ │         │    └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:5)
+ │         ├── key: (1)
+ │         └── scan mc@mc_idx
+ │              ├── columns: k:1!null geom_inverted_key:7!null
+ │              ├── constraint: /3
+ │              │    ├── [/'bar' - /'bar']
+ │              │    ├── [/'baz' - /'baz']
+ │              │    └── [/'foo' - /'foo']
+ │              ├── inverted constraint: /7/1
+ │              │    └── spans
+ │              │         ├── ["B\xfd\x10\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x10\x00\x00\x00\x00\x00\x00\x00"]
+ │              │         ├── ["B\xfd\x11\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x11\x00\x00\x00\x00\x00\x00\x00"]
+ │              │         └── ["B\xfd\x14\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x14\x00\x00\x00\x00\x00\x00\x00"]
+ │              ├── key: (1)
+ │              └── fd: (1)-->(7)
+ └── filters
+      └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:5) [outer=(5), immutable, constraints=(/5: (/NULL - ])]
+
+exec-ddl
+DROP INDEX mc_idx
+----
+
+exec-ddl
+CREATE INVERTED INDEX mc_idx ON mc (a, b, geom)
+----
+
+# Constrain the second prefix column with a CHECK constraint.
+opt expect=GenerateInvertedIndexScans
+SELECT * FROM mc WHERE a = 'x' AND ST_CoveredBy('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))'::geometry, geom)
+----
+select
+ ├── columns: k:1!null a:2!null b:3!null c:4 geom:5!null
+ ├── immutable
+ ├── key: (1)
+ ├── fd: ()-->(2), (1)-->(3-5)
+ ├── index-join mc
+ │    ├── columns: k:1!null a:2!null b:3!null c:4 geom:5
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-5)
+ │    └── inverted-filter
+ │         ├── columns: k:1!null
+ │         ├── inverted expression: /8
+ │         │    ├── tight: false
+ │         │    └── union spans
+ │         │         ├── ["B\xfd\x10\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x10\x00\x00\x00\x00\x00\x00\x00"]
+ │         │         ├── ["B\xfd\x11\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x11\x00\x00\x00\x00\x00\x00\x00"]
+ │         │         └── ["B\xfd\x14\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x14\x00\x00\x00\x00\x00\x00\x00"]
+ │         ├── pre-filterer expression
+ │         │    └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:5)
+ │         ├── key: (1)
+ │         └── scan mc@mc_idx
+ │              ├── columns: k:1!null geom_inverted_key:8!null
+ │              ├── constraint: /2/3
+ │              │    ├── [/'x'/'bar' - /'x'/'bar']
+ │              │    ├── [/'x'/'baz' - /'x'/'baz']
+ │              │    └── [/'x'/'foo' - /'x'/'foo']
+ │              ├── inverted constraint: /8/1
+ │              │    └── spans
+ │              │         ├── ["B\xfd\x10\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x10\x00\x00\x00\x00\x00\x00\x00"]
+ │              │         ├── ["B\xfd\x11\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x11\x00\x00\x00\x00\x00\x00\x00"]
+ │              │         └── ["B\xfd\x14\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x14\x00\x00\x00\x00\x00\x00\x00"]
+ │              ├── key: (1)
+ │              └── fd: (1)-->(8)
+ └── filters
+      └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:5) [outer=(5), immutable, constraints=(/5: (/NULL - ])]
+
+exec-ddl
+DROP INDEX mc_idx
+----
+
+exec-ddl
+CREATE INVERTED INDEX mc_idx ON mc (c, geom)
+----
+
+# Constrain a prefix column that is computed from a column with a constant
+# filter.
+opt expect=GenerateInvertedIndexScans
+SELECT * FROM mc WHERE a = 'foo' AND ST_CoveredBy('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))'::geometry, geom)
+----
+select
+ ├── columns: k:1!null a:2!null b:3!null c:4 geom:5!null
+ ├── immutable
+ ├── key: (1)
+ ├── fd: ()-->(2), (1)-->(3-5)
+ ├── index-join mc
+ │    ├── columns: k:1!null a:2!null b:3!null c:4 geom:5
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-5)
+ │    └── inverted-filter
+ │         ├── columns: k:1!null
+ │         ├── inverted expression: /9
+ │         │    ├── tight: false
+ │         │    └── union spans
+ │         │         ├── ["B\xfd\x10\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x10\x00\x00\x00\x00\x00\x00\x00"]
+ │         │         ├── ["B\xfd\x11\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x11\x00\x00\x00\x00\x00\x00\x00"]
+ │         │         └── ["B\xfd\x14\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x14\x00\x00\x00\x00\x00\x00\x00"]
+ │         ├── pre-filterer expression
+ │         │    └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:5)
+ │         ├── key: (1)
+ │         └── scan mc@mc_idx
+ │              ├── columns: k:1!null geom_inverted_key:9!null
+ │              ├── constraint: /4: [/'FOO' - /'FOO']
+ │              ├── inverted constraint: /9/1
+ │              │    └── spans
+ │              │         ├── ["B\xfd\x10\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x10\x00\x00\x00\x00\x00\x00\x00"]
+ │              │         ├── ["B\xfd\x11\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x11\x00\x00\x00\x00\x00\x00\x00"]
+ │              │         └── ["B\xfd\x14\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x14\x00\x00\x00\x00\x00\x00\x00"]
+ │              ├── key: (1)
+ │              └── fd: (1)-->(9)
+ └── filters
+      ├── a:2 = 'foo' [outer=(2), constraints=(/2: [/'foo' - /'foo']; tight), fd=()-->(2)]
+      └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:5) [outer=(5), immutable, constraints=(/5: (/NULL - ])]
+
+exec-ddl
+DROP INDEX mc_idx
+----
+
 # --------------------------------------------------
 # GenerateZigzagJoins
 # --------------------------------------------------

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -3046,6 +3046,23 @@ select
  └── filters
       └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:4) [outer=(4), immutable, constraints=(/4: (/NULL - ])]
 
+# Do not generate an inverted index scan when the first prefix column is not
+# constrained.
+opt expect-not=GenerateInvertedIndexScans
+SELECT * FROM m WHERE ST_CoveredBy('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))'::geometry, geom)
+----
+select
+ ├── columns: k:1!null a:2 b:3 geom:4!null
+ ├── immutable
+ ├── key: (1)
+ ├── fd: (1)-->(2-4)
+ ├── scan m
+ │    ├── columns: k:1!null a:2 b:3 geom:4
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-4)
+ └── filters
+      └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:4) [outer=(4), immutable, constraints=(/4: (/NULL - ])]
+
 # Do not generate an inverted index scan when a single prefix column is
 # constrained to a range.
 opt expect-not=GenerateInvertedIndexScans
@@ -3150,6 +3167,41 @@ select
  └── filters
       └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:4) [outer=(4), immutable, constraints=(/4: (/NULL - ])]
 
+# Do not generate an inverted index scan when the first prefix column is not
+# constrained.
+opt expect-not=GenerateInvertedIndexScans
+SELECT * FROM m WHERE b = 'foo' AND ST_CoveredBy('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))'::geometry, geom)
+----
+select
+ ├── columns: k:1!null a:2 b:3!null geom:4!null
+ ├── immutable
+ ├── key: (1)
+ ├── fd: ()-->(3), (1)-->(2,4)
+ ├── scan m
+ │    ├── columns: k:1!null a:2 b:3 geom:4
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-4)
+ └── filters
+      ├── b:3 = 'foo' [outer=(3), constraints=(/3: [/'foo' - /'foo']; tight), fd=()-->(3)]
+      └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:4) [outer=(4), immutable, constraints=(/4: (/NULL - ])]
+
+# Do not generate an inverted index scan when the second prefix column is not
+# constrained.
+opt expect-not=GenerateInvertedIndexScans
+SELECT * FROM m WHERE a = 'foo' AND ST_CoveredBy('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))'::geometry, geom)
+----
+select
+ ├── columns: k:1!null a:2!null b:3 geom:4!null
+ ├── immutable
+ ├── key: (1)
+ ├── fd: ()-->(2), (1)-->(3,4)
+ ├── scan m
+ │    ├── columns: k:1!null a:2 b:3 geom:4
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-4)
+ └── filters
+      ├── a:2 = 'foo' [outer=(2), constraints=(/2: [/'foo' - /'foo']; tight), fd=()-->(2)]
+      └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:4) [outer=(4), immutable, constraints=(/4: (/NULL - ])]
 
 # Do not generate an inverted index scan when the first prefix column is
 # constrained to a range.


### PR DESCRIPTION
#### opt: test multi-column inverted index scans with unconstrained prefix columns

This commit adds tests that verify that multi-column inverted index
scans are not generated when the prefix columns are unconstrained.
Previous tests did not test these cases.

Release note: None

#### opt: use optional filters to constrain multi-column inverted indexes

This commit enables the optimizer to use check constraints and computed
column expressions to constrain non-inverted prefix columns of
multi-column inverted index scans. This is acheived by passing these
expressions as optional filters to the index constraint builder.

Release note: None
