### PR TITLE
release-20.2: cli/exit: new package to replace direct uses of os.Exit

### DIFF
--- a/docs/generated/redact_safe.md
+++ b/docs/generated/redact_safe.md
@@ -2,6 +2,7 @@ The following types are considered always safe for reporting:
 
 File | Type
 --|--
+pkg/cli/exit/exit.go | `Code`
 pkg/jobs/jobspb/wrap.go | `Type`
 pkg/kv/kvserver/raft.go | `SnapshotRequest_Type`
 pkg/roachpb/data.go | `ReplicaChangeType`

--- a/pkg/cli/error_test.go
+++ b/pkg/cli/error_test.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/cli/exit"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -138,7 +139,7 @@ func TestErrorReporting(t *testing.T) {
 		{
 			desc: "single cliError",
 			err: &cliError{
-				exitCode: 1,
+				exitCode: exit.UnspecifiedError(),
 				severity: log.Severity_INFO,
 				cause:    errors.New("routine"),
 			},
@@ -148,10 +149,10 @@ func TestErrorReporting(t *testing.T) {
 		{
 			desc: "double cliError",
 			err: &cliError{
-				exitCode: 1,
+				exitCode: exit.UnspecifiedError(),
 				severity: log.Severity_INFO,
 				cause: &cliError{
-					exitCode: 1,
+					exitCode: exit.UnspecifiedError(),
 					severity: log.Severity_ERROR,
 					cause:    errors.New("serious"),
 				},
@@ -162,7 +163,7 @@ func TestErrorReporting(t *testing.T) {
 		{
 			desc: "wrapped cliError",
 			err: fmt.Errorf("some context: %w", &cliError{
-				exitCode: 1,
+				exitCode: exit.UnspecifiedError(),
 				severity: log.Severity_INFO,
 				cause:    errors.New("routine"),
 			}),

--- a/pkg/cli/exit/codes.go
+++ b/pkg/cli/exit/codes.go
@@ -1,0 +1,65 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package exit
+
+// Codes that are common to all command times (server + client) follow.
+
+// Success (0) represents a normal process termination.
+func Success() Code { return Code{0} }
+
+// UnspecifiedError (1) indicates the process has terminated with an
+// error condition. The specific cause of the error can be found in
+// the logging output.
+func UnspecifiedError() Code { return Code{1} }
+
+// UnspecifiedGoPanic (2) indicates the process has terminated due to
+// an uncaught Go panic or some other error in the Go runtime.
+//
+// The reporting of this exit code likely indicates a programming
+// error inside CockroachDB.
+//
+// Conversely, this should not be used when implementing features.
+func UnspecifiedGoPanic() Code { return Code{2} }
+
+// Interrupted (3) indicates the server process was interrupted with
+// Ctrl+C / SIGINT.
+func Interrupted() Code { return Code{3} }
+
+// CommandLineFlagError (4) indicates there was an error in the
+// command-line parameters.
+func CommandLineFlagError() Code { return Code{4} }
+
+// LoggingStderrUnavailable (5) indicates that an error occurred
+// during a logging operation to the process' stderr stream.
+func LoggingStderrUnavailable() Code { return Code{5} }
+
+// LoggingFileUnavailable (6) indicates that an error occurred
+// during a logging operation to a file.
+func LoggingFileUnavailable() Code { return Code{6} }
+
+// FatalError (7) indicates that a logical error in the server caused
+// an emergency shutdown.
+func FatalError() Code { return Code{7} }
+
+// TimeoutAfterFatalError (8) indicates that an emergency shutdown
+// due to a fatal error did not occur properly due to some blockage
+// in the logging system.
+func TimeoutAfterFatalError() Code { return Code{8} }
+
+// Codes that are specific to client commands follow. It's possible
+// for codes to be reused across separate client or server commands.
+// Command-specific exit codes should be allocated down from 125.
+
+// 'doctor' exit codes.
+
+// DoctorValidationFailed indicates that the 'doctor' command has detected
+// an inconsistency in the SQL metaschema.
+func DoctorValidationFailed() Code { return Code{125} }

--- a/pkg/cli/exit/codes_test.go
+++ b/pkg/cli/exit/codes_test.go
@@ -1,0 +1,14 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package exit
+
+// Silence the linter.
+var _ = UnspecifiedGoPanic()

--- a/pkg/cli/exit/doc.go
+++ b/pkg/cli/exit/doc.go
@@ -1,0 +1,49 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Package exit encapsulates calls to os.Exit to control the
+// production of process exit status codes.
+//
+// Its goal is to ensure that all possible exit codes produced
+// by the 'cockroach' process upon termination are documented.
+// It achieves this by providing a type exit.Code and requiring that
+// all possible values come from constructors in the package (see
+// codes.go). A linter ensures that no direct call to os.Exit() can be
+// present elsewhere.
+//
+// Note that due to the limited range of unix exit codes, it is not
+// possible to map all possible error situations inside a CockroachDB
+// server to a unique exit code.
+// This is why the main mechanism to explain the cause of a process
+// termination must remain the logging subsystem.
+//
+// The introduction of discrete exit codes here is thus meant to
+// merely complement logging, in those cases where logging is unable
+// to detail the reason why the process is terminating; for example:
+//
+// - before logging is initialized (e.g. during command-line parsing)
+// - when a logging operation fails.
+//
+// For client commands, the situation is different: there are much
+// fewer different exit situations, so we could envision discrete
+// error codes for them. Additionally, different client commands
+// can reuse the same numeric codes for different error situations,
+// when they do not overlap.
+//
+// This package accommodates this as follows:
+//
+// - exit codes common to all commands should be allocated
+//   incrementally starting from the last defined common error
+//   in codes.go.
+//
+// - exit codes specific to one command should be allocated downwards
+//   starting from 125.
+//
+package exit

--- a/pkg/cli/exit/exit.go
+++ b/pkg/cli/exit/exit.go
@@ -1,0 +1,43 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package exit
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/cockroachdb/redact"
+)
+
+// Code represents an exit code.
+type Code struct {
+	code int
+}
+
+// String implements the fmt.Stringer interface.
+func (c Code) String() string { return fmt.Sprint(c.code) }
+
+// Format implements the fmt.Formatter interface.
+func (c Code) Format(s fmt.State, verb rune) {
+	_, f := redact.MakeFormat(s, verb)
+	fmt.Fprintf(s, f, c.code)
+}
+
+// SafeValue implements the redact.SafeValue interface.
+func (c Code) SafeValue() {}
+
+var _ redact.SafeValue = Code{}
+
+// WithCode terminates the process and sets its exit status code to
+// the provided code.
+func WithCode(code Code) {
+	os.Exit(code.code)
+}

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/cli/cliflags"
+	"github.com/cockroachdb/cockroach/pkg/cli/exit"
 	"github.com/cockroachdb/cockroach/pkg/docs"
 	"github.com/cockroachdb/cockroach/pkg/geo/geos"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -264,7 +265,7 @@ func runStartJoin(cmd *cobra.Command, args []string) error {
 //
 // If the argument disableReplication is set the replication factor
 // will be set to 1 all zone configs.
-func runStart(cmd *cobra.Command, args []string, disableReplication bool) error {
+func runStart(cmd *cobra.Command, args []string, disableReplication bool) (returnErr error) {
 	tBegin := timeutil.Now()
 
 	// First things first: if the user wants background processing,
@@ -346,7 +347,7 @@ func runStart(cmd *cobra.Command, args []string, disableReplication bool) error 
 	// If any store has something to say against a server start-up
 	// (e.g. previously detected corruption), listen to them now.
 	if err := serverCfg.Stores.PriorCriticalAlertError(); err != nil {
-		return err
+		return &cliError{exitCode: exit.FatalError(), cause: err}
 	}
 
 	// We don't care about GRPCs fairly verbose logs in most client commands,
@@ -701,10 +702,6 @@ If problems persist, please see %s.`
 	defer shutdownSpan.Finish()
 	shutdownCtx := opentracing.ContextWithSpan(context.Background(), shutdownSpan)
 
-	// returnErr will be populated with the error to use to exit the
-	// process (reported to the shell).
-	var returnErr error
-
 	stopWithoutDrain := make(chan struct{}) // closed if interrupted very early
 
 	// Block until one of the signals above is received or the stopper
@@ -731,6 +728,7 @@ If problems persist, please see %s.`
 		log.SetSync(true)
 
 		log.Infof(shutdownCtx, "received signal '%s'", sig)
+
 		switch sig {
 		case os.Interrupt:
 			// Graceful shutdown after an interrupt should cause the process
@@ -738,7 +736,7 @@ If problems persist, please see %s.`
 			// "legitimate" and should be acknowledged with a success exit
 			// code. So we keep the error state here for later.
 			returnErr = &cliError{
-				exitCode: 1,
+				exitCode: exit.Interrupted(),
 				// INFO because a single interrupt is rather innocuous.
 				severity: log.Severity_INFO,
 				cause:    errors.New("interrupted"),

--- a/pkg/cli/start_windows.go
+++ b/pkg/cli/start_windows.go
@@ -10,7 +10,11 @@
 
 package cli
 
-import "os"
+import (
+	"os"
+
+	"github.com/cockroachdb/cockroach/pkg/cli/exit"
+)
 
 // drainSignals are the signals that will cause the server to drain and exit.
 var drainSignals = []os.Signal{os.Interrupt}
@@ -28,7 +32,7 @@ func handleSignalDuringShutdown(os.Signal) {
 	// Windows doesn't indicate whether a process exited due to a signal in the
 	// exit code, so we don't need to do anything but exit with a failing code.
 	// The error message has already been printed.
-	os.Exit(1)
+	exit.WithCode(exit.UnspecifiedError())
 }
 
 func maybeRerunBackground() (bool, error) {

--- a/pkg/cmd/allocsim/main.go
+++ b/pkg/cmd/allocsim/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/acceptance/localcluster"
 	"github.com/cockroachdb/cockroach/pkg/acceptance/localcluster/tc"
 	"github.com/cockroachdb/cockroach/pkg/cli"
+	"github.com/cockroachdb/cockroach/pkg/cli/exit"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -518,9 +519,9 @@ func main() {
 	a := newAllocSim(c)
 	a.localities = localities
 
-	log.SetExitFunc(false /* hideStack */, func(code int) {
+	log.SetExitFunc(false /* hideStack */, func(code exit.Code) {
 		c.Close()
-		os.Exit(code)
+		exit.WithCode(code)
 	})
 
 	go func() {

--- a/pkg/cmd/zerosum/main.go
+++ b/pkg/cmd/zerosum/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach-go/crdb"
 	"github.com/cockroachdb/cockroach/pkg/acceptance/cluster"
 	"github.com/cockroachdb/cockroach/pkg/acceptance/localcluster"
+	"github.com/cockroachdb/cockroach/pkg/cli/exit"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -437,9 +438,9 @@ func main() {
 	c := &localcluster.LocalCluster{Cluster: localcluster.New(cfg)}
 	defer c.Close()
 
-	log.SetExitFunc(false /* hideStack */, func(code int) {
+	log.SetExitFunc(false /* hideStack */, func(code exit.Code) {
 		c.Close()
-		os.Exit(code)
+		exit.WithCode(code)
 	})
 
 	signalCh := make(chan os.Signal, 1)

--- a/pkg/keys/gen_cpp_keys.go
+++ b/pkg/keys/gen_cpp_keys.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"sort"
 
+	"github.com/cockroachdb/cockroach/pkg/cli/exit"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 )
@@ -36,13 +37,13 @@ func main() {
 	f, err := os.Create("../../c-deps/libroach/keys.h")
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "Error opening file: ", err)
-		os.Exit(1)
+		exit.WithCode(exit.UnspecifiedError())
 	}
 
 	defer func() {
 		if err := f.Close(); err != nil {
 			fmt.Fprintln(os.Stderr, "Error closing file: ", err)
-			os.Exit(1)
+			exit.WithCode(exit.UnspecifiedError())
 		}
 	}()
 

--- a/pkg/kv/kvserver/closedts/minprop/tracker_test.go
+++ b/pkg/kv/kvserver/closedts/minprop/tracker_test.go
@@ -17,6 +17,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/cli/exit"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts/ctpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -85,7 +86,7 @@ func ExampleTracker_Close() {
 
 func TestTrackerDoubleRelease(t *testing.T) {
 	var exited bool
-	log.SetExitFunc(true /* hideStack */, func(int) { exited = true })
+	log.SetExitFunc(true /* hideStack */, func(exit.Code) { exited = true })
 	defer log.ResetExitFunc()
 
 	ctx := context.Background()

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/cli/exit"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
@@ -3286,8 +3287,8 @@ func TestReplicaAbortSpanReadError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	var exitStatus int
-	log.SetExitFunc(true /* hideStack */, func(i int) {
+	var exitStatus exit.Code
+	log.SetExitFunc(true /* hideStack */, func(i exit.Code) {
 		exitStatus = i
 	})
 	defer log.ResetExitFunc()
@@ -3322,7 +3323,7 @@ func TestReplicaAbortSpanReadError(t *testing.T) {
 	if !testutils.IsPError(pErr, "replica corruption") {
 		t.Fatal(pErr)
 	}
-	if exitStatus != 255 {
+	if exitStatus != exit.FatalError() {
 		t.Fatalf("did not fatal (exit status %d)", exitStatus)
 	}
 }
@@ -4074,8 +4075,8 @@ func TestEndTxnWithMalformedSplitTrigger(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	var exitStatus int
-	log.SetExitFunc(true /* hideStack */, func(i int) {
+	var exitStatus exit.Code
+	log.SetExitFunc(true /* hideStack */, func(i exit.Code) {
 		exitStatus = i
 	})
 	defer log.ResetExitFunc()
@@ -4118,7 +4119,7 @@ func TestEndTxnWithMalformedSplitTrigger(t *testing.T) {
 		t.Errorf("unexpected error: %s", pErr)
 	}
 
-	if exitStatus != 255 {
+	if exitStatus != exit.FatalError() {
 		t.Fatalf("unexpected exit status %d", exitStatus)
 	}
 }
@@ -6455,8 +6456,8 @@ func TestReplicaCorruption(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	var exitStatus int
-	log.SetExitFunc(true /* hideStack */, func(i int) {
+	var exitStatus exit.Code
+	log.SetExitFunc(true /* hideStack */, func(i exit.Code) {
 		exitStatus = i
 	})
 	defer log.ResetExitFunc()
@@ -6494,7 +6495,7 @@ func TestReplicaCorruption(t *testing.T) {
 	require.NoError(t, err)
 
 	// Should have triggered fatal error.
-	if exitStatus != 255 {
+	if exitStatus != exit.FatalError() {
 		t.Fatalf("unexpected exit status %d", exitStatus)
 	}
 }

--- a/pkg/roachpb/data_test.go
+++ b/pkg/roachpb/data_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/apd/v2"
+	"github.com/cockroachdb/cockroach/pkg/cli/exit"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils/zerofields"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -563,7 +564,7 @@ func TestTransactionUpdate(t *testing.T) {
 
 	// Updating a different transaction fatals.
 	var exited bool
-	log.SetExitFunc(true /* hideStack */, func(int) { exited = true })
+	log.SetExitFunc(true /* hideStack */, func(exit.Code) { exited = true })
 	defer log.ResetExitFunc()
 
 	var txn6 Transaction

--- a/pkg/server/drain.go
+++ b/pkg/server/drain.go
@@ -12,7 +12,6 @@ package server
 
 import (
 	"context"
-	"os"
 	"reflect"
 	"strings"
 	"time"
@@ -130,7 +129,7 @@ func (s *adminServer) Drain(req *serverpb.DrainRequest, stream serverpb.Admin_Dr
 		// The signal-based shutdown path uses a similar time-based escape hatch.
 		// Until we spend (potentially lots of time to) understand and fix this
 		// issue, this will serve us well.
-		os.Exit(1)
+		log.Fatal(ctx, "timeout after drain")
 		return errors.New("unreachable")
 	}
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/build"
+	"github.com/cockroachdb/cockroach/pkg/cli/exit"
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
@@ -812,9 +813,9 @@ func TestPersistHLCUpperBound(t *testing.T) {
 
 	var fatal bool
 	defer log.ResetExitFunc()
-	log.SetExitFunc(true /* hideStack */, func(r int) {
+	log.SetExitFunc(true /* hideStack */, func(r exit.Code) {
 		defer log.Flush()
-		if r != 0 {
+		if r == exit.FatalError() {
 			fatal = true
 		}
 	})

--- a/pkg/server/version_cluster_test.go
+++ b/pkg/server/version_cluster_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/cli/exit"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -400,9 +401,9 @@ func TestClusterVersionMixedVersionTooOld(t *testing.T) {
 	// GOTRACEBACK=all, as it is on CI.
 	defer log.DisableTracebacks()()
 
-	exits := make(chan int, 100)
+	exits := make(chan exit.Code, 100)
 
-	log.SetExitFunc(true /* hideStack */, func(i int) { exits <- i })
+	log.SetExitFunc(true /* hideStack */, func(i exit.Code) { exits <- i })
 	defer log.ResetExitFunc()
 
 	v0, v1 := v0v1()

--- a/pkg/sqlmigrations/migrations_test.go
+++ b/pkg/sqlmigrations/migrations_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/cli/exit"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
@@ -431,7 +432,7 @@ func TestLeaseExpiration(t *testing.T) {
 	defer func() { leaseRefreshInterval = oldLeaseRefreshInterval }()
 
 	exitCalled := make(chan bool)
-	log.SetExitFunc(true /* hideStack */, func(int) { exitCalled <- true })
+	log.SetExitFunc(true /* hideStack */, func(exit.Code) { exitCalled <- true })
 	defer log.ResetExitFunc()
 	// Disable stack traces to make the test output in teamcity less deceiving.
 	defer log.DisableTracebacks()()

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1055,6 +1055,48 @@ func TestLint(t *testing.T) {
 		}
 	})
 
+	t.Run("TestOsExit", func(t *testing.T) {
+		// t.Parallel() // Disabled due to CI not parsing failure from parallel tests correctly. Can be re-enabled on Go 1.15 (see: https://github.com/golang/go/issues/38458).
+		cmd, stderr, filter, err := dirCmd(
+			pkgDir,
+			"git",
+			"grep",
+			"-nEw",
+			`os\.Exit`,
+			"--",
+			"*.go",
+			":!*_test.go",
+			":!acceptance",
+			":!cmd",
+			":!cli/exit",
+			":!bench/cmd",
+			":!sql/opt/optgen",
+			":!sql/colexec/execgen",
+			":!roachpb/gen_batch.go",
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := cmd.Start(); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := stream.ForEach(stream.Sequence(
+			filter,
+		), func(s string) {
+			t.Errorf("\n%s <- forbidden; use 'exit.WithCode' instead", s)
+		}); err != nil {
+			t.Error(err)
+		}
+
+		if err := cmd.Wait(); err != nil {
+			if out := stderr.String(); len(out) > 0 {
+				t.Fatalf("err=%s, stderr=%s", err, out)
+			}
+		}
+	})
+
 	t.Run("TestYaml", func(t *testing.T) {
 		// t.Parallel() // Disabled due to CI not parsing failure from parallel tests correctly. Can be re-enabled on Go 1.15 (see: https://github.com/golang/go/issues/38458).
 		cmd, stderr, filter, err := dirCmd(pkgDir, "git", "grep", "-nE", `\byaml\.Unmarshal\(`, "--", "*.go")

--- a/pkg/util/hlc/hlc_test.go
+++ b/pkg/util/hlc/hlc_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/cli/exit"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
@@ -131,8 +132,8 @@ func isErrSimilar(expected *regexp.Regexp, actual error) bool {
 func TestHLCPhysicalClockJump(t *testing.T) {
 	var fatal bool
 	defer log.ResetExitFunc()
-	log.SetExitFunc(true /* hideStack */, func(r int) {
-		if r != 0 {
+	log.SetExitFunc(true /* hideStack */, func(r exit.Code) {
+		if r == exit.FatalError() {
 			fatal = true
 		}
 	})
@@ -387,9 +388,9 @@ func TestHLCMonotonicityCheck(t *testing.T) {
 func TestHLCEnforceWallTimeWithinBoundsInNow(t *testing.T) {
 	var fatal bool
 	defer log.ResetExitFunc()
-	log.SetExitFunc(true /* hideStack */, func(r int) {
+	log.SetExitFunc(true /* hideStack */, func(r exit.Code) {
 		defer log.Flush()
-		if r != 0 {
+		if r == exit.FatalError() {
 			fatal = true
 		}
 	})
@@ -436,9 +437,9 @@ func TestHLCEnforceWallTimeWithinBoundsInNow(t *testing.T) {
 func TestHLCEnforceWallTimeWithinBoundsInUpdate(t *testing.T) {
 	var fatal bool
 	defer log.ResetExitFunc()
-	log.SetExitFunc(true /* hideStack */, func(r int) {
+	log.SetExitFunc(true /* hideStack */, func(r exit.Code) {
 		defer log.Flush()
-		if r != 0 {
+		if r == exit.FatalError() {
 			fatal = true
 		}
 	})

--- a/pkg/util/log/clog_test.go
+++ b/pkg/util/log/clog_test.go
@@ -30,6 +30,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/cli/exit"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/kr/pretty"
 )
@@ -555,7 +556,7 @@ func TestRollover(t *testing.T) {
 
 	setFlags()
 	var err error
-	setExitErrFunc(false /* hideStack */, func(_ int, e error) {
+	setExitErrFunc(false /* hideStack */, func(_ exit.Code, e error) {
 		err = e
 	})
 
@@ -604,7 +605,7 @@ func TestFatalStacktraceStderr(t *testing.T) {
 
 	setFlags()
 	mainLog.stderrThreshold = Severity_NONE
-	SetExitFunc(false /* hideStack */, func(int) {})
+	SetExitFunc(false /* hideStack */, func(exit.Code) {})
 
 	defer setFlags()
 	defer mainLog.swap(mainLog.newBuffers())
@@ -701,7 +702,7 @@ func TestExitOnFullDisk(t *testing.T) {
 	var exited sync.WaitGroup
 	exited.Add(1)
 
-	SetExitFunc(false, func(int) {
+	SetExitFunc(false, func(exit.Code) {
 		exited.Done()
 	})
 
@@ -712,7 +713,7 @@ func TestExitOnFullDisk(t *testing.T) {
 	}
 
 	l.mu.Lock()
-	l.exitLocked(fmt.Errorf("out of space"))
+	l.exitLocked(fmt.Errorf("out of space"), exit.UnspecifiedError())
 	l.mu.Unlock()
 
 	exited.Wait()

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -13,10 +13,10 @@ package log
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/cli/exit"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 	opentracing "github.com/opentracing/opentracing-go"
@@ -56,7 +56,7 @@ func Shoutf(ctx context.Context, sev Severity, format string, args ...interface{
 		// Fatal error handling later already tries to exit even if I/O should
 		// block, but crash reporting might also be in the way.
 		t := time.AfterFunc(10*time.Second, func() {
-			os.Exit(1)
+			exit.WithCode(exit.TimeoutAfterFatalError())
 		})
 		defer t.Stop()
 	}
@@ -157,7 +157,7 @@ func ErrorfDepth(ctx context.Context, depth int, format string, args ...interfac
 }
 
 // Fatalf logs to the INFO, WARNING, ERROR, and FATAL logs, including a stack
-// trace of all running goroutines, then calls os.Exit(255).
+// trace of all running goroutines, then calls exit.WithCode(exit.FatalError()).
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf; a newline is
 // appended.
@@ -166,7 +166,7 @@ func Fatalf(ctx context.Context, format string, args ...interface{}) {
 }
 
 // Fatal logs to the INFO, WARNING, ERROR, and FATAL logs, including a stack
-// trace of all running goroutines, then calls os.Exit(255).
+// trace of all running goroutines, then calls exit.WithCode(exit.FatalError()).
 // It extracts log tags from the context and logs them along with the given
 // message.
 func Fatal(ctx context.Context, msg string) {
@@ -175,7 +175,7 @@ func Fatal(ctx context.Context, msg string) {
 
 // FatalfDepth logs to the INFO, WARNING, ERROR, and FATAL logs (offsetting the
 // caller's stack frame by 'depth'), including a stack trace of all running
-// goroutines, then calls os.Exit(255).
+// goroutines, then calls exit.WithCode(exit.FatalError()).
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf; a newline is
 // appended.

--- a/pkg/util/log/sync_buffer.go
+++ b/pkg/util/log/sync_buffer.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/build"
+	"github.com/cockroachdb/cockroach/pkg/cli/exit"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 )
@@ -46,13 +47,13 @@ func (sb *syncBuffer) Sync() error {
 func (sb *syncBuffer) Write(p []byte) (n int, err error) {
 	if sb.nbytes+int64(len(p)) >= atomic.LoadInt64(&LogFileMaxSize) {
 		if err := sb.rotateFileLocked(timeutil.Now()); err != nil {
-			sb.logger.exitLocked(err)
+			sb.logger.exitLocked(err, exit.LoggingFileUnavailable())
 		}
 	}
 	n, err = sb.Writer.Write(p)
 	sb.nbytes += int64(n)
 	if err != nil {
-		sb.logger.exitLocked(err)
+		sb.logger.exitLocked(err, exit.LoggingFileUnavailable())
 	}
 	return
 }

--- a/pkg/workload/cli/cli.go
+++ b/pkg/workload/cli/cli.go
@@ -11,8 +11,7 @@
 package cli
 
 import (
-	"os"
-
+	"github.com/cockroachdb/cockroach/pkg/cli/exit"
 	"github.com/cockroachdb/cockroach/pkg/workload"
 	"github.com/cockroachdb/errors"
 	"github.com/spf13/cobra"
@@ -78,7 +77,7 @@ func HandleErrs(
 			if hint != "" {
 				cmd.Println("Hint:", hint)
 			}
-			os.Exit(1)
+			exit.WithCode(exit.UnspecifiedError())
 		}
 	}
 }


### PR DESCRIPTION
Backport 1/1 commits from #56574.

/cc @cockroachdb/release

---
