### PR TITLE
stopper: wait on double Stop 

### DIFF
--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -108,11 +108,6 @@ func (tc *TestCluster) stopServers(ctx context.Context) {
 	for i := range tc.mu.serverStoppers {
 		if tc.mu.serverStoppers[i] != nil {
 			tc.mu.serverStoppers[i].Stop(context.TODO())
-			// We need to check IsStopped() in addition to just waiting for
-			// Stop() above to complete, because if there was an asynchronous
-			// Drain request ongoing, Stop() would take a shortcut and not
-			// actually wait for the async stop to complete.
-			<-tc.mu.serverStoppers[i].IsStopped()
 			tc.mu.serverStoppers[i] = nil
 		}
 	}
@@ -124,11 +119,6 @@ func (tc *TestCluster) StopServer(idx int) {
 	defer tc.mu.Unlock()
 	if tc.mu.serverStoppers[idx] != nil {
 		tc.mu.serverStoppers[idx].Stop(context.TODO())
-		// We need to check IsStopped() in addition to just waiting for
-		// Stop() above to complete, because if there was an asynchronous
-		// Drain request ongoing, Stop() would take a shortcut and not
-		// actually wait for the async stop to complete.
-		<-tc.mu.serverStoppers[idx].IsStopped()
 		tc.mu.serverStoppers[idx] = nil
 	}
 }

--- a/pkg/util/stop/stopper.go
+++ b/pkg/util/stop/stopper.go
@@ -475,6 +475,8 @@ func (s *Stopper) Stop(ctx context.Context) {
 	s.mu.Unlock()
 
 	if stopCalled {
+		// Wait for the concurrent Stop() to complete.
+		<-s.stopped
 		return
 	}
 


### PR DESCRIPTION
Fixes #56728 

If there is another `Stop()` already in progress, make the second one
wait on the first one.