### PR TITLE
kvserverpb: move quorum safeguard into execChangeReplicasTxn

### DIFF
--- a/pkg/kv/kvnemesis/BUILD.bazel
+++ b/pkg/kv/kvnemesis/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//pkg/keys",
         "//pkg/kv",
         "//pkg/kv/kvclient/kvcoord",
+        "//pkg/kv/kvserver",
         "//pkg/roachpb",
         "//pkg/storage",
         "//pkg/util/bufalloc",

--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "gc_queue.go",
         "lease_history.go",
         "log.go",
+        "markers.go",
         "merge_queue.go",
         "metrics.go",
         "queue.go",

--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -2135,14 +2135,7 @@ func TestReplicateAddAndRemove(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	testReplicaAddRemove(t, true /* addFirst */)
-}
-
-func TestReplicateRemoveAndAdd(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-
-	testReplicaAddRemove(t, false /* addFirst */)
+	testutils.RunTrueAndFalse(t, "addFirst", testReplicaAddRemove)
 }
 
 // TestQuotaPool verifies that writes get throttled in the case where we have

--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -1998,10 +1998,11 @@ func runReplicateRestartAfterTruncation(t *testing.T, removeBeforeTruncateAndReA
 
 func testReplicaAddRemove(t *testing.T, addFirst bool) {
 	sc := kvserver.TestStoreConfig(nil)
-	// We're gonna want to validate the state of the store before and after the
-	// replica GC queue does its work, so we disable the replica gc queue here
-	// and run it manually when we're ready.
+	// We're gonna want to validate the state of the store before and
+	// after the replica GC queue does its work, so we disable the
+	// replica gc queue here and run it manually when we're ready.
 	sc.TestingKnobs.DisableReplicaGCQueue = true
+	sc.TestingKnobs.DisableReplicateQueue = true
 	sc.TestingKnobs.DisableEagerReplicaRemoval = true
 	sc.Clock = nil // manual clock
 	mtc := &multiTestContext{
@@ -2852,7 +2853,7 @@ func TestRemovePlaceholderRace(t *testing.T) {
 					StoreID: mtc.stores[1].Ident.StoreID,
 				})
 				if _, err := repl.ChangeReplicas(ctx, repl.Desc(), kvserver.SnapshotRequest_REBALANCE, kvserverpb.ReasonUnknown, "", chgs); err != nil {
-					if kvserver.IsSnapshotError(err) {
+					if kvserver.IsRetriableReplicationChangeError(err) {
 						continue
 					} else {
 						t.Fatal(err)
@@ -4786,6 +4787,7 @@ func TestProcessSplitAfterRightHandSideHasBeenRemoved(t *testing.T) {
 	// Newly-started stores (including the "rogue" one) should not GC
 	// their replicas. We'll turn this back on when needed.
 	sc.TestingKnobs.DisableReplicaGCQueue = true
+	sc.TestingKnobs.DisableReplicateQueue = true
 	sc.RaftDelaySplitToSuppressSnapshotTicks = 0
 	// Make the tick interval short so we don't need to wait too long for the
 	// partitioned leader to time out. Also make the
@@ -4959,8 +4961,7 @@ func TestProcessSplitAfterRightHandSideHasBeenRemoved(t *testing.T) {
 		// and will be rolled back. Nevertheless it will have learned that it
 		// has been removed at the old replica ID.
 		err = changeReplicas(t, db, roachpb.ADD_VOTER, keyB, 0)
-		require.True(t,
-			testutils.IsError(err, "snapshot failed.*cannot apply snapshot: snapshot intersects"), err)
+		require.True(t, kvserver.IsRetriableReplicationChangeError(err), err)
 
 		// Without a partitioned RHS we'll end up always writing a tombstone here because
 		// the RHS will be created at the initial replica ID because it will get
@@ -5008,8 +5009,7 @@ func TestProcessSplitAfterRightHandSideHasBeenRemoved(t *testing.T) {
 		// and will be rolled back. Nevertheless it will have learned that it
 		// has been removed at the old replica ID.
 		err = changeReplicas(t, db, roachpb.ADD_VOTER, keyB, 0)
-		require.True(t,
-			testutils.IsError(err, "snapshot failed.*cannot apply snapshot: snapshot intersects"), err)
+		require.True(t, kvserver.IsRetriableReplicationChangeError(err), err)
 
 		// Without a partitioned RHS we'll end up always writing a tombstone here because
 		// the RHS will be created at the initial replica ID because it will get
@@ -5078,8 +5078,7 @@ func TestProcessSplitAfterRightHandSideHasBeenRemoved(t *testing.T) {
 		// and will be rolled back. Nevertheless it will have learned that it
 		// has been removed at the old replica ID.
 		err = changeReplicas(t, db, roachpb.ADD_VOTER, keyB, 0)
-		require.True(t,
-			testutils.IsError(err, "snapshot failed.*cannot apply snapshot: snapshot intersects"), err)
+		require.True(t, kvserver.IsRetriableReplicationChangeError(err), err)
 		// Ensure that the replica exists with the higher replica ID.
 		repl, err := mtc.Store(0).GetReplica(rhsInfo.Desc.RangeID)
 		require.NoError(t, err)
@@ -5135,8 +5134,7 @@ func TestProcessSplitAfterRightHandSideHasBeenRemoved(t *testing.T) {
 		// and will be rolled back. Nevertheless it will have learned that it
 		// has been removed at the old replica ID.
 		err = changeReplicas(t, db, roachpb.ADD_VOTER, keyB, 0)
-		require.True(t,
-			testutils.IsError(err, "snapshot failed.*cannot apply snapshot: snapshot intersects"), err)
+		require.True(t, kvserver.IsRetriableReplicationChangeError(err), err)
 		// Ensure that there's no tombstone.
 		// The RHS on store 0 never should have heard about its original ID.
 		ensureNoTombstone(t, mtc.Store(0), rhsID)

--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -2240,9 +2240,7 @@ func TestRandomConcurrentAdminChangeReplicasRequests(t *testing.T) {
 	var gotSuccess bool
 	for _, err := range errors {
 		if err != nil {
-			const exp = "change replicas of .* failed: descriptor changed" +
-				"|snapshot failed:"
-			assert.True(t, testutils.IsError(err, exp), err)
+			assert.True(t, kvserver.IsRetriableReplicationChangeError(err), err)
 		} else if gotSuccess {
 			t.Error("expected only one success")
 		} else {

--- a/pkg/kv/kvserver/client_split_test.go
+++ b/pkg/kv/kvserver/client_split_test.go
@@ -3172,7 +3172,7 @@ func TestSplitTriggerMeetsUnexpectedReplicaID(t *testing.T) {
 	})
 
 	close(blockPromoteCh)
-	if err := g.Wait(); !testutils.IsError(err, `descriptor changed`) {
+	if err := g.Wait(); !kvserver.IsRetriableReplicationChangeError(err) {
 		t.Fatalf(`expected "descriptor changed" error got: %+v`, err)
 	}
 
@@ -3184,8 +3184,8 @@ func TestSplitTriggerMeetsUnexpectedReplicaID(t *testing.T) {
 		// has not heard a raft message addressed to a later replica ID while the
 		// "was not found on" error is expected if the store has heard that it has
 		// a newer replica ID before receiving the snapshot.
-		if !testutils.IsError(err, `snapshot intersects existing range|r[0-9]+ was not found on s[0-9]+`) {
-			t.Fatalf(`expected snapshot intersects existing range|r[0-9]+ was not found on s[0-9]+" error got: %+v`, err)
+		if !kvserver.IsRetriableReplicationChangeError(err) {
+			t.Fatal(err)
 		}
 	}
 	for i := 0; i < 5; i++ {

--- a/pkg/kv/kvserver/markers.go
+++ b/pkg/kv/kvserver/markers.go
@@ -1,0 +1,69 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package kvserver
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/errors"
+)
+
+// NB: don't change the string here; this will cause cross-version issues
+// since this singleton is used as a marker.
+var errMarkSnapshotError = errors.New("snapshot failed")
+
+// isSnapshotError returns true iff the error indicates that a snapshot failed.
+func isSnapshotError(err error) bool {
+	return errors.Is(err, errMarkSnapshotError)
+}
+
+// NB: don't change the string here; this will cause cross-version issues
+// since this singleton is used as a marker.
+var errMarkCanRetryReplicationChangeWithUpdatedDesc = errors.New("should retry with updated descriptor")
+
+// IsRetriableReplicationChangeError detects whether an error (which is
+// assumed to have been emitted by the KV layer during a replication change
+// operation) is likely to succeed when retried with an updated descriptor.
+func IsRetriableReplicationChangeError(err error) bool {
+	return errors.Is(err, errMarkCanRetryReplicationChangeWithUpdatedDesc) || isSnapshotError(err)
+}
+
+const (
+	descChangedRangeSubsumedErrorFmt = "descriptor changed: expected %s != [actual] nil (range subsumed)"
+	descChangedErrorFmt              = "descriptor changed: [expected] %s != [actual] %s"
+)
+
+func newDescChangedError(desc, actualDesc *roachpb.RangeDescriptor) error {
+	if actualDesc == nil {
+		return errors.Mark(errors.Newf(descChangedRangeSubsumedErrorFmt, desc), errMarkCanRetryReplicationChangeWithUpdatedDesc)
+	}
+	return errors.Mark(errors.Newf(descChangedErrorFmt, desc, actualDesc), errMarkCanRetryReplicationChangeWithUpdatedDesc)
+}
+
+func wrapDescChangedError(err error, desc, actualDesc *roachpb.RangeDescriptor) error {
+	if actualDesc == nil {
+		return errors.Mark(errors.Wrapf(err, descChangedRangeSubsumedErrorFmt, desc), errMarkCanRetryReplicationChangeWithUpdatedDesc)
+	}
+	return errors.Mark(errors.Wrapf(err, descChangedErrorFmt, desc, actualDesc), errMarkCanRetryReplicationChangeWithUpdatedDesc)
+}
+
+// NB: don't change the string here; this will cause cross-version issues
+// since this singleton is used as a marker.
+var errMarkInvalidReplicationChange = errors.New("invalid replication change")
+
+// IsIllegalReplicationChangeError detects whether an error (assumed to have been emitted
+// by a replication change) indicates that the replication change is illegal, meaning
+// that it's unlikely to be handled through a retry. Examples of this are attempts to add
+// a store that is already a member of the supplied descriptor. A non-example is a change
+// detected in the descriptor at the KV layer relative to that supplied as input to the
+// replication change, which would likely benefit from a retry.
+func IsIllegalReplicationChangeError(err error) bool {
+	return errors.Is(err, errMarkInvalidReplicationChange)
+}

--- a/pkg/kv/kvserver/replica_learner_test.go
+++ b/pkg/kv/kvserver/replica_learner_test.go
@@ -396,8 +396,8 @@ func TestSplitWithLearnerOrJointConfig(t *testing.T) {
 		desc, err := tc.AddVoters(right.StartKey.AsRawKey(), tc.Target(1))
 		if err == nil {
 			right = desc
-		} else if !testutils.IsError(err, "cannot apply snapshot: snapshot intersects existing range") {
-			t.Fatal(err)
+		} else {
+			require.True(t, kvserver.IsRetriableReplicationChangeError(err), err)
 		}
 		return err
 	})

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -264,12 +264,12 @@ func (r *Replica) propose(ctx context.Context, p *ProposalData) (index int64, pE
 		replID := r.ReplicaID()
 		for _, rDesc := range crt.Removed() {
 			if rDesc.ReplicaID == replID {
-				msg := fmt.Sprintf("received invalid ChangeReplicasTrigger %s to remove self (leaseholder)", crt)
-				log.Errorf(p.ctx, "%v", msg)
-				return 0, roachpb.NewErrorf("%s: %s", r, msg)
+				err := errors.Mark(errors.Newf("received invalid ChangeReplicasTrigger %s to remove self (leaseholder)", crt),
+					errMarkInvalidReplicationChange)
+				log.Errorf(p.ctx, "%v", err)
+				return 0, roachpb.NewError(err)
 			}
 		}
-
 	} else if p.command.ReplicatedEvalResult.AddSSTable != nil {
 		log.VEvent(p.ctx, 4, "sideloadable proposal detected")
 		version = raftVersionSideloaded

--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -271,7 +271,7 @@ func (rq *replicateQueue) process(
 	for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
 		for {
 			requeue, err := rq.processOneChange(ctx, repl, rq.canTransferLease, false /* dryRun */)
-			if IsSnapshotError(err) {
+			if isSnapshotError(err) {
 				// If ChangeReplicas failed because the snapshot failed, we log the
 				// error but then return success indicating we should retry the
 				// operation. The most likely causes of the snapshot failing are a
@@ -322,23 +322,10 @@ func (rq *replicateQueue) processOneChange(
 	// quorum.
 	voterReplicas := desc.Replicas().Voters()
 	liveVoterReplicas, deadVoterReplicas := rq.allocator.storePool.liveAndDeadReplicas(voterReplicas)
-	{
-		unavailable := !desc.Replicas().CanMakeProgress(func(rDesc roachpb.ReplicaDescriptor) bool {
-			for _, inner := range liveVoterReplicas {
-				if inner.ReplicaID == rDesc.ReplicaID {
-					return true
-				}
-			}
-			return false
-		})
-		if unavailable {
-			return false, newQuorumError(
-				"range requires a replication change, but live replicas %v don't constitute a quorum for %v:",
-				liveVoterReplicas,
-				desc.Replicas().All(),
-			)
-		}
-	}
+
+	// NB: the replication layer ensures that the below operations don't cause
+	// unavailability; see:
+	_ = execChangeReplicasTxn
 
 	action, _ := rq.allocator.ComputeAction(ctx, zone, desc)
 	log.VEventf(ctx, 1, "next replica action: %s", action)

--- a/pkg/kv/kvserver/testing_knobs.go
+++ b/pkg/kv/kvserver/testing_knobs.go
@@ -255,6 +255,10 @@ type StoreTestingKnobs struct {
 	// heartbeats and then expect other replicas to take the lease without
 	// worrying about Raft).
 	AllowLeaseRequestProposalsWhenNotLeader bool
+	// AllowDangerousReplicationChanges disables safeguards
+	// in execChangeReplicasTxn that prevent moving
+	// to a configuration that cannot make progress.
+	AllowDangerousReplicationChanges bool
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.

--- a/pkg/kv/test_utils.go
+++ b/pkg/kv/test_utils.go
@@ -43,6 +43,10 @@ func OnlyFollowerReads(rec tracing.Recording) bool {
 // https://github.cm/cockroachdb/cockroach/issues/34012
 // https://github.com/cockroachdb/cockroach/issues/33683#issuecomment-454889149
 // for more failure modes not caught here.
+//
+// Note that whenever possible, callers should rely on
+// kvserver.Is{Retryable,Illegal}ReplicationChangeError,
+// which avoids string matching.
 func IsExpectedRelocateError(err error) bool {
 	allowlist := []string{
 		"descriptor changed",


### PR DESCRIPTION
This used to live in the replicate queue, but there are other
entry points to replication changes, notably the store rebalancer
which caused #54444.

Move the check in the guts of replication changes where it is
guaranteed to be invoked.

Fixes #50729
Touches #54444 (release-20.2)

@aayushshah15 only requesting your review since you're in the area.
Feel free to opt out.

Release note (bug fix): in rare situations, an automated replication
change could result in a loss of quorum. This would require down nodes
and a simultaneous change in the replication factor. Note that a change
in the replication factor can occur automatically if the cluster is
comprised of less than five available nodes. Experimentally the likeli-
hood of encountering this issue, even under contrived conditions, was
small.
