### PR TITLE
cli/demo: make the server ports more stable

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -1058,6 +1058,20 @@ The line length where sqlfmt will try to wrap.`,
 		Description: `Align the output.`,
 	}
 
+	DemoSQLPort = FlagInfo{
+		Name: "sql-port",
+		Description: `First port number for SQL servers.
+There should be as many TCP ports available as the value of --nodes
+starting at the specified value.`,
+	}
+
+	DemoHTTPPort = FlagInfo{
+		Name: "http-port",
+		Description: `First port number for HTTP servers.
+There should be as many TCP ports available as the value of --nodes
+starting at the specified value.`,
+	}
+
 	DemoNodes = FlagInfo{
 		Name:        "nodes",
 		Description: `How many in-memory nodes to create for the demo.`,

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"net/url"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -536,6 +537,8 @@ var demoCtx struct {
 	simulateLatency           bool
 	transientCluster          *transientCluster
 	insecure                  bool
+	sqlPort                   int
+	httpPort                  int
 }
 
 // setDemoContextDefaults set the default values in demoCtx.  This
@@ -554,6 +557,8 @@ func setDemoContextDefaults() {
 	demoCtx.disableLicenseAcquisition = false
 	demoCtx.transientCluster = nil
 	demoCtx.insecure = false
+	demoCtx.sqlPort, _ = strconv.Atoi(base.DefaultPort)
+	demoCtx.httpPort, _ = strconv.Atoi(base.DefaultHTTPPort)
 }
 
 // stmtDiagCtx captures the command-line parameters of the 'statement-diag'

--- a/pkg/cli/demo_test.go
+++ b/pkg/cli/demo_test.go
@@ -43,6 +43,8 @@ func TestTestServerArgsForTransientCluster(t *testing.T) {
 				PartOfCluster:           true,
 				JoinAddr:                "127.0.0.1",
 				DisableTLSForHTTP:       true,
+				SQLAddr:                 ":1234",
+				HTTPAddr:                ":4567",
 				SQLMemoryPoolSize:       2 << 10,
 				CacheSize:               1 << 10,
 				NoAutoInitializeCluster: true,
@@ -57,6 +59,8 @@ func TestTestServerArgsForTransientCluster(t *testing.T) {
 			expected: base.TestServerArgs{
 				PartOfCluster:           true,
 				JoinAddr:                "127.0.0.1",
+				SQLAddr:                 ":1236",
+				HTTPAddr:                ":4569",
 				DisableTLSForHTTP:       true,
 				SQLMemoryPoolSize:       4 << 10,
 				CacheSize:               4 << 10,
@@ -72,7 +76,7 @@ func TestTestServerArgsForTransientCluster(t *testing.T) {
 			demoCtx.sqlPoolMemorySize = tc.sqlPoolMemorySize
 			demoCtx.cacheSize = tc.cacheSize
 
-			actual := testServerArgsForTransientCluster(unixSocketDetails{}, tc.nodeID, tc.joinAddr, "")
+			actual := testServerArgsForTransientCluster(unixSocketDetails{}, tc.nodeID, tc.joinAddr, "", 1234, 4567)
 			stopper := actual.Stopper
 			defer stopper.Stop(context.Background())
 

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -772,6 +772,9 @@ func init() {
 		// variables from startCtx, this is one case where we afford
 		// sharing a variable between both.
 		stringFlag(f, &startCtx.geoLibsDir, cliflags.GeoLibsDir)
+
+		intFlag(f, &demoCtx.sqlPort, cliflags.DemoSQLPort)
+		intFlag(f, &demoCtx.httpPort, cliflags.DemoHTTPPort)
 	}
 
 	// statement-diag command.

--- a/pkg/cli/interactive_tests/test_demo.tcl
+++ b/pkg/cli/interactive_tests/test_demo.tcl
@@ -32,13 +32,17 @@ eexpect "Welcome"
 eexpect "defaultdb>"
 
 # Show the URLs.
+# Also check that the default port is used.
 send "\\demo ls\r"
 eexpect "(console)"
 eexpect "http://"
+eexpect ":8080"
 eexpect "(sql)"
 eexpect "root:unused@"
+eexpect "=26257"
 eexpect "(sql/tcp)"
 eexpect "root@"
+eexpect ":26257"
 eexpect "sslmode=disable"
 eexpect "defaultdb>"
 
@@ -79,13 +83,17 @@ eexpect "has been created."
 eexpect "defaultdb>"
 
 # Show the URLs.
+# Also check that the default port is used.
 send "\\demo ls\r"
 eexpect "(console)"
 eexpect "http://"
+eexpect ":8080"
 eexpect "(sql)"
 eexpect "demo:"
+eexpect "=26257"
 eexpect "(sql/tcp)"
 eexpect "demo:"
+eexpect ":26257"
 eexpect "sslmode=require"
 eexpect "defaultdb>"
 
@@ -159,5 +167,50 @@ eexpect "defaultdb>"
 
 send_eof
 eexpect eof
+
+end_test
+
+start_test "Check that the port numbers can be overridden from the command line."
+
+spawn $argv demo --empty --nodes 3 --http-port 8000
+eexpect "Welcome"
+eexpect "defaultdb>"
+
+# Show the URLs.
+send "\\demo ls\r"
+eexpect "http://"
+eexpect ":8000"
+eexpect "http://"
+eexpect ":8001"
+eexpect "http://"
+eexpect ":8002"
+eexpect "defaultdb>"
+
+interrupt
+eexpect eof
+
+spawn $argv demo --empty --nodes 3 --sql-port 23000
+eexpect "Welcome"
+eexpect "defaultdb>"
+
+# Show the URLs.
+send "\\demo ls\r"
+eexpect "(sql)"
+eexpect "=23000"
+eexpect "(sql/tcp)"
+eexpect ":23000"
+eexpect "(sql)"
+eexpect "=23001"
+eexpect "(sql/tcp)"
+eexpect ":23001"
+eexpect "(sql)"
+eexpect "=23002"
+eexpect "(sql/tcp)"
+eexpect ":23002"
+eexpect "defaultdb>"
+
+interrupt
+eexpect eof
+
 
 end_test

--- a/pkg/cli/interactive_tests/test_local_cmds.tcl
+++ b/pkg/cli/interactive_tests/test_local_cmds.tcl
@@ -262,6 +262,8 @@ eexpect "syntax error"
 eexpect ":/# "
 end_test
 
+stop_server $argv
+
 start_test "Check that client-side options can be overridden with set"
 
 # First establish a baseline with all the defaults.
@@ -299,5 +301,3 @@ end_test
 
 send "exit 0\r"
 eexpect eof
-
-stop_server $argv

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -204,6 +204,7 @@ func makeTestConfigFromParams(params base.TestServerArgs) Config {
 	if params.SQLAddr != "" {
 		cfg.SQLAddr = params.SQLAddr
 		cfg.SQLAdvertiseAddr = params.SQLAddr
+		cfg.SplitListenSQL = true
 	}
 	if params.HTTPAddr != "" {
 		cfg.HTTPAddr = params.HTTPAddr


### PR DESCRIPTION
Requested by @ericharmeling 
Fixes #52082 

Prior to this patch, the `cockroach demo` command would always
automatically allocate random TCP port numbers. This behavior was
inherited from the underlying `TestServer` machinery.

This proved undesirable in practice, because documentation writers
need to be able to provide simple instructions to readers; in
particular it is desirable that a common connection URL be usable
for all examples that connect to a `demo` cluster. With random TCP
ports, this was not possible.

This patch addresses this by defaulting to a deterministic port
allocation, starting with the default port numbers (26257/8080). This
default can be overridden from the command line via the (new)
command-line flags `--sql-port` / `--http-port`.

Although there was some original concern that this allocation would
cause `demo` to conflict with a crdb node running on the same machine,
this proves less likely in practice: servers tend to listen on the
external IP address of the node, whereas `demo` always listens on
`127.0.0.1`. It's possible for both processes to listen on the same
TCP port number on the separate addresses.

Release note (cli change): `cockroach demo` now tries to use the same
TCP port numbers for the SQL and HTTP servers on every
invocation. This is meant to simplify documentation. These defaults
can be overridden with the new (`demo`-specific) command line flags
`--sql-port` and/or `--http-port`.