### PR TITLE
cli/demo,server: new auto-login URL path

### DIFF
--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -126,6 +126,9 @@ type TestServerArgs struct {
 	// is running in secure mode.
 	DisableWebSessionAuthentication bool
 
+	// IF set, the demo login endpoint will be enabled.
+	EnableDemoLoginEndpoint bool
+
 	// If set, testing specific descriptor validation will be disabled. even if the server
 	DisableTestingDescriptorValidation bool
 }

--- a/pkg/cli/demo_cluster.go
+++ b/pkg/cli/demo_cluster.go
@@ -337,6 +337,7 @@ func testServerArgsForTransientCluster(
 		SQLMemoryPoolSize:       demoCtx.sqlPoolMemorySize,
 		CacheSize:               demoCtx.cacheSize,
 		NoAutoInitializeCluster: true,
+		EnableDemoLoginEndpoint: true,
 		// This disables the tenant server. We could enable it but would have to
 		// generate the suitable certs at the caller who wishes to do so.
 		TenantAddr: new(string),
@@ -884,8 +885,15 @@ func (c *transientCluster) listDemoNodes(w io.Writer, justOne bool) {
 			// the demo.
 			fmt.Fprintf(w, "node %d:\n", nodeID)
 		}
-		// Print node ID and admin UI URL.
-		fmt.Fprintf(w, "  (console) %s\n", s.AdminURL())
+		// Print node ID and console URL. Embed the autologin feature inside the URL.
+		pwauth := url.Values{
+			"username": []string{c.adminUser.Normalized()},
+			"password": []string{c.adminPassword},
+		}
+		serverURL := s.Cfg.AdminURL()
+		serverURL.Path = server.DemoLoginPath
+		serverURL.RawQuery = pwauth.Encode()
+		fmt.Fprintf(w, "  (console) %s\n", serverURL)
 		// Print unix socket if defined.
 		if c.useSockets {
 			sock := c.sockForServer(nodeID)

--- a/pkg/cli/demo_test.go
+++ b/pkg/cli/demo_test.go
@@ -49,6 +49,7 @@ func TestTestServerArgsForTransientCluster(t *testing.T) {
 				CacheSize:               1 << 10,
 				NoAutoInitializeCluster: true,
 				TenantAddr:              new(string),
+				EnableDemoLoginEndpoint: true,
 			},
 		},
 		{
@@ -66,6 +67,7 @@ func TestTestServerArgsForTransientCluster(t *testing.T) {
 				CacheSize:               4 << 10,
 				NoAutoInitializeCluster: true,
 				TenantAddr:              new(string),
+				EnableDemoLoginEndpoint: true,
 			},
 		},
 	}

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -275,6 +275,10 @@ type KVConfig struct {
 	// the Admin API's HTTP endpoints.
 	EnableWebSessionAuthentication bool
 
+	// EnableDemoLoginEndpoint enables the HTTP GET endpoint for user logins,
+	// which a feature unique to the demo shell.
+	EnableDemoLoginEndpoint bool
+
 	enginesCreated bool
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1689,6 +1689,10 @@ func (s *Server) PreStart(ctx context.Context) error {
 	s.mux.Handle(loginPath, gwMux)
 	s.mux.Handle(logoutPath, authHandler)
 
+	if s.cfg.EnableDemoLoginEndpoint {
+		s.mux.Handle(DemoLoginPath, http.HandlerFunc(s.authentication.demoLogin))
+	}
+
 	// The /_status/vars endpoint is not authenticated either. Useful for monitoring.
 	s.mux.Handle(statusVars, http.HandlerFunc(s.status.handleVars))
 

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -213,6 +213,9 @@ func makeTestConfigFromParams(params base.TestServerArgs) Config {
 	if params.DisableWebSessionAuthentication {
 		cfg.EnableWebSessionAuthentication = false
 	}
+	if params.EnableDemoLoginEndpoint {
+		cfg.EnableDemoLoginEndpoint = true
+	}
 
 	// Ensure we have the correct number of engines. Add in-memory ones where
 	// needed. There must be at least one store/engine.


### PR DESCRIPTION
Fixes #54877

Previous to this patch, the user of `cockroach demo` had to perform
two copy-paste operations from their terminal to use the admin UI: one
to copy the URL into their browser, and another oen to copy the
authentication password.

This was inconvenient and thus created friction to exploration and
bottom-up adoption.

This patch rectifies the situation by ensuring that the URL printed
int he terminal allows the user to access the UI directly, in just one
step.

![image](https://user-images.githubusercontent.com/642886/103227973-05d47680-4930-11eb-9ffd-94f553fb3750.png)

(see how the URL embeds the authentication credentials)

Technically, the approach prototyped here defines a new HTTP GET
endpoint `/demologin` which accepts the user/password parameters as
query arguments, with the same logic (more or less) as `/login`. This
endpoint is reported by (and used only by) `cockroach demo`.

Release note (cli change): The DB console URL printed by `cockroach
demo` now automatically logs the user in when pasted into a web browser.