### PR TITLE
release-20.2: pgdate: allow parsing of dates with year 0

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/datetime
+++ b/pkg/sql/logictest/testdata/logic_test/datetime
@@ -113,8 +113,8 @@ SELECT 'epoch'::date, 'infinity'::date, '-infinity'::date
 
 # Date edge cases.
 
-statement error year value 0 is out of range
-SELECT '0000-01-01'::date
+statement error only positive years are permitted in AD/BC notation
+SELECT '0000-01-01 BC'::date
 
 query TTTTT
 SELECT '4714-11-24 BC'::date, '5874897-12-31'::date, '2000-01-01'::date, '0001-01-01'::date, '0001-12-13 BC'::date

--- a/pkg/sql/logictest/testdata/logic_test/distsql_datetime
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_datetime
@@ -1,0 +1,12 @@
+# LogicTest: 5node-default-configs
+
+statement ok
+CREATE TABLE ts (a INT PRIMARY KEY, t TIMESTAMP);
+INSERT INTO ts SELECT i, '0001-01-01 00:00:00'::TIMESTAMP + i::INTERVAL FROM generate_series(1, 5) AS g(i);
+ALTER TABLE ts SPLIT AT select i FROM generate_series(2, 5) AS g(i);
+ALTER TABLE ts EXPERIMENTAL_RELOCATE SELECT ARRAY[i%5+1], i FROM generate_series(1, 5) AS g(i)
+
+# This query makes sure that we can successfully deserialize the timestamp with
+# year 0 on the remote nodes (#56554).
+statement ok
+SELECT t - (SELECT '0001-01-01 00:00:00'::TIMESTAMP - a::INTERVAL FROM ts ORDER BY a LIMIT 1) FROM ts

--- a/pkg/util/timeutil/pgdate/parsing_test.go
+++ b/pkg/util/timeutil/pgdate/parsing_test.go
@@ -397,6 +397,14 @@ var dateTestData = []timeData{
 		s:   "121212",
 		exp: time.Date(2012, 12, 12, 0, 0, 0, 0, time.UTC),
 	},
+	{
+		s:   "-0001-02-15",
+		exp: time.Date(-1, 2, 15, 0, 0, 0, 0, time.UTC),
+	},
+	{
+		s:   "0000-02-15",
+		exp: time.Date(0, 2, 15, 0, 0, 0, 0, time.UTC),
+	},
 }
 
 var timeTestData = []timeData{

--- a/pkg/util/timeutil/pgdate/pgdate_test.go
+++ b/pkg/util/timeutil/pgdate/pgdate_test.go
@@ -65,8 +65,8 @@ func TestParseDate(t *testing.T) {
 			err: "date is out of range",
 		},
 		{
-			s:   "0000-01-01",
-			err: "year value 0 is out of range",
+			s:   "0000-01-01 AD",
+			err: "only positive years are permitted in AD/BC notation",
 		},
 	} {
 		t.Run(tc.s, func(t *testing.T) {


### PR DESCRIPTION
Backport 1/1 commits from #56636.

/cc @cockroachdb/release

---

We support two formats for specifying the year: ISO8601 and AD/BC
notation while PG supports only the latter. Year 0000 in ISO is 1 BC in
AD/BC, year 0 in AD/BC notation is invalid. Previously we were erroring
out if year 0 is used in ISO notation which could lead to internal
errors when trying to deserialize a date with year 1 BC, and this is now
fixed by allowing year 0 to be used (we still check that it is invalid
in AD/BC notation).

Fixes: #56554.

Release note (bug fix): CockroachDB previously could encounter an
internal error when date/timestamp/timestamptz that is of year 1 BC was
sent between nodes for execution. Additionally, previously it was not
possible to specify the date/timestamp/timestamptz with year 1 BC
without using AD/BC notation. This is now fixed.
