### PR TITLE
release-19.2: Revert "sql: age returns normalized intervals"

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/datetime
+++ b/pkg/sql/logictest/testdata/logic_test/datetime
@@ -159,17 +159,12 @@ SELECT '5874897-12-31'::date - '4714-11-24 BC'::date
 query T
 SELECT age('2001-04-10 22:06:45', '1957-06-13')
 ----
-44 years 5 mons 17 days 22:06:45
+384190:06:45
 
 query B
 SELECT age('1957-06-13') - age(now(), '1957-06-13') = interval '0s'
 ----
 true
-
-query T
-select age('2017-12-10'::timestamptz, '2017-12-01'::timestamptz)
-----
-9 days
 
 query B
 SELECT now() - timestamp '2015-06-13' > interval '100h'

--- a/pkg/sql/opt/norm/testdata/rules/fold_constants
+++ b/pkg/sql/opt/norm/testdata/rules/fold_constants
@@ -366,7 +366,7 @@ values
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
- └── ('-1 days',) [type=tuple{interval}]
+ └── ('-24:00:00',) [type=tuple{interval}]
 
 # Fold constant.
 opt expect=FoldBinary

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -829,7 +829,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			ReturnType: types.Interval,
 			Fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				nanos := left.(*DTimestamp).Sub(right.(*DTimestamp).Time).Nanoseconds()
-				return &DInterval{Duration: duration.MakeNormalizedDuration(nanos, 0, 0)}, nil
+				return &DInterval{Duration: duration.MakeDuration(nanos, 0, 0)}, nil
 			},
 		},
 		&BinOp{
@@ -838,7 +838,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			ReturnType: types.Interval,
 			Fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				nanos := left.(*DTimestampTZ).Sub(right.(*DTimestampTZ).Time).Nanoseconds()
-				return &DInterval{Duration: duration.MakeNormalizedDuration(nanos, 0, 0)}, nil
+				return &DInterval{Duration: duration.MakeDuration(nanos, 0, 0)}, nil
 			},
 		},
 		&BinOp{
@@ -849,7 +849,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 				// These two quantities aren't directly comparable. Convert the
 				// TimestampTZ to a timestamp first.
 				nanos := left.(*DTimestamp).Sub(right.(*DTimestampTZ).stripTimeZone(ctx).Time).Nanoseconds()
-				return &DInterval{Duration: duration.MakeNormalizedDuration(nanos, 0, 0)}, nil
+				return &DInterval{Duration: duration.MakeDuration(nanos, 0, 0)}, nil
 			},
 		},
 		&BinOp{
@@ -860,7 +860,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 				// These two quantities aren't directly comparable. Convert the
 				// TimestampTZ to a timestamp first.
 				nanos := left.(*DTimestampTZ).stripTimeZone(ctx).Sub(right.(*DTimestamp).Time).Nanoseconds()
-				return &DInterval{Duration: duration.MakeNormalizedDuration(nanos, 0, 0)}, nil
+				return &DInterval{Duration: duration.MakeDuration(nanos, 0, 0)}, nil
 			},
 		},
 		&BinOp{

--- a/pkg/util/duration/duration.go
+++ b/pkg/util/duration/duration.go
@@ -81,15 +81,6 @@ func MakeDuration(nanos, days, months int64) Duration {
 	}
 }
 
-// MakeNormalizedDuration returns a normalized Duration.
-func MakeNormalizedDuration(nanos, days, months int64) Duration {
-	return Duration{
-		Months: months,
-		Days:   days,
-		nanos:  rounded(nanos),
-	}.normalize()
-}
-
 // DecodeDuration returns a Duration without rounding nanos.
 func DecodeDuration(months, days, nanos int64) Duration {
 	return Duration{


### PR DESCRIPTION
Reverting a backport as it potentially causes a worse bug than it resolves.

----

This reverts commit 41332bc13eceba74300baa30229a4b70969f5b0d.

Release note: None