### PR TITLE
release-20.2: importccl: always ignore PGDUMP statements in ignorelist

### DIFF
--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -946,9 +946,8 @@ END;
 				`,
 			query: map[string][][]string{
 				`SELECT nextval('i_seq')`:    {{"11"}},
-				`SHOW CREATE SEQUENCE i_seq`: {{"i_seq", "CREATE SEQUENCE i_seq MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1"}},
+				`SHOW CREATE SEQUENCE i_seq`: {{"i_seq", "CREATE SEQUENCE public.i_seq MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1"}},
 			},
-			skipIssue: 53958,
 		},
 		{
 			name: "INSERT without specifying all column values",

--- a/pkg/ccl/importccl/read_import_pgdump.go
+++ b/pkg/ccl/importccl/read_import_pgdump.go
@@ -93,13 +93,14 @@ func (p *postgreStream) Next() (interface{}, error) {
 
 	for p.s.Scan() {
 		t := p.s.Text()
+		// Regardless if we can parse the statement, check that it's not something
+		// we want to ignore.
+		if isIgnoredStatement(t) {
+			continue
+		}
+
 		stmts, err := parser.Parse(t)
 		if err != nil {
-			// Something non-parseable may be something we don't yet parse but still
-			// want to ignore.
-			if isIgnoredStatement(t) {
-				continue
-			}
 			return nil, err
 		}
 		switch len(stmts) {


### PR DESCRIPTION
Backport 1/1 commits from #56324.

/cc @cockroachdb/release

---

Previously, we would only ignore statements that were in our ignorelist
if we could not parse them. However, as we add the ability to parse new
statements, that does not mean that IMPORT supports them just yet.

Fixes https://github.com/cockroachdb/cockroach/issues/53958.

Release note: None
