### PR TITLE
tree: fix type checking of placeholders in an edge case

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/as_of
+++ b/pkg/sql/logictest/testdata/logic_test/as_of
@@ -87,3 +87,8 @@ SELECT * FROM t AS OF SYSTEM TIME '0'
 # Verify we can explain a statement that has AS OF.
 statement ok
 EXPLAIN SELECT * FROM t AS OF SYSTEM TIME '-1us'
+
+# Regression test for out of bounds error during the type-checking of AOST with
+# a placeholder (#56488).
+statement error pq: no value provided for placeholder: \$1
+SELECT * FROM t AS OF SYSTEM TIME $1

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -4383,6 +4383,12 @@ func (t *DOidWrapper) Eval(_ *EvalContext) (Datum, error) {
 	return t, nil
 }
 
+func makeNoValueProvidedForPlaceholderErr(pIdx PlaceholderIdx) error {
+	return pgerror.Newf(pgcode.UndefinedParameter,
+		"no value provided for placeholder: $%d", pIdx+1,
+	)
+}
+
 // Eval implements the TypedExpr interface.
 func (t *Placeholder) Eval(ctx *EvalContext) (Datum, error) {
 	if !ctx.HasPlaceholders() {
@@ -4392,8 +4398,7 @@ func (t *Placeholder) Eval(ctx *EvalContext) (Datum, error) {
 	}
 	e, ok := ctx.Placeholders.Value(t.Idx)
 	if !ok {
-		return nil, pgerror.Newf(pgcode.UndefinedParameter,
-			"no value provided for placeholder: %s", t)
+		return nil, makeNoValueProvidedForPlaceholderErr(t.Idx)
 	}
 	// Placeholder expressions cannot contain other placeholders, so we do
 	// not need to recurse.

--- a/pkg/sql/sem/tree/placeholders.go
+++ b/pkg/sql/sem/tree/placeholders.go
@@ -100,12 +100,15 @@ type PlaceholderTypesInfo struct {
 
 // Type returns the known type of a placeholder. If there is no known type yet
 // but there is a type hint, returns the type hint.
-func (p *PlaceholderTypesInfo) Type(idx PlaceholderIdx) (_ *types.T, ok bool) {
+func (p *PlaceholderTypesInfo) Type(idx PlaceholderIdx) (_ *types.T, ok bool, _ error) {
+	if len(p.Types) <= int(idx) {
+		return nil, false, makeNoValueProvidedForPlaceholderErr(idx)
+	}
 	t := p.Types[idx]
-	if t == nil && len(p.TypeHints) >= int(idx) {
+	if t == nil && len(p.TypeHints) > int(idx) {
 		t = p.TypeHints[idx]
 	}
-	return t, (t != nil)
+	return t, t != nil, nil
 }
 
 // ValueType returns the type of the value that must be supplied for a placeholder.
@@ -202,8 +205,8 @@ func (p *PlaceholderInfo) Value(idx PlaceholderIdx) (TypedExpr, bool) {
 // whether the placeholder's type remains unset in the PlaceholderInfo.
 func (p *PlaceholderInfo) IsUnresolvedPlaceholder(expr Expr) bool {
 	if t, ok := StripParens(expr).(*Placeholder); ok {
-		_, res := p.Type(t.Idx)
-		return !res
+		_, res, err := p.Type(t.Idx)
+		return !(err == nil && res)
 	}
 	return false
 }

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -1488,7 +1488,9 @@ func (expr *Placeholder) TypeCheck(
 	// when there are no available values for the placeholders yet, because
 	// during Execute all placeholders are replaced from the AST before type
 	// checking.
-	if typ, ok := semaCtx.Placeholders.Type(expr.Idx); ok {
+	if typ, ok, err := semaCtx.Placeholders.Type(expr.Idx); err != nil {
+		return expr, err
+	} else if ok {
 		if !desired.Equivalent(typ) {
 			// This indicates there's a conflict between what the type system thinks
 			// the type for this position should be, and the actual type of the


### PR DESCRIPTION
Previously, we would crash when executing a query with AS OF SYSTEM TIME
clause that used a placeholder (note that it wasn't a prepared statement -
it was an attempt to use an unspecified placeholder value on a
non-prepared statement). This is now fixed by improving the type
checking of placeholders by returning an error if the number of provided
placeholder values is insufficient for the requested placeholder index.

Fixed: #56488.

Release note (bug fix): CockroachDB previously would crash when
executing a query with AS OF SYSTEM TIME clause that used a placeholder
(note that it wasn't a prepared statement - it was an attempt to use an
unspecified placeholder value on a non-prepared statement). This is now
fixed.