### PR TITLE
sql,opt: fix a few bugs with NULL array elements and inverted joins

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/inverted_join_json_array
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_join_json_array
@@ -521,7 +521,9 @@ INSERT INTO array_tab VALUES
   (3, '{2}'),
   (4, '{1, 2}'),
   (5, '{1, 3}'),
-  (6, '{1, 2, 3, 4}')
+  (6, '{1, 2, 3, 4}'),
+  (7, ARRAY[NULL]::INT[]),
+  (8, NULL)
 
 # This query performs an inverted join.
 query ITIT
@@ -545,6 +547,7 @@ SELECT * FROM array_tab@foo_inv AS a1, array_tab AS a2 WHERE a1.b @> a2.b ORDER 
 6  {1,2,3,4}  4  {1,2}
 6  {1,2,3,4}  5  {1,3}
 6  {1,2,3,4}  6  {1,2,3,4}
+7  {NULL}     1  {}
 
 # This query performs a cross join followed by a filter.
 query ITIT
@@ -568,6 +571,7 @@ SELECT * FROM array_tab@primary AS a1, array_tab AS a2 WHERE a1.b @> a2.b ORDER 
 6  {1,2,3,4}  4  {1,2}
 6  {1,2,3,4}  5  {1,3}
 6  {1,2,3,4}  6  {1,2,3,4}
+7  {NULL}     1  {}
 
 # This query is checking that the results of the previous two queries are identical.
 # There should be no rows output.
@@ -646,6 +650,8 @@ ORDER BY a1.a, a2.a
 ----
 NULL  NULL       5  {1,3}
 NULL  NULL       6  {1,2,3,4}
+NULL  NULL       7  {NULL}
+NULL  NULL       8  NULL
 2     {1}        1  {}
 2     {1}        2  {1}
 4     {1,2}      1  {}
@@ -682,3 +688,5 @@ SELECT a2.* FROM array_tab@primary AS a2 WHERE NOT EXISTS (
 )
 ORDER BY a2.a
 ----
+7  {NULL}
+8  NULL

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
@@ -98,12 +98,13 @@ Del /Table/53/1/4/0
 
 # Tests for array inverted indexes.
 
-# Make sure that duplicate entries do not get emitted more than once, and that
-# null keys don't get emitted.
+# Make sure that duplicate entries do not get emitted more than once.
+# Null keys should also get emitted once.
 query T kvtrace
 INSERT INTO e VALUES(0, ARRAY[7,0,0,1,NULL,10,0,1,7,NULL])
 ----
 CPut /Table/54/1/0/0 -> /TUPLE/
+InitPut /Table/54/2/NULL/0/0 -> /BYTES/
 InitPut /Table/54/2/0/0/0 -> /BYTES/
 InitPut /Table/54/2/1/0/0 -> /BYTES/
 InitPut /Table/54/2/7/0/0 -> /BYTES/
@@ -122,11 +123,12 @@ INSERT INTO e VALUES(2, NULL)
 ----
 CPut /Table/54/1/2/0 -> /TUPLE/
 
-# Make sure that NULL entries within an array don't emit any keys.
+# Make sure that NULL entries within an array emit keys.
 query T kvtrace
 INSERT INTO e VALUES(3, ARRAY[NULL])
 ----
 CPut /Table/54/1/3/0 -> /TUPLE/
+InitPut /Table/54/2/NULL/3/0 -> /BYTES/
 
 # Test that array inverted indexes work okay with decimals (a type with
 # composite encoding). Also, make sure that the composite encoding is

--- a/pkg/sql/opt/invertedexpr/json_array_expression.go
+++ b/pkg/sql/opt/invertedexpr/json_array_expression.go
@@ -14,7 +14,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/errors"
 )
 
 // JSONOrArrayToContainingSpanExpr converts a JSON or Array datum to a
@@ -33,7 +32,8 @@ func JSONOrArrayToContainingSpanExpr(
 		return nil, err
 	}
 	if len(spansSlice) == 0 {
-		return nil, errors.AssertionFailedf("trying to use null key in index lookup")
+		// This can happen if the input is ARRAY[NULL].
+		return &SpanExpression{}, nil
 	}
 
 	// The spans returned by EncodeContainingInvertedIndexSpans represent the

--- a/pkg/sql/rowenc/index_encoding_test.go
+++ b/pkg/sql/rowenc/index_encoding_test.go
@@ -425,6 +425,12 @@ func TestEncodeContainingArrayInvertedIndexSpans(t *testing.T) {
 		{`{1, 2}`, `{1, 2, 1}`, true},
 		{`{1, 2, 3}`, `{1, 2, 4}`, false},
 		{`{1, 2, 3}`, `{}`, true},
+		{`{}`, `{NULL}`, false},
+		{`{NULL}`, `{}`, true},
+		{`{NULL}`, `{NULL}`, false},
+		{`{2, NULL}`, `{2, NULL}`, false},
+		{`{2, NULL}`, `{2}`, true},
+		{`{2, NULL}`, `{NULL}`, false},
 	}
 
 	evalCtx := tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
@@ -449,7 +455,7 @@ func TestEncodeContainingArrayInvertedIndexSpans(t *testing.T) {
 		// inner loop (any span in the slice can contain any of the keys), and an
 		// intersection on the outer loop (all of the span slices must contain at
 		// least one key).
-		actual := true
+		actual := len(spansSlice) > 0
 		for _, spans := range spansSlice {
 			found := false
 			for _, span := range spans {


### PR DESCRIPTION
This commit fixes a few bugs with `NULL` array elements and inverted joins.
In particular:
- Adds `NULL` elements to array inverted indexes (e.g., `'{1, 2, NULL}'` now
  has three entries in the index instead of two). This is needed since
  `'{NULL}' @> '{}'` is true. `NULL` arrays are still excluded from the
  index, since nothing is contained by `NULL`.
- `EncodeContainingInvertedIndexSpans` now returns empty spans if called with
  an array in which any element is `NULL`. This is needed since
  `'{NULL, 2}' @> '{NULL, 2}'` is false.
- `JSONOrArrayToContainingSpanExpr` no longer throws an error if the call to
  `EncodeContainingInvertedIndexSpans` returns empty spans. Instead, it returns
  an empty `SpanExpression`.

There is no release note needed since these bugs were introduced a few days
ago and are not part of any release.

Release note: None