### PR TITLE
opttester: add split-diff command arg optsteps

### DIFF
--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -206,6 +206,11 @@ type Flags struct {
 	// test catalog. This field is only used by the exec-ddl command for CREATE
 	// INDEX statements.
 	IndexVersion descpb.IndexDescriptorVersion
+
+	// OptStepsSplitDiff, if true, replaces the unified diff output of the
+	// optsteps command with a split diff where the before and after expressions
+	// are printed in their entirety. The default value is false.
+	OptStepsSplitDiff bool
 }
 
 // New constructs a new instance of the OptTester for the given SQL statement.
@@ -401,6 +406,10 @@ func New(catalog cat.Catalog, sql string) *OptTester {
 //  - index-version: controls the version of the index descriptor created in
 //    the test catalog. This is used by the exec-ddl command for CREATE INDEX
 //    statements.
+//
+//  - split-diff: replaces the unified diff output of the optsteps command with
+//    a split diff where the before and after expressions are printed in their
+//    entirety. This is only used by the optsteps command.
 //
 func (ot *OptTester) RunCommand(tb testing.TB, d *datadriven.TestData) string {
 	// Allow testcases to override the flags.
@@ -864,6 +873,9 @@ func (f *Flags) Set(arg datadriven.CmdArg) error {
 		}
 		f.IndexVersion = descpb.IndexDescriptorVersion(version)
 
+	case "split-diff":
+		f.OptStepsSplitDiff = true
+
 	default:
 		return fmt.Errorf("unknown argument: %s", arg.Key)
 	}
@@ -1176,7 +1188,6 @@ func (ot *OptTester) optStepsDisplay(before string, after string, os *optSteps) 
 		return
 	}
 
-	var diff difflib.UnifiedDiff
 	if os.IsBetter() {
 		// New expression is better than the previous expression. Diff
 		// it against the previous *best* expression (might not be the
@@ -1186,15 +1197,23 @@ func (ot *OptTester) optStepsDisplay(before string, after string, os *optSteps) 
 		altHeader("%s (higher cost)\n", os.LastRuleName())
 	}
 
-	diff = difflib.UnifiedDiff{
-		A:       difflib.SplitLines(before),
-		B:       difflib.SplitLines(after),
-		Context: 100,
+	if ot.Flags.OptStepsSplitDiff {
+		ot.output("<<<<<<< before\n")
+		ot.indent(before)
+		ot.output("=======\n")
+		ot.indent(after)
+		ot.output(">>>>>>> after\n")
+	} else {
+		diff := difflib.UnifiedDiff{
+			A:       difflib.SplitLines(before),
+			B:       difflib.SplitLines(after),
+			Context: 100,
+		}
+		text, _ := difflib.GetUnifiedDiffString(diff)
+		// Skip the "@@ ... @@" header (first line).
+		text = strings.SplitN(text, "\n", 2)[1]
+		ot.indent(text)
 	}
-	text, _ := difflib.GetUnifiedDiffString(diff)
-	// Skip the "@@ ... @@" header (first line).
-	text = strings.SplitN(text, "\n", 2)[1]
-	ot.indent(text)
 }
 
 // ExploreTrace steps through exploration transformations performed by the

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -150,10 +150,6 @@ type Flags struct {
 	// to pass.
 	UnexpectedRules RuleSet
 
-	// ExpectedMatchOnlyRules is a set of exploration rules which must match but
-	// not generate new expressions for the test to pass.
-	ExpectedMatchOnlyRules RuleSet
-
 	// ColStats is a list of ColSets for which a column statistic is requested.
 	ColStats []opt.ColSet
 


### PR DESCRIPTION
#### opttester: remove extraneous Flags.ExpectedMatchOnlyRules field

Release note: None

#### opttester: add split-diff command arg optsteps

This commit adds an arg for the `optsteps` test command that prints the
before and after expressions in their entirety, rather than printing a
diff.

For example, where `optsteps` would print:

    -project
    +values
      ├── columns: "?column?":1!null
      ├── cardinality: [1 - 1]
      ├── key: ()
      ├── fd: ()-->(1)
    - ├── values
    - │    ├── cardinality: [1 - 1]
    - │    ├── key: ()
    - │    └── ()
    - └── projections
    -      └── false [as="?column?":1]
    + └── (false,)

`opsteps split-diff` would print:

    <<<<<<< before
      project
       ├── columns: "?column?":1!null
       ├── cardinality: [1 - 1]
       ├── key: ()
       ├── fd: ()-->(1)
       ├── values
       │    ├── cardinality: [1 - 1]
       │    ├── key: ()
       │    └── ()
       └── projections
            └── false [as="?column?":1]
    =======
      values
       ├── columns: "?column?":1!null
       ├── cardinality: [1 - 1]
       ├── key: ()
       ├── fd: ()-->(1)
       └── (false,)
    >>>>>>> after

I've added this as a separate argument rather than a `format` argument
because it would be unexpected for `format=hide-all` to present this
format rather than the default unified diff.

This split diff can be a useful when debugging the optimizer and trying
to understand transformations and normalizations holistically. On
multiple occasions I've found myself recreating this format manually
from an `optsteps` unified diff in my text editor, so I thought it would
be pragmatic to automate it.

Release note: None
