### PR TITLE
storage: consider value in uncertainty interval but below intent to be uncertain

### DIFF
--- a/pkg/storage/pebble_mvcc_scanner.go
+++ b/pkg/storage/pebble_mvcc_scanner.go
@@ -360,12 +360,13 @@ func (p *pebbleMVCCScanner) getAndAdvance() bool {
 	otherIntentVisible := metaTS.LessEq(maxVisibleTS) || p.failOnMoreRecent
 
 	if !ownIntent && !otherIntentVisible {
-		// 6. The key contains an intent, but we're reading before the
-		// intent. Seek to the desired version. Note that if we own the
-		// intent (i.e. we're reading transactionally) we want to read
-		// the intent regardless of our read timestamp and fall into
-		// case 8 below.
-		return p.seekVersion(p.ts, false)
+		// 6. The key contains an intent, but we're reading below the intent.
+		// Seek to the desired version, checking for uncertainty if necessary.
+		//
+		// Note that if we own the intent (i.e. we're reading transactionally)
+		// we want to read the intent regardless of our read timestamp and fall
+		// into case 8 below.
+		return p.seekVersion(maxVisibleTS, p.checkUncertainty)
 	}
 
 	if p.inconsistent {

--- a/pkg/storage/testdata/mvcc_histories/uncertainty_interval
+++ b/pkg/storage/testdata/mvcc_histories/uncertainty_interval
@@ -84,16 +84,17 @@ scan t=txn2 k=k1
 scan: "k1"-"k1\x00" -> <no data>
 error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 0.000000005,0 encountered previous write with future timestamp 0.000000010,0 within uncertainty interval `t <= 0.000000010,0`; observed timestamps: []
 
-# TODO(nvanbenschoten): These cases are buggy. They should return a
-# ReadWithinUncertaintyIntervalError, but they currently don't.
+run error
+get t=txn2 k=k2
+----
+get: "k2" -> <no data>
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 0.000000005,0 encountered previous write with future timestamp 0.000000010,0 within uncertainty interval `t <= 0.000000010,0`; observed timestamps: []
 
-# run error
-# get t=txn2 k=k2
-# ----
-
-# run error
-# scan t=txn2 k=k2
-# ----
+run error
+scan t=txn2 k=k2
+----
+scan: "k2"-"k2\x00" -> <no data>
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 0.000000005,0 encountered previous write with future timestamp 0.000000010,0 within uncertainty interval `t <= 0.000000010,0`; observed timestamps: []
 
 
 run ok
@@ -114,16 +115,17 @@ scan t=txn3 k=k1
 scan: "k1"-"k1\x00" -> <no data>
 error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 0.000000005,0 encountered previous write with future timestamp 0.000000010,0 within uncertainty interval `t <= 0.000000015,0`; observed timestamps: []
 
-# TODO(nvanbenschoten): These cases are buggy. They should return a
-# ReadWithinUncertaintyIntervalError, but they currently don't.
+run error
+get t=txn3 k=k2
+----
+get: "k2" -> <no data>
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 0.000000005,0 encountered previous write with future timestamp 0.000000010,0 within uncertainty interval `t <= 0.000000015,0`; observed timestamps: []
 
-# run error
-# get t=txn3 k=k2
-# ----
-
-# run error
-# scan t=txn3 k=k2
-# ----
+run error
+scan t=txn3 k=k2
+----
+scan: "k2"-"k2\x00" -> <no data>
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 0.000000005,0 encountered previous write with future timestamp 0.000000010,0 within uncertainty interval `t <= 0.000000015,0`; observed timestamps: []
 
 
 run ok


### PR DESCRIPTION
This commit fixes the bug revealed in #56762.

Before this commit, the following setup during an MVCC read would not
return a ReadWithinUncertaintyIntervalError, even though it should have:
```
-----------------
- 20: intent
|
- 15: max timestamp
|
- 10: value
|
-  5: read timestamp
-----------------
```
The problem was that the `pebbleMVCCScanner` would observe the intent,
decide that the intent did not conflicting with the read, and then
skip past the read's uncertainty interval, so it would ignore the value
at time 10.

This commit fixes the bug by checking for uncertainty after ignoring
an intent, if necessary. It ended up being a smaller fix than I was
expecting.