### PR TITLE
release-20.2: ui: aggregate new statement stats on the client

### DIFF
--- a/pkg/ui/src/util/appStats.spec.ts
+++ b/pkg/ui/src/util/appStats.spec.ts
@@ -167,6 +167,8 @@ function randomStats(sensitiveInfo?: ISensitiveInfo): StatementStatistics {
     run_lat: randomStat(),
     service_lat: randomStat(),
     overhead_lat: randomStat(),
+    bytes_read: randomStat(),
+    rows_read: randomStat(),
     sensitive_info: sensitiveInfo || makeSensitiveInfo(null, null),
   };
 }

--- a/pkg/ui/src/util/appStats.ts
+++ b/pkg/ui/src/util/appStats.ts
@@ -47,7 +47,7 @@ export function addNumericStats(a: NumericStat, b: NumericStat, countA: number, 
   };
 }
 
-export function addStatementStats(a: StatementStatistics, b: StatementStatistics) {
+export function addStatementStats(a: StatementStatistics, b: StatementStatistics): Required<StatementStatistics> {
   const countA = FixLong(a.count).toInt();
   const countB = FixLong(b.count).toInt();
   return {
@@ -60,7 +60,11 @@ export function addStatementStats(a: StatementStatistics, b: StatementStatistics
     run_lat: addNumericStats(a.run_lat, b.run_lat, countA, countB),
     service_lat: addNumericStats(a.service_lat, b.service_lat, countA, countB),
     overhead_lat: addNumericStats(a.overhead_lat, b.overhead_lat, countA, countB),
+    bytes_read: addNumericStats(a.bytes_read, b.bytes_read, countA, countB),
+    rows_read: addNumericStats(a.rows_read, b.rows_read, countA, countB),
     sensitive_info: coalesceSensitiveInfo(a.sensitive_info, b.sensitive_info),
+    legacy_last_err: "",
+    legacy_last_err_redacted: "",
   };
 }
 

--- a/pkg/ui/src/views/statements/statements.spec.tsx
+++ b/pkg/ui/src/views/statements/statements.spec.tsx
@@ -447,6 +447,8 @@ function makeStats() {
     overhead_lat: makeStat(),
     service_lat: makeStat(),
     sensitive_info: makeEmptySensitiveInfo(),
+    rows_read: makeStat(),
+    bytes_read: makeStat(),
   };
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #56445.

/cc @cockroachdb/release

---

Previously, we added new stats to the statements proto
without also ensuring that our aggregation of the same
fingerprint across multiple nodes averaged values for
those new fields.

Since our protobuf definitions allow null values, TypeScript
wasn't able to enforce the setting of these new fields
in the aggregation function.

Resolves #56432.

Release note (admin ui change): fixes a bug where the "Other
Execution Statistics" box in the Statement Details page would
be empty in situations where the same fingerprint had been
processed by multiple nodes.
