### PR TITLE
teamcity-trigger: run nightly stressrace with -p 1

### DIFF
--- a/pkg/cmd/teamcity-trigger/main.go
+++ b/pkg/cmd/teamcity-trigger/main.go
@@ -107,11 +107,11 @@ func runTC(queueBuild func(string, map[string]string)) {
 			maxRuns, maxTime, maxFails, parallelism)
 		queueBuild("Cockroach_Nightlies_Stress", opts)
 
-		// Run race build. Reduce the parallelism to avoid overloading the machine.
-		parallelism /= 2
+		// Run race build. With run with -p 1 to avoid overloading the machine.
+		noParallelism := 1
 		opts["env.GOFLAGS"] = fmt.Sprintf("-race -parallel=%d", parallelism)
 		opts["env.STRESSFLAGS"] = fmt.Sprintf("-maxruns %d -maxtime %s -maxfails %d -p %d",
-			maxRuns, maxTime, maxFails, parallelism)
+			maxRuns, maxTime, maxFails, noParallelism)
 		queueBuild("Cockroach_Nightlies_Stress", opts)
 	}
 }

--- a/pkg/cmd/teamcity-trigger/main_test.go
+++ b/pkg/cmd/teamcity-trigger/main_test.go
@@ -69,8 +69,8 @@ func Example_runTC() {
 	//   env.TESTTIMEOUT: 40m0s
 	//
 	// github.com/cockroachdb/cockroach/pkg/kv/kvnemesis
-	//   env.GOFLAGS:     -race -parallel=2
-	//   env.STRESSFLAGS: -maxruns 0 -maxtime 1h0m0s -maxfails 1 -p 2
+	//   env.GOFLAGS:     -race -parallel=4
+	//   env.STRESSFLAGS: -maxruns 0 -maxtime 1h0m0s -maxfails 1 -p 1
 	//   env.TESTTIMEOUT: 40m0s
 	//
 	// github.com/cockroachdb/cockroach/pkg/sql/logictest
@@ -79,7 +79,7 @@ func Example_runTC() {
 	//   env.TESTTIMEOUT: 2h0m0s
 	//
 	// github.com/cockroachdb/cockroach/pkg/sql/logictest
-	//   env.GOFLAGS:     -race -parallel=1
+	//   env.GOFLAGS:     -race -parallel=2
 	//   env.STRESSFLAGS: -maxruns 100 -maxtime 3h0m0s -maxfails 1 -p 1
 	//   env.TESTTIMEOUT: 2h0m0s
 	//
@@ -89,7 +89,7 @@ func Example_runTC() {
 	//   env.TESTTIMEOUT: 40m0s
 	//
 	// github.com/cockroachdb/cockroach/pkg/storage
-	//   env.GOFLAGS:     -race -parallel=2
-	//   env.STRESSFLAGS: -maxruns 100 -maxtime 1h0m0s -maxfails 1 -p 2
+	//   env.GOFLAGS:     -race -parallel=4
+	//   env.STRESSFLAGS: -maxruns 100 -maxtime 1h0m0s -maxfails 1 -p 1
 	//   env.TESTTIMEOUT: 40m0s
 }


### PR DESCRIPTION
We're currently running with -p 2. We're seeing the TeamCity machines
struggle with this - we're getting mysterious failures with logs spammed
with slow requests and stalled disks.

Fixes #56693
Fixes #56484
Fixes #56355

Tests found by searching for "disk slowness detected" and applying a
modicum of common sense.

Fixes #55404
Fixes #55418
Fixes #55420
Fixes #55421
Fixes #55423
Fixes #55574
Fixes #55627
Fixes #55799
Fixes #55884
Fixes #55930
Fixes #56037
Fixes #56106
Fixes #56172
Fixes #56274
Fixes #56402
Fixes #56702
Fixes #56704

Release note: None