### PR TITLE
opt: add insertion checks for unique constraints

### DIFF
--- a/pkg/sql/opt/memo/interner.go
+++ b/pkg/sql/opt/memo/interner.go
@@ -645,6 +645,12 @@ func (h *hasher) HashFKChecksExpr(val FKChecksExpr) {
 	}
 }
 
+func (h *hasher) HashUniqueChecksExpr(val UniqueChecksExpr) {
+	for i := range val {
+		h.HashRelExpr(val[i].Check)
+	}
+}
+
 func (h *hasher) HashKVOptionsExpr(val KVOptionsExpr) {
 	for i := range val {
 		h.HashString(val[i].Key)
@@ -1039,6 +1045,18 @@ func (h *hasher) IsZipExprEqual(l, r ZipExpr) bool {
 }
 
 func (h *hasher) IsFKChecksExprEqual(l, r FKChecksExpr) bool {
+	if len(l) != len(r) {
+		return false
+	}
+	for i := range l {
+		if l[i].Check != r[i].Check {
+			return false
+		}
+	}
+	return true
+}
+
+func (h *hasher) IsUniqueChecksExprEqual(l, r UniqueChecksExpr) bool {
 	if len(l) != len(r) {
 		return false
 	}

--- a/pkg/sql/opt/norm/prune_cols_funcs.go
+++ b/pkg/sql/opt/norm/prune_cols_funcs.go
@@ -43,7 +43,7 @@ func (c *CustomFuncs) NeededExplainCols(private *memo.ExplainPrivate) opt.ColSet
 // referenced by it. Other rules filter the FetchCols, CheckCols, etc. and can
 // in turn trigger the PruneMutationInputCols rule.
 func (c *CustomFuncs) NeededMutationCols(
-	private *memo.MutationPrivate, checks memo.FKChecksExpr,
+	private *memo.MutationPrivate, uniqueChecks memo.UniqueChecksExpr, fkChecks memo.FKChecksExpr,
 ) opt.ColSet {
 	var cols opt.ColSet
 
@@ -69,8 +69,12 @@ func (c *CustomFuncs) NeededMutationCols(
 	}
 
 	if private.WithID != 0 {
-		for i := range checks {
-			withUses := memo.WithUses(checks[i].Check)
+		for i := range uniqueChecks {
+			withUses := memo.WithUses(uniqueChecks[i].Check)
+			cols.UnionWith(withUses[private.WithID].UsedCols)
+		}
+		for i := range fkChecks {
+			withUses := memo.WithUses(fkChecks[i].Check)
 			cols.UnionWith(withUses[private.WithID].UsedCols)
 		}
 	}

--- a/pkg/sql/opt/norm/rules/prune_cols.opt
+++ b/pkg/sql/opt/norm/rules/prune_cols.opt
@@ -415,7 +415,8 @@
 [PruneMutationFetchCols, Normalize]
 (Update | Upsert | Delete
     $input:*
-    $checks:*
+    $uniqueChecks:*
+    $fkChecks:*
     $mutationPrivate:* &
         (CanPruneMutationFetchCols
             $mutationPrivate
@@ -428,7 +429,8 @@
 =>
 ((OpName)
     $input
-    $checks
+    $uniqueChecks
+    $fkChecks
     (PruneMutationFetchCols $mutationPrivate $needed)
 )
 
@@ -437,15 +439,25 @@
 [PruneMutationInputCols, Normalize]
 (Insert | Update | Upsert | Delete
     $input:*
-    $checks:*
+    $uniqueChecks:*
+    $fkChecks:*
     $mutationPrivate:* &
         (CanPruneCols
             $input
-            $needed:(NeededMutationCols $mutationPrivate $checks)
+            $needed:(NeededMutationCols
+                $mutationPrivate
+                $uniqueChecks
+                $fkChecks
+            )
         )
 )
 =>
-((OpName) (PruneCols $input $needed) $checks $mutationPrivate)
+((OpName)
+    (PruneCols $input $needed)
+    $uniqueChecks
+    $fkChecks
+    $mutationPrivate
+)
 
 # PruneReturningCols removes columns from the mutation operator's ReturnCols
 # set if they are not used in the RETURNING clause of the mutation.
@@ -457,7 +469,8 @@
 (Project
     $input:(Insert | Update | Upsert | Delete
         $innerInput:*
-        $checks:*
+        $uniqueChecks:*
+        $fkChecks:*
         $mutationPrivate:*
     )
     $projections:*
@@ -475,7 +488,8 @@
 (Project
     ((OpName $input)
         $innerInput
-        $checks
+        $uniqueChecks
+        $fkChecks
         (PruneMutationReturnCols $mutationPrivate $needed)
     )
     $projections

--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -2585,6 +2585,9 @@ upsert checks
            ├── upsert_b:16 > 10 [as=check2:18, outer=(16)]
            └── column2:7 > upsert_b:16 [as=check3:19, outer=(7,16)]
 
+# TODO(rytaft): test that columns needed for unique checks are not pruned
+# from updates.
+
 # ------------------------------------------------------------------------------
 # PruneMutationReturnCols
 # ------------------------------------------------------------------------------

--- a/pkg/sql/opt/ops/mutation.opt
+++ b/pkg/sql/opt/ops/mutation.opt
@@ -20,7 +20,8 @@
 [Relational, Mutation, WithBinding]
 define Insert {
     Input RelExpr
-    Checks FKChecksExpr
+    UniqueChecks UniqueChecksExpr
+    FKChecks FKChecksExpr
     _ MutationPrivate
 }
 
@@ -182,7 +183,8 @@ define MutationPrivate {
 [Relational, Mutation, WithBinding]
 define Update {
     Input RelExpr
-    Checks FKChecksExpr
+    UniqueChecks UniqueChecksExpr
+    FKChecks FKChecksExpr
     _ MutationPrivate
 }
 
@@ -205,7 +207,8 @@ define Update {
 [Relational, Mutation, WithBinding]
 define Upsert {
     Input RelExpr
-    Checks FKChecksExpr
+    UniqueChecks UniqueChecksExpr
+    FKChecks FKChecksExpr
     _ MutationPrivate
 }
 
@@ -217,7 +220,8 @@ define Upsert {
 [Relational, Mutation, WithBinding]
 define Delete {
     Input RelExpr
-    Checks FKChecksExpr
+    UniqueChecks UniqueChecksExpr
+    FKChecks FKChecksExpr
     _ MutationPrivate
 }
 
@@ -249,6 +253,35 @@ define FKChecksItemPrivate {
     # The FK constraint is InboundForeignKey(FKOrdinal) on the referenced table.
     FKOutbound bool
     FKOrdinal int
+
+    # KeyCols are the columns in the Check query that form the value tuple shown
+    # in the error message.
+    KeyCols ColList
+
+    # OpName is the name that should be used for this check in error messages.
+    OpName string
+}
+
+# UniqueChecks is a list of uniqueness check queries, to be run after the main
+# query.
+[Scalar, List]
+define UniqueChecks {
+}
+
+# UniqueChecksItem is a unique check query, to be run after the main query.
+# An execution error will be generated if the query returns any results.
+[Scalar, ListItem]
+define UniqueChecksItem {
+    Check RelExpr
+    _ UniqueChecksItemPrivate
+}
+
+[Private]
+define UniqueChecksItemPrivate {
+    Table TableID
+
+    # This is the ordinal of the check in the table's unique constraints.
+    CheckOrdinal int
 
     # KeyCols are the columns in the Check query that form the value tuple shown
     # in the error message.

--- a/pkg/sql/opt/optbuilder/BUILD.bazel
+++ b/pkg/sql/opt/optbuilder/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "misc_statements.go",
         "mutation_builder.go",
         "mutation_builder_fk.go",
+        "mutation_builder_unique.go",
         "opaque.go",
         "orderby.go",
         "partial_index.go",

--- a/pkg/sql/opt/optbuilder/delete.go
+++ b/pkg/sql/opt/optbuilder/delete.go
@@ -77,7 +77,9 @@ func (mb *mutationBuilder) buildDelete(returning tree.ReturningExprs) {
 	mb.buildFKChecksAndCascadesForDelete()
 
 	private := mb.makeMutationPrivate(returning != nil)
-	mb.outScope.expr = mb.b.factory.ConstructDelete(mb.outScope.expr, mb.checks, private)
+	mb.outScope.expr = mb.b.factory.ConstructDelete(
+		mb.outScope.expr, mb.uniqueChecks, mb.fkChecks, private,
+	)
 
 	mb.buildReturning(returning)
 }

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -652,10 +652,14 @@ func (mb *mutationBuilder) buildInsert(returning tree.ReturningExprs) {
 	// Add any partial index put boolean columns to the input.
 	mb.projectPartialIndexPutCols(preCheckScope)
 
+	mb.buildUniqueChecksForInsert()
+
 	mb.buildFKChecksForInsert()
 
 	private := mb.makeMutationPrivate(returning != nil)
-	mb.outScope.expr = mb.b.factory.ConstructInsert(mb.outScope.expr, mb.checks, private)
+	mb.outScope.expr = mb.b.factory.ConstructInsert(
+		mb.outScope.expr, mb.uniqueChecks, mb.fkChecks, private,
+	)
 
 	mb.buildReturning(returning)
 }
@@ -1089,7 +1093,9 @@ func (mb *mutationBuilder) buildUpsert(returning tree.ReturningExprs) {
 	mb.buildFKChecksForUpsert()
 
 	private := mb.makeMutationPrivate(returning != nil)
-	mb.outScope.expr = mb.b.factory.ConstructUpsert(mb.outScope.expr, mb.checks, private)
+	mb.outScope.expr = mb.b.factory.ConstructUpsert(
+		mb.outScope.expr, mb.uniqueChecks, mb.fkChecks, private,
+	)
 
 	mb.buildReturning(returning)
 }

--- a/pkg/sql/opt/optbuilder/mutation_builder_unique.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder_unique.go
@@ -1,0 +1,196 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package optbuilder
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
+	"github.com/cockroachdb/cockroach/pkg/util"
+)
+
+// buildUniqueChecksForInsert builds uniqueness check queries for an insert.
+func (mb *mutationBuilder) buildUniqueChecksForInsert() {
+	uniqueCount := mb.tab.UniqueCount()
+	if uniqueCount == 0 {
+		// No relevant unique checks.
+		return
+	}
+
+	// We only need to build unique checks if there is at least one unique
+	// constraint without an index.
+	needChecks := false
+	i := 0
+	for ; i < uniqueCount; i++ {
+		if mb.tab.Unique(i).WithoutIndex() {
+			needChecks = true
+			break
+		}
+	}
+	if !needChecks {
+		return
+	}
+
+	mb.ensureWithID()
+	h := &mb.uniqueCheckHelper
+
+	// i is already set to the index of the first uniqueness check without an
+	// index, so start iterating from there.
+	for ; i < uniqueCount; i++ {
+		// If this constraint is already enforced by an index we don't need to plan
+		// a check.
+		if mb.tab.Unique(i).WithoutIndex() && h.init(mb, i) {
+			mb.uniqueChecks = append(mb.uniqueChecks, h.buildInsertionCheck())
+		}
+	}
+	telemetry.Inc(sqltelemetry.UniqueChecksUseCounter)
+}
+
+// uniqueCheckHelper is a type associated with a single unique constraint and
+// is used to build the "leaves" of a unique check expression, namely the
+// WithScan of the mutation input and the Scan of the table.
+type uniqueCheckHelper struct {
+	mb *mutationBuilder
+
+	unique        cat.UniqueConstraint
+	uniqueOrdinal int
+
+	// uniqueOrdinals are the table ordinals of the unique columns in the table
+	// that is being mutated. They correspond 1-to-1 to the columns in the
+	// UniqueConstraint.
+	uniqueOrdinals []int
+
+	// uniqueAndPrimaryKeyOrdinals includes all the ordinals from uniqueOrdinals,
+	// plus the ordinals from any primary key columns that are not already
+	// included in uniqueOrdinals.
+	uniqueAndPrimaryKeyOrdinals []int
+}
+
+// init initializes the helper with a unique constraint.
+//
+// Returns false if the constraint should be ignored (e.g. because the new
+// values for the unique columns are known to be always NULL).
+func (h *uniqueCheckHelper) init(mb *mutationBuilder, uniqueOrdinal int) bool {
+	*h = uniqueCheckHelper{
+		mb:            mb,
+		unique:        mb.tab.Unique(uniqueOrdinal),
+		uniqueOrdinal: uniqueOrdinal,
+	}
+
+	uniqueCount := h.unique.ColumnCount()
+
+	var uniqueOrds util.FastIntSet
+	for i := 0; i < uniqueCount; i++ {
+		uniqueOrds.Add(h.unique.ColumnOrdinal(mb.tab, i))
+	}
+
+	// Find the primary key columns that are not part of the unique constraint.
+	// If there aren't any, we don't need a check.
+	primaryOrds := getIndexLaxKeyOrdinals(mb.tab.Index(cat.PrimaryIndex))
+	primaryOrds.DifferenceWith(uniqueOrds)
+	if primaryOrds.Empty() {
+		// The primary key columns are a subset of the unique columns; unique check
+		// not needed.
+		return false
+	}
+
+	h.uniqueAndPrimaryKeyOrdinals = append(uniqueOrds.Ordered(), primaryOrds.Ordered()...)
+	h.uniqueOrdinals = h.uniqueAndPrimaryKeyOrdinals[:uniqueCount]
+
+	// Check if we are setting NULL values for the unique columns, like when this
+	// mutation is the result of a SET NULL cascade action.
+	numNullCols := 0
+	for _, tabOrd := range h.uniqueOrdinals {
+		colID := mb.mapToReturnColID(tabOrd)
+		if memo.OutputColumnIsAlwaysNull(mb.outScope.expr, colID) {
+			numNullCols++
+		}
+	}
+
+	// If at least one unique column is getting a NULL value, unique check not
+	// needed.
+	return numNullCols == 0
+}
+
+// buildInsertionCheck creates a unique check for rows which are added to a
+// table. The input to the insertion check will be produced from the input to
+// the mutation operator.
+func (h *uniqueCheckHelper) buildInsertionCheck() memo.UniqueChecksItem {
+	checkInput, withScanCols, _ := h.mb.makeCheckInputScan(
+		checkInputScanNewVals, h.uniqueAndPrimaryKeyOrdinals,
+	)
+
+	numCols := len(withScanCols)
+	f := h.mb.b.factory
+
+	// Build a self semi-join, with the new values on the left and the
+	// existing values on the right.
+
+	scanScope, _ := h.buildTableScan()
+
+	// Build the join filters:
+	//   (new_a = existing_a) AND (new_b = existing_b) AND ...
+	//
+	// Set the capacity to len(h.uniqueOrdinals)+1 since we'll have an equality
+	// condition for each column in the unique constraint, plus one additional
+	// condition to prevent rows from matching themselves (see below).
+	semiJoinFilters := make(memo.FiltersExpr, 0, len(h.uniqueOrdinals)+1)
+	for i := 0; i < len(h.uniqueOrdinals); i++ {
+		semiJoinFilters = append(semiJoinFilters, f.ConstructFiltersItem(
+			f.ConstructEq(
+				f.ConstructVariable(withScanCols[i]),
+				f.ConstructVariable(scanScope.cols[i].id),
+			),
+		))
+	}
+
+	// We need to prevent rows from matching themselves in the semi join. We can
+	// do this by adding another filter that uses the primary keys to check if
+	// two rows are identical:
+	//    (new_pk1 != existing_pk1) OR (new_pk2 != existing_pk2) OR ...
+	var pkFilter opt.ScalarExpr
+	for i := len(h.uniqueOrdinals); i < numCols; i++ {
+		pkFilterLocal := f.ConstructNe(
+			f.ConstructVariable(withScanCols[i]),
+			f.ConstructVariable(scanScope.cols[i].id),
+		)
+		if pkFilter == nil {
+			pkFilter = pkFilterLocal
+		} else {
+			pkFilter = f.ConstructOr(pkFilter, pkFilterLocal)
+		}
+	}
+	semiJoinFilters = append(semiJoinFilters, f.ConstructFiltersItem(pkFilter))
+
+	semiJoin := f.ConstructSemiJoin(checkInput, scanScope.expr, semiJoinFilters, &memo.JoinPrivate{})
+
+	return f.ConstructUniqueChecksItem(semiJoin, &memo.UniqueChecksItemPrivate{
+		Table:        h.mb.tabID,
+		CheckOrdinal: h.uniqueOrdinal,
+		KeyCols:      withScanCols,
+		OpName:       h.mb.opName,
+	})
+}
+
+// buildTableScan builds a Scan of the table.
+func (h *uniqueCheckHelper) buildTableScan() (outScope *scope, tabMeta *opt.TableMeta) {
+	tabMeta = h.mb.b.addTable(h.mb.tab, tree.NewUnqualifiedTableName(h.mb.tab.Name()))
+	return h.mb.b.buildScan(
+		tabMeta,
+		h.uniqueAndPrimaryKeyOrdinals,
+		nil, /* indexFlags */
+		noRowLocking,
+		h.mb.b.allocScope(),
+	), tabMeta
+}

--- a/pkg/sql/opt/optbuilder/testdata/unique-checks-insert
+++ b/pkg/sql/opt/optbuilder/testdata/unique-checks-insert
@@ -1,0 +1,563 @@
+exec-ddl
+CREATE TABLE uniq (
+  k INT PRIMARY KEY,
+  v INT UNIQUE,
+  w INT UNIQUE WITHOUT INDEX,
+  x INT,
+  y INT,
+  UNIQUE WITHOUT INDEX (x, y)
+)
+----
+
+# None of the inserted values have nulls.
+build
+INSERT INTO uniq VALUES (1, 1, 1, 1, 1), (2, 2, 2, 2, 2)
+----
+insert uniq
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:7 => k:1
+ │    ├── column2:8 => v:2
+ │    ├── column3:9 => w:3
+ │    ├── column4:10 => x:4
+ │    └── column5:11 => y:5
+ ├── input binding: &1
+ ├── values
+ │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null column5:11!null
+ │    ├── (1, 1, 1, 1, 1)
+ │    └── (2, 2, 2, 2, 2)
+ └── unique-checks
+      ├── unique-checks-item: uniq(w)
+      │    └── semi-join (hash)
+      │         ├── columns: column3:12!null column1:13!null
+      │         ├── with-scan &1
+      │         │    ├── columns: column3:12!null column1:13!null
+      │         │    └── mapping:
+      │         │         ├──  column3:9 => column3:12
+      │         │         └──  column1:7 => column1:13
+      │         ├── scan uniq
+      │         │    └── columns: k:14!null w:16
+      │         └── filters
+      │              ├── column3:12 = w:16
+      │              └── column1:13 != k:14
+      └── unique-checks-item: uniq(x,y)
+           └── semi-join (hash)
+                ├── columns: column4:20!null column5:21!null column1:22!null
+                ├── with-scan &1
+                │    ├── columns: column4:20!null column5:21!null column1:22!null
+                │    └── mapping:
+                │         ├──  column4:10 => column4:20
+                │         ├──  column5:11 => column5:21
+                │         └──  column1:7 => column1:22
+                ├── scan uniq
+                │    └── columns: k:23!null x:26 y:27
+                └── filters
+                     ├── column4:20 = x:26
+                     ├── column5:21 = y:27
+                     └── column1:22 != k:23
+
+# Some of the inserted values have nulls.
+build
+INSERT INTO uniq VALUES (1, 1, 1, 1, 1), (2, 2, 2, 2, 2), (3, NULL, NULL, NULL, 3)
+----
+insert uniq
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:7 => k:1
+ │    ├── column2:8 => v:2
+ │    ├── column3:9 => w:3
+ │    ├── column4:10 => x:4
+ │    └── column5:11 => y:5
+ ├── input binding: &1
+ ├── values
+ │    ├── columns: column1:7!null column2:8 column3:9 column4:10 column5:11!null
+ │    ├── (1, 1, 1, 1, 1)
+ │    ├── (2, 2, 2, 2, 2)
+ │    └── (3, NULL::INT8, NULL::INT8, NULL::INT8, 3)
+ └── unique-checks
+      ├── unique-checks-item: uniq(w)
+      │    └── semi-join (hash)
+      │         ├── columns: column3:12 column1:13!null
+      │         ├── with-scan &1
+      │         │    ├── columns: column3:12 column1:13!null
+      │         │    └── mapping:
+      │         │         ├──  column3:9 => column3:12
+      │         │         └──  column1:7 => column1:13
+      │         ├── scan uniq
+      │         │    └── columns: k:14!null w:16
+      │         └── filters
+      │              ├── column3:12 = w:16
+      │              └── column1:13 != k:14
+      └── unique-checks-item: uniq(x,y)
+           └── semi-join (hash)
+                ├── columns: column4:20 column5:21!null column1:22!null
+                ├── with-scan &1
+                │    ├── columns: column4:20 column5:21!null column1:22!null
+                │    └── mapping:
+                │         ├──  column4:10 => column4:20
+                │         ├──  column5:11 => column5:21
+                │         └──  column1:7 => column1:22
+                ├── scan uniq
+                │    └── columns: k:23!null x:26 y:27
+                └── filters
+                     ├── column4:20 = x:26
+                     ├── column5:21 = y:27
+                     └── column1:22 != k:23
+
+# No need to plan checks for w since it's aways null.
+build
+INSERT INTO uniq VALUES (1, 1, NULL, 1, 1), (2, 2, NULL, 2, 2)
+----
+insert uniq
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:7 => k:1
+ │    ├── column2:8 => v:2
+ │    ├── column3:9 => w:3
+ │    ├── column4:10 => x:4
+ │    └── column5:11 => y:5
+ ├── input binding: &1
+ ├── values
+ │    ├── columns: column1:7!null column2:8!null column3:9 column4:10!null column5:11!null
+ │    ├── (1, 1, NULL::INT8, 1, 1)
+ │    └── (2, 2, NULL::INT8, 2, 2)
+ └── unique-checks
+      └── unique-checks-item: uniq(x,y)
+           └── semi-join (hash)
+                ├── columns: column4:12!null column5:13!null column1:14!null
+                ├── with-scan &1
+                │    ├── columns: column4:12!null column5:13!null column1:14!null
+                │    └── mapping:
+                │         ├──  column4:10 => column4:12
+                │         ├──  column5:11 => column5:13
+                │         └──  column1:7 => column1:14
+                ├── scan uniq
+                │    └── columns: k:15!null x:18 y:19
+                └── filters
+                     ├── column4:12 = x:18
+                     ├── column5:13 = y:19
+                     └── column1:14 != k:15
+
+# No need to plan checks for x,y since x is aways null.
+build
+INSERT INTO uniq VALUES (1, 1, 1, NULL, 1), (2, 2, NULL, NULL, 2)
+----
+insert uniq
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:7 => k:1
+ │    ├── column2:8 => v:2
+ │    ├── column3:9 => w:3
+ │    ├── column4:10 => x:4
+ │    └── column5:11 => y:5
+ ├── input binding: &1
+ ├── values
+ │    ├── columns: column1:7!null column2:8!null column3:9 column4:10 column5:11!null
+ │    ├── (1, 1, 1, NULL::INT8, 1)
+ │    └── (2, 2, NULL::INT8, NULL::INT8, 2)
+ └── unique-checks
+      └── unique-checks-item: uniq(w)
+           └── semi-join (hash)
+                ├── columns: column3:12 column1:13!null
+                ├── with-scan &1
+                │    ├── columns: column3:12 column1:13!null
+                │    └── mapping:
+                │         ├──  column3:9 => column3:12
+                │         └──  column1:7 => column1:13
+                ├── scan uniq
+                │    └── columns: k:14!null w:16
+                └── filters
+                     ├── column3:12 = w:16
+                     └── column1:13 != k:14
+
+# No need to plan checks for x,y since y is aways null.
+build
+INSERT INTO uniq VALUES (1, 1, 1, 1, NULL), (2, 2, 2, 2, NULL)
+----
+insert uniq
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:7 => k:1
+ │    ├── column2:8 => v:2
+ │    ├── column3:9 => w:3
+ │    ├── column4:10 => x:4
+ │    └── column5:11 => y:5
+ ├── input binding: &1
+ ├── values
+ │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null column5:11
+ │    ├── (1, 1, 1, 1, NULL::INT8)
+ │    └── (2, 2, 2, 2, NULL::INT8)
+ └── unique-checks
+      └── unique-checks-item: uniq(w)
+           └── semi-join (hash)
+                ├── columns: column3:12!null column1:13!null
+                ├── with-scan &1
+                │    ├── columns: column3:12!null column1:13!null
+                │    └── mapping:
+                │         ├──  column3:9 => column3:12
+                │         └──  column1:7 => column1:13
+                ├── scan uniq
+                │    └── columns: k:14!null w:16
+                └── filters
+                     ├── column3:12 = w:16
+                     └── column1:13 != k:14
+
+# No need to plan any checks, since w, x and y are aways null.
+build
+INSERT INTO uniq VALUES (1, 1, NULL, NULL, NULL), (2, 2, NULL, NULL, NULL)
+----
+insert uniq
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:7 => k:1
+ │    ├── column2:8 => v:2
+ │    ├── column3:9 => w:3
+ │    ├── column4:10 => x:4
+ │    └── column5:11 => y:5
+ └── values
+      ├── columns: column1:7!null column2:8!null column3:9 column4:10 column5:11
+      ├── (1, 1, NULL::INT8, NULL::INT8, NULL::INT8)
+      └── (2, 2, NULL::INT8, NULL::INT8, NULL::INT8)
+
+exec-ddl
+CREATE TABLE other (k INT, v INT, w INT NOT NULL, x INT, y INT)
+----
+
+# Insert with non-constant input.
+build
+INSERT INTO uniq SELECT k, v, w, x, y FROM other
+----
+insert uniq
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── other.k:7 => uniq.k:1
+ │    ├── other.v:8 => uniq.v:2
+ │    ├── other.w:9 => uniq.w:3
+ │    ├── other.x:10 => uniq.x:4
+ │    └── other.y:11 => uniq.y:5
+ ├── input binding: &1
+ ├── project
+ │    ├── columns: other.k:7 other.v:8 other.w:9!null other.x:10 other.y:11
+ │    └── scan other
+ │         └── columns: other.k:7 other.v:8 other.w:9!null other.x:10 other.y:11 rowid:12!null other.crdb_internal_mvcc_timestamp:13
+ └── unique-checks
+      ├── unique-checks-item: uniq(w)
+      │    └── semi-join (hash)
+      │         ├── columns: w:14!null k:15
+      │         ├── with-scan &1
+      │         │    ├── columns: w:14!null k:15
+      │         │    └── mapping:
+      │         │         ├──  other.w:9 => w:14
+      │         │         └──  other.k:7 => k:15
+      │         ├── scan uniq
+      │         │    └── columns: uniq.k:16!null uniq.w:18
+      │         └── filters
+      │              ├── w:14 = uniq.w:18
+      │              └── k:15 != uniq.k:16
+      └── unique-checks-item: uniq(x,y)
+           └── semi-join (hash)
+                ├── columns: x:22 y:23 k:24
+                ├── with-scan &1
+                │    ├── columns: x:22 y:23 k:24
+                │    └── mapping:
+                │         ├──  other.x:10 => x:22
+                │         ├──  other.y:11 => y:23
+                │         └──  other.k:7 => k:24
+                ├── scan uniq
+                │    └── columns: uniq.k:25!null uniq.x:28 uniq.y:29
+                └── filters
+                     ├── x:22 = uniq.x:28
+                     ├── y:23 = uniq.y:29
+                     └── k:24 != uniq.k:25
+
+exec-ddl
+CREATE TABLE uniq_overlaps_pk (
+  a INT,
+  b INT,
+  c INT,
+  d INT,
+  PRIMARY KEY (a, b),
+  UNIQUE WITHOUT INDEX (b, c),
+  UNIQUE WITHOUT INDEX (a, b, d),
+  UNIQUE WITHOUT INDEX (a),
+  UNIQUE WITHOUT INDEX (c, d)
+)
+----
+
+# Insert with constant input.
+# Add inequality filters for the primary key columns that are not part of each
+# unique constraint to prevent rows from matching themselves in the semi join.
+build
+INSERT INTO uniq_overlaps_pk VALUES (1, 1, 1, 1), (2, 2, 2, 2)
+----
+insert uniq_overlaps_pk
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:6 => a:1
+ │    ├── column2:7 => b:2
+ │    ├── column3:8 => c:3
+ │    └── column4:9 => d:4
+ ├── input binding: &1
+ ├── values
+ │    ├── columns: column1:6!null column2:7!null column3:8!null column4:9!null
+ │    ├── (1, 1, 1, 1)
+ │    └── (2, 2, 2, 2)
+ └── unique-checks
+      ├── unique-checks-item: uniq_overlaps_pk(b,c)
+      │    └── semi-join (hash)
+      │         ├── columns: column2:10!null column3:11!null column1:12!null
+      │         ├── with-scan &1
+      │         │    ├── columns: column2:10!null column3:11!null column1:12!null
+      │         │    └── mapping:
+      │         │         ├──  column2:7 => column2:10
+      │         │         ├──  column3:8 => column3:11
+      │         │         └──  column1:6 => column1:12
+      │         ├── scan uniq_overlaps_pk
+      │         │    └── columns: a:13!null b:14!null c:15
+      │         └── filters
+      │              ├── column2:10 = b:14
+      │              ├── column3:11 = c:15
+      │              └── column1:12 != a:13
+      ├── unique-checks-item: uniq_overlaps_pk(a)
+      │    └── semi-join (hash)
+      │         ├── columns: column1:18!null column2:19!null
+      │         ├── with-scan &1
+      │         │    ├── columns: column1:18!null column2:19!null
+      │         │    └── mapping:
+      │         │         ├──  column1:6 => column1:18
+      │         │         └──  column2:7 => column2:19
+      │         ├── scan uniq_overlaps_pk
+      │         │    └── columns: a:20!null b:21!null
+      │         └── filters
+      │              ├── column1:18 = a:20
+      │              └── column2:19 != b:21
+      └── unique-checks-item: uniq_overlaps_pk(c,d)
+           └── semi-join (hash)
+                ├── columns: column3:25!null column4:26!null column1:27!null column2:28!null
+                ├── with-scan &1
+                │    ├── columns: column3:25!null column4:26!null column1:27!null column2:28!null
+                │    └── mapping:
+                │         ├──  column3:8 => column3:25
+                │         ├──  column4:9 => column4:26
+                │         ├──  column1:6 => column1:27
+                │         └──  column2:7 => column2:28
+                ├── scan uniq_overlaps_pk
+                │    └── columns: a:29!null b:30!null c:31 d:32
+                └── filters
+                     ├── column3:25 = c:31
+                     ├── column4:26 = d:32
+                     └── (column1:27 != a:29) OR (column2:28 != b:30)
+
+# Insert with non-constant input.
+# Add inequality filters for the primary key columns that are not part of each
+# unique constraint to prevent rows from matching themselves in the semi join.
+build
+INSERT INTO uniq_overlaps_pk SELECT k, v, x, y FROM other
+----
+insert uniq_overlaps_pk
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── other.k:6 => a:1
+ │    ├── other.v:7 => b:2
+ │    ├── other.x:9 => c:3
+ │    └── other.y:10 => d:4
+ ├── input binding: &1
+ ├── project
+ │    ├── columns: other.k:6 other.v:7 other.x:9 other.y:10
+ │    └── scan other
+ │         └── columns: other.k:6 other.v:7 w:8!null other.x:9 other.y:10 rowid:11!null other.crdb_internal_mvcc_timestamp:12
+ └── unique-checks
+      ├── unique-checks-item: uniq_overlaps_pk(b,c)
+      │    └── semi-join (hash)
+      │         ├── columns: v:13 x:14 k:15
+      │         ├── with-scan &1
+      │         │    ├── columns: v:13 x:14 k:15
+      │         │    └── mapping:
+      │         │         ├──  other.v:7 => v:13
+      │         │         ├──  other.x:9 => x:14
+      │         │         └──  other.k:6 => k:15
+      │         ├── scan uniq_overlaps_pk
+      │         │    └── columns: a:16!null b:17!null c:18
+      │         └── filters
+      │              ├── v:13 = b:17
+      │              ├── x:14 = c:18
+      │              └── k:15 != a:16
+      ├── unique-checks-item: uniq_overlaps_pk(a)
+      │    └── semi-join (hash)
+      │         ├── columns: k:21 v:22
+      │         ├── with-scan &1
+      │         │    ├── columns: k:21 v:22
+      │         │    └── mapping:
+      │         │         ├──  other.k:6 => k:21
+      │         │         └──  other.v:7 => v:22
+      │         ├── scan uniq_overlaps_pk
+      │         │    └── columns: a:23!null b:24!null
+      │         └── filters
+      │              ├── k:21 = a:23
+      │              └── v:22 != b:24
+      └── unique-checks-item: uniq_overlaps_pk(c,d)
+           └── semi-join (hash)
+                ├── columns: x:28 y:29 k:30 v:31
+                ├── with-scan &1
+                │    ├── columns: x:28 y:29 k:30 v:31
+                │    └── mapping:
+                │         ├──  other.x:9 => x:28
+                │         ├──  other.y:10 => y:29
+                │         ├──  other.k:6 => k:30
+                │         └──  other.v:7 => v:31
+                ├── scan uniq_overlaps_pk
+                │    └── columns: a:32!null b:33!null c:34 d:35
+                └── filters
+                     ├── x:28 = c:34
+                     ├── y:29 = d:35
+                     └── (k:30 != a:32) OR (v:31 != b:33)
+
+exec-ddl
+CREATE TABLE uniq_hidden_pk (
+  a INT,
+  b INT,
+  c INT,
+  d INT,
+  UNIQUE WITHOUT INDEX (b, c),
+  UNIQUE WITHOUT INDEX (a, b, d),
+  UNIQUE WITHOUT INDEX (a)
+)
+----
+
+# Insert with constant input.
+# Add inequality filters for the hidden primary key column.
+build
+INSERT INTO uniq_hidden_pk VALUES (1, 1, 1, 1), (2, 2, 2, 2)
+----
+insert uniq_hidden_pk
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:7 => a:1
+ │    ├── column2:8 => b:2
+ │    ├── column3:9 => c:3
+ │    ├── column4:10 => d:4
+ │    └── column11:11 => rowid:5
+ ├── input binding: &1
+ ├── project
+ │    ├── columns: column11:11 column1:7!null column2:8!null column3:9!null column4:10!null
+ │    ├── values
+ │    │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null
+ │    │    ├── (1, 1, 1, 1)
+ │    │    └── (2, 2, 2, 2)
+ │    └── projections
+ │         └── unique_rowid() [as=column11:11]
+ └── unique-checks
+      ├── unique-checks-item: uniq_hidden_pk(b,c)
+      │    └── semi-join (hash)
+      │         ├── columns: column2:12!null column3:13!null column11:14
+      │         ├── with-scan &1
+      │         │    ├── columns: column2:12!null column3:13!null column11:14
+      │         │    └── mapping:
+      │         │         ├──  column2:8 => column2:12
+      │         │         ├──  column3:9 => column3:13
+      │         │         └──  column11:11 => column11:14
+      │         ├── scan uniq_hidden_pk
+      │         │    └── columns: b:16 c:17 rowid:19!null
+      │         └── filters
+      │              ├── column2:12 = b:16
+      │              ├── column3:13 = c:17
+      │              └── column11:14 != rowid:19
+      ├── unique-checks-item: uniq_hidden_pk(a,b,d)
+      │    └── semi-join (hash)
+      │         ├── columns: column1:21!null column2:22!null column4:23!null column11:24
+      │         ├── with-scan &1
+      │         │    ├── columns: column1:21!null column2:22!null column4:23!null column11:24
+      │         │    └── mapping:
+      │         │         ├──  column1:7 => column1:21
+      │         │         ├──  column2:8 => column2:22
+      │         │         ├──  column4:10 => column4:23
+      │         │         └──  column11:11 => column11:24
+      │         ├── scan uniq_hidden_pk
+      │         │    └── columns: a:25 b:26 d:28 rowid:29!null
+      │         └── filters
+      │              ├── column1:21 = a:25
+      │              ├── column2:22 = b:26
+      │              ├── column4:23 = d:28
+      │              └── column11:24 != rowid:29
+      └── unique-checks-item: uniq_hidden_pk(a)
+           └── semi-join (hash)
+                ├── columns: column1:31!null column11:32
+                ├── with-scan &1
+                │    ├── columns: column1:31!null column11:32
+                │    └── mapping:
+                │         ├──  column1:7 => column1:31
+                │         └──  column11:11 => column11:32
+                ├── scan uniq_hidden_pk
+                │    └── columns: a:33 rowid:37!null
+                └── filters
+                     ├── column1:31 = a:33
+                     └── column11:32 != rowid:37
+
+# Insert with non-constant input.
+# Add inequality filters for the hidden primary key column.
+build
+INSERT INTO uniq_hidden_pk SELECT k, v, x, y FROM other
+----
+insert uniq_hidden_pk
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── other.k:7 => a:1
+ │    ├── other.v:8 => b:2
+ │    ├── other.x:10 => c:3
+ │    ├── other.y:11 => d:4
+ │    └── column14:14 => uniq_hidden_pk.rowid:5
+ ├── input binding: &1
+ ├── project
+ │    ├── columns: column14:14 other.k:7 other.v:8 other.x:10 other.y:11
+ │    ├── project
+ │    │    ├── columns: other.k:7 other.v:8 other.x:10 other.y:11
+ │    │    └── scan other
+ │    │         └── columns: other.k:7 other.v:8 w:9!null other.x:10 other.y:11 other.rowid:12!null other.crdb_internal_mvcc_timestamp:13
+ │    └── projections
+ │         └── unique_rowid() [as=column14:14]
+ └── unique-checks
+      ├── unique-checks-item: uniq_hidden_pk(b,c)
+      │    └── semi-join (hash)
+      │         ├── columns: v:15 x:16 column14:17
+      │         ├── with-scan &1
+      │         │    ├── columns: v:15 x:16 column14:17
+      │         │    └── mapping:
+      │         │         ├──  other.v:8 => v:15
+      │         │         ├──  other.x:10 => x:16
+      │         │         └──  column14:14 => column14:17
+      │         ├── scan uniq_hidden_pk
+      │         │    └── columns: b:19 c:20 uniq_hidden_pk.rowid:22!null
+      │         └── filters
+      │              ├── v:15 = b:19
+      │              ├── x:16 = c:20
+      │              └── column14:17 != uniq_hidden_pk.rowid:22
+      ├── unique-checks-item: uniq_hidden_pk(a,b,d)
+      │    └── semi-join (hash)
+      │         ├── columns: k:24 v:25 y:26 column14:27
+      │         ├── with-scan &1
+      │         │    ├── columns: k:24 v:25 y:26 column14:27
+      │         │    └── mapping:
+      │         │         ├──  other.k:7 => k:24
+      │         │         ├──  other.v:8 => v:25
+      │         │         ├──  other.y:11 => y:26
+      │         │         └──  column14:14 => column14:27
+      │         ├── scan uniq_hidden_pk
+      │         │    └── columns: a:28 b:29 d:31 uniq_hidden_pk.rowid:32!null
+      │         └── filters
+      │              ├── k:24 = a:28
+      │              ├── v:25 = b:29
+      │              ├── y:26 = d:31
+      │              └── column14:27 != uniq_hidden_pk.rowid:32
+      └── unique-checks-item: uniq_hidden_pk(a)
+           └── semi-join (hash)
+                ├── columns: k:34 column14:35
+                ├── with-scan &1
+                │    ├── columns: k:34 column14:35
+                │    └── mapping:
+                │         ├──  other.k:7 => k:34
+                │         └──  column14:14 => column14:35
+                ├── scan uniq_hidden_pk
+                │    └── columns: a:36 uniq_hidden_pk.rowid:40!null
+                └── filters
+                     ├── k:34 = a:36
+                     └── column14:35 != uniq_hidden_pk.rowid:40

--- a/pkg/sql/opt/optbuilder/update.go
+++ b/pkg/sql/opt/optbuilder/update.go
@@ -341,6 +341,8 @@ func (mb *mutationBuilder) buildUpdate(returning tree.ReturningExprs) {
 			private.PassthroughCols = append(private.PassthroughCols, col.id)
 		}
 	}
-	mb.outScope.expr = mb.b.factory.ConstructUpdate(mb.outScope.expr, mb.checks, private)
+	mb.outScope.expr = mb.b.factory.ConstructUpdate(
+		mb.outScope.expr, mb.uniqueChecks, mb.fkChecks, private,
+	)
 	mb.buildReturning(returning)
 }

--- a/pkg/sql/opt/xform/testdata/rules/groupby
+++ b/pkg/sql/opt/xform/testdata/rules/groupby
@@ -1795,118 +1795,53 @@ memo
 INSERT INTO xyz SELECT v, w, 1.0 FROM kuvw ON CONFLICT (x) DO NOTHING
 ----
 memo (optimized, ~19KB, required=[])
- ├── G1: (insert G2 G3 xyz)
+ ├── G1: (insert G2 G3 G4 xyz)
  │    └── []
- │         ├── best: (insert G2 G3 xyz)
+ │         ├── best: (insert G2 G3 G4 xyz)
  │         └── cost: 2158.51
- ├── G2: (upsert-distinct-on G4 G5 cols=(7)) (upsert-distinct-on G4 G5 cols=(7),ordering=+7 opt(10,11))
+ ├── G2: (upsert-distinct-on G5 G6 cols=(7)) (upsert-distinct-on G5 G6 cols=(7),ordering=+7 opt(10,11))
  │    └── []
- │         ├── best: (upsert-distinct-on G4="[ordering: +7 opt(10,11)]" G5 cols=(7),ordering=+7 opt(10,11))
+ │         ├── best: (upsert-distinct-on G5="[ordering: +7 opt(10,11)]" G6 cols=(7),ordering=+7 opt(10,11))
  │         └── cost: 2158.50
- ├── G3: (f-k-checks)
- ├── G4: (select G6 G7)
+ ├── G3: (unique-checks)
+ ├── G4: (f-k-checks)
+ ├── G5: (select G7 G8)
  │    ├── [ordering: +7 opt(10,11)]
- │    │    ├── best: (select G6="[ordering: +7 opt(10,11)]" G7)
+ │    │    ├── best: (select G7="[ordering: +7 opt(10,11)]" G8)
  │    │    └── cost: 2158.08
  │    └── []
- │         ├── best: (select G6 G7)
+ │         ├── best: (select G7 G8)
  │         └── cost: 2158.08
- ├── G5: (aggregations G8 G9)
- ├── G6: (left-join G10 G11 G12) (right-join G11 G10 G12) (merge-join G10 G11 G13 left-join,+7,+11) (lookup-join G10 G13 xyz,keyCols=[7],outCols=(7,8,10,11)) (lookup-join G10 G13 xyz@xy,keyCols=[7],outCols=(7,8,10,11)) (merge-join G11 G10 G13 right-join,+11,+7)
+ ├── G6: (aggregations G9 G10)
+ ├── G7: (left-join G11 G12 G13) (right-join G12 G11 G13) (merge-join G11 G12 G14 left-join,+7,+11) (lookup-join G11 G14 xyz,keyCols=[7],outCols=(7,8,10,11)) (lookup-join G11 G14 xyz@xy,keyCols=[7],outCols=(7,8,10,11)) (merge-join G12 G11 G14 right-join,+11,+7)
  │    ├── [ordering: +7 opt(10,11)]
- │    │    ├── best: (merge-join G10="[ordering: +7 opt(10)]" G11="[ordering: +11]" G13 left-join,+7,+11)
+ │    │    ├── best: (merge-join G11="[ordering: +7 opt(10)]" G12="[ordering: +11]" G14 left-join,+7,+11)
  │    │    └── cost: 2148.06
  │    └── []
- │         ├── best: (merge-join G10="[ordering: +7 opt(10)]" G11="[ordering: +11]" G13 left-join,+7,+11)
+ │         ├── best: (merge-join G11="[ordering: +7 opt(10)]" G12="[ordering: +11]" G14 left-join,+7,+11)
  │         └── cost: 2148.06
- ├── G7: (filters G14)
- ├── G8: (first-agg G15)
+ ├── G8: (filters G15)
  ├── G9: (first-agg G16)
- ├── G10: (project G17 G18 v w)
- │    ├── [ordering: +7 opt(10)]
- │    │    ├── best: (project G17="[ordering: +7]" G18 v w)
- │    │    └── cost: 1084.03
- │    └── []
- │         ├── best: (project G17 G18 v w)
- │         └── cost: 1084.03
- ├── G11: (scan xyz,cols=(11)) (scan xyz@xy,cols=(11)) (scan xyz@zyx,cols=(11)) (scan xyz@yy,cols=(11))
- │    ├── [ordering: +11]
- │    │    ├── best: (scan xyz@xy,cols=(11))
- │    │    └── cost: 1034.02
- │    └── []
- │         ├── best: (scan xyz@xy,cols=(11))
- │         └── cost: 1034.02
- ├── G12: (filters G19)
- ├── G13: (filters)
- ├── G14: (is G20 G21)
- ├── G15: (variable w)
- ├── G16: (variable "?column?")
- ├── G17: (scan kuvw,cols=(7,8)) (scan kuvw@uvw,cols=(7,8)) (scan kuvw@wvu,cols=(7,8)) (scan kuvw@vw,cols=(7,8)) (scan kuvw@w,cols=(7,8))
- │    ├── [ordering: +7]
- │    │    ├── best: (scan kuvw@vw,cols=(7,8))
- │    │    └── cost: 1064.02
- │    └── []
- │         ├── best: (scan kuvw,cols=(7,8))
- │         └── cost: 1064.02
- ├── G18: (projections G22)
- ├── G19: (eq G23 G20)
- ├── G20: (variable x)
- ├── G21: (null)
- ├── G22: (const 1.0)
- └── G23: (variable v)
-
-# Ensure that streaming ensure-upsert-distinct-on will be used.
-memo
-INSERT INTO xyz SELECT v, w, 1.0 FROM kuvw ON CONFLICT (x) DO UPDATE SET z=2.0
-----
-memo (optimized, ~22KB, required=[])
- ├── G1: (upsert G2 G3 xyz)
- │    └── []
- │         ├── best: (upsert G2 G3 xyz)
- │         └── cost: 2238.10
- ├── G2: (project G4 G5 v w ?column? x y z)
- │    └── []
- │         ├── best: (project G4 G5 v w ?column? x y z)
- │         └── cost: 2238.09
- ├── G3: (f-k-checks)
- ├── G4: (left-join G6 G7 G8) (right-join G7 G6 G8) (lookup-join G6 G9 xyz,keyCols=[7],outCols=(7,8,10-13)) (lookup-join G10 G9 xyz,keyCols=[11],outCols=(7,8,10-13)) (merge-join G7 G6 G9 right-join,+11,+7)
- │    └── []
- │         ├── best: (merge-join G7="[ordering: +11]" G6="[ordering: +7 opt(10)]" G9 right-join,+11,+7)
- │         └── cost: 2218.08
- ├── G5: (projections G11)
- ├── G6: (ensure-upsert-distinct-on G12 G13 cols=(7)) (ensure-upsert-distinct-on G12 G13 cols=(7),ordering=+7 opt(10))
- │    ├── [ordering: +7 opt(10)]
- │    │    ├── best: (ensure-upsert-distinct-on G12="[ordering: +7 opt(10)]" G13 cols=(7))
- │    │    └── cost: 1124.05
- │    └── []
- │         ├── best: (ensure-upsert-distinct-on G12="[ordering: +7 opt(10)]" G13 cols=(7),ordering=+7 opt(10))
- │         └── cost: 1124.05
- ├── G7: (scan xyz,cols=(11-13)) (scan xyz@zyx,cols=(11-13))
- │    ├── [ordering: +11]
- │    │    ├── best: (scan xyz,cols=(11-13))
- │    │    └── cost: 1064.02
- │    └── []
- │         ├── best: (scan xyz,cols=(11-13))
- │         └── cost: 1064.02
- ├── G8: (filters G14)
- ├── G9: (filters)
- ├── G10: (lookup-join G6 G9 xyz@xy,keyCols=[7],outCols=(7,8,10-12))
- │    └── []
- │         ├── best: (lookup-join G6 G9 xyz@xy,keyCols=[7],outCols=(7,8,10-12))
- │         └── cost: 7174.06
- ├── G11: (case G15 G16 G17)
- ├── G12: (project G18 G19 v w)
+ ├── G10: (first-agg G17)
+ ├── G11: (project G18 G19 v w)
  │    ├── [ordering: +7 opt(10)]
  │    │    ├── best: (project G18="[ordering: +7]" G19 v w)
  │    │    └── cost: 1084.03
  │    └── []
  │         ├── best: (project G18 G19 v w)
  │         └── cost: 1084.03
- ├── G13: (aggregations G20 G21)
- ├── G14: (eq G22 G23)
- ├── G15: (true)
- ├── G16: (scalar-list G24)
- ├── G17: (const 2.0)
+ ├── G12: (scan xyz,cols=(11)) (scan xyz@xy,cols=(11)) (scan xyz@zyx,cols=(11)) (scan xyz@yy,cols=(11))
+ │    ├── [ordering: +11]
+ │    │    ├── best: (scan xyz@xy,cols=(11))
+ │    │    └── cost: 1034.02
+ │    └── []
+ │         ├── best: (scan xyz@xy,cols=(11))
+ │         └── cost: 1034.02
+ ├── G13: (filters G20)
+ ├── G14: (filters)
+ ├── G15: (is G21 G22)
+ ├── G16: (variable w)
+ ├── G17: (variable "?column?")
  ├── G18: (scan kuvw,cols=(7,8)) (scan kuvw@uvw,cols=(7,8)) (scan kuvw@wvu,cols=(7,8)) (scan kuvw@vw,cols=(7,8)) (scan kuvw@w,cols=(7,8))
  │    ├── [ordering: +7]
  │    │    ├── best: (scan kuvw@vw,cols=(7,8))
@@ -1914,14 +1849,81 @@ memo (optimized, ~22KB, required=[])
  │    └── []
  │         ├── best: (scan kuvw,cols=(7,8))
  │         └── cost: 1064.02
- ├── G19: (projections G25)
- ├── G20: (first-agg G26)
+ ├── G19: (projections G23)
+ ├── G20: (eq G24 G21)
+ ├── G21: (variable x)
+ ├── G22: (null)
+ ├── G23: (const 1.0)
+ └── G24: (variable v)
+
+# Ensure that streaming ensure-upsert-distinct-on will be used.
+memo
+INSERT INTO xyz SELECT v, w, 1.0 FROM kuvw ON CONFLICT (x) DO UPDATE SET z=2.0
+----
+memo (optimized, ~22KB, required=[])
+ ├── G1: (upsert G2 G3 G4 xyz)
+ │    └── []
+ │         ├── best: (upsert G2 G3 G4 xyz)
+ │         └── cost: 2238.10
+ ├── G2: (project G5 G6 v w ?column? x y z)
+ │    └── []
+ │         ├── best: (project G5 G6 v w ?column? x y z)
+ │         └── cost: 2238.09
+ ├── G3: (unique-checks)
+ ├── G4: (f-k-checks)
+ ├── G5: (left-join G7 G8 G9) (right-join G8 G7 G9) (lookup-join G7 G10 xyz,keyCols=[7],outCols=(7,8,10-13)) (lookup-join G11 G10 xyz,keyCols=[11],outCols=(7,8,10-13)) (merge-join G8 G7 G10 right-join,+11,+7)
+ │    └── []
+ │         ├── best: (merge-join G8="[ordering: +11]" G7="[ordering: +7 opt(10)]" G10 right-join,+11,+7)
+ │         └── cost: 2218.08
+ ├── G6: (projections G12)
+ ├── G7: (ensure-upsert-distinct-on G13 G14 cols=(7)) (ensure-upsert-distinct-on G13 G14 cols=(7),ordering=+7 opt(10))
+ │    ├── [ordering: +7 opt(10)]
+ │    │    ├── best: (ensure-upsert-distinct-on G13="[ordering: +7 opt(10)]" G14 cols=(7))
+ │    │    └── cost: 1124.05
+ │    └── []
+ │         ├── best: (ensure-upsert-distinct-on G13="[ordering: +7 opt(10)]" G14 cols=(7),ordering=+7 opt(10))
+ │         └── cost: 1124.05
+ ├── G8: (scan xyz,cols=(11-13)) (scan xyz@zyx,cols=(11-13))
+ │    ├── [ordering: +11]
+ │    │    ├── best: (scan xyz,cols=(11-13))
+ │    │    └── cost: 1064.02
+ │    └── []
+ │         ├── best: (scan xyz,cols=(11-13))
+ │         └── cost: 1064.02
+ ├── G9: (filters G15)
+ ├── G10: (filters)
+ ├── G11: (lookup-join G7 G10 xyz@xy,keyCols=[7],outCols=(7,8,10-12))
+ │    └── []
+ │         ├── best: (lookup-join G7 G10 xyz@xy,keyCols=[7],outCols=(7,8,10-12))
+ │         └── cost: 7174.06
+ ├── G12: (case G16 G17 G18)
+ ├── G13: (project G19 G20 v w)
+ │    ├── [ordering: +7 opt(10)]
+ │    │    ├── best: (project G19="[ordering: +7]" G20 v w)
+ │    │    └── cost: 1084.03
+ │    └── []
+ │         ├── best: (project G19 G20 v w)
+ │         └── cost: 1084.03
+ ├── G14: (aggregations G21 G22)
+ ├── G15: (eq G23 G24)
+ ├── G16: (true)
+ ├── G17: (scalar-list G25)
+ ├── G18: (const 2.0)
+ ├── G19: (scan kuvw,cols=(7,8)) (scan kuvw@uvw,cols=(7,8)) (scan kuvw@wvu,cols=(7,8)) (scan kuvw@vw,cols=(7,8)) (scan kuvw@w,cols=(7,8))
+ │    ├── [ordering: +7]
+ │    │    ├── best: (scan kuvw@vw,cols=(7,8))
+ │    │    └── cost: 1064.02
+ │    └── []
+ │         ├── best: (scan kuvw,cols=(7,8))
+ │         └── cost: 1064.02
+ ├── G20: (projections G26)
  ├── G21: (first-agg G27)
- ├── G22: (variable v)
- ├── G23: (variable x)
- ├── G24: (when G28 G27)
- ├── G25: (const 1.0)
- ├── G26: (variable w)
- ├── G27: (variable "?column?")
- ├── G28: (is G23 G29)
- └── G29: (null)
+ ├── G22: (first-agg G28)
+ ├── G23: (variable v)
+ ├── G24: (variable x)
+ ├── G25: (when G29 G28)
+ ├── G26: (const 1.0)
+ ├── G27: (variable w)
+ ├── G28: (variable "?column?")
+ ├── G29: (is G24 G30)
+ └── G30: (null)

--- a/pkg/sql/sqltelemetry/planning.go
+++ b/pkg/sql/sqltelemetry/planning.go
@@ -33,6 +33,10 @@ var SubqueryUseCounter = telemetry.GetCounterOnce("sql.plan.subquery")
 // correlated subquery has been processed during planning.
 var CorrelatedSubqueryUseCounter = telemetry.GetCounterOnce("sql.plan.subquery.correlated")
 
+// UniqueChecksUseCounter is to be incremented every time a mutation has
+// unique checks and the checks are planned by the optimizer.
+var UniqueChecksUseCounter = telemetry.GetCounterOnce("sql.plan.unique.checks")
+
 // ForeignKeyChecksUseCounter is to be incremented every time a mutation has
 // foreign key checks and the checks are planned by the optimizer.
 var ForeignKeyChecksUseCounter = telemetry.GetCounterOnce("sql.plan.fk.checks")


### PR DESCRIPTION
This commit adds checks for unique constraints when planning insertions
in the optimizer. This does not yet impact anything outside of the optimizer
tests, since `UNIQUE WITHOUT INDEX` is still not supported outside of the
optimizer test catalog.

Informs #41535

Release note: None