### PR TITLE
build: fix teamcity-compose.sh to actually run compose tests

### DIFF
--- a/build/teamcity-compose.sh
+++ b/build/teamcity-compose.sh
@@ -24,7 +24,6 @@ tc_end_block "Compile compose tests"
 tc_start_block "Run compose tests"
 # NB: apply the same trick as teamcity-acceptance.sh
 run_json_test stdbuf -eL -oL go test \
-  -mod=vendor -json -v -timeout 30m \
-  -exec "../../build/teamcity-go-test-precompiled.sh ./pkg/compose/compose.test" ./pkg/compose \
-	-l "$TMPDIR"
+  -mod=vendor -json -v -timeout 30m -tags compose \
+  -exec "../../build/teamcity-go-test-precompiled.sh ./pkg/compose/compose.test -artifacts \"$TMPDIR\"" ./pkg/compose
 tc_end_block "Run compose tests"

--- a/pkg/compose/compare/docker-compose.yml
+++ b/pkg/compose/compare/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   postgres:
-    image: postgres:11
+    image: postgis/postgis:11-3.0
     environment:
       - POSTGRES_INITDB_ARGS=--locale=C
       - POSTGRES_HOST_AUTH_METHOD=trust


### PR DESCRIPTION
Seems like this is long broken.

Seems to have broken since at least
`4efc606ade5c404d99274f6e9d0ff97ddd6271ae`.

Release note: None