### PR TITLE
colexec: make hash joiner more dynamic

### DIFF
--- a/pkg/sql/catalog/descpb/join_type.go
+++ b/pkg/sql/catalog/descpb/join_type.go
@@ -89,3 +89,21 @@ func (j JoinType) IsEmptyOutputWhenRightIsEmpty() bool {
 		return false
 	}
 }
+
+// IsLeftOuterOrFullOuter returns whether j is either LEFT OUTER or FULL OUTER
+// join type.
+func (j JoinType) IsLeftOuterOrFullOuter() bool {
+	return j == LeftOuterJoin || j == FullOuterJoin
+}
+
+// IsLeftAntiOrExceptAll returns whether j is either LEFT ANTI or EXCEPT ALL
+// join type.
+func (j JoinType) IsLeftAntiOrExceptAll() bool {
+	return j == LeftAntiJoin || j == ExceptAllJoin
+}
+
+// IsRightSemiOrRightAnti returns whether j is either RIGHT SEMI or RIGHT ANTI
+// join type.
+func (j JoinType) IsRightSemiOrRightAnti() bool {
+	return j == RightSemiJoin || j == RightAntiJoin
+}

--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -860,7 +860,7 @@ func NewColOperator(
 			// joiner, in order to handle NULL values correctly, needs to think
 			// that an empty set of equality columns doesn't form a key.
 			rightEqColsAreKey := core.HashJoiner.RightEqColumnsAreKey && len(core.HashJoiner.RightEqColumns) > 0
-			hjSpec, err := colexec.MakeHashJoinerSpec(
+			hjSpec := colexec.MakeHashJoinerSpec(
 				core.HashJoiner.Type,
 				core.HashJoiner.LeftEqColumns,
 				core.HashJoiner.RightEqColumns,
@@ -868,9 +868,6 @@ func NewColOperator(
 				rightTypes,
 				rightEqColsAreKey,
 			)
-			if err != nil {
-				return r, err
-			}
 
 			inMemoryHashJoiner := colexec.NewHashJoiner(
 				colmem.NewAllocator(ctx, hashJoinerMemAccount, factory),

--- a/pkg/sql/colexec/hashjoiner.eg.go
+++ b/pkg/sql/colexec/hashjoiner.eg.go
@@ -9,10 +9,7 @@
 
 package colexec
 
-import (
-	"github.com/cockroachdb/cockroach/pkg/col/coldata"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
-)
+import "github.com/cockroachdb/cockroach/pkg/col/coldata"
 
 const _ = "template_collectProbeOuter"
 
@@ -24,7 +21,7 @@ func collectProbeOuter_false(
 		currentID := hj.ht.probeScratch.headID[i]
 
 		for {
-			if nResults >= coldata.BatchSize() {
+			if nResults == len(hj.probeState.buildIdx) {
 				hj.probeState.prevBatch = batch
 				hj.probeState.prevBatchResumeIdx = i
 				return nResults
@@ -71,7 +68,7 @@ func collectProbeOuter_true(
 		currentID := hj.ht.probeScratch.headID[i]
 
 		for {
-			if nResults >= coldata.BatchSize() {
+			if nResults == len(hj.probeState.buildIdx) {
 				hj.probeState.prevBatch = batch
 				hj.probeState.prevBatchResumeIdx = i
 				return nResults
@@ -118,7 +115,7 @@ func collectProbeNoOuter_false(
 	for i := hj.probeState.prevBatchResumeIdx; i < batchSize; i++ {
 		currentID := hj.ht.probeScratch.headID[i]
 		for currentID != 0 {
-			if nResults >= coldata.BatchSize() {
+			if nResults == len(hj.probeState.buildIdx) {
 				hj.probeState.prevBatch = batch
 				hj.probeState.prevBatchResumeIdx = i
 				return nResults
@@ -150,7 +147,7 @@ func collectProbeNoOuter_true(
 	for i := hj.probeState.prevBatchResumeIdx; i < batchSize; i++ {
 		currentID := hj.ht.probeScratch.headID[i]
 		for currentID != 0 {
-			if nResults >= coldata.BatchSize() {
+			if nResults == len(hj.probeState.buildIdx) {
 				hj.probeState.prevBatch = batch
 				hj.probeState.prevBatchResumeIdx = i
 				return nResults
@@ -370,12 +367,12 @@ func distinctCollectProbeNoOuter_true(
 func (hj *hashJoiner) collect(batch coldata.Batch, batchSize int, sel []int) int {
 	nResults := int(0)
 
-	if hj.spec.joinType == descpb.RightSemiJoin || hj.spec.joinType == descpb.RightAntiJoin {
+	if hj.spec.joinType.IsRightSemiOrRightAnti() {
 		collectRightSemiAnti(hj, batchSize)
 		return 0
 	}
 
-	if hj.spec.left.outer {
+	if hj.spec.joinType.IsLeftOuterOrFullOuter() {
 		if sel != nil {
 			nResults = collectProbeOuter_true(hj, batchSize, nResults, batch, sel)
 		} else {
@@ -383,17 +380,15 @@ func (hj *hashJoiner) collect(batch coldata.Batch, batchSize int, sel []int) int
 		}
 	} else {
 		if sel != nil {
-			switch hj.spec.joinType {
-			case descpb.LeftAntiJoin, descpb.ExceptAllJoin:
+			if hj.spec.joinType.IsLeftAntiOrExceptAll() {
 				nResults = collectLeftAnti_true(hj, batchSize, nResults, batch, sel)
-			default:
+			} else {
 				nResults = collectProbeNoOuter_true(hj, batchSize, nResults, batch, sel)
 			}
 		} else {
-			switch hj.spec.joinType {
-			case descpb.LeftAntiJoin, descpb.ExceptAllJoin:
+			if hj.spec.joinType.IsLeftAntiOrExceptAll() {
 				nResults = collectLeftAnti_false(hj, batchSize, nResults, batch, sel)
-			default:
+			} else {
 				nResults = collectProbeNoOuter_false(hj, batchSize, nResults, batch, sel)
 			}
 		}
@@ -408,12 +403,12 @@ func (hj *hashJoiner) collect(batch coldata.Batch, batchSize int, sel []int) int
 func (hj *hashJoiner) distinctCollect(batch coldata.Batch, batchSize int, sel []int) int {
 	nResults := int(0)
 
-	if hj.spec.joinType == descpb.RightSemiJoin || hj.spec.joinType == descpb.RightAntiJoin {
+	if hj.spec.joinType.IsRightSemiOrRightAnti() {
 		collectRightSemiAnti(hj, batchSize)
 		return 0
 	}
 
-	if hj.spec.left.outer {
+	if hj.spec.joinType.IsLeftOuterOrFullOuter() {
 		nResults = batchSize
 
 		if sel != nil {
@@ -423,23 +418,21 @@ func (hj *hashJoiner) distinctCollect(batch coldata.Batch, batchSize int, sel []
 		}
 	} else {
 		if sel != nil {
-			switch hj.spec.joinType {
-			case descpb.LeftAntiJoin, descpb.ExceptAllJoin:
+			if hj.spec.joinType.IsLeftAntiOrExceptAll() {
 				// For LEFT ANTI and EXCEPT ALL joins we don't care whether the build
 				// (right) side was distinct, so we only have single variation of COLLECT
 				// method.
 				nResults = collectLeftAnti_true(hj, batchSize, nResults, batch, sel)
-			default:
+			} else {
 				nResults = distinctCollectProbeNoOuter_true(hj, batchSize, nResults, sel)
 			}
 		} else {
-			switch hj.spec.joinType {
-			case descpb.LeftAntiJoin, descpb.ExceptAllJoin:
+			if hj.spec.joinType.IsLeftAntiOrExceptAll() {
 				// For LEFT ANTI and EXCEPT ALL joins we don't care whether the build
 				// (right) side was distinct, so we only have single variation of COLLECT
 				// method.
 				nResults = collectLeftAnti_false(hj, batchSize, nResults, batch, sel)
-			default:
+			} else {
 				nResults = distinctCollectProbeNoOuter_false(hj, batchSize, nResults, sel)
 			}
 		}

--- a/pkg/sql/colexec/hashjoiner.eg.go
+++ b/pkg/sql/colexec/hashjoiner.eg.go
@@ -30,15 +30,16 @@ func collectProbeOuter_false(
 				return nResults
 			}
 
-			hj.probeState.probeRowUnmatched[nResults] = currentID == 0
-			if currentID > 0 {
-				hj.probeState.buildIdx[nResults] = int(currentID - 1)
-			} else {
-				// If currentID == 0, then probeRowUnmatched will have been set - and
-				// we set the corresponding buildIdx to zero so that (as long as the
-				// build hash table has at least one row) we can copy the values vector
-				// without paying attention to probeRowUnmatched.
+			rowUnmatched := currentID == 0
+			hj.probeState.probeRowUnmatched[nResults] = rowUnmatched
+			if rowUnmatched {
+				// The row is unmatched, and we set the corresponding buildIdx
+				// to zero so that (as long as the build hash table has at least
+				// one row) we can copy the values vector without paying
+				// attention to probeRowUnmatched.
 				hj.probeState.buildIdx[nResults] = 0
+			} else {
+				hj.probeState.buildIdx[nResults] = int(currentID - 1)
 			}
 			{
 				var __retval_0 int
@@ -76,15 +77,16 @@ func collectProbeOuter_true(
 				return nResults
 			}
 
-			hj.probeState.probeRowUnmatched[nResults] = currentID == 0
-			if currentID > 0 {
-				hj.probeState.buildIdx[nResults] = int(currentID - 1)
-			} else {
-				// If currentID == 0, then probeRowUnmatched will have been set - and
-				// we set the corresponding buildIdx to zero so that (as long as the
-				// build hash table has at least one row) we can copy the values vector
-				// without paying attention to probeRowUnmatched.
+			rowUnmatched := currentID == 0
+			hj.probeState.probeRowUnmatched[nResults] = rowUnmatched
+			if rowUnmatched {
+				// The row is unmatched, and we set the corresponding buildIdx
+				// to zero so that (as long as the build hash table has at least
+				// one row) we can copy the values vector without paying
+				// attention to probeRowUnmatched.
 				hj.probeState.buildIdx[nResults] = 0
+			} else {
+				hj.probeState.buildIdx[nResults] = int(currentID - 1)
 			}
 			{
 				var __retval_0 int
@@ -255,7 +257,13 @@ func distinctCollectProbeOuter_false(hj *hashJoiner, batchSize int, sel []int) {
 		id := hj.ht.probeScratch.groupID[i]
 		rowUnmatched := id == 0
 		hj.probeState.probeRowUnmatched[i] = rowUnmatched
-		if !rowUnmatched {
+		if rowUnmatched {
+			// The row is unmatched, and we set the corresponding buildIdx
+			// to zero so that (as long as the build hash table has at least
+			// one row) we can copy the values vector without paying
+			// attention to probeRowUnmatched.
+			hj.probeState.buildIdx[i] = 0
+		} else {
 			hj.probeState.buildIdx[i] = int(id - 1)
 		}
 		{
@@ -282,7 +290,13 @@ func distinctCollectProbeOuter_true(hj *hashJoiner, batchSize int, sel []int) {
 		id := hj.ht.probeScratch.groupID[i]
 		rowUnmatched := id == 0
 		hj.probeState.probeRowUnmatched[i] = rowUnmatched
-		if !rowUnmatched {
+		if rowUnmatched {
+			// The row is unmatched, and we set the corresponding buildIdx
+			// to zero so that (as long as the build hash table has at least
+			// one row) we can copy the values vector without paying
+			// attention to probeRowUnmatched.
+			hj.probeState.buildIdx[i] = 0
+		} else {
 			hj.probeState.buildIdx[i] = int(id - 1)
 		}
 		{

--- a/pkg/sql/colexec/hashjoiner.go
+++ b/pkg/sql/colexec/hashjoiner.go
@@ -77,9 +77,6 @@ type hashJoinerSourceSpec struct {
 	// sourceTypes specify the types of the input columns of the source table for
 	// the hash joiner.
 	sourceTypes []*types.T
-
-	// outer specifies whether an outer join is required over the input.
-	outer bool
 }
 
 // hashJoiner performs a hash join on the input tables equality columns.
@@ -198,11 +195,10 @@ type hashJoiner struct {
 		buildIdx []int
 		probeIdx []int
 
-		// probeRowUnmatched is used in the case that the spec.left.outer is true.
-		// This means that an outer join is performed on the probe side and we use
-		// probeRowUnmatched to represent that the resulting columns should be NULL on
-		// the build table. This indicates that the probe table row did not match any
-		// build table rows.
+		// probeRowUnmatched is used in the case of left/full outer joins. We
+		// use probeRowUnmatched to represent that the resulting columns should
+		// be NULL on the build table. This indicates that the probe table row
+		// did not match any build table rows.
 		probeRowUnmatched []bool
 		// buildRowMatched is used in the case that spec.trackBuildMatches is true. This
 		// means that an outer join is performed on the build side and buildRowMatched
@@ -314,7 +310,7 @@ func (hj *hashJoiner) build(ctx context.Context) {
 
 	// We might have duplicates in the hash table, so we need to set up
 	// same and visited slices for the prober.
-	if !hj.spec.rightDistinct && hj.spec.joinType != descpb.LeftAntiJoin && hj.spec.joinType != descpb.ExceptAllJoin {
+	if !hj.spec.rightDistinct && !hj.spec.joinType.IsLeftAntiOrExceptAll() {
 		// We don't need same with LEFT ANTI and EXCEPT ALL joins because
 		// they have separate collectLeftAnti method.
 		hj.ht.same = maybeAllocateUint64Array(hj.ht.same, hj.ht.vals.Length()+1)
@@ -345,6 +341,19 @@ func (hj *hashJoiner) build(ctx context.Context) {
 // didn't get a match when matched==false (right/full outer and right anti
 // joins) or did get a match when matched==true (right semi joins).
 func (hj *hashJoiner) emitRight(matched bool) {
+	// Make sure that hj.probeState.buildIdx is of sufficient size (it is used
+	// as a selection vector to select only the necessary tuples).
+	buildIdxSize := hj.ht.vals.Length() - hj.emittingRightState.rowIdx
+	if buildIdxSize > coldata.BatchSize() {
+		buildIdxSize = coldata.BatchSize()
+	}
+	if cap(hj.probeState.buildIdx) < buildIdxSize {
+		hj.probeState.buildIdx = make([]int, buildIdxSize)
+	} else {
+		hj.probeState.buildIdx = hj.probeState.buildIdx[:buildIdxSize]
+	}
+
+	// Find the next batch of tuples that have the requested 'matched' value.
 	nResults := 0
 	for nResults < coldata.BatchSize() && hj.emittingRightState.rowIdx < hj.ht.vals.Length() {
 		if hj.probeState.buildRowMatched[hj.emittingRightState.rowIdx] == matched {
@@ -390,6 +399,45 @@ func (hj *hashJoiner) emitRight(matched bool) {
 	})
 }
 
+// prepareForCollecting sets up the hash joiner for collecting by making sure
+// that various slices in hj.probeState are of sufficient length depending on
+// the join type. Note that batchSize might cap the number of tuples collected
+// in a single output batch (this is the case with non-distinct collectProbe*
+// methods).
+func (hj *hashJoiner) prepareForCollecting(batchSize int) {
+	if hj.spec.joinType.IsRightSemiOrRightAnti() {
+		// Right semi/anti joins have a separate collecting method that simply
+		// records the fact whether build rows had a match and don't need these
+		// probing slices.
+		return
+	}
+	// Note that we don't need to zero out the slices if they have enough
+	// capacity because the correct values will always be set in the collecting
+	// methods.
+	if cap(hj.probeState.probeIdx) < batchSize {
+		hj.probeState.probeIdx = make([]int, batchSize)
+	} else {
+		hj.probeState.probeIdx = hj.probeState.probeIdx[:batchSize]
+	}
+	if hj.spec.joinType.IsLeftAntiOrExceptAll() {
+		// Left anti and except all joins have special collectLeftAnti method
+		// that only uses probeIdx slice.
+		return
+	}
+	if hj.spec.joinType.IsLeftOuterOrFullOuter() {
+		if cap(hj.probeState.probeRowUnmatched) < batchSize {
+			hj.probeState.probeRowUnmatched = make([]bool, batchSize)
+		} else {
+			hj.probeState.probeRowUnmatched = hj.probeState.probeRowUnmatched[:batchSize]
+		}
+	}
+	if cap(hj.probeState.buildIdx) < batchSize {
+		hj.probeState.buildIdx = make([]int, batchSize)
+	} else {
+		hj.probeState.buildIdx = hj.probeState.buildIdx[:batchSize]
+	}
+}
+
 // exec is a general prober that works with non-distinct build table equality
 // columns. It returns a Batch with N + M columns where N is the number of
 // left source columns and M is the number of right source columns. The first N
@@ -398,12 +446,17 @@ func (hj *hashJoiner) emitRight(matched bool) {
 func (hj *hashJoiner) exec(ctx context.Context) coldata.Batch {
 	if batch := hj.probeState.prevBatch; batch != nil {
 		// The previous result was bigger than the maximum batch size, so we didn't
-		// finish outputting it in the last call to probe. Continue outputting the
+		// finish outputting it in the last call to exec. Continue outputting the
 		// result from the previous batch.
 		hj.probeState.prevBatch = nil
 		batchSize := batch.Length()
 		sel := batch.Selection()
 
+		// Since we're probing the same batch for the second time, it is likely
+		// that every probe tuple has multiple matches, so we want to maximize
+		// the number of tuples we collect in a single output batch, and,
+		// therefore, we use coldata.BatchSize() here.
+		hj.prepareForCollecting(coldata.BatchSize())
 		nResults := hj.collect(batch, batchSize, sel)
 		hj.congregate(nResults, batch)
 	} else {
@@ -433,6 +486,7 @@ func (hj *hashJoiner) exec(ctx context.Context) coldata.Batch {
 			hj.ht.computeBuckets(
 				ctx, hj.probeState.buckets, hj.ht.keys, batchSize, sel,
 			)
+
 			// Then, we initialize groupID with the initial hash buckets and
 			// toCheck with all applicable indices.
 			hj.ht.probeScratch.setupLimitedSlices(batchSize, hj.ht.buildMode)
@@ -460,6 +514,9 @@ func (hj *hashJoiner) exec(ctx context.Context) coldata.Batch {
 				nToCheck = uint64(batchSize)
 			}
 
+			// Now we collect all matches that we can emit in the probing phase
+			// in a single batch.
+			hj.prepareForCollecting(batchSize)
 			var nResults int
 			if hj.spec.rightDistinct {
 				for nToCheck > 0 {
@@ -545,7 +602,7 @@ func (hj *hashJoiner) congregate(nResults int, batch coldata.Batch) {
 					)
 				}
 			}
-			if hj.spec.left.outer {
+			if hj.spec.joinType.IsLeftOuterOrFullOuter() {
 				// Add in the nulls we needed to set for the outer join.
 				for i := range hj.spec.right.sourceTypes {
 					outCol := hj.output.ColVec(i + rightColOffset)
@@ -560,7 +617,7 @@ func (hj *hashJoiner) congregate(nResults int, batch coldata.Batch) {
 		}
 
 		if hj.spec.trackBuildMatches {
-			if hj.spec.left.outer {
+			if hj.spec.joinType.IsLeftOuterOrFullOuter() {
 				for i := 0; i < nResults; i++ {
 					if !hj.probeState.probeRowUnmatched[i] {
 						hj.probeState.buildRowMatched[hj.probeState.buildIdx[i]] = true
@@ -653,20 +710,8 @@ func MakeHashJoinerSpec(
 	leftTypes []*types.T,
 	rightTypes []*types.T,
 	rightDistinct bool,
-) (HashJoinerSpec, error) {
-	var (
-		spec                  HashJoinerSpec
-		leftOuter, rightOuter bool
-	)
+) HashJoinerSpec {
 	switch joinType {
-	case descpb.InnerJoin:
-	case descpb.RightOuterJoin:
-		rightOuter = true
-	case descpb.LeftOuterJoin:
-		leftOuter = true
-	case descpb.FullOuterJoin:
-		rightOuter = true
-		leftOuter = true
 	case descpb.LeftSemiJoin:
 		// In a left semi join, we don't need to store anything but a single row per
 		// build row, since all we care about is whether a row on the left matches
@@ -691,8 +736,6 @@ func MakeHashJoinerSpec(
 		// TODO(yuzefovich): refactor these joins to take advantage of the
 		// actual distinctness information.
 		rightDistinct = false
-	default:
-		return spec, errors.AssertionFailedf("hash join of type %s not supported", joinType)
 	}
 	var trackBuildMatches bool
 	switch joinType {
@@ -704,21 +747,18 @@ func MakeHashJoinerSpec(
 	left := hashJoinerSourceSpec{
 		eqCols:      leftEqCols,
 		sourceTypes: leftTypes,
-		outer:       leftOuter,
 	}
 	right := hashJoinerSourceSpec{
 		eqCols:      rightEqCols,
 		sourceTypes: rightTypes,
-		outer:       rightOuter,
 	}
-	spec = HashJoinerSpec{
+	return HashJoinerSpec{
 		joinType:          joinType,
 		left:              left,
 		right:             right,
 		trackBuildMatches: trackBuildMatches,
 		rightDistinct:     rightDistinct,
 	}
-	return spec, nil
 }
 
 // NewHashJoiner creates a new equality hash join operator on the left and
@@ -738,17 +778,11 @@ func NewHashJoiner(
 	if spec.joinType.ShouldIncludeRightColsInOutput() {
 		outputTypes = append(outputTypes, spec.right.sourceTypes...)
 	}
-	hj := &hashJoiner{
+	return &hashJoiner{
 		twoInputNode:             newTwoInputNode(leftSource, rightSource),
 		buildSideAllocator:       buildSideAllocator,
 		outputUnlimitedAllocator: outputUnlimitedAllocator,
 		spec:                     spec,
 		outputTypes:              outputTypes,
 	}
-	hj.probeState.buildIdx = make([]int, coldata.BatchSize())
-	hj.probeState.probeIdx = make([]int, coldata.BatchSize())
-	if spec.left.outer {
-		hj.probeState.probeRowUnmatched = make([]bool, coldata.BatchSize())
-	}
-	return hj
 }

--- a/pkg/sql/colexec/hashjoiner_test.go
+++ b/pkg/sql/colexec/hashjoiner_test.go
@@ -1082,13 +1082,12 @@ func BenchmarkHashJoiner(b *testing.B) {
 										if fullOuter {
 											joinType = descpb.FullOuterJoin
 										}
-										hjSpec, err := MakeHashJoinerSpec(
+										hjSpec := MakeHashJoinerSpec(
 											joinType,
 											[]uint32{0, 1}, []uint32{2, 3},
 											sourceTypes, sourceTypes,
 											rightDistinct,
 										)
-										require.NoError(b, err)
 										hj := NewHashJoiner(
 											testAllocator, testAllocator, hjSpec,
 											leftSource, rightSource,

--- a/pkg/sql/colexec/hashjoiner_tmpl.go
+++ b/pkg/sql/colexec/hashjoiner_tmpl.go
@@ -12,10 +12,7 @@
 
 package colexec
 
-import (
-	"github.com/cockroachdb/cockroach/pkg/col/coldata"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
-)
+import "github.com/cockroachdb/cockroach/pkg/col/coldata"
 
 // execgen:template<useSel>
 func collectProbeOuter(
@@ -30,7 +27,7 @@ func collectProbeOuter(
 		currentID := hj.ht.probeScratch.headID[i]
 
 		for {
-			if nResults >= coldata.BatchSize() {
+			if nResults == len(hj.probeState.buildIdx) {
 				hj.probeState.prevBatch = batch
 				hj.probeState.prevBatchResumeIdx = i
 				return nResults
@@ -72,7 +69,7 @@ func collectProbeNoOuter(
 	for i := hj.probeState.prevBatchResumeIdx; i < batchSize; i++ {
 		currentID := hj.ht.probeScratch.headID[i]
 		for currentID != 0 {
-			if nResults >= coldata.BatchSize() {
+			if nResults == len(hj.probeState.buildIdx) {
 				hj.probeState.prevBatch = batch
 				hj.probeState.prevBatchResumeIdx = i
 				return nResults
@@ -184,12 +181,12 @@ func distinctCollectProbeNoOuter(
 func (hj *hashJoiner) collect(batch coldata.Batch, batchSize int, sel []int) int {
 	nResults := int(0)
 
-	if hj.spec.joinType == descpb.RightSemiJoin || hj.spec.joinType == descpb.RightAntiJoin {
+	if hj.spec.joinType.IsRightSemiOrRightAnti() {
 		collectRightSemiAnti(hj, batchSize)
 		return 0
 	}
 
-	if hj.spec.left.outer {
+	if hj.spec.joinType.IsLeftOuterOrFullOuter() {
 		if sel != nil {
 			nResults = collectProbeOuter(hj, batchSize, nResults, batch, sel, true)
 		} else {
@@ -197,17 +194,15 @@ func (hj *hashJoiner) collect(batch coldata.Batch, batchSize int, sel []int) int
 		}
 	} else {
 		if sel != nil {
-			switch hj.spec.joinType {
-			case descpb.LeftAntiJoin, descpb.ExceptAllJoin:
+			if hj.spec.joinType.IsLeftAntiOrExceptAll() {
 				nResults = collectLeftAnti(hj, batchSize, nResults, batch, sel, true)
-			default:
+			} else {
 				nResults = collectProbeNoOuter(hj, batchSize, nResults, batch, sel, true)
 			}
 		} else {
-			switch hj.spec.joinType {
-			case descpb.LeftAntiJoin, descpb.ExceptAllJoin:
+			if hj.spec.joinType.IsLeftAntiOrExceptAll() {
 				nResults = collectLeftAnti(hj, batchSize, nResults, batch, sel, false)
-			default:
+			} else {
 				nResults = collectProbeNoOuter(hj, batchSize, nResults, batch, sel, false)
 			}
 		}
@@ -222,12 +217,12 @@ func (hj *hashJoiner) collect(batch coldata.Batch, batchSize int, sel []int) int
 func (hj *hashJoiner) distinctCollect(batch coldata.Batch, batchSize int, sel []int) int {
 	nResults := int(0)
 
-	if hj.spec.joinType == descpb.RightSemiJoin || hj.spec.joinType == descpb.RightAntiJoin {
+	if hj.spec.joinType.IsRightSemiOrRightAnti() {
 		collectRightSemiAnti(hj, batchSize)
 		return 0
 	}
 
-	if hj.spec.left.outer {
+	if hj.spec.joinType.IsLeftOuterOrFullOuter() {
 		nResults = batchSize
 
 		if sel != nil {
@@ -237,23 +232,21 @@ func (hj *hashJoiner) distinctCollect(batch coldata.Batch, batchSize int, sel []
 		}
 	} else {
 		if sel != nil {
-			switch hj.spec.joinType {
-			case descpb.LeftAntiJoin, descpb.ExceptAllJoin:
+			if hj.spec.joinType.IsLeftAntiOrExceptAll() {
 				// For LEFT ANTI and EXCEPT ALL joins we don't care whether the build
 				// (right) side was distinct, so we only have single variation of COLLECT
 				// method.
 				nResults = collectLeftAnti(hj, batchSize, nResults, batch, sel, true)
-			default:
+			} else {
 				nResults = distinctCollectProbeNoOuter(hj, batchSize, nResults, sel, true)
 			}
 		} else {
-			switch hj.spec.joinType {
-			case descpb.LeftAntiJoin, descpb.ExceptAllJoin:
+			if hj.spec.joinType.IsLeftAntiOrExceptAll() {
 				// For LEFT ANTI and EXCEPT ALL joins we don't care whether the build
 				// (right) side was distinct, so we only have single variation of COLLECT
 				// method.
 				nResults = collectLeftAnti(hj, batchSize, nResults, batch, sel, false)
-			default:
+			} else {
 				nResults = distinctCollectProbeNoOuter(hj, batchSize, nResults, sel, false)
 			}
 		}

--- a/pkg/sql/colexec/hashjoiner_tmpl.go
+++ b/pkg/sql/colexec/hashjoiner_tmpl.go
@@ -36,15 +36,16 @@ func collectProbeOuter(
 				return nResults
 			}
 
-			hj.probeState.probeRowUnmatched[nResults] = currentID == 0
-			if currentID > 0 {
-				hj.probeState.buildIdx[nResults] = int(currentID - 1)
-			} else {
-				// If currentID == 0, then probeRowUnmatched will have been set - and
-				// we set the corresponding buildIdx to zero so that (as long as the
-				// build hash table has at least one row) we can copy the values vector
-				// without paying attention to probeRowUnmatched.
+			rowUnmatched := currentID == 0
+			hj.probeState.probeRowUnmatched[nResults] = rowUnmatched
+			if rowUnmatched {
+				// The row is unmatched, and we set the corresponding buildIdx
+				// to zero so that (as long as the build hash table has at least
+				// one row) we can copy the values vector without paying
+				// attention to probeRowUnmatched.
 				hj.probeState.buildIdx[nResults] = 0
+			} else {
+				hj.probeState.buildIdx[nResults] = int(currentID - 1)
 			}
 			hj.probeState.probeIdx[nResults] = getIdx(i, sel, useSel)
 			currentID = hj.ht.same[currentID]
@@ -142,7 +143,13 @@ func distinctCollectProbeOuter(hj *hashJoiner, batchSize int, sel []int, useSel 
 		id := hj.ht.probeScratch.groupID[i]
 		rowUnmatched := id == 0
 		hj.probeState.probeRowUnmatched[i] = rowUnmatched
-		if !rowUnmatched {
+		if rowUnmatched {
+			// The row is unmatched, and we set the corresponding buildIdx
+			// to zero so that (as long as the build hash table has at least
+			// one row) we can copy the values vector without paying
+			// attention to probeRowUnmatched.
+			hj.probeState.buildIdx[i] = 0
+		} else {
 			hj.probeState.buildIdx[i] = int(id - 1)
 		}
 		hj.probeState.probeIdx[i] = getIdx(i, sel, useSel)


### PR DESCRIPTION
**colexec: clean up the hash joiner a bit**

When we have unmatched tuples from the left in case of left/full outer
hash joins, we still copy the whole vectors according to `buildIdx`
selection vector from the right side and then set nulls only for the
tuples that didn't have a match. Such approach is a lot more performant
then if we were to check for each tuple whether it had a match and copy
only the matched ones. This works ok since we assume that `buildIdx`
value for unmatched tuples is left as 0 which we didn't explicitly do in
distinctCollect variation. Note that it still worked correctly in all
cases (both in in-memory hash joiner and external hash joiner) because
we're zeroing out the slice when resetting (which is important for the
external hash joiner).

Given the observation that we're now always setting the correct values
in `buildIdx`, `probeIdx`, `probeRowUnmatched`, this commit additionally
removes zeroing out of those slices during resetting.

Release note: None

**colexec: make hash joiner more dynamic**

This commit refactors the hash joiner slightly in order to avoid
allocating slices with big fixed size which makes the algorithm more
dynamic.

Release note: None
