### PR TITLE
release-20.1: sql: fix panic when getting support bundle

### DIFF
--- a/pkg/sql/explain_bundle.go
+++ b/pkg/sql/explain_bundle.go
@@ -211,7 +211,16 @@ func (b *stmtBundleBuilder) addStatement() {
 	cfg.Simplify = true
 	cfg.Align = tree.PrettyNoAlign
 	cfg.JSONFmt = true
-	output := cfg.Pretty(b.plan.stmt.AST)
+	var output string
+	// If we hit an early error, stmt or stmt.AST might not be initialized yet.
+	switch {
+	case b.plan.stmt == nil:
+		output = "No Statement."
+	case b.plan.stmt.AST == nil:
+		output = "No AST."
+	default:
+		output = cfg.Pretty(b.plan.stmt.AST)
+	}
 
 	if b.placeholders != nil && len(b.placeholders.Values) != 0 {
 		var buf bytes.Buffer


### PR DESCRIPTION
Backport 1/1 commits from #56768.

/cc @cockroachdb/release

---

Check for nil `plan.stmt` and AST when finishing the support bundle.

Fixes #56705.

Release note (bug fix): fixed internal error when collecting a
statement diagnostic bundle in some cases where the query hits an
error.
