### PR TITLE
rowenc: fuzz a larger range of times for RandDatum

### DIFF
--- a/pkg/sql/rowenc/testutils.go
+++ b/pkg/sql/rowenc/testutils.go
@@ -151,7 +151,7 @@ func RandDatumWithNullChance(rng *rand.Rand, typ *types.T, nullChance int) tree.
 		).Round(tree.TimeFamilyPrecisionToRoundDuration(typ.Precision()))
 	case types.TimestampFamily:
 		return tree.MustMakeDTimestamp(
-			timeutil.Unix(rng.Int63n(1000000), rng.Int63n(1000000)),
+			timeutil.Unix(rng.Int63n(2000000000), rng.Int63n(1000000)),
 			tree.TimeFamilyPrecisionToRoundDuration(typ.Precision()),
 		)
 	case types.IntervalFamily:
@@ -202,7 +202,7 @@ func RandDatumWithNullChance(rng *rand.Rand, typ *types.T, nullChance int) tree.
 		return tree.NewDBytes(tree.DBytes(p))
 	case types.TimestampTZFamily:
 		return tree.MustMakeDTimestampTZ(
-			timeutil.Unix(rng.Int63n(1000000), rng.Int63n(1000000)),
+			timeutil.Unix(rng.Int63n(2000000000), rng.Int63n(1000000)),
 			tree.TimeFamilyPrecisionToRoundDuration(typ.Precision()),
 		)
 	case types.CollatedStringFamily:


### PR DESCRIPTION
Looks like we only fuzz very small ranges of times. Include a wider
range that spans multiple years.

Release note: None