### PR TITLE
util/stop: fix the race between `unregister` and `IsStopped`

### DIFF
--- a/pkg/util/stop/stopper_test.go
+++ b/pkg/util/stop/stopper_test.go
@@ -135,8 +135,10 @@ func TestStopperMultipleStopees(t *testing.T) {
 
 func TestStopperStartFinishTasks(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	s := stop.NewStopper()
+
 	ctx := context.Background()
+	s := stop.NewStopper()
+	defer s.Stop(ctx)
 
 	if err := s.RunTask(ctx, "test", func(ctx context.Context) {
 		go s.Stop(ctx)


### PR DESCRIPTION
Fixes #56795
Fixes #56772
Fixes #56731

Prior to this patch, `unregister()` was called after `s.stopped` was
closed, so that it was possible for the leaked stopper check to see
a stopped stopper still registered.

This patch fixes that by ensuring unregister is called before closing
`s.stopped`.

Release note: None