### PR TITLE
testcluster: keep tc.Conns under lock

### DIFF
--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -423,6 +423,8 @@ func (tc *TestCluster) startServer(idx int, serverArgs base.TestServerArgs) erro
 		return err
 	}
 
+	tc.mu.Lock()
+	defer tc.mu.Unlock()
 	tc.Conns = append(tc.Conns, dbConn)
 	return nil
 }


### PR DESCRIPTION
Fixes #56793 
Fixes #56792 

My previous PR #56729 mistakenly removed the locking around
`tc.Conns`. This patch re-introduces it.

Release note: None