### PR TITLE
demo: don't exit workload if there is an error

### DIFF
--- a/pkg/cli/demo_cluster.go
+++ b/pkg/cli/demo_cluster.go
@@ -715,11 +715,15 @@ func (c *transientCluster) runWorkload(
 						panic(err)
 					}
 					if err := f(ctx); err != nil {
-						// Only log an error and return when the workload function throws
-						// an error, because errors these errors should be ignored, and
-						// should not interrupt the rest of the demo.
+						// Log an error without exiting the load generator when the workload
+						// function throws an error. A single error during the workload demo
+						// should not stop the demo.
 						log.Warningf(ctx, "error running workload query: %+v", err)
+					}
+					select {
+					case <-c.s.Stopper().ShouldStop():
 						return
+					default:
 					}
 				}
 			}


### PR DESCRIPTION
This is a request from Sales Engineers who want to show that a
CockroachDB node can go down, but the cluster can still handle the
workload.

fixes #56498

Release note: None