### PR TITLE
jepsen: ignore one more Java exception

### DIFF
--- a/pkg/cmd/roachtest/jepsen.go
+++ b/pkg/cmd/roachtest/jepsen.go
@@ -236,7 +236,7 @@ cd /mnt/data1/jepsen/cockroachdb && set -eo pipefail && \
 		ignoreErr := false
 		if err := runE(c, ctx, controller,
 			`grep -E "(Oh jeez, I'm sorry, Jepsen broke. Here's why|Caused by)" /mnt/data1/jepsen/cockroachdb/invoke.log -A1 `+
-				`| grep -e BrokenBarrierException -e InterruptedException -e com.jcraft.jsch.JSchException `+
+				`| grep -e BrokenBarrierException -e InterruptedException -e com.jcraft.jsch.JSchException -e ArrayIndexOutOfBoundsException`+
 				// And one more ssh failure we've seen, apparently encountered when
 				// downloading logs.
 				`-e "clojure.lang.ExceptionInfo: clj-ssh scp failure" `+


### PR DESCRIPTION
One failure with
```
ERROR [2020-11-16 01:02:43,253] main - jepsen.cli Oh jeez, I'm sorry, Jepsen broke. Here's why:
java.util.concurrent.ExecutionException: java.lang.ArrayIndexOutOfBoundsException: -2
	at java.util.concurrent.FutureTask.report(FutureTask.java:122) ~[na:1.8.0_275]
	at java.util.concurrent.FutureTask.get(FutureTask.java:192) ~[na:1.8.0_275]
	at clojure.core$deref_future.invokeStatic(core.clj:2208) ~[clojure-1.8.0.jar:na]
	at clojure.core$future_call$reify__6962.deref(core.clj:6688) ~[clojure-1.8.0.jar:na]
	at clojure.core$deref.invokeStatic(core.clj:2228) ~[clojure-1.8.0.jar:na]
	at clojure.core$deref.invoke(core.clj:2214) ~[clojure-1.8.0.jar:na]
	at clojure.core$map$fn__4785.invoke(core.clj:2644) ~[clojure-1.8.0.jar:na]
	at clojure.lang.LazySeq.sval(LazySeq.java:40) ~[clojure-1.8.0.jar:na]
	at clojure.lang.LazySeq.seq(LazySeq.java:49) ~[clojure-1.8.0.jar:na]
```

Fixes #56712

Release note: None