### PR TITLE
kvserver: replace multiTestContext with TestCluster in client_raft_test

### DIFF
--- a/pkg/kv/kvserver/node_liveness_test.go
+++ b/pkg/kv/kvserver/node_liveness_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -58,6 +59,18 @@ func pauseNodeLivenessHeartbeatLoops(mtc *multiTestContext) func() {
 	var enableFns []func()
 	for _, nl := range mtc.nodeLivenesses {
 		enableFns = append(enableFns, nl.PauseHeartbeatLoopForTest())
+	}
+	return func() {
+		for _, fn := range enableFns {
+			fn()
+		}
+	}
+}
+
+func pauseNodeLivenessHeartbeatLoopsTC(tc *testcluster.TestCluster) func() {
+	var enableFns []func()
+	for _, server := range tc.Servers {
+		enableFns = append(enableFns, server.NodeLiveness().(*liveness.NodeLiveness).PauseHeartbeatLoopForTest())
 	}
 	return func() {
 		for _, fn := range enableFns {

--- a/pkg/kv/kvserver/replica_gossip.go
+++ b/pkg/kv/kvserver/replica_gossip.go
@@ -294,10 +294,6 @@ func (r *Replica) maybeGossipFirstRange(ctx context.Context) *roachpb.Error {
 		log.Errorf(ctx, "failed to gossip cluster ID: %+v", err)
 	}
 
-	if r.store.cfg.TestingKnobs.DisablePeriodicGossips {
-		return nil
-	}
-
 	hasLease, pErr := r.getLeaseForGossip(ctx)
 	if pErr != nil {
 		return pErr

--- a/pkg/kv/kvserver/replica_init.go
+++ b/pkg/kv/kvserver/replica_init.go
@@ -173,22 +173,16 @@ func (r *Replica) loadRaftMuLockedReplicaMuLocked(desc *roachpb.RangeDescriptor)
 
 	r.setDescLockedRaftMuLocked(ctx, desc)
 
-	// Init the minLeaseProposedTS such that we won't use an existing lease (if
-	// any). This is so that, after a restart, we don't propose under old leases.
-	// If the replica is being created through a split, this value will be
-	// overridden.
-	if !r.store.cfg.TestingKnobs.DontPreventUseOfOldLeaseOnStart {
-		// Only do this if there was a previous lease. This shouldn't be important
-		// to do but consider that the first lease which is obtained is back-dated
-		// to a zero start timestamp (and this de-flakes some tests). If we set the
-		// min proposed TS here, this lease could not be renewed (by the semantics
-		// of minLeaseProposedTS); and since minLeaseProposedTS is copied on splits,
-		// this problem would multiply to a number of replicas at cluster bootstrap.
-		// Instead, we make the first lease special (which is OK) and the problem
-		// disappears.
-		if r.mu.state.Lease.Sequence > 0 {
-			r.mu.minLeaseProposedTS = r.Clock().NowAsClockTimestamp()
-		}
+	// Only do this if there was a previous lease. This shouldn't be important
+	// to do but consider that the first lease which is obtained is back-dated
+	// to a zero start timestamp (and this de-flakes some tests). If we set the
+	// min proposed TS here, this lease could not be renewed (by the semantics
+	// of minLeaseProposedTS); and since minLeaseProposedTS is copied on splits,
+	// this problem would multiply to a number of replicas at cluster bootstrap.
+	// Instead, we make the first lease special (which is OK) and the problem
+	// disappears.
+	if r.mu.state.Lease.Sequence > 0 {
+		r.mu.minLeaseProposedTS = r.Clock().NowAsClockTimestamp()
 	}
 
 	ssBase := r.Engine().GetAuxiliaryDir()

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -801,6 +801,16 @@ func (sc *StoreConfig) LeaseExpiration() int64 {
 	return 2 * (sc.RangeLeaseActiveDuration() + maxOffset).Nanoseconds()
 }
 
+// RaftElectionTimeoutTicks exposed for testing.
+func (s *Store) RaftElectionTimeoutTicks() int {
+	return s.cfg.RaftElectionTimeoutTicks
+}
+
+// CoalescedHeartbeatsInterval exposed for testing.
+func (s *Store) CoalescedHeartbeatsInterval() time.Duration {
+	return s.cfg.CoalescedHeartbeatsInterval
+}
+
 // NewStore returns a new instance of a store.
 func NewStore(
 	ctx context.Context, cfg StoreConfig, eng storage.Engine, nodeDesc *roachpb.NodeDescriptor,
@@ -1645,12 +1655,6 @@ func (s *Store) startGossip() {
 		// functions (e.g. MaybeGossipSystemConfig or MaybeGossipNodeLiveness).
 		_, pErr := repl.getLeaseForGossip(ctx)
 		return pErr.GoError()
-	}
-
-	if s.cfg.TestingKnobs.DisablePeriodicGossips {
-		wakeReplica = func(context.Context, *Replica) error {
-			return errPeriodicGossipsDisabled
-		}
 	}
 
 	gossipFns := []struct {

--- a/pkg/kv/kvserver/testing_knobs.go
+++ b/pkg/kv/kvserver/testing_knobs.go
@@ -86,11 +86,6 @@ type StoreTestingKnobs struct {
 	// should get rid of such practices once we make TestServer take a
 	// ManualClock.
 	DisableMaxOffsetCheck bool
-	// DontPreventUseOfOldLeaseOnStart disables the initialization of
-	// replica.mu.minLeaseProposedTS on replica.Init(). This has the effect of
-	// allowing the replica to use the lease that it had in a previous life (in
-	// case the tests persisted the engine used in said previous life).
-	DontPreventUseOfOldLeaseOnStart bool
 	// DisableAutomaticLeaseRenewal enables turning off the background worker
 	// that attempts to automatically renew expiration-based leases.
 	DisableAutomaticLeaseRenewal bool
@@ -128,8 +123,6 @@ type StoreTestingKnobs struct {
 	DisableConsistencyQueue bool
 	// DisableScanner disables the replica scanner.
 	DisableScanner bool
-	// DisablePeriodicGossips disables periodic gossiping.
-	DisablePeriodicGossips bool
 	// DisableLeaderFollowsLeaseholder disables attempts to transfer raft
 	// leadership when it diverges from the range's leaseholder.
 	DisableLeaderFollowsLeaseholder bool

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -403,6 +403,14 @@ func (ts *TestServer) RaftTransport() *kvserver.RaftTransport {
 	return nil
 }
 
+// NodeDialer returns the NodeDialer used by the TestServer.
+func (ts *TestServer) NodeDialer() *nodedialer.Dialer {
+	if ts != nil {
+		return ts.nodeDialer
+	}
+	return nil
+}
+
 // Start starts the TestServer by bootstrapping an in-memory store
 // (defaults to maximum of 100M). The server is started, launching the
 // node RPC server and all HTTP endpoints. Use the value of

--- a/pkg/testutils/testcluster/BUILD.bazel
+++ b/pkg/testutils/testcluster/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_logtags//:logtags",
+        "@io_etcd_go_etcd_raft_v3//:raft",
     ],
 )
 


### PR DESCRIPTION
Makes progress on #8299
Fixes #40351
Fixes #57560
Fixes #57537

multiTestContext is a legacy construct that is deprecated in favor of running
tests via TestCluster. This is one PR out of many to remove the usage of
multiTestContext in the client_raft test cases. This does not remove all the
uses of mtc, just the simple ones. Leaving the more complex uses cases for a later PR.

With this switch we can also clean up some TestingKnobs and TestServer interfaces.
    - DisablePeriodicGossips flag is removed, it does not work with TestCluster
      and is no longer used
    - DontPreventUseOfOldLeaseOnStart flag is removed, it did not work consistently
      in TestCluster. This flag tries to leave the Lease on the same node after a
      restart, but CRDB makes no such guarantees in the real world and artificially
      testing it does not prove anything. The affected tests were re-worked to
      not rely on this condition and can deal with a lease holder moving on a restart.
    - GetRaftLeader is ported from multiTestContext to TestCluster

Release note: None
