### PR TITLE
release-20.1: sql: handle bool values for compat-only session vars

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/set
+++ b/pkg/sql/logictest/testdata/logic_test/set
@@ -341,3 +341,12 @@ SET enable_zigzag_join = on;
 SET enable_zigzag_join = off;
 SET enable_zigzag_join = true;
 SET enable_zigzag_join = false
+
+statement ok
+SET standard_conforming_strings=true
+
+statement ok
+SET standard_conforming_strings='true'
+
+statement ok
+SET standard_conforming_strings='on'

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -974,6 +974,7 @@ func makeCompatBoolVar(varName string, displayValue, anyValAllowed bool) session
 			return err
 		},
 		GlobalDefault: func(sv *settings.Values) string { return displayValStr },
+		GetStringVal:  makePostgresBoolGetStringValFn(varName),
 	}
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #56662.

/cc @cockroachdb/release

---

Release note (bug fix): Some boolean session variables would only accept
string ("true" or "false") values. Now they accept unquoted true or
false values too.