### PR TITLE
jepsen: ignore another Java exception

### DIFF
--- a/pkg/cmd/roachtest/jepsen.go
+++ b/pkg/cmd/roachtest/jepsen.go
@@ -235,8 +235,12 @@ cd /mnt/data1/jepsen/cockroachdb && set -eo pipefail && \
 		// once the respective issues are fixed.
 		ignoreErr := false
 		if err := runE(c, ctx, controller,
-			`grep -E "(Oh jeez, I'm sorry, Jepsen broke. Here's why|Caused by)" /mnt/data1/jepsen/cockroachdb/invoke.log -A1 `+
-				`| grep -e BrokenBarrierException -e InterruptedException -e com.jcraft.jsch.JSchException -e ArrayIndexOutOfBoundsException`+
+			`grep -E "(Oh jeez, I'm sorry, Jepsen broke. Here's why|Caused by)" /mnt/data1/jepsen/cockroachdb/invoke.log -A1 | grep `+
+				`-e BrokenBarrierException `+
+				`-e InterruptedException `+
+				`-e com.jcraft.jsch.JSchException `+
+				`-e ArrayIndexOutOfBoundsException `+
+				`-e NullPointerException `+
 				// And one more ssh failure we've seen, apparently encountered when
 				// downloading logs.
 				`-e "clojure.lang.ExceptionInfo: clj-ssh scp failure" `+


### PR DESCRIPTION
```
java.util.concurrent.ExecutionException: java.lang.NullPointerException
at java.util.concurrent.FutureTask.report(FutureTask.java:122) ~[na:1.8.0_272]
at java.util.concurrent.FutureTask.get(FutureTask.java:192) ~[na:1.8.0_272]
at clojure.core$deref_future.invokeStatic(core.clj:2208) ~[clojure-1.8.0.jar:na]
at clojure.core$future_call$reify__6962.deref(core.clj:6688) ~[clojure-1.8.0.jar:na]
```

Fixes #56564

Release note: None