### PR TITLE
sql: Enabled correct pg_class.relPersistence for temporary tables

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2780,3 +2780,26 @@ SELECT oid FROM pg_type WHERE oid IN (19,20,24) ORDER BY oid
 
 statement ok
 SELECT * FROM pg_class WHERE oid = 10 OR oid BETWEEN 20 AND 30 OR oid = 40
+
+statement ok
+SET experimental_enable_temp_tables = 'on';
+
+statement ok
+CREATE TEMPORARY TABLE test_temp (id UUID PRIMARY KEY);
+CREATE UNLOGGED TABLE test_unlogged (id UUID PRIMARY KEY);
+CREATE TABLE test_persistent (id UUID PRIMARY KEY);
+
+# we don't store UNLOGGED beyond the parser at the moment so we expect 'p' for test_unlogged
+query T
+SELECT
+  relpersistence
+FROM
+  pg_catalog.pg_class
+WHERE
+  relname IN ('test_temp', 'test_unlogged', 'test_persistent')
+ORDER BY
+  relpersistence
+----
+p
+p
+t

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -553,6 +553,7 @@ var (
 	relKindSequence         = tree.NewDString("S")
 
 	relPersistencePermanent = tree.NewDString("p")
+	relPersistenceTemporary = tree.NewDString("t")
 )
 
 var pgCatalogClassTable = makeAllRelationsVirtualTableWithDescriptorIDIndex(
@@ -575,6 +576,10 @@ https://www.postgresql.org/docs/9.5/catalog-pg-class.html`,
 			relKind = relKindSequence
 			relAm = oidZero
 		}
+		relPersistence := relPersistencePermanent
+		if table.IsTemporary() {
+			relPersistence = relPersistenceTemporary
+		}
 		namespaceOid := h.NamespaceOid(db.GetID(), scName)
 		if err := addRow(
 			tableOid(table.GetID()),        // oid
@@ -591,10 +596,10 @@ https://www.postgresql.org/docs/9.5/catalog-pg-class.html`,
 			zeroVal,                        // relallvisible
 			oidZero,                        // reltoastrelid
 			tree.MakeDBool(tree.DBool(table.IsPhysicalTable())), // relhasindex
-			tree.DBoolFalse,         // relisshared
-			relPersistencePermanent, // relPersistence
-			tree.DBoolFalse,         // relistemp
-			relKind,                 // relkind
+			tree.DBoolFalse, // relisshared
+			relPersistence,  // relPersistence
+			tree.DBoolFalse, // relistemp
+			relKind,         // relkind
 			tree.NewDInt(tree.DInt(len(table.GetPublicColumns()))), // relnatts
 			tree.NewDInt(tree.DInt(len(table.GetChecks()))),        // relchecks
 			tree.DBoolFalse, // relhasoids


### PR DESCRIPTION
Previously, the relpersistence column in pg_catalog.pg_class displayed 'p' for
all tables regardless of persistence status. This is incorrect for temporary
tables and unlogged tables, as they are supposed to have `t` and `u` values
respectively.

This patch fixes this behavior for temp tables, but leaves it unchanged for
unlogged tables (as we don't persist unlogged information past parsing).

Fixes #56656

Release note (sql change): the relpersistence column in pg_catalog.pg_class now
correctly displays `t` as the persistence status for temporary tables.