### PR TITLE
cli: add \x command to toggle records display format

### DIFF
--- a/pkg/cli/interactive_tests/test_local_cmds.tcl
+++ b/pkg/cli/interactive_tests/test_local_cmds.tcl
@@ -105,7 +105,30 @@ eexpect "display_format\ttsv"
 eexpect root@
 end_test
 
+start_test "Check that \\x toggles display format"
+send "\\x\r\\set\r"
+eexpect "Option*|*display_format"
+eexpect "Value*|*records"
+eexpect root@
+
+send "\\x\r\\set\r"
+eexpect "display_format*|*table"
+eexpect root@
+end_test
+
+start_test "Check that \\x with on or off enables/disables records display format"
+send "\\x on\r\\set\r"
+eexpect "Option*|*display_format"
+eexpect "Value*|*records"
+eexpect root@
+
+send "\\x off\r\\set\r"
+eexpect "display_format*|*table"
+eexpect root@
+end_test
+
 start_test "Check various ways to set a boolean flag."
+send "\\set display_format=tsv\r"
 send "\\set show_times=false\r\\set\r"
 eexpect "show_times\tfalse"
 eexpect root@

--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -79,6 +79,9 @@ Informational
   \du               list the users for all databases.
   \d [TABLE]        show details about columns in the specified table, or alias for '\dt' if no table is specified.
 
+Formatting
+  \x [on|off]       toggle records display format.
+
 Operating System
   \! CMD            run an external command and print its results on standard output.
 
@@ -1160,6 +1163,28 @@ func (c *cliState) doHandleCliCmd(loopState, nextState cliStateEnum) cliStateEnu
 
 		}
 		return c.invalidSyntax(errState, `%s. Try \? for help`, c.lastInputLine)
+
+	case `\x`:
+		format := tableDisplayRecords
+		switch len(cmd) {
+		case 1:
+			if cliCtx.tableDisplayFormat == tableDisplayRecords {
+				format = tableDisplayTable
+			}
+		case 2:
+			b, err := parseBool(cmd[1])
+			if err != nil {
+				return c.invalidSyntax(errState, `%s. Try \? for help.`, c.lastInputLine)
+			} else if b {
+				format = tableDisplayRecords
+			} else {
+				format = tableDisplayTable
+			}
+		default:
+			return c.invalidSyntax(errState, `%s. Try \? for help.`, c.lastInputLine)
+		}
+		cliCtx.tableDisplayFormat = format
+		return loopState
 
 	case `\demo`:
 		return c.handleDemo(cmd[1:], loopState, errState)

--- a/pkg/cli/sql_util.go
+++ b/pkg/cli/sql_util.go
@@ -1165,3 +1165,15 @@ func formatVal(val driver.Value, showPrintableUnicode bool, showNewLinesAndTabs 
 
 	return fmt.Sprint(val)
 }
+
+// parseBool parses a boolean string for use in slash commands.
+func parseBool(s string) (bool, error) {
+	switch strings.TrimSpace(strings.ToLower(s)) {
+	case "true", "on", "yes", "1":
+		return true, nil
+	case "false", "off", "no", "0":
+		return false, nil
+	default:
+		return false, errors.Newf("invalid boolean value %q", s)
+	}
+}


### PR DESCRIPTION
`psql` has a `\x` command to toggle extended output for results. CRDB
already supports this output format via `\set display_format=records`.
This commit adds `\x [on|off]` to toggle between `records` and `table`
display formats.

The `auto` option from `psql` to automatically enable extended output
depending on the result width is not supported, only `on` and `off`.

Resolves #56706.

Release note (cli change): A `\x [on|off]` command has been added to
toggle the `records` display format, following `psql` behavior.

Also adds support for `yes` and `no` as boolean options for slash commands as a separate commit, following `psql`.
