### PR TITLE
changefeedccl, importccl, sql: IMPORT/EXPORT/changefeed feature flags

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -14,6 +14,9 @@
 <tr><td><code>external.graphite.endpoint</code></td><td>string</td><td><code></code></td><td>if nonempty, push server metrics to the Graphite or Carbon server at the specified host:port</td></tr>
 <tr><td><code>external.graphite.interval</code></td><td>duration</td><td><code>10s</code></td><td>the interval at which metrics are pushed to Graphite (if enabled)</td></tr>
 <tr><td><code>feature.backup.enabled</code></td><td>boolean</td><td><code>true</code></td><td>set to true to enable backups, false to disable; default is true</td></tr>
+<tr><td><code>feature.changefeed.enabled</code></td><td>boolean</td><td><code>true</code></td><td>set to true to enable changefeeds, false to disable; default is true</td></tr>
+<tr><td><code>feature.export.enabled</code></td><td>boolean</td><td><code>true</code></td><td>set to true to enable exports, false to disable; default is true</td></tr>
+<tr><td><code>feature.import.enabled</code></td><td>boolean</td><td><code>true</code></td><td>set to true to enable imports, false to disable; default is true</td></tr>
 <tr><td><code>feature.restore.enabled</code></td><td>boolean</td><td><code>true</code></td><td>set to true to enable restore, false to disable; default is true</td></tr>
 <tr><td><code>jobs.retention_time</code></td><td>duration</td><td><code>336h0m0s</code></td><td>the amount of time to retain records for completed jobs before</td></tr>
 <tr><td><code>kv.allocator.load_based_lease_rebalancing.enabled</code></td><td>boolean</td><td><code>true</code></td><td>set to enable rebalancing of range leases based on load and latency</td></tr>

--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -509,10 +509,9 @@ func backupPlanHook(
 		return nil, nil, nil, false, nil
 	}
 
-	// Check whether feature backup is enabled or not.
-	if !featureBackupEnabled.Get(&p.ExecCfg().Settings.SV) {
-		return nil, nil, nil, false,
-			pgerror.Newf(pgcode.OperatorIntervention, "BACKUP feature was disabled by the database administrator")
+	if err := featureflag.CheckEnabled(featureBackupEnabled, &p.ExecCfg().Settings.SV,
+		"BACKUP"); err != nil {
+		return nil, nil, nil, false, err
 	}
 
 	var err error
@@ -604,7 +603,7 @@ func backupPlanHook(
 			return err
 		}
 		if len(to) > 1 {
-			if err := requireEnterprise("partitoned destinations"); err != nil {
+			if err := requireEnterprise("partitioned destinations"); err != nil {
 				return err
 			}
 		}

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -1184,10 +1184,9 @@ func restorePlanHook(
 		return nil, nil, nil, false, nil
 	}
 
-	// Check whether feature restore is enabled or not.
-	if !featureRestoreEnabled.Get(&p.ExecCfg().Settings.SV) {
-		return nil, nil, nil, false,
-			pgerror.Newf(pgcode.OperatorIntervention, "RESTORE feature was disabled by the database administrator")
+	if err := featureflag.CheckEnabled(featureRestoreEnabled, &p.ExecCfg().Settings.SV,
+		"RESTORE"); err != nil {
+		return nil, nil, nil, false, err
 	}
 
 	fromFns := make([]func() ([]string, error), len(restoreStmt.From))

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
 	"github.com/cockroachdb/cockroach/pkg/docs"
+	"github.com/cockroachdb/cockroach/pkg/featureflag"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobsprotectedts"
@@ -30,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
@@ -51,6 +53,12 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
+// featureChangefeedEnabled is used to enable and disable the CHANGEFEED feature.
+var featureChangefeedEnabled = settings.RegisterPublicBoolSetting(
+	"feature.changefeed.enabled",
+	"set to true to enable changefeeds, false to disable; default is true",
+	featureflag.FeatureFlagEnabledDefault)
+
 func init() {
 	sql.AddPlanHook(changefeedPlanHook)
 	jobs.RegisterConstructor(
@@ -68,6 +76,11 @@ func changefeedPlanHook(
 	changefeedStmt, ok := stmt.(*tree.CreateChangefeed)
 	if !ok {
 		return nil, nil, nil, false, nil
+	}
+
+	if err := featureflag.CheckEnabled(featureChangefeedEnabled, &p.ExecCfg().Settings.SV,
+		"CHANGEFEED"); err != nil {
+		return nil, nil, nil, false, err
 	}
 
 	var sinkURIFn func() (string, error)

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -1881,6 +1881,16 @@ func TestChangefeedErrors(t *testing.T) {
 	)
 	sqlDB.Exec(t, `SET CLUSTER SETTING kv.rangefeed.enabled = true`)
 
+	// Feature flag for changefeeds is off — test that CREATE CHANGEFEED and
+	// EXPERIMENTAL CHANGEFEED FOR surface error.
+	sqlDB.Exec(t, `SET CLUSTER SETTING feature.changefeed.enabled = false`)
+	sqlDB.ExpectErr(t, `CHANGEFEED feature was disabled by the database administrator`,
+		`CREATE CHANGEFEED FOR foo`)
+	sqlDB.ExpectErr(t, `CHANGEFEED feature was disabled by the database administrator`,
+		`EXPERIMENTAL CHANGEFEED FOR foo`)
+
+	sqlDB.Exec(t, `SET CLUSTER SETTING feature.changefeed.enabled = true`)
+
 	sqlDB.ExpectErr(
 		t, `unknown format: nope`,
 		`EXPERIMENTAL CHANGEFEED FOR foo WITH format=nope`,

--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/featureflag"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobsprotectedts"
@@ -30,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
@@ -174,6 +176,12 @@ var allowedIntoFormats = map[string]struct{}{
 	"PGCOPY":    {},
 }
 
+// featureImportEnabled is used to enable and disable the IMPORT feature.
+var featureImportEnabled = settings.RegisterPublicBoolSetting(
+	"feature.import.enabled",
+	"set to true to enable imports, false to disable; default is true",
+	featureflag.FeatureFlagEnabledDefault)
+
 func validateFormatOptions(
 	format string, specified map[string]string, formatAllowed map[string]struct{},
 ) error {
@@ -259,6 +267,11 @@ func importPlanHook(
 	}
 
 	addToFileFormatTelemetry(importStmt.FileFormat, "attempted")
+
+	if err := featureflag.CheckEnabled(featureImportEnabled, &p.ExecCfg().Settings.SV,
+		"IMPORT"); err != nil {
+		return nil, nil, nil, false, err
+	}
 
 	filesFn, err := p.TypeAsStringArray(ctx, importStmt.Files, "IMPORT")
 	if err != nil {

--- a/pkg/featureflag/feature_flags.go
+++ b/pkg/featureflag/feature_flags.go
@@ -10,5 +10,22 @@
 
 package featureflag
 
-// FeatureFlagEnabledDefault is used for the default value of all feature flag cluster settings.
+import (
+	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+)
+
+// FeatureFlagEnabledDefault is used for the default value of all feature flag
+// cluster settings.
 const FeatureFlagEnabledDefault = true
+
+// CheckEnabled checks whether a specific feature has been enabled or disabled
+// via its cluster settings, and returns an error if it has been disabled.
+func CheckEnabled(s *settings.BoolSetting, sv *settings.Values, featureName string) error {
+	if enabled := s.Get(sv); !enabled {
+		return pgerror.Newf(pgcode.OperatorIntervention, "%s feature was disabled by the database "+
+			"administrator", featureName)
+	}
+	return nil
+}

--- a/pkg/sql/export.go
+++ b/pkg/sql/export.go
@@ -16,7 +16,9 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/cockroachdb/cockroach/pkg/featureflag"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
@@ -79,10 +81,26 @@ const exportFilePatternPart = "%part%"
 const exportFilePatternDefault = exportFilePatternPart + ".csv"
 const exportCompressionCodec = "gzip"
 
+// featureExportEnabled is used to enable and disable the EXPORT feature.
+var featureExportEnabled = settings.RegisterPublicBoolSetting(
+	"feature.export.enabled",
+	"set to true to enable exports, false to disable; default is true",
+	featureflag.FeatureFlagEnabledDefault)
+
 // ConstructExport is part of the exec.Factory interface.
 func (ef *execFactory) ConstructExport(
 	input exec.Node, fileName tree.TypedExpr, fileFormat string, options []exec.KVOption,
 ) (exec.Node, error) {
+	if !featureExportEnabled.Get(&ef.planner.ExecCfg().Settings.SV) {
+		return nil, pgerror.Newf(pgcode.OperatorIntervention,
+			"EXPORT feature was disabled by the database administrator")
+	}
+
+	if err := featureflag.CheckEnabled(featureExportEnabled, &ef.planner.ExecCfg().Settings.SV,
+		"EXPORT"); err != nil {
+		return nil, err
+	}
+
 	if !ef.planner.ExtendedEvalContext().TxnImplicit {
 		return nil, errors.Errorf("EXPORT cannot be used inside a transaction")
 	}


### PR DESCRIPTION
Adds a cluster setting to toggle a feature flag for the IMPORT,
EXPORT, and changefeed commands off and on. The feature is being
introduced to address a Cockroach Cloud SRE use case: needing to
disable certain categories of features in case of cluster failure.

Release note (enterprise change): Adds cluster settings to enable/
disable the IMPORT, EXPORT, and changefeed  commands. If a user
attempts to use these features while they are disabled, an error
indicating that the database administrator has disabled the
feature is surfaced.

Example usage for the database administrator:
SET CLUSTER SETTING feature.import.enabled = FALSE;
SET CLUSTER SETTING feature.import.enabled = TRUE;
SET CLUSTER SETTING feature.export.enabled = FALSE;
SET CLUSTER SETTING feature.export.enabled = TRUE;
SET CLUSTER SETTING feature.changefeed.enabled = FALSE;
SET CLUSTER SETTING feature.changefeed.enabled = TRUE;