### PR TITLE
opt: constrain multi-col inverted index prefix cols by contiguous range

### DIFF
--- a/pkg/sql/opt/idxconstraint/index_constraints_test.go
+++ b/pkg/sql/opt/idxconstraint/index_constraints_test.go
@@ -137,7 +137,7 @@ func TestIndexConstraints(t *testing.T) {
 				var ic idxconstraint.Instance
 				ic.Init(
 					filters, optionalFilters, indexCols, sv.NotNullCols(), computedCols,
-					invertedIndex, &evalCtx, &f,
+					invertedIndex, true /* consolidate */, &evalCtx, &f,
 				)
 				result := ic.Constraint()
 				var buf bytes.Buffer
@@ -250,7 +250,8 @@ func BenchmarkIndexConstraints(b *testing.B) {
 				var ic idxconstraint.Instance
 				ic.Init(
 					filters, nil /* optionalFilters */, indexCols, sv.NotNullCols(),
-					nil /* computedCols */, false /*isInverted */, &evalCtx, &f,
+					nil /* computedCols */, false /*isInverted */, true, /* consolidate */
+					&evalCtx, &f,
 				)
 				_ = ic.Constraint()
 				_ = ic.RemainingFilters()

--- a/pkg/sql/opt/xform/general_funcs.go
+++ b/pkg/sql/opt/xform/general_funcs.go
@@ -150,7 +150,7 @@ func (c *CustomFuncs) initIdxConstraintForIndex(
 	ic.Init(
 		requiredFilters, optionalFilters,
 		columns, notNullCols, tabMeta.ComputedCols,
-		isInverted, c.e.evalCtx, c.e.f,
+		isInverted, true /* consolidate */, c.e.evalCtx, c.e.f,
 	)
 	return ic
 }

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -2965,6 +2965,7 @@ CREATE TABLE m (
   k INT PRIMARY KEY,
   a STRING,
   b STRING,
+  i INT,
   geom GEOMETRY,
   INVERTED INDEX multicol (a, geom)
 )
@@ -2975,76 +2976,76 @@ opt expect=GenerateInvertedIndexScans
 SELECT * FROM m WHERE a = 'foo' AND ST_CoveredBy('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))'::geometry, geom)
 ----
 select
- ├── columns: k:1!null a:2!null b:3 geom:4!null
+ ├── columns: k:1!null a:2!null b:3 i:4 geom:5!null
  ├── immutable
  ├── key: (1)
- ├── fd: ()-->(2), (1)-->(3,4)
+ ├── fd: ()-->(2), (1)-->(3-5)
  ├── index-join m
- │    ├── columns: k:1!null a:2 b:3 geom:4
+ │    ├── columns: k:1!null a:2 b:3 i:4 geom:5
  │    ├── key: (1)
- │    ├── fd: (1)-->(2-4)
+ │    ├── fd: (1)-->(2-5)
  │    └── inverted-filter
  │         ├── columns: k:1!null
- │         ├── inverted expression: /6
+ │         ├── inverted expression: /7
  │         │    ├── tight: false
  │         │    └── union spans
  │         │         ├── ["B\xfd\x10\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x10\x00\x00\x00\x00\x00\x00\x00"]
  │         │         ├── ["B\xfd\x11\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x11\x00\x00\x00\x00\x00\x00\x00"]
  │         │         └── ["B\xfd\x14\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x14\x00\x00\x00\x00\x00\x00\x00"]
  │         ├── pre-filterer expression
- │         │    └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:4)
+ │         │    └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:5)
  │         ├── key: (1)
  │         └── scan m@multicol
- │              ├── columns: k:1!null geom_inverted_key:6!null
+ │              ├── columns: k:1!null geom_inverted_key:7!null
  │              ├── constraint: /2: [/'foo' - /'foo']
- │              ├── inverted constraint: /6/1
+ │              ├── inverted constraint: /7/1
  │              │    └── spans
  │              │         ├── ["B\xfd\x10\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x10\x00\x00\x00\x00\x00\x00\x00"]
  │              │         ├── ["B\xfd\x11\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x11\x00\x00\x00\x00\x00\x00\x00"]
  │              │         └── ["B\xfd\x14\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x14\x00\x00\x00\x00\x00\x00\x00"]
  │              ├── key: (1)
- │              └── fd: (1)-->(6)
+ │              └── fd: (1)-->(7)
  └── filters
-      └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:4) [outer=(4), immutable, constraints=(/4: (/NULL - ])]
+      └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:5) [outer=(5), immutable, constraints=(/5: (/NULL - ])]
 
 # Constrain a single prefix column to multiple point values.
 opt expect=GenerateInvertedIndexScans
 SELECT * FROM m WHERE a IN ('foo', 'bar') AND ST_CoveredBy('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))'::geometry, geom)
 ----
 select
- ├── columns: k:1!null a:2!null b:3 geom:4!null
+ ├── columns: k:1!null a:2!null b:3 i:4 geom:5!null
  ├── immutable
  ├── key: (1)
- ├── fd: (1)-->(2-4)
+ ├── fd: (1)-->(2-5)
  ├── index-join m
- │    ├── columns: k:1!null a:2 b:3 geom:4
+ │    ├── columns: k:1!null a:2 b:3 i:4 geom:5
  │    ├── key: (1)
- │    ├── fd: (1)-->(2-4)
+ │    ├── fd: (1)-->(2-5)
  │    └── inverted-filter
  │         ├── columns: k:1!null
- │         ├── inverted expression: /6
+ │         ├── inverted expression: /7
  │         │    ├── tight: false
  │         │    └── union spans
  │         │         ├── ["B\xfd\x10\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x10\x00\x00\x00\x00\x00\x00\x00"]
  │         │         ├── ["B\xfd\x11\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x11\x00\x00\x00\x00\x00\x00\x00"]
  │         │         └── ["B\xfd\x14\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x14\x00\x00\x00\x00\x00\x00\x00"]
  │         ├── pre-filterer expression
- │         │    └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:4)
+ │         │    └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:5)
  │         ├── key: (1)
  │         └── scan m@multicol
- │              ├── columns: k:1!null geom_inverted_key:6!null
+ │              ├── columns: k:1!null geom_inverted_key:7!null
  │              ├── constraint: /2
  │              │    ├── [/'bar' - /'bar']
  │              │    └── [/'foo' - /'foo']
- │              ├── inverted constraint: /6/1
+ │              ├── inverted constraint: /7/1
  │              │    └── spans
  │              │         ├── ["B\xfd\x10\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x10\x00\x00\x00\x00\x00\x00\x00"]
  │              │         ├── ["B\xfd\x11\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x11\x00\x00\x00\x00\x00\x00\x00"]
  │              │         └── ["B\xfd\x14\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x14\x00\x00\x00\x00\x00\x00\x00"]
  │              ├── key: (1)
- │              └── fd: (1)-->(6)
+ │              └── fd: (1)-->(7)
  └── filters
-      └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:4) [outer=(4), immutable, constraints=(/4: (/NULL - ])]
+      └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:5) [outer=(5), immutable, constraints=(/5: (/NULL - ])]
 
 # Do not generate an inverted index scan when the first prefix column is not
 # constrained.
@@ -3052,16 +3053,16 @@ opt expect-not=GenerateInvertedIndexScans
 SELECT * FROM m WHERE ST_CoveredBy('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))'::geometry, geom)
 ----
 select
- ├── columns: k:1!null a:2 b:3 geom:4!null
+ ├── columns: k:1!null a:2 b:3 i:4 geom:5!null
  ├── immutable
  ├── key: (1)
- ├── fd: (1)-->(2-4)
+ ├── fd: (1)-->(2-5)
  ├── scan m
- │    ├── columns: k:1!null a:2 b:3 geom:4
+ │    ├── columns: k:1!null a:2 b:3 i:4 geom:5
  │    ├── key: (1)
- │    └── fd: (1)-->(2-4)
+ │    └── fd: (1)-->(2-5)
  └── filters
-      └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:4) [outer=(4), immutable, constraints=(/4: (/NULL - ])]
+      └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:5) [outer=(5), immutable, constraints=(/5: (/NULL - ])]
 
 # Do not generate an inverted index scan when a single prefix column is
 # constrained to a range.
@@ -3069,17 +3070,17 @@ opt expect-not=GenerateInvertedIndexScans
 SELECT * FROM m WHERE a > 'x' AND a < 'y' AND ST_CoveredBy('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))'::geometry, geom)
 ----
 select
- ├── columns: k:1!null a:2!null b:3 geom:4!null
+ ├── columns: k:1!null a:2!null b:3 i:4 geom:5!null
  ├── immutable
  ├── key: (1)
- ├── fd: (1)-->(2-4)
+ ├── fd: (1)-->(2-5)
  ├── scan m
- │    ├── columns: k:1!null a:2 b:3 geom:4
+ │    ├── columns: k:1!null a:2 b:3 i:4 geom:5
  │    ├── key: (1)
- │    └── fd: (1)-->(2-4)
+ │    └── fd: (1)-->(2-5)
  └── filters
       ├── (a:2 > 'x') AND (a:2 < 'y') [outer=(2), constraints=(/2: [/e'x\x00' - /'y'); tight)]
-      └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:4) [outer=(4), immutable, constraints=(/4: (/NULL - ])]
+      └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:5) [outer=(5), immutable, constraints=(/5: (/NULL - ])]
 
 exec-ddl
 DROP INDEX multicol
@@ -3094,78 +3095,78 @@ opt expect=GenerateInvertedIndexScans
 SELECT * FROM m WHERE a = 'foo' AND b = 'bar' AND ST_CoveredBy('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))'::geometry, geom)
 ----
 select
- ├── columns: k:1!null a:2!null b:3!null geom:4!null
+ ├── columns: k:1!null a:2!null b:3!null i:4 geom:5!null
  ├── immutable
  ├── key: (1)
- ├── fd: ()-->(2,3), (1)-->(4)
+ ├── fd: ()-->(2,3), (1)-->(4,5)
  ├── index-join m
- │    ├── columns: k:1!null a:2 b:3 geom:4
+ │    ├── columns: k:1!null a:2 b:3 i:4 geom:5
  │    ├── key: (1)
- │    ├── fd: (1)-->(2-4)
+ │    ├── fd: (1)-->(2-5)
  │    └── inverted-filter
  │         ├── columns: k:1!null
- │         ├── inverted expression: /7
+ │         ├── inverted expression: /8
  │         │    ├── tight: false
  │         │    └── union spans
  │         │         ├── ["B\xfd\x10\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x10\x00\x00\x00\x00\x00\x00\x00"]
  │         │         ├── ["B\xfd\x11\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x11\x00\x00\x00\x00\x00\x00\x00"]
  │         │         └── ["B\xfd\x14\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x14\x00\x00\x00\x00\x00\x00\x00"]
  │         ├── pre-filterer expression
- │         │    └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:4)
+ │         │    └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:5)
  │         ├── key: (1)
  │         └── scan m@multicol
- │              ├── columns: k:1!null geom_inverted_key:7!null
+ │              ├── columns: k:1!null geom_inverted_key:8!null
  │              ├── constraint: /2/3: [/'foo'/'bar' - /'foo'/'bar']
- │              ├── inverted constraint: /7/1
+ │              ├── inverted constraint: /8/1
  │              │    └── spans
  │              │         ├── ["B\xfd\x10\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x10\x00\x00\x00\x00\x00\x00\x00"]
  │              │         ├── ["B\xfd\x11\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x11\x00\x00\x00\x00\x00\x00\x00"]
  │              │         └── ["B\xfd\x14\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x14\x00\x00\x00\x00\x00\x00\x00"]
  │              ├── key: (1)
- │              └── fd: (1)-->(7)
+ │              └── fd: (1)-->(8)
  └── filters
-      └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:4) [outer=(4), immutable, constraints=(/4: (/NULL - ])]
+      └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:5) [outer=(5), immutable, constraints=(/5: (/NULL - ])]
 
 # Constrain multiple prefix columns to multiple point values.
 opt expect=GenerateInvertedIndexScans
 SELECT * FROM m WHERE a IN ('foo', 'bar') AND b IN ('baz', 'bob') AND ST_CoveredBy('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))'::geometry, geom)
 ----
 select
- ├── columns: k:1!null a:2!null b:3!null geom:4!null
+ ├── columns: k:1!null a:2!null b:3!null i:4 geom:5!null
  ├── immutable
  ├── key: (1)
- ├── fd: (1)-->(2-4)
+ ├── fd: (1)-->(2-5)
  ├── index-join m
- │    ├── columns: k:1!null a:2 b:3 geom:4
+ │    ├── columns: k:1!null a:2 b:3 i:4 geom:5
  │    ├── key: (1)
- │    ├── fd: (1)-->(2-4)
+ │    ├── fd: (1)-->(2-5)
  │    └── inverted-filter
  │         ├── columns: k:1!null
- │         ├── inverted expression: /7
+ │         ├── inverted expression: /8
  │         │    ├── tight: false
  │         │    └── union spans
  │         │         ├── ["B\xfd\x10\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x10\x00\x00\x00\x00\x00\x00\x00"]
  │         │         ├── ["B\xfd\x11\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x11\x00\x00\x00\x00\x00\x00\x00"]
  │         │         └── ["B\xfd\x14\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x14\x00\x00\x00\x00\x00\x00\x00"]
  │         ├── pre-filterer expression
- │         │    └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:4)
+ │         │    └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:5)
  │         ├── key: (1)
  │         └── scan m@multicol
- │              ├── columns: k:1!null geom_inverted_key:7!null
+ │              ├── columns: k:1!null geom_inverted_key:8!null
  │              ├── constraint: /2/3
  │              │    ├── [/'bar'/'baz' - /'bar'/'baz']
  │              │    ├── [/'bar'/'bob' - /'bar'/'bob']
  │              │    ├── [/'foo'/'baz' - /'foo'/'baz']
  │              │    └── [/'foo'/'bob' - /'foo'/'bob']
- │              ├── inverted constraint: /7/1
+ │              ├── inverted constraint: /8/1
  │              │    └── spans
  │              │         ├── ["B\xfd\x10\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x10\x00\x00\x00\x00\x00\x00\x00"]
  │              │         ├── ["B\xfd\x11\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x11\x00\x00\x00\x00\x00\x00\x00"]
  │              │         └── ["B\xfd\x14\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x14\x00\x00\x00\x00\x00\x00\x00"]
  │              ├── key: (1)
- │              └── fd: (1)-->(7)
+ │              └── fd: (1)-->(8)
  └── filters
-      └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:4) [outer=(4), immutable, constraints=(/4: (/NULL - ])]
+      └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:5) [outer=(5), immutable, constraints=(/5: (/NULL - ])]
 
 # Do not generate an inverted index scan when the first prefix column is not
 # constrained.
@@ -3173,17 +3174,17 @@ opt expect-not=GenerateInvertedIndexScans
 SELECT * FROM m WHERE b = 'foo' AND ST_CoveredBy('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))'::geometry, geom)
 ----
 select
- ├── columns: k:1!null a:2 b:3!null geom:4!null
+ ├── columns: k:1!null a:2 b:3!null i:4 geom:5!null
  ├── immutable
  ├── key: (1)
- ├── fd: ()-->(3), (1)-->(2,4)
+ ├── fd: ()-->(3), (1)-->(2,4,5)
  ├── scan m
- │    ├── columns: k:1!null a:2 b:3 geom:4
+ │    ├── columns: k:1!null a:2 b:3 i:4 geom:5
  │    ├── key: (1)
- │    └── fd: (1)-->(2-4)
+ │    └── fd: (1)-->(2-5)
  └── filters
       ├── b:3 = 'foo' [outer=(3), constraints=(/3: [/'foo' - /'foo']; tight), fd=()-->(3)]
-      └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:4) [outer=(4), immutable, constraints=(/4: (/NULL - ])]
+      └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:5) [outer=(5), immutable, constraints=(/5: (/NULL - ])]
 
 # Do not generate an inverted index scan when the second prefix column is not
 # constrained.
@@ -3191,17 +3192,17 @@ opt expect-not=GenerateInvertedIndexScans
 SELECT * FROM m WHERE a = 'foo' AND ST_CoveredBy('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))'::geometry, geom)
 ----
 select
- ├── columns: k:1!null a:2!null b:3 geom:4!null
+ ├── columns: k:1!null a:2!null b:3 i:4 geom:5!null
  ├── immutable
  ├── key: (1)
- ├── fd: ()-->(2), (1)-->(3,4)
+ ├── fd: ()-->(2), (1)-->(3-5)
  ├── scan m
- │    ├── columns: k:1!null a:2 b:3 geom:4
+ │    ├── columns: k:1!null a:2 b:3 i:4 geom:5
  │    ├── key: (1)
- │    └── fd: (1)-->(2-4)
+ │    └── fd: (1)-->(2-5)
  └── filters
       ├── a:2 = 'foo' [outer=(2), constraints=(/2: [/'foo' - /'foo']; tight), fd=()-->(2)]
-      └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:4) [outer=(4), immutable, constraints=(/4: (/NULL - ])]
+      └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:5) [outer=(5), immutable, constraints=(/5: (/NULL - ])]
 
 # Do not generate an inverted index scan when the first prefix column is
 # constrained to a range.
@@ -3209,18 +3210,18 @@ opt expect-not=GenerateInvertedIndexScans
 SELECT * FROM m WHERE a > 'x' AND a < 'y' AND b = 'foo' AND ST_CoveredBy('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))'::geometry, geom)
 ----
 select
- ├── columns: k:1!null a:2!null b:3!null geom:4!null
+ ├── columns: k:1!null a:2!null b:3!null i:4 geom:5!null
  ├── immutable
  ├── key: (1)
- ├── fd: ()-->(3), (1)-->(2,4)
+ ├── fd: ()-->(3), (1)-->(2,4,5)
  ├── scan m
- │    ├── columns: k:1!null a:2 b:3 geom:4
+ │    ├── columns: k:1!null a:2 b:3 i:4 geom:5
  │    ├── key: (1)
- │    └── fd: (1)-->(2-4)
+ │    └── fd: (1)-->(2-5)
  └── filters
       ├── (a:2 > 'x') AND (a:2 < 'y') [outer=(2), constraints=(/2: [/e'x\x00' - /'y'); tight)]
       ├── b:3 = 'foo' [outer=(3), constraints=(/3: [/'foo' - /'foo']; tight), fd=()-->(3)]
-      └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:4) [outer=(4), immutable, constraints=(/4: (/NULL - ])]
+      └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:5) [outer=(5), immutable, constraints=(/5: (/NULL - ])]
 
 # Do not generate an inverted index scan when the second prefix column is
 # constrained to a range.
@@ -3228,34 +3229,87 @@ opt expect-not=GenerateInvertedIndexScans
 SELECT * FROM m WHERE a = 'foo' AND b > 'x' AND b < 'y' AND ST_CoveredBy('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))'::geometry, geom)
 ----
 select
- ├── columns: k:1!null a:2!null b:3!null geom:4!null
+ ├── columns: k:1!null a:2!null b:3!null i:4 geom:5!null
  ├── immutable
  ├── key: (1)
- ├── fd: ()-->(2), (1)-->(3,4)
+ ├── fd: ()-->(2), (1)-->(3-5)
  ├── scan m
- │    ├── columns: k:1!null a:2 b:3 geom:4
+ │    ├── columns: k:1!null a:2 b:3 i:4 geom:5
  │    ├── key: (1)
- │    └── fd: (1)-->(2-4)
+ │    └── fd: (1)-->(2-5)
  └── filters
       ├── (b:3 > 'x') AND (b:3 < 'y') [outer=(3), constraints=(/3: [/e'x\x00' - /'y'); tight)]
       ├── a:2 = 'foo' [outer=(2), constraints=(/2: [/'foo' - /'foo']; tight), fd=()-->(2)]
-      └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:4) [outer=(4), immutable, constraints=(/4: (/NULL - ])]
+      └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:5) [outer=(5), immutable, constraints=(/5: (/NULL - ])]
 
 # Do not generate an inverted index scan when neither prefix column is constrained.
 opt expect-not=GenerateInvertedIndexScans
 SELECT * FROM m WHERE ST_CoveredBy('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))'::geometry, geom)
 ----
 select
- ├── columns: k:1!null a:2 b:3 geom:4!null
+ ├── columns: k:1!null a:2 b:3 i:4 geom:5!null
  ├── immutable
  ├── key: (1)
- ├── fd: (1)-->(2-4)
+ ├── fd: (1)-->(2-5)
  ├── scan m
- │    ├── columns: k:1!null a:2 b:3 geom:4
+ │    ├── columns: k:1!null a:2 b:3 i:4 geom:5
  │    ├── key: (1)
- │    └── fd: (1)-->(2-4)
+ │    └── fd: (1)-->(2-5)
  └── filters
-      └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:4) [outer=(4), immutable, constraints=(/4: (/NULL - ])]
+      └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:5) [outer=(5), immutable, constraints=(/5: (/NULL - ])]
+
+exec-ddl
+DROP INDEX multicol
+----
+
+exec-ddl
+CREATE INVERTED INDEX multicol ON m (i, geom)
+----
+
+# Generate an inverted index scan when the prefix column is constrained to a
+# contiguous range.
+opt expect=GenerateInvertedIndexScans
+SELECT k FROM m WHERE i IN (1, 2, 3) AND ST_CoveredBy('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))'::geometry, geom)
+----
+project
+ ├── columns: k:1!null
+ ├── immutable
+ ├── key: (1)
+ └── select
+      ├── columns: k:1!null i:4!null geom:5!null
+      ├── immutable
+      ├── key: (1)
+      ├── fd: (1)-->(4,5)
+      ├── index-join m
+      │    ├── columns: k:1!null i:4 geom:5
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(4,5)
+      │    └── inverted-filter
+      │         ├── columns: k:1!null
+      │         ├── inverted expression: /9
+      │         │    ├── tight: false
+      │         │    └── union spans
+      │         │         ├── ["B\xfd\x10\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x10\x00\x00\x00\x00\x00\x00\x00"]
+      │         │         ├── ["B\xfd\x11\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x11\x00\x00\x00\x00\x00\x00\x00"]
+      │         │         └── ["B\xfd\x14\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x14\x00\x00\x00\x00\x00\x00\x00"]
+      │         ├── pre-filterer expression
+      │         │    └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:5)
+      │         ├── key: (1)
+      │         └── scan m@multicol
+      │              ├── columns: k:1!null geom_inverted_key:9!null
+      │              ├── constraint: /4
+      │              │    ├── [/1 - /1]
+      │              │    ├── [/2 - /2]
+      │              │    └── [/3 - /3]
+      │              ├── inverted constraint: /9/1
+      │              │    └── spans
+      │              │         ├── ["B\xfd\x10\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x10\x00\x00\x00\x00\x00\x00\x00"]
+      │              │         ├── ["B\xfd\x11\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x11\x00\x00\x00\x00\x00\x00\x00"]
+      │              │         └── ["B\xfd\x14\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x14\x00\x00\x00\x00\x00\x00\x00"]
+      │              ├── key: (1)
+      │              └── fd: (1)-->(9)
+      └── filters
+           └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:5) [outer=(5), immutable, constraints=(/5: (/NULL - ])]
 
 exec-ddl
 CREATE TABLE mc (


### PR DESCRIPTION
This commit allows for the prefix columns of multi-column inverted
indexes to be constrained to a contiguous range. For example, consider
the schema and query:

    CREATE TABLE t (
        k INT PRIMARY KEY,
        i INT,
        g GEOMETRY,
        INVERTED INDEX (i, g)
    )

    SELECT k FROM t WHERE i IN (1, 2, 3) AND ST_CoveredBy(..., g)

Prior to this commit, a scan over the inverted index would not be
generated for this query.

Release note: None