### PR TITLE
colexec: make merge joiner more dynamic

### DIFF
--- a/pkg/sql/colexec/mergejoiner_util.go
+++ b/pkg/sql/colexec/mergejoiner_util.go
@@ -11,8 +11,9 @@
 package colexec
 
 // circularGroupsBuffer is a struct designed to store the groups' slices for a
-// given column. We know that there is a maximum number of possible groups per
-// batch, so we can cap the buffer and make it circular.
+// given column. It starts out small and will grow dynamically if necessary
+// until pre-computed maximum capacity (since we know that there is a maximum
+// number of possible groups per batch).
 type circularGroupsBuffer struct {
 	// startIdx indicates which index the next group to be processed is stored
 	// at.
@@ -22,39 +23,73 @@ type circularGroupsBuffer struct {
 	// nextColStartIdx is the index of the first group that belongs to the next
 	// column.
 	nextColStartIdx int
-	cap             int
+	// numGroupsInBuffer tracks the number of groups that are currently in the
+	// buffer which includes both of the current column being processed as well
+	// as the next one.
+	numGroupsInBuffer int
+	// capacity is the limit on the number of groups that current
+	// {left,right}Groups slices can support. numGroupsInBuffer will never reach
+	// this number, instead, we'll allocate bigger slices and increase capacity
+	// accordingly.
+	capacity int
+	// size is the number used to calculate the current values of capacity and
+	// the groups slices' lengths. It will be doubling when reallocating.
+	size int
+	// maxSize determines the maximum value for size variable that we'll ever
+	// need (determined by the batch size).
+	maxSize int
 
 	leftGroups  []group
 	rightGroups []group
 }
 
+// groupsBufferInitialSize determines the size used in initial allocations of
+// the slices of the circularGroupsBuffer.
+const groupsBufferInitialSize = 8
+
 func makeGroupsBuffer(batchSize int) circularGroupsBuffer {
 	return circularGroupsBuffer{
-		// The maximum number of possible groups per batch is achieved with FULL
-		// OUTER JOIN when no rows have matches, so there will be exactly
-		// batchSize x 2 groups. We add an additional element to the capacity in
-		// order to be able to distinguish between an "empty" (no groups) and a
-		// "full" (2*batchSize groups) buffers.
-		cap: 2*batchSize + 1,
-		// Since we have a circular buffer, it is possible for groups to wrap when
-		// cap is reached. Consider an example when batchSize = 3 and startIdx = 6
-		// when maximum number of groups is present:
-		// buffer = [1, 2, 3, 4, 5, x, 0] (integers denote different groups and 'x'
-		// stands for a garbage).
-		// When getGroups() is called, for ease of usage we need to return the
-		// buffer "flattened out", and in order to reduce allocation, we actually
-		// reserve 4*batchSize. In the example above we will copy the buffer as:
-		// buffer = [1, 2, 3, 4, 5, x, 0, 1, 2, 3, 4, 5]
-		// and will return buffer[6:12] when getGroups is called.
-		// The calculations for why 4*batchSize is sufficient:
-		// - the largest position in which the first group can be placed is
-		//   2*batchSize (cap field enforces that)
-		// - the largest number of groups to copy from the "physical" start of the
-		//   buffer is 2*batchSize-1
-		// - adding those two numbers we arrive at 4*batchSize.
-		leftGroups:  make([]group, 4*batchSize),
-		rightGroups: make([]group, 4*batchSize),
+		capacity:    getGroupsBufferCapacity(groupsBufferInitialSize),
+		size:        groupsBufferInitialSize,
+		maxSize:     batchSize,
+		leftGroups:  make([]group, getGroupsSlicesLen(groupsBufferInitialSize)),
+		rightGroups: make([]group, getGroupsSlicesLen(groupsBufferInitialSize)),
 	}
+}
+
+// getGroupsBufferCapacity returns capacity value for circularGroupsBuffer for
+// the given size.
+//
+// The maximum number of possible groups per batch is achieved with FULL OUTER
+// JOIN when no rows have matches, so there will be exactly size x 2 groups.
+// We add an additional element to the capacity in order to be able to
+// distinguish between an "empty" (no groups) and a "full" (2*size groups)
+// buffers.
+func getGroupsBufferCapacity(size int) int {
+	return 2*size + 1
+}
+
+// getGroupsSlicesLen returns the length of {left,right}Groups slices for
+// circularGroupsBuffer for the given size.
+//
+// Since we have a circular buffer, it is possible for groups to wrap when
+// capacity is reached. Consider an example when size = 3 and startIdx = 6 when
+// maximum number of groups is present:
+//   buffer = [1, 2, 3, 4, 5, x, 0]
+//  (integers denote different groups and 'x' stands for a garbage).
+// When getGroups() is called, for ease of usage we need to return the buffer
+// "flattened out", and in order to reduce allocation, we actually reserve
+// 4*size. In the example above we will copy the buffer as:
+//   buffer = [1, 2, 3, 4, 5, x, 0, 1, 2, 3, 4, 5]
+// and will return buffer[6:12] when getGroups is called.
+// The calculations for why 4*size is sufficient:
+// - the largest position in which the first group can be placed is 2*size
+//   (capacity field enforces that)
+// - the largest number of groups to copy from the "physical" start of the
+//   buffer is 2*size-1
+// - adding those two numbers we arrive at 4*size.
+func getGroupsSlicesLen(size int) int {
+	return 4 * size
 }
 
 // reset sets the circular buffer state to groups that produce the maximal
@@ -63,9 +98,28 @@ func (b *circularGroupsBuffer) reset(lStartIdx int, lEndIdx int, rStartIdx int, 
 	b.startIdx = 0
 	b.endIdx = 1
 	b.nextColStartIdx = 1
+	b.numGroupsInBuffer = 1
 
 	b.leftGroups[0] = group{lStartIdx, lEndIdx, 1, 0, false, false}
 	b.rightGroups[0] = group{rStartIdx, rEndIdx, 1, 0, false, false}
+}
+
+func (b *circularGroupsBuffer) advanceStart() {
+	b.numGroupsInBuffer--
+	b.startIdx++
+	// Modulus on every step is more expensive than this check.
+	if b.startIdx >= b.capacity {
+		b.startIdx -= b.capacity
+	}
+}
+
+func (b *circularGroupsBuffer) advanceEnd() {
+	b.numGroupsInBuffer++
+	b.endIdx++
+	// Modulus on every step is more expensive than this check.
+	if b.endIdx >= b.capacity {
+		b.endIdx -= b.capacity
+	}
 }
 
 // nextGroupInCol returns whether or not there exists a next group in the
@@ -75,15 +129,9 @@ func (b *circularGroupsBuffer) nextGroupInCol(lGroup *group, rGroup *group) bool
 	if b.startIdx == b.nextColStartIdx {
 		return false
 	}
-	idx := b.startIdx
-	b.startIdx++
-
-	if b.startIdx >= b.cap {
-		b.startIdx -= b.cap
-	}
-
-	*lGroup = b.leftGroups[idx]
-	*rGroup = b.rightGroups[idx]
+	*lGroup = b.leftGroups[b.startIdx]
+	*rGroup = b.rightGroups[b.startIdx]
+	b.advanceStart()
 	return true
 }
 
@@ -93,12 +141,69 @@ func (b *circularGroupsBuffer) isLastGroupInCol() bool {
 	return b.startIdx == b.nextColStartIdx
 }
 
+// ensureCapacityForNewGroup makes sure that groups slices have enough space to
+// add another group to the buffer, reallocating the slices if necessary.
+func (b *circularGroupsBuffer) ensureCapacityForNewGroup() {
+	if b.size == b.maxSize || b.numGroupsInBuffer+1 < b.capacity {
+		// We either have already allocated the slices with maximally possible
+		// required capacity or we still have enough space for one more group.
+		return
+	}
+	newSize := b.size * 2
+	if newSize > b.maxSize {
+		newSize = b.maxSize
+	}
+	newLeftGroups := make([]group, getGroupsSlicesLen(newSize))
+	newRightGroups := make([]group, getGroupsSlicesLen(newSize))
+	// Note that this if block is never reached when startIdx == endIdx (because
+	// that would indicate an empty buffer and we would enough capacity given
+	// our initialization in makeGroupsBuffer).
+	if b.startIdx <= b.endIdx {
+		// Current groups are contiguous in the slices, so copying them over is
+		// simple.
+		copy(newLeftGroups, b.leftGroups[b.startIdx:b.endIdx])
+		copy(newRightGroups, b.rightGroups[b.startIdx:b.endIdx])
+		b.nextColStartIdx -= b.startIdx
+	} else {
+		// Current groups are wrapped at position b.capacity. Namely, if we have
+		// size = 3, capacity = 7, we might have the following:
+		//   buffer = [1, 2, 0', 1', 2', x, 0]
+		// where startIdx = 6, endIdx = 4, nextColStartIdx = 2, so we need to
+		// copy over with the adjustments.
+		copy(newLeftGroups, b.leftGroups[b.startIdx:b.capacity])
+		copy(newRightGroups, b.rightGroups[b.startIdx:b.capacity])
+		if b.endIdx > 0 {
+			offset := b.capacity - b.startIdx
+			copy(newLeftGroups[offset:], b.leftGroups[:b.endIdx])
+			copy(newRightGroups[offset:], b.rightGroups[:b.endIdx])
+			b.nextColStartIdx += offset
+		} else {
+			// There is a special case when endIdx is 0 - we're simply shifting
+			// the groups by startIdx to the left (which we have already done)
+			// which requires adjusting nextColStartIdx accordingly.
+			//
+			// Consider the following, size = 3, capacity = 7
+			//   buffer = [x, 0, 1, 2, 0', 1', 2']
+			// with startIdx = 1, endIdx = 0, nextColStartIdx = 4. We don't need
+			// to copy anything, but we need to decrement nextColStartIdx by 1.
+			b.nextColStartIdx -= b.startIdx
+		}
+	}
+	b.startIdx = 0
+	b.endIdx = b.numGroupsInBuffer
+	b.capacity = getGroupsBufferCapacity(newSize)
+	b.size = newSize
+	b.leftGroups = newLeftGroups
+	b.rightGroups = newRightGroups
+}
+
 // addGroupsToNextCol appends a left and right group to the buffer. In an
 // iteration of a column, these values are either processed in the next
 // equality column or used to build the cross product.
 func (b *circularGroupsBuffer) addGroupsToNextCol(
 	curLIdx int, lRunLength int, curRIdx int, rRunLength int,
 ) {
+	b.ensureCapacityForNewGroup()
 	b.leftGroups[b.endIdx] = group{
 		rowStartIdx: curLIdx,
 		rowEndIdx:   curLIdx + lRunLength,
@@ -111,18 +216,14 @@ func (b *circularGroupsBuffer) addGroupsToNextCol(
 		numRepeats:  lRunLength,
 		toBuild:     lRunLength * rRunLength,
 	}
-	b.endIdx++
-
-	// Modulus on every step is more expensive than this check.
-	if b.endIdx >= b.cap {
-		b.endIdx -= b.cap
-	}
+	b.advanceEnd()
 }
 
 // addLeftUnmatchedGroup adds a left and right group to the buffer that
 // correspond to an unmatched row from the left side in the case of LEFT OUTER,
 // LEFT ANTI, or EXCEPT ALL joins.
 func (b *circularGroupsBuffer) addLeftUnmatchedGroup(curLIdx int, curRIdx int) {
+	b.ensureCapacityForNewGroup()
 	b.leftGroups[b.endIdx] = group{
 		rowStartIdx: curLIdx,
 		rowEndIdx:   curLIdx + 1,
@@ -139,18 +240,14 @@ func (b *circularGroupsBuffer) addLeftUnmatchedGroup(curLIdx int, curRIdx int) {
 		nullGroup:   true,
 		unmatched:   false,
 	}
-	b.endIdx++
-
-	// Modulus on every step is more expensive than this check.
-	if b.endIdx >= b.cap {
-		b.endIdx -= b.cap
-	}
+	b.advanceEnd()
 }
 
 // addRightUnmatchedGroup adds a left and right group to the buffer that
 // correspond to an unmatched row from the right side in the case of RIGHT
 // OUTER and RIGHT ANTI joins.
 func (b *circularGroupsBuffer) addRightUnmatchedGroup(curLIdx int, curRIdx int) {
+	b.ensureCapacityForNewGroup()
 	b.leftGroups[b.endIdx] = group{
 		rowStartIdx: curLIdx,
 		rowEndIdx:   curLIdx + 1,
@@ -167,12 +264,7 @@ func (b *circularGroupsBuffer) addRightUnmatchedGroup(curLIdx int, curRIdx int) 
 		nullGroup:   false,
 		unmatched:   true,
 	}
-	b.endIdx++
-
-	// Modulus on every step is more expensive than this check.
-	if b.endIdx >= b.cap {
-		b.endIdx -= b.cap
-	}
+	b.advanceEnd()
 }
 
 // addLeftSemiGroup adds a left group to the buffer that corresponds to a run
@@ -182,18 +274,14 @@ func (b *circularGroupsBuffer) addRightUnmatchedGroup(curLIdx int, curRIdx int) 
 // group here since tuples from the right are not outputted in LEFT SEMI nor
 // INTERSECT ALL joins.
 func (b *circularGroupsBuffer) addLeftSemiGroup(curLIdx int, lRunLength int) {
+	b.ensureCapacityForNewGroup()
 	b.leftGroups[b.endIdx] = group{
 		rowStartIdx: curLIdx,
 		rowEndIdx:   curLIdx + lRunLength,
 		numRepeats:  1,
 		toBuild:     lRunLength,
 	}
-	b.endIdx++
-
-	// Modulus on every step is more expensive than this check.
-	if b.endIdx >= b.cap {
-		b.endIdx -= b.cap
-	}
+	b.advanceEnd()
 }
 
 // addRightSemiGroup adds a right group to the buffer that corresponds to a run
@@ -202,18 +290,14 @@ func (b *circularGroupsBuffer) addLeftSemiGroup(curLIdx int, lRunLength int) {
 // group will be used by the builder next. Note that we're not adding a left
 // group here since tuples from the left are not outputted in RIGHT SEMI joins.
 func (b *circularGroupsBuffer) addRightSemiGroup(curRIdx int, rRunLength int) {
+	b.ensureCapacityForNewGroup()
 	b.rightGroups[b.endIdx] = group{
 		rowStartIdx: curRIdx,
 		rowEndIdx:   curRIdx + rRunLength,
 		numRepeats:  1,
 		toBuild:     rRunLength,
 	}
-	b.endIdx++
-
-	// Modulus on every step is more expensive than this check.
-	if b.endIdx >= b.cap {
-		b.endIdx -= b.cap
-	}
+	b.advanceEnd()
 }
 
 // finishedCol is used to notify the circular buffer to update the indices
@@ -221,6 +305,10 @@ func (b *circularGroupsBuffer) addRightSemiGroup(curRIdx int, rRunLength int) {
 func (b *circularGroupsBuffer) finishedCol() {
 	b.startIdx = b.nextColStartIdx
 	b.nextColStartIdx = b.endIdx
+	b.numGroupsInBuffer = b.endIdx - b.startIdx
+	if b.numGroupsInBuffer < 0 {
+		b.numGroupsInBuffer += b.capacity
+	}
 }
 
 // getGroups returns left and right slices of groups that are contiguous, which
@@ -231,9 +319,9 @@ func (b *circularGroupsBuffer) getGroups() ([]group, []group) {
 	leftGroups, rightGroups := b.leftGroups, b.rightGroups
 
 	if endIdx < startIdx {
-		copy(leftGroups[b.cap:], leftGroups[:endIdx])
-		copy(rightGroups[b.cap:], rightGroups[:endIdx])
-		endIdx += b.cap
+		copy(leftGroups[b.capacity:], leftGroups[:endIdx])
+		copy(rightGroups[b.capacity:], rightGroups[:endIdx])
+		endIdx += b.capacity
 	}
 
 	return leftGroups[startIdx:endIdx], rightGroups[startIdx:endIdx]


### PR DESCRIPTION
**colexec: cleanup and extend the merge joiner benchmark**

This commit refactors the merge joiner benchmark to remove the code
duplication as well as extends it to support the number of rows smaller
than coldata.BatchSize().

Additionally, it fixes the issue with the benchmark in which we used the
same coldata.Batch object for both sources, and as a result
"oneSideRepeat" config happened to behave exactly like "no repeats"
since the later source (the right one) wasn't repeated (internally, we
populated the batch with repeated rows for the left source and then
overwrote the same batch with non-repeated rows).

Another issue was not using the "chunks" sources that adjust the
batches so that they are, in fact, ordered on the equality columns
(previously, we were returning the same batch over and over, without
adjustments, i.e. we had tuple stream like 1, 2, 3, ..., 1024, 1, 2,
3 ...).

This commit also changes the benchmark to be very similar to what we
have in the row-execution with the following:
- change the number of columns to 1
- make the right side repeated for "oneSideRepeat" config
- change the computation of "numRepeats".

Release note: None

**colexec: make groups buffer in merge joiner dynamic**

Previously, we would always allocate the maximum possible number of
groups that could ever occur (FULL OUTER JOIN with no matches), however,
this is not necessary in most cases. This commit refactors the circular
groups buffer to grow dynamically if necessary while starting out with
small initial slices.

Release note: None

**colexec: make spilling queue more dynamic**

This commit introduces the dynamic allocation of items slice until the
estimated maximum which makes the spilling queue more dynamic.

Also, currently, we're always allocating a dequeue scratch batch of
coldata.BatchSize() capacity when creating a spilling queue. However,
that batch is only needed if we actually spill to disk, so this commit
makes that allocation lazy.

Release note: None