### PR TITLE
logictest: add retryable subtests

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
@@ -372,7 +372,7 @@ plates
 statement ok
 COMMIT
 
-subtest create_as_drop_and_create_in_txn
+subtest create_as_drop_and_create_in_txn retryable
 
 statement ok
 BEGIN
@@ -1667,7 +1667,7 @@ ALTER TABLE t DROP CONSTRAINT fk
 statement ok
 DROP TABLE t, t2
 
-subtest delete_index_in_other_table
+subtest delete_index_in_other_table retryable
 
 # Test setup
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/schema_change_retry
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_retry
@@ -29,6 +29,8 @@ CREATE INDEX y_idx ON t (y);
 # priority ensures that we don't block in this test).
 user testuser
 
+subtest other_user retryable
+
 statement ok
 BEGIN TRANSACTION PRIORITY HIGH
 


### PR DESCRIPTION
A retryable subtest is retried if a retriable (40001) error is
encountered during the test.

Fixes #56700.
Fixes #53724.

Release note: None