### PR TITLE
sql: minor EXPLAIN ANALYZE cleanups

### DIFF
--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -237,4 +237,8 @@ type TestTenantArgs struct {
 	// Stopper, if not nil, is used to stop the tenant manually otherwise the
 	// TestServer stopper will be used.
 	Stopper *stop.Stopper
+
+	// DeterministicExplainAnalyze, if set, will result in overriding fields in
+	// EXPLAIN ANALYZE (PLAN) that can vary between runs (like elapsed times).
+	DeterministicExplainAnalyze bool
 }

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -599,6 +599,9 @@ func (ts *TestServer) StartTenant(
 			ClusterSettingsUpdater: st.MakeUpdater(),
 		}
 	}
+	baseCfg.TestingKnobs.SQLExecutor = &sql.ExecutorTestingKnobs{
+		DeterministicExplainAnalyze: params.DeterministicExplainAnalyze,
+	}
 	stopper := params.Stopper
 	if stopper == nil {
 		stopper = ts.Stopper()

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -350,6 +350,7 @@ func (ex *connExecutor) execStmtInOpenState(
 		} else {
 			telemetry.Inc(sqltelemetry.ExplainAnalyzeUseCounter)
 			flags := explain.MakeFlags(&e.ExplainOptions)
+			flags.MakeDeterministic = ex.server.cfg.TestingKnobs.DeterministicExplainAnalyze
 			ih.SetOutputMode(explainAnalyzePlanOutput, flags)
 		}
 		// Strip off the explain node to execute the inner statement.

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -12,7 +12,6 @@ package sql
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkeys"
@@ -72,8 +71,8 @@ func emitExplain(
 	distribution physicalplan.PlanDistribution,
 	vectorized bool,
 ) error {
-	ob.AddField("distribution", distribution.String())
-	ob.AddField("vectorized", fmt.Sprintf("%t", vectorized))
+	ob.AddDistribution(distribution.String())
+	ob.AddVectorized(vectorized)
 	spanFormatFn := func(table cat.Table, index cat.Index, scanParams exec.ScanParams) string {
 		var tabDesc *tabledesc.Immutable
 		var idxDesc *descpb.IndexDescriptor

--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -13,7 +13,6 @@ package sql
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -191,9 +190,6 @@ func (ih *instrumentationHelper) Finish(
 
 	if ih.outputMode == explainAnalyzePlanOutput && retErr == nil {
 		phaseTimes := &statsCollector.phaseTimes
-		if cfg.TestingKnobs.DeterministicExplainAnalyze {
-			phaseTimes = &deterministicPhaseTimes
-		}
 		retErr = ih.setExplainAnalyzePlanResult(ctx, res, phaseTimes)
 	}
 
@@ -338,14 +334,4 @@ func (ih *instrumentationHelper) setExplainAnalyzePlanResult(
 		}
 	}
 	return nil
-}
-
-var deterministicPhaseTimes = phaseTimes{
-	sessionQueryReceived:    time.Time{},
-	sessionStartParse:       time.Time{},
-	sessionEndParse:         time.Time{}.Add(1 * time.Microsecond),
-	plannerStartLogicalPlan: time.Time{}.Add(1 * time.Microsecond),
-	plannerEndLogicalPlan:   time.Time{}.Add(11 * time.Microsecond),
-	plannerStartExecStmt:    time.Time{}.Add(11 * time.Microsecond),
-	plannerEndExecStmt:      time.Time{}.Add(111 * time.Microsecond),
 }

--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -307,8 +307,8 @@ func (ih *instrumentationHelper) planRowsForExplainAnalyze(phaseTimes *phaseTime
 		return nil
 	}
 	ob := explain.NewOutputBuilder(ih.explainFlags)
-	ob.AddField("planning time", phaseTimes.getPlanningLatency().Round(time.Microsecond).String())
-	ob.AddField("execution time", phaseTimes.getRunLatency().Round(time.Microsecond).String())
+	ob.AddPlanningTime(phaseTimes.getPlanningLatency())
+	ob.AddExecutionTime(phaseTimes.getRunLatency())
 	if err := emitExplain(ob, ih.evalCtx, ih.codec, ih.explainPlan, ih.distribution, ih.vectorized); err != nil {
 		return []string{fmt.Sprintf("error emitting plan: %v", err)}
 	}

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1365,7 +1365,12 @@ func (t *logicTest) setup(cfg testClusterConfig, serverArgs TestServerArgs) {
 	connsForClusterSettingChanges := []*gosql.DB{t.cluster.ServerConn(0)}
 	if cfg.useTenant {
 		var err error
-		t.tenantAddr, _, err = t.cluster.Server(t.nodeIdx).StartTenant(base.TestTenantArgs{TenantID: roachpb.MakeTenantID(10), AllowSettingClusterSettings: true})
+		tenantArgs := base.TestTenantArgs{
+			TenantID:                    roachpb.MakeTenantID(10),
+			AllowSettingClusterSettings: true,
+			DeterministicExplainAnalyze: true,
+		}
+		t.tenantAddr, _, err = t.cluster.Server(t.nodeIdx).StartTenant(tenantArgs)
 		if err != nil {
 			t.rootT.Fatalf("%+v", err)
 		}

--- a/pkg/sql/logictest/testdata/logic_test/explain_analyze
+++ b/pkg/sql/logictest/testdata/logic_test/explain_analyze
@@ -1,3 +1,22 @@
+statement ok
+CREATE TABLE kv (k INT PRIMARY KEY, v INT, FAMILY (k, v))
+
+query T
+EXPLAIN ANALYZE (PLAN) SELECT k FROM kv WHERE k = 0
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+·
+• scan
+  missing stats
+  table: kv@primary
+  spans: [/0 - /0]
+·
+WARNING: this statement is experimental!
+
+
 # Regression tests for weird explain analyze cases.
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/explain_analyze_plans
+++ b/pkg/sql/logictest/testdata/logic_test/explain_analyze_plans
@@ -99,18 +99,3 @@ query T
 SELECT url FROM [EXPLAIN ANALYZE (DISTSQL) SELECT k FROM kv WHERE k = 0];
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html#eJyMkE9r4zAQxe_7KYbZyy6oWL4KCklbl5q6SWqH_gs-KPaQGjuWKsmhIfi7F1uG0EOhx_ebN096c0L70aDALEqi6zV0poHbdPkAm-hllczjBcwX8-T1LYJ_N3G2zh6T_zBZa2-sD_B8F6UR1HAJPEeGrSppIfdkUWwwxJyhNqoga5UZ0Gk0xOUnCs6wanXnBpwzLJQhFCd0lWsIBa7ltqGUZEkm4MiwJCerZoytDzNtqr00R2SYadlaAQG_CHjwFxkuOydgFiLD-ydw1Z4EcDupTjdkwZAsBXDPtkd3RnCFDLfSFe9kQXVOD1mDcdo8o7xn6NX0f-vkjlCEPft9x5SsVq2lb_V-SuZ9zpDKHfk7WtWZglZGFeMzXi7HvRGUZJ2fhl7ErR_1ef_nKwAA__9iwp6v
-
-query T
-EXPLAIN ANALYZE (PLAN) SELECT k FROM kv WHERE k = 0
-----
-planning time: 10µs
-execution time: 100µs
-distribution: full
-vectorized: true
-·
-• scan
-  missing stats
-  table: kv@primary
-  spans: [/0 - /0]
-·
-WARNING: this statement is experimental!

--- a/pkg/sql/opt/exec/explain/flags.go
+++ b/pkg/sql/opt/exec/explain/flags.go
@@ -24,6 +24,10 @@ type Flags struct {
 	// query (e.g. spans). Used internally for the plan visible in the UI.
 	// If HideValues is true, then Verbose must be false.
 	HideValues bool
+
+	// MakeDeterministic edits values that are not suitable for testing, such as
+	// planning time.
+	MakeDeterministic bool
 }
 
 // MakeFlags crates Flags from ExplainOptions.

--- a/pkg/sql/opt/exec/explain/output.go
+++ b/pkg/sql/opt/exec/explain/output.go
@@ -314,23 +314,36 @@ func (ob *OutputBuilder) AddTopLevelField(key, value string) {
 // AddDistribution adds a top-level distribution field. Cannot be called
 // while inside a node.
 func (ob *OutputBuilder) AddDistribution(value string) {
+	if ob.flags.MakeDeterministic {
+		value = "<hidden>"
+	}
 	ob.AddTopLevelField("distribution", value)
 }
 
 // AddVectorized adds a top-level vectorized field. Cannot be called
 // while inside a node.
 func (ob *OutputBuilder) AddVectorized(value bool) {
-	ob.AddTopLevelField("vectorized", fmt.Sprintf("%t", value))
+	valueStr := fmt.Sprintf("%t", value)
+	if ob.flags.MakeDeterministic {
+		valueStr = "<hidden>"
+	}
+	ob.AddTopLevelField("vectorized", valueStr)
 }
 
 // AddPlanningTime adds a top-level planning time field. Cannot be called
 // while inside a node.
 func (ob *OutputBuilder) AddPlanningTime(delta time.Duration) {
+	if ob.flags.MakeDeterministic {
+		delta = 10 * time.Microsecond
+	}
 	ob.AddTopLevelField("planning time", delta.Round(time.Microsecond).String())
 }
 
 // AddExecutionTime adds a top-level execution time field. Cannot be called
 // while inside a node.
 func (ob *OutputBuilder) AddExecutionTime(delta time.Duration) {
+	if ob.flags.MakeDeterministic {
+		delta = 100 * time.Microsecond
+	}
 	ob.AddTopLevelField("execution time", delta.Round(time.Microsecond).String())
 }

--- a/pkg/sql/opt/exec/explain/output.go
+++ b/pkg/sql/opt/exec/explain/output.go
@@ -13,11 +13,13 @@ package explain
 import (
 	"bytes"
 	"fmt"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/treeprinter"
+	"github.com/cockroachdb/errors"
 )
 
 // OutputBuilder is used to build the output of an explain tree.
@@ -298,4 +300,37 @@ func (ob *OutputBuilder) BuildProtoTree() *roachpb.ExplainTreePlanNode {
 	}
 
 	return sentinel.Children[0]
+}
+
+// AddTopLevelField adds a top-level field. Cannot be called while inside a
+// node.
+func (ob *OutputBuilder) AddTopLevelField(key, value string) {
+	if ob.level != 0 {
+		panic(errors.AssertionFailedf("inside node"))
+	}
+	ob.AddField(key, value)
+}
+
+// AddDistribution adds a top-level distribution field. Cannot be called
+// while inside a node.
+func (ob *OutputBuilder) AddDistribution(value string) {
+	ob.AddTopLevelField("distribution", value)
+}
+
+// AddVectorized adds a top-level vectorized field. Cannot be called
+// while inside a node.
+func (ob *OutputBuilder) AddVectorized(value bool) {
+	ob.AddTopLevelField("vectorized", fmt.Sprintf("%t", value))
+}
+
+// AddPlanningTime adds a top-level planning time field. Cannot be called
+// while inside a node.
+func (ob *OutputBuilder) AddPlanningTime(delta time.Duration) {
+	ob.AddTopLevelField("planning time", delta.Round(time.Microsecond).String())
+}
+
+// AddExecutionTime adds a top-level execution time field. Cannot be called
+// while inside a node.
+func (ob *OutputBuilder) AddExecutionTime(delta time.Duration) {
+	ob.AddTopLevelField("execution time", delta.Round(time.Microsecond).String())
 }


### PR DESCRIPTION
#### sql: move top-level explain fields to explain package

The explain package contains all field names, except the top-level
fields (like "distribution", "planning time"). Move them to this
package by providing specific methods to set them.

Release note: None

#### sql: add MakeDeterministic explain flag

This change adds a flag that causes editing of non-deterministic
values like planning time and even distribution/vectorization. This
allows testing of EXPLAIN ANALYZE (PLAN) output with all logic test
configs.

Release note: None