### PR TITLE
cli: rework the `--help` strings for `node drain`

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -975,8 +975,10 @@ Base64-encoded Descriptor to use as the table when decoding KVs.`,
 	DrainWait = FlagInfo{
 		Name: "drain-wait",
 		Description: `
-When non-zero, wait for the specified amount of time for the node to
-drain all active client connections and migrate away range leases.`,
+When non-zero, wait for at most the specified amount of time for the node to
+drain all active client connections and migrate away range leases.
+If zero, the command waits until the last client has disconnected and
+all range leases have been migrated away.`,
 	}
 
 	Wait = FlagInfo{

--- a/pkg/cli/node.go
+++ b/pkg/cli/node.go
@@ -599,10 +599,15 @@ var drainNodeCmd = &cobra.Command{
 	Use:   "drain",
 	Short: "drain a node without shutting it down",
 	Long: `
-Prepare a server for shutting down. This stops accepting client
-connections, stops extant connections, and finally pushes range
-leases onto other nodes, subject to various timeout parameters
-configurable via cluster settings.`,
+Prepare a server so it becomes ready to be shut down safely.
+This causes the server to stop accepting client connections, stop
+extant connections, and finally push range leases onto other
+nodes, subject to various timeout parameters configurable via
+cluster settings.
+
+After a successful drain, the server process is still running;
+use a service manager or orchestrator to terminate the process
+gracefully using e.g. a unix signal.`,
 	Args: cobra.NoArgs,
 	RunE: MaybeDecorateGRPCError(runDrain),
 }


### PR DESCRIPTION
Fixes  #55123

This emphasizes that drain does not stop the process,
and that `--drain-wait` is about a timeout.

Release note: None