### PR TITLE
backupccl: skip TestRestoreMidSchemaChange under race

### DIFF
--- a/pkg/ccl/backupccl/restore_mid_schema_change_test.go
+++ b/pkg/ccl/backupccl/restore_mid_schema_change_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -52,6 +53,9 @@ import (
 func TestRestoreMidSchemaChange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	skip.UnderRaceWithIssue(t, 56584)
+
 	const (
 		testdataBase = "testdata/restore_mid_schema_change"
 		exportDirs   = testdataBase + "/exports"


### PR DESCRIPTION
This test is intended to verify that the particular set of backups taken
of descriptors during a schema change. Not much is gained running these
under race, but they are very slow so they should be skipped.

Fixes #56584.

Release note: None