### PR TITLE
sql: return error when dropping the primary index with `DROP INDEX`

### DIFF
--- a/pkg/sql/drop_index.go
+++ b/pkg/sql/drop_index.go
@@ -440,6 +440,16 @@ func (p *planner) dropIndexByName(
 	idxCopy := *idx
 	idx = &idxCopy
 
+	// Currently, a replacement primary index must be specified when dropping the primary index,
+	// and this cannot be done with DROP INDEX.
+	if idx.ID == tableDesc.PrimaryIndex.ID {
+		return errors.WithHint(
+			pgerror.Newf(pgcode.FeatureNotSupported, "cannot drop the primary index of a table using DROP INDEX"),
+			"instead, use ALTER TABLE ... ALTER PRIMARY KEY or"+
+				"use DROP CONSTRAINT ... PRIMARY KEY followed by ADD CONSTRAINT ... PRIMARY KEY in a transaction",
+		)
+	}
+
 	found := false
 	for i, idxEntry := range tableDesc.Indexes {
 		if idxEntry.ID == idx.ID {

--- a/pkg/sql/logictest/testdata/logic_test/drop_index
+++ b/pkg/sql/logictest/testdata/logic_test/drop_index
@@ -311,3 +311,12 @@ INSERT INTO t SELECT a + 1 FROM t;
 
 statement error pgcode 23505 duplicate key value: decoding err=column-id "2" does not exist
 UPSERT INTO t SELECT a + 1 FROM t;
+
+statement ok
+COMMIT;
+
+# test the primary key cannot be dropped with drop index; see #56853
+subtest drop_primary_key
+
+statement error pgcode 0A000 cannot drop the primary index of a table using DROP INDEX
+CREATE TABLE drop_primary(); DROP INDEX drop_primary@primary CASCADE;

--- a/pkg/sql/pgwire/testdata/pgtest/notice
+++ b/pkg/sql/pgwire/testdata/pgtest/notice
@@ -55,7 +55,7 @@ Query {"String": "DROP INDEX t_x_idx"}
 until crdb_only
 CommandComplete
 ----
-{"Severity":"NOTICE","Code":"00000","Message":"the data for dropped indexes is reclaimed asynchronously","Detail":"","Hint":"The reclamation delay can be customized in the zone configuration for the table.","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"drop_index.go","Line":511,"Routine":"dropIndexByName","UnknownFields":null}
+{"Severity":"NOTICE","Code":"00000","Message":"the data for dropped indexes is reclaimed asynchronously","Detail":"","Hint":"The reclamation delay can be customized in the zone configuration for the table.","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"drop_index.go","Line":521,"Routine":"dropIndexByName","UnknownFields":null}
 {"Type":"CommandComplete","CommandTag":"DROP INDEX"}
 
 until noncrdb_only


### PR DESCRIPTION
Previously, when dropping the primary index of a table using `DROP INDEX`,
an error would occur saying that the index is in the middle of being added.
The code would search to see if the index exists (even in the state of
being added or dropped) and later check the table descriptor for the index.
If the index existed but could not be found in the table descriptor,
then it would be assumed that the state of the index is that it is being
added. However, the previous code skipped checking the primary index
when reading the table descriptor, so the assumption that the index is
being added is incorrect.

This change adds an appropriate error to be returned when the index to
drop is the primary index. It also provides hints showing supported ways
for dropping the primary index.

Closes: https://github.com/cockroachdb/cockroach/issues/56853

Release note (sql change): Dropping the primary index using `DROP INDEX`
now returns a FeatureNotSupported error along with hints showing
supported ways to drop primary indexes.