### PR TITLE
release-20.2: jobs: reduce contention on jobs table by not updating terminal jobs

### DIFF
--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -616,8 +616,12 @@ func (r *Registry) Start(
 UPDATE system.jobs
    SET claim_session_id = NULL
  WHERE claim_session_id <> $1
+   AND status NOT IN ($2, $3, $4)
    AND NOT crdb_internal.sql_liveness_is_alive(claim_session_id)`,
-			s.ID().UnsafeBytes()); err != nil {
+			s.ID().UnsafeBytes(),
+			// Don't touch terminal jobs.
+			StatusSucceeded, StatusCanceled, StatusFailed,
+		); err != nil {
 			log.Errorf(ctx, "error expiring job sessions: %s", err)
 		}
 	}

--- a/pkg/jobs/registry_external_test.go
+++ b/pkg/jobs/registry_external_test.go
@@ -11,7 +11,9 @@
 package jobs_test
 
 import (
+	"bytes"
 	"context"
+	"encoding/hex"
 	"math"
 	"reflect"
 	"testing"
@@ -25,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/optionalnodeliveness"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness/slinstance"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness/slstorage"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
@@ -37,7 +40,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRoundtripJob(t *testing.T) {
@@ -298,5 +303,98 @@ func TestRegistryResumeActiveLease(t *testing.T) {
 
 	if e, a := id, <-resumeCh; e != a {
 		t.Fatalf("expected job %d to be resumed, but got %d", e, a)
+	}
+}
+
+// TestExpiringSessionsDoesNotTouchTerminalJobs will ensure that we do not
+// update the claim_session_id field of jobs when expiring sessions or claiming
+// jobs.
+func TestExpiringSessionsAndClaimJobsDoesNotTouchTerminalJobs(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	// Don't adopt, cancel rapidly.
+	defer jobs.TestingSetAdoptAndCancelIntervals(10*time.Hour, 10*time.Millisecond)()
+
+	ctx := context.Background()
+	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+
+	payload, err := protoutil.Marshal(&jobspb.Payload{
+		Details: jobspb.WrapPayloadDetails(jobspb.BackupDetails{}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	progress, err := protoutil.Marshal(&jobspb.Progress{
+		Details: jobspb.WrapProgressDetails(jobspb.BackupProgress{}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tdb := sqlutils.MakeSQLRunner(sqlDB)
+	const insertQuery = `
+   INSERT
+     INTO system.jobs (
+                        status,
+                        payload,
+                        progress,
+                        claim_session_id,
+                        claim_instance_id
+                      )
+   VALUES ($1, $2, $3, $4, $5)
+RETURNING id;
+`
+	terminalStatuses := []jobs.Status{jobs.StatusSucceeded, jobs.StatusCanceled, jobs.StatusFailed}
+	terminalIDs := make([]int64, len(terminalStatuses))
+	terminalClaims := make([][]byte, len(terminalStatuses))
+	for i, s := range terminalStatuses {
+		terminalClaims[i] = uuid.MakeV4().GetBytes() // bogus claim
+		tdb.QueryRow(t, insertQuery, s, payload, progress, terminalClaims[i], 42).
+			Scan(&terminalIDs[i])
+	}
+	var nonTerminalID int64
+	tdb.QueryRow(t, insertQuery, jobs.StatusRunning, payload, progress, uuid.MakeV4().GetBytes(), 42).
+		Scan(&nonTerminalID)
+
+	checkClaimEqual := func(id int64, exp []byte) error {
+		const getClaimQuery = `SELECT claim_session_id FROM system.jobs WHERE id = $1`
+		var claim []byte
+		tdb.QueryRow(t, getClaimQuery, id).Scan(&claim)
+		if !bytes.Equal(claim, exp) {
+			return errors.Errorf("expected nil, got %s", hex.EncodeToString(exp))
+		}
+		return nil
+	}
+	testutils.SucceedsSoon(t, func() error {
+		return checkClaimEqual(nonTerminalID, nil)
+	})
+	for i, id := range terminalIDs {
+		require.NoError(t, checkClaimEqual(id, terminalClaims[i]))
+	}
+	// Update the terminal jobs to set them to have a NULL claim.
+	for _, id := range terminalIDs {
+		tdb.Exec(t, `UPDATE system.jobs SET claim_session_id = NULL WHERE id = $1`, id)
+	}
+	// At this point, all of the jobs should have a NULL claim.
+	// Assert that.
+	for _, id := range append(terminalIDs, nonTerminalID) {
+		require.NoError(t, checkClaimEqual(id, nil))
+	}
+
+	// Nudge the adoption queue and ensure that only the non-terminal job gets
+	// claimed.
+	s.JobRegistry().(*jobs.Registry).TestingNudgeAdoptionQueue()
+
+	sess, err := s.SQLLivenessProvider().(sqlliveness.Provider).Session(ctx)
+	require.NoError(t, err)
+	testutils.SucceedsSoon(t, func() error {
+		return checkClaimEqual(nonTerminalID, sess.ID().UnsafeBytes())
+	})
+	// Ensure that the terminal jobs still have a nil claim.
+	for _, id := range terminalIDs {
+		require.NoError(t, checkClaimEqual(id, nil))
 	}
 }


### PR DESCRIPTION
Backport 1/1 commits from #56855.

/cc @cockroachdb/release

---

Currently our session and claiming logic will interact with terminal jobs.
This is bad both in that claiming may take a very long time because it may
claim already terminal jobs and because expiring out old sessions may end
up updating long ago terminated jobs.

Release note (bug fix): Eliminate opportunity for livelock in jobs subsystem
due to frequent updates to already finished jobs.
