### PR TITLE
sql: add notice for interleaved tables

### DIFF
--- a/pkg/build/info.go
+++ b/pkg/build/info.go
@@ -118,3 +118,8 @@ func TestingOverrideTag(t string) func() {
 	tag = t
 	return func() { tag = prev }
 }
+
+// MakeIssueURL produces a URL to a CockroachDB issue.
+func MakeIssueURL(issue int) string {
+	return fmt.Sprintf("https://go.crdb.dev/issue-v/%d/%s", issue, VersionPrefix())
+}

--- a/pkg/cli/BUILD.bazel
+++ b/pkg/cli/BUILD.bazel
@@ -142,7 +142,6 @@ go_library(
         "//pkg/util/encoding",
         "//pkg/util/encoding/csv",
         "//pkg/util/envutil",
-        "//pkg/util/errorutil/unimplemented",
         "//pkg/util/flagutil",
         "//pkg/util/grpcutil",
         "//pkg/util/hlc",

--- a/pkg/cli/cliflags/BUILD.bazel
+++ b/pkg/cli/cliflags/BUILD.bazel
@@ -9,8 +9,8 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/cli/cliflags",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/build",
         "//pkg/docs",
-        "//pkg/util/errorutil/unimplemented",
         "//vendor/github.com/kr/text",
     ],
 )

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -15,8 +15,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/docs"
-	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/kr/text"
 )
 
@@ -653,7 +653,7 @@ is likely to cause the entire host server to become compromised.
 </PRE>
 To simply accept non-TLS connections for SQL clients while keeping
 the cluster secure, consider using --accept-sql-without-tls instead.
-Also see: ` + unimplemented.MakeURL(53404) + `
+Also see: ` + build.MakeIssueURL(53404) + `
 `,
 	}
 

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -20,12 +20,12 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/cli/cliflags"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
-	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logflags"
@@ -758,7 +758,7 @@ func init() {
 		// NB: Insecure for `cockroach demo` is deprecated. See #53404.
 		_ = f.MarkDeprecated(cliflags.ServerInsecure.Name,
 			"to start a test server without any security, run start-single-node --insecure\n"+
-				"For details, see: "+unimplemented.MakeURL(53404))
+				"For details, see: "+build.MakeIssueURL(53404))
 
 		boolFlag(f, &demoCtx.disableLicenseAcquisition, cliflags.DemoNoLicense)
 		// Mark the --global flag as hidden until we investigate it more.

--- a/pkg/cli/sql_util.go
+++ b/pkg/cli/sql_util.go
@@ -33,7 +33,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
-	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/version"
@@ -976,7 +975,7 @@ func maybeShowTimes(
 		// No need to print if no one's watching.
 		if sqlCtx.isInteractive {
 			fmt.Fprintf(stderr, "\nNote: timings for multiple statements on a single line are not supported. See %s.\n",
-				unimplemented.MakeURL(48180))
+				build.MakeIssueURL(48180))
 		}
 		return
 	}

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -42,7 +42,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
-	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/grpcutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
@@ -1109,7 +1108,7 @@ func setupAndInitializeLoggingAndProfiling(
 				"consider --accept-sql-without-tls instead. For other options, see:\n\n"+
 				"- %s\n"+
 				"- %s",
-			unimplemented.MakeURL(53404),
+			build.MakeIssueURL(53404),
 			log.Safe(docs.URL("secure-a-cluster.html")),
 		)
 	}

--- a/pkg/cli/testdata/dump/interleave_index
+++ b/pkg/cli/testdata/dump/interleave_index
@@ -3,9 +3,11 @@
 sql
 CREATE DATABASE d;
 CREATE TABLE d.t1 (a INT, b INT, PRIMARY KEY (a));
+SET client_min_messages = 'warning';
 CREATE INDEX b_idx ON d.t1(a, b) INTERLEAVE IN PARENT d.t1 (a);
+SET client_min_messages = 'notice';
 ----
-CREATE INDEX
+SET
 
 dump d t1
 ----
@@ -27,7 +29,9 @@ sql
 CREATE DATABASE e;
 CREATE TABLE e.t2 (a INT, b INT, PRIMARY KEY (a));
 CREATE TABLE e.t3 (a INT, b INT, PRIMARY KEY (a));
+SET client_min_messages = 'warning';
 CREATE INDEX b_idx ON e.t2(a, b) INTERLEAVE IN PARENT e.t3 (a);
+SET client_min_messages = 'notice';
 INSERT INTO e.t2 VALUES (1, 2);
 INSERT INTO e.t3 VALUES (3, 4);
 ----
@@ -65,9 +69,11 @@ CREATE INDEX b_idx ON public.t2 (a ASC, b ASC) INTERLEAVE IN PARENT public.t3 (a
 sql
 CREATE DATABASE dd;
 CREATE TABLE dd.unique (a INT, b INT, PRIMARY KEY (a));
+SET client_min_messages = 'warning';
 CREATE INDEX "b_idx" ON dd.unique(a, b) INTERLEAVE IN PARENT dd.unique (a);
+SET client_min_messages = 'notice';
 ----
-CREATE INDEX
+SET
 
 dump dd unique
 ----
@@ -88,9 +94,11 @@ CREATE INDEX b_idx ON public."unique" (a ASC, b ASC) INTERLEAVE IN PARENT public
 sql
 CREATE DATABASE ee;
 CREATE TABLE ee.a (i INT, j INT, PRIMARY KEY (i, j DESC));
+SET client_min_messages = 'warning';
 CREATE TABLE ee.d (x INT, y INT, z INT, PRIMARY KEY (x, y DESC, z DESC)) INTERLEAVE IN PARENT ee.a (x, y);
+SET client_min_messages = 'notice';
 ----
-CREATE TABLE
+SET
 
 dump ee a d
 ----

--- a/pkg/sql/alter_column_type.go
+++ b/pkg/sql/alter_column_type.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -174,7 +175,7 @@ func alterColumnTypeGeneral(
 					errors.Newf("ALTER COLUMN TYPE from %v to %v is only "+
 						"supported experimentally",
 						col.Type, toType),
-					errors.IssueLink{IssueURL: unimplemented.MakeURL(49329)}),
+					errors.IssueLink{IssueURL: build.MakeIssueURL(49329)}),
 				"you can enable alter column type general support by running "+
 					"`SET enable_experimental_alter_column_type_general = true`"),
 			pgcode.FeatureNotSupported)

--- a/pkg/sql/alter_primary_key.go
+++ b/pkg/sql/alter_primary_key.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
@@ -30,6 +31,16 @@ import (
 func (p *planner) AlterPrimaryKey(
 	ctx context.Context, tableDesc *tabledesc.Mutable, alterPKNode *tree.AlterTableAlterPrimaryKey,
 ) error {
+	if alterPKNode.Interleave != nil {
+		p.BufferClientNotice(
+			ctx,
+			errors.WithIssueLink(
+				pgnotice.Newf("interleaved tables and indexes are deprecated in 20.2 and will be removed in 21.2"),
+				errors.IssueLink{IssueURL: build.MakeIssueURL(52009)},
+			),
+		)
+	}
+
 	if alterPKNode.Sharded != nil {
 		if !p.EvalContext().SessionData.HashShardedIndexesEnabled {
 			return hashShardedIndexesDisabledError

--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -13,6 +13,7 @@ package sql
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/geo/geoindex"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
@@ -388,6 +389,16 @@ func (n *createIndexNode) startExec(params runParams) error {
 			errors.WithHint(
 				pgnotice.Newf("creating non-partitioned index on partitioned table may not be performant"),
 				"Consider modifying the index such that it is also partitioned.",
+			),
+		)
+	}
+
+	if n.n.Interleave != nil {
+		params.p.BufferClientNotice(
+			params.ctx,
+			errors.WithIssueLink(
+				pgnotice.Newf("interleaved tables and indexes are deprecated in 20.2 and will be removed in 21.2"),
+				errors.IssueLink{IssueURL: build.MakeIssueURL(52009)},
 			),
 		)
 	}

--- a/pkg/sql/logictest/BUILD.bazel
+++ b/pkg/sql/logictest/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/base",
+        "//pkg/build",
         "//pkg/col/coldata",
         "//pkg/kv/kvserver",
         "//pkg/roachpb",
@@ -30,7 +31,6 @@ go_library(
         "//pkg/testutils/sqlutils",
         "//pkg/util",
         "//pkg/util/envutil",
-        "//pkg/util/errorutil/unimplemented",
         "//pkg/util/log",
         "//pkg/util/randutil",
         "//pkg/util/syncutil",

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -18,7 +18,7 @@ import (
 	gosql "database/sql"
 	"flag"
 	"fmt"
-	"go/build"
+	gobuild "go/build"
 	"io"
 	"math"
 	"math/rand"
@@ -38,6 +38,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -61,7 +62,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
-	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -144,6 +144,8 @@ import (
 //      statement ok
 //      CREATE TABLE kv (k INT PRIMARY KEY, v INT)
 //
+//  - statement notice <regexp>
+//    Like "statement ok" but expects a notice that matches the given regexp.
 //
 //  - statement count N
 //    Like "statement ok" but expect a final RowsAffected count of N.
@@ -358,6 +360,7 @@ import (
 
 var (
 	resultsRE = regexp.MustCompile(`^(\d+)\s+values?\s+hashing\s+to\s+([0-9A-Fa-f]+)$`)
+	noticeRE  = regexp.MustCompile(`^statement\s+notice\s+(.*)$`)
 	errorRE   = regexp.MustCompile(`^(?:statement|query)\s+error\s+(?:pgcode\s+([[:alnum:]]+)\s+)?(.*)$`)
 	varRE     = regexp.MustCompile(`\$[a-zA-Z][a-zA-Z_0-9]*`)
 
@@ -746,6 +749,8 @@ type logicStatement struct {
 	pos string
 	// SQL string to be sent to the database.
 	sql string
+	// expected notice, if any.
+	expectNotice string
 	// expected error, if any. "" indicates the statement should
 	// succeed.
 	expectErr string
@@ -781,6 +786,12 @@ func (ls *logicStatement) readSQL(
 		}
 		if line == "----" {
 			separator = true
+			if ls.expectNotice != "" {
+				return false, errors.Errorf(
+					"%s: invalid ---- separator after a statement expecting a notice: %s",
+					ls.pos, ls.expectNotice,
+				)
+			}
 			if ls.expectErr != "" {
 				return false, errors.Errorf(
 					"%s: invalid ---- separator after a statement or query expecting an error: %s",
@@ -1589,7 +1600,7 @@ func processConfigs(t *testing.T, path string, defaults configSet, configNames [
 
 		blockedConfig, issueNo := getBlocklistIssueNo(configName[1:])
 		if *printBlocklistIssues && issueNo != 0 {
-			t.Logf("will skip %s config in test %s due to issue: %s", blockedConfig, path, unimplemented.MakeURL(issueNo))
+			t.Logf("will skip %s config in test %s due to issue: %s", blockedConfig, path, build.MakeIssueURL(issueNo))
 		}
 		blocklist[blockedConfig] = issueNo
 	}
@@ -1843,8 +1854,10 @@ func (t *logicTest) processSubtest(
 				pos:         fmt.Sprintf("\n%s:%d", path, s.line+subtest.lineLineIndexIntoFile),
 				expectCount: -1,
 			}
-			// Parse "statement error <regexp>"
-			if m := errorRE.FindStringSubmatch(s.Text()); m != nil {
+			// Parse "statement (notice|error) <regexp>"
+			if m := noticeRE.FindStringSubmatch(s.Text()); m != nil {
+				stmt.expectNotice = m[1]
+			} else if m := errorRE.FindStringSubmatch(s.Text()); m != nil {
 				stmt.expectErrCode = m[1]
 				stmt.expectErr = m[2]
 			}
@@ -2276,14 +2289,16 @@ func (t *logicTest) processSubtest(
 	return s.Err()
 }
 
-// verifyError checks that either no error was found where none was
-// expected, or that an error was found when one was expected.
+// verifyError checks that either:
+// - no error was found when none was expected, or
+// - in case no error was found, a notice was found when one was expected, or
+// - an error was found when one was expected.
 // Returns a nil error to indicate the behavior was as expected.  If
 // non-nil, returns also true in the boolean flag whether it is safe
 // to continue (i.e. an error was expected, an error was obtained, and
 // the errors didn't match).
 func (t *logicTest) verifyError(
-	sql, pos, expectErr, expectErrCode string, err error,
+	sql, pos, expectNotice, expectErr, expectErrCode string, err error,
 ) (bool, error) {
 	if expectErr == "" && expectErrCode == "" && err != nil {
 		cont := t.unexpectedError(sql, pos, err)
@@ -2292,6 +2307,14 @@ func (t *logicTest) verifyError(
 			err = nil
 		}
 		return cont, err
+	}
+	if expectNotice != "" {
+		foundNotice := strings.Join(t.noticeBuffer, "\n")
+		match, _ := regexp.MatchString(expectNotice, foundNotice)
+		if !match {
+			return false, errors.Errorf("%s: %s\nexpected notice pattern:\n%s\n\ngot:\n%s", pos, sql, expectNotice, foundNotice)
+		}
+		return true, nil
 	}
 	if !testutils.IsError(err, expectErr) {
 		if err == nil {
@@ -2425,7 +2448,7 @@ func (t *logicTest) execStatement(stmt logicStatement) (bool, error) {
 	//   the database in an improper state, so we stop there;
 	// - error on expected error is worth going further, even
 	//   if the obtained error does not match the expected error.
-	cont, err := t.verifyError("", stmt.pos, stmt.expectErr, stmt.expectErrCode, err)
+	cont, err := t.verifyError("", stmt.pos, stmt.expectNotice, stmt.expectErr, stmt.expectErrCode, err)
 	if err != nil {
 		t.finishOne("OK")
 	}
@@ -2468,7 +2491,7 @@ func (t *logicTest) execQuery(query logicQuery) error {
 			err = rows.Err()
 		}
 	}
-	if _, err := t.verifyError(query.sql, query.pos, query.expectErr, query.expectErrCode, err); err != nil {
+	if _, err := t.verifyError(query.sql, query.pos, "", query.expectErr, query.expectErrCode, err); err != nil {
 		return err
 	}
 	if err != nil {
@@ -3189,7 +3212,7 @@ func runSQLLiteLogicTest(t *testing.T, configOverride string, globs ...string) {
 		skip.IgnoreLint(t, "-bigtest flag must be specified to run this test")
 	}
 
-	logicTestPath := build.Default.GOPATH + "/src/github.com/cockroachdb/sqllogictest"
+	logicTestPath := gobuild.Default.GOPATH + "/src/github.com/cockroachdb/sqllogictest"
 	if _, err := os.Stat(logicTestPath); oserror.IsNotExist(err) {
 		fullPath, err := filepath.Abs(logicTestPath)
 		if err != nil {

--- a/pkg/sql/logictest/testdata/logic_test/interleaved
+++ b/pkg/sql/logictest/testdata/logic_test/interleaved
@@ -443,3 +443,21 @@ SELECT
 ;
 ----
 0 0 0
+
+# test for #56579: ensure that deprecation notice is present
+
+subtest interleaved_deprecation_notice
+statement ok
+CREATE TABLE interleave_parent (x INT PRIMARY KEY);
+
+statement notice NOTICE: interleaved tables and indexes are deprecated in 20.2 and will be removed in 21.2\nHINT: .*52009.*
+CREATE TABLE interleave_create_notice (x INT, y INT, s STRING, PRIMARY KEY (x, y)) INTERLEAVE IN PARENT interleave_parent(x);
+
+statement notice NOTICE: interleaved tables and indexes are deprecated in 20.2 and will be removed in 21.2\nHINT: .*52009.*
+CREATE INDEX interleave_index ON interleave_create_notice (x, s) INTERLEAVE IN PARENT interleave_parent(x);
+
+statement ok
+CREATE TABLE interleave_pk_notice (x INT NOT NULL, y INT);
+
+statement notice NOTICE: interleaved tables and indexes are deprecated in 20.2 and will be removed in 21.2\nHINT: .*52009.*
+ALTER TABLE interleave_pk_notice ALTER PRIMARY KEY USING COLUMNS (x) INTERLEAVE IN PARENT interleave_parent(x);

--- a/pkg/util/errorutil/unimplemented/BUILD.bazel
+++ b/pkg/util/errorutil/unimplemented/BUILD.bazel
@@ -15,5 +15,8 @@ go_test(
     name = "unimplemented_test",
     srcs = ["unimplemented_test.go"],
     embed = [":unimplemented"],
-    deps = ["//vendor/github.com/cockroachdb/errors"],
+    deps = [
+        "//pkg/build",
+        "//vendor/github.com/cockroachdb/errors",
+    ],
 )

--- a/pkg/util/errorutil/unimplemented/unimplemented.go
+++ b/pkg/util/errorutil/unimplemented/unimplemented.go
@@ -68,7 +68,7 @@ func unimplementedInternal(
 	// Create the issue link.
 	link := errors.IssueLink{Detail: detail}
 	if issue > 0 {
-		link.IssueURL = MakeURL(issue)
+		link.IssueURL = build.MakeIssueURL(issue)
 	}
 
 	// Instantiate the base error.
@@ -97,9 +97,4 @@ func unimplementedInternal(
 		err = errors.WithTelemetry(err, detail)
 	}
 	return err
-}
-
-// MakeURL produces a URL to a CockroachDB issue.
-func MakeURL(issue int) string {
-	return fmt.Sprintf("https://go.crdb.dev/issue-v/%d/%s", issue, build.VersionPrefix())
 }

--- a/pkg/util/errorutil/unimplemented/unimplemented_test.go
+++ b/pkg/util/errorutil/unimplemented/unimplemented_test.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/errors"
 )
 
@@ -49,7 +50,7 @@ func TestUnimplemented(t *testing.T) {
 				}
 				if test.expIssue != 0 {
 					ref := fmt.Sprintf("%s\nSee: %s",
-						errors.UnimplementedErrorHint, MakeURL(test.expIssue))
+						errors.UnimplementedErrorHint, build.MakeIssueURL(test.expIssue))
 					if hint == ref {
 						found |= 2
 					}
@@ -78,7 +79,7 @@ func TestUnimplemented(t *testing.T) {
 				}
 
 				if test.expIssue != 0 {
-					url := MakeURL(test.expIssue)
+					url := build.MakeIssueURL(test.expIssue)
 					if links[0].IssueURL != url {
 						t.Errorf("expected link url %q, got %q", url, links[0].IssueURL)
 					}


### PR DESCRIPTION
This patch adds a deprecation notice when the user attempts to create an
interleaved table by executing a CREATE TABLE ... INTERLEAVE IN PARENT
statement.

Fixes #56579.

Release note (sql change): Added deprecation notice to CREATE TABLE ...
INTERLEAVE IN PARENT statements.