### PR TITLE
colexecagg: improve default agg function on empty input

### DIFF
--- a/pkg/sql/colexec/colexecagg/count_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/count_agg_tmpl.go
@@ -135,11 +135,14 @@ func (a *count_COUNTKIND_AGGKINDAgg) Flush(outputIdx int) {
 	a.vec[outputIdx] = a.curAgg
 }
 
+// {{if eq "_AGGKIND" "Ordered"}}
 func (a *count_COUNTKIND_AGGKINDAgg) HandleEmptyInputScalar() {
 	// COUNT aggregates are special because they return zero in case of an
 	// empty input in the scalar context.
 	a.vec[0] = 0
 }
+
+// {{end}}
 
 type count_COUNTKIND_AGGKINDAggAlloc struct {
 	aggAllocBase

--- a/pkg/sql/colexec/colexecagg/default_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/default_agg_tmpl.go
@@ -112,16 +112,16 @@ func (a *default_AGGKINDAgg) Flush(outputIdx int) {
 	outputIdx = a.curIdx
 	a.curIdx++
 	// {{end}}
-	res, err := a.fn.Result()
-	if err != nil {
-		colexecerror.ExpectedError(err)
-	}
-	if res == tree.DNull {
-		a.nulls.SetNull(outputIdx)
-	} else {
-		coldata.SetValueAt(a.vec, a.resultConverter(res), outputIdx)
-	}
+	_SET_RESULT(a, outputIdx)
 }
+
+// {{if eq "_AGGKIND" "Ordered"}}
+func (a *default_AGGKINDAgg) HandleEmptyInputScalar() {
+	outputIdx := 0
+	_SET_RESULT(a, outputIdx)
+}
+
+// {{end}}
 
 func newDefault_AGGKINDAggAlloc(
 	allocator *colmem.Allocator,
@@ -248,7 +248,27 @@ func _ADD_TUPLE(a *default_AGGKINDAgg, groups []bool, nulls *coldata.Nulls, tupl
 	if err := a.fn.Add(a.ctx, firstArg, a.scratch.otherArgs...); err != nil {
 		colexecerror.ExpectedError(err)
 	}
-
 	// {{end}}
+
+	// {{/*
+} // */}}
+
+// {{/*
+// _SET_RESULT is a code snippet that sets the result obtained from a.fn in
+// position outputIdx of the output.
+func _SET_RESULT(a *default_AGGKINDAgg, outputIdx int) { // */}}
+	// {{define "setResult" -}}
+
+	res, err := a.fn.Result()
+	if err != nil {
+		colexecerror.ExpectedError(err)
+	}
+	if res == tree.DNull {
+		a.nulls.SetNull(outputIdx)
+	} else {
+		coldata.SetValueAt(a.vec, a.resultConverter(res), outputIdx)
+	}
+	// {{end}}
+
 	// {{/*
 } // */}}

--- a/pkg/sql/colexec/colexecagg/hash_count_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_count_agg.eg.go
@@ -63,12 +63,6 @@ func (a *countRowsHashAgg) Flush(outputIdx int) {
 	a.vec[outputIdx] = a.curAgg
 }
 
-func (a *countRowsHashAgg) HandleEmptyInputScalar() {
-	// COUNT aggregates are special because they return zero in case of an
-	// empty input in the scalar context.
-	a.vec[0] = 0
-}
-
 type countRowsHashAggAlloc struct {
 	aggAllocBase
 	aggFuncs []countRowsHashAgg
@@ -148,12 +142,6 @@ func (a *countHashAgg) Compute(
 
 func (a *countHashAgg) Flush(outputIdx int) {
 	a.vec[outputIdx] = a.curAgg
-}
-
-func (a *countHashAgg) HandleEmptyInputScalar() {
-	// COUNT aggregates are special because they return zero in case of an
-	// empty input in the scalar context.
-	a.vec[0] = 0
 }
 
 type countHashAggAlloc struct {

--- a/pkg/sql/colexec/colexecagg/hash_default_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_default_agg.eg.go
@@ -78,7 +78,6 @@ func (a *defaultHashAgg) Compute(
 				if err := a.fn.Add(a.ctx, firstArg, a.scratch.otherArgs...); err != nil {
 					colexecerror.ExpectedError(err)
 				}
-
 			}
 		}
 	})

--- a/pkg/sql/colexec/execgen/cmd/execgen/default_agg_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/default_agg_gen.go
@@ -21,6 +21,9 @@ func genDefaultAgg(inputFileContents string, wr io.Writer) error {
 	addTuple := makeFunctionRegex("_ADD_TUPLE", 4)
 	s := addTuple.ReplaceAllString(inputFileContents, `{{template "addTuple"}}`)
 
+	setResult := makeFunctionRegex("_SET_RESULT", 2)
+	s = setResult.ReplaceAllString(s, `{{template "setResult"}}`)
+
 	tmpl, err := template.New("default_agg").Parse(s)
 	if err != nil {
 		return err


### PR DESCRIPTION
`colexecagg.AggregateFunc` has `HandleEmptyInputScalar` method that for
most functions sets a single null value for the output (current only
exceptions are count and count_rows). This commit cleans up the default
aggregate function so that it delegates the handling of that method to
the wrapped function. This is necessary in order to support `regr_count`
function which returns 0 on empty input (another exception) that is
about to be added by an external contributor. Additionally this commit
modifies the templates to generate that function's implementation only
for the ordered aggregation - for the hash aggregation we'll rely on
`hashAggregateFuncBase`.

Release note: None