### PR TITLE
colexec: make aggregators more dynamic

### DIFF
--- a/pkg/sql/colexec/aggregators_util.go
+++ b/pkg/sql/colexec/aggregators_util.go
@@ -565,11 +565,11 @@ type aggBucket struct {
 }
 
 func (b *aggBucket) init(
-	batch coldata.Batch, fns []colexecagg.AggregateFunc, seen []map[string]struct{}, groups []bool,
+	fns []colexecagg.AggregateFunc, seen []map[string]struct{}, groups []bool,
 ) {
 	b.fns = fns
-	for fnIdx, fn := range b.fns {
-		fn.Init(groups, batch.ColVec(fnIdx))
+	for _, fn := range b.fns {
+		fn.Init(groups)
 	}
 	b.seen = seen
 }

--- a/pkg/sql/colexec/colexecagg/aggregate_funcs.go
+++ b/pkg/sql/colexec/colexecagg/aggregate_funcs.go
@@ -51,29 +51,21 @@ func IsAggOptimized(aggFn execinfrapb.AggregatorSpec_Func) bool {
 // in Init. The AggregateFunc performs an aggregation per group and outputs the
 // aggregation once the start of the new group is reached. If the end of the
 // group is not reached before the batch is finished, the AggregateFunc will
-// store a carry value that it will use next time Compute is called. Note that
-// this carry value is stored at the output index. Therefore if any memory
-// modification of the output vector is made, the caller *MUST* copy the value
-// at the current index inclusive for a correct aggregation.
+// store a carry value itself that it will use next time Compute is called to
+// continue the aggregation of the last group.
 type AggregateFunc interface {
-	// Init sets the groups for the aggregation and the output vector. Each index
-	// in groups corresponds to a column value in the input batch. true represents
-	// the start of a new group. Note that the very first group in the whole
-	// input should *not* be marked as a start of a new group.
+	// Init sets the groups for the aggregation and the output vector. Each
+	// index in groups corresponds to a column value in the input batch. true
+	// represents the start of a new group. Note that the very first group in
+	// the whole input should *not* be marked as a start of a new group.
 	Init(groups []bool, vec coldata.Vec)
 
-	// Reset resets the aggregate function for another run. Primarily used for
-	// benchmarks.
-	Reset()
-
-	// CurrentOutputIndex returns the current index in the output vector that the
-	// aggregate function is writing to. All indices < the index returned are
-	// finished aggregations for previous groups. A negative index may be returned
-	// to signify an aggregate function that has not yet performed any
-	// computation.
+	// CurrentOutputIndex returns the current index in the output vector that
+	// the aggregate function is writing to. All indices < the index returned
+	// are finished aggregations for previous groups.
 	CurrentOutputIndex() int
-	// SetOutputIndex sets the output index to write to. The value for the current
-	// index is carried over.
+
+	// SetOutputIndex sets the output index to write to.
 	SetOutputIndex(idx int)
 
 	// Compute computes the aggregation on the input batch.
@@ -88,8 +80,6 @@ type AggregateFunc interface {
 	// function itself should maintain the output index to write to.
 	// The caller *must* ensure that the memory accounting is done on the
 	// output vector of the aggregate function.
-	// Note: the implementations are free to not account for the memory used
-	// for the result of aggregation of the last group.
 	Flush(outputIdx int)
 
 	// HandleEmptyInputScalar populates the output for a case of an empty input
@@ -109,11 +99,6 @@ type orderedAggregateFuncBase struct {
 func (o *orderedAggregateFuncBase) Init(groups []bool, vec coldata.Vec) {
 	o.groups = groups
 	o.nulls = vec.Nulls()
-}
-
-func (o *orderedAggregateFuncBase) Reset() {
-	o.curIdx = 0
-	o.nulls.UnsetNulls()
 }
 
 func (o *orderedAggregateFuncBase) CurrentOutputIndex() int {
@@ -138,10 +123,6 @@ type hashAggregateFuncBase struct {
 
 func (h *hashAggregateFuncBase) Init(_ []bool, vec coldata.Vec) {
 	h.nulls = vec.Nulls()
-}
-
-func (h *hashAggregateFuncBase) Reset() {
-	h.nulls.UnsetNulls()
 }
 
 func (h *hashAggregateFuncBase) CurrentOutputIndex() int {

--- a/pkg/sql/colexec/colexecagg/any_not_null_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/any_not_null_agg_tmpl.go
@@ -92,16 +92,6 @@ func (a *anyNotNull_TYPE_AGGKINDAgg) Init(groups []bool, vec coldata.Vec) {
 	// {{end}}
 	a.vec = vec
 	a.col = vec.TemplateType()
-	a.Reset()
-}
-
-func (a *anyNotNull_TYPE_AGGKINDAgg) Reset() {
-	// {{if eq "_AGGKIND" "Ordered"}}
-	a.orderedAggregateFuncBase.Reset()
-	// {{else}}
-	a.hashAggregateFuncBase.Reset()
-	// {{end}}
-	a.foundNonNullForCurrentGroup = false
 }
 
 func (a *anyNotNull_TYPE_AGGKINDAgg) Compute(

--- a/pkg/sql/colexec/colexecagg/any_not_null_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/any_not_null_agg_tmpl.go
@@ -84,11 +84,11 @@ type anyNotNull_TYPE_AGGKINDAgg struct {
 
 var _ AggregateFunc = &anyNotNull_TYPE_AGGKINDAgg{}
 
-func (a *anyNotNull_TYPE_AGGKINDAgg) Init(groups []bool, vec coldata.Vec) {
+func (a *anyNotNull_TYPE_AGGKINDAgg) SetOutput(vec coldata.Vec) {
 	// {{if eq "_AGGKIND" "Ordered"}}
-	a.orderedAggregateFuncBase.Init(groups, vec)
+	a.orderedAggregateFuncBase.SetOutput(vec)
 	// {{else}}
-	a.hashAggregateFuncBase.Init(groups, vec)
+	a.hashAggregateFuncBase.SetOutput(vec)
 	// {{end}}
 	a.vec = vec
 	a.col = vec.TemplateType()

--- a/pkg/sql/colexec/colexecagg/avg_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/avg_agg_tmpl.go
@@ -107,11 +107,11 @@ type avg_TYPE_AGGKINDAgg struct {
 
 var _ AggregateFunc = &avg_TYPE_AGGKINDAgg{}
 
-func (a *avg_TYPE_AGGKINDAgg) Init(groups []bool, vec coldata.Vec) {
+func (a *avg_TYPE_AGGKINDAgg) SetOutput(vec coldata.Vec) {
 	// {{if eq "_AGGKIND" "Ordered"}}
-	a.orderedAggregateFuncBase.Init(groups, vec)
+	a.orderedAggregateFuncBase.SetOutput(vec)
 	// {{else}}
-	a.hashAggregateFuncBase.Init(groups, vec)
+	a.hashAggregateFuncBase.SetOutput(vec)
 	// {{end}}
 	a.scratch.vec = vec._RET_TYPE()
 }

--- a/pkg/sql/colexec/colexecagg/avg_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/avg_agg_tmpl.go
@@ -114,18 +114,6 @@ func (a *avg_TYPE_AGGKINDAgg) Init(groups []bool, vec coldata.Vec) {
 	a.hashAggregateFuncBase.Init(groups, vec)
 	// {{end}}
 	a.scratch.vec = vec._RET_TYPE()
-	a.Reset()
-}
-
-func (a *avg_TYPE_AGGKINDAgg) Reset() {
-	// {{if eq "_AGGKIND" "Ordered"}}
-	a.orderedAggregateFuncBase.Reset()
-	// {{else}}
-	a.hashAggregateFuncBase.Reset()
-	// {{end}}
-	a.scratch.curSum = zero_RET_TYPEValue
-	a.scratch.curCount = 0
-	a.scratch.foundNonNullForCurrentGroup = false
 }
 
 func (a *avg_TYPE_AGGKINDAgg) Compute(

--- a/pkg/sql/colexec/colexecagg/bool_and_or_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/bool_and_or_agg_tmpl.go
@@ -73,17 +73,11 @@ func (a *bool_OP_TYPE_AGGKINDAgg) Init(groups []bool, vec coldata.Vec) {
 	a.hashAggregateFuncBase.Init(groups, vec)
 	// {{end}}
 	a.vec = vec.Bool()
-	a.Reset()
-}
-
-func (a *bool_OP_TYPE_AGGKINDAgg) Reset() {
-	// {{if eq "_AGGKIND" "Ordered"}}
-	a.orderedAggregateFuncBase.Reset()
-	// {{else}}
-	a.hashAggregateFuncBase.Reset()
-	// {{end}}
-	// _DEFAULT_VAL indicates whether we are doing an AND aggregate or OR aggregate.
-	// For bool_and the _DEFAULT_VAL is true and for bool_or the _DEFAULT_VAL is false.
+	// {{/*
+	// _DEFAULT_VAL indicates whether we are doing an AND aggregate or OR
+	// aggregate. For bool_and the _DEFAULT_VAL is true and for bool_or the
+	// _DEFAULT_VAL is false.
+	// */}}
 	a.curAgg = _DEFAULT_VAL
 }
 

--- a/pkg/sql/colexec/colexecagg/bool_and_or_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/bool_and_or_agg_tmpl.go
@@ -66,19 +66,13 @@ type bool_OP_TYPE_AGGKINDAgg struct {
 
 var _ AggregateFunc = &bool_OP_TYPE_AGGKINDAgg{}
 
-func (a *bool_OP_TYPE_AGGKINDAgg) Init(groups []bool, vec coldata.Vec) {
+func (a *bool_OP_TYPE_AGGKINDAgg) SetOutput(vec coldata.Vec) {
 	// {{if eq "_AGGKIND" "Ordered"}}
-	a.orderedAggregateFuncBase.Init(groups, vec)
+	a.orderedAggregateFuncBase.SetOutput(vec)
 	// {{else}}
-	a.hashAggregateFuncBase.Init(groups, vec)
+	a.hashAggregateFuncBase.SetOutput(vec)
 	// {{end}}
 	a.vec = vec.Bool()
-	// {{/*
-	// _DEFAULT_VAL indicates whether we are doing an AND aggregate or OR
-	// aggregate. For bool_and the _DEFAULT_VAL is true and for bool_or the
-	// _DEFAULT_VAL is false.
-	// */}}
-	a.curAgg = _DEFAULT_VAL
 }
 
 func (a *bool_OP_TYPE_AGGKINDAgg) Compute(
@@ -152,6 +146,12 @@ func (a *bool_OP_TYPE_AGGKINDAggAlloc) newAggFunc() AggregateFunc {
 	}
 	f := &a.aggFuncs[0]
 	a.aggFuncs = a.aggFuncs[1:]
+	// {{/*
+	// _DEFAULT_VAL indicates whether we are doing an AND aggregate or OR
+	// aggregate. For bool_and the _DEFAULT_VAL is true and for bool_or the
+	// _DEFAULT_VAL is false.
+	// */}}
+	f.curAgg = _DEFAULT_VAL
 	return f
 }
 

--- a/pkg/sql/colexec/colexecagg/concat_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/concat_agg_tmpl.go
@@ -59,17 +59,6 @@ func (a *concat_AGGKINDAgg) Init(groups []bool, vec coldata.Vec) {
 	// {{end}}
 	a.vec = vec
 	a.col = vec.Bytes()
-	a.Reset()
-}
-
-func (a *concat_AGGKINDAgg) Reset() {
-	// {{if eq "_AGGKIND" "Ordered"}}
-	a.orderedAggregateFuncBase.Reset()
-	// {{else}}
-	a.hashAggregateFuncBase.Reset()
-	// {{end}}
-	a.foundNonNullForCurrentGroup = false
-	a.curAgg = zeroBytesValue
 }
 
 func (a *concat_AGGKINDAgg) Compute(

--- a/pkg/sql/colexec/colexecagg/concat_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/concat_agg_tmpl.go
@@ -51,11 +51,11 @@ type concat_AGGKINDAgg struct {
 	foundNonNullForCurrentGroup bool
 }
 
-func (a *concat_AGGKINDAgg) Init(groups []bool, vec coldata.Vec) {
+func (a *concat_AGGKINDAgg) SetOutput(vec coldata.Vec) {
 	// {{if eq "_AGGKIND" "Ordered"}}
-	a.orderedAggregateFuncBase.Init(groups, vec)
+	a.orderedAggregateFuncBase.SetOutput(vec)
 	// {{else}}
-	a.hashAggregateFuncBase.Init(groups, vec)
+	a.hashAggregateFuncBase.SetOutput(vec)
 	// {{end}}
 	a.vec = vec
 	a.col = vec.Bytes()

--- a/pkg/sql/colexec/colexecagg/count_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/count_agg_tmpl.go
@@ -57,16 +57,6 @@ func (a *count_COUNTKIND_AGGKINDAgg) Init(groups []bool, vec coldata.Vec) {
 	a.hashAggregateFuncBase.Init(groups, vec)
 	// {{end}}
 	a.vec = vec.Int64()
-	a.Reset()
-}
-
-func (a *count_COUNTKIND_AGGKINDAgg) Reset() {
-	// {{if eq "_AGGKIND" "Ordered"}}
-	a.orderedAggregateFuncBase.Reset()
-	// {{else}}
-	a.hashAggregateFuncBase.Reset()
-	// {{end}}
-	a.curAgg = 0
 }
 
 func (a *count_COUNTKIND_AGGKINDAgg) Compute(

--- a/pkg/sql/colexec/colexecagg/count_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/count_agg_tmpl.go
@@ -50,11 +50,11 @@ type count_COUNTKIND_AGGKINDAgg struct {
 
 var _ AggregateFunc = &count_COUNTKIND_AGGKINDAgg{}
 
-func (a *count_COUNTKIND_AGGKINDAgg) Init(groups []bool, vec coldata.Vec) {
+func (a *count_COUNTKIND_AGGKINDAgg) SetOutput(vec coldata.Vec) {
 	// {{if eq "_AGGKIND" "Ordered"}}
-	a.orderedAggregateFuncBase.Init(groups, vec)
+	a.orderedAggregateFuncBase.SetOutput(vec)
 	// {{else}}
-	a.hashAggregateFuncBase.Init(groups, vec)
+	a.hashAggregateFuncBase.SetOutput(vec)
 	// {{end}}
 	a.vec = vec.Int64()
 }

--- a/pkg/sql/colexec/colexecagg/default_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/default_agg_tmpl.go
@@ -63,16 +63,6 @@ func (a *default_AGGKINDAgg) Init(groups []bool, vec coldata.Vec) {
 	a.hashAggregateFuncBase.Init(groups, vec)
 	// {{end}}
 	a.vec = vec
-	a.Reset()
-}
-
-func (a *default_AGGKINDAgg) Reset() {
-	// {{if eq "_AGGKIND" "Ordered"}}
-	a.orderedAggregateFuncBase.Reset()
-	// {{else}}
-	a.hashAggregateFuncBase.Reset()
-	// {{end}}
-	a.fn.Reset(a.ctx)
 }
 
 func (a *default_AGGKINDAgg) Compute(

--- a/pkg/sql/colexec/colexecagg/default_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/default_agg_tmpl.go
@@ -56,11 +56,11 @@ type default_AGGKINDAgg struct {
 
 var _ AggregateFunc = &default_AGGKINDAgg{}
 
-func (a *default_AGGKINDAgg) Init(groups []bool, vec coldata.Vec) {
+func (a *default_AGGKINDAgg) SetOutput(vec coldata.Vec) {
 	// {{if eq "_AGGKIND" "Ordered"}}
-	a.orderedAggregateFuncBase.Init(groups, vec)
+	a.orderedAggregateFuncBase.SetOutput(vec)
 	// {{else}}
-	a.hashAggregateFuncBase.Init(groups, vec)
+	a.hashAggregateFuncBase.SetOutput(vec)
 	// {{end}}
 	a.vec = vec
 }

--- a/pkg/sql/colexec/colexecagg/hash_any_not_null_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_any_not_null_agg.eg.go
@@ -101,12 +101,6 @@ func (a *anyNotNullBoolHashAgg) Init(groups []bool, vec coldata.Vec) {
 	a.hashAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
 	a.col = vec.Bool()
-	a.Reset()
-}
-
-func (a *anyNotNullBoolHashAgg) Reset() {
-	a.hashAggregateFuncBase.Reset()
-	a.foundNonNullForCurrentGroup = false
 }
 
 func (a *anyNotNullBoolHashAgg) Compute(
@@ -221,12 +215,6 @@ func (a *anyNotNullBytesHashAgg) Init(groups []bool, vec coldata.Vec) {
 	a.hashAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
 	a.col = vec.Bytes()
-	a.Reset()
-}
-
-func (a *anyNotNullBytesHashAgg) Reset() {
-	a.hashAggregateFuncBase.Reset()
-	a.foundNonNullForCurrentGroup = false
 }
 
 func (a *anyNotNullBytesHashAgg) Compute(
@@ -347,12 +335,6 @@ func (a *anyNotNullDecimalHashAgg) Init(groups []bool, vec coldata.Vec) {
 	a.hashAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
 	a.col = vec.Decimal()
-	a.Reset()
-}
-
-func (a *anyNotNullDecimalHashAgg) Reset() {
-	a.hashAggregateFuncBase.Reset()
-	a.foundNonNullForCurrentGroup = false
 }
 
 func (a *anyNotNullDecimalHashAgg) Compute(
@@ -467,12 +449,6 @@ func (a *anyNotNullInt16HashAgg) Init(groups []bool, vec coldata.Vec) {
 	a.hashAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
 	a.col = vec.Int16()
-	a.Reset()
-}
-
-func (a *anyNotNullInt16HashAgg) Reset() {
-	a.hashAggregateFuncBase.Reset()
-	a.foundNonNullForCurrentGroup = false
 }
 
 func (a *anyNotNullInt16HashAgg) Compute(
@@ -587,12 +563,6 @@ func (a *anyNotNullInt32HashAgg) Init(groups []bool, vec coldata.Vec) {
 	a.hashAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
 	a.col = vec.Int32()
-	a.Reset()
-}
-
-func (a *anyNotNullInt32HashAgg) Reset() {
-	a.hashAggregateFuncBase.Reset()
-	a.foundNonNullForCurrentGroup = false
 }
 
 func (a *anyNotNullInt32HashAgg) Compute(
@@ -707,12 +677,6 @@ func (a *anyNotNullInt64HashAgg) Init(groups []bool, vec coldata.Vec) {
 	a.hashAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
 	a.col = vec.Int64()
-	a.Reset()
-}
-
-func (a *anyNotNullInt64HashAgg) Reset() {
-	a.hashAggregateFuncBase.Reset()
-	a.foundNonNullForCurrentGroup = false
 }
 
 func (a *anyNotNullInt64HashAgg) Compute(
@@ -827,12 +791,6 @@ func (a *anyNotNullFloat64HashAgg) Init(groups []bool, vec coldata.Vec) {
 	a.hashAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
 	a.col = vec.Float64()
-	a.Reset()
-}
-
-func (a *anyNotNullFloat64HashAgg) Reset() {
-	a.hashAggregateFuncBase.Reset()
-	a.foundNonNullForCurrentGroup = false
 }
 
 func (a *anyNotNullFloat64HashAgg) Compute(
@@ -947,12 +905,6 @@ func (a *anyNotNullTimestampHashAgg) Init(groups []bool, vec coldata.Vec) {
 	a.hashAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
 	a.col = vec.Timestamp()
-	a.Reset()
-}
-
-func (a *anyNotNullTimestampHashAgg) Reset() {
-	a.hashAggregateFuncBase.Reset()
-	a.foundNonNullForCurrentGroup = false
 }
 
 func (a *anyNotNullTimestampHashAgg) Compute(
@@ -1067,12 +1019,6 @@ func (a *anyNotNullIntervalHashAgg) Init(groups []bool, vec coldata.Vec) {
 	a.hashAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
 	a.col = vec.Interval()
-	a.Reset()
-}
-
-func (a *anyNotNullIntervalHashAgg) Reset() {
-	a.hashAggregateFuncBase.Reset()
-	a.foundNonNullForCurrentGroup = false
 }
 
 func (a *anyNotNullIntervalHashAgg) Compute(
@@ -1187,12 +1133,6 @@ func (a *anyNotNullDatumHashAgg) Init(groups []bool, vec coldata.Vec) {
 	a.hashAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
 	a.col = vec.Datum()
-	a.Reset()
-}
-
-func (a *anyNotNullDatumHashAgg) Reset() {
-	a.hashAggregateFuncBase.Reset()
-	a.foundNonNullForCurrentGroup = false
 }
 
 func (a *anyNotNullDatumHashAgg) Compute(

--- a/pkg/sql/colexec/colexecagg/hash_any_not_null_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_any_not_null_agg.eg.go
@@ -97,8 +97,8 @@ type anyNotNullBoolHashAgg struct {
 
 var _ AggregateFunc = &anyNotNullBoolHashAgg{}
 
-func (a *anyNotNullBoolHashAgg) Init(groups []bool, vec coldata.Vec) {
-	a.hashAggregateFuncBase.Init(groups, vec)
+func (a *anyNotNullBoolHashAgg) SetOutput(vec coldata.Vec) {
+	a.hashAggregateFuncBase.SetOutput(vec)
 	a.vec = vec
 	a.col = vec.Bool()
 }
@@ -211,8 +211,8 @@ type anyNotNullBytesHashAgg struct {
 
 var _ AggregateFunc = &anyNotNullBytesHashAgg{}
 
-func (a *anyNotNullBytesHashAgg) Init(groups []bool, vec coldata.Vec) {
-	a.hashAggregateFuncBase.Init(groups, vec)
+func (a *anyNotNullBytesHashAgg) SetOutput(vec coldata.Vec) {
+	a.hashAggregateFuncBase.SetOutput(vec)
 	a.vec = vec
 	a.col = vec.Bytes()
 }
@@ -331,8 +331,8 @@ type anyNotNullDecimalHashAgg struct {
 
 var _ AggregateFunc = &anyNotNullDecimalHashAgg{}
 
-func (a *anyNotNullDecimalHashAgg) Init(groups []bool, vec coldata.Vec) {
-	a.hashAggregateFuncBase.Init(groups, vec)
+func (a *anyNotNullDecimalHashAgg) SetOutput(vec coldata.Vec) {
+	a.hashAggregateFuncBase.SetOutput(vec)
 	a.vec = vec
 	a.col = vec.Decimal()
 }
@@ -445,8 +445,8 @@ type anyNotNullInt16HashAgg struct {
 
 var _ AggregateFunc = &anyNotNullInt16HashAgg{}
 
-func (a *anyNotNullInt16HashAgg) Init(groups []bool, vec coldata.Vec) {
-	a.hashAggregateFuncBase.Init(groups, vec)
+func (a *anyNotNullInt16HashAgg) SetOutput(vec coldata.Vec) {
+	a.hashAggregateFuncBase.SetOutput(vec)
 	a.vec = vec
 	a.col = vec.Int16()
 }
@@ -559,8 +559,8 @@ type anyNotNullInt32HashAgg struct {
 
 var _ AggregateFunc = &anyNotNullInt32HashAgg{}
 
-func (a *anyNotNullInt32HashAgg) Init(groups []bool, vec coldata.Vec) {
-	a.hashAggregateFuncBase.Init(groups, vec)
+func (a *anyNotNullInt32HashAgg) SetOutput(vec coldata.Vec) {
+	a.hashAggregateFuncBase.SetOutput(vec)
 	a.vec = vec
 	a.col = vec.Int32()
 }
@@ -673,8 +673,8 @@ type anyNotNullInt64HashAgg struct {
 
 var _ AggregateFunc = &anyNotNullInt64HashAgg{}
 
-func (a *anyNotNullInt64HashAgg) Init(groups []bool, vec coldata.Vec) {
-	a.hashAggregateFuncBase.Init(groups, vec)
+func (a *anyNotNullInt64HashAgg) SetOutput(vec coldata.Vec) {
+	a.hashAggregateFuncBase.SetOutput(vec)
 	a.vec = vec
 	a.col = vec.Int64()
 }
@@ -787,8 +787,8 @@ type anyNotNullFloat64HashAgg struct {
 
 var _ AggregateFunc = &anyNotNullFloat64HashAgg{}
 
-func (a *anyNotNullFloat64HashAgg) Init(groups []bool, vec coldata.Vec) {
-	a.hashAggregateFuncBase.Init(groups, vec)
+func (a *anyNotNullFloat64HashAgg) SetOutput(vec coldata.Vec) {
+	a.hashAggregateFuncBase.SetOutput(vec)
 	a.vec = vec
 	a.col = vec.Float64()
 }
@@ -901,8 +901,8 @@ type anyNotNullTimestampHashAgg struct {
 
 var _ AggregateFunc = &anyNotNullTimestampHashAgg{}
 
-func (a *anyNotNullTimestampHashAgg) Init(groups []bool, vec coldata.Vec) {
-	a.hashAggregateFuncBase.Init(groups, vec)
+func (a *anyNotNullTimestampHashAgg) SetOutput(vec coldata.Vec) {
+	a.hashAggregateFuncBase.SetOutput(vec)
 	a.vec = vec
 	a.col = vec.Timestamp()
 }
@@ -1015,8 +1015,8 @@ type anyNotNullIntervalHashAgg struct {
 
 var _ AggregateFunc = &anyNotNullIntervalHashAgg{}
 
-func (a *anyNotNullIntervalHashAgg) Init(groups []bool, vec coldata.Vec) {
-	a.hashAggregateFuncBase.Init(groups, vec)
+func (a *anyNotNullIntervalHashAgg) SetOutput(vec coldata.Vec) {
+	a.hashAggregateFuncBase.SetOutput(vec)
 	a.vec = vec
 	a.col = vec.Interval()
 }
@@ -1129,8 +1129,8 @@ type anyNotNullDatumHashAgg struct {
 
 var _ AggregateFunc = &anyNotNullDatumHashAgg{}
 
-func (a *anyNotNullDatumHashAgg) Init(groups []bool, vec coldata.Vec) {
-	a.hashAggregateFuncBase.Init(groups, vec)
+func (a *anyNotNullDatumHashAgg) SetOutput(vec coldata.Vec) {
+	a.hashAggregateFuncBase.SetOutput(vec)
 	a.vec = vec
 	a.col = vec.Datum()
 }

--- a/pkg/sql/colexec/colexecagg/hash_avg_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_avg_agg.eg.go
@@ -72,14 +72,6 @@ var _ AggregateFunc = &avgInt16HashAgg{}
 func (a *avgInt16HashAgg) Init(groups []bool, vec coldata.Vec) {
 	a.hashAggregateFuncBase.Init(groups, vec)
 	a.scratch.vec = vec.Decimal()
-	a.Reset()
-}
-
-func (a *avgInt16HashAgg) Reset() {
-	a.hashAggregateFuncBase.Reset()
-	a.scratch.curSum = zeroDecimalValue
-	a.scratch.curCount = 0
-	a.scratch.foundNonNullForCurrentGroup = false
 }
 
 func (a *avgInt16HashAgg) Compute(
@@ -195,14 +187,6 @@ var _ AggregateFunc = &avgInt32HashAgg{}
 func (a *avgInt32HashAgg) Init(groups []bool, vec coldata.Vec) {
 	a.hashAggregateFuncBase.Init(groups, vec)
 	a.scratch.vec = vec.Decimal()
-	a.Reset()
-}
-
-func (a *avgInt32HashAgg) Reset() {
-	a.hashAggregateFuncBase.Reset()
-	a.scratch.curSum = zeroDecimalValue
-	a.scratch.curCount = 0
-	a.scratch.foundNonNullForCurrentGroup = false
 }
 
 func (a *avgInt32HashAgg) Compute(
@@ -318,14 +302,6 @@ var _ AggregateFunc = &avgInt64HashAgg{}
 func (a *avgInt64HashAgg) Init(groups []bool, vec coldata.Vec) {
 	a.hashAggregateFuncBase.Init(groups, vec)
 	a.scratch.vec = vec.Decimal()
-	a.Reset()
-}
-
-func (a *avgInt64HashAgg) Reset() {
-	a.hashAggregateFuncBase.Reset()
-	a.scratch.curSum = zeroDecimalValue
-	a.scratch.curCount = 0
-	a.scratch.foundNonNullForCurrentGroup = false
 }
 
 func (a *avgInt64HashAgg) Compute(
@@ -440,14 +416,6 @@ var _ AggregateFunc = &avgDecimalHashAgg{}
 func (a *avgDecimalHashAgg) Init(groups []bool, vec coldata.Vec) {
 	a.hashAggregateFuncBase.Init(groups, vec)
 	a.scratch.vec = vec.Decimal()
-	a.Reset()
-}
-
-func (a *avgDecimalHashAgg) Reset() {
-	a.hashAggregateFuncBase.Reset()
-	a.scratch.curSum = zeroDecimalValue
-	a.scratch.curCount = 0
-	a.scratch.foundNonNullForCurrentGroup = false
 }
 
 func (a *avgDecimalHashAgg) Compute(
@@ -557,14 +525,6 @@ var _ AggregateFunc = &avgFloat64HashAgg{}
 func (a *avgFloat64HashAgg) Init(groups []bool, vec coldata.Vec) {
 	a.hashAggregateFuncBase.Init(groups, vec)
 	a.scratch.vec = vec.Float64()
-	a.Reset()
-}
-
-func (a *avgFloat64HashAgg) Reset() {
-	a.hashAggregateFuncBase.Reset()
-	a.scratch.curSum = zeroFloat64Value
-	a.scratch.curCount = 0
-	a.scratch.foundNonNullForCurrentGroup = false
 }
 
 func (a *avgFloat64HashAgg) Compute(
@@ -664,14 +624,6 @@ var _ AggregateFunc = &avgIntervalHashAgg{}
 func (a *avgIntervalHashAgg) Init(groups []bool, vec coldata.Vec) {
 	a.hashAggregateFuncBase.Init(groups, vec)
 	a.scratch.vec = vec.Interval()
-	a.Reset()
-}
-
-func (a *avgIntervalHashAgg) Reset() {
-	a.hashAggregateFuncBase.Reset()
-	a.scratch.curSum = zeroIntervalValue
-	a.scratch.curCount = 0
-	a.scratch.foundNonNullForCurrentGroup = false
 }
 
 func (a *avgIntervalHashAgg) Compute(

--- a/pkg/sql/colexec/colexecagg/hash_avg_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_avg_agg.eg.go
@@ -69,8 +69,8 @@ type avgInt16HashAgg struct {
 
 var _ AggregateFunc = &avgInt16HashAgg{}
 
-func (a *avgInt16HashAgg) Init(groups []bool, vec coldata.Vec) {
-	a.hashAggregateFuncBase.Init(groups, vec)
+func (a *avgInt16HashAgg) SetOutput(vec coldata.Vec) {
+	a.hashAggregateFuncBase.SetOutput(vec)
 	a.scratch.vec = vec.Decimal()
 }
 
@@ -184,8 +184,8 @@ type avgInt32HashAgg struct {
 
 var _ AggregateFunc = &avgInt32HashAgg{}
 
-func (a *avgInt32HashAgg) Init(groups []bool, vec coldata.Vec) {
-	a.hashAggregateFuncBase.Init(groups, vec)
+func (a *avgInt32HashAgg) SetOutput(vec coldata.Vec) {
+	a.hashAggregateFuncBase.SetOutput(vec)
 	a.scratch.vec = vec.Decimal()
 }
 
@@ -299,8 +299,8 @@ type avgInt64HashAgg struct {
 
 var _ AggregateFunc = &avgInt64HashAgg{}
 
-func (a *avgInt64HashAgg) Init(groups []bool, vec coldata.Vec) {
-	a.hashAggregateFuncBase.Init(groups, vec)
+func (a *avgInt64HashAgg) SetOutput(vec coldata.Vec) {
+	a.hashAggregateFuncBase.SetOutput(vec)
 	a.scratch.vec = vec.Decimal()
 }
 
@@ -413,8 +413,8 @@ type avgDecimalHashAgg struct {
 
 var _ AggregateFunc = &avgDecimalHashAgg{}
 
-func (a *avgDecimalHashAgg) Init(groups []bool, vec coldata.Vec) {
-	a.hashAggregateFuncBase.Init(groups, vec)
+func (a *avgDecimalHashAgg) SetOutput(vec coldata.Vec) {
+	a.hashAggregateFuncBase.SetOutput(vec)
 	a.scratch.vec = vec.Decimal()
 }
 
@@ -522,8 +522,8 @@ type avgFloat64HashAgg struct {
 
 var _ AggregateFunc = &avgFloat64HashAgg{}
 
-func (a *avgFloat64HashAgg) Init(groups []bool, vec coldata.Vec) {
-	a.hashAggregateFuncBase.Init(groups, vec)
+func (a *avgFloat64HashAgg) SetOutput(vec coldata.Vec) {
+	a.hashAggregateFuncBase.SetOutput(vec)
 	a.scratch.vec = vec.Float64()
 }
 
@@ -621,8 +621,8 @@ type avgIntervalHashAgg struct {
 
 var _ AggregateFunc = &avgIntervalHashAgg{}
 
-func (a *avgIntervalHashAgg) Init(groups []bool, vec coldata.Vec) {
-	a.hashAggregateFuncBase.Init(groups, vec)
+func (a *avgIntervalHashAgg) SetOutput(vec coldata.Vec) {
+	a.hashAggregateFuncBase.SetOutput(vec)
 	a.scratch.vec = vec.Interval()
 }
 

--- a/pkg/sql/colexec/colexecagg/hash_bool_and_or_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_bool_and_or_agg.eg.go
@@ -41,13 +41,6 @@ var _ AggregateFunc = &boolAndHashAgg{}
 func (a *boolAndHashAgg) Init(groups []bool, vec coldata.Vec) {
 	a.hashAggregateFuncBase.Init(groups, vec)
 	a.vec = vec.Bool()
-	a.Reset()
-}
-
-func (a *boolAndHashAgg) Reset() {
-	a.hashAggregateFuncBase.Reset()
-	// true indicates whether we are doing an AND aggregate or OR aggregate.
-	// For bool_and the true is true and for bool_or the true is false.
 	a.curAgg = true
 }
 
@@ -133,13 +126,6 @@ var _ AggregateFunc = &boolOrHashAgg{}
 func (a *boolOrHashAgg) Init(groups []bool, vec coldata.Vec) {
 	a.hashAggregateFuncBase.Init(groups, vec)
 	a.vec = vec.Bool()
-	a.Reset()
-}
-
-func (a *boolOrHashAgg) Reset() {
-	a.hashAggregateFuncBase.Reset()
-	// false indicates whether we are doing an AND aggregate or OR aggregate.
-	// For bool_and the false is true and for bool_or the false is false.
 	a.curAgg = false
 }
 

--- a/pkg/sql/colexec/colexecagg/hash_bool_and_or_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_bool_and_or_agg.eg.go
@@ -38,10 +38,9 @@ type boolAndHashAgg struct {
 
 var _ AggregateFunc = &boolAndHashAgg{}
 
-func (a *boolAndHashAgg) Init(groups []bool, vec coldata.Vec) {
-	a.hashAggregateFuncBase.Init(groups, vec)
+func (a *boolAndHashAgg) SetOutput(vec coldata.Vec) {
+	a.hashAggregateFuncBase.SetOutput(vec)
 	a.vec = vec.Bool()
-	a.curAgg = true
 }
 
 func (a *boolAndHashAgg) Compute(
@@ -102,6 +101,7 @@ func (a *boolAndHashAggAlloc) newAggFunc() AggregateFunc {
 	}
 	f := &a.aggFuncs[0]
 	a.aggFuncs = a.aggFuncs[1:]
+	f.curAgg = true
 	return f
 }
 
@@ -123,10 +123,9 @@ type boolOrHashAgg struct {
 
 var _ AggregateFunc = &boolOrHashAgg{}
 
-func (a *boolOrHashAgg) Init(groups []bool, vec coldata.Vec) {
-	a.hashAggregateFuncBase.Init(groups, vec)
+func (a *boolOrHashAgg) SetOutput(vec coldata.Vec) {
+	a.hashAggregateFuncBase.SetOutput(vec)
 	a.vec = vec.Bool()
-	a.curAgg = false
 }
 
 func (a *boolOrHashAgg) Compute(
@@ -187,5 +186,6 @@ func (a *boolOrHashAggAlloc) newAggFunc() AggregateFunc {
 	}
 	f := &a.aggFuncs[0]
 	a.aggFuncs = a.aggFuncs[1:]
+	f.curAgg = false
 	return f
 }

--- a/pkg/sql/colexec/colexecagg/hash_concat_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_concat_agg.eg.go
@@ -37,8 +37,8 @@ type concatHashAgg struct {
 	foundNonNullForCurrentGroup bool
 }
 
-func (a *concatHashAgg) Init(groups []bool, vec coldata.Vec) {
-	a.hashAggregateFuncBase.Init(groups, vec)
+func (a *concatHashAgg) SetOutput(vec coldata.Vec) {
+	a.hashAggregateFuncBase.SetOutput(vec)
 	a.vec = vec
 	a.col = vec.Bytes()
 }

--- a/pkg/sql/colexec/colexecagg/hash_concat_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_concat_agg.eg.go
@@ -41,13 +41,6 @@ func (a *concatHashAgg) Init(groups []bool, vec coldata.Vec) {
 	a.hashAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
 	a.col = vec.Bytes()
-	a.Reset()
-}
-
-func (a *concatHashAgg) Reset() {
-	a.hashAggregateFuncBase.Reset()
-	a.foundNonNullForCurrentGroup = false
-	a.curAgg = zeroBytesValue
 }
 
 func (a *concatHashAgg) Compute(

--- a/pkg/sql/colexec/colexecagg/hash_count_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_count_agg.eg.go
@@ -34,8 +34,8 @@ type countRowsHashAgg struct {
 
 var _ AggregateFunc = &countRowsHashAgg{}
 
-func (a *countRowsHashAgg) Init(groups []bool, vec coldata.Vec) {
-	a.hashAggregateFuncBase.Init(groups, vec)
+func (a *countRowsHashAgg) SetOutput(vec coldata.Vec) {
+	a.hashAggregateFuncBase.SetOutput(vec)
 	a.vec = vec.Int64()
 }
 
@@ -95,8 +95,8 @@ type countHashAgg struct {
 
 var _ AggregateFunc = &countHashAgg{}
 
-func (a *countHashAgg) Init(groups []bool, vec coldata.Vec) {
-	a.hashAggregateFuncBase.Init(groups, vec)
+func (a *countHashAgg) SetOutput(vec coldata.Vec) {
+	a.hashAggregateFuncBase.SetOutput(vec)
 	a.vec = vec.Int64()
 }
 

--- a/pkg/sql/colexec/colexecagg/hash_count_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_count_agg.eg.go
@@ -37,12 +37,6 @@ var _ AggregateFunc = &countRowsHashAgg{}
 func (a *countRowsHashAgg) Init(groups []bool, vec coldata.Vec) {
 	a.hashAggregateFuncBase.Init(groups, vec)
 	a.vec = vec.Int64()
-	a.Reset()
-}
-
-func (a *countRowsHashAgg) Reset() {
-	a.hashAggregateFuncBase.Reset()
-	a.curAgg = 0
 }
 
 func (a *countRowsHashAgg) Compute(
@@ -104,12 +98,6 @@ var _ AggregateFunc = &countHashAgg{}
 func (a *countHashAgg) Init(groups []bool, vec coldata.Vec) {
 	a.hashAggregateFuncBase.Init(groups, vec)
 	a.vec = vec.Int64()
-	a.Reset()
-}
-
-func (a *countHashAgg) Reset() {
-	a.hashAggregateFuncBase.Reset()
-	a.curAgg = 0
 }
 
 func (a *countHashAgg) Compute(

--- a/pkg/sql/colexec/colexecagg/hash_default_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_default_agg.eg.go
@@ -42,8 +42,8 @@ type defaultHashAgg struct {
 
 var _ AggregateFunc = &defaultHashAgg{}
 
-func (a *defaultHashAgg) Init(groups []bool, vec coldata.Vec) {
-	a.hashAggregateFuncBase.Init(groups, vec)
+func (a *defaultHashAgg) SetOutput(vec coldata.Vec) {
+	a.hashAggregateFuncBase.SetOutput(vec)
 	a.vec = vec
 }
 

--- a/pkg/sql/colexec/colexecagg/hash_default_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_default_agg.eg.go
@@ -45,12 +45,6 @@ var _ AggregateFunc = &defaultHashAgg{}
 func (a *defaultHashAgg) Init(groups []bool, vec coldata.Vec) {
 	a.hashAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
-	a.Reset()
-}
-
-func (a *defaultHashAgg) Reset() {
-	a.hashAggregateFuncBase.Reset()
-	a.fn.Reset(a.ctx)
 }
 
 func (a *defaultHashAgg) Compute(

--- a/pkg/sql/colexec/colexecagg/hash_min_max_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_min_max_agg.eg.go
@@ -113,12 +113,6 @@ func (a *minBoolHashAgg) Init(groups []bool, vec coldata.Vec) {
 	a.hashAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
 	a.col = vec.Bool()
-	a.Reset()
-}
-
-func (a *minBoolHashAgg) Reset() {
-	a.hashAggregateFuncBase.Reset()
-	a.foundNonNullForCurrentGroup = false
 }
 
 func (a *minBoolHashAgg) Compute(
@@ -259,12 +253,6 @@ func (a *minBytesHashAgg) Init(groups []bool, vec coldata.Vec) {
 	a.hashAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
 	a.col = vec.Bytes()
-	a.Reset()
-}
-
-func (a *minBytesHashAgg) Reset() {
-	a.hashAggregateFuncBase.Reset()
-	a.foundNonNullForCurrentGroup = false
 }
 
 func (a *minBytesHashAgg) Compute(
@@ -395,12 +383,6 @@ func (a *minDecimalHashAgg) Init(groups []bool, vec coldata.Vec) {
 	a.hashAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
 	a.col = vec.Decimal()
-	a.Reset()
-}
-
-func (a *minDecimalHashAgg) Reset() {
-	a.hashAggregateFuncBase.Reset()
-	a.foundNonNullForCurrentGroup = false
 }
 
 func (a *minDecimalHashAgg) Compute(
@@ -525,12 +507,6 @@ func (a *minInt16HashAgg) Init(groups []bool, vec coldata.Vec) {
 	a.hashAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
 	a.col = vec.Int16()
-	a.Reset()
-}
-
-func (a *minInt16HashAgg) Reset() {
-	a.hashAggregateFuncBase.Reset()
-	a.foundNonNullForCurrentGroup = false
 }
 
 func (a *minInt16HashAgg) Compute(
@@ -677,12 +653,6 @@ func (a *minInt32HashAgg) Init(groups []bool, vec coldata.Vec) {
 	a.hashAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
 	a.col = vec.Int32()
-	a.Reset()
-}
-
-func (a *minInt32HashAgg) Reset() {
-	a.hashAggregateFuncBase.Reset()
-	a.foundNonNullForCurrentGroup = false
 }
 
 func (a *minInt32HashAgg) Compute(
@@ -829,12 +799,6 @@ func (a *minInt64HashAgg) Init(groups []bool, vec coldata.Vec) {
 	a.hashAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
 	a.col = vec.Int64()
-	a.Reset()
-}
-
-func (a *minInt64HashAgg) Reset() {
-	a.hashAggregateFuncBase.Reset()
-	a.foundNonNullForCurrentGroup = false
 }
 
 func (a *minInt64HashAgg) Compute(
@@ -981,12 +945,6 @@ func (a *minFloat64HashAgg) Init(groups []bool, vec coldata.Vec) {
 	a.hashAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
 	a.col = vec.Float64()
-	a.Reset()
-}
-
-func (a *minFloat64HashAgg) Reset() {
-	a.hashAggregateFuncBase.Reset()
-	a.foundNonNullForCurrentGroup = false
 }
 
 func (a *minFloat64HashAgg) Compute(
@@ -1149,12 +1107,6 @@ func (a *minTimestampHashAgg) Init(groups []bool, vec coldata.Vec) {
 	a.hashAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
 	a.col = vec.Timestamp()
-	a.Reset()
-}
-
-func (a *minTimestampHashAgg) Reset() {
-	a.hashAggregateFuncBase.Reset()
-	a.foundNonNullForCurrentGroup = false
 }
 
 func (a *minTimestampHashAgg) Compute(
@@ -1293,12 +1245,6 @@ func (a *minIntervalHashAgg) Init(groups []bool, vec coldata.Vec) {
 	a.hashAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
 	a.col = vec.Interval()
-	a.Reset()
-}
-
-func (a *minIntervalHashAgg) Reset() {
-	a.hashAggregateFuncBase.Reset()
-	a.foundNonNullForCurrentGroup = false
 }
 
 func (a *minIntervalHashAgg) Compute(
@@ -1423,12 +1369,6 @@ func (a *minDatumHashAgg) Init(groups []bool, vec coldata.Vec) {
 	a.hashAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
 	a.col = vec.Datum()
-	a.Reset()
-}
-
-func (a *minDatumHashAgg) Reset() {
-	a.hashAggregateFuncBase.Reset()
-	a.foundNonNullForCurrentGroup = false
 }
 
 func (a *minDatumHashAgg) Compute(
@@ -1571,12 +1511,6 @@ func (a *maxBoolHashAgg) Init(groups []bool, vec coldata.Vec) {
 	a.hashAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
 	a.col = vec.Bool()
-	a.Reset()
-}
-
-func (a *maxBoolHashAgg) Reset() {
-	a.hashAggregateFuncBase.Reset()
-	a.foundNonNullForCurrentGroup = false
 }
 
 func (a *maxBoolHashAgg) Compute(
@@ -1717,12 +1651,6 @@ func (a *maxBytesHashAgg) Init(groups []bool, vec coldata.Vec) {
 	a.hashAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
 	a.col = vec.Bytes()
-	a.Reset()
-}
-
-func (a *maxBytesHashAgg) Reset() {
-	a.hashAggregateFuncBase.Reset()
-	a.foundNonNullForCurrentGroup = false
 }
 
 func (a *maxBytesHashAgg) Compute(
@@ -1853,12 +1781,6 @@ func (a *maxDecimalHashAgg) Init(groups []bool, vec coldata.Vec) {
 	a.hashAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
 	a.col = vec.Decimal()
-	a.Reset()
-}
-
-func (a *maxDecimalHashAgg) Reset() {
-	a.hashAggregateFuncBase.Reset()
-	a.foundNonNullForCurrentGroup = false
 }
 
 func (a *maxDecimalHashAgg) Compute(
@@ -1983,12 +1905,6 @@ func (a *maxInt16HashAgg) Init(groups []bool, vec coldata.Vec) {
 	a.hashAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
 	a.col = vec.Int16()
-	a.Reset()
-}
-
-func (a *maxInt16HashAgg) Reset() {
-	a.hashAggregateFuncBase.Reset()
-	a.foundNonNullForCurrentGroup = false
 }
 
 func (a *maxInt16HashAgg) Compute(
@@ -2135,12 +2051,6 @@ func (a *maxInt32HashAgg) Init(groups []bool, vec coldata.Vec) {
 	a.hashAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
 	a.col = vec.Int32()
-	a.Reset()
-}
-
-func (a *maxInt32HashAgg) Reset() {
-	a.hashAggregateFuncBase.Reset()
-	a.foundNonNullForCurrentGroup = false
 }
 
 func (a *maxInt32HashAgg) Compute(
@@ -2287,12 +2197,6 @@ func (a *maxInt64HashAgg) Init(groups []bool, vec coldata.Vec) {
 	a.hashAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
 	a.col = vec.Int64()
-	a.Reset()
-}
-
-func (a *maxInt64HashAgg) Reset() {
-	a.hashAggregateFuncBase.Reset()
-	a.foundNonNullForCurrentGroup = false
 }
 
 func (a *maxInt64HashAgg) Compute(
@@ -2439,12 +2343,6 @@ func (a *maxFloat64HashAgg) Init(groups []bool, vec coldata.Vec) {
 	a.hashAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
 	a.col = vec.Float64()
-	a.Reset()
-}
-
-func (a *maxFloat64HashAgg) Reset() {
-	a.hashAggregateFuncBase.Reset()
-	a.foundNonNullForCurrentGroup = false
 }
 
 func (a *maxFloat64HashAgg) Compute(
@@ -2607,12 +2505,6 @@ func (a *maxTimestampHashAgg) Init(groups []bool, vec coldata.Vec) {
 	a.hashAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
 	a.col = vec.Timestamp()
-	a.Reset()
-}
-
-func (a *maxTimestampHashAgg) Reset() {
-	a.hashAggregateFuncBase.Reset()
-	a.foundNonNullForCurrentGroup = false
 }
 
 func (a *maxTimestampHashAgg) Compute(
@@ -2751,12 +2643,6 @@ func (a *maxIntervalHashAgg) Init(groups []bool, vec coldata.Vec) {
 	a.hashAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
 	a.col = vec.Interval()
-	a.Reset()
-}
-
-func (a *maxIntervalHashAgg) Reset() {
-	a.hashAggregateFuncBase.Reset()
-	a.foundNonNullForCurrentGroup = false
 }
 
 func (a *maxIntervalHashAgg) Compute(
@@ -2881,12 +2767,6 @@ func (a *maxDatumHashAgg) Init(groups []bool, vec coldata.Vec) {
 	a.hashAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
 	a.col = vec.Datum()
-	a.Reset()
-}
-
-func (a *maxDatumHashAgg) Reset() {
-	a.hashAggregateFuncBase.Reset()
-	a.foundNonNullForCurrentGroup = false
 }
 
 func (a *maxDatumHashAgg) Compute(

--- a/pkg/sql/colexec/colexecagg/hash_min_max_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_min_max_agg.eg.go
@@ -109,8 +109,8 @@ type minBoolHashAgg struct {
 
 var _ AggregateFunc = &minBoolHashAgg{}
 
-func (a *minBoolHashAgg) Init(groups []bool, vec coldata.Vec) {
-	a.hashAggregateFuncBase.Init(groups, vec)
+func (a *minBoolHashAgg) SetOutput(vec coldata.Vec) {
+	a.hashAggregateFuncBase.SetOutput(vec)
 	a.vec = vec
 	a.col = vec.Bool()
 }
@@ -249,8 +249,8 @@ type minBytesHashAgg struct {
 
 var _ AggregateFunc = &minBytesHashAgg{}
 
-func (a *minBytesHashAgg) Init(groups []bool, vec coldata.Vec) {
-	a.hashAggregateFuncBase.Init(groups, vec)
+func (a *minBytesHashAgg) SetOutput(vec coldata.Vec) {
+	a.hashAggregateFuncBase.SetOutput(vec)
 	a.vec = vec
 	a.col = vec.Bytes()
 }
@@ -379,8 +379,8 @@ type minDecimalHashAgg struct {
 
 var _ AggregateFunc = &minDecimalHashAgg{}
 
-func (a *minDecimalHashAgg) Init(groups []bool, vec coldata.Vec) {
-	a.hashAggregateFuncBase.Init(groups, vec)
+func (a *minDecimalHashAgg) SetOutput(vec coldata.Vec) {
+	a.hashAggregateFuncBase.SetOutput(vec)
 	a.vec = vec
 	a.col = vec.Decimal()
 }
@@ -503,8 +503,8 @@ type minInt16HashAgg struct {
 
 var _ AggregateFunc = &minInt16HashAgg{}
 
-func (a *minInt16HashAgg) Init(groups []bool, vec coldata.Vec) {
-	a.hashAggregateFuncBase.Init(groups, vec)
+func (a *minInt16HashAgg) SetOutput(vec coldata.Vec) {
+	a.hashAggregateFuncBase.SetOutput(vec)
 	a.vec = vec
 	a.col = vec.Int16()
 }
@@ -649,8 +649,8 @@ type minInt32HashAgg struct {
 
 var _ AggregateFunc = &minInt32HashAgg{}
 
-func (a *minInt32HashAgg) Init(groups []bool, vec coldata.Vec) {
-	a.hashAggregateFuncBase.Init(groups, vec)
+func (a *minInt32HashAgg) SetOutput(vec coldata.Vec) {
+	a.hashAggregateFuncBase.SetOutput(vec)
 	a.vec = vec
 	a.col = vec.Int32()
 }
@@ -795,8 +795,8 @@ type minInt64HashAgg struct {
 
 var _ AggregateFunc = &minInt64HashAgg{}
 
-func (a *minInt64HashAgg) Init(groups []bool, vec coldata.Vec) {
-	a.hashAggregateFuncBase.Init(groups, vec)
+func (a *minInt64HashAgg) SetOutput(vec coldata.Vec) {
+	a.hashAggregateFuncBase.SetOutput(vec)
 	a.vec = vec
 	a.col = vec.Int64()
 }
@@ -941,8 +941,8 @@ type minFloat64HashAgg struct {
 
 var _ AggregateFunc = &minFloat64HashAgg{}
 
-func (a *minFloat64HashAgg) Init(groups []bool, vec coldata.Vec) {
-	a.hashAggregateFuncBase.Init(groups, vec)
+func (a *minFloat64HashAgg) SetOutput(vec coldata.Vec) {
+	a.hashAggregateFuncBase.SetOutput(vec)
 	a.vec = vec
 	a.col = vec.Float64()
 }
@@ -1103,8 +1103,8 @@ type minTimestampHashAgg struct {
 
 var _ AggregateFunc = &minTimestampHashAgg{}
 
-func (a *minTimestampHashAgg) Init(groups []bool, vec coldata.Vec) {
-	a.hashAggregateFuncBase.Init(groups, vec)
+func (a *minTimestampHashAgg) SetOutput(vec coldata.Vec) {
+	a.hashAggregateFuncBase.SetOutput(vec)
 	a.vec = vec
 	a.col = vec.Timestamp()
 }
@@ -1241,8 +1241,8 @@ type minIntervalHashAgg struct {
 
 var _ AggregateFunc = &minIntervalHashAgg{}
 
-func (a *minIntervalHashAgg) Init(groups []bool, vec coldata.Vec) {
-	a.hashAggregateFuncBase.Init(groups, vec)
+func (a *minIntervalHashAgg) SetOutput(vec coldata.Vec) {
+	a.hashAggregateFuncBase.SetOutput(vec)
 	a.vec = vec
 	a.col = vec.Interval()
 }
@@ -1365,8 +1365,8 @@ type minDatumHashAgg struct {
 
 var _ AggregateFunc = &minDatumHashAgg{}
 
-func (a *minDatumHashAgg) Init(groups []bool, vec coldata.Vec) {
-	a.hashAggregateFuncBase.Init(groups, vec)
+func (a *minDatumHashAgg) SetOutput(vec coldata.Vec) {
+	a.hashAggregateFuncBase.SetOutput(vec)
 	a.vec = vec
 	a.col = vec.Datum()
 }
@@ -1507,8 +1507,8 @@ type maxBoolHashAgg struct {
 
 var _ AggregateFunc = &maxBoolHashAgg{}
 
-func (a *maxBoolHashAgg) Init(groups []bool, vec coldata.Vec) {
-	a.hashAggregateFuncBase.Init(groups, vec)
+func (a *maxBoolHashAgg) SetOutput(vec coldata.Vec) {
+	a.hashAggregateFuncBase.SetOutput(vec)
 	a.vec = vec
 	a.col = vec.Bool()
 }
@@ -1647,8 +1647,8 @@ type maxBytesHashAgg struct {
 
 var _ AggregateFunc = &maxBytesHashAgg{}
 
-func (a *maxBytesHashAgg) Init(groups []bool, vec coldata.Vec) {
-	a.hashAggregateFuncBase.Init(groups, vec)
+func (a *maxBytesHashAgg) SetOutput(vec coldata.Vec) {
+	a.hashAggregateFuncBase.SetOutput(vec)
 	a.vec = vec
 	a.col = vec.Bytes()
 }
@@ -1777,8 +1777,8 @@ type maxDecimalHashAgg struct {
 
 var _ AggregateFunc = &maxDecimalHashAgg{}
 
-func (a *maxDecimalHashAgg) Init(groups []bool, vec coldata.Vec) {
-	a.hashAggregateFuncBase.Init(groups, vec)
+func (a *maxDecimalHashAgg) SetOutput(vec coldata.Vec) {
+	a.hashAggregateFuncBase.SetOutput(vec)
 	a.vec = vec
 	a.col = vec.Decimal()
 }
@@ -1901,8 +1901,8 @@ type maxInt16HashAgg struct {
 
 var _ AggregateFunc = &maxInt16HashAgg{}
 
-func (a *maxInt16HashAgg) Init(groups []bool, vec coldata.Vec) {
-	a.hashAggregateFuncBase.Init(groups, vec)
+func (a *maxInt16HashAgg) SetOutput(vec coldata.Vec) {
+	a.hashAggregateFuncBase.SetOutput(vec)
 	a.vec = vec
 	a.col = vec.Int16()
 }
@@ -2047,8 +2047,8 @@ type maxInt32HashAgg struct {
 
 var _ AggregateFunc = &maxInt32HashAgg{}
 
-func (a *maxInt32HashAgg) Init(groups []bool, vec coldata.Vec) {
-	a.hashAggregateFuncBase.Init(groups, vec)
+func (a *maxInt32HashAgg) SetOutput(vec coldata.Vec) {
+	a.hashAggregateFuncBase.SetOutput(vec)
 	a.vec = vec
 	a.col = vec.Int32()
 }
@@ -2193,8 +2193,8 @@ type maxInt64HashAgg struct {
 
 var _ AggregateFunc = &maxInt64HashAgg{}
 
-func (a *maxInt64HashAgg) Init(groups []bool, vec coldata.Vec) {
-	a.hashAggregateFuncBase.Init(groups, vec)
+func (a *maxInt64HashAgg) SetOutput(vec coldata.Vec) {
+	a.hashAggregateFuncBase.SetOutput(vec)
 	a.vec = vec
 	a.col = vec.Int64()
 }
@@ -2339,8 +2339,8 @@ type maxFloat64HashAgg struct {
 
 var _ AggregateFunc = &maxFloat64HashAgg{}
 
-func (a *maxFloat64HashAgg) Init(groups []bool, vec coldata.Vec) {
-	a.hashAggregateFuncBase.Init(groups, vec)
+func (a *maxFloat64HashAgg) SetOutput(vec coldata.Vec) {
+	a.hashAggregateFuncBase.SetOutput(vec)
 	a.vec = vec
 	a.col = vec.Float64()
 }
@@ -2501,8 +2501,8 @@ type maxTimestampHashAgg struct {
 
 var _ AggregateFunc = &maxTimestampHashAgg{}
 
-func (a *maxTimestampHashAgg) Init(groups []bool, vec coldata.Vec) {
-	a.hashAggregateFuncBase.Init(groups, vec)
+func (a *maxTimestampHashAgg) SetOutput(vec coldata.Vec) {
+	a.hashAggregateFuncBase.SetOutput(vec)
 	a.vec = vec
 	a.col = vec.Timestamp()
 }
@@ -2639,8 +2639,8 @@ type maxIntervalHashAgg struct {
 
 var _ AggregateFunc = &maxIntervalHashAgg{}
 
-func (a *maxIntervalHashAgg) Init(groups []bool, vec coldata.Vec) {
-	a.hashAggregateFuncBase.Init(groups, vec)
+func (a *maxIntervalHashAgg) SetOutput(vec coldata.Vec) {
+	a.hashAggregateFuncBase.SetOutput(vec)
 	a.vec = vec
 	a.col = vec.Interval()
 }
@@ -2763,8 +2763,8 @@ type maxDatumHashAgg struct {
 
 var _ AggregateFunc = &maxDatumHashAgg{}
 
-func (a *maxDatumHashAgg) Init(groups []bool, vec coldata.Vec) {
-	a.hashAggregateFuncBase.Init(groups, vec)
+func (a *maxDatumHashAgg) SetOutput(vec coldata.Vec) {
+	a.hashAggregateFuncBase.SetOutput(vec)
 	a.vec = vec
 	a.col = vec.Datum()
 }

--- a/pkg/sql/colexec/colexecagg/hash_sum_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_sum_agg.eg.go
@@ -69,12 +69,6 @@ var _ AggregateFunc = &sumInt16HashAgg{}
 func (a *sumInt16HashAgg) Init(groups []bool, vec coldata.Vec) {
 	a.hashAggregateFuncBase.Init(groups, vec)
 	a.scratch.vec = vec.Decimal()
-	a.Reset()
-}
-
-func (a *sumInt16HashAgg) Reset() {
-	a.hashAggregateFuncBase.Reset()
-	a.scratch.foundNonNullForCurrentGroup = false
 }
 
 func (a *sumInt16HashAgg) Compute(
@@ -180,12 +174,6 @@ var _ AggregateFunc = &sumInt32HashAgg{}
 func (a *sumInt32HashAgg) Init(groups []bool, vec coldata.Vec) {
 	a.hashAggregateFuncBase.Init(groups, vec)
 	a.scratch.vec = vec.Decimal()
-	a.Reset()
-}
-
-func (a *sumInt32HashAgg) Reset() {
-	a.hashAggregateFuncBase.Reset()
-	a.scratch.foundNonNullForCurrentGroup = false
 }
 
 func (a *sumInt32HashAgg) Compute(
@@ -291,12 +279,6 @@ var _ AggregateFunc = &sumInt64HashAgg{}
 func (a *sumInt64HashAgg) Init(groups []bool, vec coldata.Vec) {
 	a.hashAggregateFuncBase.Init(groups, vec)
 	a.scratch.vec = vec.Decimal()
-	a.Reset()
-}
-
-func (a *sumInt64HashAgg) Reset() {
-	a.hashAggregateFuncBase.Reset()
-	a.scratch.foundNonNullForCurrentGroup = false
 }
 
 func (a *sumInt64HashAgg) Compute(
@@ -401,12 +383,6 @@ var _ AggregateFunc = &sumDecimalHashAgg{}
 func (a *sumDecimalHashAgg) Init(groups []bool, vec coldata.Vec) {
 	a.hashAggregateFuncBase.Init(groups, vec)
 	a.scratch.vec = vec.Decimal()
-	a.Reset()
-}
-
-func (a *sumDecimalHashAgg) Reset() {
-	a.hashAggregateFuncBase.Reset()
-	a.scratch.foundNonNullForCurrentGroup = false
 }
 
 func (a *sumDecimalHashAgg) Compute(
@@ -506,12 +482,6 @@ var _ AggregateFunc = &sumFloat64HashAgg{}
 func (a *sumFloat64HashAgg) Init(groups []bool, vec coldata.Vec) {
 	a.hashAggregateFuncBase.Init(groups, vec)
 	a.scratch.vec = vec.Float64()
-	a.Reset()
-}
-
-func (a *sumFloat64HashAgg) Reset() {
-	a.hashAggregateFuncBase.Reset()
-	a.scratch.foundNonNullForCurrentGroup = false
 }
 
 func (a *sumFloat64HashAgg) Compute(
@@ -605,12 +575,6 @@ var _ AggregateFunc = &sumIntervalHashAgg{}
 func (a *sumIntervalHashAgg) Init(groups []bool, vec coldata.Vec) {
 	a.hashAggregateFuncBase.Init(groups, vec)
 	a.scratch.vec = vec.Interval()
-	a.Reset()
-}
-
-func (a *sumIntervalHashAgg) Reset() {
-	a.hashAggregateFuncBase.Reset()
-	a.scratch.foundNonNullForCurrentGroup = false
 }
 
 func (a *sumIntervalHashAgg) Compute(

--- a/pkg/sql/colexec/colexecagg/hash_sum_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_sum_agg.eg.go
@@ -66,8 +66,8 @@ type sumInt16HashAgg struct {
 
 var _ AggregateFunc = &sumInt16HashAgg{}
 
-func (a *sumInt16HashAgg) Init(groups []bool, vec coldata.Vec) {
-	a.hashAggregateFuncBase.Init(groups, vec)
+func (a *sumInt16HashAgg) SetOutput(vec coldata.Vec) {
+	a.hashAggregateFuncBase.SetOutput(vec)
 	a.scratch.vec = vec.Decimal()
 }
 
@@ -171,8 +171,8 @@ type sumInt32HashAgg struct {
 
 var _ AggregateFunc = &sumInt32HashAgg{}
 
-func (a *sumInt32HashAgg) Init(groups []bool, vec coldata.Vec) {
-	a.hashAggregateFuncBase.Init(groups, vec)
+func (a *sumInt32HashAgg) SetOutput(vec coldata.Vec) {
+	a.hashAggregateFuncBase.SetOutput(vec)
 	a.scratch.vec = vec.Decimal()
 }
 
@@ -276,8 +276,8 @@ type sumInt64HashAgg struct {
 
 var _ AggregateFunc = &sumInt64HashAgg{}
 
-func (a *sumInt64HashAgg) Init(groups []bool, vec coldata.Vec) {
-	a.hashAggregateFuncBase.Init(groups, vec)
+func (a *sumInt64HashAgg) SetOutput(vec coldata.Vec) {
+	a.hashAggregateFuncBase.SetOutput(vec)
 	a.scratch.vec = vec.Decimal()
 }
 
@@ -380,8 +380,8 @@ type sumDecimalHashAgg struct {
 
 var _ AggregateFunc = &sumDecimalHashAgg{}
 
-func (a *sumDecimalHashAgg) Init(groups []bool, vec coldata.Vec) {
-	a.hashAggregateFuncBase.Init(groups, vec)
+func (a *sumDecimalHashAgg) SetOutput(vec coldata.Vec) {
+	a.hashAggregateFuncBase.SetOutput(vec)
 	a.scratch.vec = vec.Decimal()
 }
 
@@ -479,8 +479,8 @@ type sumFloat64HashAgg struct {
 
 var _ AggregateFunc = &sumFloat64HashAgg{}
 
-func (a *sumFloat64HashAgg) Init(groups []bool, vec coldata.Vec) {
-	a.hashAggregateFuncBase.Init(groups, vec)
+func (a *sumFloat64HashAgg) SetOutput(vec coldata.Vec) {
+	a.hashAggregateFuncBase.SetOutput(vec)
 	a.scratch.vec = vec.Float64()
 }
 
@@ -572,8 +572,8 @@ type sumIntervalHashAgg struct {
 
 var _ AggregateFunc = &sumIntervalHashAgg{}
 
-func (a *sumIntervalHashAgg) Init(groups []bool, vec coldata.Vec) {
-	a.hashAggregateFuncBase.Init(groups, vec)
+func (a *sumIntervalHashAgg) SetOutput(vec coldata.Vec) {
+	a.hashAggregateFuncBase.SetOutput(vec)
 	a.scratch.vec = vec.Interval()
 }
 

--- a/pkg/sql/colexec/colexecagg/hash_sum_int_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_sum_int_agg.eg.go
@@ -56,8 +56,8 @@ type sumIntInt16HashAgg struct {
 
 var _ AggregateFunc = &sumIntInt16HashAgg{}
 
-func (a *sumIntInt16HashAgg) Init(groups []bool, vec coldata.Vec) {
-	a.hashAggregateFuncBase.Init(groups, vec)
+func (a *sumIntInt16HashAgg) SetOutput(vec coldata.Vec) {
+	a.hashAggregateFuncBase.SetOutput(vec)
 	a.scratch.vec = vec.Int64()
 }
 
@@ -155,8 +155,8 @@ type sumIntInt32HashAgg struct {
 
 var _ AggregateFunc = &sumIntInt32HashAgg{}
 
-func (a *sumIntInt32HashAgg) Init(groups []bool, vec coldata.Vec) {
-	a.hashAggregateFuncBase.Init(groups, vec)
+func (a *sumIntInt32HashAgg) SetOutput(vec coldata.Vec) {
+	a.hashAggregateFuncBase.SetOutput(vec)
 	a.scratch.vec = vec.Int64()
 }
 
@@ -254,8 +254,8 @@ type sumIntInt64HashAgg struct {
 
 var _ AggregateFunc = &sumIntInt64HashAgg{}
 
-func (a *sumIntInt64HashAgg) Init(groups []bool, vec coldata.Vec) {
-	a.hashAggregateFuncBase.Init(groups, vec)
+func (a *sumIntInt64HashAgg) SetOutput(vec coldata.Vec) {
+	a.hashAggregateFuncBase.SetOutput(vec)
 	a.scratch.vec = vec.Int64()
 }
 

--- a/pkg/sql/colexec/colexecagg/hash_sum_int_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_sum_int_agg.eg.go
@@ -59,12 +59,6 @@ var _ AggregateFunc = &sumIntInt16HashAgg{}
 func (a *sumIntInt16HashAgg) Init(groups []bool, vec coldata.Vec) {
 	a.hashAggregateFuncBase.Init(groups, vec)
 	a.scratch.vec = vec.Int64()
-	a.Reset()
-}
-
-func (a *sumIntInt16HashAgg) Reset() {
-	a.hashAggregateFuncBase.Reset()
-	a.scratch.foundNonNullForCurrentGroup = false
 }
 
 func (a *sumIntInt16HashAgg) Compute(
@@ -164,12 +158,6 @@ var _ AggregateFunc = &sumIntInt32HashAgg{}
 func (a *sumIntInt32HashAgg) Init(groups []bool, vec coldata.Vec) {
 	a.hashAggregateFuncBase.Init(groups, vec)
 	a.scratch.vec = vec.Int64()
-	a.Reset()
-}
-
-func (a *sumIntInt32HashAgg) Reset() {
-	a.hashAggregateFuncBase.Reset()
-	a.scratch.foundNonNullForCurrentGroup = false
 }
 
 func (a *sumIntInt32HashAgg) Compute(
@@ -269,12 +257,6 @@ var _ AggregateFunc = &sumIntInt64HashAgg{}
 func (a *sumIntInt64HashAgg) Init(groups []bool, vec coldata.Vec) {
 	a.hashAggregateFuncBase.Init(groups, vec)
 	a.scratch.vec = vec.Int64()
-	a.Reset()
-}
-
-func (a *sumIntInt64HashAgg) Reset() {
-	a.hashAggregateFuncBase.Reset()
-	a.scratch.foundNonNullForCurrentGroup = false
 }
 
 func (a *sumIntInt64HashAgg) Compute(

--- a/pkg/sql/colexec/colexecagg/min_max_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/min_max_agg_tmpl.go
@@ -145,16 +145,6 @@ func (a *_AGG_TYPE_AGGKINDAgg) Init(groups []bool, vec coldata.Vec) {
 	// {{end}}
 	a.vec = vec
 	a.col = vec._TYPE()
-	a.Reset()
-}
-
-func (a *_AGG_TYPE_AGGKINDAgg) Reset() {
-	// {{if eq "_AGGKIND" "Ordered"}}
-	a.orderedAggregateFuncBase.Reset()
-	// {{else}}
-	a.hashAggregateFuncBase.Reset()
-	// {{end}}
-	a.foundNonNullForCurrentGroup = false
 }
 
 func (a *_AGG_TYPE_AGGKINDAgg) Compute(

--- a/pkg/sql/colexec/colexecagg/min_max_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/min_max_agg_tmpl.go
@@ -137,11 +137,11 @@ type _AGG_TYPE_AGGKINDAgg struct {
 
 var _ AggregateFunc = &_AGG_TYPE_AGGKINDAgg{}
 
-func (a *_AGG_TYPE_AGGKINDAgg) Init(groups []bool, vec coldata.Vec) {
+func (a *_AGG_TYPE_AGGKINDAgg) SetOutput(vec coldata.Vec) {
 	// {{if eq "_AGGKIND" "Ordered"}}
-	a.orderedAggregateFuncBase.Init(groups, vec)
+	a.orderedAggregateFuncBase.SetOutput(vec)
 	// {{else}}
-	a.hashAggregateFuncBase.Init(groups, vec)
+	a.hashAggregateFuncBase.SetOutput(vec)
 	// {{end}}
 	a.vec = vec
 	a.col = vec._TYPE()

--- a/pkg/sql/colexec/colexecagg/ordered_any_not_null_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_any_not_null_agg.eg.go
@@ -101,12 +101,6 @@ func (a *anyNotNullBoolOrderedAgg) Init(groups []bool, vec coldata.Vec) {
 	a.orderedAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
 	a.col = vec.Bool()
-	a.Reset()
-}
-
-func (a *anyNotNullBoolOrderedAgg) Reset() {
-	a.orderedAggregateFuncBase.Reset()
-	a.foundNonNullForCurrentGroup = false
 }
 
 func (a *anyNotNullBoolOrderedAgg) Compute(
@@ -287,12 +281,6 @@ func (a *anyNotNullBytesOrderedAgg) Init(groups []bool, vec coldata.Vec) {
 	a.orderedAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
 	a.col = vec.Bytes()
-	a.Reset()
-}
-
-func (a *anyNotNullBytesOrderedAgg) Reset() {
-	a.orderedAggregateFuncBase.Reset()
-	a.foundNonNullForCurrentGroup = false
 }
 
 func (a *anyNotNullBytesOrderedAgg) Compute(
@@ -479,12 +467,6 @@ func (a *anyNotNullDecimalOrderedAgg) Init(groups []bool, vec coldata.Vec) {
 	a.orderedAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
 	a.col = vec.Decimal()
-	a.Reset()
-}
-
-func (a *anyNotNullDecimalOrderedAgg) Reset() {
-	a.orderedAggregateFuncBase.Reset()
-	a.foundNonNullForCurrentGroup = false
 }
 
 func (a *anyNotNullDecimalOrderedAgg) Compute(
@@ -665,12 +647,6 @@ func (a *anyNotNullInt16OrderedAgg) Init(groups []bool, vec coldata.Vec) {
 	a.orderedAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
 	a.col = vec.Int16()
-	a.Reset()
-}
-
-func (a *anyNotNullInt16OrderedAgg) Reset() {
-	a.orderedAggregateFuncBase.Reset()
-	a.foundNonNullForCurrentGroup = false
 }
 
 func (a *anyNotNullInt16OrderedAgg) Compute(
@@ -851,12 +827,6 @@ func (a *anyNotNullInt32OrderedAgg) Init(groups []bool, vec coldata.Vec) {
 	a.orderedAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
 	a.col = vec.Int32()
-	a.Reset()
-}
-
-func (a *anyNotNullInt32OrderedAgg) Reset() {
-	a.orderedAggregateFuncBase.Reset()
-	a.foundNonNullForCurrentGroup = false
 }
 
 func (a *anyNotNullInt32OrderedAgg) Compute(
@@ -1037,12 +1007,6 @@ func (a *anyNotNullInt64OrderedAgg) Init(groups []bool, vec coldata.Vec) {
 	a.orderedAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
 	a.col = vec.Int64()
-	a.Reset()
-}
-
-func (a *anyNotNullInt64OrderedAgg) Reset() {
-	a.orderedAggregateFuncBase.Reset()
-	a.foundNonNullForCurrentGroup = false
 }
 
 func (a *anyNotNullInt64OrderedAgg) Compute(
@@ -1223,12 +1187,6 @@ func (a *anyNotNullFloat64OrderedAgg) Init(groups []bool, vec coldata.Vec) {
 	a.orderedAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
 	a.col = vec.Float64()
-	a.Reset()
-}
-
-func (a *anyNotNullFloat64OrderedAgg) Reset() {
-	a.orderedAggregateFuncBase.Reset()
-	a.foundNonNullForCurrentGroup = false
 }
 
 func (a *anyNotNullFloat64OrderedAgg) Compute(
@@ -1409,12 +1367,6 @@ func (a *anyNotNullTimestampOrderedAgg) Init(groups []bool, vec coldata.Vec) {
 	a.orderedAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
 	a.col = vec.Timestamp()
-	a.Reset()
-}
-
-func (a *anyNotNullTimestampOrderedAgg) Reset() {
-	a.orderedAggregateFuncBase.Reset()
-	a.foundNonNullForCurrentGroup = false
 }
 
 func (a *anyNotNullTimestampOrderedAgg) Compute(
@@ -1595,12 +1547,6 @@ func (a *anyNotNullIntervalOrderedAgg) Init(groups []bool, vec coldata.Vec) {
 	a.orderedAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
 	a.col = vec.Interval()
-	a.Reset()
-}
-
-func (a *anyNotNullIntervalOrderedAgg) Reset() {
-	a.orderedAggregateFuncBase.Reset()
-	a.foundNonNullForCurrentGroup = false
 }
 
 func (a *anyNotNullIntervalOrderedAgg) Compute(
@@ -1781,12 +1727,6 @@ func (a *anyNotNullDatumOrderedAgg) Init(groups []bool, vec coldata.Vec) {
 	a.orderedAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
 	a.col = vec.Datum()
-	a.Reset()
-}
-
-func (a *anyNotNullDatumOrderedAgg) Reset() {
-	a.orderedAggregateFuncBase.Reset()
-	a.foundNonNullForCurrentGroup = false
 }
 
 func (a *anyNotNullDatumOrderedAgg) Compute(

--- a/pkg/sql/colexec/colexecagg/ordered_any_not_null_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_any_not_null_agg.eg.go
@@ -97,8 +97,8 @@ type anyNotNullBoolOrderedAgg struct {
 
 var _ AggregateFunc = &anyNotNullBoolOrderedAgg{}
 
-func (a *anyNotNullBoolOrderedAgg) Init(groups []bool, vec coldata.Vec) {
-	a.orderedAggregateFuncBase.Init(groups, vec)
+func (a *anyNotNullBoolOrderedAgg) SetOutput(vec coldata.Vec) {
+	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.vec = vec
 	a.col = vec.Bool()
 }
@@ -277,8 +277,8 @@ type anyNotNullBytesOrderedAgg struct {
 
 var _ AggregateFunc = &anyNotNullBytesOrderedAgg{}
 
-func (a *anyNotNullBytesOrderedAgg) Init(groups []bool, vec coldata.Vec) {
-	a.orderedAggregateFuncBase.Init(groups, vec)
+func (a *anyNotNullBytesOrderedAgg) SetOutput(vec coldata.Vec) {
+	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.vec = vec
 	a.col = vec.Bytes()
 }
@@ -463,8 +463,8 @@ type anyNotNullDecimalOrderedAgg struct {
 
 var _ AggregateFunc = &anyNotNullDecimalOrderedAgg{}
 
-func (a *anyNotNullDecimalOrderedAgg) Init(groups []bool, vec coldata.Vec) {
-	a.orderedAggregateFuncBase.Init(groups, vec)
+func (a *anyNotNullDecimalOrderedAgg) SetOutput(vec coldata.Vec) {
+	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.vec = vec
 	a.col = vec.Decimal()
 }
@@ -643,8 +643,8 @@ type anyNotNullInt16OrderedAgg struct {
 
 var _ AggregateFunc = &anyNotNullInt16OrderedAgg{}
 
-func (a *anyNotNullInt16OrderedAgg) Init(groups []bool, vec coldata.Vec) {
-	a.orderedAggregateFuncBase.Init(groups, vec)
+func (a *anyNotNullInt16OrderedAgg) SetOutput(vec coldata.Vec) {
+	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.vec = vec
 	a.col = vec.Int16()
 }
@@ -823,8 +823,8 @@ type anyNotNullInt32OrderedAgg struct {
 
 var _ AggregateFunc = &anyNotNullInt32OrderedAgg{}
 
-func (a *anyNotNullInt32OrderedAgg) Init(groups []bool, vec coldata.Vec) {
-	a.orderedAggregateFuncBase.Init(groups, vec)
+func (a *anyNotNullInt32OrderedAgg) SetOutput(vec coldata.Vec) {
+	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.vec = vec
 	a.col = vec.Int32()
 }
@@ -1003,8 +1003,8 @@ type anyNotNullInt64OrderedAgg struct {
 
 var _ AggregateFunc = &anyNotNullInt64OrderedAgg{}
 
-func (a *anyNotNullInt64OrderedAgg) Init(groups []bool, vec coldata.Vec) {
-	a.orderedAggregateFuncBase.Init(groups, vec)
+func (a *anyNotNullInt64OrderedAgg) SetOutput(vec coldata.Vec) {
+	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.vec = vec
 	a.col = vec.Int64()
 }
@@ -1183,8 +1183,8 @@ type anyNotNullFloat64OrderedAgg struct {
 
 var _ AggregateFunc = &anyNotNullFloat64OrderedAgg{}
 
-func (a *anyNotNullFloat64OrderedAgg) Init(groups []bool, vec coldata.Vec) {
-	a.orderedAggregateFuncBase.Init(groups, vec)
+func (a *anyNotNullFloat64OrderedAgg) SetOutput(vec coldata.Vec) {
+	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.vec = vec
 	a.col = vec.Float64()
 }
@@ -1363,8 +1363,8 @@ type anyNotNullTimestampOrderedAgg struct {
 
 var _ AggregateFunc = &anyNotNullTimestampOrderedAgg{}
 
-func (a *anyNotNullTimestampOrderedAgg) Init(groups []bool, vec coldata.Vec) {
-	a.orderedAggregateFuncBase.Init(groups, vec)
+func (a *anyNotNullTimestampOrderedAgg) SetOutput(vec coldata.Vec) {
+	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.vec = vec
 	a.col = vec.Timestamp()
 }
@@ -1543,8 +1543,8 @@ type anyNotNullIntervalOrderedAgg struct {
 
 var _ AggregateFunc = &anyNotNullIntervalOrderedAgg{}
 
-func (a *anyNotNullIntervalOrderedAgg) Init(groups []bool, vec coldata.Vec) {
-	a.orderedAggregateFuncBase.Init(groups, vec)
+func (a *anyNotNullIntervalOrderedAgg) SetOutput(vec coldata.Vec) {
+	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.vec = vec
 	a.col = vec.Interval()
 }
@@ -1723,8 +1723,8 @@ type anyNotNullDatumOrderedAgg struct {
 
 var _ AggregateFunc = &anyNotNullDatumOrderedAgg{}
 
-func (a *anyNotNullDatumOrderedAgg) Init(groups []bool, vec coldata.Vec) {
-	a.orderedAggregateFuncBase.Init(groups, vec)
+func (a *anyNotNullDatumOrderedAgg) SetOutput(vec coldata.Vec) {
+	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.vec = vec
 	a.col = vec.Datum()
 }

--- a/pkg/sql/colexec/colexecagg/ordered_avg_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_avg_agg.eg.go
@@ -69,8 +69,8 @@ type avgInt16OrderedAgg struct {
 
 var _ AggregateFunc = &avgInt16OrderedAgg{}
 
-func (a *avgInt16OrderedAgg) Init(groups []bool, vec coldata.Vec) {
-	a.orderedAggregateFuncBase.Init(groups, vec)
+func (a *avgInt16OrderedAgg) SetOutput(vec coldata.Vec) {
+	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.scratch.vec = vec.Decimal()
 }
 
@@ -307,8 +307,8 @@ type avgInt32OrderedAgg struct {
 
 var _ AggregateFunc = &avgInt32OrderedAgg{}
 
-func (a *avgInt32OrderedAgg) Init(groups []bool, vec coldata.Vec) {
-	a.orderedAggregateFuncBase.Init(groups, vec)
+func (a *avgInt32OrderedAgg) SetOutput(vec coldata.Vec) {
+	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.scratch.vec = vec.Decimal()
 }
 
@@ -545,8 +545,8 @@ type avgInt64OrderedAgg struct {
 
 var _ AggregateFunc = &avgInt64OrderedAgg{}
 
-func (a *avgInt64OrderedAgg) Init(groups []bool, vec coldata.Vec) {
-	a.orderedAggregateFuncBase.Init(groups, vec)
+func (a *avgInt64OrderedAgg) SetOutput(vec coldata.Vec) {
+	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.scratch.vec = vec.Decimal()
 }
 
@@ -782,8 +782,8 @@ type avgDecimalOrderedAgg struct {
 
 var _ AggregateFunc = &avgDecimalOrderedAgg{}
 
-func (a *avgDecimalOrderedAgg) Init(groups []bool, vec coldata.Vec) {
-	a.orderedAggregateFuncBase.Init(groups, vec)
+func (a *avgDecimalOrderedAgg) SetOutput(vec coldata.Vec) {
+	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.scratch.vec = vec.Decimal()
 }
 
@@ -1012,8 +1012,8 @@ type avgFloat64OrderedAgg struct {
 
 var _ AggregateFunc = &avgFloat64OrderedAgg{}
 
-func (a *avgFloat64OrderedAgg) Init(groups []bool, vec coldata.Vec) {
-	a.orderedAggregateFuncBase.Init(groups, vec)
+func (a *avgFloat64OrderedAgg) SetOutput(vec coldata.Vec) {
+	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.scratch.vec = vec.Float64()
 }
 
@@ -1210,8 +1210,8 @@ type avgIntervalOrderedAgg struct {
 
 var _ AggregateFunc = &avgIntervalOrderedAgg{}
 
-func (a *avgIntervalOrderedAgg) Init(groups []bool, vec coldata.Vec) {
-	a.orderedAggregateFuncBase.Init(groups, vec)
+func (a *avgIntervalOrderedAgg) SetOutput(vec coldata.Vec) {
+	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.scratch.vec = vec.Interval()
 }
 

--- a/pkg/sql/colexec/colexecagg/ordered_avg_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_avg_agg.eg.go
@@ -72,14 +72,6 @@ var _ AggregateFunc = &avgInt16OrderedAgg{}
 func (a *avgInt16OrderedAgg) Init(groups []bool, vec coldata.Vec) {
 	a.orderedAggregateFuncBase.Init(groups, vec)
 	a.scratch.vec = vec.Decimal()
-	a.Reset()
-}
-
-func (a *avgInt16OrderedAgg) Reset() {
-	a.orderedAggregateFuncBase.Reset()
-	a.scratch.curSum = zeroDecimalValue
-	a.scratch.curCount = 0
-	a.scratch.foundNonNullForCurrentGroup = false
 }
 
 func (a *avgInt16OrderedAgg) Compute(
@@ -318,14 +310,6 @@ var _ AggregateFunc = &avgInt32OrderedAgg{}
 func (a *avgInt32OrderedAgg) Init(groups []bool, vec coldata.Vec) {
 	a.orderedAggregateFuncBase.Init(groups, vec)
 	a.scratch.vec = vec.Decimal()
-	a.Reset()
-}
-
-func (a *avgInt32OrderedAgg) Reset() {
-	a.orderedAggregateFuncBase.Reset()
-	a.scratch.curSum = zeroDecimalValue
-	a.scratch.curCount = 0
-	a.scratch.foundNonNullForCurrentGroup = false
 }
 
 func (a *avgInt32OrderedAgg) Compute(
@@ -564,14 +548,6 @@ var _ AggregateFunc = &avgInt64OrderedAgg{}
 func (a *avgInt64OrderedAgg) Init(groups []bool, vec coldata.Vec) {
 	a.orderedAggregateFuncBase.Init(groups, vec)
 	a.scratch.vec = vec.Decimal()
-	a.Reset()
-}
-
-func (a *avgInt64OrderedAgg) Reset() {
-	a.orderedAggregateFuncBase.Reset()
-	a.scratch.curSum = zeroDecimalValue
-	a.scratch.curCount = 0
-	a.scratch.foundNonNullForCurrentGroup = false
 }
 
 func (a *avgInt64OrderedAgg) Compute(
@@ -809,14 +785,6 @@ var _ AggregateFunc = &avgDecimalOrderedAgg{}
 func (a *avgDecimalOrderedAgg) Init(groups []bool, vec coldata.Vec) {
 	a.orderedAggregateFuncBase.Init(groups, vec)
 	a.scratch.vec = vec.Decimal()
-	a.Reset()
-}
-
-func (a *avgDecimalOrderedAgg) Reset() {
-	a.orderedAggregateFuncBase.Reset()
-	a.scratch.curSum = zeroDecimalValue
-	a.scratch.curCount = 0
-	a.scratch.foundNonNullForCurrentGroup = false
 }
 
 func (a *avgDecimalOrderedAgg) Compute(
@@ -1047,14 +1015,6 @@ var _ AggregateFunc = &avgFloat64OrderedAgg{}
 func (a *avgFloat64OrderedAgg) Init(groups []bool, vec coldata.Vec) {
 	a.orderedAggregateFuncBase.Init(groups, vec)
 	a.scratch.vec = vec.Float64()
-	a.Reset()
-}
-
-func (a *avgFloat64OrderedAgg) Reset() {
-	a.orderedAggregateFuncBase.Reset()
-	a.scratch.curSum = zeroFloat64Value
-	a.scratch.curCount = 0
-	a.scratch.foundNonNullForCurrentGroup = false
 }
 
 func (a *avgFloat64OrderedAgg) Compute(
@@ -1253,14 +1213,6 @@ var _ AggregateFunc = &avgIntervalOrderedAgg{}
 func (a *avgIntervalOrderedAgg) Init(groups []bool, vec coldata.Vec) {
 	a.orderedAggregateFuncBase.Init(groups, vec)
 	a.scratch.vec = vec.Interval()
-	a.Reset()
-}
-
-func (a *avgIntervalOrderedAgg) Reset() {
-	a.orderedAggregateFuncBase.Reset()
-	a.scratch.curSum = zeroIntervalValue
-	a.scratch.curCount = 0
-	a.scratch.foundNonNullForCurrentGroup = false
 }
 
 func (a *avgIntervalOrderedAgg) Compute(

--- a/pkg/sql/colexec/colexecagg/ordered_bool_and_or_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_bool_and_or_agg.eg.go
@@ -38,10 +38,9 @@ type boolAndOrderedAgg struct {
 
 var _ AggregateFunc = &boolAndOrderedAgg{}
 
-func (a *boolAndOrderedAgg) Init(groups []bool, vec coldata.Vec) {
-	a.orderedAggregateFuncBase.Init(groups, vec)
+func (a *boolAndOrderedAgg) SetOutput(vec coldata.Vec) {
+	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.vec = vec.Bool()
-	a.curAgg = true
 }
 
 func (a *boolAndOrderedAgg) Compute(
@@ -173,6 +172,7 @@ func (a *boolAndOrderedAggAlloc) newAggFunc() AggregateFunc {
 	}
 	f := &a.aggFuncs[0]
 	a.aggFuncs = a.aggFuncs[1:]
+	f.curAgg = true
 	return f
 }
 
@@ -194,10 +194,9 @@ type boolOrOrderedAgg struct {
 
 var _ AggregateFunc = &boolOrOrderedAgg{}
 
-func (a *boolOrOrderedAgg) Init(groups []bool, vec coldata.Vec) {
-	a.orderedAggregateFuncBase.Init(groups, vec)
+func (a *boolOrOrderedAgg) SetOutput(vec coldata.Vec) {
+	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.vec = vec.Bool()
-	a.curAgg = false
 }
 
 func (a *boolOrOrderedAgg) Compute(
@@ -329,5 +328,6 @@ func (a *boolOrOrderedAggAlloc) newAggFunc() AggregateFunc {
 	}
 	f := &a.aggFuncs[0]
 	a.aggFuncs = a.aggFuncs[1:]
+	f.curAgg = false
 	return f
 }

--- a/pkg/sql/colexec/colexecagg/ordered_bool_and_or_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_bool_and_or_agg.eg.go
@@ -41,13 +41,6 @@ var _ AggregateFunc = &boolAndOrderedAgg{}
 func (a *boolAndOrderedAgg) Init(groups []bool, vec coldata.Vec) {
 	a.orderedAggregateFuncBase.Init(groups, vec)
 	a.vec = vec.Bool()
-	a.Reset()
-}
-
-func (a *boolAndOrderedAgg) Reset() {
-	a.orderedAggregateFuncBase.Reset()
-	// true indicates whether we are doing an AND aggregate or OR aggregate.
-	// For bool_and the true is true and for bool_or the true is false.
 	a.curAgg = true
 }
 
@@ -204,13 +197,6 @@ var _ AggregateFunc = &boolOrOrderedAgg{}
 func (a *boolOrOrderedAgg) Init(groups []bool, vec coldata.Vec) {
 	a.orderedAggregateFuncBase.Init(groups, vec)
 	a.vec = vec.Bool()
-	a.Reset()
-}
-
-func (a *boolOrOrderedAgg) Reset() {
-	a.orderedAggregateFuncBase.Reset()
-	// false indicates whether we are doing an AND aggregate or OR aggregate.
-	// For bool_and the false is true and for bool_or the false is false.
 	a.curAgg = false
 }
 

--- a/pkg/sql/colexec/colexecagg/ordered_concat_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_concat_agg.eg.go
@@ -41,13 +41,6 @@ func (a *concatOrderedAgg) Init(groups []bool, vec coldata.Vec) {
 	a.orderedAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
 	a.col = vec.Bytes()
-	a.Reset()
-}
-
-func (a *concatOrderedAgg) Reset() {
-	a.orderedAggregateFuncBase.Reset()
-	a.foundNonNullForCurrentGroup = false
-	a.curAgg = zeroBytesValue
 }
 
 func (a *concatOrderedAgg) Compute(

--- a/pkg/sql/colexec/colexecagg/ordered_concat_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_concat_agg.eg.go
@@ -37,8 +37,8 @@ type concatOrderedAgg struct {
 	foundNonNullForCurrentGroup bool
 }
 
-func (a *concatOrderedAgg) Init(groups []bool, vec coldata.Vec) {
-	a.orderedAggregateFuncBase.Init(groups, vec)
+func (a *concatOrderedAgg) SetOutput(vec coldata.Vec) {
+	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.vec = vec
 	a.col = vec.Bytes()
 }

--- a/pkg/sql/colexec/colexecagg/ordered_count_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_count_agg.eg.go
@@ -37,12 +37,6 @@ var _ AggregateFunc = &countRowsOrderedAgg{}
 func (a *countRowsOrderedAgg) Init(groups []bool, vec coldata.Vec) {
 	a.orderedAggregateFuncBase.Init(groups, vec)
 	a.vec = vec.Int64()
-	a.Reset()
-}
-
-func (a *countRowsOrderedAgg) Reset() {
-	a.orderedAggregateFuncBase.Reset()
-	a.curAgg = 0
 }
 
 func (a *countRowsOrderedAgg) Compute(
@@ -136,12 +130,6 @@ var _ AggregateFunc = &countOrderedAgg{}
 func (a *countOrderedAgg) Init(groups []bool, vec coldata.Vec) {
 	a.orderedAggregateFuncBase.Init(groups, vec)
 	a.vec = vec.Int64()
-	a.Reset()
-}
-
-func (a *countOrderedAgg) Reset() {
-	a.orderedAggregateFuncBase.Reset()
-	a.curAgg = 0
 }
 
 func (a *countOrderedAgg) Compute(

--- a/pkg/sql/colexec/colexecagg/ordered_count_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_count_agg.eg.go
@@ -34,8 +34,8 @@ type countRowsOrderedAgg struct {
 
 var _ AggregateFunc = &countRowsOrderedAgg{}
 
-func (a *countRowsOrderedAgg) Init(groups []bool, vec coldata.Vec) {
-	a.orderedAggregateFuncBase.Init(groups, vec)
+func (a *countRowsOrderedAgg) SetOutput(vec coldata.Vec) {
+	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.vec = vec.Int64()
 }
 
@@ -127,8 +127,8 @@ type countOrderedAgg struct {
 
 var _ AggregateFunc = &countOrderedAgg{}
 
-func (a *countOrderedAgg) Init(groups []bool, vec coldata.Vec) {
-	a.orderedAggregateFuncBase.Init(groups, vec)
+func (a *countOrderedAgg) SetOutput(vec coldata.Vec) {
+	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.vec = vec.Int64()
 }
 

--- a/pkg/sql/colexec/colexecagg/ordered_default_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_default_agg.eg.go
@@ -45,12 +45,6 @@ var _ AggregateFunc = &defaultOrderedAgg{}
 func (a *defaultOrderedAgg) Init(groups []bool, vec coldata.Vec) {
 	a.orderedAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
-	a.Reset()
-}
-
-func (a *defaultOrderedAgg) Reset() {
-	a.orderedAggregateFuncBase.Reset()
-	a.fn.Reset(a.ctx)
 }
 
 func (a *defaultOrderedAgg) Compute(

--- a/pkg/sql/colexec/colexecagg/ordered_default_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_default_agg.eg.go
@@ -42,8 +42,8 @@ type defaultOrderedAgg struct {
 
 var _ AggregateFunc = &defaultOrderedAgg{}
 
-func (a *defaultOrderedAgg) Init(groups []bool, vec coldata.Vec) {
-	a.orderedAggregateFuncBase.Init(groups, vec)
+func (a *defaultOrderedAgg) SetOutput(vec coldata.Vec) {
+	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.vec = vec
 }
 

--- a/pkg/sql/colexec/colexecagg/ordered_min_max_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_min_max_agg.eg.go
@@ -109,8 +109,8 @@ type minBoolOrderedAgg struct {
 
 var _ AggregateFunc = &minBoolOrderedAgg{}
 
-func (a *minBoolOrderedAgg) Init(groups []bool, vec coldata.Vec) {
-	a.orderedAggregateFuncBase.Init(groups, vec)
+func (a *minBoolOrderedAgg) SetOutput(vec coldata.Vec) {
+	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.vec = vec
 	a.col = vec.Bool()
 }
@@ -374,8 +374,8 @@ type minBytesOrderedAgg struct {
 
 var _ AggregateFunc = &minBytesOrderedAgg{}
 
-func (a *minBytesOrderedAgg) Init(groups []bool, vec coldata.Vec) {
-	a.orderedAggregateFuncBase.Init(groups, vec)
+func (a *minBytesOrderedAgg) SetOutput(vec coldata.Vec) {
+	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.vec = vec
 	a.col = vec.Bytes()
 }
@@ -615,8 +615,8 @@ type minDecimalOrderedAgg struct {
 
 var _ AggregateFunc = &minDecimalOrderedAgg{}
 
-func (a *minDecimalOrderedAgg) Init(groups []bool, vec coldata.Vec) {
-	a.orderedAggregateFuncBase.Init(groups, vec)
+func (a *minDecimalOrderedAgg) SetOutput(vec coldata.Vec) {
+	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.vec = vec
 	a.col = vec.Decimal()
 }
@@ -848,8 +848,8 @@ type minInt16OrderedAgg struct {
 
 var _ AggregateFunc = &minInt16OrderedAgg{}
 
-func (a *minInt16OrderedAgg) Init(groups []bool, vec coldata.Vec) {
-	a.orderedAggregateFuncBase.Init(groups, vec)
+func (a *minInt16OrderedAgg) SetOutput(vec coldata.Vec) {
+	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.vec = vec
 	a.col = vec.Int16()
 }
@@ -1125,8 +1125,8 @@ type minInt32OrderedAgg struct {
 
 var _ AggregateFunc = &minInt32OrderedAgg{}
 
-func (a *minInt32OrderedAgg) Init(groups []bool, vec coldata.Vec) {
-	a.orderedAggregateFuncBase.Init(groups, vec)
+func (a *minInt32OrderedAgg) SetOutput(vec coldata.Vec) {
+	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.vec = vec
 	a.col = vec.Int32()
 }
@@ -1402,8 +1402,8 @@ type minInt64OrderedAgg struct {
 
 var _ AggregateFunc = &minInt64OrderedAgg{}
 
-func (a *minInt64OrderedAgg) Init(groups []bool, vec coldata.Vec) {
-	a.orderedAggregateFuncBase.Init(groups, vec)
+func (a *minInt64OrderedAgg) SetOutput(vec coldata.Vec) {
+	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.vec = vec
 	a.col = vec.Int64()
 }
@@ -1679,8 +1679,8 @@ type minFloat64OrderedAgg struct {
 
 var _ AggregateFunc = &minFloat64OrderedAgg{}
 
-func (a *minFloat64OrderedAgg) Init(groups []bool, vec coldata.Vec) {
-	a.orderedAggregateFuncBase.Init(groups, vec)
+func (a *minFloat64OrderedAgg) SetOutput(vec coldata.Vec) {
+	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.vec = vec
 	a.col = vec.Float64()
 }
@@ -1988,8 +1988,8 @@ type minTimestampOrderedAgg struct {
 
 var _ AggregateFunc = &minTimestampOrderedAgg{}
 
-func (a *minTimestampOrderedAgg) Init(groups []bool, vec coldata.Vec) {
-	a.orderedAggregateFuncBase.Init(groups, vec)
+func (a *minTimestampOrderedAgg) SetOutput(vec coldata.Vec) {
+	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.vec = vec
 	a.col = vec.Timestamp()
 }
@@ -2249,8 +2249,8 @@ type minIntervalOrderedAgg struct {
 
 var _ AggregateFunc = &minIntervalOrderedAgg{}
 
-func (a *minIntervalOrderedAgg) Init(groups []bool, vec coldata.Vec) {
-	a.orderedAggregateFuncBase.Init(groups, vec)
+func (a *minIntervalOrderedAgg) SetOutput(vec coldata.Vec) {
+	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.vec = vec
 	a.col = vec.Interval()
 }
@@ -2482,8 +2482,8 @@ type minDatumOrderedAgg struct {
 
 var _ AggregateFunc = &minDatumOrderedAgg{}
 
-func (a *minDatumOrderedAgg) Init(groups []bool, vec coldata.Vec) {
-	a.orderedAggregateFuncBase.Init(groups, vec)
+func (a *minDatumOrderedAgg) SetOutput(vec coldata.Vec) {
+	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.vec = vec
 	a.col = vec.Datum()
 }
@@ -2737,8 +2737,8 @@ type maxBoolOrderedAgg struct {
 
 var _ AggregateFunc = &maxBoolOrderedAgg{}
 
-func (a *maxBoolOrderedAgg) Init(groups []bool, vec coldata.Vec) {
-	a.orderedAggregateFuncBase.Init(groups, vec)
+func (a *maxBoolOrderedAgg) SetOutput(vec coldata.Vec) {
+	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.vec = vec
 	a.col = vec.Bool()
 }
@@ -3002,8 +3002,8 @@ type maxBytesOrderedAgg struct {
 
 var _ AggregateFunc = &maxBytesOrderedAgg{}
 
-func (a *maxBytesOrderedAgg) Init(groups []bool, vec coldata.Vec) {
-	a.orderedAggregateFuncBase.Init(groups, vec)
+func (a *maxBytesOrderedAgg) SetOutput(vec coldata.Vec) {
+	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.vec = vec
 	a.col = vec.Bytes()
 }
@@ -3243,8 +3243,8 @@ type maxDecimalOrderedAgg struct {
 
 var _ AggregateFunc = &maxDecimalOrderedAgg{}
 
-func (a *maxDecimalOrderedAgg) Init(groups []bool, vec coldata.Vec) {
-	a.orderedAggregateFuncBase.Init(groups, vec)
+func (a *maxDecimalOrderedAgg) SetOutput(vec coldata.Vec) {
+	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.vec = vec
 	a.col = vec.Decimal()
 }
@@ -3476,8 +3476,8 @@ type maxInt16OrderedAgg struct {
 
 var _ AggregateFunc = &maxInt16OrderedAgg{}
 
-func (a *maxInt16OrderedAgg) Init(groups []bool, vec coldata.Vec) {
-	a.orderedAggregateFuncBase.Init(groups, vec)
+func (a *maxInt16OrderedAgg) SetOutput(vec coldata.Vec) {
+	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.vec = vec
 	a.col = vec.Int16()
 }
@@ -3753,8 +3753,8 @@ type maxInt32OrderedAgg struct {
 
 var _ AggregateFunc = &maxInt32OrderedAgg{}
 
-func (a *maxInt32OrderedAgg) Init(groups []bool, vec coldata.Vec) {
-	a.orderedAggregateFuncBase.Init(groups, vec)
+func (a *maxInt32OrderedAgg) SetOutput(vec coldata.Vec) {
+	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.vec = vec
 	a.col = vec.Int32()
 }
@@ -4030,8 +4030,8 @@ type maxInt64OrderedAgg struct {
 
 var _ AggregateFunc = &maxInt64OrderedAgg{}
 
-func (a *maxInt64OrderedAgg) Init(groups []bool, vec coldata.Vec) {
-	a.orderedAggregateFuncBase.Init(groups, vec)
+func (a *maxInt64OrderedAgg) SetOutput(vec coldata.Vec) {
+	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.vec = vec
 	a.col = vec.Int64()
 }
@@ -4307,8 +4307,8 @@ type maxFloat64OrderedAgg struct {
 
 var _ AggregateFunc = &maxFloat64OrderedAgg{}
 
-func (a *maxFloat64OrderedAgg) Init(groups []bool, vec coldata.Vec) {
-	a.orderedAggregateFuncBase.Init(groups, vec)
+func (a *maxFloat64OrderedAgg) SetOutput(vec coldata.Vec) {
+	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.vec = vec
 	a.col = vec.Float64()
 }
@@ -4616,8 +4616,8 @@ type maxTimestampOrderedAgg struct {
 
 var _ AggregateFunc = &maxTimestampOrderedAgg{}
 
-func (a *maxTimestampOrderedAgg) Init(groups []bool, vec coldata.Vec) {
-	a.orderedAggregateFuncBase.Init(groups, vec)
+func (a *maxTimestampOrderedAgg) SetOutput(vec coldata.Vec) {
+	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.vec = vec
 	a.col = vec.Timestamp()
 }
@@ -4877,8 +4877,8 @@ type maxIntervalOrderedAgg struct {
 
 var _ AggregateFunc = &maxIntervalOrderedAgg{}
 
-func (a *maxIntervalOrderedAgg) Init(groups []bool, vec coldata.Vec) {
-	a.orderedAggregateFuncBase.Init(groups, vec)
+func (a *maxIntervalOrderedAgg) SetOutput(vec coldata.Vec) {
+	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.vec = vec
 	a.col = vec.Interval()
 }
@@ -5110,8 +5110,8 @@ type maxDatumOrderedAgg struct {
 
 var _ AggregateFunc = &maxDatumOrderedAgg{}
 
-func (a *maxDatumOrderedAgg) Init(groups []bool, vec coldata.Vec) {
-	a.orderedAggregateFuncBase.Init(groups, vec)
+func (a *maxDatumOrderedAgg) SetOutput(vec coldata.Vec) {
+	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.vec = vec
 	a.col = vec.Datum()
 }

--- a/pkg/sql/colexec/colexecagg/ordered_min_max_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_min_max_agg.eg.go
@@ -113,12 +113,6 @@ func (a *minBoolOrderedAgg) Init(groups []bool, vec coldata.Vec) {
 	a.orderedAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
 	a.col = vec.Bool()
-	a.Reset()
-}
-
-func (a *minBoolOrderedAgg) Reset() {
-	a.orderedAggregateFuncBase.Reset()
-	a.foundNonNullForCurrentGroup = false
 }
 
 func (a *minBoolOrderedAgg) Compute(
@@ -384,12 +378,6 @@ func (a *minBytesOrderedAgg) Init(groups []bool, vec coldata.Vec) {
 	a.orderedAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
 	a.col = vec.Bytes()
-	a.Reset()
-}
-
-func (a *minBytesOrderedAgg) Reset() {
-	a.orderedAggregateFuncBase.Reset()
-	a.foundNonNullForCurrentGroup = false
 }
 
 func (a *minBytesOrderedAgg) Compute(
@@ -631,12 +619,6 @@ func (a *minDecimalOrderedAgg) Init(groups []bool, vec coldata.Vec) {
 	a.orderedAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
 	a.col = vec.Decimal()
-	a.Reset()
-}
-
-func (a *minDecimalOrderedAgg) Reset() {
-	a.orderedAggregateFuncBase.Reset()
-	a.foundNonNullForCurrentGroup = false
 }
 
 func (a *minDecimalOrderedAgg) Compute(
@@ -870,12 +852,6 @@ func (a *minInt16OrderedAgg) Init(groups []bool, vec coldata.Vec) {
 	a.orderedAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
 	a.col = vec.Int16()
-	a.Reset()
-}
-
-func (a *minInt16OrderedAgg) Reset() {
-	a.orderedAggregateFuncBase.Reset()
-	a.foundNonNullForCurrentGroup = false
 }
 
 func (a *minInt16OrderedAgg) Compute(
@@ -1153,12 +1129,6 @@ func (a *minInt32OrderedAgg) Init(groups []bool, vec coldata.Vec) {
 	a.orderedAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
 	a.col = vec.Int32()
-	a.Reset()
-}
-
-func (a *minInt32OrderedAgg) Reset() {
-	a.orderedAggregateFuncBase.Reset()
-	a.foundNonNullForCurrentGroup = false
 }
 
 func (a *minInt32OrderedAgg) Compute(
@@ -1436,12 +1406,6 @@ func (a *minInt64OrderedAgg) Init(groups []bool, vec coldata.Vec) {
 	a.orderedAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
 	a.col = vec.Int64()
-	a.Reset()
-}
-
-func (a *minInt64OrderedAgg) Reset() {
-	a.orderedAggregateFuncBase.Reset()
-	a.foundNonNullForCurrentGroup = false
 }
 
 func (a *minInt64OrderedAgg) Compute(
@@ -1719,12 +1683,6 @@ func (a *minFloat64OrderedAgg) Init(groups []bool, vec coldata.Vec) {
 	a.orderedAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
 	a.col = vec.Float64()
-	a.Reset()
-}
-
-func (a *minFloat64OrderedAgg) Reset() {
-	a.orderedAggregateFuncBase.Reset()
-	a.foundNonNullForCurrentGroup = false
 }
 
 func (a *minFloat64OrderedAgg) Compute(
@@ -2034,12 +1992,6 @@ func (a *minTimestampOrderedAgg) Init(groups []bool, vec coldata.Vec) {
 	a.orderedAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
 	a.col = vec.Timestamp()
-	a.Reset()
-}
-
-func (a *minTimestampOrderedAgg) Reset() {
-	a.orderedAggregateFuncBase.Reset()
-	a.foundNonNullForCurrentGroup = false
 }
 
 func (a *minTimestampOrderedAgg) Compute(
@@ -2301,12 +2253,6 @@ func (a *minIntervalOrderedAgg) Init(groups []bool, vec coldata.Vec) {
 	a.orderedAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
 	a.col = vec.Interval()
-	a.Reset()
-}
-
-func (a *minIntervalOrderedAgg) Reset() {
-	a.orderedAggregateFuncBase.Reset()
-	a.foundNonNullForCurrentGroup = false
 }
 
 func (a *minIntervalOrderedAgg) Compute(
@@ -2540,12 +2486,6 @@ func (a *minDatumOrderedAgg) Init(groups []bool, vec coldata.Vec) {
 	a.orderedAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
 	a.col = vec.Datum()
-	a.Reset()
-}
-
-func (a *minDatumOrderedAgg) Reset() {
-	a.orderedAggregateFuncBase.Reset()
-	a.foundNonNullForCurrentGroup = false
 }
 
 func (a *minDatumOrderedAgg) Compute(
@@ -2801,12 +2741,6 @@ func (a *maxBoolOrderedAgg) Init(groups []bool, vec coldata.Vec) {
 	a.orderedAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
 	a.col = vec.Bool()
-	a.Reset()
-}
-
-func (a *maxBoolOrderedAgg) Reset() {
-	a.orderedAggregateFuncBase.Reset()
-	a.foundNonNullForCurrentGroup = false
 }
 
 func (a *maxBoolOrderedAgg) Compute(
@@ -3072,12 +3006,6 @@ func (a *maxBytesOrderedAgg) Init(groups []bool, vec coldata.Vec) {
 	a.orderedAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
 	a.col = vec.Bytes()
-	a.Reset()
-}
-
-func (a *maxBytesOrderedAgg) Reset() {
-	a.orderedAggregateFuncBase.Reset()
-	a.foundNonNullForCurrentGroup = false
 }
 
 func (a *maxBytesOrderedAgg) Compute(
@@ -3319,12 +3247,6 @@ func (a *maxDecimalOrderedAgg) Init(groups []bool, vec coldata.Vec) {
 	a.orderedAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
 	a.col = vec.Decimal()
-	a.Reset()
-}
-
-func (a *maxDecimalOrderedAgg) Reset() {
-	a.orderedAggregateFuncBase.Reset()
-	a.foundNonNullForCurrentGroup = false
 }
 
 func (a *maxDecimalOrderedAgg) Compute(
@@ -3558,12 +3480,6 @@ func (a *maxInt16OrderedAgg) Init(groups []bool, vec coldata.Vec) {
 	a.orderedAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
 	a.col = vec.Int16()
-	a.Reset()
-}
-
-func (a *maxInt16OrderedAgg) Reset() {
-	a.orderedAggregateFuncBase.Reset()
-	a.foundNonNullForCurrentGroup = false
 }
 
 func (a *maxInt16OrderedAgg) Compute(
@@ -3841,12 +3757,6 @@ func (a *maxInt32OrderedAgg) Init(groups []bool, vec coldata.Vec) {
 	a.orderedAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
 	a.col = vec.Int32()
-	a.Reset()
-}
-
-func (a *maxInt32OrderedAgg) Reset() {
-	a.orderedAggregateFuncBase.Reset()
-	a.foundNonNullForCurrentGroup = false
 }
 
 func (a *maxInt32OrderedAgg) Compute(
@@ -4124,12 +4034,6 @@ func (a *maxInt64OrderedAgg) Init(groups []bool, vec coldata.Vec) {
 	a.orderedAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
 	a.col = vec.Int64()
-	a.Reset()
-}
-
-func (a *maxInt64OrderedAgg) Reset() {
-	a.orderedAggregateFuncBase.Reset()
-	a.foundNonNullForCurrentGroup = false
 }
 
 func (a *maxInt64OrderedAgg) Compute(
@@ -4407,12 +4311,6 @@ func (a *maxFloat64OrderedAgg) Init(groups []bool, vec coldata.Vec) {
 	a.orderedAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
 	a.col = vec.Float64()
-	a.Reset()
-}
-
-func (a *maxFloat64OrderedAgg) Reset() {
-	a.orderedAggregateFuncBase.Reset()
-	a.foundNonNullForCurrentGroup = false
 }
 
 func (a *maxFloat64OrderedAgg) Compute(
@@ -4722,12 +4620,6 @@ func (a *maxTimestampOrderedAgg) Init(groups []bool, vec coldata.Vec) {
 	a.orderedAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
 	a.col = vec.Timestamp()
-	a.Reset()
-}
-
-func (a *maxTimestampOrderedAgg) Reset() {
-	a.orderedAggregateFuncBase.Reset()
-	a.foundNonNullForCurrentGroup = false
 }
 
 func (a *maxTimestampOrderedAgg) Compute(
@@ -4989,12 +4881,6 @@ func (a *maxIntervalOrderedAgg) Init(groups []bool, vec coldata.Vec) {
 	a.orderedAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
 	a.col = vec.Interval()
-	a.Reset()
-}
-
-func (a *maxIntervalOrderedAgg) Reset() {
-	a.orderedAggregateFuncBase.Reset()
-	a.foundNonNullForCurrentGroup = false
 }
 
 func (a *maxIntervalOrderedAgg) Compute(
@@ -5228,12 +5114,6 @@ func (a *maxDatumOrderedAgg) Init(groups []bool, vec coldata.Vec) {
 	a.orderedAggregateFuncBase.Init(groups, vec)
 	a.vec = vec
 	a.col = vec.Datum()
-	a.Reset()
-}
-
-func (a *maxDatumOrderedAgg) Reset() {
-	a.orderedAggregateFuncBase.Reset()
-	a.foundNonNullForCurrentGroup = false
 }
 
 func (a *maxDatumOrderedAgg) Compute(

--- a/pkg/sql/colexec/colexecagg/ordered_sum_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_sum_agg.eg.go
@@ -69,12 +69,6 @@ var _ AggregateFunc = &sumInt16OrderedAgg{}
 func (a *sumInt16OrderedAgg) Init(groups []bool, vec coldata.Vec) {
 	a.orderedAggregateFuncBase.Init(groups, vec)
 	a.scratch.vec = vec.Decimal()
-	a.Reset()
-}
-
-func (a *sumInt16OrderedAgg) Reset() {
-	a.orderedAggregateFuncBase.Reset()
-	a.scratch.foundNonNullForCurrentGroup = false
 }
 
 func (a *sumInt16OrderedAgg) Compute(
@@ -281,12 +275,6 @@ var _ AggregateFunc = &sumInt32OrderedAgg{}
 func (a *sumInt32OrderedAgg) Init(groups []bool, vec coldata.Vec) {
 	a.orderedAggregateFuncBase.Init(groups, vec)
 	a.scratch.vec = vec.Decimal()
-	a.Reset()
-}
-
-func (a *sumInt32OrderedAgg) Reset() {
-	a.orderedAggregateFuncBase.Reset()
-	a.scratch.foundNonNullForCurrentGroup = false
 }
 
 func (a *sumInt32OrderedAgg) Compute(
@@ -493,12 +481,6 @@ var _ AggregateFunc = &sumInt64OrderedAgg{}
 func (a *sumInt64OrderedAgg) Init(groups []bool, vec coldata.Vec) {
 	a.orderedAggregateFuncBase.Init(groups, vec)
 	a.scratch.vec = vec.Decimal()
-	a.Reset()
-}
-
-func (a *sumInt64OrderedAgg) Reset() {
-	a.orderedAggregateFuncBase.Reset()
-	a.scratch.foundNonNullForCurrentGroup = false
 }
 
 func (a *sumInt64OrderedAgg) Compute(
@@ -704,12 +686,6 @@ var _ AggregateFunc = &sumDecimalOrderedAgg{}
 func (a *sumDecimalOrderedAgg) Init(groups []bool, vec coldata.Vec) {
 	a.orderedAggregateFuncBase.Init(groups, vec)
 	a.scratch.vec = vec.Decimal()
-	a.Reset()
-}
-
-func (a *sumDecimalOrderedAgg) Reset() {
-	a.orderedAggregateFuncBase.Reset()
-	a.scratch.foundNonNullForCurrentGroup = false
 }
 
 func (a *sumDecimalOrderedAgg) Compute(
@@ -908,12 +884,6 @@ var _ AggregateFunc = &sumFloat64OrderedAgg{}
 func (a *sumFloat64OrderedAgg) Init(groups []bool, vec coldata.Vec) {
 	a.orderedAggregateFuncBase.Init(groups, vec)
 	a.scratch.vec = vec.Float64()
-	a.Reset()
-}
-
-func (a *sumFloat64OrderedAgg) Reset() {
-	a.orderedAggregateFuncBase.Reset()
-	a.scratch.foundNonNullForCurrentGroup = false
 }
 
 func (a *sumFloat64OrderedAgg) Compute(
@@ -1100,12 +1070,6 @@ var _ AggregateFunc = &sumIntervalOrderedAgg{}
 func (a *sumIntervalOrderedAgg) Init(groups []bool, vec coldata.Vec) {
 	a.orderedAggregateFuncBase.Init(groups, vec)
 	a.scratch.vec = vec.Interval()
-	a.Reset()
-}
-
-func (a *sumIntervalOrderedAgg) Reset() {
-	a.orderedAggregateFuncBase.Reset()
-	a.scratch.foundNonNullForCurrentGroup = false
 }
 
 func (a *sumIntervalOrderedAgg) Compute(

--- a/pkg/sql/colexec/colexecagg/ordered_sum_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_sum_agg.eg.go
@@ -66,8 +66,8 @@ type sumInt16OrderedAgg struct {
 
 var _ AggregateFunc = &sumInt16OrderedAgg{}
 
-func (a *sumInt16OrderedAgg) Init(groups []bool, vec coldata.Vec) {
-	a.orderedAggregateFuncBase.Init(groups, vec)
+func (a *sumInt16OrderedAgg) SetOutput(vec coldata.Vec) {
+	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.scratch.vec = vec.Decimal()
 }
 
@@ -272,8 +272,8 @@ type sumInt32OrderedAgg struct {
 
 var _ AggregateFunc = &sumInt32OrderedAgg{}
 
-func (a *sumInt32OrderedAgg) Init(groups []bool, vec coldata.Vec) {
-	a.orderedAggregateFuncBase.Init(groups, vec)
+func (a *sumInt32OrderedAgg) SetOutput(vec coldata.Vec) {
+	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.scratch.vec = vec.Decimal()
 }
 
@@ -478,8 +478,8 @@ type sumInt64OrderedAgg struct {
 
 var _ AggregateFunc = &sumInt64OrderedAgg{}
 
-func (a *sumInt64OrderedAgg) Init(groups []bool, vec coldata.Vec) {
-	a.orderedAggregateFuncBase.Init(groups, vec)
+func (a *sumInt64OrderedAgg) SetOutput(vec coldata.Vec) {
+	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.scratch.vec = vec.Decimal()
 }
 
@@ -683,8 +683,8 @@ type sumDecimalOrderedAgg struct {
 
 var _ AggregateFunc = &sumDecimalOrderedAgg{}
 
-func (a *sumDecimalOrderedAgg) Init(groups []bool, vec coldata.Vec) {
-	a.orderedAggregateFuncBase.Init(groups, vec)
+func (a *sumDecimalOrderedAgg) SetOutput(vec coldata.Vec) {
+	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.scratch.vec = vec.Decimal()
 }
 
@@ -881,8 +881,8 @@ type sumFloat64OrderedAgg struct {
 
 var _ AggregateFunc = &sumFloat64OrderedAgg{}
 
-func (a *sumFloat64OrderedAgg) Init(groups []bool, vec coldata.Vec) {
-	a.orderedAggregateFuncBase.Init(groups, vec)
+func (a *sumFloat64OrderedAgg) SetOutput(vec coldata.Vec) {
+	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.scratch.vec = vec.Float64()
 }
 
@@ -1067,8 +1067,8 @@ type sumIntervalOrderedAgg struct {
 
 var _ AggregateFunc = &sumIntervalOrderedAgg{}
 
-func (a *sumIntervalOrderedAgg) Init(groups []bool, vec coldata.Vec) {
-	a.orderedAggregateFuncBase.Init(groups, vec)
+func (a *sumIntervalOrderedAgg) SetOutput(vec coldata.Vec) {
+	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.scratch.vec = vec.Interval()
 }
 

--- a/pkg/sql/colexec/colexecagg/ordered_sum_int_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_sum_int_agg.eg.go
@@ -56,8 +56,8 @@ type sumIntInt16OrderedAgg struct {
 
 var _ AggregateFunc = &sumIntInt16OrderedAgg{}
 
-func (a *sumIntInt16OrderedAgg) Init(groups []bool, vec coldata.Vec) {
-	a.orderedAggregateFuncBase.Init(groups, vec)
+func (a *sumIntInt16OrderedAgg) SetOutput(vec coldata.Vec) {
+	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.scratch.vec = vec.Int64()
 }
 
@@ -254,8 +254,8 @@ type sumIntInt32OrderedAgg struct {
 
 var _ AggregateFunc = &sumIntInt32OrderedAgg{}
 
-func (a *sumIntInt32OrderedAgg) Init(groups []bool, vec coldata.Vec) {
-	a.orderedAggregateFuncBase.Init(groups, vec)
+func (a *sumIntInt32OrderedAgg) SetOutput(vec coldata.Vec) {
+	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.scratch.vec = vec.Int64()
 }
 
@@ -452,8 +452,8 @@ type sumIntInt64OrderedAgg struct {
 
 var _ AggregateFunc = &sumIntInt64OrderedAgg{}
 
-func (a *sumIntInt64OrderedAgg) Init(groups []bool, vec coldata.Vec) {
-	a.orderedAggregateFuncBase.Init(groups, vec)
+func (a *sumIntInt64OrderedAgg) SetOutput(vec coldata.Vec) {
+	a.orderedAggregateFuncBase.SetOutput(vec)
 	a.scratch.vec = vec.Int64()
 }
 

--- a/pkg/sql/colexec/colexecagg/ordered_sum_int_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_sum_int_agg.eg.go
@@ -59,12 +59,6 @@ var _ AggregateFunc = &sumIntInt16OrderedAgg{}
 func (a *sumIntInt16OrderedAgg) Init(groups []bool, vec coldata.Vec) {
 	a.orderedAggregateFuncBase.Init(groups, vec)
 	a.scratch.vec = vec.Int64()
-	a.Reset()
-}
-
-func (a *sumIntInt16OrderedAgg) Reset() {
-	a.orderedAggregateFuncBase.Reset()
-	a.scratch.foundNonNullForCurrentGroup = false
 }
 
 func (a *sumIntInt16OrderedAgg) Compute(
@@ -263,12 +257,6 @@ var _ AggregateFunc = &sumIntInt32OrderedAgg{}
 func (a *sumIntInt32OrderedAgg) Init(groups []bool, vec coldata.Vec) {
 	a.orderedAggregateFuncBase.Init(groups, vec)
 	a.scratch.vec = vec.Int64()
-	a.Reset()
-}
-
-func (a *sumIntInt32OrderedAgg) Reset() {
-	a.orderedAggregateFuncBase.Reset()
-	a.scratch.foundNonNullForCurrentGroup = false
 }
 
 func (a *sumIntInt32OrderedAgg) Compute(
@@ -467,12 +455,6 @@ var _ AggregateFunc = &sumIntInt64OrderedAgg{}
 func (a *sumIntInt64OrderedAgg) Init(groups []bool, vec coldata.Vec) {
 	a.orderedAggregateFuncBase.Init(groups, vec)
 	a.scratch.vec = vec.Int64()
-	a.Reset()
-}
-
-func (a *sumIntInt64OrderedAgg) Reset() {
-	a.orderedAggregateFuncBase.Reset()
-	a.scratch.foundNonNullForCurrentGroup = false
 }
 
 func (a *sumIntInt64OrderedAgg) Compute(

--- a/pkg/sql/colexec/colexecagg/sum_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/sum_agg_tmpl.go
@@ -100,11 +100,11 @@ type sum_SUMKIND_TYPE_AGGKINDAgg struct {
 
 var _ AggregateFunc = &sum_SUMKIND_TYPE_AGGKINDAgg{}
 
-func (a *sum_SUMKIND_TYPE_AGGKINDAgg) Init(groups []bool, vec coldata.Vec) {
+func (a *sum_SUMKIND_TYPE_AGGKINDAgg) SetOutput(vec coldata.Vec) {
 	// {{if eq "_AGGKIND" "Ordered"}}
-	a.orderedAggregateFuncBase.Init(groups, vec)
+	a.orderedAggregateFuncBase.SetOutput(vec)
 	// {{else}}
-	a.hashAggregateFuncBase.Init(groups, vec)
+	a.hashAggregateFuncBase.SetOutput(vec)
 	// {{end}}
 	a.scratch.vec = vec._RET_TYPE()
 }

--- a/pkg/sql/colexec/colexecagg/sum_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/sum_agg_tmpl.go
@@ -107,16 +107,6 @@ func (a *sum_SUMKIND_TYPE_AGGKINDAgg) Init(groups []bool, vec coldata.Vec) {
 	a.hashAggregateFuncBase.Init(groups, vec)
 	// {{end}}
 	a.scratch.vec = vec._RET_TYPE()
-	a.Reset()
-}
-
-func (a *sum_SUMKIND_TYPE_AGGKINDAgg) Reset() {
-	// {{if eq "_AGGKIND" "Ordered"}}
-	a.orderedAggregateFuncBase.Reset()
-	// {{else}}
-	a.hashAggregateFuncBase.Reset()
-	// {{end}}
-	a.scratch.foundNonNullForCurrentGroup = false
 }
 
 func (a *sum_SUMKIND_TYPE_AGGKINDAgg) Compute(

--- a/pkg/sql/colexec/hash_aggregator.go
+++ b/pkg/sql/colexec/hash_aggregator.go
@@ -431,20 +431,6 @@ func (op *hashAggregator) onlineAgg(ctx context.Context, b coldata.Batch) {
 	}
 }
 
-// reset resets the hashAggregator for another run. Primarily used for
-// benchmarks.
-func (op *hashAggregator) reset(ctx context.Context) {
-	if r, ok := op.input.(resetter); ok {
-		r.reset(ctx)
-	}
-	op.bufferingState.tuples.ResetInternalBatch()
-	op.bufferingState.tuples.SetLength(0)
-	op.bufferingState.pendingBatch = nil
-	op.buckets = op.buckets[:0]
-	op.state = hashAggregatorBuffering
-	op.ht.reset(ctx)
-}
-
 func (op *hashAggregator) Close(ctx context.Context) error {
 	return op.toClose.Close(ctx)
 }

--- a/pkg/sql/colexec/hash_aggregator.go
+++ b/pkg/sql/colexec/hash_aggregator.go
@@ -179,15 +179,6 @@ func NewHashAggregator(
 
 func (op *hashAggregator) Init() {
 	op.input.Init()
-	// Note that we use a batch with fixed capacity because aggregate functions
-	// hold onto the vectors passed in into their Init method, so we cannot
-	// simply reallocate the output batch.
-	// TODO(yuzefovich): consider changing AggregateFunc interface to allow for
-	// updating the output vector.
-	op.output = op.allocator.NewMemBatchWithFixedCapacity(op.outputTypes, coldata.BatchSize())
-	op.scratch.eqChains = make([][]int, op.maxBuffered)
-	op.scratch.intSlice = make([]int, op.maxBuffered)
-	op.scratch.anotherIntSlice = make([]int, op.maxBuffered)
 	// The hash table only needs to store the grouping columns to be able to
 	// perform the equality check.
 	colsToStore := make([]int, len(op.spec.GroupCols))
@@ -247,7 +238,11 @@ func (op *hashAggregator) Next(ctx context.Context) coldata.Batch {
 			if op.bufferingState.pendingBatch.Length() == 0 {
 				// TODO(yuzefovich): we no longer need the hash table, so we
 				// could be releasing its memory here.
-				op.state = hashAggregatorOutputting
+				if len(op.buckets) == 0 {
+					op.state = hashAggregatorDone
+				} else {
+					op.state = hashAggregatorOutputting
+				}
 				continue
 			}
 			op.bufferingState.tuples.ResetInternalBatch()
@@ -255,12 +250,17 @@ func (op *hashAggregator) Next(ctx context.Context) coldata.Batch {
 			op.state = hashAggregatorBuffering
 
 		case hashAggregatorOutputting:
-			op.output.ResetInternalBatch()
+			// Note that ResetMaybeReallocate truncates the requested capacity
+			// at coldata.BatchSize(), so we can just try asking for
+			// len(op.buckets) capacity. Note that in hashAggregatorOutputting
+			// state we always have at least 1 bucket.
+			op.output, _ = op.allocator.ResetMaybeReallocate(op.outputTypes, op.output, len(op.buckets))
 			curOutputIdx := 0
 			op.allocator.PerformOperation(op.output.ColVecs(), func() {
 				for curOutputIdx < op.output.Capacity() && curOutputIdx < len(op.buckets) {
 					bucket := op.buckets[curOutputIdx]
-					for _, fn := range bucket.fns {
+					for fnIdx, fn := range bucket.fns {
+						fn.SetOutput(op.output.ColVec(fnIdx))
 						fn.Flush(curOutputIdx)
 					}
 					curOutputIdx++
@@ -281,6 +281,14 @@ func (op *hashAggregator) Next(ctx context.Context) coldata.Batch {
 			// This code is unreachable, but the compiler cannot infer that.
 			return nil
 		}
+	}
+}
+
+func (op *hashAggregator) setupScratchSlices(numBuffered int) {
+	if len(op.scratch.eqChains) < numBuffered {
+		op.scratch.eqChains = make([][]int, numBuffered)
+		op.scratch.intSlice = make([]int, numBuffered)
+		op.scratch.anotherIntSlice = make([]int, numBuffered)
 	}
 }
 
@@ -348,6 +356,7 @@ func (op *hashAggregator) Next(ctx context.Context) coldata.Batch {
 //
 //  We have processed the input fully, so we're ready to emit the output.
 func (op *hashAggregator) onlineAgg(ctx context.Context, b coldata.Batch) {
+	op.setupScratchSlices(b.Length())
 	inputVecs := b.ColVecs()
 	// Step 1: find "equality" buckets: we compute the hash buckets for all
 	// tuples, build 'next' chains between them, and then find equality buckets
@@ -407,8 +416,7 @@ func (op *hashAggregator) onlineAgg(ctx context.Context, b coldata.Batch) {
 			// We know that all selected tuples belong to the same single
 			// group, so we can pass 'nil' for the 'groups' argument.
 			bucket.init(
-				op.output, op.aggFnsAlloc.MakeAggregateFuncs(),
-				op.aggHelper.makeSeenMaps(), nil, /* groups */
+				op.aggFnsAlloc.MakeAggregateFuncs(), op.aggHelper.makeSeenMaps(), nil, /* groups */
 			)
 			op.aggHelper.performAggregation(
 				ctx, inputVecs, len(eqChain), eqChain, bucket, nil, /* groups */

--- a/pkg/sql/colexec/ordered_aggregator.go
+++ b/pkg/sql/colexec/ordered_aggregator.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecagg"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
@@ -24,6 +25,39 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/errors"
+)
+
+// orderedAggregatorState represents the state of the ordered aggregator.
+type orderedAggregatorState int
+
+const (
+	// orderedAggregatorAggregating is the state in which the ordered aggregator
+	// processes the next input batch. If the scratch batch might not have
+	// enough capacity for that next input batch, the aggregator transitions to
+	// orderedAggregatorReallocating state. If the aggregator has already
+	// accumulated coldata.BatchSize() number of output tuples or if it receives
+	// the zero-length batch, it transitions to orderedAggregatorOutputting
+	// state.
+	orderedAggregatorAggregating orderedAggregatorState = iota
+	// orderedAggregatorReallocating is the state in which the ordered
+	// aggregator reallocates the scratch batch with the capacity determined by
+	// the last read batch. Old scratch batch is discarded. From this state the
+	// aggregator always transitions to orderedAggregatorAggregating state.
+	orderedAggregatorReallocating
+	// orderedAggregatorOutputting is the state in which the ordered aggregator
+	// populates and returns an output batch. If the scratch batch contains more
+	// tuples than can fit in a single output batch, the aggregator will copy
+	// over the first coldata.BatchSize() tuples into a special "unsafe" batch
+	// and will shift all other tuples to the beginning of the scratch batch.
+	// It is the only state that needs to know what next state to transition to.
+	orderedAggregatorOutputting
+	// orderedAggregatorDone is the final state of the ordered aggregator in
+	// which it always returns a zero-length batch.
+	orderedAggregatorDone
+	// orderedAggregatorUnknown is an invalid state of the ordered aggregator
+	// used as a sanity check that we always specify the state to transition to
+	// from orderedAggregatorOutputting.
+	orderedAggregatorUnknown
 )
 
 // orderedAggregator is an aggregator that performs arbitrary aggregations on
@@ -49,9 +83,10 @@ import (
 type orderedAggregator struct {
 	OneInputNode
 
+	state orderedAggregatorState
+
 	allocator *colmem.Allocator
 	spec      *execinfrapb.AggregatorSpec
-	done      bool
 
 	outputTypes        []*types.T
 	inputArgsConverter *colconv.VecToDatumConverter
@@ -68,6 +103,10 @@ type orderedAggregator struct {
 		// writing to on the next iteration of Next().
 		resumeIdx int
 	}
+
+	// lastReadBatch is the last batch that we read from the input that hasn't
+	// been processed yet.
+	lastReadBatch coldata.Batch
 
 	// unsafeBatch is a coldata.Batch returned when only a subset of the
 	// scratch.Batch results is returned (i.e. work needs to be resumed on the
@@ -170,128 +209,197 @@ func NewOrderedAggregator(
 
 func (a *orderedAggregator) Init() {
 	a.input.Init()
-	// Twice the batchSize is allocated to avoid having to check for overflow
-	// when outputting.
-	a.scratch.Batch = a.allocator.NewMemBatchWithFixedCapacity(a.outputTypes, 2*coldata.BatchSize())
-	a.bucket.init(a.scratch.Batch, a.bucket.fns, a.aggHelper.makeSeenMaps(), a.groupCol)
-	// Note that we use a batch with fixed capacity because aggregate functions
-	// hold onto the vectors passed in into their Init method, so we cannot
-	// simply reallocate the output batch.
-	// TODO(yuzefovich): consider changing AggregateFunc interface to allow for
-	// updating the output vector.
-	a.unsafeBatch = a.allocator.NewMemBatchWithFixedCapacity(a.outputTypes, coldata.BatchSize())
+	a.bucket.init(a.bucket.fns, a.aggHelper.makeSeenMaps(), a.groupCol)
 }
 
 func (a *orderedAggregator) Next(ctx context.Context) coldata.Batch {
-	if a.done {
-		return coldata.ZeroBatch
-	}
-	a.unsafeBatch.ResetInternalBatch()
-	if a.scratch.shouldResetInternalBatch {
-		a.scratch.ResetInternalBatch()
-		a.scratch.shouldResetInternalBatch = false
-	}
-	if a.scratch.resumeIdx >= coldata.BatchSize() {
-		// Copy the second part of the output batch into the first and resume from
-		// there.
-		newResumeIdx := a.scratch.resumeIdx - coldata.BatchSize()
-		a.allocator.PerformOperation(a.scratch.ColVecs(), func() {
-			for i := 0; i < len(a.outputTypes); i++ {
-				vec := a.scratch.ColVec(i)
-				// Note that we're using Append here instead of Copy because we want the
-				// "truncation" behavior, i.e. we want to copy over the remaining tuples
-				// such the "lengths" of the vectors are equal to the number of copied
-				// elements.
-				vec.Append(
-					coldata.SliceArgs{
-						Src:         vec,
-						DestIdx:     0,
-						SrcStartIdx: coldata.BatchSize(),
-						SrcEndIdx:   a.scratch.resumeIdx,
-					},
-				)
-				// Now we need to restore the desired length for the Vec.
-				vec.SetLength(2 * coldata.BatchSize())
-				a.bucket.fns[i].SetOutputIndex(newResumeIdx)
-				// There might have been some NULLs set in the part that we
-				// have just copied over, so we need to unset the NULLs.
-				a.scratch.ColVec(i).Nulls().UnsetNullsAfter(newResumeIdx)
+	stateAfterOutputting := orderedAggregatorUnknown
+	for {
+		switch a.state {
+		case orderedAggregatorAggregating:
+			if a.scratch.shouldResetInternalBatch {
+				a.scratch.ResetInternalBatch()
+				a.scratch.shouldResetInternalBatch = false
 			}
-		})
-		a.scratch.resumeIdx = newResumeIdx
-	}
+			if a.scratch.resumeIdx >= coldata.BatchSize() {
+				a.state = orderedAggregatorOutputting
+				stateAfterOutputting = orderedAggregatorAggregating
+				continue
+			}
 
-	for a.scratch.resumeIdx < coldata.BatchSize() {
-		batch := a.input.Next(ctx)
-		batchLength := batch.Length()
-		a.seenNonEmptyBatch = a.seenNonEmptyBatch || batchLength > 0
-		if !a.seenNonEmptyBatch {
-			// The input has zero rows.
-			if a.isScalar {
-				for _, fn := range a.bucket.fns {
-					fn.HandleEmptyInputScalar()
-				}
-				// All aggregate functions will output a single value.
-				a.scratch.resumeIdx = 1
-			} else {
-				// There should be no output in non-scalar context for all aggregate
-				// functions.
-				a.scratch.resumeIdx = 0
+			batch := a.lastReadBatch
+			a.lastReadBatch = nil
+			if batch == nil {
+				batch = a.input.Next(ctx)
 			}
-		} else {
-			if batchLength > 0 {
-				a.inputArgsConverter.ConvertBatch(batch)
-				a.aggHelper.performAggregation(
-					ctx, batch.ColVecs(), batchLength, batch.Selection(), &a.bucket, a.groupCol,
-				)
-			} else {
-				a.allocator.PerformOperation(a.scratch.ColVecs(), func() {
+			batchLength := batch.Length()
+
+			if a.scratch.Batch == nil || a.scratch.Capacity() <= a.scratch.resumeIdx+batchLength {
+				// Our scratch.Batch might not have enough capacity to
+				// accommodate all possible aggregation groups from batch, so we
+				// need to reallocate it with increased capacity.
+				a.lastReadBatch = batch
+				if a.scratch.resumeIdx > 0 {
+					// We already have some results in the current
+					// scratch.Batch, so we want to emit them.
+					a.state = orderedAggregatorOutputting
+					stateAfterOutputting = orderedAggregatorReallocating
+					continue
+				}
+				// We don't have any results yet, so we simply want to restart
+				// the aggregation with the scratch.Batch of increased capacity.
+				a.state = orderedAggregatorReallocating
+				continue
+			}
+
+			a.seenNonEmptyBatch = a.seenNonEmptyBatch || batchLength > 0
+			if !a.seenNonEmptyBatch {
+				// The input has zero rows.
+				if a.isScalar {
 					for _, fn := range a.bucket.fns {
-						// The aggregate function itself is responsible for
-						// tracking the output index, so we pass in an invalid
-						// index which will allow us to catch cases when the
-						// implementation is misbehaving.
-						fn.Flush(-1 /* outputIdx */)
+						fn.HandleEmptyInputScalar()
+					}
+					// All aggregate functions will output a single value.
+					a.scratch.resumeIdx = 1
+				} else {
+					// There should be no output in non-scalar context for all
+					// aggregate functions.
+					a.scratch.resumeIdx = 0
+				}
+			} else {
+				if batchLength > 0 {
+					a.inputArgsConverter.ConvertBatch(batch)
+					a.aggHelper.performAggregation(
+						ctx, batch.ColVecs(), batchLength, batch.Selection(), &a.bucket, a.groupCol,
+					)
+				} else {
+					a.allocator.PerformOperation(a.scratch.ColVecs(), func() {
+						for _, fn := range a.bucket.fns {
+							// The aggregate function itself is responsible for
+							// tracking the output index, so we pass in an
+							// invalid index which will allow us to catch cases
+							// when the implementation is misbehaving.
+							fn.Flush(-1 /* outputIdx */)
+						}
+					})
+				}
+				a.scratch.resumeIdx = a.bucket.fns[0].CurrentOutputIndex()
+			}
+			if batchLength == 0 {
+				a.state = orderedAggregatorOutputting
+				stateAfterOutputting = orderedAggregatorDone
+				continue
+			}
+			// zero out a.groupCol. This is necessary because distinct ORs the
+			// uniqueness of a value with the groupCol, allowing the operators
+			// to be linked.
+			copy(a.groupCol[:batchLength], zeroBoolColumn)
+
+		case orderedAggregatorReallocating:
+			// Twice the batchSize is allocated to avoid having to check for
+			// overflow when outputting.
+			newMinCapacity := 2 * a.lastReadBatch.Length()
+			if newMinCapacity == 0 {
+				// If batchLength is 0, we still need to flush the last group,
+				// so we need to have the capacity of at least 1.
+				newMinCapacity = 1
+			}
+			if newMinCapacity > coldata.BatchSize() {
+				// ResetMaybeReallocate truncates the capacity to
+				// coldata.BatchSize(), but we actually want a batch with larger
+				// capacity, so we choose to instantiate the batch with fixed
+				// maximal capacity that can be needed by the aggregator.
+				if a.scratch.Batch != nil {
+					a.allocator.ReleaseBatch(a.scratch.Batch)
+				}
+				a.scratch.Batch = a.allocator.NewMemBatchWithFixedCapacity(a.outputTypes, 2*coldata.BatchSize())
+			} else {
+				a.scratch.Batch, _ = a.allocator.ResetMaybeReallocate(a.outputTypes, a.scratch.Batch, newMinCapacity)
+			}
+			for fnIdx, fn := range a.bucket.fns {
+				fn.SetOutput(a.scratch.ColVec(fnIdx))
+			}
+			a.scratch.shouldResetInternalBatch = false
+			a.state = orderedAggregatorAggregating
+			continue
+
+		case orderedAggregatorOutputting:
+			batchToReturn := a.scratch.Batch
+			if a.scratch.resumeIdx > coldata.BatchSize() {
+				// We already have more result tuples that can fit into a single
+				// batch, so we will copy first coldata.BatchSize() of them into
+				// a separate unsafe batch to output and shift the second part
+				// of the scratch batch into the beginning preparing for the
+				// next iteration.
+				if a.unsafeBatch == nil {
+					a.unsafeBatch = a.allocator.NewMemBatchWithFixedCapacity(a.outputTypes, coldata.BatchSize())
+				} else {
+					a.unsafeBatch.ResetInternalBatch()
+				}
+				a.allocator.PerformOperation(a.unsafeBatch.ColVecs(), func() {
+					for i := 0; i < len(a.outputTypes); i++ {
+						a.unsafeBatch.ColVec(i).Copy(
+							coldata.CopySliceArgs{
+								SliceArgs: coldata.SliceArgs{
+									Src:         a.scratch.ColVec(i),
+									SrcStartIdx: 0,
+									SrcEndIdx:   coldata.BatchSize(),
+								},
+							},
+						)
+					}
+					a.unsafeBatch.SetLength(coldata.BatchSize())
+				})
+				batchToReturn = a.unsafeBatch
+
+				// Copy the second part of the scratch batch into the first and
+				// we will resume from there on the next iteration.
+				newResumeIdx := a.scratch.resumeIdx - coldata.BatchSize()
+				a.allocator.PerformOperation(a.scratch.ColVecs(), func() {
+					for i := 0; i < len(a.outputTypes); i++ {
+						vec := a.scratch.ColVec(i)
+						// Note that we're using Append here instead of Copy
+						// because we want the "truncation" behavior, i.e. we
+						// want to copy over the remaining tuples such the
+						// "lengths" of the vectors are equal to the number of
+						// copied elements.
+						vec.Append(
+							coldata.SliceArgs{
+								Src:         vec,
+								DestIdx:     0,
+								SrcStartIdx: coldata.BatchSize(),
+								SrcEndIdx:   a.scratch.resumeIdx,
+							},
+						)
+						// Now we need to restore the length for the Vec.
+						vec.SetLength(a.scratch.Capacity())
+						a.bucket.fns[i].SetOutputIndex(newResumeIdx)
+						// There might have been some NULLs set in the part that
+						// we have just copied over, so we need to unset the
+						// NULLs.
+						a.scratch.ColVec(i).Nulls().UnsetNullsAfter(newResumeIdx)
 					}
 				})
+				a.scratch.resumeIdx = newResumeIdx
+			} else {
+				a.scratch.SetLength(a.scratch.resumeIdx)
+				for _, fn := range a.bucket.fns {
+					fn.SetOutputIndex(0 /* idx */)
+				}
+				a.scratch.resumeIdx = 0
+				a.scratch.shouldResetInternalBatch = true
 			}
-			a.scratch.resumeIdx = a.bucket.fns[0].CurrentOutputIndex()
-		}
-		if batchLength == 0 {
-			a.done = true
-			break
-		}
-		// zero out a.groupCol. This is necessary because distinct ORs the
-		// uniqueness of a value with the groupCol, allowing the operators to be
-		// linked.
-		copy(a.groupCol, zeroBoolColumn)
-	}
+			a.state = stateAfterOutputting
+			stateAfterOutputting = orderedAggregatorUnknown
+			return batchToReturn
 
-	batchToReturn := a.scratch.Batch
-	if a.scratch.resumeIdx > coldata.BatchSize() {
-		a.scratch.SetLength(coldata.BatchSize())
-		a.allocator.PerformOperation(a.unsafeBatch.ColVecs(), func() {
-			for i := 0; i < len(a.outputTypes); i++ {
-				a.unsafeBatch.ColVec(i).Copy(
-					coldata.CopySliceArgs{
-						SliceArgs: coldata.SliceArgs{
-							Src:         a.scratch.ColVec(i),
-							SrcStartIdx: 0,
-							SrcEndIdx:   a.scratch.Length(),
-						},
-					},
-				)
-			}
-			a.unsafeBatch.SetLength(a.scratch.Length())
-		})
-		batchToReturn = a.unsafeBatch
-		a.scratch.shouldResetInternalBatch = false
-	} else {
-		a.scratch.SetLength(a.scratch.resumeIdx)
-		a.scratch.shouldResetInternalBatch = true
-	}
+		case orderedAggregatorDone:
+			return coldata.ZeroBatch
 
-	return batchToReturn
+		default:
+			colexecerror.InternalError(errors.AssertionFailedf("unexpected orderedAggregatorState %d", a.state))
+		}
+	}
 }
 
 func (a *orderedAggregator) Close(ctx context.Context) error {

--- a/pkg/sql/colmem/allocator.go
+++ b/pkg/sql/colmem/allocator.go
@@ -45,6 +45,9 @@ func selVectorSize(capacity int) int64 {
 }
 
 func getVecMemoryFootprint(vec coldata.Vec) int64 {
+	if vec == nil {
+		return 0
+	}
 	switch vec.CanonicalTypeFamily() {
 	case types.BytesFamily:
 		return int64(vec.Bytes().Size())


### PR DESCRIPTION
**colexec: clean up AggregateFunc interface**

This commit updates the comments to reflect the current code around
aggregation as well as cleans up the ordered aggregator according to the
new contract.

Additionally, this commit removes `Reset` method from `AggregateFunc`
which is only used by the benchmarks in order to make those more
realistic (when executing a query, we don't have an aggregator that we
can reset, and we always create a new one) and to be more in line with
the row-execution benchmarks.

Release note: None

**colexec: make aggregators more dynamic and refactor ordered aggregator**

This commit refactors both aggregators to be more dynamic. This required
adding another method `SetOutput` to `AggregateFunc` interface to notify
the aggregate functions that the new vector should be used for their
output.

The changes to the hash aggregator are minor since hash aggregate
functions don't need the output vectors until `Flush` is called since
they process tuples only from a single group and don't write anything
during `Compute` method. One minor change was made to the allocator to
allow for getting the footprint of `nil` vectors.

The ordered aggregator required slightly more invasive changes, but the
general algorithm remained intact. With introduction of the dynamic
`scratch.Batch` we need to be careful to make sure that the aggregate
functions will not overflow past the capacity of the batch. We also now
instantiate the `unsafeBatch` lazily (of fixed `coldata.BatchSize()` in
size). I decided to refactor the ordered aggregator to be more like
a state machine, and the notable change is that now in case when the
results "overflow", we copy over the second part of the scratch batch
before returning the output (previously, we would do so on the next
iteration) - I think it is easier to follow the code this way. Also, we
add a minor optimization when zeroing out `groupCol` - we need to do it
only for `batchLength` number of values.

Release note: None