### PR TITLE
sqlmigrations: fix initial version setting's type

### DIFF
--- a/pkg/sqlmigrations/migrations.go
+++ b/pkg/sqlmigrations/migrations.go
@@ -1106,7 +1106,7 @@ func populateVersionSetting(ctx context.Context, r runner) error {
 	if err := r.execAsRoot(
 		ctx,
 		"insert-setting",
-		fmt.Sprintf(`INSERT INTO system.settings (name, value, "lastUpdated", "valueType") VALUES ('version', x'%x', now(), 'v') ON CONFLICT(name) DO NOTHING`, b),
+		fmt.Sprintf(`INSERT INTO system.settings (name, value, "lastUpdated", "valueType") VALUES ('version', x'%x', now(), 'm') ON CONFLICT(name) DO NOTHING`, b),
 	); err != nil {
 		return err
 	}


### PR DESCRIPTION
We had temporarily switched this to `v` but rolled it back for
mixed-version compat reasons, though failed to do so completely.

Luckily, this never got released.

Fixes #56895.

Release note: None
