### PR TITLE
server: avoid corrupting the log tags in the LogFile API

### DIFF
--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -994,10 +994,10 @@ func (s *statusServer) LogFile(
 	}
 	defer reader.Close()
 
-	var entry logpb.Entry
 	var resp serverpb.LogEntriesResponse
 	decoder := log.NewEntryDecoder(reader, inputEditMode)
 	for {
+		var entry logpb.Entry
 		if err := decoder.Decode(&entry); err != nil {
 			if err == io.EOF {
 				break

--- a/pkg/util/log/format_crdb_v1.go
+++ b/pkg/util/log/format_crdb_v1.go
@@ -267,6 +267,9 @@ func (d *EntryDecoder) Decode(entry *logpb.Entry) error {
 			continue
 		}
 
+		// Erase all the fields, to be sure.
+		*entry = logpb.Entry{}
+
 		// Process the severity.
 		entry.Severity = Severity(strings.IndexByte(severityChar, m[1][0]) + 1)
 


### PR DESCRIPTION
Fixes #56873 

Release note (bug fix): the `LogFile` reserved API, which was used
by `cockroach debug zip`, could corrupt log entries. This has been fixed.