### PR TITLE
sqlproxyccl: count successful connection attempts

### DIFF
--- a/pkg/ccl/sqlproxyccl/metrics.go
+++ b/pkg/ccl/sqlproxyccl/metrics.go
@@ -19,6 +19,7 @@ type Metrics struct {
 	CurConnCount           *metric.Gauge
 	RoutingErrCount        *metric.Counter
 	RefusedConnCount       *metric.Counter
+	SuccessfulConnCount    *metric.Counter
 }
 
 // MetricStruct implements the metrics.Struct interface.
@@ -63,6 +64,12 @@ var (
 		Measurement: "Refused",
 		Unit:        metric.Unit_COUNT,
 	}
+	metaSuccessfulConnCount = metric.Metadata{
+		Name:        "proxy.sql.successful_conns",
+		Help:        "Number of successful connections that were/are being proxied",
+		Measurement: "Successful Connections",
+		Unit:        metric.Unit_COUNT,
+	}
 )
 
 // MakeProxyMetrics instantiates the metrics holder for proxy monitoring.
@@ -74,5 +81,6 @@ func MakeProxyMetrics() Metrics {
 		CurConnCount:           metric.NewGauge(metaCurConnCount),
 		RoutingErrCount:        metric.NewCounter(metaRoutingErrCount),
 		RefusedConnCount:       metric.NewCounter(metaRefusedConnCount),
+		SuccessfulConnCount:    metric.NewCounter(metaSuccessfulConnCount),
 	}
 }

--- a/pkg/ccl/sqlproxyccl/proxy.go
+++ b/pkg/ccl/sqlproxyccl/proxy.go
@@ -183,6 +183,7 @@ func (s *Server) Proxy(conn net.Conn) error {
 			backendConfig.OutgoingAddress, err)
 	}
 
+	s.metrics.SuccessfulConnCount.Inc(1)
 	if backendConfig.OnConnectionSuccess != nil {
 		backendConfig.OnConnectionSuccess()
 	}

--- a/pkg/ccl/sqlproxyccl/proxy_test.go
+++ b/pkg/ccl/sqlproxyccl/proxy_test.go
@@ -243,6 +243,7 @@ func TestProxyAgainstSecureCRDB(t *testing.T) {
 	defer func() {
 		require.NoError(t, conn.Close(ctx))
 		require.True(t, connSuccess)
+		require.Equal(t, int64(1), s.metrics.SuccessfulConnCount.Count())
 	}()
 
 	var n int
@@ -327,4 +328,5 @@ func TestProxyRefuseConn(t *testing.T) {
 		CodeProxyRefusedConnection, "too many attempts",
 	)
 	require.Equal(t, int64(1), s.metrics.RefusedConnCount.Count())
+	require.Equal(t, int64(0), s.metrics.SuccessfulConnCount.Count())
 }


### PR DESCRIPTION
This counter will be useful to understand how many successful
connections have been cached so far unless we have gone over
the cache size limit of course.

Release note: none.