### PR TITLE
sqlsmith: disallow `crdb_internal.unsafe_*` metadata mutation builtins

### DIFF
--- a/pkg/internal/sqlsmith/schema.go
+++ b/pkg/internal/sqlsmith/schema.go
@@ -417,7 +417,8 @@ var functions = func() map[tree.FunctionClass]map[oid.Oid][]function {
 		case "pg_sleep":
 			continue
 		}
-		if strings.Contains(def.Name, "crdb_internal.force_") {
+		if strings.Contains(def.Name, "crdb_internal.force_") ||
+			strings.Contains(def.Name, "crdb_internal.unsafe_") {
 			continue
 		}
 		if _, ok := m[def.Class]; !ok {


### PR DESCRIPTION
Closes #56890.

Release note: None