### PR TITLE
sql: aggregate row counts for EXPLAIN ANALYZE (PLAN)

### DIFF
--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -361,6 +361,7 @@ go_library(
         "//vendor/github.com/cockroachdb/logtags",
         "//vendor/github.com/gogo/protobuf/jsonpb",
         "//vendor/github.com/gogo/protobuf/proto",
+        "//vendor/github.com/gogo/protobuf/types",
         "//vendor/github.com/lib/pq",
         "//vendor/github.com/lib/pq/oid",
         "//vendor/github.com/prometheus/client_model/go",

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -944,6 +944,7 @@ func (ex *connExecutor) execWithDistSQLEngine(
 	} else if planner.instrumentation.ShouldCollectBundle() {
 		planCtx.saveFlows = planCtx.getDefaultSaveFlowsFunc(ctx, planner, planComponentTypeMainQuery)
 	}
+	planCtx.traceMetadata = planner.instrumentation.traceMetadata
 
 	var evalCtxFactory func() *extendedEvalContext
 	if len(planner.curPlan.subqueryPlans) != 0 ||

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -835,6 +835,7 @@ func (dsp *DistSQLPlanner) planAndRunSubquery(
 	if planner.instrumentation.ShouldCollectBundle() {
 		subqueryPlanCtx.saveFlows = subqueryPlanCtx.getDefaultSaveFlowsFunc(ctx, planner, planComponentTypeSubquery)
 	}
+	subqueryPlanCtx.traceMetadata = planner.instrumentation.traceMetadata
 	// Don't close the top-level plan from subqueries - someone else will handle
 	// that.
 	subqueryPlanCtx.ignoreClose = true
@@ -1126,6 +1127,7 @@ func (dsp *DistSQLPlanner) planAndRunPostquery(
 	if planner.instrumentation.ShouldCollectBundle() {
 		postqueryPlanCtx.saveFlows = postqueryPlanCtx.getDefaultSaveFlowsFunc(ctx, planner, planComponentTypePostquery)
 	}
+	postqueryPlanCtx.traceMetadata = planner.instrumentation.traceMetadata
 
 	postqueryPhysPlan, err := dsp.createPhysPlan(postqueryPlanCtx, postqueryPlan)
 	if err != nil {

--- a/pkg/sql/logictest/testdata/logic_test/explain_analyze
+++ b/pkg/sql/logictest/testdata/logic_test/explain_analyze
@@ -1,8 +1,13 @@
+# LogicTest: fakedist-vec-off
+#
+# TODO(radu): enable other configs when the vectorized stat collector issue
+# #56928 is fixed.
+
 statement ok
 CREATE TABLE kv (k INT PRIMARY KEY, v INT, FAMILY (k, v))
 
 query T
-EXPLAIN ANALYZE (PLAN) SELECT k FROM kv WHERE k = 0
+EXPLAIN ANALYZE (PLAN) SELECT k FROM kv WHERE k >= 2
 ----
 planning time: 10µs
 execution time: 100µs
@@ -10,12 +15,66 @@ distribution: <hidden>
 vectorized: <hidden>
 ·
 • scan
+  actual row count: 0
   missing stats
   table: kv@primary
-  spans: [/0 - /0]
+  spans: [/2 - ]
 ·
 WARNING: this statement is experimental!
 
+statement ok
+INSERT INTO kv VALUES (1,10), (2,20), (3,30), (4,40);
+
+query T
+EXPLAIN ANALYZE (PLAN) SELECT * FROM kv WHERE k >= 2
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+·
+• scan
+  actual row count: 3
+  missing stats
+  table: kv@primary
+  spans: [/2 - ]
+·
+WARNING: this statement is experimental!
+
+statement ok
+CREATE TABLE ab (a INT PRIMARY KEY, b INT);
+INSERT INTO ab VALUES (10,100), (40,400), (50,500);
+
+query T
+EXPLAIN ANALYZE (PLAN, VERBOSE) SELECT * FROM kv JOIN ab ON v=a
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+·
+• hash join (inner)
+│ columns: (k, v, a, b)
+│ actual row count: 2
+│ estimated row count: 990 (missing stats)
+│ equality: (v) = (a)
+│ right cols are key
+│
+├── • scan
+│     columns: (k, v)
+│     actual row count: 4
+│     estimated row count: 1000 (missing stats)
+│     table: kv@primary
+│     spans: FULL SCAN
+│
+└── • scan
+      columns: (a, b)
+      actual row count: 3
+      estimated row count: 1000 (missing stats)
+      table: ab@primary
+      spans: FULL SCAN
+·
+WARNING: this statement is experimental!
 
 # Regression tests for weird explain analyze cases.
 

--- a/pkg/sql/opt/exec/explain/emit.go
+++ b/pkg/sql/opt/exec/explain/emit.go
@@ -326,6 +326,11 @@ func (e *emitter) joinNodeName(algo string, joinType descpb.JoinType) string {
 }
 
 func (e *emitter) emitNodeAttributes(n *Node) error {
+	if stats, ok := n.annotations[exec.ExecutionStatsID]; ok {
+		s := stats.(*exec.ExecutionStats)
+		e.ob.Attr("actual row count", s.RowCount)
+	}
+
 	if stats, ok := n.annotations[exec.EstimatedStatsID]; ok {
 		s := stats.(*exec.EstimatedStats)
 

--- a/pkg/sql/opt/exec/explain/explain_factory.go
+++ b/pkg/sql/opt/exec/explain/explain_factory.go
@@ -72,6 +72,14 @@ func (n *Node) WrappedNode() exec.Node {
 	return n.wrappedNode
 }
 
+// Annotate annotates the node with extra information.
+func (n *Node) Annotate(id exec.ExplainAnnotationID, value interface{}) {
+	if n.annotations == nil {
+		n.annotations = make(map[exec.ExplainAnnotationID]interface{})
+	}
+	n.annotations[id] = value
+}
+
 func (f *Factory) newNode(
 	op execOperator, args interface{}, ordering exec.OutputOrdering, children ...*Node,
 ) (*Node, error) {
@@ -114,11 +122,7 @@ func NewFactory(wrappedFactory exec.Factory) *Factory {
 
 // AnnotateNode is part of the exec.ExplainFactory interface.
 func (f *Factory) AnnotateNode(execNode exec.Node, id exec.ExplainAnnotationID, value interface{}) {
-	n := execNode.(*Node)
-	if n.annotations == nil {
-		n.annotations = make(map[exec.ExplainAnnotationID]interface{})
-	}
-	n.annotations[id] = value
+	execNode.(*Node).Annotate(id, value)
 }
 
 // ConstructPlan is part of the exec.Factory interface.

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -273,9 +273,12 @@ type ExplainAnnotationID int
 const (
 	// EstimatedStatsID is an annotation with a *EstimatedStats value.
 	EstimatedStatsID ExplainAnnotationID = iota
+
+	// ExecutionStatsID is an annotation with a *ExecutionStats value.
+	ExecutionStatsID
 )
 
-// EstimatedStats  contains estimated statistics about a given operator.
+// EstimatedStats contains estimated statistics about a given operator.
 type EstimatedStats struct {
 	// TableStatsAvailable is true if all the tables involved by this operator
 	// (directly or indirectly) had table statistics.
@@ -285,6 +288,15 @@ type EstimatedStats struct {
 	// Cost is the estimated cost of the operator. This cost includes the costs of
 	// the child operators.
 	Cost float64
+}
+
+// ExecutionStats contain statistics about a given operator gathered from the
+// execution of the query.
+//
+// TODO(radu): can/should we just use execinfrapb.ComponentStats instead?
+type ExecutionStats struct {
+	// RowCount is the number of rows produced by the operator.
+	RowCount uint64
 }
 
 // BuildPlanForExplainFn builds an execution plan against the given

--- a/pkg/sql/row/kv_fetcher.go
+++ b/pkg/sql/row/kv_fetcher.go
@@ -61,6 +61,9 @@ func newKVFetcher(batchFetcher kvBatchFetcher) *KVFetcher {
 
 // GetBytesRead returns the number of bytes read by this fetcher.
 func (f *KVFetcher) GetBytesRead() int64 {
+	if f == nil {
+		return 0
+	}
 	return f.bytesRead
 }
 


### PR DESCRIPTION
This change aggregates row counts per logical operator and shows them
in EXPLAIN ANALYZE (PLAN).

This likely doesn't work well with filtering, because the filter is
collapsed into the same processors as the last stage. That issue will
be revisited separately.

Release note: None