### PR TITLE
vendor: Bump pebble to 62f2e316b532, update x/sys

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -440,8 +440,8 @@ def go_deps():
         name = "com_github_cockroachdb_pebble",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/cockroachdb/pebble",
-        sum = "h1:SyU+66SkkE5wFIfUTFm8B4RKdbSrbkA5cTufPb2oyiQ=",
-        version = "v0.0.0-20201113231719-11399317ed18",
+        sum = "h1:W2qQOIPTgHOPrCK/8CSHGfPc3jX8XIvvuWYKlcq55oE=",
+        version = "v0.0.0-20201119153812-62f2e316b532",
     )
     go_repository(
         name = "com_github_cockroachdb_redact",
@@ -2980,8 +2980,8 @@ def go_deps():
         name = "org_golang_x_sys",
         build_file_proto_mode = "disable_global",
         importpath = "golang.org/x/sys",
-        sum = "h1:WgqgiQvkiZWz7XLhphjt2GI2GcGCTIZs9jqXMWmH+oc=",
-        version = "v0.0.0-20201022201747-fb209a7c41cd",
+        sum = "h1:nxC68pudNYkKU6jWhgrqdreuFiOQWj1Fs7T3VrH4Pjw=",
+        version = "v0.0.0-20201119102817-f84b799fce68",
     )
     go_repository(
         name = "org_golang_x_text",

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/cockroachdb/go-test-teamcity v0.0.0-20191211140407-cff980ad0a55
 	github.com/cockroachdb/gostdlib v1.13.0
 	github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f
-	github.com/cockroachdb/pebble v0.0.0-20201113231719-11399317ed18
+	github.com/cockroachdb/pebble v0.0.0-20201119153812-62f2e316b532
 	github.com/cockroachdb/redact v1.0.8
 	github.com/cockroachdb/returncheck v0.0.0-20200612231554-92cdbca611dd
 	github.com/cockroachdb/sentry-go v0.6.1-cockroachdb.2
@@ -153,7 +153,7 @@ require (
 	golang.org/x/oauth2 v0.0.0-20190115181402-5dab4167f31c
 	golang.org/x/perf v0.0.0-20180704124530-6e6d33e29852
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
-	golang.org/x/sys v0.0.0-20201022201747-fb209a7c41cd
+	golang.org/x/sys v0.0.0-20201119102817-f84b799fce68
 	golang.org/x/text v0.3.3
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
 	golang.org/x/tools v0.0.0-20200702044944-0cc1aa72b347

--- a/go.sum
+++ b/go.sum
@@ -158,8 +158,8 @@ github.com/cockroachdb/grpc-gateway v1.14.6-0.20200519165156-52697fc4a249 h1:pZu
 github.com/cockroachdb/grpc-gateway v1.14.6-0.20200519165156-52697fc4a249/go.mod h1:UJ0EZAp832vCd54Wev9N1BMKEyvcZ5+IM0AwDrnlkEc=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f h1:o/kfcElHqOiXqcou5a3rIlMc7oJbMQkeLk0VQJ7zgqY=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
-github.com/cockroachdb/pebble v0.0.0-20201113231719-11399317ed18 h1:SyU+66SkkE5wFIfUTFm8B4RKdbSrbkA5cTufPb2oyiQ=
-github.com/cockroachdb/pebble v0.0.0-20201113231719-11399317ed18/go.mod h1:c3G8ud5zF3+nYHCWmVmtsA8eEtjrDSa6qeLtcRZyevE=
+github.com/cockroachdb/pebble v0.0.0-20201119153812-62f2e316b532 h1:W2qQOIPTgHOPrCK/8CSHGfPc3jX8XIvvuWYKlcq55oE=
+github.com/cockroachdb/pebble v0.0.0-20201119153812-62f2e316b532/go.mod h1:c3G8ud5zF3+nYHCWmVmtsA8eEtjrDSa6qeLtcRZyevE=
 github.com/cockroachdb/redact v1.0.8 h1:8QG/764wK+vmEYoOlfobpe12EQcS81ukx/a4hdVMxNw=
 github.com/cockroachdb/redact v1.0.8/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/returncheck v0.0.0-20200612231554-92cdbca611dd h1:KFOt5I9nEKZgCnOSmy8r4Oykh8BYQO8bFOTgHDS8YZA=
@@ -840,8 +840,8 @@ golang.org/x/sys v0.0.0-20200121082415-34d275377bf9/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200519105757-fe76b779f299/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201009025420-dfb3f7c4e634/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20201022201747-fb209a7c41cd h1:WgqgiQvkiZWz7XLhphjt2GI2GcGCTIZs9jqXMWmH+oc=
-golang.org/x/sys v0.0.0-20201022201747-fb209a7c41cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 h1:nxC68pudNYkKU6jWhgrqdreuFiOQWj1Fs7T3VrH4Pjw=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=

--- a/pkg/ccl/storageccl/engineccl/encrypted_fs_test.go
+++ b/pkg/ccl/storageccl/engineccl/encrypted_fs_test.go
@@ -273,10 +273,10 @@ func TestPebbleEncryption(t *testing.T) {
 	// Flushing should've created a new sstable under the active key.
 	stats, err = db.GetEnvStats()
 	require.NoError(t, err)
-	require.Equal(t, uint64(5), stats.TotalFiles)
-	require.Equal(t, uint64(5), stats.ActiveKeyFiles)
-	require.Equal(t, stats.TotalBytes, stats.ActiveKeyBytes)
 	t.Logf("EnvStats:\n%+v\n\n", *stats)
+	require.Equal(t, uint64(5), stats.TotalFiles)
+	require.LessOrEqual(t, uint64(5), stats.ActiveKeyFiles)
+	require.Equal(t, stats.TotalBytes, stats.ActiveKeyBytes)
 
 	db.Close()
 }

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -339,6 +339,10 @@ func DefaultPebbleOptions() *pebble.Options {
 	// memtable. This ensures that we can reclaim space even when there's no
 	// activity on the database generating flushes.
 	opts.Experimental.DeleteRangeFlushDelay = 10 * time.Second
+	// Enable deletion pacing. This helps prevent disk slowness events on some
+	// SSDs, that kick off an expensive GC if a lot of files are deleted at
+	// once.
+	opts.Experimental.MinDeletionRate = 128 << 20 // 128 MB
 
 	for i := 0; i < len(opts.Levels); i++ {
 		l := &opts.Levels[i]

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -974,8 +974,8 @@ func (p *Pebble) GetEnvStats() (*EnvStats, error) {
 
 	m := p.db.Metrics()
 	stats.TotalFiles = 3 /* CURRENT, MANIFEST, OPTIONS */
-	stats.TotalFiles += uint64(m.WAL.Files + m.Table.ZombieCount + m.WAL.ObsoleteFiles)
-	stats.TotalBytes = m.WAL.Size + m.Table.ZombieSize
+	stats.TotalFiles += uint64(m.WAL.Files + m.Table.ZombieCount + m.WAL.ObsoleteFiles + m.Table.ObsoleteCount)
+	stats.TotalBytes = m.WAL.Size + m.Table.ZombieSize + m.Table.ObsoleteSize
 	for _, l := range m.Levels {
 		stats.TotalFiles += uint64(l.NumFiles)
 		stats.TotalBytes += uint64(l.Size)


### PR DESCRIPTION
Changes pulled in:
```
62f2e316b532ee5dcc57535e25ebcf9ca7c828d9 *: Implement deletion pacing of obsolete compaction files
75ede898b66ca98c7ff375e1b9378797a920cc57 tool: fix manifest check to not produce false positive errors
7debb5b4af76b33f0d59a47954e2f433cc73e34e vfs: add memFile.Flush, remove flushFile
0e7d2cc577d43b2e13cc05670c885b34d93368f1 *: make memFile.Write mutate its input buffer
```

Also enable deletion pacing, now that it's implemented
in Pebble.

Release note: None.