### PR TITLE
release-20.2: sql,builtins: add builtin functions to perform descriptor repair

### DIFF
--- a/pkg/sql/event_log.go
+++ b/pkg/sql/event_log.go
@@ -113,6 +113,22 @@ const (
 	// EventLogCreateStatistics is recorded when statistics are collected for a
 	// table.
 	EventLogCreateStatistics EventLogType = "create_statistics"
+
+	// EventLogUnsafeUpsertDescriptor is recorded when a descriptor is written
+	// using crdb_internal.unsafe_upsert_descriptor.
+	EventLogUnsafeUpsertDescriptor EventLogType = "unsafe_upsert_descriptor"
+
+	// EventLogUnsafeDeleteDescriptor is recorded when a descriptor is written
+	// using crdb_internal.unsafe_delete_descriptor.
+	EventLogUnsafeDeleteDescriptor EventLogType = "unsafe_delete_descriptor"
+
+	// EventLogUnsafeUpsertNamespaceEntry is recorded when a namespace entry is
+	// written using crdb_internal.unsafe_upsert_namespace_entry.
+	EventLogUnsafeUpsertNamespaceEntry EventLogType = "unsafe_upsert_namespace_entry"
+
+	// EventLogUnsafeDeleteNamespaceEntry is recorded when a namespace entry is
+	// written using crdb_internal.unsafe_delete_namespace_entry.
+	EventLogUnsafeDeleteNamespaceEntry EventLogType = "unsafe_delete_namespace_entry"
 )
 
 // EventLogSetClusterSettingDetail is the json details for a settings change.

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -86,6 +86,32 @@ func (so *DummySequenceOperators) SetSequenceValue(
 // errors.
 type DummyEvalPlanner struct{}
 
+// UnsafeUpsertDescriptor is part of the EvalPlanner interface.
+func (ep *DummyEvalPlanner) UnsafeUpsertDescriptor(
+	ctx context.Context, descID int64, encodedDescriptor []byte,
+) error {
+	return errors.WithStack(errEvalPlanner)
+}
+
+// UnsafeDeleteDescriptor is part of the EvalPlanner interface.
+func (ep *DummyEvalPlanner) UnsafeDeleteDescriptor(ctx context.Context, descID int64) error {
+	return errors.WithStack(errEvalPlanner)
+}
+
+// UnsafeUpsertNamespaceEntry is part of the EvalPlanner interface.
+func (ep *DummyEvalPlanner) UnsafeUpsertNamespaceEntry(
+	ctx context.Context, parentID, parentSchemaID int64, name string, descID int64, force bool,
+) error {
+	return errors.WithStack(errEvalPlanner)
+}
+
+// UnsafeDeleteNamespaceEntry is part of the EvalPlanner interface.
+func (ep *DummyEvalPlanner) UnsafeDeleteNamespaceEntry(
+	ctx context.Context, parentID, parentSchemaID int64, name string, descID int64,
+) error {
+	return errors.WithStack(errEvalPlanner)
+}
+
 var _ tree.EvalPlanner = &DummyEvalPlanner{}
 
 var errEvalPlanner = pgerror.New(pgcode.ScalarOperationCannotRunWithoutFullSessionContext,

--- a/pkg/sql/repair.go
+++ b/pkg/sql/repair.go
@@ -1,0 +1,421 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"context"
+	"encoding/hex"
+
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkeys"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/dbdesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemadesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/errors"
+)
+
+// UnsafeUpsertDescriptor powers the repair builtin of the same name. The idea
+// is that it should be used only by an administrator in the most dire of
+// circumstances. It exists for two practical but perhaps unfortunate reasons.
+// Firstly, the sql schema of the descriptor table does not match the way the
+// table is actually modified. Specifically, only one column family is every
+// populated and code elsewhere assumes that this is the case. Secondly, we
+// don't generally want users writing to that table.
+//
+// This method will perform *some* validation of the descriptor. Namely, it
+// will ensure that if a version currently exists, that the upserted descriptor
+// is of the subsequent version. This method may only be used to update any
+// individual descriptor one time per transaction and may not be used to
+// interact with a descriptor that has already been modified in the transaction.
+// Note however that it may be used any number of times in a transaction to
+// write to different descriptors. It will also validate the structure of the
+// descriptor but not its references.
+//
+// TODO(ajwerner): It is critical that we not validate all of the relevant
+// descriptors during statement execution as it may be the case that more than
+// one descriptor is corrupt. Instead, we should validate all of the relevant
+// descriptors just prior to committing the transaction. This would bring the
+// requirement that if a descriptor is upserted, that it leave the database in
+// a valid state, at least in terms of that descriptor and its references.
+// Perhaps transactions which do end up using this should also end up validating
+// all descriptors at the end of the transaction to ensure that this operation
+// didn't break a reference to this descriptor.
+func (p *planner) UnsafeUpsertDescriptor(
+	ctx context.Context, descID int64, encodedDesc []byte,
+) error {
+	const method = "crdb_internal.unsafe_upsert_descriptor()"
+	if err := checkPlannerStateForRepairFunctions(ctx, p, method); err != nil {
+		return err
+	}
+
+	id := descpb.ID(descID)
+	var desc descpb.Descriptor
+	if err := protoutil.Unmarshal(encodedDesc, &desc); err != nil {
+		return pgerror.Wrapf(err, pgcode.InvalidTableDefinition, "failed to decode descriptor")
+	}
+
+	// Fetch the existing descriptor.
+	existing, err := p.Descriptors().GetMutableDescriptorByID(ctx, id, p.txn)
+	if !errors.Is(err, catalog.ErrDescriptorNotFound) && err != nil {
+		return err
+	}
+
+	// Validate that existing is sane and store its hex serialization into
+	// existingStr to be written to the event log.
+	var existingStr string
+	if existing != nil {
+		if existing.IsUncommittedVersion() {
+			return pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
+				"cannot modify a modified descriptor (%d) with UnsafeUpsertDescriptor", id)
+		}
+		version := descpb.GetDescriptorVersion(&desc)
+		if version != existing.GetVersion() && version != existing.GetVersion()+1 {
+			return pgerror.Newf(pgcode.InvalidTableDefinition, "mismatched descriptor version, expected %v or %v, got %v",
+				version, version+1, existing.GetVersion())
+		}
+		marshaled, err := protoutil.Marshal(existing.DescriptorProto())
+		if err != nil {
+			return errors.AssertionFailedf("failed to marshal existing descriptor %v: %v", existing, err)
+		}
+		existingStr = hex.EncodeToString(marshaled)
+	}
+
+	switch md := existing.(type) {
+	case *tabledesc.Mutable:
+		md.TableDescriptor = *desc.GetTable() // nolint:descriptormarshal
+	case *schemadesc.Mutable:
+		md.SchemaDescriptor = *desc.GetSchema()
+	case *dbdesc.Mutable:
+		md.DatabaseDescriptor = *desc.GetDatabase()
+	case *typedesc.Mutable:
+		md.TypeDescriptor = *desc.GetType()
+	case nil:
+		// nolint:descriptormarshal
+		if tableDesc := desc.GetTable(); tableDesc != nil {
+			existing = tabledesc.NewCreatedMutable(*tableDesc)
+		} else if schemaDesc := desc.GetSchema(); schemaDesc != nil {
+			existing = schemadesc.NewCreatedMutable(*schemaDesc)
+		} else if dbDesc := desc.GetDatabase(); dbDesc != nil {
+			existing = dbdesc.NewCreatedMutable(*dbDesc)
+		} else if typeDesc := desc.GetType(); typeDesc != nil {
+			existing = typedesc.NewCreatedMutable(*typeDesc)
+		} else {
+			return pgerror.New(pgcode.InvalidTableDefinition, "invalid ")
+		}
+	default:
+		return errors.AssertionFailedf("unknown descriptor type %T for id %d", existing, id)
+	}
+	{
+		b := p.txn.NewBatch()
+		if err := p.Descriptors().WriteDescToBatch(
+			ctx, p.extendedEvalCtx.Tracing.KVTracingEnabled(), existing, b,
+		); err != nil {
+			return err
+		}
+		if err := p.txn.Run(ctx, b); err != nil {
+			return err
+		}
+	}
+	return MakeEventLogger(p.execCfg).InsertEventRecord(
+		ctx,
+		p.txn,
+		EventLogUnsafeUpsertDescriptor,
+		int32(id),
+		int32(p.EvalContext().NodeID.SQLInstanceID()),
+		&struct {
+			ID                 descpb.ID `json:"id"`
+			ExistingDescriptor string    `json:"existing_descriptor,omitempty"`
+			Descriptor         string    `json:"descriptor,omitempty"`
+		}{
+			ID:                 id,
+			ExistingDescriptor: existingStr,
+			Descriptor:         hex.EncodeToString(encodedDesc),
+		})
+}
+
+// UnsafeUpsertNamespaceEntry powers the repair builtin of the same name. The
+// idea is that it should be used only by an administrator in the most dire of
+// circumstances. It exists for two practical but perhaps unfortunate reasons.
+// Firstly, the sql schema of the namespace table does not match the way the
+// table is actually modified. Specifically, only one column family is every
+// populated and code elsewhere assumes that this is the case. Secondly, we
+// don't generally want users writing to that table.
+//
+// If force is true, most validation will be attached to the event log entry but
+// will not lead to an error.
+//
+// This method will perform *some* validation of the namespace entry. Namely, it
+// will ensure that the new entry corresponds to a non-dropped descriptor and
+// that the parents exist appropriately for the type of descriptor.
+func (p *planner) UnsafeUpsertNamespaceEntry(
+	ctx context.Context,
+	parentIDInt, parentSchemaIDInt int64,
+	name string,
+	descIDInt int64,
+	force bool,
+) error {
+	const method = "crdb_internal.unsafe_upsert_namespace_entry()"
+	if err := checkPlannerStateForRepairFunctions(ctx, p, method); err != nil {
+		return err
+	}
+	parentID, parentSchemaID, descID := descpb.ID(parentIDInt), descpb.ID(parentSchemaIDInt), descpb.ID(descIDInt)
+	key := catalogkeys.MakeNameMetadataKey(p.execCfg.Codec, parentID, parentSchemaID, name)
+	val, err := p.txn.Get(ctx, key)
+	if err != nil {
+		return errors.Wrapf(err, "failed to read namespace entry (%d, %d, %s)",
+			parentID, parentSchemaID, name)
+	}
+
+	// TODO(ajwerner): Validate properties of the existing entry if its descriptor
+	// exists.
+	var existingID descpb.ID
+	if val.Value != nil {
+		existingID = descpb.ID(val.ValueInt())
+	}
+	validateDescriptor := func() error {
+		desc, err := p.Descriptors().GetMutableDescriptorByID(ctx, descID, p.txn)
+		if err != nil && descID != keys.PublicSchemaID {
+			return errors.Wrapf(err, "failed to retrieve descriptor %d", descID)
+		}
+		switch desc.(type) {
+		case nil:
+			return nil
+		case *tabledesc.Mutable, *typedesc.Mutable:
+			if parentID == 0 || parentSchemaID == 0 {
+				return pgerror.Newf(pgcode.InvalidCatalogName,
+					"invalid prefix (%d, %d) for object %d",
+					parentID, parentSchemaID, descID)
+			}
+		case *schemadesc.Mutable:
+			if parentID == 0 || parentSchemaID != 0 {
+				return pgerror.Newf(pgcode.InvalidCatalogName,
+					"invalid prefix (%d, %d) for schema %d",
+					parentID, parentSchemaID, descID)
+			}
+		case *dbdesc.Mutable:
+			if parentID != 0 || parentSchemaID != 0 {
+				return pgerror.Newf(pgcode.InvalidCatalogName,
+					"invalid prefix (%d, %d) for database %d",
+					parentID, parentSchemaID, descID)
+			}
+		default:
+			// The public schema does not have a descriptor.
+			if descID == keys.PublicSchemaID {
+				return nil
+			}
+			return errors.AssertionFailedf(
+				"unexpected descriptor type %T for descriptor %d", desc, descID)
+		}
+		return nil
+	}
+	validateParentDescriptor := func() error {
+		if parentID == 0 {
+			return nil
+		}
+		parent, err := p.Descriptors().GetMutableDescriptorByID(
+			ctx, parentID, p.txn,
+		)
+		if err != nil {
+			return errors.Wrapf(err, "failed to look up parent %d", parentID)
+		}
+		if _, isDatabase := parent.(catalog.DatabaseDescriptor); !isDatabase {
+			return pgerror.Newf(pgcode.InvalidCatalogName,
+				"parentID %d is a %T, not a database", parentID, parent)
+		}
+		return nil
+	}
+	validateParentSchemaDescriptor := func() error {
+		if parentSchemaID == 0 || parentSchemaID == keys.PublicSchemaID {
+			return nil
+		}
+		schema, err := p.Descriptors().GetMutableDescriptorByID(
+			ctx, parentID, p.txn,
+		)
+		if err != nil {
+			return err
+		}
+		if _, isSchema := schema.(catalog.SchemaDescriptor); !isSchema {
+			return pgerror.Newf(pgcode.InvalidCatalogName,
+				"parentSchemaID %d is a %T, not a schema", parentID, schema)
+		}
+		return nil
+	}
+
+	// validationErr will hold combined errors if force is true.
+	var validationErr error
+	for _, f := range []func() error{
+		validateDescriptor,
+		validateParentDescriptor,
+		validateParentSchemaDescriptor,
+	} {
+		if err := f(); err != nil && force {
+			validationErr = errors.CombineErrors(validationErr, err)
+		} else if err != nil {
+			return err
+		}
+	}
+	if err := p.txn.Put(ctx, key, descID); err != nil {
+		return err
+	}
+	var validationErrStr string
+	if validationErr != nil {
+		validationErrStr = validationErr.Error()
+	}
+	return MakeEventLogger(p.execCfg).InsertEventRecord(
+		ctx,
+		p.txn,
+		EventLogUnsafeUpsertNamespaceEntry,
+		int32(descID),
+		int32(p.EvalContext().NodeID.SQLInstanceID()),
+		&struct {
+			ParentID         descpb.ID `json:"parent_id,omitempty"`
+			ParentSchemaID   descpb.ID `json:"parent_schema_id,omitempty"`
+			Name             string    `json:"name"`
+			ID               descpb.ID `json:"id"`
+			ExistingID       descpb.ID `json:"existing_id,omitempty"`
+			Force            bool      `json:"force,omitempty"`
+			ValidationErrors string    `json:"validation_errors,omitempty"`
+		}{
+			ParentID:         parentID,
+			ParentSchemaID:   parentSchemaID,
+			ID:               descID,
+			Name:             name,
+			ExistingID:       existingID,
+			Force:            force,
+			ValidationErrors: validationErrStr,
+		})
+}
+
+// UnsafeDeleteNamespaceEntry powers the repair builtin of the same name. The
+// idea is that it should be used only by an administrator in the most dire of
+// circumstances. It exists to empower administrators to perform repair.
+//
+// This method will perform *some* validation of the namespace entry. Namely, it
+// will ensure that the entry does not correspond to a non-dropped descriptor
+// and that the entry exists with the provided ID.
+func (p *planner) UnsafeDeleteNamespaceEntry(
+	ctx context.Context, parentIDInt, parentSchemaIDInt int64, name string, descIDInt int64,
+) error {
+	const method = "crdb_internal.unsafe_delete_namespace_entry()"
+	if err := checkPlannerStateForRepairFunctions(ctx, p, method); err != nil {
+		return err
+	}
+	parentID, parentSchemaID, descID := descpb.ID(parentIDInt), descpb.ID(parentSchemaIDInt), descpb.ID(descIDInt)
+	key := catalogkeys.MakeNameMetadataKey(p.execCfg.Codec, parentID, parentSchemaID, name)
+	val, err := p.txn.Get(ctx, key)
+	if err != nil {
+		return errors.Wrapf(err, "failed to read namespace entry (%d, %d, %s)",
+			parentID, parentSchemaID, name)
+	}
+	if val.Value == nil {
+		// Perhaps this is not the best pgcode but it's something.
+		return pgerror.Newf(pgcode.InvalidCatalogName,
+			"no namespace entry exists for (%d, %d, %s)",
+			parentID, parentSchemaID, name)
+	}
+	if val.Value != nil {
+		existingID := descpb.ID(val.ValueInt())
+		if existingID != descID {
+			return pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
+				"namespace entry for (%d, %d, %s) has id %d, not %d",
+				parentID, parentSchemaID, name, existingID, descID)
+		}
+	}
+	desc, err := p.Descriptors().GetMutableDescriptorByID(ctx, descID, p.txn)
+	if err != nil && !errors.Is(err, catalog.ErrDescriptorNotFound) {
+		return errors.Wrapf(err, "failed to retrieve descriptor %d", descID)
+	}
+	if err == nil && !desc.Dropped() {
+		return pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
+			"refusing to delete namespace entry for non-dropped descriptor")
+	}
+	if err := p.txn.Del(ctx, key); err != nil {
+		return errors.Wrap(err, "failed to delete entry")
+	}
+	return MakeEventLogger(p.execCfg).InsertEventRecord(
+		ctx,
+		p.txn,
+		EventLogUnsafeDeleteNamespaceEntry,
+		int32(descID),
+		int32(p.EvalContext().NodeID.SQLInstanceID()),
+		&struct {
+			ParentID       descpb.ID `json:"parent_id,omitempty"`
+			ParentSchemaID descpb.ID `json:"parent_schema_id,omitempty"`
+			Name           string    `json:"name"`
+			ID             descpb.ID `json:"id"`
+			ExistingID     descpb.ID `json:"existing_id,omitempty"`
+		}{
+			ParentID:       parentID,
+			ParentSchemaID: parentSchemaID,
+			ID:             descID,
+			Name:           name,
+		})
+}
+
+// UnsafeDeleteDescriptor powers the repair builtin of the same name. The
+// idea is that it should be used only by an administrator in the most dire of
+// circumstances. It exists to empower administrators to perform repair.
+//
+// This method will perform very minimal validation. An error will be returned
+// if no such descriptor exists. This method can very easily introduce
+// corruption, beware.
+func (p *planner) UnsafeDeleteDescriptor(ctx context.Context, descID int64) error {
+	const method = "crdb_internal.unsafe_delete_descriptor()"
+	if err := checkPlannerStateForRepairFunctions(ctx, p, method); err != nil {
+		return err
+	}
+	id := descpb.ID(descID)
+	mut, err := p.Descriptors().GetMutableDescriptorByID(ctx, id, p.txn)
+	if err != nil {
+		return err
+	}
+	descKey := catalogkeys.MakeDescMetadataKey(p.execCfg.Codec, id)
+	if err := p.txn.Del(ctx, descKey); err != nil {
+		return err
+	}
+	return MakeEventLogger(p.execCfg).InsertEventRecord(
+		ctx,
+		p.txn,
+		EventLogUnsafeDeleteDescriptor,
+		int32(descID),
+		int32(p.EvalContext().NodeID.SQLInstanceID()),
+		&struct {
+			ParentID       descpb.ID `json:"parent_id,omitempty"`
+			ParentSchemaID descpb.ID `json:"parent_schema_id,omitempty"`
+			Name           string    `json:"name"`
+			ID             descpb.ID `json:"id"`
+		}{
+			ParentID:       mut.GetParentID(),
+			ParentSchemaID: mut.GetParentSchemaID(),
+			ID:             mut.GetID(),
+			Name:           mut.GetName(),
+		})
+}
+
+func checkPlannerStateForRepairFunctions(ctx context.Context, p *planner, method string) error {
+	if p.extendedEvalCtx.TxnReadOnly {
+		return readOnlyError(method)
+	}
+	hasAdmin, err := p.UserHasAdminRole(ctx, p.User())
+	if err != nil {
+		return err
+	}
+	if !hasAdmin {
+		return pgerror.Newf(pgcode.InsufficientPrivilege, "admin role required for %s", method)
+	}
+	return nil
+}

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -100,6 +100,7 @@ const (
 	categorySpatial        = "Spatial"
 	categoryString         = "String and byte"
 	categorySystemInfo     = "System info"
+	categorySystemRepair   = "System repair"
 )
 
 func categorizeType(t *types.T) string {
@@ -4227,6 +4228,139 @@ may increase either contention or retry errors, or both.`,
 					ret.Array = append(ret.Array, tree.NewDString(string(key)))
 				}
 				return ret, nil
+			},
+			Info:       "This function is used only by CockroachDB's developers for testing purposes.",
+			Volatility: tree.VolatilityVolatile,
+		},
+	),
+	"crdb_internal.unsafe_upsert_descriptor": makeBuiltin(
+		tree.FunctionProperties{
+			Category:         categorySystemRepair,
+			DistsqlBlocklist: true,
+			Undocumented:     true,
+		},
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"id", types.Int},
+				{"desc", types.Bytes},
+			},
+			ReturnType: tree.FixedReturnType(types.Bool),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				if err := ctx.Planner.UnsafeUpsertDescriptor(ctx.Context,
+					int64(*args[0].(*tree.DInt)),
+					[]byte(*args[1].(*tree.DBytes))); err != nil {
+					return nil, err
+				}
+				return tree.DBoolTrue, nil
+			},
+			Info:       "This function is used only by CockroachDB's developers for testing purposes.",
+			Volatility: tree.VolatilityVolatile,
+		},
+	),
+	"crdb_internal.unsafe_delete_descriptor": makeBuiltin(
+		tree.FunctionProperties{
+			Category:         categorySystemRepair,
+			DistsqlBlocklist: true,
+			Undocumented:     true,
+		},
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"id", types.Int},
+			},
+			ReturnType: tree.FixedReturnType(types.Bool),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				if err := ctx.Planner.UnsafeDeleteDescriptor(ctx.Context,
+					int64(*args[0].(*tree.DInt)),
+				); err != nil {
+					return nil, err
+				}
+				return tree.DBoolTrue, nil
+			},
+			Info:       "This function is used only by CockroachDB's developers for testing purposes.",
+			Volatility: tree.VolatilityVolatile,
+		},
+	),
+	"crdb_internal.unsafe_upsert_namespace_entry": makeBuiltin(
+		tree.FunctionProperties{
+			Category:         categorySystemRepair,
+			DistsqlBlocklist: true,
+			Undocumented:     true,
+		},
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"parent_id", types.Int},
+				{"parent_schema_id", types.Int},
+				{"name", types.String},
+				{"desc_id", types.Int},
+				{"force", types.Bool},
+			},
+			ReturnType: tree.FixedReturnType(types.Bool),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				if err := ctx.Planner.UnsafeUpsertNamespaceEntry(
+					ctx.Context,
+					int64(*args[0].(*tree.DInt)),     // parentID
+					int64(*args[1].(*tree.DInt)),     // parentSchemaID
+					string(*args[2].(*tree.DString)), // name
+					int64(*args[3].(*tree.DInt)),     // descID
+					bool(*args[4].(*tree.DBool)),     // force
+				); err != nil {
+					return nil, err
+				}
+				return tree.DBoolTrue, nil
+			},
+			Info:       "This function is used only by CockroachDB's developers for testing purposes.",
+			Volatility: tree.VolatilityVolatile,
+		},
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"parent_id", types.Int},
+				{"parent_schema_id", types.Int},
+				{"name", types.String},
+				{"desc_id", types.Int},
+			},
+			ReturnType: tree.FixedReturnType(types.Bool),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				if err := ctx.Planner.UnsafeUpsertNamespaceEntry(
+					ctx.Context,
+					int64(*args[0].(*tree.DInt)),     // parentID
+					int64(*args[1].(*tree.DInt)),     // parentSchemaID
+					string(*args[2].(*tree.DString)), // name
+					int64(*args[3].(*tree.DInt)),     // descID
+					false,                            // force
+				); err != nil {
+					return nil, err
+				}
+				return tree.DBoolTrue, nil
+			},
+			Info:       "This function is used only by CockroachDB's developers for testing purposes.",
+			Volatility: tree.VolatilityVolatile,
+		},
+	),
+	"crdb_internal.unsafe_delete_namespace_entry": makeBuiltin(
+		tree.FunctionProperties{
+			Category:         categorySystemRepair,
+			DistsqlBlocklist: true,
+			Undocumented:     true,
+		},
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"parent_id", types.Int},
+				{"parent_schema_id", types.Int},
+				{"name", types.String},
+				{"desc_id", types.Int},
+			},
+			ReturnType: tree.FixedReturnType(types.Bool),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				if err := ctx.Planner.UnsafeDeleteNamespaceEntry(
+					ctx.Context,
+					int64(*args[0].(*tree.DInt)),     // parentID
+					int64(*args[1].(*tree.DInt)),     // parentSchemaID
+					string(*args[2].(*tree.DString)), // name
+					int64(*args[3].(*tree.DInt)),     // descID
+				); err != nil {
+					return nil, err
+				}
+				return tree.DBoolTrue, nil
 			},
 			Info:       "This function is used only by CockroachDB's developers for testing purposes.",
 			Volatility: tree.VolatilityVolatile,

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -2984,6 +2984,22 @@ type EvalPlanner interface {
 
 	// EvalSubquery returns the Datum for the given subquery node.
 	EvalSubquery(expr *Subquery) (Datum, error)
+
+	// UnsafeUpsertDescriptor is a used to repair descriptors in dire
+	// circumstances. See the comment on the planner implementation.
+	UnsafeUpsertDescriptor(ctx context.Context, descID int64, encodedDescriptor []byte) error
+
+	// UnsafeDeleteDescriptor is a used to repair descriptors in dire
+	// circumstances. See the comment on the planner implementation.
+	UnsafeDeleteDescriptor(ctx context.Context, descID int64) error
+
+	// UnsafeUpsertNamespaceEntry is a used to repair namespace entries in dire
+	// circumstances. See the comment on the planner implementation.
+	UnsafeUpsertNamespaceEntry(ctx context.Context, parentID, parentSchemaID int64, name string, descID int64, force bool) error
+
+	// UnsafeDeleteNamespaceEntry is a used to repair namespace entries in dire
+	// circumstances. See the comment on the planner implementation.
+	UnsafeDeleteNamespaceEntry(ctx context.Context, parentID, parentSchemaID int64, name string, descID int64) error
 }
 
 // EvalSessionAccessor is a limited interface to access session variables.


### PR DESCRIPTION
Backport 1/1 commits from #55699.

/cc @cockroachdb/release

---

There are bugs in previous versions (#51782, #54861, and surely others) which
can leave descriptors in an invalid state. When this occurs, the only recourse
is to inject either repaired versions directly or other descriptors that allow
use of normal DDL statements to reach the desired state. Prior to this change,
the mechanism by which this repair could be achieved was a bit of a hack
whereby the "node" users which is used internally to muck with certain system
tables could be granted to the "root" user for purposes of updating entries
in tables like system.namespace and system.descriptor. Even this was
problematic because those tables do not utilize all of the column families
when written to using the KV API. That made writing new rows to such tables
extremely dangerous as low-level code for determining zone configurations in
kv assumes that there will be appropriate values in all kv rows in those
tables (which is not the case for certain column families).

Fixes #50948.

Release note (sql change): Added admin-only, crdb_internal functions to enable
descriptor repair in dire circumstances.
