### PR TITLE
roachtest: add flag to testSpec to disable release-blocker tag, mark random schema change tests as non-release-blocking

### DIFF
--- a/pkg/cmd/roachtest/schemachange_random_load.go
+++ b/pkg/cmd/roachtest/schemachange_random_load.go
@@ -29,6 +29,9 @@ func registerSchemaChangeRandomLoad(r *testRegistry) {
 		Owner:      OwnerSQLSchema,
 		Cluster:    makeClusterSpec(3),
 		MinVersion: "v20.1.0",
+		// This is set while development is still happening on the workload and we
+		// fix (or bypass) minor schema change bugs that are discovered.
+		NonReleaseBlocker: true,
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			maxOps := 5000
 			concurrency := 20
@@ -69,6 +72,9 @@ func registerRandomLoadBenchSpec(r *testRegistry, b randomLoadBenchSpec) {
 		Owner:      OwnerSQLSchema,
 		Cluster:    makeClusterSpec(b.Nodes),
 		MinVersion: "v20.1.0",
+		// This is set while development is still happening on the workload and we
+		// fix (or bypass) minor schema change bugs that are discovered.
+		NonReleaseBlocker: true,
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runSchemaChangeRandomLoad(ctx, t, c, b.Ops, b.Concurrency)
 		},

--- a/pkg/cmd/roachtest/test.go
+++ b/pkg/cmd/roachtest/test.go
@@ -69,6 +69,11 @@ type testSpec struct {
 	// care about.
 	UseIOBarrier bool
 
+	// NonReleaseBlocker indicates that a test failure should not be tagged as a
+	// release blocker. Use this for tests that are not yet stable but should
+	// still be run regularly.
+	NonReleaseBlocker bool
+
 	// Run is the test function.
 	Run func(ctx context.Context, t *test, c *cluster)
 }

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -642,19 +642,24 @@ func (r *testRunner) runTest(
 					branch, cloud, output)
 				artifacts := fmt.Sprintf("/%s", t.Name())
 
+				// Issues posted from roachtest are identifiable as such and
+				// they are also release blockers (this label may be removed
+				// by a human upon closer investigation).
+				labels := []string{"O-roachtest"}
+				if !t.spec.NonReleaseBlocker {
+					labels = append(labels, "release-blocker")
+				}
+
 				req := issues.PostRequest{
 					// TODO(tbg): actually use this as a template.
 					TitleTemplate: fmt.Sprintf("roachtest: %s failed", t.Name()),
 					// TODO(tbg): make a template better adapted to roachtest.
-					BodyTemplate: issues.UnitTestFailureBody,
-					PackageName:  "roachtest",
-					TestName:     t.Name(),
-					Message:      msg,
-					Artifacts:    artifacts,
-					// Issues posted from roachtest are identifiable as such and
-					// they are also release blockers (this label may be removed
-					// by a human upon closer investigation).
-					ExtraLabels:     []string{"O-roachtest", "release-blocker"},
+					BodyTemplate:    issues.UnitTestFailureBody,
+					PackageName:     "roachtest",
+					TestName:        t.Name(),
+					Message:         msg,
+					Artifacts:       artifacts,
+					ExtraLabels:     labels,
 					ProjectColumnID: projectColumnID,
 				}
 				if err := issues.Post(


### PR DESCRIPTION
## roachtest: add flag to testSpec to disable release-blocker tag

This commit adds a field `NonReleaseBlocker` to `testSpec` which, when
set to true, causes the `release-blocker` tag to not be applied to the
GitHub issues for test failures. Its intended purpose is to allow
roachtests to be run nightly while they're not yet stable and we still
expect non-release-blocking failures frequently.

Release note: None

----

## roachtest: mark random schema change tests as non-release-blocking

We're still adding new features to the `schemachange` workload
frequently and finding minor bugs. We want this test to run nightly, but
it's not stable enough to warrant failures being marked as release
blockers.

Release note: None