### PR TITLE
sql: Add information_schema.character_sets table

### DIFF
--- a/pkg/sql/catalog/catconstants/constants.go
+++ b/pkg/sql/catalog/catconstants/constants.go
@@ -78,6 +78,7 @@ const (
 	InformationSchemaID
 	InformationSchemaAdministrableRoleAuthorizationsID
 	InformationSchemaApplicableRolesID
+	InformationSchemaCharacterSets
 	InformationSchemaCheckConstraints
 	InformationSchemaColumnPrivilegesID
 	InformationSchemaColumnsTableID

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -125,6 +125,7 @@ var informationSchema = virtualSchema{
 	tableDefs: map[descpb.ID]virtualSchemaDef{
 		catconstants.InformationSchemaAdministrableRoleAuthorizationsID: informationSchemaAdministrableRoleAuthorizations,
 		catconstants.InformationSchemaApplicableRolesID:                 informationSchemaApplicableRoles,
+		catconstants.InformationSchemaCharacterSets:                     informationSchemaCharacterSets,
 		catconstants.InformationSchemaCheckConstraints:                  informationSchemaCheckConstraints,
 		catconstants.InformationSchemaColumnPrivilegesID:                informationSchemaColumnPrivileges,
 		catconstants.InformationSchemaColumnsTableID:                    informationSchemaColumnsTable,
@@ -259,6 +260,28 @@ https://www.postgresql.org/docs/9.5/infoschema-applicable-roles.html`,
 		}
 
 		return nil
+	},
+}
+
+var informationSchemaCharacterSets = virtualSchemaTable{
+	comment: `character sets available in the current database
+` + docs.URL("information-schema.html#character_sets") + `
+https://www.postgresql.org/docs/9.5/infoschema-character-sets.html`,
+	schema: vtable.InformationSchemaCharacterSets,
+	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
+		return forEachDatabaseDesc(ctx, p, nil /* all databases */, true, /* requiresPrivileges */
+			func(db *dbdesc.Immutable) error {
+				return addRow(
+					tree.DNull,                    // character_set_catalog
+					tree.DNull,                    // character_set_schema
+					tree.NewDString("UTF8"),       // character_set_name: UTF8 is the only available encoding
+					tree.NewDString("UCS"),        // character_repertoire: UCS for UTF8 encoding
+					tree.NewDString("UTF8"),       // form_of_use: same as the database encoding
+					tree.NewDString(db.GetName()), // default_collate_catalog
+					tree.DNull,                    // default_collate_schema
+					tree.DNull,                    // default_collate_name
+				)
+			})
 	},
 }
 

--- a/pkg/sql/logictest/testdata/logic_test/grant_table
+++ b/pkg/sql/logictest/testdata/logic_test/grant_table
@@ -82,6 +82,7 @@ test           information_schema  NULL                               admin    A
 test           information_schema  NULL                               root     ALL
 test           information_schema  administrable_role_authorizations  public   SELECT
 test           information_schema  applicable_roles                   public   SELECT
+test           information_schema  character_sets                     public   SELECT
 test           information_schema  check_constraints                  public   SELECT
 test           information_schema  column_privileges                  public   SELECT
 test           information_schema  column_udt_usage                   public   SELECT

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -18,6 +18,7 @@ SHOW TABLES FROM information_schema
 ----
 information_schema  administrable_role_authorizations  table  NULL  NULL
 information_schema  applicable_roles                   table  NULL  NULL
+information_schema  character_sets                     table  NULL  NULL
 information_schema  check_constraints                  table  NULL  NULL
 information_schema  column_privileges                  table  NULL  NULL
 information_schema  column_udt_usage                   table  NULL  NULL
@@ -127,6 +128,7 @@ SHOW TABLES FROM test.information_schema
 ----
 information_schema  administrable_role_authorizations  table  NULL  NULL
 information_schema  applicable_roles                   table  NULL  NULL
+information_schema  character_sets                     table  NULL  NULL
 information_schema  check_constraints                  table  NULL  NULL
 information_schema  column_privileges                  table  NULL  NULL
 information_schema  column_udt_usage                   table  NULL  NULL
@@ -265,6 +267,7 @@ crdb_internal       tables
 crdb_internal       zones
 information_schema  administrable_role_authorizations
 information_schema  applicable_roles
+information_schema  character_sets
 information_schema  check_constraints
 information_schema  column_privileges
 information_schema  column_udt_usage
@@ -420,6 +423,7 @@ tables
 zones
 administrable_role_authorizations
 applicable_roles
+character_sets
 check_constraints
 column_privileges
 column_udt_usage
@@ -594,6 +598,7 @@ system         crdb_internal       tables                             SYSTEM VIE
 system         crdb_internal       zones                              SYSTEM VIEW  NO                  1
 system         information_schema  administrable_role_authorizations  SYSTEM VIEW  NO                  1
 system         information_schema  applicable_roles                   SYSTEM VIEW  NO                  1
+system         information_schema  character_sets                     SYSTEM VIEW  NO                  1
 system         information_schema  check_constraints                  SYSTEM VIEW  NO                  1
 system         information_schema  column_privileges                  SYSTEM VIEW  NO                  1
 system         information_schema  column_udt_usage                   SYSTEM VIEW  NO                  1
@@ -746,6 +751,7 @@ statement ok
 SET DATABASE = test
 
 ## information_schema.table_constraints
+## information_schema.character_sets
 ## information_schema.check_constraints
 ## information_schema.constraint_column_usage
 
@@ -894,6 +900,17 @@ system              public             630200280_19_7_not_null   system         
 system              public             primary                   system         public        web_sessions                     PRIMARY KEY      NO             NO
 system              public             630200280_5_1_not_null    system         public        zones                            CHECK            NO             NO
 system              public             primary                   system         public        zones                            PRIMARY KEY      NO             NO
+
+query TTTTTTTT colnames
+SELECT *
+FROM system.information_schema.character_sets
+----
+character_set_catalog  character_set_schema  character_set_name  character_repertoire  form_of_use  default_collate_catalog  default_collate_schema  default_collate_name
+NULL                   NULL                  UTF8                UCS                   UTF8         defaultdb                NULL                    NULL
+NULL                   NULL                  UTF8                UCS                   UTF8         postgres                 NULL                    NULL
+NULL                   NULL                  UTF8                UCS                   UTF8         system                   NULL                    NULL
+NULL                   NULL                  UTF8                UCS                   UTF8         test                     NULL                    NULL
+
 
 query TTTT colnames
 SELECT *
@@ -1704,6 +1721,7 @@ NULL     public   system         crdb_internal       tables                     
 NULL     public   system         crdb_internal       zones                              SELECT          NULL          YES
 NULL     public   system         information_schema  administrable_role_authorizations  SELECT          NULL          YES
 NULL     public   system         information_schema  applicable_roles                   SELECT          NULL          YES
+NULL     public   system         information_schema  character_sets                     SELECT          NULL          YES
 NULL     public   system         information_schema  check_constraints                  SELECT          NULL          YES
 NULL     public   system         information_schema  column_privileges                  SELECT          NULL          YES
 NULL     public   system         information_schema  column_udt_usage                   SELECT          NULL          YES
@@ -2084,6 +2102,7 @@ NULL     public   system         crdb_internal       tables                     
 NULL     public   system         crdb_internal       zones                              SELECT          NULL          YES
 NULL     public   system         information_schema  administrable_role_authorizations  SELECT          NULL          YES
 NULL     public   system         information_schema  applicable_roles                   SELECT          NULL          YES
+NULL     public   system         information_schema  character_sets                     SELECT          NULL          YES
 NULL     public   system         information_schema  check_constraints                  SELECT          NULL          YES
 NULL     public   system         information_schema  column_privileges                  SELECT          NULL          YES
 NULL     public   system         information_schema  column_udt_usage                   SELECT          NULL          YES

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -952,8 +952,8 @@ FROM pg_catalog.pg_depend
 ORDER BY objid
 ----
 classid     objid       objsubid  refclassid  refobjid   refobjsubid  deptype
-4294967217  2143281868  0         4294967219  450499961  0            n
-4294967217  4089604113  0         4294967219  450499960  0            n
+4294967216  2143281868  0         4294967218  450499961  0            n
+4294967216  4089604113  0         4294967218  450499960  0            n
 
 # All entries in pg_depend are dependency links from the pg_constraint system
 # table to the pg_class system table.
@@ -965,7 +965,7 @@ JOIN pg_class cla ON classid=cla.oid
 JOIN pg_class refcla ON refclassid=refcla.oid
 ----
 classid     refclassid  tablename      reftablename
-4294967217  4294967219  pg_constraint  pg_class
+4294967216  4294967218  pg_constraint  pg_class
 
 # All entries in pg_depend are foreign key constraints that reference an index
 # in pg_class.
@@ -1635,125 +1635,126 @@ SELECT objoid, classoid, objsubid, regexp_replace(description, e'\n.*', '') AS d
   FROM pg_catalog.pg_description
 ----
 objoid      classoid    objsubid  description
-4294967294  4294967219  0         backward inter-descriptor dependencies starting from tables accessible by current user in current database (KV scan)
-4294967292  4294967219  0         built-in functions (RAM/static)
-4294967291  4294967219  0         running queries visible by current user (cluster RPC; expensive!)
-4294967289  4294967219  0         running sessions visible to current user (cluster RPC; expensive!)
-4294967288  4294967219  0         cluster settings (RAM)
-4294967290  4294967219  0         running user transactions visible by the current user (cluster RPC; expensive!)
-4294967287  4294967219  0         CREATE and ALTER statements for all tables accessible by current user in current database (KV scan)
-4294967286  4294967219  0         CREATE statements for all user defined types accessible by the current user in current database (KV scan)
-4294967285  4294967219  0         databases accessible by the current user (KV scan)
-4294967284  4294967219  0         telemetry counters (RAM; local node only)
-4294967283  4294967219  0         forward inter-descriptor dependencies starting from tables accessible by current user in current database (KV scan)
-4294967281  4294967219  0         locally known gossiped health alerts (RAM; local node only)
-4294967280  4294967219  0         locally known gossiped node liveness (RAM; local node only)
-4294967279  4294967219  0         locally known edges in the gossip network (RAM; local node only)
-4294967282  4294967219  0         locally known gossiped node details (RAM; local node only)
-4294967278  4294967219  0         index columns for all indexes accessible by current user in current database (KV scan)
-4294967253  4294967219  0         virtual table to validate descriptors
-4294967277  4294967219  0         decoded job metadata from system.jobs (KV scan)
-4294967276  4294967219  0         node details across the entire cluster (cluster RPC; expensive!)
-4294967275  4294967219  0         store details and status (cluster RPC; expensive!)
-4294967274  4294967219  0         acquired table leases (RAM; local node only)
-4294967293  4294967219  0         detailed identification strings (RAM, local node only)
-4294967270  4294967219  0         current values for metrics (RAM; local node only)
-4294967273  4294967219  0         running queries visible by current user (RAM; local node only)
-4294967265  4294967219  0         server parameters, useful to construct connection URLs (RAM, local node only)
-4294967271  4294967219  0         running sessions visible by current user (RAM; local node only)
-4294967261  4294967219  0         statement statistics (in-memory, not durable; local node only). This table is wiped periodically (by default, at least every two hours)
-4294967256  4294967219  0         finer-grained transaction statistics (in-memory, not durable; local node only). This table is wiped periodically (by default, at least every two hours)
-4294967272  4294967219  0         running user transactions visible by the current user (RAM; local node only)
-4294967255  4294967219  0         per-application transaction statistics (in-memory, not durable; local node only). This table is wiped periodically (by default, at least every two hours)
-4294967269  4294967219  0         defined partitions for all tables/indexes accessible by the current user in the current database (KV scan)
-4294967268  4294967219  0         comments for predefined virtual tables (RAM/static)
-4294967267  4294967219  0         range metadata without leaseholder details (KV join; expensive!)
-4294967264  4294967219  0         ongoing schema changes, across all descriptors accessible by current user (KV scan; expensive!)
-4294967263  4294967219  0         session trace accumulated so far (RAM)
-4294967262  4294967219  0         session variables (RAM)
-4294967260  4294967219  0         details for all columns accessible by current user in current database (KV scan)
-4294967259  4294967219  0         indexes accessible by current user in current database (KV scan)
-4294967257  4294967219  0         the latest stats for all tables accessible by current user in current database (KV scan)
-4294967258  4294967219  0         table descriptors accessible by current user, including non-public and virtual (KV scan; expensive!)
-4294967254  4294967219  0         decoded zone configurations from system.zones (KV scan)
-4294967251  4294967219  0         roles for which the current user has admin option
-4294967250  4294967219  0         roles available to the current user
-4294967249  4294967219  0         check constraints
-4294967248  4294967219  0         column privilege grants (incomplete)
-4294967246  4294967219  0         columns with user defined types
-4294967247  4294967219  0         table and view columns (incomplete)
-4294967245  4294967219  0         columns usage by constraints
-4294967244  4294967219  0         roles for the current user
-4294967243  4294967219  0         column usage by indexes and key constraints
-4294967242  4294967219  0         built-in function parameters (empty - introspection not yet supported)
-4294967241  4294967219  0         foreign key constraints
-4294967240  4294967219  0         privileges granted on table or views (incomplete; see also information_schema.table_privileges; may contain excess users or roles)
-4294967239  4294967219  0         built-in functions (empty - introspection not yet supported)
-4294967237  4294967219  0         schema privileges (incomplete; may contain excess users or roles)
-4294967238  4294967219  0         database schemas (may contain schemata without permission)
-4294967236  4294967219  0         sequences
-4294967235  4294967219  0         index metadata and statistics (incomplete)
-4294967234  4294967219  0         table constraints
-4294967233  4294967219  0         privileges granted on table or views (incomplete; may contain excess users or roles)
-4294967232  4294967219  0         tables and views
-4294967231  4294967219  0         type privileges (incomplete; may contain excess users or roles)
-4294967229  4294967219  0         grantable privileges (incomplete)
-4294967230  4294967219  0         views (incomplete)
-4294967227  4294967219  0         aggregated built-in functions (incomplete)
-4294967226  4294967219  0         index access methods (incomplete)
-4294967225  4294967219  0         column default values
-4294967224  4294967219  0         table columns (incomplete - see also information_schema.columns)
-4294967222  4294967219  0         role membership
-4294967223  4294967219  0         authorization identifiers - differs from postgres as we do not display passwords,
-4294967221  4294967219  0         available extensions
-4294967220  4294967219  0         casts (empty - needs filling out)
-4294967219  4294967219  0         tables and relation-like objects (incomplete - see also information_schema.tables/sequences/views)
-4294967218  4294967219  0         available collations (incomplete)
-4294967217  4294967219  0         table constraints (incomplete - see also information_schema.table_constraints)
-4294967216  4294967219  0         encoding conversions (empty - unimplemented)
-4294967215  4294967219  0         available databases (incomplete)
-4294967214  4294967219  0         default ACLs (empty - unimplemented)
-4294967213  4294967219  0         dependency relationships (incomplete)
-4294967212  4294967219  0         object comments
-4294967210  4294967219  0         enum types and labels (empty - feature does not exist)
-4294967209  4294967219  0         event triggers (empty - feature does not exist)
-4294967208  4294967219  0         installed extensions (empty - feature does not exist)
-4294967207  4294967219  0         foreign data wrappers (empty - feature does not exist)
-4294967206  4294967219  0         foreign servers (empty - feature does not exist)
-4294967205  4294967219  0         foreign tables (empty  - feature does not exist)
-4294967204  4294967219  0         indexes (incomplete)
-4294967203  4294967219  0         index creation statements
-4294967202  4294967219  0         table inheritance hierarchy (empty - feature does not exist)
-4294967201  4294967219  0         available languages (empty - feature does not exist)
-4294967200  4294967219  0         locks held by active processes (empty - feature does not exist)
-4294967199  4294967219  0         available materialized views (empty - feature does not exist)
-4294967198  4294967219  0         available namespaces (incomplete; namespaces and databases are congruent in CockroachDB)
-4294967197  4294967219  0         opclass (empty - Operator classes not supported yet)
-4294967196  4294967219  0         operators (incomplete)
-4294967195  4294967219  0         prepared statements
-4294967194  4294967219  0         prepared transactions (empty - feature does not exist)
-4294967193  4294967219  0         built-in functions (incomplete)
-4294967192  4294967219  0         range types (empty - feature does not exist)
-4294967191  4294967219  0         rewrite rules (empty - feature does not exist)
-4294967190  4294967219  0         database roles
-4294967177  4294967219  0         security labels (empty - feature does not exist)
-4294967189  4294967219  0         security labels (empty)
-4294967188  4294967219  0         sequences (see also information_schema.sequences)
-4294967187  4294967219  0         session variables (incomplete)
-4294967186  4294967219  0         shared dependencies (empty - not implemented)
-4294967211  4294967219  0         shared object comments
-4294967176  4294967219  0         shared security labels (empty - feature not supported)
-4294967178  4294967219  0         backend access statistics (empty - monitoring works differently in CockroachDB)
-4294967183  4294967219  0         tables summary (see also information_schema.tables, pg_catalog.pg_class)
-4294967182  4294967219  0         available tablespaces (incomplete; concept inapplicable to CockroachDB)
-4294967181  4294967219  0         triggers (empty - feature does not exist)
-4294967180  4294967219  0         scalar types (incomplete)
-4294967185  4294967219  0         database users
-4294967184  4294967219  0         local to remote user mapping (empty - feature does not exist)
-4294967179  4294967219  0         view definitions (incomplete - see also information_schema.views)
-4294967174  4294967219  0         Shows all defined geography columns. Matches PostGIS' geography_columns functionality.
-4294967173  4294967219  0         Shows all defined geometry columns. Matches PostGIS' geometry_columns functionality.
-4294967172  4294967219  0         Shows all defined Spatial Reference Identifiers (SRIDs). Matches PostGIS' spatial_ref_sys table.
+4294967294  4294967218  0         backward inter-descriptor dependencies starting from tables accessible by current user in current database (KV scan)
+4294967292  4294967218  0         built-in functions (RAM/static)
+4294967291  4294967218  0         running queries visible by current user (cluster RPC; expensive!)
+4294967289  4294967218  0         running sessions visible to current user (cluster RPC; expensive!)
+4294967288  4294967218  0         cluster settings (RAM)
+4294967290  4294967218  0         running user transactions visible by the current user (cluster RPC; expensive!)
+4294967287  4294967218  0         CREATE and ALTER statements for all tables accessible by current user in current database (KV scan)
+4294967286  4294967218  0         CREATE statements for all user defined types accessible by the current user in current database (KV scan)
+4294967285  4294967218  0         databases accessible by the current user (KV scan)
+4294967284  4294967218  0         telemetry counters (RAM; local node only)
+4294967283  4294967218  0         forward inter-descriptor dependencies starting from tables accessible by current user in current database (KV scan)
+4294967281  4294967218  0         locally known gossiped health alerts (RAM; local node only)
+4294967280  4294967218  0         locally known gossiped node liveness (RAM; local node only)
+4294967279  4294967218  0         locally known edges in the gossip network (RAM; local node only)
+4294967282  4294967218  0         locally known gossiped node details (RAM; local node only)
+4294967278  4294967218  0         index columns for all indexes accessible by current user in current database (KV scan)
+4294967253  4294967218  0         virtual table to validate descriptors
+4294967277  4294967218  0         decoded job metadata from system.jobs (KV scan)
+4294967276  4294967218  0         node details across the entire cluster (cluster RPC; expensive!)
+4294967275  4294967218  0         store details and status (cluster RPC; expensive!)
+4294967274  4294967218  0         acquired table leases (RAM; local node only)
+4294967293  4294967218  0         detailed identification strings (RAM, local node only)
+4294967270  4294967218  0         current values for metrics (RAM; local node only)
+4294967273  4294967218  0         running queries visible by current user (RAM; local node only)
+4294967265  4294967218  0         server parameters, useful to construct connection URLs (RAM, local node only)
+4294967271  4294967218  0         running sessions visible by current user (RAM; local node only)
+4294967261  4294967218  0         statement statistics (in-memory, not durable; local node only). This table is wiped periodically (by default, at least every two hours)
+4294967256  4294967218  0         finer-grained transaction statistics (in-memory, not durable; local node only). This table is wiped periodically (by default, at least every two hours)
+4294967272  4294967218  0         running user transactions visible by the current user (RAM; local node only)
+4294967255  4294967218  0         per-application transaction statistics (in-memory, not durable; local node only). This table is wiped periodically (by default, at least every two hours)
+4294967269  4294967218  0         defined partitions for all tables/indexes accessible by the current user in the current database (KV scan)
+4294967268  4294967218  0         comments for predefined virtual tables (RAM/static)
+4294967267  4294967218  0         range metadata without leaseholder details (KV join; expensive!)
+4294967264  4294967218  0         ongoing schema changes, across all descriptors accessible by current user (KV scan; expensive!)
+4294967263  4294967218  0         session trace accumulated so far (RAM)
+4294967262  4294967218  0         session variables (RAM)
+4294967260  4294967218  0         details for all columns accessible by current user in current database (KV scan)
+4294967259  4294967218  0         indexes accessible by current user in current database (KV scan)
+4294967257  4294967218  0         the latest stats for all tables accessible by current user in current database (KV scan)
+4294967258  4294967218  0         table descriptors accessible by current user, including non-public and virtual (KV scan; expensive!)
+4294967254  4294967218  0         decoded zone configurations from system.zones (KV scan)
+4294967251  4294967218  0         roles for which the current user has admin option
+4294967250  4294967218  0         roles available to the current user
+4294967249  4294967218  0         character sets available in the current database
+4294967248  4294967218  0         check constraints
+4294967247  4294967218  0         column privilege grants (incomplete)
+4294967245  4294967218  0         columns with user defined types
+4294967246  4294967218  0         table and view columns (incomplete)
+4294967244  4294967218  0         columns usage by constraints
+4294967243  4294967218  0         roles for the current user
+4294967242  4294967218  0         column usage by indexes and key constraints
+4294967241  4294967218  0         built-in function parameters (empty - introspection not yet supported)
+4294967240  4294967218  0         foreign key constraints
+4294967239  4294967218  0         privileges granted on table or views (incomplete; see also information_schema.table_privileges; may contain excess users or roles)
+4294967238  4294967218  0         built-in functions (empty - introspection not yet supported)
+4294967236  4294967218  0         schema privileges (incomplete; may contain excess users or roles)
+4294967237  4294967218  0         database schemas (may contain schemata without permission)
+4294967235  4294967218  0         sequences
+4294967234  4294967218  0         index metadata and statistics (incomplete)
+4294967233  4294967218  0         table constraints
+4294967232  4294967218  0         privileges granted on table or views (incomplete; may contain excess users or roles)
+4294967231  4294967218  0         tables and views
+4294967230  4294967218  0         type privileges (incomplete; may contain excess users or roles)
+4294967228  4294967218  0         grantable privileges (incomplete)
+4294967229  4294967218  0         views (incomplete)
+4294967226  4294967218  0         aggregated built-in functions (incomplete)
+4294967225  4294967218  0         index access methods (incomplete)
+4294967224  4294967218  0         column default values
+4294967223  4294967218  0         table columns (incomplete - see also information_schema.columns)
+4294967221  4294967218  0         role membership
+4294967222  4294967218  0         authorization identifiers - differs from postgres as we do not display passwords,
+4294967220  4294967218  0         available extensions
+4294967219  4294967218  0         casts (empty - needs filling out)
+4294967218  4294967218  0         tables and relation-like objects (incomplete - see also information_schema.tables/sequences/views)
+4294967217  4294967218  0         available collations (incomplete)
+4294967216  4294967218  0         table constraints (incomplete - see also information_schema.table_constraints)
+4294967215  4294967218  0         encoding conversions (empty - unimplemented)
+4294967214  4294967218  0         available databases (incomplete)
+4294967213  4294967218  0         default ACLs (empty - unimplemented)
+4294967212  4294967218  0         dependency relationships (incomplete)
+4294967211  4294967218  0         object comments
+4294967209  4294967218  0         enum types and labels (empty - feature does not exist)
+4294967208  4294967218  0         event triggers (empty - feature does not exist)
+4294967207  4294967218  0         installed extensions (empty - feature does not exist)
+4294967206  4294967218  0         foreign data wrappers (empty - feature does not exist)
+4294967205  4294967218  0         foreign servers (empty - feature does not exist)
+4294967204  4294967218  0         foreign tables (empty  - feature does not exist)
+4294967203  4294967218  0         indexes (incomplete)
+4294967202  4294967218  0         index creation statements
+4294967201  4294967218  0         table inheritance hierarchy (empty - feature does not exist)
+4294967200  4294967218  0         available languages (empty - feature does not exist)
+4294967199  4294967218  0         locks held by active processes (empty - feature does not exist)
+4294967198  4294967218  0         available materialized views (empty - feature does not exist)
+4294967197  4294967218  0         available namespaces (incomplete; namespaces and databases are congruent in CockroachDB)
+4294967196  4294967218  0         opclass (empty - Operator classes not supported yet)
+4294967195  4294967218  0         operators (incomplete)
+4294967194  4294967218  0         prepared statements
+4294967193  4294967218  0         prepared transactions (empty - feature does not exist)
+4294967192  4294967218  0         built-in functions (incomplete)
+4294967191  4294967218  0         range types (empty - feature does not exist)
+4294967190  4294967218  0         rewrite rules (empty - feature does not exist)
+4294967189  4294967218  0         database roles
+4294967176  4294967218  0         security labels (empty - feature does not exist)
+4294967188  4294967218  0         security labels (empty)
+4294967187  4294967218  0         sequences (see also information_schema.sequences)
+4294967186  4294967218  0         session variables (incomplete)
+4294967185  4294967218  0         shared dependencies (empty - not implemented)
+4294967210  4294967218  0         shared object comments
+4294967175  4294967218  0         shared security labels (empty - feature not supported)
+4294967177  4294967218  0         backend access statistics (empty - monitoring works differently in CockroachDB)
+4294967182  4294967218  0         tables summary (see also information_schema.tables, pg_catalog.pg_class)
+4294967181  4294967218  0         available tablespaces (incomplete; concept inapplicable to CockroachDB)
+4294967180  4294967218  0         triggers (empty - feature does not exist)
+4294967179  4294967218  0         scalar types (incomplete)
+4294967184  4294967218  0         database users
+4294967183  4294967218  0         local to remote user mapping (empty - feature does not exist)
+4294967178  4294967218  0         view definitions (incomplete - see also information_schema.views)
+4294967173  4294967218  0         Shows all defined geography columns. Matches PostGIS' geography_columns functionality.
+4294967172  4294967218  0         Shows all defined geometry columns. Matches PostGIS' geometry_columns functionality.
+4294967171  4294967218  0         Shows all defined Spatial Reference Identifiers (SRIDs). Matches PostGIS' spatial_ref_sys table.
 
 ## pg_catalog.pg_shdescription
 

--- a/pkg/sql/logictest/testdata/logic_test/table
+++ b/pkg/sql/logictest/testdata/logic_test/table
@@ -576,6 +576,7 @@ tables                             NULL
 zones                              NULL
 administrable_role_authorizations  NULL
 applicable_roles                   NULL
+character_sets                     NULL
 check_constraints                  NULL
 column_privileges                  NULL
 column_udt_usage                   NULL

--- a/pkg/sql/vtable/information_schema.go
+++ b/pkg/sql/vtable/information_schema.go
@@ -101,6 +101,22 @@ CREATE TABLE information_schema.applicable_roles (
 	IS_GRANTABLE STRING NOT NULL
 )`
 
+// InformationSchemaCharacterSets describes the schema of the
+// information_schema.character_sets table.
+// Postgres: https://www.postgresql.org/docs/9.5/infoschema-character-sets.html
+// MySQL:	 https://dev.mysql.com/doc/refman/5.7/en/information-schema-character-sets-table.html
+const InformationSchemaCharacterSets = `
+CREATE TABLE information_schema.character_sets (
+    CHARACTER_SET_CATALOG   STRING,
+    CHARACTER_SET_SCHEMA    STRING,
+    CHARACTER_SET_NAME      STRING NOT NULL,
+    CHARACTER_REPERTOIRE    STRING NOT NULL,
+    FORM_OF_USE             STRING NOT NULL,
+    DEFAULT_COLLATE_CATALOG STRING,
+    DEFAULT_COLLATE_SCHEMA  STRING,
+    DEFAULT_COLLATE_NAME    STRING
+)`
+
 // InformationSchemaCheckConstraints describes the schema of the
 // information_schema.check_constraints table.
 // Postgres: https://www.postgresql.org/docs/9.6/static/infoschema-check-constraints.html


### PR DESCRIPTION
The `character_sets` table identifies the character sets available in the current database. Since CockroachDB supports only UTF-8 encoding at the moment ~and the collation is not stored per table, but column basis, every row in this table will look the same~, the encoding name in each row will be the same.
Release note (sql change): Added character_sets table to the information_schema.

Relates to: #8675

PostgreSQL table for reference: https://www.postgresql.org/docs/9.5/infoschema-character-sets.html