### PR TITLE
sql/catalog/lease: add more details to assertion error

### DIFF
--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -414,7 +414,9 @@ func (s storage) getForExpiration(
 			return err
 		}
 		if prevTimestamp.LessEq(desc.GetModificationTime()) {
-			return errors.AssertionFailedf("unable to read descriptor (%d, %s)", id, expiration)
+			return errors.AssertionFailedf("unable to read descriptor"+
+				" (%d, %s) found descriptor with modificationTime %s",
+				id, expiration, desc.GetModificationTime())
 		}
 		// Create a descriptorVersionState with the descriptor and without a lease.
 		descVersionState = &descriptorVersionState{


### PR DESCRIPTION
In #56958 we see an assertion failure because the modification time is less
than or equal to the timestamp we're looking for. It feels like this has an
off by one, that the descriptor should have a modification time that is less
the expiration, not less than the prev timestamp. Regardless, it'd be nice to
know whether this was the equal case or something different.

Release note: None