### PR TITLE
server: Add sentry tag for encryption-at-rest

### DIFF
--- a/pkg/util/log/crash_reporting_packet_test.go
+++ b/pkg/util/log/crash_reporting_packet_test.go
@@ -128,7 +128,7 @@ func TestCrashReportingPacket(t *testing.T) {
 		}(), []extraPair{
 			{"1: details", "panic: " + panicPre},
 		}},
-		{regexp.MustCompile(`^[a-z0-9]{8}-1$`), 11, func() string {
+		{regexp.MustCompile(`^[a-z0-9]{8}-1$`), 12, func() string {
 			message := prefix
 			// gccgo stack traces are different in the presence of function literals.
 			if runtime.Compiler == "gccgo" {


### PR DESCRIPTION
Sometimes, storage-level issues can be specific to the use of
encryption-at-rest. This change helps us isolate these by setting
a sentry event tag on whether encryption-at-rest is enabled or not.

Release note: None.