### PR TITLE
dev: introduce a general purpose dev-tool for crdb engineers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1690,6 +1690,7 @@ bins = \
   bin/github-pull-request-make \
   bin/gossipsim \
   bin/langgen \
+  bin/dev \
   bin/protoc-gen-gogoroach \
   bin/publish-artifacts \
   bin/publish-provisional-artifacts \

--- a/pkg/cmd/dev/BUILD.bazel
+++ b/pkg/cmd/dev/BUILD.bazel
@@ -1,0 +1,25 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "dev_lib",
+    srcs = [
+        "bench.go",
+        "build.go",
+        "generate.go",
+        "lint.go",
+        "main.go",
+        "test.go",
+    ],
+    importpath = "github.com/cockroachdb/cockroach/pkg/cmd/dev",
+    visibility = ["//visibility:private"],
+    deps = [
+        "@com_github_cockroachdb_errors//:errors",
+        "@com_github_spf13_cobra//:cobra",
+    ],
+)
+
+go_binary(
+    name = "dev",
+    embed = [":dev_lib"],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/cmd/dev/BUILD.bazel
+++ b/pkg/cmd/dev/BUILD.bazel
@@ -9,11 +9,14 @@ go_library(
         "lint.go",
         "main.go",
         "test.go",
+        "util.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/dev",
     visibility = ["//visibility:private"],
     deps = [
+        "//pkg/util/log",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
         "@com_github_spf13_cobra//:cobra",
     ],
 )

--- a/pkg/cmd/dev/bench.go
+++ b/pkg/cmd/dev/bench.go
@@ -1,0 +1,32 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import (
+	"github.com/cockroachdb/errors"
+	"github.com/spf13/cobra"
+)
+
+// benchCmd runs the specified cockroachdb benchmarks.
+var benchCmd = &cobra.Command{
+	Use:   "bench",
+	Short: `Run the specified benchmarks`,
+	Long:  `Run the specified benchmarks.`,
+	Example: `
+	dev bench --pkg=sql/parser --filter=BenchmarkParse`,
+	Args: cobra.NoArgs,
+	RunE: runBench,
+}
+
+func runBench(cmd *cobra.Command, args []string) error {
+	// TODO(irfansharif): Flesh out the example usage patterns.
+	return errors.New("unimplemented")
+}

--- a/pkg/cmd/dev/build.go
+++ b/pkg/cmd/dev/build.go
@@ -17,7 +17,7 @@ import (
 
 // buildCmd builds the specified binaries.
 var buildCmd = &cobra.Command{
-	Use:   "build",
+	Use:   "build <binary>",
 	Short: "Build the specified binaries",
 	Long:  "Build the specified binaries.",
 	Example: `

--- a/pkg/cmd/dev/build.go
+++ b/pkg/cmd/dev/build.go
@@ -11,6 +11,9 @@
 package main
 
 import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 	"github.com/spf13/cobra"
 )
@@ -20,15 +23,56 @@ var buildCmd = &cobra.Command{
 	Use:   "build <binary>",
 	Short: "Build the specified binaries",
 	Long:  "Build the specified binaries.",
+	// TODO(irfansharif): Flesh out the example usage patterns.
 	Example: `
 	dev build cockroach --tags=deadlock
 	dev build cockroach-{short,oss}
 	dev build {opt,exec}gen`,
-	Args: cobra.NoArgs,
+	Args: cobra.MinimumNArgs(0),
 	RunE: runBuild,
 }
 
-func runBuild(cmd *cobra.Command, args []string) error {
-	// TODO(irfansharif): Flesh out the example usage patterns.
-	return errors.New("unimplemented")
+var buildTargetMapping = map[string]string{
+	"cockroach":        "@cockroach//pkg/cmd/cockroach",
+	"cockroach-oss":    "@cockroach//pkg/cmd/cockroach-oss",
+	"cockroach-short":  "@cockroach//pkg/cmd/cockroach-short",
+	"dev":              "@cockroach//pkg/cmd/dev",
+	"docgen":           "@cockroach//pkg/cmd/docgen",
+	"execgen":          "@cockroach//pkg/sql/colexec/execgen/cmd/execgen",
+	"optgen":           "@cockroach//pkg/sql/opt/optgen/cmd/optgen",
+	"optfmt":           "@cockroach//pkg/sql/opt/optgen/cmd/optfmt",
+	"langgen":          "@cockroach//pkg/sql/opt/optgen/cmd/langgen",
+	"roachprod":        "@cockroach//pkg/cmd/roachprod",
+	"roachprod-stress": "@cockroach//pkg/cmd/roachprod-stress",
+	"workload":         "@cockroach//pkg/cmd/workload",
+	"roachtest":        "@cockroach//pkg/cmd/roachtest",
+}
+
+func runBuild(cmd *cobra.Command, targets []string) error {
+	ctx := context.Background()
+
+	if len(targets) == 0 {
+		// Default to building the cockroach binary.
+		targets = append(targets, "cockroach")
+	}
+
+	// TODO(irfansharif): Add grouping shorthands like "all" or "bins", etc.
+	// TODO(irfansharif): Extract built binaries out of the bazel sandbox.
+	// TODO(irfansharif): Make sure all the relevant binary targets are defined
+	// above, and in usage docs.
+
+	var args []string
+	args = append(args, "build")
+	args = append(args, "--color=yes")
+
+	for _, target := range targets {
+		buildTarget, ok := buildTargetMapping[target]
+		if !ok {
+			log.Errorf(ctx, "unrecognized target: %s", target)
+			return errors.Newf("unrecognized target")
+		}
+
+		args = append(args, buildTarget)
+	}
+	return execute(ctx, "bazel", args...)
 }

--- a/pkg/cmd/dev/build.go
+++ b/pkg/cmd/dev/build.go
@@ -1,0 +1,34 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import (
+	"github.com/cockroachdb/errors"
+	"github.com/spf13/cobra"
+)
+
+// buildCmd builds the specified binaries.
+var buildCmd = &cobra.Command{
+	Use:   "build",
+	Short: "Build the specified binaries",
+	Long:  "Build the specified binaries.",
+	Example: `
+	dev build cockroach --tags=deadlock
+	dev build cockroach-{short,oss}
+	dev build {opt,exec}gen`,
+	Args: cobra.NoArgs,
+	RunE: runBuild,
+}
+
+func runBuild(cmd *cobra.Command, args []string) error {
+	// TODO(irfansharif): Flesh out the example usage patterns.
+	return errors.New("unimplemented")
+}

--- a/pkg/cmd/dev/generate.go
+++ b/pkg/cmd/dev/generate.go
@@ -1,0 +1,36 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import (
+	"github.com/cockroachdb/errors"
+	"github.com/spf13/cobra"
+)
+
+// generateCmd generates the specified files.
+var generateCmd = &cobra.Command{
+	Use:     "generate",
+	Aliases: []string{"gen"},
+	Short:   `Generate the specified files`,
+	Long:    `Generate the specified files.`,
+	Example: `
+	dev gen bazel
+	dev generate protobuf
+	dev generate {exec,opt}gen
+`,
+	Args: cobra.NoArgs,
+	RunE: runGenerate,
+}
+
+func runGenerate(cmd *cobra.Command, args []string) error {
+	// TODO(irfansharif): Flesh out the example usage patterns.
+	return errors.New("unimplemented")
+}

--- a/pkg/cmd/dev/generate.go
+++ b/pkg/cmd/dev/generate.go
@@ -13,6 +13,7 @@ package main
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 	"github.com/spf13/cobra"
 )
@@ -29,6 +30,9 @@ var generateCmd = &cobra.Command{
 	dev generate protobuf
 	dev generate {exec,opt}gen`,
 	Args: cobra.MinimumNArgs(0),
+	// TODO(irfansharif): Errors but default just eaten up. Let's wrap these
+	// invocations in something that prints out the appropriate error log
+	// (especially considering we've SilenceErrors-ed things away).
 	RunE: runGenerate,
 }
 
@@ -58,7 +62,8 @@ func runGenerate(cmd *cobra.Command, targets []string) error {
 		case "bazel":
 			gen = generateBazel
 		default:
-			return errors.Newf("unrecognized target: %s", target)
+			log.Errorf(ctx, "unrecognized target: %s", target)
+			return errors.Newf("unrecognized target")
 		}
 
 		if err := gen(ctx, cmd); err != nil {

--- a/pkg/cmd/dev/generate.go
+++ b/pkg/cmd/dev/generate.go
@@ -17,7 +17,7 @@ import (
 
 // generateCmd generates the specified files.
 var generateCmd = &cobra.Command{
-	Use:     "generate",
+	Use:     "generate <target>",
 	Aliases: []string{"gen"},
 	Short:   `Generate the specified files`,
 	Long:    `Generate the specified files.`,

--- a/pkg/cmd/dev/lint.go
+++ b/pkg/cmd/dev/lint.go
@@ -1,0 +1,32 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import (
+	"github.com/cockroachdb/errors"
+	"github.com/spf13/cobra"
+)
+
+// lintCmd runs the specified linters.
+var lintCmd = &cobra.Command{
+	Use:   "lint [pkg] (flags)",
+	Short: `Run the specified linters`,
+	Long:  `Run the specified linters.`,
+	Example: `
+	dev lint --filter=TestLowercaseFunctionNames --short --timeout=1m`,
+	Args: cobra.NoArgs,
+	RunE: runLint,
+}
+
+func runLint(cmd *cobra.Command, args []string) error {
+	// TODO(irfansharif): Flesh out the example usage patterns.
+	return errors.New("unimplemented")
+}

--- a/pkg/cmd/dev/lint.go
+++ b/pkg/cmd/dev/lint.go
@@ -17,7 +17,7 @@ import (
 
 // lintCmd runs the specified linters.
 var lintCmd = &cobra.Command{
-	Use:   "lint [pkg] (flags)",
+	Use:   "lint",
 	Short: `Run the specified linters`,
 	Long:  `Run the specified linters.`,
 	Example: `

--- a/pkg/cmd/dev/main.go
+++ b/pkg/cmd/dev/main.go
@@ -1,0 +1,59 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var devCmd = &cobra.Command{
+	Use:   "dev [command] (flags)",
+	Short: "Dev is the general-purpose dev tool for folks working on cockroachdb/cockroach.",
+	Long: `
+Dev is the general-purpose dev tool for folks working cockroachdb/cockroach. It
+lets engineers do a few things:
+
+- build various binaries (cockroach, optgen, ...)
+- run arbitrary tests (unit tests, logic tests, ...)
+- run tests under arbitrary configurations (under stress, using race builds, ...)
+- generate code (bazel files, protobufs, ...)
+
+...and much more.
+
+(PS: Almost none of the above is implemented yet, haha.)
+`,
+}
+
+func init() {
+	devCmd.AddCommand(
+		benchCmd,
+		buildCmd,
+		generateCmd,
+		lintCmd,
+		testCmd,
+	)
+
+	// Hide the `help` sub-command.
+	devCmd.SetHelpCommand(&cobra.Command{
+		Use:    "noop-help",
+		Hidden: true,
+	})
+}
+
+func main() {
+	if err := devCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}

--- a/pkg/cmd/dev/test.go
+++ b/pkg/cmd/dev/test.go
@@ -1,0 +1,35 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import (
+	"github.com/cockroachdb/errors"
+	"github.com/spf13/cobra"
+)
+
+// testCmd runs the specified cockroachdb tests.
+var testCmd = &cobra.Command{
+	Use:   "test [pkg] (flags)",
+	Short: `Run the specified tests`,
+	Long:  `Run the specified tests.`,
+	Example: `
+	dev test kv/kvserver --filter=TestReplicaGC* -v -show-logs --timeout=1m
+	dev test --stress --race ...
+	dev test --logic --files=prepare|fk --subtests=20042 --config=local
+	dev test --fuzz sql/sem/tree --filter=Decimal`,
+	Args: cobra.NoArgs,
+	RunE: runTest,
+}
+
+func runTest(cmd *cobra.Command, args []string) error {
+	// TODO(irfansharif): Flesh out the example usage patterns.
+	return errors.New("unimplemented")
+}

--- a/pkg/cmd/dev/test.go
+++ b/pkg/cmd/dev/test.go
@@ -11,25 +11,179 @@
 package main
 
 import (
+	"bufio"
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 	"github.com/spf13/cobra"
 )
 
 // testCmd runs the specified cockroachdb tests.
 var testCmd = &cobra.Command{
-	Use:   "test [pkg] (flags)",
+	Use:   "test [pkg..]",
 	Short: `Run the specified tests`,
 	Long:  `Run the specified tests.`,
 	Example: `
-	dev test kv/kvserver --filter=TestReplicaGC* -v -show-logs --timeout=1m
+	dev test
+	dev test pkg/kv/kvserver --filter=TestReplicaGC* -v -show-logs --timeout=1m
 	dev test --stress --race ...
 	dev test --logic --files=prepare|fk --subtests=20042 --config=local
 	dev test --fuzz sql/sem/tree --filter=Decimal`,
-	Args: cobra.NoArgs,
-	RunE: runTest,
+	Args: cobra.MinimumNArgs(0),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := context.Background()
+		return runTest(ctx, cmd, args)
+	},
 }
 
-func runTest(cmd *cobra.Command, args []string) error {
-	// TODO(irfansharif): Flesh out the example usage patterns.
-	return errors.New("unimplemented")
+var (
+	// General testing flags.
+	filterFlag      = "filter"
+	timeoutFlag     = "timeout"
+	showLogsFlag    = "show-logs"
+	vFlag           = "verbose"
+	stressFlag      = "stress"
+	raceFlag        = "race"
+	ignoreCacheFlag = "ignore-cache"
+
+	// Fuzz testing related flag.
+	fuzzFlag = "fuzz"
+
+	// Logic test related flags.
+	logicFlag    = "logic"
+	filesFlag    = "files"
+	subtestsFlag = "subtests"
+	configFlag   = "config"
+)
+
+func init() {
+	// Attach flags for the test sub-command.
+	testCmd.Flags().StringP(filterFlag, "f", "", "run unit tests matching this regex")
+	testCmd.Flags().Duration(timeoutFlag, 20*time.Minute, "timeout for test")
+	testCmd.Flags().Bool(showLogsFlag, false, "print logs instead of saving them in files")
+	testCmd.Flags().BoolP(vFlag, "v", false, "enable logging during test runs")
+	testCmd.Flags().Bool(stressFlag, false, "run tests under stress")
+	testCmd.Flags().Bool(raceFlag, false, "run tests using race builds")
+	testCmd.Flags().Bool(ignoreCacheFlag, false, "ignore cached test runs")
+
+	// Fuzz testing related flag.
+	testCmd.Flags().Bool(fuzzFlag, false, "run fuzz tests")
+
+	// Logic test related flags.
+	testCmd.Flags().Bool(logicFlag, false, "run logic tests")
+	testCmd.Flags().String(filesFlag, "", "run logic tests for files matching this regex")
+	testCmd.Flags().String(subtestsFlag, "", "run logic test subtests matching this regex")
+	testCmd.Flags().String(configFlag, "", "run logic tests under the specified config")
+}
+
+func runTest(ctx context.Context, cmd *cobra.Command, pkgs []string) error {
+	if logicTest := mustGetFlagBool(cmd, logicFlag); logicTest {
+		return runLogicTest(ctx, cmd)
+	}
+
+	if fuzzTest := mustGetFlagBool(cmd, fuzzFlag); fuzzTest {
+		return runFuzzTest(ctx, cmd, pkgs)
+	}
+
+	return runUnitTest(ctx, cmd, pkgs)
+}
+
+func runUnitTest(ctx context.Context, cmd *cobra.Command, pkgs []string) error {
+	stress := mustGetFlagBool(cmd, stressFlag)
+	race := mustGetFlagBool(cmd, raceFlag)
+	filter := mustGetFlagString(cmd, filterFlag)
+	timeout := mustGetFlagDuration(cmd, timeoutFlag)
+	ignoreCache := mustGetFlagBool(cmd, ignoreCacheFlag)
+	verbose := mustGetFlagBool(cmd, vFlag)
+	showLogs := mustGetFlagBool(cmd, showLogsFlag)
+
+	if showLogs {
+		return errors.New("-show-logs unimplemented")
+	}
+
+	log.Infof(ctx, "unit test args: stress=%t  race=%t  filter=%s  timeout=%s  ignore-cache=%t  pkgs=%s",
+		stress, race, filter, timeout, ignoreCache, pkgs)
+
+	var args []string
+	args = append(args, "test")
+	if race {
+		args = append(args, "--features", "race")
+	}
+
+	args = append(args, "--color=yes")
+	for _, pkg := range pkgs {
+		if strings.HasSuffix(pkg, "...") {
+			args = append(args, fmt.Sprintf("@cockroach//%s", pkg))
+		} else {
+			components := strings.Split(pkg, "/")
+			pkgName := components[len(components)-1]
+			args = append(args, fmt.Sprintf("@cockroach//%s:%s_test", pkg, pkgName))
+		}
+	}
+
+	if ignoreCache {
+		args = append(args, "--nocache_test_results")
+	}
+	if stress {
+		// TODO(irfansharif): Should this be pulled into a top-level flag?
+		// Should we just re-purpose timeout here?
+		args = append(args, "--run_under", fmt.Sprintf("stress -maxtime=%s", timeout))
+	}
+	if filter != "" {
+		args = append(args, fmt.Sprintf("--test_filter=%s", filter))
+	}
+	if verbose {
+		args = append(args, "--test_output", "all", "--test_arg", "-test.v")
+	}
+
+	bazelCmd := exec.CommandContext(ctx, "bazel", args...)
+
+	log.Infof(ctx, "executing: %s", log.Safe(bazelCmd.String()))
+
+	stdout, err := bazelCmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+	bazelCmd.Stderr = bazelCmd.Stdout
+
+	if err := bazelCmd.Start(); err != nil {
+		return err
+	}
+
+	scanner := bufio.NewScanner(stdout)
+	for scanner.Scan() {
+		line := scanner.Text()
+		log.Infof(ctx, "-- %s\n", redact.Safe(line))
+	}
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+	if err := bazelCmd.Wait(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func runLogicTest(ctx context.Context, cmd *cobra.Command) error {
+	files := mustGetFlagString(cmd, filesFlag)
+	subtests := mustGetFlagString(cmd, subtestsFlag)
+	config := mustGetFlagString(cmd, configFlag)
+
+	log.Infof(ctx, "logic test args: files=%s  subtests=%s  config=%s",
+		files, subtests, config)
+	return errors.New("--logic unimplemented")
+}
+
+func runFuzzTest(ctx context.Context, cmd *cobra.Command, pkgs []string) error {
+	filter := mustGetFlagString(cmd, filterFlag)
+
+	log.Infof(ctx, "fuzz test args: filter=%s  pkgs=%s", filter, pkgs)
+	return errors.New("--fuzz unimplemented")
 }

--- a/pkg/cmd/dev/util.go
+++ b/pkg/cmd/dev/util.go
@@ -16,9 +16,8 @@ import (
 	"os/exec"
 	"time"
 
-	"github.com/cockroachdb/redact"
-
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/redact"
 	"github.com/spf13/cobra"
 )
 

--- a/pkg/cmd/dev/util.go
+++ b/pkg/cmd/dev/util.go
@@ -1,0 +1,43 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import (
+	"context"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/spf13/cobra"
+)
+
+func mustGetFlagString(cmd *cobra.Command, name string) string {
+	val, err := cmd.Flags().GetString(name)
+	if err != nil {
+		log.Fatalf(context.Background(), "unexpected error: %v", err)
+	}
+	return val
+}
+
+func mustGetFlagBool(cmd *cobra.Command, name string) bool {
+	val, err := cmd.Flags().GetBool(name)
+	if err != nil {
+		log.Fatalf(context.Background(), "unexpected error: %v", err)
+	}
+	return val
+}
+
+func mustGetFlagDuration(cmd *cobra.Command, name string) time.Duration {
+	val, err := cmd.Flags().GetDuration(name)
+	if err != nil {
+		log.Fatalf(context.Background(), "unexpected error: %v", err)
+	}
+	return val
+}


### PR DESCRIPTION
Our Makefile UX has grown organically over the last six years, and is
now home to various scripts that are orthogonal to simply building the
crdb binary. These include the ability to run linters, building various
useful binaries (such as roachprod, roachtest), running different kinds
of tests (unit tests, logic tests, acceptance tests), and much more.

Now that we're exploring a move towards Bazel for our build system
(#55687), we have a chance to tuck away Bazel specific under a general
purpose dev-tool, larva.

The intent here is to house all day-to-day dev operations under this
tool, written in Go. This will be the component that actually replaces
our Makefile in its entirety. It'll be (predictably) powered by bazel
underneath, but with much nicer UX. It should capturing all common usage
patterns in high-level docs.

Strawman UX (I've only really deliberated on the `test` subcommand):
```
	larva test --pkg=kv/kvserver --filter=TestReplicaGC* -v -show-logs --timeout=1m
	larva test --stress --race ...
	larva test --logic --files=prepare|fk --subtests=20042 --config=local
	larva test --fuzz --pkg=... --filter=Decimal`
	larva bench --pkg=sql/parser --filter=BenchmarkParse
	larva build cockroach --tags=deadlock
	larva build cockroach-oss
	larva build {opt,exec}gen
	larva generate bazel
	larva generate protobuf
	larva generate {opt,exec}gen
        larva lint --filter=TestLowercaseFunctionNames --short --timeout=1m
```

---

Aside: The naming here is cause of this tool's infancy, relation to
cockroaches, and it starting with the letter "l" (which is featured
prominently in "bazel"/"blaze"). Whatever.

Release note: None