### PR TITLE
colexec: retune hash table constants in all of its uses

### DIFF
--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -872,6 +872,7 @@ func NewColOperator(
 			inMemoryHashJoiner := colexec.NewHashJoiner(
 				colmem.NewAllocator(ctx, hashJoinerMemAccount, factory),
 				hashJoinerUnlimitedAllocator, hjSpec, inputs[0], inputs[1],
+				colexec.HashJoinerInitialNumBuckets,
 			)
 			if args.TestingKnobs.DiskSpillingDisabled {
 				// We will not be creating a disk-backed hash joiner because we're

--- a/pkg/sql/colexec/default_agg_test.go
+++ b/pkg/sql/colexec/default_agg_test.go
@@ -158,14 +158,13 @@ func TestDefaultAggregateFunc(t *testing.T) {
 }
 
 func BenchmarkDefaultAggregateFunction(b *testing.B) {
-	const numInputBatches = 64
 	aggFn := execinfrapb.AggregatorSpec_STRING_AGG
 	for _, agg := range aggTypes {
-		for _, groupSize := range []int{1, 2, 32, 128, coldata.BatchSize() / 2, coldata.BatchSize()} {
-			for _, nullProb := range []float64{0.0, nullProbability} {
+		for _, numInputRows := range []int{32, 32 * coldata.BatchSize()} {
+			for _, groupSize := range []int{1, 2, 32, 128, coldata.BatchSize()} {
 				benchmarkAggregateFunction(
 					b, agg, aggFn, []*types.T{types.String, types.String}, groupSize,
-					0 /* distinctProb */, nullProb, numInputBatches,
+					0 /* distinctProb */, numInputRows,
 				)
 			}
 		}

--- a/pkg/sql/colexec/distinct_test.go
+++ b/pkg/sql/colexec/distinct_test.go
@@ -233,16 +233,22 @@ func BenchmarkDistinct(b *testing.B) {
 	}
 	distinctNames := []string{"Unordered", "PartiallyOrdered", "Ordered"}
 	orderedColsFraction := []float64{0, 0.5, 1.0}
+	nRowsOptions := []int{1, 64, 4 * coldata.BatchSize(), 256 * coldata.BatchSize()}
+	nColsOptions := []int{2, 4}
+	if testing.Short() {
+		nRowsOptions = []int{coldata.BatchSize()}
+		nColsOptions = []int{2}
+	}
 	for _, hasNulls := range []bool{false, true} {
-		for _, newTupleProbability := range []float64{0.001, 0.01, 0.1} {
-			for _, nBatches := range []int{1 << 2, 1 << 6} {
-				for _, nCols := range []int{2, 4} {
+		for _, newTupleProbability := range []float64{0.001, 0.1} {
+			for _, nRows := range nRowsOptions {
+				for _, nCols := range nColsOptions {
 					typs := make([]*types.T, nCols)
+					cols := make([]coldata.Vec, nCols)
 					for i := range typs {
 						typs[i] = types.Int
+						cols[i] = testAllocator.NewMemColumn(typs[i], nRows)
 					}
-					batch := testAllocator.NewMemBatchWithMaxCapacity(typs)
-					batch.SetLength(coldata.BatchSize())
 					distinctCols := []uint32{0, 1, 2, 3}[:nCols]
 					// We have the following equation:
 					//   newTupleProbability = 1 - (1 - newValueProbability) ^ nCols,
@@ -250,19 +256,16 @@ func BenchmarkDistinct(b *testing.B) {
 					//   newValueProbability = 1 - (1 - newTupleProbability) ^ (1 / nCols).
 					newValueProbability := 1.0 - math.Pow(1-newTupleProbability, 1.0/float64(nCols))
 					for i := range distinctCols {
-						col := batch.ColVec(i).Int64()
+						col := cols[i].Int64()
 						col[0] = 0
-						for j := 1; j < coldata.BatchSize(); j++ {
+						for j := 1; j < nRows; j++ {
 							col[j] = col[j-1]
 							if rng.Float64() < newValueProbability {
 								col[j]++
 							}
 						}
-						nulls := batch.ColVec(i).Nulls()
 						if hasNulls {
-							nulls.SetNull(0)
-						} else {
-							nulls.UnsetNulls()
+							cols[i].Nulls().SetNull(0)
 						}
 					}
 					for distinctIdx, distinctConstructor := range distinctConstructors {
@@ -270,16 +273,16 @@ func BenchmarkDistinct(b *testing.B) {
 						b.Run(
 							fmt.Sprintf("%s/hasNulls=%v/newTupleProbability=%.3f/rows=%d/cols=%d/ordCols=%d",
 								distinctNames[distinctIdx], hasNulls, newTupleProbability,
-								nBatches*coldata.BatchSize(), nCols, numOrderedCols,
+								nRows, nCols, numOrderedCols,
 							),
 							func(b *testing.B) {
-								b.SetBytes(int64(8 * nBatches * coldata.BatchSize() * nCols))
+								b.SetBytes(int64(8 * nRows * nCols))
 								b.ResetTimer()
 								for n := 0; n < b.N; n++ {
 									// Note that the source will be ordered on all nCols so that the
 									// number of distinct tuples doesn't vary between different
 									// distinct operator variations.
-									source := newFiniteChunksSource(batch, typs, nBatches, nCols)
+									source := newChunkingBatchSource(typs, cols, nRows)
 									distinct, err := distinctConstructor(testAllocator, source, distinctCols, numOrderedCols, typs)
 									if err != nil {
 										b.Fatal(err)

--- a/pkg/sql/colexec/external_hash_joiner.go
+++ b/pkg/sql/colexec/external_hash_joiner.go
@@ -374,6 +374,9 @@ func NewExternalHashJoiner(
 		// buildSideAllocator and outputUnlimitedAllocator arguments.
 		inMemHashJoiner: NewHashJoiner(
 			unlimitedAllocator, unlimitedAllocator, spec, leftJoinerInput, rightJoinerInput,
+			// We start with relatively large initial number of buckets since we
+			// expect each partition to be of significant size.
+			uint64(coldata.BatchSize()),
 		).(*hashJoiner),
 		diskBackedSortMerge: diskBackedSortMerge,
 	}

--- a/pkg/sql/colexec/hash_aggregator.go
+++ b/pkg/sql/colexec/hash_aggregator.go
@@ -185,12 +185,14 @@ func (op *hashAggregator) Init() {
 	for i := range colsToStore {
 		colsToStore[i] = int(op.spec.GroupCols[i])
 	}
-	// This number was chosen after running the micro-benchmarks and relevant
+	// These numbers were chosen after running the micro-benchmarks and relevant
 	// TPCH queries using tpchvec/bench.
-	const hashTableLoadFactor = 0.25
+	const hashTableLoadFactor = 0.1
+	const hashTableNumBuckets = 256
 	op.ht = newHashTable(
 		op.allocator,
 		hashTableLoadFactor,
+		hashTableNumBuckets,
 		op.inputTypes,
 		op.spec.GroupCols,
 		colsToStore,

--- a/pkg/sql/colexec/hashjoiner_test.go
+++ b/pkg/sql/colexec/hashjoiner_test.go
@@ -1090,7 +1090,7 @@ func BenchmarkHashJoiner(b *testing.B) {
 										)
 										hj := NewHashJoiner(
 											testAllocator, testAllocator, hjSpec,
-											leftSource, rightSource,
+											leftSource, rightSource, HashJoinerInitialNumBuckets,
 										)
 										hj.Init()
 

--- a/pkg/sql/colexec/mergejoiner_test.go
+++ b/pkg/sql/colexec/mergejoiner_test.go
@@ -1846,7 +1846,7 @@ func TestMergeJoinCrossProduct(t *testing.T) {
 			right: hashJoinerSourceSpec{
 				eqCols: []uint32{0}, sourceTypes: typs,
 			},
-		}, leftHJSource, rightHJSource)
+		}, leftHJSource, rightHJSource, HashJoinerInitialNumBuckets)
 	hj.Init()
 
 	var mjOutputTuples, hjOutputTuples tuples

--- a/pkg/sql/colexec/unordered_distinct.go
+++ b/pkg/sql/colexec/unordered_distinct.go
@@ -26,11 +26,13 @@ import (
 func NewUnorderedDistinct(
 	allocator *colmem.Allocator, input colexecbase.Operator, distinctCols []uint32, typs []*types.T,
 ) colexecbase.Operator {
-	// This number was chosen after running the micro-benchmarks.
+	// These numbers were chosen after running the micro-benchmarks.
 	const hashTableLoadFactor = 2.0
+	const hashTableNumBuckets = 128
 	ht := newHashTable(
 		allocator,
 		hashTableLoadFactor,
+		hashTableNumBuckets,
 		typs,
 		distinctCols,
 		// Store all columns from the source since the unordered distinct


### PR DESCRIPTION
**colexec: adjust benchmarks to include cases with small number of tuples**

This commit adjusts several benchmarks in order to run them against
inputs with small number of tuples. The reasoning for such change is
that we intend to remove the vectorize_row_count_threshold, so we now
should be paying attention to both small and large input sets.

Additionally, this commit removes the "with-nulls" cases from the
aggregation benchmarks because the speed of "no-nulls" and "with-nulls"
are roughly the same, so having both doesn't provide us more useful
info, yet slows down the benchmark by a factor of 2.

Release note: None

**colexec: retune hash table constants in all of its uses**

This commit changes the load factor and the initial number of buckets of
the hash table according to the recent micro-benchmarking and running of
TPCH queries. The numbers needed an update since we made the hash table
as well as the operators that use it more dynamic. The benchmarks show
an improvement on the inputs with small sizes, sometimes a regression on
inputs roughly of `coldata.BatchSize()` in size, and mostly improvements
on larger inputs. This trade-off seems beneficial to me.

Release note: None