### PR TITLE
roachtest: introduce new tpce/c=5000/nodes=3 roachtest

### DIFF
--- a/pkg/cmd/roachtest/BUILD.bazel
+++ b/pkg/cmd/roachtest/BUILD.bazel
@@ -106,6 +106,7 @@ go_library(
         "tpc_utils.go",
         "tpcc.go",
         "tpcdsvec.go",
+        "tpce.go",
         "tpchbench.go",
         "tpchvec.go",
         "ts_util.go",

--- a/pkg/cmd/roachtest/registry.go
+++ b/pkg/cmd/roachtest/registry.go
@@ -92,6 +92,7 @@ func registerTests(r *testRegistry) {
 	registerSysbench(r)
 	registerTPCC(r)
 	registerTPCDSVec(r)
+	registerTPCE(r)
 	registerTPCHVec(r)
 	registerKVBench(r)
 	registerTypeORM(r)

--- a/pkg/cmd/roachtest/tpce.go
+++ b/pkg/cmd/roachtest/tpce.go
@@ -1,0 +1,77 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/cockroachdb/errors"
+)
+
+func registerTPCE(r *testRegistry) {
+	const customers = 5000
+	const nodes = 3
+	const duration = 1 * time.Hour
+	r.Add(testSpec{
+		Name:    fmt.Sprintf("tpce/c=%d/nodes=%d", customers, nodes),
+		Owner:   OwnerKV,
+		Cluster: makeClusterSpec(nodes+1, cpu(4)),
+		Run: func(ctx context.Context, t *test, c *cluster) {
+			roachNodes := c.Range(1, nodes)
+			loadNode := c.Node(nodes + 1)
+			racks := nodes
+
+			t.Status("installing cockroach")
+			c.Put(ctx, cockroach, "./cockroach", roachNodes)
+			c.Start(ctx, t, roachNodes, startArgs(fmt.Sprintf("--racks=%d", racks)))
+
+			t.Status("installing docker")
+			if err := c.Install(ctx, t.l, loadNode, "docker"); err != nil {
+				t.Fatal(err)
+			}
+
+			m := newMonitor(ctx, c, roachNodes)
+			m.Go(func(ctx context.Context) error {
+				// TODO(nvanbenschoten): switch this to `cockroachdb/tpce` once
+				// I get permissions to push the docker image there.
+				const dockerRun = `sudo docker run nvanbenschoten/tpce:latest`
+
+				roachNodeIPs := c.InternalIP(ctx, roachNodes)
+				roachNodeIPFlags := make([]string, len(roachNodeIPs))
+				for i, ip := range roachNodeIPs {
+					roachNodeIPFlags[i] = fmt.Sprintf("--hosts=%s", ip)
+				}
+
+				t.Status("preparing workload")
+				c.Run(ctx, loadNode, fmt.Sprintf("%s --customers=%d --racks=%d --init %s",
+					dockerRun, customers, racks, roachNodeIPFlags[0]))
+
+				t.Status("running workload")
+				out, err := c.RunWithBuffer(ctx, t.l, loadNode,
+					fmt.Sprintf("%s --customers=%d --racks=%d --duration=%s %s",
+						dockerRun, customers, racks, duration, strings.Join(roachNodeIPFlags, " ")))
+				if err != nil {
+					t.Fatalf("%v\n%s", err, out)
+				}
+				outStr := string(out)
+				t.l.Printf("workload output:\n%s\n", outStr)
+				if strings.Contains(outStr, "Reported tpsE :    --   (not between 80% and 100%)") {
+					return errors.New("invalid tpsE fraction")
+				}
+				return nil
+			})
+			m.Wait()
+		},
+	})
+}


### PR DESCRIPTION
This commit introduces a new roachtest called `tpce/c=5000/nodes=3`, which
uses a Dockerized version of https://github.com/cockroachlabs/tpc-e to run
an instance of the TPC-E benchmark. The setup is not spec-compliant because
it uses a merged Driver and Tier A process, allowing for easier deployment.

The benchmark first IMPORTs a 5000 customer dataset from Google Storage and
then runs the workload for an hour. The workload spits out a report at the
end of the run that looks like:
```
_Transaction_______|__pass_mix___pass_lat__|______txns______txns/s_______mix__________avg__________p50__________p90__________p99_________pMax
 BrokerVolume      |     false       true  |      2909        4.85    4.956%     18.345ms      8.689ms     52.051ms     63.575ms     77.651ms
 CustomerPosition  |     false       true  |      7726       12.88   13.163%     13.311ms      7.941ms     35.595ms     55.825ms     74.606ms
 DataMaintenance   |       n/a        n/a  |        10        0.02    0.017%      17.94ms     19.147ms     25.083ms     27.172ms     27.172ms
 MarketFeed        |     false       true  |       534        0.89    0.910%    145.943ms    140.083ms     179.87ms     245.24ms    265.666ms
 MarketWatch       |     false       true  |     10679       17.80   18.194%     12.509ms      7.404ms     32.858ms     45.705ms     58.103ms
 SecurityDetail    |     false       true  |      8301       13.84   14.142%     28.778ms      8.021ms     97.732ms     114.69ms    148.745ms
 TradeLookup       |     false       true  |      4753        7.92    8.098%     10.749ms      7.862ms      22.47ms     35.241ms     47.571ms
 TradeOrder        |     false       true  |      5999       10.00   10.220%     35.219ms     17.499ms    103.776ms     134.59ms    172.817ms
 TradeResult       |     false       true  |      5341        8.90    9.099%     47.782ms     27.721ms     114.69ms    140.083ms    174.554ms
 TradeStatus       |     false       true  |     11265       18.77   19.192%     19.358ms      6.123ms     71.681ms      89.32ms    115.843ms
 TradeUpdate       |     false       true  |      1189        1.98    2.026%     18.025ms     15.062ms      34.89ms     46.629ms     55.825ms

Customers     :     5000
Nominal  tpsE :    10.00
Measured tpsE :     8.90
tpsE fraction :   89.02% (80% - 100% passing)

Reported tpsE :     8.90
```

This report is not yet hooked up to roachperf.