### PR TITLE
sql: fix for column type for pg_constraint.confkey to smallint[]

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2806,3 +2806,17 @@ ORDER BY
 p
 p
 t
+
+# Issue 44793
+statement ok
+CREATE TABLE PARENT_TABLE_A(id UUID PRIMARY KEY);
+CREATE TABLE CHILD_TABLE_B(
+  id UUID PRIMARY KEY,
+  a_id UUID,
+  CONSTRAINT fk_b_to_a FOREIGN KEY (a_id) REFERENCES PARENT_TABLE_A (id)
+);
+
+query TT
+SELECT pg_typeof(confkey), pg_typeof(conkey) FROM pg_constraint WHERE conname = 'fk_b_to_a'
+----
+smallint[]  smallint[]

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -1019,7 +1019,7 @@ func colIDArrayToDatum(arr []descpb.ColumnID) (tree.Datum, error) {
 	if len(arr) == 0 {
 		return tree.DNull, nil
 	}
-	d := tree.NewDArray(types.Int)
+	d := tree.NewDArray(types.Int2)
 	for _, val := range arr {
 		if err := d.Append(tree.NewDInt(tree.DInt(val))); err != nil {
 			return nil, err


### PR DESCRIPTION
Previously, type of pg_constraint.confkey reported bigint[], but
postgresql reports smallint[], to address this, this patch changes
the array data type for this column from types.Int to types.Int2.
This address the data type for conkey column as well.

Fixes #44793

Release note (sql change): Changed pg_constraint column types
for confkey and conkey to smallint[] to improve compatibility with
Postgres