### PR TITLE
opt: do not generate empty Value expressions with SplitDisjunction

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/subquery
+++ b/pkg/sql/opt/exec/execbuilder/testdata/subquery
@@ -209,21 +209,36 @@ WHERE
 distribution: local
 vectorized: true
 ·
-• project
+• root
 │ columns: (col0)
-│ estimated row count: 311 (missing stats)
 │
-└── • project
-    │ columns: (col0, col3, col4)
-    │ estimated row count: 311 (missing stats)
+├── • project
+│   │ columns: (col0)
+│   │ estimated row count: 311 (missing stats)
+│   │
+│   └── • filter
+│       │ columns: (col0, col3, col4)
+│       │ estimated row count: 311 (missing stats)
+│       │ filter: ((col0 <= 0) AND (col4 <= 5.38)) OR ((((col4 = ANY @S1) AND (col3 <= 5)) AND (col3 >= 7)) AND (col3 <= 9))
+│       │
+│       └── • scan
+│             columns: (col0, col3, col4)
+│             estimated row count: 1000 (missing stats)
+│             table: tab4@primary
+│             spans: FULL SCAN
+│
+└── • subquery
+    │ id: @S1
+    │ original sql: (SELECT col1 FROM tab4 WHERE col1 > 8.27)
+    │ exec mode: any rows
     │
     └── • filter
-        │ columns: (col0, col3, col4, rowid)
-        │ estimated row count: 311 (missing stats)
-        │ filter: (col0 <= 0) AND (col4 <= 5.38)
+        │ columns: (col1)
+        │ estimated row count: 333 (missing stats)
+        │ filter: col1 > 8.27
         │
         └── • scan
-              columns: (col0, col3, col4, rowid)
+              columns: (col1)
               estimated row count: 1000 (missing stats)
               table: tab4@primary
               spans: FULL SCAN

--- a/pkg/sql/opt/norm/general_funcs.go
+++ b/pkg/sql/opt/norm/general_funcs.go
@@ -1029,10 +1029,21 @@ func (c *CustomFuncs) DatumsEqual(first, second tree.Datum) bool {
 //
 // ----------------------------------------------------------------------
 
+// DuplicateScan constructs a new Scan with new table and column IDs. Only the
+// Index, Flags, and Locking fields are copied from the input Scan. Panics if s
+// is not a ScanExpr.
+func (c *CustomFuncs) DuplicateScan(s memo.RelExpr) memo.RelExpr {
+	scan, ok := s.(*memo.ScanExpr)
+	if !ok {
+		panic(errors.AssertionFailedf("s must be a ScanExpr"))
+	}
+	return c.f.ConstructScan(c.DuplicateScanPrivate(&scan.ScanPrivate))
+}
+
 // DuplicateScanPrivate constructs a new ScanPrivate with new table and column
-// IDs. Only the Index, Flags and Locking fields are copied from the old
-// ScanPrivate, so the new ScanPrivate will not have constraints even if the old
-// one did.
+// IDs. Only the Index, Flags, and Locking fields are copied from the input
+// ScanPrivate, so the new ScanPrivate will not have constraints even if the
+// input ScanPrivate did.
 func (c *CustomFuncs) DuplicateScanPrivate(sp *memo.ScanPrivate) *memo.ScanPrivate {
 	md := c.mem.Metadata()
 	tabMeta := md.TableMeta(sp.Table)

--- a/pkg/sql/opt/norm/rules/set.opt
+++ b/pkg/sql/opt/norm/rules/set.opt
@@ -4,31 +4,14 @@
 
 # EliminateUnionAllLeft replaces a union all with a right side having a
 # cardinality of zero, with just the left side operand.
-#
-# It is possible for the left and right sides of the UnionAll to have column
-# IDs that are also present in the output columns of the UnionAll, e.g. after
-# the SplitDisjunction exploration rule has been applied. These columns are
-# included as passthrough columns in the generated Project because they do not
-# need to be projected. All other column IDs are added to the ProjectionsExpr.
 [EliminateUnionAllLeft, Normalize]
 (UnionAll $left:* $right:* & (HasZeroRows $right) $colmap:*)
 =>
-(Project
-    $left
-    (ProjectColMapLeft $colmap)
-    (ProjectPassthroughLeft $colmap)
-)
+(Project $left (ProjectColMapLeft $colmap) (MakeEmptyColSet))
 
 # EliminateUnionAllRight replaces a union all with a left side having a
 # cardinality of zero, with just the right side operand.
-#
-# See the comment above EliminateUnionAllLeft which describes when columns are
-# projected vs. passed-through.
 [EliminateUnionAllRight, Normalize]
 (UnionAll $left:* & (HasZeroRows $left) $right:* $colmap:*)
 =>
-(Project
-    $right
-    (ProjectColMapRight $colmap)
-    (ProjectPassthroughRight $colmap)
-)
+(Project $right (ProjectColMapRight $colmap) (MakeEmptyColSet))

--- a/pkg/sql/opt/norm/set_funcs.go
+++ b/pkg/sql/opt/norm/set_funcs.go
@@ -46,26 +46,6 @@ func (c *CustomFuncs) projectColMapSide(toList, fromList opt.ColList) memo.Proje
 	return items
 }
 
-// ProjectPassthroughLeft returns a ColSet that contains the columns that can
-// be passed-through from the left side in a SetPrivate when eliminating a set
-// operation, like in EliminateUnionAllLeft. Columns in both the output
-// ColList and the left ColList should be passed-through.
-func (c *CustomFuncs) ProjectPassthroughLeft(set *memo.SetPrivate) opt.ColSet {
-	out := set.OutCols.ToSet()
-	out.IntersectionWith(set.LeftCols.ToSet())
-	return out
-}
-
-// ProjectPassthroughRight returns a ColSet that contains the columns that can
-// be passed-through from the right side in a SetPrivate when eliminating a set
-// operation, like in EliminateUnionAllRight. Columns in both the output
-// ColList and the right ColList should be passed-through.
-func (c *CustomFuncs) ProjectPassthroughRight(set *memo.SetPrivate) opt.ColSet {
-	out := set.OutCols.ToSet()
-	out.IntersectionWith(set.RightCols.ToSet())
-	return out
-}
-
 // PruneSetPrivate returns a SetPrivate based on the given SetPrivate, but with
 // unneeded input and output columns discarded.
 func (c *CustomFuncs) PruneSetPrivate(needed opt.ColSet, set *memo.SetPrivate) *memo.SetPrivate {

--- a/pkg/sql/opt/props/cardinality.go
+++ b/pkg/sql/opt/props/cardinality.go
@@ -30,7 +30,7 @@ var AnyCardinality = Cardinality{Min: 0, Max: math.MaxUint32}
 // that indicates there is no limit to the number of returned rows. Max should
 // always be >= Min, or method results are undefined. Cardinality is determined
 // from the relational properties, and are "hard" bounds that are never
-// incorrect. This constrasts with row cardinality derived by the statistics
+// incorrect. This contrasts with row cardinality derived by the statistics
 // code, which are only estimates and may be incorrect.
 type Cardinality struct {
 	Min uint32

--- a/pkg/sql/opt/xform/memo_format.go
+++ b/pkg/sql/opt/xform/memo_format.go
@@ -29,7 +29,15 @@ const (
 	// FmtPretty performs a breadth-first topological sort on the memo groups,
 	// and shows the root group at the top of the memo.
 	FmtPretty FmtFlags = iota
+
+	// FmtHideState does not show group states in the output of the memo command.
+	FmtHideState
 )
+
+// hasFlags tests whether the given flags are all set.
+func (f FmtFlags) hasFlags(subset FmtFlags) bool {
+	return f&subset == subset
+}
 
 type group struct {
 	first  opt.Expr
@@ -85,12 +93,14 @@ func (mf *memoFormatter) format() string {
 		}
 		mf.formatGroup(rel)
 		tpChild := tpRoot.Childf("G%d: %s", i+1, mf.buf.String())
-		for _, s := range e.states {
-			mf.buf.Reset()
-			c := tpChild.Childf("%s", s.required)
-			mf.formatBest(s.best, s.required)
-			c.Childf("best: %s", mf.buf.String())
-			c.Childf("cost: %.2f", s.cost)
+		if !mf.flags.hasFlags(FmtHideState) {
+			for _, s := range e.states {
+				mf.buf.Reset()
+				c := tpChild.Childf("%s", s.required)
+				mf.formatBest(s.best, s.required)
+				c.Childf("best: %s", mf.buf.String())
+				c.Childf("cost: %.2f", s.cost)
+			}
 		}
 	}
 

--- a/pkg/sql/opt/xform/rules/select.opt
+++ b/pkg/sql/opt/xform/rules/select.opt
@@ -105,12 +105,25 @@
 # the Or expression. The execution plan can use both indexes to satisfy both
 # sides of the disjunction and union the results together.
 #
-# Note that this rule only matches Selects with canonical scans. Therefore scan
-# constraints do not need to be duplicated in the left and right scans of the
-# union.
+# The actual expression generated is a (DistinctOn (UnionAll ...)). This is more
+# performant than a (Union ...) when there are many non-key columns of the
+# expression. During execution a Union expression has to store and compare all
+# columns when de-duplicating rows from its inputs. The generated (DistinctOn
+# (UnionAll ...)) de-duplicates rows during the DistinctOn expression, where
+# only the key columns are compared.
 #
-# Also note that this rule only matches Selects that have strict keys. See
-# SplitDisjunctionAddKey which handles Selects that do not have strict keys.
+# This rule only matches when the following conditions are true:
+#
+#   - The Scan within the Select is a canonical scan. Because of this, scan
+#     constraints do no need to be duplicated in the left and right scans of the
+#     UnionAll.
+#   - The Select's output column include a strict key. This is required for
+#     generating the DistinctOn expression. SplitDisjunctionAddKey is a similar
+#     rule that matches Selects without strict keys.
+#   - The newly constructed Selects on the left and right side of the UnionAll
+#     have non-zero cardinality. This avoids constructing unnecessary UnionAlls
+#     which normalize to Value expressions with zero rows.
+#
 [SplitDisjunction, Explore]
 (Select
     $input:(Scan
@@ -123,74 +136,50 @@
                 $scanPrivate
                 $filters
             )
+        ) &
+        ^(HasZeroRows
+            $leftSelect:(MakeSelect
+                $input
+                (ReplaceFiltersItem
+                    $filters
+                    (ExprPairFiltersItemToReplace $pair)
+                    (ExprPairLeft $pair)
+                )
+            )
+        ) &
+        ^(HasZeroRows
+            $rightSelect:(MakeSelect
+                $rightScan:(DuplicateScan $input)
+                (MapScanFilterCols
+                    (ReplaceFiltersItem
+                        $filters
+                        (ExprPairFiltersItemToReplace $pair)
+                        (ExprPairRight $pair)
+                    )
+                    $input
+                    $rightScan
+                )
+            )
         )
 )
 =>
 (DistinctOn
     (UnionAll
-        (Select
-            $input
-            (ReplaceFiltersItem
-                $filters
-                (ExprPairFiltersItemToReplace $pair)
-                (ExprPairLeft $pair)
-            )
-        )
-        (Select
-            (Scan
-                $rightScanPrivate:(DuplicateScanPrivate
-                    $scanPrivate
-                )
-            )
-            (MapScanFilterCols
-                (ReplaceFiltersItem
-                    $filters
-                    (ExprPairFiltersItemToReplace $pair)
-                    (ExprPairRight $pair)
-                )
-                $scanPrivate
-                $rightScanPrivate
-            )
-        )
-        (MakeSetPrivateForSplitDisjunction
-            $scanPrivate
-            $rightScanPrivate
-        )
+        $leftSelect
+        $rightSelect
+        (MakeSetPrivateForSplitDisjunction $input $rightScan)
     )
     (MakeAggCols ConstAgg (NonKeyCols $input))
     (MakeGrouping (KeyCols $input) (EmptyOrdering))
 )
 
-# SplitDisjunctionAddKey performs a transformation similar to
-# SplitDisjunction, but it handles the special case when the original Scan
-# does not have a strict key in its ColSet.
+# SplitDisjunctionAddKey performs a transformation similar to SplitDisjunction,
+# but it handles the special case when the original Scan does not have a strict
+# key in its output ColSet. The generated DistinctOn requires strict key columns
+# in order to de-duplicate rows.
 #
-# For this special case, the replace pattern adds primary key columns to the
-# original Scan ColSet. It also adds a Project to remove those columns after the
-# Union operation. Inclusion of the primary keys is required to prevent the
-# generated Union from de-duplicating rows that have the same selected values.
-#
-# To understand why the addition of the primary key columns to the Scans is
-# necessary, consider the following:
-#
-#     CREATE TABLE t (k INT PRIMARY KEY, a INT, b INT)
-#     INSERT INTO t VALUES (1, 1, 3)
-#     INSERT INTO t VALUES (2, 1, 3)
-#     SELECT a, b FROM t WHERE a = 1 OR b = 3
-#
-# The expected result of the Select query is 2 rows, with values (1, 3). Now
-# consider the following query:
-#
-#     SELECT a, b FROM t WHERE a = 1
-#     UNION
-#     SELECT a, b FROM t WHERE b = 3
-#
-# Union de-duplicates all tuples with the same set of values. So, this
-# query returns only a single row.
-#
-# By adding a primary key in the output columns, each input row to the Union is
-# guaranteed to be unique. This prevents incorrect de-duplication and guarantees
-# that the newly generated plan is equivalent to the original plan.
+# The replace pattern adds primary key columns to the original Scan ColSet. It
+# also adds a Project to remove those columns after the DistinctOn expression.
 [SplitDisjunctionAddKey, Explore]
 (Select
     $input:(Scan
@@ -203,17 +192,11 @@
                 $scanPrivate
                 $filters
             )
-        )
-)
-=>
-(Project
-    (DistinctOn
-        (UnionAll
-            (Select
-                $leftScan:(Scan
-                    $leftScanPrivate:(AddPrimaryKeyColsToScanPrivate
-                        $scanPrivate
-                    )
+        ) &
+        ^(HasZeroRows
+            $leftSelect:(MakeSelect
+                $leftScan:(MakeScanAddPrimaryKeyCols
+                    $scanPrivate
                 )
                 (ReplaceFiltersItem
                     $filters
@@ -221,25 +204,31 @@
                     (ExprPairLeft $pair)
                 )
             )
-            (Select
-                (Scan
-                    $rightScanPrivate:(DuplicateScanPrivate
-                        $leftScanPrivate
-                    )
-                )
+        ) &
+        ^(HasZeroRows
+            $rightSelect:(MakeSelect
+                $rightScan:(DuplicateScan $leftScan)
                 (MapScanFilterCols
                     (ReplaceFiltersItem
                         $filters
                         (ExprPairFiltersItemToReplace $pair)
                         (ExprPairRight $pair)
                     )
-                    $leftScanPrivate
-                    $rightScanPrivate
+                    $leftScan
+                    $rightScan
                 )
             )
+        )
+)
+=>
+(Project
+    (DistinctOn
+        (UnionAll
+            $leftSelect
+            $rightSelect
             (MakeSetPrivateForSplitDisjunction
-                $leftScanPrivate
-                $rightScanPrivate
+                $leftScan
+                $rightScan
             )
         )
         (MakeAggCols ConstAgg (NonKeyCols $leftScan))

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -5494,35 +5494,108 @@ project
            └── const-agg [as=v:3, outer=(3)]
                 └── v:3
 
-# Columns are passed-through correctly when EliminateUnionAllLeft is applied.
-opt expect=SplitDisjunction
+# Don't apply to disjunctions with a contradiction on the right.
+opt expect-not=SplitDisjunction
 SELECT k FROM d WHERE u = 2 OR (v = 1 AND v = 3)
 ----
 project
  ├── columns: k:1!null
  ├── key: (1)
- └── distinct-on
+ └── select
       ├── columns: k:1!null u:2!null v:3
-      ├── grouping columns: k:1!null
-      ├── internal-ordering: +1 opt(2)
       ├── key: (1)
       ├── fd: ()-->(2), (1)-->(3)
-      ├── index-join d
-      │    ├── columns: k:1!null u:2!null v:3
+      ├── scan d
+      │    ├── columns: k:1!null u:2 v:3
       │    ├── key: (1)
-      │    ├── fd: ()-->(2), (1)-->(3)
-      │    ├── ordering: +1 opt(2) [actual: +1]
-      │    └── scan d@u
-      │         ├── columns: k:1!null u:2!null
-      │         ├── constraint: /2/1: [/2 - /2]
-      │         ├── key: (1)
-      │         ├── fd: ()-->(2)
-      │         └── ordering: +1 opt(2) [actual: +1]
-      └── aggregations
-           ├── const-agg [as=u:2, outer=(2)]
-           │    └── u:2
-           └── const-agg [as=v:3, outer=(3)]
-                └── v:3
+      │    └── fd: (1)-->(2,3)
+      └── filters
+           └── (u:2 = 2) OR ((v:3 = 1) AND (v:3 = 3)) [outer=(2,3), constraints=(/2: [/2 - /2]; tight), fd=()-->(2)]
+
+# Don't apply to disjunctions with a contradiction on the left.
+opt expect-not=SplitDisjunction
+SELECT k FROM d WHERE (u = 2 AND u = 4) OR v = 1
+----
+project
+ ├── columns: k:1!null
+ ├── key: (1)
+ └── select
+      ├── columns: k:1!null u:2 v:3!null
+      ├── key: (1)
+      ├── fd: ()-->(3), (1)-->(2)
+      ├── scan d
+      │    ├── columns: k:1!null u:2 v:3
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2,3)
+      └── filters
+           └── ((u:2 = 2) AND (u:2 = 4)) OR (v:3 = 1) [outer=(2,3), constraints=(/3: [/1 - /1]; tight), fd=()-->(3)]
+
+# Before SplitDisjunction was updated to ensure that it does not fire when
+# either side of the UnionAll has a cardinality of zero, SplitDisjunction could
+# generate plans with empty Value expressions. This was the result of
+# normalizing a UnionAll with zero-cardinality left and right inputs. This test
+# shows that empty Value expressions are no longer generated in the memo.
+memo memo-format=hide-state
+SELECT k FROM d WHERE
+  (u >= 6 OR v < 8) AND
+  (u = 1 OR v >= 12) AND
+  (u < 1 OR v = 6.8) AND
+  (u > 4 OR v <= 5.23)
+----
+memo (optimized, ~21KB, required=[presentation: k:1])
+ ├── G1: (project G2 G3 k)
+ ├── G2: (select G4 G5) (distinct-on G6 G7 cols=(1))
+ ├── G3: (projections)
+ ├── G4: (scan d,cols=(1-3))
+ ├── G5: (filters G8 G9 G10 G11)
+ ├── G6: (union-all G12 G13)
+ ├── G7: (aggregations G14 G15)
+ ├── G8: (or G16 G17)
+ ├── G9: (or G18 G19)
+ ├── G10: (or G20 G21)
+ ├── G11: (or G22 G23)
+ ├── G12: (select G4 G24) (select G25 G26)
+ ├── G13: (select G27 G28) (select G29 G30)
+ ├── G14: (const-agg G31)
+ ├── G15: (const-agg G32)
+ ├── G16: (ge G31 G33)
+ ├── G17: (lt G32 G34)
+ ├── G18: (eq G31 G35)
+ ├── G19: (ge G32 G36)
+ ├── G20: (lt G31 G35)
+ ├── G21: (eq G32 G37)
+ ├── G22: (gt G31 G38)
+ ├── G23: (le G32 G39)
+ ├── G24: (filters G16 G9 G10 G11)
+ ├── G25: (index-join G40 d,cols=(1-3))
+ ├── G26: (filters G9 G10)
+ ├── G27: (scan d,cols=(6-8))
+ ├── G28: (filters G41 G42 G43 G44)
+ ├── G29: (index-join G45 d,cols=(6-8))
+ ├── G30: (filters G42 G43 G44)
+ ├── G31: (variable u)
+ ├── G32: (variable v)
+ ├── G33: (const 6)
+ ├── G34: (const 8)
+ ├── G35: (const 1)
+ ├── G36: (const 12)
+ ├── G37: (const 6.8)
+ ├── G38: (const 4)
+ ├── G39: (const 5.23)
+ ├── G40: (scan d@u,cols=(1,2),constrained)
+ ├── G41: (lt G46 G34)
+ ├── G42: (or G47 G48)
+ ├── G43: (or G49 G50)
+ ├── G44: (or G51 G52)
+ ├── G45: (scan d@v,cols=(6,8),constrained)
+ ├── G46: (variable v)
+ ├── G47: (eq G53 G35)
+ ├── G48: (ge G46 G36)
+ ├── G49: (lt G53 G35)
+ ├── G50: (eq G46 G37)
+ ├── G51: (gt G53 G38)
+ ├── G52: (le G46 G39)
+ └── G53: (variable u)
 
 # Regression test for #52207. Partial index predicates in TableMeta must be
 # duplicated when TableMeta is duplicated.
@@ -6563,22 +6636,29 @@ project
            └── const-agg [as=v:3, outer=(3)]
                 └── v:3
 
-# Columns are passed-through correctly when EliminateUnionAllLeft is applied.
-opt expect=SplitDisjunctionAddKey
+# Don't apply to disjunctions with a contradiction on the right.
+opt expect-not=SplitDisjunctionAddKey
 SELECT u, v FROM d WHERE u = 2 OR (v = 1 AND v = 3)
 ----
-project
+select
  ├── columns: u:2!null v:3
  ├── fd: ()-->(2)
- └── index-join d
-      ├── columns: k:1!null u:2!null v:3
-      ├── key: (1)
-      ├── fd: ()-->(2), (1)-->(3)
-      └── scan d@u
-           ├── columns: k:1!null u:2!null
-           ├── constraint: /2/1: [/2 - /2]
-           ├── key: (1)
-           └── fd: ()-->(2)
+ ├── scan d
+ │    └── columns: u:2 v:3
+ └── filters
+      └── (u:2 = 2) OR ((v:3 = 1) AND (v:3 = 3)) [outer=(2,3), constraints=(/2: [/2 - /2]; tight), fd=()-->(2)]
+
+# Don't apply to disjunctions with a contradiction on the left.
+opt expect-not=SplitDisjunctionAddKey
+SELECT u, v FROM d WHERE (u = 2 AND u = 4) OR v = 1
+----
+select
+ ├── columns: u:2 v:3!null
+ ├── fd: ()-->(3)
+ ├── scan d
+ │    └── columns: u:2 v:3
+ └── filters
+      └── ((u:2 = 2) AND (u:2 = 4)) OR (v:3 = 1) [outer=(2,3), constraints=(/3: [/1 - /1]; tight), fd=()-->(3)]
 
 exec-ddl
 CREATE INDEX idx_i ON p (i)


### PR DESCRIPTION
#### opttester: add memo-format flag for memo command

This commit adds a new flag, `memo-format`, to be used with `memo`
opttest commands. A `hide-state` value is supported which will hide
group states of the memo in the output, allowing for a condensed
representation of the memo. This can be useful when the only concern for
in a test is the type of expressions in the memo.

Release note: None

#### opt: do not generate empty Value expressions with SplitDisjunction

Previously, complex query filters with disjunctions could result in
plans with unnecessary empty Value expressions. This was the result of
generating UnionAll expressions in SplitDisjunction with contradictory
filters on each side of the UnionAll. Normalization rules would convert
these ultimately to empty Value expressions.

To address this issue, this commit moves the construction of the Select
expression children of the UnionAll to the match pattern of
SplitDisjunction (and SplitDisjunctionAddKey). This allows the rule to
only match when the cardinality of both children are non-zero, by
calling the `HasZeroRows` custom function.

Fixes #56690

Release note (performance improvement): Previously, complex query
filters with OR expressions could result in query plans with unnecessary
operators. The optimizer no longer explores these types of plans and
they will not be generated. This may result in more efficient query
plans in some cases, as well as reduced query planning time.

#### opt: remove special cases for EliminateUnionAll(Left|Right)

This commit reverts a change to the EliminateUnionAllLeft and
EliminateUnionAllRight exploration rules that was added in #47617 to
support the SplitDisjunction exploration rule. Specifically, it handled
the case in which the output columns of the UnionAll might be
passthrough columns from the children, rather than projected columns.

Now that SplitDisjunction no longer generates a UnionAll if either the
left or right child has a cardinality of zero, both these normalization
rules will never fire during the SplitDisjunction exploration rule, and
handling this special case is not necessary.

Release note: None
