### PR TITLE
release-20.2: workload/tpcc: fix race condition in scattering tables

### DIFF
--- a/pkg/workload/tpcc/ddls.go
+++ b/pkg/workload/tpcc/ddls.go
@@ -208,8 +208,8 @@ func scatterRanges(db *gosql.DB) error {
 
 	var g errgroup.Group
 	for _, table := range tables {
+		sql := fmt.Sprintf(`ALTER TABLE %s SCATTER`, table)
 		g.Go(func() error {
-			sql := fmt.Sprintf(`ALTER TABLE %s SCATTER`, table)
 			if _, err := db.Exec(sql); err != nil {
 				return errors.Wrapf(err, "Couldn't exec %q", sql)
 			}


### PR DESCRIPTION
Backport 1/1 commits from #56942.

/cc @cockroachdb/release

---

When iterating over the names of tables to scatter, we were sharing the
loop variable between the goroutines, which is racy and caused a test
failure due to reading a garbage string value for the table name. In
general, this function may not scatter each table exactly once. This PR
fixes the bug by moving the read out of the goroutine.

Closes #56892.

Release note (bug fix): Fixed a race condition in the `tpcc` workload
with the `--scatter` flag where tables could be scattered multiple times
or not at all.
