### PR TITLE
sql: format arrays in pg_catalog to match Postgres

### DIFF
--- a/pkg/sql/catalog/schemaexpr/expr.go
+++ b/pkg/sql/catalog/schemaexpr/expr.go
@@ -164,7 +164,7 @@ func FormatExprForDisplay(
 	semaCtx *tree.SemaContext,
 	fmtFlags tree.FmtFlags,
 ) (string, error) {
-	expr, err := deserializeExprForFormatting(ctx, desc, exprStr, semaCtx)
+	expr, err := deserializeExprForFormatting(ctx, desc, exprStr, semaCtx, fmtFlags)
 	if err != nil {
 		return "", err
 	}
@@ -172,7 +172,11 @@ func FormatExprForDisplay(
 }
 
 func deserializeExprForFormatting(
-	ctx context.Context, desc catalog.TableDescriptor, exprStr string, semaCtx *tree.SemaContext,
+	ctx context.Context,
+	desc catalog.TableDescriptor,
+	exprStr string,
+	semaCtx *tree.SemaContext,
+	fmtFlags tree.FmtFlags,
 ) (tree.Expr, error) {
 	expr, err := parser.ParseExpr(exprStr)
 	if err != nil {
@@ -181,15 +185,34 @@ func deserializeExprForFormatting(
 
 	// Replace the column variables with dummyColumns so that they can be
 	// type-checked.
-	expr, _, err = replaceColumnVars(desc, expr)
+	replacedExpr, _, err := replaceColumnVars(desc, expr)
 	if err != nil {
 		return nil, err
 	}
 
 	// Type-check the expression to resolve user defined types.
-	typedExpr, err := expr.TypeCheck(ctx, semaCtx, types.Any)
+	typedExpr, err := replacedExpr.TypeCheck(ctx, semaCtx, types.Any)
 	if err != nil {
 		return nil, err
+	}
+
+	// In pg_catalog, we need to make sure we always display constants instead of
+	// expressions, when possible (e.g., turn Array expr into a DArrray). This is
+	// best-effort, so if there is any error, it is safe to fallback to the
+	// typedExpr.
+	if fmtFlags == tree.FmtPGCatalog {
+		sanitizedExpr, err := SanitizeVarFreeExpr(ctx, expr, typedExpr.ResolvedType(), "FORMAT", semaCtx,
+			tree.VolatilityImmutable)
+		// If the expr has no variables and has VolatilityImmutable, we can evaluate
+		// it and turn it into a constant.
+		if err == nil {
+			// An empty EvalContext is fine here since the expression has
+			// VolatilityImmutable.
+			d, err := sanitizedExpr.Eval(&tree.EvalContext{})
+			if err == nil {
+				return d, nil
+			}
+		}
 	}
 
 	return typedExpr, nil

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2754,6 +2754,31 @@ WHERE
 ----
 'howdy'::STRING
 
+# Regression test for array formatting logic, #55320.
+statement ok
+CREATE TABLE default_arrays (
+  id INT8 NOT NULL PRIMARY KEY,
+  string_array text[] DEFAULT '{cat, dog}',
+  weird_array text[] DEFAULT '{a,"", "b,c", "a''::string","''::string", "a''::string, ''::string",null}',
+  int_array int[] default '{1, 2}'
+);
+
+query TTTBOI
+SELECT a.attname, format_type(a.atttypid, a.atttypmod),
+  pg_get_expr(d.adbin, d.adrelid), a.attnotnull, a.atttypid, a.atttypmod
+ FROM pg_attribute a
+ LEFT JOIN pg_attrdef d ON a.attrelid = d.adrelid AND a.attnum = d.adnum
+ LEFT JOIN pg_type t ON a.atttypid = t.oid
+ LEFT JOIN pg_collation c ON a.attcollation = c.oid AND a.attcollation <> t.typcollation
+WHERE a.attrelid = 'default_arrays'::regclass
+  AND a.attnum > 0 AND NOT a.attisdropped
+ORDER BY a.attnum;
+----
+id            bigint    NULL                                                                            true   20    -1
+string_array  text[]    '{cat,dog}'::STRING[]                                                           false  1009  -1
+weird_array   text[]    '{a,"","b,c",a''::string,''::string,"a''::string, ''::string",NULL}'::STRING[]  false  1009  -1
+int_array     bigint[]  '{1,2}'::INT8[]                                                                 false  1016  -1
+
 # Regression test for limits on virtual index scans. (#53522)
 
 let $testid

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -3849,7 +3849,7 @@ func (d *DArray) AmbiguousFormat() bool {
 
 // Format implements the NodeFormatter interface.
 func (d *DArray) Format(ctx *FmtCtx) {
-	if ctx.HasFlags(fmtPgwireFormat) {
+	if ctx.flags.HasAnyFlags(fmtPgwireFormat | FmtPGCatalog) {
 		d.pgwireFormat(ctx)
 		return
 	}

--- a/pkg/sql/sem/tree/format.go
+++ b/pkg/sql/sem/tree/format.go
@@ -382,6 +382,8 @@ func (ctx *FmtCtx) FormatNode(n NodeFormatter) {
 				typ = p.typ
 			} else if d.AmbiguousFormat() {
 				typ = d.ResolvedType()
+			} else if _, isArray := d.(*DArray); isArray && f.HasFlags(FmtPGCatalog) {
+				typ = d.ResolvedType()
 			}
 		}
 		if typ != nil {


### PR DESCRIPTION
Postgres uses the curly brace syntax to display array constants that are
in pg_catalog, like those in default expressions.

CockroachDB stores arrays in descriptors as tree.Array exprs, so in
order to use the curly brace syntax, now we check if the array has any
variables or functions, and if not, we turn the Array expr into a
DArray. The formatting logic for DArrays also is updated to use single
quotes as appropriate, when formatting for pg_catalog.

fixes #55320

Release note (sql change): Arrays in pg_catalog tables now are displyed
in a format that matches PostgreSQL.