### PR TITLE
opttester: add optsteps split-diff test

### DIFF
--- a/pkg/sql/opt/testutils/opttester/testdata/opt-steps
+++ b/pkg/sql/opt/testutils/opttester/testdata/opt-steps
@@ -754,3 +754,58 @@ Final best expression
    ├── columns: k:1(int!null) c:2(bool)
    ├── constraint: /2/1/3: [/true/1 - /true/1]
    └── fd: ()-->(1)
+
+optsteps split-diff
+SELECT 1
+----
+================================================================================
+Initial expression
+  Cost: 0.05
+================================================================================
+  project
+   ├── columns: "?column?":1(int!null)
+   ├── cardinality: [1 - 1]
+   ├── key: ()
+   ├── fd: ()-->(1)
+   ├── values
+   │    ├── cardinality: [1 - 1]
+   │    ├── key: ()
+   │    └── tuple [type=tuple]
+   └── projections
+        └── const: 1 [as="?column?":1, type=int]
+================================================================================
+MergeProjectWithValues
+  Cost: 0.02
+================================================================================
+<<<<<<< before
+  project
+   ├── columns: "?column?":1(int!null)
+   ├── cardinality: [1 - 1]
+   ├── key: ()
+   ├── fd: ()-->(1)
+   ├── values
+   │    ├── cardinality: [1 - 1]
+   │    ├── key: ()
+   │    └── tuple [type=tuple]
+   └── projections
+        └── const: 1 [as="?column?":1, type=int]
+=======
+  values
+   ├── columns: "?column?":1(int!null)
+   ├── cardinality: [1 - 1]
+   ├── key: ()
+   ├── fd: ()-->(1)
+   └── tuple [type=tuple{int}]
+        └── const: 1 [type=int]
+>>>>>>> after
+================================================================================
+Final best expression
+  Cost: 0.02
+================================================================================
+  values
+   ├── columns: "?column?":1(int!null)
+   ├── cardinality: [1 - 1]
+   ├── key: ()
+   ├── fd: ()-->(1)
+   └── tuple [type=tuple{int}]
+        └── const: 1 [type=int]


### PR DESCRIPTION
This commit adds a test for the `split-diff` flag added to the
`optsteps` test command in #56765.

Release note: None