### PR TITLE
row: reduce allocations in kv fetchers

### DIFF
--- a/pkg/sql/row/fetcher.go
+++ b/pkg/sql/row/fetcher.go
@@ -619,7 +619,7 @@ func (rf *Fetcher) StartInconsistentScan(
 	// on read transactions, but perhaps one day it will release some resources.
 
 	rf.traceKV = traceKV
-	f, err := makeKVBatchFetcherWithSendFunc(
+	f, err := makeKVBatchFetcherWithSender(
 		sendFunc(sendFn),
 		spans,
 		rf.reverse,

--- a/pkg/sql/row/fetcher.go
+++ b/pkg/sql/row/fetcher.go
@@ -551,7 +551,7 @@ func (rf *Fetcher) StartScan(
 	if err != nil {
 		return err
 	}
-	return rf.StartScanFrom(ctx, &f)
+	return rf.StartScanFrom(ctx, f)
 }
 
 // StartInconsistentScan initializes and starts an inconsistent scan, where each
@@ -632,7 +632,7 @@ func (rf *Fetcher) StartInconsistentScan(
 	if err != nil {
 		return err
 	}
-	return rf.StartScanFrom(ctx, &f)
+	return rf.StartScanFrom(ctx, f)
 }
 
 func (rf *Fetcher) firstBatchLimit(limitHint int64) int64 {

--- a/pkg/sql/row/kv_fetcher.go
+++ b/pkg/sql/row/kv_fetcher.go
@@ -49,7 +49,7 @@ func NewKVFetcher(
 	kvBatchFetcher, err := makeKVBatchFetcher(
 		txn, spans, reverse, useBatchLimit, firstBatchLimit, lockStrength, lockWaitPolicy, mon,
 	)
-	return newKVFetcher(&kvBatchFetcher), err
+	return newKVFetcher(kvBatchFetcher), err
 }
 
 func newKVFetcher(batchFetcher kvBatchFetcher) *KVFetcher {


### PR DESCRIPTION
Pool allocations of txnKVFetcher and reuse a bunch of slice memory.

Also, remove a pointless closure allocation.

```
name                                           old time/op    new time/op    delta
FlowSetup/vectorize=false/distribute=false-24    14.0µs ± 5%    14.2µs ± 4%    ~     (p=0.243 n=9+10)

name                                           old alloc/op   new alloc/op   delta
FlowSetup/vectorize=false/distribute=false-24    29.8kB ± 0%    29.4kB ± 0%  -1.41%  (p=0.000 n=9+9)

name                                           old allocs/op  new allocs/op  delta
FlowSetup/vectorize=false/distribute=false-24       215 ± 0%       208 ± 0%  -3.26%  (p=0.000 n=10+10)
```

Release note: None