### PR TITLE
geos: link to docs if GEOS is not installed

### DIFF
--- a/pkg/geo/geos/BUILD.bazel
+++ b/pkg/geo/geos/BUILD.bazel
@@ -57,6 +57,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/geo/geos",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/docs",
         "//pkg/geo/geopb",
         "//vendor/github.com/cockroachdb/errors",
     ],

--- a/pkg/geo/geos/geos_test.go
+++ b/pkg/geo/geos/geos_test.go
@@ -11,6 +11,7 @@
 package geos
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/cockroachdb/errors"
@@ -21,11 +22,13 @@ func TestInitGEOS(t *testing.T) {
 	t.Run("test no initGEOS paths", func(t *testing.T) {
 		_, _, err := initGEOS([]string{})
 		require.Error(t, err)
+		require.Regexp(t, "Ensure you have the spatial libraries installed as per the instructions in .*install-cockroachdb-", strings.Join(errors.GetAllHints(err), "\n"))
 	})
 
 	t.Run("test invalid initGEOS paths", func(t *testing.T) {
 		_, _, err := initGEOS([]string{"/invalid/path"})
 		require.Error(t, err)
+		require.Regexp(t, "Ensure you have the spatial libraries installed as per the instructions in .*install-cockroachdb-", strings.Join(errors.GetAllHints(err), "\n"))
 	})
 
 	t.Run("test valid initGEOS paths", func(t *testing.T) {


### PR DESCRIPTION
Release note (sql change): Introduce a hint when GEOS is improperly
installed to the docs instructions on installing CockroachDB.