### PR TITLE
parser: remove CREATE DATABASE ... REGION from docs

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -2242,8 +2242,7 @@ signed_iconst ::=
 	| only_signed_iconst
 
 region_or_regions ::=
-	'REGION'
-	| 'REGIONS'
+	'REGIONS'
 
 region_name_list ::=
 	name_list

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -7611,6 +7611,9 @@ opt_regions_list:
 
 region_or_regions:
   REGION
+  {
+    /* SKIP DOC */
+  }
 | REGIONS
 
 survival_goal_clause:


### PR DESCRIPTION
Release note (sql change): Remove usage of `CREATE DATABASE ... REGION =
...` from documentation. However, this is still usable.