### PR TITLE
kv: eliminate heap allocations throughout Raft messaging and processing logic

### DIFF
--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -223,6 +223,9 @@ type Replica struct {
 	// connectionClass controls the ConnectionClass used to send raft messages.
 	connectionClass atomicConnectionClass
 
+	// schedulerCtx is a cached instance of an annotated Raft scheduler context.
+	schedulerCtx atomic.Value // context.Context
+
 	// raftMu protects Raft processing the replica.
 	//
 	// Locking notes: Replica.raftMu < Replica.mu

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -417,10 +417,6 @@ var noSnap IncomingSnapshot
 func (r *Replica) handleRaftReady(
 	ctx context.Context, inSnap IncomingSnapshot,
 ) (handleRaftReadyStats, string, error) {
-	defer func(start time.Time) {
-		elapsed := timeutil.Since(start)
-		r.store.metrics.RaftHandleReadyLatency.RecordValue(elapsed.Nanoseconds())
-	}(timeutil.Now())
 	r.raftMu.Lock()
 	defer r.raftMu.Unlock()
 	return r.handleRaftReadyRaftMuLocked(ctx, inSnap)

--- a/pkg/kv/kvserver/store_raft.go
+++ b/pkg/kv/kvserver/store_raft.go
@@ -484,6 +484,7 @@ func (s *Store) processReady(ctx context.Context, rangeID roachpb.RangeID) {
 	removed := maybeFatalOnRaftReadyErr(ctx, expl, err)
 	elapsed := timeutil.Since(start)
 	s.metrics.RaftWorkingDurationNanos.Inc(elapsed.Nanoseconds())
+	s.metrics.RaftHandleReadyLatency.RecordValue(elapsed.Nanoseconds())
 	// Warn if Raft processing took too long. We use the same duration as we
 	// use for warning about excessive raft mutex lock hold times. Long
 	// processing time means we'll have starved local replicas of ticks and

--- a/pkg/kv/kvserver/store_snapshot.go
+++ b/pkg/kv/kvserver/store_snapshot.go
@@ -705,8 +705,9 @@ func (s *Store) shouldAcceptSnapshotData(
 	if snapHeader.IsPreemptive() {
 		return errors.AssertionFailedf(`expected a raft or learner snapshot`)
 	}
-	pErr := s.withReplicaForRequest(ctx, &snapHeader.RaftMessageRequest,
-		func(ctx context.Context, r *Replica) *roachpb.Error {
+	pErr := s.withReplicaForRequest(
+		ctx, &snapHeader.RaftMessageRequest, func(ctx context.Context, r *Replica) *roachpb.Error {
+			ctx = r.AnnotateCtx(ctx)
 			// If the current replica is not initialized then we should accept this
 			// snapshot if it doesn't overlap existing ranges.
 			if !r.IsInitialized() {
@@ -717,7 +718,8 @@ func (s *Store) shouldAcceptSnapshotData(
 			// If the current range is initialized then we need to accept this
 			// snapshot.
 			return nil
-		})
+		},
+	)
 	return pErr.GoError()
 }
 


### PR DESCRIPTION
This PR contains a few improvements within the Raft messaging and processing code to avoid common heap allocations that stuck out during tests in #56860. This will improve the general efficiency of the Raft pipeline and will specifically reduce the cost of handling large coalesced heartbeats. This will reduce the impact that these heartbeats have on the [scheduler latency](https://github.com/cockroachdb/cockroach/pull/56943) of other active ranges.