### PR TITLE
sql: pool SpanBuilders

### DIFF
--- a/pkg/sql/distsql_plan_stats.go
+++ b/pkg/sql/distsql_plan_stats.go
@@ -86,6 +86,7 @@ func (dsp *DistSQLPlanner) createStatsPlan(
 		colIdxMap.Set(c.GetID(), i)
 	}
 	sb := span.MakeBuilder(planCtx.EvalContext(), planCtx.ExtendedEvalCtx.Codec, desc, scan.index)
+	defer sb.Release()
 	scan.spans, err = sb.UnconstrainedSpans()
 	if err != nil {
 		return nil, err

--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -188,6 +188,7 @@ func (e *distSQLSpecExecFactory) ConstructScan(
 	colCfg := makeScanColumnsConfig(table, params.NeededCols)
 
 	sb := span.MakeBuilder(e.planner.EvalContext(), e.planner.ExecCfg().Codec, tabDesc, idx)
+	defer sb.Release()
 
 	// Note that initColsForScan and setting ResultColumns below are equivalent
 	// to what scan.initTable call does in execFactory.ConstructScan.

--- a/pkg/sql/insert_fast_path.go
+++ b/pkg/sql/insert_fast_path.go
@@ -325,6 +325,12 @@ func (n *insertFastPathNode) BatchedValues(rowIdx int) tree.Datums { return n.ru
 
 func (n *insertFastPathNode) Close(ctx context.Context) {
 	n.run.ti.close(ctx)
+	for i := range n.run.fkChecks {
+		builder := n.run.fkChecks[i].spanBuilder
+		if builder != nil {
+			builder.Release()
+		}
+	}
 	*n = insertFastPathNode{}
 	insertFastPathNodePool.Put(n)
 }

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -148,6 +148,7 @@ func generateScanSpans(
 	params exec.ScanParams,
 ) (roachpb.Spans, error) {
 	sb := span.MakeBuilder(evalCtx, codec, tabDesc, index)
+	defer sb.Release()
 	if params.InvertedConstraint != nil {
 		return sb.SpansFromInvertedSpans(params.InvertedConstraint, params.IndexConstraint, nil /* scratch */)
 	}
@@ -1733,6 +1734,7 @@ func (ef *execFactory) ConstructDeleteRange(
 ) (exec.Node, error) {
 	tabDesc := table.(*optTable).desc
 	sb := span.MakeBuilder(ef.planner.EvalContext(), ef.planner.ExecCfg().Codec, tabDesc, tabDesc.GetPrimaryIndex())
+	defer sb.Release()
 
 	if err := ef.planner.maybeSetSystemConfig(tabDesc.GetID()); err != nil {
 		return nil, err

--- a/pkg/sql/rowexec/inverted_joiner.go
+++ b/pkg/sql/rowexec/inverted_joiner.go
@@ -767,6 +767,9 @@ func (ij *invertedJoiner) close() {
 		if ij.diskMonitor != nil {
 			ij.diskMonitor.Stop(ij.Ctx)
 		}
+		if ij.spanBuilder != nil {
+			ij.spanBuilder.Release()
+		}
 	}
 }
 

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -478,9 +478,12 @@ func (jr *joinReader) initJoinReaderStrategy(
 			generator = multiSpanGen
 		} else {
 			localityOptSpanGen := &localityOptimizedSpanGenerator{}
+			remoteSpanBuilder := span.MakeBuilder(flowCtx.EvalCtx, flowCtx.Codec(), jr.desc, jr.index)
+			remoteSpanBuilder.SetNeededColumns(neededRightCols)
 			remoteSpanGenMemAcc := jr.MemMonitor.MakeBoundAccount()
 			if err := localityOptSpanGen.init(
 				spanBuilder,
+				remoteSpanBuilder,
 				numKeyCols,
 				len(jr.input.OutputTypes()),
 				&jr.lookupExpr,

--- a/pkg/sql/rowexec/joinreader_span_generator.go
+++ b/pkg/sql/rowexec/joinreader_span_generator.go
@@ -179,6 +179,7 @@ func (g *defaultSpanGenerator) memUsage() int64 {
 
 func (g *defaultSpanGenerator) close(ctx context.Context) {
 	g.memAcc.Close(ctx)
+	g.spanBuilder.Release()
 	*g = defaultSpanGenerator{}
 }
 
@@ -728,6 +729,7 @@ func (g *multiSpanGenerator) memUsage() int64 {
 
 func (g *multiSpanGenerator) close(ctx context.Context) {
 	g.memAcc.Close(ctx)
+	g.spanBuilder.Release()
 	*g = multiSpanGenerator{}
 }
 
@@ -741,9 +743,12 @@ type localityOptimizedSpanGenerator struct {
 }
 
 // init must be called before the localityOptimizedSpanGenerator can be used to
-// generate spans.
+// generate spans. Note that we use two different span builders so that both
+// local and remote span generators could release their own when they are
+// close()d.
 func (g *localityOptimizedSpanGenerator) init(
-	spanBuilder *span.Builder,
+	localSpanBuilder *span.Builder,
+	remoteSpanBuilder *span.Builder,
 	numKeyCols int,
 	numInputCols int,
 	localExprHelper *execinfrapb.ExprHelper,
@@ -753,12 +758,12 @@ func (g *localityOptimizedSpanGenerator) init(
 	remoteSpanGenMemAcc *mon.BoundAccount,
 ) error {
 	if err := g.localSpanGen.init(
-		spanBuilder, numKeyCols, numInputCols, localExprHelper, tableOrdToIndexOrd, localSpanGenMemAcc,
+		localSpanBuilder, numKeyCols, numInputCols, localExprHelper, tableOrdToIndexOrd, localSpanGenMemAcc,
 	); err != nil {
 		return err
 	}
 	if err := g.remoteSpanGen.init(
-		spanBuilder, numKeyCols, numInputCols, remoteExprHelper, tableOrdToIndexOrd, remoteSpanGenMemAcc,
+		remoteSpanBuilder, numKeyCols, numInputCols, remoteExprHelper, tableOrdToIndexOrd, remoteSpanGenMemAcc,
 	); err != nil {
 		return err
 	}

--- a/pkg/sql/rowexec/zigzagjoiner.go
+++ b/pkg/sql/rowexec/zigzagjoiner.go
@@ -519,6 +519,9 @@ func (z *zigzagJoiner) close() {
 	if z.InternalClose() {
 		for i := range z.infos {
 			z.infos[i].fetcher.Close(z.Ctx)
+			if sb := z.infos[i].spanBuilder; sb != nil {
+				sb.Release()
+			}
 		}
 		log.VEventf(z.Ctx, 2, "exiting zigzag joiner run")
 	}

--- a/pkg/sql/scrub_physical.go
+++ b/pkg/sql/scrub_physical.go
@@ -114,6 +114,7 @@ func (o *physicalCheckOperation) Start(params runParams) error {
 	}
 	scan.index = scan.specifiedIndex
 	sb := span.MakeBuilder(params.EvalContext(), params.ExecCfg().Codec, o.tableDesc, o.index)
+	defer sb.Release()
 	scan.spans, err = sb.UnconstrainedSpans()
 	if err != nil {
 		return err

--- a/pkg/sql/span/span_builder.go
+++ b/pkg/sql/span/span_builder.go
@@ -12,6 +12,7 @@ package span
 
 import (
 	"sort"
+	"sync"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -55,18 +56,25 @@ var _ = (*Builder).UnsetNeededColumns
 var _ = (*Builder).SetNeededFamilies
 var _ = (*Builder).UnsetNeededFamilies
 
-// MakeBuilder creates a Builder for a table and index.
+var builderPool = sync.Pool{
+	New: func() interface{} { return &Builder{} },
+}
+
+// MakeBuilder creates a Builder for a table and index. The returned object must
+// be Release()d when no longer needed.
 func MakeBuilder(
 	evalCtx *tree.EvalContext,
 	codec keys.SQLCodec,
 	table catalog.TableDescriptor,
 	index catalog.Index,
 ) *Builder {
-	s := &Builder{
+	s := builderPool.Get().(*Builder)
+	*s = Builder{
 		evalCtx:        evalCtx,
 		codec:          codec,
 		table:          table,
 		index:          index,
+		indexColTypes:  s.indexColTypes,
 		KeyPrefix:      rowenc.MakeIndexKeyPrefix(codec, table, index.GetID()),
 		interstices:    make([][]byte, index.NumKeyColumns()+index.NumKeySuffixColumns()+1),
 		neededFamilies: nil,
@@ -74,7 +82,11 @@ func MakeBuilder(
 
 	var columnIDs descpb.ColumnIDs
 	columnIDs, s.indexColDirs = catalog.FullIndexColumnIDs(index)
-	s.indexColTypes = make([]*types.T, len(columnIDs))
+	if cap(s.indexColTypes) < len(columnIDs) {
+		s.indexColTypes = make([]*types.T, len(columnIDs))
+	} else {
+		s.indexColTypes = s.indexColTypes[:len(columnIDs)]
+	}
 	for i, colID := range columnIDs {
 		col, _ := table.FindColumnWithID(colID)
 		// TODO (rohany): do I need to look at table columns with mutations here as well?
@@ -536,4 +548,14 @@ func (s *Builder) generateInvertedSpanKey(
 
 	span, _, err := s.SpanFromEncDatums(scratchRow, keyLen)
 	return span.Key, err
+}
+
+// Release implements the execinfra.Releasable interface.
+func (s *Builder) Release() {
+	*s = Builder{
+		// Note that the types are small objects, so we don't bother deeply
+		// resetting the indexColTypes slice.
+		indexColTypes: s.indexColTypes[:0],
+	}
+	builderPool.Put(s)
 }


### PR DESCRIPTION
The SpanBuilder is an object that is allocated at least once per query, along
with slice memory inside of it, making it a good candidate for object
pooling.

```
name                                           old time/op    new time/op    delta
FlowSetup/vectorize=true/distribute=true-24       232µs ± 3%     232µs ± 2%    ~     (p=1.000 n=9+10)
FlowSetup/vectorize=true/distribute=false-24      222µs ± 2%     224µs ± 6%    ~     (p=0.315 n=10+10)
FlowSetup/vectorize=false/distribute=true-24      218µs ± 5%     219µs ± 4%    ~     (p=0.529 n=10+10)
FlowSetup/vectorize=false/distribute=false-24     209µs ± 3%     213µs ± 5%    ~     (p=0.123 n=10+10)

name                                           old alloc/op   new alloc/op   delta
FlowSetup/vectorize=true/distribute=true-24      38.1kB ± 3%    37.0kB ± 1%  -2.91%  (p=0.000 n=9+9)
FlowSetup/vectorize=true/distribute=false-24     36.0kB ± 0%    35.5kB ± 4%  -1.47%  (p=0.034 n=8+10)
FlowSetup/vectorize=false/distribute=true-24     42.8kB ± 0%    41.9kB ± 0%  -2.09%  (p=0.000 n=8+9)
FlowSetup/vectorize=false/distribute=false-24    41.1kB ± 0%    40.1kB ± 0%  -2.39%  (p=0.000 n=9+9)

name                                           old allocs/op  new allocs/op  delta
FlowSetup/vectorize=true/distribute=true-24         358 ± 1%       354 ± 0%  -1.14%  (p=0.000 n=9+8)
FlowSetup/vectorize=true/distribute=false-24        343 ± 0%       340 ± 0%  -0.87%  (p=0.000 n=9+8)
FlowSetup/vectorize=false/distribute=true-24        336 ± 0%       333 ± 0%  -0.89%  (p=0.000 n=9+9)
FlowSetup/vectorize=false/distribute=false-24       322 ± 0%       319 ± 0%  -0.93%  (p=0.001 n=8+9)
```

Release note: None