### PR TITLE
ui: update link on sessions page documentation

### DIFF
--- a/pkg/ui/src/util/docs.ts
+++ b/pkg/ui/src/util/docs.ts
@@ -51,6 +51,7 @@ export const clusterGlossary = docsURL("architecture/overview.html#glossary");
 export const reviewOfCockroachTerminology = docsURL("admin-ui-replication-dashboard.html#review-of-cockroachdb-terminology");
 export const privileges = docsURL("authorization.html#privileges");
 export const showSessions = docsURL("show-sessions.html");
+export const sessionsTable = docsURL("ui-sessions-page.html");
 // Note that these explicitly don't use the current version, since we want to
 // link to the most up-to-date documentation available.
 export const upgradeCockroachVersion = "https://www.cockroachlabs.com/docs/stable/upgrade-cockroach-version.html";

--- a/pkg/ui/src/views/sessions/sessionsPage.tsx
+++ b/pkg/ui/src/views/sessions/sessionsPage.tsx
@@ -30,7 +30,7 @@ import {createSelector} from "reselect";
 import {SessionsResponseMessage} from "src/util/api";
 import TerminateSessionModal, {TerminateSessionModalRef} from "src/views/sessions/terminateSessionModal";
 import TerminateQueryModal, {TerminateQueryModalRef} from "src/views/sessions/terminateQueryModal";
-import {showSessions} from "src/util/docs";
+import { sessionsTable } from "src/util/docs";
 import { Pagination, ResultsPerPageLabel } from "@cockroachlabs/admin-ui-components";
 import emptyTableResultsIcon from "!!url-loader!assets/emptyState/empty-table-results.svg";
 import { Anchor } from "src/components";
@@ -169,8 +169,7 @@ export class SessionsPage extends React.Component<SessionsPageProps, SessionsPag
                 message="Sessions show you which statements and transactions are running for the active session."
                 footer={
                   <Anchor
-                    // TODO(jordan): point this to a more appropriate page.
-                    href={showSessions}
+                    href={sessionsTable}
                     target="_blank"
                   >
                     Learn more about sessions


### PR DESCRIPTION
Replace link for sessions page documentation with correct one.

Release note: none