### PR TITLE
release-20.1: backupccl: check for running backups before writing enc opts

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -635,6 +635,14 @@ func backupPlanHook(
 			return err
 		}
 
+		// TODO (lucy): For partitioned backups, also add verification for other
+		// stores we are writing to in addition to the default.
+		if err := VerifyUsableExportTarget(
+			ctx, p.ExecCfg().Settings, defaultStore, defaultURI, encryption,
+		); err != nil {
+			return err
+		}
+
 		// If we didn't load any prior backups from which get encryption info, we
 		// need to pick a new salt and record it.
 		if encryptionPassphrase != nil && encryption == nil {
@@ -651,14 +659,6 @@ func backupPlanHook(
 				return err
 			}
 			encryption = &roachpb.FileEncryptionOptions{Key: storageccl.GenerateKey(encryptionPassphrase, salt)}
-		}
-
-		// TODO (lucy): For partitioned backups, also add verification for other
-		// stores we are writing to in addition to the default.
-		if err := VerifyUsableExportTarget(
-			ctx, p.ExecCfg().Settings, defaultStore, defaultURI, encryption,
-		); err != nil {
-			return err
 		}
 
 		backupDetails := jobspb.BackupDetails{

--- a/pkg/ccl/backupccl/manifest_handling.go
+++ b/pkg/ccl/backupccl/manifest_handling.go
@@ -628,13 +628,13 @@ func VerifyUsableExportTarget(
 			"%s already contains a %s file",
 			redactedURI, BackupManifestName)
 	}
-	if r, err := exportStore.ReadFile(ctx, BackupManifestName); err == nil {
+	if r, err := exportStore.ReadFile(ctx, BackupNewManifestName); err == nil {
 		// TODO(dt): If we audit exactly what not-exists error each ExternalStorage
 		// returns (and then wrap/tag them), we could narrow this check.
 		r.Close()
 		return pgerror.Newf(pgcode.FileAlreadyExists,
 			"%s already contains a %s file",
-			redactedURI, BackupManifestName)
+			redactedURI, BackupNewManifestName)
 	}
 	if r, err := exportStore.ReadFile(ctx, BackupManifestCheckpointName); err == nil {
 		r.Close()


### PR DESCRIPTION
If a BACKUP-CHECKPOINT file exists we assume another backup is running
and error out to avoid having two run at the same time, clobber each
other's writes and both end up unusable.

However previously we would write the encryption information -- namely
the randomly chosen salt -- when we picked the random salt, before we
checked if there was another backup running. This would overwrite the
randomly picked salt the previously started backup had written, then
observe the checkpoint file and terminate. However the data then written
by the existing job -- using the salt that had since been overwritten --
would never be readable, as the salt needed to decrypt it was lost.

Instead, this change delays presisting the chosen random salt until
after the check for a running backup.

Release note (bug fix): Fixed case where attempting to start a second BACKUP to the same location while the first was running using passphrase-based encryption could overwrite the metadata required to decrypt it and thus render it unreadbale.