### PR TITLE
opt: add rule to normalize @> to false when const array contains NULLs

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
@@ -782,7 +782,6 @@ vectorized: true
       spans: FULL SCAN
 
 # Test that searching for a NULL element using the inverted index.
-# TODO(rytaft): This filter should be normalized to false (see #56799).
 query T
 EXPLAIN (VERBOSE) SELECT * from e where b @> ARRAY[NULL]::INT[]
 ----
@@ -791,7 +790,7 @@ vectorized: true
 ·
 • filter
 │ columns: (a, b)
-│ estimated row count: 110 (missing stats)
+│ estimated row count: 0
 │ filter: b @> ARRAY[NULL]
 │
 └── • scan

--- a/pkg/sql/opt/memo/constraint_builder.go
+++ b/pkg/sql/opt/memo/constraint_builder.go
@@ -206,6 +206,11 @@ func (cb *constraintsBuilder) buildSingleColumnConstraintConst(
 		}
 
 	case opt.ContainsOp:
+		if arr, ok := datum.(*tree.DArray); ok {
+			if arr.HasNulls {
+				return contradiction, true
+			}
+		}
 		// NULL cannot contain anything, so a non-tight, not-null span is built.
 		return cb.notNullSpan(col), false
 	}

--- a/pkg/sql/opt/memo/testdata/logprops/constraints
+++ b/pkg/sql/opt/memo/testdata/logprops/constraints
@@ -1444,3 +1444,25 @@ project
  │              └── const: ARRAY[1] [type=int[]]
  └── projections
       └── const: 1 [as="?column?":5, type=int]
+
+opt
+SELECT * from f where a @> ARRAY[NULL]::INT[]
+----
+select
+ ├── columns: k:1(int!null) j:2(jsonb) a:3(int[])
+ ├── cardinality: [0 - 0]
+ ├── immutable
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── prune: (1,2)
+ ├── interesting orderings: (+1)
+ ├── scan f
+ │    ├── columns: k:1(int!null) j:2(jsonb) a:3(int[])
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,3)
+ │    ├── prune: (1-3)
+ │    └── interesting orderings: (+1)
+ └── filters
+      └── contains [type=bool, outer=(3), immutable, constraints=(contradiction; tight)]
+           ├── variable: a:3 [type=int[]]
+           └── const: ARRAY[NULL] [type=int[]]

--- a/pkg/sql/opt/optgen/lang/doc.go
+++ b/pkg/sql/opt/optgen/lang/doc.go
@@ -102,7 +102,13 @@ rule has a unique name and consists of a match pattern and a corresponding
 replace pattern. A rule's match pattern is tested against every node in the
 target expression tree, bottom-up. Each matching node is replaced by a node
 constructed according to the replace pattern. The replacement node is itself
-tested against every rule, and so on, until no further rules match.
+tested against every rule, and so on, until no further rules match. The order
+that rules are applied depends on the order of the rules in each file, the
+lexicographical ordering of files, and whether or not a rule is marked as high
+or low priority as it is depicted below:
+
+[InlineConstVar, Normalize, HighPriority]
+
 
 Note that this is just a conceptual description. Optgen does not actually do
 any of this matching or replacing itself. Other components use the Optgen


### PR DESCRIPTION
This PR adds a normalization rule that normalize a contains expression
(@>) to false when a right argument is a constant array and it contains
NULL elements.

Fixes: #56799

Release note: None