### PR TITLE
colexec: support running colexec tests through bazel

### DIFF
--- a/pkg/sql/colexec/COLEXEC.bzl
+++ b/pkg/sql/colexec/COLEXEC.bzl
@@ -21,6 +21,7 @@ def _generate_impl(ctx):
             outputs = [generated_file],
             progress_message = "Generating pkg/cmd/colexec/%s" % generated_file_name,
             command = """
+            ln -s external/cockroach/pkg pkg
             %s -fmt=false pkg/sql/colexec/%s > %s
             %s -w %s
             """ % (execgen_binary.path, generated_file_name, generated_file.path, goimports_binary.path, generated_file.path),


### PR DESCRIPTION
The way `execgen` is constructed, it expects to find the relevant
_tmpl.go files in the hardcoded paths (which happen to be relative to
the repo root). With bazel the code-gen process occurs within the
sandbox, and the template files aren't placed in the exact same paths as
in the repo (it's placed within `external/cockroach/pkg/...` instead).
When trying to execute pkg/sql/colexec tests through bazel, the template
files aren't found in the right paths, and the `execgen` processes
subsequently fail. See #56982 for more details.

```
$ bazel test @cockroach//pkg/sql/colexec:colexec_test
...
INFO: From Generating pkg/cmd/colexec/and_or_projection.eg.go:
ERROR: open pkg/sql/colexec/and_or_projection_tmpl.go: no such file or directory
```

Short of changing out `execgen` to consider template files as data
dependencies, for now lets just symlink the relevant files into the
"right" path within the bazel sandbox.

Release note: None