### PR TITLE
release-20.1: sql: fix leak due to retained references to SystemConfig

### DIFF
--- a/pkg/sql/database.go
+++ b/pkg/sql/database.go
@@ -262,7 +262,6 @@ func (dc *databaseCache) getCachedDatabaseID(name string) (sqlbase.ID, error) {
 	if name == sqlbase.SystemDB.Name {
 		return sqlbase.SystemDB.ID, nil
 	}
-
 	var nameKey sqlbase.DescriptorKey = sqlbase.NewDatabaseKey(name)
 	nameVal := dc.systemConfig.GetValue(nameKey.Key())
 	if nameVal == nil {

--- a/pkg/sql/physical_schema_accessors.go
+++ b/pkg/sql/physical_schema_accessors.go
@@ -271,7 +271,7 @@ func (a *CachedPhysicalAccessor) GetDatabaseDesc(
 			return nil, err
 		}
 
-		if dbID != sqlbase.InvalidID {
+		if dbID != sqlbase.InvalidID && a.tc.maybeSetDatabaseCache() {
 			// Some database ID was found in the list of uncommitted DB changes.
 			// Use that to get the descriptor.
 			desc, err := a.tc.databaseCache.getDatabaseDescByID(ctx, txn, dbID)
@@ -283,7 +283,9 @@ func (a *CachedPhysicalAccessor) GetDatabaseDesc(
 
 		// The database was not known in the uncommitted list. Have the db
 		// cache look it up by name for us.
-		return a.tc.databaseCache.getDatabaseDesc(ctx, a.tc.leaseMgr.db.Txn, name, flags.Required)
+		if a.tc.maybeSetDatabaseCache() {
+			return a.tc.databaseCache.getDatabaseDesc(ctx, a.tc.leaseMgr.db.Txn, name, flags.Required)
+		}
 	}
 
 	// We avoided the cache. Go lower.


### PR DESCRIPTION
We've noticed recently that there are apparent memory leaks due to holding
on to references to the SystemConfig. It turns out that there are two places
where we seem to retain such references: in the optCatalog and in
the database cache. This approach was discovered in a pretty ad-hoc way
by reproducing the issues by repeatedly creating and dropping schema elements.

```bash
cockroach sql --insecure --watch 100ms -e '
CREATE DATABASE db;
CREATE TABLE db.foo (i INT PRIMARY KEY);
CREATE TABLE db.bar (i INT PRIMARY KEY);
ALTER TABLE db.bar ADD COLUMN j INT UNIQUE;
ALTER TABLE db.foo ADD COLUMN j INT UNIQUE;
ALTER TABLE db.foo ADD CONSTRAINT fk FOREIGN KEY (j) REFERENCES db.bar(j);
DROP DATABASE db CASCADE;
'
```

The reason why this is practially a problem is that we construct a planner
with its executor for executing jobs. This comes up in the context of many
schema changes in that we generally create these GC jobs which hold on to
references to the database cache (prior to this change).

Fixes #56970.

Release note (bug fix): Fix memory leak due to rapid schema changes involving
dropping schema elements.