### PR TITLE
release-20.2: geos: link to docs if GEOS is not installed

### DIFF
--- a/pkg/geo/geos/geos_test.go
+++ b/pkg/geo/geos/geos_test.go
@@ -11,6 +11,7 @@
 package geos
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/cockroachdb/errors"
@@ -21,11 +22,13 @@ func TestInitGEOS(t *testing.T) {
 	t.Run("test no initGEOS paths", func(t *testing.T) {
 		_, _, err := initGEOS([]string{})
 		require.Error(t, err)
+		require.Regexp(t, "Ensure you have the spatial libraries installed as per the instructions in .*install-cockroachdb-", strings.Join(errors.GetAllHints(err), "\n"))
 	})
 
 	t.Run("test invalid initGEOS paths", func(t *testing.T) {
 		_, _, err := initGEOS([]string{"/invalid/path"})
 		require.Error(t, err)
+		require.Regexp(t, "Ensure you have the spatial libraries installed as per the instructions in .*install-cockroachdb-", strings.Join(errors.GetAllHints(err), "\n"))
 	})
 
 	t.Run("test valid initGEOS paths", func(t *testing.T) {


### PR DESCRIPTION
Backport 1/1 commits from #57004.

/cc @cockroachdb/release

---

Release note (sql change): Introduce a hint when GEOS is improperly
installed to the docs instructions on installing CockroachDB.
