### PR TITLE
cli: add reset-quorum command

### DIFF
--- a/pkg/cli/BUILD.bazel
+++ b/pkg/cli/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "debug.go",
         "debug_check_store.go",
         "debug_merge_logs.go",
+        "debug_reset_quorum.go",
         "debug_synctest.go",
         "decode.go",
         "demo.go",

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -1178,6 +1178,7 @@ var debugCmds = append(DebugCmdsForRocksDB,
 	debugEnvCmd,
 	debugZipCmd,
 	debugMergeLogsCommand,
+	debugResetQuorumCmd,
 )
 
 // DebugCmd is the root of all debug commands. Exported to allow modification by CCL code.

--- a/pkg/cli/debug_reset_quorum.go
+++ b/pkg/cli/debug_reset_quorum.go
@@ -1,0 +1,68 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package cli
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/spf13/cobra"
+)
+
+var debugResetQuorumCmd = &cobra.Command{
+	Use: "reset-quorum [range ID]",
+	Short: "Reset quorum on the given range" +
+		" by designating the target node as the sole voter.",
+	Long: `
+Reset quorum on the given range by designating the current node as 
+the sole voter. Any existing data for the range is discarded. 
+
+This command is UNSAFE and should only be used with the supervision 
+of Cockroach Labs support. It is a last-resort option to recover a 
+specified range after multiple node failures and loss of quorum.
+
+Data on any surviving replicas will not be used to restore quorum. 
+Instead, these replicas will be removed irrevocably.
+`,
+	Args: cobra.ExactArgs(1),
+	RunE: MaybeDecorateGRPCError(runDebugResetQuorum),
+}
+
+func runDebugResetQuorum(cmd *cobra.Command, args []string) error {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	rangeID, err := strconv.ParseInt(args[0], 10, 32)
+	if err != nil {
+		return err
+	}
+
+	// Set up GRPC Connection for running ResetQuorum.
+	cc, _, finish, err := getClientGRPCConn(ctx, serverCfg)
+	if err != nil {
+		return err
+	}
+	defer finish()
+
+	// Call ResetQuorum to reset quorum for given range on target node.
+	_, err = roachpb.NewInternalClient(cc).ResetQuorum(ctx, &roachpb.ResetQuorumRequest{
+		RangeID: int32(rangeID),
+	})
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("ok; please verify https://<ui>/#/reports/range/%d", rangeID)
+
+	return nil
+}


### PR DESCRIPTION
This adds `reset-quorum` as a command in the debug CLI. This command utilizes the functionality added in #56333 to recover unavailable ranges where all replicas are lost. 