### PR TITLE
colflow: add sync protection to latency getter map

### DIFF
--- a/pkg/server/serverpb/BUILD.bazel
+++ b/pkg/server/serverpb/BUILD.bazel
@@ -34,6 +34,7 @@ go_library(
         "//pkg/util/errorutil",
         "//pkg/util/log/logpb",
         "//pkg/util/metric",
+        "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "//pkg/util/uuid",
         "//vendor/github.com/gogo/protobuf/proto",
@@ -53,7 +54,14 @@ go_library(
 
 go_test(
     name = "serverpb_test",
-    srcs = ["admin_test.go"],
+    srcs = [
+        "admin_test.go",
+        "status_test.go",
+    ],
     embed = [":serverpb"],
-    deps = ["//vendor/github.com/stretchr/testify/assert"],
+    deps = [
+        "//pkg/roachpb",
+        "//pkg/util/timeutil",
+        "//vendor/github.com/stretchr/testify/assert",
+    ],
 )

--- a/pkg/server/serverpb/status.go
+++ b/pkg/server/serverpb/status.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
@@ -69,9 +70,12 @@ func (s *OptionalNodesStatusServer) OptionalNodesStatusServer(
 // These latencies are displayed on the streams of EXPLAIN ANALYZE diagrams.
 // This struct is put here to avoid import cycles.
 type LatencyGetter struct {
-	latencyMap        map[roachpb.NodeID]map[roachpb.NodeID]int64
-	lastUpdatedTime   time.Time
 	NodesStatusServer *OptionalNodesStatusServer
+	mu                struct {
+		syncutil.Mutex
+		lastUpdatedTime time.Time
+		latencyMap      map[roachpb.NodeID]map[roachpb.NodeID]int64
+	}
 }
 
 const updateThreshold = 5 * time.Second
@@ -82,35 +86,41 @@ const updateThreshold = 5 * time.Second
 func (lg *LatencyGetter) GetLatency(
 	ctx context.Context, originNodeID roachpb.NodeID, targetNodeID roachpb.NodeID,
 ) int64 {
-	if timeutil.Since(lg.lastUpdatedTime) < updateThreshold {
-		return lg.latencyMap[originNodeID][targetNodeID]
+	lg.mu.Lock()
+	defer lg.mu.Unlock()
+	if timeutil.Since(lg.mu.lastUpdatedTime) < updateThreshold {
+		return lg.mu.latencyMap[originNodeID][targetNodeID]
 	}
 	// Update latencies in latencyMap.
+	if lg.NodesStatusServer == nil {
+		// When latency is 0, it is not shown on EXPLAIN ANALYZE diagrams.
+		return 0
+	}
 	ss, err := lg.NodesStatusServer.OptionalNodesStatusServer(errorutil.FeatureNotAvailableToNonSystemTenantsIssue)
 	if err != nil {
 		// When latency is 0, it is not shown on EXPLAIN ANALYZE diagrams.
 		return 0
 	}
-	if lg.latencyMap == nil {
-		lg.latencyMap = make(map[roachpb.NodeID]map[roachpb.NodeID]int64)
+	if lg.mu.latencyMap == nil {
+		lg.mu.latencyMap = make(map[roachpb.NodeID]map[roachpb.NodeID]int64)
 	}
 	response, err := ss.Nodes(ctx, &NodesRequest{})
 	if err != nil {
 		// When latency is 0, it is not shown on EXPLAIN ANALYZE diagrams.
 		return 0
 	}
-	for _, sendingNode := range response.Nodes {
-		sendingNodeID := sendingNode.Desc.NodeID
-		if lg.latencyMap[sendingNodeID] == nil {
-			lg.latencyMap[sendingNodeID] = make(map[roachpb.NodeID]int64)
+	for i := 0; i < len(response.Nodes); i++ {
+		sendingNodeID := response.Nodes[i].Desc.NodeID
+		if lg.mu.latencyMap[sendingNodeID] == nil {
+			lg.mu.latencyMap[sendingNodeID] = make(map[roachpb.NodeID]int64)
 		}
-		for _, receivingNode := range response.Nodes {
-			receivingNodeID := receivingNode.Desc.NodeID
+		for j := 0; j < len(response.Nodes); j++ {
+			receivingNodeID := response.Nodes[i].Desc.NodeID
 			if sendingNodeID != receivingNodeID {
-				lg.latencyMap[sendingNodeID][receivingNodeID] = sendingNode.Activity[receivingNodeID].Latency
+				lg.mu.latencyMap[sendingNodeID][receivingNodeID] = response.Nodes[i].Activity[receivingNodeID].Latency
 			}
 		}
 	}
-	lg.lastUpdatedTime = timeutil.Now()
-	return lg.latencyMap[originNodeID][targetNodeID]
+	lg.mu.lastUpdatedTime = timeutil.Now()
+	return lg.mu.latencyMap[originNodeID][targetNodeID]
 }

--- a/pkg/server/serverpb/status_test.go
+++ b/pkg/server/serverpb/status_test.go
@@ -1,0 +1,75 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package serverpb
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+func TestLatencyGetter_GetLatency(t *testing.T) {
+	type fields struct {
+		lastUpdatedTime time.Time
+		latencyMap      map[roachpb.NodeID]map[roachpb.NodeID]int64
+	}
+	type args struct {
+		ctx          context.Context
+		originNodeID roachpb.NodeID
+		targetNodeID roachpb.NodeID
+	}
+
+	latencyMap := map[roachpb.NodeID]map[roachpb.NodeID]int64{
+		1: {2: 5},
+		2: {1: 3},
+	}
+
+	tests := []struct {
+		name            string
+		fields          fields
+		args            args
+		expectedLatency int64
+	}{
+		{
+			name: "GetLatencyWithoutUpdate",
+			fields: fields{
+				lastUpdatedTime: timeutil.Now().Add(time.Hour),
+				latencyMap:      latencyMap,
+			},
+			args:            args{ctx: context.Background(), originNodeID: 1, targetNodeID: 2},
+			expectedLatency: 5,
+		},
+		{
+			name: "UpdateLatencies",
+			fields: fields{
+				lastUpdatedTime: timeutil.Now().Add(time.Hour * -1),
+				latencyMap:      latencyMap,
+			},
+			args: args{ctx: context.Background(), originNodeID: 1, targetNodeID: 2},
+			// expectedLatency is 0 for this test because when the NodesStatusServer can't be accessed,
+			// a latency of 0 is returned so that it isn't displayed on EXPLAIN ANALYZE diagrams.
+			expectedLatency: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lg := &LatencyGetter{}
+			lg.mu.lastUpdatedTime = tt.fields.lastUpdatedTime
+			lg.mu.latencyMap = tt.fields.latencyMap
+			if got := lg.GetLatency(tt.args.ctx, tt.args.originNodeID, tt.args.targetNodeID); got != tt.expectedLatency {
+				t.Errorf("GetLatency() = %v, want %v", got, tt.expectedLatency)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This commit adds a mutex lock to LatencyGetter, ensuring that concurrent
writes to the latencyMap do not occur.

Closes: #56997 
Closes: #56360
Closes: #56278
Closes: #56275

Release note: None.