### PR TITLE
ccl/sqlproxyccl: allow non-TLS connections, expose Done channel

### DIFF
--- a/pkg/ccl/cliccl/mtproxy.go
+++ b/pkg/ccl/cliccl/mtproxy.go
@@ -149,7 +149,7 @@ Uuwb2FVdh76ZK0AVd3Jh3KJs4+hr2u9syHaa7UPKXTcZsFWlGwZuu6X5A+0SO0S2
 			Certificates: []tls.Certificate{cer},
 		},
 		BackendConfigFromParams: func(
-			params map[string]string, _ net.Conn,
+			params map[string]string, _ *sqlproxyccl.Conn,
 		) (config *sqlproxyccl.BackendConfig, clientErr error) {
 			const magic = "prancing-pony"
 			cfg := &sqlproxyccl.BackendConfig{

--- a/pkg/ccl/sqlproxyccl/proxy.go
+++ b/pkg/ccl/sqlproxyccl/proxy.go
@@ -45,7 +45,7 @@ type Options struct {
 	// connection. The TLS config is in it and it must have an appropriate
 	// ServerName for the remote backend.
 	BackendConfigFromParams func(
-		params map[string]string, incomingConn net.Conn,
+		params map[string]string, incomingConn *Conn,
 	) (config *BackendConfig, clientErr error)
 
 	// If set, consulted to modify the parameters set by the frontend before
@@ -59,7 +59,7 @@ type Options struct {
 
 // Proxy takes an incoming client connection and relays it to a backend SQL
 // server.
-func (s *Server) Proxy(conn net.Conn) error {
+func (s *Server) Proxy(proxyConn *Conn) error {
 	sendErrToClient := func(conn net.Conn, code ErrorCode, msg string) {
 		if s.opts.OnSendErrToClient != nil {
 			msg = s.opts.OnSendErrToClient(code, msg)
@@ -71,6 +71,7 @@ func (s *Server) Proxy(conn net.Conn) error {
 		}).Encode(nil))
 	}
 
+	var conn net.Conn = proxyConn
 	{
 		m, err := pgproto3.NewBackend(pgproto3.NewChunkReader(conn), conn).ReceiveStartupMessage()
 		if err != nil {
@@ -126,7 +127,7 @@ func (s *Server) Proxy(conn net.Conn) error {
 	var backendConfig *BackendConfig
 	{
 		var clientErr error
-		backendConfig, clientErr = s.opts.BackendConfigFromParams(msg.Parameters, conn)
+		backendConfig, clientErr = s.opts.BackendConfigFromParams(msg.Parameters, proxyConn)
 		if clientErr != nil {
 			var codeErr *codeError
 			if !errors.As(clientErr, &codeErr) {

--- a/pkg/ccl/sqlproxyccl/proxy.go
+++ b/pkg/ccl/sqlproxyccl/proxy.go
@@ -72,7 +72,9 @@ func (s *Server) Proxy(proxyConn *Conn) error {
 	}
 
 	var conn net.Conn = proxyConn
-	{
+	// If we have an incoming TLS Config, require that the client initiates
+	// with a TLS connection.
+	if s.opts.IncomingTLSConfig != nil {
 		m, err := pgproto3.NewBackend(pgproto3.NewChunkReader(conn), conn).ReceiveStartupMessage()
 		if err != nil {
 			return NewErrorf(CodeClientReadFailed, "while receiving startup message")
@@ -154,25 +156,27 @@ func (s *Server) Proxy(proxyConn *Conn) error {
 		return NewErrorf(code, "dialing backend server: %v", err)
 	}
 
-	// Send SSLRequest.
-	if err := binary.Write(crdbConn, binary.BigEndian, pgSSLRequest); err != nil {
-		s.metrics.BackendDownCount.Inc(1)
-		return NewErrorf(CodeBackendDown, "sending SSLRequest to target server: %v", err)
-	}
+	if backendConfig.TLSConf != nil {
+		// Send SSLRequest.
+		if err := binary.Write(crdbConn, binary.BigEndian, pgSSLRequest); err != nil {
+			s.metrics.BackendDownCount.Inc(1)
+			return NewErrorf(CodeBackendDown, "sending SSLRequest to target server: %v", err)
+		}
 
-	response := make([]byte, 1)
-	if _, err = io.ReadFull(crdbConn, response); err != nil {
-		s.metrics.BackendDownCount.Inc(1)
-		return NewErrorf(CodeBackendDown, "reading response to SSLRequest")
-	}
+		response := make([]byte, 1)
+		if _, err = io.ReadFull(crdbConn, response); err != nil {
+			s.metrics.BackendDownCount.Inc(1)
+			return NewErrorf(CodeBackendDown, "reading response to SSLRequest")
+		}
 
-	if response[0] != pgAcceptSSLRequest {
-		s.metrics.BackendDownCount.Inc(1)
-		return NewErrorf(CodeBackendRefusedTLS, "target server refused TLS connection")
-	}
+		if response[0] != pgAcceptSSLRequest {
+			s.metrics.BackendDownCount.Inc(1)
+			return NewErrorf(CodeBackendRefusedTLS, "target server refused TLS connection")
+		}
 
-	outCfg := backendConfig.TLSConf.Clone()
-	crdbConn = tls.Client(crdbConn, outCfg)
+		outCfg := backendConfig.TLSConf.Clone()
+		crdbConn = tls.Client(crdbConn, outCfg)
+	}
 
 	if s.opts.ModifyRequestParams != nil {
 		s.opts.ModifyRequestParams(msg.Parameters)

--- a/pkg/ccl/sqlproxyccl/proxy_test.go
+++ b/pkg/ccl/sqlproxyccl/proxy_test.go
@@ -66,8 +66,8 @@ openssl req -new -x509 -sha256 -key testserver.key -out testserver.crt \
 
 func testingTenantIDFromDatabaseForAddr(
 	addr string, validTenant string,
-) func(map[string]string, net.Conn) (config *BackendConfig, clientErr error) {
-	return func(p map[string]string, _ net.Conn) (config *BackendConfig, clientErr error) {
+) func(map[string]string, *Conn) (config *BackendConfig, clientErr error) {
+	return func(p map[string]string, _ *Conn) (config *BackendConfig, clientErr error) {
 		const dbKey = "database"
 		db, ok := p[dbKey]
 		if !ok {
@@ -135,7 +135,7 @@ func TestLongDBName(t *testing.T) {
 	var m map[string]string
 	opts := Options{
 		BackendConfigFromParams: func(
-			mm map[string]string, _ net.Conn) (config *BackendConfig, clientErr error) {
+			mm map[string]string, _ *Conn) (config *BackendConfig, clientErr error) {
 			m = mm
 			return nil, errors.New("boom")
 		},
@@ -225,7 +225,7 @@ func TestProxyAgainstSecureCRDB(t *testing.T) {
 
 	var connSuccess bool
 	opts := Options{
-		BackendConfigFromParams: func(params map[string]string, _ net.Conn) (*BackendConfig, error) {
+		BackendConfigFromParams: func(params map[string]string, _ *Conn) (*BackendConfig, error) {
 			return &BackendConfig{
 				OutgoingAddress:     tc.Server(0).ServingSQLAddr(),
 				TLSConf:             outgoingTLSConfig,
@@ -263,7 +263,7 @@ func TestProxyModifyRequestParams(t *testing.T) {
 	outgoingTLSConfig.InsecureSkipVerify = true
 
 	opts := Options{
-		BackendConfigFromParams: func(params map[string]string, _ net.Conn) (*BackendConfig, error) {
+		BackendConfigFromParams: func(params map[string]string, _ *Conn) (*BackendConfig, error) {
 			return &BackendConfig{
 				OutgoingAddress: tc.Server(0).ServingSQLAddr(),
 				TLSConf:         outgoingTLSConfig,
@@ -311,7 +311,7 @@ func TestProxyRefuseConn(t *testing.T) {
 
 	ac := makeAssertCtx()
 	opts := Options{
-		BackendConfigFromParams: func(params map[string]string, _ net.Conn) (*BackendConfig, error) {
+		BackendConfigFromParams: func(params map[string]string, _ *Conn) (*BackendConfig, error) {
 			return &BackendConfig{
 				OutgoingAddress: tc.Server(0).ServingSQLAddr(),
 				TLSConf:         outgoingTLSConfig,

--- a/pkg/ccl/sqlproxyccl/proxy_test.go
+++ b/pkg/ccl/sqlproxyccl/proxy_test.go
@@ -298,6 +298,87 @@ func TestProxyModifyRequestParams(t *testing.T) {
 	require.EqualValues(t, 1, n)
 }
 
+func newInsecureProxyServer(
+	t *testing.T, outgoingAddr string, outgoingTLSConfig *tls.Config,
+) (addr string, cleanup func()) {
+	s := NewServer(Options{
+		BackendConfigFromParams: func(params map[string]string, _ *Conn) (*BackendConfig, error) {
+			return &BackendConfig{
+				OutgoingAddress: outgoingAddr,
+				TLSConf:         outgoingTLSConfig,
+			}, nil
+		},
+	})
+	const listenAddress = "127.0.0.1:0"
+	ln, err := net.Listen("tcp", listenAddress)
+	require.NoError(t, err)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_ = s.Serve(ln)
+	}()
+	return ln.Addr().String(), func() {
+		_ = ln.Close()
+		wg.Wait()
+	}
+}
+
+func TestInsecureProxy(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	tc := serverutils.StartNewTestCluster(t, 1, base.TestClusterArgs{})
+	defer tc.Stopper().Stop(ctx)
+
+	outgoingTLSConfig, err := tc.Server(0).RPCContext().GetClientTLSConfig()
+	require.NoError(t, err)
+	outgoingTLSConfig.InsecureSkipVerify = true
+
+	addr, cleanup := newInsecureProxyServer(t, tc.Server(0).ServingSQLAddr(), outgoingTLSConfig)
+	defer cleanup()
+
+	u := fmt.Sprintf("postgres://root:admin@%s/?sslmode=disable", addr)
+	conn, err := pgx.Connect(ctx, u)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, conn.Close(ctx))
+	}()
+
+	var n int
+	err = conn.QueryRow(ctx, "SELECT $1::int", 1).Scan(&n)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, n)
+}
+
+func TestInsecureDoubleProxy(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	tc := serverutils.StartNewTestCluster(t, 1, base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{Insecure: true},
+	})
+	defer tc.Stopper().Stop(ctx)
+
+	// Test multiple proxies:  proxyB -> proxyA -> tc
+	proxyA, cleanupA := newInsecureProxyServer(t, tc.Server(0).ServingSQLAddr(), nil /* tls config */)
+	defer cleanupA()
+	proxyB, cleanupB := newInsecureProxyServer(t, proxyA, nil /* tls config */)
+	defer cleanupB()
+
+	u := fmt.Sprintf("postgres://root:admin@%s/?sslmode=disable", proxyB)
+	conn, err := pgx.Connect(ctx, u)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, conn.Close(ctx))
+	}()
+
+	var n int
+	err = conn.QueryRow(ctx, "SELECT $1::int", 1).Scan(&n)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, n)
+}
+
 func TestProxyRefuseConn(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 


### PR DESCRIPTION
ccl/sqlproxyccl: expose a connection Done channel 

Expose a per-connection Done channel to package consumers. This will be
used by the CC superuser sql proxy to clean up auxiliary resources when
connections are terminated.

ccl/sqlproxyccl: allow insecure non-TLS connections

Allow sqlproxy to be configured without TLS for either the incoming or
outgoing connections. This is helpful for the Cockroach Cloud local
development environment which by default does not use TLS.