### PR TITLE
release-20.1: jobs: paginate job deletions

### DIFF
--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -593,13 +593,44 @@ func (r *Registry) isOrphaned(ctx context.Context, payload *jobspb.Payload) (boo
 	return true, nil
 }
 
+const cleanupPageSize = 100
+
 func (r *Registry) cleanupOldJobs(ctx context.Context, olderThan time.Time) error {
-	const stmt = `SELECT id, payload, status, created FROM system.jobs WHERE created < $1
-		      ORDER BY created LIMIT 1000`
-	rows, err := r.ex.Query(ctx, "gc-jobs", nil /* txn */, stmt, olderThan)
-	if err != nil {
-		return err
+	var maxID int64
+	for {
+		var done bool
+		var err error
+		done, maxID, err = r.cleanupOldJobsPage(ctx, olderThan, maxID, cleanupPageSize)
+		if err != nil || done {
+			return err
+		}
 	}
+}
+
+// cleanupOldJobsPage deletes up to cleanupPageSize job rows with ID > minID.
+// minID is supposed to be the maximum ID returned by the previous page (0 if no
+// previous page).
+func (r *Registry) cleanupOldJobsPage(
+	ctx context.Context, olderThan time.Time, minID int64, pageSize int,
+) (done bool, maxID int64, _ error) {
+	const stmt = "SELECT id, payload, status, created FROM system.jobs " +
+		"WHERE created < $1 AND id > $2 " +
+		"ORDER BY id " + // the ordering is important as we keep track of the maximum ID we've seen
+		"LIMIT $3"
+	rows, err := r.ex.Query(ctx, "gc-jobs", nil /* txn */, stmt, olderThan, minID, pageSize)
+	if err != nil {
+		return false, 0, err
+	}
+	log.VEventf(ctx, 2, "read potentially expired jobs: %d", len(rows))
+
+	if len(rows) == 0 {
+		return true, 0, nil
+	}
+	// Track the highest ID we encounter, so it can serve as the bottom of the
+	// next page.
+	maxID = int64(*(rows[len(rows)-1][0].(*tree.DInt)))
+	// If we got as many rows as we asked for, there might be more.
+	morePages := len(rows) == pageSize
 
 	toDelete := tree.NewDArray(types.Int)
 	toDelete.Array = make(tree.Datums, 0, len(rows))
@@ -607,14 +638,14 @@ func (r *Registry) cleanupOldJobs(ctx context.Context, olderThan time.Time) erro
 	for _, row := range rows {
 		payload, err := UnmarshalPayload(row[1])
 		if err != nil {
-			return err
+			return false, 0, err
 		}
 		remove := false
 		switch Status(*row[2].(*tree.DString)) {
 		case StatusRunning, StatusPending:
 			done, err := r.isOrphaned(ctx, payload)
 			if err != nil {
-				return err
+				return false, 0, err
 			}
 			remove = done && row[3].(*tree.DTimestamp).Time.Before(olderThan)
 		case StatusSucceeded, StatusCanceled, StatusFailed:
@@ -625,20 +656,20 @@ func (r *Registry) cleanupOldJobs(ctx context.Context, olderThan time.Time) erro
 		}
 	}
 	if len(toDelete.Array) > 0 {
-		log.Infof(ctx, "cleaning up %d expired job records", len(toDelete.Array))
+		log.Infof(ctx, "cleaning up expired job records: %d", len(toDelete.Array))
 		const stmt = `DELETE FROM system.jobs WHERE id = ANY($1)`
 		var nDeleted int
 		if nDeleted, err = r.ex.Exec(
 			ctx, "gc-jobs", nil /* txn */, stmt, toDelete,
 		); err != nil {
-			return errors.Wrap(err, "deleting old jobs")
+			return false, 0, errors.Wrap(err, "deleting old jobs")
 		}
 		if nDeleted != len(toDelete.Array) {
-			return errors.Errorf("asked to delete %d rows but %d were actually deleted",
+			return false, 0, errors.AssertionFailedf("asked to delete %d rows but %d were actually deleted",
 				len(toDelete.Array), nDeleted)
 		}
 	}
-	return nil
+	return !morePages, maxID, nil
 }
 
 // getJobFn attempts to get a resumer from the given job id. If the job id

--- a/pkg/jobs/registry_test.go
+++ b/pkg/jobs/registry_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/stretchr/testify/require"
 )
 
 func FakePHS(opName, user string) (interface{}, func()) {
@@ -346,4 +347,27 @@ CREATE DATABASE IF NOT EXISTS t; CREATE TABLE IF NOT EXISTS t.to_be_mutated AS S
 			}
 		}
 	}
+}
+
+func TestRegistryGCPagination(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	db := sqlutils.MakeSQLRunner(sqlDB)
+	defer s.Stopper().Stop(ctx)
+
+	for i := 0; i < 2*cleanupPageSize+1; i++ {
+		payload, err := protoutil.Marshal(&jobspb.Payload{})
+		require.NoError(t, err)
+		db.Exec(t,
+			`INSERT INTO system.jobs (status, created, payload) VALUES ($1, $2, $3)`,
+			StatusCanceled, timeutil.Now().Add(-time.Hour), payload)
+	}
+
+	ts := timeutil.Now()
+	require.NoError(t, s.JobRegistry().(*Registry).cleanupOldJobs(ctx, ts.Add(-10*time.Minute)))
+	var count int
+	db.QueryRow(t, `SELECT count(1) FROM system.jobs`).Scan(&count)
+	require.Zero(t, count)
 }


### PR DESCRIPTION
Backport 2/2 commits from #57041.

/cc @cockroachdb/release

---

Before this patch, a cleanup iteration (which happens once per hour per
node) would only cleanup up to 1k rows. This patch makes it cleanup up
all eligible jobs, and do so in batches smaller than 1000. We've seen a
case where having 3 ndoes trying to cleanup 1000 jobs at once led to
thrashing.

Release note: None
