### PR TITLE
rditer: include lock table ranges when making key ranges

### DIFF
--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -3082,6 +3082,9 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 			inSnap.State.Desc.RangeID != roachpb.RangeID(2) {
 			return nil
 		}
+		// TODO(sumeer): fix this test (and others in this file) when
+		// DisallowSeparatedIntents=false
+
 		// The seven SSTs we are expecting to ingest are in the following order:
 		// 1. Replicated range-id local keys of the range in the snapshot.
 		// 2. Range-local keys of the range in the snapshot.
@@ -3134,7 +3137,7 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 				if err != nil {
 					return err
 				}
-				if !valid || r.End.Key.Compare(it.Key().Key) <= 0 {
+				if !valid || r.End.Key.Compare(it.UnsafeKey().Key) <= 0 {
 					if err := sst.Finish(); err != nil {
 						return err
 					}
@@ -3142,7 +3145,7 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 					expectedSSTs = append(expectedSSTs, sstFile.Data())
 					break
 				}
-				if err := sst.PutEngineKey(it.Key(), it.Value()); err != nil {
+				if err := sst.PutEngineKey(it.UnsafeKey(), it.Value()); err != nil {
 					return err
 				}
 			}

--- a/pkg/kv/kvserver/gc/gc_iterator.go
+++ b/pkg/kv/kvserver/gc/gc_iterator.go
@@ -28,8 +28,7 @@ type gcIterator struct {
 
 func makeGCIterator(desc *roachpb.RangeDescriptor, snap storage.Reader) gcIterator {
 	return gcIterator{
-		it: rditer.NewReplicaMVCCDataIterator(desc, snap,
-			true /* replicatedOnly */, true /* seekEnd */),
+		it: rditer.NewReplicaMVCCDataIterator(desc, snap, true /* seekEnd */),
 	}
 }
 

--- a/pkg/kv/kvserver/gc/gc_old_test.go
+++ b/pkg/kv/kvserver/gc/gc_old_test.go
@@ -50,8 +50,7 @@ func runGCOld(
 	cleanupTxnIntentsAsyncFn CleanupTxnIntentsAsyncFunc,
 ) (Info, error) {
 
-	iter := rditer.NewReplicaMVCCDataIterator(desc, snap,
-		true /* replicatedOnly */, false /* seekEnd */)
+	iter := rditer.NewReplicaMVCCDataIterator(desc, snap, false /* seekEnd */)
 	defer iter.Close()
 
 	// Compute intent expiration (intent age at which we attempt to resolve).
@@ -149,8 +148,6 @@ func runGCOld(
 
 							err := gcer.GC(ctx, batchGCKeys)
 
-							// Succeed or fail, allow releasing the memory backing batchGCKeys.
-							iter.ResetAllocator()
 							batchGCKeys = nil
 							batchGCKeysBytes = 0
 

--- a/pkg/kv/kvserver/rditer/BUILD.bazel
+++ b/pkg/kv/kvserver/rditer/BUILD.bazel
@@ -13,7 +13,6 @@ go_library(
         "//pkg/roachpb",
         "//pkg/storage",
         "//pkg/storage/enginepb",
-        "//pkg/util/bufalloc",
     ],
 )
 

--- a/pkg/kv/kvserver/rditer/stats.go
+++ b/pkg/kv/kvserver/rditer/stats.go
@@ -26,7 +26,7 @@ func ComputeStatsForRange(
 	defer iter.Close()
 
 	ms := enginepb.MVCCStats{}
-	for _, keyRange := range MakeReplicatedKeyRanges(d) {
+	for _, keyRange := range MakeReplicatedKeyRangesExceptLockTable(d) {
 		msDelta, err := iter.ComputeStats(keyRange.Start.Key, keyRange.End.Key, nowNanos)
 		if err != nil {
 			return enginepb.MVCCStats{}, err

--- a/pkg/kv/kvserver/replica_consistency.go
+++ b/pkg/kv/kvserver/replica_consistency.go
@@ -628,13 +628,13 @@ func (r *Replica) sha512(
 	// In statsOnly mode, we hash only the RangeAppliedState. In regular mode, hash
 	// all of the replicated key space.
 	if !statsOnly {
-		// TODO(sumeer): remember that this caller of MakeReplicatedKeyRanges does
-		// not want the lock table ranges since the iter has been constructed using
-		// MVCCKeyAndIntentsIterKind. By the time we have replicated locks
-		// other than exclusive locks, we will probably not have any interleaved
-		// intents so we could stop using MVCCKeyAndIntentsIterKind and
-		// consider all locks here.
-		for _, span := range rditer.MakeReplicatedKeyRanges(&desc) {
+		// Do not want the lock table ranges since the iter has been constructed
+		// using MVCCKeyAndIntentsIterKind.
+		//
+		// TODO(sumeer): When we have replicated locks other than exclusive locks,
+		// we will probably not have any interleaved intents so we could stop
+		// using MVCCKeyAndIntentsIterKind and consider all locks here.
+		for _, span := range rditer.MakeReplicatedKeyRangesExceptLockTable(&desc) {
 			spanMS, err := storage.ComputeStatsForRange(
 				iter, span.Start.Key, span.End.Key, 0 /* nowNanos */, visitor,
 			)

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -1038,14 +1038,11 @@ func (r *Replica) clearSubsumedReplicaDiskData(
 	subsumedRepls []*Replica,
 	subsumedNextReplicaID roachpb.ReplicaID,
 ) error {
-	getKeyRanges := func(desc *roachpb.RangeDescriptor) [2]rditer.KeyRange {
-		return [...]rditer.KeyRange{
-			rditer.MakeRangeLocalKeyRange(desc),
-			rditer.MakeUserKeyRange(desc),
-		}
-	}
+	// NB: we don't clear RangeID local key ranges here. That happens
+	// via the call to preDestroyRaftMuLocked.
+	getKeyRanges := rditer.MakeReplicatedKeyRangesExceptRangeID
 	keyRanges := getKeyRanges(desc)
-	totalKeyRanges := append([]rditer.KeyRange(nil), keyRanges[:]...)
+	totalKeyRanges := append([]rditer.KeyRange(nil), keyRanges...)
 	for _, sr := range subsumedRepls {
 		// We mark the replica as destroyed so that new commands are not
 		// accepted. This destroy status will be detected after the batch

--- a/pkg/kv/kvserver/replica_sst_snapshot_storage_test.go
+++ b/pkg/kv/kvserver/replica_sst_snapshot_storage_test.go
@@ -106,7 +106,7 @@ func TestSSTSnapshotStorage(t *testing.T) {
 }
 
 // TestMultiSSTWriterInitSST tests that multiSSTWriter initializes each of the
-// SST files associated with the three replicated key ranges by writing a range
+// SST files associated with the replicated key ranges by writing a range
 // deletion tombstone that spans the entire range of each respectively.
 func TestMultiSSTWriterInitSST(t *testing.T) {
 	defer leaktest.AfterTest(t)()

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -7006,7 +7006,7 @@ func TestReplicaDestroy(t *testing.T) {
 		t.Fatal(err)
 	} else if ok {
 		// If the range is destroyed, only a tombstone key should be there.
-		k1 := iter.Key().Key
+		k1 := iter.UnsafeKey().Key
 		if tombstoneKey := keys.RangeTombstoneKey(tc.repl.RangeID); !bytes.Equal(k1, tombstoneKey) {
 			t.Errorf("expected a tombstone key %q, but found %q", tombstoneKey, k1)
 		}

--- a/pkg/kv/kvserver/replica_tscache.go
+++ b/pkg/kv/kvserver/replica_tscache.go
@@ -33,7 +33,7 @@ import (
 func setTimestampCacheLowWaterMark(
 	tc tscache.Cache, desc *roachpb.RangeDescriptor, ts hlc.Timestamp,
 ) {
-	for _, keyRange := range rditer.MakeReplicatedKeyRanges(desc) {
+	for _, keyRange := range rditer.MakeReplicatedKeyRangesExceptLockTable(desc) {
 		tc.SetLowWater(keyRange.Start.Key, keyRange.End.Key, ts)
 	}
 }

--- a/pkg/kv/kvserver/store_snapshot.go
+++ b/pkg/kv/kvserver/store_snapshot.go
@@ -209,13 +209,14 @@ func (msstw *multiSSTWriter) Close() {
 //
 // 1. Replicated range-id local key range
 // 2. Range-local key range
-// 3. User key range
+// 3. Two lock-table key ranges (optional)
+// 4. User key range
 func (kvSS *kvBatchSnapshotStrategy) Receive(
 	ctx context.Context, stream incomingSnapshotStream, header SnapshotRequest_Header,
 ) (IncomingSnapshot, error) {
 	assertStrategy(ctx, header, SnapshotRequest_KV_BATCH)
 
-	// At the moment we'll write at most three SSTs.
+	// At the moment we'll write at most five SSTs.
 	// TODO(jeffreyxiao): Re-evaluate as the default range size grows.
 	keyRanges := rditer.MakeReplicatedKeyRanges(header.State.Desc)
 	msstw, err := newMultiSSTWriter(ctx, kvSS.scratch, keyRanges, kvSS.sstChunkSize)

--- a/pkg/storage/engine_key.go
+++ b/pkg/storage/engine_key.go
@@ -17,7 +17,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 )
@@ -68,19 +67,6 @@ const (
 // Copy makes a copy of the key.
 func (k EngineKey) Copy() EngineKey {
 	buf := make([]byte, len(k.Key)+len(k.Version))
-	return k.copyUsingSizedBuf(buf)
-}
-
-// CopyUsingAlloc makes a copy of the key using the given allocator.
-func (k EngineKey) CopyUsingAlloc(
-	alloc bufalloc.ByteAllocator,
-) (EngineKey, bufalloc.ByteAllocator) {
-	var buf []byte
-	alloc, buf = alloc.Alloc(len(k.Key)+len(k.Version), 0)
-	return k.copyUsingSizedBuf(buf), alloc
-}
-
-func (k EngineKey) copyUsingSizedBuf(buf []byte) EngineKey {
 	copy(buf, k.Key)
 	k.Key = buf[:len(k.Key)]
 	if len(k.Version) > 0 {

--- a/pkg/storage/intent_interleaving_iter_test.go
+++ b/pkg/storage/intent_interleaving_iter_test.go
@@ -33,11 +33,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TODO(sumeer):
-// - randomized test with random intents that are interleaved and
-//   compare with no interleaved intents without using intentInterleavingIter.
-// - microbenchmarks to compare with non-interleaved intents.
-
 func scanRoachKey(t *testing.T, td *datadriven.TestData, field string) roachpb.Key {
 	var k string
 	td.ScanArgs(t, field, &k)

--- a/pkg/storage/intent_reader_writer.go
+++ b/pkg/storage/intent_reader_writer.go
@@ -21,7 +21,7 @@ import (
 
 // Configuration information for enabling/disabling separated intents. Eventually, these
 // will not be constants defined in this file, and will be externally configurable.
-// For now, our goal is make all tests pass with disallowSeparatedIntents=true.
+// For now, our goal is make all tests pass with DisallowSeparatedIntents=true.
 //
 // TODO(sumeer): once all integration changes are complete, ensure all tests pass
 // with (disallow=false, enabled=false), (disallow=false, enabled=true) and with
@@ -41,7 +41,10 @@ import (
 // force all remaining interleaved intents to be rewritten (these may
 // potentially be of committed transactions whose intent resolution did not
 // happen yet).
-const disallowSeparatedIntents = true
+
+// DisallowSeparatedIntents is true when separated intents have never been allowed.
+const DisallowSeparatedIntents = true
+
 const enabledSeparatedIntents = false
 
 // This file defines wrappers for Reader and Writer, and functions to do the
@@ -55,7 +58,7 @@ type intentDemuxWriter struct {
 }
 
 func tryWrapIntentWriter(w Writer) (idw intentDemuxWriter, wrapped bool) {
-	if disallowSeparatedIntents {
+	if DisallowSeparatedIntents {
 		return intentDemuxWriter{}, false
 	}
 	return intentDemuxWriter{w: w, enabledSeparatedIntents: enabledSeparatedIntents}, true
@@ -173,7 +176,7 @@ type wrappableReader interface {
 }
 
 func tryWrapReader(r wrappableReader, iterKind MVCCIterKind) (reader Reader, wrapped bool) {
-	if disallowSeparatedIntents || iterKind == MVCCKeyIterKind {
+	if DisallowSeparatedIntents || iterKind == MVCCKeyIterKind {
 		return r, false
 	}
 	return intentInterleavingReader{wrappableReader: r}, true


### PR DESCRIPTION
- Lock table ranges are included based on the value of
  DisallowSeparatedIntents. Callers have been fixed to
  call the appropriate range construction method.
- ReplicaMVCCDataIterator is simplified, e.g., the
  ByteAllocator member is removed since it was only
  used in methods called by tests.
- There is now direct test coverage for
  ReplicaEngineDataIterator.

Informs #41720

Release note: None