### PR TITLE
storage: delete mvccGetInternal, use mvccGet directly

### DIFF
--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -109,20 +109,6 @@ func (n mvccKeys) Len() int           { return len(n) }
 func (n mvccKeys) Swap(i, j int)      { n[i], n[j] = n[j], n[i] }
 func (n mvccKeys) Less(i, j int) bool { return n[i].Less(n[j]) }
 
-// TODO(nvanbenschoten): remove this.
-var mvccGetImpls = []struct {
-	name string
-	fn   func(
-		ctx context.Context,
-		reader Reader,
-		key roachpb.Key,
-		timestamp hlc.Timestamp,
-		opts MVCCGetOptions,
-	) (*roachpb.Value, *roachpb.Intent, error)
-}{
-	{"cpp", MVCCGet},
-}
-
 func TestMVCCStatsAddSubForward(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -300,22 +286,16 @@ func TestMVCCGetNotExist(t *testing.T) {
 
 	for _, engineImpl := range mvccEngineImpls {
 		t.Run(engineImpl.name, func(t *testing.T) {
-			for _, impl := range mvccGetImpls {
-				t.Run(impl.name, func(t *testing.T) {
-					mvccGet := impl.fn
+			engine := engineImpl.create()
+			defer engine.Close()
 
-					engine := engineImpl.create()
-					defer engine.Close()
-
-					value, _, err := mvccGet(context.Background(), engine, testKey1, hlc.Timestamp{Logical: 1},
-						MVCCGetOptions{})
-					if err != nil {
-						t.Fatal(err)
-					}
-					if value != nil {
-						t.Fatal("the value should be empty")
-					}
-				})
+			value, _, err := MVCCGet(context.Background(), engine, testKey1, hlc.Timestamp{Logical: 1},
+				MVCCGetOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if value != nil {
+				t.Fatal("the value should be empty")
 			}
 		})
 	}
@@ -329,40 +309,34 @@ func TestMVCCGetNoMoreOldVersion(t *testing.T) {
 
 	for _, engineImpl := range mvccEngineImpls {
 		t.Run(engineImpl.name, func(t *testing.T) {
-			for _, impl := range mvccGetImpls {
-				t.Run(impl.name, func(t *testing.T) {
-					mvccGet := impl.fn
+			// Need to handle the case here where the scan takes us to the
+			// next key, which may not match the key we're looking for. In
+			// other words, if we're looking for a<T=2>, and we have the
+			// following keys:
+			//
+			// a: MVCCMetadata(a)
+			// a<T=3>
+			// b: MVCCMetadata(b)
+			// b<T=1>
+			//
+			// If we search for a<T=2>, the scan should not return "b".
 
-					// Need to handle the case here where the scan takes us to the
-					// next key, which may not match the key we're looking for. In
-					// other words, if we're looking for a<T=2>, and we have the
-					// following keys:
-					//
-					// a: MVCCMetadata(a)
-					// a<T=3>
-					// b: MVCCMetadata(b)
-					// b<T=1>
-					//
-					// If we search for a<T=2>, the scan should not return "b".
+			engine := engineImpl.create()
+			defer engine.Close()
 
-					engine := engineImpl.create()
-					defer engine.Close()
+			if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 3}, value1, nil); err != nil {
+				t.Fatal(err)
+			}
+			if err := MVCCPut(ctx, engine, nil, testKey2, hlc.Timestamp{WallTime: 1}, value2, nil); err != nil {
+				t.Fatal(err)
+			}
 
-					if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 3}, value1, nil); err != nil {
-						t.Fatal(err)
-					}
-					if err := MVCCPut(ctx, engine, nil, testKey2, hlc.Timestamp{WallTime: 1}, value2, nil); err != nil {
-						t.Fatal(err)
-					}
-
-					value, _, err := mvccGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 2}, MVCCGetOptions{})
-					if err != nil {
-						t.Fatal(err)
-					}
-					if value != nil {
-						t.Fatal("the value should be empty")
-					}
-				})
+			value, _, err := MVCCGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 2}, MVCCGetOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if value != nil {
+				t.Fatal("the value should be empty")
 			}
 		})
 	}
@@ -376,58 +350,52 @@ func TestMVCCGetAndDelete(t *testing.T) {
 
 	for _, engineImpl := range mvccEngineImpls {
 		t.Run(engineImpl.name, func(t *testing.T) {
-			for _, impl := range mvccGetImpls {
-				t.Run(impl.name, func(t *testing.T) {
-					mvccGet := impl.fn
+			engine := engineImpl.create()
+			defer engine.Close()
 
-					engine := engineImpl.create()
-					defer engine.Close()
+			if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value1, nil); err != nil {
+				t.Fatal(err)
+			}
+			value, _, err := MVCCGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 2}, MVCCGetOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if value == nil {
+				t.Fatal("the value should not be empty")
+			}
 
-					if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value1, nil); err != nil {
-						t.Fatal(err)
-					}
-					value, _, err := mvccGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 2}, MVCCGetOptions{})
-					if err != nil {
-						t.Fatal(err)
-					}
-					if value == nil {
-						t.Fatal("the value should not be empty")
-					}
+			err = MVCCDelete(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 3}, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-					err = MVCCDelete(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 3}, nil)
-					if err != nil {
-						t.Fatal(err)
-					}
+			// Read the latest version which should be deleted.
+			value, _, err = MVCCGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 4}, MVCCGetOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if value != nil {
+				t.Fatal("the value should be empty")
+			}
+			// Read the latest version with tombstone.
+			value, _, err = MVCCGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 4},
+				MVCCGetOptions{Tombstones: true})
+			if err != nil {
+				t.Fatal(err)
+			} else if value == nil || len(value.RawBytes) != 0 {
+				t.Fatalf("the value should be non-nil with empty RawBytes; got %+v", value)
+			}
 
-					// Read the latest version which should be deleted.
-					value, _, err = mvccGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 4}, MVCCGetOptions{})
-					if err != nil {
-						t.Fatal(err)
-					}
-					if value != nil {
-						t.Fatal("the value should be empty")
-					}
-					// Read the latest version with tombstone.
-					value, _, err = MVCCGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 4},
-						MVCCGetOptions{Tombstones: true})
-					if err != nil {
-						t.Fatal(err)
-					} else if value == nil || len(value.RawBytes) != 0 {
-						t.Fatalf("the value should be non-nil with empty RawBytes; got %+v", value)
-					}
-
-					// Read the old version which should still exist.
-					for _, logical := range []int32{0, math.MaxInt32} {
-						value, _, err = mvccGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 2, Logical: logical},
-							MVCCGetOptions{})
-						if err != nil {
-							t.Fatal(err)
-						}
-						if value == nil {
-							t.Fatal("the value should not be empty")
-						}
-					}
-				})
+			// Read the old version which should still exist.
+			for _, logical := range []int32{0, math.MaxInt32} {
+				value, _, err = MVCCGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 2, Logical: logical},
+					MVCCGetOptions{})
+				if err != nil {
+					t.Fatal(err)
+				}
+				if value == nil {
+					t.Fatal("the value should not be empty")
+				}
 			}
 		})
 	}
@@ -559,59 +527,53 @@ func TestMVCCGetAndDeleteInTxn(t *testing.T) {
 
 	for _, engineImpl := range mvccEngineImpls {
 		t.Run(engineImpl.name, func(t *testing.T) {
-			for _, impl := range mvccGetImpls {
-				t.Run(impl.name, func(t *testing.T) {
-					mvccGet := impl.fn
+			engine := engineImpl.create()
+			defer engine.Close()
 
-					engine := engineImpl.create()
-					defer engine.Close()
+			txn := makeTxn(*txn1, hlc.Timestamp{WallTime: 1})
+			txn.Sequence++
+			if err := MVCCPut(ctx, engine, nil, testKey1, txn.ReadTimestamp, value1, txn); err != nil {
+				t.Fatal(err)
+			}
 
-					txn := makeTxn(*txn1, hlc.Timestamp{WallTime: 1})
-					txn.Sequence++
-					if err := MVCCPut(ctx, engine, nil, testKey1, txn.ReadTimestamp, value1, txn); err != nil {
-						t.Fatal(err)
-					}
+			if value, _, err := MVCCGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 2}, MVCCGetOptions{
+				Txn: txn,
+			}); err != nil {
+				t.Fatal(err)
+			} else if value == nil {
+				t.Fatal("the value should not be empty")
+			}
 
-					if value, _, err := mvccGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 2}, MVCCGetOptions{
-						Txn: txn,
-					}); err != nil {
-						t.Fatal(err)
-					} else if value == nil {
-						t.Fatal("the value should not be empty")
-					}
+			txn.Sequence++
+			txn.WriteTimestamp = hlc.Timestamp{WallTime: 3}
+			if err := MVCCDelete(ctx, engine, nil, testKey1, txn.ReadTimestamp, txn); err != nil {
+				t.Fatal(err)
+			}
 
-					txn.Sequence++
-					txn.WriteTimestamp = hlc.Timestamp{WallTime: 3}
-					if err := MVCCDelete(ctx, engine, nil, testKey1, txn.ReadTimestamp, txn); err != nil {
-						t.Fatal(err)
-					}
+			// Read the latest version which should be deleted.
+			if value, _, err := MVCCGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 4}, MVCCGetOptions{
+				Txn: txn,
+			}); err != nil {
+				t.Fatal(err)
+			} else if value != nil {
+				t.Fatal("the value should be empty")
+			}
+			// Read the latest version with tombstone.
+			if value, _, err := MVCCGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 4}, MVCCGetOptions{
+				Tombstones: true,
+				Txn:        txn,
+			}); err != nil {
+				t.Fatal(err)
+			} else if value == nil || len(value.RawBytes) != 0 {
+				t.Fatalf("the value should be non-nil with empty RawBytes; got %+v", value)
+			}
 
-					// Read the latest version which should be deleted.
-					if value, _, err := mvccGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 4}, MVCCGetOptions{
-						Txn: txn,
-					}); err != nil {
-						t.Fatal(err)
-					} else if value != nil {
-						t.Fatal("the value should be empty")
-					}
-					// Read the latest version with tombstone.
-					if value, _, err := MVCCGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 4}, MVCCGetOptions{
-						Tombstones: true,
-						Txn:        txn,
-					}); err != nil {
-						t.Fatal(err)
-					} else if value == nil || len(value.RawBytes) != 0 {
-						t.Fatalf("the value should be non-nil with empty RawBytes; got %+v", value)
-					}
-
-					// Read the old version which shouldn't exist, as within a
-					// transaction, we delete previous values.
-					if value, _, err := mvccGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 2}, MVCCGetOptions{}); err != nil {
-						t.Fatal(err)
-					} else if value != nil {
-						t.Fatalf("expected value nil, got: %s", value)
-					}
-				})
+			// Read the old version which shouldn't exist, as within a
+			// transaction, we delete previous values.
+			if value, _, err := MVCCGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 2}, MVCCGetOptions{}); err != nil {
+				t.Fatal(err)
+			} else if value != nil {
+				t.Fatalf("expected value nil, got: %s", value)
 			}
 		})
 	}
@@ -625,27 +587,21 @@ func TestMVCCGetWriteIntentError(t *testing.T) {
 
 	for _, engineImpl := range mvccEngineImpls {
 		t.Run(engineImpl.name, func(t *testing.T) {
-			for _, impl := range mvccGetImpls {
-				t.Run(impl.name, func(t *testing.T) {
-					mvccGet := impl.fn
+			engine := engineImpl.create()
+			defer engine.Close()
 
-					engine := engineImpl.create()
-					defer engine.Close()
+			if err := MVCCPut(ctx, engine, nil, testKey1, txn1.ReadTimestamp, value1, txn1); err != nil {
+				t.Fatal(err)
+			}
 
-					if err := MVCCPut(ctx, engine, nil, testKey1, txn1.ReadTimestamp, value1, txn1); err != nil {
-						t.Fatal(err)
-					}
+			if _, _, err := MVCCGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 1}, MVCCGetOptions{}); err == nil {
+				t.Fatal("cannot read the value of a write intent without TxnID")
+			}
 
-					if _, _, err := mvccGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 1}, MVCCGetOptions{}); err == nil {
-						t.Fatal("cannot read the value of a write intent without TxnID")
-					}
-
-					if _, _, err := mvccGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 1}, MVCCGetOptions{
-						Txn: txn2,
-					}); err == nil {
-						t.Fatal("cannot read the value of a write intent from a different TxnID")
-					}
-				})
+			if _, _, err := MVCCGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 1}, MVCCGetOptions{
+				Txn: txn2,
+			}); err == nil {
+				t.Fatal("cannot read the value of a write intent from a different TxnID")
 			}
 		})
 	}
@@ -788,60 +744,54 @@ func TestMVCCGetInconsistent(t *testing.T) {
 
 	for _, engineImpl := range mvccEngineImpls {
 		t.Run(engineImpl.name, func(t *testing.T) {
-			for _, impl := range mvccGetImpls {
-				t.Run(impl.name, func(t *testing.T) {
-					mvccGet := impl.fn
+			engine := engineImpl.create()
+			defer engine.Close()
 
-					engine := engineImpl.create()
-					defer engine.Close()
+			// Put two values to key 1, the latest with a txn.
+			if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value1, nil); err != nil {
+				t.Fatal(err)
+			}
+			txn1ts := makeTxn(*txn1, hlc.Timestamp{WallTime: 2})
+			if err := MVCCPut(ctx, engine, nil, testKey1, txn1ts.ReadTimestamp, value2, txn1ts); err != nil {
+				t.Fatal(err)
+			}
 
-					// Put two values to key 1, the latest with a txn.
-					if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value1, nil); err != nil {
+			// A get with consistent=false should fail in a txn.
+			if _, _, err := MVCCGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 1}, MVCCGetOptions{
+				Inconsistent: true,
+				Txn:          txn1,
+			}); err == nil {
+				t.Error("expected an error getting with consistent=false in txn")
+			}
+
+			// Inconsistent get will fetch value1 for any timestamp.
+			for _, ts := range []hlc.Timestamp{{WallTime: 1}, {WallTime: 2}} {
+				val, intent, err := MVCCGet(ctx, engine, testKey1, ts, MVCCGetOptions{Inconsistent: true})
+				if ts.Less(hlc.Timestamp{WallTime: 2}) {
+					if err != nil {
 						t.Fatal(err)
 					}
-					txn1ts := makeTxn(*txn1, hlc.Timestamp{WallTime: 2})
-					if err := MVCCPut(ctx, engine, nil, testKey1, txn1ts.ReadTimestamp, value2, txn1ts); err != nil {
-						t.Fatal(err)
+				} else {
+					if intent == nil || !intent.Key.Equal(testKey1) {
+						t.Fatalf("expected %v, but got %v", testKey1, intent)
 					}
+				}
+				if !bytes.Equal(val.RawBytes, value1.RawBytes) {
+					t.Errorf("@%s expected %q; got %q", ts, value1.RawBytes, val.RawBytes)
+				}
+			}
 
-					// A get with consistent=false should fail in a txn.
-					if _, _, err := mvccGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 1}, MVCCGetOptions{
-						Inconsistent: true,
-						Txn:          txn1,
-					}); err == nil {
-						t.Error("expected an error getting with consistent=false in txn")
-					}
-
-					// Inconsistent get will fetch value1 for any timestamp.
-					for _, ts := range []hlc.Timestamp{{WallTime: 1}, {WallTime: 2}} {
-						val, intent, err := mvccGet(ctx, engine, testKey1, ts, MVCCGetOptions{Inconsistent: true})
-						if ts.Less(hlc.Timestamp{WallTime: 2}) {
-							if err != nil {
-								t.Fatal(err)
-							}
-						} else {
-							if intent == nil || !intent.Key.Equal(testKey1) {
-								t.Fatalf("expected %v, but got %v", testKey1, intent)
-							}
-						}
-						if !bytes.Equal(val.RawBytes, value1.RawBytes) {
-							t.Errorf("@%s expected %q; got %q", ts, value1.RawBytes, val.RawBytes)
-						}
-					}
-
-					// Write a single intent for key 2 and verify get returns empty.
-					if err := MVCCPut(ctx, engine, nil, testKey2, txn2.ReadTimestamp, value1, txn2); err != nil {
-						t.Fatal(err)
-					}
-					val, intent, err := mvccGet(ctx, engine, testKey2, hlc.Timestamp{WallTime: 2},
-						MVCCGetOptions{Inconsistent: true})
-					if intent == nil || !intent.Key.Equal(testKey2) {
-						t.Fatal(err)
-					}
-					if val != nil {
-						t.Errorf("expected empty val; got %+v", val)
-					}
-				})
+			// Write a single intent for key 2 and verify get returns empty.
+			if err := MVCCPut(ctx, engine, nil, testKey2, txn2.ReadTimestamp, value1, txn2); err != nil {
+				t.Fatal(err)
+			}
+			val, intent, err := MVCCGet(ctx, engine, testKey2, hlc.Timestamp{WallTime: 2},
+				MVCCGetOptions{Inconsistent: true})
+			if intent == nil || !intent.Key.Equal(testKey2) {
+				t.Fatal(err)
+			}
+			if val != nil {
+				t.Errorf("expected empty val; got %+v", val)
 			}
 		})
 	}
@@ -3376,54 +3326,47 @@ func TestMVCCGetWithDiffEpochs(t *testing.T) {
 
 	for _, engineImpl := range mvccEngineImpls {
 		t.Run(engineImpl.name, func(t *testing.T) {
+			ctx := context.Background()
+			engine := engineImpl.create()
+			defer engine.Close()
 
-			for _, impl := range mvccGetImpls {
-				t.Run(impl.name, func(t *testing.T) {
-					mvccGet := impl.fn
-
-					ctx := context.Background()
-					engine := engineImpl.create()
-					defer engine.Close()
-
-					// Write initial value without a txn.
-					if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{Logical: 1}, value1, nil); err != nil {
-						t.Fatal(err)
-					}
-					// Now write using txn1, epoch 1.
-					txn1ts := makeTxn(*txn1, hlc.Timestamp{WallTime: 1})
-					if err := MVCCPut(ctx, engine, nil, testKey1, txn1ts.ReadTimestamp, value2, txn1ts); err != nil {
-						t.Fatal(err)
-					}
-					// Try reading using different txns & epochs.
-					testCases := []struct {
-						txn      *roachpb.Transaction
-						expValue *roachpb.Value
-						expErr   bool
-					}{
-						// No transaction; should see error.
-						{nil, nil, true},
-						// Txn1, epoch 1; should see new value2.
-						{txn1, &value2, false},
-						// Txn1, epoch 2; should see original value1.
-						{txn1e2, &value1, false},
-						// Txn2; should see error.
-						{txn2, nil, true},
-					}
-					for i, test := range testCases {
-						t.Run(strconv.Itoa(i), func(t *testing.T) {
-							value, _, err := mvccGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 2}, MVCCGetOptions{
-								Txn: test.txn,
-							})
-							if test.expErr {
-								if err == nil {
-									t.Errorf("test %d: unexpected success", i)
-								} else if !errors.HasType(err, (*roachpb.WriteIntentError)(nil)) {
-									t.Errorf("test %d: expected write intent error; got %v", i, err)
-								}
-							} else if err != nil || value == nil || !bytes.Equal(test.expValue.RawBytes, value.RawBytes) {
-								t.Errorf("test %d: expected value %q, err nil; got %+v, %v", i, test.expValue.RawBytes, value, err)
-							}
-						})
+			// Write initial value without a txn.
+			if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{Logical: 1}, value1, nil); err != nil {
+				t.Fatal(err)
+			}
+			// Now write using txn1, epoch 1.
+			txn1ts := makeTxn(*txn1, hlc.Timestamp{WallTime: 1})
+			if err := MVCCPut(ctx, engine, nil, testKey1, txn1ts.ReadTimestamp, value2, txn1ts); err != nil {
+				t.Fatal(err)
+			}
+			// Try reading using different txns & epochs.
+			testCases := []struct {
+				txn      *roachpb.Transaction
+				expValue *roachpb.Value
+				expErr   bool
+			}{
+				// No transaction; should see error.
+				{nil, nil, true},
+				// Txn1, epoch 1; should see new value2.
+				{txn1, &value2, false},
+				// Txn1, epoch 2; should see original value1.
+				{txn1e2, &value1, false},
+				// Txn2; should see error.
+				{txn2, nil, true},
+			}
+			for i, test := range testCases {
+				t.Run(strconv.Itoa(i), func(t *testing.T) {
+					value, _, err := MVCCGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 2}, MVCCGetOptions{
+						Txn: test.txn,
+					})
+					if test.expErr {
+						if err == nil {
+							t.Errorf("test %d: unexpected success", i)
+						} else if !errors.HasType(err, (*roachpb.WriteIntentError)(nil)) {
+							t.Errorf("test %d: expected write intent error; got %v", i, err)
+						}
+					} else if err != nil || value == nil || !bytes.Equal(test.expValue.RawBytes, value.RawBytes) {
+						t.Errorf("test %d: expected value %q, err nil; got %+v, %v", i, test.expValue.RawBytes, value, err)
 					}
 				})
 			}
@@ -3444,67 +3387,61 @@ func TestMVCCGetWithDiffEpochsAndTimestamps(t *testing.T) {
 
 	for _, engineImpl := range mvccEngineImpls {
 		t.Run(engineImpl.name, func(t *testing.T) {
-			for _, impl := range mvccGetImpls {
-				t.Run(impl.name, func(t *testing.T) {
-					mvccGet := impl.fn
+			ctx := context.Background()
+			engine := engineImpl.create()
+			defer engine.Close()
 
-					ctx := context.Background()
-					engine := engineImpl.create()
-					defer engine.Close()
-
-					// Write initial value without a txn at timestamp 1.
-					if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value1, nil); err != nil {
-						t.Fatal(err)
-					}
-					// Write another value without a txn at timestamp 3.
-					if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 3}, value2, nil); err != nil {
-						t.Fatal(err)
-					}
-					// Now write using txn1, epoch 1.
-					txn1ts := makeTxn(*txn1, hlc.Timestamp{WallTime: 1})
-					// Bump epoch 1's write timestamp to timestamp 4.
-					txn1ts.WriteTimestamp = hlc.Timestamp{WallTime: 4}
-					// Expected to hit WriteTooOld error but to still lay down intent.
-					err := MVCCPut(ctx, engine, nil, testKey1, txn1ts.ReadTimestamp, value3, txn1ts)
-					if wtoErr := (*roachpb.WriteTooOldError)(nil); !errors.As(err, &wtoErr) {
-						t.Fatalf("unexpectedly not WriteTooOld: %+v", err)
-					} else if expTS, actTS := txn1ts.WriteTimestamp, wtoErr.ActualTimestamp; expTS != actTS {
-						t.Fatalf("expected write too old error with actual ts %s; got %s", expTS, actTS)
-					}
-					// Try reading using different epochs & timestamps.
-					testCases := []struct {
-						txn      *roachpb.Transaction
-						readTS   hlc.Timestamp
-						expValue *roachpb.Value
-					}{
-						// Epoch 1, read 1; should see new value3.
-						{txn1, hlc.Timestamp{WallTime: 1}, &value3},
-						// Epoch 1, read 2; should see new value3.
-						{txn1, hlc.Timestamp{WallTime: 2}, &value3},
-						// Epoch 1, read 3; should see new value3.
-						{txn1, hlc.Timestamp{WallTime: 3}, &value3},
-						// Epoch 1, read 4; should see new value3.
-						{txn1, hlc.Timestamp{WallTime: 4}, &value3},
-						// Epoch 1, read 5; should see new value3.
-						{txn1, hlc.Timestamp{WallTime: 5}, &value3},
-						// Epoch 2, read 1; should see committed value1.
-						{txn1e2, hlc.Timestamp{WallTime: 1}, &value1},
-						// Epoch 2, read 2; should see committed value1.
-						{txn1e2, hlc.Timestamp{WallTime: 2}, &value1},
-						// Epoch 2, read 3; should see committed value2.
-						{txn1e2, hlc.Timestamp{WallTime: 3}, &value2},
-						// Epoch 2, read 4; should see committed value2.
-						{txn1e2, hlc.Timestamp{WallTime: 4}, &value2},
-						// Epoch 2, read 5; should see committed value2.
-						{txn1e2, hlc.Timestamp{WallTime: 5}, &value2},
-					}
-					for i, test := range testCases {
-						t.Run(strconv.Itoa(i), func(t *testing.T) {
-							value, _, err := mvccGet(ctx, engine, testKey1, test.readTS, MVCCGetOptions{Txn: test.txn})
-							if err != nil || value == nil || !bytes.Equal(test.expValue.RawBytes, value.RawBytes) {
-								t.Errorf("test %d: expected value %q, err nil; got %+v, %v", i, test.expValue.RawBytes, value, err)
-							}
-						})
+			// Write initial value without a txn at timestamp 1.
+			if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value1, nil); err != nil {
+				t.Fatal(err)
+			}
+			// Write another value without a txn at timestamp 3.
+			if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 3}, value2, nil); err != nil {
+				t.Fatal(err)
+			}
+			// Now write using txn1, epoch 1.
+			txn1ts := makeTxn(*txn1, hlc.Timestamp{WallTime: 1})
+			// Bump epoch 1's write timestamp to timestamp 4.
+			txn1ts.WriteTimestamp = hlc.Timestamp{WallTime: 4}
+			// Expected to hit WriteTooOld error but to still lay down intent.
+			err := MVCCPut(ctx, engine, nil, testKey1, txn1ts.ReadTimestamp, value3, txn1ts)
+			if wtoErr := (*roachpb.WriteTooOldError)(nil); !errors.As(err, &wtoErr) {
+				t.Fatalf("unexpectedly not WriteTooOld: %+v", err)
+			} else if expTS, actTS := txn1ts.WriteTimestamp, wtoErr.ActualTimestamp; expTS != actTS {
+				t.Fatalf("expected write too old error with actual ts %s; got %s", expTS, actTS)
+			}
+			// Try reading using different epochs & timestamps.
+			testCases := []struct {
+				txn      *roachpb.Transaction
+				readTS   hlc.Timestamp
+				expValue *roachpb.Value
+			}{
+				// Epoch 1, read 1; should see new value3.
+				{txn1, hlc.Timestamp{WallTime: 1}, &value3},
+				// Epoch 1, read 2; should see new value3.
+				{txn1, hlc.Timestamp{WallTime: 2}, &value3},
+				// Epoch 1, read 3; should see new value3.
+				{txn1, hlc.Timestamp{WallTime: 3}, &value3},
+				// Epoch 1, read 4; should see new value3.
+				{txn1, hlc.Timestamp{WallTime: 4}, &value3},
+				// Epoch 1, read 5; should see new value3.
+				{txn1, hlc.Timestamp{WallTime: 5}, &value3},
+				// Epoch 2, read 1; should see committed value1.
+				{txn1e2, hlc.Timestamp{WallTime: 1}, &value1},
+				// Epoch 2, read 2; should see committed value1.
+				{txn1e2, hlc.Timestamp{WallTime: 2}, &value1},
+				// Epoch 2, read 3; should see committed value2.
+				{txn1e2, hlc.Timestamp{WallTime: 3}, &value2},
+				// Epoch 2, read 4; should see committed value2.
+				{txn1e2, hlc.Timestamp{WallTime: 4}, &value2},
+				// Epoch 2, read 5; should see committed value2.
+				{txn1e2, hlc.Timestamp{WallTime: 5}, &value2},
+			}
+			for i, test := range testCases {
+				t.Run(strconv.Itoa(i), func(t *testing.T) {
+					value, _, err := MVCCGet(ctx, engine, testKey1, test.readTS, MVCCGetOptions{Txn: test.txn})
+					if err != nil || value == nil || !bytes.Equal(test.expValue.RawBytes, value.RawBytes) {
+						t.Errorf("test %d: expected value %q, err nil; got %+v, %v", i, test.expValue.RawBytes, value, err)
 					}
 				})
 			}
@@ -3520,24 +3457,18 @@ func TestMVCCGetWithOldEpoch(t *testing.T) {
 
 	for _, engineImpl := range mvccEngineImpls {
 		t.Run(engineImpl.name, func(t *testing.T) {
-			for _, impl := range mvccGetImpls {
-				t.Run(impl.name, func(t *testing.T) {
-					mvccGet := impl.fn
+			ctx := context.Background()
+			engine := engineImpl.create()
+			defer engine.Close()
 
-					ctx := context.Background()
-					engine := engineImpl.create()
-					defer engine.Close()
-
-					if err := MVCCPut(ctx, engine, nil, testKey1, txn1e2.ReadTimestamp, value2, txn1e2); err != nil {
-						t.Fatal(err)
-					}
-					_, _, err := mvccGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 2}, MVCCGetOptions{
-						Txn: txn1,
-					})
-					if err == nil {
-						t.Fatalf("unexpected success of get")
-					}
-				})
+			if err := MVCCPut(ctx, engine, nil, testKey1, txn1e2.ReadTimestamp, value2, txn1e2); err != nil {
+				t.Fatal(err)
+			}
+			_, _, err := MVCCGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 2}, MVCCGetOptions{
+				Txn: txn1,
+			})
+			if err == nil {
+				t.Fatalf("unexpected success of get")
 			}
 		})
 	}
@@ -3631,34 +3562,26 @@ func TestMVCCGetWithPushedTimestamp(t *testing.T) {
 
 	for _, engineImpl := range mvccEngineImpls {
 		t.Run(engineImpl.name, func(t *testing.T) {
+			ctx := context.Background()
 			engine := engineImpl.create()
 			defer engine.Close()
-			for _, impl := range mvccGetImpls {
-				t.Run(impl.name, func(t *testing.T) {
-					mvccGet := impl.fn
 
-					ctx := context.Background()
-					engine := engineImpl.create()
-					defer engine.Close()
-
-					// Start with epoch 1.
-					if err := MVCCPut(ctx, engine, nil, testKey1, txn1.ReadTimestamp, value1, txn1); err != nil {
-						t.Fatal(err)
-					}
-					// Resolve the intent, pushing its timestamp forward.
-					txn := makeTxn(*txn1, hlc.Timestamp{WallTime: 1})
-					if _, err := MVCCResolveWriteIntent(ctx, engine, nil,
-						roachpb.MakeLockUpdate(txn, roachpb.Span{Key: testKey1})); err != nil {
-						t.Fatal(err)
-					}
-					// Attempt to read using naive txn's previous timestamp.
-					value, _, err := mvccGet(ctx, engine, testKey1, hlc.Timestamp{Logical: 1}, MVCCGetOptions{
-						Txn: txn1,
-					})
-					if err != nil || value == nil || !bytes.Equal(value.RawBytes, value1.RawBytes) {
-						t.Errorf("expected value %q, err nil; got %+v, %v", value1.RawBytes, value, err)
-					}
-				})
+			// Start with epoch 1.
+			if err := MVCCPut(ctx, engine, nil, testKey1, txn1.ReadTimestamp, value1, txn1); err != nil {
+				t.Fatal(err)
+			}
+			// Resolve the intent, pushing its timestamp forward.
+			txn := makeTxn(*txn1, hlc.Timestamp{WallTime: 1})
+			if _, err := MVCCResolveWriteIntent(ctx, engine, nil,
+				roachpb.MakeLockUpdate(txn, roachpb.Span{Key: testKey1})); err != nil {
+				t.Fatal(err)
+			}
+			// Attempt to read using naive txn's previous timestamp.
+			value, _, err := MVCCGet(ctx, engine, testKey1, hlc.Timestamp{Logical: 1}, MVCCGetOptions{
+				Txn: txn1,
+			})
+			if err != nil || value == nil || !bytes.Equal(value.RawBytes, value1.RawBytes) {
+				t.Errorf("expected value %q, err nil; got %+v, %v", value1.RawBytes, value, err)
 			}
 		})
 	}


### PR DESCRIPTION
This commit deletes a major chunk of legacy code in MVCC mutation code. `mvccPutInternal` was avoiding using mvccGet because this used to result in a cgo call. This led to a large amount of duplicate logic. Now that `mvccGet` calls into the `pebbleIterator` in Go, using it is much less expensive, so we can remove the re-implementation.

With a bit of tuning in follow-on commits, this results in a negligible performance hit which is well worth the elimination of duplicate code:
```
name                                                  old time/op    new time/op    delta
MVCCConditionalPut_Pebble/Create/valueSize=10-16        7.33µs ± 8%    7.04µs ± 7%     ~     (p=0.075 n=10+10)
MVCCConditionalPut_Pebble/Create/valueSize=100-16       7.99µs ± 8%    7.89µs ± 8%     ~     (p=0.631 n=10+10)
MVCCConditionalPut_Pebble/Create/valueSize=1000-16      8.51µs ± 7%    8.47µs ± 4%     ~     (p=0.529 n=10+10)
MVCCConditionalPut_Pebble/Create/valueSize=10000-16     23.7µs ± 6%    23.8µs ± 5%     ~     (p=0.897 n=10+8)
MVCCConditionalPut_Pebble/Replace/valueSize=10-16       12.0µs ± 6%    12.0µs ± 7%     ~     (p=0.704 n=10+9)
MVCCConditionalPut_Pebble/Replace/valueSize=100-16      13.2µs ± 7%    13.0µs ± 9%     ~     (p=0.604 n=9+10)
MVCCConditionalPut_Pebble/Replace/valueSize=10000-16    28.8µs ± 7%    30.2µs ± 3%   +4.91%  (p=0.008 n=10+9)
MVCCConditionalPut_Pebble/Replace/valueSize=1000-16     11.5µs ± 6%    12.1µs ± 6%   +5.22%  (p=0.007 n=10+10)

name                                                  old speed      new speed      delta
MVCCConditionalPut_Pebble/Create/valueSize=10-16      1.37MB/s ± 8%  1.42MB/s ± 8%     ~     (p=0.085 n=10+10)
MVCCConditionalPut_Pebble/Create/valueSize=100-16     12.5MB/s ± 7%  12.7MB/s ± 9%     ~     (p=0.645 n=10+10)
MVCCConditionalPut_Pebble/Create/valueSize=1000-16     118MB/s ± 8%   118MB/s ± 4%     ~     (p=0.529 n=10+10)
MVCCConditionalPut_Pebble/Create/valueSize=10000-16    423MB/s ± 6%   421MB/s ± 5%     ~     (p=0.897 n=10+8)
MVCCConditionalPut_Pebble/Replace/valueSize=10-16      835kB/s ± 5%   833kB/s ± 7%     ~     (p=0.734 n=10+9)
MVCCConditionalPut_Pebble/Replace/valueSize=100-16    7.56MB/s ± 7%  7.69MB/s ±10%     ~     (p=0.619 n=9+10)
MVCCConditionalPut_Pebble/Replace/valueSize=10000-16   347MB/s ± 7%   331MB/s ± 3%   -4.80%  (p=0.008 n=10+9)
MVCCConditionalPut_Pebble/Replace/valueSize=1000-16   87.1MB/s ± 6%  82.8MB/s ± 6%   -4.96%  (p=0.007 n=10+10)

name                                                  old alloc/op   new alloc/op   delta
MVCCConditionalPut_Pebble/Create/valueSize=10-16          366B ± 3%      366B ± 2%     ~     (p=1.000 n=10+10)
MVCCConditionalPut_Pebble/Create/valueSize=100-16         909B ± 2%      905B ± 2%     ~     (p=0.492 n=10+10)
MVCCConditionalPut_Pebble/Create/valueSize=1000-16      6.42kB ± 2%    6.46kB ± 1%     ~     (p=0.197 n=10+10)
MVCCConditionalPut_Pebble/Create/valueSize=10000-16     79.8kB ± 8%    77.7kB ±10%     ~     (p=0.190 n=10+10)
MVCCConditionalPut_Pebble/Replace/valueSize=1000-16     8.37kB ± 6%    9.05kB ± 4%   +8.20%  (p=0.000 n=10+9)
MVCCConditionalPut_Pebble/Replace/valueSize=10-16         390B ± 3%      435B ± 4%  +11.41%  (p=0.000 n=10+10)
MVCCConditionalPut_Pebble/Replace/valueSize=10000-16    72.0kB ± 7%    81.0kB ± 3%  +12.38%  (p=0.000 n=9+10)
MVCCConditionalPut_Pebble/Replace/valueSize=100-16      1.02kB ± 3%    1.16kB ± 2%  +14.05%  (p=0.000 n=10+10)

name                                                  old allocs/op  new allocs/op  delta
MVCCConditionalPut_Pebble/Create/valueSize=10-16          2.00 ± 0%      2.00 ± 0%     ~     (all equal)
MVCCConditionalPut_Pebble/Create/valueSize=100-16         2.00 ± 0%      2.00 ± 0%     ~     (all equal)
MVCCConditionalPut_Pebble/Create/valueSize=1000-16        2.00 ± 0%      2.00 ± 0%     ~     (all equal)
MVCCConditionalPut_Pebble/Create/valueSize=10000-16       3.00 ± 0%      3.00 ± 0%     ~     (all equal)
MVCCConditionalPut_Pebble/Replace/valueSize=10-16         4.00 ± 0%      4.00 ± 0%     ~     (all equal)
MVCCConditionalPut_Pebble/Replace/valueSize=100-16        4.00 ± 0%      4.00 ± 0%     ~     (all equal)
MVCCConditionalPut_Pebble/Replace/valueSize=1000-16       4.00 ± 0%      4.00 ± 0%     ~     (all equal)
MVCCConditionalPut_Pebble/Replace/valueSize=10000-16      6.00 ± 0%      6.00 ± 0%     ~     (all equal)
```

If we want to continue pulling on this – 2 of the 4 remaining heap allocations here are due to the key copy in [`pebble.Iterator.SeekPrefixGE`](https://github.com/cockroachdb/pebble/blob/2da62788eedefce8dfbeef56a2324603606e18fb/iterator.go#L386). Caching this buffer across calls to `SeekPrefixGE` seems trivial. Caching the buffer across other method calls seems trickier due to the way we use the existence of the slice to indicate "prefix iteration". Maybe someone closer to this code will have good ideas about what to do about this.