### PR TITLE
backupccl: clean up system table filtering logic

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -33,7 +33,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemadesc"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/covering"
@@ -1899,36 +1898,24 @@ func (r *restoreResumer) restoreSystemTables(
 
 		if err := db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 			txn.SetDebugName("system-restore-txn")
-			stmtDebugName := fmt.Sprintf("restore-system-systemTable-%s", systemTableName)
-			// Don't clear the jobs table as to not delete the jobs that are performing
-			// the restore.
-			if systemTableName == systemschema.SettingsTable.Name {
-				// Don't delete the cluster version.
-				deleteQuery := fmt.Sprintf("DELETE FROM system.%s WHERE name <> 'version';", systemTableName)
-				_, err = executor.Exec(ctx, stmtDebugName+"-data-deletion", txn, deleteQuery)
-				if err != nil {
-					return errors.Wrapf(err, "deleting data from system.%s", systemTableName)
-				}
-			} else if systemTableName != systemschema.JobsTable.Name {
-				// Don't clear the jobs table as to not delete the jobs that are
-				// performing the restore.
-				deleteQuery := fmt.Sprintf("DELETE FROM system.%s WHERE true;", systemTableName)
-				_, err = executor.Exec(ctx, stmtDebugName+"-data-deletion", txn, deleteQuery)
-				if err != nil {
-					return errors.Wrapf(err, "deleting data from system.%s", systemTableName)
-				}
+			config, ok := systemTableBackupConfiguration[systemTableName]
+			if !ok {
+				log.Warningf(ctx, "no configuration specified for table %s... skipping restoration",
+					systemTableName)
 			}
 
-			restoreQuery := fmt.Sprintf("INSERT INTO system.%s (SELECT * FROM %s.%s);", systemTableName,
-				restoreTempSystemDB, systemTableName)
-			if systemTableName == systemschema.SettingsTable.Name {
-				// Don't overwrite the cluster version.
-				restoreQuery = fmt.Sprintf("INSERT INTO system.%s (SELECT * FROM %s.%s WHERE name <> 'version');",
-					systemTableName, restoreTempSystemDB, systemTableName)
+			restoreFunc := defaultSystemTableRestoreFunc
+			if config.customRestoreFunc != nil {
+				restoreFunc = config.customRestoreFunc
+				log.Eventf(ctx, "using custom restore function for table %s", systemTableName)
 			}
-			if _, err := executor.Exec(ctx, stmtDebugName+"-data-insert", txn, restoreQuery); err != nil {
-				return errors.Wrapf(err, "inserting data to system.%s", systemTableName)
+
+			log.Eventf(ctx, "restoring system table %s", systemTableName)
+			err := restoreFunc(ctx, r.execCfg, txn, systemTableName, restoreTempSystemDB+"."+systemTableName)
+			if err != nil {
+				return errors.Wrapf(err, "restoring system table %s", systemTableName)
 			}
+
 			return nil
 		}); err != nil {
 			return err

--- a/pkg/ccl/backupccl/system_schema_test.go
+++ b/pkg/ccl/backupccl/system_schema_test.go
@@ -38,3 +38,20 @@ func TestAllSystemTablesHaveBackupConfig(t *testing.T) {
 		}
 	}
 }
+
+func TestConfigurationDetailsOnlySetForIncludedTables(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	for systemTable, configuration := range systemTableBackupConfiguration {
+		if configuration.customRestoreFunc != nil {
+			// If some restore options were specified, we probably want to also
+			// include in in the set of system tables that are looked at by cluster
+			// backup/restore.
+			if optInToClusterBackup != configuration.includeInClusterBackup {
+				t.Fatalf("custom restore function specified for table %q, but it's not included in cluster backups",
+					systemTable)
+			}
+		}
+	}
+}


### PR DESCRIPTION
There is some bespoke logic in restoring some of the system tables. This
commit attempts to clean it that logic by moving the special cases to
the systemBackupConfiguration.

Release note: None