### PR TITLE
sql: add feature flag for CREATE STATISTICS/ANALYZE

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -18,6 +18,7 @@
 <tr><td><code>feature.export.enabled</code></td><td>boolean</td><td><code>true</code></td><td>set to true to enable exports, false to disable; default is true</td></tr>
 <tr><td><code>feature.import.enabled</code></td><td>boolean</td><td><code>true</code></td><td>set to true to enable imports, false to disable; default is true</td></tr>
 <tr><td><code>feature.restore.enabled</code></td><td>boolean</td><td><code>true</code></td><td>set to true to enable restore, false to disable; default is true</td></tr>
+<tr><td><code>feature.stats.enabled</code></td><td>boolean</td><td><code>true</code></td><td>set to true to enable CREATE STATISTICS/ANALYZE, false to disable; default is true</td></tr>
 <tr><td><code>jobs.retention_time</code></td><td>duration</td><td><code>336h0m0s</code></td><td>the amount of time to retain records for completed jobs before</td></tr>
 <tr><td><code>kv.allocator.load_based_lease_rebalancing.enabled</code></td><td>boolean</td><td><code>true</code></td><td>set to enable rebalancing of range leases based on load and latency</td></tr>
 <tr><td><code>kv.allocator.load_based_rebalancing</code></td><td>enumeration</td><td><code>leases and replicas</code></td><td>whether to rebalance based on the distribution of QPS across stores [off = 0, leases = 1, leases and replicas = 2]</td></tr>

--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -43,6 +43,19 @@ NULL       /1       {1}       1
 /8         /9       {4}       4
 /9         NULL     {5}       5
 
+# Turn feature flag off and verify errors.
+statement ok
+SET CLUSTER SETTING feature.stats.enabled = FALSE
+
+statement error pq: ANALYZE/CREATE STATISTICS feature was disabled by the database administrator
+CREATE STATISTICS s1 ON a FROM data
+
+statement error pq: ANALYZE/CREATE STATISTICS feature was disabled by the database administrator
+ANALYZE data
+
+statement ok
+SET CLUSTER SETTING feature.stats.enabled = TRUE
+
 statement ok
 CREATE STATISTICS s1 ON a FROM data
 


### PR DESCRIPTION
See #51643 for background.

---Commit message---

This change adds a feature flag for the CREATE STATISTICS command
as well as ANALYZE, which is syntactic sugar for the former. The
feature is being added to address a CockroachCloud SRE use case:
needing to disable certain features, such as this, in case of
cluster failure.

Release note (sql change): Adds a feature flag via cluster settings
for the CREATE STATISTICS and ANALYZE feature. If a user attempts
to use the command while disabled, an error indicating that the
database administrator had disabled the feature is surfaced.

Example usage for the database administrator:
SET CLUSTER SETTING feature.stats.enabled = FALSE;
SET CLUSTER SETITNG feature.stats.enabled = TRUE;