### PR TITLE
storage: pass correct parameters to PutIntent, ClearIntent

### DIFF
--- a/pkg/kv/kvserver/spanset/batch.go
+++ b/pkg/kv/kvserver/spanset/batch.go
@@ -162,6 +162,11 @@ func (i *MVCCIterator) UnsafeValue() []byte {
 	return i.i.UnsafeValue()
 }
 
+// IsCurIntentSeparated implements the MVCCIterator interface.
+func (i *MVCCIterator) IsCurIntentSeparated() bool {
+	return i.i.IsCurIntentSeparated()
+}
+
 // ComputeStats is part of the storage.MVCCIterator interface.
 func (i *MVCCIterator) ComputeStats(
 	start, end roachpb.Key, nowNanos int64,

--- a/pkg/storage/intent_interleaving_iter.go
+++ b/pkg/storage/intent_interleaving_iter.go
@@ -619,6 +619,10 @@ func (i *intentInterleavingIter) ValueProto(msg protoutil.Message) error {
 	return protoutil.Unmarshal(value, msg)
 }
 
+func (i *intentInterleavingIter) IsCurIntentSeparated() bool {
+	return i.isCurAtIntentIter()
+}
+
 func (i *intentInterleavingIter) ComputeStats(
 	start, end roachpb.Key, nowNanos int64,
 ) (enginepb.MVCCStats, error) {

--- a/pkg/storage/pebble_iterator.go
+++ b/pkg/storage/pebble_iterator.go
@@ -360,6 +360,11 @@ func (p *pebbleIterator) ValueProto(msg protoutil.Message) error {
 	return protoutil.Unmarshal(value, msg)
 }
 
+// IsCurIntentSeparated implements the MVCCIterator interface.
+func (p *pebbleIterator) IsCurIntentSeparated() bool {
+	return false
+}
+
 // ComputeStats implements the MVCCIterator interface.
 func (p *pebbleIterator) ComputeStats(
 	start, end roachpb.Key, nowNanos int64,

--- a/pkg/storage/testdata/mvcc_histories/conditional_put_with_txn
+++ b/pkg/storage/testdata/mvcc_histories/conditional_put_with_txn
@@ -104,6 +104,7 @@ txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=1 ts=0.000000003,0 min=0,
 >> txn_step t=A
 txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=1 ts=0.000000003,0 min=0,0 seq=1} lock=true stat=PENDING rts=0.000000003,0 wto=false max=0,0
 >> cput k=c v=cput cond=value t=A
+called PutIntent("c", _, ExistingIntentInterleaved, TDNUM(false), 00000000-0000-0000-0000-000000000002)
 meta: "c"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=1 ts=0.000000003,0 min=0,0 seq=1} ts=0.000000003,0 del=false klen=12 vlen=9
 data: "c"/0.000000003,0 -> /BYTES/cput
 data: "c"/0.000000001,0 -> /BYTES/value

--- a/pkg/storage/testdata/mvcc_histories/intent_history
+++ b/pkg/storage/testdata/mvcc_histories/intent_history
@@ -27,27 +27,32 @@ with t=A
 >> txn_begin ts=2 t=A
 txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000002,0 min=0,0 seq=0} lock=true stat=PENDING rts=0.000000002,0 wto=false max=0,0
 >> put v=first k=a t=A
+called PutIntent("a", _, NoExistingIntent, TDNUM(true), 00000000-0000-0000-0000-000000000002)
 meta: "a"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000002,0 min=0,0 seq=0} ts=0.000000002,0 del=false klen=12 vlen=10
 data: "a"/0.000000002,0 -> /BYTES/first
 data: "a"/0.000000001,0 -> /BYTES/default
 >> txn_step k=a t=A
 txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000002,0 min=0,0 seq=1} lock=true stat=PENDING rts=0.000000002,0 wto=false max=0,0
 >> put v=second k=a t=A
+called PutIntent("a", _, ExistingIntentInterleaved, TDNUM(false), 00000000-0000-0000-0000-000000000002)
 meta: "a"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000002,0 min=0,0 seq=1} ts=0.000000002,0 del=false klen=12 vlen=11 ih={{0 /BYTES/first}}
 data: "a"/0.000000002,0 -> /BYTES/second
 data: "a"/0.000000001,0 -> /BYTES/default
 >> txn_step n=2 k=a t=A
 txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000002,0 min=0,0 seq=3} lock=true stat=PENDING rts=0.000000002,0 wto=false max=0,0
 >> del k=a t=A
+called PutIntent("a", _, ExistingIntentInterleaved, TDNUM(false), 00000000-0000-0000-0000-000000000002)
 meta: "a"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000002,0 min=0,0 seq=3} ts=0.000000002,0 del=true klen=12 vlen=0 ih={{0 /BYTES/first}{1 /BYTES/second}}
 data: "a"/0.000000002,0 -> /<empty>
 data: "a"/0.000000001,0 -> /BYTES/default
 >> txn_step n=6 k=a t=A
 txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000002,0 min=0,0 seq=9} lock=true stat=PENDING rts=0.000000002,0 wto=false max=0,0
 >> put v=first k=a t=A
+called PutIntent("a", _, ExistingIntentInterleaved, TDNUM(false), 00000000-0000-0000-0000-000000000002)
 meta: "a"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000002,0 min=0,0 seq=9} ts=0.000000002,0 del=false klen=12 vlen=10 ih={{0 /BYTES/first}{1 /BYTES/second}{3 /<empty>}}
 data: "a"/0.000000002,0 -> /BYTES/first
 data: "a"/0.000000001,0 -> /BYTES/default
 >> resolve_intent k=a t=A
+called ClearIntent("a", ExistingIntentInterleaved, TDNUM(false), 00000000-0000-0000-0000-000000000000)
 data: "a"/0.000000002,0 -> /BYTES/first
 data: "a"/0.000000001,0 -> /BYTES/default

--- a/pkg/storage/testdata/mvcc_histories/intent_with_write_tracing
+++ b/pkg/storage/testdata/mvcc_histories/intent_with_write_tracing
@@ -1,0 +1,87 @@
+run trace ok
+with t=A
+  txn_begin ts=2
+  put k=k1 v=v1
+----
+>> txn_begin ts=2 t=A
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000002,0 min=0,0 seq=0} lock=true stat=PENDING rts=0.000000002,0 wto=false max=0,0
+>> put k=k1 v=v1 t=A
+called PutIntent("k1", _, NoExistingIntent, TDNUM(true), 00000000-0000-0000-0000-000000000001)
+meta: "k1"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000002,0 min=0,0 seq=0} ts=0.000000002,0 del=false klen=12 vlen=7
+data: "k1"/0.000000002,0 -> /BYTES/v1
+
+run trace ok
+with t=A
+  txn_advance ts=3
+  txn_step
+  put k=k1 v=v1
+  put k=k2 v=v2
+----
+>> txn_advance ts=3 t=A
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000003,0 min=0,0 seq=0} lock=true stat=PENDING rts=0.000000002,0 wto=false max=0,0
+>> txn_step t=A
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000003,0 min=0,0 seq=1} lock=true stat=PENDING rts=0.000000002,0 wto=false max=0,0
+>> put k=k1 v=v1 t=A
+called PutIntent("k1", _, ExistingIntentInterleaved, TDNUM(false), 00000000-0000-0000-0000-000000000001)
+meta: "k1"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000003,0 min=0,0 seq=1} ts=0.000000003,0 del=false klen=12 vlen=7 ih={{0 /BYTES/v1}}
+data: "k1"/0.000000003,0 -> /BYTES/v1
+>> put k=k2 v=v2 t=A
+called PutIntent("k2", _, NoExistingIntent, TDNUM(true), 00000000-0000-0000-0000-000000000001)
+meta: "k1"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000003,0 min=0,0 seq=1} ts=0.000000003,0 del=false klen=12 vlen=7 ih={{0 /BYTES/v1}}
+data: "k1"/0.000000003,0 -> /BYTES/v1
+meta: "k2"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000003,0 min=0,0 seq=1} ts=0.000000003,0 del=false klen=12 vlen=7
+data: "k2"/0.000000003,0 -> /BYTES/v2
+
+run trace ok
+put k=k3 v=v3 ts=1
+----
+>> put k=k3 v=v3 ts=1
+meta: "k1"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000003,0 min=0,0 seq=1} ts=0.000000003,0 del=false klen=12 vlen=7 ih={{0 /BYTES/v1}}
+data: "k1"/0.000000003,0 -> /BYTES/v1
+meta: "k2"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000003,0 min=0,0 seq=1} ts=0.000000003,0 del=false klen=12 vlen=7
+data: "k2"/0.000000003,0 -> /BYTES/v2
+data: "k3"/0.000000001,0 -> /BYTES/v3
+
+run trace ok
+with t=A
+  put k=k3 v=v33
+----
+>> put k=k3 v=v33 t=A
+called PutIntent("k3", _, NoExistingIntent, TDNUM(true), 00000000-0000-0000-0000-000000000001)
+meta: "k1"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000003,0 min=0,0 seq=1} ts=0.000000003,0 del=false klen=12 vlen=7 ih={{0 /BYTES/v1}}
+data: "k1"/0.000000003,0 -> /BYTES/v1
+meta: "k2"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000003,0 min=0,0 seq=1} ts=0.000000003,0 del=false klen=12 vlen=7
+data: "k2"/0.000000003,0 -> /BYTES/v2
+meta: "k3"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000003,0 min=0,0 seq=1} ts=0.000000003,0 del=false klen=12 vlen=8
+data: "k3"/0.000000003,0 -> /BYTES/v33
+data: "k3"/0.000000001,0 -> /BYTES/v3
+
+# transactionDidNotUpdateMeta (TDNUM) is false below for k2 and k3 since
+# disallowSeparatedIntents=true causes mvcc.go to always set it to false to maintain
+# consistency in a mixed version cluster.
+run trace ok
+with t=A
+  resolve_intent k=k1
+  resolve_intent k=k2 status=ABORTED
+  resolve_intent k=k3 status=ABORTED
+  txn_remove
+----
+>> resolve_intent k=k1 t=A
+called ClearIntent("k1", ExistingIntentInterleaved, TDNUM(false), 00000000-0000-0000-0000-000000000000)
+data: "k1"/0.000000003,0 -> /BYTES/v1
+meta: "k2"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000003,0 min=0,0 seq=1} ts=0.000000003,0 del=false klen=12 vlen=7
+data: "k2"/0.000000003,0 -> /BYTES/v2
+meta: "k3"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000003,0 min=0,0 seq=1} ts=0.000000003,0 del=false klen=12 vlen=8
+data: "k3"/0.000000003,0 -> /BYTES/v33
+data: "k3"/0.000000001,0 -> /BYTES/v3
+>> resolve_intent k=k2 status=ABORTED t=A
+called ClearIntent("k2", ExistingIntentInterleaved, TDNUM(false), 00000000-0000-0000-0000-000000000000)
+data: "k1"/0.000000003,0 -> /BYTES/v1
+meta: "k3"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000003,0 min=0,0 seq=1} ts=0.000000003,0 del=false klen=12 vlen=8
+data: "k3"/0.000000003,0 -> /BYTES/v33
+data: "k3"/0.000000001,0 -> /BYTES/v3
+>> resolve_intent k=k3 status=ABORTED t=A
+called ClearIntent("k3", ExistingIntentInterleaved, TDNUM(false), 00000000-0000-0000-0000-000000000000)
+data: "k1"/0.000000003,0 -> /BYTES/v1
+data: "k3"/0.000000001,0 -> /BYTES/v3
+>> txn_remove t=A

--- a/pkg/storage/testdata/mvcc_histories/no_read_after_abort
+++ b/pkg/storage/testdata/mvcc_histories/no_read_after_abort
@@ -10,9 +10,11 @@ with t=A k=a
 >> txn_begin ts=22 t=A k=a
 txn: "A" meta={id=00000000 key="a" pri=0.00000000 epo=0 ts=0.000000022,0 min=0,0 seq=0} lock=true stat=PENDING rts=0.000000022,0 wto=false max=0,0
 >> put v=cde t=A k=a
+called PutIntent("a", _, NoExistingIntent, TDNUM(true), 00000000-0000-0000-0000-000000000001)
 meta: "a"/0,0 -> txn={id=00000000 key="a" pri=0.00000000 epo=0 ts=0.000000022,0 min=0,0 seq=0} ts=0.000000022,0 del=false klen=12 vlen=8
 data: "a"/0.000000022,0 -> /BYTES/cde
 >> resolve_intent status=ABORTED t=A k=a
+called ClearIntent("a", ExistingIntentInterleaved, TDNUM(false), 00000000-0000-0000-0000-000000000000)
 <no data>
 >> txn_remove t=A k=a
 

--- a/pkg/storage/testdata/mvcc_histories/read_after_write
+++ b/pkg/storage/testdata/mvcc_histories/read_after_write
@@ -11,11 +11,13 @@ with t=A
 >> txn_begin ts=11 t=A
 txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=0} lock=true stat=PENDING rts=0.000000011,0 wto=false max=0,0
 >> put v=abc k=a t=A
+called PutIntent("a", _, NoExistingIntent, TDNUM(true), 00000000-0000-0000-0000-000000000001)
 meta: "a"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=0} ts=0.000000011,0 del=false klen=12 vlen=8
 data: "a"/0.000000011,0 -> /BYTES/abc
 >> get k=a t=A
 get: "a" -> /BYTES/abc @0.000000011,0
 >> resolve_intent k=a t=A
+called ClearIntent("a", ExistingIntentInterleaved, TDNUM(false), 00000000-0000-0000-0000-000000000000)
 data: "a"/0.000000011,0 -> /BYTES/abc
 
 run ok


### PR DESCRIPTION
- IsCurIntentSeparated method is added to MVCCIterator,
  to provide the value that needs to be passed to
  PutIntent, ClearIntent.
- The code in mvcc.go now keeps track of whether the
  txn previously updated the intent.

Informs #41720

Release note: None