### PR TITLE
testutils: Improve TestCluster to support server restarts similar to multiTestContext

### DIFF
--- a/pkg/cli/demo_cluster.go
+++ b/pkg/cli/demo_cluster.go
@@ -60,6 +60,8 @@ type transientCluster struct {
 
 	adminPassword string
 	adminUser     security.SQLUsername
+
+	stickyEngineRegistry server.StickyInMemEnginesRegistry
 }
 
 func (c *transientCluster) checkConfigAndSetupLogging(
@@ -110,6 +112,7 @@ func (c *transientCluster) checkConfigAndSetupLogging(
 	c.httpFirstPort = demoCtx.httpPort
 	c.sqlFirstPort = demoCtx.sqlPort
 
+	c.stickyEngineRegistry = server.NewStickyInMemEnginesRegistry()
 	return nil
 }
 
@@ -138,6 +141,7 @@ func (c *transientCluster) start(
 			c.sockForServer(nodeID), nodeID, joinAddr, c.demoDir,
 			c.sqlFirstPort,
 			c.httpFirstPort,
+			c.stickyEngineRegistry,
 		)
 		if i == 0 {
 			// The first node also auto-inits the cluster.
@@ -149,14 +153,11 @@ func (c *transientCluster) start(
 		servRPCReadyCh := make(chan struct{})
 
 		if demoCtx.simulateLatency {
-			args.Knobs = base.TestingKnobs{
-				Server: &server.TestingKnobs{
-					PauseAfterGettingRPCAddress:  latencyMapWaitCh,
-					SignalAfterGettingRPCAddress: servRPCReadyCh,
-					ContextTestingKnobs: rpc.ContextTestingKnobs{
-						ArtificialLatencyMap: make(map[string]int),
-					},
-				},
+			serverKnobs := args.Knobs.Server.(*server.TestingKnobs)
+			serverKnobs.PauseAfterGettingRPCAddress = latencyMapWaitCh
+			serverKnobs.SignalAfterGettingRPCAddress = servRPCReadyCh
+			serverKnobs.ContextTestingKnobs = rpc.ContextTestingKnobs{
+				ArtificialLatencyMap: make(map[string]int),
 			}
 		}
 
@@ -211,23 +212,9 @@ func (c *transientCluster) start(
 		}
 
 		// Ensure we close all sticky stores we've created.
-		for _, store := range args.StoreSpecs {
-			if store.StickyInMemoryEngineID != "" {
-				engineID := store.StickyInMemoryEngineID
-				c.stopper.AddCloser(stop.CloserFn(func() {
-					if err := server.CloseStickyInMemEngine(engineID); err != nil {
-						// Something else may have already closed the sticky store.
-						// Since we are closer, it doesn't really matter.
-						log.Warningf(
-							ctx,
-							"could not close sticky in-memory store %s: %+v",
-							engineID,
-							err,
-						)
-					}
-				}))
-			}
-		}
+		c.stopper.AddCloser(stop.CloserFn(func() {
+			c.stickyEngineRegistry.CloseAllStickyInMemEngines()
+		}))
 	}
 
 	c.servers = servers
@@ -322,6 +309,7 @@ func testServerArgsForTransientCluster(
 	joinAddr string,
 	demoDir string,
 	sqlBasePort, httpBasePort int,
+	stickyEngineRegistry server.StickyInMemEnginesRegistry,
 ) base.TestServerArgs {
 	// Assign a path to the store spec, to be saved.
 	storeSpec := base.DefaultTestStoreSpec
@@ -341,6 +329,11 @@ func testServerArgsForTransientCluster(
 		// This disables the tenant server. We could enable it but would have to
 		// generate the suitable certs at the caller who wishes to do so.
 		TenantAddr: new(string),
+		Knobs: base.TestingKnobs{
+			Server: &server.TestingKnobs{
+				StickyEngineRegistry: stickyEngineRegistry,
+			},
+		},
 	}
 
 	if !testingForceRandomizeDemoPorts {
@@ -504,7 +497,7 @@ func (c *transientCluster) RestartNode(nodeID roachpb.NodeID) error {
 
 	// TODO(#42243): re-compute the latency mapping.
 	args := testServerArgsForTransientCluster(c.sockForServer(nodeID), nodeID, c.s.ServingRPCAddr(), c.demoDir,
-		c.sqlFirstPort, c.httpFirstPort)
+		c.sqlFirstPort, c.httpFirstPort, c.stickyEngineRegistry)
 	s, err := server.TestServerFactory.New(args)
 	if err != nil {
 		return err

--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -3571,7 +3571,8 @@ func makeReplicationTargets(ids ...int) (targets []roachpb.ReplicationTarget) {
 func TestTenantID(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	defer server.CloseAllStickyInMemEngines()
+	stickyEngineRegistry := server.NewStickyInMemEnginesRegistry()
+	defer stickyEngineRegistry.CloseAllStickyInMemEngines()
 	ctx := context.Background()
 	// Create a config with a sticky-in-mem engine so we can restart the server.
 	// We also configure the settings to be as robust as possible to problems
@@ -3588,6 +3589,11 @@ func TestTenantID(t *testing.T) {
 			{
 				InMemory:               true,
 				StickyInMemoryEngineID: "1",
+			},
+		},
+		Knobs: base.TestingKnobs{
+			Server: &server.TestingKnobs{
+				StickyEngineRegistry: stickyEngineRegistry,
 			},
 		},
 	}

--- a/pkg/server/testing_knobs.go
+++ b/pkg/server/testing_knobs.go
@@ -77,6 +77,9 @@ type TestingKnobs struct {
 	// An (additional) callback invoked whenever a
 	// node is permanently removed from the cluster.
 	OnDecommissionedCallback func(livenesspb.Liveness)
+	// StickyEngineRegistry manages the lifecycle of sticky in memory engines,
+	// which can be enabled via base.StoreSpec.StickyInMemoryEngineID.
+	StickyEngineRegistry StickyInMemEnginesRegistry
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.

--- a/pkg/testutils/testcluster/BUILD.bazel
+++ b/pkg/testutils/testcluster/BUILD.bazel
@@ -39,6 +39,7 @@ go_test(
     deps = [
         "//pkg/base",
         "//pkg/keys",
+        "//pkg/kv",
         "//pkg/roachpb",
         "//pkg/rpc",
         "//pkg/security",
@@ -52,5 +53,6 @@ go_test(
         "//pkg/util/httputil",
         "//pkg/util/leaktest",
         "//pkg/util/log",
+        "@com_github_stretchr_testify//require",
     ],
 )


### PR DESCRIPTION
Makes progress on #8299

TestCluster does not have an easy way to restart a Server. Today to make
that work one has to use a sticky_engine with TestCluster.StopServer and
TestCluster.AddAndStartServer. While this works it quickly gets complicated
to use and track where the newly restarted server(s) are running, as they
just get appended to list of running servers. This change introduces two new
methods TestCluster.Restart and TestCluster.RestartServer, which will
restart the server with a sticky engine in place, keeping its position in the
list. This matches the behavior of mtc and is easier to use in tests.

Sticky engines work well for this use case, but they are global. This means
if we run multiple tests in parallel they could have a potential to leak
engines to each other. This change makes the StickEngineRegistry scoped by
TestCluster, so that one TestCluster would not be able to accidentally use an
engine from another cluster.

Release note: None