### PR TITLE
 backupccl: refactor backup/restore processors to use ProcessorBase

### DIFF
--- a/pkg/ccl/backupccl/backup_processor.go
+++ b/pkg/ccl/backupccl/backup_processor.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowexec"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -32,7 +33,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
-	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 	gogotypes "github.com/gogo/protobuf/types"
 )
@@ -59,6 +59,8 @@ var (
 	)
 )
 
+const backupProcessorName = "backupDataProcessor"
+
 // TODO(pbardea): It would be nice if we could add some DistSQL processor tests
 // we would probably want to have a mock cloudStorage object that we could
 // verify with.
@@ -69,55 +71,77 @@ var (
 // will each export a span at a time. After exporting the span, it will stream
 // back its progress through the metadata channel provided by DistSQL.
 type backupDataProcessor struct {
+	execinfra.ProcessorBase
+
 	flowCtx *execinfra.FlowCtx
 	spec    execinfrapb.BackupDataSpec
 	output  execinfra.RowReceiver
+
+	progCh    chan execinfrapb.RemoteProducerMetadata_BulkProcessorProgress
+	backupErr error
 }
 
 var _ execinfra.Processor = &backupDataProcessor{}
-
-func (bp *backupDataProcessor) OutputTypes() []*types.T {
-	return backupOutputTypes
-}
+var _ execinfra.RowSource = &backupDataProcessor{}
 
 func newBackupDataProcessor(
 	flowCtx *execinfra.FlowCtx,
 	processorID int32,
 	spec execinfrapb.BackupDataSpec,
+	post *execinfrapb.PostProcessSpec,
 	output execinfra.RowReceiver,
 ) (execinfra.Processor, error) {
 	bp := &backupDataProcessor{
 		flowCtx: flowCtx,
 		spec:    spec,
 		output:  output,
+		progCh:  make(chan execinfrapb.RemoteProducerMetadata_BulkProcessorProgress),
+	}
+	if err := bp.Init(bp, post, backupOutputTypes, flowCtx, processorID, output, nil, /* memMonitor */
+		execinfra.ProcStateOpts{
+			// This processor doesn't have any inputs to drain.
+			InputsToDrain: nil,
+		}); err != nil {
+		return nil, err
 	}
 	return bp, nil
 }
 
-func (bp *backupDataProcessor) Run(ctx context.Context) {
-	ctx, span := tracing.ChildSpan(ctx, "backupDataProcessor")
-	defer span.Finish()
-	defer bp.output.ProducerDone()
-
-	progCh := make(chan execinfrapb.RemoteProducerMetadata_BulkProcessorProgress)
-
-	var err error
-	// We don't have to worry about this go routine leaking because next we loop over progCh
-	// which is closed only after the go routine returns.
+// Start is part of the RowSource interface.
+func (bp *backupDataProcessor) Start(ctx context.Context) context.Context {
 	go func() {
-		defer close(progCh)
-		err = runBackupProcessor(ctx, bp.flowCtx, &bp.spec, progCh)
+		defer close(bp.progCh)
+		bp.backupErr = runBackupProcessor(ctx, bp.flowCtx, &bp.spec, bp.progCh)
 	}()
+	return bp.StartInternal(ctx, backupProcessorName)
+}
 
-	for prog := range progCh {
-		// Take a copy so that we can send the progress address to the output processor.
+// Next is part of the RowSource interface.
+func (bp *backupDataProcessor) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMetadata) {
+	if bp.State != execinfra.StateRunning {
+		return nil, bp.DrainHelper()
+	}
+
+	for prog := range bp.progCh {
+		// Take a copy so that we can send the progress address to the output
+		// processor.
 		p := prog
-		bp.output.Push(nil, &execinfrapb.ProducerMetadata{BulkProcessorProgress: &p})
+		return nil, &execinfrapb.ProducerMetadata{BulkProcessorProgress: &p}
 	}
 
-	if err != nil {
-		bp.output.Push(nil, &execinfrapb.ProducerMetadata{Err: err})
+	if bp.backupErr != nil {
+		bp.MoveToDraining(bp.backupErr)
+		return nil, bp.DrainHelper()
 	}
+
+	bp.MoveToDraining(nil /* error */)
+	return nil, bp.DrainHelper()
+}
+
+// ConsumerClosed is part of the RowSource interface.
+func (bp *backupDataProcessor) ConsumerClosed() {
+	// The consumer is done, Next() will not be called again.
+	bp.InternalClose()
 }
 
 type spanAndTime struct {

--- a/pkg/ccl/backupccl/split_and_scatter_processor_test.go
+++ b/pkg/ccl/backupccl/split_and_scatter_processor_test.go
@@ -268,7 +268,8 @@ func TestSplitAndScatterProcessor(t *testing.T) {
 			out, err := rowflow.MakeTestRouter(ctx, &flowCtx, &routerSpec, recvs, colTypes, &wg)
 			require.NoError(t, err)
 
-			proc, err := newSplitAndScatterProcessor(&flowCtx, 0 /* processorID */, c.procSpec, out)
+			post := execinfrapb.PostProcessSpec{}
+			proc, err := newSplitAndScatterProcessor(&flowCtx, 0 /* processorID */, c.procSpec, &post, out)
 			require.NoError(t, err)
 			ssp, ok := proc.(*splitAndScatterProcessor)
 			if !ok {

--- a/pkg/sql/rowexec/processors.go
+++ b/pkg/sql/rowexec/processors.go
@@ -256,7 +256,7 @@ func NewProcessor(
 		if NewSplitAndScatterProcessor == nil {
 			return nil, errors.New("SplitAndScatter processor unimplemented")
 		}
-		return NewSplitAndScatterProcessor(flowCtx, processorID, *core.SplitAndScatter, outputs[0])
+		return NewSplitAndScatterProcessor(flowCtx, processorID, *core.SplitAndScatter, post, outputs[0])
 	}
 	if core.RestoreData != nil {
 		if err := checkNumInOut(inputs, outputs, 1, 1); err != nil {
@@ -369,7 +369,7 @@ var NewReadImportDataProcessor func(*execinfra.FlowCtx, int32, execinfrapb.ReadI
 var NewBackupDataProcessor func(*execinfra.FlowCtx, int32, execinfrapb.BackupDataSpec, *execinfrapb.PostProcessSpec, execinfra.RowReceiver) (execinfra.Processor, error)
 
 // NewSplitAndScatterProcessor is implemented in the non-free (CCL) codebase and then injected here via runtime initialization.
-var NewSplitAndScatterProcessor func(*execinfra.FlowCtx, int32, execinfrapb.SplitAndScatterSpec, execinfra.RowReceiver) (execinfra.Processor, error)
+var NewSplitAndScatterProcessor func(*execinfra.FlowCtx, int32, execinfrapb.SplitAndScatterSpec, *execinfrapb.PostProcessSpec, execinfra.RowReceiver) (execinfra.Processor, error)
 
 // NewRestoreDataProcessor is implemented in the non-free (CCL) codebase and then injected here via runtime initialization.
 var NewRestoreDataProcessor func(*execinfra.FlowCtx, int32, execinfrapb.RestoreDataSpec, *execinfrapb.PostProcessSpec, execinfra.RowSource, execinfra.RowReceiver) (execinfra.Processor, error)

--- a/pkg/sql/rowexec/processors.go
+++ b/pkg/sql/rowexec/processors.go
@@ -247,7 +247,7 @@ func NewProcessor(
 		if NewBackupDataProcessor == nil {
 			return nil, errors.New("BackupData processor unimplemented")
 		}
-		return NewBackupDataProcessor(flowCtx, processorID, *core.BackupData, outputs[0])
+		return NewBackupDataProcessor(flowCtx, processorID, *core.BackupData, post, outputs[0])
 	}
 	if core.SplitAndScatter != nil {
 		if err := checkNumInOut(inputs, outputs, 0, 1); err != nil {
@@ -366,7 +366,7 @@ func NewProcessor(
 var NewReadImportDataProcessor func(*execinfra.FlowCtx, int32, execinfrapb.ReadImportDataSpec, *execinfrapb.PostProcessSpec, execinfra.RowReceiver) (execinfra.Processor, error)
 
 // NewBackupDataProcessor is implemented in the non-free (CCL) codebase and then injected here via runtime initialization.
-var NewBackupDataProcessor func(*execinfra.FlowCtx, int32, execinfrapb.BackupDataSpec, execinfra.RowReceiver) (execinfra.Processor, error)
+var NewBackupDataProcessor func(*execinfra.FlowCtx, int32, execinfrapb.BackupDataSpec, *execinfrapb.PostProcessSpec, execinfra.RowReceiver) (execinfra.Processor, error)
 
 // NewSplitAndScatterProcessor is implemented in the non-free (CCL) codebase and then injected here via runtime initialization.
 var NewSplitAndScatterProcessor func(*execinfra.FlowCtx, int32, execinfrapb.SplitAndScatterSpec, execinfra.RowReceiver) (execinfra.Processor, error)


### PR DESCRIPTION
This PR refactors the remaining processors used in backup/restore to use ProcessorBase.

Informs https://github.com/cockroachdb/cockroach/issues/57293.

See individual commits.