### PR TITLE
sqlproxyccl: add KeepAlive option to BackendConfig

### DIFF
--- a/pkg/ccl/sqlproxyccl/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/BUILD.bazel
@@ -41,6 +41,7 @@ go_test(
         "//pkg/testutils/testcluster",
         "//pkg/util/leaktest",
         "//pkg/util/randutil",
+        "//pkg/util/timeutil",
         "//vendor/github.com/cockroachdb/errors",
         "//vendor/github.com/jackc/pgx/v4:pgx",
         "//vendor/github.com/stretchr/testify/require",

--- a/pkg/ccl/sqlproxyccl/error.go
+++ b/pkg/ccl/sqlproxyccl/error.go
@@ -62,6 +62,10 @@ const (
 	// CodeProxyRefusedConnection indicates that the proxy refused the connection
 	// request due to high load or too many connection attempts.
 	CodeProxyRefusedConnection
+
+	// CodeExpiredClientConnection indicates that proxy connection to the client
+	// has expired and should be closed.
+	CodeExpiredClientConnection
 )
 
 type codeError struct {

--- a/pkg/ccl/sqlproxyccl/errorcode_string.go
+++ b/pkg/ccl/sqlproxyccl/errorcode_string.go
@@ -19,11 +19,12 @@ func _() {
 	_ = x[CodeBackendDisconnected-9]
 	_ = x[CodeClientDisconnected-10]
 	_ = x[CodeProxyRefusedConnection-11]
+	_ = x[CodeExpiredClientConnection-12]
 }
 
-const _ErrorCode_name = "CodeClientReadFailedCodeClientWriteFailedCodeUnexpectedInsecureStartupMessageCodeSNIRoutingFailedCodeUnexpectedStartupMessageCodeParamsRoutingFailedCodeBackendDownCodeBackendRefusedTLSCodeBackendDisconnectedCodeClientDisconnectedCodeProxyRefusedConnection"
+const _ErrorCode_name = "CodeClientReadFailedCodeClientWriteFailedCodeUnexpectedInsecureStartupMessageCodeSNIRoutingFailedCodeUnexpectedStartupMessageCodeParamsRoutingFailedCodeBackendDownCodeBackendRefusedTLSCodeBackendDisconnectedCodeClientDisconnectedCodeProxyRefusedConnectionCodeExpiredClientConnection"
 
-var _ErrorCode_index = [...]uint8{0, 20, 41, 77, 97, 125, 148, 163, 184, 207, 229, 255}
+var _ErrorCode_index = [...]uint16{0, 20, 41, 77, 97, 125, 148, 163, 184, 207, 229, 255, 282}
 
 func (i ErrorCode) String() string {
 	i -= 1

--- a/pkg/ccl/sqlproxyccl/metrics.go
+++ b/pkg/ccl/sqlproxyccl/metrics.go
@@ -20,6 +20,7 @@ type Metrics struct {
 	RoutingErrCount        *metric.Counter
 	RefusedConnCount       *metric.Counter
 	SuccessfulConnCount    *metric.Counter
+	ExpiredClientConnCount *metric.Counter
 }
 
 // MetricStruct implements the metrics.Struct interface.
@@ -70,6 +71,12 @@ var (
 		Measurement: "Successful Connections",
 		Unit:        metric.Unit_COUNT,
 	}
+	metaExpiredClientConnCount = metric.Metadata{
+		Name:        "proxy.sql.expired_client_conns",
+		Help:        "Number of expired client connections",
+		Measurement: "Expired Client Connections",
+		Unit:        metric.Unit_COUNT,
+	}
 )
 
 // MakeProxyMetrics instantiates the metrics holder for proxy monitoring.
@@ -82,5 +89,6 @@ func MakeProxyMetrics() Metrics {
 		RoutingErrCount:        metric.NewCounter(metaRoutingErrCount),
 		RefusedConnCount:       metric.NewCounter(metaRefusedConnCount),
 		SuccessfulConnCount:    metric.NewCounter(metaSuccessfulConnCount),
+		ExpiredClientConnCount: metric.NewCounter(metaExpiredClientConnCount),
 	}
 }


### PR DESCRIPTION
It is useful for clients of sqlproxy server to signal that a connection
should be expired; for example if the user's credentials are no longer
valid or if the user has to be blocked immediately from accessing the
DB.

To that end, we provide a new `BackendConfig` closure `KeepAliveLoop`
which sqlproxy clients can use to define business logic for expiring
connections.

Alternatives considered:

We could instead expose a channel that can signal to clients when a
connection is closed and also share the conn resource outside of the
`Proxy` go routine so that clients can close it on demand. This would
give proxy users much more flexibility of course but on the flip side I
see several problems this approach:
1. `conn` can now be modified outside of the `Proxy` function which
   makes it harder to reason about code correctness and could lead to
subtle bugs. We also lose the nice property that only `Proxy` function
can mutate `conn`.
2.  We start mixing different concurrency approaches, shared mutable
    state (`conn`) and message passing. IMO this should be avoided
unless there are good reasons for it.
3. `net.Conn` cannot be used anymore and requires wrapping it in another
   struct which is unnecessary for clients that don't need to cancel
connections.
4. Leaving too much freedom to clients may lead to a proliferation of
   different approaches to controlling the connection vs trying to
standardize it so that it' easier to avoid bugs in this critical
security component.

Release note: none.