### PR TITLE
sql: fix bug during drop user defined schema

### DIFF
--- a/pkg/sql/drop_schema.go
+++ b/pkg/sql/drop_schema.go
@@ -199,8 +199,8 @@ func (p *planner) dropSchemaImpl(
 	if parentDB.Schemas == nil {
 		parentDB.Schemas = make(map[string]descpb.DatabaseDescriptor_SchemaInfo)
 	}
-	parentDB.Schemas[parentDB.Name] = descpb.DatabaseDescriptor_SchemaInfo{
-		ID:      parentDB.ID,
+	parentDB.Schemas[sc.Name] = descpb.DatabaseDescriptor_SchemaInfo{
+		ID:      sc.ID,
 		Dropped: true,
 	}
 	// Mark the descriptor as dropped.


### PR DESCRIPTION
On dropping a user defined schema one of the steps is to update the
parent DBs `Schemas` slice entry for the schema being dropped.
Previously, we were incorrectly using the parent DB name as the key,
while we should actually be using the name of the schema being dropped.

Release note: None