### PR TITLE
sql: feature flag for ALTER TABLE/INDEX SPLIT/UNSPLIT

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/schema_change_feature_flags
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_feature_flags
@@ -126,6 +126,18 @@ ALTER TABLE t SET SCHEMA s
 statement error pq: feature ALTER TABLE is part of the schema change category, which was disabled by the database administrator
 ALTER TABLE t SET REGIONAL AFFINITY TO NONE
 
+# Test ALTER TABLE SPLIT AT.
+statement error pq: feature ALTER TABLE/INDEX SPLIT AT is part of the schema change category, which was disabled by the database administrator
+ALTER TABLE t1 SPLIT AT VALUES ('1')
+
+# Test ALTER TABLE UNSPLIT AT.
+statement error pq: feature ALTER TABLE/INDEX UNSPLIT AT is part of the schema change category, which was disabled by the database administrator
+ALTER TABLE t1 UNSPLIT AT VALUES ('1')
+
+# Test ALTER TABLE UNSPLIT ALL.
+statement error pq: feature ALTER TABLE/INDEX UNSPLIT ALL is part of the schema change category, which was disabled by the database administrator
+ALTER TABLE t1 UNSPLIT ALL
+
 statement ok
 SET CLUSTER SETTING feature.schema_change.enabled = TRUE;
 CREATE INDEX i on t1 (a, b);
@@ -142,6 +154,18 @@ ALTER INDEX t1@i CONFIGURE ZONE DISCARD
 # Test RENAME INDEX
 statement error pq: feature RENAME INDEX is part of the schema change category, which was disabled by the database administrator
 ALTER INDEX t1@i RENAME TO r
+
+# TODO(angelaw): Test ALTER INDEX SPLIT AT. This does not throw error.
+statement error pq: feature ALTER TABLE/INDEX SPLIT AT is part of the schema change category, which was disabled by the database administrator
+ALTER INDEX t1@i SPLIT AT VALUES('1')
+
+# Test ALTER INDEX UNSPLIT AT.
+statement error pq: feature ALTER TABLE/INDEX UNSPLIT AT is part of the schema change category, which was disabled by the database administrator
+ALTER INDEX t1@i UNSPLIT AT VALUES('1')
+
+# Test ALTER INDEX UNSPLIT ALL.
+statement error pq: feature ALTER TABLE/INDEX UNSPLIT ALL is part of the schema change category, which was disabled by the database administrator
+ALTER INDEX t1@i UNSPLIT ALL
 
 # Test RENAME SCHEMA, throws ALTER SCHEMA error.
 statement error pq: feature ALTER SCHEMA is part of the schema change category, which was disabled by the database administrator

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1724,6 +1724,13 @@ func (ef *execFactory) ConstructOpaque(metadata opt.OpaqueMetadata) (exec.Node, 
 func (ef *execFactory) ConstructAlterTableSplit(
 	index cat.Index, input exec.Node, expiration tree.TypedExpr,
 ) (exec.Node, error) {
+	if err := checkSchemaChangeEnabled(
+		&ef.planner.ExecCfg().Settings.SV,
+		"ALTER TABLE/INDEX SPLIT AT",
+	); err != nil {
+		return nil, err
+	}
+
 	if !ef.planner.ExecCfg().Codec.ForSystemTenant() {
 		return nil, errorutil.UnsupportedWithMultiTenancy(54254)
 	}
@@ -1745,6 +1752,13 @@ func (ef *execFactory) ConstructAlterTableSplit(
 func (ef *execFactory) ConstructAlterTableUnsplit(
 	index cat.Index, input exec.Node,
 ) (exec.Node, error) {
+	if err := checkSchemaChangeEnabled(
+		&ef.planner.ExecCfg().Settings.SV,
+		"ALTER TABLE/INDEX UNSPLIT AT",
+	); err != nil {
+		return nil, err
+	}
+
 	if !ef.planner.ExecCfg().Codec.ForSystemTenant() {
 		return nil, errorutil.UnsupportedWithMultiTenancy(54254)
 	}
@@ -1758,6 +1772,13 @@ func (ef *execFactory) ConstructAlterTableUnsplit(
 
 // ConstructAlterTableUnsplitAll is part of the exec.Factory interface.
 func (ef *execFactory) ConstructAlterTableUnsplitAll(index cat.Index) (exec.Node, error) {
+	if err := checkSchemaChangeEnabled(
+		&ef.planner.ExecCfg().Settings.SV,
+		"ALTER TABLE/INDEX UNSPLIT ALL",
+	); err != nil {
+		return nil, err
+	}
+
 	if !ef.planner.ExecCfg().Codec.ForSystemTenant() {
 		return nil, errorutil.UnsupportedWithMultiTenancy(54254)
 	}


### PR DESCRIPTION
Release note (sql change): Gates the ALTER TABLE...SPLIT/UNSPLIT
and ALTER INDEX...SPLIT/UNSPLIT commands under the schema change
feature flag added previously. If a user attempts to use these
features while they are disabled, an error indicating that the
system administrator has disabled the feature is surfaced.

Example usage for the database administrator:
SET CLUSTER SETTING feature.schema_change.enabled = FALSE
SET CLUSTER SETTING feature.schema_change.enabled = TRUE