### PR TITLE
sql: stop creating GC jobs for dropped views

### DIFF
--- a/pkg/sql/gcjob/BUILD.bazel
+++ b/pkg/sql/gcjob/BUILD.bazel
@@ -26,7 +26,6 @@ go_library(
         "//pkg/settings/cluster",
         "//pkg/sql",
         "//pkg/sql/catalog",
-        "//pkg/sql/catalog/catalogkeys",
         "//pkg/sql/catalog/catalogkv",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/descs",

--- a/pkg/sql/gcjob/table_garbage_collection.go
+++ b/pkg/sql/gcjob/table_garbage_collection.go
@@ -71,7 +71,7 @@ func gcTables(
 		}
 
 		// Finished deleting all the table data, now delete the table meta data.
-		if err := dropTableDesc(ctx, execCfg.DB, execCfg.Codec, table); err != nil {
+		if err := sql.DeleteTableDescAndZoneConfig(ctx, execCfg.DB, execCfg.Codec, table); err != nil {
 			return errors.Wrapf(err, "dropping table descriptor for table %d", table.ID)
 		}
 


### PR DESCRIPTION
Previously, GC jobs were created for all dropped tables, including tables
with no physical representation in the KV layer, such as non-materialized
views. This is pointless, hence this patch which restricts GC job
creation to physical tables.

Fixes #55084

Release note: None