### PR TITLE
opt: don't hold on to evalCtx from detached Memo

### DIFF
--- a/pkg/sql/opt/norm/factory.go
+++ b/pkg/sql/opt/norm/factory.go
@@ -124,11 +124,11 @@ func (f *Factory) FoldingControl() *FoldingControl {
 // placeholders are assigned. If there are no placeholders, there is no need
 // for column statistics, since the memo is already fully optimized.
 func (f *Factory) DetachMemo() *memo.Memo {
-	f.mem.ClearColStats(f.mem.RootExpr())
-	detach := f.mem
+	m := f.mem
 	f.mem = nil
+	m.Detach()
 	f.Init(f.evalCtx, nil /* catalog */)
-	return detach
+	return m
 }
 
 // DisableOptimizations disables all transformation rules. The unaltered input


### PR DESCRIPTION
This change adds more "cleanup" code when detaching a Memo (a detached
memo is stored in the query cache and is reused later in a "read-only"
fashion). In particular, we clear the EvalContext in
logicalPropsBuilder which can lead to inadvertently holding on to a
lot of memory.

Fixes #57059.

Release note: None