### PR TITLE
storage: split UnsafeRawKey into two methods

### DIFF
--- a/pkg/keys/keys.go
+++ b/pkg/keys/keys.go
@@ -458,6 +458,10 @@ func DecodeLockTableSingleKey(key roachpb.Key) (lockedKey roachpb.Key, err error
 		return nil, errors.Errorf("key %q is not for a single-key lock", key)
 	}
 	b = b[len(LockTableSingleKeyInfix):]
+	// We pass nil as the second parameter instead of trying to reuse a
+	// previously allocated buffer since escaping of \x00 to \x00\xff is not
+	// common. And when there is no such escaping, lockedKey will be a sub-slice
+	// of b.
 	b, lockedKey, err = encoding.DecodeBytesAscending(b, nil)
 	if err != nil {
 		return nil, err

--- a/pkg/kv/kvserver/spanset/batch.go
+++ b/pkg/kv/kvserver/spanset/batch.go
@@ -157,6 +157,11 @@ func (i *MVCCIterator) UnsafeRawKey() []byte {
 	return i.i.UnsafeRawKey()
 }
 
+// UnsafeRawMVCCKey is part of the storage.MVCCIterator interface.
+func (i *MVCCIterator) UnsafeRawMVCCKey() []byte {
+	return i.i.UnsafeRawMVCCKey()
+}
+
 // UnsafeValue is part of the storage.MVCCIterator interface.
 func (i *MVCCIterator) UnsafeValue() []byte {
 	return i.i.UnsafeValue()
@@ -305,6 +310,11 @@ func (i *EngineIterator) EngineKey() (storage.EngineKey, error) {
 // Value is part of the storage.EngineIterator interface.
 func (i *EngineIterator) Value() []byte {
 	return i.i.Value()
+}
+
+// UnsafeRawEngineKey is part of the storage.EngineIterator interface.
+func (i *EngineIterator) UnsafeRawEngineKey() []byte {
+	return i.i.UnsafeRawEngineKey()
 }
 
 // SetUpperBound is part of the storage.EngineIterator interface.

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -98,10 +98,23 @@ type MVCCIterator interface {
 	Prev()
 	// Key returns the current key.
 	Key() MVCCKey
-	// UnsafeRawKey returns the current raw key (i.e. the encoded MVCC key).
-	// TODO(sumeer): this is a dangerous method since it may expose the
-	// raw key of a separated intent. Audit all callers and fix.
+	// UnsafeRawKey returns the current raw key which could be an encoded
+	// MVCCKey, or the more general EngineKey (for a lock table key).
+	// This is a low-level and dangerous method since it will expose the
+	// raw key of the lock table, i.e., the intentInterleavingIter will not
+	// hide the difference between interleaved and separated intents.
+	// Callers should be very careful when using this. This is currently
+	// only used by callers who are iterating and deleting all data in a
+	// range.
 	UnsafeRawKey() []byte
+	// UnsafeRawMVCCKey returns a serialized MVCCKey. The memory is invalidated
+	// on the next call to {Next,NextKey,Prev,SeekGE,SeekLT,Close}. If the
+	// iterator is currently positioned at a separated intent (when
+	// intentInterleavingIter is used), it makes that intent look like an
+	// interleaved intent key, i.e., an MVCCKey with an empty timestamp. This is
+	// currently used by callers who pass around key information as a []byte --
+	// this seems avoidable, and we should consider cleaning up the callers.
+	UnsafeRawMVCCKey() []byte
 	// Value returns the current value as a byte slice.
 	Value() []byte
 	// ValueProto unmarshals the value the iterator is currently
@@ -168,17 +181,22 @@ type EngineIterator interface {
 	// the iteration. After this call, valid will be true if the iterator was
 	// not originally positioned at the first key.
 	PrevEngineKey() (valid bool, err error)
-	// UnsafeEngineKey returns the same value as Key, but the memory is
+	// UnsafeEngineKey returns the same value as EngineKey, but the memory is
 	// invalidated on the next call to {Next,NextKey,Prev,SeekGE,SeekLT,Close}.
 	// REQUIRES: latest positioning function returned valid=true.
 	UnsafeEngineKey() (EngineKey, error)
+	// EngineKey returns the current key.
+	// REQUIRES: latest positioning function returned valid=true.
+	EngineKey() (EngineKey, error)
+	// UnsafeRawEngineKey returns the current raw (encoded) key corresponding to
+	// EngineKey. This is a low-level method and callers should avoid using
+	// it. This is currently only used by intentInterleavingIter to implement
+	// UnsafeRawKey.
+	UnsafeRawEngineKey() []byte
 	// UnsafeValue returns the same value as Value, but the memory is
 	// invalidated on the next call to {Next,NextKey,Prev,SeekGE,SeekLT,Close}.
 	// REQUIRES: latest positioning function returned valid=true.
 	UnsafeValue() []byte
-	// EngineKey returns the current key.
-	// REQUIRES: latest positioning function returned valid=true.
-	EngineKey() (EngineKey, error)
 	// Value returns the current value as a byte slice.
 	// REQUIRES: latest positioning function returned valid=true.
 	Value() []byte

--- a/pkg/storage/intent_interleaving_iter.go
+++ b/pkg/storage/intent_interleaving_iter.go
@@ -67,7 +67,9 @@ type intentInterleavingIter struct {
 	// exhausted. Note that the intentIter may still be positioned
 	// at a valid position in the case of prefix iteration, but the
 	// state of the intentKey overrides that state.
-	intentKey roachpb.Key
+	intentKey                            roachpb.Key
+	intentKeyAsNoTimestampMVCCKey        []byte
+	intentKeyAsNoTimestampMVCCKeyBacking []byte
 
 	// - cmp output of (intentKey, current iter key) when both are valid.
 	//   This does not take timestamps into consideration. So if intentIter
@@ -208,6 +210,30 @@ func (i *intentInterleavingIter) tryDecodeLockKey(valid bool) error {
 		i.err = err
 		i.valid = false
 		return err
+	}
+	// If we were to encode MVCCKey{Key: i.intentKey}, i.e., encode it as an
+	// MVCCKey with no timestamp, the encoded bytes would be intentKey + \x00.
+	// Such an encoding is needed by callers of UnsafeRawMVCCKey. We would like
+	// to avoid copying the bytes in intentKey, if possible, for this encoding.
+	// Fortunately, the common case in the above call of
+	// DecodeLockTableSingleKey, that decodes intentKey from engineKey.Key, is
+	// for intentKey to not need un-escaping, so it will point to the slice that
+	// was backing engineKey.Key. engineKey.Key uses an encoding that terminates
+	// the intent key using \x00\x01. So the \x00 we need is conveniently there.
+	// This optimization also usually works when there is un-escaping, since the
+	// slice growth algorithm usually ends up with a cap greater than len. Since
+	// these extra bytes in the cap are 0-initialized, the first byte following
+	// intentKey is \x00.
+	//
+	// If this optimization is not possible, we leave
+	// intentKeyAsNoTimestampMVCCKey as nil, and lazily initialize it, if
+	// needed.
+	i.intentKeyAsNoTimestampMVCCKey = nil
+	if cap(i.intentKey) > len(i.intentKey) {
+		prospectiveKey := i.intentKey[:len(i.intentKey)+1]
+		if prospectiveKey[len(i.intentKey)] == 0 {
+			i.intentKeyAsNoTimestampMVCCKey = prospectiveKey
+		}
 	}
 	return nil
 }
@@ -602,14 +628,26 @@ func (i *intentInterleavingIter) Prev() {
 
 func (i *intentInterleavingIter) UnsafeRawKey() []byte {
 	if i.isCurAtIntentIter() {
-		// TODO(sumeer): this is inefficient, but the users of UnsafeRawKey are
-		// incorrect, so this method will go away.
-		key, err := i.intentIter.UnsafeEngineKey()
-		if err != nil {
-			// Should be able to parse it again.
-			panic(err)
+		return i.intentIter.UnsafeRawEngineKey()
+	}
+	return i.iter.UnsafeRawKey()
+}
+
+func (i *intentInterleavingIter) UnsafeRawMVCCKey() []byte {
+	if i.isCurAtIntentIter() {
+		if i.intentKeyAsNoTimestampMVCCKey == nil {
+			// Slow-path: tryDecodeLockKey was not able to initialize.
+			if cap(i.intentKeyAsNoTimestampMVCCKeyBacking) < len(i.intentKey)+1 {
+				i.intentKeyAsNoTimestampMVCCKeyBacking = make([]byte, 0, len(i.intentKey)+1)
+			}
+			i.intentKeyAsNoTimestampMVCCKeyBacking = append(
+				i.intentKeyAsNoTimestampMVCCKeyBacking[:0], i.intentKey...)
+			// Append the 0 byte representing the absence of a timestamp.
+			i.intentKeyAsNoTimestampMVCCKeyBacking = append(
+				i.intentKeyAsNoTimestampMVCCKeyBacking, 0)
+			i.intentKeyAsNoTimestampMVCCKey = i.intentKeyAsNoTimestampMVCCKeyBacking
 		}
-		return key.Encode()
+		return i.intentKeyAsNoTimestampMVCCKey
 	}
 	return i.iter.UnsafeRawKey()
 }

--- a/pkg/storage/pebble_batch.go
+++ b/pkg/storage/pebble_batch.go
@@ -389,7 +389,8 @@ func (p *pebbleBatch) ClearIterRange(iter MVCCIterator, start, end roachpb.Key) 
 		} else if !valid {
 			break
 		}
-
+		// NB: UnsafeRawKey could be a serialized lock table key, and not just an
+		// MVCCKey.
 		err = p.batch.Delete(iter.UnsafeRawKey(), nil)
 		if err != nil {
 			return err

--- a/pkg/storage/pebble_iterator.go
+++ b/pkg/storage/pebble_iterator.go
@@ -285,6 +285,16 @@ func (p *pebbleIterator) UnsafeRawKey() []byte {
 	return p.iter.Key()
 }
 
+// UnsafeRawMVCCKey implements the MVCCIterator interface.
+func (p *pebbleIterator) UnsafeRawMVCCKey() []byte {
+	return p.iter.Key()
+}
+
+// UnsafeRawEngineKey implements the EngineIterator interface.
+func (p *pebbleIterator) UnsafeRawEngineKey() []byte {
+	return p.iter.Key()
+}
+
 // UnsafeValue implements the MVCCIterator and EngineIterator interfaces.
 func (p *pebbleIterator) UnsafeValue() []byte {
 	if valid, err := p.Valid(); err != nil || !valid {

--- a/pkg/storage/pebble_mvcc_scanner.go
+++ b/pkg/storage/pebble_mvcc_scanner.go
@@ -668,7 +668,7 @@ func (p *pebbleMVCCScanner) updateCurrent() bool {
 		return false
 	}
 
-	p.curRawKey = p.parent.UnsafeRawKey()
+	p.curRawKey = p.parent.UnsafeRawMVCCKey()
 
 	var err error
 	p.curKey, err = DecodeMVCCKey(p.curRawKey)

--- a/pkg/storage/sst_writer.go
+++ b/pkg/storage/sst_writer.go
@@ -237,29 +237,7 @@ func (fw *SSTWriter) SingleClearEngineKey(key EngineKey) error {
 
 // ClearIterRange implements the Writer interface.
 func (fw *SSTWriter) ClearIterRange(iter MVCCIterator, start, end roachpb.Key) error {
-	if fw.fw == nil {
-		return errors.New("cannot call ClearIterRange on a closed writer")
-	}
-
-	// Set an upper bound on the iterator. This is okay because all calls to
-	// ClearIterRange are with throwaway iterators, so there should be no new
-	// side effects.
-	iter.SetUpperBound(end)
-	iter.SeekGE(MakeMVCCMetadataKey(start))
-
-	valid, err := iter.Valid()
-	for valid && err == nil {
-		key := iter.UnsafeKey()
-		fw.scratch = EncodeKeyToBuf(fw.scratch[:0], key)
-		fw.DataSize += int64(len(key.Key))
-		if err := fw.fw.Delete(fw.scratch); err != nil {
-			return err
-		}
-
-		iter.Next()
-		valid, err = iter.Valid()
-	}
-	return err
+	panic("ClearIterRange is unsupported")
 }
 
 // Merge implements the Writer interface.

--- a/pkg/storage/testdata/intent_interleaving_iter/basic
+++ b/pkg/storage/testdata/intent_interleaving_iter/basic
@@ -426,3 +426,61 @@ next: output: .
 seek-ge "Lb"/0.000000025,0: output: value k=Lb ts=20 v=b20
 next: output: .
 seek-ge "Lc"/0.000000025,0: output: .
+
+# Keys with \x00 byte. To exercise the slow-path in UnsafeRawMVCCKey. The keys
+# that are length 8, 16 will exercise the slow-path. The len(key) < 8 does
+# not. DecodeLockTableSingleKey allocates a new slice for all these keys, due
+# to the escaping. However the starting capacity is 8, and the next growth
+# step is 16, which means that when len(key) < 8, the len of the allocated
+# slice is smaller than cap and the first byte beyond len is 0.
+define
+locks
+meta k=abcdefg\0 ts=20 txn=1
+meta k=b\0c\0d ts=20 txn=1
+meta k=bcdefgh\0 ts=20 txn=1
+meta k=cdefghijklmnopq\0 ts=20 txn=1
+mvcc
+value k=abcdefg\0 ts=20 v=a
+value k=b\0c\0d ts=20 v=b1
+value k=bcdefgh\0 ts=20 v=b2
+value k=cdefghijklmnopq\0 ts=20 v=c
+----
+
+iter lower=a upper=d
+seek-ge k=a
+next
+next
+next
+next
+next
+next
+next
+next
+prev
+prev
+prev
+prev
+prev
+prev
+prev
+prev
+prev
+----
+seek-ge "a"/0,0: output: meta k=abcdefg\0 ts=20 txn=1
+next: output: value k=abcdefg\0 ts=20 v=a
+next: output: meta k=b\0c\0d ts=20 txn=1
+next: output: value k=b\0c\0d ts=20 v=b1
+next: output: meta k=bcdefgh\0 ts=20 txn=1
+next: output: value k=bcdefgh\0 ts=20 v=b2
+next: output: meta k=cdefghijklmnopq\0 ts=20 txn=1
+next: output: value k=cdefghijklmnopq\0 ts=20 v=c
+next: output: .
+prev: output: value k=cdefghijklmnopq\0 ts=20 v=c
+prev: output: meta k=cdefghijklmnopq\0 ts=20 txn=1
+prev: output: value k=bcdefgh\0 ts=20 v=b2
+prev: output: meta k=bcdefgh\0 ts=20 txn=1
+prev: output: value k=b\0c\0d ts=20 v=b1
+prev: output: meta k=b\0c\0d ts=20 txn=1
+prev: output: value k=abcdefg\0 ts=20 v=a
+prev: output: meta k=abcdefg\0 ts=20 txn=1
+prev: output: .


### PR DESCRIPTION
UnsafeRawKey is used in two cases:
- To write point deletions. For this we don't
  mind exposing the lock table key. Though there
  is still a warning to be careful.
- For passing information out of pebbleMVCCScanner,
  where we want the lock table key to pretend to
  be a serialized MVCCKey for an interleaved intent.

These cases are now fixed, by having UnsafeRawKey
satisfy the first case, and UnsafeRawMVCCKey for
the second.

Informs #41720

Release note: None