### PR TITLE
sql,clusterversion: remove VersionAuthLocalAndTrustRejectMethods

### DIFF
--- a/pkg/ccl/gssapiccl/gssapi.go
+++ b/pkg/ccl/gssapiccl/gssapi.go
@@ -21,7 +21,6 @@ import (
 	"unsafe"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire"
@@ -207,5 +206,5 @@ func checkEntry(entry hba.Entry) error {
 }
 
 func init() {
-	pgwire.RegisterAuthMethod("gss", authGSS, clusterversion.Version19_1, hba.ConnHostSSL, checkEntry)
+	pgwire.RegisterAuthMethod("gss", authGSS, hba.ConnHostSSL, checkEntry)
 }

--- a/pkg/clusterversion/.gitattributes
+++ b/pkg/clusterversion/.gitattributes
@@ -1,0 +1,1 @@
+versionkey_string.go binary

--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -121,23 +121,6 @@ const (
 
 	// v20.1 versions.
 	//
-	// VersionContainsEstimatesCounter is
-	// https://github.com/cockroachdb/cockroach/pull/37583.
-	//
-	// MVCCStats.ContainsEstimates has been migrated from boolean to a
-	// counter so that the consistency checker and splits can reset it by
-	// returning -ContainsEstimates, avoiding racing with other operations
-	// that want to also change it.
-	//
-	// The migration maintains the invariant that raft commands with
-	// ContainsEstimates zero or one want the bool behavior (i.e. 1+1=1).
-	// Before the cluster version is active, at proposal time we'll refuse
-	// any negative ContainsEstimates plus we clamp all others to {0,1}.
-	// When the version is active, and ContainsEstimates is positive, we
-	// multiply it by 2 (i.e. we avoid 1). Downstream of raft, we use old
-	// behavior for ContainsEstimates=1 and the additive behavior for
-	// anything else.
-	VersionContainsEstimatesCounter
 	// VersionNamespaceTableWithSchemas is
 	// https://github.com/cockroachdb/cockroach/pull/41977
 	//
@@ -260,10 +243,6 @@ var versionsSingleton = keyedVersions([]keyedVersion{
 	{
 		Key:     Version19_1,
 		Version: roachpb.Version{Major: 19, Minor: 1},
-	},
-	{
-		Key:     VersionContainsEstimatesCounter,
-		Version: roachpb.Version{Major: 19, Minor: 2, Internal: 2},
 	},
 	{
 		Key:     VersionNamespaceTableWithSchemas,

--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -115,10 +115,6 @@ type VersionKey int
 const (
 	_ VersionKey = iota - 1 // want first named one to start at zero
 
-	// Version19_1 is CockroachDB v19.1. It's used for all v19.1.x patch
-	// releases.
-	Version19_1
-
 	// v20.1 versions.
 	//
 	// VersionNamespaceTableWithSchemas is
@@ -128,14 +124,6 @@ const (
 	// added parentSchemaID column. In addition to the new column, the table is
 	// no longer in the system config range -- implying it is no longer gossiped.
 	VersionNamespaceTableWithSchemas
-	// VersionAuthLocalAndTrustRejectMethods introduces the HBA rule
-	// prefix 'local' and auth methods 'trust' and 'reject', for use
-	// in server.host_based_authentication.configuration.
-	//
-	// A separate cluster version ensures the new syntax is not
-	// introduced while previous-version nodes are still running, as
-	// this would block any new SQL client.
-	VersionAuthLocalAndTrustRejectMethods
 
 	// TODO(irfansharif): The versions above can/should all be removed. They
 	// were orinally introduced in v20.1. There are inflight PRs to do so
@@ -241,16 +229,8 @@ const (
 // to be added (i.e., when cutting the final release candidate).
 var versionsSingleton = keyedVersions([]keyedVersion{
 	{
-		Key:     Version19_1,
-		Version: roachpb.Version{Major: 19, Minor: 1},
-	},
-	{
 		Key:     VersionNamespaceTableWithSchemas,
 		Version: roachpb.Version{Major: 19, Minor: 2, Internal: 5},
-	},
-	{
-		Key:     VersionAuthLocalAndTrustRejectMethods,
-		Version: roachpb.Version{Major: 19, Minor: 2, Internal: 8},
 	},
 
 	// v20.2 versions.

--- a/pkg/clusterversion/versionkey_string.go
+++ b/pkg/clusterversion/versionkey_string.go
@@ -9,38 +9,37 @@ func _() {
 	// Re-run the stringer command to generate them again.
 	var x [1]struct{}
 	_ = x[Version19_1-0]
-	_ = x[VersionContainsEstimatesCounter-1]
-	_ = x[VersionNamespaceTableWithSchemas-2]
-	_ = x[VersionAuthLocalAndTrustRejectMethods-3]
-	_ = x[VersionStart20_2-4]
-	_ = x[VersionGeospatialType-5]
-	_ = x[VersionEnums-6]
-	_ = x[VersionRangefeedLeases-7]
-	_ = x[VersionAlterColumnTypeGeneral-8]
-	_ = x[VersionAlterSystemJobsAddCreatedByColumns-9]
-	_ = x[VersionAddScheduledJobsTable-10]
-	_ = x[VersionUserDefinedSchemas-11]
-	_ = x[VersionNoOriginFKIndexes-12]
-	_ = x[VersionClientRangeInfosOnBatchResponse-13]
-	_ = x[VersionNodeMembershipStatus-14]
-	_ = x[VersionRangeStatsRespHasDesc-15]
-	_ = x[VersionMinPasswordLength-16]
-	_ = x[VersionAbortSpanBytes-17]
-	_ = x[VersionAlterSystemJobsAddSqllivenessColumnsAddNewSystemSqllivenessTable-18]
-	_ = x[VersionMaterializedViews-19]
-	_ = x[VersionBox2DType-20]
-	_ = x[VersionLeasedDatabaseDescriptors-21]
-	_ = x[VersionUpdateScheduledJobsSchema-22]
-	_ = x[VersionCreateLoginPrivilege-23]
-	_ = x[VersionHBAForNonTLS-24]
-	_ = x[Version20_2-25]
-	_ = x[VersionStart21_1-26]
-	_ = x[VersionEmptyArraysInInvertedIndexes-27]
+	_ = x[VersionNamespaceTableWithSchemas-1]
+	_ = x[VersionAuthLocalAndTrustRejectMethods-2]
+	_ = x[VersionStart20_2-3]
+	_ = x[VersionGeospatialType-4]
+	_ = x[VersionEnums-5]
+	_ = x[VersionRangefeedLeases-6]
+	_ = x[VersionAlterColumnTypeGeneral-7]
+	_ = x[VersionAlterSystemJobsAddCreatedByColumns-8]
+	_ = x[VersionAddScheduledJobsTable-9]
+	_ = x[VersionUserDefinedSchemas-10]
+	_ = x[VersionNoOriginFKIndexes-11]
+	_ = x[VersionClientRangeInfosOnBatchResponse-12]
+	_ = x[VersionNodeMembershipStatus-13]
+	_ = x[VersionRangeStatsRespHasDesc-14]
+	_ = x[VersionMinPasswordLength-15]
+	_ = x[VersionAbortSpanBytes-16]
+	_ = x[VersionAlterSystemJobsAddSqllivenessColumnsAddNewSystemSqllivenessTable-17]
+	_ = x[VersionMaterializedViews-18]
+	_ = x[VersionBox2DType-19]
+	_ = x[VersionLeasedDatabaseDescriptors-20]
+	_ = x[VersionUpdateScheduledJobsSchema-21]
+	_ = x[VersionCreateLoginPrivilege-22]
+	_ = x[VersionHBAForNonTLS-23]
+	_ = x[Version20_2-24]
+	_ = x[VersionStart21_1-25]
+	_ = x[VersionEmptyArraysInInvertedIndexes-26]
 }
 
-const _VersionKey_name = "Version19_1VersionContainsEstimatesCounterVersionNamespaceTableWithSchemasVersionAuthLocalAndTrustRejectMethodsVersionStart20_2VersionGeospatialTypeVersionEnumsVersionRangefeedLeasesVersionAlterColumnTypeGeneralVersionAlterSystemJobsAddCreatedByColumnsVersionAddScheduledJobsTableVersionUserDefinedSchemasVersionNoOriginFKIndexesVersionClientRangeInfosOnBatchResponseVersionNodeMembershipStatusVersionRangeStatsRespHasDescVersionMinPasswordLengthVersionAbortSpanBytesVersionAlterSystemJobsAddSqllivenessColumnsAddNewSystemSqllivenessTableVersionMaterializedViewsVersionBox2DTypeVersionLeasedDatabaseDescriptorsVersionUpdateScheduledJobsSchemaVersionCreateLoginPrivilegeVersionHBAForNonTLSVersion20_2VersionStart21_1VersionEmptyArraysInInvertedIndexes"
+const _VersionKey_name = "Version19_1VersionNamespaceTableWithSchemasVersionAuthLocalAndTrustRejectMethodsVersionStart20_2VersionGeospatialTypeVersionEnumsVersionRangefeedLeasesVersionAlterColumnTypeGeneralVersionAlterSystemJobsAddCreatedByColumnsVersionAddScheduledJobsTableVersionUserDefinedSchemasVersionNoOriginFKIndexesVersionClientRangeInfosOnBatchResponseVersionNodeMembershipStatusVersionRangeStatsRespHasDescVersionMinPasswordLengthVersionAbortSpanBytesVersionAlterSystemJobsAddSqllivenessColumnsAddNewSystemSqllivenessTableVersionMaterializedViewsVersionBox2DTypeVersionLeasedDatabaseDescriptorsVersionUpdateScheduledJobsSchemaVersionCreateLoginPrivilegeVersionHBAForNonTLSVersion20_2VersionStart21_1VersionEmptyArraysInInvertedIndexes"
 
-var _VersionKey_index = [...]uint16{0, 11, 42, 74, 111, 127, 148, 160, 182, 211, 252, 280, 305, 329, 367, 394, 422, 446, 467, 538, 562, 578, 610, 642, 669, 688, 699, 715, 750}
+var _VersionKey_index = [...]uint16{0, 11, 43, 80, 96, 117, 129, 151, 180, 221, 249, 274, 298, 336, 363, 391, 415, 436, 507, 531, 547, 579, 611, 638, 657, 668, 684, 719}
 
 func (i VersionKey) String() string {
 	if i < 0 || i >= VersionKey(len(_VersionKey_index)-1) {

--- a/pkg/clusterversion/versionkey_string.go
+++ b/pkg/clusterversion/versionkey_string.go
@@ -8,38 +8,36 @@ func _() {
 	// An "invalid array index" compiler error signifies that the constant values have changed.
 	// Re-run the stringer command to generate them again.
 	var x [1]struct{}
-	_ = x[Version19_1-0]
-	_ = x[VersionNamespaceTableWithSchemas-1]
-	_ = x[VersionAuthLocalAndTrustRejectMethods-2]
-	_ = x[VersionStart20_2-3]
-	_ = x[VersionGeospatialType-4]
-	_ = x[VersionEnums-5]
-	_ = x[VersionRangefeedLeases-6]
-	_ = x[VersionAlterColumnTypeGeneral-7]
-	_ = x[VersionAlterSystemJobsAddCreatedByColumns-8]
-	_ = x[VersionAddScheduledJobsTable-9]
-	_ = x[VersionUserDefinedSchemas-10]
-	_ = x[VersionNoOriginFKIndexes-11]
-	_ = x[VersionClientRangeInfosOnBatchResponse-12]
-	_ = x[VersionNodeMembershipStatus-13]
-	_ = x[VersionRangeStatsRespHasDesc-14]
-	_ = x[VersionMinPasswordLength-15]
-	_ = x[VersionAbortSpanBytes-16]
-	_ = x[VersionAlterSystemJobsAddSqllivenessColumnsAddNewSystemSqllivenessTable-17]
-	_ = x[VersionMaterializedViews-18]
-	_ = x[VersionBox2DType-19]
-	_ = x[VersionLeasedDatabaseDescriptors-20]
-	_ = x[VersionUpdateScheduledJobsSchema-21]
-	_ = x[VersionCreateLoginPrivilege-22]
-	_ = x[VersionHBAForNonTLS-23]
-	_ = x[Version20_2-24]
-	_ = x[VersionStart21_1-25]
-	_ = x[VersionEmptyArraysInInvertedIndexes-26]
+	_ = x[VersionNamespaceTableWithSchemas-0]
+	_ = x[VersionStart20_2-1]
+	_ = x[VersionGeospatialType-2]
+	_ = x[VersionEnums-3]
+	_ = x[VersionRangefeedLeases-4]
+	_ = x[VersionAlterColumnTypeGeneral-5]
+	_ = x[VersionAlterSystemJobsAddCreatedByColumns-6]
+	_ = x[VersionAddScheduledJobsTable-7]
+	_ = x[VersionUserDefinedSchemas-8]
+	_ = x[VersionNoOriginFKIndexes-9]
+	_ = x[VersionClientRangeInfosOnBatchResponse-10]
+	_ = x[VersionNodeMembershipStatus-11]
+	_ = x[VersionRangeStatsRespHasDesc-12]
+	_ = x[VersionMinPasswordLength-13]
+	_ = x[VersionAbortSpanBytes-14]
+	_ = x[VersionAlterSystemJobsAddSqllivenessColumnsAddNewSystemSqllivenessTable-15]
+	_ = x[VersionMaterializedViews-16]
+	_ = x[VersionBox2DType-17]
+	_ = x[VersionLeasedDatabaseDescriptors-18]
+	_ = x[VersionUpdateScheduledJobsSchema-19]
+	_ = x[VersionCreateLoginPrivilege-20]
+	_ = x[VersionHBAForNonTLS-21]
+	_ = x[Version20_2-22]
+	_ = x[VersionStart21_1-23]
+	_ = x[VersionEmptyArraysInInvertedIndexes-24]
 }
 
-const _VersionKey_name = "Version19_1VersionNamespaceTableWithSchemasVersionAuthLocalAndTrustRejectMethodsVersionStart20_2VersionGeospatialTypeVersionEnumsVersionRangefeedLeasesVersionAlterColumnTypeGeneralVersionAlterSystemJobsAddCreatedByColumnsVersionAddScheduledJobsTableVersionUserDefinedSchemasVersionNoOriginFKIndexesVersionClientRangeInfosOnBatchResponseVersionNodeMembershipStatusVersionRangeStatsRespHasDescVersionMinPasswordLengthVersionAbortSpanBytesVersionAlterSystemJobsAddSqllivenessColumnsAddNewSystemSqllivenessTableVersionMaterializedViewsVersionBox2DTypeVersionLeasedDatabaseDescriptorsVersionUpdateScheduledJobsSchemaVersionCreateLoginPrivilegeVersionHBAForNonTLSVersion20_2VersionStart21_1VersionEmptyArraysInInvertedIndexes"
+const _VersionKey_name = "VersionNamespaceTableWithSchemasVersionStart20_2VersionGeospatialTypeVersionEnumsVersionRangefeedLeasesVersionAlterColumnTypeGeneralVersionAlterSystemJobsAddCreatedByColumnsVersionAddScheduledJobsTableVersionUserDefinedSchemasVersionNoOriginFKIndexesVersionClientRangeInfosOnBatchResponseVersionNodeMembershipStatusVersionRangeStatsRespHasDescVersionMinPasswordLengthVersionAbortSpanBytesVersionAlterSystemJobsAddSqllivenessColumnsAddNewSystemSqllivenessTableVersionMaterializedViewsVersionBox2DTypeVersionLeasedDatabaseDescriptorsVersionUpdateScheduledJobsSchemaVersionCreateLoginPrivilegeVersionHBAForNonTLSVersion20_2VersionStart21_1VersionEmptyArraysInInvertedIndexes"
 
-var _VersionKey_index = [...]uint16{0, 11, 43, 80, 96, 117, 129, 151, 180, 221, 249, 274, 298, 336, 363, 391, 415, 436, 507, 531, 547, 579, 611, 638, 657, 668, 684, 719}
+var _VersionKey_index = [...]uint16{0, 32, 48, 69, 81, 103, 132, 173, 201, 226, 250, 288, 315, 343, 367, 388, 459, 483, 499, 531, 563, 590, 609, 620, 636, 671}
 
 func (i VersionKey) String() string {
 	if i < 0 || i >= VersionKey(len(_VersionKey_index)-1) {

--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
@@ -13,7 +13,6 @@ package batcheval
 import (
 	"context"
 
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval/result"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
@@ -175,7 +174,6 @@ func EvalAddSSTable(
 		stats.Subtract(skippedKVStats)
 		stats.ContainsEstimates = 0
 	} else {
-		_ = clusterversion.VersionContainsEstimatesCounter // see for info on ContainsEstimates migration
 		stats.ContainsEstimates++
 	}
 

--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
@@ -1020,9 +1020,6 @@ func splitTriggerHelper(
 	}
 
 	deltaPostSplitLeft := h.DeltaPostSplitLeft()
-	if !rec.ClusterSettings().Version.IsActive(ctx, clusterversion.VersionContainsEstimatesCounter) {
-		deltaPostSplitLeft.ContainsEstimates = 0
-	}
 	return deltaPostSplitLeft, pd, nil
 }
 

--- a/pkg/kv/kvserver/batcheval/cmd_recompute_stats.go
+++ b/pkg/kv/kvserver/batcheval/cmd_recompute_stats.go
@@ -13,7 +13,6 @@ package batcheval
 import (
 	"context"
 
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval/result"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/rditer"
@@ -102,12 +101,6 @@ func RecomputeStats(
 		// stats for timeseries ranges (which go cold and the approximate stats are
 		// wildly overcounting) and this is paced by the consistency checker, but it
 		// means some extra engine churn.
-		if !cArgs.EvalCtx.ClusterSettings().Version.IsActive(ctx, clusterversion.VersionContainsEstimatesCounter) {
-			// We are running with the older version of MVCCStats.ContainsEstimates
-			// which was a boolean, so we should keep it in {0,1} and not reset it
-			// to avoid racing with another command that sets it to true.
-			delta.ContainsEstimates = currentStats.ContainsEstimates
-		}
 		cArgs.Stats.Add(delta)
 	}
 

--- a/pkg/kv/kvserver/replica_application_state_machine.go
+++ b/pkg/kv/kvserver/replica_application_state_machine.go
@@ -15,7 +15,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/apply"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
@@ -796,46 +795,12 @@ func (b *replicaAppBatch) stageTrivialReplicatedEvalResult(
 	}
 	res := cmd.replicatedResult()
 
-	// Detect whether the incoming stats contain estimates that resulted from the
-	// evaluation of a command under the 19.1 cluster version. These were either
-	// evaluated on a 19.1 node (where ContainsEstimates is a bool, which maps
-	// to 0 and 1 in 19.2+) or on a 19.2 node which hadn't yet had its cluster
-	// version bumped.
-	//
-	// 19.2 nodes will never emit a ContainsEstimates outside of 0 or 1 until
-	// the cluster version is active (during command evaluation). When the
-	// version is active, they will never emit odd positive numbers (1, 3, ...).
-	//
-	// As a result, we can pinpoint exactly when the proposer of this command
-	// has used the old cluster version: it's when the incoming
-	// ContainsEstimates is 1. If so, we need to assume that an old node is processing
-	// the same commands (as `true + true = true`), so make sure that `1 + 1 = 1`.
-	_ = clusterversion.VersionContainsEstimatesCounter // see for info on ContainsEstimates migration
-	deltaStats := res.Delta.ToStats()
-	if deltaStats.ContainsEstimates == 1 && b.state.Stats.ContainsEstimates == 1 {
-		deltaStats.ContainsEstimates = 0
-	}
-
 	// Special-cased MVCC stats handling to exploit commutativity of stats delta
 	// upgrades. Thanks to commutativity, the spanlatch manager does not have to
 	// serialize on the stats key.
+	deltaStats := res.Delta.ToStats()
 	b.state.Stats.Add(deltaStats)
-	// Exploit the fact that a split will result in a full stats
-	// recomputation to reset the ContainsEstimates flag.
-	// If we were running the new VersionContainsEstimatesCounter cluster version,
-	// the consistency checker will be able to reset the stats itself, and splits
-	// will as a side effect also remove estimates from both the resulting left and right hand sides.
-	//
-	// TODO(tbg): this can be removed in v20.2 and not earlier.
-	// Consider the following scenario:
-	// - all nodes are running 19.2
-	// - all nodes rebooted into 20.1
-	// - cluster version bumped, but node1 doesn't receive the gossip update for that
-	// node1 runs a split that should emit ContainsEstimates=-1, but it clamps it to 0/1 because it
-	// doesn't know that 20.1 is active.
-	if res.Split != nil && deltaStats.ContainsEstimates == 0 {
-		b.state.Stats.ContainsEstimates = 0
-	}
+
 	if res.State != nil && res.State.UsingAppliedStateKey && !b.state.UsingAppliedStateKey {
 		b.migrateToAppliedStateKey = true
 	}

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -34,7 +34,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/apply"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval/result"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency"
@@ -12730,15 +12729,11 @@ func TestReplicateQueueProcessOne(t *testing.T) {
 }
 
 // TestContainsEstimatesClamp tests the massaging of ContainsEstimates
-// before proposing a raft command.
-// - If the proposing node's version is lower than the VersionContainsEstimatesCounter,
-// ContainsEstimates must be clamped to {0,1}.
-// - Otherwise, it should always be >1 and an even number.
+// before proposing a raft command. It should always be >1 and an even number.
+// See the comment on ContainEstimates to understand why.
 func TestContainsEstimatesClampProposal(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-
-	_ = clusterversion.VersionContainsEstimatesCounter // see for details on the ContainsEstimates migration
 
 	someRequestToProposal := func(tc *testContext, ctx context.Context) *ProposalData {
 		cmdIDKey := kvserverbase.CmdIDKey("some-cmdid-key")
@@ -12757,23 +12752,6 @@ func TestContainsEstimatesClampProposal(t *testing.T) {
 	// any number >1.
 	defer setMockPutWithEstimates(2)()
 
-	t.Run("Pre-VersionContainsEstimatesCounter", func(t *testing.T) {
-		ctx := context.Background()
-		stopper := stop.NewStopper()
-		defer stopper.Stop(ctx)
-		cfg := TestStoreConfig(nil)
-		version := clusterversion.VersionByKey(clusterversion.VersionContainsEstimatesCounter - 1)
-		cfg.Settings = cluster.MakeTestingClusterSettingsWithVersions(version, version, false /* initializeVersion */)
-		var tc testContext
-		tc.StartWithStoreConfigAndVersion(t, stopper, cfg, version)
-
-		proposal := someRequestToProposal(&tc, ctx)
-
-		if proposal.command.ReplicatedEvalResult.Delta.ContainsEstimates != 1 {
-			t.Error("Expected ContainsEstimates to be 1, was", proposal.command.ReplicatedEvalResult.Delta.ContainsEstimates)
-		}
-	})
-
 	t.Run("VersionContainsEstimatesCounter", func(t *testing.T) {
 		ctx := context.Background()
 		stopper := stop.NewStopper()
@@ -12788,77 +12766,6 @@ func TestContainsEstimatesClampProposal(t *testing.T) {
 		}
 	})
 
-}
-
-// TestContainsEstimatesClampApplication tests that if the ContainsEstimates
-// delta from a proposed command is 1 (and the replica state ContainsEstimates <= 1),
-// ContainsEstimates will be kept 1 in the replica state. This is because
-// ContainsEstimates==1 in a proposed command means that the proposer may run
-// with a version older than VersionContainsEstimatesCounter, in which ContainsEstimates
-// is a bool.
-func TestContainsEstimatesClampApplication(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-
-	_ = clusterversion.VersionContainsEstimatesCounter // see for details on the ContainsEstimates migration
-
-	ctx := context.Background()
-	stopper := stop.NewStopper()
-	defer stopper.Stop(ctx)
-	tc := testContext{}
-	tc.Start(t, stopper)
-
-	// We will stage and apply 2 batches with a command that has ContainsEstimates=1
-	// and expect that ReplicaState.Stats.ContainsEstimates will not become greater than 1.
-	applyBatch := func() {
-		tc.repl.raftMu.Lock()
-		defer tc.repl.raftMu.Unlock()
-		sm := tc.repl.getStateMachine()
-		batch := sm.NewBatch(false /* ephemeral */)
-		rAppbatch := batch.(*replicaAppBatch)
-
-		lease, _ := tc.repl.GetLease()
-
-		cmd := replicatedCmd{
-			ctx: ctx,
-			ent: &raftpb.Entry{
-				// Term:  1,
-				Index: rAppbatch.state.RaftAppliedIndex + 1,
-				Type:  raftpb.EntryNormal,
-			},
-			decodedRaftEntry: decodedRaftEntry{
-				idKey: makeIDKey(),
-				raftCmd: kvserverpb.RaftCommand{
-					ProposerLeaseSequence: rAppbatch.state.Lease.Sequence,
-					ReplicatedEvalResult: kvserverpb.ReplicatedEvalResult{
-						Timestamp:      tc.Clock().Now(),
-						IsLeaseRequest: true,
-						State: &kvserverpb.ReplicaState{
-							Lease: &lease,
-						},
-						Delta: enginepb.MVCCStatsDelta{
-							ContainsEstimates: 1,
-						},
-					},
-				},
-			},
-		}
-
-		_, err := rAppbatch.Stage(apply.Command(&cmd))
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if err := batch.ApplyToStateMachine(ctx); err != nil {
-			t.Fatal(err)
-		}
-	}
-
-	applyBatch()
-	assert.Equal(t, int64(1), tc.repl.State().ReplicaState.Stats.ContainsEstimates)
-
-	applyBatch()
-	assert.Equal(t, int64(1), tc.repl.State().ReplicaState.Stats.ContainsEstimates)
 }
 
 // setMockPutWithEstimates mocks the Put command (could be any) to simulate a command

--- a/pkg/sql/pgwire/auth_methods.go
+++ b/pkg/sql/pgwire/auth_methods.go
@@ -16,7 +16,6 @@ import (
 	"crypto/tls"
 	"fmt"
 
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/hba"
@@ -41,27 +40,26 @@ func loadDefaultMethods() {
 	//
 	// Care should be taken by administrators to only accept this auth
 	// method over secure connections, e.g. those encrypted using SSL.
-	RegisterAuthMethod("password", authPassword, clusterversion.Version19_1, hba.ConnAny, nil)
+	RegisterAuthMethod("password", authPassword, hba.ConnAny, nil)
 
 	// The "cert" method requires a valid client certificate for the
 	// user attempting to connect.
 	//
 	// This method is only usable over SSL connections.
-	RegisterAuthMethod("cert", authCert, clusterversion.Version19_1, hba.ConnHostSSL, nil)
+	RegisterAuthMethod("cert", authCert, hba.ConnHostSSL, nil)
 
 	// The "cert-password" method requires either a valid client
 	// certificate for the connecting user, or, if no cert is provided,
 	// a cleartext password.
-	RegisterAuthMethod("cert-password", authCertPassword, clusterversion.Version19_1, hba.ConnAny, nil)
+	RegisterAuthMethod("cert-password", authCertPassword, hba.ConnAny, nil)
 
 	// The "reject" method rejects any connection attempt that matches
 	// the current rule.
-	RegisterAuthMethod("reject", authReject, clusterversion.VersionAuthLocalAndTrustRejectMethods, hba.ConnAny, nil)
+	RegisterAuthMethod("reject", authReject, hba.ConnAny, nil)
 
 	// The "trust" method accepts any connection attempt that matches
 	// the current rule.
-	RegisterAuthMethod("trust", authTrust, clusterversion.VersionAuthLocalAndTrustRejectMethods, hba.ConnAny, nil)
-
+	RegisterAuthMethod("trust", authTrust, hba.ConnAny, nil)
 }
 
 // AuthMethod defines a method for authentication of a connection.

--- a/pkg/sql/pgwire/hba_conf.go
+++ b/pkg/sql/pgwire/hba_conf.go
@@ -143,13 +143,6 @@ func checkHBASyntaxBeforeUpdatingSetting(values *settings.Values, s string) erro
 		switch entry.ConnType {
 		case hba.ConnHostAny:
 		case hba.ConnLocal:
-			if vh != nil &&
-				!vh.IsActive(context.TODO(), clusterversion.VersionAuthLocalAndTrustRejectMethods) {
-				return pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
-					`authentication rule type 'local' requires all nodes to be upgraded to %s`,
-					clusterversion.VersionByKey(clusterversion.VersionAuthLocalAndTrustRejectMethods),
-				)
-			}
 		case hba.ConnHostSSL, hba.ConnHostNoSSL:
 			if vh != nil &&
 				!vh.IsActive(context.TODO(), clusterversion.VersionHBAForNonTLS) {
@@ -198,13 +191,6 @@ func checkHBASyntaxBeforeUpdatingSetting(values *settings.Values, s string) erro
 				"unknown auth method %q", entry.Method.Value),
 				"Supported methods: %s", listRegisteredMethods())
 		}
-		// Verify that the cluster setting is at least the required version.
-		if vh != nil && !vh.IsActive(context.TODO(), method.minReqVersion) {
-			return pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
-				`authentication method '%s' requires all nodes to be upgraded to %s`,
-				entry.Method.Value,
-				clusterversion.VersionByKey(method.minReqVersion))
-		}
 		// Run the per-method validation.
 		if check := hbaCheckHBAEntries[entry.Method.Value]; check != nil {
 			if err := check(entry); err != nil {
@@ -238,14 +224,14 @@ func ParseAndNormalize(val string) (*hba.Conf, error) {
 	// Lookup and cache the auth methods.
 	for i := range conf.Entries {
 		method := conf.Entries[i].Method.Value
-		methodEntry, ok := hbaAuthMethods[method]
+		info, ok := hbaAuthMethods[method]
 		if !ok {
 			// TODO(knz): Determine if an error should be reported
 			// upon unknown auth methods.
 			// See: https://github.com/cockroachdb/cockroach/issues/43716
 			return nil, errors.Errorf("unknown auth method %s", method)
 		}
-		conf.Entries[i].MethodFn = methodEntry.methodInfo
+		conf.Entries[i].MethodFn = info
 	}
 
 	return conf, nil
@@ -323,13 +309,9 @@ func (s *Server) GetAuthenticationConfiguration() *hba.Conf {
 // configuration. It can block the configuration if e.g. the syntax is
 // invalid.
 func RegisterAuthMethod(
-	method string,
-	fn AuthMethod,
-	minReqVersion clusterversion.VersionKey,
-	validConnTypes hba.ConnType,
-	checkEntry CheckHBAEntry,
+	method string, fn AuthMethod, validConnTypes hba.ConnType, checkEntry CheckHBAEntry,
 ) {
-	hbaAuthMethods[method] = authMethodEntry{methodInfo{validConnTypes, fn}, minReqVersion}
+	hbaAuthMethods[method] = methodInfo{validConnTypes, fn}
 	if checkEntry != nil {
 		hbaCheckHBAEntries[method] = checkEntry
 	}
@@ -347,14 +329,9 @@ func listRegisteredMethods() string {
 }
 
 var (
-	hbaAuthMethods     = map[string]authMethodEntry{}
+	hbaAuthMethods     = map[string]methodInfo{}
 	hbaCheckHBAEntries = map[string]CheckHBAEntry{}
 )
-
-type authMethodEntry struct {
-	methodInfo
-	minReqVersion clusterversion.VersionKey
-}
 
 type methodInfo struct {
 	validConnTypes hba.ConnType

--- a/pkg/storage/BUILD.bazel
+++ b/pkg/storage/BUILD.bazel
@@ -74,7 +74,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/base",
-        "//pkg/clusterversion",
         "//pkg/keys",
         "//pkg/kv/kvserver/concurrency/lock",
         "//pkg/kv/kvserver/diskmap",

--- a/pkg/storage/enginepb/mvcc.pb.go
+++ b/pkg/storage/enginepb/mvcc.pb.go
@@ -78,7 +78,7 @@ type MVCCMetadata struct {
 func (m *MVCCMetadata) Reset()      { *m = MVCCMetadata{} }
 func (*MVCCMetadata) ProtoMessage() {}
 func (*MVCCMetadata) Descriptor() ([]byte, []int) {
-	return fileDescriptor_mvcc_883f89000dcabd92, []int{0}
+	return fileDescriptor_mvcc_33d1719bb1dfaf1f, []int{0}
 }
 func (m *MVCCMetadata) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -118,7 +118,7 @@ type MVCCMetadata_SequencedIntent struct {
 func (m *MVCCMetadata_SequencedIntent) Reset()      { *m = MVCCMetadata_SequencedIntent{} }
 func (*MVCCMetadata_SequencedIntent) ProtoMessage() {}
 func (*MVCCMetadata_SequencedIntent) Descriptor() ([]byte, []int) {
-	return fileDescriptor_mvcc_883f89000dcabd92, []int{0, 0}
+	return fileDescriptor_mvcc_33d1719bb1dfaf1f, []int{0, 0}
 }
 func (m *MVCCMetadata_SequencedIntent) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -162,7 +162,7 @@ func (m *MVCCMetadataSubsetForMergeSerialization) Reset() {
 }
 func (*MVCCMetadataSubsetForMergeSerialization) ProtoMessage() {}
 func (*MVCCMetadataSubsetForMergeSerialization) Descriptor() ([]byte, []int) {
-	return fileDescriptor_mvcc_883f89000dcabd92, []int{1}
+	return fileDescriptor_mvcc_33d1719bb1dfaf1f, []int{1}
 }
 func (m *MVCCMetadataSubsetForMergeSerialization) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -221,8 +221,20 @@ type MVCCStats struct {
 	// contains_estimates indicates that the MVCCStats object contains values
 	// which have been estimated. This means that the stats should not be used
 	// where complete accuracy is required, and instead should be recomputed
-	// when necessary. See clusterversion.VersionContainsEstimatesCounter for
-	// details about the migration from bool to int64.
+	// when necessary.
+	//
+	// This field used to be a bool; in #37583 we migrated it to int64. See #37120
+	// for the motivation for doing so. If zero, it's "false". If non-zero, it's
+	// "true".
+	//
+	// As a result of the migration, our usage of this int64 field is now a bit
+	// involved. When ContainsEstimates is 0 or 1, we behave like a boolean
+	// (i.e. `1+1=1` aka `true+true=true`). Downstream of raft, we use the
+	// boolean behavior for ContainsEstimates=1 and the additive behavior for
+	// anything else. If non-zero, we encode the fact that we're allowed to use
+	// regular arithmetic for this field by making sure it contains a value >1 (we
+	// multiply it by 2, and thus avoiding 1). This is then interpreted during
+	// command application.
 	ContainsEstimates int64 `protobuf:"varint,14,opt,name=contains_estimates,json=containsEstimates" json:"contains_estimates"`
 	// last_update_nanos is a timestamp at which the ages were last
 	// updated. See the comment on MVCCStats.
@@ -280,7 +292,7 @@ func (m *MVCCStats) Reset()         { *m = MVCCStats{} }
 func (m *MVCCStats) String() string { return proto.CompactTextString(m) }
 func (*MVCCStats) ProtoMessage()    {}
 func (*MVCCStats) Descriptor() ([]byte, []int) {
-	return fileDescriptor_mvcc_883f89000dcabd92, []int{2}
+	return fileDescriptor_mvcc_33d1719bb1dfaf1f, []int{2}
 }
 func (m *MVCCStats) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -334,7 +346,7 @@ func (m *MVCCStatsLegacyRepresentation) Reset()         { *m = MVCCStatsLegacyRe
 func (m *MVCCStatsLegacyRepresentation) String() string { return proto.CompactTextString(m) }
 func (*MVCCStatsLegacyRepresentation) ProtoMessage()    {}
 func (*MVCCStatsLegacyRepresentation) Descriptor() ([]byte, []int) {
-	return fileDescriptor_mvcc_883f89000dcabd92, []int{3}
+	return fileDescriptor_mvcc_33d1719bb1dfaf1f, []int{3}
 }
 func (m *MVCCStatsLegacyRepresentation) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2277,9 +2289,9 @@ var (
 	ErrIntOverflowMvcc   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("storage/enginepb/mvcc.proto", fileDescriptor_mvcc_883f89000dcabd92) }
+func init() { proto.RegisterFile("storage/enginepb/mvcc.proto", fileDescriptor_mvcc_33d1719bb1dfaf1f) }
 
-var fileDescriptor_mvcc_883f89000dcabd92 = []byte{
+var fileDescriptor_mvcc_33d1719bb1dfaf1f = []byte{
 	// 780 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xec, 0x95, 0x31, 0x4f, 0xdb, 0x4c,
 	0x18, 0xc7, 0xe3, 0x37, 0x01, 0x9c, 0x4b, 0x48, 0xc0, 0x2f, 0xd2, 0x1b, 0x85, 0xb7, 0x4e, 0x0a,

--- a/pkg/storage/enginepb/mvcc.proto
+++ b/pkg/storage/enginepb/mvcc.proto
@@ -141,8 +141,20 @@ message MVCCStats {
   // contains_estimates indicates that the MVCCStats object contains values
   // which have been estimated. This means that the stats should not be used
   // where complete accuracy is required, and instead should be recomputed
-  // when necessary. See clusterversion.VersionContainsEstimatesCounter for
-  // details about the migration from bool to int64.
+  // when necessary.
+  //
+  // This field used to be a bool; in #37583 we migrated it to int64. See #37120
+  // for the motivation for doing so. If zero, it's "false". If non-zero, it's
+  // "true".
+  //
+  // As a result of the migration, our usage of this int64 field is now a bit
+  // involved. When ContainsEstimates is 0 or 1, we behave like a boolean
+  // (i.e. `1+1=1` aka `true+true=true`). Downstream of raft, we use the
+  // boolean behavior for ContainsEstimates=1 and the additive behavior for
+  // anything else. If non-zero, we encode the fact that we're allowed to use
+  // regular arithmetic for this field by making sure it contains a value >1 (we
+  // multiply it by 2, and thus avoiding 1). This is then interpreted during
+  // command application.
   optional int64 contains_estimates = 14 [(gogoproto.nullable) = false];
 
   // last_update_nanos is a timestamp at which the ages were last

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -22,7 +22,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
@@ -283,7 +282,6 @@ func updateStatsOnMerge(key roachpb.Key, valSize, nowNanos int64) enginepb.MVCCS
 	sys := isSysLocal(key)
 	ms.AgeTo(nowNanos)
 
-	_ = clusterversion.VersionContainsEstimatesCounter // see for info on ContainsEstimates migration
 	ms.ContainsEstimates = 1
 
 	if sys {


### PR DESCRIPTION
It's an old cluster version, introduced in the 19.2 release cycle. It's
now safe to remove. Part of #47447. Fixes #56398.


Release note: None

---

See only last commit. First two are from #57154 and #57155 respectively.