### PR TITLE
cli: Warn users if --locality doesn't include "region"

### DIFF
--- a/pkg/cli/interactive_tests/test_flags.tcl
+++ b/pkg/cli/interactive_tests/test_flags.tcl
@@ -93,6 +93,13 @@ interrupt
 eexpect ":/# "
 end_test
 
+start_test "Check that locality flags without a region tier warn"
+send "$argv start-single-node --insecure --locality=data-center=us-east,zone=a\r"
+eexpect "WARNING: The --locality flag does not contain a"
+interrupt
+eexpect ":/# "
+end_test
+
 start_server $argv
 
 start_test "Check that server start-up flags are reported to telemetry"

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -1121,6 +1121,20 @@ func setupAndInitializeLoggingAndProfiling(
 		)
 	}
 
+	// The new multi-region abstractions require that nodes be labeled in "regions"
+	// (and optionally, "zones").  To push users in that direction, we warn them here
+	// if they've provided a --locality value which doesn't include a "region" tier.
+	if len(serverCfg.Locality.Tiers) > 0 {
+		if _, containsRegion := serverCfg.Locality.Find("region"); !containsRegion {
+			const warningString string = "The --locality flag does not contain a \"region\" tier. To add regions\n" +
+				"to databases, the --locality flag must contain a \"region\" tier.\n" +
+				"For more information, see:\n\n" +
+				"- %s"
+			log.Shoutf(context.Background(), severity.WARNING, warningString,
+				log.Safe(docs.URL("cockroach-start.html#locality")))
+		}
+	}
+
 	maybeWarnMemorySizes(ctx)
 
 	// We log build information to stdout (for the short summary), but also


### PR DESCRIPTION
With the new multi-region abstractions coming in 21.1, users will need
to add regions to databases (and optionally, tables).  The regions
defined at the cluster level are derived from the locality flags, but we
search explicitly for "region".  As a result, if the user wishes to
leverage the new abstractions, they must provide a "region" tier in the
locality flag when starting their nodes.

To push users in that direction, we warn on `cockroach start` if the
supplied locality flag doesn't include a region tier.

Release note (cli change): Warn users if locality flag doesn't contain a
"region" tier.