### PR TITLE
release-20.2: sql: fix: allow nulls in materialized views

### DIFF
--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -403,6 +403,9 @@ func addResultColumns(
 ) error {
 	for _, colRes := range resultColumns {
 		columnTableDef := tree.ColumnTableDef{Name: tree.Name(colRes.Name), Type: colRes.Typ}
+		// Nullability constraints do not need to exist on the view, since they are
+		// already enforced on the source data.
+		columnTableDef.Nullable.Nullability = tree.SilentNull
 		// The new types in the CREATE VIEW column specs never use
 		// SERIAL so we need not process SERIAL types here.
 		col, _, _, err := tabledesc.MakeColumnDefDescs(ctx, &columnTableDef, semaCtx, evalCtx)

--- a/pkg/sql/logictest/testdata/logic_test/dependencies
+++ b/pkg/sql/logictest/testdata/logic_test/dependencies
@@ -29,8 +29,8 @@ descriptor_id  descriptor_name  column_id  column_name  column_type             
 57             test_kvi1        1          k            family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 time_precision_is_set:false        false     NULL            false
 58             test_kvi2        1          k            family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 time_precision_is_set:false        false     NULL            false
 58             test_kvi2        2          v            family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 time_precision_is_set:false        true      NULL            false
-59             test_v1          1          v            family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 time_precision_is_set:false        false     NULL            false
-60             test_v2          1          v            family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 time_precision_is_set:false        false     NULL            false
+59             test_v1          1          v            family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 time_precision_is_set:false        true      NULL            false
+60             test_v2          1          v            family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 time_precision_is_set:false        true      NULL            false
 
 query ITITTBB colnames
 SELECT * FROM crdb_internal.table_indexes WHERE descriptor_name LIKE 'test_%' ORDER BY descriptor_id, index_id

--- a/pkg/sql/logictest/testdata/logic_test/materialized_view
+++ b/pkg/sql/logictest/testdata/logic_test/materialized_view
@@ -149,3 +149,15 @@ REFRESH MATERIALIZED VIEW with_options WITH NO DATA
 
 query I
 SELECT * FROM with_options
+
+# Regression test for null data in materialized views.
+statement ok
+CREATE TABLE t57108 (id INT PRIMARY KEY, a INT);
+INSERT INTO t57108 VALUES(1, 1), (2, NULL);
+CREATE MATERIALIZED VIEW t57108_v AS SELECT t57108.a from t57108;
+
+query I rowsort
+SELECT * FROM t57108_v
+----
+NULL
+1

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -490,11 +490,11 @@ t3            rowid     -1         NULL      NULL        NULL      true        t
 primary       rowid     -1         NULL      NULL        NULL      true        true
 t3_a_b_idx    a         -1         NULL      NULL        NULL      false       false
 t3_a_b_idx    b         -1         NULL      NULL        NULL      false       false
-v1            p         -1         NULL      NULL        NULL      true        false
-v1            a         -1         NULL      NULL        NULL      true        false
-v1            b         -1         NULL      NULL        NULL      true        false
-v1            c         -1         NULL      NULL        NULL      true        false
-mv1           ?column?  -1         NULL      NULL        NULL      true        false
+v1            p         -1         NULL      NULL        NULL      false       false
+v1            a         -1         NULL      NULL        NULL      false       false
+v1            b         -1         NULL      NULL        NULL      false       false
+v1            c         -1         NULL      NULL        NULL      false       false
+mv1           ?column?  -1         NULL      NULL        NULL      false       false
 mv1           rowid     -1         NULL      NULL        NULL      true        true
 primary       rowid     -1         NULL      NULL        NULL      true        true
 


### PR DESCRIPTION
Backport 1/1 commits from #57139.

/cc @cockroachdb/release

---

fixes #57108 

Release note (bug fix): Creating a materialized view that references a
column with a NULL value no longer results in an error.
