### PR TITLE
sql: remove a bunch of allocations from name and type resolution paths

### DIFF
--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -212,7 +212,9 @@ func (tc *Collection) getLeasedDescriptorByName(
 	// continue to use N to refer to X even if N is renamed during the
 	// transaction.
 	if desc = tc.leasedDescriptors.getByName(parentID, parentSchemaID, name); desc != nil {
-		log.VEventf(ctx, 2, "found descriptor in collection for '%s'", name)
+		if log.V(2) {
+			log.Eventf(ctx, "found descriptor in collection for '%s'", name)
+		}
 		return desc, false, nil
 	}
 
@@ -236,7 +238,9 @@ func (tc *Collection) getLeasedDescriptorByName(
 	}
 
 	tc.leasedDescriptors.add(desc)
-	log.VEventf(ctx, 2, "added descriptor '%s' to collection: %+v", name, desc)
+	if log.V(2) {
+		log.Eventf(ctx, "added descriptor '%s' to collection: %+v", name, desc)
+	}
 
 	// If the descriptor we just acquired expires before the txn's deadline,
 	// reduce the deadline. We use ReadTimestamp() that doesn't return the commit

--- a/pkg/sql/colfetcher/colbatch_scan.go
+++ b/pkg/sql/colfetcher/colbatch_scan.go
@@ -174,13 +174,11 @@ func NewColBatchScan(
 		columnIdxMap.Set(sysColDescs[i].ID, columnIdxMap.Len())
 	}
 
-	semaCtx := tree.MakeSemaContext()
 	// Before we can safely use types from the table descriptor, we need to
 	// make sure they are hydrated. In row execution engine it is done during
 	// the processor initialization, but neither ColBatchScan nor cFetcher are
 	// processors, so we need to do the hydration ourselves.
 	resolver := flowCtx.TypeResolverFactory.NewTypeResolver(evalCtx.Txn)
-	semaCtx.TypeResolver = resolver
 	if err := resolver.HydrateTypeSlice(ctx, typs); err != nil {
 		return nil, err
 	}

--- a/pkg/sql/colflow/BUILD.bazel
+++ b/pkg/sql/colflow/BUILD.bazel
@@ -65,6 +65,7 @@ go_test(
         "//pkg/server/serverpb",
         "//pkg/settings/cluster",
         "//pkg/sql/catalog/catalogkv",
+        "//pkg/sql/catalog/descs",
         "//pkg/sql/colcontainer",
         "//pkg/sql/colexec",
         "//pkg/sql/colexec/colbuilder",

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -480,7 +480,7 @@ type vectorizedFlowCreator struct {
 	nodeDialer                     *nodedialer.Dialer
 	flowID                         execinfrapb.FlowID
 	exprHelper                     *colexec.ExprHelper
-	typeResolver                   *descs.DistSQLTypeResolver
+	typeResolver                   descs.DistSQLTypeResolver
 
 	// numOutboxes counts how many exec.Outboxes have been set up on this node.
 	// It must be accessed atomically.
@@ -538,7 +538,7 @@ func newVectorizedFlowCreator(
 	flowID execinfrapb.FlowID,
 	diskQueueCfg colcontainer.DiskQueueCfg,
 	fdSemaphore semaphore.Semaphore,
-	typeResolver *descs.DistSQLTypeResolver,
+	typeResolver descs.DistSQLTypeResolver,
 ) *vectorizedFlowCreator {
 	creator := vectorizedFlowCreatorPool.Get().(*vectorizedFlowCreator)
 	*creator = vectorizedFlowCreator{

--- a/pkg/sql/colflow/vectorized_flow_test.go
+++ b/pkg/sql/colflow/vectorized_flow_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/colcontainer"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/colflow/colrpc"
@@ -228,7 +229,7 @@ func TestDrainOnlyInputDAG(t *testing.T) {
 	vfc := newVectorizedFlowCreator(
 		&vectorizedFlowCreatorHelper{f: f}, componentCreator, false, &wg, &execinfra.RowChannel{},
 		nil /* nodeDialer */, execinfrapb.FlowID{}, colcontainer.DiskQueueCfg{},
-		nil /* fdSemaphore */, nil, /* typeResolver */
+		nil /* fdSemaphore */, descs.DistSQLTypeResolver{},
 	)
 
 	_, err := vfc.setupFlow(ctx, &f.FlowCtx, procs, flowinfra.FuseNormally)

--- a/pkg/sql/execinfra/processorsbase.go
+++ b/pkg/sql/execinfra/processorsbase.go
@@ -473,6 +473,9 @@ type ProcessorBase struct {
 	// EvalCtx is used for expression evaluation. It overrides the one in flowCtx.
 	EvalCtx *tree.EvalContext
 
+	// SemaCtx is used to avoid allocating a new SemaCtx during processor setup.
+	SemaCtx tree.SemaContext
+
 	// MemMonitor is the processor's memory monitor.
 	MemMonitor *mon.BytesMonitor
 
@@ -857,10 +860,11 @@ func (pb *ProcessorBase) InitWithEvalCtx(
 	if err := resolver.HydrateTypeSlice(evalCtx.Context, coreOutputTypes); err != nil {
 		return err
 	}
-	semaCtx := tree.MakeSemaContext()
-	semaCtx.TypeResolver = resolver
 
-	return pb.Out.Init(post, coreOutputTypes, &semaCtx, pb.EvalCtx, output)
+	pb.SemaCtx = tree.MakeSemaContext()
+	pb.SemaCtx.TypeResolver = resolver
+
+	return pb.Out.Init(post, coreOutputTypes, &pb.SemaCtx, pb.EvalCtx, output)
 }
 
 // AddInputToDrain adds an input to drain when moving the processor to a


### PR DESCRIPTION
See individual commits. This PR shaves 3% of the total number of allocations in the FlowSetup benchmark via a variety of methods.

```
name                                          old time/op    new time/op    delta
FlowSetup/vectorize=true/distribute=false-24     144µs ± 1%     142µs ± 2%  -1.01%  (p=0.023 n=10+10)

name                                          old alloc/op   new alloc/op   delta
FlowSetup/vectorize=true/distribute=false-24    28.3kB ± 1%    27.8kB ± 1%  -1.76%  (p=0.000 n=9+9)

name                                          old allocs/op  new allocs/op  delta
FlowSetup/vectorize=true/distribute=false-24       232 ± 0%       224 ± 0%  -3.45%  (p=0.000 n=8+8)
```