### PR TITLE
sql: remove pointless Clock update closure allocation

### DIFF
--- a/pkg/ccl/backupccl/backup_processor_planning.go
+++ b/pkg/ccl/backupccl/backup_processor_planning.go
@@ -110,7 +110,7 @@ func distBackup(
 		tree.Rows,
 		nil,   /* rangeCache */
 		noTxn, /* txn - the flow does not read or write the database */
-		func(ts hlc.Timestamp) {},
+		nil,   /* clockUpdater */
 		evalCtx.Tracing,
 	)
 	defer recv.Release()

--- a/pkg/ccl/backupccl/restore_processor_planning.go
+++ b/pkg/ccl/backupccl/restore_processor_planning.go
@@ -217,7 +217,7 @@ func distRestore(
 		tree.Rows,
 		nil,   /* rangeCache */
 		noTxn, /* txn - the flow does not read or write the database */
-		func(ts hlc.Timestamp) {},
+		nil,   /* clockUpdater */
 		evalCtx.Tracing,
 	)
 	defer recv.Release()

--- a/pkg/ccl/changefeedccl/changefeed_dist.go
+++ b/pkg/ccl/changefeedccl/changefeed_dist.go
@@ -176,7 +176,7 @@ func distChangefeedFlow(
 		tree.Rows,
 		execCfg.RangeDescriptorCache,
 		noTxn,
-		func(ts hlc.Timestamp) {},
+		nil, /* clockUpdater */
 		evalCtx.Tracing,
 	)
 	defer recv.Release()

--- a/pkg/sql/apply_join.go
+++ b/pkg/sql/apply_join.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowcontainer"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 )
@@ -238,9 +237,7 @@ func runPlanInsidePlan(
 		params.ctx, rowResultWriter, tree.Rows,
 		params.extendedEvalCtx.ExecCfg.RangeDescriptorCache,
 		params.p.Txn(),
-		func(ts hlc.Timestamp) {
-			params.extendedEvalCtx.ExecCfg.Clock.Update(ts)
-		},
+		params.extendedEvalCtx.ExecCfg.Clock,
 		params.p.extendedEvalCtx.Tracing,
 	)
 	defer recv.Release()

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -999,9 +999,7 @@ func (sc *SchemaChanger) distBackfill(
 				tree.Rows, /* stmtType - doesn't matter here since no result are produced */
 				sc.rangeDescriptorCache,
 				nil, /* txn - the flow does not run wholly in a txn */
-				func(ts hlc.Timestamp) {
-					sc.clock.Update(ts)
-				},
+				sc.clock,
 				evalCtx.Tracing,
 			)
 			defer recv.Release()

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -928,9 +928,7 @@ func (ex *connExecutor) execWithDistSQLEngine(
 		ctx, res, stmtType,
 		ex.server.cfg.RangeDescriptorCache,
 		planner.txn,
-		func(ts hlc.Timestamp) {
-			ex.server.cfg.Clock.Update(ts)
-		},
+		ex.server.cfg.Clock,
 		&ex.sessionTracing,
 	)
 	recv.progressAtomic = progressAtomic

--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -266,7 +266,7 @@ func TestDistSQLReceiverUpdatesCaches(t *testing.T) {
 	rangeCache := kvcoord.NewRangeDescriptorCache(st, nil /* db */, size, stopper)
 	r := MakeDistSQLReceiver(
 		ctx, nil /* resultWriter */, tree.Rows,
-		rangeCache, nil /* txn */, nil /* updateClock */, &SessionTracing{})
+		rangeCache, nil /* txn */, nil /* clockUpdater */, &SessionTracing{})
 
 	replicas := []roachpb.ReplicaDescriptor{{ReplicaID: 1}, {ReplicaID: 2}, {ReplicaID: 3}}
 

--- a/pkg/sql/distsql_plan_csv.go
+++ b/pkg/sql/distsql_plan_csv.go
@@ -28,7 +28,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
-	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/logtags"
@@ -291,7 +290,7 @@ func DistIngest(
 		tree.Rows,
 		nil, /* rangeCache */
 		nil, /* txn - the flow does not read or write the database */
-		func(ts hlc.Timestamp) {},
+		nil, /* clockUpdater */
 		evalCtx.Tracing,
 	)
 	defer recv.Release()

--- a/pkg/sql/distsql_plan_stats.go
+++ b/pkg/sql/distsql_plan_stats.go
@@ -26,7 +26,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/span"
 	"github.com/cockroachdb/cockroach/pkg/sql/stats"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
-	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
 )
@@ -278,9 +277,7 @@ func (dsp *DistSQLPlanner) planAndRunCreateStats(
 		tree.DDL,
 		evalCtx.ExecCfg.RangeDescriptorCache,
 		txn,
-		func(ts hlc.Timestamp) {
-			evalCtx.ExecCfg.Clock.Update(ts)
-		},
+		evalCtx.ExecCfg.Clock,
 		evalCtx.Tracing,
 	)
 	defer recv.Release()

--- a/pkg/sql/distsql_running_test.go
+++ b/pkg/sql/distsql_running_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
-	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
@@ -142,9 +141,7 @@ func TestDistSQLRunningInAbortedTxn(t *testing.T) {
 			stmt.AST.StatementType(),
 			execCfg.RangeDescriptorCache,
 			txn,
-			func(ts hlc.Timestamp) {
-				execCfg.Clock.Update(ts)
-			},
+			execCfg.Clock,
 			p.ExtendedEvalContext().Tracing,
 		)
 
@@ -204,7 +201,7 @@ func TestDistSQLReceiverErrorRanking(t *testing.T) {
 		tree.Rows, /* StatementType */
 		nil,       /* rangeCache */
 		txn,
-		func(hlc.Timestamp) {}, /* updateClock */
+		nil, /* clockUpdater */
 		&SessionTracing{},
 	)
 

--- a/pkg/sql/explain_distsql.go
+++ b/pkg/sql/explain_distsql.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/physicalplan"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
-	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 )
@@ -128,9 +127,7 @@ func (n *explainDistSQLNode) startExec(params runParams) error {
 			tree.Rows,
 			execCfg.RangeDescriptorCache,
 			params.p.txn,
-			func(ts hlc.Timestamp) {
-				execCfg.Clock.Update(ts)
-			},
+			execCfg.Clock,
 			params.extendedEvalCtx.Tracing,
 		)
 		if !distSQLPlanner.PlanAndRunSubqueries(
@@ -199,9 +196,7 @@ func (n *explainDistSQLNode) startExec(params runParams) error {
 			stmtType,
 			execCfg.RangeDescriptorCache,
 			newParams.p.txn,
-			func(ts hlc.Timestamp) {
-				execCfg.Clock.Update(ts)
-			},
+			execCfg.Clock,
 			newParams.extendedEvalCtx.Tracing,
 		)
 		defer recv.Release()
@@ -256,9 +251,7 @@ func (n *explainDistSQLNode) startExec(params runParams) error {
 			tree.Rows,
 			execCfg.RangeDescriptorCache,
 			params.p.txn,
-			func(ts hlc.Timestamp) {
-				execCfg.Clock.Update(ts)
-			},
+			execCfg.Clock,
 			params.extendedEvalCtx.Tracing,
 		)
 		if !distSQLPlanner.PlanAndRunCascadesAndChecks(

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -282,9 +282,7 @@ func (sc *SchemaChanger) backfillQueryIntoTable(
 			tree.Rows,
 			sc.execCfg.RangeDescriptorCache,
 			txn,
-			func(ts hlc.Timestamp) {
-				sc.clock.Update(ts)
-			},
+			sc.clock,
 			// Make a session tracing object on-the-fly. This is OK
 			// because it sets "enabled: false" and thus none of the
 			// other fields are used.

--- a/pkg/sql/scrub.go
+++ b/pkg/sql/scrub.go
@@ -479,9 +479,7 @@ func scrubRunDistSQL(
 		tree.Rows,
 		p.ExecCfg().RangeDescriptorCache,
 		p.txn,
-		func(ts hlc.Timestamp) {
-			p.ExecCfg().Clock.Update(ts)
-		},
+		p.ExecCfg().Clock,
 		p.extendedEvalCtx.Tracing,
 	)
 	defer recv.Release()

--- a/pkg/sql/testutils.go
+++ b/pkg/sql/testutils.go
@@ -128,9 +128,7 @@ func (dsp *DistSQLPlanner) Exec(
 		stmt.AST.StatementType(),
 		execCfg.RangeDescriptorCache,
 		p.txn,
-		func(ts hlc.Timestamp) {
-			execCfg.Clock.Update(ts)
-		},
+		execCfg.Clock,
 		p.ExtendedEvalContext().Tracing,
 	)
 	defer recv.Release()


### PR DESCRIPTION
Previously, we made a pointless closure on every query to update the
hlc.Clock on receipt of new observed timestamps. This is pointless
because we can be passing pre-allocated objects that can update
themselves (most often the *hlc.Clock itself).

```
name                                          old time/op    new time/op    delta
FlowSetup/vectorize=true/distribute=false-24     132µs ± 2%     132µs ± 1%    ~     (p=0.661 n=10+9)

name                                          old alloc/op   new alloc/op   delta
FlowSetup/vectorize=true/distribute=false-24    28.3kB ± 1%    28.2kB ± 1%    ~     (p=0.605 n=9+9)

name                                          old allocs/op  new allocs/op  delta
FlowSetup/vectorize=true/distribute=false-24       232 ± 0%       230 ± 0%  -0.86%  (p=0.000 n=8+8)
```

Release note: None