### PR TITLE
sql: more allocation reductions

### DIFF
--- a/pkg/sql/colexecop/operator.go
+++ b/pkg/sql/colexecop/operator.go
@@ -161,14 +161,13 @@ type Closers []Closer
 // sense.
 func (c Closers) CloseAndLogOnErr(ctx context.Context, prefix string) {
 	if err := colexecerror.CatchVectorizedRuntimeError(func() {
-		prefix += ":"
 		for _, closer := range c {
 			if err := closer.Close(); err != nil && log.V(1) {
-				log.Infof(ctx, "%s error closing Closer: %v", prefix, err)
+				log.Infof(ctx, "%s: error closing Closer: %v", prefix, err)
 			}
 		}
 	}); err != nil && log.V(1) {
-		log.Infof(ctx, "%s runtime error closing the closers: %v", prefix, err)
+		log.Infof(ctx, "%s: runtime error closing the closers: %v", prefix, err)
 	}
 }
 

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1202,15 +1202,25 @@ type connExecutor struct {
 		// connExecutor's closure.
 		prepStmtsNamespaceMemAcc mon.BoundAccount
 
-		// onTxnFinish (if non-nil) will be called when txn is finished (either
-		// committed or aborted). It is set when txn is started but can remain
-		// unset when txn is executed within another higher-level txn.
-		onTxnFinish func(context.Context, txnEvent)
+		// shouldExecuteOnTxnFinish indicates that ex.onTxnFinish will be called
+		// when txn is finished (either committed or aborted). It is true when
+		// txn is started but can remain false when txn is executed within
+		// another higher-level txn.
+		shouldExecuteOnTxnFinish bool
 
-		// onTxnRestart (if non-nil) will be called when a txn is being retried. It
-		// is set when the txn is started but can remain unset when a txn is
-		// executed within another higher-level txn.
-		onTxnRestart func()
+		// txnFinishClosure contains fields that ex.onTxnFinish uses to execute.
+		txnFinishClosure struct {
+			// txnStartTime is the time that the transaction started.
+			txnStartTime time.Time
+			// implicit is whether or not the transaction was implicit.
+			implicit bool
+		}
+
+		// shouldExecuteOnTxnRestart indicates that ex.onTxnRestart will be
+		// called when txn is being retried. It is true when txn is started but
+		// can remain false when txn is executed within another higher-level
+		// txn.
+		shouldExecuteOnTxnRestart bool
 
 		// savepoints maintains the stack of savepoints currently open.
 		savepoints savepointStack
@@ -1505,15 +1515,9 @@ func (ex *connExecutor) resetExtraTxnState(ctx context.Context, ev txnEvent) err
 			delete(ex.extraTxnState.prepStmtsNamespaceAtTxnRewindPos.portals, name)
 		}
 		ex.extraTxnState.savepoints.clear()
-		// After txn is finished, we need to call onTxnFinish (if it's non-nil).
-		if ex.extraTxnState.onTxnFinish != nil {
-			ex.extraTxnState.onTxnFinish(ctx, ev)
-			ex.extraTxnState.onTxnFinish = nil
-		}
+		ex.onTxnFinish(ctx, ev)
 	case txnRestart:
-		if ex.extraTxnState.onTxnRestart != nil {
-			ex.extraTxnState.onTxnRestart()
-		}
+		ex.onTxnRestart()
 		ex.state.mu.Lock()
 		defer ex.state.mu.Unlock()
 		ex.state.mu.stmtCount = 0
@@ -2634,7 +2638,7 @@ func (ex *connExecutor) txnStateTransitionsApplyWrapper(
 	case txnStart:
 		ex.extraTxnState.autoRetryCounter = 0
 		ex.extraTxnState.autoRetryReason = nil
-		ex.extraTxnState.onTxnFinish, ex.extraTxnState.onTxnRestart = ex.recordTransactionStart()
+		ex.recordTransactionStart()
 		// Bump the txn counter for logging.
 		ex.extraTxnState.txnCounter++
 		if !ex.server.cfg.Codec.ForSystemTenant() {

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -54,7 +54,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/sslocal"
 	"github.com/cockroachdb/cockroach/pkg/sql/stmtdiagnostics"
 	"github.com/cockroachdb/cockroach/pkg/util"
-	"github.com/cockroachdb/cockroach/pkg/util/cancelchecker"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
 	"github.com/cockroachdb/cockroach/pkg/util/fsm"
@@ -2537,7 +2536,7 @@ func (ex *connExecutor) implicitTxn() bool {
 // initPlanner initializes a planner so it can can be used for planning a
 // query in the context of this session.
 func (ex *connExecutor) initPlanner(ctx context.Context, p *planner) {
-	p.cancelChecker = cancelchecker.NewCancelChecker(ctx)
+	p.cancelChecker.Reset(ctx)
 
 	ex.initEvalCtx(ctx, &p.extendedEvalCtx, p)
 

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -699,7 +699,7 @@ func (ex *connExecutor) execStmtInOpenState(
 	p.extendedEvalCtx.Placeholders = &p.semaCtx.Placeholders
 	p.extendedEvalCtx.Annotations = &p.semaCtx.Annotations
 	p.stmt = stmt
-	p.cancelChecker = cancelchecker.NewCancelChecker(ctx)
+	p.cancelChecker.Reset(ctx)
 	p.autoCommit = os.ImplicitTxn.Get() && !ex.server.cfg.TestingKnobs.DisableAutoCommit
 
 	var stmtThresholdSpan *tracing.Span

--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -91,9 +91,9 @@ type instrumentationHelper struct {
 	// See EXECUTE .. DISCARD ROWS.
 	discardRows bool
 
-	diagRequestID               stmtdiagnostics.RequestID
-	finishCollectionDiagnostics func()
-	withStatementTrace          func(trace tracing.Recording, stmt string)
+	diagRequestID           stmtdiagnostics.RequestID
+	stmtDiagnosticsRecorder *stmtdiagnostics.Registry
+	withStatementTrace      func(trace tracing.Recording, stmt string)
 
 	sp *tracing.Span
 	// shouldFinishSpan determines whether sp needs to be finished in
@@ -166,10 +166,11 @@ func (ih *instrumentationHelper) Setup(
 		ih.discardRows = true
 
 	default:
-		ih.collectBundle, ih.diagRequestID, ih.finishCollectionDiagnostics =
+		ih.collectBundle, ih.diagRequestID =
 			stmtDiagnosticsRecorder.ShouldCollectDiagnostics(ctx, fingerprint)
 	}
 
+	ih.stmtDiagnosticsRecorder = stmtDiagnosticsRecorder
 	ih.withStatementTrace = cfg.TestingKnobs.WithStatementTrace
 
 	ih.savePlanForStats =
@@ -312,10 +313,8 @@ func (ih *instrumentationHelper) Finish(
 			ih.origCtx, cfg.DB, ie, &p.curPlan, ob.BuildString(), trace, placeholders,
 		)
 		bundle.insert(ctx, ih.fingerprint, ast, cfg.StmtDiagnosticsRecorder, ih.diagRequestID)
-		if ih.finishCollectionDiagnostics != nil {
-			ih.finishCollectionDiagnostics()
-			telemetry.Inc(sqltelemetry.StatementDiagnosticsCollectedCounter)
-		}
+		ih.stmtDiagnosticsRecorder.RemoveOngoing(ih.diagRequestID)
+		telemetry.Inc(sqltelemetry.StatementDiagnosticsCollectedCounter)
 	}
 
 	// If there was a communication error already, no point in setting any

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -184,7 +184,7 @@ type planner struct {
 
 	// cancelChecker is used by planNodes to check for cancellation of the associated
 	// query.
-	cancelChecker *cancelchecker.CancelChecker
+	cancelChecker cancelchecker.CancelChecker
 
 	// isPreparing is true if this planner is currently preparing.
 	isPreparing bool
@@ -324,7 +324,7 @@ func newInternalPlanner(
 
 	p.txn = txn
 	p.stmt = Statement{}
-	p.cancelChecker = cancelchecker.NewCancelChecker(ctx)
+	p.cancelChecker.Reset(ctx)
 	p.isInternalPlanner = true
 
 	p.semaCtx = tree.MakeSemaContext()

--- a/pkg/sql/rowcontainer/row_container.go
+++ b/pkg/sql/rowcontainer/row_container.go
@@ -220,8 +220,9 @@ func (mc *MemRowContainer) AddRow(ctx context.Context, row rowenc.EncDatumRow) e
 // Sort is part of the SortableRowContainer interface.
 func (mc *MemRowContainer) Sort(ctx context.Context) {
 	mc.invertSorting = false
-	cancelChecker := cancelchecker.NewCancelChecker(ctx)
-	sort.Sort(mc, cancelChecker)
+	var cancelChecker cancelchecker.CancelChecker
+	cancelChecker.Reset(ctx)
+	sort.Sort(mc, &cancelChecker)
 }
 
 // Reorder implements ReorderableRowContainer. We don't need to create a new

--- a/pkg/sql/rowexec/aggregator.go
+++ b/pkg/sql/rowexec/aggregator.go
@@ -75,7 +75,7 @@ type aggregatorBase struct {
 	row              rowenc.EncDatumRow
 	scratch          []byte
 
-	cancelChecker *cancelchecker.CancelChecker
+	cancelChecker cancelchecker.CancelChecker
 }
 
 // init initializes the aggregatorBase.
@@ -335,7 +335,7 @@ func (ag *orderedAggregator) Start(ctx context.Context) {
 func (ag *aggregatorBase) start(ctx context.Context, procName string) {
 	ctx = ag.StartInternal(ctx, procName)
 	ag.input.Start(ctx)
-	ag.cancelChecker = cancelchecker.NewCancelChecker(ctx)
+	ag.cancelChecker.Reset(ctx)
 	ag.runningState = aggAccumulating
 }
 

--- a/pkg/sql/rowexec/hashjoiner.go
+++ b/pkg/sql/rowexec/hashjoiner.go
@@ -82,7 +82,7 @@ type hashJoiner struct {
 	}
 
 	// Context cancellation checker.
-	cancelChecker *cancelchecker.CancelChecker
+	cancelChecker cancelchecker.CancelChecker
 }
 
 var _ execinfra.Processor = &hashJoiner{}
@@ -161,7 +161,7 @@ func (h *hashJoiner) Start(ctx context.Context) {
 	ctx = h.StartInternal(ctx, hashJoinerProcName)
 	h.leftSource.Start(ctx)
 	h.rightSource.Start(ctx)
-	h.cancelChecker = cancelchecker.NewCancelChecker(ctx)
+	h.cancelChecker.Reset(ctx)
 	h.runningState = hjBuilding
 }
 

--- a/pkg/sql/rowexec/mergejoiner.go
+++ b/pkg/sql/rowexec/mergejoiner.go
@@ -30,7 +30,7 @@ import (
 type mergeJoiner struct {
 	joinerBase
 
-	cancelChecker *cancelchecker.CancelChecker
+	cancelChecker cancelchecker.CancelChecker
 
 	leftSource, rightSource execinfra.RowSource
 	leftRows, rightRows     []rowenc.EncDatumRow
@@ -117,7 +117,7 @@ func newMergeJoiner(
 func (m *mergeJoiner) Start(ctx context.Context) {
 	ctx = m.StartInternal(ctx, mergeJoinerProcName)
 	m.streamMerger.start(ctx)
-	m.cancelChecker = cancelchecker.NewCancelChecker(ctx)
+	m.cancelChecker.Reset(ctx)
 }
 
 // Next is part of the Processor interface.

--- a/pkg/sql/rowexec/project_set.go
+++ b/pkg/sql/rowexec/project_set.go
@@ -57,7 +57,7 @@ type projectSetProcessor struct {
 	// thus also whether NULLs should be emitted instead.
 	done []bool
 
-	cancelChecker *cancelchecker.CancelChecker
+	cancelChecker cancelchecker.CancelChecker
 }
 
 var _ execinfra.Processor = &projectSetProcessor{}
@@ -124,7 +124,7 @@ func newProjectSetProcessor(
 func (ps *projectSetProcessor) Start(ctx context.Context) {
 	ctx = ps.StartInternal(ctx, projectSetProcName)
 	ps.input.Start(ctx)
-	ps.cancelChecker = cancelchecker.NewCancelChecker(ctx)
+	ps.cancelChecker.Reset(ctx)
 }
 
 // nextInputRow returns the next row or metadata from ps.input. It also

--- a/pkg/sql/rowexec/windower.go
+++ b/pkg/sql/rowexec/windower.go
@@ -69,7 +69,7 @@ type windower struct {
 	diskMonitor  *mon.BytesMonitor
 
 	scratch       []byte
-	cancelChecker *cancelchecker.CancelChecker
+	cancelChecker cancelchecker.CancelChecker
 
 	partitionBy                []uint32
 	allRowsPartitioned         *rowcontainer.HashDiskBackedRowContainer
@@ -207,7 +207,7 @@ func newWindower(
 func (w *windower) Start(ctx context.Context) {
 	ctx = w.StartInternal(ctx, windowerProcName)
 	w.input.Start(ctx)
-	w.cancelChecker = cancelchecker.NewCancelChecker(ctx)
+	w.cancelChecker.Reset(ctx)
 	w.runningState = windowerAccumulating
 }
 

--- a/pkg/sql/rowexec/zigzagjoiner.go
+++ b/pkg/sql/rowexec/zigzagjoiner.go
@@ -229,7 +229,7 @@ import (
 type zigzagJoiner struct {
 	joinerBase
 
-	cancelChecker *cancelchecker.CancelChecker
+	cancelChecker cancelchecker.CancelChecker
 
 	// numTables stores the number of tables involved in the join.
 	numTables int
@@ -373,7 +373,7 @@ func valuesSpecToEncDatum(
 // Start is part of the RowSource interface.
 func (z *zigzagJoiner) Start(ctx context.Context) {
 	ctx = z.StartInternal(ctx, zigzagJoinerProcName)
-	z.cancelChecker = cancelchecker.NewCancelChecker(ctx)
+	z.cancelChecker.Reset(ctx)
 	log.VEventf(ctx, 2, "starting zigzag joiner run")
 }
 

--- a/pkg/util/cancelchecker/cancel_checker.go
+++ b/pkg/util/cancelchecker/cancel_checker.go
@@ -22,21 +22,14 @@ import (
 // has been canceled or not. Encapsulates all logic for waiting for cancelCheckInterval
 // rows before actually checking for cancellation. The cancellation check
 // has a significant time overhead, so it's not checked in every iteration.
+// TODO(yuzefovich): audit all processors to make sure that the ones that should
+// use the cancel checker actually do so.
 type CancelChecker struct {
 	// Reference to associated context to check.
 	ctx context.Context
 
 	// Number of times Check() has been called since last context cancellation check.
 	callsSinceLastCheck uint32
-}
-
-// NewCancelChecker returns a new CancelChecker.
-// TODO(yuzefovich): audit all processors to make sure that the ones that
-// should use the cancel checker actually do so.
-func NewCancelChecker(ctx context.Context) *CancelChecker {
-	return &CancelChecker{
-		ctx: ctx,
-	}
 }
 
 // Check returns an error if the associated query has been canceled.


### PR DESCRIPTION
See individual commits for details.

```
name                                          old time/op    new time/op    delta
FlowSetup/vectorize=true/distribute=true-24      283µs ± 9%     279µs ± 6%    ~     (p=0.316 n=29+30)
FlowSetup/vectorize=true/distribute=false-24     275µs ± 4%     273µs ± 6%    ~     (p=0.107 n=29+30)

name                                          old alloc/op   new alloc/op   delta
FlowSetup/vectorize=true/distribute=true-24     37.9kB ± 1%    37.9kB ± 1%    ~     (p=0.503 n=24+24)
FlowSetup/vectorize=true/distribute=false-24    36.1kB ± 1%    36.0kB ± 0%  -0.22%  (p=0.009 n=25+25)

name                                          old allocs/op  new allocs/op  delta
FlowSetup/vectorize=true/distribute=true-24        361 ± 0%       358 ± 0%  -0.81%  (p=0.000 n=25+26)
FlowSetup/vectorize=true/distribute=false-24       348 ± 1%       346 ± 1%  -0.84%  (p=0.000 n=28+28)
```