### PR TITLE
builtins: add uuid_generate_v4 builtin alias

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -711,6 +711,8 @@ has no relationship with the commit order of concurrent transactions.</p>
 </span></td></tr>
 <tr><td><a name="unique_rowid"></a><code>unique_rowid() &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Returns a unique ID used by CockroachDB to generate unique row IDs if a Primary Key isn’t defined for the table. The value is a combination of the insert timestamp and the ID of the node executing the statement, which guarantees this combination is globally unique. However, there can be gaps and the order is not completely guaranteed.</p>
 </span></td></tr>
+<tr><td><a name="uuid_generate_v4"></a><code>uuid_generate_v4() &rarr; <a href="uuid.html">uuid</a></code></td><td><span class="funcdesc"><p>Generates a random UUID and returns it as a value of UUID type.</p>
+</span></td></tr>
 <tr><td><a name="uuid_v4"></a><code>uuid_v4() &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Returns a UUID.</p>
 </span></td></tr></tbody>
 </table>

--- a/pkg/sql/logictest/testdata/logic_test/impure
+++ b/pkg/sql/logictest/testdata/logic_test/impure
@@ -34,27 +34,50 @@ SELECT count(*) FROM kab WHERE a=b
 0
 
 statement ok
+CREATE TABLE kabc (k INT PRIMARY KEY, a UUID, b UUID)
+
+statement ok
+INSERT INTO kabc VALUES (1, uuid_generate_v4(), uuid_generate_v4())
+
+statement ok
+INSERT INTO kabc VALUES (2, uuid_generate_v4(), uuid_generate_v4())
+
+statement ok
+INSERT INTO kabc VALUES (3, uuid_generate_v4(), uuid_generate_v4()),
+                       (4, uuid_generate_v4(), uuid_generate_v4()),
+                       (5, uuid_generate_v4(), uuid_generate_v4()),
+                       (6, uuid_generate_v4(), uuid_generate_v4())
+
+query I
+SELECT count(*) FROM kabc WHERE a=b
+----
+0
+
+statement ok
 CREATE TABLE kabcd (
   k INT PRIMARY KEY,
   a UUID,
   b UUID,
   c UUID DEFAULT gen_random_uuid(),
-  d UUID DEFAULT gen_random_uuid()
+  d UUID DEFAULT gen_random_uuid(),
+  e UUID DEFAULT uuid_generate_v4(),
+  f UUID DEFAULT uuid_generate_v4()
 )
 
 statement ok
-INSERT INTO kabcd VALUES (1, gen_random_uuid(), gen_random_uuid())
+INSERT INTO kabcd VALUES (1, gen_random_uuid(), uuid_generate_v4())
 
 statement ok
-INSERT INTO kabcd VALUES (2, gen_random_uuid(), gen_random_uuid())
+INSERT INTO kabcd VALUES (2, gen_random_uuid(), uuid_generate_v4())
 
 statement ok
-INSERT INTO kabcd VALUES (3, gen_random_uuid(), gen_random_uuid()),
-                         (4, gen_random_uuid(), gen_random_uuid()),
-                         (5, gen_random_uuid(), gen_random_uuid()),
-                         (6, gen_random_uuid(), gen_random_uuid())
+INSERT INTO kabcd VALUES (3, gen_random_uuid(), uuid_generate_v4()),
+                         (4, gen_random_uuid(), uuid_generate_v4()),
+                         (5, gen_random_uuid(), uuid_generate_v4()),
+                         (6, gen_random_uuid(), uuid_generate_v4())
 
 query I
-SELECT count(*) FROM kabcd WHERE a=b OR a=c OR a=d OR b=c OR b=d OR c=d
+SELECT count(*) FROM kabcd WHERE a=b OR a=c OR a=d OR a=e OR a=f
+OR b=c OR b=d OR b=e OR b=f OR c=d OR c=e OR c=f OR d=e OR d=f OR e=f
 ----
 0

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -551,21 +551,8 @@ var builtins = map[string]builtinDefinition{
 			Volatility: tree.VolatilityImmutable,
 		}),
 
-	"gen_random_uuid": makeBuiltin(
-		tree.FunctionProperties{
-			Category: categoryIDGeneration,
-		},
-		tree.Overload{
-			Types:      tree.ArgTypes{},
-			ReturnType: tree.FixedReturnType(types.Uuid),
-			Fn: func(_ *tree.EvalContext, _ tree.Datums) (tree.Datum, error) {
-				uv := uuid.MakeV4()
-				return tree.NewDUuid(tree.DUuid{UUID: uv}), nil
-			},
-			Info:       "Generates a random UUID and returns it as a value of UUID type.",
-			Volatility: tree.VolatilityVolatile,
-		},
-	),
+	"gen_random_uuid":  generateRandomUUIDImpl,
+	"uuid_generate_v4": generateRandomUUIDImpl,
 
 	"to_uuid": makeBuiltin(defProps(),
 		tree.Overload{
@@ -4737,6 +4724,22 @@ func getSubstringFromIndexOfLength(str, errMsg string, start, length int) (strin
 	}
 	return string(runes[start:end]), nil
 }
+
+var generateRandomUUIDImpl = makeBuiltin(
+	tree.FunctionProperties{
+		Category: categoryIDGeneration,
+	},
+	tree.Overload{
+		Types:      tree.ArgTypes{},
+		ReturnType: tree.FixedReturnType(types.Uuid),
+		Fn: func(_ *tree.EvalContext, _ tree.Datums) (tree.Datum, error) {
+			uv := uuid.MakeV4()
+			return tree.NewDUuid(tree.DUuid{UUID: uv}), nil
+		},
+		Info:       "Generates a random UUID and returns it as a value of UUID type.",
+		Volatility: tree.VolatilityVolatile,
+	},
+)
 
 var uuidV4Impl = makeBuiltin(
 	tree.FunctionProperties{


### PR DESCRIPTION
Closes https://github.com/cockroachdb/cockroach/issues/56014

Release note (sql change): The uuid_generate_v4() builtin
function was added. It works exactly like gen_random_uuid()
function but was added for compatbility with Postgres versions
older than PG13.