### PR TITLE
ui: fix hardware metric labels

### DIFF
--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/hardware.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/hardware.tsx
@@ -58,7 +58,7 @@ export default function (props: GraphDashboardProps) {
     </LineGraph>,
 
     <LineGraph
-      title="Disk Read Bytes"
+      title="Disk Read MiB/s"
       sources={nodeSources}
     >
       <Axis units={AxisUnits.Bytes} label="bytes">
@@ -74,7 +74,7 @@ export default function (props: GraphDashboardProps) {
     </LineGraph>,
 
     <LineGraph
-      title="Disk Write Bytes"
+      title="Disk Write MiB/s"
       sources={nodeSources}
     >
       <Axis units={AxisUnits.Bytes} label="bytes">
@@ -90,10 +90,10 @@ export default function (props: GraphDashboardProps) {
     </LineGraph>,
 
     <LineGraph
-      title="Disk Read Ops"
+      title="Disk Read IOPS"
       sources={nodeSources}
     >
-      <Axis units={AxisUnits.Count} label="Read Ops">
+      <Axis units={AxisUnits.Count} label="IOPS">
         {nodeIDs.map((nid) => (
           <Metric
             name="cr.node.sys.host.disk.read.count"
@@ -106,10 +106,10 @@ export default function (props: GraphDashboardProps) {
     </LineGraph>,
 
     <LineGraph
-      title="Disk Write Ops"
+      title="Disk Write IOPS"
       sources={nodeSources}
     >
-      <Axis units={AxisUnits.Count} label="Write Ops">
+      <Axis units={AxisUnits.Count} label="IOPS">
         {nodeIDs.map((nid) => (
           <Metric
             name="cr.node.sys.host.disk.write.count"
@@ -122,10 +122,10 @@ export default function (props: GraphDashboardProps) {
     </LineGraph>,
 
     <LineGraph
-      title="Disk IOPS In Progress"
+      title="Disk Ops In Progress"
       sources={nodeSources}
     >
-      <Axis units={AxisUnits.Count} label="IOPS">
+      <Axis units={AxisUnits.Count} label="Ops">
         {nodeIDs.map((nid) => (
           <Metric
             name="cr.node.sys.host.disk.iopsinprogress"


### PR DESCRIPTION
"Disk IOPS In Progress" => "Disk Ops In Progress", axis label => "OPS"
"Disk Read Ops" and "Disk Write Ops" => "Disk Read IOPS" and "Disk Write IOPS", axis label => "IOPS"
"Disk Read Bytes" and "Disk Write Bytes" => "Disk Read MB/s" and "Disk Write MiB/s"

Resolves: #48462

Release note (ui): update labels on hardware metrics page to be more accurate