### PR TITLE
release-20.2: server: Add sentry tag for encryption-at-rest

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -1241,9 +1242,13 @@ func (s *Server) Start(ctx context.Context) error {
 		listenHTTP:   s.cfg.HTTPAdvertiseAddr,
 	}.Iter()
 
+	encryptedStore := false
 	for _, storeSpec := range s.cfg.Stores.Specs {
 		if storeSpec.InMemory {
 			continue
+		}
+		if len(storeSpec.ExtraOptions) > 0 {
+			encryptedStore = true
 		}
 
 		for name, val := range listenerFiles {
@@ -1482,10 +1487,11 @@ func (s *Server) Start(ctx context.Context) error {
 
 	sentry.ConfigureScope(func(scope *sentry.Scope) {
 		scope.SetTags(map[string]string{
-			"cluster":     s.ClusterID().String(),
-			"node":        s.NodeID().String(),
-			"server_id":   fmt.Sprintf("%s-%s", s.ClusterID().Short(), s.NodeID()),
-			"engine_type": s.cfg.StorageEngine.String(),
+			"cluster":         s.ClusterID().String(),
+			"node":            s.NodeID().String(),
+			"server_id":       fmt.Sprintf("%s-%s", s.ClusterID().Short(), s.NodeID()),
+			"engine_type":     s.cfg.StorageEngine.String(),
+			"encrypted_store": strconv.FormatBool(encryptedStore),
 		})
 	})
 

--- a/pkg/util/log/crash_reporting_packet_test.go
+++ b/pkg/util/log/crash_reporting_packet_test.go
@@ -128,7 +128,7 @@ func TestCrashReportingPacket(t *testing.T) {
 		}(), []extraPair{
 			{"1: details", "panic: " + panicPre},
 		}},
-		{regexp.MustCompile(`^[a-z0-9]{8}-1$`), 11, func() string {
+		{regexp.MustCompile(`^[a-z0-9]{8}-1$`), 12, func() string {
 			message := prefix
 			// gccgo stack traces are different in the presence of function literals.
 			if runtime.Compiler == "gccgo" {


### PR DESCRIPTION
Backport 1/1 commits from #56962.

/cc @cockroachdb/release

---

Sometimes, storage-level issues can be specific to the use of
encryption-at-rest. This change helps us isolate these by setting
a sentry event tag on whether encryption-at-rest is enabled or not.

Release note: None.
