### PR TITLE
roachtest: skip jobs/mixed-version

### DIFF
--- a/pkg/cmd/roachtest/mixed_version_jobs.go
+++ b/pkg/cmd/roachtest/mixed_version_jobs.go
@@ -319,6 +319,7 @@ func registerJobsMixedVersions(r *testRegistry) {
 		// is to to test the state transitions of jobs from paused to resumed and
 		// vice versa in order to detect regressions in the work done for 20.1.
 		MinVersion: "v20.1.0",
+		Skip:       "https://github.com/cockroachdb/cockroach/issues/57230",
 		Cluster:    makeClusterSpec(4),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			predV, err := PredecessorVersion(r.buildVersion)


### PR DESCRIPTION
This test runs import in a mixed-version setting, which is known to be
not supported. This test is failing often enough that we're not getting
good signal from it.

Fixes https://github.com/cockroachdb/cockroach/issues/56038.

Release note: None