### PR TITLE
release-20.2: kvserver: avoid serving an unsafe string to log.Fatalf

### DIFF
--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -265,7 +265,7 @@ func (r *Replica) computeChecksumPostApply(ctx context.Context, cc kvserverpb.Co
 			_ = r.store.engine.MkdirAll(auxDir)
 			path := base.PreventedStartupFile(auxDir)
 
-			preventStartupMsg := fmt.Sprintf(`ATTENTION:
+			const attentionFmt = `ATTENTION:
 
 this node is terminating because a replica inconsistency was detected between %s
 and its other replicas. Please check your cluster-wide log files for more
@@ -277,8 +277,8 @@ A checkpoints directory to aid (expert) debugging should be present in:
 
 A file preventing this node from restarting was placed at:
 %s
-`, r, auxDir, path)
-
+`
+			preventStartupMsg := fmt.Sprintf(attentionFmt, r, auxDir, path)
 			if err := fs.WriteFile(r.store.engine, path, []byte(preventStartupMsg)); err != nil {
 				log.Warningf(ctx, "%v", err)
 			}
@@ -287,7 +287,7 @@ A file preventing this node from restarting was placed at:
 				p(*r.store.Ident)
 			} else {
 				time.Sleep(10 * time.Second)
-				log.Fatalf(r.AnnotateCtx(context.Background()), preventStartupMsg)
+				log.Fatalf(r.AnnotateCtx(context.Background()), attentionFmt, r, auxDir, path)
 			}
 		}
 


### PR DESCRIPTION
Backport 1/1 commits from #57242.

/cc @cockroachdb/release

---
