### PR TITLE
rowenc: de-flake TestEncodeContainingArrayInvertedIndexSpans

### DIFF
--- a/pkg/sql/rowenc/index_encoding_test.go
+++ b/pkg/sql/rowenc/index_encoding_test.go
@@ -533,7 +533,7 @@ func TestEncodeContainingArrayInvertedIndexSpans(t *testing.T) {
 		arr := right.(*tree.DArray).Array
 		expectUnique := len(arr) > 0
 		for i := range arr {
-			if i > 0 && !reflect.DeepEqual(arr[i], arr[0]) {
+			if i > 0 && arr[i].Compare(&evalCtx, arr[0]) != 0 {
 				expectUnique = false
 				break
 			}


### PR DESCRIPTION
`TestEncodeContainingArrayInvertedIndexSpans` was failing sporadically
because of randomized test cases that were incorrectly determining the
expected value for the `unique` return value from
`EncodeContainingInvertedIndexSpans`. The test was using the
`reflect.DeepEqual` function to check for `Datum` equality, which does
not return true in all cases where `Datum.Compare` returns `0`.

Fixes #57237

Release note: None