### PR TITLE
release-20.1: opt: don't hold on to evalCtx from detached Memo

### DIFF
--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -384,17 +384,29 @@ func (m *Memo) NextWithID() opt.WithID {
 	return m.curWithID
 }
 
-// ClearColStats clears all column statistics from every relational expression
-// in the memo. This is used to free up the potentially large amount of memory
-// used by histograms.
-func (m *Memo) ClearColStats(parent opt.Expr) {
-	for i, n := 0, parent.ChildCount(); i < n; i++ {
-		child := parent.Child(i)
-		m.ClearColStats(child)
-	}
+// Detach is used when we detach a memo that is to be reused later (either for
+// execbuilding or with AssignPlaceholders). New expressions should no longer be
+// constructed in this memo.
+func (m *Memo) Detach() {
+	m.interner = interner{}
+	// It is important to not hold on to the EvalCtx in the logicalPropsBuilder
+	// (#57059).
+	m.logPropsBuilder = logicalPropsBuilder{}
 
-	switch t := parent.(type) {
-	case RelExpr:
-		t.Relational().Stats.ColStats = props.ColStatsMap{}
+	// Clear all column statistics from every relational expression in the memo.
+	// This is used to free up the potentially large amount of memory used by
+	// histograms.
+	var clearColStats func(parent opt.Expr)
+	clearColStats = func(parent opt.Expr) {
+		for i, n := 0, parent.ChildCount(); i < n; i++ {
+			child := parent.Child(i)
+			clearColStats(child)
+		}
+
+		switch t := parent.(type) {
+		case RelExpr:
+			t.Relational().Stats.ColStats = props.ColStatsMap{}
+		}
 	}
+	clearColStats(m.RootExpr())
 }

--- a/pkg/sql/opt/norm/factory.go
+++ b/pkg/sql/opt/norm/factory.go
@@ -114,11 +114,11 @@ func (f *Factory) Init(evalCtx *tree.EvalContext, catalog cat.Catalog) {
 // placeholders are assigned. If there are no placeholders, there is no need
 // for column statistics, since the memo is already fully optimized.
 func (f *Factory) DetachMemo() *memo.Memo {
-	f.mem.ClearColStats(f.mem.RootExpr())
-	detach := f.mem
+	m := f.mem
 	f.mem = nil
+	m.Detach()
 	f.Init(f.evalCtx, nil /* catalog */)
-	return detach
+	return m
 }
 
 // DisableOptimizations disables all transformation rules. The unaltered input


### PR DESCRIPTION
Backport 1/1 commits from #57149.

/cc @cockroachdb/release

---

This change adds more "cleanup" code when detaching a Memo (a detached
memo is stored in the query cache and is reused later in a "read-only"
fashion). In particular, we clear the EvalContext in
logicalPropsBuilder which can lead to inadvertently holding on to a
lot of memory.

Fixes #57059.

Release note: None
