### PR TITLE
tree: block COLLATE "DEFAULT" from working during TypeCheck

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/collatedstring
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring
@@ -474,3 +474,6 @@ SELECT s FROM nocase_strings WHERE s = ('bbb' COLLATE "en-us-u-ks-l""evel2")
 
 statement error at or near "evel2": syntax error
 SELECT s FROM nocase_strings WHERE s = ('bbb' COLLATE "en-us-u-ks-l"evel2")
+
+statement error DEFAULT collations are not supported
+SELECT 'default collate'::text collate "default"

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -575,6 +575,15 @@ func (expr *AnnotateTypeExpr) TypeCheck(
 func (expr *CollateExpr) TypeCheck(
 	ctx context.Context, semaCtx *SemaContext, desired *types.T,
 ) (TypedExpr, error) {
+	if strings.ToLower(expr.Locale) == DefaultCollationTag {
+		return nil, errors.WithHint(
+			unimplemented.NewWithIssuef(
+				57255,
+				"DEFAULT collations are not supported",
+			),
+			`omit the 'COLLATE "default"' clause in your statement`,
+		)
+	}
 	_, err := language.Parse(expr.Locale)
 	if err != nil {
 		return nil, pgerror.Wrapf(err, pgcode.InvalidParameterValue,


### PR DESCRIPTION
Release note (sql change): In 21.1, we introduced DEFAULT collation
types, which behave correctly as column definitions. However, getting
COLLATE to work as a value (e.g. `SELECT a::text COLLATE "default"`) is
trickier to make work as it involves a complex change to our type
system. This now returns an unimplemented error pointing to #57255.