### PR TITLE
sql: raise error if opaque statement receives nil plan node

### DIFF
--- a/pkg/sql/opaque.go
+++ b/pkg/sql/opaque.go
@@ -187,6 +187,9 @@ func buildOpaque(
 	if err != nil {
 		return nil, err
 	}
+	if plan == nil {
+		return nil, errors.AssertionFailedf("planNode cannot be nil for %T", stmt)
+	}
 	res := &opaqueMetadata{
 		info:    stmt.StatementTag(),
 		plan:    plan,


### PR DESCRIPTION
Addresses #56861.

Previously there was no check for a situation in which a planNode
was nil. For opaque statements, this  resulted in occasional panics
when a nil planNode was returned. This commit adds a check for
opaque statements to make sure the planNode is not nil before
moving on to execution.

Release note: None