### PR TITLE
sql,colexec: minor cleanup of scan-related things

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -965,7 +965,7 @@ func getIndexIdx(index *descpb.IndexDescriptor, desc *tabledesc.Immutable) (uint
 // initTableReaderSpec initializes a TableReaderSpec/PostProcessSpec that
 // corresponds to a scanNode, except for the Spans and OutputColumns.
 func initTableReaderSpec(
-	n *scanNode, planCtx *PlanningCtx, indexVarMap []int,
+	n *scanNode,
 ) (*execinfrapb.TableReaderSpec, execinfrapb.PostProcessSpec, error) {
 	s := physicalplan.NewTableReaderSpec()
 	*s = execinfrapb.TableReaderSpec{
@@ -1013,8 +1013,9 @@ func tableOrdinal(
 	}
 	if visibility == execinfra.ScanVisibilityPublicAndNotPublic {
 		offset := len(desc.Columns)
-		for i, col := range desc.MutationColumns() {
-			if col.ID == colID {
+		mutationColumns := desc.MutationColumns()
+		for i := range mutationColumns {
+			if mutationColumns[i].ID == colID {
 				return offset + i
 			}
 		}
@@ -1156,7 +1157,6 @@ func (dsp *DistSQLPlanner) CheckNodeHealthAndVersion(
 
 // createTableReaders generates a plan consisting of table reader processors,
 // one for each node that has spans that we are reading.
-// overridesResultColumns is optional.
 func (dsp *DistSQLPlanner) createTableReaders(
 	planCtx *PlanningCtx, n *scanNode,
 ) (*PhysicalPlan, error) {
@@ -1166,7 +1166,7 @@ func (dsp *DistSQLPlanner) createTableReaders(
 	// scanNodeToTableOrdinalMap is a map from scan node column ordinal to
 	// table reader column ordinal.
 	scanNodeToTableOrdinalMap := toTableOrdinals(n.cols, n.desc, n.colCfg.visibility)
-	spec, post, err := initTableReaderSpec(n, planCtx, scanNodeToTableOrdinalMap)
+	spec, post, err := initTableReaderSpec(n)
 	if err != nil {
 		return nil, err
 	}
@@ -1285,8 +1285,9 @@ func (dsp *DistSQLPlanner) planTableReaders(
 		typs = append(typs, info.desc.Columns[i].Type)
 	}
 	if returnMutations {
-		for _, col := range info.desc.MutationColumns() {
-			typs = append(typs, col.Type)
+		mutationColumns := info.desc.MutationColumns()
+		for i := range mutationColumns {
+			typs = append(typs, mutationColumns[i].Type)
 		}
 	}
 	if info.containsSystemColumns {
@@ -1308,8 +1309,9 @@ func (dsp *DistSQLPlanner) planTableReaders(
 		colID++
 	}
 	if returnMutations {
-		for _, c := range info.desc.MutationColumns() {
-			descColumnIDs.Set(colID, int(c.ID))
+		mutationColumns := info.desc.MutationColumns()
+		for i := range mutationColumns {
+			descColumnIDs.Set(colID, int(mutationColumns[i].ID))
 			colID++
 		}
 	}

--- a/pkg/sql/distsql_plan_scrub_physical.go
+++ b/pkg/sql/distsql_plan_scrub_physical.go
@@ -11,11 +11,9 @@
 package sql
 
 import (
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/physicalplan"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowexec"
-	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 )
 
 // createScrubPhysicalCheck generates a plan for running a physical
@@ -24,13 +22,9 @@ import (
 // TableReaders will only emit errors encountered during scanning
 // instead of row data. The plan is finalized.
 func (dsp *DistSQLPlanner) createScrubPhysicalCheck(
-	planCtx *PlanningCtx,
-	n *scanNode,
-	desc descpb.TableDescriptor,
-	indexDesc descpb.IndexDescriptor,
-	readAsOf hlc.Timestamp,
+	planCtx *PlanningCtx, n *scanNode,
 ) (*PhysicalPlan, error) {
-	spec, _, err := initTableReaderSpec(n, planCtx, nil /* indexVarMap */)
+	spec, _, err := initTableReaderSpec(n)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/distsql_plan_stats.go
+++ b/pkg/sql/distsql_plan_stats.go
@@ -80,6 +80,10 @@ func (dsp *DistSQLPlanner) createStatsPlan(
 	if err != nil {
 		return nil, err
 	}
+	var colIdxMap catalog.TableColMap
+	for i, c := range scan.cols {
+		colIdxMap.Set(c.ID, i)
+	}
 	sb := span.MakeBuilder(planCtx.EvalContext(), planCtx.ExtendedEvalCtx.Codec, desc, scan.index)
 	scan.spans, err = sb.UnconstrainedSpans()
 	if err != nil {
@@ -112,7 +116,7 @@ func (dsp *DistSQLPlanner) createStatsPlan(
 			StatName:            s.name,
 		}
 		for i, colID := range s.columns {
-			colIdx, ok := scan.colIdxMap.Get(colID)
+			colIdx, ok := colIdxMap.Get(colID)
 			if !ok {
 				panic("necessary column not scanned")
 			}

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -15,7 +15,6 @@ import (
 	"sync"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
@@ -63,9 +62,6 @@ type scanNode struct {
 	cols []*descpb.ColumnDescriptor
 	// There is a 1-1 correspondence between cols and resultColumns.
 	resultColumns colinfo.ResultColumns
-
-	// Map used to get the index for columns in cols.
-	colIdxMap catalog.TableColMap
 
 	spans   []roachpb.Span
 	reverse bool
@@ -329,8 +325,5 @@ func (n *scanNode) initDescDefaults(colCfg scanColumnsConfig) error {
 
 	// Set up the rest of the scanNode.
 	n.resultColumns = colinfo.ResultColumnsFromColDescPtrs(n.desc.GetID(), n.cols)
-	for i, c := range n.cols {
-		n.colIdxMap.Set(c.ID, i)
-	}
 	return nil
 }

--- a/pkg/sql/scrub_physical.go
+++ b/pkg/sql/scrub_physical.go
@@ -124,8 +124,7 @@ func (o *physicalCheckOperation) Start(params runParams) error {
 	// that scrubNode needs to perform, we need to make sure that scrubNode
 	// is not closed when this physical check operation is being cleaned up.
 	planCtx.ignoreClose = true
-	physPlan, err := params.extendedEvalCtx.DistSQLPlanner.createScrubPhysicalCheck(
-		planCtx, scan, *o.tableDesc.TableDesc(), *o.indexDesc, params.p.ExecCfg().Clock.Now())
+	physPlan, err := params.extendedEvalCtx.DistSQLPlanner.createScrubPhysicalCheck(planCtx, scan)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This commit removes multiple arguments in favor of using the spec when
initializing the cFetcher as well as refactors several loops in order to
avoid making copies of descriptors during table reader planning.

Additionally, it moves a map from scanNode next to the map's only user
(stats job) and removes the map from the scanNode itself as well as
removes some of the unused arguments.

Release note: None