### PR TITLE
logictest: test multi-column inverted indexes

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/inverted_index_multi_column
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index_multi_column
@@ -63,6 +63,48 @@ CREATE TABLE public.s (
    FAMILY fam_2_geom (geom)
 )
 
+# Dropping the inverted column of the index drops the index.
+statement ok
+CREATE TABLE drop_j (
+  a INT,
+  b INT,
+  j JSON,
+  INVERTED INDEX (a, j),
+  INVERTED INDEX (b, a, j),
+  FAMILY (a, b, j)
+);
+ALTER TABLE drop_j DROP COLUMN j;
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE drop_j]
+----
+CREATE TABLE public.drop_j (
+   a INT8 NULL,
+   b INT8 NULL,
+   FAMILY fam_0_a_b_j_rowid (a, b, rowid)
+)
+
+# Dropping the non-inverted column of the index drops the index.
+statement ok
+CREATE TABLE drop_a (
+  a INT,
+  b INT,
+  j JSON,
+  INVERTED INDEX (a, j),
+  INVERTED INDEX (b, a, j),
+  FAMILY (a, b, j)
+);
+ALTER TABLE drop_a DROP COLUMN a;
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE drop_a]
+----
+CREATE TABLE public.drop_a (
+   b INT8 NULL,
+   j JSONB NULL,
+   FAMILY fam_0_a_b_j_rowid (b, j, rowid)
+)
+
 # Backfill a multi-column inverted index.
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/inverted_index_multi_column
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index_multi_column
@@ -105,6 +105,23 @@ CREATE TABLE public.drop_a (
    FAMILY fam_0_a_b_j_rowid (b, j, rowid)
 )
 
+# CREATE TABLE LIKE ... INCLUDING INDEXES copies multi-column inverted indexes.
+statement ok
+CREATE TABLE src (a INT, b INT, j JSON, INVERTED INDEX (a, j), INVERTED INDEX (a, b, j));
+CREATE TABLE dst (LIKE src INCLUDING INDEXES);
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE dst]
+----
+CREATE TABLE public.dst (
+   a INT8 NULL,
+   b INT8 NULL,
+   j JSONB NULL,
+   INVERTED INDEX src_a_j_idx (a, j),
+   INVERTED INDEX src_a_b_j_idx (a, b, j),
+   FAMILY "primary" (a, b, j, rowid)
+)
+
 # Backfill a multi-column inverted index.
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/inverted_index_multi_column
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index_multi_column
@@ -122,6 +122,103 @@ CREATE TABLE public.dst (
    FAMILY "primary" (a, b, j, rowid)
 )
 
+# Test dropping a table with a multi-column inverted index.
+statement ok
+CREATE TABLE t (i INT, s STRING, j JSON, INVERTED INDEX (i, s, j));
+DROP TABLE t;
+
+# Test selecting, inserting, updating, and deleting on a table with a
+# multi-column inverted index.
+statement ok
+CREATE TABLE t (
+  i INT,
+  s STRING,
+  j JSON,
+  INVERTED INDEX idx (i, s, j)
+)
+
+statement ok
+INSERT INTO t VALUES
+    (1, 'foo', '{"x": "y", "num": 1}'),
+    (2, 'bar', '{"x": "y", "num": 2}'),
+    (3, 'baz', '{"x": "y", "num": 3}')
+
+query ITT
+SELECT * FROM t@idx WHERE i IN (1, 2, 3) AND s = 'foo' AND j @> '{"x": "y"}'
+----
+1  foo  {"num": 1, "x": "y"}
+
+query ITT
+SELECT * FROM t@idx WHERE i = 1 AND s IN ('foo', 'bar') AND j @> '{"x": "y"}'
+----
+1  foo  {"num": 1, "x": "y"}
+
+query ITT
+SELECT * FROM t@idx WHERE i IN (1, 2, 3) AND s IN ('foo', 'bar') AND j @> '{"num": 1}'
+----
+1  foo  {"num": 1, "x": "y"}
+
+query ITT
+SELECT * FROM t@idx WHERE i IN (1, 2, 3) AND s IN ('foo', 'baz') AND j @> '{"x": "y"}' ORDER BY i
+----
+1  foo  {"num": 1, "x": "y"}
+3  baz  {"num": 3, "x": "y"}
+
+# Delete a row.
+statement ok
+DELETE FROM t WHERE i = 3
+
+query ITT
+SELECT * FROM t@idx WHERE i IN (1, 2, 3) AND s IN ('foo', 'baz') AND j @> '{"x": "y"}'
+----
+1  foo  {"num": 1, "x": "y"}
+
+# Update the JSON column of a row.
+statement ok
+UPDATE t SET j = '{"x": "y", "num": 10}' WHERE i = 1
+
+query ITT
+SELECT * FROM t@idx WHERE i IN (1, 2, 3) AND s = 'foo' AND j @> '{"num": 10}'
+----
+1  foo  {"num": 10, "x": "y"}
+
+# Update the non-inverted prefix columns of rows.
+statement ok
+UPDATE t SET i = 10 WHERE i = 1;
+UPDATE t SET s = 'bar' WHERE i = 2;
+
+query ITT
+SELECT * FROM t@idx WHERE i IN (2, 10) AND s IN ('foo', 'bar') AND j @> '{"x": "y"}' ORDER BY i
+----
+2   bar  {"num": 2, "x": "y"}
+10  foo  {"num": 10, "x": "y"}
+
+# Upsert a non-conflicting row.
+statement ok
+UPSERT INTO t VALUES (3, 'bar', '{"x": "y", "num": 3}')
+
+query ITT
+SELECT * FROM t@idx WHERE i IN (1, 2, 3) AND s = 'bar' AND j @> '{"x": "y"}' ORDER BY i
+----
+2  bar  {"num": 2, "x": "y"}
+3  bar  {"num": 3, "x": "y"}
+
+# Upsert a conflicting row with a different JSON value.
+statement ok
+UPSERT INTO t VALUES (3, 'bar', '{"x": "y", "num": 4}')
+
+query ITT
+SELECT * FROM t@idx WHERE i IN (1, 2, 3) AND s = 'bar' AND j @> '{"num": 4}'
+----
+3  bar  {"num": 4, "x": "y"}
+
+# The non-inverted prefix columns must be constrained in order to use the index.
+statement error index "idx" is inverted and cannot be used for this query
+SELECT * FROM t@idx WHERE i = 1 AND j @> '{"num": 2}'
+
+statement error index "idx" is inverted and cannot be used for this query
+SELECT * FROM t@idx WHERE s = 'foo' AND j @> '{"num": 2}'
+
 # Backfill a multi-column inverted index.
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/partial_index
+++ b/pkg/sql/logictest/testdata/logic_test/partial_index
@@ -1343,9 +1343,10 @@ SELECT * FROM t52702@t52702_false WHERE 1 = 2;
 SELECT * FROM t52702@t52702_false WHERE 's' = 't';
 SELECT * FROM t52702@t52702_false WHERE false;
 
-# Regression test for #53922. Do not build function dependency keys from partial
-# indexes. This causes incorrect results. For example, the optimizer could
-# incorrectly remove distinct operators if it thinks the column is a strict key.
+# Regression test for #53922. Do not build functional dependency keys from
+# partial indexes. This causes incorrect results. For example, the optimizer
+# could incorrectly remove distinct operators if it thinks the column is a
+# strict key.
 subtest regression_53922
 
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index_multi_column
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index_multi_column
@@ -15,6 +15,21 @@ CREATE TABLE t (
 )
 
 query T kvtrace
+SELECT k FROM t WHERE i = 10 AND j @> '1'
+----
+Scan /Table/53/2/10/1{-/PrefixEnd}, /Table/53/2/10/Arr/1{-/PrefixEnd}
+
+query T kvtrace
+SELECT k FROM t WHERE i = 10 AND s = 'foo' AND j @> '1'
+----
+Scan /Table/53/3/10/"foo"/1{-/PrefixEnd}, /Table/53/3/10/"foo"/Arr/1{-/PrefixEnd}
+
+query T kvtrace
+SELECT k FROM t WHERE i = 10 AND s = 'foo' AND j @> '{"a": "b"}'
+----
+Scan /Table/53/3/10/"foo"/"a"/"b"{-/PrefixEnd}
+
+query T kvtrace
 INSERT INTO t VALUES (1, 333, 'foo', '{"a": "b"}'::json)
 ----
 CPut /Table/53/1/1/0 -> /TUPLE/2:2:Int/333/1:3:Bytes/foo/


### PR DESCRIPTION
#### logictest: test dropping columns from tables with multi-col inverted indexes

Release note: None

#### logictest: test CREATE TABLE LIKE from table with multi-col inverted indexes

Release note: None

#### logictest: test mutating tables with multi-col inverted indexes

Release note: None
