### PR TITLE
lease: add logging for questionable descriptors

### DIFF
--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -16,6 +16,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"runtime/debug"
 	"sort"
 	"strings"
 	"sync"
@@ -1644,6 +1645,11 @@ func (m *Manager) findDescriptorState(id descpb.ID, create bool) *descriptorStat
 	t := m.mu.descriptors[id]
 	if t == nil && create {
 		t = &descriptorState{id: id, stopper: m.stopper}
+		if id >= 4294867200 {
+			stack := debug.Stack()
+			log.Warningf(context.TODO(), "adding questionable descriptor %d to lease manager: %v %s",
+				id, t, string(stack))
+		}
 		m.mu.descriptors[id] = t
 	}
 	return t


### PR DESCRIPTION
This is meant to be temporary until we discover the cause of #55290.

Release note: None