### PR TITLE
roachtest: Add missing gossiped StoreDescriptor to expected relocate errors

### DIFF
--- a/pkg/kv/test_utils.go
+++ b/pkg/kv/test_utils.go
@@ -38,7 +38,6 @@ func OnlyFollowerReads(rec tracing.Recording) bool {
 // IsExpectedRelocateError maintains an allowlist of errors related to
 // atomic-replication-changes we want to ignore / retry on for tests.
 // See:
-// https://github.com/cockroachdb/cockroach/issues/33732
 // https://github.com/cockroachdb/cockroach/issues/33708
 // https://github.cm/cockroachdb/cockroach/issues/34012
 // https://github.com/cockroachdb/cockroach/issues/33683#issuecomment-454889149
@@ -53,6 +52,7 @@ func IsExpectedRelocateError(err error) bool {
 		"snapshot failed:",
 		"breaker open",
 		"unable to select removal target", // https://github.com/cockroachdb/cockroach/issues/49513
+		"cannot up-replicate to .*; missing gossiped StoreDescriptor",
 	}
 	pattern := "(" + strings.Join(allowlist, "|") + ")"
 	return testutils.IsError(err, pattern)


### PR DESCRIPTION
Closes #57191.

This seems possible shortly after the cluster starts up, if gossip hasn't propagated by the time the `ALTER TABLE _ EXPERIMENTAL_RELOCATE _` statement is run.