### PR TITLE
tracing: remove unnecessary optimization

### DIFF
--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -159,27 +159,6 @@ func (t *Tracer) getShadowTracer() *shadowTracer {
 
 // StartSpan starts a Span. See SpanOption for details.
 func (t *Tracer) StartSpan(operationName string, os ...SpanOption) *Span {
-	// Fast paths to avoid the allocation of StartSpanOptions below when tracing
-	// is disabled: if we have no options or a single SpanReference (the common
-	// case) with a black hole span, return a noop Span now.
-	if !t.AlwaysTrace() {
-		if len(os) == 1 {
-			switch o := os[0].(type) {
-			case *parentAndAutoCollectionOption:
-				if (*Span)(o).IsBlackHole() {
-					return t.noopSpan
-				}
-			case *parentAndManualCollectionOption:
-				if (*SpanMeta)(o).isNilOrNoop() {
-					return t.noopSpan
-				}
-			}
-		}
-		if len(os) == 0 {
-			return t.noopSpan
-		}
-	}
-
 	// NB: apply takes and returns a value to avoid forcing
 	// `opts` on the heap here.
 	var opts spanOptions


### PR DESCRIPTION
`StartSpan` was bailing out early if it was asked to derive from
a non-recording parent, but `startSpanGeneric` already handles
that optimally, as I verified via

```
$ go test -benchtime 1000x -bench
'BenchmarkScan/MultinodeCockroach/count=1$/limit=1$' -memprofilerate 1
-memprofile mem.prof ./pkg/bench/
```

and inspecting the resulting memory profile. This showed that the
allocations in `startSpanGeneric` are all from
`sql.(*txnState).resetForNewSQLTxn`, which always wants a real `*Span`.

Release note: None
