### PR TITLE
tracing: allow background tracing via trace.mode cluster

### DIFF
--- a/pkg/util/tracing/span.go
+++ b/pkg/util/tracing/span.go
@@ -14,6 +14,7 @@ import (
 	"bytes"
 	"fmt"
 	"sort"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -289,13 +290,19 @@ func (s *crdbSpan) disableRecording() {
 // enabled. This can be called while spans that are part of the recording are
 // still open; it can run concurrently with operations on those spans.
 func (s *Span) GetRecording() Recording {
-	return s.crdb.getRecording()
+	return s.crdb.getRecording(s.tracer.mode())
 }
 
-func (s *crdbSpan) getRecording() Recording {
-	if s.recordingType() == RecordingOff {
-		// TODO(tbg): is this desired? If a span is not currently recording,
-		// it can still hold a recording.
+func (s *crdbSpan) getRecording(m mode) Recording {
+	if s == nil {
+		return nil
+	}
+	if m == modeLegacy && s.recordingType() == RecordingOff {
+		// In legacy tracing (pre always-on), we avoid allocations when the
+		// Span is not actively recording.
+		//
+		// TODO(tbg): we could consider doing the same when background tracing
+		// is on but the current span contains "nothing of interest".
 		return nil
 	}
 	s.mu.Lock()
@@ -304,34 +311,56 @@ func (s *crdbSpan) getRecording() Recording {
 	result := make(Recording, 0, 1+len(s.mu.recording.children)+len(s.mu.recording.remoteSpans))
 	// Shallow-copy the children so we can process them without the lock.
 	children := s.mu.recording.children
-	result = append(result, s.getRecordingLocked())
+	result = append(result, s.getRecordingLocked(m))
 	result = append(result, s.mu.recording.remoteSpans...)
 	s.mu.Unlock()
 
 	for _, child := range children {
-		result = append(result, child.getRecording()...)
+		result = append(result, child.getRecording(m)...)
 	}
 
 	// Sort the spans by StartTime, except the first Span (the root of this
 	// recording) which stays in place.
-	toSort := result[1:]
-	sort.Slice(toSort, func(i, j int) bool {
-		return toSort[i].StartTime.Before(toSort[j].StartTime)
-	})
+	toSort := sortPool.Get().(*Recording) // avoids allocations in sort.Sort
+	*toSort = result[1:]
+	sort.Sort(toSort)
+	*toSort = nil
+	sortPool.Put(toSort)
 	return result
+}
+
+var sortPool = sync.Pool{
+	New: func() interface{} {
+		return &Recording{}
+	},
+}
+
+// Less implements sort.Interface.
+func (r Recording) Less(i, j int) bool {
+	return r[i].StartTime.Before(r[j].StartTime)
+}
+
+// Swap implements sort.Interface.
+func (r Recording) Swap(i, j int) {
+	r[i], r[j] = r[j], r[i]
+}
+
+// Len implements sort.Interface.
+func (r Recording) Len() int {
+	return len(r)
 }
 
 // ImportRemoteSpans adds RecordedSpan data to the recording of the given Span;
 // these spans will be part of the result of GetRecording. Used to import
 // recorded traces from other nodes.
 func (s *Span) ImportRemoteSpans(remoteSpans []tracingpb.RecordedSpan) error {
+	if s.tracer.mode() == modeLegacy && s.crdb.recordingType() == RecordingOff {
+		return nil
+	}
 	return s.crdb.ImportRemoteSpans(remoteSpans)
 }
 
 func (s *crdbSpan) ImportRemoteSpans(remoteSpans []tracingpb.RecordedSpan) error {
-	if s.recordingType() == RecordingOff {
-		return errors.AssertionFailedf("adding Raw Spans to a Span that isn't recording")
-	}
 	// Change the root of the remote recording to be a child of this Span. This is
 	// usually already the case, except with DistSQL traces where remote
 	// processors run in spans that FollowFrom an RPC Span that we don't collect.
@@ -600,7 +629,7 @@ func (s *Span) Tracer() *Tracer {
 
 // getRecordingLocked returns the Span's recording. This does not include
 // children.
-func (s *crdbSpan) getRecordingLocked() tracingpb.RecordedSpan {
+func (s *crdbSpan) getRecordingLocked(m mode) tracingpb.RecordedSpan {
 	rs := tracingpb.RecordedSpan{
 		TraceID:      s.traceID,
 		SpanID:       s.spanID,
@@ -617,15 +646,20 @@ func (s *crdbSpan) getRecordingLocked() tracingpb.RecordedSpan {
 		rs.Tags[k] = v
 	}
 
-	if rs.Duration == -1 {
-		// -1 indicates an unfinished Span. For a recording it's better to put some
-		// duration in it, otherwise tools get confused. For example, we export
-		// recordings to Jaeger, and spans with a zero duration don't look nice.
-		rs.Duration = timeutil.Now().Sub(rs.StartTime)
-		addTag("_unfinished", "1")
-	}
-	if s.mu.recording.recordingType.load() == RecordingVerbose {
-		addTag("_verbose", "1")
+	// When nobody is configured to see our spans, skip some allocations
+	// related to Span UX improvements.
+	onlyBackgroundTracing := m == modeBackground && s.recordingType() == RecordingOff
+	if !onlyBackgroundTracing {
+		if rs.Duration == -1 {
+			// -1 indicates an unfinished Span. For a recording it's better to put some
+			// duration in it, otherwise tools get confused. For example, we export
+			// recordings to Jaeger, and spans with a zero duration don't look nice.
+			rs.Duration = timeutil.Now().Sub(rs.StartTime)
+			addTag("_unfinished", "1")
+		}
+		if s.mu.recording.recordingType.load() == RecordingVerbose {
+			addTag("_verbose", "1")
+		}
 	}
 
 	if s.mu.stats != nil {
@@ -642,7 +676,7 @@ func (s *crdbSpan) getRecordingLocked() tracingpb.RecordedSpan {
 			rs.Baggage[k] = v
 		}
 	}
-	if s.logTags != nil {
+	if !onlyBackgroundTracing && s.logTags != nil {
 		setLogTags(s.logTags.Get(), func(remappedKey string, tag *logtags.Tag) {
 			addTag(remappedKey, tag.ValueStr())
 		})

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -53,6 +53,44 @@ const (
 	fieldNameShadowType = prefixTracerState + "shadowtype"
 )
 
+type mode int32
+
+const (
+	modeLegacy mode = iota
+	modeBackground
+)
+
+// tracingMode informs the creation of noop spans
+// and the default recording mode of created spans.
+var tracingMode = settings.RegisterEnumSetting(
+	"trace.mode",
+	`configures the CockroachDB-internal tracing subsystem.
+
+If set to 'background', trace spans will be created for all operations, but
+these trace spans will only be recording sparse structured information,
+unless an operation explicitly requests verbose recording. This is
+optimized for low overhead, and powers fine-grained statistics and alerts.
+
+If set to 'legacy', trace spans will not be created (unless an
+auxiliary tracer such as Lightstep or Zipkin, is configured, or an
+internal code path explicitly requests a trace to be created) but
+when they are, they record verbose information. This has two effects:
+the observability of the cluster may be degraded (as some trace spans
+are elided) and where trace spans are created, they may consume large
+amounts of memory. This mode should not be used with auxiliary tracing
+sinks as that leads to expensive trace spans being created throughout.
+
+Note that regardless of this setting, configuring an auxiliary
+trace sink will cause verbose traces to be created for all
+operations, which may lead to high memory consumption. It is not
+currently possible to send non-verbose traces to auxiliary sinks.
+`,
+	"legacy",
+	map[int64]string{
+		int64(modeLegacy):     "legacy",
+		int64(modeBackground): "background",
+	})
+
 var enableNetTrace = settings.RegisterBoolSetting(
 	"trace.debug.enable",
 	"if set, traces for recent requests can be seen at https://<ui>/debug/requests",
@@ -94,6 +132,8 @@ type Tracer struct {
 	// x/net/trace or lightstep and we are not recording.
 	noopSpan *Span
 
+	_mode int32 // modeLegacy or modeBackground, accessed atomically
+
 	// True if tracing to the debug/requests endpoint. Accessed via t.useNetTrace().
 	_useNetTrace int32 // updated atomically
 
@@ -114,6 +154,7 @@ func NewTracer() *Tracer {
 // it updated if they change).
 func (t *Tracer) Configure(sv *settings.Values) {
 	reconfigure := func() {
+		atomic.StoreInt32(&t._mode, int32(tracingMode.Get(sv)))
 		if lsToken := lightstepToken.Get(sv); lsToken != "" {
 			t.setShadowTracer(createLightStepTracer(lsToken))
 		} else if zipkinAddr := zipkinCollector.Get(sv); zipkinAddr != "" {
@@ -174,6 +215,10 @@ func (t *Tracer) StartSpan(operationName string, os ...SpanOption) *Span {
 	return t.startSpanGeneric(operationName, opts)
 }
 
+func (t *Tracer) mode() mode {
+	return mode(atomic.LoadInt32(&t._mode))
+}
+
 // AlwaysTrace returns true if operations should be traced regardless of the
 // context.
 func (t *Tracer) AlwaysTrace() bool {
@@ -191,6 +236,10 @@ func (t *Tracer) startSpanGeneric(opName string, opts spanOptions) *Span {
 		if opts.RemoteParent != nil {
 			panic("can't specify both Parent and RemoteParent")
 		}
+	}
+
+	if t.mode() == modeBackground {
+		opts.ForceRealSpan = true
 	}
 
 	// Avoid creating a real span when possible. If tracing is globally


### PR DESCRIPTION
When `trace.mode` is set to `background`, our tracer

1. never creates noop spans
2. always returns a recording from `GetRecording()`

The recording in 2) is usually only minimally populated as
the spans are not automatically put in verbose mode.

This is introduced as a cluster setting now for ease of perf optimizing,
which will be necessary if we want to make background tracing the
default, as well to introducing structured metadata (#55584) and
testing. The hope is that we can remove it before the release;
it's not marked as public.

Relates to #55584.

Release note: None