### PR TITLE
sqlproxyccl: close proxy connections properly

### DIFF
--- a/pkg/ccl/sqlproxyccl/server.go
+++ b/pkg/ccl/sqlproxyccl/server.go
@@ -147,13 +147,13 @@ func (s *Server) Serve(ln net.Listener) error {
 
 		go func() {
 			s.metrics.CurConnCount.Inc(1)
-			defer func() { _ = conn.Close() }()
 			defer s.metrics.CurConnCount.Dec(1)
 			tBegin := timeutil.Now()
-			log.Infof(context.Background(), "handling client %s", conn.RemoteAddr())
+			remoteAddr := conn.RemoteAddr()
+			log.Infof(context.Background(), "handling client %s", remoteAddr)
 			err := s.Proxy(conn)
 			log.Infof(context.Background(), "client %s disconnected after %.2fs: %v",
-				conn.RemoteAddr(), timeutil.Since(tBegin).Seconds(), err)
+				remoteAddr, timeutil.Since(tBegin).Seconds(), err)
 		}()
 	}
 }


### PR DESCRIPTION
Issue:
The sqlproxy opens a connection to the client and backend and proxies
data between them. The backend connection is never closed. Moreover the
client connection in certain situations may not be closed properly as
well because it may be embedded in a tls connection whose `Close`
method will never be called.

Details:
Proxy connection to the client is closed in `func (s *Server) Serve`
https://github.com/cockroachdb/cockroach/blob/master/pkg/ccl/sqlproxyccl/server.go#L149
However the client connection, if the proxy is using TLS, is further
embedded in `tls.Conn` in func (s *Server) Proxy here
https://github.com/cockroachdb/cockroach/blob/master/pkg/ccl/sqlproxyccl/proxy.go#L117.
`tls.Conn` has a more involved `Close` implementation which will not be
called; see https://golang.org/src/crypto/tls/conn.go. In particular,
readers/writers on this connection may not be notified of the connection
closure potentially leading to never exiting the go routines at
https://github.com/cockroachdb/cockroach/blob/master/pkg/ccl/sqlproxyccl/proxy.go#L204.

Note that this fix does not prevent another party from calling `Close`
on `proxyConn` which may lead again to `tls.Conn Close` not being
called when then proxy is using TLS.

Release note: none.