### PR TITLE
sql: show EXPLAIN ANALYZE plan stats in bundle

### DIFF
--- a/pkg/sql/explain_tree_test.go
+++ b/pkg/sql/explain_tree_test.go
@@ -78,7 +78,7 @@ func TestPlanToTreeAndPlanToString(t *testing.T) {
 			p.curPlan.flags.Set(planFlagExecDone)
 			p.curPlan.close(ctx)
 			if d.Cmd == "plan-string" {
-				return ih.planStringForBundle()
+				return ih.planStringForBundle(&phaseTimes{})
 			}
 			treeYaml, err := yaml.Marshal(ih.PlanForStats(ctx))
 			if err != nil {

--- a/pkg/sql/testdata/explain_tree
+++ b/pkg/sql/testdata/explain_tree
@@ -7,6 +7,8 @@ plan-string
 SELECT oid FROM t.orders WHERE oid = 123
 ----
 ----
+planning time: 0s
+execution time: 0s
 distribution: local
 vectorized: false
 
@@ -35,6 +37,8 @@ plan-string
 SELECT cid, date, value FROM t.orders
 ----
 ----
+planning time: 0s
+execution time: 0s
 distribution: local
 vectorized: false
 
@@ -63,6 +67,8 @@ plan-string
 SELECT cid, sum(value) FROM t.orders WHERE date > '2015-01-01' GROUP BY cid ORDER BY 1 - sum(value)
 ----
 ----
+planning time: 0s
+execution time: 0s
 distribution: local
 vectorized: false
 
@@ -139,6 +145,8 @@ plan-string
 SELECT value FROM (SELECT cid, date, value FROM t.orders)
 ----
 ----
+planning time: 0s
+execution time: 0s
 distribution: local
 vectorized: false
 
@@ -167,6 +175,8 @@ plan-string
 SELECT cid, date, value FROM t.orders WHERE date IN (SELECT date FROM t.orders)
 ----
 ----
+planning time: 0s
+execution time: 0s
 distribution: local
 vectorized: false
 
@@ -253,6 +263,8 @@ plan-string
 SELECT id AS movie_id, title, (SELECT name FROM t.actors WHERE name = 'Foo') FROM t.movies
 ----
 ----
+planning time: 0s
+execution time: 0s
 distribution: local
 vectorized: false
 


### PR DESCRIPTION
This change moves some code around so that the new plan annotations
(execution time, row counts) make it into the plan in the bundle.
I tested it manually. I will spend some time thinking how we could
write some test infrastructure for bundles.

Release note: None