### PR TITLE
release-20.2: vendor: bump Pebble to de084f80f458

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/cockroachdb/go-test-teamcity v0.0.0-20191211140407-cff980ad0a55
 	github.com/cockroachdb/gostdlib v1.13.0
 	github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f
-	github.com/cockroachdb/pebble v0.0.0-20201113230643-8f63fcd266a5
+	github.com/cockroachdb/pebble v0.0.0-20201201154502-de084f80f458
 	github.com/cockroachdb/redact v1.0.7
 	github.com/cockroachdb/returncheck v0.0.0-20200612231554-92cdbca611dd
 	github.com/cockroachdb/sentry-go v0.6.1-cockroachdb.2

--- a/go.sum
+++ b/go.sum
@@ -162,8 +162,8 @@ github.com/cockroachdb/grpc-gateway v1.14.6-0.20200519165156-52697fc4a249 h1:pZu
 github.com/cockroachdb/grpc-gateway v1.14.6-0.20200519165156-52697fc4a249/go.mod h1:UJ0EZAp832vCd54Wev9N1BMKEyvcZ5+IM0AwDrnlkEc=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f h1:o/kfcElHqOiXqcou5a3rIlMc7oJbMQkeLk0VQJ7zgqY=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
-github.com/cockroachdb/pebble v0.0.0-20201113230643-8f63fcd266a5 h1:VIYiLaijH0TY/WLGCo2er3SSxPDxlbvLFzndh/I7O6M=
-github.com/cockroachdb/pebble v0.0.0-20201113230643-8f63fcd266a5/go.mod h1:hU7vhtrqonEphNF+xt8/lHdaBprxmV1h8BOGrd9XwmQ=
+github.com/cockroachdb/pebble v0.0.0-20201201154502-de084f80f458 h1:euslS08mwfX7S2gFBhuL6D5nRx5Qn7eZBbJxjfYJNRc=
+github.com/cockroachdb/pebble v0.0.0-20201201154502-de084f80f458/go.mod h1:hU7vhtrqonEphNF+xt8/lHdaBprxmV1h8BOGrd9XwmQ=
 github.com/cockroachdb/redact v0.0.0-20200622112456-cd282804bbd3 h1:2+dpIJzYMSbLi0587YXpi8tOJT52qCOI/1I0UNThc/I=
 github.com/cockroachdb/redact v0.0.0-20200622112456-cd282804bbd3/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/redact v1.0.6 h1:W34uRRyNR4dlZFd0MibhNELsZSgMkl52uRV/tA1xToY=


### PR DESCRIPTION
```
de084f80 db: fix L0->LBase input expansion
774b34d9 db: fix L0->LBase compaction picking bug with shared largest user keys
3096751b internal/base: provide more context in MustExist
```

Release note (bug fix): Fix a bug that in rare circumstances could cause
a crash loop.