### PR TITLE
release-20.2: sql: avoid copying apd.Decimal when computing its size

### DIFF
--- a/pkg/sql/colmem/allocator.go
+++ b/pkg/sql/colmem/allocator.go
@@ -333,8 +333,8 @@ const (
 
 func sizeOfDecimals(decimals coldata.Decimals) uintptr {
 	var size uintptr
-	for _, d := range decimals {
-		size += tree.SizeOfDecimal(d)
+	for i := range decimals {
+		size += tree.SizeOfDecimal(&decimals[i])
 	}
 	size += uintptr(cap(decimals)-len(decimals)) * sizeOfDecimal
 	return size

--- a/pkg/sql/sem/builtins/aggregate_builtins.go
+++ b/pkg/sql/sem/builtins/aggregate_builtins.go
@@ -2158,7 +2158,7 @@ func (a *intSumAggregate) Add(ctx context.Context, datum tree.Datum, _ ...tree.D
 			if err != nil {
 				return err
 			}
-			if err := a.updateMemoryUsage(ctx, int64(tree.SizeOfDecimal(a.decSum))); err != nil {
+			if err := a.updateMemoryUsage(ctx, int64(tree.SizeOfDecimal(&a.decSum))); err != nil {
 				return err
 			}
 		}
@@ -2226,7 +2226,7 @@ func (a *decimalSumAggregate) Add(ctx context.Context, datum tree.Datum, _ ...tr
 		return err
 	}
 
-	if err := a.updateMemoryUsage(ctx, int64(tree.SizeOfDecimal(a.sum))); err != nil {
+	if err := a.updateMemoryUsage(ctx, int64(tree.SizeOfDecimal(&a.sum))); err != nil {
 		return err
 	}
 
@@ -2526,11 +2526,11 @@ func (a *decimalSqrDiffAggregate) Add(
 	a.ed.Sub(&a.tmp, d, &a.mean)
 	a.ed.Add(&a.sqrDiff, &a.sqrDiff, a.ed.Mul(&a.delta, &a.delta, &a.tmp))
 
-	size := int64(tree.SizeOfDecimal(a.count) +
-		tree.SizeOfDecimal(a.mean) +
-		tree.SizeOfDecimal(a.sqrDiff) +
-		tree.SizeOfDecimal(a.delta) +
-		tree.SizeOfDecimal(a.tmp))
+	size := int64(tree.SizeOfDecimal(&a.count) +
+		tree.SizeOfDecimal(&a.mean) +
+		tree.SizeOfDecimal(&a.sqrDiff) +
+		tree.SizeOfDecimal(&a.delta) +
+		tree.SizeOfDecimal(&a.tmp))
 	if err := a.updateMemoryUsage(ctx, size); err != nil {
 		return err
 	}
@@ -2725,13 +2725,13 @@ func (a *decimalSumSqrDiffsAggregate) Add(
 	// Update running mean.
 	a.ed.Add(&a.mean, &a.mean, &a.tmp)
 
-	size := int64(tree.SizeOfDecimal(a.count) +
-		tree.SizeOfDecimal(a.mean) +
-		tree.SizeOfDecimal(a.sqrDiff) +
-		tree.SizeOfDecimal(a.tmpCount) +
-		tree.SizeOfDecimal(a.tmpMean) +
-		tree.SizeOfDecimal(a.delta) +
-		tree.SizeOfDecimal(a.tmp))
+	size := int64(tree.SizeOfDecimal(&a.count) +
+		tree.SizeOfDecimal(&a.mean) +
+		tree.SizeOfDecimal(&a.sqrDiff) +
+		tree.SizeOfDecimal(&a.tmpCount) +
+		tree.SizeOfDecimal(&a.tmpMean) +
+		tree.SizeOfDecimal(&a.delta) +
+		tree.SizeOfDecimal(&a.tmp))
 	if err := a.updateMemoryUsage(ctx, size); err != nil {
 		return err
 	}

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -1070,13 +1070,13 @@ func (d *DDecimal) Format(ctx *FmtCtx) {
 const shallowDecimalSize = unsafe.Sizeof(apd.Decimal{})
 
 // SizeOfDecimal returns the size in bytes of an apd.Decimal.
-func SizeOfDecimal(d apd.Decimal) uintptr {
+func SizeOfDecimal(d *apd.Decimal) uintptr {
 	return shallowDecimalSize + uintptr(cap(d.Coeff.Bits()))*unsafe.Sizeof(big.Word(0))
 }
 
 // Size implements the Datum interface.
 func (d *DDecimal) Size() uintptr {
-	return SizeOfDecimal(d.Decimal)
+	return SizeOfDecimal(&d.Decimal)
 }
 
 var (


### PR DESCRIPTION
Backport 1/1 commits from #57270.

/cc @cockroachdb/release

---

This commit changes `SizeOfDecimal` function signature to take in
a pointer to `apd.Decimal` which removes the need to copy it by value.
Those copied showed up very noticeably when used by
`colmem.sizeOfDecimals` method.

Release note: None
