### PR TITLE
sql: categorize undefined column error when adding unique constraints

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -195,6 +195,14 @@ func (n *alterTableNode) startExec(params runParams) error {
 					}
 					continue
 				}
+
+				// Check if the columns exist on the table.
+				for _, column := range d.Columns {
+					if _, _, err := n.tableDesc.FindColumnByName(column.Column); err != nil {
+						return err
+					}
+				}
+
 				idx := descpb.IndexDescriptor{
 					Name:             string(d.Name),
 					Unique:           true,

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -67,6 +67,9 @@ INSERT INTO t VALUES (2, 9, 1, 1), (3, 9, 2, 1)
 statement error pgcode 23505 violates unique constraint "bar"
 ALTER TABLE t ADD CONSTRAINT bar UNIQUE (c)
 
+statement error pgcode 42703 column "dne" does not exist
+ALTER TABLE t ADD CONSTRAINT dne_unique UNIQUE (dne)
+
 # Test that rollback was successful
 query TTTTTR
 SELECT job_type, regexp_replace(description, 'JOB \d+', 'JOB ...'), user_name, status, running_status, fraction_completed::decimal(10,2)

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -1756,7 +1756,7 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT8);
 		// eventually not get added. The column aa will also be dropped as
 		// a result.
 		{`ALTER TABLE t.public.test ADD COLUMN aa INT8, ADD CONSTRAINT foo UNIQUE (a)`,
-			"contains unknown column"},
+			"column \"a\" does not exist"},
 
 		// The purge of column 'a' doesn't influence these schema changes.
 
@@ -1778,10 +1778,10 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT8);
 		// eventually not get added. The column bb will also be dropped as
 		// a result.
 		{`ALTER TABLE t.public.test ADD COLUMN bb INT8, ADD CONSTRAINT bar UNIQUE (never_existed)`,
-			"contains unknown column"},
+			"column \"never_existed\" does not exist"},
 		// Cascading of purges. column 'c' -> column 'bb' -> constraint 'idx_bb'.
 		{`ALTER TABLE t.public.test ADD CONSTRAINT idx_bb UNIQUE (bb)`,
-			"contains unknown column"},
+			"column \"bb\" does not exist"},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Previously, adding a unique constraint to a table on one or more columns
that do not exist would cause uncategorized error. Now, the error is
categorized as pgcode.UndefinedColumn.

Closes: #57314 

Release note (sql change): A pgcode.UndefinedColumn will now be returned
when adding a unique constraint to one or more undefined columns.