### PR TITLE
colexecagg: fix memory accounting for decimals with avg and sum

### DIFF
--- a/pkg/sql/colexec/colexecagg/aggregate_funcs.go
+++ b/pkg/sql/colexec/colexecagg/aggregate_funcs.go
@@ -96,7 +96,10 @@ type AggregateFunc interface {
 type orderedAggregateFuncBase struct {
 	groups []bool
 	// curIdx tracks the current output index of this function.
-	curIdx int
+	curIdx    int
+	allocator *colmem.Allocator
+	// vec is the output vector of this function.
+	vec coldata.Vec
 	// nulls is the nulls vector of the output vector of this function.
 	nulls *coldata.Nulls
 }
@@ -106,6 +109,7 @@ func (o *orderedAggregateFuncBase) Init(groups []bool) {
 }
 
 func (o *orderedAggregateFuncBase) SetOutput(vec coldata.Vec) {
+	o.vec = vec
 	o.nulls = vec.Nulls()
 }
 
@@ -125,6 +129,9 @@ func (o *orderedAggregateFuncBase) HandleEmptyInputScalar() {
 }
 
 type hashAggregateFuncBase struct {
+	allocator *colmem.Allocator
+	// vec is the output vector of this function.
+	vec coldata.Vec
 	// nulls is the nulls vector of the output vector of this function.
 	nulls *coldata.Nulls
 }
@@ -132,6 +139,7 @@ type hashAggregateFuncBase struct {
 func (h *hashAggregateFuncBase) Init(_ []bool) {}
 
 func (h *hashAggregateFuncBase) SetOutput(vec coldata.Vec) {
+	h.vec = vec
 	h.nulls = vec.Nulls()
 }
 

--- a/pkg/sql/colexec/colexecagg/any_not_null_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/any_not_null_agg_tmpl.go
@@ -75,8 +75,6 @@ type anyNotNull_TYPE_AGGKINDAgg struct {
 	// {{else}}
 	hashAggregateFuncBase
 	// {{end}}
-	allocator                   *colmem.Allocator
-	vec                         coldata.Vec
 	col                         _GOTYPESLICE
 	curAgg                      _GOTYPE
 	foundNonNullForCurrentGroup bool
@@ -90,7 +88,6 @@ func (a *anyNotNull_TYPE_AGGKINDAgg) SetOutput(vec coldata.Vec) {
 	// {{else}}
 	a.hashAggregateFuncBase.SetOutput(vec)
 	// {{end}}
-	a.vec = vec
 	a.col = vec.TemplateType()
 }
 
@@ -117,47 +114,44 @@ func (a *anyNotNull_TYPE_AGGKINDAgg) Compute(
 	// {{end}}
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.TemplateType(), vec.Nulls()
-
-	a.allocator.PerformOperation(
-		[]coldata.Vec{a.vec},
-		func() {
-			// Capture col to force bounds check to work. See
-			// https://github.com/golang/go/issues/39756
-			col := col
-			_ = col.Get(inputLen - 1)
-			// {{if eq "_AGGKIND" "Ordered"}}
-			groups := a.groups
-			// {{/*
-			// We don't need to check whether sel is non-nil when performing
-			// hash aggregation because the hash aggregator always uses non-nil
-			// sel to specify the tuples to be aggregated.
-			// */}}
-			if sel == nil {
-				_ = groups[inputLen-1]
-				if nulls.MaybeHasNulls() {
-					for i := 0; i < inputLen; i++ {
-						_FIND_ANY_NOT_NULL(a, groups, nulls, i, true)
-					}
-				} else {
-					for i := 0; i < inputLen; i++ {
-						_FIND_ANY_NOT_NULL(a, groups, nulls, i, false)
-					}
+	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
+		_ = col.Get(inputLen - 1)
+		// {{if eq "_AGGKIND" "Ordered"}}
+		groups := a.groups
+		// {{/*
+		// We don't need to check whether sel is non-nil when performing
+		// hash aggregation because the hash aggregator always uses non-nil
+		// sel to specify the tuples to be aggregated.
+		// */}}
+		if sel == nil {
+			_ = groups[inputLen-1]
+			if nulls.MaybeHasNulls() {
+				for i := 0; i < inputLen; i++ {
+					_FIND_ANY_NOT_NULL(a, groups, nulls, i, true)
 				}
-			} else
-			// {{end}}
-			{
-				sel = sel[:inputLen]
-				if nulls.MaybeHasNulls() {
-					for _, i := range sel {
-						_FIND_ANY_NOT_NULL(a, groups, nulls, i, true)
-					}
-				} else {
-					for _, i := range sel {
-						_FIND_ANY_NOT_NULL(a, groups, nulls, i, false)
-					}
+			} else {
+				for i := 0; i < inputLen; i++ {
+					_FIND_ANY_NOT_NULL(a, groups, nulls, i, false)
 				}
 			}
-		},
+		} else
+		// {{end}}
+		{
+			sel = sel[:inputLen]
+			if nulls.MaybeHasNulls() {
+				for _, i := range sel {
+					_FIND_ANY_NOT_NULL(a, groups, nulls, i, true)
+				}
+			} else {
+				for _, i := range sel {
+					_FIND_ANY_NOT_NULL(a, groups, nulls, i, false)
+				}
+			}
+		}
+	},
 	)
 	// {{if eq .VecMethod "Bytes"}}
 	newCurAggSize := len(a.curAgg)

--- a/pkg/sql/colexec/colexecagg/concat_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/concat_agg_tmpl.go
@@ -39,13 +39,10 @@ type concat_AGGKINDAgg struct {
 	// {{else}}
 	hashAggregateFuncBase
 	// {{end}}
-	allocator *colmem.Allocator
 	// curAgg holds the running total.
 	curAgg []byte
 	// col points to the output vector we are updating.
 	col *coldata.Bytes
-	// vec is the same as col before conversion from coldata.Vec.
-	vec coldata.Vec
 	// foundNonNullForCurrentGroup tracks if we have seen any non-null values
 	// for the group that is currently being aggregated.
 	foundNonNullForCurrentGroup bool
@@ -57,7 +54,6 @@ func (a *concat_AGGKINDAgg) SetOutput(vec coldata.Vec) {
 	// {{else}}
 	a.hashAggregateFuncBase.SetOutput(vec)
 	// {{end}}
-	a.vec = vec
 	a.col = vec.Bytes()
 }
 
@@ -67,42 +63,40 @@ func (a *concat_AGGKINDAgg) Compute(
 	oldCurAggSize := len(a.curAgg)
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Bytes(), vec.Nulls()
-	a.allocator.PerformOperation(
-		[]coldata.Vec{a.vec},
-		func() {
-			// {{if eq "_AGGKIND" "Ordered"}}
-			groups := a.groups
-			// {{/*
-			// We don't need to check whether sel is non-nil when performing
-			// hash aggregation because the hash aggregator always uses non-nil
-			// sel to specify the tuples to be aggregated.
-			// */}}
-			if sel == nil {
-				_ = groups[inputLen-1]
-				if nulls.MaybeHasNulls() {
-					for i := 0; i < inputLen; i++ {
-						_ACCUMULATE_CONCAT(a, nulls, i, true)
-					}
-				} else {
-					for i := 0; i < inputLen; i++ {
-						_ACCUMULATE_CONCAT(a, nulls, i, false)
-					}
+	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+		// {{if eq "_AGGKIND" "Ordered"}}
+		groups := a.groups
+		// {{/*
+		// We don't need to check whether sel is non-nil when performing
+		// hash aggregation because the hash aggregator always uses non-nil
+		// sel to specify the tuples to be aggregated.
+		// */}}
+		if sel == nil {
+			_ = groups[inputLen-1]
+			if nulls.MaybeHasNulls() {
+				for i := 0; i < inputLen; i++ {
+					_ACCUMULATE_CONCAT(a, nulls, i, true)
 				}
-			} else
-			// {{end}}
-			{
-				sel = sel[:inputLen]
-				if nulls.MaybeHasNulls() {
-					for _, i := range sel {
-						_ACCUMULATE_CONCAT(a, nulls, i, true)
-					}
-				} else {
-					for _, i := range sel {
-						_ACCUMULATE_CONCAT(a, nulls, i, false)
-					}
+			} else {
+				for i := 0; i < inputLen; i++ {
+					_ACCUMULATE_CONCAT(a, nulls, i, false)
 				}
 			}
-		},
+		} else
+		// {{end}}
+		{
+			sel = sel[:inputLen]
+			if nulls.MaybeHasNulls() {
+				for _, i := range sel {
+					_ACCUMULATE_CONCAT(a, nulls, i, true)
+				}
+			} else {
+				for _, i := range sel {
+					_ACCUMULATE_CONCAT(a, nulls, i, false)
+				}
+			}
+		}
+	},
 	)
 	newCurAggSize := len(a.curAgg)
 	a.allocator.AdjustMemoryUsage(int64(newCurAggSize - oldCurAggSize))

--- a/pkg/sql/colexec/colexecagg/hash_avg_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_avg_agg.eg.go
@@ -50,28 +50,26 @@ func newAvgHashAggAlloc(
 
 type avgInt16HashAgg struct {
 	hashAggregateFuncBase
-	scratch struct {
-		// curSum keeps track of the sum of elements belonging to the current group,
-		// so we can index into the slice once per group, instead of on each
-		// iteration.
-		curSum apd.Decimal
-		// curCount keeps track of the number of elements that we've seen
-		// belonging to the current group.
-		curCount int64
-		// vec points to the output vector.
-		vec []apd.Decimal
-		// foundNonNullForCurrentGroup tracks if we have seen any non-null values
-		// for the group that is currently being aggregated.
-		foundNonNullForCurrentGroup bool
-	}
-	overloadHelper execgen.OverloadHelper
+	// curSum keeps track of the sum of elements belonging to the current group,
+	// so we can index into the slice once per group, instead of on each
+	// iteration.
+	curSum apd.Decimal
+	// curCount keeps track of the number of elements that we've seen
+	// belonging to the current group.
+	curCount int64
+	// col points to the statically-typed output vector.
+	col []apd.Decimal
+	// foundNonNullForCurrentGroup tracks if we have seen any non-null values
+	// for the group that is currently being aggregated.
+	foundNonNullForCurrentGroup bool
+	overloadHelper              execgen.OverloadHelper
 }
 
 var _ AggregateFunc = &avgInt16HashAgg{}
 
 func (a *avgInt16HashAgg) SetOutput(vec coldata.Vec) {
 	a.hashAggregateFuncBase.SetOutput(vec)
-	a.scratch.vec = vec.Decimal()
+	a.col = vec.Decimal()
 }
 
 func (a *avgInt16HashAgg) Compute(
@@ -82,62 +80,68 @@ func (a *avgInt16HashAgg) Compute(
 	_overloadHelper := a.overloadHelper
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int16(), vec.Nulls()
-	{
-		sel = sel[:inputLen]
-		if nulls.MaybeHasNulls() {
-			for _, i := range sel {
+	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
+		{
+			sel = sel[:inputLen]
+			if nulls.MaybeHasNulls() {
+				for _, i := range sel {
 
-				var isNull bool
-				isNull = nulls.NullAt(i)
-				if !isNull {
+					var isNull bool
+					isNull = nulls.NullAt(i)
+					if !isNull {
 
-					{
+						{
 
-						tmpDec := &_overloadHelper.TmpDec1
-						tmpDec.SetInt64(int64(col[i]))
-						if _, err := tree.ExactCtx.Add(&a.scratch.curSum, &a.scratch.curSum, tmpDec); err != nil {
-							colexecerror.ExpectedError(err)
+							tmpDec := &_overloadHelper.TmpDec1
+							tmpDec.SetInt64(int64(col[i]))
+							if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, tmpDec); err != nil {
+								colexecerror.ExpectedError(err)
+							}
 						}
-					}
 
-					a.scratch.curCount++
-					a.scratch.foundNonNullForCurrentGroup = true
+						a.curCount++
+						a.foundNonNullForCurrentGroup = true
+					}
 				}
-			}
-		} else {
-			for _, i := range sel {
+			} else {
+				for _, i := range sel {
 
-				var isNull bool
-				isNull = false
-				if !isNull {
+					var isNull bool
+					isNull = false
+					if !isNull {
 
-					{
+						{
 
-						tmpDec := &_overloadHelper.TmpDec1
-						tmpDec.SetInt64(int64(col[i]))
-						if _, err := tree.ExactCtx.Add(&a.scratch.curSum, &a.scratch.curSum, tmpDec); err != nil {
-							colexecerror.ExpectedError(err)
+							tmpDec := &_overloadHelper.TmpDec1
+							tmpDec.SetInt64(int64(col[i]))
+							if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, tmpDec); err != nil {
+								colexecerror.ExpectedError(err)
+							}
 						}
-					}
 
-					a.scratch.curCount++
-					a.scratch.foundNonNullForCurrentGroup = true
+						a.curCount++
+						a.foundNonNullForCurrentGroup = true
+					}
 				}
 			}
 		}
-	}
+	},
+	)
 }
 
 func (a *avgInt16HashAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should be
 	// NULL.
-	if !a.scratch.foundNonNullForCurrentGroup {
+	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
 
-		a.scratch.vec[outputIdx].SetInt64(a.scratch.curCount)
-		if _, err := tree.DecimalCtx.Quo(&a.scratch.vec[outputIdx], &a.scratch.curSum, &a.scratch.vec[outputIdx]); err != nil {
+		a.col[outputIdx].SetInt64(a.curCount)
+		if _, err := tree.DecimalCtx.Quo(&a.col[outputIdx], &a.curSum, &a.col[outputIdx]); err != nil {
 			colexecerror.InternalError(err)
 		}
 	}
@@ -159,34 +163,33 @@ func (a *avgInt16HashAggAlloc) newAggFunc() AggregateFunc {
 		a.aggFuncs = make([]avgInt16HashAgg, a.allocSize)
 	}
 	f := &a.aggFuncs[0]
+	f.allocator = a.allocator
 	a.aggFuncs = a.aggFuncs[1:]
 	return f
 }
 
 type avgInt32HashAgg struct {
 	hashAggregateFuncBase
-	scratch struct {
-		// curSum keeps track of the sum of elements belonging to the current group,
-		// so we can index into the slice once per group, instead of on each
-		// iteration.
-		curSum apd.Decimal
-		// curCount keeps track of the number of elements that we've seen
-		// belonging to the current group.
-		curCount int64
-		// vec points to the output vector.
-		vec []apd.Decimal
-		// foundNonNullForCurrentGroup tracks if we have seen any non-null values
-		// for the group that is currently being aggregated.
-		foundNonNullForCurrentGroup bool
-	}
-	overloadHelper execgen.OverloadHelper
+	// curSum keeps track of the sum of elements belonging to the current group,
+	// so we can index into the slice once per group, instead of on each
+	// iteration.
+	curSum apd.Decimal
+	// curCount keeps track of the number of elements that we've seen
+	// belonging to the current group.
+	curCount int64
+	// col points to the statically-typed output vector.
+	col []apd.Decimal
+	// foundNonNullForCurrentGroup tracks if we have seen any non-null values
+	// for the group that is currently being aggregated.
+	foundNonNullForCurrentGroup bool
+	overloadHelper              execgen.OverloadHelper
 }
 
 var _ AggregateFunc = &avgInt32HashAgg{}
 
 func (a *avgInt32HashAgg) SetOutput(vec coldata.Vec) {
 	a.hashAggregateFuncBase.SetOutput(vec)
-	a.scratch.vec = vec.Decimal()
+	a.col = vec.Decimal()
 }
 
 func (a *avgInt32HashAgg) Compute(
@@ -197,62 +200,68 @@ func (a *avgInt32HashAgg) Compute(
 	_overloadHelper := a.overloadHelper
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int32(), vec.Nulls()
-	{
-		sel = sel[:inputLen]
-		if nulls.MaybeHasNulls() {
-			for _, i := range sel {
+	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
+		{
+			sel = sel[:inputLen]
+			if nulls.MaybeHasNulls() {
+				for _, i := range sel {
 
-				var isNull bool
-				isNull = nulls.NullAt(i)
-				if !isNull {
+					var isNull bool
+					isNull = nulls.NullAt(i)
+					if !isNull {
 
-					{
+						{
 
-						tmpDec := &_overloadHelper.TmpDec1
-						tmpDec.SetInt64(int64(col[i]))
-						if _, err := tree.ExactCtx.Add(&a.scratch.curSum, &a.scratch.curSum, tmpDec); err != nil {
-							colexecerror.ExpectedError(err)
+							tmpDec := &_overloadHelper.TmpDec1
+							tmpDec.SetInt64(int64(col[i]))
+							if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, tmpDec); err != nil {
+								colexecerror.ExpectedError(err)
+							}
 						}
-					}
 
-					a.scratch.curCount++
-					a.scratch.foundNonNullForCurrentGroup = true
+						a.curCount++
+						a.foundNonNullForCurrentGroup = true
+					}
 				}
-			}
-		} else {
-			for _, i := range sel {
+			} else {
+				for _, i := range sel {
 
-				var isNull bool
-				isNull = false
-				if !isNull {
+					var isNull bool
+					isNull = false
+					if !isNull {
 
-					{
+						{
 
-						tmpDec := &_overloadHelper.TmpDec1
-						tmpDec.SetInt64(int64(col[i]))
-						if _, err := tree.ExactCtx.Add(&a.scratch.curSum, &a.scratch.curSum, tmpDec); err != nil {
-							colexecerror.ExpectedError(err)
+							tmpDec := &_overloadHelper.TmpDec1
+							tmpDec.SetInt64(int64(col[i]))
+							if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, tmpDec); err != nil {
+								colexecerror.ExpectedError(err)
+							}
 						}
-					}
 
-					a.scratch.curCount++
-					a.scratch.foundNonNullForCurrentGroup = true
+						a.curCount++
+						a.foundNonNullForCurrentGroup = true
+					}
 				}
 			}
 		}
-	}
+	},
+	)
 }
 
 func (a *avgInt32HashAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should be
 	// NULL.
-	if !a.scratch.foundNonNullForCurrentGroup {
+	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
 
-		a.scratch.vec[outputIdx].SetInt64(a.scratch.curCount)
-		if _, err := tree.DecimalCtx.Quo(&a.scratch.vec[outputIdx], &a.scratch.curSum, &a.scratch.vec[outputIdx]); err != nil {
+		a.col[outputIdx].SetInt64(a.curCount)
+		if _, err := tree.DecimalCtx.Quo(&a.col[outputIdx], &a.curSum, &a.col[outputIdx]); err != nil {
 			colexecerror.InternalError(err)
 		}
 	}
@@ -274,34 +283,33 @@ func (a *avgInt32HashAggAlloc) newAggFunc() AggregateFunc {
 		a.aggFuncs = make([]avgInt32HashAgg, a.allocSize)
 	}
 	f := &a.aggFuncs[0]
+	f.allocator = a.allocator
 	a.aggFuncs = a.aggFuncs[1:]
 	return f
 }
 
 type avgInt64HashAgg struct {
 	hashAggregateFuncBase
-	scratch struct {
-		// curSum keeps track of the sum of elements belonging to the current group,
-		// so we can index into the slice once per group, instead of on each
-		// iteration.
-		curSum apd.Decimal
-		// curCount keeps track of the number of elements that we've seen
-		// belonging to the current group.
-		curCount int64
-		// vec points to the output vector.
-		vec []apd.Decimal
-		// foundNonNullForCurrentGroup tracks if we have seen any non-null values
-		// for the group that is currently being aggregated.
-		foundNonNullForCurrentGroup bool
-	}
-	overloadHelper execgen.OverloadHelper
+	// curSum keeps track of the sum of elements belonging to the current group,
+	// so we can index into the slice once per group, instead of on each
+	// iteration.
+	curSum apd.Decimal
+	// curCount keeps track of the number of elements that we've seen
+	// belonging to the current group.
+	curCount int64
+	// col points to the statically-typed output vector.
+	col []apd.Decimal
+	// foundNonNullForCurrentGroup tracks if we have seen any non-null values
+	// for the group that is currently being aggregated.
+	foundNonNullForCurrentGroup bool
+	overloadHelper              execgen.OverloadHelper
 }
 
 var _ AggregateFunc = &avgInt64HashAgg{}
 
 func (a *avgInt64HashAgg) SetOutput(vec coldata.Vec) {
 	a.hashAggregateFuncBase.SetOutput(vec)
-	a.scratch.vec = vec.Decimal()
+	a.col = vec.Decimal()
 }
 
 func (a *avgInt64HashAgg) Compute(
@@ -312,62 +320,68 @@ func (a *avgInt64HashAgg) Compute(
 	_overloadHelper := a.overloadHelper
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int64(), vec.Nulls()
-	{
-		sel = sel[:inputLen]
-		if nulls.MaybeHasNulls() {
-			for _, i := range sel {
+	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
+		{
+			sel = sel[:inputLen]
+			if nulls.MaybeHasNulls() {
+				for _, i := range sel {
 
-				var isNull bool
-				isNull = nulls.NullAt(i)
-				if !isNull {
+					var isNull bool
+					isNull = nulls.NullAt(i)
+					if !isNull {
 
-					{
+						{
 
-						tmpDec := &_overloadHelper.TmpDec1
-						tmpDec.SetInt64(int64(col[i]))
-						if _, err := tree.ExactCtx.Add(&a.scratch.curSum, &a.scratch.curSum, tmpDec); err != nil {
-							colexecerror.ExpectedError(err)
+							tmpDec := &_overloadHelper.TmpDec1
+							tmpDec.SetInt64(int64(col[i]))
+							if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, tmpDec); err != nil {
+								colexecerror.ExpectedError(err)
+							}
 						}
-					}
 
-					a.scratch.curCount++
-					a.scratch.foundNonNullForCurrentGroup = true
+						a.curCount++
+						a.foundNonNullForCurrentGroup = true
+					}
 				}
-			}
-		} else {
-			for _, i := range sel {
+			} else {
+				for _, i := range sel {
 
-				var isNull bool
-				isNull = false
-				if !isNull {
+					var isNull bool
+					isNull = false
+					if !isNull {
 
-					{
+						{
 
-						tmpDec := &_overloadHelper.TmpDec1
-						tmpDec.SetInt64(int64(col[i]))
-						if _, err := tree.ExactCtx.Add(&a.scratch.curSum, &a.scratch.curSum, tmpDec); err != nil {
-							colexecerror.ExpectedError(err)
+							tmpDec := &_overloadHelper.TmpDec1
+							tmpDec.SetInt64(int64(col[i]))
+							if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, tmpDec); err != nil {
+								colexecerror.ExpectedError(err)
+							}
 						}
-					}
 
-					a.scratch.curCount++
-					a.scratch.foundNonNullForCurrentGroup = true
+						a.curCount++
+						a.foundNonNullForCurrentGroup = true
+					}
 				}
 			}
 		}
-	}
+	},
+	)
 }
 
 func (a *avgInt64HashAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should be
 	// NULL.
-	if !a.scratch.foundNonNullForCurrentGroup {
+	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
 
-		a.scratch.vec[outputIdx].SetInt64(a.scratch.curCount)
-		if _, err := tree.DecimalCtx.Quo(&a.scratch.vec[outputIdx], &a.scratch.curSum, &a.scratch.vec[outputIdx]); err != nil {
+		a.col[outputIdx].SetInt64(a.curCount)
+		if _, err := tree.DecimalCtx.Quo(&a.col[outputIdx], &a.curSum, &a.col[outputIdx]); err != nil {
 			colexecerror.InternalError(err)
 		}
 	}
@@ -389,33 +403,32 @@ func (a *avgInt64HashAggAlloc) newAggFunc() AggregateFunc {
 		a.aggFuncs = make([]avgInt64HashAgg, a.allocSize)
 	}
 	f := &a.aggFuncs[0]
+	f.allocator = a.allocator
 	a.aggFuncs = a.aggFuncs[1:]
 	return f
 }
 
 type avgDecimalHashAgg struct {
 	hashAggregateFuncBase
-	scratch struct {
-		// curSum keeps track of the sum of elements belonging to the current group,
-		// so we can index into the slice once per group, instead of on each
-		// iteration.
-		curSum apd.Decimal
-		// curCount keeps track of the number of elements that we've seen
-		// belonging to the current group.
-		curCount int64
-		// vec points to the output vector.
-		vec []apd.Decimal
-		// foundNonNullForCurrentGroup tracks if we have seen any non-null values
-		// for the group that is currently being aggregated.
-		foundNonNullForCurrentGroup bool
-	}
+	// curSum keeps track of the sum of elements belonging to the current group,
+	// so we can index into the slice once per group, instead of on each
+	// iteration.
+	curSum apd.Decimal
+	// curCount keeps track of the number of elements that we've seen
+	// belonging to the current group.
+	curCount int64
+	// col points to the statically-typed output vector.
+	col []apd.Decimal
+	// foundNonNullForCurrentGroup tracks if we have seen any non-null values
+	// for the group that is currently being aggregated.
+	foundNonNullForCurrentGroup bool
 }
 
 var _ AggregateFunc = &avgDecimalHashAgg{}
 
 func (a *avgDecimalHashAgg) SetOutput(vec coldata.Vec) {
 	a.hashAggregateFuncBase.SetOutput(vec)
-	a.scratch.vec = vec.Decimal()
+	a.col = vec.Decimal()
 }
 
 func (a *avgDecimalHashAgg) Compute(
@@ -423,60 +436,66 @@ func (a *avgDecimalHashAgg) Compute(
 ) {
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Decimal(), vec.Nulls()
-	{
-		sel = sel[:inputLen]
-		if nulls.MaybeHasNulls() {
-			for _, i := range sel {
+	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
+		{
+			sel = sel[:inputLen]
+			if nulls.MaybeHasNulls() {
+				for _, i := range sel {
 
-				var isNull bool
-				isNull = nulls.NullAt(i)
-				if !isNull {
+					var isNull bool
+					isNull = nulls.NullAt(i)
+					if !isNull {
 
-					{
+						{
 
-						_, err := tree.ExactCtx.Add(&a.scratch.curSum, &a.scratch.curSum, &col[i])
-						if err != nil {
-							colexecerror.ExpectedError(err)
+							_, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, &col[i])
+							if err != nil {
+								colexecerror.ExpectedError(err)
+							}
 						}
-					}
 
-					a.scratch.curCount++
-					a.scratch.foundNonNullForCurrentGroup = true
+						a.curCount++
+						a.foundNonNullForCurrentGroup = true
+					}
 				}
-			}
-		} else {
-			for _, i := range sel {
+			} else {
+				for _, i := range sel {
 
-				var isNull bool
-				isNull = false
-				if !isNull {
+					var isNull bool
+					isNull = false
+					if !isNull {
 
-					{
+						{
 
-						_, err := tree.ExactCtx.Add(&a.scratch.curSum, &a.scratch.curSum, &col[i])
-						if err != nil {
-							colexecerror.ExpectedError(err)
+							_, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, &col[i])
+							if err != nil {
+								colexecerror.ExpectedError(err)
+							}
 						}
-					}
 
-					a.scratch.curCount++
-					a.scratch.foundNonNullForCurrentGroup = true
+						a.curCount++
+						a.foundNonNullForCurrentGroup = true
+					}
 				}
 			}
 		}
-	}
+	},
+	)
 }
 
 func (a *avgDecimalHashAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should be
 	// NULL.
-	if !a.scratch.foundNonNullForCurrentGroup {
+	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
 
-		a.scratch.vec[outputIdx].SetInt64(a.scratch.curCount)
-		if _, err := tree.DecimalCtx.Quo(&a.scratch.vec[outputIdx], &a.scratch.curSum, &a.scratch.vec[outputIdx]); err != nil {
+		a.col[outputIdx].SetInt64(a.curCount)
+		if _, err := tree.DecimalCtx.Quo(&a.col[outputIdx], &a.curSum, &a.col[outputIdx]); err != nil {
 			colexecerror.InternalError(err)
 		}
 	}
@@ -498,33 +517,32 @@ func (a *avgDecimalHashAggAlloc) newAggFunc() AggregateFunc {
 		a.aggFuncs = make([]avgDecimalHashAgg, a.allocSize)
 	}
 	f := &a.aggFuncs[0]
+	f.allocator = a.allocator
 	a.aggFuncs = a.aggFuncs[1:]
 	return f
 }
 
 type avgFloat64HashAgg struct {
 	hashAggregateFuncBase
-	scratch struct {
-		// curSum keeps track of the sum of elements belonging to the current group,
-		// so we can index into the slice once per group, instead of on each
-		// iteration.
-		curSum float64
-		// curCount keeps track of the number of elements that we've seen
-		// belonging to the current group.
-		curCount int64
-		// vec points to the output vector.
-		vec []float64
-		// foundNonNullForCurrentGroup tracks if we have seen any non-null values
-		// for the group that is currently being aggregated.
-		foundNonNullForCurrentGroup bool
-	}
+	// curSum keeps track of the sum of elements belonging to the current group,
+	// so we can index into the slice once per group, instead of on each
+	// iteration.
+	curSum float64
+	// curCount keeps track of the number of elements that we've seen
+	// belonging to the current group.
+	curCount int64
+	// col points to the statically-typed output vector.
+	col []float64
+	// foundNonNullForCurrentGroup tracks if we have seen any non-null values
+	// for the group that is currently being aggregated.
+	foundNonNullForCurrentGroup bool
 }
 
 var _ AggregateFunc = &avgFloat64HashAgg{}
 
 func (a *avgFloat64HashAgg) SetOutput(vec coldata.Vec) {
 	a.hashAggregateFuncBase.SetOutput(vec)
-	a.scratch.vec = vec.Float64()
+	a.col = vec.Float64()
 }
 
 func (a *avgFloat64HashAgg) Compute(
@@ -532,52 +550,58 @@ func (a *avgFloat64HashAgg) Compute(
 ) {
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Float64(), vec.Nulls()
-	{
-		sel = sel[:inputLen]
-		if nulls.MaybeHasNulls() {
-			for _, i := range sel {
+	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
+		{
+			sel = sel[:inputLen]
+			if nulls.MaybeHasNulls() {
+				for _, i := range sel {
 
-				var isNull bool
-				isNull = nulls.NullAt(i)
-				if !isNull {
+					var isNull bool
+					isNull = nulls.NullAt(i)
+					if !isNull {
 
-					{
+						{
 
-						a.scratch.curSum = float64(a.scratch.curSum) + float64(col[i])
+							a.curSum = float64(a.curSum) + float64(col[i])
+						}
+
+						a.curCount++
+						a.foundNonNullForCurrentGroup = true
 					}
-
-					a.scratch.curCount++
-					a.scratch.foundNonNullForCurrentGroup = true
 				}
-			}
-		} else {
-			for _, i := range sel {
+			} else {
+				for _, i := range sel {
 
-				var isNull bool
-				isNull = false
-				if !isNull {
+					var isNull bool
+					isNull = false
+					if !isNull {
 
-					{
+						{
 
-						a.scratch.curSum = float64(a.scratch.curSum) + float64(col[i])
+							a.curSum = float64(a.curSum) + float64(col[i])
+						}
+
+						a.curCount++
+						a.foundNonNullForCurrentGroup = true
 					}
-
-					a.scratch.curCount++
-					a.scratch.foundNonNullForCurrentGroup = true
 				}
 			}
 		}
-	}
+	},
+	)
 }
 
 func (a *avgFloat64HashAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should be
 	// NULL.
-	if !a.scratch.foundNonNullForCurrentGroup {
+	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.scratch.vec[outputIdx] = a.scratch.curSum / float64(a.scratch.curCount)
+		a.col[outputIdx] = a.curSum / float64(a.curCount)
 	}
 }
 
@@ -597,33 +621,32 @@ func (a *avgFloat64HashAggAlloc) newAggFunc() AggregateFunc {
 		a.aggFuncs = make([]avgFloat64HashAgg, a.allocSize)
 	}
 	f := &a.aggFuncs[0]
+	f.allocator = a.allocator
 	a.aggFuncs = a.aggFuncs[1:]
 	return f
 }
 
 type avgIntervalHashAgg struct {
 	hashAggregateFuncBase
-	scratch struct {
-		// curSum keeps track of the sum of elements belonging to the current group,
-		// so we can index into the slice once per group, instead of on each
-		// iteration.
-		curSum duration.Duration
-		// curCount keeps track of the number of elements that we've seen
-		// belonging to the current group.
-		curCount int64
-		// vec points to the output vector.
-		vec []duration.Duration
-		// foundNonNullForCurrentGroup tracks if we have seen any non-null values
-		// for the group that is currently being aggregated.
-		foundNonNullForCurrentGroup bool
-	}
+	// curSum keeps track of the sum of elements belonging to the current group,
+	// so we can index into the slice once per group, instead of on each
+	// iteration.
+	curSum duration.Duration
+	// curCount keeps track of the number of elements that we've seen
+	// belonging to the current group.
+	curCount int64
+	// col points to the statically-typed output vector.
+	col []duration.Duration
+	// foundNonNullForCurrentGroup tracks if we have seen any non-null values
+	// for the group that is currently being aggregated.
+	foundNonNullForCurrentGroup bool
 }
 
 var _ AggregateFunc = &avgIntervalHashAgg{}
 
 func (a *avgIntervalHashAgg) SetOutput(vec coldata.Vec) {
 	a.hashAggregateFuncBase.SetOutput(vec)
-	a.scratch.vec = vec.Interval()
+	a.col = vec.Interval()
 }
 
 func (a *avgIntervalHashAgg) Compute(
@@ -631,42 +654,48 @@ func (a *avgIntervalHashAgg) Compute(
 ) {
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Interval(), vec.Nulls()
-	{
-		sel = sel[:inputLen]
-		if nulls.MaybeHasNulls() {
-			for _, i := range sel {
+	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
+		{
+			sel = sel[:inputLen]
+			if nulls.MaybeHasNulls() {
+				for _, i := range sel {
 
-				var isNull bool
-				isNull = nulls.NullAt(i)
-				if !isNull {
-					a.scratch.curSum = a.scratch.curSum.Add(col[i])
-					a.scratch.curCount++
-					a.scratch.foundNonNullForCurrentGroup = true
+					var isNull bool
+					isNull = nulls.NullAt(i)
+					if !isNull {
+						a.curSum = a.curSum.Add(col[i])
+						a.curCount++
+						a.foundNonNullForCurrentGroup = true
+					}
 				}
-			}
-		} else {
-			for _, i := range sel {
+			} else {
+				for _, i := range sel {
 
-				var isNull bool
-				isNull = false
-				if !isNull {
-					a.scratch.curSum = a.scratch.curSum.Add(col[i])
-					a.scratch.curCount++
-					a.scratch.foundNonNullForCurrentGroup = true
+					var isNull bool
+					isNull = false
+					if !isNull {
+						a.curSum = a.curSum.Add(col[i])
+						a.curCount++
+						a.foundNonNullForCurrentGroup = true
+					}
 				}
 			}
 		}
-	}
+	},
+	)
 }
 
 func (a *avgIntervalHashAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should be
 	// NULL.
-	if !a.scratch.foundNonNullForCurrentGroup {
+	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.scratch.vec[outputIdx] = a.scratch.curSum.Div(int64(a.scratch.curCount))
+		a.col[outputIdx] = a.curSum.Div(int64(a.curCount))
 	}
 }
 
@@ -686,6 +715,7 @@ func (a *avgIntervalHashAggAlloc) newAggFunc() AggregateFunc {
 		a.aggFuncs = make([]avgIntervalHashAgg, a.allocSize)
 	}
 	f := &a.aggFuncs[0]
+	f.allocator = a.allocator
 	a.aggFuncs = a.aggFuncs[1:]
 	return f
 }

--- a/pkg/sql/colexec/colexecagg/hash_bool_and_or_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_bool_and_or_agg.eg.go
@@ -31,8 +31,8 @@ func newBoolAndHashAggAlloc(
 
 type boolAndHashAgg struct {
 	hashAggregateFuncBase
+	col        []bool
 	sawNonNull bool
-	vec        []bool
 	curAgg     bool
 }
 
@@ -40,7 +40,7 @@ var _ AggregateFunc = &boolAndHashAgg{}
 
 func (a *boolAndHashAgg) SetOutput(vec coldata.Vec) {
 	a.hashAggregateFuncBase.SetOutput(vec)
-	a.vec = vec.Bool()
+	a.col = vec.Bool()
 }
 
 func (a *boolAndHashAgg) Compute(
@@ -48,39 +48,42 @@ func (a *boolAndHashAgg) Compute(
 ) {
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Bool(), vec.Nulls()
-	{
-		sel = sel[:inputLen]
-		if nulls.MaybeHasNulls() {
-			for _, i := range sel {
+	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+		{
+			sel = sel[:inputLen]
+			if nulls.MaybeHasNulls() {
+				for _, i := range sel {
 
-				var isNull bool
-				isNull = nulls.NullAt(i)
-				if !isNull {
-					a.curAgg = a.curAgg && col[i]
-					a.sawNonNull = true
+					var isNull bool
+					isNull = nulls.NullAt(i)
+					if !isNull {
+						a.curAgg = a.curAgg && col[i]
+						a.sawNonNull = true
+					}
+
 				}
+			} else {
+				for _, i := range sel {
 
-			}
-		} else {
-			for _, i := range sel {
+					var isNull bool
+					isNull = false
+					if !isNull {
+						a.curAgg = a.curAgg && col[i]
+						a.sawNonNull = true
+					}
 
-				var isNull bool
-				isNull = false
-				if !isNull {
-					a.curAgg = a.curAgg && col[i]
-					a.sawNonNull = true
 				}
-
 			}
 		}
-	}
+	},
+	)
 }
 
 func (a *boolAndHashAgg) Flush(outputIdx int) {
 	if !a.sawNonNull {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.vec[outputIdx] = a.curAgg
+		a.col[outputIdx] = a.curAgg
 	}
 }
 
@@ -100,6 +103,7 @@ func (a *boolAndHashAggAlloc) newAggFunc() AggregateFunc {
 		a.aggFuncs = make([]boolAndHashAgg, a.allocSize)
 	}
 	f := &a.aggFuncs[0]
+	f.allocator = a.allocator
 	a.aggFuncs = a.aggFuncs[1:]
 	f.curAgg = true
 	return f
@@ -116,8 +120,8 @@ func newBoolOrHashAggAlloc(
 
 type boolOrHashAgg struct {
 	hashAggregateFuncBase
+	col        []bool
 	sawNonNull bool
-	vec        []bool
 	curAgg     bool
 }
 
@@ -125,7 +129,7 @@ var _ AggregateFunc = &boolOrHashAgg{}
 
 func (a *boolOrHashAgg) SetOutput(vec coldata.Vec) {
 	a.hashAggregateFuncBase.SetOutput(vec)
-	a.vec = vec.Bool()
+	a.col = vec.Bool()
 }
 
 func (a *boolOrHashAgg) Compute(
@@ -133,39 +137,42 @@ func (a *boolOrHashAgg) Compute(
 ) {
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Bool(), vec.Nulls()
-	{
-		sel = sel[:inputLen]
-		if nulls.MaybeHasNulls() {
-			for _, i := range sel {
+	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+		{
+			sel = sel[:inputLen]
+			if nulls.MaybeHasNulls() {
+				for _, i := range sel {
 
-				var isNull bool
-				isNull = nulls.NullAt(i)
-				if !isNull {
-					a.curAgg = a.curAgg || col[i]
-					a.sawNonNull = true
+					var isNull bool
+					isNull = nulls.NullAt(i)
+					if !isNull {
+						a.curAgg = a.curAgg || col[i]
+						a.sawNonNull = true
+					}
+
 				}
+			} else {
+				for _, i := range sel {
 
-			}
-		} else {
-			for _, i := range sel {
+					var isNull bool
+					isNull = false
+					if !isNull {
+						a.curAgg = a.curAgg || col[i]
+						a.sawNonNull = true
+					}
 
-				var isNull bool
-				isNull = false
-				if !isNull {
-					a.curAgg = a.curAgg || col[i]
-					a.sawNonNull = true
 				}
-
 			}
 		}
-	}
+	},
+	)
 }
 
 func (a *boolOrHashAgg) Flush(outputIdx int) {
 	if !a.sawNonNull {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.vec[outputIdx] = a.curAgg
+		a.col[outputIdx] = a.curAgg
 	}
 }
 
@@ -185,6 +192,7 @@ func (a *boolOrHashAggAlloc) newAggFunc() AggregateFunc {
 		a.aggFuncs = make([]boolOrHashAgg, a.allocSize)
 	}
 	f := &a.aggFuncs[0]
+	f.allocator = a.allocator
 	a.aggFuncs = a.aggFuncs[1:]
 	f.curAgg = false
 	return f

--- a/pkg/sql/colexec/colexecagg/hash_concat_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_concat_agg.eg.go
@@ -25,13 +25,10 @@ func newConcatHashAggAlloc(allocator *colmem.Allocator, allocSize int64) aggrega
 
 type concatHashAgg struct {
 	hashAggregateFuncBase
-	allocator *colmem.Allocator
 	// curAgg holds the running total.
 	curAgg []byte
 	// col points to the output vector we are updating.
 	col *coldata.Bytes
-	// vec is the same as col before conversion from coldata.Vec.
-	vec coldata.Vec
 	// foundNonNullForCurrentGroup tracks if we have seen any non-null values
 	// for the group that is currently being aggregated.
 	foundNonNullForCurrentGroup bool
@@ -39,7 +36,6 @@ type concatHashAgg struct {
 
 func (a *concatHashAgg) SetOutput(vec coldata.Vec) {
 	a.hashAggregateFuncBase.SetOutput(vec)
-	a.vec = vec
 	a.col = vec.Bytes()
 }
 
@@ -49,34 +45,32 @@ func (a *concatHashAgg) Compute(
 	oldCurAggSize := len(a.curAgg)
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Bytes(), vec.Nulls()
-	a.allocator.PerformOperation(
-		[]coldata.Vec{a.vec},
-		func() {
-			{
-				sel = sel[:inputLen]
-				if nulls.MaybeHasNulls() {
-					for _, i := range sel {
+	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+		{
+			sel = sel[:inputLen]
+			if nulls.MaybeHasNulls() {
+				for _, i := range sel {
 
-						var isNull bool
-						isNull = nulls.NullAt(i)
-						if !isNull {
-							a.curAgg = append(a.curAgg, col.Get(i)...)
-							a.foundNonNullForCurrentGroup = true
-						}
+					var isNull bool
+					isNull = nulls.NullAt(i)
+					if !isNull {
+						a.curAgg = append(a.curAgg, col.Get(i)...)
+						a.foundNonNullForCurrentGroup = true
 					}
-				} else {
-					for _, i := range sel {
+				}
+			} else {
+				for _, i := range sel {
 
-						var isNull bool
-						isNull = false
-						if !isNull {
-							a.curAgg = append(a.curAgg, col.Get(i)...)
-							a.foundNonNullForCurrentGroup = true
-						}
+					var isNull bool
+					isNull = false
+					if !isNull {
+						a.curAgg = append(a.curAgg, col.Get(i)...)
+						a.foundNonNullForCurrentGroup = true
 					}
 				}
 			}
-		},
+		}
+	},
 	)
 	newCurAggSize := len(a.curAgg)
 	a.allocator.AdjustMemoryUsage(int64(newCurAggSize - oldCurAggSize))

--- a/pkg/sql/colexec/colexecagg/hash_default_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_default_agg.eg.go
@@ -25,14 +25,12 @@ import (
 
 type defaultHashAgg struct {
 	hashAggregateFuncBase
-	allocator *colmem.Allocator
-	fn        tree.AggregateFunc
-	ctx       context.Context
+	fn  tree.AggregateFunc
+	ctx context.Context
 	// inputArgsConverter is managed by the aggregator, and this function can
 	// simply call GetDatumColumn.
 	inputArgsConverter *colconv.VecToDatumConverter
 	resultConverter    func(tree.Datum) interface{}
-	vec                coldata.Vec
 	scratch            struct {
 		// Note that this scratch space is shared among all aggregate function
 		// instances created by the same alloc object.
@@ -44,7 +42,6 @@ var _ AggregateFunc = &defaultHashAgg{}
 
 func (a *defaultHashAgg) SetOutput(vec coldata.Vec) {
 	a.hashAggregateFuncBase.SetOutput(vec)
-	a.vec = vec
 }
 
 func (a *defaultHashAgg) Compute(
@@ -162,12 +159,12 @@ func (a *defaultHashAggAlloc) newAggFunc() AggregateFunc {
 	}
 	f := &a.aggFuncs[0]
 	*f = defaultHashAgg{
-		allocator:          a.allocator,
 		fn:                 a.constructor(a.evalCtx, a.arguments),
 		ctx:                a.evalCtx.Context,
 		inputArgsConverter: a.inputArgsConverter,
 		resultConverter:    a.resultConverter,
 	}
+	f.allocator = a.allocator
 	f.scratch.otherArgs = a.otherArgsScratch
 	a.allocator.AdjustMemoryUsage(f.fn.Size())
 	a.aggFuncs = a.aggFuncs[1:]


### PR DESCRIPTION
Previously, we were not calling `PerformOperation` to account for the
memory used by the decimals (which are of variable size), and this is
now fixed. Additionally, this commit refactors several other templates to
be more similar to each other.

Note that we decided to call `PerformOperation` on all of the aggregate
functions even if we know that all types that the functions operate on
are of fixed size and that call is not strictly necessary. However, this
has negligible impact on performance in most cases and makes the layout
of `Compute` methods of all functions the same ensuring that we don't
forget these calls in the future.

Additionally, this commit adds capturing of the column to force bounds
check to work for min/max and sum aggregates.

Release note: None