### PR TITLE
sql,partitionccl: allow partitioning by user-defined types

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_enum
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_enum
@@ -1,11 +1,13 @@
 
-# Enums are not supported as the values for partitioning as of 20.2 because of
-# unfortunate interactions during validation. Assert that that is true.
+# Enums are supported for partitioning both by list and range.
+# In 20.2 alphas, partitioning by enums was permitted but led to
+# subsequent validation errors upon reading due to the type not
+# being hydrated, hence the reading of crdb_internal.tables.
 
 statement ok
-CREATE TYPE places AS ENUM ('us', 'eu');
+CREATE TYPE places AS ENUM ('us', 'eu', 'ap');
 
-statement error partitioning by enum values is not supported
+statement ok
 CREATE TABLE partitioned_table (
     place places, id INT8,
     PRIMARY KEY (place, id)
@@ -20,15 +22,37 @@ statement ok
 SELECT * FROM crdb_internal.tables
 
 statement ok
-CREATE TABLE partitioned_table (
+CREATE TABLE partitioned_table_2 (
     place places, id INT8,
     PRIMARY KEY (place, id)
 );
 
-statement error partitioning by enum values is not supported
-ALTER TABLE partitioned_table PARTITION BY LIST (place)
+statement ok
+ALTER TABLE partitioned_table_2 PARTITION BY LIST (place)
         (
             PARTITION us VALUES IN ('us'),
             PARTITION eu VALUES IN ('eu')
         );
+
+statement ok
+SELECT * FROM crdb_internal.tables
+
+
+statement ok
+CREATE TABLE partitioned_table_3 (
+    place places, id INT8,
+    PRIMARY KEY (place, id)
+);
+
+# Ensure that partition validation occurs at write time.
+
+statement error partitions eu and us overlap
+ALTER TABLE partitioned_table_3 PARTITION BY RANGE (place)
+        (
+            PARTITION eu VALUES FROM (MINVALUE) TO ('eu'),
+            PARTITION us VALUES FROM ('us') TO (MAXVALUE)
+        );
+
+statement ok
+SELECT * FROM crdb_internal.tables
 

--- a/pkg/ccl/partitionccl/partition.go
+++ b/pkg/ccl/partitionccl/partition.go
@@ -97,17 +97,6 @@ func valueEncodePartitionTuple(
 		}
 
 		var semaCtx tree.SemaContext
-
-		// Disallow partitioning by user-defined types because it causes issues
-		// during table descriptor validation.
-		//
-		// TODO(ajwerner): Fix this limitation by reworking validation in the
-		// descs.Collection to operate on hydrated descriptors.
-		if cols[i].Type.UserDefined() {
-			return nil, errors.UnimplementedError(errors.IssueLink{
-				IssueURL: "https://github.com/cockroachdb/cockroach/issues/55342",
-			}, "partitioning by enum values is not supported")
-		}
 		typedExpr, err := schemaexpr.SanitizeVarFreeExpr(evalCtx.Context, expr, cols[i].Type, "partition",
 			&semaCtx,
 			tree.VolatilityImmutable,


### PR DESCRIPTION
Parititoning by user-defined types was disallowed because we attempted to
validate the partitioning every time we retreived the descriptor, even if
we had not yet hydrated the types. When writing a partitioning, we'll always
have the types hydrated. Thus, we will be doing the proper validation when it
matters.

This unblocks work to utilize enums for partitioning. This work will be
augmented by future work to validate entire descriptor graphs when modifying
any member of the graph at some future point in this release (21.1).

Fixes #55342.

Release note (enterprise change): Permit partitioning by user-defined types
such as enums.