### PR TITLE
ccl, sql: add telemetry, logs for feature denials by feature flags

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -681,7 +681,9 @@ func backupPlanHook(
 		return nil, nil, nil, false, nil
 	}
 
-	if err := featureflag.CheckEnabled(featureBackupEnabled,
+	if err := featureflag.CheckEnabled(
+		ctx,
+		featureBackupEnabled,
 		&p.ExecCfg().Settings.SV,
 		"BACKUP",
 	); err != nil {

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -1287,7 +1287,9 @@ func restorePlanHook(
 		return nil, nil, nil, false, nil
 	}
 
-	if err := featureflag.CheckEnabled(featureRestoreEnabled,
+	if err := featureflag.CheckEnabled(
+		ctx,
+		featureRestoreEnabled,
 		&p.ExecCfg().Settings.SV,
 		"RESTORE",
 	); err != nil {

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -78,7 +78,9 @@ func changefeedPlanHook(
 		return nil, nil, nil, false, nil
 	}
 
-	if err := featureflag.CheckEnabled(featureChangefeedEnabled,
+	if err := featureflag.CheckEnabled(
+		ctx,
+		featureChangefeedEnabled,
 		&p.ExecCfg().Settings.SV,
 		"CHANGEFEED",
 	); err != nil {

--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -268,7 +268,9 @@ func importPlanHook(
 
 	addToFileFormatTelemetry(importStmt.FileFormat, "attempted")
 
-	if err := featureflag.CheckEnabled(featureImportEnabled,
+	if err := featureflag.CheckEnabled(
+		ctx,
+		featureImportEnabled,
 		&p.ExecCfg().Settings.SV,
 		"IMPORT",
 	); err != nil {

--- a/pkg/featureflag/BUILD.bazel
+++ b/pkg/featureflag/BUILD.bazel
@@ -6,8 +6,11 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/featureflag",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/server/telemetry",
         "//pkg/settings",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
+        "//pkg/sql/sqltelemetry",
+        "//pkg/util/log",
     ],
 )

--- a/pkg/featureflag/feature_flags.go
+++ b/pkg/featureflag/feature_flags.go
@@ -11,9 +11,14 @@
 package featureflag
 
 import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
 // FeatureFlagEnabledDefault is used for the default value of all feature flag
@@ -21,12 +26,27 @@ import (
 const FeatureFlagEnabledDefault = true
 
 // CheckEnabled checks whether a specific feature has been enabled or disabled
-// via its cluster settings, and returns an error if it has been disabled.
-func CheckEnabled(s *settings.BoolSetting, sv *settings.Values, featureName string) error {
+// via its cluster settings, and returns an error if it has been disabled. It
+// increments a telemetry counter for any feature flag that is denied and logs
+// the feature and category that was denied.
+func CheckEnabled(
+	ctx context.Context, s *settings.BoolSetting, sv *settings.Values, featureName string,
+) error {
 	if enabled := s.Get(sv); !enabled {
-		return pgerror.Newf(pgcode.OperatorIntervention,
+		telemetry.Inc(sqltelemetry.FeatureDeniedByFeatureFlagCounter)
+		if log.V(2) {
+			log.Warningf(
+				ctx,
+				"feature %s was attempted but disabled via cluster settings",
+				featureName,
+			)
+		}
+
+		return pgerror.Newf(
+			pgcode.OperatorIntervention,
 			"feature %s was disabled by the database administrator",
-			featureName)
+			featureName,
+		)
 	}
 	return nil
 }

--- a/pkg/sql/alter_database.go
+++ b/pkg/sql/alter_database.go
@@ -31,6 +31,7 @@ func (p *planner) AlterDatabaseOwner(
 	ctx context.Context, n *tree.AlterDatabaseOwner,
 ) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
+		ctx,
 		&p.ExecCfg().Settings.SV,
 		"ALTER DATABASE",
 	); err != nil {
@@ -110,6 +111,7 @@ func (p *planner) AlterDatabaseAddRegion(
 	ctx context.Context, n *tree.AlterDatabaseAddRegion,
 ) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
+		ctx,
 		&p.ExecCfg().Settings.SV,
 		"ALTER DATABASE",
 	); err != nil {
@@ -123,6 +125,7 @@ func (p *planner) AlterDatabaseDropRegion(
 	ctx context.Context, n *tree.AlterDatabaseDropRegion,
 ) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
+		ctx,
 		&p.ExecCfg().Settings.SV,
 		"ALTER DATABASE",
 	); err != nil {
@@ -143,6 +146,7 @@ func (p *planner) AlterDatabaseSurvivalGoal(
 	ctx context.Context, n *tree.AlterDatabaseSurvivalGoal,
 ) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
+		ctx,
 		&p.ExecCfg().Settings.SV,
 		"ALTER DATABASE",
 	); err != nil {

--- a/pkg/sql/alter_index.go
+++ b/pkg/sql/alter_index.go
@@ -32,6 +32,7 @@ type alterIndexNode struct {
 // Privileges: CREATE on table.
 func (p *planner) AlterIndex(ctx context.Context, n *tree.AlterIndex) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
+		ctx,
 		&p.ExecCfg().Settings.SV,
 		"ALTER INDEX",
 	); err != nil {

--- a/pkg/sql/alter_schema.go
+++ b/pkg/sql/alter_schema.go
@@ -40,6 +40,7 @@ var _ planNode = &alterSchemaNode{n: nil}
 
 func (p *planner) AlterSchema(ctx context.Context, n *tree.AlterSchema) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
+		ctx,
 		&p.ExecCfg().Settings.SV,
 		"ALTER SCHEMA",
 	); err != nil {

--- a/pkg/sql/alter_sequence.go
+++ b/pkg/sql/alter_sequence.go
@@ -29,6 +29,7 @@ type alterSequenceNode struct {
 // AlterSequence transforms a tree.AlterSequence into a plan node.
 func (p *planner) AlterSequence(ctx context.Context, n *tree.AlterSequence) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
+		ctx,
 		&p.ExecCfg().Settings.SV,
 		"ALTER SEQUENCE",
 	); err != nil {

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -54,6 +54,7 @@ type alterTableNode struct {
 //          mysql requires ALTER, CREATE, INSERT on the table.
 func (p *planner) AlterTable(ctx context.Context, n *tree.AlterTable) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
+		ctx,
 		&p.ExecCfg().Settings.SV,
 		"ALTER TABLE",
 	); err != nil {

--- a/pkg/sql/alter_table_regional_affinity.go
+++ b/pkg/sql/alter_table_regional_affinity.go
@@ -22,6 +22,7 @@ func (p *planner) AlterTableRegionalAffinity(
 	ctx context.Context, n *tree.AlterTableRegionalAffinity,
 ) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
+		ctx,
 		&p.ExecCfg().Settings.SV,
 		"ALTER TABLE",
 	); err != nil {

--- a/pkg/sql/alter_table_set_schema.go
+++ b/pkg/sql/alter_table_set_schema.go
@@ -34,6 +34,7 @@ func (p *planner) AlterTableSetSchema(
 	ctx context.Context, n *tree.AlterTableSetSchema,
 ) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
+		ctx,
 		&p.ExecCfg().Settings.SV,
 		"ALTER TABLE/VIEW/SEQUENCE SET SCHEMA",
 	); err != nil {

--- a/pkg/sql/alter_type.go
+++ b/pkg/sql/alter_type.go
@@ -37,6 +37,7 @@ var _ planNode = &alterTypeNode{n: nil}
 
 func (p *planner) AlterType(ctx context.Context, n *tree.AlterType) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
+		ctx,
 		&p.ExecCfg().Settings.SV,
 		"ALTER TYPE",
 	); err != nil {

--- a/pkg/sql/comment_on_column.go
+++ b/pkg/sql/comment_on_column.go
@@ -30,6 +30,7 @@ type commentOnColumnNode struct {
 // Privileges: CREATE on table.
 func (p *planner) CommentOnColumn(ctx context.Context, n *tree.CommentOnColumn) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
+		ctx,
 		&p.ExecCfg().Settings.SV,
 		"COMMENT ON COLUMN",
 	); err != nil {

--- a/pkg/sql/comment_on_database.go
+++ b/pkg/sql/comment_on_database.go
@@ -33,6 +33,7 @@ func (p *planner) CommentOnDatabase(
 	ctx context.Context, n *tree.CommentOnDatabase,
 ) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
+		ctx,
 		&p.ExecCfg().Settings.SV,
 		"COMMENT ON DATABASE",
 	); err != nil {

--- a/pkg/sql/comment_on_index.go
+++ b/pkg/sql/comment_on_index.go
@@ -32,6 +32,7 @@ type commentOnIndexNode struct {
 // Privileges: CREATE on table.
 func (p *planner) CommentOnIndex(ctx context.Context, n *tree.CommentOnIndex) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
+		ctx,
 		&p.ExecCfg().Settings.SV,
 		"COMMENT ON INDEX",
 	); err != nil {

--- a/pkg/sql/comment_on_table.go
+++ b/pkg/sql/comment_on_table.go
@@ -32,6 +32,7 @@ type commentOnTableNode struct {
 //          mysql requires ALTER, CREATE, INSERT on the table.
 func (p *planner) CommentOnTable(ctx context.Context, n *tree.CommentOnTable) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
+		ctx,
 		&p.ExecCfg().Settings.SV,
 		"COMMENT ON TABLE",
 	); err != nil {

--- a/pkg/sql/create_database.go
+++ b/pkg/sql/create_database.go
@@ -31,6 +31,7 @@ type createDatabaseNode struct {
 // Privileges: superuser or CREATEDB
 func (p *planner) CreateDatabase(ctx context.Context, n *tree.CreateDatabase) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
+		ctx,
 		&p.ExecCfg().Settings.SV,
 		"CREATE DATABASE",
 	); err != nil {

--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -45,6 +45,7 @@ type createIndexNode struct {
 //          mysql requires INDEX on the table.
 func (p *planner) CreateIndex(ctx context.Context, n *tree.CreateIndex) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
+		ctx,
 		&p.ExecCfg().Settings.SV,
 		"CREATE INDEX",
 	); err != nil {

--- a/pkg/sql/create_schema.go
+++ b/pkg/sql/create_schema.go
@@ -38,6 +38,7 @@ func (n *createSchemaNode) startExec(params runParams) error {
 
 func (p *planner) createUserDefinedSchema(params runParams, n *tree.CreateSchema) error {
 	if err := checkSchemaChangeEnabled(
+		p.EvalContext().Context,
 		&p.ExecCfg().Settings.SV,
 		"CREATE SCHEMA",
 	); err != nil {
@@ -185,6 +186,7 @@ func (n *createSchemaNode) Close(ctx context.Context)  {}
 // CreateSchema creates a schema.
 func (p *planner) CreateSchema(ctx context.Context, n *tree.CreateSchema) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
+		ctx,
 		&p.ExecCfg().Settings.SV,
 		"CREATE SCHEMA",
 	); err != nil {

--- a/pkg/sql/create_sequence.go
+++ b/pkg/sql/create_sequence.go
@@ -35,6 +35,7 @@ type createSequenceNode struct {
 
 func (p *planner) CreateSequence(ctx context.Context, n *tree.CreateSequence) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
+		ctx,
 		&p.ExecCfg().Settings.SV,
 		"CREATE SEQUENCE",
 	); err != nil {

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -58,6 +58,7 @@ var featureStatsEnabled = settings.RegisterPublicBoolSetting(
 
 func (p *planner) CreateStatistics(ctx context.Context, n *tree.CreateStats) (planNode, error) {
 	if err := featureflag.CheckEnabled(
+		ctx,
 		featureStatsEnabled,
 		&p.ExecCfg().Settings.SV,
 		"ANALYZE/CREATE STATISTICS",
@@ -74,6 +75,7 @@ func (p *planner) CreateStatistics(ctx context.Context, n *tree.CreateStats) (pl
 // Analyze is syntactic sugar for CreateStatistics.
 func (p *planner) Analyze(ctx context.Context, n *tree.Analyze) (planNode, error) {
 	if err := featureflag.CheckEnabled(
+		ctx,
 		featureStatsEnabled,
 		&p.ExecCfg().Settings.SV,
 		"ANALYZE/CREATE STATISTICS",

--- a/pkg/sql/create_type.go
+++ b/pkg/sql/create_type.go
@@ -53,6 +53,7 @@ var _ planNode = &createTypeNode{n: nil}
 
 func (p *planner) CreateType(ctx context.Context, n *tree.CreateType) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
+		ctx,
 		&p.ExecCfg().Settings.SV,
 		"CREATE TYPE",
 	); err != nil {

--- a/pkg/sql/drop_database.go
+++ b/pkg/sql/drop_database.go
@@ -45,6 +45,7 @@ type dropDatabaseNode struct {
 //          mysql requires the DROP privileges on the database.
 func (p *planner) DropDatabase(ctx context.Context, n *tree.DropDatabase) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
+		ctx,
 		&p.ExecCfg().Settings.SV,
 		"DROP DATABASE",
 	); err != nil {

--- a/pkg/sql/drop_index.go
+++ b/pkg/sql/drop_index.go
@@ -43,6 +43,7 @@ type dropIndexNode struct {
 //          mysql requires the INDEX privilege on the table.
 func (p *planner) DropIndex(ctx context.Context, n *tree.DropIndex) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
+		ctx,
 		&p.ExecCfg().Settings.SV,
 		"DROP INDEX",
 	); err != nil {

--- a/pkg/sql/drop_owned_by.go
+++ b/pkg/sql/drop_owned_by.go
@@ -27,6 +27,7 @@ type dropOwnedByNode struct {
 
 func (p *planner) DropOwnedBy(ctx context.Context) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
+		ctx,
 		&p.ExecCfg().Settings.SV,
 		"DROP OWNED BY",
 	); err != nil {

--- a/pkg/sql/drop_schema.go
+++ b/pkg/sql/drop_schema.go
@@ -40,6 +40,7 @@ var _ planNode = &dropSchemaNode{n: nil}
 
 func (p *planner) DropSchema(ctx context.Context, n *tree.DropSchema) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
+		ctx,
 		&p.ExecCfg().Settings.SV,
 		"DROP SCHEMA",
 	); err != nil {

--- a/pkg/sql/drop_sequence.go
+++ b/pkg/sql/drop_sequence.go
@@ -33,6 +33,7 @@ type dropSequenceNode struct {
 
 func (p *planner) DropSequence(ctx context.Context, n *tree.DropSequence) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
+		ctx,
 		&p.ExecCfg().Settings.SV,
 		"DROP SEQUENCE",
 	); err != nil {

--- a/pkg/sql/drop_table.go
+++ b/pkg/sql/drop_table.go
@@ -48,6 +48,7 @@ type toDelete struct {
 //          mysql requires the DROP privilege on the table.
 func (p *planner) DropTable(ctx context.Context, n *tree.DropTable) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
+		ctx,
 		&p.ExecCfg().Settings.SV,
 		"DROP TABLE",
 	); err != nil {

--- a/pkg/sql/drop_type.go
+++ b/pkg/sql/drop_type.go
@@ -37,6 +37,7 @@ var _ planNode = &dropTypeNode{n: nil}
 
 func (p *planner) DropType(ctx context.Context, n *tree.DropType) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
+		ctx,
 		&p.ExecCfg().Settings.SV,
 		"DROP TYPE",
 	); err != nil {

--- a/pkg/sql/drop_view.go
+++ b/pkg/sql/drop_view.go
@@ -36,6 +36,7 @@ type dropViewNode struct {
 //          mysql requires the DROP privilege on the view.
 func (p *planner) DropView(ctx context.Context, n *tree.DropView) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
+		ctx,
 		&p.ExecCfg().Settings.SV,
 		"DROP VIEW",
 	); err != nil {

--- a/pkg/sql/export.go
+++ b/pkg/sql/export.go
@@ -98,7 +98,9 @@ func (ef *execFactory) ConstructExport(
 		)
 	}
 
-	if err := featureflag.CheckEnabled(featureExportEnabled,
+	if err := featureflag.CheckEnabled(
+		ef.planner.EvalContext().Context,
+		featureExportEnabled,
 		&ef.planner.ExecCfg().Settings.SV,
 		"EXPORT",
 	); err != nil {

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1608,6 +1608,7 @@ func (ef *execFactory) ConstructCreateTable(
 	schema cat.Schema, ct *tree.CreateTable,
 ) (exec.Node, error) {
 	if err := checkSchemaChangeEnabled(
+		ef.planner.EvalContext().Context,
 		&ef.planner.ExecCfg().Settings.SV,
 		"CREATE TABLE",
 	); err != nil {
@@ -1624,6 +1625,7 @@ func (ef *execFactory) ConstructCreateTableAs(
 	input exec.Node, schema cat.Schema, ct *tree.CreateTable,
 ) (exec.Node, error) {
 	if err := checkSchemaChangeEnabled(
+		ef.planner.EvalContext().Context,
 		&ef.planner.ExecCfg().Settings.SV,
 		"CREATE TABLE",
 	); err != nil {
@@ -1651,6 +1653,7 @@ func (ef *execFactory) ConstructCreateView(
 ) (exec.Node, error) {
 
 	if err := checkSchemaChangeEnabled(
+		ef.planner.EvalContext().Context,
 		&ef.planner.ExecCfg().Settings.SV,
 		"CREATE VIEW",
 	); err != nil {
@@ -1725,6 +1728,7 @@ func (ef *execFactory) ConstructAlterTableSplit(
 	index cat.Index, input exec.Node, expiration tree.TypedExpr,
 ) (exec.Node, error) {
 	if err := checkSchemaChangeEnabled(
+		ef.planner.EvalContext().Context,
 		&ef.planner.ExecCfg().Settings.SV,
 		"ALTER TABLE/INDEX SPLIT AT",
 	); err != nil {
@@ -1753,6 +1757,7 @@ func (ef *execFactory) ConstructAlterTableUnsplit(
 	index cat.Index, input exec.Node,
 ) (exec.Node, error) {
 	if err := checkSchemaChangeEnabled(
+		ef.planner.EvalContext().Context,
 		&ef.planner.ExecCfg().Settings.SV,
 		"ALTER TABLE/INDEX UNSPLIT AT",
 	); err != nil {
@@ -1773,6 +1778,7 @@ func (ef *execFactory) ConstructAlterTableUnsplit(
 // ConstructAlterTableUnsplitAll is part of the exec.Factory interface.
 func (ef *execFactory) ConstructAlterTableUnsplitAll(index cat.Index) (exec.Node, error) {
 	if err := checkSchemaChangeEnabled(
+		ef.planner.EvalContext().Context,
 		&ef.planner.ExecCfg().Settings.SV,
 		"ALTER TABLE/INDEX UNSPLIT ALL",
 	); err != nil {

--- a/pkg/sql/pgwire/testdata/pgtest/notice
+++ b/pkg/sql/pgwire/testdata/pgtest/notice
@@ -55,7 +55,7 @@ Query {"String": "DROP INDEX t_x_idx"}
 until crdb_only
 CommandComplete
 ----
-{"Severity":"NOTICE","Code":"00000","Message":"the data for dropped indexes is reclaimed asynchronously","Detail":"","Hint":"The reclamation delay can be customized in the zone configuration for the table.","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"drop_index.go","Line":528,"Routine":"dropIndexByName","UnknownFields":null}
+{"Severity":"NOTICE","Code":"00000","Message":"the data for dropped indexes is reclaimed asynchronously","Detail":"","Hint":"The reclamation delay can be customized in the zone configuration for the table.","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"drop_index.go","Line":529,"Routine":"dropIndexByName","UnknownFields":null}
 {"Type":"CommandComplete","CommandTag":"DROP INDEX"}
 
 until noncrdb_only

--- a/pkg/sql/reassign_owned_by.go
+++ b/pkg/sql/reassign_owned_by.go
@@ -32,6 +32,7 @@ type reassignOwnedByNode struct {
 
 func (p *planner) ReassignOwnedBy(ctx context.Context, n *tree.ReassignOwnedBy) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
+		ctx,
 		&p.ExecCfg().Settings.SV,
 		"REASSIGN OWNED BY",
 	); err != nil {

--- a/pkg/sql/rename_column.go
+++ b/pkg/sql/rename_column.go
@@ -38,6 +38,7 @@ type renameColumnNode struct {
 //          mysql requires ALTER, CREATE, INSERT on the table.
 func (p *planner) RenameColumn(ctx context.Context, n *tree.RenameColumn) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
+		ctx,
 		&p.ExecCfg().Settings.SV,
 		"RENAME COLUMN",
 	); err != nil {

--- a/pkg/sql/rename_database.go
+++ b/pkg/sql/rename_database.go
@@ -43,6 +43,7 @@ type renameDatabaseNode struct {
 //   Notes: mysql >= 5.1.23 does not allow database renames.
 func (p *planner) RenameDatabase(ctx context.Context, n *tree.RenameDatabase) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
+		ctx,
 		&p.ExecCfg().Settings.SV,
 		"ALTER DATABASE",
 	); err != nil {

--- a/pkg/sql/rename_index.go
+++ b/pkg/sql/rename_index.go
@@ -36,6 +36,7 @@ type renameIndexNode struct {
 //          mysql requires ALTER, CREATE, INSERT on the table.
 func (p *planner) RenameIndex(ctx context.Context, n *tree.RenameIndex) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
+		ctx,
 		&p.ExecCfg().Settings.SV,
 		"RENAME INDEX",
 	); err != nil {

--- a/pkg/sql/rename_table.go
+++ b/pkg/sql/rename_table.go
@@ -42,6 +42,7 @@ type renameTableNode struct {
 //          on the new table (and does not copy privileges over).
 func (p *planner) RenameTable(ctx context.Context, n *tree.RenameTable) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
+		ctx,
 		&p.ExecCfg().Settings.SV,
 		"RENAME TABLE/VIEW/SEQUENCE",
 	); err != nil {

--- a/pkg/sql/reparent_database.go
+++ b/pkg/sql/reparent_database.go
@@ -42,6 +42,7 @@ func (p *planner) ReparentDatabase(
 	ctx context.Context, n *tree.ReparentDatabase,
 ) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
+		ctx,
 		&p.ExecCfg().Settings.SV,
 		"REPARENT DATABASE",
 	); err != nil {

--- a/pkg/sql/schema_change_cluster_setting.go
+++ b/pkg/sql/schema_change_cluster_setting.go
@@ -11,6 +11,7 @@
 package sql
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/featureflag"
@@ -27,8 +28,11 @@ var featureSchemaChangeEnabled = settings.RegisterPublicBoolSetting(
 
 // checkSchemaChangeEnabled is a method that wraps the featureflag.CheckEnabled
 // method specifically for all features that are categorized as schema changes.
-func checkSchemaChangeEnabled(sv *settings.Values, schemaFeatureName string) error {
+func checkSchemaChangeEnabled(
+	ctx context.Context, sv *settings.Values, schemaFeatureName string,
+) error {
 	if err := featureflag.CheckEnabled(
+		ctx,
 		featureSchemaChangeEnabled,
 		sv,
 		fmt.Sprintf("%s is part of the schema change category, which", schemaFeatureName),

--- a/pkg/sql/set_zone_config.go
+++ b/pkg/sql/set_zone_config.go
@@ -104,6 +104,7 @@ func loadYAML(dst interface{}, yamlString string) {
 
 func (p *planner) SetZoneConfig(ctx context.Context, n *tree.SetZoneConfig) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
+		ctx,
 		&p.ExecCfg().Settings.SV,
 		"CONFIGURE ZONE",
 	); err != nil {

--- a/pkg/sql/sqltelemetry/BUILD.bazel
+++ b/pkg/sql/sqltelemetry/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "enum.go",
         "exec.go",
         "extension.go",
+        "feature_flags.go",
         "follower_reads.go",
         "iam.go",
         "partitioning.go",

--- a/pkg/sql/sqltelemetry/feature_flags.go
+++ b/pkg/sql/sqltelemetry/feature_flags.go
@@ -1,0 +1,17 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sqltelemetry
+
+import "github.com/cockroachdb/cockroach/pkg/server/telemetry"
+
+// FeatureDeniedByFeatureFlagCounter is a counter that is incremented every time a feature is
+// denied via the feature flag cluster setting, for example. feature.schema_change.enabled = FALSE.
+var FeatureDeniedByFeatureFlagCounter = telemetry.GetCounterOnce("sql.feature_flag_denied")

--- a/pkg/sql/sqltelemetry/schema.go
+++ b/pkg/sql/sqltelemetry/schema.go
@@ -139,6 +139,6 @@ var SchemaChangeInExplicitTxnCounter = telemetry.GetCounterOnce("sql.schema.chan
 // a secondary index that is separated into different column families is created.
 var SecondaryIndexColumnFamiliesCounter = telemetry.GetCounterOnce("sql.schema.secondary_index_column_families")
 
-// CreateUnloggedTableCounter is a counter that is incremented everytime an unlogged
+// CreateUnloggedTableCounter is a counter that is incremented every time an unlogged
 // table is created.
 var CreateUnloggedTableCounter = telemetry.GetCounterOnce("sql.schema.create_unlogged_table")

--- a/pkg/sql/testdata/telemetry/feature_flags
+++ b/pkg/sql/testdata/telemetry/feature_flags
@@ -1,0 +1,34 @@
+# This file contains telemetry tests for the sql.feature_flag.denied counter.
+
+feature-allowlist
+sql.feature_flag_denied.*
+----
+
+exec
+SET CLUSTER SETTING feature.schema_change.enabled = FALSE;
+----
+
+# Test that a schema change denial is counted.
+feature-usage
+CREATE DATABASE d;
+----
+error: pq: feature CREATE DATABASE is part of the schema change category, which was disabled by the database administrator
+sql.feature_flag_denied
+
+# Reset schema change feature flag to enabled.
+exec
+SET CLUSTER SETTING feature.schema_change.enabled = TRUE;
+----
+
+# Test that a CREATE STATISTICS/ANALYZE denial is counted.
+exec
+CREATE TABLE t(a int, b int);
+INSERT INTO t (a, b) VALUES (0, 1);
+SET CLUSTER SETTING feature.stats.enabled = FALSE;
+----
+
+feature-usage
+CREATE STATISTICS s FROM t;
+----
+error: pq: feature ANALYZE/CREATE STATISTICS was disabled by the database administrator
+sql.feature_flag_denied


### PR DESCRIPTION
This change adds a telemetry counter, sql.feature_flag.denied, in
the case where a feature is denied by its corresponding feature flag
being set to disabled in cluster settings. It also adds a log
warning for the database administrator to view the denied command
as well as its optional category.

Release note: none