### PR TITLE
sql/catalog: unify the descs.Collection resolution-by-ID API

### DIFF
--- a/pkg/ccl/changefeedccl/rowfetcher_cache.go
+++ b/pkg/ccl/changefeedccl/rowfetcher_cache.go
@@ -108,7 +108,7 @@ func (c *rowFetcherCache) TableDescForKey(
 			if err := c.db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 				txn.SetFixedTimestamp(ctx, ts)
 				var err error
-				tableDesc, err = c.collection.GetTableVersionByID(ctx, txn, tableID, tree.ObjectLookupFlagsWithRequired())
+				tableDesc, err = c.collection.GetImmutableTableByID(ctx, txn, tableID, tree.ObjectLookupFlags{})
 				return err
 			}); err != nil {
 				// Manager can return all kinds of errors during chaos, but based on

--- a/pkg/sql/alter_primary_key.go
+++ b/pkg/sql/alter_primary_key.go
@@ -100,7 +100,7 @@ func (p *planner) AlterPrimaryKey(
 			if i != 0 {
 				sb.WriteString(comma)
 			}
-			childTable, err := p.Descriptors().GetTableVersionByID(
+			childTable, err := p.Descriptors().GetImmutableTableByID(
 				ctx,
 				p.Txn(),
 				interleaveTableID,

--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -505,7 +505,8 @@ func (p *planner) canCreateOnSchema(
 	user security.SQLUsername,
 	checkPublicSchema shouldCheckPublicSchema,
 ) error {
-	resolvedSchema, err := p.Descriptors().ResolveSchemaByID(ctx, p.Txn(), schemaID)
+	resolvedSchema, err := p.Descriptors().GetImmutableSchemaByID(
+		ctx, p.Txn(), schemaID, tree.SchemaLookupFlags{})
 	if err != nil {
 		return err
 	}
@@ -517,8 +518,8 @@ func (p *planner) canCreateOnSchema(
 			// The caller wishes to skip this check.
 			return nil
 		}
-		dbDesc, err := p.Descriptors().GetDatabaseVersionByID(
-			ctx, p.Txn(), dbID, tree.DatabaseLookupFlags{Required: true})
+		dbDesc, err := p.Descriptors().GetImmutableDatabaseByID(
+			ctx, p.Txn(), dbID, tree.DatabaseLookupFlags{})
 		if err != nil {
 			return err
 		}
@@ -545,7 +546,8 @@ func (p *planner) canResolveDescUnderSchema(
 	if tbl, ok := desc.(catalog.TableDescriptor); ok && tbl.IsTemporary() {
 		return nil
 	}
-	resolvedSchema, err := p.Descriptors().ResolveSchemaByID(ctx, p.Txn(), schemaID)
+	resolvedSchema, err := p.Descriptors().GetImmutableSchemaByID(
+		ctx, p.Txn(), schemaID, tree.SchemaLookupFlags{})
 	if err != nil {
 		return err
 	}
@@ -633,8 +635,8 @@ func (p *planner) HasOwnershipOnSchema(
 		// Only the node user has ownership over the system database.
 		return p.User().IsNodeUser(), nil
 	}
-	resolvedSchema, err := p.Descriptors().ResolveSchemaByID(
-		ctx, p.Txn(), schemaID,
+	resolvedSchema, err := p.Descriptors().GetImmutableSchemaByID(
+		ctx, p.Txn(), schemaID, tree.SchemaLookupFlags{},
 	)
 	if err != nil {
 		return false, err

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -445,14 +445,14 @@ func (sc *SchemaChanger) dropConstraints(
 	if err := sc.txn(ctx, func(
 		ctx context.Context, txn *kv.Txn, descsCol *descs.Collection,
 	) (err error) {
-		if tableDescs[sc.descID], err = descsCol.GetTableVersionByID(
-			ctx, txn, sc.descID, tree.ObjectLookupFlagsWithRequired(),
+		if tableDescs[sc.descID], err = descsCol.GetImmutableTableByID(
+			ctx, txn, sc.descID, tree.ObjectLookupFlags{},
 		); err != nil {
 			return err
 		}
 		for id := range fksByBackrefTable {
-			if tableDescs[id], err = descsCol.GetTableVersionByID(
-				ctx, txn, id, tree.ObjectLookupFlagsWithRequired(),
+			if tableDescs[id], err = descsCol.GetImmutableTableByID(
+				ctx, txn, id, tree.ObjectLookupFlags{},
 			); err != nil {
 				return err
 			}
@@ -692,7 +692,7 @@ func (sc *SchemaChanger) validateConstraints(
 func (sc *SchemaChanger) getTableVersion(
 	ctx context.Context, txn *kv.Txn, tc *descs.Collection, version descpb.DescriptorVersion,
 ) (*tabledesc.Immutable, error) {
-	tableDesc, err := tc.GetTableVersionByID(ctx, txn, sc.descID, tree.ObjectLookupFlags{})
+	tableDesc, err := tc.GetImmutableTableByID(ctx, txn, sc.descID, tree.ObjectLookupFlags{})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -259,6 +259,42 @@ func (tc *Collection) getLeasedDescriptorByName(
 	return desc, false, nil
 }
 
+// getLeasedDescriptorByID return a leased descriptor valid for the transaction,
+// acquiring one if necessary.
+// We set a deadline on the transaction based on the lease expiration, which is
+// the usual case, unless setTxnDeadline is false.
+func (tc *Collection) getLeasedDescriptorByID(
+	ctx context.Context, txn *kv.Txn, id descpb.ID, setTxnDeadline bool,
+) (catalog.Descriptor, error) {
+	// First, look to see if we already have the table in the shared cache.
+	if desc := tc.leasedDescriptors.getByID(id); desc != nil {
+		log.VEventf(ctx, 2, "found descriptor %d in cache", id)
+		return desc, nil
+	}
+
+	readTimestamp := txn.ReadTimestamp()
+	desc, expiration, err := tc.leaseMgr.Acquire(ctx, readTimestamp, id)
+	if err != nil {
+		return nil, err
+	}
+
+	if expiration.LessEq(readTimestamp) {
+		log.Fatalf(ctx, "bad descriptor for T=%s, expiration=%s", readTimestamp, expiration)
+	}
+
+	tc.leasedDescriptors.add(desc)
+	log.VEventf(ctx, 2, "added descriptor %q to collection", desc.GetName())
+
+	if setTxnDeadline {
+		// If the descriptor we just acquired expires before the txn's deadline,
+		// reduce the deadline. We use ReadTimestamp() that doesn't return the commit
+		// timestamp, so we need to set a deadline on the transaction to prevent it
+		// from committing beyond the version's expiration time.
+		txn.UpdateDeadlineMaybe(ctx, expiration)
+	}
+	return desc, nil
+}
+
 // getDescriptorFromStore gets a descriptor from its namespace entry. It does
 // not return the descriptor if the name is being drained.
 func (tc *Collection) getDescriptorFromStore(
@@ -394,7 +430,7 @@ func (tc *Collection) getDatabaseByName(
 		}
 		return false, nil, nil
 	}
-	if dropped, err := filterDescriptorState(db, flags); err != nil || dropped {
+	if dropped, err := filterDescriptorState(db, flags.Required, flags); err != nil || dropped {
 		return false, nil, err
 	}
 	return true, db, nil
@@ -545,7 +581,7 @@ func (tc *Collection) getTableByName(
 		// and it becomes more clear what the callers should be.
 		return true, table, nil
 	}
-	if dropped, err := filterDescriptorState(table, flags.CommonLookupFlags); err != nil || dropped {
+	if dropped, err := filterDescriptorState(table, flags.Required, flags.CommonLookupFlags); err != nil || dropped {
 		return false, nil, err
 	}
 	hydrated, err := tc.hydrateTypesInTableDesc(ctx, txn, table)
@@ -605,9 +641,7 @@ func (tc *Collection) getTypeByName(
 		}
 		return false, nil, nil
 	}
-	if dropped, err := filterDescriptorState(
-		typ, flags.CommonLookupFlags,
-	); err != nil || dropped {
+	if dropped, err := filterDescriptorState(typ, flags.Required, flags.CommonLookupFlags); err != nil || dropped {
 		return false, nil, err
 	}
 	return true, typ, nil
@@ -680,7 +714,7 @@ func (tc *Collection) getUserDefinedSchemaByName(
 		// the database which doesn't reflect the changes to the schema. But this
 		// isn't a problem for correctness; it can only happen on other sessions
 		// before the schema change has returned results.
-		desc, err := tc.getDescriptorVersionByID(ctx, txn, schemaInfo.ID, flags, true /* setTxnDeadline */)
+		desc, err := tc.getDescriptorByID(ctx, txn, schemaInfo.ID, flags, mutable)
 		if err != nil {
 			if errors.Is(err, catalog.ErrDescriptorNotFound) {
 				return false, nil, nil
@@ -706,7 +740,7 @@ func (tc *Collection) getUserDefinedSchemaByName(
 		}
 		return nil, nil
 	}
-	if dropped, err := filterDescriptorState(schema, flags); dropped || err != nil {
+	if dropped, err := filterDescriptorState(schema, flags.Required, flags); dropped || err != nil {
 		return nil, err
 	}
 	return schema, nil
@@ -716,11 +750,23 @@ func (tc *Collection) getUserDefinedSchemaByName(
 // the error if the descriptor is being dropped and the descriptor is not
 // required. In that case, dropped will be true. A return value of false, nil
 // means this descriptor is okay given the flags.
+// TODO (lucy): We would like the ByID methods to ignore the Required flag and
+// unconditionally return an error for dropped descriptors if IncludeDropped is
+// not set, so we can't just pass the flags passed into the methods into this
+// function, hence the boolean argument. This is the only user of
+// catalog.FilterDescriptorState which needs to pass in nontrivial flags, at
+// time of writing, so we should clean up the interface around this bit of
+// functionality.
 func filterDescriptorState(
-	desc catalog.Descriptor, flags tree.CommonLookupFlags,
+	desc catalog.Descriptor, required bool, flags tree.CommonLookupFlags,
 ) (dropped bool, _ error) {
+	flags = tree.CommonLookupFlags{
+		Required:       required,
+		IncludeOffline: flags.IncludeOffline,
+		IncludeDropped: flags.IncludeDropped,
+	}
 	if err := catalog.FilterDescriptorState(desc, flags); err != nil {
-		if flags.Required || !errors.Is(err, catalog.ErrDescriptorDropped) {
+		if required || !errors.Is(err, catalog.ErrDescriptorDropped) {
 			return false, err
 		}
 		return true, nil
@@ -810,17 +856,54 @@ func (tc *Collection) getSchemaByName(
 
 // GetDatabaseVersionByID returns a database descriptor valid for the
 // transaction. See GetDatabaseVersion.
+// Deprecated in favor of GetImmutableDatabaseByID.
 func (tc *Collection) GetDatabaseVersionByID(
 	ctx context.Context, txn *kv.Txn, dbID descpb.ID, flags tree.DatabaseLookupFlags,
 ) (*dbdesc.Immutable, error) {
-	desc, err := tc.getDescriptorVersionByID(ctx, txn, dbID, flags, true /* setTxnDeadline */)
+	return tc.GetImmutableDatabaseByID(ctx, txn, dbID, flags)
+}
+
+// GetMutableDatabaseByID returns a mutable database descriptor with
+// properties according to the provided lookup flags. RequireMutable is ignored.
+// Required is ignored, and an error is always returned if no descriptor with
+// the ID exists.
+func (tc *Collection) GetMutableDatabaseByID(
+	ctx context.Context, txn *kv.Txn, dbID descpb.ID, flags tree.DatabaseLookupFlags,
+) (*dbdesc.Mutable, error) {
+	desc, err := tc.getDatabaseByID(ctx, txn, dbID, flags, true /* mutable */)
+	if err != nil {
+		return nil, err
+	}
+	return desc.(*dbdesc.Mutable), nil
+}
+
+var _ = (*Collection)(nil).GetMutableDatabaseByID
+
+// GetImmutableDatabaseByID returns an immutable database descriptor with
+// properties according to the provided lookup flags. RequireMutable is ignored.
+// Required is ignored, and an error is always returned if no descriptor with
+// the ID exists.
+func (tc *Collection) GetImmutableDatabaseByID(
+	ctx context.Context, txn *kv.Txn, dbID descpb.ID, flags tree.DatabaseLookupFlags,
+) (*dbdesc.Immutable, error) {
+	desc, err := tc.getDatabaseByID(ctx, txn, dbID, flags, false /* mutable */)
+	if err != nil {
+		return nil, err
+	}
+	return desc.(*dbdesc.Immutable), nil
+}
+
+func (tc *Collection) getDatabaseByID(
+	ctx context.Context, txn *kv.Txn, dbID descpb.ID, flags tree.DatabaseLookupFlags, mutable bool,
+) (catalog.DatabaseDescriptor, error) {
+	desc, err := tc.getDescriptorByID(ctx, txn, dbID, flags, mutable)
 	if err != nil {
 		if errors.Is(err, catalog.ErrDescriptorNotFound) {
 			return nil, sqlerrors.NewUndefinedDatabaseError(fmt.Sprintf("[%d]", dbID))
 		}
 		return nil, err
 	}
-	db, ok := desc.(*dbdesc.Immutable)
+	db, ok := desc.(catalog.DatabaseDescriptor)
 	if !ok {
 		return nil, sqlerrors.NewUndefinedDatabaseError(fmt.Sprintf("[%d]", dbID))
 	}
@@ -828,10 +911,45 @@ func (tc *Collection) GetDatabaseVersionByID(
 }
 
 // GetTableVersionByID is a by-ID variant of GetTableVersion (i.e. uses same cache).
+// Deprecated in favor of GetImmutableTableByID.
 func (tc *Collection) GetTableVersionByID(
 	ctx context.Context, txn *kv.Txn, tableID descpb.ID, flags tree.ObjectLookupFlags,
 ) (*tabledesc.Immutable, error) {
-	desc, err := tc.getDescriptorVersionByID(ctx, txn, tableID, flags.CommonLookupFlags, true /* setTxnDeadline */)
+	return tc.GetImmutableTableByID(ctx, txn, tableID, flags)
+}
+
+// GetMutableTableByID returns a mutable table descriptor with
+// properties according to the provided lookup flags. RequireMutable is ignored.
+// Required is ignored, and an error is always returned if no descriptor with
+// the ID exists.
+func (tc *Collection) GetMutableTableByID(
+	ctx context.Context, txn *kv.Txn, tableID descpb.ID, flags tree.ObjectLookupFlags,
+) (*tabledesc.Mutable, error) {
+	desc, err := tc.getTableByID(ctx, txn, tableID, flags, true /* mutable */)
+	if err != nil {
+		return nil, err
+	}
+	return desc.(*tabledesc.Mutable), nil
+}
+
+// GetImmutableTableByID returns an immutable table descriptor with
+// properties according to the provided lookup flags. RequireMutable is ignored.
+// Required is ignored, and an error is always returned if no descriptor with
+// the ID exists.
+func (tc *Collection) GetImmutableTableByID(
+	ctx context.Context, txn *kv.Txn, tableID descpb.ID, flags tree.ObjectLookupFlags,
+) (*tabledesc.Immutable, error) {
+	desc, err := tc.getTableByID(ctx, txn, tableID, flags, false /* mutable */)
+	if err != nil {
+		return nil, err
+	}
+	return desc.(*tabledesc.Immutable), nil
+}
+
+func (tc *Collection) getTableByID(
+	ctx context.Context, txn *kv.Txn, tableID descpb.ID, flags tree.ObjectLookupFlags, mutable bool,
+) (catalog.TableDescriptor, error) {
+	desc, err := tc.getDescriptorByID(ctx, txn, tableID, flags.CommonLookupFlags, mutable)
 	if err != nil {
 		if errors.Is(err, catalog.ErrDescriptorNotFound) {
 			return nil, sqlerrors.NewUndefinedRelationError(
@@ -839,7 +957,7 @@ func (tc *Collection) GetTableVersionByID(
 		}
 		return nil, err
 	}
-	table, ok := desc.(*tabledesc.Immutable)
+	table, ok := desc.(catalog.TableDescriptor)
 	if !ok {
 		return nil, sqlerrors.NewUndefinedRelationError(
 			&tree.TableRef{TableID: int64(tableID)})
@@ -848,119 +966,161 @@ func (tc *Collection) GetTableVersionByID(
 	if err != nil {
 		return nil, err
 	}
-	return hydrated.(*tabledesc.Immutable), nil
+	return hydrated, nil
 }
 
-func (tc *Collection) getDescriptorVersionByID(
-	ctx context.Context, txn *kv.Txn, id descpb.ID, flags tree.CommonLookupFlags, setTxnDeadline bool,
+func (tc *Collection) getDescriptorByID(
+	ctx context.Context, txn *kv.Txn, id descpb.ID, flags tree.CommonLookupFlags, mutable bool,
 ) (catalog.Descriptor, error) {
-	if flags.AvoidCached || lease.TestingTableLeasesAreDisabled() {
-		desc, err := catalogkv.GetDescriptorByID(ctx, txn, tc.codec(), id, catalogkv.Immutable,
-			catalogkv.AnyDescriptorKind, true /* required */)
+	return tc.getDescriptorByIDMaybeSetTxnDeadline(
+		ctx, txn, id, flags, mutable, false /* setTxnDeadline */)
+}
+
+// getDescriptorByIDMaybeSetTxnDeadline returns a descriptor according to the
+// provided lookup flags. Note that flags.Required is ignored, and an error is
+// always returned if no descriptor with the ID exists.
+func (tc *Collection) getDescriptorByIDMaybeSetTxnDeadline(
+	ctx context.Context,
+	txn *kv.Txn,
+	id descpb.ID,
+	flags tree.CommonLookupFlags,
+	mutable, setTxnDeadline bool,
+) (catalog.Descriptor, error) {
+	getDescriptorByID := func() (catalog.Descriptor, error) {
+		if ud := tc.getUncommittedDescriptorByID(id); ud != nil {
+			log.VEventf(ctx, 2, "found uncommitted descriptor %d", id)
+			if mutable {
+				return ud.mutable, nil
+			}
+			return ud.immutable, nil
+		}
+
+		if flags.AvoidCached || mutable || lease.TestingTableLeasesAreDisabled() {
+			// Always pick up a mutable copy so it can be cached.
+			// TODO (lucy): If the descriptor doesn't exist, should we generate our
+			// own error here instead of using the one from catalogkv?
+			desc, err := catalogkv.GetDescriptorByID(ctx, txn, tc.codec(), id,
+				catalogkv.Mutable, catalogkv.AnyDescriptorKind, true /* required */)
+			if err != nil {
+				return nil, err
+			}
+			ud, err := tc.addUncommittedDescriptor(desc.(catalog.MutableDescriptor))
+			if err != nil {
+				return nil, err
+			}
+			if !mutable {
+				desc = ud.immutable
+			}
+			return desc, nil
+		}
+
+		desc, err := tc.getLeasedDescriptorByID(ctx, txn, id, setTxnDeadline)
 		if err != nil {
 			return nil, err
 		}
-		if dropped, err := filterDescriptorState(desc, flags); err != nil || dropped {
-			return nil, err
-		}
 		return desc, nil
 	}
 
-	for _, ud := range tc.uncommittedDescriptors {
-		if immut := ud.immutable; immut.GetID() == id {
-			log.VEventf(ctx, 2, "found uncommitted descriptor %d", id)
-			if immut.Dropped() {
-				// TODO (lucy): This error is meant to be parallel to the error returned
-				// from FilterDescriptorState, but it may be too low-level for getting
-				// descriptors from the descriptor collection. In general the errors
-				// being returned from this method aren't that consistent.
-				return nil, catalog.NewInactiveDescriptorError(catalog.ErrDescriptorDropped)
-			}
-			return immut, nil
-		}
-	}
-
-	// First, look to see if we already have the table in the shared cache.
-	if desc := tc.leasedDescriptors.getByID(id); desc != nil {
-		log.VEventf(ctx, 2, "found descriptor %d in cache", id)
-		return desc, nil
-	}
-
-	readTimestamp := txn.ReadTimestamp()
-	desc, expiration, err := tc.leaseMgr.Acquire(ctx, readTimestamp, id)
+	desc, err := getDescriptorByID()
 	if err != nil {
 		return nil, err
 	}
-
-	if expiration.LessEq(readTimestamp) {
-		log.Fatalf(ctx, "bad descriptor for T=%s, expiration=%s", readTimestamp, expiration)
-	}
-
-	tc.leasedDescriptors.add(desc)
-	log.VEventf(ctx, 2, "added descriptor %q to collection", desc.GetName())
-
-	if setTxnDeadline {
-		// If the descriptor we just acquired expires before the txn's deadline,
-		// reduce the deadline. We use ReadTimestamp() that doesn't return the commit
-		// timestamp, so we need to set a deadline on the transaction to prevent it
-		// from committing beyond the version's expiration time.
-		txn.UpdateDeadlineMaybe(ctx, expiration)
+	if dropped, err := filterDescriptorState(desc, true /* required */, flags); err != nil || dropped {
+		// This is a special case for tables in the adding state: Roughly speaking,
+		// we always need to resolve tables in the adding state by ID when they were
+		// newly created in the transaction for DDL statements and for some
+		// information queries (but not for ordinary name resolution for queries/
+		// DML), but we also need to make these tables public in the schema change
+		// job in a separate transaction.
+		// TODO (lucy): We need something like an IncludeAdding flag so that callers
+		// can specify this behavior, instead of having the collection infer the
+		// desired behavior based on the flags (and likely producing unintended
+		// behavior). See the similar comment on getDescriptorByName, which covers
+		// the ordinary name resolution path as well as DDL statements.
+		if desc.Adding() && (desc.IsUncommittedVersion() || flags.AvoidCached || mutable) {
+			return desc, nil
+		}
+		return nil, err
 	}
 	return desc, nil
 }
 
 // GetMutableTableVersionByID is a variant of sqlbase.getTableDescFromID which returns a mutable
 // table descriptor of the table modified in the same transaction.
+// Deprecated in favor of GetMutableTableByID.
+// TODO (lucy): Usages should be replaced with GetMutableTableByID, but this
+// needs a careful look at what flags should be passed in at each call site.
 func (tc *Collection) GetMutableTableVersionByID(
 	ctx context.Context, tableID descpb.ID, txn *kv.Txn,
 ) (*tabledesc.Mutable, error) {
-	desc, err := tc.GetMutableDescriptorByID(ctx, tableID, txn)
-	if err != nil {
-		return nil, err
-	}
-	table := desc.(*tabledesc.Mutable)
-	hydrated, err := tc.hydrateTypesInTableDesc(ctx, txn, table)
-	if err != nil {
-		return nil, err
-	}
-	return hydrated.(*tabledesc.Mutable), nil
+	return tc.GetMutableTableByID(ctx, txn, tableID, tree.ObjectLookupFlags{
+		CommonLookupFlags: tree.CommonLookupFlags{
+			IncludeOffline: true,
+			IncludeDropped: true,
+		},
+	})
 }
 
 // GetMutableDescriptorByID returns a mutable implementation of the descriptor
 // with the requested id. An error is returned if no descriptor exists.
+// Deprecated in favor of GetMutableDescriptorByIDWithFlags.
 func (tc *Collection) GetMutableDescriptorByID(
 	ctx context.Context, id descpb.ID, txn *kv.Txn,
 ) (catalog.MutableDescriptor, error) {
+	return tc.GetMutableDescriptorByIDWithFlags(ctx, txn, id, tree.CommonLookupFlags{
+		IncludeOffline: true,
+		IncludeDropped: true,
+	})
+}
+
+// GetMutableDescriptorByIDWithFlags returns a mutable implementation of the
+// descriptor with the requested id. An error is returned if no descriptor exists.
+// TODO (lucy): This is meant to replace GetMutableDescriptorByID. Once it does,
+// rename this function.
+func (tc *Collection) GetMutableDescriptorByIDWithFlags(
+	ctx context.Context, txn *kv.Txn, id descpb.ID, flags tree.CommonLookupFlags,
+) (catalog.MutableDescriptor, error) {
 	log.VEventf(ctx, 2, "planner getting mutable descriptor for id %d", id)
 
-	if desc := tc.getUncommittedDescriptorByID(id); desc != nil {
-		log.VEventf(ctx, 2, "found uncommitted descriptor %d", id)
-		return desc, nil
-	}
-	desc, err := catalogkv.GetDescriptorByID(ctx, txn, tc.codec(), id, catalogkv.Mutable,
-		catalogkv.AnyDescriptorKind, true /* required */)
+	desc, err := tc.getDescriptorByID(ctx, txn, id, flags, true /* mutable */)
 	if err != nil {
 		return nil, err
 	}
-	mut := desc.(catalog.MutableDescriptor)
-	if err := tc.AddUncommittedDescriptor(mut); err != nil {
-		return nil, err
-	}
-	return mut, nil
+	return desc.(catalog.MutableDescriptor), nil
 }
 
 // ResolveSchemaByID looks up a schema by ID.
-//
-// TODO(ajwerner): refactor this to take flags or more generally conform to the
-// other resolution APIs.
+// Deprecated in favor of GetImmutableSchemaByID.
 func (tc *Collection) ResolveSchemaByID(
 	ctx context.Context, txn *kv.Txn, schemaID descpb.ID,
 ) (catalog.ResolvedSchema, error) {
-	return tc.resolveSchemaByID(ctx, txn, schemaID, false /* mutable */, false /* includeOffline */)
+	return tc.GetImmutableSchemaByID(ctx, txn, schemaID, tree.SchemaLookupFlags{})
 }
 
-func (tc *Collection) resolveSchemaByID(
-	ctx context.Context, txn *kv.Txn, schemaID descpb.ID, mutable, includeOffline bool,
+// GetMutableSchemaByID returns a ResolvedSchema wrapping a mutable
+// descriptor, if applicable. RequireMutable is ignored.
+// Required is ignored, and an error is always returned if no descriptor with
+// the ID exists.
+func (tc *Collection) GetMutableSchemaByID(
+	ctx context.Context, txn *kv.Txn, schemaID descpb.ID, flags tree.SchemaLookupFlags,
+) (catalog.ResolvedSchema, error) {
+	return tc.getSchemaByID(ctx, txn, schemaID, flags, true /* mutable */)
+}
+
+var _ = (*Collection)(nil).GetMutableSchemaByID
+
+// GetImmutableSchemaByID returns a ResolvedSchema wrapping an immutable
+// descriptor, if applicable. RequireMutable is ignored.
+// Required is ignored, and an error is always returned if no descriptor with
+// the ID exists.
+func (tc *Collection) GetImmutableSchemaByID(
+	ctx context.Context, txn *kv.Txn, schemaID descpb.ID, flags tree.SchemaLookupFlags,
+) (catalog.ResolvedSchema, error) {
+	return tc.getSchemaByID(ctx, txn, schemaID, flags, false /* mutable */)
+}
+
+func (tc *Collection) getSchemaByID(
+	ctx context.Context, txn *kv.Txn, schemaID descpb.ID, flags tree.SchemaLookupFlags, mutable bool,
 ) (catalog.ResolvedSchema, error) {
 	if schemaID == keys.PublicSchemaID {
 		return catalog.ResolvedSchema{
@@ -989,27 +1149,9 @@ func (tc *Collection) resolveSchemaByID(
 			Name: tc.sessionData.SearchPath.GetTemporarySchemaName(),
 		}, nil
 	}
-	// Map the valid option passed to this function into flags.
-	flags := tree.SchemaLookupFlags{
-		Required:       true,
-		RequireMutable: mutable,
-		IncludeOffline: includeOffline,
-	}
+
 	// Otherwise, fall back to looking up the descriptor with the desired ID.
-	var desc catalog.Descriptor
-	var err error
-	if flags.RequireMutable {
-		desc, err = tc.GetMutableDescriptorByID(ctx, schemaID, txn)
-		if err == nil {
-			// Required is always true so there's no dealing with the dropped
-			// bool.
-			_, err = filterDescriptorState(desc, flags)
-		}
-	} else {
-		desc, err = tc.getDescriptorVersionByID(
-			ctx, txn, schemaID, flags, true, /* setTxnDeadline */
-		)
-	}
+	desc, err := tc.getDescriptorByID(ctx, txn, schemaID, flags, mutable)
 	if err != nil {
 		return catalog.ResolvedSchema{}, err
 	}
@@ -1056,8 +1198,9 @@ func (tc *Collection) hydrateTypesInTableDesc(
 			if err != nil {
 				return tree.TypeName{}, nil, err
 			}
-			sc, err := tc.resolveSchemaByID(ctx, txn, desc.ParentSchemaID,
-				true /* requireMutable */, true /* includeOffline */)
+			sc, err := tc.getSchemaByID(ctx, txn, desc.ParentSchemaID,
+				tree.SchemaLookupFlags{IncludeOffline: true},
+				true /* requireMutable */)
 			if err != nil {
 				return tree.TypeName{}, nil, err
 			}
@@ -1277,11 +1420,29 @@ func (tc *Collection) GetUncommittedTables() (tables []*tabledesc.Immutable) {
 
 // GetMutableTypeVersionByID is the equivalent of GetMutableTableDescriptorByID
 // but for accessing types.
+// Deprecated in favor of GetMutableTypeByID.
+// TODO (lucy): Usages should be replaced with GetMutableTypeByID, but this
+// needs a careful look at what flags should be passed in at each call site.
 func (tc *Collection) GetMutableTypeVersionByID(
 	ctx context.Context, txn *kv.Txn, typeID descpb.ID,
 ) (*typedesc.Mutable, error) {
-	desc, err := tc.GetMutableDescriptorByID(ctx, typeID, txn)
-	if err != nil || desc == nil {
+	return tc.GetMutableTypeByID(ctx, txn, typeID, tree.ObjectLookupFlags{
+		CommonLookupFlags: tree.CommonLookupFlags{
+			IncludeOffline: true,
+			IncludeDropped: true,
+		},
+	})
+}
+
+// GetMutableTypeByID returns a mutable type descriptor with
+// properties according to the provided lookup flags. RequireMutable is ignored.
+// Required is ignored, and an error is always returned if no descriptor with
+// the ID exists.
+func (tc *Collection) GetMutableTypeByID(
+	ctx context.Context, txn *kv.Txn, typeID descpb.ID, flags tree.ObjectLookupFlags,
+) (*typedesc.Mutable, error) {
+	desc, err := tc.getTypeByID(ctx, txn, typeID, flags, true /* mutable */)
+	if err != nil {
 		return nil, err
 	}
 	return desc.(*typedesc.Mutable), nil
@@ -1289,10 +1450,31 @@ func (tc *Collection) GetMutableTypeVersionByID(
 
 // GetTypeVersionByID is the equivalent of GetTableVersionByID but for accessing
 // types.
+// Deprecated in favor of GetImmutableTypeByID.
 func (tc *Collection) GetTypeVersionByID(
 	ctx context.Context, txn *kv.Txn, typeID descpb.ID, flags tree.ObjectLookupFlags,
 ) (*typedesc.Immutable, error) {
-	desc, err := tc.getDescriptorVersionByID(ctx, txn, typeID, flags.CommonLookupFlags, true /* setTxnDeadline */)
+	return tc.GetImmutableTypeByID(ctx, txn, typeID, flags)
+}
+
+// GetImmutableTypeByID returns an immutable type descriptor with
+// properties according to the provided lookup flags. RequireMutable is ignored.
+// Required is ignored, and an error is always returned if no descriptor with
+// the ID exists.
+func (tc *Collection) GetImmutableTypeByID(
+	ctx context.Context, txn *kv.Txn, typeID descpb.ID, flags tree.ObjectLookupFlags,
+) (*typedesc.Immutable, error) {
+	desc, err := tc.getTypeByID(ctx, txn, typeID, flags, false /* mutable */)
+	if err != nil {
+		return nil, err
+	}
+	return desc.(*typedesc.Immutable), nil
+}
+
+func (tc *Collection) getTypeByID(
+	ctx context.Context, txn *kv.Txn, typeID descpb.ID, flags tree.ObjectLookupFlags, mutable bool,
+) (catalog.TypeDescriptor, error) {
+	desc, err := tc.getDescriptorByID(ctx, txn, typeID, flags.CommonLookupFlags, mutable)
 	if err != nil {
 		if errors.Is(err, catalog.ErrDescriptorNotFound) {
 			return nil, pgerror.Newf(
@@ -1300,7 +1482,7 @@ func (tc *Collection) GetTypeVersionByID(
 		}
 		return nil, err
 	}
-	typ, ok := desc.(*typedesc.Immutable)
+	typ, ok := desc.(catalog.TypeDescriptor)
 	if !ok {
 		return nil, pgerror.Newf(
 			pgcode.UndefinedObject, "type with ID %d does not exist", typeID)
@@ -1349,19 +1531,18 @@ func (tc *Collection) getUncommittedDescriptor(
 
 // GetUncommittedTableByID returns an uncommitted table by its ID.
 func (tc *Collection) GetUncommittedTableByID(id descpb.ID) *tabledesc.Mutable {
-	desc := tc.getUncommittedDescriptorByID(id)
-	if desc != nil {
-		if table, ok := desc.(*tabledesc.Mutable); ok {
+	if ud := tc.getUncommittedDescriptorByID(id); ud != nil {
+		if table, ok := ud.mutable.(*tabledesc.Mutable); ok {
 			return table
 		}
 	}
 	return nil
 }
 
-func (tc *Collection) getUncommittedDescriptorByID(id descpb.ID) catalog.MutableDescriptor {
+func (tc *Collection) getUncommittedDescriptorByID(id descpb.ID) *uncommittedDescriptor {
 	for _, desc := range tc.uncommittedDescriptors {
 		if desc.mutable.GetID() == id {
-			return desc.mutable
+			return desc
 		}
 	}
 	return nil
@@ -1704,11 +1885,12 @@ func (dt DistSQLTypeResolver) ResolveTypeByOID(ctx context.Context, oid oid.Oid)
 func (dt DistSQLTypeResolver) GetTypeDescriptor(
 	ctx context.Context, id descpb.ID,
 ) (tree.TypeName, catalog.TypeDescriptor, error) {
-	desc, err := dt.descriptors.getDescriptorVersionByID(
+	desc, err := dt.descriptors.getDescriptorByIDMaybeSetTxnDeadline(
 		ctx,
 		dt.txn,
 		id,
 		tree.CommonLookupFlags{Required: true},
+		false, /* mutable */
 		false, /* setTxnDeadline */
 	)
 	if err != nil {

--- a/pkg/sql/catalog/descs/collection_test.go
+++ b/pkg/sql/catalog/descs/collection_test.go
@@ -208,7 +208,7 @@ func TestAddUncommittedDescriptorAndMutableResolution(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, mut.OriginalVersion(), immByName.GetVersion())
 
-			immByID, err := descriptors.GetDatabaseVersionByID(ctx, txn, db.GetID(), flags)
+			immByID, err := descriptors.GetImmutableDatabaseByID(ctx, txn, db.GetID(), flags)
 			require.NoError(t, err)
 			require.Same(t, immByName, immByID)
 
@@ -236,7 +236,7 @@ func TestAddUncommittedDescriptorAndMutableResolution(t *testing.T) {
 			require.Equal(t, db.GetVersion(), immByNameAfter.GetVersion())
 			require.Equal(t, mut.ImmutableCopy(), immByNameAfter)
 
-			immByIDAfter, err := descriptors.GetDatabaseVersionByID(ctx, txn, db.GetID(), flags)
+			immByIDAfter, err := descriptors.GetImmutableDatabaseByID(ctx, txn, db.GetID(), flags)
 			require.NoError(t, err)
 			require.Same(t, immByNameAfter, immByIDAfter)
 

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -172,7 +172,7 @@ func (n *createStatsNode) makeJobRecord(ctx context.Context) (*jobs.Record, erro
 		flags := tree.ObjectLookupFlags{CommonLookupFlags: tree.CommonLookupFlags{
 			AvoidCached: n.p.avoidCachedDescriptors,
 		}}
-		tableDesc, err = n.p.Descriptors().GetTableVersionByID(ctx, n.p.txn, descpb.ID(t.TableID), flags)
+		tableDesc, err = n.p.Descriptors().GetImmutableTableByID(ctx, n.p.txn, descpb.ID(t.TableID), flags)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -366,11 +366,11 @@ func (n *createTableNode) startExec(params runParams) error {
 	// TODO(otan): for MR databases with no locality set, set a default locality
 	// and add a notice.
 	if desc.LocalityConfig != nil {
-		dbDesc, err := params.p.Descriptors().GetDatabaseVersionByID(
+		dbDesc, err := params.p.Descriptors().GetImmutableDatabaseByID(
 			params.ctx,
 			params.p.txn,
 			desc.ParentID,
-			tree.DatabaseLookupFlags{Required: true},
+			tree.DatabaseLookupFlags{},
 		)
 		if err != nil {
 			return errors.Wrap(err, "error resolving database for multi-region")

--- a/pkg/sql/create_type.go
+++ b/pkg/sql/create_type.go
@@ -336,7 +336,8 @@ func (p *planner) createEnumWithID(
 	// However having USAGE on a parent schema of the type
 	// gives USAGE privilege to the type.
 	privs := descpb.NewDefaultPrivilegeDescriptor(params.p.User())
-	resolvedSchema, err := p.Descriptors().ResolveSchemaByID(params.ctx, p.Txn(), schemaID)
+	resolvedSchema, err := p.Descriptors().GetImmutableSchemaByID(
+		params.ctx, p.Txn(), schemaID, tree.SchemaLookupFlags{})
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/drop_database.go
+++ b/pkg/sql/drop_database.go
@@ -271,7 +271,8 @@ func (p *planner) accumulateOwnedSequences(
 				// Special case error swallowing for #50711 and #50781, which can
 				// cause columns to own sequences that have been dropped/do not
 				// exist.
-				if errors.Is(err, catalog.ErrDescriptorNotFound) {
+				if errors.Is(err, catalog.ErrDescriptorDropped) ||
+					pgerror.GetPGCode(err) == pgcode.UndefinedTable {
 					log.Infof(ctx,
 						"swallowing error for owned sequence that was not found %s", err.Error())
 					continue

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -921,7 +921,7 @@ type oneAtATimeSchemaResolver struct {
 }
 
 func (r oneAtATimeSchemaResolver) getDatabaseByID(id descpb.ID) (*dbdesc.Immutable, error) {
-	return r.p.Descriptors().GetDatabaseVersionByID(r.ctx, r.p.txn, id, tree.DatabaseLookupFlags{})
+	return r.p.Descriptors().GetImmutableDatabaseByID(r.ctx, r.p.txn, id, tree.DatabaseLookupFlags{})
 }
 
 func (r oneAtATimeSchemaResolver) getTableByID(id descpb.ID) (catalog.TableDescriptor, error) {
@@ -1011,7 +1011,8 @@ func makeAllRelationsVirtualTableWithDescriptorIDIndex(
 					}
 					h := makeOidHasher()
 					scResolver := oneAtATimeSchemaResolver{p: p, ctx: ctx}
-					sc, err := p.Descriptors().ResolveSchemaByID(ctx, p.txn, table.GetParentSchemaID())
+					sc, err := p.Descriptors().GetImmutableSchemaByID(
+						ctx, p.txn, table.GetParentSchemaID(), tree.SchemaLookupFlags{})
 					if err != nil {
 						return false, err
 					}
@@ -2382,7 +2383,8 @@ https://www.postgresql.org/docs/9.5/catalog-pg-type.html`,
 
 				// Now generate rows for user defined types in this database.
 				return forEachTypeDesc(ctx, p, dbContext, func(_ *dbdesc.Immutable, _ string, typDesc *typedesc.Immutable) error {
-					sc, err := p.Descriptors().ResolveSchemaByID(ctx, p.txn, typDesc.ParentSchemaID)
+					sc, err := p.Descriptors().GetImmutableSchemaByID(
+						ctx, p.txn, typDesc.ParentSchemaID, tree.SchemaLookupFlags{})
 					if err != nil {
 						return err
 					}
@@ -2426,7 +2428,7 @@ https://www.postgresql.org/docs/9.5/catalog-pg-type.html`,
 
 				// Check if it is a user defined type.
 				id := typedesc.UserDefinedTypeOIDToID(ooid)
-				typDesc, err := p.Descriptors().GetTypeVersionByID(ctx, p.txn, id, tree.ObjectLookupFlags{})
+				typDesc, err := p.Descriptors().GetImmutableTypeByID(ctx, p.txn, id, tree.ObjectLookupFlags{})
 				if err != nil {
 					if errors.Is(err, catalog.ErrDescriptorNotFound) {
 						return false, nil
@@ -2436,7 +2438,8 @@ https://www.postgresql.org/docs/9.5/catalog-pg-type.html`,
 					}
 					return false, err
 				}
-				sc, err := p.Descriptors().ResolveSchemaByID(ctx, p.txn, typDesc.ParentSchemaID)
+				sc, err := p.Descriptors().GetImmutableSchemaByID(
+					ctx, p.txn, typDesc.ParentSchemaID, tree.SchemaLookupFlags{})
 				if err != nil {
 					return false, err
 				}

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -511,7 +511,7 @@ func (p *planner) LookupTableByID(
 		return entry.desc, nil
 	}
 	flags := tree.ObjectLookupFlags{CommonLookupFlags: tree.CommonLookupFlags{AvoidCached: p.avoidCachedDescriptors}}
-	table, err := p.Descriptors().GetTableVersionByID(ctx, p.txn, tableID, flags)
+	table, err := p.Descriptors().GetImmutableTableByID(ctx, p.txn, tableID, flags)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -1043,7 +1043,7 @@ func (sc *SchemaChanger) done(ctx context.Context) error {
 		}
 
 		referencedTypeIDs, err = scTable.GetAllReferencedTypeIDs(func(id descpb.ID) (catalog.TypeDescriptor, error) {
-			desc, err := descsCol.GetTypeVersionByID(ctx, txn, id, tree.ObjectLookupFlagsWithRequired())
+			desc, err := descsCol.GetImmutableTypeByID(ctx, txn, id, tree.ObjectLookupFlags{})
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/sql/sequence.go
+++ b/pkg/sql/sequence.go
@@ -54,7 +54,7 @@ func (p *planner) GetSerialSequenceNameFromColumn(
 			//       as well as backward compatibility) so we're using this heuristic for now.
 			// TODO(#52487): fix this up.
 			if len(col.UsesSequenceIds) == 1 {
-				seq, err := p.Descriptors().GetTableVersionByID(
+				seq, err := p.Descriptors().GetImmutableTableByID(
 					ctx,
 					p.txn,
 					col.UsesSequenceIds[0],

--- a/pkg/sql/sequence.go
+++ b/pkg/sql/sequence.go
@@ -383,7 +383,8 @@ func removeSequenceOwnerIfExists(
 	if err != nil {
 		// Special case error swallowing for #50711 and #50781, which can cause a
 		// column to own sequences that have been dropped/do not exist.
-		if errors.Is(err, catalog.ErrDescriptorNotFound) {
+		if errors.Is(err, catalog.ErrDescriptorDropped) ||
+			pgerror.GetPGCode(err) == pgcode.UndefinedTable {
 			log.Eventf(ctx, "swallowing error during sequence ownership unlinking: %s", err.Error())
 			return nil
 		}
@@ -542,7 +543,8 @@ func (p *planner) dropSequencesOwnedByCol(
 		// Special case error swallowing for #50781, which can cause a
 		// column to own sequences that do not exist.
 		if err != nil {
-			if errors.Is(err, catalog.ErrDescriptorNotFound) {
+			if errors.Is(err, catalog.ErrDescriptorDropped) ||
+				pgerror.GetPGCode(err) == pgcode.UndefinedTable {
 				log.Eventf(ctx, "swallowing error dropping owned sequences: %s", err.Error())
 				continue
 			}


### PR DESCRIPTION
See commits for details. This PR mostly standardizes the `ByID` methods on `descs.Collection` for the specific descriptor types.

Closes #57539.