### PR TITLE
colexec: fix jsonb - string projection

### DIFF
--- a/pkg/sql/colexec/execgen/cmd/execgen/overloads_bin.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/overloads_bin.go
@@ -806,10 +806,18 @@ func convertNativeToDatum(
 		// TODO(yuzefovich): figure out a better way to perform type resolution
 		// for types that have the same physical representation.
 		switch op {
-		case tree.JSONFetchVal:
+		case tree.Minus, tree.JSONFetchVal:
+			// We currently support two operations that take in one datum
+			// argument and one argument with Bytes canonical type family (Minus
+			// and JSONFetchVal) and both require the value to be of String
+			// type, so we perform such conversion.
 			runtimeConversion = fmt.Sprintf("tree.DString(%s)", nativeElem)
 		default:
-			runtimeConversion = fmt.Sprintf("tree.DBytes(%s)", nativeElem)
+			// In order to mistakenly not add support for another binary
+			// operator in such mixed representation scenario while forgetting
+			// to choose the correct conversion, we'll panic for all other
+			// operators (during the code generation).
+			colexecerror.InternalError(errors.AssertionFailedf("unexpected binary op %s that requires conversion from Bytes canonical type family", op))
 		}
 	default:
 		colexecerror.InternalError(errors.AssertionFailedf("unexpected canonical type family: %s", canonicalTypeFamily))

--- a/pkg/sql/colexec/proj_const_left_ops.eg.go
+++ b/pkg/sql/colexec/proj_const_left_ops.eg.go
@@ -10142,7 +10142,7 @@ func (p projMinusDatumConstBytesOp) Next(ctx context.Context) coldata.Batch {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
-						_convertedNativeElem := tree.DBytes(arg)
+						_convertedNativeElem := tree.DString(arg)
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
@@ -10167,7 +10167,7 @@ func (p projMinusDatumConstBytesOp) Next(ctx context.Context) coldata.Batch {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
-						_convertedNativeElem := tree.DBytes(arg)
+						_convertedNativeElem := tree.DString(arg)
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
@@ -10195,7 +10195,7 @@ func (p projMinusDatumConstBytesOp) Next(ctx context.Context) coldata.Batch {
 				for _, i := range sel {
 					arg := col.Get(i)
 
-					_convertedNativeElem := tree.DBytes(arg)
+					_convertedNativeElem := tree.DString(arg)
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
@@ -10217,7 +10217,7 @@ func (p projMinusDatumConstBytesOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
-					_convertedNativeElem := tree.DBytes(arg)
+					_convertedNativeElem := tree.DString(arg)
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 

--- a/pkg/sql/colexec/proj_const_right_ops.eg.go
+++ b/pkg/sql/colexec/proj_const_right_ops.eg.go
@@ -10143,7 +10143,7 @@ func (p projMinusDatumBytesConstOp) Next(ctx context.Context) coldata.Batch {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
-						_convertedNativeElem := tree.DBytes(p.constArg)
+						_convertedNativeElem := tree.DString(p.constArg)
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
@@ -10166,7 +10166,7 @@ func (p projMinusDatumBytesConstOp) Next(ctx context.Context) coldata.Batch {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
-						_convertedNativeElem := tree.DBytes(p.constArg)
+						_convertedNativeElem := tree.DString(p.constArg)
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
@@ -10194,7 +10194,7 @@ func (p projMinusDatumBytesConstOp) Next(ctx context.Context) coldata.Batch {
 				for _, i := range sel {
 					arg := col.Get(i)
 
-					_convertedNativeElem := tree.DBytes(p.constArg)
+					_convertedNativeElem := tree.DString(p.constArg)
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
@@ -10214,7 +10214,7 @@ func (p projMinusDatumBytesConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
-					_convertedNativeElem := tree.DBytes(p.constArg)
+					_convertedNativeElem := tree.DString(p.constArg)
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 

--- a/pkg/sql/colexec/proj_non_const_ops.eg.go
+++ b/pkg/sql/colexec/proj_non_const_ops.eg.go
@@ -11091,7 +11091,7 @@ func (p projMinusDatumBytesOp) Next(ctx context.Context) coldata.Batch {
 						arg1 := col1.Get(i)
 						arg2 := col2.Get(i)
 
-						_convertedNativeElem := tree.DBytes(arg2)
+						_convertedNativeElem := tree.DString(arg2)
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
@@ -11118,7 +11118,7 @@ func (p projMinusDatumBytesOp) Next(ctx context.Context) coldata.Batch {
 						arg1 := col1.Get(i)
 						arg2 := col2.Get(i)
 
-						_convertedNativeElem := tree.DBytes(arg2)
+						_convertedNativeElem := tree.DString(arg2)
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
@@ -11147,7 +11147,7 @@ func (p projMinusDatumBytesOp) Next(ctx context.Context) coldata.Batch {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
 
-					_convertedNativeElem := tree.DBytes(arg2)
+					_convertedNativeElem := tree.DString(arg2)
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
@@ -11170,7 +11170,7 @@ func (p projMinusDatumBytesOp) Next(ctx context.Context) coldata.Batch {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
 
-					_convertedNativeElem := tree.DBytes(arg2)
+					_convertedNativeElem := tree.DString(arg2)
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 

--- a/pkg/sql/logictest/testdata/logic_test/json
+++ b/pkg/sql/logictest/testdata/logic_test/json
@@ -766,3 +766,28 @@ SELECT j FROM t49143 WHERE NOT (j -> 'b' @> '[1]') ORDER BY k
 {"b": 1}
 {"b": 2}
 {"b": [3, 4]}
+
+# Regression tests for #57165 (wrong type conversion in the vectorized engine).
+subtest regression_57165
+
+statement ok
+CREATE TABLE t57165(j JSON, s STRING);
+INSERT INTO t57165 VALUES ('{"foo": "bar"}', 'foo'), ('{"bar": "foo"}', 'bar')
+
+query TT
+SELECT j - 'foo' AS a, j - 'bar' AS b FROM t57165 ORDER BY rowid
+----
+{}              {"foo": "bar"}
+{"bar": "foo"}  {}
+
+query TT
+SELECT '{"foo": "bar"}' - s AS a, '{"bar": "foo"}' - s AS b FROM t57165 ORDER BY rowid
+----
+{}              {"bar": "foo"}
+{"foo": "bar"}  {}
+
+query T
+SELECT j - s FROM t57165
+----
+{}
+{}

--- a/pkg/sql/sem/tree/testdata/eval/minus
+++ b/pkg/sql/sem/tree/testdata/eval/minus
@@ -1,0 +1,14 @@
+eval
+'{}'::JSON - 'foo'
+----
+'{}'
+
+eval
+'{"foo": "bar"}'::JSON - 'foo'
+----
+'{}'
+
+eval
+'{"foo": "bar"}'::JSON - 'bar'
+----
+'{"foo": "bar"}'


### PR DESCRIPTION
Bytes canonical type family represents several types, and whenever we're
performing a binary operation with one datum and one non-datum arguments
we need to convert the latter to the correct datum type. Previously, we
had an incorrect conversion for Minus operation.

Fixes: #57165.

Release note (bug fix): Previously, CockroachDB would encounter an
internal error when performing `JSONB - String` operation via the
vectorized execution engine, and this has been fixed. The bug was
introduced in 20.2.0 version.