### PR TITLE
release-20.2: sql: require SELECT and UPDATE privileges for SELECT FOR UPDATE

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/select_for_update
+++ b/pkg/sql/logictest/testdata/logic_test/select_for_update
@@ -190,7 +190,7 @@ SELECT * FROM (SELECT * FROM generate_series(1, 2)) a FOR UPDATE
 1
 2
 
-# Use of SELECT FOR UPDATE/SHARE requires UPDATE privileges, not just SELECT privileges.
+# Use of SELECT FOR UPDATE/SHARE requires SELECT and UPDATE privileges.
 
 statement ok
 CREATE TABLE t (k INT PRIMARY KEY, v int)
@@ -199,6 +199,12 @@ user testuser
 
 statement error pgcode 42501 user testuser does not have SELECT privilege on relation t
 SELECT * FROM t
+
+statement error pgcode 42501 user testuser does not have SELECT privilege on relation t
+SELECT * FROM t FOR UPDATE
+
+statement error pgcode 42501 user testuser does not have SELECT privilege on relation t
+SELECT * FROM t FOR SHARE
 
 user root
 
@@ -219,9 +225,31 @@ SELECT * FROM t FOR SHARE
 user root
 
 statement ok
+REVOKE SELECT ON t FROM testuser
+
+statement ok
 GRANT UPDATE ON t TO testuser
 
 user testuser
+
+statement error pgcode 42501 user testuser does not have SELECT privilege on relation t
+SELECT * FROM t
+
+statement error pgcode 42501 user testuser does not have SELECT privilege on relation t
+SELECT * FROM t FOR UPDATE
+
+statement error pgcode 42501 user testuser does not have SELECT privilege on relation t
+SELECT * FROM t FOR SHARE
+
+user root
+
+statement ok
+GRANT SELECT ON t TO testuser
+
+user testuser
+
+statement ok
+SELECT * FROM t
 
 statement ok
 SELECT * FROM t FOR UPDATE
@@ -303,6 +331,9 @@ ROLLBACK
 
 statement ok
 CREATE TABLE t2 (k INT PRIMARY KEY, v2 int)
+
+statement ok
+GRANT SELECT ON t2 TO testuser
 
 statement ok
 GRANT UPDATE ON t2 TO testuser

--- a/pkg/sql/logictest/testdata/logic_test/select_for_update_nowait_interleaved
+++ b/pkg/sql/logictest/testdata/logic_test/select_for_update_nowait_interleaved
@@ -29,6 +29,9 @@ CREATE TABLE p1_1 (
 ) INTERLEAVE IN PARENT p2 (i)
 
 statement ok
+GRANT SELECT ON p2   TO testuser;
+GRANT SELECT ON p1_0 TO testuser;
+GRANT SELECT ON p1_1 TO testuser;
 GRANT UPDATE ON p2   TO testuser;
 GRANT UPDATE ON p1_0 TO testuser;
 GRANT UPDATE ON p1_1 TO testuser;

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -387,7 +387,7 @@ func (b *Builder) maybeTrackRegclassDependenciesForViews(texpr tree.TypedExpr) {
 					panic(err)
 				}
 				tn := tree.MakeUnqualifiedTableName(tree.Name(regclass.String()))
-				ds, _ := b.resolveDataSource(&tn, privilege.SELECT)
+				ds, _, _ := b.resolveDataSource(&tn, privilege.SELECT)
 
 				b.viewDeps = append(b.viewDeps, opt.ViewDep{
 					DataSource: ds,

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -522,7 +522,7 @@ func (b *Builder) buildFunction(
 		}
 		if name != nil {
 			tn := tree.MakeUnqualifiedTableName(tree.Name(*name))
-			ds, _ := b.resolveDataSource(&tn, privilege.SELECT)
+			ds, _, _ := b.resolveDataSource(&tn, privilege.SELECT)
 
 			b.viewDeps = append(b.viewDeps, opt.ViewDep{
 				DataSource: ds,

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -100,14 +100,14 @@ func (b *Builder) buildDataSource(
 			return outScope
 		}
 
-		priv := privilege.SELECT
+		ds, depName, resName := b.resolveDataSource(tn, privilege.SELECT)
+
 		locking = locking.filter(tn.ObjectName)
 		if locking.isSet() {
-			// SELECT ... FOR [KEY] UPDATE/SHARE requires UPDATE privileges.
-			priv = privilege.UPDATE
+			// SELECT ... FOR [KEY] UPDATE/SHARE also requires UPDATE privileges.
+			b.checkPrivilege(depName, ds, privilege.UPDATE)
 		}
 
-		ds, resName := b.resolveDataSource(tn, priv)
 		switch t := ds.(type) {
 		case cat.Table:
 			tabMeta := b.addTable(t, &resName)
@@ -205,14 +205,14 @@ func (b *Builder) buildDataSource(
 		return outScope
 
 	case *tree.TableRef:
-		priv := privilege.SELECT
+		ds, depName := b.resolveDataSourceRef(source, privilege.SELECT)
+
 		locking = locking.filter(source.As.Alias)
 		if locking.isSet() {
-			// SELECT ... FOR [KEY] UPDATE/SHARE requires UPDATE privileges.
-			priv = privilege.UPDATE
+			// SELECT ... FOR [KEY] UPDATE/SHARE also requires UPDATE privileges.
+			b.checkPrivilege(depName, ds, privilege.UPDATE)
 		}
 
-		ds := b.resolveDataSourceRef(source, priv)
 		switch t := ds.(type) {
 		case cat.Table:
 			outScope = b.buildScanFromTableRef(t, source, indexFlags, locking, inScope)


### PR DESCRIPTION
Backport 1/1 commits from #57309.

/cc @cockroachdb/release

---

Fixes #57282.

Before this change, `SELECT ... FOR [KEY] UPDATE/SHARE` statements replaced
the SELECT privilege check with an UPDATE privilege check. This was incorrect,
as the desired behavior is that the statement requires both SELECT and UPDATE
privileges. This commit fixes that bug.

Release note (bug fix): SELECT FOR UPDATE now requires both SELECT
and UPDATE privileges, instead of just UPDATE privileges.
