### PR TITLE
backupccl: make backup (mostly) work in tenants

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -1122,7 +1122,7 @@ func backupPlanHook(
 			EncryptionInfo:    encryptionInfo,
 			CollectionURI:     collectionURI,
 		}
-		if len(spans) > 0 {
+		if len(spans) > 0 && p.ExecCfg().Codec.ForSystemTenant() {
 			protectedtsID := uuid.MakeV4()
 			backupDetails.ProtectedTimestampRecord = &protectedtsID
 		}
@@ -1310,6 +1310,9 @@ func protectTimestampForBackup(
 	startTime, endTime hlc.Timestamp,
 	backupDetails jobspb.BackupDetails,
 ) error {
+	if backupDetails.ProtectedTimestampRecord == nil {
+		return nil
+	}
 	if len(spans) > 0 {
 		tsToProtect := endTime
 		if !startTime.IsEmpty() {

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -6124,6 +6124,11 @@ func TestBackupRestoreTenant(t *testing.T) {
 	systemDB.Exec(t, `BACKUP TENANT 11 TO 'nodelocal://1/t11'`)
 	systemDB.Exec(t, `BACKUP TENANT 20 TO 'nodelocal://1/t20'`)
 
+	t.Run("inside-tenant", func(t *testing.T) {
+		skip.WithIssue(t, 57317)
+		tenant10.Exec(t, `BACKUP DATABASE foo TO 'userfile://defaultdb.myfililes/test'`)
+	})
+
 	t.Run("non-existent", func(t *testing.T) {
 		systemDB.ExpectErr(t, "tenant 123 does not exist", `BACKUP TENANT 123 TO 'nodelocal://1/t1'`)
 		systemDB.ExpectErr(t, "tenant 21 does not exist", `BACKUP TENANT 21 TO 'nodelocal://1/t20'`)
@@ -7087,7 +7092,7 @@ schema_name`
 	sqlDBRestore.CheckQueryResults(t, checkSchemasQuery,
 		[][]string{{"pg_temp_0_0"}, {"pg_temp_0_1"}, {"pg_temp_0_2"}, {"pg_temp_0_3"}})
 
-	checkTempTablesQuery := `SELECT schema_name, 
+	checkTempTablesQuery := `SELECT schema_name,
 table_name FROM [SHOW TABLES] ORDER BY schema_name, table_name`
 	sqlDBRestore.CheckQueryResults(t, checkTempTablesQuery, [][]string{{"pg_temp_0_0", "t"},
 		{"pg_temp_0_1", "t"}, {"pg_temp_0_2", "t"}, {"pg_temp_0_3", "t"}})

--- a/pkg/rpc/auth_tenant.go
+++ b/pkg/rpc/auth_tenant.go
@@ -99,6 +99,7 @@ var reqMethodAllowlist = [...]bool{
 	roachpb.QueryIntent:    true,
 	roachpb.InitPut:        true,
 	roachpb.AddSSTable:     true,
+	roachpb.Export:         true,
 	roachpb.Refresh:        true,
 	roachpb.RefreshRange:   true,
 }


### PR DESCRIPTION
These changes conditionally remove the dependencies on gossip/protected ts/etc that would prevent a BACKUP from being planned and run inside a tenant. They also allow tenants to run ExportRequest so long as they are asking for the exported data to be returned, rather than sent directly from the kv node handling the request to a third party destination. This addition of this last limitation however does means that BACKUP will not work in tenants until #57317 lands as well.