### PR TITLE
sql: remove range loop copies > 128 bytes

### DIFF
--- a/pkg/sql/catalog/tabledesc/structured.go
+++ b/pkg/sql/catalog/tabledesc/structured.go
@@ -3197,7 +3197,8 @@ func (desc *Mutable) MakeMutationComplete(m descpb.DescriptorMutation) error {
 		case *descpb.DescriptorMutation_PrimaryKeySwap:
 			args := t.PrimaryKeySwap
 			getIndexIdxByID := func(id descpb.IndexID) (int, error) {
-				for i, idx := range desc.Indexes {
+				for i := range desc.Indexes {
+					idx := &desc.Indexes[i]
 					if idx.ID == id {
 						return i, nil
 					}

--- a/pkg/sql/colfetcher/colbatch_scan.go
+++ b/pkg/sql/colfetcher/colbatch_scan.go
@@ -133,8 +133,9 @@ func (s *ColBatchScan) GetRowsRead() int64 {
 // GetCumulativeContentionTime is part of the execinfra.KVReader interface.
 func (s *ColBatchScan) GetCumulativeContentionTime() time.Duration {
 	var totalContentionTime time.Duration
-	for _, e := range s.rf.fetcher.GetContentionEvents() {
-		totalContentionTime += e.Duration
+	events := s.rf.fetcher.GetContentionEvents()
+	for i := range events {
+		totalContentionTime += events[i].Duration
 	}
 	return totalContentionTime
 }

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -1109,7 +1109,8 @@ CREATE TABLE crdb_internal.session_trace (
 		if err != nil {
 			return err
 		}
-		for _, r := range rows {
+		for i := range rows {
+			r := &rows[i]
 			if err := addRow(r[:]...); err != nil {
 				return err
 			}
@@ -2497,7 +2498,8 @@ CREATE TABLE crdb_internal.ranges_no_leases (
 				parents[id] = uint32(desc.ParentID)
 				tableNames[id] = desc.GetName()
 				indexNames[id] = make(map[uint32]string)
-				for _, idx := range desc.Indexes {
+				for i := range desc.Indexes {
+					idx := &desc.Indexes[i]
 					indexNames[id][uint32(idx.ID)] = idx.Name
 				}
 			case *dbdesc.Immutable:
@@ -2518,7 +2520,8 @@ CREATE TABLE crdb_internal.ranges_no_leases (
 			return nil, nil, err
 		}
 		nodeIDToLocality := make(map[roachpb.NodeID]roachpb.Locality)
-		for _, desc := range descriptors {
+		for i := range descriptors {
+			desc := &descriptors[i]
 			nodeIDToLocality[desc.NodeID] = desc.Locality
 		}
 
@@ -2938,7 +2941,8 @@ CREATE TABLE crdb_internal.gossip_nodes (
 		}
 
 		alive := make(map[roachpb.NodeID]tree.DBool)
-		for _, d := range descriptors {
+		for i := range descriptors {
+			d := &descriptors[i]
 			if _, err := g.GetInfo(gossip.MakeGossipClientsKey(d.NodeID)); err == nil {
 				alive[d.NodeID] = true
 			}
@@ -3287,7 +3291,8 @@ func addPartitioningRows(
 		}
 		subzoneID := base.SubzoneID(0)
 		if subzone != nil {
-			for i, s := range zone.Subzones {
+			for i := range zone.Subzones {
+				s := &zone.Subzones[i]
 				if s.IndexID == subzone.IndexID && s.PartitionName == subzone.PartitionName {
 					subzoneID = base.SubzoneIDFromIndex(i)
 				}
@@ -3343,7 +3348,8 @@ func addPartitioningRows(
 		}
 		subzoneID := base.SubzoneID(0)
 		if subzone != nil {
-			for i, s := range zone.Subzones {
+			for i := range zone.Subzones {
+				s := &zone.Subzones[i]
 				if s.IndexID == subzone.IndexID && s.PartitionName == subzone.PartitionName {
 					subzoneID = base.SubzoneIDFromIndex(i)
 				}
@@ -3569,7 +3575,8 @@ CREATE TABLE crdb_internal.kv_store_status (
 			return err
 		}
 
-		for _, n := range response.Nodes {
+		for i := range response.Nodes {
+			n := &response.Nodes[i]
 			for _, s := range n.StoreStatuses {
 				attrs := json.NewArrayBuilder(len(s.Desc.Attrs.Attrs))
 				for _, a := range s.Desc.Attrs.Attrs {

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -3590,7 +3590,8 @@ func (dsp *DistSQLPlanner) FinalizePlan(planCtx *PlanningCtx, plan *PhysicalPlan
 	// Find all MetadataTestSenders in the plan, so that the MetadataTestReceiver
 	// knows how many sender IDs it should expect.
 	var metadataSenders []string
-	for _, proc := range plan.Processors {
+	for i := range plan.Processors {
+		proc := &plan.Processors[i]
 		if proc.Spec.Core.MetadataTestSender != nil {
 			metadataSenders = append(metadataSenders, proc.Spec.Core.MetadataTestSender.ID)
 		}

--- a/pkg/sql/distsql_plan_bulk.go
+++ b/pkg/sql/distsql_plan_bulk.go
@@ -36,7 +36,8 @@ func (dsp *DistSQLPlanner) SetupAllNodesPlanning(
 	// Because we're not going through the normal pathways, we have to set up the
 	// planCtx.NodeStatuses map ourselves. CheckNodeHealthAndVersion() will
 	// populate it.
-	for _, node := range resp.Nodes {
+	for i := range resp.Nodes {
+		node := &resp.Nodes[i]
 		_ /* NodeStatus */ = dsp.CheckNodeHealthAndVersion(planCtx, node.Desc.NodeID)
 	}
 	nodes := make([]roachpb.NodeID, 0, len(planCtx.NodeStatuses))

--- a/pkg/sql/distsql_plan_stats.go
+++ b/pkg/sql/distsql_plan_stats.go
@@ -130,9 +130,11 @@ func (dsp *DistSQLPlanner) createStatsPlan(
 			// TODO(mjibson): allow multiple inverted indexes on the same column (i.e.,
 			// with different configurations). See #50655.
 			col := s.columns[0]
-			for _, indexDesc := range desc.GetPublicNonPrimaryIndexes() {
+			indexes := desc.GetPublicNonPrimaryIndexes()
+			for i := range indexes {
+				indexDesc := &indexes[i]
 				if indexDesc.Type == descpb.IndexDescriptor_INVERTED && indexDesc.ColumnIDs[0] == col {
-					spec.Index = &indexDesc
+					spec.Index = indexDesc
 					break
 				}
 			}

--- a/pkg/sql/drop_index.go
+++ b/pkg/sql/drop_index.go
@@ -274,7 +274,8 @@ func (p *planner) dropIndexByName(
 			return err
 		}
 
-		for _, s := range zone.Subzones {
+		for i := range zone.Subzones {
+			s := &zone.Subzones[i]
 			if s.IndexID != uint32(idx.ID) {
 				_, err = GenerateSubzoneSpans(
 					p.ExecCfg().Settings,
@@ -458,7 +459,8 @@ func (p *planner) dropIndexByName(
 	}
 
 	found := false
-	for i, idxEntry := range tableDesc.Indexes {
+	for i := range tableDesc.Indexes {
+		idxEntry := &tableDesc.Indexes[i]
 		if idxEntry.ID == idx.ID {
 			// Unsplit all manually split ranges in the index so they can be
 			// automatically merged by the merge queue. Gate this on being the
@@ -489,11 +491,13 @@ func (p *planner) dropIndexByName(
 				}
 			}
 
+			// Deliberately make a copy of idxEntry now.
 			// the idx we picked up with FindIndexByID at the top may not
 			// contain the same field any more due to other schema changes
 			// intervening since the initial lookup. So we send the recent
 			// copy idxEntry for drop instead.
-			if err := tableDesc.AddIndexMutation(&idxEntry, descpb.DescriptorMutation_DROP); err != nil {
+			entryCopy := *idxEntry
+			if err := tableDesc.AddIndexMutation(&entryCopy, descpb.DescriptorMutation_DROP); err != nil {
 				return err
 			}
 			tableDesc.Indexes = append(tableDesc.Indexes[:i], tableDesc.Indexes[i+1:]...)

--- a/pkg/sql/execinfrapb/flow_diagram.go
+++ b/pkg/sql/execinfrapb/flow_diagram.go
@@ -256,9 +256,10 @@ func (zj *ZigzagJoinerSpec) summary() (string, []string) {
 	name := "ZigzagJoiner"
 	tables := zj.Tables
 	details := make([]string, 0, len(tables)+1)
-	for i, table := range tables {
+	for i := range tables {
+		table := &tables[i]
 		details = append(details, fmt.Sprintf(
-			"Side %d: %s", i, indexDetail(&table, zj.IndexOrdinals[i]),
+			"Side %d: %s", i, indexDetail(table, zj.IndexOrdinals[i]),
 		))
 	}
 	if !zj.OnExpr.Empty() {

--- a/pkg/sql/opt/constraint/spans_test.go
+++ b/pkg/sql/opt/constraint/spans_test.go
@@ -179,7 +179,8 @@ func TestSpans_KeyCount(t *testing.T) {
 		},
 	}
 
-	for i, tc := range testCases {
+	for i := range testCases {
+		tc := &testCases[i]
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 			toStr := func(keyCount int64, ok bool) string {
 				if !ok {
@@ -277,7 +278,8 @@ func TestSpans_ExtractSingleKeySpans(t *testing.T) {
 		},
 	}
 
-	for i, tc := range testCases {
+	for i := range testCases {
+		tc := &testCases[i]
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 			toStr := func(spans *Spans, ok bool) string {
 				if !ok {

--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -249,16 +249,18 @@ func (n FiltersExpr) RemoveFiltersItem(search *FiltersItem) FiltersExpr {
 func (n *FiltersExpr) RemoveCommonFilters(other FiltersExpr) {
 	// TODO(ridwanmsharif): Faster intersection using a map
 	common := (*n)[:0]
-	for _, filter := range *n {
+	for i := range *n {
+		filter := &(*n)[i]
 		found := false
-		for _, otherFilter := range other {
+		for j := range other {
+			otherFilter := &other[j]
 			if filter.Condition == otherFilter.Condition {
 				found = true
 				break
 			}
 		}
 		if !found {
-			common = append(common, filter)
+			common = append(common, *filter)
 		}
 	}
 	*n = common

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -1195,7 +1195,8 @@ func (b *logicalPropsBuilder) buildWindowProps(window *WindowExpr, rel *props.Re
 	// Output columns are all the passthrough columns with the addition of the
 	// window function column.
 	rel.OutputCols = inputProps.OutputCols.Copy()
-	for _, w := range window.Windows {
+	for i := range window.Windows {
+		w := &window.Windows[i]
 		rel.OutputCols.Add(w.Col)
 	}
 

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -2174,7 +2174,8 @@ func (sb *statisticsBuilder) colStatWindow(
 	colStat, _ := s.ColStats.Add(colSet)
 
 	var windowCols opt.ColSet
-	for _, w := range window.Windows {
+	for i := range window.Windows {
+		w := &window.Windows[i]
 		windowCols.Add(w.Col)
 	}
 

--- a/pkg/sql/opt/norm/prune_cols_funcs.go
+++ b/pkg/sql/opt/norm/prune_cols_funcs.go
@@ -446,7 +446,8 @@ func (c *CustomFuncs) NeededWindowCols(windows memo.WindowsExpr, p *memo.WindowP
 // CanPruneWindows is true if the list of window functions contains a column
 // which is not included in needed, meaning that it can be pruned.
 func (c *CustomFuncs) CanPruneWindows(needed opt.ColSet, windows memo.WindowsExpr) bool {
-	for _, w := range windows {
+	for i := range windows {
+		w := &windows[i]
 		if !needed.Contains(w.Col) {
 			return true
 		}
@@ -459,9 +460,10 @@ func (c *CustomFuncs) CanPruneWindows(needed opt.ColSet, windows memo.WindowsExp
 // remove the expression entirely.
 func (c *CustomFuncs) PruneWindows(needed opt.ColSet, windows memo.WindowsExpr) memo.WindowsExpr {
 	result := make(memo.WindowsExpr, 0, len(windows))
-	for _, w := range windows {
+	for i := range windows {
+		w := &windows[i]
 		if needed.Contains(w.Col) {
-			result = append(result, w)
+			result = append(result, *w)
 		}
 	}
 	return result

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -549,7 +549,8 @@ func (b *Builder) buildScan(
 			dep.ColumnIDToOrd = make(map[opt.ColumnID]int)
 			// We will track the ColumnID to Ord mapping so Ords can be added
 			// when a column is referenced.
-			for i, col := range outScope.cols {
+			for i := range outScope.cols {
+				col := &outScope.cols[i]
 				dep.ColumnIDToOrd[col.id] = ordinals[i]
 			}
 			if private.Flags.ForceIndex {
@@ -1393,7 +1394,8 @@ func (b *Builder) validateLockingInFrom(
 			// to improve the time complexity here, but we expect the number of
 			// columns to be small enough that doing so is likely not worth it.
 			found := false
-			for _, col := range fromScope.cols {
+			for i := range fromScope.cols {
+				col := &fromScope.cols[i]
 				if target.ObjectName == col.table.ObjectName {
 					found = true
 					break

--- a/pkg/sql/opt/optbuilder/update.go
+++ b/pkg/sql/opt/optbuilder/update.go
@@ -351,7 +351,8 @@ func (mb *mutationBuilder) buildUpdate(returning tree.ReturningExprs) {
 	mb.buildFKChecksForUpdate()
 
 	private := mb.makeMutationPrivate(returning != nil)
-	for _, col := range mb.extraAccessibleCols {
+	for i := range mb.extraAccessibleCols {
+		col := &mb.extraAccessibleCols[i]
 		if col.id != 0 {
 			private.PassthroughCols = append(private.PassthroughCols, col.id)
 		}

--- a/pkg/sql/opt/optgen/exprgen/private.go
+++ b/pkg/sql/opt/optgen/exprgen/private.go
@@ -128,7 +128,9 @@ func (eg *exprGen) findIndex(str string) int {
 	}
 	table, index := a[0], a[1]
 	var tab cat.Table
-	for _, meta := range eg.mem.Metadata().AllTables() {
+	allTables := eg.mem.Metadata().AllTables()
+	for i := range allTables {
+		meta := &allTables[i]
 		if meta.Alias.Table() == table {
 			if tab != nil {
 				panic(errorf("ambiguous table name %s", table))

--- a/pkg/sql/partition_utils.go
+++ b/pkg/sql/partition_utils.go
@@ -90,7 +90,8 @@ func GenerateSubzoneSpans(
 
 	subzoneIndexByIndexID := make(map[descpb.IndexID]int32)
 	subzoneIndexByPartition := make(map[string]int32)
-	for i, subzone := range subzones {
+	for i := range subzones {
+		subzone := &subzones[i]
 		if len(subzone.PartitionName) > 0 {
 			subzoneIndexByPartition[subzone.PartitionName] = int32(i)
 		} else {

--- a/pkg/sql/region_util.go
+++ b/pkg/sql/region_util.go
@@ -47,7 +47,8 @@ func (p *planner) getLiveClusterRegions() (liveClusterRegions, error) {
 		return nil, err
 	}
 	var ret liveClusterRegions = make(map[descpb.Region]struct{})
-	for _, node := range nodes {
+	for i := range nodes {
+		node := &nodes[i]
 		for _, tier := range node.Locality.Tiers {
 			if tier.Key == "region" {
 				ret[descpb.Region(tier.Value)] = struct{}{}

--- a/pkg/sql/rowexec/rowfetcher.go
+++ b/pkg/sql/rowexec/rowfetcher.go
@@ -121,7 +121,8 @@ func initRowFetcher(
 // contention time from a slice of roachpb.ContentionEvents.
 func getCumulativeContentionTime(events []roachpb.ContentionEvent) time.Duration {
 	var cumulativeContentionTime time.Duration
-	for _, e := range events {
+	for i := range events {
+		e := &events[i]
 		cumulativeContentionTime += e.Duration
 	}
 	return cumulativeContentionTime

--- a/pkg/sql/rowflow/row_based_flow.go
+++ b/pkg/sql/rowflow/row_based_flow.go
@@ -257,7 +257,8 @@ func (f *rowBasedFlow) setupInputSyncs(
 	ctx context.Context, spec *execinfrapb.FlowSpec, opt flowinfra.FuseOpt,
 ) ([][]execinfra.RowSource, error) {
 	inputSyncs := make([][]execinfra.RowSource, len(spec.Processors))
-	for pIdx, ps := range spec.Processors {
+	for pIdx := range spec.Processors {
+		ps := &spec.Processors[pIdx]
 		for _, is := range ps.Input {
 			if len(is.Streams) == 0 {
 				return nil, errors.Errorf("input sync with no streams")

--- a/pkg/sql/scatter.go
+++ b/pkg/sql/scatter.go
@@ -144,7 +144,8 @@ func (n *scatterNode) startExec(params runParams) error {
 	n.run.rangeIdx = -1
 	n.run.ranges = make([]roachpb.Span, len(scatterRes.RangeInfos))
 	if len(scatterRes.RangeInfos) != 0 {
-		for i, rangeInfo := range scatterRes.RangeInfos {
+		for i := range scatterRes.RangeInfos {
+			rangeInfo := &scatterRes.RangeInfos[i]
 			n.run.ranges[i] = roachpb.Span{
 				Key:    rangeInfo.Desc.StartKey.AsRawKey(),
 				EndKey: rangeInfo.Desc.EndKey.AsRawKey(),

--- a/pkg/sql/sem/tree/create.go
+++ b/pkg/sql/sem/tree/create.go
@@ -1566,9 +1566,6 @@ func (o KVOptions) ToRoleOptions(
 					return nil, err
 				}
 
-				if err != nil {
-					return nil, err
-				}
 				roleOptions[i] = roleoption.RoleOption{
 					Option: option, Value: strFn, HasValue: true,
 				}

--- a/pkg/sql/set_zone_config.go
+++ b/pkg/sql/set_zone_config.go
@@ -822,7 +822,8 @@ func validateZoneAttrsAndLocalities(
 		}
 		var found bool
 	node:
-		for _, node := range nodes.Nodes {
+		for i := range nodes.Nodes {
+			node := &nodes.Nodes[i]
 			for _, store := range node.StoreStatuses {
 				// We could alternatively use zonepb.StoreMatchesConstraint here to
 				// catch typos in prohibited constraints as well, but as noted in the


### PR DESCRIPTION
This commit removes code that uses a value range loop over a slice,
where the value's type is over 128 bytes in size. It was mostly
automatically generated, using the following ruleguard ruleset:

```
// +build ignore

package gorules

import "github.com/quasilyte/go-ruleguard/dsl/fluent"

func largeloopslicecopy(m fluent.Matcher) {
	m.Match(
		`for _, $v := range $s { $b } `,
	).
		Where(m["s"].Type.Underlying().Is(`[]$T`) && m["v"].Type.Size > 128).
		Suggest(`for i := range $s {
$v := &$s[i]
$b
} `)
	m.Match(
		`for $i, $v := range $s { $b } `,
	).
		Where(m["s"].Type.Underlying().Is(`[]$T`) && m["v"].Type.Size > 128).
		Suggest(`for $i := range $s {
$v := &$s[$i]
$b
} `)
}
```

Some small manual fixups were required.

Release note: None