### PR TITLE
kv/concurrency: bump goroutine stall delay

### DIFF
--- a/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
@@ -985,7 +985,7 @@ func (m *monitor) waitForAsyncGoroutinesToStall(t *testing.T) {
 		// Add a small fixed delay after each iteration. This is sufficient to
 		// prevents false detection of stalls in a few cases, like when
 		// receiving on a buffered channel that already has an element in it.
-		defer time.Sleep(1 * time.Millisecond)
+		defer time.Sleep(5 * time.Millisecond)
 
 		prevStatus := status
 		status = goroutineStatus(t, filter, &m.buf)


### PR DESCRIPTION
Fixes #57273.

This commit bumps the goroutine stall delay in the TestConcurrencyManagerBasic
framework from 1ms to 5ms. In #57273, we saw a flake due to a goroutine being
classified as stalled when it was actually waiting for a multi-goroutine
chain of events to fire (request exits lockTable, signals lockTable wait-queue,
which is noticed by watchForNotifications, which cancels the pushers context).
This chain of events plus the 1ms wait in the framework led to a flake under
stress roughly every 16k iterations. With this delay bumped to 3ms, I have never
reproduced the flake after over 2M iterations. This PR bumps the delay all the
way up to 5ms to be extra sure. This increases the runtime of all subtests
combined from 1.6s to 3.9s.