### PR TITLE
logictest: fix -rewrite option with floating point numbers

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -2657,33 +2657,7 @@ func (t *logicTest) execQuery(query logicQuery) error {
 		}
 	}
 
-	if *rewriteResultsInTestfiles || *rewriteSQL {
-		if query.expectedHash != "" {
-			if query.expectedValues == 1 {
-				t.emit(fmt.Sprintf("1 value hashing to %s", query.expectedHash))
-			} else {
-				t.emit(fmt.Sprintf("%d values hashing to %s", query.expectedValues, query.expectedHash))
-			}
-		}
-
-		if query.checkResults {
-			// If the results match or we're not rewriting, emit them the way they were originally
-			// formatted/ordered in the testfile. Otherwise, emit the actual results.
-			if !*rewriteResultsInTestfiles || reflect.DeepEqual(query.expectedResults, actualResults) {
-				for _, l := range query.expectedResultsRaw {
-					t.emit(l)
-				}
-			} else {
-				// Emit the actual results.
-				for _, line := range t.formatValues(actualResultsRaw, query.valsPerLine) {
-					t.emit(line)
-				}
-			}
-		}
-		return nil
-	}
-
-	if query.checkResults {
+	resultsMatch := func() error {
 		makeError := func() error {
 			var buf bytes.Buffer
 			fmt.Fprintf(&buf, "%s: %s\nexpected:\n", query.pos, query.sql)
@@ -2724,6 +2698,39 @@ func (t *logicTest) execQuery(query logicQuery) error {
 			if !resultMatches {
 				return makeError()
 			}
+		}
+		return nil
+	}
+
+	if *rewriteResultsInTestfiles || *rewriteSQL {
+		if query.expectedHash != "" {
+			if query.expectedValues == 1 {
+				t.emit(fmt.Sprintf("1 value hashing to %s", query.expectedHash))
+			} else {
+				t.emit(fmt.Sprintf("%d values hashing to %s", query.expectedValues, query.expectedHash))
+			}
+		}
+
+		if query.checkResults {
+			// If the results match or we're not rewriting, emit them the way they were originally
+			// formatted/ordered in the testfile. Otherwise, emit the actual results.
+			if !*rewriteResultsInTestfiles || resultsMatch() == nil {
+				for _, l := range query.expectedResultsRaw {
+					t.emit(l)
+				}
+			} else {
+				// Emit the actual results.
+				for _, line := range t.formatValues(actualResultsRaw, query.valsPerLine) {
+					t.emit(line)
+				}
+			}
+		}
+		return nil
+	}
+
+	if query.checkResults {
+		if err := resultsMatch(); err != nil {
+			return err
 		}
 	}
 


### PR DESCRIPTION
We recently introduced a new `F` type for floating point numbers that
allow for the actual results to deviate from the expected slightly.
However, we forget to use the same matcher when `-rewrite` option is
passed, and now the expected results are updated to the actual results
even if the matched. This is undesirable and is now fixed.

Fixes: #57199.

Release note: None