### PR TITLE
docs,server: add reference examples for `_status` endpoints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1603,7 +1603,7 @@ bin/.docgen_http: bin/docgen $(PROTOC)
 	--protoc $(PROTOC) \
 	--gendoc ./bin/protoc-gen-doc \
 	--out docs/generated/http \
-	--protobuf pkg:$(GOGO_PROTOBUF_PATH):$(PROTOBUF_PATH):$(COREOS_PATH):$(GRPC_GATEWAY_GOOGLEAPIS_PATH):$(ERRORS_PATH)
+	--protobuf pkg:./vendor/github.com:$(GOGO_PROTOBUF_PATH):$(PROTOBUF_PATH):$(COREOS_PATH):$(GRPC_GATEWAY_GOOGLEAPIS_PATH):$(ERRORS_PATH)
 	touch $@
 
 .PHONY: docs/generated/redact_safe.md

--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -103,6 +103,25 @@ availability and stability in external uses.
 
 Details retrieves details about the nodes in the cluster.
 
+ Reference example:
+ ```
+ curl http://127.0.0.1:51875/_status/details/1
+   ->
+ {
+ "nodeId": 1,
+   "address": {
+   "networkField": "tcp",
+   "addressField": "127.0.0.1:51876"
+   },
+   "buildInfo": {...},
+   "systemInfo": {...},
+   "sqlAddress": {
+   "networkField": "tcp",
+   "addressField": "127.0.0.1:51877"
+   }
+ }
+ ```
+
 Note: this is a “reserved” API endpoint and should not be relied upon to
 build external tools. No guarantee is made about its
 availability and stability in external uses.
@@ -181,6 +200,142 @@ availability and stability in external uses.
 Nodes retrieves an overview of the nodes in the cluster.
 
 
+ Reference example:
+ ``` 
+ curl http://127.0.0.1:51875/_status/nodes   
+  ->
+ {
+  "nodes": [
+    {
+      "desc": {
+        "nodeId": 1,
+        "address": {
+          "networkField": "tcp",
+          "addressField": "127.0.0.1:51876"
+        },
+        "attrs": {
+          "attrs": []
+        },
+        "locality": {
+          "tiers": [
+            {
+              "key": "region",
+              "value": "us-east1"
+            },
+            {
+              "key": "az",
+              "value": "b"
+            }
+          ]
+        },
+        "ServerVersion": {
+          "majorVal": 20,
+          "minorVal": 2,
+          "patch": 0,
+          "unstable": 1
+        },
+        "buildTag": "v20.2.0-alpha.3-2061-gb4156e4e2c",
+        "startedAt": "1606913361337496000",
+        "localityAddress": [],
+        "clusterName": "",
+        "sqlAddress": {
+          "networkField": "tcp",
+          "addressField": "127.0.0.1:51877"
+        }
+      },
+      "buildInfo": {...},
+      "startedAt": "1606913361337496000",
+      "updatedAt": "1606920801488818000",
+      "metrics": {...},
+      "storeStatuses": [
+        {
+          "desc": {
+            "storeId": 1,
+            "attrs": {
+              "attrs": []
+            },
+            "node": {
+              "nodeId": 1,
+              "address": {
+                "networkField": "tcp",
+                "addressField": "127.0.0.1:51876"
+              },
+              "attrs": {
+                "attrs": []
+              },
+              "locality": {
+                "tiers": [
+                  {
+                    "key": "region",
+                    "value": "us-east1"
+                  },
+                  {
+                    "key": "az",
+                    "value": "b"
+                  }
+                ]
+              },
+              "ServerVersion": {
+                "majorVal": 20,
+                "minorVal": 2,
+                "patch": 0,
+                "unstable": 1
+              },
+              "buildTag": "v20.2.0-alpha.3-2061-gb4156e4e2c",
+              "startedAt": "1606913361337496000",
+              "localityAddress": [],
+              "clusterName": "",
+              "sqlAddress": {
+                "networkField": "tcp",
+                "addressField": "127.0.0.1:51877"
+              }
+            },
+            "capacity": {
+              "capacity": "536870912",
+              "available": "536870912",
+              "used": "0",
+              "logicalBytes": "21518089",
+              "rangeCount": 65,
+              "leaseCount": 65,
+              "queriesPerSecond": 10.326122145577715,
+              "writesPerSecond": 82.90851430132487,
+              "bytesPerReplica": {
+                "p10": 0,
+                "p25": 0,
+                "p50": 460,
+                "p75": 10118,
+                "p90": 40825,
+                "pMax": 20712052
+              },
+              "writesPerReplica": {...}
+            }
+          }
+          "metrics": {...}
+        }
+      ],
+      "args": [
+        "./cockroach",
+        "demo",
+        "--insecure"
+      ],
+      "env": [],
+      "latencies": {},
+      "activity": {
+        "1": {
+          "incoming": "235921",
+          "outgoing": "222073",
+          "latency": "677603"
+        }
+      },
+      "totalSystemMemory": "34359738368",
+      "numCpus": 16
+    }
+  ],
+  "livenessByNodeId": {
+    "1": 3
+  }
+}   
+ ```
 Don't introduce additional usages of this RPC. See #50707 for more details.
 The underlying response type is something we're looking to get rid of.
 
@@ -541,6 +696,7 @@ availability and stability in external uses.
 `GET /_status/raft`
 
 RaftDebug requests internal details about Raft.
+TODO DURING REVIEW: Not sure if this needs a reference example
 
 Note: this is a “reserved” API endpoint and should not be relied upon to
 build external tools. No guarantee is made about its
@@ -834,6 +990,7 @@ availability and stability in external uses.
 `GET /_status/ranges/{node_id}`
 
 Ranges requests internal details about ranges on a given node.
+TODO DURING REVIEW: Not sure if this needs a reference example
 
 Note: this is a “reserved” API endpoint and should not be relied upon to
 build external tools. No guarantee is made about its
@@ -1040,6 +1197,7 @@ availability and stability in external uses.
 `GET /_status/gossip/{node_id}`
 
 Gossip retrieves gossip-level details about a given node.
+TODO DURING REVIEW: Not sure if this needs a reference example
 
 Note: this is a “reserved” API endpoint and should not be relied upon to
 build external tools. No guarantee is made about its
@@ -1076,6 +1234,23 @@ availability and stability in external uses.
 `GET /_status/enginestats/{node_id}`
 
 EngineStats retrieves statistics about a storage engine.
+
+ Reference example:
+ ``` 
+ curl http://127.0.0.1:51875/_status/enginestats/1   
+  ->
+ {
+  "stats": [
+    {
+      "storeId": 1,
+      "tickersAndHistograms": {...},
+      "engineType": 2
+    }
+  ]
+}   
+ ```
+TODO DURING REVIEW: This looks like it was only used by RocksDB and not Pebble. 
+Not sure if we still want to keep the example.
 
 Note: this is a “reserved” API endpoint and should not be relied upon to
 build external tools. No guarantee is made about its
@@ -1149,6 +1324,51 @@ availability and stability in external uses.
 `GET /_status/allocator/node/{node_id}`
 
 Allocator retrieves statistics about the replica allocator.
+
+ Reference example:
+ ``` 
+ curl http://127.0.0.1:51875/_status/allocator/node/1   
+  ->
+ {
+  "dryRuns": [
+    {
+      "rangeId": "1",
+      "events": [
+        {
+          "time": "2020-12-02T14:53:24.252733Z",
+          "message": "kv/kvserver/replicate_queue.go:343 [n1,status] next replica action: consider rebalance"
+        },
+        {
+          "time": "2020-12-02T14:53:24.252789Z",
+          "message": "kv/kvserver/replicate_queue.go:849 [n1,status] no suitable rebalance target"
+        },
+        {
+          "time": "2020-12-02T14:53:24.252798Z",
+          "message": "kv/kvserver/allocator.go:847 [n1,status] no lease transfer target found"
+        }
+      ]
+    },
+    {
+      "rangeId": "2",
+      "events": [
+        {
+          "time": "2020-12-02T14:53:24.252825Z",
+          "message": "kv/kvserver/replicate_queue.go:343 [n1,status] next replica action: consider rebalance"
+        },
+        {
+          "time": "2020-12-02T14:53:24.252840Z",
+          "message": "kv/kvserver/replicate_queue.go:849 [n1,status] no suitable rebalance target"
+        },
+        {
+          "time": "2020-12-02T14:53:24.252847Z",
+          "message": "kv/kvserver/allocator.go:847 [n1,status] no lease transfer target found"
+        }
+      ]
+    },
+    ...
+  ]
+}   
+ ```
 
 Note: this is a “reserved” API endpoint and should not be relied upon to
 build external tools. No guarantee is made about its
@@ -1332,6 +1552,31 @@ availability and stability in external uses.
 `GET /_status/sessions`
 
 ListSessions retrieves the SQL sessions across the entire cluster.
+
+ Reference example:
+ ``` 
+ curl http://127.0.0.1:51875/_status/sessions   
+  ->
+ {
+  "sessions": [
+    {
+      "nodeId": 1,
+      "username": "root",
+      "clientAddress": "127.0.0.1:51883",
+      "applicationName": "$ cockroach demo",
+      "activeQueries": [],
+      "start": "2020-12-02T12:49:22.173886Z",
+      "lastActiveQuery": "SHOW database",
+      "id": "FkznMGk07HgAAAAAAAAAAQ==",
+      "allocBytes": "0",
+      "maxAllocBytes": "30720",
+      "activeTxn": null,
+      "lastActiveQueryAnon": "SHOW database"
+    }
+  ],
+  "errors": []
+}   
+ ```
 
 Note: this is a “reserved” API endpoint and should not be relied upon to
 build external tools. No guarantee is made about its
@@ -1641,6 +1886,16 @@ availability and stability in external uses.
 
 CancelQuery cancels a SQL query given its ID.
 
+ Reference example:
+ ```
+ curl http://127.0.0.1:26258/_status/cancel_query/1 -X POST -d  '{"node_id": "1", "query_id": "164cf86bc40442380000000000000001"}'
+ ->
+ {
+   "canceled": true,
+   "error": ""
+ }
+ ```
+
 Note: this is a “reserved” API endpoint and should not be relied upon to
 build external tools. No guarantee is made about its
 availability and stability in external uses.
@@ -1697,6 +1952,11 @@ availability and stability in external uses.
 `POST /_status/cancel_session/{node_id}`
 
 CancelSessions forcefully terminates a SQL session given its ID.
+TODO DURING REVIEW: The way we internally seem to be using this is
+by parsing the session ID string (returned by something like
+`SHOW SESSIONS`) into a uint128 and then casting that into a byte array of 
+length 16. Not sure if this is supposed to ever be used externally, since 
+it seems so unergonomic to use.
 
 Note: this is a “reserved” API endpoint and should not be relied upon to
 build external tools. No guarantee is made about its
@@ -1817,6 +2077,15 @@ availability and stability in external uses.
 
 Stacks retrieves the stack traces of all goroutines on a given node.
 
+ Reference example:
+ ``` 
+ curl http://127.0.0.1:51875/_status/stacks/1   
+  ->
+ {
+  "data": "<payload>"
+}   
+ ```
+
 Note: this is a “reserved” API endpoint and should not be relied upon to
 build external tools. No guarantee is made about its
 availability and stability in external uses.
@@ -1871,6 +2140,15 @@ availability and stability in external uses.
 `GET /_status/profile/{node_id}`
 
 Profile retrieves a CPU profile on a given node.
+
+ Reference example:
+ ``` 
+ curl http://127.0.0.1:51875/_status/profile/1   
+  ->
+ {
+  "data": "<payload>"
+}   
+ ```
 
 Note: this is a “reserved” API endpoint and should not be relied upon to
 build external tools. No guarantee is made about its
@@ -1932,6 +2210,15 @@ Note: this is a “reserved” API and should not be relied upon to
 build external tools. No guarantee is made about its
 availability and stability in external uses.
 
+ Reference example:
+ ``` 
+ curl http://127.0.0.1:51875/_status/metrics/1   
+  ->
+ {
+  "data": "<payload>"
+}   
+ ```
+
 Note: this is a “reserved” API endpoint and should not be relied upon to
 build external tools. No guarantee is made about its
 availability and stability in external uses.
@@ -1985,6 +2272,19 @@ availability and stability in external uses.
 `GET /_status/files/{node_id}`
 
 GetFiles retrieves heap or goroutine dump files from a given node.
+
+ Reference example:
+ ``` 
+ curl http://127.0.0.1:51875/_status/files/1   
+  ->
+ {
+ "files": [{
+  "name": "...",
+  "file_size": ...,
+  "contents": "..."    
+}]
+}   
+ ```
 
 Note: this is a “reserved” API endpoint and should not be relied upon to
 build external tools. No guarantee is made about its
@@ -2061,6 +2361,19 @@ availability and stability in external uses.
 `GET /_status/logfiles/{node_id}`
 
 LogFilesList retrieves a list of log files on a given node.
+
+ Reference example:
+ ``` 
+ curl http://127.0.0.1:51875/_status/logfiles/1   
+  ->
+ {
+ "files": [{
+  "name": "...",
+  "file_size": ...,
+  "contents": "..."    
+}]
+}   
+ ```
 
 Note: this is a “reserved” API endpoint and should not be relied upon to
 build external tools. No guarantee is made about its
@@ -2234,6 +2547,28 @@ availability and stability in external uses.
 
 ProblemRanges retrieves the list of “problem ranges”.
 
+ Reference example:
+ ``` 
+ curl http://127.0.0.1:51875/_status/problemranges   
+  ->
+ {
+  "nodeId": 1,
+  "problemsByNodeId": {
+    "1": {
+      "errorMessage": "",
+      "unavailableRangeIds": [],
+      "raftLeaderNotLeaseHolderRangeIds": [],
+      "noRaftLeaderRangeIds": [],
+      "noLeaseRangeIds": [],
+      "underreplicatedRangeIds": [],
+      "overreplicatedRangeIds": [],
+      "quiescentEqualsTickingRangeIds": [],
+      "raftLogTooLargeRangeIds": []
+    }
+  }
+}   
+ ```
+
 Note: this is a “reserved” API endpoint and should not be relied upon to
 build external tools. No guarantee is made about its
 availability and stability in external uses.
@@ -2328,7 +2663,50 @@ availability and stability in external uses.
 
 `GET /_status/hotranges`
 
+HotRanges retrieves a list of ranges ordered by the amount of traffic being 
+received.
 
+ Reference example:
+ ``` 
+ curl http://127.0.0.1:51875/_status/hotranges   
+  ->
+ {
+  "nodeId": 1,
+  "hotRangesByNodeId": {
+    "1": {
+      "errorMessage": "",
+      "stores": [
+        {
+          "storeId": 1,
+          "hotRanges": [
+            {
+              "desc": {
+                "rangeId": "6",
+                "startKey": "iA==",
+                "endKey": "kw==",
+                "internalReplicas": [
+                  {
+                    "nodeId": 1,
+                    "storeId": 1,
+                    "replicaId": 1,
+                    "type": null
+                  }
+                ],
+                "nextReplicaId": 2,
+                "generation": "0",
+                "deprecatedGenerationComparable": null,
+                "stickyBit": null
+              },
+              "queriesPerSecond": 5.36106511320822
+            },
+            ...
+          ]
+        }
+      ]
+    }
+  }
+}   
+ ```
 
 Note: this is a “reserved” API endpoint and should not be relied upon to
 build external tools. No guarantee is made about its
@@ -2452,7 +2830,7 @@ advance notice in a subsequent release.
 
 `GET /_status/range/{range_id}`
 
-
+TODO DURING REVIEW: Not sure if this needs a reference example
 
 Note: this is a “reserved” API endpoint and should not be relied upon to
 build external tools. No guarantee is made about its
@@ -2694,7 +3072,308 @@ availability and stability in external uses.
 
 `GET /_status/diagnostics/{node_id}`
 
-
+TODO DURING REVIEW: Do we want to redact this response even further? 
+ Reference example:
+ ``` 
+ curl http://127.0.0.1:51875/_status/diagnostics/1   
+  ->
+ {
+  "node": {
+    "nodeId": 1,
+    "bytes": "21565824",
+    "keyCount": "5668",
+    "rangeCount": "65",
+    "locality": {
+      "tiers": [
+        {
+          "key": "5d64eba5",
+          "value": "67b07925"
+        },
+        {
+          "key": "d4f35d56",
+          "value": "d5a474fc"
+        }
+      ]
+    },
+    "hardware": {
+      "virtualization": "",
+      "cpu": {...},
+      "mem": {
+        "total": "34359738368",
+        "available": "15584899072"
+      },
+      "loadavg15": 4.7993164,
+      "provider": "",
+      "instanceClass": ""
+    },
+    "os": {
+      "family": "Standalone Workstation",
+      "platform": "darwin",
+      "version": "10.15.7"
+    },
+    "build": {...},
+    "uptime": "7443",
+    "licenseType": "Evaluation",
+    "topology": {
+      "provider": "",
+      "region": ""
+    }
+  },
+  "stores": [
+    {
+      "nodeId": 1,
+      "storeId": 1,
+      "bytes": "21565824",
+      "keyCount": "5668",
+      "rangeCount": "65",
+      "capacity": "536870912",
+      "available": "536870912",
+      "used": "0",
+      "encryptionAlgorithm": "0"
+    }
+  ],
+  "schema": [
+    {
+      "name": "_",
+      "id": 53,
+      "version": 7,
+      "modificationTime": {
+        "wallTime": "1606913362141165000",
+        "logical": 0
+      },
+      "drainingNames": [],
+      "parentId": 52,
+      "unexposedParentSchemaId": 29,
+      "columns": [
+        {
+          "name": "_",
+          "id": 1,
+          "type": {},
+          "nullable": false,
+          "defaultExpr": null,
+          "hidden": false,
+          "usesSequenceIds": [],
+          "ownsSequenceIds": [],
+          "computeExpr": null,
+          "pgAttributeNum": 0,
+          "alterColumnTypeInProgress": false,
+          "systemColumnKind": 0
+        },
+        ...
+      ],
+      "nextColumnId": 6,
+      "families": [
+        {
+          "name": "_",
+          "id": 0,
+          "columnNames": [
+            "_",
+            "_",
+            "_",
+            "_",
+            "_"
+          ],
+          "columnIds": [
+            1,
+            2,
+            3,
+            4,
+            5
+          ],
+          "defaultColumnId": 0
+        }
+      ],
+      "nextFamilyId": 1,
+      "primaryIndex": {
+        "name": "_",
+        "id": 1,
+        "unique": true,
+        "version": 1,
+        "columnNames": [
+          "_",
+          "_"
+        ],
+        "columnDirections": [
+          0,
+          0
+        ],
+        "storeColumnNames": [],
+        "columnIds": [
+          2,
+          1
+        ],
+        "extraColumnIds": [],
+        "storeColumnIds": [],
+        "compositeColumnIds": [],
+        "foreignKey": {
+          "table": 0,
+          "index": 0,
+          "name": "",
+          "validity": 0,
+          "sharedPrefixLen": 0,
+          "onDelete": "NO_ACTION",
+          "onUpdate": "NO_ACTION",
+          "match": "SIMPLE"
+        },
+        "referencedBy": [],
+        "interleave": {
+          "ancestors": []
+        },
+        "interleavedBy": [],
+        "partitioning": {
+          "numColumns": 0,
+          "list": [],
+          "range": []
+        },
+        "type": 0,
+        "createdExplicitly": false,
+        "encodingType": 0,
+        "sharded": {
+          "isSharded": false,
+          "name": "",
+          "shardBuckets": 0,
+          "columnNames": []
+        },
+        "disabled": false,
+        "geoConfig": {
+          "s2Geography": null,
+          "s2Geometry": null
+        },
+        "predicate": ""
+      },
+      "indexes": [],
+      "nextIndexId": 2,
+      "privileges": {
+        "users": [
+          {
+            "user": "_",
+            "privileges": 2
+          },
+          {
+            "user": "_",
+            "privileges": 2
+          }
+        ],
+        "owner": "_",
+        "version": 1
+      },
+      "mutations": [],
+      "lease": null,
+      "nextMutationId": 1,
+      "formatVersion": 3,
+      "state": 0,
+      "offlineReason": "",
+      "checks": [],
+      "viewQuery": "",
+      "isMaterializedView": false,
+      "dependsOn": [],
+      "dependedOnBy": [],
+      "mutationJobs": [],
+      "sequenceOpts": null,
+      "dropTime": "0",
+      "replacementOf": {
+        "id": 0,
+        "time": {
+          "wallTime": "0",
+          "logical": 0
+        }
+      },
+      "auditMode": 0,
+      "dropJobId": "0",
+      "gcMutations": [],
+      "createQuery": "",
+      "createAsOfTime": {
+        "wallTime": "1606913361488922000",
+        "logical": 0
+      },
+      "outboundFks": [],
+      "inboundFks": [
+        {
+          "originTableId": 54,
+          "originColumnIds": [
+            2,
+            4
+          ],
+          "referencedColumnIds": [
+            2,
+            1
+          ],
+          "referencedTableId": 53,
+          "name": "_",
+          "validity": 2,
+          "onDelete": "NO_ACTION",
+          "onUpdate": "NO_ACTION",
+          "match": "SIMPLE"
+        },
+        {
+          "originTableId": 55,
+          "originColumnIds": [
+            2,
+            4
+          ],
+          "referencedColumnIds": [
+            2,
+            1
+          ],
+          "referencedTableId": 53,
+          "name": "_",
+          "validity": 2,
+          "onDelete": "NO_ACTION",
+          "onUpdate": "NO_ACTION",
+          "match": "SIMPLE"
+        },
+        {
+          "originTableId": 58,
+          "originColumnIds": [
+            1,
+            2
+          ],
+          "referencedColumnIds": [
+            2,
+            1
+          ],
+          "referencedTableId": 53,
+          "name": "_",
+          "validity": 2,
+          "onDelete": "NO_ACTION",
+          "onUpdate": "NO_ACTION",
+          "match": "SIMPLE"
+        }
+      ],
+      "temporary": false
+    },
+    ...
+  ],
+  "sqlStats": [],
+  "alteredSettings": {
+    "cluster.organization": "<redacted>",
+    "cluster.secret": "<redacted>",
+    "diagnostics.reporting.enabled": "true",
+    "enterprise.license": "<redacted>",
+    "version": "20.2-1"
+  },
+  "zoneConfigs": {
+    "0": {
+      "rangeMinBytes": "134217728",
+      "rangeMaxBytes": "536870912",
+      "gc": {
+        "ttlSeconds": 90000
+      },
+      "numReplicas": 1,
+      "constraints": [],
+      "inheritedConstraints": false,
+      "leasePreferences": [],
+      "inheritedLeasePreferences": false,
+      "subzones": [],
+      "subzoneSpans": []
+    },
+    ...
+  },
+  "featureUsage": {...},
+  "legacyUnimplementedErrors": {},
+  "legacyErrorCounts": {}
+}   
+ ```
 
 Note: this is a “reserved” API endpoint and should not be relied upon to
 build external tools. No guarantee is made about its
@@ -2730,7 +3409,23 @@ availability and stability in external uses.
 
 `GET /_status/stores/{node_id}`
 
-
+Reference example:
+ ``` 
+ curl http://127.0.0.1:51875/_status/stores/1   
+  ->
+ {
+  "stores": [
+    {
+      "storeId": 1,
+      "encryptionStatus": null,
+      "totalFiles": "0",
+      "totalBytes": "0",
+      "activeKeyFiles": "0",
+      "activeKeyBytes": "0"
+    }
+  ]
+}   
+ ```
 
 Note: this is a “reserved” API endpoint and should not be relied upon to
 build external tools. No guarantee is made about its
@@ -3138,7 +3833,15 @@ availability and stability in external uses.
 
 `GET /_status/job_registry/{node_id}`
 
-
+Reference example:
+ ``` 
+ curl http://127.0.0.1:51875/_status/job_registry/1   
+  ->
+ {
+  "nodeId": 1,
+  "runningJobs": []
+}   
+ ```
 
 Note: this is a “reserved” API endpoint and should not be relied upon to
 build external tools. No guarantee is made about its
@@ -3210,7 +3913,48 @@ availability and stability in external uses.
 
 `GET /_status/job/{job_id}`
 
-
+Reference example:
+ ``` 
+ curl http://127.0.0.1:51875/_status/job/612247017297477633   
+  ->
+ {
+  "job": {
+    "id": "612247017297477633",
+    "progress": {
+      "fractionCompleted": 1,
+      "modifiedMicros": "1606913361839096",
+      "runningStatus": "",
+      "schemaChange": {}
+    },
+    "payload": {
+      "description": "ALTER TABLE ...",
+      "statement": "",
+      "username": "root",
+      "startedMicros": "1606913361836868",
+      "finishedMicros": "1606913361839914",
+      "descriptorIds": [
+        53
+      ],
+      "error": "",
+      "resumeErrors": [],
+      "cleanupErrors": [],
+      "finalResumeError": null,
+      "lease": null,
+      "noncancelable": false,
+      "schemaChange": {
+        "resumeSpanList": [],
+        "droppedTables": [],
+        "droppedTypes": [],
+        "droppedSchemas": [],
+        "droppedDatabaseId": 0,
+        "descId": 53,
+        "tableMutationId": 0,
+        "formatVersion": 2
+      }
+    }
+  }
+}   
+ ```
 
 Note: this is a “reserved” API endpoint and should not be relied upon to
 build external tools. No guarantee is made about its

--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -2,16 +2,27 @@
 
 `GET /_status/certificates/{node_id}`
 
+Certificates retrieves a copy of the TLS certificates.
 
+Note: this is a “reserved” API endpoint and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
 
 #### Request Parameters
 
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [string](#cockroach.server.serverpb.CertificatesRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [string](#cockroach.server.serverpb.CertificatesRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -24,9 +35,16 @@
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| certificates | [CertificateDetails](#cockroach.server.serverpb.CertificatesResponse-cockroach.server.serverpb.CertificateDetails) | repeated |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| certificates | [CertificateDetails](#cockroach.server.serverpb.CertificatesResponse-cockroach.server.serverpb.CertificateDetails) | repeated |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -36,12 +54,18 @@
 <a name="cockroach.server.serverpb.CertificatesResponse-cockroach.server.serverpb.CertificateDetails"></a>
 #### CertificateDetails
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| type | [CertificateDetails.CertificateType](#cockroach.server.serverpb.CertificatesResponse-cockroach.server.serverpb.CertificateDetails.CertificateType) |  |  |
-| error_message | [string](#cockroach.server.serverpb.CertificatesResponse-string) |  | "error_message" and "data" are mutually exclusive. |
-| data | [bytes](#cockroach.server.serverpb.CertificatesResponse-bytes) |  | data is the raw file contents of the certificate. This means PEM-encoded DER data. |
-| fields | [CertificateDetails.Fields](#cockroach.server.serverpb.CertificatesResponse-cockroach.server.serverpb.CertificateDetails.Fields) | repeated |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| type | [CertificateDetails.CertificateType](#cockroach.server.serverpb.CertificatesResponse-cockroach.server.serverpb.CertificateDetails.CertificateType) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| error_message | [string](#cockroach.server.serverpb.CertificatesResponse-string) |  | "error_message" and "data" are mutually exclusive. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| data | [bytes](#cockroach.server.serverpb.CertificatesResponse-bytes) |  | data is the raw file contents of the certificate. This means PEM-encoded DER data. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| fields | [CertificateDetails.Fields](#cockroach.server.serverpb.CertificatesResponse-cockroach.server.serverpb.CertificateDetails.Fields) | repeated |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -50,17 +74,23 @@
 <a name="cockroach.server.serverpb.CertificatesResponse-cockroach.server.serverpb.CertificateDetails.Fields"></a>
 #### CertificateDetails.Fields
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| issuer | [string](#cockroach.server.serverpb.CertificatesResponse-string) |  |  |
-| subject | [string](#cockroach.server.serverpb.CertificatesResponse-string) |  |  |
-| valid_from | [int64](#cockroach.server.serverpb.CertificatesResponse-int64) |  |  |
-| valid_until | [int64](#cockroach.server.serverpb.CertificatesResponse-int64) |  |  |
-| addresses | [string](#cockroach.server.serverpb.CertificatesResponse-string) | repeated |  |
-| signature_algorithm | [string](#cockroach.server.serverpb.CertificatesResponse-string) |  |  |
-| public_key | [string](#cockroach.server.serverpb.CertificatesResponse-string) |  |  |
-| key_usage | [string](#cockroach.server.serverpb.CertificatesResponse-string) | repeated |  |
-| extended_key_usage | [string](#cockroach.server.serverpb.CertificatesResponse-string) | repeated |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| issuer | [string](#cockroach.server.serverpb.CertificatesResponse-string) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| subject | [string](#cockroach.server.serverpb.CertificatesResponse-string) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| valid_from | [int64](#cockroach.server.serverpb.CertificatesResponse-int64) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| valid_until | [int64](#cockroach.server.serverpb.CertificatesResponse-int64) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| addresses | [string](#cockroach.server.serverpb.CertificatesResponse-string) | repeated |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| signature_algorithm | [string](#cockroach.server.serverpb.CertificatesResponse-string) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| public_key | [string](#cockroach.server.serverpb.CertificatesResponse-string) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| key_usage | [string](#cockroach.server.serverpb.CertificatesResponse-string) | repeated |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| extended_key_usage | [string](#cockroach.server.serverpb.CertificatesResponse-string) | repeated |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -71,16 +101,28 @@
 
 `GET /_status/details/{node_id}`
 
+Details retrieves details about the nodes in the cluster.
 
+Note: this is a “reserved” API endpoint and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
 
 #### Request Parameters
 
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [string](#cockroach.server.serverpb.DetailsRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. |
+DetailsRequest requests a nodes details.
+Note: this does *not* check readiness. Use the Health RPC for that purpose.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [string](#cockroach.server.serverpb.DetailsRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -93,13 +135,20 @@
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [int32](#cockroach.server.serverpb.DetailsResponse-int32) |  |  |
-| address | [cockroach.util.UnresolvedAddr](#cockroach.server.serverpb.DetailsResponse-cockroach.util.UnresolvedAddr) |  |  |
-| build_info | [cockroach.build.Info](#cockroach.server.serverpb.DetailsResponse-cockroach.build.Info) |  |  |
-| system_info | [SystemInfo](#cockroach.server.serverpb.DetailsResponse-cockroach.server.serverpb.SystemInfo) |  |  |
-| sql_address | [cockroach.util.UnresolvedAddr](#cockroach.server.serverpb.DetailsResponse-cockroach.util.UnresolvedAddr) |  |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [int32](#cockroach.server.serverpb.DetailsResponse-int32) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| address | [cockroach.util.UnresolvedAddr](#cockroach.server.serverpb.DetailsResponse-cockroach.util.UnresolvedAddr) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| build_info | [cockroach.build.Info](#cockroach.server.serverpb.DetailsResponse-cockroach.build.Info) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| system_info | [SystemInfo](#cockroach.server.serverpb.DetailsResponse-cockroach.server.serverpb.SystemInfo) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| sql_address | [cockroach.util.UnresolvedAddr](#cockroach.server.serverpb.DetailsResponse-cockroach.util.UnresolvedAddr) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -109,10 +158,16 @@
 <a name="cockroach.server.serverpb.DetailsResponse-cockroach.server.serverpb.SystemInfo"></a>
 #### SystemInfo
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| system_info | [string](#cockroach.server.serverpb.DetailsResponse-string) |  | system_info is the output from `uname -a` |
-| kernel_info | [string](#cockroach.server.serverpb.DetailsResponse-string) |  | kernel_info is the output from `uname -r`. |
+SystemInfo contains information about the host system.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| system_info | [string](#cockroach.server.serverpb.DetailsResponse-string) |  | system_info is the output from `uname -a` | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| kernel_info | [string](#cockroach.server.serverpb.DetailsResponse-string) |  | kernel_info is the output from `uname -r`. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -123,12 +178,25 @@
 
 `GET /_status/nodes`
 
+Nodes retrieves an overview of the nodes in the cluster.
+
+
 Don't introduce additional usages of this RPC. See #50707 for more details.
 The underlying response type is something we're looking to get rid of.
+
+Note: this is an “alpha” API endpoint. It is subject to change without
+advance notice in a subsequent release.
 
 #### Request Parameters
 
 
+
+
+NodesRequest requests a copy of the node information as known to gossip
+and the KV layer.
+
+Note: this is an “alpha” API payload. It is subject to change without
+advance notice in a subsequent release.
 
 
 
@@ -142,11 +210,146 @@ The underlying response type is something we're looking to get rid of.
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| nodes | [cockroach.server.status.statuspb.NodeStatus](#cockroach.server.serverpb.NodesResponse-cockroach.server.status.statuspb.NodeStatus) | repeated |  |
-| liveness_by_node_id | [NodesResponse.LivenessByNodeIdEntry](#cockroach.server.serverpb.NodesResponse-cockroach.server.serverpb.NodesResponse.LivenessByNodeIdEntry) | repeated |  |
+NodesResponse describe the nodes in the cluster.
 
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| nodes | [cockroach.server.status.statuspb.NodeStatus](#cockroach.server.serverpb.NodesResponse-cockroach.server.status.statuspb.NodeStatus) | repeated | nodes carries the status payloads for all nodes in the cluster. | Note: this is an “alpha” API field. It is subject to change without advance notice in a subsequent release. |
+| liveness_by_node_id | [NodesResponse.LivenessByNodeIdEntry](#cockroach.server.serverpb.NodesResponse-cockroach.server.serverpb.NodesResponse.LivenessByNodeIdEntry) | repeated | liveness_by_node_id maps each node ID to a liveness status. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.NodesResponse-cockroach.server.status.statuspb.NodeStatus"></a>
+#### NodeStatus
+
+NodeStatus records the most recent values of metrics for a node.
+
+Note: this is an “alpha” API payload. It is subject to change without
+advance notice in a subsequent release.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| desc | [cockroach.roachpb.NodeDescriptor](#cockroach.server.serverpb.NodesResponse-cockroach.roachpb.NodeDescriptor) |  | desc is the node descriptor. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| build_info | [cockroach.build.Info](#cockroach.server.serverpb.NodesResponse-cockroach.build.Info) |  | build_info describes the 'cockroach' executable file. | Note: this is an “alpha” API field. It is subject to change without advance notice in a subsequent release. |
+| started_at | [int64](#cockroach.server.serverpb.NodesResponse-int64) |  | started_at is the unix timestamp at which the node process was last started. | Note: this is an “alpha” API field. It is subject to change without advance notice in a subsequent release. |
+| updated_at | [int64](#cockroach.server.serverpb.NodesResponse-int64) |  | updated_at is the unix timestamp at which the node status record was last updated. | Note: this is an “alpha” API field. It is subject to change without advance notice in a subsequent release. |
+| metrics | [NodeStatus.MetricsEntry](#cockroach.server.serverpb.NodesResponse-cockroach.server.status.statuspb.NodeStatus.MetricsEntry) | repeated | metrics contains the last sampled values for the node metrics. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| store_statuses | [StoreStatus](#cockroach.server.serverpb.NodesResponse-cockroach.server.status.statuspb.StoreStatus) | repeated | store_statuses provides the store status payloads for all the stores on that node. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| args | [string](#cockroach.server.serverpb.NodesResponse-string) | repeated | args is the list of command-line arguments used to last start the node. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| env | [string](#cockroach.server.serverpb.NodesResponse-string) | repeated | env is the list of environment variables that influenced the node's configuration. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| latencies | [NodeStatus.LatenciesEntry](#cockroach.server.serverpb.NodesResponse-cockroach.server.status.statuspb.NodeStatus.LatenciesEntry) | repeated | latencies is a map of nodeIDs to nanoseconds which is the latency between this node and the other node.<br><br>NOTE: this is deprecated and is only set if the min supported       cluster version is >= VersionRPCNetworkStats. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| activity | [NodeStatus.ActivityEntry](#cockroach.server.serverpb.NodesResponse-cockroach.server.status.statuspb.NodeStatus.ActivityEntry) | repeated | activity is a map of nodeIDs to network statistics from this node to other nodes. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| total_system_memory | [int64](#cockroach.server.serverpb.NodesResponse-int64) |  | total_system_memory is the total RAM available to the system (or, if detected, the memory available to the cgroup this process is in) in bytes. | Note: this is an “alpha” API field. It is subject to change without advance notice in a subsequent release. |
+| num_cpus | [int32](#cockroach.server.serverpb.NodesResponse-int32) |  | num_cpus is the number of logical CPUs as reported by the operating system on the host where the 'cockroach' process is running. Note that this does not report the number of CPUs actually used by 'cockroach'; this parameter is controlled separately. | Note: this is an “alpha” API field. It is subject to change without advance notice in a subsequent release. |
+
+
+
+
+
+<a name="cockroach.server.serverpb.NodesResponse-cockroach.server.status.statuspb.NodeStatus.MetricsEntry"></a>
+#### NodeStatus.MetricsEntry
+
+
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [string](#cockroach.server.serverpb.NodesResponse-string) |  |  |  |
+| value | [double](#cockroach.server.serverpb.NodesResponse-double) |  |  |  |
+
+
+
+
+
+<a name="cockroach.server.serverpb.NodesResponse-cockroach.server.status.statuspb.StoreStatus"></a>
+#### StoreStatus
+
+StoreStatus records the most recent values of metrics for a store.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| desc | [cockroach.roachpb.StoreDescriptor](#cockroach.server.serverpb.NodesResponse-cockroach.roachpb.StoreDescriptor) |  | desc is the store descriptor. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| metrics | [StoreStatus.MetricsEntry](#cockroach.server.serverpb.NodesResponse-cockroach.server.status.statuspb.StoreStatus.MetricsEntry) | repeated | metrics contains the last sampled values for the node metrics. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+
+
+
+
+<a name="cockroach.server.serverpb.NodesResponse-cockroach.server.status.statuspb.StoreStatus.MetricsEntry"></a>
+#### StoreStatus.MetricsEntry
+
+
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [string](#cockroach.server.serverpb.NodesResponse-string) |  |  |  |
+| value | [double](#cockroach.server.serverpb.NodesResponse-double) |  |  |  |
+
+
+
+
+
+<a name="cockroach.server.serverpb.NodesResponse-cockroach.server.status.statuspb.NodeStatus.LatenciesEntry"></a>
+#### NodeStatus.LatenciesEntry
+
+
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [int32](#cockroach.server.serverpb.NodesResponse-int32) |  |  |  |
+| value | [int64](#cockroach.server.serverpb.NodesResponse-int64) |  |  |  |
+
+
+
+
+
+<a name="cockroach.server.serverpb.NodesResponse-cockroach.server.status.statuspb.NodeStatus.ActivityEntry"></a>
+#### NodeStatus.ActivityEntry
+
+
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [int32](#cockroach.server.serverpb.NodesResponse-int32) |  |  |  |
+| value | [NodeStatus.NetworkActivity](#cockroach.server.serverpb.NodesResponse-cockroach.server.status.statuspb.NodeStatus.NetworkActivity) |  |  |  |
+
+
+
+
+
+<a name="cockroach.server.serverpb.NodesResponse-cockroach.server.status.statuspb.NodeStatus.NetworkActivity"></a>
+#### NodeStatus.NetworkActivity
+
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| incoming | [int64](#cockroach.server.serverpb.NodesResponse-int64) |  | in bytes | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| outgoing | [int64](#cockroach.server.serverpb.NodesResponse-int64) |  | in bytes | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| latency | [int64](#cockroach.server.serverpb.NodesResponse-int64) |  | in nanoseconds | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -155,10 +358,14 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.NodesResponse-cockroach.server.serverpb.NodesResponse.LivenessByNodeIdEntry"></a>
 #### NodesResponse.LivenessByNodeIdEntry
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| key | [int32](#cockroach.server.serverpb.NodesResponse-int32) |  |  |
-| value | [cockroach.kv.kvserver.storagepb.NodeLivenessStatus](#cockroach.server.serverpb.NodesResponse-cockroach.kv.kvserver.storagepb.NodeLivenessStatus) |  |  |
+
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [int32](#cockroach.server.serverpb.NodesResponse-int32) |  |  |  |
+| value | [cockroach.kv.kvserver.storagepb.NodeLivenessStatus](#cockroach.server.serverpb.NodesResponse-cockroach.kv.kvserver.storagepb.NodeLivenessStatus) |  |  |  |
 
 
 
@@ -169,16 +376,26 @@ The underlying response type is something we're looking to get rid of.
 
 `GET /_status/nodes/{node_id}`
 
+Node retrieves details about a single node.
 
+Note: this is an “alpha” API endpoint. It is subject to change without
+advance notice in a subsequent release.
 
 #### Request Parameters
 
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [string](#cockroach.server.serverpb.NodeRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [string](#cockroach.server.serverpb.NodeRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -187,6 +404,135 @@ The underlying response type is something we're looking to get rid of.
 
 
 #### Response Parameters
+
+
+
+
+NodeStatus records the most recent values of metrics for a node.
+
+Note: this is an “alpha” API payload. It is subject to change without
+advance notice in a subsequent release.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| desc | [cockroach.roachpb.NodeDescriptor](#cockroach.server.status.statuspb.NodeStatus-cockroach.roachpb.NodeDescriptor) |  | desc is the node descriptor. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| build_info | [cockroach.build.Info](#cockroach.server.status.statuspb.NodeStatus-cockroach.build.Info) |  | build_info describes the 'cockroach' executable file. | Note: this is an “alpha” API field. It is subject to change without advance notice in a subsequent release. |
+| started_at | [int64](#cockroach.server.status.statuspb.NodeStatus-int64) |  | started_at is the unix timestamp at which the node process was last started. | Note: this is an “alpha” API field. It is subject to change without advance notice in a subsequent release. |
+| updated_at | [int64](#cockroach.server.status.statuspb.NodeStatus-int64) |  | updated_at is the unix timestamp at which the node status record was last updated. | Note: this is an “alpha” API field. It is subject to change without advance notice in a subsequent release. |
+| metrics | [NodeStatus.MetricsEntry](#cockroach.server.status.statuspb.NodeStatus-cockroach.server.status.statuspb.NodeStatus.MetricsEntry) | repeated | metrics contains the last sampled values for the node metrics. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| store_statuses | [StoreStatus](#cockroach.server.status.statuspb.NodeStatus-cockroach.server.status.statuspb.StoreStatus) | repeated | store_statuses provides the store status payloads for all the stores on that node. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| args | [string](#cockroach.server.status.statuspb.NodeStatus-string) | repeated | args is the list of command-line arguments used to last start the node. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| env | [string](#cockroach.server.status.statuspb.NodeStatus-string) | repeated | env is the list of environment variables that influenced the node's configuration. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| latencies | [NodeStatus.LatenciesEntry](#cockroach.server.status.statuspb.NodeStatus-cockroach.server.status.statuspb.NodeStatus.LatenciesEntry) | repeated | latencies is a map of nodeIDs to nanoseconds which is the latency between this node and the other node.<br><br>NOTE: this is deprecated and is only set if the min supported       cluster version is >= VersionRPCNetworkStats. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| activity | [NodeStatus.ActivityEntry](#cockroach.server.status.statuspb.NodeStatus-cockroach.server.status.statuspb.NodeStatus.ActivityEntry) | repeated | activity is a map of nodeIDs to network statistics from this node to other nodes. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| total_system_memory | [int64](#cockroach.server.status.statuspb.NodeStatus-int64) |  | total_system_memory is the total RAM available to the system (or, if detected, the memory available to the cgroup this process is in) in bytes. | Note: this is an “alpha” API field. It is subject to change without advance notice in a subsequent release. |
+| num_cpus | [int32](#cockroach.server.status.statuspb.NodeStatus-int32) |  | num_cpus is the number of logical CPUs as reported by the operating system on the host where the 'cockroach' process is running. Note that this does not report the number of CPUs actually used by 'cockroach'; this parameter is controlled separately. | Note: this is an “alpha” API field. It is subject to change without advance notice in a subsequent release. |
+
+
+
+
+
+
+<a name="cockroach.server.status.statuspb.NodeStatus-cockroach.server.status.statuspb.NodeStatus.MetricsEntry"></a>
+#### NodeStatus.MetricsEntry
+
+
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [string](#cockroach.server.status.statuspb.NodeStatus-string) |  |  |  |
+| value | [double](#cockroach.server.status.statuspb.NodeStatus-double) |  |  |  |
+
+
+
+
+
+<a name="cockroach.server.status.statuspb.NodeStatus-cockroach.server.status.statuspb.StoreStatus"></a>
+#### StoreStatus
+
+StoreStatus records the most recent values of metrics for a store.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| desc | [cockroach.roachpb.StoreDescriptor](#cockroach.server.status.statuspb.NodeStatus-cockroach.roachpb.StoreDescriptor) |  | desc is the store descriptor. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| metrics | [StoreStatus.MetricsEntry](#cockroach.server.status.statuspb.NodeStatus-cockroach.server.status.statuspb.StoreStatus.MetricsEntry) | repeated | metrics contains the last sampled values for the node metrics. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+
+
+
+
+<a name="cockroach.server.status.statuspb.NodeStatus-cockroach.server.status.statuspb.StoreStatus.MetricsEntry"></a>
+#### StoreStatus.MetricsEntry
+
+
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [string](#cockroach.server.status.statuspb.NodeStatus-string) |  |  |  |
+| value | [double](#cockroach.server.status.statuspb.NodeStatus-double) |  |  |  |
+
+
+
+
+
+<a name="cockroach.server.status.statuspb.NodeStatus-cockroach.server.status.statuspb.NodeStatus.LatenciesEntry"></a>
+#### NodeStatus.LatenciesEntry
+
+
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [int32](#cockroach.server.status.statuspb.NodeStatus-int32) |  |  |  |
+| value | [int64](#cockroach.server.status.statuspb.NodeStatus-int64) |  |  |  |
+
+
+
+
+
+<a name="cockroach.server.status.statuspb.NodeStatus-cockroach.server.status.statuspb.NodeStatus.ActivityEntry"></a>
+#### NodeStatus.ActivityEntry
+
+
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [int32](#cockroach.server.status.statuspb.NodeStatus-int32) |  |  |  |
+| value | [NodeStatus.NetworkActivity](#cockroach.server.status.statuspb.NodeStatus-cockroach.server.status.statuspb.NodeStatus.NetworkActivity) |  |  |  |
+
+
+
+
+
+<a name="cockroach.server.status.statuspb.NodeStatus-cockroach.server.status.statuspb.NodeStatus.NetworkActivity"></a>
+#### NodeStatus.NetworkActivity
+
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| incoming | [int64](#cockroach.server.status.statuspb.NodeStatus-int64) |  | in bytes | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| outgoing | [int64](#cockroach.server.status.statuspb.NodeStatus-int64) |  | in bytes | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| latency | [int64](#cockroach.server.status.statuspb.NodeStatus-int64) |  | in nanoseconds | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+
+
 
 
 
@@ -194,16 +540,27 @@ The underlying response type is something we're looking to get rid of.
 
 `GET /_status/raft`
 
+RaftDebug requests internal details about Raft.
 
+Note: this is a “reserved” API endpoint and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
 
 #### Request Parameters
 
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| range_ids | [int64](#cockroach.server.serverpb.RaftDebugRequest-int64) | repeated |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| range_ids | [int64](#cockroach.server.serverpb.RaftDebugRequest-int64) | repeated |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -216,10 +573,17 @@ The underlying response type is something we're looking to get rid of.
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| ranges | [RaftDebugResponse.RangesEntry](#cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RaftDebugResponse.RangesEntry) | repeated |  |
-| errors | [RaftRangeError](#cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RaftRangeError) | repeated |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| ranges | [RaftDebugResponse.RangesEntry](#cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RaftDebugResponse.RangesEntry) | repeated |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| errors | [RaftRangeError](#cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RaftRangeError) | repeated |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -229,10 +593,14 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RaftDebugResponse.RangesEntry"></a>
 #### RaftDebugResponse.RangesEntry
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| key | [int64](#cockroach.server.serverpb.RaftDebugResponse-int64) |  |  |
-| value | [RaftRangeStatus](#cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RaftRangeStatus) |  |  |
+
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [int64](#cockroach.server.serverpb.RaftDebugResponse-int64) |  |  |  |
+| value | [RaftRangeStatus](#cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RaftRangeStatus) |  |  |  |
 
 
 
@@ -241,11 +609,17 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RaftRangeStatus"></a>
 #### RaftRangeStatus
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| range_id | [int64](#cockroach.server.serverpb.RaftDebugResponse-int64) |  |  |
-| errors | [RaftRangeError](#cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RaftRangeError) | repeated |  |
-| nodes | [RaftRangeNode](#cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RaftRangeNode) | repeated |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| range_id | [int64](#cockroach.server.serverpb.RaftDebugResponse-int64) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| errors | [RaftRangeError](#cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RaftRangeError) | repeated |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| nodes | [RaftRangeNode](#cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RaftRangeNode) | repeated |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -254,9 +628,15 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RaftRangeError"></a>
 #### RaftRangeError
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| message | [string](#cockroach.server.serverpb.RaftDebugResponse-string) |  |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| message | [string](#cockroach.server.serverpb.RaftDebugResponse-string) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -265,10 +645,16 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RaftRangeNode"></a>
 #### RaftRangeNode
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [int32](#cockroach.server.serverpb.RaftDebugResponse-int32) |  |  |
-| range | [RangeInfo](#cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RangeInfo) |  |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [int32](#cockroach.server.serverpb.RaftDebugResponse-int32) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| range | [RangeInfo](#cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RangeInfo) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -277,22 +663,28 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RangeInfo"></a>
 #### RangeInfo
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| span | [PrettySpan](#cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.PrettySpan) |  |  |
-| raft_state | [RaftState](#cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RaftState) |  |  |
-| state | [cockroach.kv.kvserver.storagepb.RangeInfo](#cockroach.server.serverpb.RaftDebugResponse-cockroach.kv.kvserver.storagepb.RangeInfo) |  |  |
-| source_node_id | [int32](#cockroach.server.serverpb.RaftDebugResponse-int32) |  |  |
-| source_store_id | [int32](#cockroach.server.serverpb.RaftDebugResponse-int32) |  |  |
-| error_message | [string](#cockroach.server.serverpb.RaftDebugResponse-string) |  |  |
-| lease_history | [cockroach.roachpb.Lease](#cockroach.server.serverpb.RaftDebugResponse-cockroach.roachpb.Lease) | repeated |  |
-| problems | [RangeProblems](#cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RangeProblems) |  |  |
-| stats | [RangeStatistics](#cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RangeStatistics) |  |  |
-| latches_local | [cockroach.kv.kvserver.storagepb.LatchManagerInfo](#cockroach.server.serverpb.RaftDebugResponse-cockroach.kv.kvserver.storagepb.LatchManagerInfo) |  |  |
-| latches_global | [cockroach.kv.kvserver.storagepb.LatchManagerInfo](#cockroach.server.serverpb.RaftDebugResponse-cockroach.kv.kvserver.storagepb.LatchManagerInfo) |  |  |
-| lease_status | [cockroach.kv.kvserver.storagepb.LeaseStatus](#cockroach.server.serverpb.RaftDebugResponse-cockroach.kv.kvserver.storagepb.LeaseStatus) |  |  |
-| quiescent | [bool](#cockroach.server.serverpb.RaftDebugResponse-bool) |  |  |
-| ticking | [bool](#cockroach.server.serverpb.RaftDebugResponse-bool) |  |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| span | [PrettySpan](#cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.PrettySpan) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| raft_state | [RaftState](#cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RaftState) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| state | [cockroach.kv.kvserver.storagepb.RangeInfo](#cockroach.server.serverpb.RaftDebugResponse-cockroach.kv.kvserver.storagepb.RangeInfo) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| source_node_id | [int32](#cockroach.server.serverpb.RaftDebugResponse-int32) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| source_store_id | [int32](#cockroach.server.serverpb.RaftDebugResponse-int32) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| error_message | [string](#cockroach.server.serverpb.RaftDebugResponse-string) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| lease_history | [cockroach.roachpb.Lease](#cockroach.server.serverpb.RaftDebugResponse-cockroach.roachpb.Lease) | repeated |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| problems | [RangeProblems](#cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RangeProblems) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| stats | [RangeStatistics](#cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RangeStatistics) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| latches_local | [cockroach.kv.kvserver.storagepb.LatchManagerInfo](#cockroach.server.serverpb.RaftDebugResponse-cockroach.kv.kvserver.storagepb.LatchManagerInfo) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| latches_global | [cockroach.kv.kvserver.storagepb.LatchManagerInfo](#cockroach.server.serverpb.RaftDebugResponse-cockroach.kv.kvserver.storagepb.LatchManagerInfo) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| lease_status | [cockroach.kv.kvserver.storagepb.LeaseStatus](#cockroach.server.serverpb.RaftDebugResponse-cockroach.kv.kvserver.storagepb.LeaseStatus) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| quiescent | [bool](#cockroach.server.serverpb.RaftDebugResponse-bool) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| ticking | [bool](#cockroach.server.serverpb.RaftDebugResponse-bool) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -301,10 +693,16 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.PrettySpan"></a>
 #### PrettySpan
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| start_key | [string](#cockroach.server.serverpb.RaftDebugResponse-string) |  |  |
-| end_key | [string](#cockroach.server.serverpb.RaftDebugResponse-string) |  |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| start_key | [string](#cockroach.server.serverpb.RaftDebugResponse-string) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| end_key | [string](#cockroach.server.serverpb.RaftDebugResponse-string) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -313,15 +711,22 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RaftState"></a>
 #### RaftState
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| replica_id | [uint64](#cockroach.server.serverpb.RaftDebugResponse-uint64) |  |  |
-| hard_state | [raftpb.HardState](#cockroach.server.serverpb.RaftDebugResponse-raftpb.HardState) |  |  |
-| lead | [uint64](#cockroach.server.serverpb.RaftDebugResponse-uint64) |  | Lead is part of Raft's SoftState. |
-| state | [string](#cockroach.server.serverpb.RaftDebugResponse-string) |  | State is part of Raft's SoftState. It's not an enum because this is primarily for ui consumption and there are issues associated with them. |
-| applied | [uint64](#cockroach.server.serverpb.RaftDebugResponse-uint64) |  |  |
-| progress | [RaftState.ProgressEntry](#cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RaftState.ProgressEntry) | repeated |  |
-| lead_transferee | [uint64](#cockroach.server.serverpb.RaftDebugResponse-uint64) |  |  |
+RaftState gives internal details about a Raft group's state.
+Closely mirrors the upstream definitions in github.com/etcd-io/etcd/raft.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| replica_id | [uint64](#cockroach.server.serverpb.RaftDebugResponse-uint64) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| hard_state | [raftpb.HardState](#cockroach.server.serverpb.RaftDebugResponse-raftpb.HardState) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| lead | [uint64](#cockroach.server.serverpb.RaftDebugResponse-uint64) |  | Lead is part of Raft's SoftState. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| state | [string](#cockroach.server.serverpb.RaftDebugResponse-string) |  | State is part of Raft's SoftState. It's not an enum because this is primarily for ui consumption and there are issues associated with them. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| applied | [uint64](#cockroach.server.serverpb.RaftDebugResponse-uint64) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| progress | [RaftState.ProgressEntry](#cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RaftState.ProgressEntry) | repeated |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| lead_transferee | [uint64](#cockroach.server.serverpb.RaftDebugResponse-uint64) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -330,10 +735,14 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RaftState.ProgressEntry"></a>
 #### RaftState.ProgressEntry
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| key | [uint64](#cockroach.server.serverpb.RaftDebugResponse-uint64) |  |  |
-| value | [RaftState.Progress](#cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RaftState.Progress) |  |  |
+
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [uint64](#cockroach.server.serverpb.RaftDebugResponse-uint64) |  |  |  |
+| value | [RaftState.Progress](#cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RaftState.Progress) |  |  |  |
 
 
 
@@ -342,13 +751,19 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RaftState.Progress"></a>
 #### RaftState.Progress
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| match | [uint64](#cockroach.server.serverpb.RaftDebugResponse-uint64) |  |  |
-| next | [uint64](#cockroach.server.serverpb.RaftDebugResponse-uint64) |  |  |
-| state | [string](#cockroach.server.serverpb.RaftDebugResponse-string) |  |  |
-| paused | [bool](#cockroach.server.serverpb.RaftDebugResponse-bool) |  |  |
-| pending_snapshot | [uint64](#cockroach.server.serverpb.RaftDebugResponse-uint64) |  |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| match | [uint64](#cockroach.server.serverpb.RaftDebugResponse-uint64) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| next | [uint64](#cockroach.server.serverpb.RaftDebugResponse-uint64) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| state | [string](#cockroach.server.serverpb.RaftDebugResponse-string) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| paused | [bool](#cockroach.server.serverpb.RaftDebugResponse-bool) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| pending_snapshot | [uint64](#cockroach.server.serverpb.RaftDebugResponse-uint64) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -357,16 +772,22 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RangeProblems"></a>
 #### RangeProblems
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| unavailable | [bool](#cockroach.server.serverpb.RaftDebugResponse-bool) |  |  |
-| leader_not_lease_holder | [bool](#cockroach.server.serverpb.RaftDebugResponse-bool) |  |  |
-| no_raft_leader | [bool](#cockroach.server.serverpb.RaftDebugResponse-bool) |  |  |
-| underreplicated | [bool](#cockroach.server.serverpb.RaftDebugResponse-bool) |  |  |
-| overreplicated | [bool](#cockroach.server.serverpb.RaftDebugResponse-bool) |  |  |
-| no_lease | [bool](#cockroach.server.serverpb.RaftDebugResponse-bool) |  |  |
-| quiescent_equals_ticking | [bool](#cockroach.server.serverpb.RaftDebugResponse-bool) |  | Quiescent ranges do not tick by definition, but we track this in two different ways and suspect that they're getting out of sync. If the replica's quiescent flag doesn't agree with the store's list of replicas that are ticking, warn about it. |
-| raft_log_too_large | [bool](#cockroach.server.serverpb.RaftDebugResponse-bool) |  | When the raft log is too large, it can be a symptom of other issues. |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| unavailable | [bool](#cockroach.server.serverpb.RaftDebugResponse-bool) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| leader_not_lease_holder | [bool](#cockroach.server.serverpb.RaftDebugResponse-bool) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| no_raft_leader | [bool](#cockroach.server.serverpb.RaftDebugResponse-bool) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| underreplicated | [bool](#cockroach.server.serverpb.RaftDebugResponse-bool) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| overreplicated | [bool](#cockroach.server.serverpb.RaftDebugResponse-bool) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| no_lease | [bool](#cockroach.server.serverpb.RaftDebugResponse-bool) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| quiescent_equals_ticking | [bool](#cockroach.server.serverpb.RaftDebugResponse-bool) |  | Quiescent ranges do not tick by definition, but we track this in two different ways and suspect that they're getting out of sync. If the replica's quiescent flag doesn't agree with the store's list of replicas that are ticking, warn about it. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| raft_log_too_large | [bool](#cockroach.server.serverpb.RaftDebugResponse-bool) |  | When the raft log is too large, it can be a symptom of other issues. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -375,10 +796,16 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RangeStatistics"></a>
 #### RangeStatistics
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| queries_per_second | [double](#cockroach.server.serverpb.RaftDebugResponse-double) |  | Note that queries per second will only be known by the leaseholder. All other replicas will report it as 0. |
-| writes_per_second | [double](#cockroach.server.serverpb.RaftDebugResponse-double) |  |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| queries_per_second | [double](#cockroach.server.serverpb.RaftDebugResponse-double) |  | Note that queries per second will only be known by the leaseholder. All other replicas will report it as 0. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| writes_per_second | [double](#cockroach.server.serverpb.RaftDebugResponse-double) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -387,9 +814,15 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RaftRangeError"></a>
 #### RaftRangeError
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| message | [string](#cockroach.server.serverpb.RaftDebugResponse-string) |  |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| message | [string](#cockroach.server.serverpb.RaftDebugResponse-string) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -400,17 +833,28 @@ The underlying response type is something we're looking to get rid of.
 
 `GET /_status/ranges/{node_id}`
 
+Ranges requests internal details about ranges on a given node.
 
+Note: this is a “reserved” API endpoint and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
 
 #### Request Parameters
 
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [string](#cockroach.server.serverpb.RangesRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. |
-| range_ids | [int64](#cockroach.server.serverpb.RangesRequest-int64) | repeated |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [string](#cockroach.server.serverpb.RangesRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| range_ids | [int64](#cockroach.server.serverpb.RangesRequest-int64) | repeated |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -423,9 +867,16 @@ The underlying response type is something we're looking to get rid of.
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| ranges | [RangeInfo](#cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.RangeInfo) | repeated |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| ranges | [RangeInfo](#cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.RangeInfo) | repeated |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -435,22 +886,28 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.RangeInfo"></a>
 #### RangeInfo
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| span | [PrettySpan](#cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.PrettySpan) |  |  |
-| raft_state | [RaftState](#cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.RaftState) |  |  |
-| state | [cockroach.kv.kvserver.storagepb.RangeInfo](#cockroach.server.serverpb.RangesResponse-cockroach.kv.kvserver.storagepb.RangeInfo) |  |  |
-| source_node_id | [int32](#cockroach.server.serverpb.RangesResponse-int32) |  |  |
-| source_store_id | [int32](#cockroach.server.serverpb.RangesResponse-int32) |  |  |
-| error_message | [string](#cockroach.server.serverpb.RangesResponse-string) |  |  |
-| lease_history | [cockroach.roachpb.Lease](#cockroach.server.serverpb.RangesResponse-cockroach.roachpb.Lease) | repeated |  |
-| problems | [RangeProblems](#cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.RangeProblems) |  |  |
-| stats | [RangeStatistics](#cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.RangeStatistics) |  |  |
-| latches_local | [cockroach.kv.kvserver.storagepb.LatchManagerInfo](#cockroach.server.serverpb.RangesResponse-cockroach.kv.kvserver.storagepb.LatchManagerInfo) |  |  |
-| latches_global | [cockroach.kv.kvserver.storagepb.LatchManagerInfo](#cockroach.server.serverpb.RangesResponse-cockroach.kv.kvserver.storagepb.LatchManagerInfo) |  |  |
-| lease_status | [cockroach.kv.kvserver.storagepb.LeaseStatus](#cockroach.server.serverpb.RangesResponse-cockroach.kv.kvserver.storagepb.LeaseStatus) |  |  |
-| quiescent | [bool](#cockroach.server.serverpb.RangesResponse-bool) |  |  |
-| ticking | [bool](#cockroach.server.serverpb.RangesResponse-bool) |  |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| span | [PrettySpan](#cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.PrettySpan) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| raft_state | [RaftState](#cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.RaftState) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| state | [cockroach.kv.kvserver.storagepb.RangeInfo](#cockroach.server.serverpb.RangesResponse-cockroach.kv.kvserver.storagepb.RangeInfo) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| source_node_id | [int32](#cockroach.server.serverpb.RangesResponse-int32) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| source_store_id | [int32](#cockroach.server.serverpb.RangesResponse-int32) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| error_message | [string](#cockroach.server.serverpb.RangesResponse-string) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| lease_history | [cockroach.roachpb.Lease](#cockroach.server.serverpb.RangesResponse-cockroach.roachpb.Lease) | repeated |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| problems | [RangeProblems](#cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.RangeProblems) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| stats | [RangeStatistics](#cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.RangeStatistics) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| latches_local | [cockroach.kv.kvserver.storagepb.LatchManagerInfo](#cockroach.server.serverpb.RangesResponse-cockroach.kv.kvserver.storagepb.LatchManagerInfo) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| latches_global | [cockroach.kv.kvserver.storagepb.LatchManagerInfo](#cockroach.server.serverpb.RangesResponse-cockroach.kv.kvserver.storagepb.LatchManagerInfo) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| lease_status | [cockroach.kv.kvserver.storagepb.LeaseStatus](#cockroach.server.serverpb.RangesResponse-cockroach.kv.kvserver.storagepb.LeaseStatus) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| quiescent | [bool](#cockroach.server.serverpb.RangesResponse-bool) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| ticking | [bool](#cockroach.server.serverpb.RangesResponse-bool) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -459,10 +916,16 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.PrettySpan"></a>
 #### PrettySpan
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| start_key | [string](#cockroach.server.serverpb.RangesResponse-string) |  |  |
-| end_key | [string](#cockroach.server.serverpb.RangesResponse-string) |  |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| start_key | [string](#cockroach.server.serverpb.RangesResponse-string) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| end_key | [string](#cockroach.server.serverpb.RangesResponse-string) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -471,15 +934,22 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.RaftState"></a>
 #### RaftState
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| replica_id | [uint64](#cockroach.server.serverpb.RangesResponse-uint64) |  |  |
-| hard_state | [raftpb.HardState](#cockroach.server.serverpb.RangesResponse-raftpb.HardState) |  |  |
-| lead | [uint64](#cockroach.server.serverpb.RangesResponse-uint64) |  | Lead is part of Raft's SoftState. |
-| state | [string](#cockroach.server.serverpb.RangesResponse-string) |  | State is part of Raft's SoftState. It's not an enum because this is primarily for ui consumption and there are issues associated with them. |
-| applied | [uint64](#cockroach.server.serverpb.RangesResponse-uint64) |  |  |
-| progress | [RaftState.ProgressEntry](#cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.RaftState.ProgressEntry) | repeated |  |
-| lead_transferee | [uint64](#cockroach.server.serverpb.RangesResponse-uint64) |  |  |
+RaftState gives internal details about a Raft group's state.
+Closely mirrors the upstream definitions in github.com/etcd-io/etcd/raft.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| replica_id | [uint64](#cockroach.server.serverpb.RangesResponse-uint64) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| hard_state | [raftpb.HardState](#cockroach.server.serverpb.RangesResponse-raftpb.HardState) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| lead | [uint64](#cockroach.server.serverpb.RangesResponse-uint64) |  | Lead is part of Raft's SoftState. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| state | [string](#cockroach.server.serverpb.RangesResponse-string) |  | State is part of Raft's SoftState. It's not an enum because this is primarily for ui consumption and there are issues associated with them. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| applied | [uint64](#cockroach.server.serverpb.RangesResponse-uint64) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| progress | [RaftState.ProgressEntry](#cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.RaftState.ProgressEntry) | repeated |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| lead_transferee | [uint64](#cockroach.server.serverpb.RangesResponse-uint64) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -488,10 +958,14 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.RaftState.ProgressEntry"></a>
 #### RaftState.ProgressEntry
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| key | [uint64](#cockroach.server.serverpb.RangesResponse-uint64) |  |  |
-| value | [RaftState.Progress](#cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.RaftState.Progress) |  |  |
+
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [uint64](#cockroach.server.serverpb.RangesResponse-uint64) |  |  |  |
+| value | [RaftState.Progress](#cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.RaftState.Progress) |  |  |  |
 
 
 
@@ -500,13 +974,19 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.RaftState.Progress"></a>
 #### RaftState.Progress
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| match | [uint64](#cockroach.server.serverpb.RangesResponse-uint64) |  |  |
-| next | [uint64](#cockroach.server.serverpb.RangesResponse-uint64) |  |  |
-| state | [string](#cockroach.server.serverpb.RangesResponse-string) |  |  |
-| paused | [bool](#cockroach.server.serverpb.RangesResponse-bool) |  |  |
-| pending_snapshot | [uint64](#cockroach.server.serverpb.RangesResponse-uint64) |  |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| match | [uint64](#cockroach.server.serverpb.RangesResponse-uint64) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| next | [uint64](#cockroach.server.serverpb.RangesResponse-uint64) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| state | [string](#cockroach.server.serverpb.RangesResponse-string) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| paused | [bool](#cockroach.server.serverpb.RangesResponse-bool) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| pending_snapshot | [uint64](#cockroach.server.serverpb.RangesResponse-uint64) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -515,16 +995,22 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.RangeProblems"></a>
 #### RangeProblems
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| unavailable | [bool](#cockroach.server.serverpb.RangesResponse-bool) |  |  |
-| leader_not_lease_holder | [bool](#cockroach.server.serverpb.RangesResponse-bool) |  |  |
-| no_raft_leader | [bool](#cockroach.server.serverpb.RangesResponse-bool) |  |  |
-| underreplicated | [bool](#cockroach.server.serverpb.RangesResponse-bool) |  |  |
-| overreplicated | [bool](#cockroach.server.serverpb.RangesResponse-bool) |  |  |
-| no_lease | [bool](#cockroach.server.serverpb.RangesResponse-bool) |  |  |
-| quiescent_equals_ticking | [bool](#cockroach.server.serverpb.RangesResponse-bool) |  | Quiescent ranges do not tick by definition, but we track this in two different ways and suspect that they're getting out of sync. If the replica's quiescent flag doesn't agree with the store's list of replicas that are ticking, warn about it. |
-| raft_log_too_large | [bool](#cockroach.server.serverpb.RangesResponse-bool) |  | When the raft log is too large, it can be a symptom of other issues. |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| unavailable | [bool](#cockroach.server.serverpb.RangesResponse-bool) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| leader_not_lease_holder | [bool](#cockroach.server.serverpb.RangesResponse-bool) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| no_raft_leader | [bool](#cockroach.server.serverpb.RangesResponse-bool) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| underreplicated | [bool](#cockroach.server.serverpb.RangesResponse-bool) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| overreplicated | [bool](#cockroach.server.serverpb.RangesResponse-bool) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| no_lease | [bool](#cockroach.server.serverpb.RangesResponse-bool) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| quiescent_equals_ticking | [bool](#cockroach.server.serverpb.RangesResponse-bool) |  | Quiescent ranges do not tick by definition, but we track this in two different ways and suspect that they're getting out of sync. If the replica's quiescent flag doesn't agree with the store's list of replicas that are ticking, warn about it. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| raft_log_too_large | [bool](#cockroach.server.serverpb.RangesResponse-bool) |  | When the raft log is too large, it can be a symptom of other issues. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -533,10 +1019,16 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.RangeStatistics"></a>
 #### RangeStatistics
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| queries_per_second | [double](#cockroach.server.serverpb.RangesResponse-double) |  | Note that queries per second will only be known by the leaseholder. All other replicas will report it as 0. |
-| writes_per_second | [double](#cockroach.server.serverpb.RangesResponse-double) |  |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| queries_per_second | [double](#cockroach.server.serverpb.RangesResponse-double) |  | Note that queries per second will only be known by the leaseholder. All other replicas will report it as 0. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| writes_per_second | [double](#cockroach.server.serverpb.RangesResponse-double) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -547,16 +1039,27 @@ The underlying response type is something we're looking to get rid of.
 
 `GET /_status/gossip/{node_id}`
 
+Gossip retrieves gossip-level details about a given node.
 
+Note: this is a “reserved” API endpoint and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
 
 #### Request Parameters
 
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [string](#cockroach.server.serverpb.GossipRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [string](#cockroach.server.serverpb.GossipRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -572,16 +1075,27 @@ The underlying response type is something we're looking to get rid of.
 
 `GET /_status/enginestats/{node_id}`
 
+EngineStats retrieves statistics about a storage engine.
 
+Note: this is a “reserved” API endpoint and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
 
 #### Request Parameters
 
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [string](#cockroach.server.serverpb.EngineStatsRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [string](#cockroach.server.serverpb.EngineStatsRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -594,9 +1108,16 @@ The underlying response type is something we're looking to get rid of.
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| stats | [EngineStatsInfo](#cockroach.server.serverpb.EngineStatsResponse-cockroach.server.serverpb.EngineStatsInfo) | repeated |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| stats | [EngineStatsInfo](#cockroach.server.serverpb.EngineStatsResponse-cockroach.server.serverpb.EngineStatsInfo) | repeated |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -606,11 +1127,17 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.EngineStatsResponse-cockroach.server.serverpb.EngineStatsInfo"></a>
 #### EngineStatsInfo
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| store_id | [int32](#cockroach.server.serverpb.EngineStatsResponse-int32) |  |  |
-| tickers_and_histograms | [cockroach.storage.enginepb.TickersAndHistograms](#cockroach.server.serverpb.EngineStatsResponse-cockroach.storage.enginepb.TickersAndHistograms) |  |  |
-| engine_type | [cockroach.storage.enginepb.EngineType](#cockroach.server.serverpb.EngineStatsResponse-cockroach.storage.enginepb.EngineType) |  |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| store_id | [int32](#cockroach.server.serverpb.EngineStatsResponse-int32) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| tickers_and_histograms | [cockroach.storage.enginepb.TickersAndHistograms](#cockroach.server.serverpb.EngineStatsResponse-cockroach.storage.enginepb.TickersAndHistograms) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| engine_type | [cockroach.storage.enginepb.EngineType](#cockroach.server.serverpb.EngineStatsResponse-cockroach.storage.enginepb.EngineType) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -621,17 +1148,28 @@ The underlying response type is something we're looking to get rid of.
 
 `GET /_status/allocator/node/{node_id}`
 
+Allocator retrieves statistics about the replica allocator.
 
+Note: this is a “reserved” API endpoint and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
 
 #### Request Parameters
 
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [string](#cockroach.server.serverpb.AllocatorRequest-string) |  |  |
-| range_ids | [int64](#cockroach.server.serverpb.AllocatorRequest-int64) | repeated |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [string](#cockroach.server.serverpb.AllocatorRequest-string) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| range_ids | [int64](#cockroach.server.serverpb.AllocatorRequest-int64) | repeated |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -644,9 +1182,16 @@ The underlying response type is something we're looking to get rid of.
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| dry_runs | [AllocatorDryRun](#cockroach.server.serverpb.AllocatorResponse-cockroach.server.serverpb.AllocatorDryRun) | repeated |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| dry_runs | [AllocatorDryRun](#cockroach.server.serverpb.AllocatorResponse-cockroach.server.serverpb.AllocatorDryRun) | repeated |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -656,10 +1201,16 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.AllocatorResponse-cockroach.server.serverpb.AllocatorDryRun"></a>
 #### AllocatorDryRun
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| range_id | [int64](#cockroach.server.serverpb.AllocatorResponse-int64) |  |  |
-| events | [TraceEvent](#cockroach.server.serverpb.AllocatorResponse-cockroach.server.serverpb.TraceEvent) | repeated |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| range_id | [int64](#cockroach.server.serverpb.AllocatorResponse-int64) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| events | [TraceEvent](#cockroach.server.serverpb.AllocatorResponse-cockroach.server.serverpb.TraceEvent) | repeated |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -668,10 +1219,16 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.AllocatorResponse-cockroach.server.serverpb.TraceEvent"></a>
 #### TraceEvent
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| time | [google.protobuf.Timestamp](#cockroach.server.serverpb.AllocatorResponse-google.protobuf.Timestamp) |  |  |
-| message | [string](#cockroach.server.serverpb.AllocatorResponse-string) |  |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| time | [google.protobuf.Timestamp](#cockroach.server.serverpb.AllocatorResponse-google.protobuf.Timestamp) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| message | [string](#cockroach.server.serverpb.AllocatorResponse-string) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -682,16 +1239,28 @@ The underlying response type is something we're looking to get rid of.
 
 `GET /_status/allocator/range/{range_id}`
 
+AllocatorRange retrieves statistics about the replica allocator given
+a specific range.
 
+Note: this is a “reserved” API endpoint and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
 
 #### Request Parameters
 
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| range_id | [int64](#cockroach.server.serverpb.AllocatorRangeRequest-int64) |  |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| range_id | [int64](#cockroach.server.serverpb.AllocatorRangeRequest-int64) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -704,10 +1273,17 @@ The underlying response type is something we're looking to get rid of.
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [int64](#cockroach.server.serverpb.AllocatorRangeResponse-int64) |  | The NodeID of the store whose dry run is returned. Only the leaseholder for a given range will do an allocator dry run for it. |
-| dry_run | [AllocatorDryRun](#cockroach.server.serverpb.AllocatorRangeResponse-cockroach.server.serverpb.AllocatorDryRun) |  |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [int64](#cockroach.server.serverpb.AllocatorRangeResponse-int64) |  | The NodeID of the store whose dry run is returned. Only the leaseholder for a given range will do an allocator dry run for it. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| dry_run | [AllocatorDryRun](#cockroach.server.serverpb.AllocatorRangeResponse-cockroach.server.serverpb.AllocatorDryRun) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -717,10 +1293,16 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.AllocatorRangeResponse-cockroach.server.serverpb.AllocatorDryRun"></a>
 #### AllocatorDryRun
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| range_id | [int64](#cockroach.server.serverpb.AllocatorRangeResponse-int64) |  |  |
-| events | [TraceEvent](#cockroach.server.serverpb.AllocatorRangeResponse-cockroach.server.serverpb.TraceEvent) | repeated |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| range_id | [int64](#cockroach.server.serverpb.AllocatorRangeResponse-int64) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| events | [TraceEvent](#cockroach.server.serverpb.AllocatorRangeResponse-cockroach.server.serverpb.TraceEvent) | repeated |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -729,10 +1311,16 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.AllocatorRangeResponse-cockroach.server.serverpb.TraceEvent"></a>
 #### TraceEvent
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| time | [google.protobuf.Timestamp](#cockroach.server.serverpb.AllocatorRangeResponse-google.protobuf.Timestamp) |  |  |
-| message | [string](#cockroach.server.serverpb.AllocatorRangeResponse-string) |  |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| time | [google.protobuf.Timestamp](#cockroach.server.serverpb.AllocatorRangeResponse-google.protobuf.Timestamp) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| message | [string](#cockroach.server.serverpb.AllocatorRangeResponse-string) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -743,16 +1331,27 @@ The underlying response type is something we're looking to get rid of.
 
 `GET /_status/sessions`
 
+ListSessions retrieves the SQL sessions across the entire cluster.
 
+Note: this is a “reserved” API endpoint and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
 
 #### Request Parameters
 
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| username | [string](#cockroach.server.serverpb.ListSessionsRequest-string) |  | Username of the user making this request. |
+Request object for ListSessions and ListLocalSessions.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| username | [string](#cockroach.server.serverpb.ListSessionsRequest-string) |  | Username of the user making this request. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -765,10 +1364,17 @@ The underlying response type is something we're looking to get rid of.
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| sessions | [Session](#cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.Session) | repeated | A list of sessions on this node or cluster. |
-| errors | [ListSessionsError](#cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.ListSessionsError) | repeated | Any errors that occurred during fan-out calls to other nodes. |
+Response object for ListSessions and ListLocalSessions.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| sessions | [Session](#cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.Session) | repeated | A list of sessions on this node or cluster. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| errors | [ListSessionsError](#cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.ListSessionsError) | repeated | Any errors that occurred during fan-out calls to other nodes. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -778,20 +1384,26 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.Session"></a>
 #### Session
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [int32](#cockroach.server.serverpb.ListSessionsResponse-int32) |  | ID of node where this session exists. |
-| username | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | Username of the user for this session. |
-| client_address | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | Connected client's IP address and port. |
-| application_name | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | Application name specified by the client. |
-| active_queries | [ActiveQuery](#cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.ActiveQuery) | repeated | Queries in progress on this session. |
-| start | [google.protobuf.Timestamp](#cockroach.server.serverpb.ListSessionsResponse-google.protobuf.Timestamp) |  | Timestamp of session's start. |
-| last_active_query | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | SQL string of the last query executed on this session. |
-| id | [bytes](#cockroach.server.serverpb.ListSessionsResponse-bytes) |  | ID of the session (uint128 represented as raw bytes). |
-| alloc_bytes | [int64](#cockroach.server.serverpb.ListSessionsResponse-int64) |  | Number of currently allocated bytes in the session memory monitor. |
-| max_alloc_bytes | [int64](#cockroach.server.serverpb.ListSessionsResponse-int64) |  | High water mark of allocated bytes in the session memory monitor. |
-| active_txn | [TxnInfo](#cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.TxnInfo) |  | Information about the txn in progress on this session. Nil if the session doesn't currently have a transaction. |
-| last_active_query_anon | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | The SQL statement fingerprint of the last query executed on this session, compatible with StatementStatisticsKey. |
+Session represents one SQL session.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [int32](#cockroach.server.serverpb.ListSessionsResponse-int32) |  | ID of node where this session exists. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| username | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | Username of the user for this session. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| client_address | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | Connected client's IP address and port. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| application_name | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | Application name specified by the client. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| active_queries | [ActiveQuery](#cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.ActiveQuery) | repeated | Queries in progress on this session. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| start | [google.protobuf.Timestamp](#cockroach.server.serverpb.ListSessionsResponse-google.protobuf.Timestamp) |  | Timestamp of session's start. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| last_active_query | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | SQL string of the last query executed on this session. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| id | [bytes](#cockroach.server.serverpb.ListSessionsResponse-bytes) |  | ID of the session (uint128 represented as raw bytes). | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| alloc_bytes | [int64](#cockroach.server.serverpb.ListSessionsResponse-int64) |  | Number of currently allocated bytes in the session memory monitor. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| max_alloc_bytes | [int64](#cockroach.server.serverpb.ListSessionsResponse-int64) |  | High water mark of allocated bytes in the session memory monitor. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| active_txn | [TxnInfo](#cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.TxnInfo) |  | Information about the txn in progress on this session. Nil if the session doesn't currently have a transaction. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| last_active_query_anon | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | The SQL statement fingerprint of the last query executed on this session, compatible with StatementStatisticsKey. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -800,16 +1412,22 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.ActiveQuery"></a>
 #### ActiveQuery
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| id | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | ID of the query (uint128 presented as a hexadecimal string). |
-| txn_id | [bytes](#cockroach.server.serverpb.ListSessionsResponse-bytes) |  | The UUID of the transaction this query is running in. |
-| sql | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | SQL query string specified by the user. |
-| start | [google.protobuf.Timestamp](#cockroach.server.serverpb.ListSessionsResponse-google.protobuf.Timestamp) |  | Start timestamp of this query. |
-| is_distributed | [bool](#cockroach.server.serverpb.ListSessionsResponse-bool) |  | True if this query is distributed. |
-| phase | [ActiveQuery.Phase](#cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.ActiveQuery.Phase) |  | phase stores the current phase of execution for this query. |
-| progress | [float](#cockroach.server.serverpb.ListSessionsResponse-float) |  |  |
-| sql_anon | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | The SQL statement fingerprint, compatible with StatementStatisticsKey. |
+ActiveQuery represents a query in flight on some Session.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| id | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | ID of the query (uint128 presented as a hexadecimal string). | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| txn_id | [bytes](#cockroach.server.serverpb.ListSessionsResponse-bytes) |  | The UUID of the transaction this query is running in. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| sql | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | SQL query string specified by the user. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| start | [google.protobuf.Timestamp](#cockroach.server.serverpb.ListSessionsResponse-google.protobuf.Timestamp) |  | Start timestamp of this query. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| is_distributed | [bool](#cockroach.server.serverpb.ListSessionsResponse-bool) |  | True if this query is distributed. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| phase | [ActiveQuery.Phase](#cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.ActiveQuery.Phase) |  | phase stores the current phase of execution for this query. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| progress | [float](#cockroach.server.serverpb.ListSessionsResponse-float) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| sql_anon | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | The SQL statement fingerprint, compatible with StatementStatisticsKey. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -818,21 +1436,27 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.TxnInfo"></a>
 #### TxnInfo
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| id | [bytes](#cockroach.server.serverpb.ListSessionsResponse-bytes) |  |  |
-| start | [google.protobuf.Timestamp](#cockroach.server.serverpb.ListSessionsResponse-google.protobuf.Timestamp) |  | The start timestamp of the transaction. |
-| txn_description | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | txn_description is a text description of the underlying kv.Txn, intended for troubleshooting purposes. |
-| num_statements_executed | [int32](#cockroach.server.serverpb.ListSessionsResponse-int32) |  | num_statements_executed is the number of statements that were executed so far on this transaction. |
-| num_retries | [int32](#cockroach.server.serverpb.ListSessionsResponse-int32) |  | num_retries is the number of times that this transaction was retried. |
-| num_auto_retries | [int32](#cockroach.server.serverpb.ListSessionsResponse-int32) |  | num_retries is the number of times that this transaction was automatically retried by the SQL executor. |
-| deadline | [google.protobuf.Timestamp](#cockroach.server.serverpb.ListSessionsResponse-google.protobuf.Timestamp) |  | The deadline by which the transaction must be committed. |
-| implicit | [bool](#cockroach.server.serverpb.ListSessionsResponse-bool) |  | implicit is true if this transaction was an implicit SQL transaction. |
-| alloc_bytes | [int64](#cockroach.server.serverpb.ListSessionsResponse-int64) |  | Number of currently allocated bytes in the txn memory monitor. |
-| max_alloc_bytes | [int64](#cockroach.server.serverpb.ListSessionsResponse-int64) |  | High water mark of allocated bytes in the txn memory monitor. |
-| read_only | [bool](#cockroach.server.serverpb.ListSessionsResponse-bool) |  |  |
-| is_historical | [bool](#cockroach.server.serverpb.ListSessionsResponse-bool) |  |  |
-| priority | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  |  |
+TxnInfo represents an in flight user transaction on some Session.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| id | [bytes](#cockroach.server.serverpb.ListSessionsResponse-bytes) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| start | [google.protobuf.Timestamp](#cockroach.server.serverpb.ListSessionsResponse-google.protobuf.Timestamp) |  | The start timestamp of the transaction. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| txn_description | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | txn_description is a text description of the underlying kv.Txn, intended for troubleshooting purposes. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| num_statements_executed | [int32](#cockroach.server.serverpb.ListSessionsResponse-int32) |  | num_statements_executed is the number of statements that were executed so far on this transaction. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| num_retries | [int32](#cockroach.server.serverpb.ListSessionsResponse-int32) |  | num_retries is the number of times that this transaction was retried. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| num_auto_retries | [int32](#cockroach.server.serverpb.ListSessionsResponse-int32) |  | num_retries is the number of times that this transaction was automatically retried by the SQL executor. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| deadline | [google.protobuf.Timestamp](#cockroach.server.serverpb.ListSessionsResponse-google.protobuf.Timestamp) |  | The deadline by which the transaction must be committed. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| implicit | [bool](#cockroach.server.serverpb.ListSessionsResponse-bool) |  | implicit is true if this transaction was an implicit SQL transaction. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| alloc_bytes | [int64](#cockroach.server.serverpb.ListSessionsResponse-int64) |  | Number of currently allocated bytes in the txn memory monitor. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| max_alloc_bytes | [int64](#cockroach.server.serverpb.ListSessionsResponse-int64) |  | High water mark of allocated bytes in the txn memory monitor. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| read_only | [bool](#cockroach.server.serverpb.ListSessionsResponse-bool) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| is_historical | [bool](#cockroach.server.serverpb.ListSessionsResponse-bool) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| priority | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -841,10 +1465,16 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.ListSessionsError"></a>
 #### ListSessionsError
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [int32](#cockroach.server.serverpb.ListSessionsResponse-int32) |  | ID of node that was being contacted when this error occurred |
-| message | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | Error message. |
+An error wrapper object for ListSessionsResponse.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [int32](#cockroach.server.serverpb.ListSessionsResponse-int32) |  | ID of node that was being contacted when this error occurred | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| message | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | Error message. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -855,16 +1485,27 @@ The underlying response type is something we're looking to get rid of.
 
 `GET /_status/local_sessions`
 
+ListLocalSessions retrieves the SQL sessions on this node.
 
+Note: this is a “reserved” API endpoint and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
 
 #### Request Parameters
 
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| username | [string](#cockroach.server.serverpb.ListSessionsRequest-string) |  | Username of the user making this request. |
+Request object for ListSessions and ListLocalSessions.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| username | [string](#cockroach.server.serverpb.ListSessionsRequest-string) |  | Username of the user making this request. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -877,10 +1518,17 @@ The underlying response type is something we're looking to get rid of.
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| sessions | [Session](#cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.Session) | repeated | A list of sessions on this node or cluster. |
-| errors | [ListSessionsError](#cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.ListSessionsError) | repeated | Any errors that occurred during fan-out calls to other nodes. |
+Response object for ListSessions and ListLocalSessions.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| sessions | [Session](#cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.Session) | repeated | A list of sessions on this node or cluster. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| errors | [ListSessionsError](#cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.ListSessionsError) | repeated | Any errors that occurred during fan-out calls to other nodes. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -890,20 +1538,26 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.Session"></a>
 #### Session
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [int32](#cockroach.server.serverpb.ListSessionsResponse-int32) |  | ID of node where this session exists. |
-| username | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | Username of the user for this session. |
-| client_address | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | Connected client's IP address and port. |
-| application_name | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | Application name specified by the client. |
-| active_queries | [ActiveQuery](#cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.ActiveQuery) | repeated | Queries in progress on this session. |
-| start | [google.protobuf.Timestamp](#cockroach.server.serverpb.ListSessionsResponse-google.protobuf.Timestamp) |  | Timestamp of session's start. |
-| last_active_query | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | SQL string of the last query executed on this session. |
-| id | [bytes](#cockroach.server.serverpb.ListSessionsResponse-bytes) |  | ID of the session (uint128 represented as raw bytes). |
-| alloc_bytes | [int64](#cockroach.server.serverpb.ListSessionsResponse-int64) |  | Number of currently allocated bytes in the session memory monitor. |
-| max_alloc_bytes | [int64](#cockroach.server.serverpb.ListSessionsResponse-int64) |  | High water mark of allocated bytes in the session memory monitor. |
-| active_txn | [TxnInfo](#cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.TxnInfo) |  | Information about the txn in progress on this session. Nil if the session doesn't currently have a transaction. |
-| last_active_query_anon | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | The SQL statement fingerprint of the last query executed on this session, compatible with StatementStatisticsKey. |
+Session represents one SQL session.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [int32](#cockroach.server.serverpb.ListSessionsResponse-int32) |  | ID of node where this session exists. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| username | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | Username of the user for this session. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| client_address | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | Connected client's IP address and port. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| application_name | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | Application name specified by the client. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| active_queries | [ActiveQuery](#cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.ActiveQuery) | repeated | Queries in progress on this session. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| start | [google.protobuf.Timestamp](#cockroach.server.serverpb.ListSessionsResponse-google.protobuf.Timestamp) |  | Timestamp of session's start. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| last_active_query | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | SQL string of the last query executed on this session. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| id | [bytes](#cockroach.server.serverpb.ListSessionsResponse-bytes) |  | ID of the session (uint128 represented as raw bytes). | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| alloc_bytes | [int64](#cockroach.server.serverpb.ListSessionsResponse-int64) |  | Number of currently allocated bytes in the session memory monitor. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| max_alloc_bytes | [int64](#cockroach.server.serverpb.ListSessionsResponse-int64) |  | High water mark of allocated bytes in the session memory monitor. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| active_txn | [TxnInfo](#cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.TxnInfo) |  | Information about the txn in progress on this session. Nil if the session doesn't currently have a transaction. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| last_active_query_anon | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | The SQL statement fingerprint of the last query executed on this session, compatible with StatementStatisticsKey. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -912,16 +1566,22 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.ActiveQuery"></a>
 #### ActiveQuery
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| id | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | ID of the query (uint128 presented as a hexadecimal string). |
-| txn_id | [bytes](#cockroach.server.serverpb.ListSessionsResponse-bytes) |  | The UUID of the transaction this query is running in. |
-| sql | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | SQL query string specified by the user. |
-| start | [google.protobuf.Timestamp](#cockroach.server.serverpb.ListSessionsResponse-google.protobuf.Timestamp) |  | Start timestamp of this query. |
-| is_distributed | [bool](#cockroach.server.serverpb.ListSessionsResponse-bool) |  | True if this query is distributed. |
-| phase | [ActiveQuery.Phase](#cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.ActiveQuery.Phase) |  | phase stores the current phase of execution for this query. |
-| progress | [float](#cockroach.server.serverpb.ListSessionsResponse-float) |  |  |
-| sql_anon | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | The SQL statement fingerprint, compatible with StatementStatisticsKey. |
+ActiveQuery represents a query in flight on some Session.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| id | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | ID of the query (uint128 presented as a hexadecimal string). | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| txn_id | [bytes](#cockroach.server.serverpb.ListSessionsResponse-bytes) |  | The UUID of the transaction this query is running in. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| sql | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | SQL query string specified by the user. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| start | [google.protobuf.Timestamp](#cockroach.server.serverpb.ListSessionsResponse-google.protobuf.Timestamp) |  | Start timestamp of this query. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| is_distributed | [bool](#cockroach.server.serverpb.ListSessionsResponse-bool) |  | True if this query is distributed. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| phase | [ActiveQuery.Phase](#cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.ActiveQuery.Phase) |  | phase stores the current phase of execution for this query. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| progress | [float](#cockroach.server.serverpb.ListSessionsResponse-float) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| sql_anon | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | The SQL statement fingerprint, compatible with StatementStatisticsKey. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -930,21 +1590,27 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.TxnInfo"></a>
 #### TxnInfo
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| id | [bytes](#cockroach.server.serverpb.ListSessionsResponse-bytes) |  |  |
-| start | [google.protobuf.Timestamp](#cockroach.server.serverpb.ListSessionsResponse-google.protobuf.Timestamp) |  | The start timestamp of the transaction. |
-| txn_description | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | txn_description is a text description of the underlying kv.Txn, intended for troubleshooting purposes. |
-| num_statements_executed | [int32](#cockroach.server.serverpb.ListSessionsResponse-int32) |  | num_statements_executed is the number of statements that were executed so far on this transaction. |
-| num_retries | [int32](#cockroach.server.serverpb.ListSessionsResponse-int32) |  | num_retries is the number of times that this transaction was retried. |
-| num_auto_retries | [int32](#cockroach.server.serverpb.ListSessionsResponse-int32) |  | num_retries is the number of times that this transaction was automatically retried by the SQL executor. |
-| deadline | [google.protobuf.Timestamp](#cockroach.server.serverpb.ListSessionsResponse-google.protobuf.Timestamp) |  | The deadline by which the transaction must be committed. |
-| implicit | [bool](#cockroach.server.serverpb.ListSessionsResponse-bool) |  | implicit is true if this transaction was an implicit SQL transaction. |
-| alloc_bytes | [int64](#cockroach.server.serverpb.ListSessionsResponse-int64) |  | Number of currently allocated bytes in the txn memory monitor. |
-| max_alloc_bytes | [int64](#cockroach.server.serverpb.ListSessionsResponse-int64) |  | High water mark of allocated bytes in the txn memory monitor. |
-| read_only | [bool](#cockroach.server.serverpb.ListSessionsResponse-bool) |  |  |
-| is_historical | [bool](#cockroach.server.serverpb.ListSessionsResponse-bool) |  |  |
-| priority | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  |  |
+TxnInfo represents an in flight user transaction on some Session.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| id | [bytes](#cockroach.server.serverpb.ListSessionsResponse-bytes) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| start | [google.protobuf.Timestamp](#cockroach.server.serverpb.ListSessionsResponse-google.protobuf.Timestamp) |  | The start timestamp of the transaction. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| txn_description | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | txn_description is a text description of the underlying kv.Txn, intended for troubleshooting purposes. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| num_statements_executed | [int32](#cockroach.server.serverpb.ListSessionsResponse-int32) |  | num_statements_executed is the number of statements that were executed so far on this transaction. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| num_retries | [int32](#cockroach.server.serverpb.ListSessionsResponse-int32) |  | num_retries is the number of times that this transaction was retried. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| num_auto_retries | [int32](#cockroach.server.serverpb.ListSessionsResponse-int32) |  | num_retries is the number of times that this transaction was automatically retried by the SQL executor. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| deadline | [google.protobuf.Timestamp](#cockroach.server.serverpb.ListSessionsResponse-google.protobuf.Timestamp) |  | The deadline by which the transaction must be committed. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| implicit | [bool](#cockroach.server.serverpb.ListSessionsResponse-bool) |  | implicit is true if this transaction was an implicit SQL transaction. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| alloc_bytes | [int64](#cockroach.server.serverpb.ListSessionsResponse-int64) |  | Number of currently allocated bytes in the txn memory monitor. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| max_alloc_bytes | [int64](#cockroach.server.serverpb.ListSessionsResponse-int64) |  | High water mark of allocated bytes in the txn memory monitor. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| read_only | [bool](#cockroach.server.serverpb.ListSessionsResponse-bool) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| is_historical | [bool](#cockroach.server.serverpb.ListSessionsResponse-bool) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| priority | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -953,10 +1619,16 @@ The underlying response type is something we're looking to get rid of.
 <a name="cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.ListSessionsError"></a>
 #### ListSessionsError
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [int32](#cockroach.server.serverpb.ListSessionsResponse-int32) |  | ID of node that was being contacted when this error occurred |
-| message | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | Error message. |
+An error wrapper object for ListSessionsResponse.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [int32](#cockroach.server.serverpb.ListSessionsResponse-int32) |  | ID of node that was being contacted when this error occurred | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| message | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | Error message. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -967,18 +1639,29 @@ The underlying response type is something we're looking to get rid of.
 
 `POST /_status/cancel_query/{node_id}`
 
+CancelQuery cancels a SQL query given its ID.
 
+Note: this is a “reserved” API endpoint and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
 
 #### Request Parameters
 
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [string](#cockroach.server.serverpb.CancelQueryRequest-string) |  | ID of gateway node for the query to be canceled.<br><br>TODO(itsbilal): use [(gogoproto.customname) = "NodeID"] below. Need to figure out how to teach grpc-gateway about custom names.<br><br>node_id is a string so that "local" can be used to specify that no forwarding is necessary. |
-| query_id | [string](#cockroach.server.serverpb.CancelQueryRequest-string) |  | ID of query to be canceled (converted to string). |
-| username | [string](#cockroach.server.serverpb.CancelQueryRequest-string) |  | Username of the user making this cancellation request. This may be omitted if the user is the same as the one issuing the CancelQueryRequest. |
+Request object for issing a query cancel request.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [string](#cockroach.server.serverpb.CancelQueryRequest-string) |  | ID of gateway node for the query to be canceled.<br><br>TODO(itsbilal): use [(gogoproto.customname) = "NodeID"] below. Need to figure out how to teach grpc-gateway about custom names.<br><br>node_id is a string so that "local" can be used to specify that no forwarding is necessary. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| query_id | [string](#cockroach.server.serverpb.CancelQueryRequest-string) |  | ID of query to be canceled (converted to string). | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| username | [string](#cockroach.server.serverpb.CancelQueryRequest-string) |  | Username of the user making this cancellation request. This may be omitted if the user is the same as the one issuing the CancelQueryRequest. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -991,10 +1674,17 @@ The underlying response type is something we're looking to get rid of.
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| canceled | [bool](#cockroach.server.serverpb.CancelQueryResponse-bool) |  | Whether the cancellation request succeeded and the query was canceled. |
-| error | [string](#cockroach.server.serverpb.CancelQueryResponse-string) |  | Error message (accompanied with canceled = false). |
+Response returned by target query's gateway node.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| canceled | [bool](#cockroach.server.serverpb.CancelQueryResponse-bool) |  | Whether the cancellation request succeeded and the query was canceled. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| error | [string](#cockroach.server.serverpb.CancelQueryResponse-string) |  | Error message (accompanied with canceled = false). | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -1006,18 +1696,29 @@ The underlying response type is something we're looking to get rid of.
 
 `POST /_status/cancel_session/{node_id}`
 
+CancelSessions forcefully terminates a SQL session given its ID.
 
+Note: this is a “reserved” API endpoint and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
 
 #### Request Parameters
 
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [string](#cockroach.server.serverpb.CancelSessionRequest-string) |  | TODO(abhimadan): use [(gogoproto.customname) = "NodeID"] below. Need to figure out how to teach grpc-gateway about custom names.<br><br>node_id is a string so that "local" can be used to specify that no forwarding is necessary. |
-| session_id | [bytes](#cockroach.server.serverpb.CancelSessionRequest-bytes) |  |  |
-| username | [string](#cockroach.server.serverpb.CancelSessionRequest-string) |  | Username of the user making this cancellation request. This may be omitted if the user is the same as the one issuing the CancelSessionRequest. |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [string](#cockroach.server.serverpb.CancelSessionRequest-string) |  | TODO(abhimadan): use [(gogoproto.customname) = "NodeID"] below. Need to figure out how to teach grpc-gateway about custom names.<br><br>node_id is a string so that "local" can be used to specify that no forwarding is necessary. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| session_id | [bytes](#cockroach.server.serverpb.CancelSessionRequest-bytes) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| username | [string](#cockroach.server.serverpb.CancelSessionRequest-string) |  | Username of the user making this cancellation request. This may be omitted if the user is the same as the one issuing the CancelSessionRequest. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -1030,10 +1731,17 @@ The underlying response type is something we're looking to get rid of.
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| canceled | [bool](#cockroach.server.serverpb.CancelSessionResponse-bool) |  |  |
-| error | [string](#cockroach.server.serverpb.CancelSessionResponse-string) |  |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| canceled | [bool](#cockroach.server.serverpb.CancelSessionResponse-bool) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| error | [string](#cockroach.server.serverpb.CancelSessionResponse-string) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -1051,16 +1759,27 @@ in that span. This is designed to compute stats specific to a SQL table:
 it will be called with the highest/lowest key for a SQL table, and return
 information about the resources on a node used by that table.
 
+Note: this is a “reserved” API endpoint and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
 #### Request Parameters
 
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [string](#cockroach.server.serverpb.SpanStatsRequest-string) |  |  |
-| start_key | [bytes](#cockroach.server.serverpb.SpanStatsRequest-bytes) |  |  |
-| end_key | [bytes](#cockroach.server.serverpb.SpanStatsRequest-bytes) |  |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [string](#cockroach.server.serverpb.SpanStatsRequest-string) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| start_key | [bytes](#cockroach.server.serverpb.SpanStatsRequest-bytes) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| end_key | [bytes](#cockroach.server.serverpb.SpanStatsRequest-bytes) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -1073,11 +1792,18 @@ information about the resources on a node used by that table.
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| range_count | [int32](#cockroach.server.serverpb.SpanStatsResponse-int32) |  |  |
-| approximate_disk_bytes | [uint64](#cockroach.server.serverpb.SpanStatsResponse-uint64) |  |  |
-| total_stats | [cockroach.storage.enginepb.MVCCStats](#cockroach.server.serverpb.SpanStatsResponse-cockroach.storage.enginepb.MVCCStats) |  |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| range_count | [int32](#cockroach.server.serverpb.SpanStatsResponse-int32) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| approximate_disk_bytes | [uint64](#cockroach.server.serverpb.SpanStatsResponse-uint64) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| total_stats | [cockroach.storage.enginepb.MVCCStats](#cockroach.server.serverpb.SpanStatsResponse-cockroach.storage.enginepb.MVCCStats) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -1089,17 +1815,28 @@ information about the resources on a node used by that table.
 
 `GET /_status/stacks/{node_id}`
 
+Stacks retrieves the stack traces of all goroutines on a given node.
 
+Note: this is a “reserved” API endpoint and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
 
 #### Request Parameters
 
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [string](#cockroach.server.serverpb.StacksRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. |
-| type | [StacksType](#cockroach.server.serverpb.StacksRequest-cockroach.server.serverpb.StacksType) |  |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [string](#cockroach.server.serverpb.StacksRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| type | [StacksType](#cockroach.server.serverpb.StacksRequest-cockroach.server.serverpb.StacksType) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -1112,9 +1849,16 @@ information about the resources on a node used by that table.
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| data | [bytes](#cockroach.server.serverpb.JSONResponse-bytes) |  |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| data | [bytes](#cockroach.server.serverpb.JSONResponse-bytes) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -1126,18 +1870,29 @@ information about the resources on a node used by that table.
 
 `GET /_status/profile/{node_id}`
 
+Profile retrieves a CPU profile on a given node.
 
+Note: this is a “reserved” API endpoint and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
 
 #### Request Parameters
 
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [string](#cockroach.server.serverpb.ProfileRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. |
-| type | [ProfileRequest.Type](#cockroach.server.serverpb.ProfileRequest-cockroach.server.serverpb.ProfileRequest.Type) |  | The type of profile to retrieve. |
-| seconds | [int32](#cockroach.server.serverpb.ProfileRequest-int32) |  | applies only to Type=CPU, defaults to 30 |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [string](#cockroach.server.serverpb.ProfileRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| type | [ProfileRequest.Type](#cockroach.server.serverpb.ProfileRequest-cockroach.server.serverpb.ProfileRequest.Type) |  | The type of profile to retrieve. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| seconds | [int32](#cockroach.server.serverpb.ProfileRequest-int32) |  | applies only to Type=CPU, defaults to 30 | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -1150,9 +1905,16 @@ information about the resources on a node used by that table.
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| data | [bytes](#cockroach.server.serverpb.JSONResponse-bytes) |  |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| data | [bytes](#cockroach.server.serverpb.JSONResponse-bytes) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -1164,16 +1926,31 @@ information about the resources on a node used by that table.
 
 `GET /_status/metrics/{node_id}`
 
+Metrics retrieves the node metrics for a given node.
 
+Note: this is a “reserved” API and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+Note: this is a “reserved” API endpoint and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
 
 #### Request Parameters
 
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [string](#cockroach.server.serverpb.MetricsRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [string](#cockroach.server.serverpb.MetricsRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -1186,9 +1963,16 @@ information about the resources on a node used by that table.
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| data | [bytes](#cockroach.server.serverpb.JSONResponse-bytes) |  |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| data | [bytes](#cockroach.server.serverpb.JSONResponse-bytes) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -1200,19 +1984,30 @@ information about the resources on a node used by that table.
 
 `GET /_status/files/{node_id}`
 
+GetFiles retrieves heap or goroutine dump files from a given node.
 
+Note: this is a “reserved” API endpoint and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
 
 #### Request Parameters
 
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [string](#cockroach.server.serverpb.GetFilesRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. |
-| list_only | [bool](#cockroach.server.serverpb.GetFilesRequest-bool) |  | If list_only is true then the contents of the files will not be populated in the response. Only filenames and sizes will be returned. |
-| type | [FileType](#cockroach.server.serverpb.GetFilesRequest-cockroach.server.serverpb.FileType) |  |  |
-| patterns | [string](#cockroach.server.serverpb.GetFilesRequest-string) | repeated | Each pattern given is matched with Files of the above type in the node using filepath.Glob(). The patterns only match to filenames and so path separators cannot be used. Example: * will match all files of requested type. |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [string](#cockroach.server.serverpb.GetFilesRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| list_only | [bool](#cockroach.server.serverpb.GetFilesRequest-bool) |  | If list_only is true then the contents of the files will not be populated in the response. Only filenames and sizes will be returned. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| type | [FileType](#cockroach.server.serverpb.GetFilesRequest-cockroach.server.serverpb.FileType) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| patterns | [string](#cockroach.server.serverpb.GetFilesRequest-string) | repeated | Each pattern given is matched with Files of the above type in the node using filepath.Glob(). The patterns only match to filenames and so path separators cannot be used. Example: * will match all files of requested type. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -1225,9 +2020,16 @@ information about the resources on a node used by that table.
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| files | [File](#cockroach.server.serverpb.GetFilesResponse-cockroach.server.serverpb.File) | repeated |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| files | [File](#cockroach.server.serverpb.GetFilesResponse-cockroach.server.serverpb.File) | repeated |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -1237,11 +2039,17 @@ information about the resources on a node used by that table.
 <a name="cockroach.server.serverpb.GetFilesResponse-cockroach.server.serverpb.File"></a>
 #### File
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| name | [string](#cockroach.server.serverpb.GetFilesResponse-string) |  |  |
-| file_size | [int64](#cockroach.server.serverpb.GetFilesResponse-int64) |  |  |
-| contents | [bytes](#cockroach.server.serverpb.GetFilesResponse-bytes) |  | Contents may not be populated if only a list of Files are requested. |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| name | [string](#cockroach.server.serverpb.GetFilesResponse-string) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| file_size | [int64](#cockroach.server.serverpb.GetFilesResponse-int64) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| contents | [bytes](#cockroach.server.serverpb.GetFilesResponse-bytes) |  | Contents may not be populated if only a list of Files are requested. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -1252,16 +2060,27 @@ information about the resources on a node used by that table.
 
 `GET /_status/logfiles/{node_id}`
 
+LogFilesList retrieves a list of log files on a given node.
 
+Note: this is a “reserved” API endpoint and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
 
 #### Request Parameters
 
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [string](#cockroach.server.serverpb.LogFilesListRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [string](#cockroach.server.serverpb.LogFilesListRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -1274,9 +2093,16 @@ information about the resources on a node used by that table.
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| files | [cockroach.util.log.FileInfo](#cockroach.server.serverpb.LogFilesListResponse-cockroach.util.log.FileInfo) | repeated |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| files | [cockroach.util.log.FileInfo](#cockroach.server.serverpb.LogFilesListResponse-cockroach.util.log.FileInfo) | repeated |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -1288,19 +2114,30 @@ information about the resources on a node used by that table.
 
 `GET /_status/logfiles/{node_id}/{file}`
 
+LogFile retrieves a given log file.
 
+Note: this is a “reserved” API endpoint and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
 
 #### Request Parameters
 
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [string](#cockroach.server.serverpb.LogFileRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. |
-| file | [string](#cockroach.server.serverpb.LogFileRequest-string) |  |  |
-| redact | [bool](#cockroach.server.serverpb.LogFileRequest-bool) |  | redact, if true, requests redaction of sensitive data away from the retrieved log entries. Only admin users can send a request with redact = false. |
-| keep_redactable | [bool](#cockroach.server.serverpb.LogFileRequest-bool) |  | keep_redactable, if true, requests that retrieved entries preserve the redaction markers if any were present in the log files. If false, redaction markers are stripped away. Note that redact = false && redactable = false implies "flat" entries with all sensitive information enclosed and no markers; this is suitable for backward-compatibility with RPC clients from prior the introduction of redactable logs. |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [string](#cockroach.server.serverpb.LogFileRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| file | [string](#cockroach.server.serverpb.LogFileRequest-string) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| redact | [bool](#cockroach.server.serverpb.LogFileRequest-bool) |  | redact, if true, requests redaction of sensitive data away from the retrieved log entries. Only admin users can send a request with redact = false. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| keep_redactable | [bool](#cockroach.server.serverpb.LogFileRequest-bool) |  | keep_redactable, if true, requests that retrieved entries preserve the redaction markers if any were present in the log files. If false, redaction markers are stripped away. Note that redact = false && redactable = false implies "flat" entries with all sensitive information enclosed and no markers; this is suitable for backward-compatibility with RPC clients from prior the introduction of redactable logs. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -1313,9 +2150,16 @@ information about the resources on a node used by that table.
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| entries | [cockroach.util.log.Entry](#cockroach.server.serverpb.LogEntriesResponse-cockroach.util.log.Entry) | repeated |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| entries | [cockroach.util.log.Entry](#cockroach.server.serverpb.LogEntriesResponse-cockroach.util.log.Entry) | repeated |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -1327,23 +2171,34 @@ information about the resources on a node used by that table.
 
 `GET /_status/logs/{node_id}`
 
+Logs retrieves individual log entries.
 
+Note: this is a “reserved” API endpoint and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
 
 #### Request Parameters
 
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [string](#cockroach.server.serverpb.LogsRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. |
-| level | [string](#cockroach.server.serverpb.LogsRequest-string) |  |  |
-| start_time | [string](#cockroach.server.serverpb.LogsRequest-string) |  |  |
-| end_time | [string](#cockroach.server.serverpb.LogsRequest-string) |  |  |
-| max | [string](#cockroach.server.serverpb.LogsRequest-string) |  |  |
-| pattern | [string](#cockroach.server.serverpb.LogsRequest-string) |  |  |
-| redact | [bool](#cockroach.server.serverpb.LogsRequest-bool) |  | redact, if true, requests redaction of sensitive data away from the retrieved log entries. Only admin users can send a request with redact = false. |
-| keep_redactable | [bool](#cockroach.server.serverpb.LogsRequest-bool) |  | keep_redactable, if true, requests that retrieved entries preserve the redaction markers if any were present in the log files. If false, redaction markers are stripped away. Note that redact = false && redactable = false implies "flat" entries with all sensitive information enclosed and no markers; this is suitable for backward-compatibility with RPC clients from prior the introduction of redactable logs. |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [string](#cockroach.server.serverpb.LogsRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| level | [string](#cockroach.server.serverpb.LogsRequest-string) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| start_time | [string](#cockroach.server.serverpb.LogsRequest-string) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| end_time | [string](#cockroach.server.serverpb.LogsRequest-string) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| max | [string](#cockroach.server.serverpb.LogsRequest-string) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| pattern | [string](#cockroach.server.serverpb.LogsRequest-string) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| redact | [bool](#cockroach.server.serverpb.LogsRequest-bool) |  | redact, if true, requests redaction of sensitive data away from the retrieved log entries. Only admin users can send a request with redact = false. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| keep_redactable | [bool](#cockroach.server.serverpb.LogsRequest-bool) |  | keep_redactable, if true, requests that retrieved entries preserve the redaction markers if any were present in the log files. If false, redaction markers are stripped away. Note that redact = false && redactable = false implies "flat" entries with all sensitive information enclosed and no markers; this is suitable for backward-compatibility with RPC clients from prior the introduction of redactable logs. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -1356,9 +2211,16 @@ information about the resources on a node used by that table.
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| entries | [cockroach.util.log.Entry](#cockroach.server.serverpb.LogEntriesResponse-cockroach.util.log.Entry) | repeated |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| entries | [cockroach.util.log.Entry](#cockroach.server.serverpb.LogEntriesResponse-cockroach.util.log.Entry) | repeated |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -1370,16 +2232,27 @@ information about the resources on a node used by that table.
 
 `GET /_status/problemranges`
 
+ProblemRanges retrieves the list of “problem ranges”.
 
+Note: this is a “reserved” API endpoint and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
 
 #### Request Parameters
 
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [string](#cockroach.server.serverpb.ProblemRangesRequest-string) |  | If left empty, problem ranges for all nodes/stores will be returned. |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [string](#cockroach.server.serverpb.ProblemRangesRequest-string) |  | If left empty, problem ranges for all nodes/stores will be returned. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -1392,10 +2265,17 @@ information about the resources on a node used by that table.
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [int32](#cockroach.server.serverpb.ProblemRangesResponse-int32) |  | NodeID is the node that submitted all the requests. |
-| problems_by_node_id | [ProblemRangesResponse.ProblemsByNodeIdEntry](#cockroach.server.serverpb.ProblemRangesResponse-cockroach.server.serverpb.ProblemRangesResponse.ProblemsByNodeIdEntry) | repeated |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [int32](#cockroach.server.serverpb.ProblemRangesResponse-int32) |  | NodeID is the node that submitted all the requests. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| problems_by_node_id | [ProblemRangesResponse.ProblemsByNodeIdEntry](#cockroach.server.serverpb.ProblemRangesResponse-cockroach.server.serverpb.ProblemRangesResponse.ProblemsByNodeIdEntry) | repeated |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -1405,10 +2285,14 @@ information about the resources on a node used by that table.
 <a name="cockroach.server.serverpb.ProblemRangesResponse-cockroach.server.serverpb.ProblemRangesResponse.ProblemsByNodeIdEntry"></a>
 #### ProblemRangesResponse.ProblemsByNodeIdEntry
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| key | [int32](#cockroach.server.serverpb.ProblemRangesResponse-int32) |  |  |
-| value | [ProblemRangesResponse.NodeProblems](#cockroach.server.serverpb.ProblemRangesResponse-cockroach.server.serverpb.ProblemRangesResponse.NodeProblems) |  |  |
+
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [int32](#cockroach.server.serverpb.ProblemRangesResponse-int32) |  |  |  |
+| value | [ProblemRangesResponse.NodeProblems](#cockroach.server.serverpb.ProblemRangesResponse-cockroach.server.serverpb.ProblemRangesResponse.NodeProblems) |  |  |  |
 
 
 
@@ -1417,17 +2301,23 @@ information about the resources on a node used by that table.
 <a name="cockroach.server.serverpb.ProblemRangesResponse-cockroach.server.serverpb.ProblemRangesResponse.NodeProblems"></a>
 #### ProblemRangesResponse.NodeProblems
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| error_message | [string](#cockroach.server.serverpb.ProblemRangesResponse-string) |  |  |
-| unavailable_range_ids | [int64](#cockroach.server.serverpb.ProblemRangesResponse-int64) | repeated |  |
-| raft_leader_not_lease_holder_range_ids | [int64](#cockroach.server.serverpb.ProblemRangesResponse-int64) | repeated |  |
-| no_raft_leader_range_ids | [int64](#cockroach.server.serverpb.ProblemRangesResponse-int64) | repeated |  |
-| no_lease_range_ids | [int64](#cockroach.server.serverpb.ProblemRangesResponse-int64) | repeated |  |
-| underreplicated_range_ids | [int64](#cockroach.server.serverpb.ProblemRangesResponse-int64) | repeated |  |
-| overreplicated_range_ids | [int64](#cockroach.server.serverpb.ProblemRangesResponse-int64) | repeated |  |
-| quiescent_equals_ticking_range_ids | [int64](#cockroach.server.serverpb.ProblemRangesResponse-int64) | repeated |  |
-| raft_log_too_large_range_ids | [int64](#cockroach.server.serverpb.ProblemRangesResponse-int64) | repeated |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| error_message | [string](#cockroach.server.serverpb.ProblemRangesResponse-string) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| unavailable_range_ids | [int64](#cockroach.server.serverpb.ProblemRangesResponse-int64) | repeated |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| raft_leader_not_lease_holder_range_ids | [int64](#cockroach.server.serverpb.ProblemRangesResponse-int64) | repeated |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| no_raft_leader_range_ids | [int64](#cockroach.server.serverpb.ProblemRangesResponse-int64) | repeated |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| no_lease_range_ids | [int64](#cockroach.server.serverpb.ProblemRangesResponse-int64) | repeated |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| underreplicated_range_ids | [int64](#cockroach.server.serverpb.ProblemRangesResponse-int64) | repeated |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| overreplicated_range_ids | [int64](#cockroach.server.serverpb.ProblemRangesResponse-int64) | repeated |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| quiescent_equals_ticking_range_ids | [int64](#cockroach.server.serverpb.ProblemRangesResponse-int64) | repeated |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| raft_log_too_large_range_ids | [int64](#cockroach.server.serverpb.ProblemRangesResponse-int64) | repeated |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -1440,14 +2330,25 @@ information about the resources on a node used by that table.
 
 
 
+Note: this is a “reserved” API endpoint and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
 #### Request Parameters
 
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [string](#cockroach.server.serverpb.HotRangesRequest-string) |  | NodeID indicates which node to query for a hot range report. It is posssible to populate any node ID; if the node receiving the request is not the target node, it will forward the request to the target node.<br><br>If left empty, the request is forwarded to every node in the cluster. |
+HotRangesRequest queries one or more cluster nodes for a list
+of ranges currently considered “hot” by the node(s).
+
+Note: this is an “alpha” API payload. It is subject to change without
+advance notice in a subsequent release.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [string](#cockroach.server.serverpb.HotRangesRequest-string) |  | NodeID indicates which node to query for a hot range report. It is posssible to populate any node ID; if the node receiving the request is not the target node, it will forward the request to the target node.<br><br>If left empty, the request is forwarded to every node in the cluster. | Note: this is an “alpha” API field. It is subject to change without advance notice in a subsequent release. |
 
 
 
@@ -1460,10 +2361,17 @@ information about the resources on a node used by that table.
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [int32](#cockroach.server.serverpb.HotRangesResponse-int32) |  | NodeID is the node that received the HotRangesRequest and forwarded requests to the selected target node(s). |
-| hot_ranges_by_node_id | [HotRangesResponse.HotRangesByNodeIdEntry](#cockroach.server.serverpb.HotRangesResponse-cockroach.server.serverpb.HotRangesResponse.HotRangesByNodeIdEntry) | repeated | HotRangesByNodeID contains a hot range report for each selected target node ID in the HotRangesRequest. |
+HotRangesResponse is the payload produced in response
+to a HotRangesRequest.
+
+Note: this is an “alpha” API payload. It is subject to change without
+advance notice in a subsequent release.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [int32](#cockroach.server.serverpb.HotRangesResponse-int32) |  | NodeID is the node that received the HotRangesRequest and forwarded requests to the selected target node(s). | Note: this is an “alpha” API field. It is subject to change without advance notice in a subsequent release. |
+| hot_ranges_by_node_id | [HotRangesResponse.HotRangesByNodeIdEntry](#cockroach.server.serverpb.HotRangesResponse-cockroach.server.serverpb.HotRangesResponse.HotRangesByNodeIdEntry) | repeated | HotRangesByNodeID contains a hot range report for each selected target node ID in the HotRangesRequest. | Note: this is an “alpha” API field. It is subject to change without advance notice in a subsequent release. |
 
 
 
@@ -1473,10 +2381,14 @@ information about the resources on a node used by that table.
 <a name="cockroach.server.serverpb.HotRangesResponse-cockroach.server.serverpb.HotRangesResponse.HotRangesByNodeIdEntry"></a>
 #### HotRangesResponse.HotRangesByNodeIdEntry
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| key | [int32](#cockroach.server.serverpb.HotRangesResponse-int32) |  |  |
-| value | [HotRangesResponse.NodeResponse](#cockroach.server.serverpb.HotRangesResponse-cockroach.server.serverpb.HotRangesResponse.NodeResponse) |  |  |
+
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [int32](#cockroach.server.serverpb.HotRangesResponse-int32) |  |  |  |
+| value | [HotRangesResponse.NodeResponse](#cockroach.server.serverpb.HotRangesResponse-cockroach.server.serverpb.HotRangesResponse.NodeResponse) |  |  |  |
 
 
 
@@ -1485,10 +2397,15 @@ information about the resources on a node used by that table.
 <a name="cockroach.server.serverpb.HotRangesResponse-cockroach.server.serverpb.HotRangesResponse.NodeResponse"></a>
 #### HotRangesResponse.NodeResponse
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| error_message | [string](#cockroach.server.serverpb.HotRangesResponse-string) |  | ErrorMessage is set to a non-empty string if this target node was unable to produce a hot range report.<br><br>The contents of this string indicates the cause of the failure. |
-| stores | [HotRangesResponse.StoreResponse](#cockroach.server.serverpb.HotRangesResponse-cockroach.server.serverpb.HotRangesResponse.StoreResponse) | repeated | Stores contains the hot ranges report if no error was encountered. There is one part to the report for each store in the target node. |
+NodeResponse is a hot range report for a single target node.
+
+Note: this is an “alpha” API payload. It is subject to change without
+advance notice in a subsequent release.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| error_message | [string](#cockroach.server.serverpb.HotRangesResponse-string) |  | ErrorMessage is set to a non-empty string if this target node was unable to produce a hot range report.<br><br>The contents of this string indicates the cause of the failure. | Note: this is an “alpha” API field. It is subject to change without advance notice in a subsequent release. |
+| stores | [HotRangesResponse.StoreResponse](#cockroach.server.serverpb.HotRangesResponse-cockroach.server.serverpb.HotRangesResponse.StoreResponse) | repeated | Stores contains the hot ranges report if no error was encountered. There is one part to the report for each store in the target node. | Note: this is an “alpha” API field. It is subject to change without advance notice in a subsequent release. |
 
 
 
@@ -1497,10 +2414,16 @@ information about the resources on a node used by that table.
 <a name="cockroach.server.serverpb.HotRangesResponse-cockroach.server.serverpb.HotRangesResponse.StoreResponse"></a>
 #### HotRangesResponse.StoreResponse
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| store_id | [int32](#cockroach.server.serverpb.HotRangesResponse-int32) |  | StoreID identifies the store for which the report was produced. |
-| hot_ranges | [HotRangesResponse.HotRange](#cockroach.server.serverpb.HotRangesResponse-cockroach.server.serverpb.HotRangesResponse.HotRange) | repeated | HotRanges is the hot ranges report for this store on the target node. |
+StoreResponse contains the part of a hot ranges report that
+pertains to a single store on a target node.
+
+Note: this is an “alpha” API payload. It is subject to change without
+advance notice in a subsequent release.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| store_id | [int32](#cockroach.server.serverpb.HotRangesResponse-int32) |  | StoreID identifies the store for which the report was produced. | Note: this is an “alpha” API field. It is subject to change without advance notice in a subsequent release. |
+| hot_ranges | [HotRangesResponse.HotRange](#cockroach.server.serverpb.HotRangesResponse-cockroach.server.serverpb.HotRangesResponse.HotRange) | repeated | HotRanges is the hot ranges report for this store on the target node. | Note: this is an “alpha” API field. It is subject to change without advance notice in a subsequent release. |
 
 
 
@@ -1509,10 +2432,16 @@ information about the resources on a node used by that table.
 <a name="cockroach.server.serverpb.HotRangesResponse-cockroach.server.serverpb.HotRangesResponse.HotRange"></a>
 #### HotRangesResponse.HotRange
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| desc | [cockroach.roachpb.RangeDescriptor](#cockroach.server.serverpb.HotRangesResponse-cockroach.roachpb.RangeDescriptor) |  | Desc is the descriptor of the range for which the report was produced.<br><br>Note: this field is generally RESERVED and will likely be removed or replaced in a later version. See: https://github.com/cockroachdb/cockroach/issues/53212 |
-| queries_per_second | [double](#cockroach.server.serverpb.HotRangesResponse-double) |  | QueriesPerSecond is the recent number of queries per second on this range. |
+HotRange is a hot range report for a single store on one of the
+target node(s) selected in a HotRangesRequest.
+
+Note: this is an “alpha” API payload. It is subject to change without
+advance notice in a subsequent release.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| desc | [cockroach.roachpb.RangeDescriptor](#cockroach.server.serverpb.HotRangesResponse-cockroach.roachpb.RangeDescriptor) |  | Desc is the descriptor of the range for which the report was produced.<br><br>TODO(knz): This field should be removed. See: https://github.com/cockroachdb/cockroach/issues/53212 | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| queries_per_second | [double](#cockroach.server.serverpb.HotRangesResponse-double) |  | QueriesPerSecond is the recent number of queries per second on this range. | Note: this is an “alpha” API field. It is subject to change without advance notice in a subsequent release. |
 
 
 
@@ -1525,14 +2454,25 @@ information about the resources on a node used by that table.
 
 
 
+Note: this is a “reserved” API endpoint and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
 #### Request Parameters
 
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| range_id | [int64](#cockroach.server.serverpb.RangeRequest-int64) |  |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| range_id | [int64](#cockroach.server.serverpb.RangeRequest-int64) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -1545,11 +2485,18 @@ information about the resources on a node used by that table.
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [int32](#cockroach.server.serverpb.RangeResponse-int32) |  | NodeID is the node that submitted all the requests. |
-| range_id | [int64](#cockroach.server.serverpb.RangeResponse-int64) |  |  |
-| responses_by_node_id | [RangeResponse.ResponsesByNodeIdEntry](#cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RangeResponse.ResponsesByNodeIdEntry) | repeated |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [int32](#cockroach.server.serverpb.RangeResponse-int32) |  | NodeID is the node that submitted all the requests. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| range_id | [int64](#cockroach.server.serverpb.RangeResponse-int64) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| responses_by_node_id | [RangeResponse.ResponsesByNodeIdEntry](#cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RangeResponse.ResponsesByNodeIdEntry) | repeated |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -1559,10 +2506,14 @@ information about the resources on a node used by that table.
 <a name="cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RangeResponse.ResponsesByNodeIdEntry"></a>
 #### RangeResponse.ResponsesByNodeIdEntry
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| key | [int32](#cockroach.server.serverpb.RangeResponse-int32) |  |  |
-| value | [RangeResponse.NodeResponse](#cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RangeResponse.NodeResponse) |  |  |
+
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [int32](#cockroach.server.serverpb.RangeResponse-int32) |  |  |  |
+| value | [RangeResponse.NodeResponse](#cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RangeResponse.NodeResponse) |  |  |  |
 
 
 
@@ -1571,11 +2522,17 @@ information about the resources on a node used by that table.
 <a name="cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RangeResponse.NodeResponse"></a>
 #### RangeResponse.NodeResponse
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| response | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  |  |
-| error_message | [string](#cockroach.server.serverpb.RangeResponse-string) |  |  |
-| infos | [RangeInfo](#cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RangeInfo) | repeated |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| response | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| error_message | [string](#cockroach.server.serverpb.RangeResponse-string) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| infos | [RangeInfo](#cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RangeInfo) | repeated |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -1584,22 +2541,28 @@ information about the resources on a node used by that table.
 <a name="cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RangeInfo"></a>
 #### RangeInfo
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| span | [PrettySpan](#cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.PrettySpan) |  |  |
-| raft_state | [RaftState](#cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RaftState) |  |  |
-| state | [cockroach.kv.kvserver.storagepb.RangeInfo](#cockroach.server.serverpb.RangeResponse-cockroach.kv.kvserver.storagepb.RangeInfo) |  |  |
-| source_node_id | [int32](#cockroach.server.serverpb.RangeResponse-int32) |  |  |
-| source_store_id | [int32](#cockroach.server.serverpb.RangeResponse-int32) |  |  |
-| error_message | [string](#cockroach.server.serverpb.RangeResponse-string) |  |  |
-| lease_history | [cockroach.roachpb.Lease](#cockroach.server.serverpb.RangeResponse-cockroach.roachpb.Lease) | repeated |  |
-| problems | [RangeProblems](#cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RangeProblems) |  |  |
-| stats | [RangeStatistics](#cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RangeStatistics) |  |  |
-| latches_local | [cockroach.kv.kvserver.storagepb.LatchManagerInfo](#cockroach.server.serverpb.RangeResponse-cockroach.kv.kvserver.storagepb.LatchManagerInfo) |  |  |
-| latches_global | [cockroach.kv.kvserver.storagepb.LatchManagerInfo](#cockroach.server.serverpb.RangeResponse-cockroach.kv.kvserver.storagepb.LatchManagerInfo) |  |  |
-| lease_status | [cockroach.kv.kvserver.storagepb.LeaseStatus](#cockroach.server.serverpb.RangeResponse-cockroach.kv.kvserver.storagepb.LeaseStatus) |  |  |
-| quiescent | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  |  |
-| ticking | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| span | [PrettySpan](#cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.PrettySpan) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| raft_state | [RaftState](#cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RaftState) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| state | [cockroach.kv.kvserver.storagepb.RangeInfo](#cockroach.server.serverpb.RangeResponse-cockroach.kv.kvserver.storagepb.RangeInfo) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| source_node_id | [int32](#cockroach.server.serverpb.RangeResponse-int32) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| source_store_id | [int32](#cockroach.server.serverpb.RangeResponse-int32) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| error_message | [string](#cockroach.server.serverpb.RangeResponse-string) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| lease_history | [cockroach.roachpb.Lease](#cockroach.server.serverpb.RangeResponse-cockroach.roachpb.Lease) | repeated |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| problems | [RangeProblems](#cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RangeProblems) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| stats | [RangeStatistics](#cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RangeStatistics) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| latches_local | [cockroach.kv.kvserver.storagepb.LatchManagerInfo](#cockroach.server.serverpb.RangeResponse-cockroach.kv.kvserver.storagepb.LatchManagerInfo) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| latches_global | [cockroach.kv.kvserver.storagepb.LatchManagerInfo](#cockroach.server.serverpb.RangeResponse-cockroach.kv.kvserver.storagepb.LatchManagerInfo) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| lease_status | [cockroach.kv.kvserver.storagepb.LeaseStatus](#cockroach.server.serverpb.RangeResponse-cockroach.kv.kvserver.storagepb.LeaseStatus) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| quiescent | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| ticking | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -1608,10 +2571,16 @@ information about the resources on a node used by that table.
 <a name="cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.PrettySpan"></a>
 #### PrettySpan
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| start_key | [string](#cockroach.server.serverpb.RangeResponse-string) |  |  |
-| end_key | [string](#cockroach.server.serverpb.RangeResponse-string) |  |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| start_key | [string](#cockroach.server.serverpb.RangeResponse-string) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| end_key | [string](#cockroach.server.serverpb.RangeResponse-string) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -1620,15 +2589,22 @@ information about the resources on a node used by that table.
 <a name="cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RaftState"></a>
 #### RaftState
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| replica_id | [uint64](#cockroach.server.serverpb.RangeResponse-uint64) |  |  |
-| hard_state | [raftpb.HardState](#cockroach.server.serverpb.RangeResponse-raftpb.HardState) |  |  |
-| lead | [uint64](#cockroach.server.serverpb.RangeResponse-uint64) |  | Lead is part of Raft's SoftState. |
-| state | [string](#cockroach.server.serverpb.RangeResponse-string) |  | State is part of Raft's SoftState. It's not an enum because this is primarily for ui consumption and there are issues associated with them. |
-| applied | [uint64](#cockroach.server.serverpb.RangeResponse-uint64) |  |  |
-| progress | [RaftState.ProgressEntry](#cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RaftState.ProgressEntry) | repeated |  |
-| lead_transferee | [uint64](#cockroach.server.serverpb.RangeResponse-uint64) |  |  |
+RaftState gives internal details about a Raft group's state.
+Closely mirrors the upstream definitions in github.com/etcd-io/etcd/raft.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| replica_id | [uint64](#cockroach.server.serverpb.RangeResponse-uint64) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| hard_state | [raftpb.HardState](#cockroach.server.serverpb.RangeResponse-raftpb.HardState) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| lead | [uint64](#cockroach.server.serverpb.RangeResponse-uint64) |  | Lead is part of Raft's SoftState. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| state | [string](#cockroach.server.serverpb.RangeResponse-string) |  | State is part of Raft's SoftState. It's not an enum because this is primarily for ui consumption and there are issues associated with them. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| applied | [uint64](#cockroach.server.serverpb.RangeResponse-uint64) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| progress | [RaftState.ProgressEntry](#cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RaftState.ProgressEntry) | repeated |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| lead_transferee | [uint64](#cockroach.server.serverpb.RangeResponse-uint64) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -1637,10 +2613,14 @@ information about the resources on a node used by that table.
 <a name="cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RaftState.ProgressEntry"></a>
 #### RaftState.ProgressEntry
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| key | [uint64](#cockroach.server.serverpb.RangeResponse-uint64) |  |  |
-| value | [RaftState.Progress](#cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RaftState.Progress) |  |  |
+
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [uint64](#cockroach.server.serverpb.RangeResponse-uint64) |  |  |  |
+| value | [RaftState.Progress](#cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RaftState.Progress) |  |  |  |
 
 
 
@@ -1649,13 +2629,19 @@ information about the resources on a node used by that table.
 <a name="cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RaftState.Progress"></a>
 #### RaftState.Progress
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| match | [uint64](#cockroach.server.serverpb.RangeResponse-uint64) |  |  |
-| next | [uint64](#cockroach.server.serverpb.RangeResponse-uint64) |  |  |
-| state | [string](#cockroach.server.serverpb.RangeResponse-string) |  |  |
-| paused | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  |  |
-| pending_snapshot | [uint64](#cockroach.server.serverpb.RangeResponse-uint64) |  |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| match | [uint64](#cockroach.server.serverpb.RangeResponse-uint64) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| next | [uint64](#cockroach.server.serverpb.RangeResponse-uint64) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| state | [string](#cockroach.server.serverpb.RangeResponse-string) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| paused | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| pending_snapshot | [uint64](#cockroach.server.serverpb.RangeResponse-uint64) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -1664,16 +2650,22 @@ information about the resources on a node used by that table.
 <a name="cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RangeProblems"></a>
 #### RangeProblems
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| unavailable | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  |  |
-| leader_not_lease_holder | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  |  |
-| no_raft_leader | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  |  |
-| underreplicated | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  |  |
-| overreplicated | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  |  |
-| no_lease | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  |  |
-| quiescent_equals_ticking | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  | Quiescent ranges do not tick by definition, but we track this in two different ways and suspect that they're getting out of sync. If the replica's quiescent flag doesn't agree with the store's list of replicas that are ticking, warn about it. |
-| raft_log_too_large | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  | When the raft log is too large, it can be a symptom of other issues. |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| unavailable | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| leader_not_lease_holder | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| no_raft_leader | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| underreplicated | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| overreplicated | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| no_lease | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| quiescent_equals_ticking | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  | Quiescent ranges do not tick by definition, but we track this in two different ways and suspect that they're getting out of sync. If the replica's quiescent flag doesn't agree with the store's list of replicas that are ticking, warn about it. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| raft_log_too_large | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  | When the raft log is too large, it can be a symptom of other issues. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -1682,10 +2674,16 @@ information about the resources on a node used by that table.
 <a name="cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RangeStatistics"></a>
 #### RangeStatistics
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| queries_per_second | [double](#cockroach.server.serverpb.RangeResponse-double) |  | Note that queries per second will only be known by the leaseholder. All other replicas will report it as 0. |
-| writes_per_second | [double](#cockroach.server.serverpb.RangeResponse-double) |  |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| queries_per_second | [double](#cockroach.server.serverpb.RangeResponse-double) |  | Note that queries per second will only be known by the leaseholder. All other replicas will report it as 0. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| writes_per_second | [double](#cockroach.server.serverpb.RangeResponse-double) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -1698,14 +2696,25 @@ information about the resources on a node used by that table.
 
 
 
+Note: this is a “reserved” API endpoint and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
 #### Request Parameters
 
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [string](#cockroach.server.serverpb.DiagnosticsRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. |
+DiagnosticsRequest requests a diagnostics report.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [string](#cockroach.server.serverpb.DiagnosticsRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -1723,14 +2732,25 @@ information about the resources on a node used by that table.
 
 
 
+Note: this is a “reserved” API endpoint and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
 #### Request Parameters
 
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [string](#cockroach.server.serverpb.StoresRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [string](#cockroach.server.serverpb.StoresRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -1743,9 +2763,16 @@ information about the resources on a node used by that table.
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| stores | [StoreDetails](#cockroach.server.serverpb.StoresResponse-cockroach.server.serverpb.StoreDetails) | repeated |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| stores | [StoreDetails](#cockroach.server.serverpb.StoresResponse-cockroach.server.serverpb.StoreDetails) | repeated |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -1755,14 +2782,20 @@ information about the resources on a node used by that table.
 <a name="cockroach.server.serverpb.StoresResponse-cockroach.server.serverpb.StoreDetails"></a>
 #### StoreDetails
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| store_id | [int32](#cockroach.server.serverpb.StoresResponse-int32) |  |  |
-| encryption_status | [bytes](#cockroach.server.serverpb.StoresResponse-bytes) |  | encryption_status is a serialized ccl/storageccl/engineccl/enginepbccl/stats.go::EncryptionStatus protobuf. |
-| total_files | [uint64](#cockroach.server.serverpb.StoresResponse-uint64) |  | Basic file stats when encryption is enabled. Total files/bytes. |
-| total_bytes | [uint64](#cockroach.server.serverpb.StoresResponse-uint64) |  |  |
-| active_key_files | [uint64](#cockroach.server.serverpb.StoresResponse-uint64) |  | Files/bytes using the active data key. |
-| active_key_bytes | [uint64](#cockroach.server.serverpb.StoresResponse-uint64) |  |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| store_id | [int32](#cockroach.server.serverpb.StoresResponse-int32) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| encryption_status | [bytes](#cockroach.server.serverpb.StoresResponse-bytes) |  | encryption_status is a serialized ccl/storageccl/engineccl/enginepbccl/stats.go::EncryptionStatus protobuf. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| total_files | [uint64](#cockroach.server.serverpb.StoresResponse-uint64) |  | Basic file stats when encryption is enabled. Total files/bytes. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| total_bytes | [uint64](#cockroach.server.serverpb.StoresResponse-uint64) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| active_key_files | [uint64](#cockroach.server.serverpb.StoresResponse-uint64) |  | Files/bytes using the active data key. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| active_key_bytes | [uint64](#cockroach.server.serverpb.StoresResponse-uint64) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -1775,14 +2808,25 @@ information about the resources on a node used by that table.
 
 
 
+Note: this is a “reserved” API endpoint and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
 #### Request Parameters
 
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [string](#cockroach.server.serverpb.StatementsRequest-string) |  |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [string](#cockroach.server.serverpb.StatementsRequest-string) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -1795,12 +2839,19 @@ information about the resources on a node used by that table.
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| statements | [StatementsResponse.CollectedStatementStatistics](#cockroach.server.serverpb.StatementsResponse-cockroach.server.serverpb.StatementsResponse.CollectedStatementStatistics) | repeated |  |
-| last_reset | [google.protobuf.Timestamp](#cockroach.server.serverpb.StatementsResponse-google.protobuf.Timestamp) |  | Timestamp of the last stats reset. |
-| internal_app_name_prefix | [string](#cockroach.server.serverpb.StatementsResponse-string) |  | If set and non-empty, indicates the prefix to application_name used for statements/queries issued internally by CockroachDB. |
-| transactions | [StatementsResponse.ExtendedCollectedTransactionStatistics](#cockroach.server.serverpb.StatementsResponse-cockroach.server.serverpb.StatementsResponse.ExtendedCollectedTransactionStatistics) | repeated | Transactions is transaction-level statistics for the collection of statements in this response. |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| statements | [StatementsResponse.CollectedStatementStatistics](#cockroach.server.serverpb.StatementsResponse-cockroach.server.serverpb.StatementsResponse.CollectedStatementStatistics) | repeated |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| last_reset | [google.protobuf.Timestamp](#cockroach.server.serverpb.StatementsResponse-google.protobuf.Timestamp) |  | Timestamp of the last stats reset. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| internal_app_name_prefix | [string](#cockroach.server.serverpb.StatementsResponse-string) |  | If set and non-empty, indicates the prefix to application_name used for statements/queries issued internally by CockroachDB. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| transactions | [StatementsResponse.ExtendedCollectedTransactionStatistics](#cockroach.server.serverpb.StatementsResponse-cockroach.server.serverpb.StatementsResponse.ExtendedCollectedTransactionStatistics) | repeated | Transactions is transaction-level statistics for the collection of statements in this response. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -1810,11 +2861,17 @@ information about the resources on a node used by that table.
 <a name="cockroach.server.serverpb.StatementsResponse-cockroach.server.serverpb.StatementsResponse.CollectedStatementStatistics"></a>
 #### StatementsResponse.CollectedStatementStatistics
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| key | [StatementsResponse.ExtendedStatementStatisticsKey](#cockroach.server.serverpb.StatementsResponse-cockroach.server.serverpb.StatementsResponse.ExtendedStatementStatisticsKey) |  |  |
-| id | [uint64](#cockroach.server.serverpb.StatementsResponse-uint64) |  |  |
-| stats | [cockroach.sql.StatementStatistics](#cockroach.server.serverpb.StatementsResponse-cockroach.sql.StatementStatistics) |  |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [StatementsResponse.ExtendedStatementStatisticsKey](#cockroach.server.serverpb.StatementsResponse-cockroach.server.serverpb.StatementsResponse.ExtendedStatementStatisticsKey) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| id | [uint64](#cockroach.server.serverpb.StatementsResponse-uint64) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| stats | [cockroach.sql.StatementStatistics](#cockroach.server.serverpb.StatementsResponse-cockroach.sql.StatementStatistics) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -1823,10 +2880,16 @@ information about the resources on a node used by that table.
 <a name="cockroach.server.serverpb.StatementsResponse-cockroach.server.serverpb.StatementsResponse.ExtendedStatementStatisticsKey"></a>
 #### StatementsResponse.ExtendedStatementStatisticsKey
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| key_data | [cockroach.sql.StatementStatisticsKey](#cockroach.server.serverpb.StatementsResponse-cockroach.sql.StatementStatisticsKey) |  |  |
-| node_id | [int32](#cockroach.server.serverpb.StatementsResponse-int32) |  |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key_data | [cockroach.sql.StatementStatisticsKey](#cockroach.server.serverpb.StatementsResponse-cockroach.sql.StatementStatisticsKey) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| node_id | [int32](#cockroach.server.serverpb.StatementsResponse-int32) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -1835,10 +2898,16 @@ information about the resources on a node used by that table.
 <a name="cockroach.server.serverpb.StatementsResponse-cockroach.server.serverpb.StatementsResponse.ExtendedCollectedTransactionStatistics"></a>
 #### StatementsResponse.ExtendedCollectedTransactionStatistics
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| stats_data | [cockroach.sql.CollectedTransactionStatistics](#cockroach.server.serverpb.StatementsResponse-cockroach.sql.CollectedTransactionStatistics) |  |  |
-| node_id | [int32](#cockroach.server.serverpb.StatementsResponse-int32) |  |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| stats_data | [cockroach.sql.CollectedTransactionStatistics](#cockroach.server.serverpb.StatementsResponse-cockroach.sql.CollectedTransactionStatistics) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| node_id | [int32](#cockroach.server.serverpb.StatementsResponse-int32) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -1851,14 +2920,25 @@ information about the resources on a node used by that table.
 
 
 
+Note: this is a “reserved” API endpoint and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
 #### Request Parameters
 
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| statement_fingerprint | [string](#cockroach.server.serverpb.CreateStatementDiagnosticsReportRequest-string) |  |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| statement_fingerprint | [string](#cockroach.server.serverpb.CreateStatementDiagnosticsReportRequest-string) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -1871,9 +2951,16 @@ information about the resources on a node used by that table.
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| report | [StatementDiagnosticsReport](#cockroach.server.serverpb.CreateStatementDiagnosticsReportResponse-cockroach.server.serverpb.StatementDiagnosticsReport) |  |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| report | [StatementDiagnosticsReport](#cockroach.server.serverpb.CreateStatementDiagnosticsReportResponse-cockroach.server.serverpb.StatementDiagnosticsReport) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -1883,13 +2970,19 @@ information about the resources on a node used by that table.
 <a name="cockroach.server.serverpb.CreateStatementDiagnosticsReportResponse-cockroach.server.serverpb.StatementDiagnosticsReport"></a>
 #### StatementDiagnosticsReport
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| id | [int64](#cockroach.server.serverpb.CreateStatementDiagnosticsReportResponse-int64) |  |  |
-| completed | [bool](#cockroach.server.serverpb.CreateStatementDiagnosticsReportResponse-bool) |  |  |
-| statement_fingerprint | [string](#cockroach.server.serverpb.CreateStatementDiagnosticsReportResponse-string) |  |  |
-| statement_diagnostics_id | [int64](#cockroach.server.serverpb.CreateStatementDiagnosticsReportResponse-int64) |  |  |
-| requested_at | [google.protobuf.Timestamp](#cockroach.server.serverpb.CreateStatementDiagnosticsReportResponse-google.protobuf.Timestamp) |  |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| id | [int64](#cockroach.server.serverpb.CreateStatementDiagnosticsReportResponse-int64) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| completed | [bool](#cockroach.server.serverpb.CreateStatementDiagnosticsReportResponse-bool) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| statement_fingerprint | [string](#cockroach.server.serverpb.CreateStatementDiagnosticsReportResponse-string) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| statement_diagnostics_id | [int64](#cockroach.server.serverpb.CreateStatementDiagnosticsReportResponse-int64) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| requested_at | [google.protobuf.Timestamp](#cockroach.server.serverpb.CreateStatementDiagnosticsReportResponse-google.protobuf.Timestamp) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -1902,9 +2995,20 @@ information about the resources on a node used by that table.
 
 
 
+Note: this is a “reserved” API endpoint and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
 #### Request Parameters
 
 
+
+
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
 
 
 
@@ -1918,9 +3022,16 @@ information about the resources on a node used by that table.
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| reports | [StatementDiagnosticsReport](#cockroach.server.serverpb.StatementDiagnosticsReportsResponse-cockroach.server.serverpb.StatementDiagnosticsReport) | repeated |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| reports | [StatementDiagnosticsReport](#cockroach.server.serverpb.StatementDiagnosticsReportsResponse-cockroach.server.serverpb.StatementDiagnosticsReport) | repeated |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -1930,13 +3041,19 @@ information about the resources on a node used by that table.
 <a name="cockroach.server.serverpb.StatementDiagnosticsReportsResponse-cockroach.server.serverpb.StatementDiagnosticsReport"></a>
 #### StatementDiagnosticsReport
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| id | [int64](#cockroach.server.serverpb.StatementDiagnosticsReportsResponse-int64) |  |  |
-| completed | [bool](#cockroach.server.serverpb.StatementDiagnosticsReportsResponse-bool) |  |  |
-| statement_fingerprint | [string](#cockroach.server.serverpb.StatementDiagnosticsReportsResponse-string) |  |  |
-| statement_diagnostics_id | [int64](#cockroach.server.serverpb.StatementDiagnosticsReportsResponse-int64) |  |  |
-| requested_at | [google.protobuf.Timestamp](#cockroach.server.serverpb.StatementDiagnosticsReportsResponse-google.protobuf.Timestamp) |  |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| id | [int64](#cockroach.server.serverpb.StatementDiagnosticsReportsResponse-int64) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| completed | [bool](#cockroach.server.serverpb.StatementDiagnosticsReportsResponse-bool) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| statement_fingerprint | [string](#cockroach.server.serverpb.StatementDiagnosticsReportsResponse-string) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| statement_diagnostics_id | [int64](#cockroach.server.serverpb.StatementDiagnosticsReportsResponse-int64) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| requested_at | [google.protobuf.Timestamp](#cockroach.server.serverpb.StatementDiagnosticsReportsResponse-google.protobuf.Timestamp) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -1949,14 +3066,25 @@ information about the resources on a node used by that table.
 
 
 
+Note: this is a “reserved” API endpoint and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
 #### Request Parameters
 
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| statement_diagnostics_id | [int64](#cockroach.server.serverpb.StatementDiagnosticsRequest-int64) |  |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| statement_diagnostics_id | [int64](#cockroach.server.serverpb.StatementDiagnosticsRequest-int64) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -1969,9 +3097,16 @@ information about the resources on a node used by that table.
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| diagnostics | [StatementDiagnostics](#cockroach.server.serverpb.StatementDiagnosticsResponse-cockroach.server.serverpb.StatementDiagnostics) |  |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| diagnostics | [StatementDiagnostics](#cockroach.server.serverpb.StatementDiagnosticsResponse-cockroach.server.serverpb.StatementDiagnostics) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -1981,12 +3116,18 @@ information about the resources on a node used by that table.
 <a name="cockroach.server.serverpb.StatementDiagnosticsResponse-cockroach.server.serverpb.StatementDiagnostics"></a>
 #### StatementDiagnostics
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| id | [int64](#cockroach.server.serverpb.StatementDiagnosticsResponse-int64) |  |  |
-| statement_fingerprint | [string](#cockroach.server.serverpb.StatementDiagnosticsResponse-string) |  |  |
-| collected_at | [google.protobuf.Timestamp](#cockroach.server.serverpb.StatementDiagnosticsResponse-google.protobuf.Timestamp) |  |  |
-| trace | [string](#cockroach.server.serverpb.StatementDiagnosticsResponse-string) |  |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| id | [int64](#cockroach.server.serverpb.StatementDiagnosticsResponse-int64) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| statement_fingerprint | [string](#cockroach.server.serverpb.StatementDiagnosticsResponse-string) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| collected_at | [google.protobuf.Timestamp](#cockroach.server.serverpb.StatementDiagnosticsResponse-google.protobuf.Timestamp) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| trace | [string](#cockroach.server.serverpb.StatementDiagnosticsResponse-string) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -1999,14 +3140,25 @@ information about the resources on a node used by that table.
 
 
 
+Note: this is a “reserved” API endpoint and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
 #### Request Parameters
 
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [string](#cockroach.server.serverpb.JobRegistryStatusRequest-string) |  |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [string](#cockroach.server.serverpb.JobRegistryStatusRequest-string) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -2019,10 +3171,17 @@ information about the resources on a node used by that table.
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| node_id | [int32](#cockroach.server.serverpb.JobRegistryStatusResponse-int32) |  |  |
-| running_jobs | [JobRegistryStatusResponse.Job](#cockroach.server.serverpb.JobRegistryStatusResponse-cockroach.server.serverpb.JobRegistryStatusResponse.Job) | repeated |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [int32](#cockroach.server.serverpb.JobRegistryStatusResponse-int32) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| running_jobs | [JobRegistryStatusResponse.Job](#cockroach.server.serverpb.JobRegistryStatusResponse-cockroach.server.serverpb.JobRegistryStatusResponse.Job) | repeated |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -2032,9 +3191,15 @@ information about the resources on a node used by that table.
 <a name="cockroach.server.serverpb.JobRegistryStatusResponse-cockroach.server.serverpb.JobRegistryStatusResponse.Job"></a>
 #### JobRegistryStatusResponse.Job
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| id | [int64](#cockroach.server.serverpb.JobRegistryStatusResponse-int64) |  |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| id | [int64](#cockroach.server.serverpb.JobRegistryStatusResponse-int64) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -2047,14 +3212,25 @@ information about the resources on a node used by that table.
 
 
 
+Note: this is a “reserved” API endpoint and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
 #### Request Parameters
 
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| job_id | [int64](#cockroach.server.serverpb.JobStatusRequest-int64) |  |  |
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| job_id | [int64](#cockroach.server.serverpb.JobStatusRequest-int64) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 
@@ -2067,10 +3243,1994 @@ information about the resources on a node used by that table.
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| job | [cockroach.sql.jobs.jobspb.Job](#cockroach.server.serverpb.JobStatusResponse-cockroach.sql.jobs.jobspb.Job) |  |  |
 
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| job | [cockroach.sql.jobs.jobspb.Job](#cockroach.server.serverpb.JobStatusResponse-cockroach.sql.jobs.jobspb.Job) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+
+
+
+
+
+
+## Users
+
+`GET /_admin/v1/users`
+
+URL: /_admin/v1/users
+
+Note: this is a “reserved” API endpoint and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+#### Request Parameters
+
+
+
+
+UsersRequest requests a list of users.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+
+
+
+
+
+
+#### Response Parameters
+
+
+
+
+UsersResponse returns a list of users.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| users | [UsersResponse.User](#cockroach.server.serverpb.UsersResponse-cockroach.server.serverpb.UsersResponse.User) | repeated | usernames is a list of users for the CockroachDB cluster. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.UsersResponse-cockroach.server.serverpb.UsersResponse.User"></a>
+#### UsersResponse.User
+
+User is a CockroachDB user.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| username | [string](#cockroach.server.serverpb.UsersResponse-string) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+
+
+
+
+
+## Databases
+
+`GET /_admin/v1/databases`
+
+URL: /_admin/v1/databases
+
+Note: this is a “reserved” API endpoint and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+#### Request Parameters
+
+
+
+
+DatabasesRequest requests a list of databases.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+
+
+
+
+
+
+#### Response Parameters
+
+
+
+
+DatabasesResponse contains a list of databases.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| databases | [string](#cockroach.server.serverpb.DatabasesResponse-string) | repeated |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+
+
+
+
+
+
+## DatabaseDetails
+
+`GET /_admin/v1/databases/{database}`
+
+Example URL: /_admin/v1/databases/system
+
+Note: this is a “reserved” API endpoint and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+#### Request Parameters
+
+
+
+
+DatabaseDetailsRequest requests detailed information about the specified
+database
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| database | [string](#cockroach.server.serverpb.DatabaseDetailsRequest-string) |  | database is the name of the database we are querying. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+
+
+
+
+
+
+#### Response Parameters
+
+
+
+
+DatabaseDetailsResponse contains grant information and table names for a
+database.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| grants | [DatabaseDetailsResponse.Grant](#cockroach.server.serverpb.DatabaseDetailsResponse-cockroach.server.serverpb.DatabaseDetailsResponse.Grant) | repeated | grants are the results of SHOW GRANTS for this database. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| table_names | [string](#cockroach.server.serverpb.DatabaseDetailsResponse-string) | repeated | table_names contains the names of all tables in this database. Note that all responses will be schema-qualified (schema.table) and that every schema or table that contains a "sql unsafe character" such as uppercase letters or dots will be surrounded with double quotes, such as "naughty schema".table. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| descriptor_id | [int64](#cockroach.server.serverpb.DatabaseDetailsResponse-int64) |  | descriptor_id is an identifier used to uniquely identify this database. It can be used to find events pertaining to this database by filtering on the 'target_id' field of events. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| zone_config | [cockroach.config.zonepb.ZoneConfig](#cockroach.server.serverpb.DatabaseDetailsResponse-cockroach.config.zonepb.ZoneConfig) |  | The zone configuration in effect for this database. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| zone_config_level | [ZoneConfigurationLevel](#cockroach.server.serverpb.DatabaseDetailsResponse-cockroach.server.serverpb.ZoneConfigurationLevel) |  | The level at which this object's zone configuration is set. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.DatabaseDetailsResponse-cockroach.server.serverpb.DatabaseDetailsResponse.Grant"></a>
+#### DatabaseDetailsResponse.Grant
+
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| user | [string](#cockroach.server.serverpb.DatabaseDetailsResponse-string) |  | user is the user that this grant applies to. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| privileges | [string](#cockroach.server.serverpb.DatabaseDetailsResponse-string) | repeated | privileges are the abilities this grant gives to the user. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+
+
+
+
+
+## TableDetails
+
+`GET /_admin/v1/databases/{database}/tables/{table}`
+
+Example URL: /_admin/v1/databases/system/tables/ui
+
+Note: this is a “reserved” API endpoint and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+#### Request Parameters
+
+
+
+
+TableDetailsRequest is a request for detailed information about a table.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| database | [string](#cockroach.server.serverpb.TableDetailsRequest-string) |  | database is the database that contains the table we're interested in. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| table | [string](#cockroach.server.serverpb.TableDetailsRequest-string) |  | table is the name of the table that we're querying. Table may be schema-qualified (schema.table) and each name component that contains sql unsafe characters such as . or uppercase letters must be surrounded in double quotes like "naughty schema".table. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+
+
+
+
+
+
+#### Response Parameters
+
+
+
+
+TableDetailsResponse contains grants, column names, and indexes for
+a table.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| grants | [TableDetailsResponse.Grant](#cockroach.server.serverpb.TableDetailsResponse-cockroach.server.serverpb.TableDetailsResponse.Grant) | repeated |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| columns | [TableDetailsResponse.Column](#cockroach.server.serverpb.TableDetailsResponse-cockroach.server.serverpb.TableDetailsResponse.Column) | repeated |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| indexes | [TableDetailsResponse.Index](#cockroach.server.serverpb.TableDetailsResponse-cockroach.server.serverpb.TableDetailsResponse.Index) | repeated |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| range_count | [int64](#cockroach.server.serverpb.TableDetailsResponse-int64) |  | range_count is the size of the table in ranges. This provides a rough estimate of the storage requirements for the table. TODO(mrtracy): The TableStats method also returns a range_count field which is more accurate than this one; TableDetails calculates this number using a potentially faster method that is subject to cache staleness. We should consider removing or renaming this field to reflect that difference. See Github issue #5435 for more information. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| create_table_statement | [string](#cockroach.server.serverpb.TableDetailsResponse-string) |  | create_table_statement is the output of "SHOW CREATE" for this table; it is a SQL statement that would re-create the table's current schema if executed. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| zone_config | [cockroach.config.zonepb.ZoneConfig](#cockroach.server.serverpb.TableDetailsResponse-cockroach.config.zonepb.ZoneConfig) |  | The zone configuration in effect for this table. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| zone_config_level | [ZoneConfigurationLevel](#cockroach.server.serverpb.TableDetailsResponse-cockroach.server.serverpb.ZoneConfigurationLevel) |  | The level at which this object's zone configuration is set. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| descriptor_id | [int64](#cockroach.server.serverpb.TableDetailsResponse-int64) |  | descriptor_id is an identifier used to uniquely identify this table. It can be used to find events pertaining to this table by filtering on the 'target_id' field of events. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.TableDetailsResponse-cockroach.server.serverpb.TableDetailsResponse.Grant"></a>
+#### TableDetailsResponse.Grant
+
+Grant is an entry from SHOW GRANTS.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| user | [string](#cockroach.server.serverpb.TableDetailsResponse-string) |  | user is the user that this grant applies to. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| privileges | [string](#cockroach.server.serverpb.TableDetailsResponse-string) | repeated | privileges are the abilities this grant gives to the user. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+
+
+
+
+<a name="cockroach.server.serverpb.TableDetailsResponse-cockroach.server.serverpb.TableDetailsResponse.Column"></a>
+#### TableDetailsResponse.Column
+
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| name | [string](#cockroach.server.serverpb.TableDetailsResponse-string) |  | name is the name of the column. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| type | [string](#cockroach.server.serverpb.TableDetailsResponse-string) |  | type is the SQL type (INT, STRING, etc.) of this column. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| nullable | [bool](#cockroach.server.serverpb.TableDetailsResponse-bool) |  | nullable is whether this column can contain NULL. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| default_value | [string](#cockroach.server.serverpb.TableDetailsResponse-string) |  | default_value is the default value of this column. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| generation_expression | [string](#cockroach.server.serverpb.TableDetailsResponse-string) |  | generation_expression is the generator expression if the column is computed. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| hidden | [bool](#cockroach.server.serverpb.TableDetailsResponse-bool) |  | hidden is whether this column is hidden. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+
+
+
+
+<a name="cockroach.server.serverpb.TableDetailsResponse-cockroach.server.serverpb.TableDetailsResponse.Index"></a>
+#### TableDetailsResponse.Index
+
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| name | [string](#cockroach.server.serverpb.TableDetailsResponse-string) |  | name is the name of this index. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| unique | [bool](#cockroach.server.serverpb.TableDetailsResponse-bool) |  | unique is whether this a unique index (i.e. CREATE UNIQUE INDEX). | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| seq | [int64](#cockroach.server.serverpb.TableDetailsResponse-int64) |  | seq is an internal variable that's passed along. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| column | [string](#cockroach.server.serverpb.TableDetailsResponse-string) |  | column is the column that this index indexes. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| direction | [string](#cockroach.server.serverpb.TableDetailsResponse-string) |  | direction is either "ASC" (ascending) or "DESC" (descending). | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| storing | [bool](#cockroach.server.serverpb.TableDetailsResponse-bool) |  | storing is an internal variable that's passed along. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| implicit | [bool](#cockroach.server.serverpb.TableDetailsResponse-bool) |  | implicit is an internal variable that's passed along. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+
+
+
+
+
+## TableStats
+
+`GET /_admin/v1/databases/{database}/tables/{table}/stats`
+
+Example URL: /_admin/v1/databases/system/tables/ui/stats
+
+Note: this is a “reserved” API endpoint and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+#### Request Parameters
+
+
+
+
+TableStatsRequest is a request for detailed, computationally expensive
+information about a table.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| database | [string](#cockroach.server.serverpb.TableStatsRequest-string) |  | database is the database that contains the table we're interested in. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| table | [string](#cockroach.server.serverpb.TableStatsRequest-string) |  | table is the name of the table that we're querying. Table may be schema-qualified (schema.table) and each name component that contains sql unsafe characters such as . or uppercase letters must be surrounded in double quotes like "naughty schema".table. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+
+
+
+
+
+
+#### Response Parameters
+
+
+
+
+TableStatsResponse contains detailed, computationally expensive information
+about a table.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| range_count | [int64](#cockroach.server.serverpb.TableStatsResponse-int64) |  | range_count is the number of ranges, as determined from a query of range meta keys. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| replica_count | [int64](#cockroach.server.serverpb.TableStatsResponse-int64) |  | replica_count is the number of replicas of any range of this table, as found by querying nodes which are known to have replicas. When compared with range_count, this can be used to estimate the current replication factor of the table. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| node_count | [int64](#cockroach.server.serverpb.TableStatsResponse-int64) |  | node_count is the number of nodes which contain data for this table, according to a query of range meta keys. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| stats | [cockroach.storage.enginepb.MVCCStats](#cockroach.server.serverpb.TableStatsResponse-cockroach.storage.enginepb.MVCCStats) |  | stats is the summation of MVCCStats for all replicas of this table across the cluster. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| approximate_disk_bytes | [uint64](#cockroach.server.serverpb.TableStatsResponse-uint64) |  | approximate_disk_bytes is an approximation of the disk space (in bytes) used for all replicas of this table across the cluster. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| missing_nodes | [TableStatsResponse.MissingNode](#cockroach.server.serverpb.TableStatsResponse-cockroach.server.serverpb.TableStatsResponse.MissingNode) | repeated | A list of nodes which should contain data for this table (according to cluster metadata), but could not be contacted during this request. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.TableStatsResponse-cockroach.server.serverpb.TableStatsResponse.MissingNode"></a>
+#### TableStatsResponse.MissingNode
+
+MissingNode represents information on a node which should contain data
+for this table, but could not be contacted during this request.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [string](#cockroach.server.serverpb.TableStatsResponse-string) |  | The ID of the missing node. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| error_message | [string](#cockroach.server.serverpb.TableStatsResponse-string) |  | The error message that resulted when the query sent to this node failed. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+
+
+
+
+
+## NonTableStats
+
+`GET /_admin/v1/nontablestats`
+
+Example URL: /_admin/v1/nontablestats
+
+Note: this is a “reserved” API endpoint and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+#### Request Parameters
+
+
+
+
+NonTableStatsRequest requests statistics on cluster data ranges that do not
+belong to SQL tables.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+
+
+
+
+
+
+#### Response Parameters
+
+
+
+
+NonTableStatsResponse returns statistics on various cluster data ranges
+that do not belong to SQL tables. The statistics for each range are returned
+as a TableStatsResponse.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| time_series_stats | [TableStatsResponse](#cockroach.server.serverpb.NonTableStatsResponse-cockroach.server.serverpb.TableStatsResponse) |  | Information on time series ranges. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| internal_use_stats | [TableStatsResponse](#cockroach.server.serverpb.NonTableStatsResponse-cockroach.server.serverpb.TableStatsResponse) |  | Information for remaining (non-table, non-time-series) ranges. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.NonTableStatsResponse-cockroach.server.serverpb.TableStatsResponse"></a>
+#### TableStatsResponse
+
+TableStatsResponse contains detailed, computationally expensive information
+about a table.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| range_count | [int64](#cockroach.server.serverpb.NonTableStatsResponse-int64) |  | range_count is the number of ranges, as determined from a query of range meta keys. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| replica_count | [int64](#cockroach.server.serverpb.NonTableStatsResponse-int64) |  | replica_count is the number of replicas of any range of this table, as found by querying nodes which are known to have replicas. When compared with range_count, this can be used to estimate the current replication factor of the table. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| node_count | [int64](#cockroach.server.serverpb.NonTableStatsResponse-int64) |  | node_count is the number of nodes which contain data for this table, according to a query of range meta keys. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| stats | [cockroach.storage.enginepb.MVCCStats](#cockroach.server.serverpb.NonTableStatsResponse-cockroach.storage.enginepb.MVCCStats) |  | stats is the summation of MVCCStats for all replicas of this table across the cluster. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| approximate_disk_bytes | [uint64](#cockroach.server.serverpb.NonTableStatsResponse-uint64) |  | approximate_disk_bytes is an approximation of the disk space (in bytes) used for all replicas of this table across the cluster. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| missing_nodes | [TableStatsResponse.MissingNode](#cockroach.server.serverpb.NonTableStatsResponse-cockroach.server.serverpb.TableStatsResponse.MissingNode) | repeated | A list of nodes which should contain data for this table (according to cluster metadata), but could not be contacted during this request. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+
+
+
+
+<a name="cockroach.server.serverpb.NonTableStatsResponse-cockroach.server.serverpb.TableStatsResponse.MissingNode"></a>
+#### TableStatsResponse.MissingNode
+
+MissingNode represents information on a node which should contain data
+for this table, but could not be contacted during this request.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [string](#cockroach.server.serverpb.NonTableStatsResponse-string) |  | The ID of the missing node. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| error_message | [string](#cockroach.server.serverpb.NonTableStatsResponse-string) |  | The error message that resulted when the query sent to this node failed. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+
+
+
+
+<a name="cockroach.server.serverpb.NonTableStatsResponse-cockroach.server.serverpb.TableStatsResponse"></a>
+#### TableStatsResponse
+
+TableStatsResponse contains detailed, computationally expensive information
+about a table.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| range_count | [int64](#cockroach.server.serverpb.NonTableStatsResponse-int64) |  | range_count is the number of ranges, as determined from a query of range meta keys. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| replica_count | [int64](#cockroach.server.serverpb.NonTableStatsResponse-int64) |  | replica_count is the number of replicas of any range of this table, as found by querying nodes which are known to have replicas. When compared with range_count, this can be used to estimate the current replication factor of the table. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| node_count | [int64](#cockroach.server.serverpb.NonTableStatsResponse-int64) |  | node_count is the number of nodes which contain data for this table, according to a query of range meta keys. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| stats | [cockroach.storage.enginepb.MVCCStats](#cockroach.server.serverpb.NonTableStatsResponse-cockroach.storage.enginepb.MVCCStats) |  | stats is the summation of MVCCStats for all replicas of this table across the cluster. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| approximate_disk_bytes | [uint64](#cockroach.server.serverpb.NonTableStatsResponse-uint64) |  | approximate_disk_bytes is an approximation of the disk space (in bytes) used for all replicas of this table across the cluster. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| missing_nodes | [TableStatsResponse.MissingNode](#cockroach.server.serverpb.NonTableStatsResponse-cockroach.server.serverpb.TableStatsResponse.MissingNode) | repeated | A list of nodes which should contain data for this table (according to cluster metadata), but could not be contacted during this request. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+
+
+
+
+
+## Events
+
+`GET /_admin/v1/events`
+
+Example URLs:
+Example URLs:
+- /_admin/v1/events
+- /_admin/v1/events?limit=100
+- /_admin/v1/events?type=create_table
+- /_admin/v1/events?type=create_table&limit=100
+- /_admin/v1/events?type=drop_table&target_id=4
+- /_admin/v1/events?type=drop_table&target_id=4&limit=100
+
+Note: this is a “reserved” API endpoint and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+#### Request Parameters
+
+
+
+
+EventsRequest is a request for event log entries, optionally filtered
+by the specified event type and/or target_id.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| type | [string](#cockroach.server.serverpb.EventsRequest-string) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| target_id | [int64](#cockroach.server.serverpb.EventsRequest-int64) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| limit | [int32](#cockroach.server.serverpb.EventsRequest-int32) |  | limit is the total number of results that are retrieved by the query. If this is omitted or set to 0, the default maximum number of results are returned. When set to > 0, at most only that number of results are returned. When set to < 0, an unlimited number of results are returned. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| unredacted_events | [bool](#cockroach.server.serverpb.EventsRequest-bool) |  | unredacted_events indicates that the values in the events should not be redacted. The default is to redact, so that older versions of `cockroach zip` do not see un-redacted values by default. For good security, this field is only obeyed by the server after checking that the client of the RPC is an admin user. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+
+
+
+
+
+
+#### Response Parameters
+
+
+
+
+EventsResponse contains a set of event log entries. This is always limited
+to the latest N entries (N is enforced in the associated endpoint).
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| events | [EventsResponse.Event](#cockroach.server.serverpb.EventsResponse-cockroach.server.serverpb.EventsResponse.Event) | repeated |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.EventsResponse-cockroach.server.serverpb.EventsResponse.Event"></a>
+#### EventsResponse.Event
+
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| timestamp | [google.protobuf.Timestamp](#cockroach.server.serverpb.EventsResponse-google.protobuf.Timestamp) |  | timestamp is the time at which the event occurred. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| event_type | [string](#cockroach.server.serverpb.EventsResponse-string) |  | event_type is the type of the event (e.g. "create_table", "drop_table". | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| target_id | [int64](#cockroach.server.serverpb.EventsResponse-int64) |  | target_id is the target for this event. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| reporting_id | [int64](#cockroach.server.serverpb.EventsResponse-int64) |  | reporting_id is the reporting ID for this event. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| info | [string](#cockroach.server.serverpb.EventsResponse-string) |  | info has more detailed information for the event. The contents vary depending on the event. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| unique_id | [bytes](#cockroach.server.serverpb.EventsResponse-bytes) |  | unique_id is a unique identifier for this event. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+
+
+
+
+
+## SetUIData
+
+`POST /_admin/v1/uidata`
+
+This requires a POST. Because of the libraries we're using, the POST body
+must be in the following format:
+
+{"key_values":
+  { "key1": "base64_encoded_value1"},
+  ...
+  { "keyN": "base64_encoded_valueN"},
+}
+
+Note that all keys are quoted strings and that all values are base64-
+encoded.
+
+Together, SetUIData and GetUIData provide access to a "cookie jar" for the
+admin UI. The structure of the underlying data is meant to be opaque to the
+server.
+
+Note: this is a “reserved” API endpoint and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+#### Request Parameters
+
+
+
+
+SetUIDataRequest stores the given key/value pairs in the system.ui table.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key_values | [SetUIDataRequest.KeyValuesEntry](#cockroach.server.serverpb.SetUIDataRequest-cockroach.server.serverpb.SetUIDataRequest.KeyValuesEntry) | repeated | key_values is a map of keys to bytes values. Each key will be stored with its corresponding value as a separate row in system.ui. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.SetUIDataRequest-cockroach.server.serverpb.SetUIDataRequest.KeyValuesEntry"></a>
+#### SetUIDataRequest.KeyValuesEntry
+
+
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [string](#cockroach.server.serverpb.SetUIDataRequest-string) |  |  |  |
+| value | [bytes](#cockroach.server.serverpb.SetUIDataRequest-bytes) |  |  |  |
+
+
+
+
+
+
+#### Response Parameters
+
+
+
+
+SetUIDataResponse is currently an empty response.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+
+
+
+
+
+
+## GetUIData
+
+`GET /_admin/v1/uidata`
+
+Example URLs:
+- /_admin/v1/uidata?keys=MYKEY
+- /_admin/v1/uidata?keys=MYKEY1&keys=MYKEY2
+
+Yes, it's a little odd that the query parameter is named "keys" instead of
+"key". I would've preferred that the URL parameter be named "key". However,
+it's clearer for the protobuf field to be named "keys," which makes the URL
+parameter "keys" as well.
+
+Note: this is a “reserved” API endpoint and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+#### Request Parameters
+
+
+
+
+GETUIDataRequest requests the values for the given keys from the system.ui
+table.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| keys | [string](#cockroach.server.serverpb.GetUIDataRequest-string) | repeated |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+
+
+
+
+
+
+#### Response Parameters
+
+
+
+
+GetUIDataResponse contains the requested values and the times at which
+the values were last updated.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key_values | [GetUIDataResponse.KeyValuesEntry](#cockroach.server.serverpb.GetUIDataResponse-cockroach.server.serverpb.GetUIDataResponse.KeyValuesEntry) | repeated | key_values maps keys to their retrieved values. If this doesn't contain a a requested key, that key was not found. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.GetUIDataResponse-cockroach.server.serverpb.GetUIDataResponse.KeyValuesEntry"></a>
+#### GetUIDataResponse.KeyValuesEntry
+
+
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [string](#cockroach.server.serverpb.GetUIDataResponse-string) |  |  |  |
+| value | [GetUIDataResponse.Value](#cockroach.server.serverpb.GetUIDataResponse-cockroach.server.serverpb.GetUIDataResponse.Value) |  |  |  |
+
+
+
+
+
+<a name="cockroach.server.serverpb.GetUIDataResponse-cockroach.server.serverpb.GetUIDataResponse.Value"></a>
+#### GetUIDataResponse.Value
+
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| value | [bytes](#cockroach.server.serverpb.GetUIDataResponse-bytes) |  | value is the value of the requested key. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| last_updated | [google.protobuf.Timestamp](#cockroach.server.serverpb.GetUIDataResponse-google.protobuf.Timestamp) |  | last_updated is the time at which the value was last updated. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+
+
+
+
+
+## Cluster
+
+`GET /_admin/v1/cluster`
+
+Cluster returns metadata for the cluster.
+
+Note: this is a “reserved” API endpoint and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+#### Request Parameters
+
+
+
+
+ClusterRequest requests metadata for the cluster.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+
+
+
+
+
+
+#### Response Parameters
+
+
+
+
+ClusterResponse contains metadata for the cluster.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| cluster_id | [string](#cockroach.server.serverpb.ClusterResponse-string) |  | The unique ID used to identify this cluster. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| reporting_enabled | [bool](#cockroach.server.serverpb.ClusterResponse-bool) |  | True if diagnostics reporting is enabled for the cluster. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| enterprise_enabled | [bool](#cockroach.server.serverpb.ClusterResponse-bool) |  | True if enterprise features are enabled for the cluster. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+
+
+
+
+
+
+## Settings
+
+`GET /_admin/v1/settings`
+
+Settings returns the cluster-wide settings for the cluster.
+
+Note: this is a “reserved” API endpoint and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+#### Request Parameters
+
+
+
+
+SettingsRequest inquires what are the current settings in the cluster.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| keys | [string](#cockroach.server.serverpb.SettingsRequest-string) | repeated | The array of setting names to retrieve. An empty keys array means "all". | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| unredacted_values | [bool](#cockroach.server.serverpb.SettingsRequest-bool) |  | Indicate whether to see unredacted setting values. This is opt-in so that a previous version `cockroach zip` does not start reporting values when this becomes active. For good security, the server only obeys this after it checks that the logger-in user has admin privilege. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+
+
+
+
+
+
+#### Response Parameters
+
+
+
+
+SettingsResponse is the response to SettingsRequest.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key_values | [SettingsResponse.KeyValuesEntry](#cockroach.server.serverpb.SettingsResponse-cockroach.server.serverpb.SettingsResponse.KeyValuesEntry) | repeated |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.SettingsResponse-cockroach.server.serverpb.SettingsResponse.KeyValuesEntry"></a>
+#### SettingsResponse.KeyValuesEntry
+
+
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [string](#cockroach.server.serverpb.SettingsResponse-string) |  |  |  |
+| value | [SettingsResponse.Value](#cockroach.server.serverpb.SettingsResponse-cockroach.server.serverpb.SettingsResponse.Value) |  |  |  |
+
+
+
+
+
+<a name="cockroach.server.serverpb.SettingsResponse-cockroach.server.serverpb.SettingsResponse.Value"></a>
+#### SettingsResponse.Value
+
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| value | [string](#cockroach.server.serverpb.SettingsResponse-string) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| type | [string](#cockroach.server.serverpb.SettingsResponse-string) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| description | [string](#cockroach.server.serverpb.SettingsResponse-string) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| public | [bool](#cockroach.server.serverpb.SettingsResponse-bool) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+
+
+
+
+
+## Health
+
+`GET /health`
+
+Health returns liveness for the node target of the request.
+
+This is a public API endpoint.
+
+#### Request Parameters
+
+
+
+
+HealthRequest requests a liveness or readiness check.
+
+A liveness check is triggered via ready set to false. In this mode,
+an empty response is returned immediately, that is, the caller merely
+learns that the process is running.
+
+A readiness check (ready == true) is suitable for determining whether
+user traffic should be directed at a given node, for example by a load
+balancer. In this mode, a successful response is returned only if the
+node:
+
+- is not in the process of shutting down or booting up (including
+  waiting for cluster bootstrap);
+- is regarded as healthy by the cluster via the recent broadcast of
+  a liveness beacon. Absent either of these conditions, an error
+  code will result.
+
+This is a public API payload.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| ready | [bool](#cockroach.server.serverpb.HealthRequest-bool) |  | ready specifies whether the client wants to know whether the target node is ready to receive traffic. If a node is unready, an error will be returned. | This is a public API field. |
+
+
+
+
+
+
+
+#### Response Parameters
+
+
+
+
+HealthResponse is the response to HealthRequest. It currently does not
+contain any information.
+
+This is a public API payload.
+
+
+
+
+
+
+
+
+## Liveness
+
+`GET /_admin/v1/liveness`
+
+Liveness returns the liveness state of all nodes on the cluster.
+
+Note: this is a “reserved” API endpoint and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+#### Request Parameters
+
+
+
+
+LivenessRequest requests liveness data for all nodes on the cluster.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+
+
+
+
+
+
+#### Response Parameters
+
+
+
+
+LivenessResponse contains the liveness status of each node on the cluster.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| livenesses | [cockroach.kv.kvserver.storagepb.Liveness](#cockroach.server.serverpb.LivenessResponse-cockroach.kv.kvserver.storagepb.Liveness) | repeated |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| statuses | [LivenessResponse.StatusesEntry](#cockroach.server.serverpb.LivenessResponse-cockroach.server.serverpb.LivenessResponse.StatusesEntry) | repeated |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.LivenessResponse-cockroach.server.serverpb.LivenessResponse.StatusesEntry"></a>
+#### LivenessResponse.StatusesEntry
+
+
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [int32](#cockroach.server.serverpb.LivenessResponse-int32) |  |  |  |
+| value | [cockroach.kv.kvserver.storagepb.NodeLivenessStatus](#cockroach.server.serverpb.LivenessResponse-cockroach.kv.kvserver.storagepb.NodeLivenessStatus) |  |  |  |
+
+
+
+
+
+
+## Jobs
+
+`GET /_admin/v1/jobs`
+
+Jobs returns the job records for all jobs of the given status and type.
+
+Note: this is a “reserved” API endpoint and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+#### Request Parameters
+
+
+
+
+JobsRequest requests system job information of the given status and type.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| limit | [int32](#cockroach.server.serverpb.JobsRequest-int32) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| status | [string](#cockroach.server.serverpb.JobsRequest-string) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| type | [cockroach.sql.jobs.jobspb.Type](#cockroach.server.serverpb.JobsRequest-cockroach.sql.jobs.jobspb.Type) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+
+
+
+
+
+
+#### Response Parameters
+
+
+
+
+JobsResponse contains the job record for each matching job.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| jobs | [JobsResponse.Job](#cockroach.server.serverpb.JobsResponse-cockroach.server.serverpb.JobsResponse.Job) | repeated |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.JobsResponse-cockroach.server.serverpb.JobsResponse.Job"></a>
+#### JobsResponse.Job
+
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| id | [int64](#cockroach.server.serverpb.JobsResponse-int64) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| type | [string](#cockroach.server.serverpb.JobsResponse-string) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| description | [string](#cockroach.server.serverpb.JobsResponse-string) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| statement | [string](#cockroach.server.serverpb.JobsResponse-string) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| username | [string](#cockroach.server.serverpb.JobsResponse-string) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| descriptor_ids | [uint32](#cockroach.server.serverpb.JobsResponse-uint32) | repeated |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| status | [string](#cockroach.server.serverpb.JobsResponse-string) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| created | [google.protobuf.Timestamp](#cockroach.server.serverpb.JobsResponse-google.protobuf.Timestamp) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| started | [google.protobuf.Timestamp](#cockroach.server.serverpb.JobsResponse-google.protobuf.Timestamp) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| finished | [google.protobuf.Timestamp](#cockroach.server.serverpb.JobsResponse-google.protobuf.Timestamp) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| modified | [google.protobuf.Timestamp](#cockroach.server.serverpb.JobsResponse-google.protobuf.Timestamp) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| fraction_completed | [float](#cockroach.server.serverpb.JobsResponse-float) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| error | [string](#cockroach.server.serverpb.JobsResponse-string) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| highwater_timestamp | [google.protobuf.Timestamp](#cockroach.server.serverpb.JobsResponse-google.protobuf.Timestamp) |  | highwater_timestamp is the highwater timestamp returned as normal timestamp. This is appropriate for display to humans. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| highwater_decimal | [string](#cockroach.server.serverpb.JobsResponse-string) |  | highwater_decimal is the highwater timestamp in the proprietary decimal form used by logical timestamps internally. This is appropriate to pass to a "AS OF SYSTEM TIME" SQL statement. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| running_status | [string](#cockroach.server.serverpb.JobsResponse-string) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+
+
+
+
+
+## Locations
+
+`GET /_admin/v1/locations`
+
+Locations returns the locality location records.
+
+Note: this is a “reserved” API endpoint and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+#### Request Parameters
+
+
+
+
+LocationsRequest requests system locality location information.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+
+
+
+
+
+
+#### Response Parameters
+
+
+
+
+JobsResponse contains the job record for each matching job.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| locations | [LocationsResponse.Location](#cockroach.server.serverpb.LocationsResponse-cockroach.server.serverpb.LocationsResponse.Location) | repeated |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.LocationsResponse-cockroach.server.serverpb.LocationsResponse.Location"></a>
+#### LocationsResponse.Location
+
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| locality_key | [string](#cockroach.server.serverpb.LocationsResponse-string) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| locality_value | [string](#cockroach.server.serverpb.LocationsResponse-string) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| latitude | [double](#cockroach.server.serverpb.LocationsResponse-double) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| longitude | [double](#cockroach.server.serverpb.LocationsResponse-double) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+
+
+
+
+
+## QueryPlan
+
+`GET /_admin/v1/queryplan`
+
+QueryPlan returns the query plans for a SQL string.
+
+Note: this is a “reserved” API endpoint and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+#### Request Parameters
+
+
+
+
+QueryPlanRequest requests the query plans for a SQL string.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| query | [string](#cockroach.server.serverpb.QueryPlanRequest-string) |  | query is the SQL query string. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+
+
+
+
+
+
+#### Response Parameters
+
+
+
+
+QueryPlanResponse contains the query plans for a SQL string (currently only
+the distsql physical query plan).
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| distsql_physical_query_plan | [string](#cockroach.server.serverpb.QueryPlanResponse-string) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+
+
+
+
+
+
+## Drain
+
+
+
+Drain puts the node into the specified drain mode(s) and optionally
+instructs the process to terminate.
+We do not expose this via HTTP unless we have a way to authenticate
++ authorize streaming RPC connections. See #42567.
+
+Note: this is a “reserved” API endpoint and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+#### Request Parameters
+
+
+
+
+DrainRequest instructs the receiving node to drain.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| pre201_marker | [int32](#cockroach.server.serverpb.DrainRequest-int32) | repeated | pre_201_marker represents a field that clients stopped using in 20.1. It's maintained to reject requests from such clients, since they're not setting other required fields. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| shutdown | [bool](#cockroach.server.serverpb.DrainRequest-bool) |  | When true, terminates the process after the server has started draining. Setting both shutdown and do_drain to false causes the request to only operate as a probe. Setting do_drain to false and shutdown to true causes the server to shut down immediately without first draining. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| do_drain | [bool](#cockroach.server.serverpb.DrainRequest-bool) |  | When true, perform the drain phase. See the comment above on shutdown for an explanation of the interaction between the two. do_drain is also implied by a non-nil deprecated_probe_indicator. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+
+
+
+
+
+
+#### Response Parameters
+
+
+
+
+DrainResponse is the response to a successful DrainRequest.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| is_draining | [bool](#cockroach.server.serverpb.DrainResponse-bool) |  | is_draining is set to true iff the server is currently draining. This is set to true in response to a request where skip_drain is false; but it can also be set to true in response to a probe request (!shutdown && skip_drain) if another drain request has been issued prior or asynchronously. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| drain_remaining_indicator | [uint64](#cockroach.server.serverpb.DrainResponse-uint64) |  | drain_remaining_indicator measures, at the time of starting to process the corresponding drain request, how many actions to fully drain the node were deemed to be necessary. Some, but not all, of these actions may already have been carried out by the time this indicator is received by the client. The client should issue requests until this indicator first reaches zero, which indicates that the node is fully drained.<br><br>The API contract is the following:<br><br>- upon a first Drain call with do_drain set, the remaining   indicator will have some value >=0. If >0, it indicates that   drain is pushing state away from the node. (What this state   precisely means is left unspecified for this field. See below   for details.)<br><br>- upon a subsequent Drain call with do_drain set, the remaining   indicator should have reduced in value. The drain process does best   effort at shedding state away from the node; hopefully, all the   state is shed away upon the first call and the progress   indicator can be zero as early as the second call. However,   if there was a lot of state to shed, it is possible for   timeout to be encountered upon the first call. In that case, the   second call will do some more work and return a non-zero value   as well.<br><br>- eventually, in an iterated sequence of DrainRequests with   do_drain set, the remaining indicator should reduce to zero. At   that point the client can conclude that no state is left to   shed, and it should be safe to shut down the node with a   DrainRequest with shutdown = true.<br><br>Note that this field is left unpopulated (and thus remains at zero) for pre-20.1 nodes. A client can recognize this by observing is_draining to be false after a request with do_drain = true: the is_draining field is also left unpopulated by pre-20.1 nodes. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| drain_remaining_description | [string](#cockroach.server.serverpb.DrainResponse-string) |  | drain_remaining_description is an informal (= not machine-parsable) string that explains the progress of the drain process to human eyes. This is intended for use mainly for troubleshooting.<br><br>The field is only populated if do_drain is true in the request. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+
+
+
+
+
+
+## Decommission
+
+
+
+Decommission puts the node(s) into the specified decommissioning state.
+If this ever becomes exposed via HTTP, ensure that it performs
+authorization. See #42567.
+
+Note: this is a “reserved” API endpoint and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+#### Request Parameters
+
+
+
+
+DecommissionRequest requests the server to set the membership status on
+all nodes specified by NodeIDs to the value of TargetMembership.
+
+If no NodeIDs are given, it targets the recipient node.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_ids | [int32](#cockroach.server.serverpb.DecommissionRequest-int32) | repeated |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| target_membership | [cockroach.kv.kvserver.storagepb.MembershipStatus](#cockroach.server.serverpb.DecommissionRequest-cockroach.kv.kvserver.storagepb.MembershipStatus) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+
+
+
+
+
+
+#### Response Parameters
+
+
+
+
+DecommissionStatusResponse lists decommissioning statuses for a number of NodeIDs.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| status | [DecommissionStatusResponse.Status](#cockroach.server.serverpb.DecommissionStatusResponse-cockroach.server.serverpb.DecommissionStatusResponse.Status) | repeated | Status of all affected nodes. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.DecommissionStatusResponse-cockroach.server.serverpb.DecommissionStatusResponse.Status"></a>
+#### DecommissionStatusResponse.Status
+
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [int32](#cockroach.server.serverpb.DecommissionStatusResponse-int32) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| is_live | [bool](#cockroach.server.serverpb.DecommissionStatusResponse-bool) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| replica_count | [int64](#cockroach.server.serverpb.DecommissionStatusResponse-int64) |  | The number of replicas on the node, computed by scanning meta2 ranges. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| membership | [cockroach.kv.kvserver.storagepb.MembershipStatus](#cockroach.server.serverpb.DecommissionStatusResponse-cockroach.kv.kvserver.storagepb.MembershipStatus) |  | The membership status of the given node. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| draining | [bool](#cockroach.server.serverpb.DecommissionStatusResponse-bool) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+
+
+
+
+
+## DecommissionStatus
+
+
+
+DecommissionStatus retrieves the decommissioning status of the specified nodes.
+If this ever becomes exposed via HTTP, ensure that it performs
+authorization. See #42567.
+
+Note: this is a “reserved” API endpoint and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+#### Request Parameters
+
+
+
+
+DecommissionStatusRequest requests the decommissioning status for the
+specified or, if none are specified, all nodes.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_ids | [int32](#cockroach.server.serverpb.DecommissionStatusRequest-int32) | repeated |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+
+
+
+
+
+
+#### Response Parameters
+
+
+
+
+DecommissionStatusResponse lists decommissioning statuses for a number of NodeIDs.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| status | [DecommissionStatusResponse.Status](#cockroach.server.serverpb.DecommissionStatusResponse-cockroach.server.serverpb.DecommissionStatusResponse.Status) | repeated | Status of all affected nodes. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.DecommissionStatusResponse-cockroach.server.serverpb.DecommissionStatusResponse.Status"></a>
+#### DecommissionStatusResponse.Status
+
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [int32](#cockroach.server.serverpb.DecommissionStatusResponse-int32) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| is_live | [bool](#cockroach.server.serverpb.DecommissionStatusResponse-bool) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| replica_count | [int64](#cockroach.server.serverpb.DecommissionStatusResponse-int64) |  | The number of replicas on the node, computed by scanning meta2 ranges. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| membership | [cockroach.kv.kvserver.storagepb.MembershipStatus](#cockroach.server.serverpb.DecommissionStatusResponse-cockroach.kv.kvserver.storagepb.MembershipStatus) |  | The membership status of the given node. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| draining | [bool](#cockroach.server.serverpb.DecommissionStatusResponse-bool) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+
+
+
+
+
+## RangeLog
+
+`GET /_admin/v1/rangelog/{range_id}`
+
+URL: /_admin/v1/rangelog
+URL: /_admin/v1/rangelog?limit=100
+URL: /_admin/v1/rangelog/1
+URL: /_admin/v1/rangelog/1?limit=100
+
+Note: this is a “reserved” API endpoint and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+#### Request Parameters
+
+
+
+
+RangeLogRequest request the history of a range from the range log.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| range_id | [int64](#cockroach.server.serverpb.RangeLogRequest-int64) |  | TODO(tamird): use [(gogoproto.customname) = "RangeID"] below. Need to figure out how to teach grpc-gateway about custom names. If RangeID is 0, returns range log history without filtering by range. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| limit | [int32](#cockroach.server.serverpb.RangeLogRequest-int32) |  | limit is the total number of results that are retrieved by the query. If this is omitted or set to 0, the default maximum number of results are returned. When set to > 0, at most only that number of results are returned. When set to < 0, an unlimited number of results are returned. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+
+
+
+
+
+
+#### Response Parameters
+
+
+
+
+RangeLogResponse contains a list of entries from the range log table.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| events | [RangeLogResponse.Event](#cockroach.server.serverpb.RangeLogResponse-cockroach.server.serverpb.RangeLogResponse.Event) | repeated |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.RangeLogResponse-cockroach.server.serverpb.RangeLogResponse.Event"></a>
+#### RangeLogResponse.Event
+
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| event | [cockroach.kv.kvserver.storagepb.RangeLogEvent](#cockroach.server.serverpb.RangeLogResponse-cockroach.kv.kvserver.storagepb.RangeLogEvent) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| pretty_info | [RangeLogResponse.PrettyInfo](#cockroach.server.serverpb.RangeLogResponse-cockroach.server.serverpb.RangeLogResponse.PrettyInfo) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+
+
+
+
+<a name="cockroach.server.serverpb.RangeLogResponse-cockroach.server.serverpb.RangeLogResponse.PrettyInfo"></a>
+#### RangeLogResponse.PrettyInfo
+
+To avoid porting the pretty printing of keys and descriptors to
+javascript, they will be precomputed on the serverside.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| updated_desc | [string](#cockroach.server.serverpb.RangeLogResponse-string) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| new_desc | [string](#cockroach.server.serverpb.RangeLogResponse-string) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| added_replica | [string](#cockroach.server.serverpb.RangeLogResponse-string) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| removed_replica | [string](#cockroach.server.serverpb.RangeLogResponse-string) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| reason | [string](#cockroach.server.serverpb.RangeLogResponse-string) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| details | [string](#cockroach.server.serverpb.RangeLogResponse-string) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+
+
+
+
+
+## DataDistribution
+
+`GET /_admin/v1/data_distribution`
+
+
+
+Note: this is a “reserved” API endpoint and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+#### Request Parameters
+
+
+
+
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+
+
+
+
+
+
+#### Response Parameters
+
+
+
+
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| database_info | [DataDistributionResponse.DatabaseInfoEntry](#cockroach.server.serverpb.DataDistributionResponse-cockroach.server.serverpb.DataDistributionResponse.DatabaseInfoEntry) | repeated | By database name. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| zone_configs | [DataDistributionResponse.ZoneConfigsEntry](#cockroach.server.serverpb.DataDistributionResponse-cockroach.server.serverpb.DataDistributionResponse.ZoneConfigsEntry) | repeated | By zone name. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.DataDistributionResponse-cockroach.server.serverpb.DataDistributionResponse.DatabaseInfoEntry"></a>
+#### DataDistributionResponse.DatabaseInfoEntry
+
+
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [string](#cockroach.server.serverpb.DataDistributionResponse-string) |  |  |  |
+| value | [DataDistributionResponse.DatabaseInfo](#cockroach.server.serverpb.DataDistributionResponse-cockroach.server.serverpb.DataDistributionResponse.DatabaseInfo) |  |  |  |
+
+
+
+
+
+<a name="cockroach.server.serverpb.DataDistributionResponse-cockroach.server.serverpb.DataDistributionResponse.DatabaseInfo"></a>
+#### DataDistributionResponse.DatabaseInfo
+
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| table_info | [DataDistributionResponse.DatabaseInfo.TableInfoEntry](#cockroach.server.serverpb.DataDistributionResponse-cockroach.server.serverpb.DataDistributionResponse.DatabaseInfo.TableInfoEntry) | repeated | By table name. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+
+
+
+
+<a name="cockroach.server.serverpb.DataDistributionResponse-cockroach.server.serverpb.DataDistributionResponse.DatabaseInfo.TableInfoEntry"></a>
+#### DataDistributionResponse.DatabaseInfo.TableInfoEntry
+
+
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [string](#cockroach.server.serverpb.DataDistributionResponse-string) |  |  |  |
+| value | [DataDistributionResponse.TableInfo](#cockroach.server.serverpb.DataDistributionResponse-cockroach.server.serverpb.DataDistributionResponse.TableInfo) |  |  |  |
+
+
+
+
+
+<a name="cockroach.server.serverpb.DataDistributionResponse-cockroach.server.serverpb.DataDistributionResponse.TableInfo"></a>
+#### DataDistributionResponse.TableInfo
+
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| replica_count_by_node_id | [DataDistributionResponse.TableInfo.ReplicaCountByNodeIdEntry](#cockroach.server.serverpb.DataDistributionResponse-cockroach.server.serverpb.DataDistributionResponse.TableInfo.ReplicaCountByNodeIdEntry) | repeated |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| zone_config_id | [int64](#cockroach.server.serverpb.DataDistributionResponse-int64) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| dropped_at | [google.protobuf.Timestamp](#cockroach.server.serverpb.DataDistributionResponse-google.protobuf.Timestamp) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+
+
+
+
+<a name="cockroach.server.serverpb.DataDistributionResponse-cockroach.server.serverpb.DataDistributionResponse.TableInfo.ReplicaCountByNodeIdEntry"></a>
+#### DataDistributionResponse.TableInfo.ReplicaCountByNodeIdEntry
+
+
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [int32](#cockroach.server.serverpb.DataDistributionResponse-int32) |  |  |  |
+| value | [int64](#cockroach.server.serverpb.DataDistributionResponse-int64) |  |  |  |
+
+
+
+
+
+<a name="cockroach.server.serverpb.DataDistributionResponse-cockroach.server.serverpb.DataDistributionResponse.ZoneConfigsEntry"></a>
+#### DataDistributionResponse.ZoneConfigsEntry
+
+
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [string](#cockroach.server.serverpb.DataDistributionResponse-string) |  |  |  |
+| value | [DataDistributionResponse.ZoneConfig](#cockroach.server.serverpb.DataDistributionResponse-cockroach.server.serverpb.DataDistributionResponse.ZoneConfig) |  |  |  |
+
+
+
+
+
+<a name="cockroach.server.serverpb.DataDistributionResponse-cockroach.server.serverpb.DataDistributionResponse.ZoneConfig"></a>
+#### DataDistributionResponse.ZoneConfig
+
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| target | [string](#cockroach.server.serverpb.DataDistributionResponse-string) |  | target is the object the zone config applies to, e.g. "DATABASE db" or "PARTITION north_america OF TABLE users". | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| config | [cockroach.config.zonepb.ZoneConfig](#cockroach.server.serverpb.DataDistributionResponse-cockroach.config.zonepb.ZoneConfig) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| config_sql | [string](#cockroach.server.serverpb.DataDistributionResponse-string) |  | config_sql is the SQL representation of config. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+
+
+
+
+
+## AllMetricMetadata
+
+`GET /_admin/v1/metricmetadata`
+
+URL: /_admin/v1/metricmetadata
+
+Note: this is a “reserved” API endpoint and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+#### Request Parameters
+
+
+
+
+MetricMetadataRequest requests metadata for all metrics.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+
+
+
+
+
+
+#### Response Parameters
+
+
+
+
+MetricMetadataResponse contains the metadata for all metics.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| metadata | [MetricMetadataResponse.MetadataEntry](#cockroach.server.serverpb.MetricMetadataResponse-cockroach.server.serverpb.MetricMetadataResponse.MetadataEntry) | repeated |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.MetricMetadataResponse-cockroach.server.serverpb.MetricMetadataResponse.MetadataEntry"></a>
+#### MetricMetadataResponse.MetadataEntry
+
+
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [string](#cockroach.server.serverpb.MetricMetadataResponse-string) |  |  |  |
+| value | [cockroach.util.metric.Metadata](#cockroach.server.serverpb.MetricMetadataResponse-cockroach.util.metric.Metadata) |  |  |  |
+
+
+
+
+
+
+## ChartCatalog
+
+`GET /_admin/v1/chartcatalog`
+
+URL: /_admin/v1/chartcatalog
+
+Note: this is a “reserved” API endpoint and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+#### Request Parameters
+
+
+
+
+ChartCatalogRequest requests returns a catalog of Admin UI charts.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+
+
+
+
+
+
+#### Response Parameters
+
+
+
+
+ChartCatalogResponse returns a catalog of Admin UI charts useful for debugging.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| catalog | [cockroach.ts.catalog.ChartSection](#cockroach.server.serverpb.ChartCatalogResponse-cockroach.ts.catalog.ChartSection) | repeated |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+
+
+
+
+
+
+## EnqueueRange
+
+`POST /_admin/v1/enqueue_range`
+
+EnqueueRange runs the specified range through the specified queue on the
+range's leaseholder store, returning the detailed trace and error
+information from doing so. Parameters must be provided in the body of the
+POST request.
+For example:
+
+{
+  "queue": "raftlog",
+  "rangeId": 10
+}
+
+Note: this is a “reserved” API endpoint and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+#### Request Parameters
+
+
+
+
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [int32](#cockroach.server.serverpb.EnqueueRangeRequest-int32) |  | The node on which the queue should process the range. If node_id is 0, the request will be forwarded to all other nodes. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| queue | [string](#cockroach.server.serverpb.EnqueueRangeRequest-string) |  | The name of the replica queue to run the range through. Matched against each queue's name field. See the implementation of baseQueue for details. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| range_id | [int32](#cockroach.server.serverpb.EnqueueRangeRequest-int32) |  | The ID of the range to run through the queue. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| skip_should_queue | [bool](#cockroach.server.serverpb.EnqueueRangeRequest-bool) |  | If set, run the queue's process method without first checking whether the replica should be processed by calling shouldQueue. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+
+
+
+
+
+
+#### Response Parameters
+
+
+
+
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| details | [EnqueueRangeResponse.Details](#cockroach.server.serverpb.EnqueueRangeResponse-cockroach.server.serverpb.EnqueueRangeResponse.Details) | repeated |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.EnqueueRangeResponse-cockroach.server.serverpb.EnqueueRangeResponse.Details"></a>
+#### EnqueueRangeResponse.Details
+
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [int32](#cockroach.server.serverpb.EnqueueRangeResponse-int32) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| events | [TraceEvent](#cockroach.server.serverpb.EnqueueRangeResponse-cockroach.server.serverpb.TraceEvent) | repeated | All trace events collected while processing the range in the queue. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| error | [string](#cockroach.server.serverpb.EnqueueRangeResponse-string) |  | The error message from the queue's processing, if any. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+
+
+
+
+<a name="cockroach.server.serverpb.EnqueueRangeResponse-cockroach.server.serverpb.TraceEvent"></a>
+#### TraceEvent
+
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| time | [google.protobuf.Timestamp](#cockroach.server.serverpb.EnqueueRangeResponse-google.protobuf.Timestamp) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| message | [string](#cockroach.server.serverpb.EnqueueRangeResponse-string) |  |  | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
 
 
 

--- a/docs/generated/http/health-request.md
+++ b/docs/generated/http/health-request.md
@@ -1,0 +1,30 @@
+
+
+<a name="cockroach.server.serverpb.HealthRequest"></a>
+#### HealthRequest
+
+HealthRequest requests a liveness or readiness check.
+
+A liveness check is triggered via ready set to false. In this mode,
+an empty response is returned immediately, that is, the caller merely
+learns that the process is running.
+
+A readiness check (ready == true) is suitable for determining whether
+user traffic should be directed at a given node, for example by a load
+balancer. In this mode, a successful response is returned only if the
+node:
+
+- is not in the process of shutting down or booting up (including
+  waiting for cluster bootstrap);
+- is regarded as healthy by the cluster via the recent broadcast of
+  a liveness beacon. Absent either of these conditions, an error
+  code will result.
+
+This is a public API payload.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| ready | [bool](#bool) |  | ready specifies whether the client wants to know whether the target node is ready to receive traffic. If a node is unready, an error will be returned. | This is a public API field. |
+
+

--- a/docs/generated/http/health-response.md
+++ b/docs/generated/http/health-response.md
@@ -1,0 +1,12 @@
+
+
+<a name="cockroach.server.serverpb.HealthResponse"></a>
+#### HealthResponse
+
+HealthResponse is the response to HealthRequest. It currently does not
+contain any information.
+
+This is a public API payload.
+
+
+

--- a/docs/generated/http/hotranges-other.md
+++ b/docs/generated/http/hotranges-other.md
@@ -3,10 +3,15 @@
 <a name="cockroach.server.serverpb.HotRangesResponse.HotRangesByNodeIdEntry"></a>
 #### HotRangesResponse.HotRangesByNodeIdEntry
 
-| Field | Type | Label |
-| ----- | ---- | ----- |
-| key | [int32](#int32) |  |
-| value | [HotRangesResponse.NodeResponse](#cockroach.server.serverpb.HotRangesResponse.NodeResponse) |  |
+
+
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [int32](#int32) |  |  |  |
+| value | [HotRangesResponse.NodeResponse](#cockroach.server.serverpb.HotRangesResponse.NodeResponse) |  |  |  |
 
 
 
@@ -14,10 +19,16 @@
 <a name="cockroach.server.serverpb.HotRangesResponse.NodeResponse"></a>
 #### HotRangesResponse.NodeResponse
 
-| Field | Type | Label |
-| ----- | ---- | ----- |
-| error_message | [string](#string) |  |
-| stores | [HotRangesResponse.StoreResponse](#cockroach.server.serverpb.HotRangesResponse.StoreResponse) | repeated |
+NodeResponse is a hot range report for a single target node.
+
+Note: this is an “alpha” API payload. It is subject to change without
+advance notice in a subsequent release.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| error_message | [string](#string) |  | ErrorMessage is set to a non-empty string if this target node was unable to produce a hot range report.<br><br>The contents of this string indicates the cause of the failure. | Note: this is an “alpha” API field. It is subject to change without advance notice in a subsequent release. |
+| stores | [HotRangesResponse.StoreResponse](#cockroach.server.serverpb.HotRangesResponse.StoreResponse) | repeated | Stores contains the hot ranges report if no error was encountered. There is one part to the report for each store in the target node. | Note: this is an “alpha” API field. It is subject to change without advance notice in a subsequent release. |
 
 
 
@@ -25,10 +36,17 @@
 <a name="cockroach.server.serverpb.HotRangesResponse.StoreResponse"></a>
 #### HotRangesResponse.StoreResponse
 
-| Field | Type | Label |
-| ----- | ---- | ----- |
-| store_id | [int32](#int32) |  |
-| hot_ranges | [HotRangesResponse.HotRange](#cockroach.server.serverpb.HotRangesResponse.HotRange) | repeated |
+StoreResponse contains the part of a hot ranges report that
+pertains to a single store on a target node.
+
+Note: this is an “alpha” API payload. It is subject to change without
+advance notice in a subsequent release.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| store_id | [int32](#int32) |  | StoreID identifies the store for which the report was produced. | Note: this is an “alpha” API field. It is subject to change without advance notice in a subsequent release. |
+| hot_ranges | [HotRangesResponse.HotRange](#cockroach.server.serverpb.HotRangesResponse.HotRange) | repeated | HotRanges is the hot ranges report for this store on the target node. | Note: this is an “alpha” API field. It is subject to change without advance notice in a subsequent release. |
 
 
 
@@ -36,9 +54,16 @@
 <a name="cockroach.server.serverpb.HotRangesResponse.HotRange"></a>
 #### HotRangesResponse.HotRange
 
-| Field | Type | Label |
-| ----- | ---- | ----- |
-| desc | [cockroach.roachpb.RangeDescriptor](#cockroach.roachpb.RangeDescriptor) |  |
-| queries_per_second | [double](#double) |  |
+HotRange is a hot range report for a single store on one of the
+target node(s) selected in a HotRangesRequest.
+
+Note: this is an “alpha” API payload. It is subject to change without
+advance notice in a subsequent release.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| desc | [cockroach.roachpb.RangeDescriptor](#cockroach.roachpb.RangeDescriptor) |  | Desc is the descriptor of the range for which the report was produced.<br><br>TODO(knz): This field should be removed. See: https://github.com/cockroachdb/cockroach/issues/53212 | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| queries_per_second | [double](#double) |  | QueriesPerSecond is the recent number of queries per second on this range. | Note: this is an “alpha” API field. It is subject to change without advance notice in a subsequent release. |
 
 

--- a/docs/generated/http/hotranges-request.md
+++ b/docs/generated/http/hotranges-request.md
@@ -3,8 +3,15 @@
 <a name="cockroach.server.serverpb.HotRangesRequest"></a>
 #### HotRangesRequest
 
-| Field | Type | Label |
-| ----- | ---- | ----- |
-| node_id | [string](#string) |  |
+HotRangesRequest queries one or more cluster nodes for a list
+of ranges currently considered “hot” by the node(s).
+
+Note: this is an “alpha” API payload. It is subject to change without
+advance notice in a subsequent release.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [string](#string) |  | NodeID indicates which node to query for a hot range report. It is posssible to populate any node ID; if the node receiving the request is not the target node, it will forward the request to the target node.<br><br>If left empty, the request is forwarded to every node in the cluster. | Note: this is an “alpha” API field. It is subject to change without advance notice in a subsequent release. |
 
 

--- a/docs/generated/http/hotranges-response.md
+++ b/docs/generated/http/hotranges-response.md
@@ -3,9 +3,16 @@
 <a name="cockroach.server.serverpb.HotRangesResponse"></a>
 #### HotRangesResponse
 
-| Field | Type | Label |
-| ----- | ---- | ----- |
-| node_id | [int32](#int32) |  |
-| hot_ranges_by_node_id | [HotRangesResponse.HotRangesByNodeIdEntry](#cockroach.server.serverpb.HotRangesResponse.HotRangesByNodeIdEntry) | repeated |
+HotRangesResponse is the payload produced in response
+to a HotRangesRequest.
+
+Note: this is an “alpha” API payload. It is subject to change without
+advance notice in a subsequent release.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [int32](#int32) |  | NodeID is the node that received the HotRangesRequest and forwarded requests to the selected target node(s). | Note: this is an “alpha” API field. It is subject to change without advance notice in a subsequent release. |
+| hot_ranges_by_node_id | [HotRangesResponse.HotRangesByNodeIdEntry](#cockroach.server.serverpb.HotRangesResponse.HotRangesByNodeIdEntry) | repeated | HotRangesByNodeID contains a hot range report for each selected target node ID in the HotRangesRequest. | Note: this is an “alpha” API field. It is subject to change without advance notice in a subsequent release. |
 
 

--- a/docs/generated/http/nodes-other.md
+++ b/docs/generated/http/nodes-other.md
@@ -1,0 +1,144 @@
+
+
+<a name="cockroach.server.status.statuspb.NodeStatus"></a>
+#### NodeStatus
+
+NodeStatus records the most recent values of metrics for a node.
+
+Note: this is an “alpha” API payload. It is subject to change without
+advance notice in a subsequent release.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| desc | [cockroach.roachpb.NodeDescriptor](#cockroach.roachpb.NodeDescriptor) |  | desc is the node descriptor. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| build_info | [cockroach.build.Info](#cockroach.build.Info) |  | build_info describes the 'cockroach' executable file. | Note: this is an “alpha” API field. It is subject to change without advance notice in a subsequent release. |
+| started_at | [int64](#int64) |  | started_at is the unix timestamp at which the node process was last started. | Note: this is an “alpha” API field. It is subject to change without advance notice in a subsequent release. |
+| updated_at | [int64](#int64) |  | updated_at is the unix timestamp at which the node status record was last updated. | Note: this is an “alpha” API field. It is subject to change without advance notice in a subsequent release. |
+| metrics | [NodeStatus.MetricsEntry](#cockroach.server.status.statuspb.NodeStatus.MetricsEntry) | repeated | metrics contains the last sampled values for the node metrics. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| store_statuses | [StoreStatus](#cockroach.server.status.statuspb.StoreStatus) | repeated | store_statuses provides the store status payloads for all the stores on that node. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| args | [string](#string) | repeated | args is the list of command-line arguments used to last start the node. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| env | [string](#string) | repeated | env is the list of environment variables that influenced the node's configuration. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| latencies | [NodeStatus.LatenciesEntry](#cockroach.server.status.statuspb.NodeStatus.LatenciesEntry) | repeated | latencies is a map of nodeIDs to nanoseconds which is the latency between this node and the other node.<br><br>NOTE: this is deprecated and is only set if the min supported       cluster version is >= VersionRPCNetworkStats. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| activity | [NodeStatus.ActivityEntry](#cockroach.server.status.statuspb.NodeStatus.ActivityEntry) | repeated | activity is a map of nodeIDs to network statistics from this node to other nodes. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| total_system_memory | [int64](#int64) |  | total_system_memory is the total RAM available to the system (or, if detected, the memory available to the cgroup this process is in) in bytes. | Note: this is an “alpha” API field. It is subject to change without advance notice in a subsequent release. |
+| num_cpus | [int32](#int32) |  | num_cpus is the number of logical CPUs as reported by the operating system on the host where the 'cockroach' process is running. Note that this does not report the number of CPUs actually used by 'cockroach'; this parameter is controlled separately. | Note: this is an “alpha” API field. It is subject to change without advance notice in a subsequent release. |
+
+
+
+
+<a name="cockroach.server.status.statuspb.NodeStatus.MetricsEntry"></a>
+#### NodeStatus.MetricsEntry
+
+
+
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [string](#string) |  |  |  |
+| value | [double](#double) |  |  |  |
+
+
+
+
+<a name="cockroach.server.status.statuspb.StoreStatus"></a>
+#### StoreStatus
+
+StoreStatus records the most recent values of metrics for a store.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| desc | [cockroach.roachpb.StoreDescriptor](#cockroach.roachpb.StoreDescriptor) |  | desc is the store descriptor. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| metrics | [StoreStatus.MetricsEntry](#cockroach.server.status.statuspb.StoreStatus.MetricsEntry) | repeated | metrics contains the last sampled values for the node metrics. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+
+
+
+<a name="cockroach.server.status.statuspb.StoreStatus.MetricsEntry"></a>
+#### StoreStatus.MetricsEntry
+
+
+
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [string](#string) |  |  |  |
+| value | [double](#double) |  |  |  |
+
+
+
+
+<a name="cockroach.server.status.statuspb.NodeStatus.LatenciesEntry"></a>
+#### NodeStatus.LatenciesEntry
+
+
+
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [int32](#int32) |  |  |  |
+| value | [int64](#int64) |  |  |  |
+
+
+
+
+<a name="cockroach.server.status.statuspb.NodeStatus.ActivityEntry"></a>
+#### NodeStatus.ActivityEntry
+
+
+
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [int32](#int32) |  |  |  |
+| value | [NodeStatus.NetworkActivity](#cockroach.server.status.statuspb.NodeStatus.NetworkActivity) |  |  |  |
+
+
+
+
+<a name="cockroach.server.status.statuspb.NodeStatus.NetworkActivity"></a>
+#### NodeStatus.NetworkActivity
+
+
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| incoming | [int64](#int64) |  | in bytes | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| outgoing | [int64](#int64) |  | in bytes | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+| latency | [int64](#int64) |  | in nanoseconds | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+
+
+
+<a name="cockroach.server.serverpb.NodesResponse.LivenessByNodeIdEntry"></a>
+#### NodesResponse.LivenessByNodeIdEntry
+
+
+
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [int32](#int32) |  |  |  |
+| value | [cockroach.kv.kvserver.storagepb.NodeLivenessStatus](#cockroach.kv.kvserver.storagepb.NodeLivenessStatus) |  |  |  |
+
+

--- a/docs/generated/http/nodes-request.md
+++ b/docs/generated/http/nodes-request.md
@@ -1,0 +1,13 @@
+
+
+<a name="cockroach.server.serverpb.NodesRequest"></a>
+#### NodesRequest
+
+NodesRequest requests a copy of the node information as known to gossip
+and the KV layer.
+
+Note: this is an “alpha” API payload. It is subject to change without
+advance notice in a subsequent release.
+
+
+

--- a/docs/generated/http/nodes-response.md
+++ b/docs/generated/http/nodes-response.md
@@ -1,0 +1,18 @@
+
+
+<a name="cockroach.server.serverpb.NodesResponse"></a>
+#### NodesResponse
+
+NodesResponse describe the nodes in the cluster.
+
+Note: this is a “reserved” API payload and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| nodes | [cockroach.server.status.statuspb.NodeStatus](#cockroach.server.status.statuspb.NodeStatus) | repeated | nodes carries the status payloads for all nodes in the cluster. | Note: this is an “alpha” API field. It is subject to change without advance notice in a subsequent release. |
+| liveness_by_node_id | [NodesResponse.LivenessByNodeIdEntry](#cockroach.server.serverpb.NodesResponse.LivenessByNodeIdEntry) | repeated | liveness_by_node_id maps each node ID to a liveness status. | Note: this is a “reserved” API field and should not be relied upon to build external tools. No guarantee is made about its availability and stability in external uses. |
+
+

--- a/pkg/build/info.pb.go
+++ b/pkg/build/info.pb.go
@@ -22,17 +22,28 @@ const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
 
 // Info describes build information for this CockroachDB binary.
 type Info struct {
-	GoVersion       string `protobuf:"bytes,1,opt,name=go_version,json=goVersion" json:"go_version"`
-	Tag             string `protobuf:"bytes,2,opt,name=tag" json:"tag"`
-	Time            string `protobuf:"bytes,3,opt,name=time" json:"time"`
-	Revision        string `protobuf:"bytes,4,opt,name=revision" json:"revision"`
-	CgoCompiler     string `protobuf:"bytes,5,opt,name=cgo_compiler,json=cgoCompiler" json:"cgo_compiler"`
+	// go_version is the version of the Go toolchain used to compile this executable.
+	GoVersion string `protobuf:"bytes,1,opt,name=go_version,json=goVersion" json:"go_version"`
+	// tag is the git tag for the revision of the source code for this executable.
+	Tag string `protobuf:"bytes,2,opt,name=tag" json:"tag"`
+	// time is the time at which the build started.
+	Time string `protobuf:"bytes,3,opt,name=time" json:"time"`
+	// revision is the git commit identifier for the source code of this executable.
+	Revision string `protobuf:"bytes,4,opt,name=revision" json:"revision"`
+	// cgo_compiler is the C/C++ compiler used to build non-go dependencies.
+	CgoCompiler string `protobuf:"bytes,5,opt,name=cgo_compiler,json=cgoCompiler" json:"cgo_compiler"`
+	// cgo_target_triple is the platform identifier that identifies the cross-compilation target for C/C++ components.
 	CgoTargetTriple string `protobuf:"bytes,10,opt,name=cgo_target_triple,json=cgoTargetTriple" json:"cgo_target_triple"`
-	Platform        string `protobuf:"bytes,6,opt,name=platform" json:"platform"`
-	Distribution    string `protobuf:"bytes,7,opt,name=distribution" json:"distribution"`
-	Type            string `protobuf:"bytes,8,opt,name=type" json:"type"`
-	Channel         string `protobuf:"bytes,9,opt,name=channel" json:"channel"`
-	EnvChannel      string `protobuf:"bytes,11,opt,name=env_channel,json=envChannel" json:"env_channel"`
+	// platform is the platform identifiers that identifies the cross-compilation target for Go code.
+	Platform string `protobuf:"bytes,6,opt,name=platform" json:"platform"`
+	// distribution indicates which licensing conditions apply (OSS: full open source; CCL: includes CCL code).
+	Distribution string `protobuf:"bytes,7,opt,name=distribution" json:"distribution"`
+	// type indicates whether this is a development or release build.
+	Type string `protobuf:"bytes,8,opt,name=type" json:"type"`
+	// channel identifies through which product channel the executable was released.
+	Channel string `protobuf:"bytes,9,opt,name=channel" json:"channel"`
+	// env_channel identifies the product channel as overridden by the COCKROACH_CHANNEL environment variable.
+	EnvChannel string `protobuf:"bytes,11,opt,name=env_channel,json=envChannel" json:"env_channel"`
 	// dependencies exists to allow tests that run against old clusters
 	// to unmarshal JSON containing this field. The tag is unimportant,
 	// but the field name must remain unchanged.
@@ -47,7 +58,7 @@ func (m *Info) Reset()         { *m = Info{} }
 func (m *Info) String() string { return proto.CompactTextString(m) }
 func (*Info) ProtoMessage()    {}
 func (*Info) Descriptor() ([]byte, []int) {
-	return fileDescriptor_info_144091887156c658, []int{0}
+	return fileDescriptor_info_6120d08447ce7654, []int{0}
 }
 func (m *Info) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -708,9 +719,9 @@ var (
 	ErrIntOverflowInfo   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("build/info.proto", fileDescriptor_info_144091887156c658) }
+func init() { proto.RegisterFile("build/info.proto", fileDescriptor_info_6120d08447ce7654) }
 
-var fileDescriptor_info_144091887156c658 = []byte{
+var fileDescriptor_info_6120d08447ce7654 = []byte{
 	// 339 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x54, 0x91, 0x41, 0x8e, 0xda, 0x30,
 	0x14, 0x86, 0x93, 0x12, 0x0a, 0x18, 0x24, 0x5a, 0xab, 0xaa, 0xac, 0x2e, 0x5c, 0x54, 0x54, 0xc1,

--- a/pkg/build/info.proto
+++ b/pkg/build/info.proto
@@ -16,16 +16,27 @@ import "gogoproto/gogo.proto";
 
 // Info describes build information for this CockroachDB binary.
 message Info {
+  // go_version is the version of the Go toolchain used to compile this executable.
   optional string go_version = 1 [(gogoproto.nullable) = false];
+  // tag is the git tag for the revision of the source code for this executable.
   optional string tag = 2 [(gogoproto.nullable) = false];
+  // time is the time at which the build started.
   optional string time = 3 [(gogoproto.nullable) = false];
+  // revision is the git commit identifier for the source code of this executable.
   optional string revision = 4 [(gogoproto.nullable) = false];
+  // cgo_compiler is the C/C++ compiler used to build non-go dependencies.
   optional string cgo_compiler = 5 [(gogoproto.nullable) = false];
+  // cgo_target_triple is the platform identifier that identifies the cross-compilation target for C/C++ components.
   optional string cgo_target_triple = 10 [(gogoproto.nullable) = false];
+  // platform is the platform identifiers that identifies the cross-compilation target for Go code.
   optional string platform = 6 [(gogoproto.nullable) = false];
+  // distribution indicates which licensing conditions apply (OSS: full open source; CCL: includes CCL code).
   optional string distribution = 7 [(gogoproto.nullable) = false];
+  // type indicates whether this is a development or release build.
   optional string type = 8 [(gogoproto.nullable) = false];
+  // channel identifies through which product channel the executable was released.
   optional string channel = 9 [(gogoproto.nullable) = false];
+  // env_channel identifies the product channel as overridden by the COCKROACH_CHANNEL environment variable.
   optional string env_channel = 11 [(gogoproto.nullable) = false];
 
   // dependencies exists to allow tests that run against old clusters

--- a/pkg/cmd/docgen/http.go
+++ b/pkg/cmd/docgen/http.go
@@ -52,6 +52,8 @@ func init() {
 
 var singleMethods = []string{
 	"HotRanges",
+	"Nodes",
+	"Health",
 }
 
 // runHTTP extracts HTTP endpoint documentation. It does this by reading the
@@ -86,6 +88,8 @@ func runHTTP(protocPath, genDocPath, protobufPath, outPath string) error {
 		fmt.Sprintf("--doc_out=%s", tmpJSON),
 		fmt.Sprintf("--doc_opt=%s,http.json", jsonTmpl),
 		"./pkg/server/serverpb/status.proto",
+		"./pkg/server/serverpb/admin.proto",
+		"./pkg/server/status/statuspb/status.proto",
 	)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		fmt.Println(string(out))
@@ -99,20 +103,53 @@ func runHTTP(protocPath, genDocPath, protobufPath, outPath string) error {
 	if err := json.Unmarshal(dataFile, &data); err != nil {
 		return fmt.Errorf("json unmarshal: %w", err)
 	}
-	if len(data.Files) != 1 || len(data.Files[0].Services) != 1 {
-		return fmt.Errorf("expected 1 file with 1 service")
+
+	// Annotate all non-public message, method and field descriptions
+	// with a disclaimer.
+	for k := range data.Files {
+		file := &data.Files[k]
+		for i := range file.Messages {
+			m := &file.Messages[i]
+			if !(strings.HasSuffix(m.Name, "Entry") && len(m.Fields) == 2 && m.Fields[0].Name == "key" && m.Fields[1].Name == "value") {
+				// We only annotate the support status for non-KV
+				// (auto-generated, intermediate) message types.
+				annotateStatus(&m.Description, &m.SupportStatus, "payload")
+				for j := range m.Fields {
+					f := &m.Fields[j]
+					annotateStatus(&f.Description, &f.SupportStatus, "field")
+				}
+			}
+		}
+		for j := range file.Services {
+			service := &file.Services[j]
+			for i := range service.Methods {
+				m := &service.Methods[i]
+				annotateStatus(&m.Description, &m.SupportStatus, "endpoint")
+				if len(m.Options.GoogleAPIHTTP.Rules) > 0 {
+					// Just keep the last entry. This is a special accommodation for
+					// "/health" which aliases "/_admin/v1/health": we only
+					// want to document the latter.
+					m.Options.GoogleAPIHTTP.Rules = m.Options.GoogleAPIHTTP.Rules[len(m.Options.GoogleAPIHTTP.Rules)-1:]
+				}
+			}
+		}
 	}
-	file := data.Files[0]
-	service := file.Services[0]
 
 	// Start by making maps of methods and messages for lookup.
 	messages := make(map[string]*protoMessage)
-	for i := range file.Messages {
-		messages[file.Messages[i].FullName] = &file.Messages[i]
-	}
 	methods := make(map[string]*protoMethod)
-	for i := range service.Methods {
-		methods[service.Methods[i].Name] = &service.Methods[i]
+	for f := range data.Files {
+		file := &data.Files[f]
+		for i := range file.Messages {
+			messages[file.Messages[i].FullName] = &file.Messages[i]
+		}
+
+		for j := range file.Services {
+			service := &file.Services[j]
+			for i := range service.Methods {
+				methods[service.Methods[i].Name] = &service.Methods[i]
+			}
+		}
 	}
 
 	// Given a message type, returns all message types in its type field that are
@@ -165,7 +202,7 @@ func runHTTP(protocPath, genDocPath, protobufPath, outPath string) error {
 	tmplMessages := template.Must(template.New("single").Funcs(tmplFuncs).Parse(messagesTemplate))
 
 	// JSON data is now in memory. Generate full doc page.
-	if err := execHTTPTmpl(tmplFull, &file, filepath.Join(outPath, "full.md")); err != nil {
+	if err := execHTTPTmpl(tmplFull, &data, filepath.Join(outPath, "full.md")); err != nil {
 		return fmt.Errorf("execHTTPTmpl: %w", err)
 	}
 
@@ -186,6 +223,24 @@ func runHTTP(protocPath, genDocPath, protobufPath, outPath string) error {
 		}
 	}
 	return nil
+}
+
+func annotateStatus(desc *string, status *string, kind string) {
+	if !strings.Contains(*desc, "API: PUBLIC") {
+		*status = `Note: this is a “reserved” API ` + kind + ` and should not be relied upon to
+build external tools. No guarantee is made about its
+availability and stability in external uses.`
+	}
+	if strings.Contains(*desc, "API: PUBLIC ALPHA") {
+		*status = `Note: this is an “alpha” API ` + kind + `. It is subject to change without
+advance notice in a subsequent release.`
+	}
+	if *status == "" {
+		*status = "This is a public API " + kind + "."
+	}
+	*desc = strings.Replace(*desc, "API: PUBLIC ALPHA", "", 1)
+	*desc = strings.Replace(*desc, "API: PUBLIC", "", 1)
+	*desc = strings.TrimSpace(*desc)
 }
 
 func execHTTPTmpl(tmpl *template.Template, data interface{}, path string) error {
@@ -242,6 +297,7 @@ type protoData struct {
 type protoMethod struct {
 	Name              string `json:"name"`
 	Description       string `json:"description"`
+	SupportStatus     string `json:"supportStatus"`
 	RequestType       string `json:"requestType"`
 	RequestLongType   string `json:"requestLongType"`
 	RequestFullType   string `json:"requestFullType"`
@@ -265,18 +321,20 @@ type protoMessage struct {
 	LongName      string        `json:"longName"`
 	FullName      string        `json:"fullName"`
 	Description   string        `json:"description"`
+	SupportStatus string        `json:"supportStatus"`
 	HasExtensions bool          `json:"hasExtensions"`
 	HasFields     bool          `json:"hasFields"`
 	Extensions    []interface{} `json:"extensions"`
 	Fields        []struct {
-		Name         string `json:"name"`
-		Description  string `json:"description"`
-		Label        string `json:"label"`
-		Type         string `json:"type"`
-		LongType     string `json:"longType"`
-		FullType     string `json:"fullType"`
-		Ismap        bool   `json:"ismap"`
-		DefaultValue string `json:"defaultValue"`
+		Name          string `json:"name"`
+		Description   string `json:"description"`
+		SupportStatus string `json:"supportStatus"`
+		Label         string `json:"label"`
+		Type          string `json:"type"`
+		LongType      string `json:"longType"`
+		FullType      string `json:"fullType"`
+		Ismap         bool   `json:"ismap"`
+		DefaultValue  string `json:"defaultValue"`
 	} `json:"fields"`
 }
 
@@ -286,11 +344,16 @@ const fullTemplate = `
 {{- define "FIELDS" -}}
 {{with getMessage .}}
 {{$message := .}}
+
+{{with .Description}}{{.}}{{end}}
+
+{{with .SupportStatus}}{{.}}{{end}}
+
 {{with .Fields}}
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
 {{- range .}}
-| {{.Name}} | [{{.LongType}}](#{{$message.FullName}}-{{.FullType}}) | {{.Label}} | {{.Description | tableCell}}{{if .DefaultValue}} Default: {{.DefaultValue}}{{end}} |
+| {{.Name}} | [{{.LongType}}](#{{$message.FullName}}-{{.FullType}}) | {{.Label}} | {{.Description | tableCell}}{{if .DefaultValue}} Default: {{.DefaultValue}}{{end}} | {{.SupportStatus | tableCell}} |
 {{- end}} {{- /* range */}}
 {{end}} {{- /* with .Fields */}}
 
@@ -301,10 +364,14 @@ const fullTemplate = `
 <a name="{{$message.FullName}}-{{.FullName}}"></a>
 #### {{.LongName}}
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
+{{.Description}}
+
+{{.SupportStatus}}
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
 {{- range .Fields}}
-| {{.Name}} | [{{.LongType}}](#{{$message.FullName}}-{{.FullType}}) | {{.Label}} | {{.Description | tableCell}}{{if .DefaultValue}} Default: {{.DefaultValue}}{{end}} |
+| {{.Name}} | [{{.LongType}}](#{{$message.FullName}}-{{.FullType}}) | {{.Label}} | {{.Description | tableCell}}{{if .DefaultValue}} Default: {{.DefaultValue}}{{end}} | {{.SupportStatus | tableCell}} |
 {{- end}} {{- /* range */}}
 {{end}} {{- /* if .Fields */}}
 {{end}} {{- /* with getMessage */}}
@@ -313,16 +380,20 @@ const fullTemplate = `
 {{end}} {{- /* with getMessage */}}
 {{- end}} {{- /* template */}}
 
+{{- range .Files}}
+
 {{- range .Services}}
 
 {{- range .Methods -}}
 ## {{.Name}}
 
 {{range .Options.GoogleAPIHTTP.Rules -}}
-` + "`{{.Method}} {{.Pattern}}`" + `
+` + "`{{.Method}} {{.Pattern}}` " + `
 {{- end}}
 
 {{with .Description}}{{.}}{{end}}
+
+{{with .SupportStatus}}{{.}}{{end}}
 
 #### Request Parameters
 
@@ -335,6 +406,7 @@ const fullTemplate = `
 {{end}} {{- /* methods */}}
 
 {{- end -}} {{- /* services */ -}}
+{{- end -}} {{- /* files */ -}}
 `
 
 var messagesTemplate = `
@@ -342,11 +414,16 @@ var messagesTemplate = `
 {{with getMessage .}}
 <a name="{{.FullName}}"></a>
 #### {{.LongName}}
+
+{{.Description}}
+
+{{.SupportStatus}}
+
 {{with .Fields}}
-| Field | Type | Label |
-| ----- | ---- | ----- |
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
 {{- range .}}
-| {{.Name}} | [{{.LongType}}](#{{.FullType}}) | {{.Label}} |
+| {{.Name}} | [{{.LongType}}](#{{.FullType}}) | {{.Label}} | {{.Description|tableCell}} | {{.SupportStatus | tableCell}} |
 {{- end}} {{- /* range */}}
 {{end}}{{- /* with .Fields */}}
 {{end}}{{- /* with getMessage */}}

--- a/pkg/server/serverpb/admin.pb.go
+++ b/pkg/server/serverpb/admin.pb.go
@@ -73,7 +73,7 @@ func (x ZoneConfigurationLevel) String() string {
 	return proto.EnumName(ZoneConfigurationLevel_name, int32(x))
 }
 func (ZoneConfigurationLevel) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{0}
+	return fileDescriptor_admin_42294f563913d383, []int{0}
 }
 
 // DatabasesRequest requests a list of databases.
@@ -84,7 +84,7 @@ func (m *DatabasesRequest) Reset()         { *m = DatabasesRequest{} }
 func (m *DatabasesRequest) String() string { return proto.CompactTextString(m) }
 func (*DatabasesRequest) ProtoMessage()    {}
 func (*DatabasesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{0}
+	return fileDescriptor_admin_42294f563913d383, []int{0}
 }
 func (m *DatabasesRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -118,7 +118,7 @@ func (m *DatabasesResponse) Reset()         { *m = DatabasesResponse{} }
 func (m *DatabasesResponse) String() string { return proto.CompactTextString(m) }
 func (*DatabasesResponse) ProtoMessage()    {}
 func (*DatabasesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{1}
+	return fileDescriptor_admin_42294f563913d383, []int{1}
 }
 func (m *DatabasesResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -154,7 +154,7 @@ func (m *DatabaseDetailsRequest) Reset()         { *m = DatabaseDetailsRequest{}
 func (m *DatabaseDetailsRequest) String() string { return proto.CompactTextString(m) }
 func (*DatabaseDetailsRequest) ProtoMessage()    {}
 func (*DatabaseDetailsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{2}
+	return fileDescriptor_admin_42294f563913d383, []int{2}
 }
 func (m *DatabaseDetailsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -203,7 +203,7 @@ func (m *DatabaseDetailsResponse) Reset()         { *m = DatabaseDetailsResponse
 func (m *DatabaseDetailsResponse) String() string { return proto.CompactTextString(m) }
 func (*DatabaseDetailsResponse) ProtoMessage()    {}
 func (*DatabaseDetailsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{3}
+	return fileDescriptor_admin_42294f563913d383, []int{3}
 }
 func (m *DatabaseDetailsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -239,7 +239,7 @@ func (m *DatabaseDetailsResponse_Grant) Reset()         { *m = DatabaseDetailsRe
 func (m *DatabaseDetailsResponse_Grant) String() string { return proto.CompactTextString(m) }
 func (*DatabaseDetailsResponse_Grant) ProtoMessage()    {}
 func (*DatabaseDetailsResponse_Grant) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{3, 0}
+	return fileDescriptor_admin_42294f563913d383, []int{3, 0}
 }
 func (m *DatabaseDetailsResponse_Grant) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -279,7 +279,7 @@ func (m *TableDetailsRequest) Reset()         { *m = TableDetailsRequest{} }
 func (m *TableDetailsRequest) String() string { return proto.CompactTextString(m) }
 func (*TableDetailsRequest) ProtoMessage()    {}
 func (*TableDetailsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{4}
+	return fileDescriptor_admin_42294f563913d383, []int{4}
 }
 func (m *TableDetailsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -336,7 +336,7 @@ func (m *TableDetailsResponse) Reset()         { *m = TableDetailsResponse{} }
 func (m *TableDetailsResponse) String() string { return proto.CompactTextString(m) }
 func (*TableDetailsResponse) ProtoMessage()    {}
 func (*TableDetailsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{5}
+	return fileDescriptor_admin_42294f563913d383, []int{5}
 }
 func (m *TableDetailsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -373,7 +373,7 @@ func (m *TableDetailsResponse_Grant) Reset()         { *m = TableDetailsResponse
 func (m *TableDetailsResponse_Grant) String() string { return proto.CompactTextString(m) }
 func (*TableDetailsResponse_Grant) ProtoMessage()    {}
 func (*TableDetailsResponse_Grant) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{5, 0}
+	return fileDescriptor_admin_42294f563913d383, []int{5, 0}
 }
 func (m *TableDetailsResponse_Grant) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -417,7 +417,7 @@ func (m *TableDetailsResponse_Column) Reset()         { *m = TableDetailsRespons
 func (m *TableDetailsResponse_Column) String() string { return proto.CompactTextString(m) }
 func (*TableDetailsResponse_Column) ProtoMessage()    {}
 func (*TableDetailsResponse_Column) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{5, 1}
+	return fileDescriptor_admin_42294f563913d383, []int{5, 1}
 }
 func (m *TableDetailsResponse_Column) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -463,7 +463,7 @@ func (m *TableDetailsResponse_Index) Reset()         { *m = TableDetailsResponse
 func (m *TableDetailsResponse_Index) String() string { return proto.CompactTextString(m) }
 func (*TableDetailsResponse_Index) ProtoMessage()    {}
 func (*TableDetailsResponse_Index) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{5, 2}
+	return fileDescriptor_admin_42294f563913d383, []int{5, 2}
 }
 func (m *TableDetailsResponse_Index) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -504,7 +504,7 @@ func (m *TableStatsRequest) Reset()         { *m = TableStatsRequest{} }
 func (m *TableStatsRequest) String() string { return proto.CompactTextString(m) }
 func (*TableStatsRequest) ProtoMessage()    {}
 func (*TableStatsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{6}
+	return fileDescriptor_admin_42294f563913d383, []int{6}
 }
 func (m *TableStatsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -558,7 +558,7 @@ func (m *TableStatsResponse) Reset()         { *m = TableStatsResponse{} }
 func (m *TableStatsResponse) String() string { return proto.CompactTextString(m) }
 func (*TableStatsResponse) ProtoMessage()    {}
 func (*TableStatsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{7}
+	return fileDescriptor_admin_42294f563913d383, []int{7}
 }
 func (m *TableStatsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -596,7 +596,7 @@ func (m *TableStatsResponse_MissingNode) Reset()         { *m = TableStatsRespon
 func (m *TableStatsResponse_MissingNode) String() string { return proto.CompactTextString(m) }
 func (*TableStatsResponse_MissingNode) ProtoMessage()    {}
 func (*TableStatsResponse_MissingNode) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{7, 0}
+	return fileDescriptor_admin_42294f563913d383, []int{7, 0}
 }
 func (m *TableStatsResponse_MissingNode) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -630,7 +630,7 @@ func (m *NonTableStatsRequest) Reset()         { *m = NonTableStatsRequest{} }
 func (m *NonTableStatsRequest) String() string { return proto.CompactTextString(m) }
 func (*NonTableStatsRequest) ProtoMessage()    {}
 func (*NonTableStatsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{8}
+	return fileDescriptor_admin_42294f563913d383, []int{8}
 }
 func (m *NonTableStatsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -669,7 +669,7 @@ func (m *NonTableStatsResponse) Reset()         { *m = NonTableStatsResponse{} }
 func (m *NonTableStatsResponse) String() string { return proto.CompactTextString(m) }
 func (*NonTableStatsResponse) ProtoMessage()    {}
 func (*NonTableStatsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{9}
+	return fileDescriptor_admin_42294f563913d383, []int{9}
 }
 func (m *NonTableStatsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -702,7 +702,7 @@ func (m *UsersRequest) Reset()         { *m = UsersRequest{} }
 func (m *UsersRequest) String() string { return proto.CompactTextString(m) }
 func (*UsersRequest) ProtoMessage()    {}
 func (*UsersRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{10}
+	return fileDescriptor_admin_42294f563913d383, []int{10}
 }
 func (m *UsersRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -737,7 +737,7 @@ func (m *UsersResponse) Reset()         { *m = UsersResponse{} }
 func (m *UsersResponse) String() string { return proto.CompactTextString(m) }
 func (*UsersResponse) ProtoMessage()    {}
 func (*UsersResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{11}
+	return fileDescriptor_admin_42294f563913d383, []int{11}
 }
 func (m *UsersResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -771,7 +771,7 @@ func (m *UsersResponse_User) Reset()         { *m = UsersResponse_User{} }
 func (m *UsersResponse_User) String() string { return proto.CompactTextString(m) }
 func (*UsersResponse_User) ProtoMessage()    {}
 func (*UsersResponse_User) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{11, 0}
+	return fileDescriptor_admin_42294f563913d383, []int{11, 0}
 }
 func (m *UsersResponse_User) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -818,7 +818,7 @@ func (m *EventsRequest) Reset()         { *m = EventsRequest{} }
 func (m *EventsRequest) String() string { return proto.CompactTextString(m) }
 func (*EventsRequest) ProtoMessage()    {}
 func (*EventsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{12}
+	return fileDescriptor_admin_42294f563913d383, []int{12}
 }
 func (m *EventsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -853,7 +853,7 @@ func (m *EventsResponse) Reset()         { *m = EventsResponse{} }
 func (m *EventsResponse) String() string { return proto.CompactTextString(m) }
 func (*EventsResponse) ProtoMessage()    {}
 func (*EventsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{13}
+	return fileDescriptor_admin_42294f563913d383, []int{13}
 }
 func (m *EventsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -898,7 +898,7 @@ func (m *EventsResponse_Event) Reset()         { *m = EventsResponse_Event{} }
 func (m *EventsResponse_Event) String() string { return proto.CompactTextString(m) }
 func (*EventsResponse_Event) ProtoMessage()    {}
 func (*EventsResponse_Event) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{13, 0}
+	return fileDescriptor_admin_42294f563913d383, []int{13, 0}
 }
 func (m *EventsResponse_Event) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -934,7 +934,7 @@ func (m *SetUIDataRequest) Reset()         { *m = SetUIDataRequest{} }
 func (m *SetUIDataRequest) String() string { return proto.CompactTextString(m) }
 func (*SetUIDataRequest) ProtoMessage()    {}
 func (*SetUIDataRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{14}
+	return fileDescriptor_admin_42294f563913d383, []int{14}
 }
 func (m *SetUIDataRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -967,7 +967,7 @@ func (m *SetUIDataResponse) Reset()         { *m = SetUIDataResponse{} }
 func (m *SetUIDataResponse) String() string { return proto.CompactTextString(m) }
 func (*SetUIDataResponse) ProtoMessage()    {}
 func (*SetUIDataResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{15}
+	return fileDescriptor_admin_42294f563913d383, []int{15}
 }
 func (m *SetUIDataResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1002,7 +1002,7 @@ func (m *GetUIDataRequest) Reset()         { *m = GetUIDataRequest{} }
 func (m *GetUIDataRequest) String() string { return proto.CompactTextString(m) }
 func (*GetUIDataRequest) ProtoMessage()    {}
 func (*GetUIDataRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{16}
+	return fileDescriptor_admin_42294f563913d383, []int{16}
 }
 func (m *GetUIDataRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1039,7 +1039,7 @@ func (m *GetUIDataResponse) Reset()         { *m = GetUIDataResponse{} }
 func (m *GetUIDataResponse) String() string { return proto.CompactTextString(m) }
 func (*GetUIDataResponse) ProtoMessage()    {}
 func (*GetUIDataResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{17}
+	return fileDescriptor_admin_42294f563913d383, []int{17}
 }
 func (m *GetUIDataResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1075,7 +1075,7 @@ func (m *GetUIDataResponse_Value) Reset()         { *m = GetUIDataResponse_Value
 func (m *GetUIDataResponse_Value) String() string { return proto.CompactTextString(m) }
 func (*GetUIDataResponse_Value) ProtoMessage()    {}
 func (*GetUIDataResponse_Value) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{17, 0}
+	return fileDescriptor_admin_42294f563913d383, []int{17, 0}
 }
 func (m *GetUIDataResponse_Value) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1108,7 +1108,7 @@ func (m *ClusterRequest) Reset()         { *m = ClusterRequest{} }
 func (m *ClusterRequest) String() string { return proto.CompactTextString(m) }
 func (*ClusterRequest) ProtoMessage()    {}
 func (*ClusterRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{18}
+	return fileDescriptor_admin_42294f563913d383, []int{18}
 }
 func (m *ClusterRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1147,7 +1147,7 @@ func (m *ClusterResponse) Reset()         { *m = ClusterResponse{} }
 func (m *ClusterResponse) String() string { return proto.CompactTextString(m) }
 func (*ClusterResponse) ProtoMessage()    {}
 func (*ClusterResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{19}
+	return fileDescriptor_admin_42294f563913d383, []int{19}
 }
 func (m *ClusterResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1195,7 +1195,7 @@ func (m *DrainRequest) Reset()         { *m = DrainRequest{} }
 func (m *DrainRequest) String() string { return proto.CompactTextString(m) }
 func (*DrainRequest) ProtoMessage()    {}
 func (*DrainRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{20}
+	return fileDescriptor_admin_42294f563913d383, []int{20}
 }
 func (m *DrainRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1280,7 +1280,7 @@ func (m *DrainResponse) Reset()         { *m = DrainResponse{} }
 func (m *DrainResponse) String() string { return proto.CompactTextString(m) }
 func (*DrainResponse) ProtoMessage()    {}
 func (*DrainResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{21}
+	return fileDescriptor_admin_42294f563913d383, []int{21}
 }
 func (m *DrainResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1315,7 +1315,7 @@ func (m *DecommissionStatusRequest) Reset()         { *m = DecommissionStatusReq
 func (m *DecommissionStatusRequest) String() string { return proto.CompactTextString(m) }
 func (*DecommissionStatusRequest) ProtoMessage()    {}
 func (*DecommissionStatusRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{22}
+	return fileDescriptor_admin_42294f563913d383, []int{22}
 }
 func (m *DecommissionStatusRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1353,7 +1353,7 @@ func (m *DecommissionRequest) Reset()         { *m = DecommissionRequest{} }
 func (m *DecommissionRequest) String() string { return proto.CompactTextString(m) }
 func (*DecommissionRequest) ProtoMessage()    {}
 func (*DecommissionRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{23}
+	return fileDescriptor_admin_42294f563913d383, []int{23}
 }
 func (m *DecommissionRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1388,7 +1388,7 @@ func (m *DecommissionStatusResponse) Reset()         { *m = DecommissionStatusRe
 func (m *DecommissionStatusResponse) String() string { return proto.CompactTextString(m) }
 func (*DecommissionStatusResponse) ProtoMessage()    {}
 func (*DecommissionStatusResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{24}
+	return fileDescriptor_admin_42294f563913d383, []int{24}
 }
 func (m *DecommissionStatusResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1427,7 +1427,7 @@ func (m *DecommissionStatusResponse_Status) Reset()         { *m = DecommissionS
 func (m *DecommissionStatusResponse_Status) String() string { return proto.CompactTextString(m) }
 func (*DecommissionStatusResponse_Status) ProtoMessage()    {}
 func (*DecommissionStatusResponse_Status) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{24, 0}
+	return fileDescriptor_admin_42294f563913d383, []int{24, 0}
 }
 func (m *DecommissionStatusResponse_Status) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1469,7 +1469,7 @@ func (m *SettingsRequest) Reset()         { *m = SettingsRequest{} }
 func (m *SettingsRequest) String() string { return proto.CompactTextString(m) }
 func (*SettingsRequest) ProtoMessage()    {}
 func (*SettingsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{25}
+	return fileDescriptor_admin_42294f563913d383, []int{25}
 }
 func (m *SettingsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1503,7 +1503,7 @@ func (m *SettingsResponse) Reset()         { *m = SettingsResponse{} }
 func (m *SettingsResponse) String() string { return proto.CompactTextString(m) }
 func (*SettingsResponse) ProtoMessage()    {}
 func (*SettingsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{26}
+	return fileDescriptor_admin_42294f563913d383, []int{26}
 }
 func (m *SettingsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1539,7 +1539,7 @@ func (m *SettingsResponse_Value) Reset()         { *m = SettingsResponse_Value{}
 func (m *SettingsResponse_Value) String() string { return proto.CompactTextString(m) }
 func (*SettingsResponse_Value) ProtoMessage()    {}
 func (*SettingsResponse_Value) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{26, 0}
+	return fileDescriptor_admin_42294f563913d383, []int{26, 0}
 }
 func (m *SettingsResponse_Value) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1581,10 +1581,12 @@ var xxx_messageInfo_SettingsResponse_Value proto.InternalMessageInfo
 //   a liveness beacon. Absent either of these conditions, an error
 //   code will result.
 //
+// API: PUBLIC
 type HealthRequest struct {
 	// ready specifies whether the client wants to know whether the
 	// target node is ready to receive traffic. If a node is unready, an
 	// error will be returned.
+	// API: PUBLIC
 	Ready bool `protobuf:"varint,1,opt,name=ready,proto3" json:"ready,omitempty"`
 }
 
@@ -1592,7 +1594,7 @@ func (m *HealthRequest) Reset()         { *m = HealthRequest{} }
 func (m *HealthRequest) String() string { return proto.CompactTextString(m) }
 func (*HealthRequest) ProtoMessage()    {}
 func (*HealthRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{27}
+	return fileDescriptor_admin_42294f563913d383, []int{27}
 }
 func (m *HealthRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1619,6 +1621,7 @@ var xxx_messageInfo_HealthRequest proto.InternalMessageInfo
 
 // HealthResponse is the response to HealthRequest. It currently does not
 // contain any information.
+// API: PUBLIC
 type HealthResponse struct {
 }
 
@@ -1626,7 +1629,7 @@ func (m *HealthResponse) Reset()         { *m = HealthResponse{} }
 func (m *HealthResponse) String() string { return proto.CompactTextString(m) }
 func (*HealthResponse) ProtoMessage()    {}
 func (*HealthResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{28}
+	return fileDescriptor_admin_42294f563913d383, []int{28}
 }
 func (m *HealthResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1659,7 +1662,7 @@ func (m *LivenessRequest) Reset()         { *m = LivenessRequest{} }
 func (m *LivenessRequest) String() string { return proto.CompactTextString(m) }
 func (*LivenessRequest) ProtoMessage()    {}
 func (*LivenessRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{29}
+	return fileDescriptor_admin_42294f563913d383, []int{29}
 }
 func (m *LivenessRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1694,7 +1697,7 @@ func (m *LivenessResponse) Reset()         { *m = LivenessResponse{} }
 func (m *LivenessResponse) String() string { return proto.CompactTextString(m) }
 func (*LivenessResponse) ProtoMessage()    {}
 func (*LivenessResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{30}
+	return fileDescriptor_admin_42294f563913d383, []int{30}
 }
 func (m *LivenessResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1730,7 +1733,7 @@ func (m *JobsRequest) Reset()         { *m = JobsRequest{} }
 func (m *JobsRequest) String() string { return proto.CompactTextString(m) }
 func (*JobsRequest) ProtoMessage()    {}
 func (*JobsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{31}
+	return fileDescriptor_admin_42294f563913d383, []int{31}
 }
 func (m *JobsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1764,7 +1767,7 @@ func (m *JobsResponse) Reset()         { *m = JobsResponse{} }
 func (m *JobsResponse) String() string { return proto.CompactTextString(m) }
 func (*JobsResponse) ProtoMessage()    {}
 func (*JobsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{32}
+	return fileDescriptor_admin_42294f563913d383, []int{32}
 }
 func (m *JobsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1817,7 +1820,7 @@ func (m *JobsResponse_Job) Reset()         { *m = JobsResponse_Job{} }
 func (m *JobsResponse_Job) String() string { return proto.CompactTextString(m) }
 func (*JobsResponse_Job) ProtoMessage()    {}
 func (*JobsResponse_Job) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{32, 0}
+	return fileDescriptor_admin_42294f563913d383, []int{32, 0}
 }
 func (m *JobsResponse_Job) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1850,7 +1853,7 @@ func (m *LocationsRequest) Reset()         { *m = LocationsRequest{} }
 func (m *LocationsRequest) String() string { return proto.CompactTextString(m) }
 func (*LocationsRequest) ProtoMessage()    {}
 func (*LocationsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{33}
+	return fileDescriptor_admin_42294f563913d383, []int{33}
 }
 func (m *LocationsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1884,7 +1887,7 @@ func (m *LocationsResponse) Reset()         { *m = LocationsResponse{} }
 func (m *LocationsResponse) String() string { return proto.CompactTextString(m) }
 func (*LocationsResponse) ProtoMessage()    {}
 func (*LocationsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{34}
+	return fileDescriptor_admin_42294f563913d383, []int{34}
 }
 func (m *LocationsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1920,7 +1923,7 @@ func (m *LocationsResponse_Location) Reset()         { *m = LocationsResponse_Lo
 func (m *LocationsResponse_Location) String() string { return proto.CompactTextString(m) }
 func (*LocationsResponse_Location) ProtoMessage()    {}
 func (*LocationsResponse_Location) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{34, 0}
+	return fileDescriptor_admin_42294f563913d383, []int{34, 0}
 }
 func (m *LocationsResponse_Location) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1962,7 +1965,7 @@ func (m *RangeLogRequest) Reset()         { *m = RangeLogRequest{} }
 func (m *RangeLogRequest) String() string { return proto.CompactTextString(m) }
 func (*RangeLogRequest) ProtoMessage()    {}
 func (*RangeLogRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{35}
+	return fileDescriptor_admin_42294f563913d383, []int{35}
 }
 func (m *RangeLogRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1996,7 +1999,7 @@ func (m *RangeLogResponse) Reset()         { *m = RangeLogResponse{} }
 func (m *RangeLogResponse) String() string { return proto.CompactTextString(m) }
 func (*RangeLogResponse) ProtoMessage()    {}
 func (*RangeLogResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{36}
+	return fileDescriptor_admin_42294f563913d383, []int{36}
 }
 func (m *RangeLogResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2036,7 +2039,7 @@ func (m *RangeLogResponse_PrettyInfo) Reset()         { *m = RangeLogResponse_Pr
 func (m *RangeLogResponse_PrettyInfo) String() string { return proto.CompactTextString(m) }
 func (*RangeLogResponse_PrettyInfo) ProtoMessage()    {}
 func (*RangeLogResponse_PrettyInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{36, 0}
+	return fileDescriptor_admin_42294f563913d383, []int{36, 0}
 }
 func (m *RangeLogResponse_PrettyInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2070,7 +2073,7 @@ func (m *RangeLogResponse_Event) Reset()         { *m = RangeLogResponse_Event{}
 func (m *RangeLogResponse_Event) String() string { return proto.CompactTextString(m) }
 func (*RangeLogResponse_Event) ProtoMessage()    {}
 func (*RangeLogResponse_Event) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{36, 1}
+	return fileDescriptor_admin_42294f563913d383, []int{36, 1}
 }
 func (m *RangeLogResponse_Event) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2105,7 +2108,7 @@ func (m *QueryPlanRequest) Reset()         { *m = QueryPlanRequest{} }
 func (m *QueryPlanRequest) String() string { return proto.CompactTextString(m) }
 func (*QueryPlanRequest) ProtoMessage()    {}
 func (*QueryPlanRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{37}
+	return fileDescriptor_admin_42294f563913d383, []int{37}
 }
 func (m *QueryPlanRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2140,7 +2143,7 @@ func (m *QueryPlanResponse) Reset()         { *m = QueryPlanResponse{} }
 func (m *QueryPlanResponse) String() string { return proto.CompactTextString(m) }
 func (*QueryPlanResponse) ProtoMessage()    {}
 func (*QueryPlanResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{38}
+	return fileDescriptor_admin_42294f563913d383, []int{38}
 }
 func (m *QueryPlanResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2172,7 +2175,7 @@ func (m *DataDistributionRequest) Reset()         { *m = DataDistributionRequest
 func (m *DataDistributionRequest) String() string { return proto.CompactTextString(m) }
 func (*DataDistributionRequest) ProtoMessage()    {}
 func (*DataDistributionRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{39}
+	return fileDescriptor_admin_42294f563913d383, []int{39}
 }
 func (m *DataDistributionRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2208,7 +2211,7 @@ func (m *DataDistributionResponse) Reset()         { *m = DataDistributionRespon
 func (m *DataDistributionResponse) String() string { return proto.CompactTextString(m) }
 func (*DataDistributionResponse) ProtoMessage()    {}
 func (*DataDistributionResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{40}
+	return fileDescriptor_admin_42294f563913d383, []int{40}
 }
 func (m *DataDistributionResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2246,7 +2249,7 @@ func (m *DataDistributionResponse_ZoneConfig) Reset()         { *m = DataDistrib
 func (m *DataDistributionResponse_ZoneConfig) String() string { return proto.CompactTextString(m) }
 func (*DataDistributionResponse_ZoneConfig) ProtoMessage()    {}
 func (*DataDistributionResponse_ZoneConfig) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{40, 0}
+	return fileDescriptor_admin_42294f563913d383, []int{40, 0}
 }
 func (m *DataDistributionResponse_ZoneConfig) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2281,7 +2284,7 @@ func (m *DataDistributionResponse_TableInfo) Reset()         { *m = DataDistribu
 func (m *DataDistributionResponse_TableInfo) String() string { return proto.CompactTextString(m) }
 func (*DataDistributionResponse_TableInfo) ProtoMessage()    {}
 func (*DataDistributionResponse_TableInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{40, 1}
+	return fileDescriptor_admin_42294f563913d383, []int{40, 1}
 }
 func (m *DataDistributionResponse_TableInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2315,7 +2318,7 @@ func (m *DataDistributionResponse_DatabaseInfo) Reset()         { *m = DataDistr
 func (m *DataDistributionResponse_DatabaseInfo) String() string { return proto.CompactTextString(m) }
 func (*DataDistributionResponse_DatabaseInfo) ProtoMessage()    {}
 func (*DataDistributionResponse_DatabaseInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{40, 2}
+	return fileDescriptor_admin_42294f563913d383, []int{40, 2}
 }
 func (m *DataDistributionResponse_DatabaseInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2348,7 +2351,7 @@ func (m *MetricMetadataRequest) Reset()         { *m = MetricMetadataRequest{} }
 func (m *MetricMetadataRequest) String() string { return proto.CompactTextString(m) }
 func (*MetricMetadataRequest) ProtoMessage()    {}
 func (*MetricMetadataRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{41}
+	return fileDescriptor_admin_42294f563913d383, []int{41}
 }
 func (m *MetricMetadataRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2382,7 +2385,7 @@ func (m *MetricMetadataResponse) Reset()         { *m = MetricMetadataResponse{}
 func (m *MetricMetadataResponse) String() string { return proto.CompactTextString(m) }
 func (*MetricMetadataResponse) ProtoMessage()    {}
 func (*MetricMetadataResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{42}
+	return fileDescriptor_admin_42294f563913d383, []int{42}
 }
 func (m *MetricMetadataResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2425,7 +2428,7 @@ func (m *EnqueueRangeRequest) Reset()         { *m = EnqueueRangeRequest{} }
 func (m *EnqueueRangeRequest) String() string { return proto.CompactTextString(m) }
 func (*EnqueueRangeRequest) ProtoMessage()    {}
 func (*EnqueueRangeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{43}
+	return fileDescriptor_admin_42294f563913d383, []int{43}
 }
 func (m *EnqueueRangeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2458,7 +2461,7 @@ func (m *EnqueueRangeResponse) Reset()         { *m = EnqueueRangeResponse{} }
 func (m *EnqueueRangeResponse) String() string { return proto.CompactTextString(m) }
 func (*EnqueueRangeResponse) ProtoMessage()    {}
 func (*EnqueueRangeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{44}
+	return fileDescriptor_admin_42294f563913d383, []int{44}
 }
 func (m *EnqueueRangeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2495,7 +2498,7 @@ func (m *EnqueueRangeResponse_Details) Reset()         { *m = EnqueueRangeRespon
 func (m *EnqueueRangeResponse_Details) String() string { return proto.CompactTextString(m) }
 func (*EnqueueRangeResponse_Details) ProtoMessage()    {}
 func (*EnqueueRangeResponse_Details) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{44, 0}
+	return fileDescriptor_admin_42294f563913d383, []int{44, 0}
 }
 func (m *EnqueueRangeResponse_Details) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2528,7 +2531,7 @@ func (m *ChartCatalogRequest) Reset()         { *m = ChartCatalogRequest{} }
 func (m *ChartCatalogRequest) String() string { return proto.CompactTextString(m) }
 func (*ChartCatalogRequest) ProtoMessage()    {}
 func (*ChartCatalogRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{45}
+	return fileDescriptor_admin_42294f563913d383, []int{45}
 }
 func (m *ChartCatalogRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2562,7 +2565,7 @@ func (m *ChartCatalogResponse) Reset()         { *m = ChartCatalogResponse{} }
 func (m *ChartCatalogResponse) String() string { return proto.CompactTextString(m) }
 func (*ChartCatalogResponse) ProtoMessage()    {}
 func (*ChartCatalogResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_d35ae12d295a7e1d, []int{46}
+	return fileDescriptor_admin_42294f563913d383, []int{46}
 }
 func (m *ChartCatalogResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2728,6 +2731,7 @@ type AdminClient interface {
 	// Settings returns the cluster-wide settings for the cluster.
 	Settings(ctx context.Context, in *SettingsRequest, opts ...grpc.CallOption) (*SettingsResponse, error)
 	// Health returns liveness for the node target of the request.
+	// API: PUBLIC
 	Health(ctx context.Context, in *HealthRequest, opts ...grpc.CallOption) (*HealthResponse, error)
 	// Liveness returns the liveness state of all nodes on the cluster.
 	Liveness(ctx context.Context, in *LivenessRequest, opts ...grpc.CallOption) (*LivenessResponse, error)
@@ -3073,6 +3077,7 @@ type AdminServer interface {
 	// Settings returns the cluster-wide settings for the cluster.
 	Settings(context.Context, *SettingsRequest) (*SettingsResponse, error)
 	// Health returns liveness for the node target of the request.
+	// API: PUBLIC
 	Health(context.Context, *HealthRequest) (*HealthResponse, error)
 	// Liveness returns the liveness state of all nodes on the cluster.
 	Liveness(context.Context, *LivenessRequest) (*LivenessResponse, error)
@@ -15675,9 +15680,9 @@ var (
 	ErrIntOverflowAdmin   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("server/serverpb/admin.proto", fileDescriptor_admin_d35ae12d295a7e1d) }
+func init() { proto.RegisterFile("server/serverpb/admin.proto", fileDescriptor_admin_42294f563913d383) }
 
-var fileDescriptor_admin_d35ae12d295a7e1d = []byte{
+var fileDescriptor_admin_42294f563913d383 = []byte{
 	// 4157 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xbc, 0x3a, 0xcf, 0x73, 0x1b, 0xd7,
 	0x79, 0x5a, 0x80, 0xf8, 0xf5, 0x11, 0x20, 0xc1, 0x27, 0x8a, 0x02, 0x21, 0x85, 0xa0, 0x57, 0x51,

--- a/pkg/server/serverpb/admin.proto
+++ b/pkg/server/serverpb/admin.proto
@@ -497,15 +497,18 @@ message SettingsResponse {
 //   a liveness beacon. Absent either of these conditions, an error
 //   code will result.
 //
+// API: PUBLIC
 message HealthRequest {
   // ready specifies whether the client wants to know whether the
   // target node is ready to receive traffic. If a node is unready, an
   // error will be returned.
+  // API: PUBLIC
   bool ready = 1;
 }
 
 // HealthResponse is the response to HealthRequest. It currently does not
 // contain any information.
+// API: PUBLIC
 message HealthResponse {
 }
 
@@ -816,6 +819,7 @@ service Admin {
   }
 
   // Health returns liveness for the node target of the request.
+  // API: PUBLIC
   rpc Health(HealthRequest) returns (HealthResponse) {
     option (google.api.http) = {
       get: "/_admin/v1/health"

--- a/pkg/server/serverpb/status.pb.go
+++ b/pkg/server/serverpb/status.pb.go
@@ -65,7 +65,7 @@ func (x StacksType) String() string {
 	return proto.EnumName(StacksType_name, int32(x))
 }
 func (StacksType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{0}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{0}
 }
 
 // Represents the type of file.
@@ -92,7 +92,7 @@ func (x FileType) String() string {
 	return proto.EnumName(FileType_name, int32(x))
 }
 func (FileType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{1}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{1}
 }
 
 // We use an enum to allow reporting of client certs and potential others (eg:
@@ -129,7 +129,7 @@ func (x CertificateDetails_CertificateType) String() string {
 	return proto.EnumName(CertificateDetails_CertificateType_name, int32(x))
 }
 func (CertificateDetails_CertificateType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{1, 0}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{1, 0}
 }
 
 type ProfileRequest_Type int32
@@ -152,7 +152,7 @@ func (x ProfileRequest_Type) String() string {
 	return proto.EnumName(ProfileRequest_Type_name, int32(x))
 }
 func (ProfileRequest_Type) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{37, 0}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{37, 0}
 }
 
 // Enum for phase of execution.
@@ -176,7 +176,7 @@ func (x ActiveQuery_Phase) String() string {
 	return proto.EnumName(ActiveQuery_Phase_name, int32(x))
 }
 func (ActiveQuery_Phase) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{45, 0}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{45, 0}
 }
 
 type CertificatesRequest struct {
@@ -189,7 +189,7 @@ func (m *CertificatesRequest) Reset()         { *m = CertificatesRequest{} }
 func (m *CertificatesRequest) String() string { return proto.CompactTextString(m) }
 func (*CertificatesRequest) ProtoMessage()    {}
 func (*CertificatesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{0}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{0}
 }
 func (m *CertificatesRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -228,7 +228,7 @@ func (m *CertificateDetails) Reset()         { *m = CertificateDetails{} }
 func (m *CertificateDetails) String() string { return proto.CompactTextString(m) }
 func (*CertificateDetails) ProtoMessage()    {}
 func (*CertificateDetails) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{1}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{1}
 }
 func (m *CertificateDetails) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -269,7 +269,7 @@ func (m *CertificateDetails_Fields) Reset()         { *m = CertificateDetails_Fi
 func (m *CertificateDetails_Fields) String() string { return proto.CompactTextString(m) }
 func (*CertificateDetails_Fields) ProtoMessage()    {}
 func (*CertificateDetails_Fields) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{1, 0}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{1, 0}
 }
 func (m *CertificateDetails_Fields) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -302,7 +302,7 @@ func (m *CertificatesResponse) Reset()         { *m = CertificatesResponse{} }
 func (m *CertificatesResponse) String() string { return proto.CompactTextString(m) }
 func (*CertificatesResponse) ProtoMessage()    {}
 func (*CertificatesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{2}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{2}
 }
 func (m *CertificatesResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -339,7 +339,7 @@ func (m *DetailsRequest) Reset()         { *m = DetailsRequest{} }
 func (m *DetailsRequest) String() string { return proto.CompactTextString(m) }
 func (*DetailsRequest) ProtoMessage()    {}
 func (*DetailsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{3}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{3}
 }
 func (m *DetailsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -376,7 +376,7 @@ func (m *SystemInfo) Reset()         { *m = SystemInfo{} }
 func (m *SystemInfo) String() string { return proto.CompactTextString(m) }
 func (*SystemInfo) ProtoMessage()    {}
 func (*SystemInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{4}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{4}
 }
 func (m *SystemInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -413,7 +413,7 @@ func (m *DetailsResponse) Reset()         { *m = DetailsResponse{} }
 func (m *DetailsResponse) String() string { return proto.CompactTextString(m) }
 func (*DetailsResponse) ProtoMessage()    {}
 func (*DetailsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{5}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{5}
 }
 func (m *DetailsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -438,6 +438,9 @@ func (m *DetailsResponse) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_DetailsResponse proto.InternalMessageInfo
 
+// NodesRequest requests a copy of the node information as known to gossip
+// and the KV layer.
+// API: PUBLIC ALPHA
 type NodesRequest struct {
 }
 
@@ -445,7 +448,7 @@ func (m *NodesRequest) Reset()         { *m = NodesRequest{} }
 func (m *NodesRequest) String() string { return proto.CompactTextString(m) }
 func (*NodesRequest) ProtoMessage()    {}
 func (*NodesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{6}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{6}
 }
 func (m *NodesRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -470,8 +473,12 @@ func (m *NodesRequest) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_NodesRequest proto.InternalMessageInfo
 
+// NodesResponse describe the nodes in the cluster.
 type NodesResponse struct {
-	Nodes            []statuspb.NodeStatus                                                                 `protobuf:"bytes,1,rep,name=nodes,proto3" json:"nodes"`
+	// nodes carries the status payloads for all nodes in the cluster.
+	// API: PUBLIC ALPHA
+	Nodes []statuspb.NodeStatus `protobuf:"bytes,1,rep,name=nodes,proto3" json:"nodes"`
+	// liveness_by_node_id maps each node ID to a liveness status.
 	LivenessByNodeID map[github_com_cockroachdb_cockroach_pkg_roachpb.NodeID]kvserverpb.NodeLivenessStatus `protobuf:"bytes,2,rep,name=liveness_by_node_id,json=livenessByNodeId,proto3,castkey=github.com/cockroachdb/cockroach/pkg/roachpb.NodeID" json:"liveness_by_node_id" protobuf_key:"varint,1,opt,name=key,proto3" protobuf_val:"varint,2,opt,name=value,proto3,enum=cockroach.kv.kvserver.storagepb.NodeLivenessStatus"`
 }
 
@@ -479,7 +486,7 @@ func (m *NodesResponse) Reset()         { *m = NodesResponse{} }
 func (m *NodesResponse) String() string { return proto.CompactTextString(m) }
 func (*NodesResponse) ProtoMessage()    {}
 func (*NodesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{7}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{7}
 }
 func (m *NodesResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -514,7 +521,7 @@ func (m *NodeRequest) Reset()         { *m = NodeRequest{} }
 func (m *NodeRequest) String() string { return proto.CompactTextString(m) }
 func (*NodeRequest) ProtoMessage()    {}
 func (*NodeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{8}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{8}
 }
 func (m *NodeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -559,7 +566,7 @@ func (m *RaftState) Reset()         { *m = RaftState{} }
 func (m *RaftState) String() string { return proto.CompactTextString(m) }
 func (*RaftState) ProtoMessage()    {}
 func (*RaftState) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{9}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{9}
 }
 func (m *RaftState) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -596,7 +603,7 @@ func (m *RaftState_Progress) Reset()         { *m = RaftState_Progress{} }
 func (m *RaftState_Progress) String() string { return proto.CompactTextString(m) }
 func (*RaftState_Progress) ProtoMessage()    {}
 func (*RaftState_Progress) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{9, 0}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{9, 0}
 }
 func (m *RaftState_Progress) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -641,7 +648,7 @@ func (m *RangeProblems) Reset()         { *m = RangeProblems{} }
 func (m *RangeProblems) String() string { return proto.CompactTextString(m) }
 func (*RangeProblems) ProtoMessage()    {}
 func (*RangeProblems) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{10}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{10}
 }
 func (m *RangeProblems) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -677,7 +684,7 @@ func (m *RangeStatistics) Reset()         { *m = RangeStatistics{} }
 func (m *RangeStatistics) String() string { return proto.CompactTextString(m) }
 func (*RangeStatistics) ProtoMessage()    {}
 func (*RangeStatistics) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{11}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{11}
 }
 func (m *RangeStatistics) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -711,7 +718,7 @@ func (m *PrettySpan) Reset()         { *m = PrettySpan{} }
 func (m *PrettySpan) String() string { return proto.CompactTextString(m) }
 func (*PrettySpan) ProtoMessage()    {}
 func (*PrettySpan) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{12}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{12}
 }
 func (m *PrettySpan) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -757,7 +764,7 @@ func (m *RangeInfo) Reset()         { *m = RangeInfo{} }
 func (m *RangeInfo) String() string { return proto.CompactTextString(m) }
 func (*RangeInfo) ProtoMessage()    {}
 func (*RangeInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{13}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{13}
 }
 func (m *RangeInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -793,7 +800,7 @@ func (m *RangesRequest) Reset()         { *m = RangesRequest{} }
 func (m *RangesRequest) String() string { return proto.CompactTextString(m) }
 func (*RangesRequest) ProtoMessage()    {}
 func (*RangesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{14}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{14}
 }
 func (m *RangesRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -826,7 +833,7 @@ func (m *RangesResponse) Reset()         { *m = RangesResponse{} }
 func (m *RangesResponse) String() string { return proto.CompactTextString(m) }
 func (*RangesResponse) ProtoMessage()    {}
 func (*RangesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{15}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{15}
 }
 func (m *RangesResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -861,7 +868,7 @@ func (m *GossipRequest) Reset()         { *m = GossipRequest{} }
 func (m *GossipRequest) String() string { return proto.CompactTextString(m) }
 func (*GossipRequest) ProtoMessage()    {}
 func (*GossipRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{16}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{16}
 }
 func (m *GossipRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -896,7 +903,7 @@ func (m *EngineStatsInfo) Reset()         { *m = EngineStatsInfo{} }
 func (m *EngineStatsInfo) String() string { return proto.CompactTextString(m) }
 func (*EngineStatsInfo) ProtoMessage()    {}
 func (*EngineStatsInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{17}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{17}
 }
 func (m *EngineStatsInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -931,7 +938,7 @@ func (m *EngineStatsRequest) Reset()         { *m = EngineStatsRequest{} }
 func (m *EngineStatsRequest) String() string { return proto.CompactTextString(m) }
 func (*EngineStatsRequest) ProtoMessage()    {}
 func (*EngineStatsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{18}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{18}
 }
 func (m *EngineStatsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -964,7 +971,7 @@ func (m *EngineStatsResponse) Reset()         { *m = EngineStatsResponse{} }
 func (m *EngineStatsResponse) String() string { return proto.CompactTextString(m) }
 func (*EngineStatsResponse) ProtoMessage()    {}
 func (*EngineStatsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{19}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{19}
 }
 func (m *EngineStatsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -998,7 +1005,7 @@ func (m *TraceEvent) Reset()         { *m = TraceEvent{} }
 func (m *TraceEvent) String() string { return proto.CompactTextString(m) }
 func (*TraceEvent) ProtoMessage()    {}
 func (*TraceEvent) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{20}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{20}
 }
 func (m *TraceEvent) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1032,7 +1039,7 @@ func (m *AllocatorDryRun) Reset()         { *m = AllocatorDryRun{} }
 func (m *AllocatorDryRun) String() string { return proto.CompactTextString(m) }
 func (*AllocatorDryRun) ProtoMessage()    {}
 func (*AllocatorDryRun) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{21}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{21}
 }
 func (m *AllocatorDryRun) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1065,7 +1072,7 @@ func (m *AllocatorRangeRequest) Reset()         { *m = AllocatorRangeRequest{} }
 func (m *AllocatorRangeRequest) String() string { return proto.CompactTextString(m) }
 func (*AllocatorRangeRequest) ProtoMessage()    {}
 func (*AllocatorRangeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{22}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{22}
 }
 func (m *AllocatorRangeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1101,7 +1108,7 @@ func (m *AllocatorRangeResponse) Reset()         { *m = AllocatorRangeResponse{}
 func (m *AllocatorRangeResponse) String() string { return proto.CompactTextString(m) }
 func (*AllocatorRangeResponse) ProtoMessage()    {}
 func (*AllocatorRangeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{23}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{23}
 }
 func (m *AllocatorRangeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1135,7 +1142,7 @@ func (m *AllocatorRequest) Reset()         { *m = AllocatorRequest{} }
 func (m *AllocatorRequest) String() string { return proto.CompactTextString(m) }
 func (*AllocatorRequest) ProtoMessage()    {}
 func (*AllocatorRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{24}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{24}
 }
 func (m *AllocatorRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1168,7 +1175,7 @@ func (m *AllocatorResponse) Reset()         { *m = AllocatorResponse{} }
 func (m *AllocatorResponse) String() string { return proto.CompactTextString(m) }
 func (*AllocatorResponse) ProtoMessage()    {}
 func (*AllocatorResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{25}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{25}
 }
 func (m *AllocatorResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1201,7 +1208,7 @@ func (m *JSONResponse) Reset()         { *m = JSONResponse{} }
 func (m *JSONResponse) String() string { return proto.CompactTextString(m) }
 func (*JSONResponse) ProtoMessage()    {}
 func (*JSONResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{26}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{26}
 }
 func (m *JSONResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1237,7 +1244,7 @@ func (m *ResponseError) Reset()         { *m = ResponseError{} }
 func (m *ResponseError) String() string { return proto.CompactTextString(m) }
 func (*ResponseError) ProtoMessage()    {}
 func (*ResponseError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{27}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{27}
 }
 func (m *ResponseError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1289,7 +1296,7 @@ func (m *LogsRequest) Reset()         { *m = LogsRequest{} }
 func (m *LogsRequest) String() string { return proto.CompactTextString(m) }
 func (*LogsRequest) ProtoMessage()    {}
 func (*LogsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{28}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{28}
 }
 func (m *LogsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1322,7 +1329,7 @@ func (m *LogEntriesResponse) Reset()         { *m = LogEntriesResponse{} }
 func (m *LogEntriesResponse) String() string { return proto.CompactTextString(m) }
 func (*LogEntriesResponse) ProtoMessage()    {}
 func (*LogEntriesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{29}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{29}
 }
 func (m *LogEntriesResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1357,7 +1364,7 @@ func (m *LogFilesListRequest) Reset()         { *m = LogFilesListRequest{} }
 func (m *LogFilesListRequest) String() string { return proto.CompactTextString(m) }
 func (*LogFilesListRequest) ProtoMessage()    {}
 func (*LogFilesListRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{30}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{30}
 }
 func (m *LogFilesListRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1390,7 +1397,7 @@ func (m *LogFilesListResponse) Reset()         { *m = LogFilesListResponse{} }
 func (m *LogFilesListResponse) String() string { return proto.CompactTextString(m) }
 func (*LogFilesListResponse) ProtoMessage()    {}
 func (*LogFilesListResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{31}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{31}
 }
 func (m *LogFilesListResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1438,7 +1445,7 @@ func (m *LogFileRequest) Reset()         { *m = LogFileRequest{} }
 func (m *LogFileRequest) String() string { return proto.CompactTextString(m) }
 func (*LogFileRequest) ProtoMessage()    {}
 func (*LogFileRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{32}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{32}
 }
 func (m *LogFileRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1474,7 +1481,7 @@ func (m *StacksRequest) Reset()         { *m = StacksRequest{} }
 func (m *StacksRequest) String() string { return proto.CompactTextString(m) }
 func (*StacksRequest) ProtoMessage()    {}
 func (*StacksRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{33}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{33}
 }
 func (m *StacksRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1510,7 +1517,7 @@ func (m *File) Reset()         { *m = File{} }
 func (m *File) String() string { return proto.CompactTextString(m) }
 func (*File) ProtoMessage()    {}
 func (*File) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{34}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{34}
 }
 func (m *File) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1554,7 +1561,7 @@ func (m *GetFilesRequest) Reset()         { *m = GetFilesRequest{} }
 func (m *GetFilesRequest) String() string { return proto.CompactTextString(m) }
 func (*GetFilesRequest) ProtoMessage()    {}
 func (*GetFilesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{35}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{35}
 }
 func (m *GetFilesRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1587,7 +1594,7 @@ func (m *GetFilesResponse) Reset()         { *m = GetFilesResponse{} }
 func (m *GetFilesResponse) String() string { return proto.CompactTextString(m) }
 func (*GetFilesResponse) ProtoMessage()    {}
 func (*GetFilesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{36}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{36}
 }
 func (m *GetFilesResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1625,7 +1632,7 @@ func (m *ProfileRequest) Reset()         { *m = ProfileRequest{} }
 func (m *ProfileRequest) String() string { return proto.CompactTextString(m) }
 func (*ProfileRequest) ProtoMessage()    {}
 func (*ProfileRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{37}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{37}
 }
 func (m *ProfileRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1660,7 +1667,7 @@ func (m *MetricsRequest) Reset()         { *m = MetricsRequest{} }
 func (m *MetricsRequest) String() string { return proto.CompactTextString(m) }
 func (*MetricsRequest) ProtoMessage()    {}
 func (*MetricsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{38}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{38}
 }
 func (m *MetricsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1694,7 +1701,7 @@ func (m *RaftRangeNode) Reset()         { *m = RaftRangeNode{} }
 func (m *RaftRangeNode) String() string { return proto.CompactTextString(m) }
 func (*RaftRangeNode) ProtoMessage()    {}
 func (*RaftRangeNode) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{39}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{39}
 }
 func (m *RaftRangeNode) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1727,7 +1734,7 @@ func (m *RaftRangeError) Reset()         { *m = RaftRangeError{} }
 func (m *RaftRangeError) String() string { return proto.CompactTextString(m) }
 func (*RaftRangeError) ProtoMessage()    {}
 func (*RaftRangeError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{40}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{40}
 }
 func (m *RaftRangeError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1762,7 +1769,7 @@ func (m *RaftRangeStatus) Reset()         { *m = RaftRangeStatus{} }
 func (m *RaftRangeStatus) String() string { return proto.CompactTextString(m) }
 func (*RaftRangeStatus) ProtoMessage()    {}
 func (*RaftRangeStatus) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{41}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{41}
 }
 func (m *RaftRangeStatus) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1795,7 +1802,7 @@ func (m *RaftDebugRequest) Reset()         { *m = RaftDebugRequest{} }
 func (m *RaftDebugRequest) String() string { return proto.CompactTextString(m) }
 func (*RaftDebugRequest) ProtoMessage()    {}
 func (*RaftDebugRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{42}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{42}
 }
 func (m *RaftDebugRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1829,7 +1836,7 @@ func (m *RaftDebugResponse) Reset()         { *m = RaftDebugResponse{} }
 func (m *RaftDebugResponse) String() string { return proto.CompactTextString(m) }
 func (*RaftDebugResponse) ProtoMessage()    {}
 func (*RaftDebugResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{43}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{43}
 }
 func (m *RaftDebugResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1887,7 +1894,7 @@ func (m *TxnInfo) Reset()         { *m = TxnInfo{} }
 func (m *TxnInfo) String() string { return proto.CompactTextString(m) }
 func (*TxnInfo) ProtoMessage()    {}
 func (*TxnInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{44}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{44}
 }
 func (m *TxnInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1935,7 +1942,7 @@ func (m *ActiveQuery) Reset()         { *m = ActiveQuery{} }
 func (m *ActiveQuery) String() string { return proto.CompactTextString(m) }
 func (*ActiveQuery) ProtoMessage()    {}
 func (*ActiveQuery) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{45}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{45}
 }
 func (m *ActiveQuery) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1970,7 +1977,7 @@ func (m *ListSessionsRequest) Reset()         { *m = ListSessionsRequest{} }
 func (m *ListSessionsRequest) String() string { return proto.CompactTextString(m) }
 func (*ListSessionsRequest) ProtoMessage()    {}
 func (*ListSessionsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{46}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{46}
 }
 func (m *ListSessionsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2029,7 +2036,7 @@ func (m *Session) Reset()         { *m = Session{} }
 func (m *Session) String() string { return proto.CompactTextString(m) }
 func (*Session) ProtoMessage()    {}
 func (*Session) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{47}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{47}
 }
 func (m *Session) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2066,7 +2073,7 @@ func (m *ListSessionsError) Reset()         { *m = ListSessionsError{} }
 func (m *ListSessionsError) String() string { return proto.CompactTextString(m) }
 func (*ListSessionsError) ProtoMessage()    {}
 func (*ListSessionsError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{48}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{48}
 }
 func (m *ListSessionsError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2103,7 +2110,7 @@ func (m *ListSessionsResponse) Reset()         { *m = ListSessionsResponse{} }
 func (m *ListSessionsResponse) String() string { return proto.CompactTextString(m) }
 func (*ListSessionsResponse) ProtoMessage()    {}
 func (*ListSessionsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{49}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{49}
 }
 func (m *ListSessionsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2149,7 +2156,7 @@ func (m *CancelQueryRequest) Reset()         { *m = CancelQueryRequest{} }
 func (m *CancelQueryRequest) String() string { return proto.CompactTextString(m) }
 func (*CancelQueryRequest) ProtoMessage()    {}
 func (*CancelQueryRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{50}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{50}
 }
 func (m *CancelQueryRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2186,7 +2193,7 @@ func (m *CancelQueryResponse) Reset()         { *m = CancelQueryResponse{} }
 func (m *CancelQueryResponse) String() string { return proto.CompactTextString(m) }
 func (*CancelQueryResponse) ProtoMessage()    {}
 func (*CancelQueryResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{51}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{51}
 }
 func (m *CancelQueryResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2228,7 +2235,7 @@ func (m *CancelSessionRequest) Reset()         { *m = CancelSessionRequest{} }
 func (m *CancelSessionRequest) String() string { return proto.CompactTextString(m) }
 func (*CancelSessionRequest) ProtoMessage()    {}
 func (*CancelSessionRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{52}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{52}
 }
 func (m *CancelSessionRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2262,7 +2269,7 @@ func (m *CancelSessionResponse) Reset()         { *m = CancelSessionResponse{} }
 func (m *CancelSessionResponse) String() string { return proto.CompactTextString(m) }
 func (*CancelSessionResponse) ProtoMessage()    {}
 func (*CancelSessionResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{53}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{53}
 }
 func (m *CancelSessionResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2297,7 +2304,7 @@ func (m *SpanStatsRequest) Reset()         { *m = SpanStatsRequest{} }
 func (m *SpanStatsRequest) String() string { return proto.CompactTextString(m) }
 func (*SpanStatsRequest) ProtoMessage()    {}
 func (*SpanStatsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{54}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{54}
 }
 func (m *SpanStatsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2332,7 +2339,7 @@ func (m *SpanStatsResponse) Reset()         { *m = SpanStatsResponse{} }
 func (m *SpanStatsResponse) String() string { return proto.CompactTextString(m) }
 func (*SpanStatsResponse) ProtoMessage()    {}
 func (*SpanStatsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{55}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{55}
 }
 func (m *SpanStatsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2366,7 +2373,7 @@ func (m *ProblemRangesRequest) Reset()         { *m = ProblemRangesRequest{} }
 func (m *ProblemRangesRequest) String() string { return proto.CompactTextString(m) }
 func (*ProblemRangesRequest) ProtoMessage()    {}
 func (*ProblemRangesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{56}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{56}
 }
 func (m *ProblemRangesRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2401,7 +2408,7 @@ func (m *ProblemRangesResponse) Reset()         { *m = ProblemRangesResponse{} }
 func (m *ProblemRangesResponse) String() string { return proto.CompactTextString(m) }
 func (*ProblemRangesResponse) ProtoMessage()    {}
 func (*ProblemRangesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{57}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{57}
 }
 func (m *ProblemRangesResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2442,7 +2449,7 @@ func (m *ProblemRangesResponse_NodeProblems) Reset()         { *m = ProblemRange
 func (m *ProblemRangesResponse_NodeProblems) String() string { return proto.CompactTextString(m) }
 func (*ProblemRangesResponse_NodeProblems) ProtoMessage()    {}
 func (*ProblemRangesResponse_NodeProblems) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{57, 0}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{57, 0}
 }
 func (m *ProblemRangesResponse_NodeProblems) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2469,8 +2476,7 @@ var xxx_messageInfo_ProblemRangesResponse_NodeProblems proto.InternalMessageInfo
 
 // HotRangesRequest queries one or more cluster nodes for a list
 // of ranges currently considered “hot” by the node(s).
-//
-// The server responds with a HotRangesResponse payload.
+// API: PUBLIC ALPHA
 type HotRangesRequest struct {
 	// NodeID indicates which node to query for a hot range report.
 	// It is posssible to populate any node ID; if the node receiving
@@ -2479,6 +2485,7 @@ type HotRangesRequest struct {
 	//
 	// If left empty, the request is forwarded to every node
 	// in the cluster.
+	// API: PUBLIC ALPHA
 	NodeID string `protobuf:"bytes,1,opt,name=node_id,json=nodeId,proto3" json:"node_id,omitempty"`
 }
 
@@ -2486,7 +2493,7 @@ func (m *HotRangesRequest) Reset()         { *m = HotRangesRequest{} }
 func (m *HotRangesRequest) String() string { return proto.CompactTextString(m) }
 func (*HotRangesRequest) ProtoMessage()    {}
 func (*HotRangesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{58}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{58}
 }
 func (m *HotRangesRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2513,12 +2520,15 @@ var xxx_messageInfo_HotRangesRequest proto.InternalMessageInfo
 
 // HotRangesResponse is the payload produced in response
 // to a HotRangesRequest.
+// API: PUBLIC ALPHA
 type HotRangesResponse struct {
 	// NodeID is the node that received the HotRangesRequest and
 	// forwarded requests to the selected target node(s).
+	// API: PUBLIC ALPHA
 	NodeID github_com_cockroachdb_cockroach_pkg_roachpb.NodeID `protobuf:"varint,1,opt,name=node_id,json=nodeId,proto3,casttype=github.com/cockroachdb/cockroach/pkg/roachpb.NodeID" json:"node_id,omitempty"`
 	// HotRangesByNodeID contains a hot range report for each selected
 	// target node ID in the HotRangesRequest.
+	// API: PUBLIC ALPHA
 	HotRangesByNodeID map[github_com_cockroachdb_cockroach_pkg_roachpb.NodeID]HotRangesResponse_NodeResponse `protobuf:"bytes,2,rep,name=hot_ranges_by_node_id,json=hotRangesByNodeId,proto3,castkey=github.com/cockroachdb/cockroach/pkg/roachpb.NodeID" json:"hot_ranges_by_node_id" protobuf_key:"varint,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 }
 
@@ -2526,7 +2536,7 @@ func (m *HotRangesResponse) Reset()         { *m = HotRangesResponse{} }
 func (m *HotRangesResponse) String() string { return proto.CompactTextString(m) }
 func (*HotRangesResponse) ProtoMessage()    {}
 func (*HotRangesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{59}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{59}
 }
 func (m *HotRangesResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2553,16 +2563,17 @@ var xxx_messageInfo_HotRangesResponse proto.InternalMessageInfo
 
 // HotRange is a hot range report for a single store on one of the
 // target node(s) selected in a HotRangesRequest.
+// API: PUBLIC ALPHA
 type HotRangesResponse_HotRange struct {
 	// Desc is the descriptor of the range for which the report
 	// was produced.
 	//
-	// Note: this field is generally RESERVED and will likely be removed
-	// or replaced in a later version.
+	// TODO(knz): This field should be removed.
 	// See: https://github.com/cockroachdb/cockroach/issues/53212
 	Desc roachpb.RangeDescriptor `protobuf:"bytes,1,opt,name=desc,proto3" json:"desc"`
 	// QueriesPerSecond is the recent number of queries per second
 	// on this range.
+	// API: PUBLIC ALPHA
 	QueriesPerSecond float64 `protobuf:"fixed64,2,opt,name=queries_per_second,json=queriesPerSecond,proto3" json:"queries_per_second,omitempty"`
 }
 
@@ -2570,7 +2581,7 @@ func (m *HotRangesResponse_HotRange) Reset()         { *m = HotRangesResponse_Ho
 func (m *HotRangesResponse_HotRange) String() string { return proto.CompactTextString(m) }
 func (*HotRangesResponse_HotRange) ProtoMessage()    {}
 func (*HotRangesResponse_HotRange) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{59, 0}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{59, 0}
 }
 func (m *HotRangesResponse_HotRange) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2597,12 +2608,15 @@ var xxx_messageInfo_HotRangesResponse_HotRange proto.InternalMessageInfo
 
 // StoreResponse contains the part of a hot ranges report that
 // pertains to a single store on a target node.
+// API: PUBLIC ALPHA
 type HotRangesResponse_StoreResponse struct {
 	// StoreID identifies the store for which the report was
 	// produced.
+	// API: PUBLIC ALPHA
 	StoreID github_com_cockroachdb_cockroach_pkg_roachpb.StoreID `protobuf:"varint,1,opt,name=store_id,json=storeId,proto3,casttype=github.com/cockroachdb/cockroach/pkg/roachpb.StoreID" json:"store_id,omitempty"`
 	// HotRanges is the hot ranges report for this store
 	// on the target node.
+	// API: PUBLIC ALPHA
 	HotRanges []HotRangesResponse_HotRange `protobuf:"bytes,2,rep,name=hot_ranges,json=hotRanges,proto3" json:"hot_ranges"`
 }
 
@@ -2610,7 +2624,7 @@ func (m *HotRangesResponse_StoreResponse) Reset()         { *m = HotRangesRespon
 func (m *HotRangesResponse_StoreResponse) String() string { return proto.CompactTextString(m) }
 func (*HotRangesResponse_StoreResponse) ProtoMessage()    {}
 func (*HotRangesResponse_StoreResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{59, 1}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{59, 1}
 }
 func (m *HotRangesResponse_StoreResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2636,15 +2650,18 @@ func (m *HotRangesResponse_StoreResponse) XXX_DiscardUnknown() {
 var xxx_messageInfo_HotRangesResponse_StoreResponse proto.InternalMessageInfo
 
 // NodeResponse is a hot range report for a single target node.
+// API: PUBLIC ALPHA
 type HotRangesResponse_NodeResponse struct {
 	// ErrorMessage is set to a non-empty string if this target
 	// node was unable to produce a hot range report.
 	//
 	// The contents of this string indicates the cause of the failure.
+	// API: PUBLIC ALPHA
 	ErrorMessage string `protobuf:"bytes,1,opt,name=error_message,json=errorMessage,proto3" json:"error_message,omitempty"`
 	// Stores contains the hot ranges report if no error was encountered.
 	// There is one part to the report for each store in the
 	// target node.
+	// API: PUBLIC ALPHA
 	Stores []*HotRangesResponse_StoreResponse `protobuf:"bytes,2,rep,name=stores,proto3" json:"stores,omitempty"`
 }
 
@@ -2652,7 +2669,7 @@ func (m *HotRangesResponse_NodeResponse) Reset()         { *m = HotRangesRespons
 func (m *HotRangesResponse_NodeResponse) String() string { return proto.CompactTextString(m) }
 func (*HotRangesResponse_NodeResponse) ProtoMessage()    {}
 func (*HotRangesResponse_NodeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{59, 2}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{59, 2}
 }
 func (m *HotRangesResponse_NodeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2685,7 +2702,7 @@ func (m *RangeRequest) Reset()         { *m = RangeRequest{} }
 func (m *RangeRequest) String() string { return proto.CompactTextString(m) }
 func (*RangeRequest) ProtoMessage()    {}
 func (*RangeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{60}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{60}
 }
 func (m *RangeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2721,7 +2738,7 @@ func (m *RangeResponse) Reset()         { *m = RangeResponse{} }
 func (m *RangeResponse) String() string { return proto.CompactTextString(m) }
 func (*RangeResponse) ProtoMessage()    {}
 func (*RangeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{61}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{61}
 }
 func (m *RangeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2756,7 +2773,7 @@ func (m *RangeResponse_NodeResponse) Reset()         { *m = RangeResponse_NodeRe
 func (m *RangeResponse_NodeResponse) String() string { return proto.CompactTextString(m) }
 func (*RangeResponse_NodeResponse) ProtoMessage()    {}
 func (*RangeResponse_NodeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{61, 0}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{61, 0}
 }
 func (m *RangeResponse_NodeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2792,7 +2809,7 @@ func (m *DiagnosticsRequest) Reset()         { *m = DiagnosticsRequest{} }
 func (m *DiagnosticsRequest) String() string { return proto.CompactTextString(m) }
 func (*DiagnosticsRequest) ProtoMessage()    {}
 func (*DiagnosticsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{62}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{62}
 }
 func (m *DiagnosticsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2827,7 +2844,7 @@ func (m *StoresRequest) Reset()         { *m = StoresRequest{} }
 func (m *StoresRequest) String() string { return proto.CompactTextString(m) }
 func (*StoresRequest) ProtoMessage()    {}
 func (*StoresRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{63}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{63}
 }
 func (m *StoresRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2870,7 +2887,7 @@ func (m *StoreDetails) Reset()         { *m = StoreDetails{} }
 func (m *StoreDetails) String() string { return proto.CompactTextString(m) }
 func (*StoreDetails) ProtoMessage()    {}
 func (*StoreDetails) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{64}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{64}
 }
 func (m *StoreDetails) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2903,7 +2920,7 @@ func (m *StoresResponse) Reset()         { *m = StoresResponse{} }
 func (m *StoresResponse) String() string { return proto.CompactTextString(m) }
 func (*StoresResponse) ProtoMessage()    {}
 func (*StoresResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{65}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{65}
 }
 func (m *StoresResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2936,7 +2953,7 @@ func (m *StatementsRequest) Reset()         { *m = StatementsRequest{} }
 func (m *StatementsRequest) String() string { return proto.CompactTextString(m) }
 func (*StatementsRequest) ProtoMessage()    {}
 func (*StatementsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{66}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{66}
 }
 func (m *StatementsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2977,7 +2994,7 @@ func (m *StatementsResponse) Reset()         { *m = StatementsResponse{} }
 func (m *StatementsResponse) String() string { return proto.CompactTextString(m) }
 func (*StatementsResponse) ProtoMessage()    {}
 func (*StatementsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{67}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{67}
 }
 func (m *StatementsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3015,7 +3032,7 @@ func (m *StatementsResponse_ExtendedStatementStatisticsKey) String() string {
 }
 func (*StatementsResponse_ExtendedStatementStatisticsKey) ProtoMessage() {}
 func (*StatementsResponse_ExtendedStatementStatisticsKey) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{67, 0}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{67, 0}
 }
 func (m *StatementsResponse_ExtendedStatementStatisticsKey) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3054,7 +3071,7 @@ func (m *StatementsResponse_CollectedStatementStatistics) String() string {
 }
 func (*StatementsResponse_CollectedStatementStatistics) ProtoMessage() {}
 func (*StatementsResponse_CollectedStatementStatistics) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{67, 1}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{67, 1}
 }
 func (m *StatementsResponse_CollectedStatementStatistics) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3092,7 +3109,7 @@ func (m *StatementsResponse_ExtendedCollectedTransactionStatistics) String() str
 }
 func (*StatementsResponse_ExtendedCollectedTransactionStatistics) ProtoMessage() {}
 func (*StatementsResponse_ExtendedCollectedTransactionStatistics) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{67, 2}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{67, 2}
 }
 func (m *StatementsResponse_ExtendedCollectedTransactionStatistics) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3129,7 +3146,7 @@ func (m *StatementDiagnosticsReport) Reset()         { *m = StatementDiagnostics
 func (m *StatementDiagnosticsReport) String() string { return proto.CompactTextString(m) }
 func (*StatementDiagnosticsReport) ProtoMessage()    {}
 func (*StatementDiagnosticsReport) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{68}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{68}
 }
 func (m *StatementDiagnosticsReport) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3164,7 +3181,7 @@ func (m *CreateStatementDiagnosticsReportRequest) Reset() {
 func (m *CreateStatementDiagnosticsReportRequest) String() string { return proto.CompactTextString(m) }
 func (*CreateStatementDiagnosticsReportRequest) ProtoMessage()    {}
 func (*CreateStatementDiagnosticsReportRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{69}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{69}
 }
 func (m *CreateStatementDiagnosticsReportRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3199,7 +3216,7 @@ func (m *CreateStatementDiagnosticsReportResponse) Reset() {
 func (m *CreateStatementDiagnosticsReportResponse) String() string { return proto.CompactTextString(m) }
 func (*CreateStatementDiagnosticsReportResponse) ProtoMessage()    {}
 func (*CreateStatementDiagnosticsReportResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{70}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{70}
 }
 func (m *CreateStatementDiagnosticsReportResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3231,7 +3248,7 @@ func (m *StatementDiagnosticsReportsRequest) Reset()         { *m = StatementDia
 func (m *StatementDiagnosticsReportsRequest) String() string { return proto.CompactTextString(m) }
 func (*StatementDiagnosticsReportsRequest) ProtoMessage()    {}
 func (*StatementDiagnosticsReportsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{71}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{71}
 }
 func (m *StatementDiagnosticsReportsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3264,7 +3281,7 @@ func (m *StatementDiagnosticsReportsResponse) Reset()         { *m = StatementDi
 func (m *StatementDiagnosticsReportsResponse) String() string { return proto.CompactTextString(m) }
 func (*StatementDiagnosticsReportsResponse) ProtoMessage()    {}
 func (*StatementDiagnosticsReportsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{72}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{72}
 }
 func (m *StatementDiagnosticsReportsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3300,7 +3317,7 @@ func (m *StatementDiagnostics) Reset()         { *m = StatementDiagnostics{} }
 func (m *StatementDiagnostics) String() string { return proto.CompactTextString(m) }
 func (*StatementDiagnostics) ProtoMessage()    {}
 func (*StatementDiagnostics) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{73}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{73}
 }
 func (m *StatementDiagnostics) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3333,7 +3350,7 @@ func (m *StatementDiagnosticsRequest) Reset()         { *m = StatementDiagnostic
 func (m *StatementDiagnosticsRequest) String() string { return proto.CompactTextString(m) }
 func (*StatementDiagnosticsRequest) ProtoMessage()    {}
 func (*StatementDiagnosticsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{74}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{74}
 }
 func (m *StatementDiagnosticsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3366,7 +3383,7 @@ func (m *StatementDiagnosticsResponse) Reset()         { *m = StatementDiagnosti
 func (m *StatementDiagnosticsResponse) String() string { return proto.CompactTextString(m) }
 func (*StatementDiagnosticsResponse) ProtoMessage()    {}
 func (*StatementDiagnosticsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{75}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{75}
 }
 func (m *StatementDiagnosticsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3399,7 +3416,7 @@ func (m *JobRegistryStatusRequest) Reset()         { *m = JobRegistryStatusReque
 func (m *JobRegistryStatusRequest) String() string { return proto.CompactTextString(m) }
 func (*JobRegistryStatusRequest) ProtoMessage()    {}
 func (*JobRegistryStatusRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{76}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{76}
 }
 func (m *JobRegistryStatusRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3433,7 +3450,7 @@ func (m *JobRegistryStatusResponse) Reset()         { *m = JobRegistryStatusResp
 func (m *JobRegistryStatusResponse) String() string { return proto.CompactTextString(m) }
 func (*JobRegistryStatusResponse) ProtoMessage()    {}
 func (*JobRegistryStatusResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{77}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{77}
 }
 func (m *JobRegistryStatusResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3466,7 +3483,7 @@ func (m *JobRegistryStatusResponse_Job) Reset()         { *m = JobRegistryStatus
 func (m *JobRegistryStatusResponse_Job) String() string { return proto.CompactTextString(m) }
 func (*JobRegistryStatusResponse_Job) ProtoMessage()    {}
 func (*JobRegistryStatusResponse_Job) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{77, 0}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{77, 0}
 }
 func (m *JobRegistryStatusResponse_Job) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3499,7 +3516,7 @@ func (m *JobStatusRequest) Reset()         { *m = JobStatusRequest{} }
 func (m *JobStatusRequest) String() string { return proto.CompactTextString(m) }
 func (*JobStatusRequest) ProtoMessage()    {}
 func (*JobStatusRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{78}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{78}
 }
 func (m *JobStatusRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3532,7 +3549,7 @@ func (m *JobStatusResponse) Reset()         { *m = JobStatusResponse{} }
 func (m *JobStatusResponse) String() string { return proto.CompactTextString(m) }
 func (*JobStatusResponse) ProtoMessage()    {}
 func (*JobStatusResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_fdd87e929f38276a, []int{79}
+	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{79}
 }
 func (m *JobStatusResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3701,21 +3718,39 @@ const _ = grpc.SupportPackageIsVersion4
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type StatusClient interface {
+	// Certificates retrieves a copy of the TLS certificates.
 	Certificates(ctx context.Context, in *CertificatesRequest, opts ...grpc.CallOption) (*CertificatesResponse, error)
+	// Details retrieves details about the nodes in the cluster.
 	Details(ctx context.Context, in *DetailsRequest, opts ...grpc.CallOption) (*DetailsResponse, error)
+	// Nodes retrieves an overview of the nodes in the cluster.
+	// API: PUBLIC ALPHA
+	//
 	// Don't introduce additional usages of this RPC. See #50707 for more details.
 	// The underlying response type is something we're looking to get rid of.
 	Nodes(ctx context.Context, in *NodesRequest, opts ...grpc.CallOption) (*NodesResponse, error)
+	// Node retrieves details about a single node.
+	// API: PUBLIC ALPHA
 	Node(ctx context.Context, in *NodeRequest, opts ...grpc.CallOption) (*statuspb.NodeStatus, error)
+	// RaftDebug requests internal details about Raft.
 	RaftDebug(ctx context.Context, in *RaftDebugRequest, opts ...grpc.CallOption) (*RaftDebugResponse, error)
+	// Ranges requests internal details about ranges on a given node.
 	Ranges(ctx context.Context, in *RangesRequest, opts ...grpc.CallOption) (*RangesResponse, error)
+	// Gossip retrieves gossip-level details about a given node.
 	Gossip(ctx context.Context, in *GossipRequest, opts ...grpc.CallOption) (*gossip.InfoStatus, error)
+	// EngineStats retrieves statistics about a storage engine.
 	EngineStats(ctx context.Context, in *EngineStatsRequest, opts ...grpc.CallOption) (*EngineStatsResponse, error)
+	// Allocator retrieves statistics about the replica allocator.
 	Allocator(ctx context.Context, in *AllocatorRequest, opts ...grpc.CallOption) (*AllocatorResponse, error)
+	// AllocatorRange retrieves statistics about the replica allocator given
+	// a specific range.
 	AllocatorRange(ctx context.Context, in *AllocatorRangeRequest, opts ...grpc.CallOption) (*AllocatorRangeResponse, error)
+	// ListSessions retrieves the SQL sessions across the entire cluster.
 	ListSessions(ctx context.Context, in *ListSessionsRequest, opts ...grpc.CallOption) (*ListSessionsResponse, error)
+	// ListLocalSessions retrieves the SQL sessions on this node.
 	ListLocalSessions(ctx context.Context, in *ListSessionsRequest, opts ...grpc.CallOption) (*ListSessionsResponse, error)
+	// CancelQuery cancels a SQL query given its ID.
 	CancelQuery(ctx context.Context, in *CancelQueryRequest, opts ...grpc.CallOption) (*CancelQueryResponse, error)
+	// CancelSessions forcefully terminates a SQL session given its ID.
 	CancelSession(ctx context.Context, in *CancelSessionRequest, opts ...grpc.CallOption) (*CancelSessionResponse, error)
 	// SpanStats accepts a key span and node ID, and returns a set of stats
 	// summed from all ranges on the stores on that node which contain keys
@@ -3723,13 +3758,25 @@ type StatusClient interface {
 	// it will be called with the highest/lowest key for a SQL table, and return
 	// information about the resources on a node used by that table.
 	SpanStats(ctx context.Context, in *SpanStatsRequest, opts ...grpc.CallOption) (*SpanStatsResponse, error)
+	// Stacks retrieves the stack traces of all goroutines on a given node.
 	Stacks(ctx context.Context, in *StacksRequest, opts ...grpc.CallOption) (*JSONResponse, error)
+	// Profile retrieves a CPU profile on a given node.
 	Profile(ctx context.Context, in *ProfileRequest, opts ...grpc.CallOption) (*JSONResponse, error)
+	// Metrics retrieves the node metrics for a given node.
+	//
+	// Note: this is a “reserved” API and should not be relied upon to
+	// build external tools. No guarantee is made about its
+	// availability and stability in external uses.
 	Metrics(ctx context.Context, in *MetricsRequest, opts ...grpc.CallOption) (*JSONResponse, error)
+	// GetFiles retrieves heap or goroutine dump files from a given node.
 	GetFiles(ctx context.Context, in *GetFilesRequest, opts ...grpc.CallOption) (*GetFilesResponse, error)
+	// LogFilesList retrieves a list of log files on a given node.
 	LogFilesList(ctx context.Context, in *LogFilesListRequest, opts ...grpc.CallOption) (*LogFilesListResponse, error)
+	// LogFile retrieves a given log file.
 	LogFile(ctx context.Context, in *LogFileRequest, opts ...grpc.CallOption) (*LogEntriesResponse, error)
+	// Logs retrieves individual log entries.
 	Logs(ctx context.Context, in *LogsRequest, opts ...grpc.CallOption) (*LogEntriesResponse, error)
+	// ProblemRanges retrieves the list of “problem ranges”.
 	ProblemRanges(ctx context.Context, in *ProblemRangesRequest, opts ...grpc.CallOption) (*ProblemRangesResponse, error)
 	HotRanges(ctx context.Context, in *HotRangesRequest, opts ...grpc.CallOption) (*HotRangesResponse, error)
 	Range(ctx context.Context, in *RangeRequest, opts ...grpc.CallOption) (*RangeResponse, error)
@@ -4050,21 +4097,39 @@ func (c *statusClient) JobStatus(ctx context.Context, in *JobStatusRequest, opts
 
 // StatusServer is the server API for Status service.
 type StatusServer interface {
+	// Certificates retrieves a copy of the TLS certificates.
 	Certificates(context.Context, *CertificatesRequest) (*CertificatesResponse, error)
+	// Details retrieves details about the nodes in the cluster.
 	Details(context.Context, *DetailsRequest) (*DetailsResponse, error)
+	// Nodes retrieves an overview of the nodes in the cluster.
+	// API: PUBLIC ALPHA
+	//
 	// Don't introduce additional usages of this RPC. See #50707 for more details.
 	// The underlying response type is something we're looking to get rid of.
 	Nodes(context.Context, *NodesRequest) (*NodesResponse, error)
+	// Node retrieves details about a single node.
+	// API: PUBLIC ALPHA
 	Node(context.Context, *NodeRequest) (*statuspb.NodeStatus, error)
+	// RaftDebug requests internal details about Raft.
 	RaftDebug(context.Context, *RaftDebugRequest) (*RaftDebugResponse, error)
+	// Ranges requests internal details about ranges on a given node.
 	Ranges(context.Context, *RangesRequest) (*RangesResponse, error)
+	// Gossip retrieves gossip-level details about a given node.
 	Gossip(context.Context, *GossipRequest) (*gossip.InfoStatus, error)
+	// EngineStats retrieves statistics about a storage engine.
 	EngineStats(context.Context, *EngineStatsRequest) (*EngineStatsResponse, error)
+	// Allocator retrieves statistics about the replica allocator.
 	Allocator(context.Context, *AllocatorRequest) (*AllocatorResponse, error)
+	// AllocatorRange retrieves statistics about the replica allocator given
+	// a specific range.
 	AllocatorRange(context.Context, *AllocatorRangeRequest) (*AllocatorRangeResponse, error)
+	// ListSessions retrieves the SQL sessions across the entire cluster.
 	ListSessions(context.Context, *ListSessionsRequest) (*ListSessionsResponse, error)
+	// ListLocalSessions retrieves the SQL sessions on this node.
 	ListLocalSessions(context.Context, *ListSessionsRequest) (*ListSessionsResponse, error)
+	// CancelQuery cancels a SQL query given its ID.
 	CancelQuery(context.Context, *CancelQueryRequest) (*CancelQueryResponse, error)
+	// CancelSessions forcefully terminates a SQL session given its ID.
 	CancelSession(context.Context, *CancelSessionRequest) (*CancelSessionResponse, error)
 	// SpanStats accepts a key span and node ID, and returns a set of stats
 	// summed from all ranges on the stores on that node which contain keys
@@ -4072,13 +4137,25 @@ type StatusServer interface {
 	// it will be called with the highest/lowest key for a SQL table, and return
 	// information about the resources on a node used by that table.
 	SpanStats(context.Context, *SpanStatsRequest) (*SpanStatsResponse, error)
+	// Stacks retrieves the stack traces of all goroutines on a given node.
 	Stacks(context.Context, *StacksRequest) (*JSONResponse, error)
+	// Profile retrieves a CPU profile on a given node.
 	Profile(context.Context, *ProfileRequest) (*JSONResponse, error)
+	// Metrics retrieves the node metrics for a given node.
+	//
+	// Note: this is a “reserved” API and should not be relied upon to
+	// build external tools. No guarantee is made about its
+	// availability and stability in external uses.
 	Metrics(context.Context, *MetricsRequest) (*JSONResponse, error)
+	// GetFiles retrieves heap or goroutine dump files from a given node.
 	GetFiles(context.Context, *GetFilesRequest) (*GetFilesResponse, error)
+	// LogFilesList retrieves a list of log files on a given node.
 	LogFilesList(context.Context, *LogFilesListRequest) (*LogFilesListResponse, error)
+	// LogFile retrieves a given log file.
 	LogFile(context.Context, *LogFileRequest) (*LogEntriesResponse, error)
+	// Logs retrieves individual log entries.
 	Logs(context.Context, *LogsRequest) (*LogEntriesResponse, error)
+	// ProblemRanges retrieves the list of “problem ranges”.
 	ProblemRanges(context.Context, *ProblemRangesRequest) (*ProblemRangesResponse, error)
 	HotRanges(context.Context, *HotRangesRequest) (*HotRangesResponse, error)
 	Range(context.Context, *RangeRequest) (*RangeResponse, error)
@@ -22442,10 +22519,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("server/serverpb/status.proto", fileDescriptor_status_fdd87e929f38276a)
+	proto.RegisterFile("server/serverpb/status.proto", fileDescriptor_status_0a3e72b0cdc5b0fe)
 }
 
-var fileDescriptor_status_fdd87e929f38276a = []byte{
+var fileDescriptor_status_0a3e72b0cdc5b0fe = []byte{
 	// 6184 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xcc, 0x7c, 0x5d, 0x6c, 0x5b, 0x47,
 	0x76, 0xbf, 0x2f, 0x49, 0x51, 0xe4, 0xa1, 0x3e, 0xa8, 0xd1, 0x87, 0x69, 0xda, 0x91, 0x9c, 0xeb,

--- a/pkg/server/serverpb/status.pb.go
+++ b/pkg/server/serverpb/status.pb.go
@@ -65,7 +65,7 @@ func (x StacksType) String() string {
 	return proto.EnumName(StacksType_name, int32(x))
 }
 func (StacksType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{0}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{0}
 }
 
 // Represents the type of file.
@@ -92,7 +92,7 @@ func (x FileType) String() string {
 	return proto.EnumName(FileType_name, int32(x))
 }
 func (FileType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{1}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{1}
 }
 
 // We use an enum to allow reporting of client certs and potential others (eg:
@@ -129,7 +129,7 @@ func (x CertificateDetails_CertificateType) String() string {
 	return proto.EnumName(CertificateDetails_CertificateType_name, int32(x))
 }
 func (CertificateDetails_CertificateType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{1, 0}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{1, 0}
 }
 
 type ProfileRequest_Type int32
@@ -152,7 +152,7 @@ func (x ProfileRequest_Type) String() string {
 	return proto.EnumName(ProfileRequest_Type_name, int32(x))
 }
 func (ProfileRequest_Type) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{37, 0}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{37, 0}
 }
 
 // Enum for phase of execution.
@@ -176,7 +176,7 @@ func (x ActiveQuery_Phase) String() string {
 	return proto.EnumName(ActiveQuery_Phase_name, int32(x))
 }
 func (ActiveQuery_Phase) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{45, 0}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{45, 0}
 }
 
 type CertificatesRequest struct {
@@ -189,7 +189,7 @@ func (m *CertificatesRequest) Reset()         { *m = CertificatesRequest{} }
 func (m *CertificatesRequest) String() string { return proto.CompactTextString(m) }
 func (*CertificatesRequest) ProtoMessage()    {}
 func (*CertificatesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{0}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{0}
 }
 func (m *CertificatesRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -228,7 +228,7 @@ func (m *CertificateDetails) Reset()         { *m = CertificateDetails{} }
 func (m *CertificateDetails) String() string { return proto.CompactTextString(m) }
 func (*CertificateDetails) ProtoMessage()    {}
 func (*CertificateDetails) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{1}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{1}
 }
 func (m *CertificateDetails) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -269,7 +269,7 @@ func (m *CertificateDetails_Fields) Reset()         { *m = CertificateDetails_Fi
 func (m *CertificateDetails_Fields) String() string { return proto.CompactTextString(m) }
 func (*CertificateDetails_Fields) ProtoMessage()    {}
 func (*CertificateDetails_Fields) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{1, 0}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{1, 0}
 }
 func (m *CertificateDetails_Fields) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -302,7 +302,7 @@ func (m *CertificatesResponse) Reset()         { *m = CertificatesResponse{} }
 func (m *CertificatesResponse) String() string { return proto.CompactTextString(m) }
 func (*CertificatesResponse) ProtoMessage()    {}
 func (*CertificatesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{2}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{2}
 }
 func (m *CertificatesResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -339,7 +339,7 @@ func (m *DetailsRequest) Reset()         { *m = DetailsRequest{} }
 func (m *DetailsRequest) String() string { return proto.CompactTextString(m) }
 func (*DetailsRequest) ProtoMessage()    {}
 func (*DetailsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{3}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{3}
 }
 func (m *DetailsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -376,7 +376,7 @@ func (m *SystemInfo) Reset()         { *m = SystemInfo{} }
 func (m *SystemInfo) String() string { return proto.CompactTextString(m) }
 func (*SystemInfo) ProtoMessage()    {}
 func (*SystemInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{4}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{4}
 }
 func (m *SystemInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -413,7 +413,7 @@ func (m *DetailsResponse) Reset()         { *m = DetailsResponse{} }
 func (m *DetailsResponse) String() string { return proto.CompactTextString(m) }
 func (*DetailsResponse) ProtoMessage()    {}
 func (*DetailsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{5}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{5}
 }
 func (m *DetailsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -448,7 +448,7 @@ func (m *NodesRequest) Reset()         { *m = NodesRequest{} }
 func (m *NodesRequest) String() string { return proto.CompactTextString(m) }
 func (*NodesRequest) ProtoMessage()    {}
 func (*NodesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{6}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{6}
 }
 func (m *NodesRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -486,7 +486,7 @@ func (m *NodesResponse) Reset()         { *m = NodesResponse{} }
 func (m *NodesResponse) String() string { return proto.CompactTextString(m) }
 func (*NodesResponse) ProtoMessage()    {}
 func (*NodesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{7}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{7}
 }
 func (m *NodesResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -521,7 +521,7 @@ func (m *NodeRequest) Reset()         { *m = NodeRequest{} }
 func (m *NodeRequest) String() string { return proto.CompactTextString(m) }
 func (*NodeRequest) ProtoMessage()    {}
 func (*NodeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{8}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{8}
 }
 func (m *NodeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -566,7 +566,7 @@ func (m *RaftState) Reset()         { *m = RaftState{} }
 func (m *RaftState) String() string { return proto.CompactTextString(m) }
 func (*RaftState) ProtoMessage()    {}
 func (*RaftState) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{9}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{9}
 }
 func (m *RaftState) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -603,7 +603,7 @@ func (m *RaftState_Progress) Reset()         { *m = RaftState_Progress{} }
 func (m *RaftState_Progress) String() string { return proto.CompactTextString(m) }
 func (*RaftState_Progress) ProtoMessage()    {}
 func (*RaftState_Progress) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{9, 0}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{9, 0}
 }
 func (m *RaftState_Progress) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -648,7 +648,7 @@ func (m *RangeProblems) Reset()         { *m = RangeProblems{} }
 func (m *RangeProblems) String() string { return proto.CompactTextString(m) }
 func (*RangeProblems) ProtoMessage()    {}
 func (*RangeProblems) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{10}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{10}
 }
 func (m *RangeProblems) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -684,7 +684,7 @@ func (m *RangeStatistics) Reset()         { *m = RangeStatistics{} }
 func (m *RangeStatistics) String() string { return proto.CompactTextString(m) }
 func (*RangeStatistics) ProtoMessage()    {}
 func (*RangeStatistics) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{11}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{11}
 }
 func (m *RangeStatistics) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -718,7 +718,7 @@ func (m *PrettySpan) Reset()         { *m = PrettySpan{} }
 func (m *PrettySpan) String() string { return proto.CompactTextString(m) }
 func (*PrettySpan) ProtoMessage()    {}
 func (*PrettySpan) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{12}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{12}
 }
 func (m *PrettySpan) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -764,7 +764,7 @@ func (m *RangeInfo) Reset()         { *m = RangeInfo{} }
 func (m *RangeInfo) String() string { return proto.CompactTextString(m) }
 func (*RangeInfo) ProtoMessage()    {}
 func (*RangeInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{13}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{13}
 }
 func (m *RangeInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -800,7 +800,7 @@ func (m *RangesRequest) Reset()         { *m = RangesRequest{} }
 func (m *RangesRequest) String() string { return proto.CompactTextString(m) }
 func (*RangesRequest) ProtoMessage()    {}
 func (*RangesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{14}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{14}
 }
 func (m *RangesRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -833,7 +833,7 @@ func (m *RangesResponse) Reset()         { *m = RangesResponse{} }
 func (m *RangesResponse) String() string { return proto.CompactTextString(m) }
 func (*RangesResponse) ProtoMessage()    {}
 func (*RangesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{15}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{15}
 }
 func (m *RangesResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -868,7 +868,7 @@ func (m *GossipRequest) Reset()         { *m = GossipRequest{} }
 func (m *GossipRequest) String() string { return proto.CompactTextString(m) }
 func (*GossipRequest) ProtoMessage()    {}
 func (*GossipRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{16}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{16}
 }
 func (m *GossipRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -903,7 +903,7 @@ func (m *EngineStatsInfo) Reset()         { *m = EngineStatsInfo{} }
 func (m *EngineStatsInfo) String() string { return proto.CompactTextString(m) }
 func (*EngineStatsInfo) ProtoMessage()    {}
 func (*EngineStatsInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{17}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{17}
 }
 func (m *EngineStatsInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -938,7 +938,7 @@ func (m *EngineStatsRequest) Reset()         { *m = EngineStatsRequest{} }
 func (m *EngineStatsRequest) String() string { return proto.CompactTextString(m) }
 func (*EngineStatsRequest) ProtoMessage()    {}
 func (*EngineStatsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{18}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{18}
 }
 func (m *EngineStatsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -971,7 +971,7 @@ func (m *EngineStatsResponse) Reset()         { *m = EngineStatsResponse{} }
 func (m *EngineStatsResponse) String() string { return proto.CompactTextString(m) }
 func (*EngineStatsResponse) ProtoMessage()    {}
 func (*EngineStatsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{19}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{19}
 }
 func (m *EngineStatsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1005,7 +1005,7 @@ func (m *TraceEvent) Reset()         { *m = TraceEvent{} }
 func (m *TraceEvent) String() string { return proto.CompactTextString(m) }
 func (*TraceEvent) ProtoMessage()    {}
 func (*TraceEvent) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{20}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{20}
 }
 func (m *TraceEvent) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1039,7 +1039,7 @@ func (m *AllocatorDryRun) Reset()         { *m = AllocatorDryRun{} }
 func (m *AllocatorDryRun) String() string { return proto.CompactTextString(m) }
 func (*AllocatorDryRun) ProtoMessage()    {}
 func (*AllocatorDryRun) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{21}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{21}
 }
 func (m *AllocatorDryRun) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1072,7 +1072,7 @@ func (m *AllocatorRangeRequest) Reset()         { *m = AllocatorRangeRequest{} }
 func (m *AllocatorRangeRequest) String() string { return proto.CompactTextString(m) }
 func (*AllocatorRangeRequest) ProtoMessage()    {}
 func (*AllocatorRangeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{22}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{22}
 }
 func (m *AllocatorRangeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1108,7 +1108,7 @@ func (m *AllocatorRangeResponse) Reset()         { *m = AllocatorRangeResponse{}
 func (m *AllocatorRangeResponse) String() string { return proto.CompactTextString(m) }
 func (*AllocatorRangeResponse) ProtoMessage()    {}
 func (*AllocatorRangeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{23}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{23}
 }
 func (m *AllocatorRangeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1142,7 +1142,7 @@ func (m *AllocatorRequest) Reset()         { *m = AllocatorRequest{} }
 func (m *AllocatorRequest) String() string { return proto.CompactTextString(m) }
 func (*AllocatorRequest) ProtoMessage()    {}
 func (*AllocatorRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{24}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{24}
 }
 func (m *AllocatorRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1175,7 +1175,7 @@ func (m *AllocatorResponse) Reset()         { *m = AllocatorResponse{} }
 func (m *AllocatorResponse) String() string { return proto.CompactTextString(m) }
 func (*AllocatorResponse) ProtoMessage()    {}
 func (*AllocatorResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{25}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{25}
 }
 func (m *AllocatorResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1208,7 +1208,7 @@ func (m *JSONResponse) Reset()         { *m = JSONResponse{} }
 func (m *JSONResponse) String() string { return proto.CompactTextString(m) }
 func (*JSONResponse) ProtoMessage()    {}
 func (*JSONResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{26}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{26}
 }
 func (m *JSONResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1244,7 +1244,7 @@ func (m *ResponseError) Reset()         { *m = ResponseError{} }
 func (m *ResponseError) String() string { return proto.CompactTextString(m) }
 func (*ResponseError) ProtoMessage()    {}
 func (*ResponseError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{27}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{27}
 }
 func (m *ResponseError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1296,7 +1296,7 @@ func (m *LogsRequest) Reset()         { *m = LogsRequest{} }
 func (m *LogsRequest) String() string { return proto.CompactTextString(m) }
 func (*LogsRequest) ProtoMessage()    {}
 func (*LogsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{28}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{28}
 }
 func (m *LogsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1329,7 +1329,7 @@ func (m *LogEntriesResponse) Reset()         { *m = LogEntriesResponse{} }
 func (m *LogEntriesResponse) String() string { return proto.CompactTextString(m) }
 func (*LogEntriesResponse) ProtoMessage()    {}
 func (*LogEntriesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{29}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{29}
 }
 func (m *LogEntriesResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1364,7 +1364,7 @@ func (m *LogFilesListRequest) Reset()         { *m = LogFilesListRequest{} }
 func (m *LogFilesListRequest) String() string { return proto.CompactTextString(m) }
 func (*LogFilesListRequest) ProtoMessage()    {}
 func (*LogFilesListRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{30}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{30}
 }
 func (m *LogFilesListRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1397,7 +1397,7 @@ func (m *LogFilesListResponse) Reset()         { *m = LogFilesListResponse{} }
 func (m *LogFilesListResponse) String() string { return proto.CompactTextString(m) }
 func (*LogFilesListResponse) ProtoMessage()    {}
 func (*LogFilesListResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{31}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{31}
 }
 func (m *LogFilesListResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1445,7 +1445,7 @@ func (m *LogFileRequest) Reset()         { *m = LogFileRequest{} }
 func (m *LogFileRequest) String() string { return proto.CompactTextString(m) }
 func (*LogFileRequest) ProtoMessage()    {}
 func (*LogFileRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{32}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{32}
 }
 func (m *LogFileRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1481,7 +1481,7 @@ func (m *StacksRequest) Reset()         { *m = StacksRequest{} }
 func (m *StacksRequest) String() string { return proto.CompactTextString(m) }
 func (*StacksRequest) ProtoMessage()    {}
 func (*StacksRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{33}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{33}
 }
 func (m *StacksRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1517,7 +1517,7 @@ func (m *File) Reset()         { *m = File{} }
 func (m *File) String() string { return proto.CompactTextString(m) }
 func (*File) ProtoMessage()    {}
 func (*File) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{34}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{34}
 }
 func (m *File) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1561,7 +1561,7 @@ func (m *GetFilesRequest) Reset()         { *m = GetFilesRequest{} }
 func (m *GetFilesRequest) String() string { return proto.CompactTextString(m) }
 func (*GetFilesRequest) ProtoMessage()    {}
 func (*GetFilesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{35}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{35}
 }
 func (m *GetFilesRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1594,7 +1594,7 @@ func (m *GetFilesResponse) Reset()         { *m = GetFilesResponse{} }
 func (m *GetFilesResponse) String() string { return proto.CompactTextString(m) }
 func (*GetFilesResponse) ProtoMessage()    {}
 func (*GetFilesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{36}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{36}
 }
 func (m *GetFilesResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1632,7 +1632,7 @@ func (m *ProfileRequest) Reset()         { *m = ProfileRequest{} }
 func (m *ProfileRequest) String() string { return proto.CompactTextString(m) }
 func (*ProfileRequest) ProtoMessage()    {}
 func (*ProfileRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{37}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{37}
 }
 func (m *ProfileRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1667,7 +1667,7 @@ func (m *MetricsRequest) Reset()         { *m = MetricsRequest{} }
 func (m *MetricsRequest) String() string { return proto.CompactTextString(m) }
 func (*MetricsRequest) ProtoMessage()    {}
 func (*MetricsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{38}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{38}
 }
 func (m *MetricsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1701,7 +1701,7 @@ func (m *RaftRangeNode) Reset()         { *m = RaftRangeNode{} }
 func (m *RaftRangeNode) String() string { return proto.CompactTextString(m) }
 func (*RaftRangeNode) ProtoMessage()    {}
 func (*RaftRangeNode) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{39}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{39}
 }
 func (m *RaftRangeNode) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1734,7 +1734,7 @@ func (m *RaftRangeError) Reset()         { *m = RaftRangeError{} }
 func (m *RaftRangeError) String() string { return proto.CompactTextString(m) }
 func (*RaftRangeError) ProtoMessage()    {}
 func (*RaftRangeError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{40}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{40}
 }
 func (m *RaftRangeError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1769,7 +1769,7 @@ func (m *RaftRangeStatus) Reset()         { *m = RaftRangeStatus{} }
 func (m *RaftRangeStatus) String() string { return proto.CompactTextString(m) }
 func (*RaftRangeStatus) ProtoMessage()    {}
 func (*RaftRangeStatus) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{41}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{41}
 }
 func (m *RaftRangeStatus) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1802,7 +1802,7 @@ func (m *RaftDebugRequest) Reset()         { *m = RaftDebugRequest{} }
 func (m *RaftDebugRequest) String() string { return proto.CompactTextString(m) }
 func (*RaftDebugRequest) ProtoMessage()    {}
 func (*RaftDebugRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{42}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{42}
 }
 func (m *RaftDebugRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1836,7 +1836,7 @@ func (m *RaftDebugResponse) Reset()         { *m = RaftDebugResponse{} }
 func (m *RaftDebugResponse) String() string { return proto.CompactTextString(m) }
 func (*RaftDebugResponse) ProtoMessage()    {}
 func (*RaftDebugResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{43}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{43}
 }
 func (m *RaftDebugResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1894,7 +1894,7 @@ func (m *TxnInfo) Reset()         { *m = TxnInfo{} }
 func (m *TxnInfo) String() string { return proto.CompactTextString(m) }
 func (*TxnInfo) ProtoMessage()    {}
 func (*TxnInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{44}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{44}
 }
 func (m *TxnInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1942,7 +1942,7 @@ func (m *ActiveQuery) Reset()         { *m = ActiveQuery{} }
 func (m *ActiveQuery) String() string { return proto.CompactTextString(m) }
 func (*ActiveQuery) ProtoMessage()    {}
 func (*ActiveQuery) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{45}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{45}
 }
 func (m *ActiveQuery) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1977,7 +1977,7 @@ func (m *ListSessionsRequest) Reset()         { *m = ListSessionsRequest{} }
 func (m *ListSessionsRequest) String() string { return proto.CompactTextString(m) }
 func (*ListSessionsRequest) ProtoMessage()    {}
 func (*ListSessionsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{46}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{46}
 }
 func (m *ListSessionsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2036,7 +2036,7 @@ func (m *Session) Reset()         { *m = Session{} }
 func (m *Session) String() string { return proto.CompactTextString(m) }
 func (*Session) ProtoMessage()    {}
 func (*Session) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{47}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{47}
 }
 func (m *Session) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2073,7 +2073,7 @@ func (m *ListSessionsError) Reset()         { *m = ListSessionsError{} }
 func (m *ListSessionsError) String() string { return proto.CompactTextString(m) }
 func (*ListSessionsError) ProtoMessage()    {}
 func (*ListSessionsError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{48}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{48}
 }
 func (m *ListSessionsError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2110,7 +2110,7 @@ func (m *ListSessionsResponse) Reset()         { *m = ListSessionsResponse{} }
 func (m *ListSessionsResponse) String() string { return proto.CompactTextString(m) }
 func (*ListSessionsResponse) ProtoMessage()    {}
 func (*ListSessionsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{49}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{49}
 }
 func (m *ListSessionsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2156,7 +2156,7 @@ func (m *CancelQueryRequest) Reset()         { *m = CancelQueryRequest{} }
 func (m *CancelQueryRequest) String() string { return proto.CompactTextString(m) }
 func (*CancelQueryRequest) ProtoMessage()    {}
 func (*CancelQueryRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{50}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{50}
 }
 func (m *CancelQueryRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2193,7 +2193,7 @@ func (m *CancelQueryResponse) Reset()         { *m = CancelQueryResponse{} }
 func (m *CancelQueryResponse) String() string { return proto.CompactTextString(m) }
 func (*CancelQueryResponse) ProtoMessage()    {}
 func (*CancelQueryResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{51}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{51}
 }
 func (m *CancelQueryResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2235,7 +2235,7 @@ func (m *CancelSessionRequest) Reset()         { *m = CancelSessionRequest{} }
 func (m *CancelSessionRequest) String() string { return proto.CompactTextString(m) }
 func (*CancelSessionRequest) ProtoMessage()    {}
 func (*CancelSessionRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{52}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{52}
 }
 func (m *CancelSessionRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2269,7 +2269,7 @@ func (m *CancelSessionResponse) Reset()         { *m = CancelSessionResponse{} }
 func (m *CancelSessionResponse) String() string { return proto.CompactTextString(m) }
 func (*CancelSessionResponse) ProtoMessage()    {}
 func (*CancelSessionResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{53}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{53}
 }
 func (m *CancelSessionResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2304,7 +2304,7 @@ func (m *SpanStatsRequest) Reset()         { *m = SpanStatsRequest{} }
 func (m *SpanStatsRequest) String() string { return proto.CompactTextString(m) }
 func (*SpanStatsRequest) ProtoMessage()    {}
 func (*SpanStatsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{54}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{54}
 }
 func (m *SpanStatsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2339,7 +2339,7 @@ func (m *SpanStatsResponse) Reset()         { *m = SpanStatsResponse{} }
 func (m *SpanStatsResponse) String() string { return proto.CompactTextString(m) }
 func (*SpanStatsResponse) ProtoMessage()    {}
 func (*SpanStatsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{55}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{55}
 }
 func (m *SpanStatsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2373,7 +2373,7 @@ func (m *ProblemRangesRequest) Reset()         { *m = ProblemRangesRequest{} }
 func (m *ProblemRangesRequest) String() string { return proto.CompactTextString(m) }
 func (*ProblemRangesRequest) ProtoMessage()    {}
 func (*ProblemRangesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{56}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{56}
 }
 func (m *ProblemRangesRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2408,7 +2408,7 @@ func (m *ProblemRangesResponse) Reset()         { *m = ProblemRangesResponse{} }
 func (m *ProblemRangesResponse) String() string { return proto.CompactTextString(m) }
 func (*ProblemRangesResponse) ProtoMessage()    {}
 func (*ProblemRangesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{57}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{57}
 }
 func (m *ProblemRangesResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2449,7 +2449,7 @@ func (m *ProblemRangesResponse_NodeProblems) Reset()         { *m = ProblemRange
 func (m *ProblemRangesResponse_NodeProblems) String() string { return proto.CompactTextString(m) }
 func (*ProblemRangesResponse_NodeProblems) ProtoMessage()    {}
 func (*ProblemRangesResponse_NodeProblems) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{57, 0}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{57, 0}
 }
 func (m *ProblemRangesResponse_NodeProblems) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2493,7 +2493,7 @@ func (m *HotRangesRequest) Reset()         { *m = HotRangesRequest{} }
 func (m *HotRangesRequest) String() string { return proto.CompactTextString(m) }
 func (*HotRangesRequest) ProtoMessage()    {}
 func (*HotRangesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{58}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{58}
 }
 func (m *HotRangesRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2536,7 +2536,7 @@ func (m *HotRangesResponse) Reset()         { *m = HotRangesResponse{} }
 func (m *HotRangesResponse) String() string { return proto.CompactTextString(m) }
 func (*HotRangesResponse) ProtoMessage()    {}
 func (*HotRangesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{59}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{59}
 }
 func (m *HotRangesResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2581,7 +2581,7 @@ func (m *HotRangesResponse_HotRange) Reset()         { *m = HotRangesResponse_Ho
 func (m *HotRangesResponse_HotRange) String() string { return proto.CompactTextString(m) }
 func (*HotRangesResponse_HotRange) ProtoMessage()    {}
 func (*HotRangesResponse_HotRange) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{59, 0}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{59, 0}
 }
 func (m *HotRangesResponse_HotRange) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2624,7 +2624,7 @@ func (m *HotRangesResponse_StoreResponse) Reset()         { *m = HotRangesRespon
 func (m *HotRangesResponse_StoreResponse) String() string { return proto.CompactTextString(m) }
 func (*HotRangesResponse_StoreResponse) ProtoMessage()    {}
 func (*HotRangesResponse_StoreResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{59, 1}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{59, 1}
 }
 func (m *HotRangesResponse_StoreResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2669,7 +2669,7 @@ func (m *HotRangesResponse_NodeResponse) Reset()         { *m = HotRangesRespons
 func (m *HotRangesResponse_NodeResponse) String() string { return proto.CompactTextString(m) }
 func (*HotRangesResponse_NodeResponse) ProtoMessage()    {}
 func (*HotRangesResponse_NodeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{59, 2}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{59, 2}
 }
 func (m *HotRangesResponse_NodeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2702,7 +2702,7 @@ func (m *RangeRequest) Reset()         { *m = RangeRequest{} }
 func (m *RangeRequest) String() string { return proto.CompactTextString(m) }
 func (*RangeRequest) ProtoMessage()    {}
 func (*RangeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{60}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{60}
 }
 func (m *RangeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2738,7 +2738,7 @@ func (m *RangeResponse) Reset()         { *m = RangeResponse{} }
 func (m *RangeResponse) String() string { return proto.CompactTextString(m) }
 func (*RangeResponse) ProtoMessage()    {}
 func (*RangeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{61}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{61}
 }
 func (m *RangeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2773,7 +2773,7 @@ func (m *RangeResponse_NodeResponse) Reset()         { *m = RangeResponse_NodeRe
 func (m *RangeResponse_NodeResponse) String() string { return proto.CompactTextString(m) }
 func (*RangeResponse_NodeResponse) ProtoMessage()    {}
 func (*RangeResponse_NodeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{61, 0}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{61, 0}
 }
 func (m *RangeResponse_NodeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2809,7 +2809,7 @@ func (m *DiagnosticsRequest) Reset()         { *m = DiagnosticsRequest{} }
 func (m *DiagnosticsRequest) String() string { return proto.CompactTextString(m) }
 func (*DiagnosticsRequest) ProtoMessage()    {}
 func (*DiagnosticsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{62}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{62}
 }
 func (m *DiagnosticsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2844,7 +2844,7 @@ func (m *StoresRequest) Reset()         { *m = StoresRequest{} }
 func (m *StoresRequest) String() string { return proto.CompactTextString(m) }
 func (*StoresRequest) ProtoMessage()    {}
 func (*StoresRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{63}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{63}
 }
 func (m *StoresRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2887,7 +2887,7 @@ func (m *StoreDetails) Reset()         { *m = StoreDetails{} }
 func (m *StoreDetails) String() string { return proto.CompactTextString(m) }
 func (*StoreDetails) ProtoMessage()    {}
 func (*StoreDetails) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{64}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{64}
 }
 func (m *StoreDetails) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2920,7 +2920,7 @@ func (m *StoresResponse) Reset()         { *m = StoresResponse{} }
 func (m *StoresResponse) String() string { return proto.CompactTextString(m) }
 func (*StoresResponse) ProtoMessage()    {}
 func (*StoresResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{65}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{65}
 }
 func (m *StoresResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2953,7 +2953,7 @@ func (m *StatementsRequest) Reset()         { *m = StatementsRequest{} }
 func (m *StatementsRequest) String() string { return proto.CompactTextString(m) }
 func (*StatementsRequest) ProtoMessage()    {}
 func (*StatementsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{66}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{66}
 }
 func (m *StatementsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2994,7 +2994,7 @@ func (m *StatementsResponse) Reset()         { *m = StatementsResponse{} }
 func (m *StatementsResponse) String() string { return proto.CompactTextString(m) }
 func (*StatementsResponse) ProtoMessage()    {}
 func (*StatementsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{67}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{67}
 }
 func (m *StatementsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3032,7 +3032,7 @@ func (m *StatementsResponse_ExtendedStatementStatisticsKey) String() string {
 }
 func (*StatementsResponse_ExtendedStatementStatisticsKey) ProtoMessage() {}
 func (*StatementsResponse_ExtendedStatementStatisticsKey) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{67, 0}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{67, 0}
 }
 func (m *StatementsResponse_ExtendedStatementStatisticsKey) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3071,7 +3071,7 @@ func (m *StatementsResponse_CollectedStatementStatistics) String() string {
 }
 func (*StatementsResponse_CollectedStatementStatistics) ProtoMessage() {}
 func (*StatementsResponse_CollectedStatementStatistics) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{67, 1}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{67, 1}
 }
 func (m *StatementsResponse_CollectedStatementStatistics) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3109,7 +3109,7 @@ func (m *StatementsResponse_ExtendedCollectedTransactionStatistics) String() str
 }
 func (*StatementsResponse_ExtendedCollectedTransactionStatistics) ProtoMessage() {}
 func (*StatementsResponse_ExtendedCollectedTransactionStatistics) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{67, 2}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{67, 2}
 }
 func (m *StatementsResponse_ExtendedCollectedTransactionStatistics) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3146,7 +3146,7 @@ func (m *StatementDiagnosticsReport) Reset()         { *m = StatementDiagnostics
 func (m *StatementDiagnosticsReport) String() string { return proto.CompactTextString(m) }
 func (*StatementDiagnosticsReport) ProtoMessage()    {}
 func (*StatementDiagnosticsReport) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{68}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{68}
 }
 func (m *StatementDiagnosticsReport) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3181,7 +3181,7 @@ func (m *CreateStatementDiagnosticsReportRequest) Reset() {
 func (m *CreateStatementDiagnosticsReportRequest) String() string { return proto.CompactTextString(m) }
 func (*CreateStatementDiagnosticsReportRequest) ProtoMessage()    {}
 func (*CreateStatementDiagnosticsReportRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{69}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{69}
 }
 func (m *CreateStatementDiagnosticsReportRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3216,7 +3216,7 @@ func (m *CreateStatementDiagnosticsReportResponse) Reset() {
 func (m *CreateStatementDiagnosticsReportResponse) String() string { return proto.CompactTextString(m) }
 func (*CreateStatementDiagnosticsReportResponse) ProtoMessage()    {}
 func (*CreateStatementDiagnosticsReportResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{70}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{70}
 }
 func (m *CreateStatementDiagnosticsReportResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3248,7 +3248,7 @@ func (m *StatementDiagnosticsReportsRequest) Reset()         { *m = StatementDia
 func (m *StatementDiagnosticsReportsRequest) String() string { return proto.CompactTextString(m) }
 func (*StatementDiagnosticsReportsRequest) ProtoMessage()    {}
 func (*StatementDiagnosticsReportsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{71}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{71}
 }
 func (m *StatementDiagnosticsReportsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3281,7 +3281,7 @@ func (m *StatementDiagnosticsReportsResponse) Reset()         { *m = StatementDi
 func (m *StatementDiagnosticsReportsResponse) String() string { return proto.CompactTextString(m) }
 func (*StatementDiagnosticsReportsResponse) ProtoMessage()    {}
 func (*StatementDiagnosticsReportsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{72}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{72}
 }
 func (m *StatementDiagnosticsReportsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3317,7 +3317,7 @@ func (m *StatementDiagnostics) Reset()         { *m = StatementDiagnostics{} }
 func (m *StatementDiagnostics) String() string { return proto.CompactTextString(m) }
 func (*StatementDiagnostics) ProtoMessage()    {}
 func (*StatementDiagnostics) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{73}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{73}
 }
 func (m *StatementDiagnostics) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3350,7 +3350,7 @@ func (m *StatementDiagnosticsRequest) Reset()         { *m = StatementDiagnostic
 func (m *StatementDiagnosticsRequest) String() string { return proto.CompactTextString(m) }
 func (*StatementDiagnosticsRequest) ProtoMessage()    {}
 func (*StatementDiagnosticsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{74}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{74}
 }
 func (m *StatementDiagnosticsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3383,7 +3383,7 @@ func (m *StatementDiagnosticsResponse) Reset()         { *m = StatementDiagnosti
 func (m *StatementDiagnosticsResponse) String() string { return proto.CompactTextString(m) }
 func (*StatementDiagnosticsResponse) ProtoMessage()    {}
 func (*StatementDiagnosticsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{75}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{75}
 }
 func (m *StatementDiagnosticsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3416,7 +3416,7 @@ func (m *JobRegistryStatusRequest) Reset()         { *m = JobRegistryStatusReque
 func (m *JobRegistryStatusRequest) String() string { return proto.CompactTextString(m) }
 func (*JobRegistryStatusRequest) ProtoMessage()    {}
 func (*JobRegistryStatusRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{76}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{76}
 }
 func (m *JobRegistryStatusRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3450,7 +3450,7 @@ func (m *JobRegistryStatusResponse) Reset()         { *m = JobRegistryStatusResp
 func (m *JobRegistryStatusResponse) String() string { return proto.CompactTextString(m) }
 func (*JobRegistryStatusResponse) ProtoMessage()    {}
 func (*JobRegistryStatusResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{77}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{77}
 }
 func (m *JobRegistryStatusResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3483,7 +3483,7 @@ func (m *JobRegistryStatusResponse_Job) Reset()         { *m = JobRegistryStatus
 func (m *JobRegistryStatusResponse_Job) String() string { return proto.CompactTextString(m) }
 func (*JobRegistryStatusResponse_Job) ProtoMessage()    {}
 func (*JobRegistryStatusResponse_Job) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{77, 0}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{77, 0}
 }
 func (m *JobRegistryStatusResponse_Job) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3516,7 +3516,7 @@ func (m *JobStatusRequest) Reset()         { *m = JobStatusRequest{} }
 func (m *JobStatusRequest) String() string { return proto.CompactTextString(m) }
 func (*JobStatusRequest) ProtoMessage()    {}
 func (*JobStatusRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{78}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{78}
 }
 func (m *JobStatusRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3549,7 +3549,7 @@ func (m *JobStatusResponse) Reset()         { *m = JobStatusResponse{} }
 func (m *JobStatusResponse) String() string { return proto.CompactTextString(m) }
 func (*JobStatusResponse) ProtoMessage()    {}
 func (*JobStatusResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_0a3e72b0cdc5b0fe, []int{79}
+	return fileDescriptor_status_b6f9c0e85bc99cc8, []int{79}
 }
 func (m *JobStatusResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3721,10 +3721,165 @@ type StatusClient interface {
 	// Certificates retrieves a copy of the TLS certificates.
 	Certificates(ctx context.Context, in *CertificatesRequest, opts ...grpc.CallOption) (*CertificatesResponse, error)
 	// Details retrieves details about the nodes in the cluster.
+	//
+	//  Reference example:
+	//  ```
+	//  curl http://127.0.0.1:51875/_status/details/1
+	//    ->
+	//  {
+	//  "nodeId": 1,
+	//    "address": {
+	//    "networkField": "tcp",
+	//    "addressField": "127.0.0.1:51876"
+	//    },
+	//    "buildInfo": {...},
+	//    "systemInfo": {...},
+	//    "sqlAddress": {
+	//    "networkField": "tcp",
+	//    "addressField": "127.0.0.1:51877"
+	//    }
+	//  }
+	//  ```
 	Details(ctx context.Context, in *DetailsRequest, opts ...grpc.CallOption) (*DetailsResponse, error)
 	// Nodes retrieves an overview of the nodes in the cluster.
 	// API: PUBLIC ALPHA
 	//
+	//  Reference example:
+	//  ```
+	//  curl http://127.0.0.1:51875/_status/nodes
+	//   ->
+	//  {
+	//   "nodes": [
+	//     {
+	//       "desc": {
+	//         "nodeId": 1,
+	//         "address": {
+	//           "networkField": "tcp",
+	//           "addressField": "127.0.0.1:51876"
+	//         },
+	//         "attrs": {
+	//           "attrs": []
+	//         },
+	//         "locality": {
+	//           "tiers": [
+	//             {
+	//               "key": "region",
+	//               "value": "us-east1"
+	//             },
+	//             {
+	//               "key": "az",
+	//               "value": "b"
+	//             }
+	//           ]
+	//         },
+	//         "ServerVersion": {
+	//           "majorVal": 20,
+	//           "minorVal": 2,
+	//           "patch": 0,
+	//           "unstable": 1
+	//         },
+	//         "buildTag": "v20.2.0-alpha.3-2061-gb4156e4e2c",
+	//         "startedAt": "1606913361337496000",
+	//         "localityAddress": [],
+	//         "clusterName": "",
+	//         "sqlAddress": {
+	//           "networkField": "tcp",
+	//           "addressField": "127.0.0.1:51877"
+	//         }
+	//       },
+	//       "buildInfo": {...},
+	//       "startedAt": "1606913361337496000",
+	//       "updatedAt": "1606920801488818000",
+	//       "metrics": {...},
+	//       "storeStatuses": [
+	//         {
+	//           "desc": {
+	//             "storeId": 1,
+	//             "attrs": {
+	//               "attrs": []
+	//             },
+	//             "node": {
+	//               "nodeId": 1,
+	//               "address": {
+	//                 "networkField": "tcp",
+	//                 "addressField": "127.0.0.1:51876"
+	//               },
+	//               "attrs": {
+	//                 "attrs": []
+	//               },
+	//               "locality": {
+	//                 "tiers": [
+	//                   {
+	//                     "key": "region",
+	//                     "value": "us-east1"
+	//                   },
+	//                   {
+	//                     "key": "az",
+	//                     "value": "b"
+	//                   }
+	//                 ]
+	//               },
+	//               "ServerVersion": {
+	//                 "majorVal": 20,
+	//                 "minorVal": 2,
+	//                 "patch": 0,
+	//                 "unstable": 1
+	//               },
+	//               "buildTag": "v20.2.0-alpha.3-2061-gb4156e4e2c",
+	//               "startedAt": "1606913361337496000",
+	//               "localityAddress": [],
+	//               "clusterName": "",
+	//               "sqlAddress": {
+	//                 "networkField": "tcp",
+	//                 "addressField": "127.0.0.1:51877"
+	//               }
+	//             },
+	//             "capacity": {
+	//               "capacity": "536870912",
+	//               "available": "536870912",
+	//               "used": "0",
+	//               "logicalBytes": "21518089",
+	//               "rangeCount": 65,
+	//               "leaseCount": 65,
+	//               "queriesPerSecond": 10.326122145577715,
+	//               "writesPerSecond": 82.90851430132487,
+	//               "bytesPerReplica": {
+	//                 "p10": 0,
+	//                 "p25": 0,
+	//                 "p50": 460,
+	//                 "p75": 10118,
+	//                 "p90": 40825,
+	//                 "pMax": 20712052
+	//               },
+	//               "writesPerReplica": {...}
+	//             }
+	//           }
+	//           "metrics": {...}
+	//         }
+	//       ],
+	//       "args": [
+	//         "./cockroach",
+	//         "demo",
+	//         "--insecure"
+	//       ],
+	//       "env": [],
+	//       "latencies": {},
+	//       "activity": {
+	//         "1": {
+	//           "incoming": "235921",
+	//           "outgoing": "222073",
+	//           "latency": "677603"
+	//         }
+	//       },
+	//       "totalSystemMemory": "34359738368",
+	//       "numCpus": 16
+	//     }
+	//   ],
+	//   "livenessByNodeId": {
+	//     "1": 3
+	//   }
+	// }
+	//  ```
 	// Don't introduce additional usages of this RPC. See #50707 for more details.
 	// The underlying response type is something we're looking to get rid of.
 	Nodes(ctx context.Context, in *NodesRequest, opts ...grpc.CallOption) (*NodesResponse, error)
@@ -3732,25 +3887,130 @@ type StatusClient interface {
 	// API: PUBLIC ALPHA
 	Node(ctx context.Context, in *NodeRequest, opts ...grpc.CallOption) (*statuspb.NodeStatus, error)
 	// RaftDebug requests internal details about Raft.
+	// TODO DURING REVIEW: Not sure if this needs a reference example
 	RaftDebug(ctx context.Context, in *RaftDebugRequest, opts ...grpc.CallOption) (*RaftDebugResponse, error)
 	// Ranges requests internal details about ranges on a given node.
+	// TODO DURING REVIEW: Not sure if this needs a reference example
 	Ranges(ctx context.Context, in *RangesRequest, opts ...grpc.CallOption) (*RangesResponse, error)
 	// Gossip retrieves gossip-level details about a given node.
+	// TODO DURING REVIEW: Not sure if this needs a reference example
 	Gossip(ctx context.Context, in *GossipRequest, opts ...grpc.CallOption) (*gossip.InfoStatus, error)
 	// EngineStats retrieves statistics about a storage engine.
+	//
+	//  Reference example:
+	//  ```
+	//  curl http://127.0.0.1:51875/_status/enginestats/1
+	//   ->
+	//  {
+	//   "stats": [
+	//     {
+	//       "storeId": 1,
+	//       "tickersAndHistograms": {...},
+	//       "engineType": 2
+	//     }
+	//   ]
+	// }
+	//  ```
+	// TODO DURING REVIEW: This looks like it was only used by RocksDB and not Pebble.
+	// Not sure if we still want to keep the example.
 	EngineStats(ctx context.Context, in *EngineStatsRequest, opts ...grpc.CallOption) (*EngineStatsResponse, error)
 	// Allocator retrieves statistics about the replica allocator.
+	//
+	//  Reference example:
+	//  ```
+	//  curl http://127.0.0.1:51875/_status/allocator/node/1
+	//   ->
+	//  {
+	//   "dryRuns": [
+	//     {
+	//       "rangeId": "1",
+	//       "events": [
+	//         {
+	//           "time": "2020-12-02T14:53:24.252733Z",
+	//           "message": "kv/kvserver/replicate_queue.go:343 [n1,status] next replica action: consider rebalance"
+	//         },
+	//         {
+	//           "time": "2020-12-02T14:53:24.252789Z",
+	//           "message": "kv/kvserver/replicate_queue.go:849 [n1,status] no suitable rebalance target"
+	//         },
+	//         {
+	//           "time": "2020-12-02T14:53:24.252798Z",
+	//           "message": "kv/kvserver/allocator.go:847 [n1,status] no lease transfer target found"
+	//         }
+	//       ]
+	//     },
+	//     {
+	//       "rangeId": "2",
+	//       "events": [
+	//         {
+	//           "time": "2020-12-02T14:53:24.252825Z",
+	//           "message": "kv/kvserver/replicate_queue.go:343 [n1,status] next replica action: consider rebalance"
+	//         },
+	//         {
+	//           "time": "2020-12-02T14:53:24.252840Z",
+	//           "message": "kv/kvserver/replicate_queue.go:849 [n1,status] no suitable rebalance target"
+	//         },
+	//         {
+	//           "time": "2020-12-02T14:53:24.252847Z",
+	//           "message": "kv/kvserver/allocator.go:847 [n1,status] no lease transfer target found"
+	//         }
+	//       ]
+	//     },
+	//     ...
+	//   ]
+	// }
+	//  ```
 	Allocator(ctx context.Context, in *AllocatorRequest, opts ...grpc.CallOption) (*AllocatorResponse, error)
 	// AllocatorRange retrieves statistics about the replica allocator given
 	// a specific range.
 	AllocatorRange(ctx context.Context, in *AllocatorRangeRequest, opts ...grpc.CallOption) (*AllocatorRangeResponse, error)
 	// ListSessions retrieves the SQL sessions across the entire cluster.
+	//
+	//  Reference example:
+	//  ```
+	//  curl http://127.0.0.1:51875/_status/sessions
+	//   ->
+	//  {
+	//   "sessions": [
+	//     {
+	//       "nodeId": 1,
+	//       "username": "root",
+	//       "clientAddress": "127.0.0.1:51883",
+	//       "applicationName": "$ cockroach demo",
+	//       "activeQueries": [],
+	//       "start": "2020-12-02T12:49:22.173886Z",
+	//       "lastActiveQuery": "SHOW database",
+	//       "id": "FkznMGk07HgAAAAAAAAAAQ==",
+	//       "allocBytes": "0",
+	//       "maxAllocBytes": "30720",
+	//       "activeTxn": null,
+	//       "lastActiveQueryAnon": "SHOW database"
+	//     }
+	//   ],
+	//   "errors": []
+	// }
+	//  ```
 	ListSessions(ctx context.Context, in *ListSessionsRequest, opts ...grpc.CallOption) (*ListSessionsResponse, error)
 	// ListLocalSessions retrieves the SQL sessions on this node.
 	ListLocalSessions(ctx context.Context, in *ListSessionsRequest, opts ...grpc.CallOption) (*ListSessionsResponse, error)
 	// CancelQuery cancels a SQL query given its ID.
+	//
+	//  Reference example:
+	//  ```
+	//  curl http://127.0.0.1:26258/_status/cancel_query/1 -X POST -d  '{"node_id": "1", "query_id": "164cf86bc40442380000000000000001"}'
+	//  ->
+	//  {
+	//    "canceled": true,
+	//    "error": ""
+	//  }
+	//  ```
 	CancelQuery(ctx context.Context, in *CancelQueryRequest, opts ...grpc.CallOption) (*CancelQueryResponse, error)
 	// CancelSessions forcefully terminates a SQL session given its ID.
+	// TODO DURING REVIEW: The way we internally seem to be using this is
+	// by parsing the session ID string (returned by something like
+	// `SHOW SESSIONS`) into a uint128 and then casting that into a byte array of
+	// length 16. Not sure if this is supposed to ever be used externally, since
+	// it seems so unergonomic to use.
 	CancelSession(ctx context.Context, in *CancelSessionRequest, opts ...grpc.CallOption) (*CancelSessionResponse, error)
 	// SpanStats accepts a key span and node ID, and returns a set of stats
 	// summed from all ranges on the stores on that node which contain keys
@@ -3759,34 +4019,524 @@ type StatusClient interface {
 	// information about the resources on a node used by that table.
 	SpanStats(ctx context.Context, in *SpanStatsRequest, opts ...grpc.CallOption) (*SpanStatsResponse, error)
 	// Stacks retrieves the stack traces of all goroutines on a given node.
+	//
+	//  Reference example:
+	//  ```
+	//  curl http://127.0.0.1:51875/_status/stacks/1
+	//   ->
+	//  {
+	//   "data": "<payload>"
+	// }
+	//  ```
 	Stacks(ctx context.Context, in *StacksRequest, opts ...grpc.CallOption) (*JSONResponse, error)
 	// Profile retrieves a CPU profile on a given node.
+	//
+	//  Reference example:
+	//  ```
+	//  curl http://127.0.0.1:51875/_status/profile/1
+	//   ->
+	//  {
+	//   "data": "<payload>"
+	// }
+	//  ```
 	Profile(ctx context.Context, in *ProfileRequest, opts ...grpc.CallOption) (*JSONResponse, error)
 	// Metrics retrieves the node metrics for a given node.
 	//
 	// Note: this is a “reserved” API and should not be relied upon to
 	// build external tools. No guarantee is made about its
 	// availability and stability in external uses.
+	//
+	//  Reference example:
+	//  ```
+	//  curl http://127.0.0.1:51875/_status/metrics/1
+	//   ->
+	//  {
+	//   "data": "<payload>"
+	// }
+	//  ```
 	Metrics(ctx context.Context, in *MetricsRequest, opts ...grpc.CallOption) (*JSONResponse, error)
 	// GetFiles retrieves heap or goroutine dump files from a given node.
+	//
+	//  Reference example:
+	//  ```
+	//  curl http://127.0.0.1:51875/_status/files/1
+	//   ->
+	//  {
+	//  "files": [{
+	//   "name": "...",
+	//   "file_size": ...,
+	//   "contents": "..."
+	// }]
+	// }
+	//  ```
 	GetFiles(ctx context.Context, in *GetFilesRequest, opts ...grpc.CallOption) (*GetFilesResponse, error)
 	// LogFilesList retrieves a list of log files on a given node.
+	//
+	//  Reference example:
+	//  ```
+	//  curl http://127.0.0.1:51875/_status/logfiles/1
+	//   ->
+	//  {
+	//  "files": [{
+	//   "name": "...",
+	//   "file_size": ...,
+	//   "contents": "..."
+	// }]
+	// }
+	//  ```
 	LogFilesList(ctx context.Context, in *LogFilesListRequest, opts ...grpc.CallOption) (*LogFilesListResponse, error)
 	// LogFile retrieves a given log file.
 	LogFile(ctx context.Context, in *LogFileRequest, opts ...grpc.CallOption) (*LogEntriesResponse, error)
 	// Logs retrieves individual log entries.
 	Logs(ctx context.Context, in *LogsRequest, opts ...grpc.CallOption) (*LogEntriesResponse, error)
 	// ProblemRanges retrieves the list of “problem ranges”.
+	//
+	//  Reference example:
+	//  ```
+	//  curl http://127.0.0.1:51875/_status/problemranges
+	//   ->
+	//  {
+	//   "nodeId": 1,
+	//   "problemsByNodeId": {
+	//     "1": {
+	//       "errorMessage": "",
+	//       "unavailableRangeIds": [],
+	//       "raftLeaderNotLeaseHolderRangeIds": [],
+	//       "noRaftLeaderRangeIds": [],
+	//       "noLeaseRangeIds": [],
+	//       "underreplicatedRangeIds": [],
+	//       "overreplicatedRangeIds": [],
+	//       "quiescentEqualsTickingRangeIds": [],
+	//       "raftLogTooLargeRangeIds": []
+	//     }
+	//   }
+	// }
+	//  ```
 	ProblemRanges(ctx context.Context, in *ProblemRangesRequest, opts ...grpc.CallOption) (*ProblemRangesResponse, error)
+	// HotRanges retrieves a list of ranges ordered by the amount of traffic being
+	// received.
+	//
+	//  Reference example:
+	//  ```
+	//  curl http://127.0.0.1:51875/_status/hotranges
+	//   ->
+	//  {
+	//   "nodeId": 1,
+	//   "hotRangesByNodeId": {
+	//     "1": {
+	//       "errorMessage": "",
+	//       "stores": [
+	//         {
+	//           "storeId": 1,
+	//           "hotRanges": [
+	//             {
+	//               "desc": {
+	//                 "rangeId": "6",
+	//                 "startKey": "iA==",
+	//                 "endKey": "kw==",
+	//                 "internalReplicas": [
+	//                   {
+	//                     "nodeId": 1,
+	//                     "storeId": 1,
+	//                     "replicaId": 1,
+	//                     "type": null
+	//                   }
+	//                 ],
+	//                 "nextReplicaId": 2,
+	//                 "generation": "0",
+	//                 "deprecatedGenerationComparable": null,
+	//                 "stickyBit": null
+	//               },
+	//               "queriesPerSecond": 5.36106511320822
+	//             },
+	//             ...
+	//           ]
+	//         }
+	//       ]
+	//     }
+	//   }
+	// }
+	//  ```
 	HotRanges(ctx context.Context, in *HotRangesRequest, opts ...grpc.CallOption) (*HotRangesResponse, error)
+	// TODO DURING REVIEW: Not sure if this needs a reference example
 	Range(ctx context.Context, in *RangeRequest, opts ...grpc.CallOption) (*RangeResponse, error)
+	// TODO DURING REVIEW: Do we want to redact this response even further?
+	//  Reference example:
+	//  ```
+	//  curl http://127.0.0.1:51875/_status/diagnostics/1
+	//   ->
+	//  {
+	//   "node": {
+	//     "nodeId": 1,
+	//     "bytes": "21565824",
+	//     "keyCount": "5668",
+	//     "rangeCount": "65",
+	//     "locality": {
+	//       "tiers": [
+	//         {
+	//           "key": "5d64eba5",
+	//           "value": "67b07925"
+	//         },
+	//         {
+	//           "key": "d4f35d56",
+	//           "value": "d5a474fc"
+	//         }
+	//       ]
+	//     },
+	//     "hardware": {
+	//       "virtualization": "",
+	//       "cpu": {...},
+	//       "mem": {
+	//         "total": "34359738368",
+	//         "available": "15584899072"
+	//       },
+	//       "loadavg15": 4.7993164,
+	//       "provider": "",
+	//       "instanceClass": ""
+	//     },
+	//     "os": {
+	//       "family": "Standalone Workstation",
+	//       "platform": "darwin",
+	//       "version": "10.15.7"
+	//     },
+	//     "build": {...},
+	//     "uptime": "7443",
+	//     "licenseType": "Evaluation",
+	//     "topology": {
+	//       "provider": "",
+	//       "region": ""
+	//     }
+	//   },
+	//   "stores": [
+	//     {
+	//       "nodeId": 1,
+	//       "storeId": 1,
+	//       "bytes": "21565824",
+	//       "keyCount": "5668",
+	//       "rangeCount": "65",
+	//       "capacity": "536870912",
+	//       "available": "536870912",
+	//       "used": "0",
+	//       "encryptionAlgorithm": "0"
+	//     }
+	//   ],
+	//   "schema": [
+	//     {
+	//       "name": "_",
+	//       "id": 53,
+	//       "version": 7,
+	//       "modificationTime": {
+	//         "wallTime": "1606913362141165000",
+	//         "logical": 0
+	//       },
+	//       "drainingNames": [],
+	//       "parentId": 52,
+	//       "unexposedParentSchemaId": 29,
+	//       "columns": [
+	//         {
+	//           "name": "_",
+	//           "id": 1,
+	//           "type": {},
+	//           "nullable": false,
+	//           "defaultExpr": null,
+	//           "hidden": false,
+	//           "usesSequenceIds": [],
+	//           "ownsSequenceIds": [],
+	//           "computeExpr": null,
+	//           "pgAttributeNum": 0,
+	//           "alterColumnTypeInProgress": false,
+	//           "systemColumnKind": 0
+	//         },
+	//         ...
+	//       ],
+	//       "nextColumnId": 6,
+	//       "families": [
+	//         {
+	//           "name": "_",
+	//           "id": 0,
+	//           "columnNames": [
+	//             "_",
+	//             "_",
+	//             "_",
+	//             "_",
+	//             "_"
+	//           ],
+	//           "columnIds": [
+	//             1,
+	//             2,
+	//             3,
+	//             4,
+	//             5
+	//           ],
+	//           "defaultColumnId": 0
+	//         }
+	//       ],
+	//       "nextFamilyId": 1,
+	//       "primaryIndex": {
+	//         "name": "_",
+	//         "id": 1,
+	//         "unique": true,
+	//         "version": 1,
+	//         "columnNames": [
+	//           "_",
+	//           "_"
+	//         ],
+	//         "columnDirections": [
+	//           0,
+	//           0
+	//         ],
+	//         "storeColumnNames": [],
+	//         "columnIds": [
+	//           2,
+	//           1
+	//         ],
+	//         "extraColumnIds": [],
+	//         "storeColumnIds": [],
+	//         "compositeColumnIds": [],
+	//         "foreignKey": {
+	//           "table": 0,
+	//           "index": 0,
+	//           "name": "",
+	//           "validity": 0,
+	//           "sharedPrefixLen": 0,
+	//           "onDelete": "NO_ACTION",
+	//           "onUpdate": "NO_ACTION",
+	//           "match": "SIMPLE"
+	//         },
+	//         "referencedBy": [],
+	//         "interleave": {
+	//           "ancestors": []
+	//         },
+	//         "interleavedBy": [],
+	//         "partitioning": {
+	//           "numColumns": 0,
+	//           "list": [],
+	//           "range": []
+	//         },
+	//         "type": 0,
+	//         "createdExplicitly": false,
+	//         "encodingType": 0,
+	//         "sharded": {
+	//           "isSharded": false,
+	//           "name": "",
+	//           "shardBuckets": 0,
+	//           "columnNames": []
+	//         },
+	//         "disabled": false,
+	//         "geoConfig": {
+	//           "s2Geography": null,
+	//           "s2Geometry": null
+	//         },
+	//         "predicate": ""
+	//       },
+	//       "indexes": [],
+	//       "nextIndexId": 2,
+	//       "privileges": {
+	//         "users": [
+	//           {
+	//             "user": "_",
+	//             "privileges": 2
+	//           },
+	//           {
+	//             "user": "_",
+	//             "privileges": 2
+	//           }
+	//         ],
+	//         "owner": "_",
+	//         "version": 1
+	//       },
+	//       "mutations": [],
+	//       "lease": null,
+	//       "nextMutationId": 1,
+	//       "formatVersion": 3,
+	//       "state": 0,
+	//       "offlineReason": "",
+	//       "checks": [],
+	//       "viewQuery": "",
+	//       "isMaterializedView": false,
+	//       "dependsOn": [],
+	//       "dependedOnBy": [],
+	//       "mutationJobs": [],
+	//       "sequenceOpts": null,
+	//       "dropTime": "0",
+	//       "replacementOf": {
+	//         "id": 0,
+	//         "time": {
+	//           "wallTime": "0",
+	//           "logical": 0
+	//         }
+	//       },
+	//       "auditMode": 0,
+	//       "dropJobId": "0",
+	//       "gcMutations": [],
+	//       "createQuery": "",
+	//       "createAsOfTime": {
+	//         "wallTime": "1606913361488922000",
+	//         "logical": 0
+	//       },
+	//       "outboundFks": [],
+	//       "inboundFks": [
+	//         {
+	//           "originTableId": 54,
+	//           "originColumnIds": [
+	//             2,
+	//             4
+	//           ],
+	//           "referencedColumnIds": [
+	//             2,
+	//             1
+	//           ],
+	//           "referencedTableId": 53,
+	//           "name": "_",
+	//           "validity": 2,
+	//           "onDelete": "NO_ACTION",
+	//           "onUpdate": "NO_ACTION",
+	//           "match": "SIMPLE"
+	//         },
+	//         {
+	//           "originTableId": 55,
+	//           "originColumnIds": [
+	//             2,
+	//             4
+	//           ],
+	//           "referencedColumnIds": [
+	//             2,
+	//             1
+	//           ],
+	//           "referencedTableId": 53,
+	//           "name": "_",
+	//           "validity": 2,
+	//           "onDelete": "NO_ACTION",
+	//           "onUpdate": "NO_ACTION",
+	//           "match": "SIMPLE"
+	//         },
+	//         {
+	//           "originTableId": 58,
+	//           "originColumnIds": [
+	//             1,
+	//             2
+	//           ],
+	//           "referencedColumnIds": [
+	//             2,
+	//             1
+	//           ],
+	//           "referencedTableId": 53,
+	//           "name": "_",
+	//           "validity": 2,
+	//           "onDelete": "NO_ACTION",
+	//           "onUpdate": "NO_ACTION",
+	//           "match": "SIMPLE"
+	//         }
+	//       ],
+	//       "temporary": false
+	//     },
+	//     ...
+	//   ],
+	//   "sqlStats": [],
+	//   "alteredSettings": {
+	//     "cluster.organization": "<redacted>",
+	//     "cluster.secret": "<redacted>",
+	//     "diagnostics.reporting.enabled": "true",
+	//     "enterprise.license": "<redacted>",
+	//     "version": "20.2-1"
+	//   },
+	//   "zoneConfigs": {
+	//     "0": {
+	//       "rangeMinBytes": "134217728",
+	//       "rangeMaxBytes": "536870912",
+	//       "gc": {
+	//         "ttlSeconds": 90000
+	//       },
+	//       "numReplicas": 1,
+	//       "constraints": [],
+	//       "inheritedConstraints": false,
+	//       "leasePreferences": [],
+	//       "inheritedLeasePreferences": false,
+	//       "subzones": [],
+	//       "subzoneSpans": []
+	//     },
+	//     ...
+	//   },
+	//   "featureUsage": {...},
+	//   "legacyUnimplementedErrors": {},
+	//   "legacyErrorCounts": {}
+	// }
+	//  ```
 	Diagnostics(ctx context.Context, in *DiagnosticsRequest, opts ...grpc.CallOption) (*diagnosticspb.DiagnosticReport, error)
+	//  Reference example:
+	//  ```
+	//  curl http://127.0.0.1:51875/_status/stores/1
+	//   ->
+	//  {
+	//   "stores": [
+	//     {
+	//       "storeId": 1,
+	//       "encryptionStatus": null,
+	//       "totalFiles": "0",
+	//       "totalBytes": "0",
+	//       "activeKeyFiles": "0",
+	//       "activeKeyBytes": "0"
+	//     }
+	//   ]
+	// }
+	//  ```
 	Stores(ctx context.Context, in *StoresRequest, opts ...grpc.CallOption) (*StoresResponse, error)
 	Statements(ctx context.Context, in *StatementsRequest, opts ...grpc.CallOption) (*StatementsResponse, error)
 	CreateStatementDiagnosticsReport(ctx context.Context, in *CreateStatementDiagnosticsReportRequest, opts ...grpc.CallOption) (*CreateStatementDiagnosticsReportResponse, error)
 	StatementDiagnosticsRequests(ctx context.Context, in *StatementDiagnosticsReportsRequest, opts ...grpc.CallOption) (*StatementDiagnosticsReportsResponse, error)
 	StatementDiagnostics(ctx context.Context, in *StatementDiagnosticsRequest, opts ...grpc.CallOption) (*StatementDiagnosticsResponse, error)
+	//  Reference example:
+	//  ```
+	//  curl http://127.0.0.1:51875/_status/job_registry/1
+	//   ->
+	//  {
+	//   "nodeId": 1,
+	//   "runningJobs": []
+	// }
+	//  ```
 	JobRegistryStatus(ctx context.Context, in *JobRegistryStatusRequest, opts ...grpc.CallOption) (*JobRegistryStatusResponse, error)
+	//  Reference example:
+	//  ```
+	//  curl http://127.0.0.1:51875/_status/job/612247017297477633
+	//   ->
+	//  {
+	//   "job": {
+	//     "id": "612247017297477633",
+	//     "progress": {
+	//       "fractionCompleted": 1,
+	//       "modifiedMicros": "1606913361839096",
+	//       "runningStatus": "",
+	//       "schemaChange": {}
+	//     },
+	//     "payload": {
+	//       "description": "ALTER TABLE ...",
+	//       "statement": "",
+	//       "username": "root",
+	//       "startedMicros": "1606913361836868",
+	//       "finishedMicros": "1606913361839914",
+	//       "descriptorIds": [
+	//         53
+	//       ],
+	//       "error": "",
+	//       "resumeErrors": [],
+	//       "cleanupErrors": [],
+	//       "finalResumeError": null,
+	//       "lease": null,
+	//       "noncancelable": false,
+	//       "schemaChange": {
+	//         "resumeSpanList": [],
+	//         "droppedTables": [],
+	//         "droppedTypes": [],
+	//         "droppedSchemas": [],
+	//         "droppedDatabaseId": 0,
+	//         "descId": 53,
+	//         "tableMutationId": 0,
+	//         "formatVersion": 2
+	//       }
+	//     }
+	//   }
+	// }
+	//  ```
 	JobStatus(ctx context.Context, in *JobStatusRequest, opts ...grpc.CallOption) (*JobStatusResponse, error)
 }
 
@@ -4100,10 +4850,165 @@ type StatusServer interface {
 	// Certificates retrieves a copy of the TLS certificates.
 	Certificates(context.Context, *CertificatesRequest) (*CertificatesResponse, error)
 	// Details retrieves details about the nodes in the cluster.
+	//
+	//  Reference example:
+	//  ```
+	//  curl http://127.0.0.1:51875/_status/details/1
+	//    ->
+	//  {
+	//  "nodeId": 1,
+	//    "address": {
+	//    "networkField": "tcp",
+	//    "addressField": "127.0.0.1:51876"
+	//    },
+	//    "buildInfo": {...},
+	//    "systemInfo": {...},
+	//    "sqlAddress": {
+	//    "networkField": "tcp",
+	//    "addressField": "127.0.0.1:51877"
+	//    }
+	//  }
+	//  ```
 	Details(context.Context, *DetailsRequest) (*DetailsResponse, error)
 	// Nodes retrieves an overview of the nodes in the cluster.
 	// API: PUBLIC ALPHA
 	//
+	//  Reference example:
+	//  ```
+	//  curl http://127.0.0.1:51875/_status/nodes
+	//   ->
+	//  {
+	//   "nodes": [
+	//     {
+	//       "desc": {
+	//         "nodeId": 1,
+	//         "address": {
+	//           "networkField": "tcp",
+	//           "addressField": "127.0.0.1:51876"
+	//         },
+	//         "attrs": {
+	//           "attrs": []
+	//         },
+	//         "locality": {
+	//           "tiers": [
+	//             {
+	//               "key": "region",
+	//               "value": "us-east1"
+	//             },
+	//             {
+	//               "key": "az",
+	//               "value": "b"
+	//             }
+	//           ]
+	//         },
+	//         "ServerVersion": {
+	//           "majorVal": 20,
+	//           "minorVal": 2,
+	//           "patch": 0,
+	//           "unstable": 1
+	//         },
+	//         "buildTag": "v20.2.0-alpha.3-2061-gb4156e4e2c",
+	//         "startedAt": "1606913361337496000",
+	//         "localityAddress": [],
+	//         "clusterName": "",
+	//         "sqlAddress": {
+	//           "networkField": "tcp",
+	//           "addressField": "127.0.0.1:51877"
+	//         }
+	//       },
+	//       "buildInfo": {...},
+	//       "startedAt": "1606913361337496000",
+	//       "updatedAt": "1606920801488818000",
+	//       "metrics": {...},
+	//       "storeStatuses": [
+	//         {
+	//           "desc": {
+	//             "storeId": 1,
+	//             "attrs": {
+	//               "attrs": []
+	//             },
+	//             "node": {
+	//               "nodeId": 1,
+	//               "address": {
+	//                 "networkField": "tcp",
+	//                 "addressField": "127.0.0.1:51876"
+	//               },
+	//               "attrs": {
+	//                 "attrs": []
+	//               },
+	//               "locality": {
+	//                 "tiers": [
+	//                   {
+	//                     "key": "region",
+	//                     "value": "us-east1"
+	//                   },
+	//                   {
+	//                     "key": "az",
+	//                     "value": "b"
+	//                   }
+	//                 ]
+	//               },
+	//               "ServerVersion": {
+	//                 "majorVal": 20,
+	//                 "minorVal": 2,
+	//                 "patch": 0,
+	//                 "unstable": 1
+	//               },
+	//               "buildTag": "v20.2.0-alpha.3-2061-gb4156e4e2c",
+	//               "startedAt": "1606913361337496000",
+	//               "localityAddress": [],
+	//               "clusterName": "",
+	//               "sqlAddress": {
+	//                 "networkField": "tcp",
+	//                 "addressField": "127.0.0.1:51877"
+	//               }
+	//             },
+	//             "capacity": {
+	//               "capacity": "536870912",
+	//               "available": "536870912",
+	//               "used": "0",
+	//               "logicalBytes": "21518089",
+	//               "rangeCount": 65,
+	//               "leaseCount": 65,
+	//               "queriesPerSecond": 10.326122145577715,
+	//               "writesPerSecond": 82.90851430132487,
+	//               "bytesPerReplica": {
+	//                 "p10": 0,
+	//                 "p25": 0,
+	//                 "p50": 460,
+	//                 "p75": 10118,
+	//                 "p90": 40825,
+	//                 "pMax": 20712052
+	//               },
+	//               "writesPerReplica": {...}
+	//             }
+	//           }
+	//           "metrics": {...}
+	//         }
+	//       ],
+	//       "args": [
+	//         "./cockroach",
+	//         "demo",
+	//         "--insecure"
+	//       ],
+	//       "env": [],
+	//       "latencies": {},
+	//       "activity": {
+	//         "1": {
+	//           "incoming": "235921",
+	//           "outgoing": "222073",
+	//           "latency": "677603"
+	//         }
+	//       },
+	//       "totalSystemMemory": "34359738368",
+	//       "numCpus": 16
+	//     }
+	//   ],
+	//   "livenessByNodeId": {
+	//     "1": 3
+	//   }
+	// }
+	//  ```
 	// Don't introduce additional usages of this RPC. See #50707 for more details.
 	// The underlying response type is something we're looking to get rid of.
 	Nodes(context.Context, *NodesRequest) (*NodesResponse, error)
@@ -4111,25 +5016,130 @@ type StatusServer interface {
 	// API: PUBLIC ALPHA
 	Node(context.Context, *NodeRequest) (*statuspb.NodeStatus, error)
 	// RaftDebug requests internal details about Raft.
+	// TODO DURING REVIEW: Not sure if this needs a reference example
 	RaftDebug(context.Context, *RaftDebugRequest) (*RaftDebugResponse, error)
 	// Ranges requests internal details about ranges on a given node.
+	// TODO DURING REVIEW: Not sure if this needs a reference example
 	Ranges(context.Context, *RangesRequest) (*RangesResponse, error)
 	// Gossip retrieves gossip-level details about a given node.
+	// TODO DURING REVIEW: Not sure if this needs a reference example
 	Gossip(context.Context, *GossipRequest) (*gossip.InfoStatus, error)
 	// EngineStats retrieves statistics about a storage engine.
+	//
+	//  Reference example:
+	//  ```
+	//  curl http://127.0.0.1:51875/_status/enginestats/1
+	//   ->
+	//  {
+	//   "stats": [
+	//     {
+	//       "storeId": 1,
+	//       "tickersAndHistograms": {...},
+	//       "engineType": 2
+	//     }
+	//   ]
+	// }
+	//  ```
+	// TODO DURING REVIEW: This looks like it was only used by RocksDB and not Pebble.
+	// Not sure if we still want to keep the example.
 	EngineStats(context.Context, *EngineStatsRequest) (*EngineStatsResponse, error)
 	// Allocator retrieves statistics about the replica allocator.
+	//
+	//  Reference example:
+	//  ```
+	//  curl http://127.0.0.1:51875/_status/allocator/node/1
+	//   ->
+	//  {
+	//   "dryRuns": [
+	//     {
+	//       "rangeId": "1",
+	//       "events": [
+	//         {
+	//           "time": "2020-12-02T14:53:24.252733Z",
+	//           "message": "kv/kvserver/replicate_queue.go:343 [n1,status] next replica action: consider rebalance"
+	//         },
+	//         {
+	//           "time": "2020-12-02T14:53:24.252789Z",
+	//           "message": "kv/kvserver/replicate_queue.go:849 [n1,status] no suitable rebalance target"
+	//         },
+	//         {
+	//           "time": "2020-12-02T14:53:24.252798Z",
+	//           "message": "kv/kvserver/allocator.go:847 [n1,status] no lease transfer target found"
+	//         }
+	//       ]
+	//     },
+	//     {
+	//       "rangeId": "2",
+	//       "events": [
+	//         {
+	//           "time": "2020-12-02T14:53:24.252825Z",
+	//           "message": "kv/kvserver/replicate_queue.go:343 [n1,status] next replica action: consider rebalance"
+	//         },
+	//         {
+	//           "time": "2020-12-02T14:53:24.252840Z",
+	//           "message": "kv/kvserver/replicate_queue.go:849 [n1,status] no suitable rebalance target"
+	//         },
+	//         {
+	//           "time": "2020-12-02T14:53:24.252847Z",
+	//           "message": "kv/kvserver/allocator.go:847 [n1,status] no lease transfer target found"
+	//         }
+	//       ]
+	//     },
+	//     ...
+	//   ]
+	// }
+	//  ```
 	Allocator(context.Context, *AllocatorRequest) (*AllocatorResponse, error)
 	// AllocatorRange retrieves statistics about the replica allocator given
 	// a specific range.
 	AllocatorRange(context.Context, *AllocatorRangeRequest) (*AllocatorRangeResponse, error)
 	// ListSessions retrieves the SQL sessions across the entire cluster.
+	//
+	//  Reference example:
+	//  ```
+	//  curl http://127.0.0.1:51875/_status/sessions
+	//   ->
+	//  {
+	//   "sessions": [
+	//     {
+	//       "nodeId": 1,
+	//       "username": "root",
+	//       "clientAddress": "127.0.0.1:51883",
+	//       "applicationName": "$ cockroach demo",
+	//       "activeQueries": [],
+	//       "start": "2020-12-02T12:49:22.173886Z",
+	//       "lastActiveQuery": "SHOW database",
+	//       "id": "FkznMGk07HgAAAAAAAAAAQ==",
+	//       "allocBytes": "0",
+	//       "maxAllocBytes": "30720",
+	//       "activeTxn": null,
+	//       "lastActiveQueryAnon": "SHOW database"
+	//     }
+	//   ],
+	//   "errors": []
+	// }
+	//  ```
 	ListSessions(context.Context, *ListSessionsRequest) (*ListSessionsResponse, error)
 	// ListLocalSessions retrieves the SQL sessions on this node.
 	ListLocalSessions(context.Context, *ListSessionsRequest) (*ListSessionsResponse, error)
 	// CancelQuery cancels a SQL query given its ID.
+	//
+	//  Reference example:
+	//  ```
+	//  curl http://127.0.0.1:26258/_status/cancel_query/1 -X POST -d  '{"node_id": "1", "query_id": "164cf86bc40442380000000000000001"}'
+	//  ->
+	//  {
+	//    "canceled": true,
+	//    "error": ""
+	//  }
+	//  ```
 	CancelQuery(context.Context, *CancelQueryRequest) (*CancelQueryResponse, error)
 	// CancelSessions forcefully terminates a SQL session given its ID.
+	// TODO DURING REVIEW: The way we internally seem to be using this is
+	// by parsing the session ID string (returned by something like
+	// `SHOW SESSIONS`) into a uint128 and then casting that into a byte array of
+	// length 16. Not sure if this is supposed to ever be used externally, since
+	// it seems so unergonomic to use.
 	CancelSession(context.Context, *CancelSessionRequest) (*CancelSessionResponse, error)
 	// SpanStats accepts a key span and node ID, and returns a set of stats
 	// summed from all ranges on the stores on that node which contain keys
@@ -4138,34 +5148,524 @@ type StatusServer interface {
 	// information about the resources on a node used by that table.
 	SpanStats(context.Context, *SpanStatsRequest) (*SpanStatsResponse, error)
 	// Stacks retrieves the stack traces of all goroutines on a given node.
+	//
+	//  Reference example:
+	//  ```
+	//  curl http://127.0.0.1:51875/_status/stacks/1
+	//   ->
+	//  {
+	//   "data": "<payload>"
+	// }
+	//  ```
 	Stacks(context.Context, *StacksRequest) (*JSONResponse, error)
 	// Profile retrieves a CPU profile on a given node.
+	//
+	//  Reference example:
+	//  ```
+	//  curl http://127.0.0.1:51875/_status/profile/1
+	//   ->
+	//  {
+	//   "data": "<payload>"
+	// }
+	//  ```
 	Profile(context.Context, *ProfileRequest) (*JSONResponse, error)
 	// Metrics retrieves the node metrics for a given node.
 	//
 	// Note: this is a “reserved” API and should not be relied upon to
 	// build external tools. No guarantee is made about its
 	// availability and stability in external uses.
+	//
+	//  Reference example:
+	//  ```
+	//  curl http://127.0.0.1:51875/_status/metrics/1
+	//   ->
+	//  {
+	//   "data": "<payload>"
+	// }
+	//  ```
 	Metrics(context.Context, *MetricsRequest) (*JSONResponse, error)
 	// GetFiles retrieves heap or goroutine dump files from a given node.
+	//
+	//  Reference example:
+	//  ```
+	//  curl http://127.0.0.1:51875/_status/files/1
+	//   ->
+	//  {
+	//  "files": [{
+	//   "name": "...",
+	//   "file_size": ...,
+	//   "contents": "..."
+	// }]
+	// }
+	//  ```
 	GetFiles(context.Context, *GetFilesRequest) (*GetFilesResponse, error)
 	// LogFilesList retrieves a list of log files on a given node.
+	//
+	//  Reference example:
+	//  ```
+	//  curl http://127.0.0.1:51875/_status/logfiles/1
+	//   ->
+	//  {
+	//  "files": [{
+	//   "name": "...",
+	//   "file_size": ...,
+	//   "contents": "..."
+	// }]
+	// }
+	//  ```
 	LogFilesList(context.Context, *LogFilesListRequest) (*LogFilesListResponse, error)
 	// LogFile retrieves a given log file.
 	LogFile(context.Context, *LogFileRequest) (*LogEntriesResponse, error)
 	// Logs retrieves individual log entries.
 	Logs(context.Context, *LogsRequest) (*LogEntriesResponse, error)
 	// ProblemRanges retrieves the list of “problem ranges”.
+	//
+	//  Reference example:
+	//  ```
+	//  curl http://127.0.0.1:51875/_status/problemranges
+	//   ->
+	//  {
+	//   "nodeId": 1,
+	//   "problemsByNodeId": {
+	//     "1": {
+	//       "errorMessage": "",
+	//       "unavailableRangeIds": [],
+	//       "raftLeaderNotLeaseHolderRangeIds": [],
+	//       "noRaftLeaderRangeIds": [],
+	//       "noLeaseRangeIds": [],
+	//       "underreplicatedRangeIds": [],
+	//       "overreplicatedRangeIds": [],
+	//       "quiescentEqualsTickingRangeIds": [],
+	//       "raftLogTooLargeRangeIds": []
+	//     }
+	//   }
+	// }
+	//  ```
 	ProblemRanges(context.Context, *ProblemRangesRequest) (*ProblemRangesResponse, error)
+	// HotRanges retrieves a list of ranges ordered by the amount of traffic being
+	// received.
+	//
+	//  Reference example:
+	//  ```
+	//  curl http://127.0.0.1:51875/_status/hotranges
+	//   ->
+	//  {
+	//   "nodeId": 1,
+	//   "hotRangesByNodeId": {
+	//     "1": {
+	//       "errorMessage": "",
+	//       "stores": [
+	//         {
+	//           "storeId": 1,
+	//           "hotRanges": [
+	//             {
+	//               "desc": {
+	//                 "rangeId": "6",
+	//                 "startKey": "iA==",
+	//                 "endKey": "kw==",
+	//                 "internalReplicas": [
+	//                   {
+	//                     "nodeId": 1,
+	//                     "storeId": 1,
+	//                     "replicaId": 1,
+	//                     "type": null
+	//                   }
+	//                 ],
+	//                 "nextReplicaId": 2,
+	//                 "generation": "0",
+	//                 "deprecatedGenerationComparable": null,
+	//                 "stickyBit": null
+	//               },
+	//               "queriesPerSecond": 5.36106511320822
+	//             },
+	//             ...
+	//           ]
+	//         }
+	//       ]
+	//     }
+	//   }
+	// }
+	//  ```
 	HotRanges(context.Context, *HotRangesRequest) (*HotRangesResponse, error)
+	// TODO DURING REVIEW: Not sure if this needs a reference example
 	Range(context.Context, *RangeRequest) (*RangeResponse, error)
+	// TODO DURING REVIEW: Do we want to redact this response even further?
+	//  Reference example:
+	//  ```
+	//  curl http://127.0.0.1:51875/_status/diagnostics/1
+	//   ->
+	//  {
+	//   "node": {
+	//     "nodeId": 1,
+	//     "bytes": "21565824",
+	//     "keyCount": "5668",
+	//     "rangeCount": "65",
+	//     "locality": {
+	//       "tiers": [
+	//         {
+	//           "key": "5d64eba5",
+	//           "value": "67b07925"
+	//         },
+	//         {
+	//           "key": "d4f35d56",
+	//           "value": "d5a474fc"
+	//         }
+	//       ]
+	//     },
+	//     "hardware": {
+	//       "virtualization": "",
+	//       "cpu": {...},
+	//       "mem": {
+	//         "total": "34359738368",
+	//         "available": "15584899072"
+	//       },
+	//       "loadavg15": 4.7993164,
+	//       "provider": "",
+	//       "instanceClass": ""
+	//     },
+	//     "os": {
+	//       "family": "Standalone Workstation",
+	//       "platform": "darwin",
+	//       "version": "10.15.7"
+	//     },
+	//     "build": {...},
+	//     "uptime": "7443",
+	//     "licenseType": "Evaluation",
+	//     "topology": {
+	//       "provider": "",
+	//       "region": ""
+	//     }
+	//   },
+	//   "stores": [
+	//     {
+	//       "nodeId": 1,
+	//       "storeId": 1,
+	//       "bytes": "21565824",
+	//       "keyCount": "5668",
+	//       "rangeCount": "65",
+	//       "capacity": "536870912",
+	//       "available": "536870912",
+	//       "used": "0",
+	//       "encryptionAlgorithm": "0"
+	//     }
+	//   ],
+	//   "schema": [
+	//     {
+	//       "name": "_",
+	//       "id": 53,
+	//       "version": 7,
+	//       "modificationTime": {
+	//         "wallTime": "1606913362141165000",
+	//         "logical": 0
+	//       },
+	//       "drainingNames": [],
+	//       "parentId": 52,
+	//       "unexposedParentSchemaId": 29,
+	//       "columns": [
+	//         {
+	//           "name": "_",
+	//           "id": 1,
+	//           "type": {},
+	//           "nullable": false,
+	//           "defaultExpr": null,
+	//           "hidden": false,
+	//           "usesSequenceIds": [],
+	//           "ownsSequenceIds": [],
+	//           "computeExpr": null,
+	//           "pgAttributeNum": 0,
+	//           "alterColumnTypeInProgress": false,
+	//           "systemColumnKind": 0
+	//         },
+	//         ...
+	//       ],
+	//       "nextColumnId": 6,
+	//       "families": [
+	//         {
+	//           "name": "_",
+	//           "id": 0,
+	//           "columnNames": [
+	//             "_",
+	//             "_",
+	//             "_",
+	//             "_",
+	//             "_"
+	//           ],
+	//           "columnIds": [
+	//             1,
+	//             2,
+	//             3,
+	//             4,
+	//             5
+	//           ],
+	//           "defaultColumnId": 0
+	//         }
+	//       ],
+	//       "nextFamilyId": 1,
+	//       "primaryIndex": {
+	//         "name": "_",
+	//         "id": 1,
+	//         "unique": true,
+	//         "version": 1,
+	//         "columnNames": [
+	//           "_",
+	//           "_"
+	//         ],
+	//         "columnDirections": [
+	//           0,
+	//           0
+	//         ],
+	//         "storeColumnNames": [],
+	//         "columnIds": [
+	//           2,
+	//           1
+	//         ],
+	//         "extraColumnIds": [],
+	//         "storeColumnIds": [],
+	//         "compositeColumnIds": [],
+	//         "foreignKey": {
+	//           "table": 0,
+	//           "index": 0,
+	//           "name": "",
+	//           "validity": 0,
+	//           "sharedPrefixLen": 0,
+	//           "onDelete": "NO_ACTION",
+	//           "onUpdate": "NO_ACTION",
+	//           "match": "SIMPLE"
+	//         },
+	//         "referencedBy": [],
+	//         "interleave": {
+	//           "ancestors": []
+	//         },
+	//         "interleavedBy": [],
+	//         "partitioning": {
+	//           "numColumns": 0,
+	//           "list": [],
+	//           "range": []
+	//         },
+	//         "type": 0,
+	//         "createdExplicitly": false,
+	//         "encodingType": 0,
+	//         "sharded": {
+	//           "isSharded": false,
+	//           "name": "",
+	//           "shardBuckets": 0,
+	//           "columnNames": []
+	//         },
+	//         "disabled": false,
+	//         "geoConfig": {
+	//           "s2Geography": null,
+	//           "s2Geometry": null
+	//         },
+	//         "predicate": ""
+	//       },
+	//       "indexes": [],
+	//       "nextIndexId": 2,
+	//       "privileges": {
+	//         "users": [
+	//           {
+	//             "user": "_",
+	//             "privileges": 2
+	//           },
+	//           {
+	//             "user": "_",
+	//             "privileges": 2
+	//           }
+	//         ],
+	//         "owner": "_",
+	//         "version": 1
+	//       },
+	//       "mutations": [],
+	//       "lease": null,
+	//       "nextMutationId": 1,
+	//       "formatVersion": 3,
+	//       "state": 0,
+	//       "offlineReason": "",
+	//       "checks": [],
+	//       "viewQuery": "",
+	//       "isMaterializedView": false,
+	//       "dependsOn": [],
+	//       "dependedOnBy": [],
+	//       "mutationJobs": [],
+	//       "sequenceOpts": null,
+	//       "dropTime": "0",
+	//       "replacementOf": {
+	//         "id": 0,
+	//         "time": {
+	//           "wallTime": "0",
+	//           "logical": 0
+	//         }
+	//       },
+	//       "auditMode": 0,
+	//       "dropJobId": "0",
+	//       "gcMutations": [],
+	//       "createQuery": "",
+	//       "createAsOfTime": {
+	//         "wallTime": "1606913361488922000",
+	//         "logical": 0
+	//       },
+	//       "outboundFks": [],
+	//       "inboundFks": [
+	//         {
+	//           "originTableId": 54,
+	//           "originColumnIds": [
+	//             2,
+	//             4
+	//           ],
+	//           "referencedColumnIds": [
+	//             2,
+	//             1
+	//           ],
+	//           "referencedTableId": 53,
+	//           "name": "_",
+	//           "validity": 2,
+	//           "onDelete": "NO_ACTION",
+	//           "onUpdate": "NO_ACTION",
+	//           "match": "SIMPLE"
+	//         },
+	//         {
+	//           "originTableId": 55,
+	//           "originColumnIds": [
+	//             2,
+	//             4
+	//           ],
+	//           "referencedColumnIds": [
+	//             2,
+	//             1
+	//           ],
+	//           "referencedTableId": 53,
+	//           "name": "_",
+	//           "validity": 2,
+	//           "onDelete": "NO_ACTION",
+	//           "onUpdate": "NO_ACTION",
+	//           "match": "SIMPLE"
+	//         },
+	//         {
+	//           "originTableId": 58,
+	//           "originColumnIds": [
+	//             1,
+	//             2
+	//           ],
+	//           "referencedColumnIds": [
+	//             2,
+	//             1
+	//           ],
+	//           "referencedTableId": 53,
+	//           "name": "_",
+	//           "validity": 2,
+	//           "onDelete": "NO_ACTION",
+	//           "onUpdate": "NO_ACTION",
+	//           "match": "SIMPLE"
+	//         }
+	//       ],
+	//       "temporary": false
+	//     },
+	//     ...
+	//   ],
+	//   "sqlStats": [],
+	//   "alteredSettings": {
+	//     "cluster.organization": "<redacted>",
+	//     "cluster.secret": "<redacted>",
+	//     "diagnostics.reporting.enabled": "true",
+	//     "enterprise.license": "<redacted>",
+	//     "version": "20.2-1"
+	//   },
+	//   "zoneConfigs": {
+	//     "0": {
+	//       "rangeMinBytes": "134217728",
+	//       "rangeMaxBytes": "536870912",
+	//       "gc": {
+	//         "ttlSeconds": 90000
+	//       },
+	//       "numReplicas": 1,
+	//       "constraints": [],
+	//       "inheritedConstraints": false,
+	//       "leasePreferences": [],
+	//       "inheritedLeasePreferences": false,
+	//       "subzones": [],
+	//       "subzoneSpans": []
+	//     },
+	//     ...
+	//   },
+	//   "featureUsage": {...},
+	//   "legacyUnimplementedErrors": {},
+	//   "legacyErrorCounts": {}
+	// }
+	//  ```
 	Diagnostics(context.Context, *DiagnosticsRequest) (*diagnosticspb.DiagnosticReport, error)
+	//  Reference example:
+	//  ```
+	//  curl http://127.0.0.1:51875/_status/stores/1
+	//   ->
+	//  {
+	//   "stores": [
+	//     {
+	//       "storeId": 1,
+	//       "encryptionStatus": null,
+	//       "totalFiles": "0",
+	//       "totalBytes": "0",
+	//       "activeKeyFiles": "0",
+	//       "activeKeyBytes": "0"
+	//     }
+	//   ]
+	// }
+	//  ```
 	Stores(context.Context, *StoresRequest) (*StoresResponse, error)
 	Statements(context.Context, *StatementsRequest) (*StatementsResponse, error)
 	CreateStatementDiagnosticsReport(context.Context, *CreateStatementDiagnosticsReportRequest) (*CreateStatementDiagnosticsReportResponse, error)
 	StatementDiagnosticsRequests(context.Context, *StatementDiagnosticsReportsRequest) (*StatementDiagnosticsReportsResponse, error)
 	StatementDiagnostics(context.Context, *StatementDiagnosticsRequest) (*StatementDiagnosticsResponse, error)
+	//  Reference example:
+	//  ```
+	//  curl http://127.0.0.1:51875/_status/job_registry/1
+	//   ->
+	//  {
+	//   "nodeId": 1,
+	//   "runningJobs": []
+	// }
+	//  ```
 	JobRegistryStatus(context.Context, *JobRegistryStatusRequest) (*JobRegistryStatusResponse, error)
+	//  Reference example:
+	//  ```
+	//  curl http://127.0.0.1:51875/_status/job/612247017297477633
+	//   ->
+	//  {
+	//   "job": {
+	//     "id": "612247017297477633",
+	//     "progress": {
+	//       "fractionCompleted": 1,
+	//       "modifiedMicros": "1606913361839096",
+	//       "runningStatus": "",
+	//       "schemaChange": {}
+	//     },
+	//     "payload": {
+	//       "description": "ALTER TABLE ...",
+	//       "statement": "",
+	//       "username": "root",
+	//       "startedMicros": "1606913361836868",
+	//       "finishedMicros": "1606913361839914",
+	//       "descriptorIds": [
+	//         53
+	//       ],
+	//       "error": "",
+	//       "resumeErrors": [],
+	//       "cleanupErrors": [],
+	//       "finalResumeError": null,
+	//       "lease": null,
+	//       "noncancelable": false,
+	//       "schemaChange": {
+	//         "resumeSpanList": [],
+	//         "droppedTables": [],
+	//         "droppedTypes": [],
+	//         "droppedSchemas": [],
+	//         "droppedDatabaseId": 0,
+	//         "descId": 53,
+	//         "tableMutationId": 0,
+	//         "formatVersion": 2
+	//       }
+	//     }
+	//   }
+	// }
+	//  ```
 	JobStatus(context.Context, *JobStatusRequest) (*JobStatusResponse, error)
 }
 
@@ -22519,10 +24019,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("server/serverpb/status.proto", fileDescriptor_status_0a3e72b0cdc5b0fe)
+	proto.RegisterFile("server/serverpb/status.proto", fileDescriptor_status_b6f9c0e85bc99cc8)
 }
 
-var fileDescriptor_status_0a3e72b0cdc5b0fe = []byte{
+var fileDescriptor_status_b6f9c0e85bc99cc8 = []byte{
 	// 6184 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xcc, 0x7c, 0x5d, 0x6c, 0x5b, 0x47,
 	0x76, 0xbf, 0x2f, 0x49, 0x51, 0xe4, 0xa1, 0x3e, 0xa8, 0xd1, 0x87, 0x69, 0xda, 0x91, 0x9c, 0xeb,

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -1004,6 +1004,25 @@ service Status {
   }
 
   // Details retrieves details about the nodes in the cluster.
+  //
+  //  Reference example:
+  //  ```
+  //  curl http://127.0.0.1:51875/_status/details/1
+  //    ->
+  //  {
+  //  "nodeId": 1,
+  //    "address": {
+  //    "networkField": "tcp",
+  //    "addressField": "127.0.0.1:51876"
+  //    },
+  //    "buildInfo": {...},
+  //    "systemInfo": {...},
+  //    "sqlAddress": {
+  //    "networkField": "tcp",
+  //    "addressField": "127.0.0.1:51877"
+  //    }
+  //  }
+  //  ```
   rpc Details(DetailsRequest) returns (DetailsResponse) {
     option (google.api.http) = {
       get : "/_status/details/{node_id}"
@@ -1013,6 +1032,142 @@ service Status {
   // Nodes retrieves an overview of the nodes in the cluster.
   // API: PUBLIC ALPHA
   //
+  //  Reference example:
+  //  ``` 
+  //  curl http://127.0.0.1:51875/_status/nodes   
+  //   ->
+  //  {
+  //   "nodes": [
+  //     {
+  //       "desc": {
+  //         "nodeId": 1,
+  //         "address": {
+  //           "networkField": "tcp",
+  //           "addressField": "127.0.0.1:51876"
+  //         },
+  //         "attrs": {
+  //           "attrs": []
+  //         },
+  //         "locality": {
+  //           "tiers": [
+  //             {
+  //               "key": "region",
+  //               "value": "us-east1"
+  //             },
+  //             {
+  //               "key": "az",
+  //               "value": "b"
+  //             }
+  //           ]
+  //         },
+  //         "ServerVersion": {
+  //           "majorVal": 20,
+  //           "minorVal": 2,
+  //           "patch": 0,
+  //           "unstable": 1
+  //         },
+  //         "buildTag": "v20.2.0-alpha.3-2061-gb4156e4e2c",
+  //         "startedAt": "1606913361337496000",
+  //         "localityAddress": [],
+  //         "clusterName": "",
+  //         "sqlAddress": {
+  //           "networkField": "tcp",
+  //           "addressField": "127.0.0.1:51877"
+  //         }
+  //       },
+  //       "buildInfo": {...},
+  //       "startedAt": "1606913361337496000",
+  //       "updatedAt": "1606920801488818000",
+  //       "metrics": {...},
+  //       "storeStatuses": [
+  //         {
+  //           "desc": {
+  //             "storeId": 1,
+  //             "attrs": {
+  //               "attrs": []
+  //             },
+  //             "node": {
+  //               "nodeId": 1,
+  //               "address": {
+  //                 "networkField": "tcp",
+  //                 "addressField": "127.0.0.1:51876"
+  //               },
+  //               "attrs": {
+  //                 "attrs": []
+  //               },
+  //               "locality": {
+  //                 "tiers": [
+  //                   {
+  //                     "key": "region",
+  //                     "value": "us-east1"
+  //                   },
+  //                   {
+  //                     "key": "az",
+  //                     "value": "b"
+  //                   }
+  //                 ]
+  //               },
+  //               "ServerVersion": {
+  //                 "majorVal": 20,
+  //                 "minorVal": 2,
+  //                 "patch": 0,
+  //                 "unstable": 1
+  //               },
+  //               "buildTag": "v20.2.0-alpha.3-2061-gb4156e4e2c",
+  //               "startedAt": "1606913361337496000",
+  //               "localityAddress": [],
+  //               "clusterName": "",
+  //               "sqlAddress": {
+  //                 "networkField": "tcp",
+  //                 "addressField": "127.0.0.1:51877"
+  //               }
+  //             },
+  //             "capacity": {
+  //               "capacity": "536870912",
+  //               "available": "536870912",
+  //               "used": "0",
+  //               "logicalBytes": "21518089",
+  //               "rangeCount": 65,
+  //               "leaseCount": 65,
+  //               "queriesPerSecond": 10.326122145577715,
+  //               "writesPerSecond": 82.90851430132487,
+  //               "bytesPerReplica": {
+  //                 "p10": 0,
+  //                 "p25": 0,
+  //                 "p50": 460,
+  //                 "p75": 10118,
+  //                 "p90": 40825,
+  //                 "pMax": 20712052
+  //               },
+  //               "writesPerReplica": {...}
+  //             }
+  //           }
+  //           "metrics": {...}
+  //         }
+  //       ],
+  //       "args": [
+  //         "./cockroach",
+  //         "demo",
+  //         "--insecure"
+  //       ],
+  //       "env": [],
+  //       "latencies": {},
+  //       "activity": {
+  //         "1": {
+  //           "incoming": "235921",
+  //           "outgoing": "222073",
+  //           "latency": "677603"
+  //         }
+  //       },
+  //       "totalSystemMemory": "34359738368",
+  //       "numCpus": 16
+  //     }
+  //   ],
+  //   "livenessByNodeId": {
+  //     "1": 3
+  //   }
+  // }   
+  //  ```
   // Don't introduce additional usages of this RPC. See #50707 for more details.
   // The underlying response type is something we're looking to get rid of.
   rpc Nodes(NodesRequest) returns (NodesResponse) {
@@ -1031,6 +1186,7 @@ service Status {
 
 
   // RaftDebug requests internal details about Raft.
+  // TODO DURING REVIEW: Not sure if this needs a reference example
   rpc RaftDebug(RaftDebugRequest) returns (RaftDebugResponse) {
     option (google.api.http) = {
       get : "/_status/raft"
@@ -1038,6 +1194,7 @@ service Status {
   }
 
   // Ranges requests internal details about ranges on a given node.
+  // TODO DURING REVIEW: Not sure if this needs a reference example
   rpc Ranges(RangesRequest) returns (RangesResponse) {
     option (google.api.http) = {
       get : "/_status/ranges/{node_id}"
@@ -1045,6 +1202,7 @@ service Status {
   }
 
   // Gossip retrieves gossip-level details about a given node.
+  // TODO DURING REVIEW: Not sure if this needs a reference example
   rpc Gossip(GossipRequest) returns (gossip.InfoStatus) {
     option (google.api.http) = {
       get : "/_status/gossip/{node_id}"
@@ -1052,6 +1210,23 @@ service Status {
   }
 
   // EngineStats retrieves statistics about a storage engine.
+  //
+  //  Reference example:
+  //  ``` 
+  //  curl http://127.0.0.1:51875/_status/enginestats/1   
+  //   ->
+  //  {
+  //   "stats": [
+  //     {
+  //       "storeId": 1,
+  //       "tickersAndHistograms": {...},
+  //       "engineType": 2
+  //     }
+  //   ]
+  // }   
+  //  ```
+  // TODO DURING REVIEW: This looks like it was only used by RocksDB and not Pebble. 
+  // Not sure if we still want to keep the example.
   rpc EngineStats(EngineStatsRequest) returns (EngineStatsResponse) {
     option (google.api.http) = {
       get : "/_status/enginestats/{node_id}"
@@ -1059,6 +1234,51 @@ service Status {
   }
 
   // Allocator retrieves statistics about the replica allocator.
+  //
+  //  Reference example:
+  //  ``` 
+  //  curl http://127.0.0.1:51875/_status/allocator/node/1   
+  //   ->
+  //  {
+  //   "dryRuns": [
+  //     {
+  //       "rangeId": "1",
+  //       "events": [
+  //         {
+  //           "time": "2020-12-02T14:53:24.252733Z",
+  //           "message": "kv/kvserver/replicate_queue.go:343 [n1,status] next replica action: consider rebalance"
+  //         },
+  //         {
+  //           "time": "2020-12-02T14:53:24.252789Z",
+  //           "message": "kv/kvserver/replicate_queue.go:849 [n1,status] no suitable rebalance target"
+  //         },
+  //         {
+  //           "time": "2020-12-02T14:53:24.252798Z",
+  //           "message": "kv/kvserver/allocator.go:847 [n1,status] no lease transfer target found"
+  //         }
+  //       ]
+  //     },
+  //     {
+  //       "rangeId": "2",
+  //       "events": [
+  //         {
+  //           "time": "2020-12-02T14:53:24.252825Z",
+  //           "message": "kv/kvserver/replicate_queue.go:343 [n1,status] next replica action: consider rebalance"
+  //         },
+  //         {
+  //           "time": "2020-12-02T14:53:24.252840Z",
+  //           "message": "kv/kvserver/replicate_queue.go:849 [n1,status] no suitable rebalance target"
+  //         },
+  //         {
+  //           "time": "2020-12-02T14:53:24.252847Z",
+  //           "message": "kv/kvserver/allocator.go:847 [n1,status] no lease transfer target found"
+  //         }
+  //       ]
+  //     },
+  //     ...
+  //   ]
+  // }   
+  //  ```
   rpc Allocator(AllocatorRequest) returns (AllocatorResponse) {
     option (google.api.http) = {
       get : "/_status/allocator/node/{node_id}"
@@ -1074,6 +1294,31 @@ service Status {
   }
 
   // ListSessions retrieves the SQL sessions across the entire cluster.
+  //
+  //  Reference example:
+  //  ``` 
+  //  curl http://127.0.0.1:51875/_status/sessions   
+  //   ->
+  //  {
+  //   "sessions": [
+  //     {
+  //       "nodeId": 1,
+  //       "username": "root",
+  //       "clientAddress": "127.0.0.1:51883",
+  //       "applicationName": "$ cockroach demo",
+  //       "activeQueries": [],
+  //       "start": "2020-12-02T12:49:22.173886Z",
+  //       "lastActiveQuery": "SHOW database",
+  //       "id": "FkznMGk07HgAAAAAAAAAAQ==",
+  //       "allocBytes": "0",
+  //       "maxAllocBytes": "30720",
+  //       "activeTxn": null,
+  //       "lastActiveQueryAnon": "SHOW database"
+  //     }
+  //   ],
+  //   "errors": []
+  // }   
+  //  ```
   rpc ListSessions(ListSessionsRequest) returns (ListSessionsResponse) {
     option (google.api.http) = {
       get : "/_status/sessions"
@@ -1088,6 +1333,16 @@ service Status {
   }
 
   // CancelQuery cancels a SQL query given its ID.
+  //
+  //  Reference example:
+  //  ```
+  //  curl http://127.0.0.1:26258/_status/cancel_query/1 -X POST -d  '{"node_id": "1", "query_id": "164cf86bc40442380000000000000001"}'
+  //  ->
+  //  {
+  //    "canceled": true,
+  //    "error": ""
+  //  }
+  //  ```
   rpc CancelQuery(CancelQueryRequest) returns (CancelQueryResponse) {
     option (google.api.http) = {
       post : "/_status/cancel_query/{node_id}"
@@ -1096,6 +1351,11 @@ service Status {
   }
 
   // CancelSessions forcefully terminates a SQL session given its ID.
+  // TODO DURING REVIEW: The way we internally seem to be using this is
+  // by parsing the session ID string (returned by something like
+  // `SHOW SESSIONS`) into a uint128 and then casting that into a byte array of 
+  // length 16. Not sure if this is supposed to ever be used externally, since 
+  // it seems so unergonomic to use.
   rpc CancelSession(CancelSessionRequest) returns (CancelSessionResponse) {
     option (google.api.http) = {
       post : "/_status/cancel_session/{node_id}"
@@ -1116,6 +1376,15 @@ service Status {
   }
 
   // Stacks retrieves the stack traces of all goroutines on a given node.
+  //
+  //  Reference example:
+  //  ``` 
+  //  curl http://127.0.0.1:51875/_status/stacks/1   
+  //   ->
+  //  {
+  //   "data": "<payload>"
+  // }   
+  //  ```
   rpc Stacks(StacksRequest) returns (JSONResponse) {
     option (google.api.http) = {
       get : "/_status/stacks/{node_id}"
@@ -1123,6 +1392,15 @@ service Status {
   }
 
   // Profile retrieves a CPU profile on a given node.
+  //
+  //  Reference example:
+  //  ``` 
+  //  curl http://127.0.0.1:51875/_status/profile/1   
+  //   ->
+  //  {
+  //   "data": "<payload>"
+  // }   
+  //  ```
   rpc Profile(ProfileRequest) returns (JSONResponse) {
     option (google.api.http) = {
       get : "/_status/profile/{node_id}"
@@ -1134,6 +1412,15 @@ service Status {
   // Note: this is a “reserved” API and should not be relied upon to
   // build external tools. No guarantee is made about its
   // availability and stability in external uses.
+  //
+  //  Reference example:
+  //  ``` 
+  //  curl http://127.0.0.1:51875/_status/metrics/1   
+  //   ->
+  //  {
+  //   "data": "<payload>"
+  // }   
+  //  ``` 
   rpc Metrics(MetricsRequest) returns (JSONResponse) {
     option (google.api.http) = {
       get : "/_status/metrics/{node_id}"
@@ -1141,6 +1428,19 @@ service Status {
   }
 
   // GetFiles retrieves heap or goroutine dump files from a given node.
+  //
+  //  Reference example:
+  //  ``` 
+  //  curl http://127.0.0.1:51875/_status/files/1   
+  //   ->
+  //  {
+  //  "files": [{
+  //   "name": "...",
+  //   "file_size": ...,
+  //   "contents": "..."    
+  // }]
+  // }   
+  //  ```
   rpc GetFiles(GetFilesRequest) returns (GetFilesResponse) {
     option (google.api.http) = {
       get : "/_status/files/{node_id}"
@@ -1148,11 +1448,28 @@ service Status {
   }
 
   // LogFilesList retrieves a list of log files on a given node.
+  //
+  //  Reference example:
+  //  ``` 
+  //  curl http://127.0.0.1:51875/_status/logfiles/1   
+  //   ->
+  //  {
+  //  "files": [{
+  //   "name": "...",
+  //   "file_size": ...,
+  //   "contents": "..."    
+  // }]
+  // }   
+  //  ```
   rpc LogFilesList(LogFilesListRequest) returns (LogFilesListResponse) {
     option (google.api.http) = {
       get : "/_status/logfiles/{node_id}"
     };
   }
+
+  // TODO DURING REVIEW:
+  // I'm not sure if the next two services can even be properly used via
+  // grpc gateway, since they're GET endpoints but seem to require a bunch of auxilliary info.
 
   // LogFile retrieves a given log file.
   rpc LogFile(LogFileRequest) returns (LogEntriesResponse) {
@@ -1169,28 +1486,418 @@ service Status {
   }
 
   // ProblemRanges retrieves the list of “problem ranges”.
+  //
+  //  Reference example:
+  //  ``` 
+  //  curl http://127.0.0.1:51875/_status/problemranges   
+  //   ->
+  //  {
+  //   "nodeId": 1,
+  //   "problemsByNodeId": {
+  //     "1": {
+  //       "errorMessage": "",
+  //       "unavailableRangeIds": [],
+  //       "raftLeaderNotLeaseHolderRangeIds": [],
+  //       "noRaftLeaderRangeIds": [],
+  //       "noLeaseRangeIds": [],
+  //       "underreplicatedRangeIds": [],
+  //       "overreplicatedRangeIds": [],
+  //       "quiescentEqualsTickingRangeIds": [],
+  //       "raftLogTooLargeRangeIds": []
+  //     }
+  //   }
+  // }   
+  //  ```   
   rpc ProblemRanges(ProblemRangesRequest) returns (ProblemRangesResponse) {
     option (google.api.http) = {
       get : "/_status/problemranges"
     };
   }
 
+
+  // HotRanges retrieves a list of ranges ordered by the amount of traffic being 
+  // received.
+  //
+  //  Reference example:
+  //  ``` 
+  //  curl http://127.0.0.1:51875/_status/hotranges   
+  //   ->
+  //  {
+  //   "nodeId": 1,
+  //   "hotRangesByNodeId": {
+  //     "1": {
+  //       "errorMessage": "",
+  //       "stores": [
+  //         {
+  //           "storeId": 1,
+  //           "hotRanges": [
+  //             {
+  //               "desc": {
+  //                 "rangeId": "6",
+  //                 "startKey": "iA==",
+  //                 "endKey": "kw==",
+  //                 "internalReplicas": [
+  //                   {
+  //                     "nodeId": 1,
+  //                     "storeId": 1,
+  //                     "replicaId": 1,
+  //                     "type": null
+  //                   }
+  //                 ],
+  //                 "nextReplicaId": 2,
+  //                 "generation": "0",
+  //                 "deprecatedGenerationComparable": null,
+  //                 "stickyBit": null
+  //               },
+  //               "queriesPerSecond": 5.36106511320822
+  //             },
+  //             ...
+  //           ]
+  //         }
+  //       ]
+  //     }
+  //   }
+  // }   
+  //  ```
   rpc HotRanges(HotRangesRequest) returns (HotRangesResponse) {
     option (google.api.http) = {
       get : "/_status/hotranges"
     };
   }
+
+  // TODO DURING REVIEW: Not sure if this needs a reference example
   rpc Range(RangeRequest) returns (RangeResponse) {
     option (google.api.http) = {
       get : "/_status/range/{range_id}"
     };
   }
+  
+  // TODO DURING REVIEW: Do we want to redact this response even further? 
+  //  Reference example:
+  //  ``` 
+  //  curl http://127.0.0.1:51875/_status/diagnostics/1   
+  //   ->
+  //  {
+  //   "node": {
+  //     "nodeId": 1,
+  //     "bytes": "21565824",
+  //     "keyCount": "5668",
+  //     "rangeCount": "65",
+  //     "locality": {
+  //       "tiers": [
+  //         {
+  //           "key": "5d64eba5",
+  //           "value": "67b07925"
+  //         },
+  //         {
+  //           "key": "d4f35d56",
+  //           "value": "d5a474fc"
+  //         }
+  //       ]
+  //     },
+  //     "hardware": {
+  //       "virtualization": "",
+  //       "cpu": {...},
+  //       "mem": {
+  //         "total": "34359738368",
+  //         "available": "15584899072"
+  //       },
+  //       "loadavg15": 4.7993164,
+  //       "provider": "",
+  //       "instanceClass": ""
+  //     },
+  //     "os": {
+  //       "family": "Standalone Workstation",
+  //       "platform": "darwin",
+  //       "version": "10.15.7"
+  //     },
+  //     "build": {...},
+  //     "uptime": "7443",
+  //     "licenseType": "Evaluation",
+  //     "topology": {
+  //       "provider": "",
+  //       "region": ""
+  //     }
+  //   },
+  //   "stores": [
+  //     {
+  //       "nodeId": 1,
+  //       "storeId": 1,
+  //       "bytes": "21565824",
+  //       "keyCount": "5668",
+  //       "rangeCount": "65",
+  //       "capacity": "536870912",
+  //       "available": "536870912",
+  //       "used": "0",
+  //       "encryptionAlgorithm": "0"
+  //     }
+  //   ],
+  //   "schema": [
+  //     {
+  //       "name": "_",
+  //       "id": 53,
+  //       "version": 7,
+  //       "modificationTime": {
+  //         "wallTime": "1606913362141165000",
+  //         "logical": 0
+  //       },
+  //       "drainingNames": [],
+  //       "parentId": 52,
+  //       "unexposedParentSchemaId": 29,
+  //       "columns": [
+  //         {
+  //           "name": "_",
+  //           "id": 1,
+  //           "type": {},
+  //           "nullable": false,
+  //           "defaultExpr": null,
+  //           "hidden": false,
+  //           "usesSequenceIds": [],
+  //           "ownsSequenceIds": [],
+  //           "computeExpr": null,
+  //           "pgAttributeNum": 0,
+  //           "alterColumnTypeInProgress": false,
+  //           "systemColumnKind": 0
+  //         },
+  //         ...
+  //       ],
+  //       "nextColumnId": 6,
+  //       "families": [
+  //         {
+  //           "name": "_",
+  //           "id": 0,
+  //           "columnNames": [
+  //             "_",
+  //             "_",
+  //             "_",
+  //             "_",
+  //             "_"
+  //           ],
+  //           "columnIds": [
+  //             1,
+  //             2,
+  //             3,
+  //             4,
+  //             5
+  //           ],
+  //           "defaultColumnId": 0
+  //         }
+  //       ],
+  //       "nextFamilyId": 1,
+  //       "primaryIndex": {
+  //         "name": "_",
+  //         "id": 1,
+  //         "unique": true,
+  //         "version": 1,
+  //         "columnNames": [
+  //           "_",
+  //           "_"
+  //         ],
+  //         "columnDirections": [
+  //           0,
+  //           0
+  //         ],
+  //         "storeColumnNames": [],
+  //         "columnIds": [
+  //           2,
+  //           1
+  //         ],
+  //         "extraColumnIds": [],
+  //         "storeColumnIds": [],
+  //         "compositeColumnIds": [],
+  //         "foreignKey": {
+  //           "table": 0,
+  //           "index": 0,
+  //           "name": "",
+  //           "validity": 0,
+  //           "sharedPrefixLen": 0,
+  //           "onDelete": "NO_ACTION",
+  //           "onUpdate": "NO_ACTION",
+  //           "match": "SIMPLE"
+  //         },
+  //         "referencedBy": [],
+  //         "interleave": {
+  //           "ancestors": []
+  //         },
+  //         "interleavedBy": [],
+  //         "partitioning": {
+  //           "numColumns": 0,
+  //           "list": [],
+  //           "range": []
+  //         },
+  //         "type": 0,
+  //         "createdExplicitly": false,
+  //         "encodingType": 0,
+  //         "sharded": {
+  //           "isSharded": false,
+  //           "name": "",
+  //           "shardBuckets": 0,
+  //           "columnNames": []
+  //         },
+  //         "disabled": false,
+  //         "geoConfig": {
+  //           "s2Geography": null,
+  //           "s2Geometry": null
+  //         },
+  //         "predicate": ""
+  //       },
+  //       "indexes": [],
+  //       "nextIndexId": 2,
+  //       "privileges": {
+  //         "users": [
+  //           {
+  //             "user": "_",
+  //             "privileges": 2
+  //           },
+  //           {
+  //             "user": "_",
+  //             "privileges": 2
+  //           }
+  //         ],
+  //         "owner": "_",
+  //         "version": 1
+  //       },
+  //       "mutations": [],
+  //       "lease": null,
+  //       "nextMutationId": 1,
+  //       "formatVersion": 3,
+  //       "state": 0,
+  //       "offlineReason": "",
+  //       "checks": [],
+  //       "viewQuery": "",
+  //       "isMaterializedView": false,
+  //       "dependsOn": [],
+  //       "dependedOnBy": [],
+  //       "mutationJobs": [],
+  //       "sequenceOpts": null,
+  //       "dropTime": "0",
+  //       "replacementOf": {
+  //         "id": 0,
+  //         "time": {
+  //           "wallTime": "0",
+  //           "logical": 0
+  //         }
+  //       },
+  //       "auditMode": 0,
+  //       "dropJobId": "0",
+  //       "gcMutations": [],
+  //       "createQuery": "",
+  //       "createAsOfTime": {
+  //         "wallTime": "1606913361488922000",
+  //         "logical": 0
+  //       },
+  //       "outboundFks": [],
+  //       "inboundFks": [
+  //         {
+  //           "originTableId": 54,
+  //           "originColumnIds": [
+  //             2,
+  //             4
+  //           ],
+  //           "referencedColumnIds": [
+  //             2,
+  //             1
+  //           ],
+  //           "referencedTableId": 53,
+  //           "name": "_",
+  //           "validity": 2,
+  //           "onDelete": "NO_ACTION",
+  //           "onUpdate": "NO_ACTION",
+  //           "match": "SIMPLE"
+  //         },
+  //         {
+  //           "originTableId": 55,
+  //           "originColumnIds": [
+  //             2,
+  //             4
+  //           ],
+  //           "referencedColumnIds": [
+  //             2,
+  //             1
+  //           ],
+  //           "referencedTableId": 53,
+  //           "name": "_",
+  //           "validity": 2,
+  //           "onDelete": "NO_ACTION",
+  //           "onUpdate": "NO_ACTION",
+  //           "match": "SIMPLE"
+  //         },
+  //         {
+  //           "originTableId": 58,
+  //           "originColumnIds": [
+  //             1,
+  //             2
+  //           ],
+  //           "referencedColumnIds": [
+  //             2,
+  //             1
+  //           ],
+  //           "referencedTableId": 53,
+  //           "name": "_",
+  //           "validity": 2,
+  //           "onDelete": "NO_ACTION",
+  //           "onUpdate": "NO_ACTION",
+  //           "match": "SIMPLE"
+  //         }
+  //       ],
+  //       "temporary": false
+  //     },
+  //     ...
+  //   ],
+  //   "sqlStats": [],
+  //   "alteredSettings": {
+  //     "cluster.organization": "<redacted>",
+  //     "cluster.secret": "<redacted>",
+  //     "diagnostics.reporting.enabled": "true",
+  //     "enterprise.license": "<redacted>",
+  //     "version": "20.2-1"
+  //   },
+  //   "zoneConfigs": {
+  //     "0": {
+  //       "rangeMinBytes": "134217728",
+  //       "rangeMaxBytes": "536870912",
+  //       "gc": {
+  //         "ttlSeconds": 90000
+  //       },
+  //       "numReplicas": 1,
+  //       "constraints": [],
+  //       "inheritedConstraints": false,
+  //       "leasePreferences": [],
+  //       "inheritedLeasePreferences": false,
+  //       "subzones": [],
+  //       "subzoneSpans": []
+  //     },
+  //     ...
+  //   },
+  //   "featureUsage": {...},
+  //   "legacyUnimplementedErrors": {},
+  //   "legacyErrorCounts": {}
+  // }   
+  //  ```
   rpc Diagnostics(DiagnosticsRequest)
       returns (cockroach.server.diagnosticspb.DiagnosticReport) {
     option (google.api.http) = {
       get : "/_status/diagnostics/{node_id}"
     };
   }
+
+  //  Reference example:
+  //  ``` 
+  //  curl http://127.0.0.1:51875/_status/stores/1   
+  //   ->
+  //  {
+  //   "stores": [
+  //     {
+  //       "storeId": 1,
+  //       "encryptionStatus": null,
+  //       "totalFiles": "0",
+  //       "totalBytes": "0",
+  //       "activeKeyFiles": "0",
+  //       "activeKeyBytes": "0"
+  //     }
+  //   ]
+  // }   
+  //  ```
   rpc Stores(StoresRequest) returns (StoresResponse) {
     option (google.api.http) = {
       get : "/_status/stores/{node_id}"
@@ -1217,11 +1924,66 @@ service Status {
       get: "/_status/stmtdiag/{statement_diagnostics_id}"
     };
   }
+
+
+  //  Reference example:
+  //  ``` 
+  //  curl http://127.0.0.1:51875/_status/job_registry/1   
+  //   ->
+  //  {
+  //   "nodeId": 1,
+  //   "runningJobs": []
+  // }   
+  //  ```
   rpc JobRegistryStatus(JobRegistryStatusRequest) returns (JobRegistryStatusResponse) {
     option (google.api.http) = {
       get : "/_status/job_registry/{node_id}"
     };
   }
+
+
+  //  Reference example:
+  //  ``` 
+  //  curl http://127.0.0.1:51875/_status/job/612247017297477633   
+  //   ->
+  //  {
+  //   "job": {
+  //     "id": "612247017297477633",
+  //     "progress": {
+  //       "fractionCompleted": 1,
+  //       "modifiedMicros": "1606913361839096",
+  //       "runningStatus": "",
+  //       "schemaChange": {}
+  //     },
+  //     "payload": {
+  //       "description": "ALTER TABLE ...",
+  //       "statement": "",
+  //       "username": "root",
+  //       "startedMicros": "1606913361836868",
+  //       "finishedMicros": "1606913361839914",
+  //       "descriptorIds": [
+  //         53
+  //       ],
+  //       "error": "",
+  //       "resumeErrors": [],
+  //       "cleanupErrors": [],
+  //       "finalResumeError": null,
+  //       "lease": null,
+  //       "noncancelable": false,
+  //       "schemaChange": {
+  //         "resumeSpanList": [],
+  //         "droppedTables": [],
+  //         "droppedTypes": [],
+  //         "droppedSchemas": [],
+  //         "droppedDatabaseId": 0,
+  //         "descId": 53,
+  //         "tableMutationId": 0,
+  //         "formatVersion": 2
+  //       }
+  //     }
+  //   }
+  // }   
+  //  ```
   rpc JobStatus(JobStatusRequest) returns (JobStatusResponse) {
     option (google.api.http) = {
       get : "/_status/job/{job_id}"

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -108,10 +108,18 @@ message DetailsResponse {
   util.UnresolvedAddr sql_address = 5 [ (gogoproto.nullable) = false, (gogoproto.customname) = "SQLAddress" ];
 }
 
+// NodesRequest requests a copy of the node information as known to gossip
+// and the KV layer.
+// API: PUBLIC ALPHA
 message NodesRequest {}
 
+// NodesResponse describe the nodes in the cluster.
 message NodesResponse {
+  // nodes carries the status payloads for all nodes in the cluster.
+  // API: PUBLIC ALPHA
   repeated server.status.statuspb.NodeStatus nodes = 1 [ (gogoproto.nullable) = false ];
+
+  // liveness_by_node_id maps each node ID to a liveness status.
   map<int32, cockroach.kv.kvserver.storagepb.NodeLivenessStatus> liveness_by_node_id = 2 [
     (gogoproto.castkey) = "github.com/cockroachdb/cockroach/pkg/roachpb.NodeID",
     (gogoproto.nullable) = false,
@@ -727,8 +735,7 @@ message ProblemRangesResponse {
 
 // HotRangesRequest queries one or more cluster nodes for a list
 // of ranges currently considered “hot” by the node(s).
-//
-// The server responds with a HotRangesResponse payload.
+// API: PUBLIC ALPHA
 message HotRangesRequest {
   // NodeID indicates which node to query for a hot range report.
   // It is posssible to populate any node ID; if the node receiving
@@ -737,14 +744,17 @@ message HotRangesRequest {
   //
   // If left empty, the request is forwarded to every node
   // in the cluster.
+  // API: PUBLIC ALPHA
   string node_id = 1 [(gogoproto.customname) = "NodeID"];
 }
 
 // HotRangesResponse is the payload produced in response
 // to a HotRangesRequest.
+// API: PUBLIC ALPHA
 message HotRangesResponse {
   // NodeID is the node that received the HotRangesRequest and
   // forwarded requests to the selected target node(s).
+  // API: PUBLIC ALPHA
   int32 node_id = 1 [
     (gogoproto.customname) = "NodeID",
     (gogoproto.casttype) =
@@ -753,25 +763,28 @@ message HotRangesResponse {
 
   // HotRange is a hot range report for a single store on one of the
   // target node(s) selected in a HotRangesRequest.
+  // API: PUBLIC ALPHA
   message HotRange {
     // Desc is the descriptor of the range for which the report
     // was produced.
     //
-    // Note: this field is generally RESERVED and will likely be removed
-    // or replaced in a later version.
+    // TODO(knz): This field should be removed.
     // See: https://github.com/cockroachdb/cockroach/issues/53212
     cockroach.roachpb.RangeDescriptor desc = 1 [(gogoproto.nullable) = false];
 
     // QueriesPerSecond is the recent number of queries per second
     // on this range.
+    // API: PUBLIC ALPHA
     double queries_per_second = 2;
   }
 
   // StoreResponse contains the part of a hot ranges report that
   // pertains to a single store on a target node.
+  // API: PUBLIC ALPHA
   message StoreResponse {
     // StoreID identifies the store for which the report was
     // produced.
+    // API: PUBLIC ALPHA
     int32 store_id = 1 [
       (gogoproto.customname) = "StoreID",
       (gogoproto.casttype) =
@@ -780,25 +793,30 @@ message HotRangesResponse {
 
     // HotRanges is the hot ranges report for this store
     // on the target node.
+    // API: PUBLIC ALPHA
     repeated HotRange hot_ranges = 2 [(gogoproto.nullable) = false];
   }
 
   // NodeResponse is a hot range report for a single target node.
+  // API: PUBLIC ALPHA
   message NodeResponse {
     // ErrorMessage is set to a non-empty string if this target
     // node was unable to produce a hot range report.
     //
     // The contents of this string indicates the cause of the failure.
+    // API: PUBLIC ALPHA
     string error_message = 1;
 
     // Stores contains the hot ranges report if no error was encountered.
     // There is one part to the report for each store in the
     // target node.
+    // API: PUBLIC ALPHA
     repeated StoreResponse stores = 2;
   }
 
   // HotRangesByNodeID contains a hot range report for each selected
   // target node ID in the HotRangesRequest.
+  // API: PUBLIC ALPHA
   map<int32, NodeResponse> hot_ranges_by_node_id = 2 [
     (gogoproto.castkey) = "github.com/cockroachdb/cockroach/pkg/roachpb.NodeID",
     (gogoproto.customname) = "HotRangesByNodeID",
@@ -978,17 +996,23 @@ message JobStatusResponse {
 }
 
 service Status {
+  // Certificates retrieves a copy of the TLS certificates.
   rpc Certificates(CertificatesRequest) returns (CertificatesResponse) {
     option (google.api.http) = {
       get : "/_status/certificates/{node_id}"
     };
   }
+
+  // Details retrieves details about the nodes in the cluster.
   rpc Details(DetailsRequest) returns (DetailsResponse) {
     option (google.api.http) = {
       get : "/_status/details/{node_id}"
     };
   }
 
+  // Nodes retrieves an overview of the nodes in the cluster.
+  // API: PUBLIC ALPHA
+  //
   // Don't introduce additional usages of this RPC. See #50707 for more details.
   // The underlying response type is something we're looking to get rid of.
   rpc Nodes(NodesRequest) returns (NodesResponse) {
@@ -996,57 +1020,82 @@ service Status {
       get : "/_status/nodes"
     };
   }
+
+  // Node retrieves details about a single node.
+  // API: PUBLIC ALPHA
   rpc Node(NodeRequest) returns (server.status.statuspb.NodeStatus) {
     option (google.api.http) = {
       get : "/_status/nodes/{node_id}"
     };
   }
+
+
+  // RaftDebug requests internal details about Raft.
   rpc RaftDebug(RaftDebugRequest) returns (RaftDebugResponse) {
     option (google.api.http) = {
       get : "/_status/raft"
     };
   }
+
+  // Ranges requests internal details about ranges on a given node.
   rpc Ranges(RangesRequest) returns (RangesResponse) {
     option (google.api.http) = {
       get : "/_status/ranges/{node_id}"
     };
   }
+
+  // Gossip retrieves gossip-level details about a given node.
   rpc Gossip(GossipRequest) returns (gossip.InfoStatus) {
     option (google.api.http) = {
       get : "/_status/gossip/{node_id}"
     };
   }
+
+  // EngineStats retrieves statistics about a storage engine.
   rpc EngineStats(EngineStatsRequest) returns (EngineStatsResponse) {
     option (google.api.http) = {
       get : "/_status/enginestats/{node_id}"
     };
   }
+
+  // Allocator retrieves statistics about the replica allocator.
   rpc Allocator(AllocatorRequest) returns (AllocatorResponse) {
     option (google.api.http) = {
       get : "/_status/allocator/node/{node_id}"
     };
   }
+
+  // AllocatorRange retrieves statistics about the replica allocator given
+  // a specific range.
   rpc AllocatorRange(AllocatorRangeRequest) returns (AllocatorRangeResponse) {
     option (google.api.http) = {
       get : "/_status/allocator/range/{range_id}"
     };
   }
+
+  // ListSessions retrieves the SQL sessions across the entire cluster.
   rpc ListSessions(ListSessionsRequest) returns (ListSessionsResponse) {
     option (google.api.http) = {
       get : "/_status/sessions"
     };
   }
+
+  // ListLocalSessions retrieves the SQL sessions on this node.
   rpc ListLocalSessions(ListSessionsRequest) returns (ListSessionsResponse) {
     option (google.api.http) = {
       get : "/_status/local_sessions"
     };
   }
+
+  // CancelQuery cancels a SQL query given its ID.
   rpc CancelQuery(CancelQueryRequest) returns (CancelQueryResponse) {
     option (google.api.http) = {
       post : "/_status/cancel_query/{node_id}"
 			body: "*"
     };
   }
+
+  // CancelSessions forcefully terminates a SQL session given its ID.
   rpc CancelSession(CancelSessionRequest) returns (CancelSessionResponse) {
     option (google.api.http) = {
       post : "/_status/cancel_session/{node_id}"
@@ -1065,46 +1114,67 @@ service Status {
       body : "*"
     };
   }
+
+  // Stacks retrieves the stack traces of all goroutines on a given node.
   rpc Stacks(StacksRequest) returns (JSONResponse) {
     option (google.api.http) = {
       get : "/_status/stacks/{node_id}"
     };
   }
+
+  // Profile retrieves a CPU profile on a given node.
   rpc Profile(ProfileRequest) returns (JSONResponse) {
     option (google.api.http) = {
       get : "/_status/profile/{node_id}"
     };
   }
+
+  // Metrics retrieves the node metrics for a given node.
+  //
+  // Note: this is a “reserved” API and should not be relied upon to
+  // build external tools. No guarantee is made about its
+  // availability and stability in external uses.
   rpc Metrics(MetricsRequest) returns (JSONResponse) {
     option (google.api.http) = {
       get : "/_status/metrics/{node_id}"
     };
   }
+
+  // GetFiles retrieves heap or goroutine dump files from a given node.
   rpc GetFiles(GetFilesRequest) returns (GetFilesResponse) {
     option (google.api.http) = {
       get : "/_status/files/{node_id}"
     };
   }
+
+  // LogFilesList retrieves a list of log files on a given node.
   rpc LogFilesList(LogFilesListRequest) returns (LogFilesListResponse) {
     option (google.api.http) = {
       get : "/_status/logfiles/{node_id}"
     };
   }
+
+  // LogFile retrieves a given log file.
   rpc LogFile(LogFileRequest) returns (LogEntriesResponse) {
     option (google.api.http) = {
       get : "/_status/logfiles/{node_id}/{file}"
     };
   }
+
+  // Logs retrieves individual log entries.
   rpc Logs(LogsRequest) returns (LogEntriesResponse) {
     option (google.api.http) = {
       get : "/_status/logs/{node_id}"
     };
   }
+
+  // ProblemRanges retrieves the list of “problem ranges”.
   rpc ProblemRanges(ProblemRangesRequest) returns (ProblemRangesResponse) {
     option (google.api.http) = {
       get : "/_status/problemranges"
     };
   }
+
   rpc HotRanges(HotRangesRequest) returns (HotRangesResponse) {
     option (google.api.http) = {
       get : "/_status/hotranges"

--- a/pkg/server/status/statuspb/status.pb.go
+++ b/pkg/server/status/statuspb/status.pb.go
@@ -47,20 +47,22 @@ func (x HealthAlert_Category) String() string {
 	return proto.EnumName(HealthAlert_Category_name, int32(x))
 }
 func (HealthAlert_Category) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_status_f9872bd1035fefcc, []int{2, 0}
+	return fileDescriptor_status_d4a2af5985fe7f65, []int{2, 0}
 }
 
 // StoreStatus records the most recent values of metrics for a store.
 type StoreStatus struct {
-	Desc    roachpb.StoreDescriptor `protobuf:"bytes,1,opt,name=desc,proto3" json:"desc"`
-	Metrics map[string]float64      `protobuf:"bytes,2,rep,name=metrics,proto3" json:"metrics,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"fixed64,2,opt,name=value,proto3"`
+	// desc is the store descriptor.
+	Desc roachpb.StoreDescriptor `protobuf:"bytes,1,opt,name=desc,proto3" json:"desc"`
+	// metrics contains the last sampled values for the node metrics.
+	Metrics map[string]float64 `protobuf:"bytes,2,rep,name=metrics,proto3" json:"metrics,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"fixed64,2,opt,name=value,proto3"`
 }
 
 func (m *StoreStatus) Reset()         { *m = StoreStatus{} }
 func (m *StoreStatus) String() string { return proto.CompactTextString(m) }
 func (*StoreStatus) ProtoMessage()    {}
 func (*StoreStatus) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_f9872bd1035fefcc, []int{0}
+	return fileDescriptor_status_d4a2af5985fe7f65, []int{0}
 }
 func (m *StoreStatus) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -86,15 +88,31 @@ func (m *StoreStatus) XXX_DiscardUnknown() {
 var xxx_messageInfo_StoreStatus proto.InternalMessageInfo
 
 // NodeStatus records the most recent values of metrics for a node.
+// API: PUBLIC ALPHA
 type NodeStatus struct {
-	Desc          roachpb.NodeDescriptor `protobuf:"bytes,1,opt,name=desc,proto3" json:"desc"`
-	BuildInfo     build.Info             `protobuf:"bytes,2,opt,name=build_info,json=buildInfo,proto3" json:"build_info"`
-	StartedAt     int64                  `protobuf:"varint,3,opt,name=started_at,json=startedAt,proto3" json:"started_at,omitempty"`
-	UpdatedAt     int64                  `protobuf:"varint,4,opt,name=updated_at,json=updatedAt,proto3" json:"updated_at,omitempty"`
-	Metrics       map[string]float64     `protobuf:"bytes,5,rep,name=metrics,proto3" json:"metrics,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"fixed64,2,opt,name=value,proto3"`
-	StoreStatuses []StoreStatus          `protobuf:"bytes,6,rep,name=store_statuses,json=storeStatuses,proto3" json:"store_statuses"`
-	Args          []string               `protobuf:"bytes,7,rep,name=args,proto3" json:"args,omitempty"`
-	Env           []string               `protobuf:"bytes,8,rep,name=env,proto3" json:"env,omitempty"`
+	// desc is the node descriptor.
+	Desc roachpb.NodeDescriptor `protobuf:"bytes,1,opt,name=desc,proto3" json:"desc"`
+	// build_info describes the 'cockroach' executable file.
+	// API: PUBLIC ALPHA
+	BuildInfo build.Info `protobuf:"bytes,2,opt,name=build_info,json=buildInfo,proto3" json:"build_info"`
+	// started_at is the unix timestamp at which the node process was
+	// last started.
+	// API: PUBLIC ALPHA
+	StartedAt int64 `protobuf:"varint,3,opt,name=started_at,json=startedAt,proto3" json:"started_at,omitempty"`
+	// updated_at is the unix timestamp at which the node status record
+	// was last updated.
+	// API: PUBLIC ALPHA
+	UpdatedAt int64 `protobuf:"varint,4,opt,name=updated_at,json=updatedAt,proto3" json:"updated_at,omitempty"`
+	// metrics contains the last sampled values for the node metrics.
+	Metrics map[string]float64 `protobuf:"bytes,5,rep,name=metrics,proto3" json:"metrics,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"fixed64,2,opt,name=value,proto3"`
+	// store_statuses provides the store status payloads for all
+	// the stores on that node.
+	StoreStatuses []StoreStatus `protobuf:"bytes,6,rep,name=store_statuses,json=storeStatuses,proto3" json:"store_statuses"`
+	// args is the list of command-line arguments used to last start the node.
+	Args []string `protobuf:"bytes,7,rep,name=args,proto3" json:"args,omitempty"`
+	// env is the list of environment variables that influenced
+	// the node's configuration.
+	Env []string `protobuf:"bytes,8,rep,name=env,proto3" json:"env,omitempty"`
 	// latencies is a map of nodeIDs to nanoseconds which is the latency
 	// between this node and the other node.
 	//
@@ -105,10 +123,15 @@ type NodeStatus struct {
 	// to other nodes.
 	Activity map[github_com_cockroachdb_cockroach_pkg_roachpb.NodeID]NodeStatus_NetworkActivity `protobuf:"bytes,10,rep,name=activity,proto3,castkey=github.com/cockroachdb/cockroach/pkg/roachpb.NodeID" json:"activity" protobuf_key:"varint,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 	// total_system_memory is the total RAM available to the system
-	// (or, if possible, the memory available to the cgroup this process is in)
+	// (or, if detected, the memory available to the cgroup this process is in)
 	// in bytes.
+	// API: PUBLIC ALPHA
 	TotalSystemMemory int64 `protobuf:"varint,11,opt,name=total_system_memory,json=totalSystemMemory,proto3" json:"total_system_memory,omitempty"`
-	// num_cpus is the number of logical CPUs on this machine.
+	// num_cpus is the number of logical CPUs as reported by the operating system
+	// on the host where the 'cockroach' process is running. Note that
+	// this does not report the number of CPUs actually used by 'cockroach';
+	// this parameter is controlled separately.
+	// API: PUBLIC ALPHA
 	NumCpus int32 `protobuf:"varint,12,opt,name=num_cpus,json=numCpus,proto3" json:"num_cpus,omitempty"`
 }
 
@@ -116,7 +139,7 @@ func (m *NodeStatus) Reset()         { *m = NodeStatus{} }
 func (m *NodeStatus) String() string { return proto.CompactTextString(m) }
 func (*NodeStatus) ProtoMessage()    {}
 func (*NodeStatus) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_f9872bd1035fefcc, []int{1}
+	return fileDescriptor_status_d4a2af5985fe7f65, []int{1}
 }
 func (m *NodeStatus) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -151,7 +174,7 @@ func (m *NodeStatus_NetworkActivity) Reset()         { *m = NodeStatus_NetworkAc
 func (m *NodeStatus_NetworkActivity) String() string { return proto.CompactTextString(m) }
 func (*NodeStatus_NetworkActivity) ProtoMessage()    {}
 func (*NodeStatus_NetworkActivity) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_f9872bd1035fefcc, []int{1, 2}
+	return fileDescriptor_status_d4a2af5985fe7f65, []int{1, 2}
 }
 func (m *NodeStatus_NetworkActivity) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -190,7 +213,7 @@ func (m *HealthAlert) Reset()         { *m = HealthAlert{} }
 func (m *HealthAlert) String() string { return proto.CompactTextString(m) }
 func (*HealthAlert) ProtoMessage()    {}
 func (*HealthAlert) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_f9872bd1035fefcc, []int{2}
+	return fileDescriptor_status_d4a2af5985fe7f65, []int{2}
 }
 func (m *HealthAlert) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -224,7 +247,7 @@ func (m *HealthCheckResult) Reset()         { *m = HealthCheckResult{} }
 func (m *HealthCheckResult) String() string { return proto.CompactTextString(m) }
 func (*HealthCheckResult) ProtoMessage()    {}
 func (*HealthCheckResult) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_f9872bd1035fefcc, []int{3}
+	return fileDescriptor_status_d4a2af5985fe7f65, []int{3}
 }
 func (m *HealthCheckResult) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1929,10 +1952,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("server/status/statuspb/status.proto", fileDescriptor_status_f9872bd1035fefcc)
+	proto.RegisterFile("server/status/statuspb/status.proto", fileDescriptor_status_d4a2af5985fe7f65)
 }
 
-var fileDescriptor_status_f9872bd1035fefcc = []byte{
+var fileDescriptor_status_d4a2af5985fe7f65 = []byte{
 	// 817 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xac, 0x55, 0x5f, 0x6f, 0xe3, 0x44,
 	0x10, 0xcf, 0x36, 0x69, 0xe3, 0x8c, 0xef, 0x4a, 0x6f, 0x39, 0x90, 0x89, 0x44, 0x6a, 0x02, 0x0f,

--- a/pkg/server/status/statuspb/status.proto
+++ b/pkg/server/status/statuspb/status.proto
@@ -18,20 +18,47 @@ import "gogoproto/gogo.proto";
 
 // StoreStatus records the most recent values of metrics for a store.
 message StoreStatus {
+  // desc is the store descriptor.
   roachpb.StoreDescriptor desc = 1 [(gogoproto.nullable) = false];
+
+  // metrics contains the last sampled values for the node metrics.
   map<string, double> metrics = 2;
 }
 
 // NodeStatus records the most recent values of metrics for a node.
+// API: PUBLIC ALPHA
 message NodeStatus {
+  // desc is the node descriptor.
   roachpb.NodeDescriptor desc = 1 [(gogoproto.nullable) = false];
+
+  // build_info describes the 'cockroach' executable file.
+  // API: PUBLIC ALPHA
   build.Info build_info = 2 [(gogoproto.nullable) = false];
+
+  // started_at is the unix timestamp at which the node process was
+  // last started.
+  // API: PUBLIC ALPHA
   int64 started_at = 3;
+
+  // updated_at is the unix timestamp at which the node status record
+  // was last updated.
+  // API: PUBLIC ALPHA
   int64 updated_at = 4;
+
+  // metrics contains the last sampled values for the node metrics.
   map<string, double> metrics = 5;
+
+  // store_statuses provides the store status payloads for all
+  // the stores on that node.
   repeated StoreStatus store_statuses = 6 [(gogoproto.nullable) = false];
+
+  // args is the list of command-line arguments used to last start the node.
   repeated string args = 7;
+
+  // env is the list of environment variables that influenced
+  // the node's configuration.
   repeated string env = 8;
+
   // latencies is a map of nodeIDs to nanoseconds which is the latency
   // between this node and the other node.
   //
@@ -53,11 +80,18 @@ message NodeStatus {
     (gogoproto.nullable) = false,
     (gogoproto.castkey) = "github.com/cockroachdb/cockroach/pkg/roachpb.NodeID"
   ];
+
   // total_system_memory is the total RAM available to the system
-  // (or, if possible, the memory available to the cgroup this process is in)
+  // (or, if detected, the memory available to the cgroup this process is in)
   // in bytes.
+  // API: PUBLIC ALPHA
   int64 total_system_memory = 11;
-  // num_cpus is the number of logical CPUs on this machine.
+
+  // num_cpus is the number of logical CPUs as reported by the operating system
+  // on the host where the 'cockroach' process is running. Note that
+  // this does not report the number of CPUs actually used by 'cockroach';
+  // this parameter is controlled separately.
+  // API: PUBLIC ALPHA
   int32 num_cpus = 12;
 }
 


### PR DESCRIPTION
This commit populates the `_status` rpc definitions with reference
examples.

Release note: None