### PR TITLE
importccl: add more fine grained EXPORT privileges

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -657,7 +657,7 @@ func checkPrivilegesForBackup(
 	}
 	// Check that none of the destinations require an admin role.
 	for _, uri := range to {
-		hasExplicitAuth, uriScheme, err := cloudimpl.AccessIsWithExplicitAuth(uri)
+		hasExplicitAuth, uriScheme, err := cloud.AccessIsWithExplicitAuth(uri)
 		if err != nil {
 			return err
 		}

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -1465,7 +1465,7 @@ func checkPrivilegesForRestore(
 	for i := range from {
 		for j := range from[i] {
 			uri := from[i][j]
-			hasExplicitAuth, uriScheme, err := cloudimpl.AccessIsWithExplicitAuth(uri)
+			hasExplicitAuth, uriScheme, err := cloud.AccessIsWithExplicitAuth(uri)
 			if err != nil {
 				return err
 			}

--- a/pkg/ccl/importccl/exportcsv.go
+++ b/pkg/ccl/importccl/exportcsv.go
@@ -131,7 +131,6 @@ func newCSVWriterProcessor(
 	input execinfra.RowSource,
 	output execinfra.RowReceiver,
 ) (execinfra.Processor, error) {
-
 	c := &csvWriter{
 		flowCtx:     flowCtx,
 		processorID: processorID,

--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -47,6 +47,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/storage/cloud"
 	"github.com/cockroachdb/cockroach/pkg/storage/cloudimpl"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
@@ -317,7 +318,7 @@ func importPlanHook(
 		// Certain ExternalStorage URIs require super-user access. Check all the
 		// URIs passed to the IMPORT command.
 		for _, file := range filenamePatterns {
-			hasExplicitAuth, uriScheme, err := cloudimpl.AccessIsWithExplicitAuth(file)
+			hasExplicitAuth, uriScheme, err := cloud.AccessIsWithExplicitAuth(file)
 			if err != nil {
 				return err
 			}

--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/stats"
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
+	"github.com/cockroachdb/cockroach/pkg/storage/cloud"
 	"github.com/cockroachdb/cockroach/pkg/storage/cloudimpl"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/jobutils"
@@ -2519,7 +2520,7 @@ func TestURIRequiresAdminRole(t *testing.T) {
 		})
 
 		t.Run(tc.name+"-direct", func(t *testing.T) {
-			requires, scheme, err := cloudimpl.AccessIsWithExplicitAuth(tc.uri)
+			requires, scheme, err := cloud.AccessIsWithExplicitAuth(tc.uri)
 			require.NoError(t, err)
 			require.Equal(t, requires, !tc.requiresAdmin)
 

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -325,6 +325,7 @@ go_library(
         "//pkg/sql/stmtdiagnostics",
         "//pkg/sql/types",
         "//pkg/sql/vtable",
+        "//pkg/storage/cloud",
         "//pkg/util",
         "//pkg/util/bitarray",
         "//pkg/util/cancelchecker",

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -3536,13 +3536,13 @@ func (dsp *DistSQLPlanner) createPlanForExport(
 	if err != nil {
 		return nil, err
 	}
-
 	core := execinfrapb.ProcessorCoreUnion{CSVWriter: &execinfrapb.CSVWriterSpec{
 		Destination:      n.destination,
 		NamePattern:      n.fileNamePattern,
 		Options:          n.csvOpts,
 		ChunkRows:        int64(n.chunkRows),
 		CompressionCodec: n.fileCompression,
+		UserProto:        planCtx.planner.User().EncodeProto(),
 	}}
 
 	resTypes := make([]*types.T, len(colinfo.ExportColumns))

--- a/pkg/sql/export.go
+++ b/pkg/sql/export.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/storage/cloud"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/errors"
 )
@@ -121,6 +122,21 @@ func (ef *execFactory) ConstructExport(
 	destination, ok := destinationDatum.(*tree.DString)
 	if !ok {
 		return nil, errors.Errorf("expected string value for the file location")
+	}
+	admin, err := ef.planner.HasAdminRole(ef.planner.EvalContext().Context)
+	if err != nil {
+		panic(err)
+	}
+	if !admin {
+		hasExplicitAuth, _, err := cloud.AccessIsWithExplicitAuth(string(*destination))
+		if err != nil {
+			panic(err)
+		}
+		if !hasExplicitAuth {
+			panic(pgerror.Newf(
+				pgcode.InsufficientPrivilege,
+				"only users with the admin role are allowed to EXPORT to the specified URI"))
+		}
 	}
 
 	optVals, err := evalStringOptions(ef.planner.EvalContext(), options, exportOptionExpectValues)

--- a/pkg/sql/opt/optbuilder/export.go
+++ b/pkg/sql/opt/optbuilder/export.go
@@ -19,9 +19,6 @@ import (
 
 // buildExport builds an EXPORT statement.
 func (b *Builder) buildExport(export *tree.Export, inScope *scope) (outScope *scope) {
-	if err := b.catalog.RequireAdminRole(b.ctx, "EXPORT"); err != nil {
-		panic(err)
-	}
 	// We don't allow the input statement to reference outer columns, so we
 	// pass a "blank" scope rather than inScope.
 	emptyScope := b.allocScope()
@@ -31,6 +28,7 @@ func (b *Builder) buildExport(export *tree.Export, inScope *scope) (outScope *sc
 	fileName := b.buildScalar(
 		texpr, emptyScope, nil /* outScope */, nil /* outCol */, nil, /* colRefs */
 	)
+
 	options := b.buildKVOptions(export.Options, emptyScope)
 
 	outScope = inScope.push()

--- a/pkg/storage/cloud/external_storage.go
+++ b/pkg/storage/cloud/external_storage.go
@@ -91,3 +91,7 @@ type SQLConnI interface {
 	driver.QueryerContext
 	driver.ExecerContext
 }
+
+// AccessIsWithExplicitAuth is used to check if the provided path has explicit
+// authentication.
+var AccessIsWithExplicitAuth func(path string) (bool, string, error)

--- a/pkg/storage/cloudimpl/external_storage.go
+++ b/pkg/storage/cloudimpl/external_storage.go
@@ -122,6 +122,10 @@ var ErrListingUnsupported = errors.New("listing is not supported")
 // This error is raised by the ReadFile method.
 var ErrFileDoesNotExist = errors.New("external_storage: file doesn't exist")
 
+func init() {
+	cloud.AccessIsWithExplicitAuth = AccessIsWithExplicitAuth
+}
+
 // ExternalStorageConfFromURI generates an ExternalStorage config from a URI string.
 func ExternalStorageConfFromURI(
 	path string, user security.SQLUsername,


### PR DESCRIPTION
Previously, EXPORT could only be used by admin users. This change
removes the umbrella admin check and relies on the user having SELECT
privilege on the table being exported. It also adds a check to ensure
admin role is required for certain external storage endpoints. This is
in keeping with changes made to the other bulk operations such as
import/backup/restore.

Note about the approach: In an ideal world we would have the external
storage check while the optimizer is resolving the export node in
`buildExport`. There is a rather nasty dep cycle `sql -> opt ->
cloudimpl -> sql` which would require moving a large number of
definitions out of cloudimpl to be able to reuse
`AccessIsWithExplicitAuth`. The least invasive change was to perform
this check during export processor setup.

Fixes: #57259

Release note (sql change): EXPORT can now be used by non-admin users with SELECT
privilege on the table being exported. Unless, the destination URI is
one which requires admin privileges.