### PR TITLE
importccl: support IMPORT in mixed-version cluster

### DIFF
--- a/pkg/ccl/backupccl/backup_processor_planning.go
+++ b/pkg/ccl/backupccl/backup_processor_planning.go
@@ -48,6 +48,8 @@ func distBackup(
 	dsp := execCtx.DistSQLPlanner()
 	evalCtx := execCtx.ExtendedEvalContext()
 
+	// We don't return the compatible nodes here since PartitionSpans will
+	// filter out incompatible nodes.
 	planCtx, _, err := dsp.SetupAllNodesPlanning(ctx, evalCtx, execCtx.ExecCfg())
 	if err != nil {
 		return errors.Wrap(err, "failed to determine nodes on which to run")

--- a/pkg/ccl/backupccl/restore_processor_planning.go
+++ b/pkg/ccl/backupccl/restore_processor_planning.go
@@ -76,12 +76,10 @@ func distRestore(
 		fileEncryption = &roachpb.FileEncryptionOptions{Key: encryption.Key}
 	}
 
-	planCtx, _, err := dsp.SetupAllNodesPlanning(ctx, evalCtx, execCtx.ExecCfg())
+	planCtx, nodes, err := dsp.SetupAllNodesPlanning(ctx, evalCtx, execCtx.ExecCfg())
 	if err != nil {
 		return err
 	}
-
-	nodes := getAllCompatibleNodes(planCtx)
 
 	splitAndScatterSpecs, err := makeSplitAndScatterSpecs(nodes, chunks, rekeys)
 	if err != nil {
@@ -226,18 +224,6 @@ func distRestore(
 	evalCtxCopy := *evalCtx
 	dsp.Run(planCtx, noTxn, p, recv, &evalCtxCopy, nil /* finishedSetupFn */)()
 	return rowResultWriter.Err()
-}
-
-// getAllCompatibleNodes returns all nodes that are OK to use in the DistSQL
-// plan.
-func getAllCompatibleNodes(planCtx *sql.PlanningCtx) []roachpb.NodeID {
-	nodes := make([]roachpb.NodeID, 0, len(planCtx.NodeStatuses))
-	for node, status := range planCtx.NodeStatuses {
-		if status == sql.NodeOK {
-			nodes = append(nodes, node)
-		}
-	}
-	return nodes
 }
 
 // makeSplitAndScatterSpecs returns a map from nodeID to the SplitAndScatter

--- a/pkg/cmd/roachtest/registry.go
+++ b/pkg/cmd/roachtest/registry.go
@@ -41,6 +41,7 @@ func registerTests(r *testRegistry) {
 	registerGossip(r)
 	registerHibernate(r)
 	registerHotSpotSplits(r)
+	registerImportDecommissioned(r)
 	registerImportMixedVersion(r)
 	registerImportTPCC(r)
 	registerImportTPCH(r)

--- a/pkg/cmd/roachtest/registry.go
+++ b/pkg/cmd/roachtest/registry.go
@@ -41,6 +41,7 @@ func registerTests(r *testRegistry) {
 	registerGossip(r)
 	registerHibernate(r)
 	registerHotSpotSplits(r)
+	registerImportMixedVersion(r)
 	registerImportTPCC(r)
 	registerImportTPCH(r)
 	registerInconsistency(r)

--- a/pkg/sql/distsql_plan_bulk.go
+++ b/pkg/sql/distsql_plan_bulk.go
@@ -19,7 +19,7 @@ import (
 )
 
 // SetupAllNodesPlanning creates a planCtx and sets up the planCtx.NodeStatuses
-// map for all nodes.
+// map for all nodes. It returns all nodes that can be used for planning.
 func (dsp *DistSQLPlanner) SetupAllNodesPlanning(
 	ctx context.Context, evalCtx *extendedEvalContext, execCfg *ExecutorConfig,
 ) (*PlanningCtx, []roachpb.NodeID, error) {
@@ -41,8 +41,10 @@ func (dsp *DistSQLPlanner) SetupAllNodesPlanning(
 		_ /* NodeStatus */ = dsp.CheckNodeHealthAndVersion(planCtx, node.Desc.NodeID)
 	}
 	nodes := make([]roachpb.NodeID, 0, len(planCtx.NodeStatuses))
-	for nodeID := range planCtx.NodeStatuses {
-		nodes = append(nodes, nodeID)
+	for nodeID, status := range planCtx.NodeStatuses {
+		if status == NodeOK {
+			nodes = append(nodes, nodeID)
+		}
 	}
 	// Shuffle node order so that multiple IMPORTs done in parallel will not
 	// identically schedule CSV reading. For example, if there are 3 nodes and 4


### PR DESCRIPTION
This commit adds support for running IMPORT in a mixed-version cluster.
Note, that it does not add support for running an IMPORT during the
upgrade of a node however. The IMPORT job would need to be restarted in
that case.

Release note (sql change): Add support for running IMPORT in a
mixed-version cluster.