### PR TITLE
CODEOWNERS: add sqlproxy-prs group to pkg/ccl/sqlproxyccl

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -39,3 +39,5 @@
 
 /docs/generated/http         @cockroachdb/http-api-prs
 /pkg/cmd/docgen/http.go      @cockroachdb/http-api-prs
+
+/pkg/ccl/sqlproxyccl/        @cockroachdb/sqlproxy-prs

--- a/TEAMS.yaml
+++ b/TEAMS.yaml
@@ -94,3 +94,7 @@ cockroachdb/http-api-prs:
   email: TODO@cockroachlabs.com
   slack: TODO
   triage_column_id: 0 # TODO
+cockroachdb/sqlproxy-prs:
+  email: TODO@cockroachlabs.com
+  slack: cc-intrusion-team
+  triage_column_id: 0 # TODO


### PR DESCRIPTION
Since sqlproxy is used in several places in cloud it's helpful to
coordinate any changes to the core proxy code and keep all
stakeholders involved.

A new github group `sqlproxy-prs` has been created which will be
assigned to review any changes to sqlproxyccl code and also will
be assigned to other sqlproxy related code in the future.

Release note: none.