### PR TITLE
ccl/sqlproxyccl: idle connection timeout support

### DIFF
--- a/pkg/ccl/cliccl/BUILD.bazel
+++ b/pkg/ccl/cliccl/BUILD.bazel
@@ -40,6 +40,7 @@ go_library(
         "//vendor/github.com/cockroachdb/cmux",
         "//vendor/github.com/cockroachdb/errors",
         "//vendor/github.com/cockroachdb/errors/oserror",
+        "//vendor/github.com/jackc/pgproto3/v2:pgproto3",
         "//vendor/github.com/spf13/cobra",
         "//vendor/golang.org/x/sync/errgroup",
     ],

--- a/pkg/ccl/sqlproxyccl/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/BUILD.bazel
@@ -3,8 +3,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "sqlproxyccl",
     srcs = [
+        "backend_dialer.go",
         "error.go",
         "errorcode_string.go",
+        "idle_disconnect_connection.go",
         "metrics.go",
         "proxy.go",
         "server.go",
@@ -26,6 +28,7 @@ go_library(
 go_test(
     name = "sqlproxyccl_test",
     srcs = [
+        "idle_disconnect_connection_test.go",
         "main_test.go",
         "proxy_test.go",
         "server_test.go",
@@ -43,6 +46,7 @@ go_test(
         "//pkg/util/randutil",
         "//pkg/util/timeutil",
         "//vendor/github.com/cockroachdb/errors",
+        "//vendor/github.com/jackc/pgproto3/v2:pgproto3",
         "//vendor/github.com/jackc/pgx/v4:pgx",
         "//vendor/github.com/stretchr/testify/require",
     ],

--- a/pkg/ccl/sqlproxyccl/backend_dialer.go
+++ b/pkg/ccl/sqlproxyccl/backend_dialer.go
@@ -1,0 +1,79 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package sqlproxyccl
+
+import (
+	"crypto/tls"
+	"encoding/binary"
+	"io"
+	"net"
+
+	"github.com/jackc/pgproto3/v2"
+)
+
+// BackendDial is an example backend dialer that does a TCP/IP connection
+// to a backend, SSL and forwards the start message.
+func BackendDial(
+	msg *pgproto3.StartupMessage, outgoingAddress string, tlsConfig *tls.Config,
+) (net.Conn, error) {
+	conn, err := net.Dial("tcp", outgoingAddress)
+	if err != nil {
+		return nil, NewErrorf(
+			CodeBackendDown, "unable to reach backend SQL server: %v", err,
+		)
+	}
+	conn, err = SSLOverlay(conn, tlsConfig)
+	if err != nil {
+		return nil, err
+	}
+	err = RelayStartupMsg(conn, msg)
+	if err != nil {
+		return nil, NewErrorf(
+			CodeBackendDown, "relaying StartupMessage to target server %v: %v",
+			outgoingAddress, err)
+	}
+	return conn, nil
+}
+
+// SSLOverlay attempts to upgrade the PG connection to use SSL
+// if a tls.Config is specified..
+func SSLOverlay(conn net.Conn, tlsConfig *tls.Config) (net.Conn, error) {
+	if tlsConfig == nil {
+		return conn, nil
+	}
+
+	var err error
+	// Send SSLRequest.
+	if err := binary.Write(conn, binary.BigEndian, pgSSLRequest); err != nil {
+		return nil, NewErrorf(
+			CodeBackendDown, "sending SSLRequest to target server: %v", err,
+		)
+	}
+
+	response := make([]byte, 1)
+	if _, err = io.ReadFull(conn, response); err != nil {
+		return nil,
+			NewErrorf(CodeBackendDown, "reading response to SSLRequest")
+	}
+
+	if response[0] != pgAcceptSSLRequest {
+		return nil, NewErrorf(
+			CodeBackendRefusedTLS, "target server refused TLS connection",
+		)
+	}
+
+	outCfg := tlsConfig.Clone()
+	return tls.Client(conn, outCfg), nil
+}
+
+// RelayStartupMsg forwards the start message on the backend connection.
+func RelayStartupMsg(conn net.Conn, msg *pgproto3.StartupMessage) (err error) {
+	_, err = conn.Write(msg.Encode(nil))
+	return
+}

--- a/pkg/ccl/sqlproxyccl/error.go
+++ b/pkg/ccl/sqlproxyccl/error.go
@@ -66,20 +66,26 @@ const (
 	// CodeExpiredClientConnection indicates that proxy connection to the client
 	// has expired and should be closed.
 	CodeExpiredClientConnection
+
+	// CodeIdleDisconnect indicates that the connection was disconnected for
+	// being idle for longer than the specified timeout.
+	CodeIdleDisconnect
 )
 
-type codeError struct {
+// CodeError is combines an error with one of the above codes to ease
+// the processing of the errors.
+type CodeError struct {
 	code ErrorCode
 	err  error
 }
 
-func (e *codeError) Error() string {
+func (e *CodeError) Error() string {
 	return fmt.Sprintf("%s: %s", e.code, e.err)
 }
 
-// NewErrorf returns a new codeError out of the supplied args.
+// NewErrorf returns a new CodeError out of the supplied args.
 func NewErrorf(code ErrorCode, format string, args ...interface{}) error {
-	return &codeError{
+	return &CodeError{
 		code: code,
 		err:  errors.Errorf(format, args...),
 	}

--- a/pkg/ccl/sqlproxyccl/errorcode_string.go
+++ b/pkg/ccl/sqlproxyccl/errorcode_string.go
@@ -20,11 +20,12 @@ func _() {
 	_ = x[CodeClientDisconnected-10]
 	_ = x[CodeProxyRefusedConnection-11]
 	_ = x[CodeExpiredClientConnection-12]
+	_ = x[CodeIdleDisconnect-13]
 }
 
-const _ErrorCode_name = "CodeClientReadFailedCodeClientWriteFailedCodeUnexpectedInsecureStartupMessageCodeSNIRoutingFailedCodeUnexpectedStartupMessageCodeParamsRoutingFailedCodeBackendDownCodeBackendRefusedTLSCodeBackendDisconnectedCodeClientDisconnectedCodeProxyRefusedConnectionCodeExpiredClientConnection"
+const _ErrorCode_name = "CodeClientReadFailedCodeClientWriteFailedCodeUnexpectedInsecureStartupMessageCodeSNIRoutingFailedCodeUnexpectedStartupMessageCodeParamsRoutingFailedCodeBackendDownCodeBackendRefusedTLSCodeBackendDisconnectedCodeClientDisconnectedCodeProxyRefusedConnectionCodeExpiredClientConnectionCodeIdleDisconnect"
 
-var _ErrorCode_index = [...]uint16{0, 20, 41, 77, 97, 125, 148, 163, 184, 207, 229, 255, 282}
+var _ErrorCode_index = [...]uint16{0, 20, 41, 77, 97, 125, 148, 163, 184, 207, 229, 255, 282, 300}
 
 func (i ErrorCode) String() string {
 	i -= 1

--- a/pkg/ccl/sqlproxyccl/idle_disconnect_connection.go
+++ b/pkg/ccl/sqlproxyccl/idle_disconnect_connection.go
@@ -1,0 +1,97 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package sqlproxyccl
+
+import (
+	"net"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
+)
+
+// IdleDisconnectConnection is a wrapper around net.Conn that disconnects if
+// connection is idle. The idle time is only counted while the client is
+// waiting, blocked on Read.
+type IdleDisconnectConnection struct {
+	net.Conn
+	timeout time.Duration
+	mu      struct {
+		syncutil.Mutex
+		lastDeadlineSetAt time.Time
+	}
+}
+
+var errNotSupported = errors.Errorf(
+	"Not supported for IdleDisconnectConnection",
+)
+
+func (c *IdleDisconnectConnection) updateDeadline() error {
+	now := timeutil.Now()
+	// If it has been more than 1% of the timeout duration - advance the deadline.
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if now.Sub(c.mu.lastDeadlineSetAt) > c.timeout/100 {
+		c.mu.lastDeadlineSetAt = now
+
+		if err := c.Conn.SetReadDeadline(now.Add(c.timeout)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Read reads data from the connection with timeout.
+func (c *IdleDisconnectConnection) Read(b []byte) (n int, err error) {
+	if err := c.updateDeadline(); err != nil {
+		return 0, err
+	}
+	return c.Conn.Read(b)
+}
+
+// Write writes data to the connection and sets the read timeout.
+func (c *IdleDisconnectConnection) Write(b []byte) (n int, err error) {
+	// The Write for the connection is not blocking (or can block only temporary
+	// in case of flow control). For idle connections, the Read will be the call
+	// that will block and stay blocked until the backend doesn't send something.
+	// However, it is theoretically possible, that the traffic is only going in
+	// one direction - from the proxy to the backend, in which case we will call
+	// repeatedly Write but stay blocked on the Read. For that specific case - the
+	// write pushes further out the read deadline so the read doesn't timeout.
+	if err := c.updateDeadline(); err != nil {
+		return 0, err
+	}
+	return c.Conn.Write(b)
+}
+
+// SetDeadline is unsupported as it will interfere with the reads.
+func (c *IdleDisconnectConnection) SetDeadline(t time.Time) error {
+	return errNotSupported
+}
+
+// SetReadDeadline is unsupported as it will interfere with the reads.
+func (c *IdleDisconnectConnection) SetReadDeadline(t time.Time) error {
+	return errNotSupported
+}
+
+// SetWriteDeadline is unsupported as it will interfere with the reads.
+func (c *IdleDisconnectConnection) SetWriteDeadline(t time.Time) error {
+	return errNotSupported
+}
+
+// IdleDisconnectOverlay upgrades the connection to one that closes when
+// idle for more than timeout duration. Timeout of zero will turn off
+// the idle disconnect code.
+func IdleDisconnectOverlay(conn net.Conn, timeout time.Duration) net.Conn {
+	if timeout != 0 {
+		return &IdleDisconnectConnection{Conn: conn, timeout: timeout}
+	}
+	return conn
+}

--- a/pkg/ccl/sqlproxyccl/idle_disconnect_connection_test.go
+++ b/pkg/ccl/sqlproxyccl/idle_disconnect_connection_test.go
@@ -1,0 +1,137 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package sqlproxyccl
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func setupServerWithIdleDisconnect(t testing.TB, timeout time.Duration) net.Addr {
+	server, err := net.Listen("tcp", "")
+	require.NoError(t, err)
+
+	// Server is echoing back bytes in an infinite loop.
+	go func() {
+		cServ, err := server.Accept()
+		if err != nil {
+			t.Errorf("Error during accept: %v", err)
+		}
+		defer cServ.Close()
+		cServ = IdleDisconnectOverlay(cServ, timeout)
+		_, _ = io.Copy(cServ, cServ)
+	}()
+	return server.Addr()
+}
+
+func ping(conn net.Conn) error {
+	n, err := conn.Write([]byte{1})
+	if err != nil {
+		return err
+	}
+	if n != 1 {
+		return errors.Newf("Expected 1 written byte but got %d", n)
+	}
+	n, err = conn.Read([]byte{1})
+	if err != nil {
+		return err
+	}
+	if n != 1 {
+		return errors.Newf("Expected 1 read byte but got %d", n)
+	}
+	return nil
+}
+
+func benchmarkSocketRead(timeout time.Duration, b *testing.B) {
+	addr := setupServerWithIdleDisconnect(b, timeout)
+
+	cCli, err := net.Dial("tcp", addr.String())
+	if err != nil {
+		b.Errorf("Error during dial: %v", err)
+	}
+	defer cCli.Close()
+
+	bCli := []byte{1}
+	for i := 0; i < b.N; i++ {
+		_, err = cCli.Write(bCli)
+		if err != nil {
+			b.Errorf("Error during write: %v", err)
+		}
+		_, err = cCli.Read(bCli)
+		if err != nil {
+			b.Errorf("Error during read: %v", err)
+		}
+	}
+	_, err = cCli.Write([]byte{}) // This serves as EOF and shuts down the echo server
+	if err != nil {
+		b.Errorf("Error during read: %v", err)
+	}
+}
+
+// No statistically significant difference in a single roundtrip time between
+// using and not using deadline as implemented above. Both show the same value in my tests.
+// SocketReadWithDeadline-32     11.1µs ± 1%
+// SocketReadWithoutDeadline-32  11.0µs ± 3%
+func BenchmarkSocketReadWithoutDeadline(b *testing.B) {
+	benchmarkSocketRead(0, b)
+}
+func BenchmarkSocketReadWithDeadline(b *testing.B) {
+	benchmarkSocketRead(1e8, b)
+}
+
+func TestIdleDisconnectOverlay(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	tests := []struct {
+		timeout          time.Duration
+		willCloseAtCheck int
+	}{
+		// The disconnect checks are done at 0.2s, 0.7s and 1.5s marks.
+		{0, 0},
+		{0.1e9, 1},
+		{0.3e9, 2},
+		{0.6e9, 3},
+		{1e9, 0},
+	}
+
+	for _, tt := range tests {
+		name := fmt.Sprintf(
+			"timeout(%s)-willCloseAt(%d)", tt.timeout, tt.willCloseAtCheck,
+		)
+		t.Run(name, func(t *testing.T) {
+			addr := setupServerWithIdleDisconnect(t, tt.timeout)
+			conn, err := net.Dial("tcp", addr.String())
+			require.NoError(t, err, "Unable to dial server")
+			time.Sleep(.2e9)
+			if tt.willCloseAtCheck == 1 {
+				require.Error(t, ping(conn))
+				return
+			}
+			require.NoError(t, ping(conn))
+			time.Sleep(.5e9)
+			if tt.willCloseAtCheck == 2 {
+				require.Error(t, ping(conn))
+				return
+			}
+			require.NoError(t, ping(conn))
+			time.Sleep(.8e9)
+			if tt.willCloseAtCheck == 3 {
+				require.Error(t, ping(conn))
+				return
+			}
+			require.NoError(t, ping(conn))
+		})
+	}
+}

--- a/pkg/ccl/sqlproxyccl/metrics.go
+++ b/pkg/ccl/sqlproxyccl/metrics.go
@@ -14,6 +14,7 @@ import "github.com/cockroachdb/cockroach/pkg/util/metric"
 // operations.
 type Metrics struct {
 	BackendDisconnectCount *metric.Counter
+	IdleDisconnectCount    *metric.Counter
 	BackendDownCount       *metric.Counter
 	ClientDisconnectCount  *metric.Counter
 	CurConnCount           *metric.Gauge
@@ -53,10 +54,16 @@ var (
 		Measurement: "Disconnects",
 		Unit:        metric.Unit_COUNT,
 	}
+	metaIdleDisconnectCount = metric.Metadata{
+		Name:        "proxy.err.idle_disconnect",
+		Help:        "Number of disconnects due to idle timeout",
+		Measurement: "Idle Disconnects",
+		Unit:        metric.Unit_COUNT,
+	}
 	metaClientDisconnectCount = metric.Metadata{
 		Name:        "proxy.err.client_disconnect",
 		Help:        "Number of disconnects initiated by clients",
-		Measurement: "Disconnects",
+		Measurement: "Client Disconnects",
 		Unit:        metric.Unit_COUNT,
 	}
 	metaRefusedConnCount = metric.Metadata{
@@ -83,6 +90,7 @@ var (
 func MakeProxyMetrics() Metrics {
 	return Metrics{
 		BackendDisconnectCount: metric.NewCounter(metaBackendDisconnectCount),
+		IdleDisconnectCount:    metric.NewCounter(metaIdleDisconnectCount),
 		BackendDownCount:       metric.NewCounter(metaBackendDownCount),
 		ClientDisconnectCount:  metric.NewCounter(metaClientDisconnectCount),
 		CurConnCount:           metric.NewGauge(metaCurConnCount),


### PR DESCRIPTION
Previusly, the connection from the end user to the backend
can be idle for any period of time without disconnecting.
In certain cases, we want the ability for idle connections
to disconnect when the idle time exceeds redefined timeout.
To address this, this patch adds tracking of how long
the connection to the backend has been idle. If there is
a timeout specified, the connection will be disconnected
and an error message will be sent back to the end user.

Release note: None