### PR TITLE
release-20.2: sqlmigrations: fix pagination in pre-20.1 schema change job migration

### DIFF
--- a/pkg/sqlmigrations/migrations_test.go
+++ b/pkg/sqlmigrations/migrations_test.go
@@ -993,6 +993,13 @@ func TestMarkDeprecatedSchemaChangeJobsFailed(t *testing.T) {
 	migration := mt.pop(t, "mark non-terminal schema change jobs with a pre-20.1 format version as failed")
 	mt.start(t, base.TestServerArgs{})
 
+	// First, pad the jobs table with 100 GC jobs in the running state to ensure
+	// that the batching works. Regression test for #56859.
+	for i := 0; i < 100; i++ {
+		mt.sqlDB.Exec(t, `CREATE TABLE tbl_to_drop()`)
+		mt.sqlDB.Exec(t, `DROP TABLE tbl_to_drop`)
+	}
+
 	// Write some fake job records for schema changes with a pre-20.1 format
 	// version. Due to their format version, they will never be adopted. We just
 	// verify that the migration marks them as failed if in a non-terminal state,


### PR DESCRIPTION
Previously, the `mark non-terminal schema change jobs with a pre-20.1
format version as failed` migration had pagination implemented
incorrectly: The non-terminal jobs read in each batch were not
guaranteed to be pre-20.1 schema change jobs and thus marked as terminal
and removed from the query results, so the presence of at least 100 jobs
not undergoing the migration could cause the migration to never
terminate. This PR fixes the bug by paginating on `id`.

Fixes #56859.

Release note (bug fix): Fixed a bug where new nodes could fail to start
up when upgrading to 20.2, due to a startup migration which would fail
to terminate due to incorrect pagination in the presence of at least 100
running jobs.