### PR TITLE
release-20.2: backupccl: correctly manage temp objects during a full cluster restore

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -110,8 +110,8 @@ func (d *datadrivenTestState) cleanup(ctx context.Context) {
 }
 
 func (d *datadrivenTestState) addServer(
-	t *testing.T, name, iodir string, allowImplicitAccess bool,
-) {
+	t *testing.T, name, iodir, tempCleanupFrequency string, allowImplicitAccess bool,
+) error {
 	var tc serverutils.TestClusterInterface
 	var cleanup func()
 	params := base.TestClusterArgs{}
@@ -119,6 +119,15 @@ func (d *datadrivenTestState) addServer(
 		params.ServerArgs.Knobs.BackupRestore = &sql.BackupRestoreTestingKnobs{
 			AllowImplicitAccess: true,
 		}
+	}
+	if tempCleanupFrequency != "" {
+		duration, err := time.ParseDuration(tempCleanupFrequency)
+		if err != nil {
+			return errors.New("unable to parse tempCleanupFrequency during server creation")
+		}
+		settings := cluster.MakeTestingClusterSettings()
+		sql.TempObjectCleanupInterval.Override(&settings.SV, duration)
+		params.ServerArgs.Settings = settings
 	}
 	if iodir == "" {
 		_, tc, _, iodir, cleanup = backupRestoreTestSetupWithParams(t, singleNode, 0, InitNone, params)
@@ -128,6 +137,8 @@ func (d *datadrivenTestState) addServer(
 	d.servers[name] = tc.Server(0)
 	d.dataDirs[name] = iodir
 	d.cleanupFns = append(d.cleanupFns, cleanup)
+
+	return nil
 }
 
 func (d *datadrivenTestState) getIODir(t *testing.T, server string) string {
@@ -188,12 +199,21 @@ func TestBackupRestoreDataDriven(t *testing.T) {
 		defer ds.cleanup(ctx)
 		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
 			switch d.Cmd {
+			case "sleep":
+				var sleepDuration string
+				d.ScanArgs(t, "time", &sleepDuration)
+				duration, err := time.ParseDuration(sleepDuration)
+				if err != nil {
+					return err.Error()
+				}
+				time.Sleep(duration)
+				return ""
 			case "reset":
 				ds.cleanup(ctx)
 				ds = newDatadrivenTestState()
 				return ""
 			case "new-server":
-				var name, shareDirWith, iodir string
+				var name, shareDirWith, iodir, tempCleanupFrequency string
 				var allowImplicitAccess bool
 				d.ScanArgs(t, "name", &name)
 				if d.HasArg("share-io-dir") {
@@ -205,8 +225,14 @@ func TestBackupRestoreDataDriven(t *testing.T) {
 				if d.HasArg("allow-implicit-access") {
 					allowImplicitAccess = true
 				}
+				if d.HasArg("temp-cleanup-freq") {
+					d.ScanArgs(t, "temp-cleanup-freq", &tempCleanupFrequency)
+				}
 				lastCreatedServer = name
-				ds.addServer(t, name, iodir, allowImplicitAccess)
+				err := ds.addServer(t, name, iodir, tempCleanupFrequency, allowImplicitAccess)
+				if err != nil {
+					return err.Error()
+				}
 				return ""
 			case "exec-sql":
 				server := lastCreatedServer
@@ -596,7 +622,8 @@ func TestBackupRestoreAppend(t *testing.T) {
 				// restoring cluster needs to be empty, which means it can't contain any
 				// userfile tables.
 
-				_, _, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(t, MultiNode, tmpDir, InitNone)
+				_, _, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(t, MultiNode,
+					tmpDir, InitNone, base.TestClusterArgs{})
 				defer cleanupEmptyCluster()
 				sqlDBRestore.Exec(t, "RESTORE FROM $4 IN ($1, $2, $3) AS OF SYSTEM TIME "+ts2, append(collections, fullBackup2)...)
 			}
@@ -2045,7 +2072,7 @@ INSERT INTO sc.tb2 VALUES ('hello');
 		// Now backup the full cluster.
 		sqlDB.Exec(t, `BACKUP TO 'nodelocal://0/test/'`)
 		// Start a new server that shares the data directory.
-		_, _, sqlDBRestore, cleanupRestore := backupRestoreTestSetupEmpty(t, singleNode, dataDir, InitNone)
+		_, _, sqlDBRestore, cleanupRestore := backupRestoreTestSetupEmpty(t, singleNode, dataDir, InitNone, base.TestClusterArgs{})
 		defer cleanupRestore()
 
 		// Restore into the new cluster.
@@ -6477,4 +6504,129 @@ func flipBitInManifests(t *testing.T, rawDir string) {
 	if !foundManifest {
 		t.Fatal("found no manifest")
 	}
+}
+
+func TestFullClusterTemporaryBackupAndRestore(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	skip.UnderRace(t, "times out under race cause it starts up two test servers")
+
+	numNodes := 4
+	// Start a new server that shares the data directory.
+	dir, dirCleanupFn := testutils.TempDir(t)
+	defer dirCleanupFn()
+	params := base.TestClusterArgs{}
+	params.ServerArgs.ExternalIODir = dir
+	params.ServerArgs.UseDatabase = "defaultdb"
+	knobs := base.TestingKnobs{
+		SQLExecutor: &sql.ExecutorTestingKnobs{
+			DisableTempObjectsCleanupOnSessionExit: true,
+		},
+	}
+	params.ServerArgs.Knobs = knobs
+	tc := serverutils.StartNewTestCluster(
+		t, numNodes, params,
+	)
+	defer tc.Stopper().Stop(context.Background())
+
+	// Start two temporary schemas and create a table in each. This table will
+	// have different pg_temp schemas but will be created in the same defaultdb.
+	comment := "never see this"
+	for _, connID := range []int{0, 1} {
+		conn := tc.ServerConn(connID)
+		sqlDB := sqlutils.MakeSQLRunner(conn)
+		sqlDB.Exec(t, `SET experimental_enable_temp_tables=true`)
+		sqlDB.Exec(t, `CREATE TEMP TABLE t (x INT)`)
+		sqlDB.Exec(t, fmt.Sprintf(`COMMENT ON TABLE t IS '%s'`, comment))
+		require.NoError(t, conn.Close())
+	}
+
+	// Create a third session where we have two temp tables which will be in the
+	// same pg_temp schema with the same name but in different DBs.
+	diffDBConn := tc.ServerConn(2)
+	diffDB := sqlutils.MakeSQLRunner(diffDBConn)
+	diffDB.Exec(t, `SET experimental_enable_temp_tables=true`)
+	diffDB.Exec(t, `CREATE DATABASE d1`)
+	diffDB.Exec(t, `USE d1`)
+	diffDB.Exec(t, `CREATE TEMP TABLE t (x INT)`)
+	diffDB.Exec(t, `CREATE DATABASE d2`)
+	diffDB.Exec(t, `USE d2`)
+	diffDB.Exec(t, `CREATE TEMP TABLE t (x INT)`)
+	require.NoError(t, diffDBConn.Close())
+
+	backupDBConn := tc.ServerConn(3)
+	backupDB := sqlutils.MakeSQLRunner(backupDBConn)
+	backupDB.Exec(t, `BACKUP TO 'nodelocal://0/full_cluster_backup'`)
+	require.NoError(t, backupDBConn.Close())
+
+	params = base.TestClusterArgs{}
+	ch := make(chan time.Time)
+	finishedCh := make(chan struct{})
+	knobs = base.TestingKnobs{
+		SQLExecutor: &sql.ExecutorTestingKnobs{
+			OnTempObjectsCleanupDone: func() {
+				finishedCh <- struct{}{}
+			},
+			TempObjectsCleanupCh: ch,
+		},
+	}
+	params.ServerArgs.Knobs = knobs
+	_, _, sqlDBRestore, cleanupRestore := backupRestoreTestSetupEmpty(t, singleNode, dir, InitNone,
+		params)
+	defer cleanupRestore()
+	sqlDBRestore.Exec(t, `RESTORE FROM 'nodelocal://0/full_cluster_backup'`)
+
+	// Before the reconciliation job runs we should be able to see the following:
+	// - 4 synthesized pg_temp sessions in defaultdb.
+	// We synthesize a new temp schema for each unique backed-up <dbID, schemaID>
+	// tuple of a temporary table descriptor.
+	// - All temp tables remapped to belong to the associated synthesized temp
+	// schema, and in the defaultdb.
+	checkSchemasQuery := `SELECT schema_name FROM [SHOW SCHEMAS] WHERE schema_name LIKE 'pg_temp_%' ORDER BY
+schema_name`
+	sqlDBRestore.CheckQueryResults(t, checkSchemasQuery,
+		[][]string{{"pg_temp_0_0"}, {"pg_temp_0_1"}, {"pg_temp_0_2"}, {"pg_temp_0_3"}})
+
+	checkTempTablesQuery := `SELECT schema_name, 
+table_name FROM [SHOW TABLES] ORDER BY schema_name, table_name`
+	sqlDBRestore.CheckQueryResults(t, checkTempTablesQuery, [][]string{{"pg_temp_0_0", "t"},
+		{"pg_temp_0_1", "t"}, {"pg_temp_0_2", "t"}, {"pg_temp_0_3", "t"}})
+
+	// Sanity check that the databases the temporary tables originally belonged to
+	// are restored and empty because of the remapping.
+	sqlDBRestore.CheckQueryResults(t,
+		`SELECT database_name FROM [SHOW DATABASES] ORDER BY database_name`,
+		[][]string{{"d1"}, {"d2"}, {"defaultdb"}, {"postgres"}, {"system"}})
+
+	// Check that we can see the comment on the temporary tables before the
+	// reconciliation job runs.
+	checkCommentQuery := fmt.Sprintf(`SELECT count(comment) FROM system.comments WHERE comment='%s'`,
+		comment)
+	var commentCount int
+	sqlDBRestore.QueryRow(t, checkCommentQuery).Scan(&commentCount)
+	require.Equal(t, commentCount, 2)
+
+	// Check that show tables in one of the restored DBs returns an empty result.
+	sqlDBRestore.Exec(t, "USE d1")
+	sqlDBRestore.CheckQueryResults(t, "SHOW TABLES", [][]string{})
+
+	sqlDBRestore.Exec(t, "USE d2")
+	sqlDBRestore.CheckQueryResults(t, "SHOW TABLES", [][]string{})
+
+	testutils.SucceedsSoon(t, func() error {
+		ch <- timeutil.Now()
+		<-finishedCh
+
+		// Check that all the synthesized temp schemas have been wiped.
+		sqlDBRestore.CheckQueryResults(t, checkSchemasQuery, [][]string{})
+
+		// Check that all the temp tables have been wiped.
+		sqlDBRestore.CheckQueryResults(t, checkTempTablesQuery, [][]string{})
+
+		// Check that all the temp table comments have been wiped.
+		sqlDBRestore.QueryRow(t, checkCommentQuery).Scan(&commentCount)
+		require.Equal(t, commentCount, 0)
+		return nil
+	})
 }

--- a/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
+++ b/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
@@ -38,7 +38,7 @@ func TestFullClusterBackup(t *testing.T) {
 
 	const numAccounts = 10
 	_, _, sqlDB, tempDir, cleanupFn := BackupRestoreTestSetup(t, singleNode, numAccounts, InitNone)
-	_, _, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(t, singleNode, tempDir, InitNone)
+	_, _, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(t, singleNode, tempDir, InitNone, base.TestClusterArgs{})
 	defer cleanupFn()
 	defer cleanupEmptyCluster()
 
@@ -272,7 +272,7 @@ func TestFullClusterBackupDroppedTables(t *testing.T) {
 
 	const numAccounts = 10
 	_, _, sqlDB, tempDir, cleanupFn := BackupRestoreTestSetup(t, singleNode, numAccounts, InitNone)
-	_, _, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(t, singleNode, tempDir, InitNone)
+	_, _, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(t, singleNode, tempDir, InitNone, base.TestClusterArgs{})
 	defer cleanupFn()
 	defer cleanupEmptyCluster()
 
@@ -294,7 +294,7 @@ func TestIncrementalFullClusterBackup(t *testing.T) {
 	const numAccounts = 10
 	const incrementalBackupLocation = "nodelocal://0/inc-full-backup"
 	_, _, sqlDB, tempDir, cleanupFn := BackupRestoreTestSetup(t, singleNode, numAccounts, InitNone)
-	_, _, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(t, singleNode, tempDir, InitNone)
+	_, _, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(t, singleNode, tempDir, InitNone, base.TestClusterArgs{})
 	defer cleanupFn()
 	defer cleanupEmptyCluster()
 
@@ -315,7 +315,7 @@ func TestEmptyFullClusterRestore(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	sqlDB, tempDir, cleanupFn := createEmptyCluster(t, singleNode)
-	_, _, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(t, singleNode, tempDir, InitNone)
+	_, _, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(t, singleNode, tempDir, InitNone, base.TestClusterArgs{})
 	defer cleanupFn()
 	defer cleanupEmptyCluster()
 
@@ -335,7 +335,7 @@ func TestClusterRestoreEmptyDB(t *testing.T) {
 
 	const numAccounts = 10
 	_, _, sqlDB, tempDir, cleanupFn := BackupRestoreTestSetup(t, singleNode, numAccounts, InitNone)
-	_, _, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(t, singleNode, tempDir, InitNone)
+	_, _, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(t, singleNode, tempDir, InitNone, base.TestClusterArgs{})
 	defer cleanupFn()
 	defer cleanupEmptyCluster()
 
@@ -354,7 +354,7 @@ func TestDisallowFullClusterRestoreOnNonFreshCluster(t *testing.T) {
 
 	const numAccounts = 10
 	_, _, sqlDB, tempDir, cleanupFn := BackupRestoreTestSetup(t, singleNode, numAccounts, InitNone)
-	_, _, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(t, singleNode, tempDir, InitNone)
+	_, _, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(t, singleNode, tempDir, InitNone, base.TestClusterArgs{})
 	defer cleanupFn()
 	defer cleanupEmptyCluster()
 
@@ -372,7 +372,7 @@ func TestDisallowFullClusterRestoreOfNonFullBackup(t *testing.T) {
 
 	const numAccounts = 10
 	_, _, sqlDB, tempDir, cleanupFn := BackupRestoreTestSetup(t, singleNode, numAccounts, InitNone)
-	_, _, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(t, singleNode, tempDir, InitNone)
+	_, _, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(t, singleNode, tempDir, InitNone, base.TestClusterArgs{})
 	defer cleanupFn()
 	defer cleanupEmptyCluster()
 
@@ -497,9 +497,7 @@ func TestClusterRestoreFailCleanup(t *testing.T) {
 	sqlDB.Exec(t, `BACKUP TO $1`, LocalFoo)
 
 	t.Run("during restoration of data", func(t *testing.T) {
-		_, _, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(
-			t, singleNode, tempDir, InitNone,
-		)
+		_, _, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(t, singleNode, tempDir, InitNone, base.TestClusterArgs{})
 		defer cleanupEmptyCluster()
 		sqlDBRestore.ExpectErr(t, "sst: no such file", `RESTORE FROM 'nodelocal://1/missing-ssts'`)
 		// Verify the failed RESTORE added some DROP tables.
@@ -524,9 +522,7 @@ func TestClusterRestoreFailCleanup(t *testing.T) {
 	})
 
 	t.Run("during system table restoration", func(t *testing.T) {
-		_, tcRestore, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(
-			t, singleNode, tempDir, InitNone,
-		)
+		_, tcRestore, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(t, singleNode, tempDir, InitNone, base.TestClusterArgs{})
 		defer cleanupEmptyCluster()
 
 		// Bugger the backup by injecting a failure while restoring the system data.
@@ -566,9 +562,7 @@ func TestClusterRestoreFailCleanup(t *testing.T) {
 	})
 
 	t.Run("after offline tables", func(t *testing.T) {
-		_, tcRestore, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(
-			t, singleNode, tempDir, InitNone,
-		)
+		_, tcRestore, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(t, singleNode, tempDir, InitNone, base.TestClusterArgs{})
 		defer cleanupEmptyCluster()
 
 		// Bugger the backup by injecting a failure while restoring the system data.
@@ -701,9 +695,7 @@ func TestClusterRevisionHistory(t *testing.T) {
 
 	for i, testCase := range testCases {
 		t.Run(fmt.Sprintf("t%d", i), func(t *testing.T) {
-			_, _, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(
-				t, singleNode, tempDir, InitNone,
-			)
+			_, _, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(t, singleNode, tempDir, InitNone, base.TestClusterArgs{})
 			defer cleanupEmptyCluster()
 
 			sqlDBRestore.Exec(t, `RESTORE FROM $1 AS OF SYSTEM TIME `+testCase.ts, LocalFoo)

--- a/pkg/ccl/backupccl/helpers_test.go
+++ b/pkg/ccl/backupccl/helpers_test.go
@@ -52,6 +52,7 @@ func backupRestoreTestSetupWithParams(
 	dir, dirCleanupFn := testutils.TempDir(t)
 	params.ServerArgs.ExternalIODir = dir
 	params.ServerArgs.UseDatabase = "data"
+
 	tc = testcluster.StartTestCluster(t, clusterSize, params)
 	init(tc)
 
@@ -94,9 +95,13 @@ func BackupRestoreTestSetup(
 }
 
 func backupRestoreTestSetupEmpty(
-	t testing.TB, clusterSize int, tempDir string, init func(*testcluster.TestCluster),
+	t testing.TB,
+	clusterSize int,
+	tempDir string,
+	init func(*testcluster.TestCluster),
+	params base.TestClusterArgs,
 ) (ctx context.Context, tc *testcluster.TestCluster, sqlDB *sqlutils.SQLRunner, cleanup func()) {
-	return backupRestoreTestSetupEmptyWithParams(t, clusterSize, tempDir, init, base.TestClusterArgs{})
+	return backupRestoreTestSetupEmptyWithParams(t, clusterSize, tempDir, init, params)
 }
 
 func verifyBackupRestoreStatementResult(

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"path"
 	"sort"
+	"strconv"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
@@ -150,6 +151,46 @@ func maybeFilterMissingViews(
 		}
 	}
 	return filteredTablesByID, nil
+}
+
+func synthesizePGTempSchema(
+	ctx context.Context, p sql.PlanHookState, schemaName string,
+) (descpb.ID, descpb.ID, error) {
+	var synthesizedSchemaID descpb.ID
+	var defaultDBID descpb.ID
+	err := p.ExecCfg().DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+		var err error
+		defaultDBID, err = lookupDatabaseID(ctx, txn, p.ExecCfg().Codec,
+			catalogkeys.DefaultDatabaseName)
+		if err != nil {
+			return err
+		}
+
+		sKey := catalogkeys.NewSchemaKey(defaultDBID, schemaName)
+		schemaID, err := catalogkv.GetDescriptorID(ctx, txn, p.ExecCfg().Codec, sKey)
+		if err != nil {
+			return err
+		}
+		if schemaID != descpb.InvalidID {
+			return errors.Newf("attempted to synthesize temp schema during RESTORE but found"+
+				" another schema already using the same schema key %s", sKey.Name())
+		}
+		synthesizedSchemaID, err = catalogkv.GenerateUniqueDescID(ctx, p.ExecCfg().DB, p.ExecCfg().Codec)
+		if err != nil {
+			return err
+		}
+		return p.CreateSchemaNamespaceEntry(ctx, sKey.Key(p.ExecCfg().Codec), synthesizedSchemaID)
+	})
+
+	return synthesizedSchemaID, defaultDBID, err
+}
+
+// dbSchemaKey is used when generating fake pg_temp schemas for the purpose of
+// restoring temporary objects. Detailed comments can be found where it is being
+// used.
+type dbSchemaKey struct {
+	parentID descpb.ID
+	schemaID descpb.ID
 }
 
 // allocateDescriptorRewrites determines the new ID and parentID (a "DescriptorRewrite")
@@ -322,6 +363,64 @@ func allocateDescriptorRewrites(
 		for _, typ := range typesByID {
 			if typ.GetParentID() == systemschema.SystemDB.ID {
 				descriptorRewrites[typ.GetID()] = &jobspb.RestoreDetails_DescriptorRewrite{ParentID: tempSysDBID}
+			}
+		}
+
+		// When restoring a temporary object, the parent schema which the descriptor
+		// is originally pointing to is never part of the BACKUP. This is because
+		// the "pg_temp" schema in which temporary objects are created is not
+		// represented as a descriptor and thus is not picked up during a full
+		// cluster BACKUP.
+		// To overcome this orphaned schema pointer problem, when restoring a
+		// temporary object we create a "fake" pg_temp schema in defaultdb and add
+		// it to the namespace table. We then remap the temporary object descriptors
+		// to point to this schema. This allows us to piggy back on the temporary
+		// reconciliation job which looks for "pg_temp" schemas linked to temporary
+		// sessions and properly cleans up the temporary objects in it.
+		haveSynthesizedTempSchema := make(map[dbSchemaKey]bool)
+		var defaultDBID descpb.ID
+		var synthesizedTempSchemaCount int
+		for _, table := range tablesByID {
+			if table.IsTemporary() {
+				// We generate a "fake" temporary schema for every unique
+				// <dbID,schemaID> tuple of the backed-up temporary table descriptors.
+				// This is important because post rewrite all the "fake" schemas and
+				// consequently temp table objects are going to be in defaultdb. Placing
+				// them under different "fake" schemas prevents name collisions if the
+				// backed up tables had the same names but were in different temp
+				// schemas/databases in the cluster which was backed up.
+				dbSchemaIDKey := dbSchemaKey{parentID: table.GetParentID(),
+					schemaID: table.GetParentSchemaID()}
+				if _, ok := haveSynthesizedTempSchema[dbSchemaIDKey]; !ok {
+					var synthesizedSchemaID descpb.ID
+					var err error
+					// NB: TemporarySchemaNameForRestorePrefix is a special value that has
+					// been chosen to trick the reconciliation job into performing our
+					// cleanup for us. The reconciliation job strips the "pg_temp" prefix
+					// and parses the remainder of the string into a session ID. It then
+					// checks the session ID against its active sessions, and performs
+					// cleanup on the inactive ones.
+					// We reserve the high bit to be 0 so as to never collide with an
+					// actual session ID as normally the high bit is the hlc.Timestamp at
+					// which the cluster was started.
+					schemaName := sql.TemporarySchemaNameForRestorePrefix +
+						strconv.Itoa(synthesizedTempSchemaCount)
+					synthesizedSchemaID, defaultDBID, err = synthesizePGTempSchema(ctx, p, schemaName)
+					if err != nil {
+						return nil, err
+					}
+					// Write a schema descriptor rewrite so that we can remap all
+					// temporary table descs which were under the original session
+					// specific pg_temp schema to point to this synthesized schema when we
+					// are performing the table rewrites.
+					descriptorRewrites[table.GetParentSchemaID()] = &jobspb.RestoreDetails_DescriptorRewrite{ID: synthesizedSchemaID}
+					haveSynthesizedTempSchema[dbSchemaIDKey] = true
+					synthesizedTempSchemaCount++
+				}
+
+				// Remap the temp table descriptors to belong to the defaultdb where we
+				// have synthesized the temp schema.
+				descriptorRewrites[table.GetID()] = &jobspb.RestoreDetails_DescriptorRewrite{ParentID: defaultDBID}
 			}
 		}
 	}
@@ -812,7 +911,8 @@ func rewriteTypeDescs(types []*typedesc.Mutable, descriptorRewrites DescRewriteM
 		typ.ModificationTime = hlc.Timestamp{}
 
 		typ.ID = rewrite.ID
-		typ.ParentSchemaID = maybeRewriteSchemaID(typ.ParentSchemaID, descriptorRewrites)
+		typ.ParentSchemaID = maybeRewriteSchemaID(typ.ParentSchemaID, descriptorRewrites,
+			false /* isTemporaryDesc */)
 		typ.ParentID = rewrite.ParentID
 		for i := range typ.ReferencingDescriptorIDs {
 			id := typ.ReferencingDescriptorIDs[i]
@@ -853,10 +953,12 @@ func rewriteSchemaDescs(schemas []*schemadesc.Mutable, descriptorRewrites DescRe
 	return nil
 }
 
-func maybeRewriteSchemaID(curSchemaID descpb.ID, descriptorRewrites DescRewriteMap) descpb.ID {
+func maybeRewriteSchemaID(
+	curSchemaID descpb.ID, descriptorRewrites DescRewriteMap, isTemporaryDesc bool,
+) descpb.ID {
 	// If the current schema is the public schema, then don't attempt to
 	// do any rewriting.
-	if curSchemaID == keys.PublicSchemaID {
+	if curSchemaID == keys.PublicSchemaID && !isTemporaryDesc {
 		return curSchemaID
 	}
 	rw, ok := descriptorRewrites[curSchemaID]
@@ -904,7 +1006,8 @@ func RewriteTableDescs(
 		}
 
 		table.ID = tableRewrite.ID
-		table.UnexposedParentSchemaID = maybeRewriteSchemaID(table.GetParentSchemaID(), descriptorRewrites)
+		table.UnexposedParentSchemaID = maybeRewriteSchemaID(table.GetParentSchemaID(),
+			descriptorRewrites, table.IsTemporary())
 		table.ParentID = tableRewrite.ParentID
 
 		// Remap type IDs in all serialized expressions within the TableDescriptor.

--- a/pkg/ccl/backupccl/show_test.go
+++ b/pkg/ccl/backupccl/show_test.go
@@ -35,7 +35,7 @@ func TestShowBackup(t *testing.T) {
 	const numAccounts = 11
 	_, tc, sqlDB, tempDir, cleanupFn := BackupRestoreTestSetup(t, singleNode, numAccounts, InitNone)
 	kvDB := tc.Server(0).DB()
-	_, _, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(t, singleNode, tempDir, InitNone)
+	_, _, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(t, singleNode, tempDir, InitNone, base.TestClusterArgs{})
 	defer cleanupFn()
 	defer cleanupEmptyCluster()
 	sqlDB.Exec(t, `
@@ -374,7 +374,7 @@ func TestShowBackups(t *testing.T) {
 
 	const numAccounts = 11
 	_, _, sqlDB, tempDir, cleanupFn := BackupRestoreTestSetup(t, singleNode, numAccounts, InitNone)
-	_, _, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(t, singleNode, tempDir, InitNone)
+	_, _, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(t, singleNode, tempDir, InitNone, base.TestClusterArgs{})
 	defer cleanupFn()
 	defer cleanupEmptyCluster()
 

--- a/pkg/ccl/backupccl/testdata/backup-restore/temp-tables
+++ b/pkg/ccl/backupccl/testdata/backup-restore/temp-tables
@@ -9,6 +9,7 @@ SET experimental_enable_temp_tables=true;
 CREATE DATABASE d1;
 USE d1;
 CREATE TEMP TABLE temp_table (id int primary key);
+CREATE TEMP SEQUENCE temp_seq;
 CREATE TABLE perm_table (id int primary key)
 ----
 
@@ -16,6 +17,7 @@ query-sql
 SELECT table_name FROM [SHOW TABLES] ORDER BY table_name
 ----
 perm_table
+temp_seq
 temp_table
 
 query-sql
@@ -41,6 +43,11 @@ BACKUP DATABASE d1 TO 'nodelocal://0/d1_backup/'
 
 exec-sql
 BACKUP d1.* TO 'nodelocal://0/d1_star_backup/'
+----
+
+exec-sql
+COMMENT ON TABLE temp_table IS 'should not show up in restore';
+BACKUP TO 'nodelocal://0/full_cluster_backup/';
 ----
 
 exec-sql
@@ -83,6 +90,80 @@ information_schema
 pg_catalog
 pg_extension
 public
+
+query-sql
+USE d1;
+SELECT table_name FROM [SHOW TABLES] ORDER BY table_name
+----
+perm_table
+
+new-server name=s2 share-io-dir=s1 temp-cleanup-freq=5s
+----
+
+exec-sql
+USE defaultdb;
+RESTORE FROM 'nodelocal://0/full_cluster_backup/';
+----
+
+# The pg_temp schema from the BACKUP should not show up after restoration.
+query-sql
+USE d1;
+SELECT schema_name FROM [SHOW SCHEMAS] ORDER BY schema_name
+----
+crdb_internal
+information_schema
+pg_catalog
+pg_extension
+public
+
+
+# We should see a synthesized pg_temp schema.
+query-sql
+USE defaultdb;
+SELECT schema_name FROM [SHOW SCHEMAS] ORDER BY schema_name
+----
+crdb_internal
+information_schema
+pg_catalog
+pg_extension
+pg_temp_0_0
+public
+
+# On full cluster restore we remap the temp tables to defaultdb so we should not
+# see them in the restored db.
+query-sql
+USE d1;
+SELECT table_name FROM [SHOW TABLES] ORDER BY table_name
+----
+perm_table
+
+query-sql
+USE defaultdb;
+SELECT table_name FROM [SHOW TABLES] ORDER BY table_name
+----
+temp_seq
+temp_table
+
+# Wait for the temp cleanup job to run.
+sleep time=5s
+----
+
+# The synthetic temp schema should have been erased.
+query-sql
+USE defaultdb;
+SELECT schema_name FROM [SHOW SCHEMAS] ORDER BY schema_name
+----
+crdb_internal
+information_schema
+pg_catalog
+pg_extension
+public
+
+# The temp tables should have been erased.
+query-sql
+USE defaultdb;
+SELECT table_name FROM [SHOW TABLES] ORDER BY table_name
+----
 
 query-sql
 USE d1;

--- a/pkg/sql/descriptor.go
+++ b/pkg/sql/descriptor.go
@@ -96,7 +96,8 @@ func (p *planner) createDatabase(
 	// be created in every database in >= 20.2.
 	if shouldCreatePublicSchema {
 		// Every database must be initialized with the public schema.
-		if err := p.createSchemaNamespaceEntry(ctx, catalogkeys.NewPublicSchemaKey(id).Key(p.ExecCfg().Codec), keys.PublicSchemaID); err != nil {
+		if err := p.CreateSchemaNamespaceEntry(ctx,
+			catalogkeys.NewPublicSchemaKey(id).Key(p.ExecCfg().Codec), keys.PublicSchemaID); err != nil {
 			return nil, true, err
 		}
 	}

--- a/pkg/sql/planhook.go
+++ b/pkg/sql/planhook.go
@@ -13,6 +13,7 @@ package sql
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/dbdesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -100,6 +101,8 @@ type PlanHookState interface {
 	ShowCreate(
 		ctx context.Context, dbPrefix string, allDescs []descpb.Descriptor, desc *tabledesc.Immutable, displayOptions ShowCreateDisplayOptions,
 	) (string, error)
+	CreateSchemaNamespaceEntry(ctx context.Context, schemaNameKey roachpb.Key,
+		schemaID descpb.ID) error
 }
 
 // AddPlanHook adds a hook used to short-circuit creating a planNode from a

--- a/pkg/sql/temporary_schema.go
+++ b/pkg/sql/temporary_schema.go
@@ -86,6 +86,12 @@ var (
 	}
 )
 
+// TemporarySchemaNameForRestorePrefix is the prefix name of the schema we
+// synthesize during a full cluster restore. All temporary objects being
+// restored are remapped to belong to this schema allowing the reconciliation
+// job to gracefully clean up these objects when it runs.
+const TemporarySchemaNameForRestorePrefix string = "pg_temp_0_"
+
 func (p *planner) getOrCreateTemporarySchema(
 	ctx context.Context, dbID descpb.ID,
 ) (descpb.ID, error) {
@@ -100,7 +106,7 @@ func (p *planner) getOrCreateTemporarySchema(
 		if err != nil {
 			return descpb.InvalidID, err
 		}
-		if err := p.createSchemaNamespaceEntry(ctx, sKey.Key(p.ExecCfg().Codec), id); err != nil {
+		if err := p.CreateSchemaNamespaceEntry(ctx, sKey.Key(p.ExecCfg().Codec), id); err != nil {
 			return descpb.InvalidID, err
 		}
 		p.sessionDataMutator.SetTemporarySchemaName(sKey.Name())
@@ -110,7 +116,9 @@ func (p *planner) getOrCreateTemporarySchema(
 	return schemaID, nil
 }
 
-func (p *planner) createSchemaNamespaceEntry(
+// CreateSchemaNamespaceEntry creates an entry for the schema in the
+// system.namespace table.
+func (p *planner) CreateSchemaNamespaceEntry(
 	ctx context.Context, schemaNameKey roachpb.Key, schemaID descpb.ID,
 ) error {
 	if p.ExtendedEvalContext().Tracing.KVTracingEnabled() {


### PR DESCRIPTION
Backport 1/1 commits from #56956.

/cc @cockroachdb/release

---

Discussion about the design at #56512.

Fixes: #56512

Release note: None
