### PR TITLE
sql: add open txns gauge

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -313,6 +313,7 @@ func makeMetrics(internal bool) Metrics {
 				6*metricsSampleInterval),
 			SQLTxnLatency: metric.NewLatency(getMetricMeta(MetaSQLTxnLatency, internal),
 				6*metricsSampleInterval),
+			SQLTxnsOpen: metric.NewGauge(getMetricMeta(MetaSQLTxnsOpen, internal)),
 
 			TxnAbortCount: metric.NewCounter(getMetricMeta(MetaTxnAbort, internal)),
 			FailureCount:  metric.NewCounter(getMetricMeta(MetaFailure, internal)),

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -1455,6 +1455,8 @@ func (ex *connExecutor) recordTransactionStart() (onTxnFinish func(txnEvent), on
 	ex.extraTxnState.transactionStatementIDs = nil
 	ex.extraTxnState.numRows = 0
 
+	ex.metrics.EngineMetrics.SQLTxnsOpen.Inc(1)
+
 	onTxnFinish = func(ev txnEvent) {
 		ex.phaseTimes[sessionEndExecTransaction] = timeutil.Now()
 		ex.recordTransaction(ev, implicit, txnStart)
@@ -1471,6 +1473,7 @@ func (ex *connExecutor) recordTransactionStart() (onTxnFinish func(txnEvent), on
 func (ex *connExecutor) recordTransaction(ev txnEvent, implicit bool, txnStart time.Time) {
 	txnEnd := timeutil.Now()
 	txnTime := txnEnd.Sub(txnStart)
+	ex.metrics.EngineMetrics.SQLTxnsOpen.Dec(1)
 	ex.metrics.EngineMetrics.SQLTxnLatency.RecordValue(txnTime.Nanoseconds())
 
 	txnServiceLat := ex.phaseTimes.getTransactionServiceLatency()

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -474,6 +474,12 @@ var (
 		Measurement: "Latency",
 		Unit:        metric.Unit_NANOSECONDS,
 	}
+	MetaSQLTxnsOpen = metric.Metadata{
+		Name:        "sql.txns.open",
+		Help:        "Number of currently open SQL transactions",
+		Measurement: "Open SQL Transactions",
+		Unit:        metric.Unit_COUNT,
+	}
 
 	// Below are the metadata for the statement started counters.
 

--- a/pkg/sql/execinfra/metrics.go
+++ b/pkg/sql/execinfra/metrics.go
@@ -41,19 +41,19 @@ var _ metric.Struct = DistSQLMetrics{}
 var (
 	metaQueriesActive = metric.Metadata{
 		Name:        "sql.distsql.queries.active",
-		Help:        "Number of distributed SQL queries currently active",
+		Help:        "Number of SQL queries currently active",
 		Measurement: "Queries",
 		Unit:        metric.Unit_COUNT,
 	}
 	metaQueriesTotal = metric.Metadata{
 		Name:        "sql.distsql.queries.total",
-		Help:        "Number of distributed SQL queries executed",
+		Help:        "Number of SQL queries executed",
 		Measurement: "Queries",
 		Unit:        metric.Unit_COUNT,
 	}
 	metaContendedQueriesCount = metric.Metadata{
 		Name:        "sql.distsql.contended_queries.count",
-		Help:        "Number of distributed SQL queries that experienced contention",
+		Help:        "Number of SQL queries that experienced contention",
 		Measurement: "Queries",
 		Unit:        metric.Unit_COUNT,
 	}

--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -131,6 +131,7 @@ type EngineMetrics struct {
 	DistSQLServiceLatency *metric.Histogram
 	SQLServiceLatency     *metric.Histogram
 	SQLTxnLatency         *metric.Histogram
+	SQLTxnsOpen           *metric.Gauge
 
 	// TxnAbortCount counts transactions that were aborted, either due
 	// to non-retriable errors, or retriable errors when the client-side

--- a/pkg/ts/catalog/catalog_generator.go
+++ b/pkg/ts/catalog/catalog_generator.go
@@ -429,8 +429,8 @@ func (ic *IndividualChart) addDisplayProperties(cd chartDescription) error {
 
 		for _, m := range ic.Metrics {
 			if m.AxisLabel != al {
-				return errors.Errorf(`Chart %s has metrics with different axis labels; 
-				need to specify an AxisLabel in its chartDescription: %v`, cd.Title, ic)
+				return errors.Errorf(`Chart %s has metrics with different axis labels (%s vs %s); 
+				need to specify an AxisLabel in its chartDescription: %v`, al, m.AxisLabel, cd.Title, ic)
 			}
 		}
 

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -1857,6 +1857,7 @@ var charts = []sectionDescription{
 					"sql.txns.open",
 					"sql.txns.open.internal",
 				},
+				AxisLabel: "Transactions",
 			},
 			{
 				Title: "Byte I/O",

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -1852,6 +1852,13 @@ var charts = []sectionDescription{
 				},
 			},
 			{
+				Title: "Open Transactions",
+				Metrics: []string{
+					"sql.txns.open",
+					"sql.txns.open.internal",
+				},
+			},
+			{
 				Title: "Byte I/O",
 				Metrics: []string{
 					"sql.bytesin",

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
@@ -26,9 +26,9 @@ export default function (props: GraphDashboardProps) {
 
   return [
     <LineGraph
-      title="SQL Connections"
+      title="Open SQL Sessions"
       sources={nodeSources}
-      tooltip={`The total number of active SQL connections ${tooltipSelection}.`}
+      tooltip={`The total number of open SQL Sessions ${tooltipSelection}.`}
     >
       <Axis label="connections">
         {_.map(nodeIDs, (node) => (
@@ -44,6 +44,29 @@ export default function (props: GraphDashboardProps) {
     </LineGraph>,
 
     <LineGraph
+      title="Open SQL Transactions"
+      sources={nodeSources}
+      tooltip={`The total number of SQL transactions currently open ${tooltipSelection}.`}
+    >
+      <Axis label="transactions">
+        <Metric name="cr.node.sql.txns.open" title="Open Transactions" />
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph
+      title="Active SQL Statements"
+      sources={nodeSources}
+      tooltip={`The total number of SQL statements currently running ${tooltipSelection}.`}
+    >
+      <Axis label="queries">
+        <Metric
+          name="cr.node.sql.distsql.queries.active"
+          title="Active Statements"
+        />
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph
       title="SQL Byte Traffic"
       sources={nodeSources}
       tooltip={`The total amount of SQL client network traffic in bytes per second ${tooltipSelection}.`}
@@ -55,7 +78,7 @@ export default function (props: GraphDashboardProps) {
     </LineGraph>,
 
     <LineGraph
-      title="SQL Queries"
+      title="SQL Statements"
       sources={nodeSources}
       tooltip={`A ten-second moving average of the # of SELECT, INSERT, UPDATE, and DELETE statements
         successfully executed per second ${tooltipSelection}.`}
@@ -85,7 +108,7 @@ export default function (props: GraphDashboardProps) {
     </LineGraph>,
 
     <LineGraph
-      title="SQL Query Errors"
+      title="SQL Statement Errors"
       sources={nodeSources}
       tooltip={
         "The number of statements which returned a planning or runtime error."
@@ -101,21 +124,8 @@ export default function (props: GraphDashboardProps) {
     </LineGraph>,
 
     <LineGraph
-      title="Active Distributed SQL Queries"
-      sources={nodeSources}
-      tooltip={`The total number of distributed SQL queries currently running ${tooltipSelection}.`}
-    >
-      <Axis label="queries">
-        <Metric
-          name="cr.node.sql.distsql.queries.active"
-          title="Active Queries"
-        />
-      </Axis>
-    </LineGraph>,
-
-    <LineGraph
-      title="Active Flows for Distributed SQL Queries"
-      tooltip="The number of flows on each node contributing to currently running distributed SQL queries."
+      title="Active Flows for Distributed SQL Statements"
+      tooltip="The number of flows on each node contributing to currently running distributed SQL statements."
     >
       <Axis label="flows">
         {_.map(nodeIDs, (node) => (


### PR DESCRIPTION
This is a new gauge in `sql.txns.open` that tracks the number of open
transactions.

Closes #57475
Closes #52005

cc @a-entin @awoods187 

The dashboard now contains the following 3 graphs first:

1. Open SQL Sessions
2. Open SQL Transactions
3. Active SQL Queries

Release note (ui change): add Open SQL Transactions to SQL dashboard in
DB Console. Rename SQL Queries to SQL Statements in SQL metrics
dashboard. Remove references to "Distributed SQL Queries" when metrics
really are discussing all SQL queries.
