### PR TITLE
release-20.1: roachtest: remove initial disk space check from drop test

### DIFF
--- a/pkg/cmd/roachtest/drop.go
+++ b/pkg/cmd/roachtest/drop.go
@@ -29,7 +29,7 @@ func registerDrop(r *testRegistry) {
 	// by a truncation for the `stock` table (which contains warehouses*100k
 	// rows). Next, it issues a `DROP` for the whole database, and sets the GC TTL
 	// to one second.
-	runDrop := func(ctx context.Context, t *test, c *cluster, warehouses, nodes int, initDiskSpace int) {
+	runDrop := func(ctx context.Context, t *test, c *cluster, warehouses, nodes int) {
 		c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
 		c.Put(ctx, workload, "./workload", c.Range(1, nodes))
 		c.Start(ctx, t, c.Range(1, nodes), startArgs("-e", "COCKROACH_MEMPROF_INTERVAL=15s"))
@@ -86,12 +86,6 @@ func registerDrop(r *testRegistry) {
 				}
 
 				t.l.Printf("Node %d space used: %s\n", j, humanizeutil.IBytes(int64(size)))
-
-				// Return if the size of the directory is less than expected.
-				if size < initDiskSpace {
-					t.Fatalf("Node %d space used: %s less than %s", j, humanizeutil.IBytes(int64(size)),
-						humanizeutil.IBytes(int64(initDiskSpace)))
-				}
 			}
 
 			for i := minWarehouse; i <= maxWarehouse; i++ {
@@ -159,7 +153,6 @@ func registerDrop(r *testRegistry) {
 
 	warehouses := 100
 	numNodes := 9
-	initDiskSpace := 256 << 20 // 256 MB
 
 	r.Add(testSpec{
 		Name:       fmt.Sprintf("drop/tpcc/w=%d,nodes=%d", warehouses, numNodes),
@@ -172,10 +165,9 @@ func registerDrop(r *testRegistry) {
 			if local {
 				numNodes = 4
 				warehouses = 1
-				initDiskSpace = 5 << 20 // 5 MB
 				fmt.Printf("running with w=%d,nodes=%d in local mode\n", warehouses, numNodes)
 			}
-			runDrop(ctx, t, c, warehouses, numNodes, initDiskSpace)
+			runDrop(ctx, t, c, warehouses, numNodes)
 		},
 	})
 }


### PR DESCRIPTION
Backport 1/1 commits from #57274.

/cc @cockroachdb/release

---

Fixes #56040.

Will need to be backported.

This assertion seemed like a good idea, but it was repeatedly (dec148a)
a source of flakiness when fixtures changed. Now that we're using IMPORT
for TPC-C, the check is even harder to get right without making it so
small as to be useless. It doesn't seem to be worth the instability, so
remove it.