### PR TITLE
bulkio: Correctly export backup specific metrics.

### DIFF
--- a/pkg/ccl/backupccl/create_scheduled_backup_test.go
+++ b/pkg/ccl/backupccl/create_scheduled_backup_test.go
@@ -751,7 +751,7 @@ INSERT INTO t values (1), (10), (100);
 		ex, _, err := jobs.GetScheduledJobExecutor(tree.ScheduledBackupExecutor.InternalName())
 		require.NoError(t, err)
 		require.NotNil(t, ex.Metrics())
-		return &ex.Metrics().(*backupMetrics).ExecutorMetrics
+		return ex.Metrics().(*backupMetrics).ExecutorMetrics
 	}()
 
 	t.Run("retry", func(t *testing.T) {


### PR DESCRIPTION
Fixes #57459

Fix backup metrics struct to be compatible with metrics registry,
which expects all metrics to be exported struct fields, and embedded
structs to implement "metrics.Struct" interface.

Release Note: Correctly export schedules_BACKUP_* metrics as well
as backup RPO metric.