### PR TITLE
sql: add KV stats to TraceAnalyzer 

### DIFF
--- a/pkg/sql/execstats/BUILD.bazel
+++ b/pkg/sql/execstats/BUILD.bazel
@@ -20,9 +20,10 @@ go_test(
     srcs = [
         "main_test.go",
         "traceanalyzer_test.go",
+        "utils_test.go",
     ],
+    embed = [":execstats"],
     deps = [
-        ":execstats",
         "//pkg/base",
         "//pkg/roachpb",
         "//pkg/security",
@@ -37,7 +38,10 @@ go_test(
         "//pkg/testutils/testcluster",
         "//pkg/util/leaktest",
         "//pkg/util/log",
+        "//pkg/util/optional",
         "//pkg/util/tracing",
+        "//pkg/util/uuid",
+        "//vendor/github.com/stretchr/testify/assert",
         "//vendor/github.com/stretchr/testify/require",
     ],
 )

--- a/pkg/sql/execstats/traceanalyzer_test.go
+++ b/pkg/sql/execstats/traceanalyzer_test.go
@@ -133,41 +133,36 @@ func TestTraceAnalyzer(t *testing.T) {
 		}
 	}
 
-	t.Run("NetworkBytesSent", func(t *testing.T) {
-		for _, analyzer := range []*execstats.TraceAnalyzer{
-			rowexecTraceAnalyzer, colexecTraceAnalyzer,
-		} {
-			nodeLevelStats := analyzer.GetNodeLevelStats()
-			require.Equal(
-				t, numNodes-1, len(nodeLevelStats.NetworkBytesSentGroupedByNode), "expected all nodes minus the gateway node to have sent bytes",
-			)
+	for _, tc := range []struct {
+		analyzer            *execstats.TraceAnalyzer
+		expectedMaxMemUsage int64
+	}{
+		{
+			analyzer:            rowexecTraceAnalyzer,
+			expectedMaxMemUsage: int64(20480),
+		},
+		{
+			analyzer:            colexecTraceAnalyzer,
+			expectedMaxMemUsage: int64(30720),
+		},
+	} {
+		nodeLevelStats := tc.analyzer.GetNodeLevelStats()
+		require.Equal(
+			t, numNodes-1, len(nodeLevelStats.NetworkBytesSentGroupedByNode), "expected all nodes minus the gateway node to have sent bytes",
+		)
 
-			queryLevelStats := analyzer.GetQueryLevelStats()
+		queryLevelStats := tc.analyzer.GetQueryLevelStats()
 
-			// The stats don't count the actual bytes, but they are a synthetic value
-			// based on the number of tuples. In this test 21 tuples flow over the
-			// network.
-			require.Equal(t, queryLevelStats.NetworkBytesSent, int64(21*8))
-		}
-	})
+		// The stats don't count the actual bytes, but they are a synthetic value
+		// based on the number of tuples. In this test 21 tuples flow over the
+		// network.
+		require.Equal(t, int64(21*8), queryLevelStats.NetworkBytesSent)
 
-	t.Run("MaxMemoryUsage", func(t *testing.T) {
-		for _, tc := range []struct {
-			analyzer            *execstats.TraceAnalyzer
-			expectedMaxMemUsage int64
-		}{
-			{
-				analyzer:            rowexecTraceAnalyzer,
-				expectedMaxMemUsage: int64(20480),
-			},
-			{
-				analyzer:            colexecTraceAnalyzer,
-				expectedMaxMemUsage: int64(30720),
-			},
-		} {
-			queryLevelStats := tc.analyzer.GetQueryLevelStats()
+		require.Equal(t, tc.expectedMaxMemUsage, queryLevelStats.MaxMemUsage)
 
-			require.Equal(t, tc.expectedMaxMemUsage, queryLevelStats.MaxMemUsage)
-		}
-	})
+		require.Equal(t, int64(30), queryLevelStats.KVRowsRead)
+		// For tests, the bytes read is based on the number of rows read, rather
+		// than actual bytes read.
+		require.Equal(t, int64(30*8), queryLevelStats.KVBytesRead)
+	}
 }

--- a/pkg/sql/execstats/utils_test.go
+++ b/pkg/sql/execstats/utils_test.go
@@ -1,0 +1,52 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package execstats
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+)
+
+// Modifies TraceAnalyzer internal state to add stats for the processor/stream/flow specified
+// in stats.ComponentID and the given node ID.
+func (a *TraceAnalyzer) AddComponentStats(
+	nodeID roachpb.NodeID, stats *execinfrapb.ComponentStats,
+) {
+	switch stats.Component.Type {
+	case execinfrapb.ComponentID_PROCESSOR:
+		processorStat := &processorStats{
+			nodeID: nodeID,
+			stats:  stats,
+		}
+		if a.FlowMetadata.processorStats == nil {
+			a.FlowMetadata.processorStats = make(map[execinfrapb.ProcessorID]*processorStats)
+		}
+		a.FlowMetadata.processorStats[execinfrapb.ProcessorID(stats.Component.ID)] = processorStat
+	case execinfrapb.ComponentID_STREAM:
+		streamStat := &streamStats{
+			originNodeID: nodeID,
+			stats:        stats,
+		}
+		if a.FlowMetadata.streamStats == nil {
+			a.FlowMetadata.streamStats = make(map[execinfrapb.StreamID]*streamStats)
+		}
+		a.FlowMetadata.streamStats[execinfrapb.StreamID(stats.Component.ID)] = streamStat
+	default:
+		flowStat := &flowStats{
+			nodeID: nodeID,
+		}
+		flowStat.stats = append(flowStat.stats, stats)
+		if a.FlowMetadata.flowStats == nil {
+			a.FlowMetadata.flowStats = make(map[execinfrapb.FlowID]*flowStats)
+		}
+		a.FlowMetadata.flowStats[stats.Component.FlowID] = flowStat
+	}
+}


### PR DESCRIPTION
The first commit adds total bytes and total rows read from KV to the TraceAnalyzer.
Closes: #56605

The second commit adds cumulative time spent in KV to the TraceAnalyzer.
Closes: #56604

Release note: None.