### PR TITLE
colfetcher: fix kvtrace logic test option for inverted index scans

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index_multi_column
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index_multi_column
@@ -36,6 +36,14 @@ CPut /Table/53/1/1/0 -> /TUPLE/2:2:Int/333/1:3:Bytes/foo/
 InitPut /Table/53/2/333/"a"/"b"/1/0 -> /BYTES/
 InitPut /Table/53/3/333/"foo"/"a"/"b"/1/0 -> /BYTES/
 
+# This test shows an inverted index scan followed by a primary index scan to
+# retrieve all the table's columns.
+query T kvtrace
+SELECT * FROM t WHERE i = 333 AND j @> '{"a": "b"}'
+----
+Scan /Table/53/2/333/"a"/"b"{-/PrefixEnd}
+Scan /Table/53/1/1{-/#}
+
 # Don't insert duplicate values.
 query T kvtrace
 INSERT INTO t VALUES (2, 333, 'foo', '[7, 0, 7]'::json)

--- a/pkg/sql/rowenc/column_type_encoding.go
+++ b/pkg/sql/rowenc/column_type_encoding.go
@@ -281,7 +281,13 @@ func DecodeTableKey(
 		d, err := tree.NewDCollatedString(r, valType.Locale(), &a.env)
 		return d, rkey, err
 	case types.JsonFamily:
-		return tree.DNull, []byte{}, nil
+		// Don't attempt to decode the JSON value. Instead, just return the
+		// remaining bytes of the key.
+		jsonLen, err := encoding.PeekLength(key)
+		if err != nil {
+			return nil, nil, err
+		}
+		return tree.DNull, key[jsonLen:], nil
 	case types.BytesFamily:
 		var r []byte
 		if dir == encoding.Ascending {

--- a/pkg/util/encoding/encoding.go
+++ b/pkg/util/encoding/encoding.go
@@ -313,17 +313,17 @@ func getVarintLen(b []byte) (int, error) {
 	return length, nil
 }
 
-// DecodeVarintAscending decodes a value encoded by EncodeVaringAscending.
+// DecodeVarintAscending decodes a value encoded by EncodeVarintAscending.
 func DecodeVarintAscending(b []byte) ([]byte, int64, error) {
 	if len(b) == 0 {
-		return nil, 0, errors.Errorf("insufficient bytes to decode uvarint value")
+		return nil, 0, errors.Errorf("insufficient bytes to decode varint value")
 	}
 	length := int(b[0]) - intZero
 	if length < 0 {
 		length = -length
 		remB := b[1:]
 		if len(remB) < length {
-			return nil, 0, errors.Errorf("insufficient bytes to decode uvarint value: %q", remB)
+			return nil, 0, errors.Errorf("insufficient bytes to decode varint value: %q", remB)
 		}
 		var v int64
 		// Use the ones-complement of each encoded byte in order to build
@@ -345,7 +345,7 @@ func DecodeVarintAscending(b []byte) ([]byte, int64, error) {
 	return remB, int64(v), nil
 }
 
-// DecodeVarintDescending decodes a uint64 value which was encoded
+// DecodeVarintDescending decodes a int64 value which was encoded
 // using EncodeVarintDescending.
 func DecodeVarintDescending(b []byte) ([]byte, int64, error) {
 	leftover, v, err := DecodeVarintAscending(b)
@@ -456,7 +456,7 @@ func EncLenUvarintDescending(v uint64) int {
 	return 2 + highestByteIndex(v)
 }
 
-// DecodeUvarintAscending decodes a varint encoded uint64 from the input
+// DecodeUvarintAscending decodes a uint64 encoded uint64 from the input
 // buffer. The remainder of the input buffer and the decoded uint64
 // are returned.
 func DecodeUvarintAscending(b []byte) ([]byte, uint64, error) {


### PR DESCRIPTION
#### rowenc: fix kvtrace logic test option for JSON inverted index scans

Previously, `kvtrace` logic tests of queries that performed JSON
inverted index scans would error if the scan output any rows. When
`cFetcher` attempted to decode the JSON portion of the key,
`rowenc.DecodeTableKey` returned an empty `[]byte` as the portion of the
key remaining after the JSON value. Attempting to decode this empty
`[]byte` as the primary key value caused an error.

Now, `rowenc.DecodeTableKey` will correctly return the remaining bytes
of the key after the JSON value. Note that this function still does not
actually decode the JSON value.

Release note: None

#### encoding: fix typos in DecodeVarintAscending and DecodeVarintDescending

Release note: None
