### PR TITLE
storage,kvserver: fix bugs and tests when using separated intents

### DIFF
--- a/pkg/ccl/storageccl/engineccl/bench_test.go
+++ b/pkg/ccl/storageccl/engineccl/bench_test.go
@@ -180,7 +180,7 @@ func BenchmarkTimeBoundIterate(b *testing.B) {
 			})
 			b.Run("TimeBoundIterator", func(b *testing.B) {
 				runIterate(b, loadFactor, func(e storage.Engine, startTime, endTime hlc.Timestamp) storage.MVCCIterator {
-					return e.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{
+					return e.NewMVCCIterator(storage.MVCCKeyIterKind, storage.IterOptions{
 						MinTimestampHint: startTime,
 						MaxTimestampHint: endTime,
 						UpperBound:       roachpb.KeyMax,

--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
@@ -392,7 +392,7 @@ func TestAddSSTableMVCCStats(t *testing.T) {
 			beforeStats := func() enginepb.MVCCStats {
 				iter := e.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{UpperBound: roachpb.KeyMax})
 				defer iter.Close()
-				beforeStats, err := storage.ComputeStatsForRange(iter, roachpb.KeyMin, roachpb.KeyMax, 10)
+				beforeStats, err := storage.ComputeStatsForRange(iter, keys.LocalMax, roachpb.KeyMax, 10)
 				if err != nil {
 					t.Fatalf("%+v", err)
 				}
@@ -443,7 +443,7 @@ func TestAddSSTableMVCCStats(t *testing.T) {
 			afterStats := func() enginepb.MVCCStats {
 				iter := e.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{UpperBound: roachpb.KeyMax})
 				defer iter.Close()
-				afterStats, err := storage.ComputeStatsForRange(iter, roachpb.KeyMin, roachpb.KeyMax, 10)
+				afterStats, err := storage.ComputeStatsForRange(iter, keys.LocalMax, roachpb.KeyMax, 10)
 				if err != nil {
 					t.Fatalf("%+v", err)
 				}

--- a/pkg/kv/kvserver/batcheval/cmd_revert_range_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_revert_range_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
@@ -44,7 +45,7 @@ func getStats(t *testing.T, reader storage.Reader) enginepb.MVCCStats {
 	t.Helper()
 	iter := reader.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{UpperBound: roachpb.KeyMax})
 	defer iter.Close()
-	s, err := storage.ComputeStatsForRange(iter, roachpb.KeyMin, roachpb.KeyMax, 1100)
+	s, err := storage.ComputeStatsForRange(iter, keys.LocalMax, roachpb.KeyMax, 1100)
 	if err != nil {
 		t.Fatalf("%+v", err)
 	}

--- a/pkg/kv/kvserver/consistency_queue_test.go
+++ b/pkg/kv/kvserver/consistency_queue_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
@@ -442,7 +443,9 @@ func TestCheckConsistencyInconsistent(t *testing.T) {
 		iter := cpEng.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{UpperBound: []byte("\xff")})
 		defer iter.Close()
 
-		ms, err := storage.ComputeStatsForRange(iter, roachpb.KeyMin, roachpb.KeyMax, 0 /* nowNanos */)
+		// The range is specified using only global keys, since the implementation
+		// may use an intentInterleavingIter.
+		ms, err := storage.ComputeStatsForRange(iter, keys.LocalMax, roachpb.KeyMax, 0 /* nowNanos */)
 		assert.NoError(t, err)
 
 		assert.NotZero(t, ms.KeyBytes)

--- a/pkg/kv/kvserver/gc_queue_test.go
+++ b/pkg/kv/kvserver/gc_queue_test.go
@@ -972,7 +972,9 @@ func TestGCQueueIntentResolution(t *testing.T) {
 	// is initiated asynchronously from the GC queue.
 	testutils.SucceedsSoon(t, func() error {
 		meta := &enginepb.MVCCMetadata{}
-		return tc.store.Engine().MVCCIterate(roachpb.KeyMin, roachpb.KeyMax, storage.MVCCKeyAndIntentsIterKind, func(kv storage.MVCCKeyValue) error {
+		// The range is specified using only global keys, since the implementation
+		// may use an intentInterleavingIter.
+		return tc.store.Engine().MVCCIterate(keys.LocalMax, roachpb.KeyMax, storage.MVCCKeyAndIntentsIterKind, func(kv storage.MVCCKeyValue) error {
 			if !kv.Key.IsValue() {
 				if err := protoutil.Unmarshal(kv.Value, meta); err != nil {
 					return err

--- a/pkg/storage/batch_test.go
+++ b/pkg/storage/batch_test.go
@@ -206,7 +206,7 @@ func TestReadOnlyBasics(t *testing.T) {
 				},
 				func() { ro.NewMVCCIterator(MVCCKeyIterKind, IterOptions{UpperBound: roachpb.KeyMax}).Close() },
 				func() {
-					ro.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{
+					ro.NewMVCCIterator(MVCCKeyIterKind, IterOptions{
 						MinTimestampHint: hlc.MinTimestamp,
 						MaxTimestampHint: hlc.MaxTimestamp,
 						UpperBound:       roachpb.KeyMax,

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -645,6 +645,10 @@ type Engine interface {
 
 // Batch is the interface for batch specific operations.
 type Batch interface {
+	// Iterators created on a batch can see some mutations performed after the
+	// iterator creation. To guarantee that they see all the mutations, the
+	// iterator has to be repositioned using a seek operation, after the
+	// mutations were done.
 	ReadWriter
 	// Commit atomically applies any batched updates to the underlying
 	// engine. This is a noop unless the batch was created via NewBatch(). If
@@ -669,6 +673,12 @@ type Batch interface {
 	//
 	// TODO(itsbilal): Improve comments around how/why distinct batches are an
 	// optimization in the rocksdb write path.
+	//
+	// TODO(sumeer): Most Distinct() batches are being created on Pebble indexed
+	// batches, so the comment about only seeing writes before the batch was
+	// created is incorrect. See discussion in
+	// https://github.com/cockroachdb/pebble/issues/943
+	// https://github.com/cockroachdb/cockroach/pull/57661
 	Distinct() ReadWriter
 	// Empty returns whether the batch has been written to or not.
 	Empty() bool
@@ -785,9 +795,11 @@ func PutProto(
 	return int64(MVCCKey{Key: key}.EncodedSize()), int64(len(bytes)), nil
 }
 
-// Scan returns up to max key/value objects starting from
-// start (inclusive) and ending at end (non-inclusive).
-// Specify max=0 for unbounded scans.
+// Scan returns up to max key/value objects starting from start (inclusive)
+// and ending at end (non-inclusive). Specify max=0 for unbounded scans. Since
+// this code may use an intentInterleavingIter, the caller should not attempt
+// a single scan to span local and global keys. See the comment in the
+// declaration of intentInterleavingIter for details.
 func Scan(reader Reader, start, end roachpb.Key, max int64) ([]MVCCKeyValue, error) {
 	var kvs []MVCCKeyValue
 	err := reader.MVCCIterate(start, end, MVCCKeyAndIntentsIterKind, func(kv MVCCKeyValue) error {

--- a/pkg/storage/engine_test.go
+++ b/pkg/storage/engine_test.go
@@ -661,7 +661,7 @@ func TestEngineTimeBound(t *testing.T) {
 			}{
 				// Completely to the right, not touching.
 				{
-					iter: batch.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{
+					iter: batch.NewMVCCIterator(MVCCKeyIterKind, IterOptions{
 						MinTimestampHint: maxTimestamp.Next(),
 						MaxTimestampHint: maxTimestamp.Next().Next(),
 						UpperBound:       roachpb.KeyMax,
@@ -672,7 +672,7 @@ func TestEngineTimeBound(t *testing.T) {
 				},
 				// Completely to the left, not touching.
 				{
-					iter: batch.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{
+					iter: batch.NewMVCCIterator(MVCCKeyIterKind, IterOptions{
 						MinTimestampHint: minTimestamp.Prev().Prev(),
 						MaxTimestampHint: minTimestamp.Prev(),
 						UpperBound:       roachpb.KeyMax,
@@ -683,7 +683,7 @@ func TestEngineTimeBound(t *testing.T) {
 				},
 				// Touching on the right.
 				{
-					iter: batch.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{
+					iter: batch.NewMVCCIterator(MVCCKeyIterKind, IterOptions{
 						MinTimestampHint: maxTimestamp,
 						MaxTimestampHint: maxTimestamp,
 						UpperBound:       roachpb.KeyMax,
@@ -694,7 +694,7 @@ func TestEngineTimeBound(t *testing.T) {
 				},
 				// Touching on the left.
 				{
-					iter: batch.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{
+					iter: batch.NewMVCCIterator(MVCCKeyIterKind, IterOptions{
 						MinTimestampHint: minTimestamp,
 						MaxTimestampHint: minTimestamp,
 						UpperBound:       roachpb.KeyMax,
@@ -706,7 +706,7 @@ func TestEngineTimeBound(t *testing.T) {
 				// Copy of last case, but confirm that we don't get SST stats if we don't
 				// ask for them.
 				{
-					iter: batch.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{
+					iter: batch.NewMVCCIterator(MVCCKeyIterKind, IterOptions{
 						MinTimestampHint: minTimestamp,
 						MaxTimestampHint: minTimestamp,
 						UpperBound:       roachpb.KeyMax,
@@ -717,7 +717,7 @@ func TestEngineTimeBound(t *testing.T) {
 				},
 				// Copy of last case, but confirm that upper bound is respected.
 				{
-					iter: batch.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{
+					iter: batch.NewMVCCIterator(MVCCKeyIterKind, IterOptions{
 						MinTimestampHint: minTimestamp,
 						MaxTimestampHint: minTimestamp,
 						UpperBound:       []byte("02"),

--- a/pkg/storage/intent_interleaving_iter.go
+++ b/pkg/storage/intent_interleaving_iter.go
@@ -11,6 +11,8 @@
 package storage
 
 import (
+	"fmt"
+
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
@@ -46,6 +48,32 @@ import (
 // The one exception to the minimal distance rule is a sub-case of prefix
 // iteration, when we know that no separated intents need to be seen, and so
 // don't bother positioning intentIter.
+//
+// The implementation of intentInterleavingIter assumes callers iterating
+// forward (reverse) are setting an upper (lower) bound. There is protection
+// for misbehavior by the callers for the lock table iterator, which prevents
+// that iterator from leaving the lock table key space, by adding additional
+// bounds. But we do not manufacture bounds to prevent MVCCIterator to iterate
+// into the lock table key space, for the following reasons:
+// - Adding a bound where the caller has not specified one adds a key
+//   comparison when iterating. We don't expect much iteration (next/prev
+//   calls) over the lock table iterator, because of the rarity of intents,
+//   but that is not the case for the MVCC key space.
+// - The MVCC key space is split into two spans: local keys preceding the lock
+//   table key space, and global keys. Adding a bound where one is not
+//   specified by the caller requires us to know which one the caller wants to
+//   iterate over -- the bounds may not fully specify the intent of the caller
+//   e.g. a caller could use ["", \xFF\xFF) as the bounds, and use the seek
+//   key to narrow down iteration over the local key space or the global key
+//   space.
+// Instead, pebbleIterator, the base implementation of MVCCIterator, cheaply
+// checks whether it has iterated into the lock table key space, and if so,
+// marks itself as exhausted (Valid() returns false, nil).
+//
+// A limitation of these MVCCIterator implementations, that follows from the
+// fact that the MVCC key space is split into two spans, is that one can't
+// typically iterate using next/prev from the local MVCC key space to the
+// global one and vice versa. One needs to seek in-between.
 type intentInterleavingIter struct {
 	prefix bool
 
@@ -95,9 +123,22 @@ type intentInterleavingIter struct {
 
 var _ MVCCIterator = &intentInterleavingIter{}
 
+func isLocal(k roachpb.Key) bool {
+	return len(k) == 0 || keys.IsLocal(k)
+}
+
 func newIntentInterleavingIterator(reader Reader, opts IterOptions) MVCCIterator {
 	if !opts.MinTimestampHint.IsEmpty() || !opts.MaxTimestampHint.IsEmpty() {
 		panic("intentInterleavingIter must not be used with timestamp hints")
+	}
+	if opts.LowerBound != nil && opts.UpperBound != nil {
+		lowerIsLocal := isLocal(opts.LowerBound)
+		upperIsLocal := isLocal(opts.UpperBound)
+		if lowerIsLocal != upperIsLocal {
+			panic(fmt.Sprintf(
+				"intentInterleavingIter cannot span from lowerIsLocal %t to upperIsLocal %t",
+				lowerIsLocal, upperIsLocal))
+		}
 	}
 	intentOpts := opts
 	var intentKeyBuf []byte
@@ -115,6 +156,10 @@ func newIntentInterleavingIterator(reader Reader, opts IterOptions) MVCCIterator
 		// Make sure we don't step outside the lock table key space.
 		intentOpts.UpperBound = keys.LockTableSingleKeyEnd
 	}
+	// TODO(sumeer): the creation of these iterators can race with concurrent
+	// mutations, which may make them inconsistent with each other. Add a way to
+	// cheaply clone the underlying Pebble iterator and use it in both places
+	// (the clones will have the same underlying memtables and sstables).
 	// Note that we can reuse intentKeyBuf after NewEngineIterator returns.
 	intentIter := reader.NewEngineIterator(intentOpts)
 

--- a/pkg/storage/metamorphic/operations.go
+++ b/pkg/storage/metamorphic/operations.go
@@ -589,7 +589,7 @@ type clearRangeOp struct {
 func (c clearRangeOp) run(ctx context.Context) string {
 	// ClearRange calls in Cockroach usually happen with boundaries demarcated
 	// using unversioned keys, so mimic the same behavior here.
-	err := c.m.engine.ClearRawRange(c.key, c.endKey)
+	err := c.m.engine.ClearMVCCRangeAndIntents(c.key, c.endKey)
 	if err != nil {
 		return fmt.Sprintf("error: %s", err.Error())
 	}

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -34,7 +34,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
-	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/errors/oserror"
 	"github.com/dustin/go-humanize"
@@ -2801,7 +2800,7 @@ func mvccResolveWriteIntent(
 				rw, metaKey, precedingIntentState, txnDidNotUpdateMeta, &buf.newMeta)
 		} else {
 			metaKeySize = int64(metaKey.EncodedSize())
-			err = rw.ClearIntent(metaKey.Key, precedingIntentState, txnDidNotUpdateMeta, uuid.UUID{})
+			err = rw.ClearIntent(metaKey.Key, precedingIntentState, txnDidNotUpdateMeta, meta.Txn.ID)
 		}
 		if err != nil {
 			return false, err
@@ -2904,7 +2903,7 @@ func mvccResolveWriteIntent(
 
 	if !ok {
 		// If there is no other version, we should just clean up the key entirely.
-		if err = rw.ClearIntent(metaKey.Key, precedingIntentState, txnDidNotUpdateMeta, uuid.UUID{}); err != nil {
+		if err = rw.ClearIntent(metaKey.Key, precedingIntentState, txnDidNotUpdateMeta, meta.Txn.ID); err != nil {
 			return false, err
 		}
 		// Clear stat counters attributable to the intent we're aborting.
@@ -2922,7 +2921,7 @@ func mvccResolveWriteIntent(
 		KeyBytes: MVCCVersionTimestampSize,
 		ValBytes: valueSize,
 	}
-	if err := rw.ClearIntent(metaKey.Key, precedingIntentState, txnDidNotUpdateMeta, uuid.UUID{}); err != nil {
+	if err := rw.ClearIntent(metaKey.Key, precedingIntentState, txnDidNotUpdateMeta, meta.Txn.ID); err != nil {
 		return false, err
 	}
 	metaKeySize := int64(metaKey.EncodedSize())
@@ -3424,9 +3423,7 @@ func willOverflow(a, b int64) bool {
 
 // ComputeStatsForRange scans the underlying engine from start to end keys and
 // computes stats counters based on the values. This method is used after a
-// range is split to recompute stats for each subrange. The start key is always
-// adjusted to avoid counting local keys in the event stats are being recomputed
-// for the first range (i.e. the one with start key == KeyMin). The nowNanos arg
+// range is split to recompute stats for each subrange. The nowNanos arg
 // specifies the wall time in nanoseconds since the epoch and is used to compute
 // the total age of all intents.
 //

--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
@@ -88,8 +89,7 @@ func TestMVCCHistories(t *testing.T) {
 		t.Run(engineImpl.name, func(t *testing.T) {
 
 			// Everything reads/writes under the same prefix.
-			key := roachpb.Key("")
-			span := roachpb.Span{Key: key, EndKey: key.PrefixEnd()}
+			span := roachpb.Span{Key: keys.LocalMax, EndKey: roachpb.KeyMax}
 
 			datadriven.Walk(t, "testdata/mvcc_histories", func(t *testing.T, path string) {
 				if strings.Contains(path, "_disallow_separated") && !DisallowSeparatedIntents {
@@ -578,7 +578,7 @@ func cmdCheckIntent(e *evalCtx) error {
 
 func cmdClearRange(e *evalCtx) error {
 	key, endKey := e.getKeyRange()
-	return e.engine.ClearRawRange(key, endKey)
+	return e.engine.ClearMVCCRangeAndIntents(key, endKey)
 }
 
 func cmdCPut(e *evalCtx) error {

--- a/pkg/storage/mvcc_incremental_iterator_test.go
+++ b/pkg/storage/mvcc_incremental_iterator_test.go
@@ -190,7 +190,7 @@ func TestMVCCIncrementalIterator(t *testing.T) {
 	ctx := context.Background()
 
 	var (
-		keyMin   = roachpb.KeyMin
+		localMax = keys.LocalMax
 		keyMax   = roachpb.KeyMax
 		testKey1 = roachpb.Key("/db1")
 		testKey2 = roachpb.Key("/db2")
@@ -226,7 +226,7 @@ func TestMVCCIncrementalIterator(t *testing.T) {
 			e := engineImpl.create()
 			defer e.Close()
 
-			t.Run("empty", assertEqualKVs(e, keyMin, keyMax, tsMin, ts3, latest, nil))
+			t.Run("empty", assertEqualKVs(e, localMax, keyMax, tsMin, ts3, latest, nil))
 
 			for _, kv := range kvs(kv1_1_1, kv1_2_2, kv2_2_2) {
 				v := roachpb.Value{RawBytes: kv.Value}
@@ -236,12 +236,12 @@ func TestMVCCIncrementalIterator(t *testing.T) {
 			}
 
 			// Exercise time ranges.
-			t.Run("ts (0-0]", assertEqualKVs(e, keyMin, keyMax, tsMin, tsMin, latest, nil))
-			t.Run("ts (0-1]", assertEqualKVs(e, keyMin, keyMax, tsMin, ts1, latest, kvs(kv1_1_1)))
-			t.Run("ts (0-∞]", assertEqualKVs(e, keyMin, keyMax, tsMin, tsMax, latest, kvs(kv1_2_2, kv2_2_2)))
-			t.Run("ts (1-1]", assertEqualKVs(e, keyMin, keyMax, ts1, ts1, latest, nil))
-			t.Run("ts (1-2]", assertEqualKVs(e, keyMin, keyMax, ts1, ts2, latest, kvs(kv1_2_2, kv2_2_2)))
-			t.Run("ts (2-2]", assertEqualKVs(e, keyMin, keyMax, ts2, ts2, latest, nil))
+			t.Run("ts (0-0]", assertEqualKVs(e, localMax, keyMax, tsMin, tsMin, latest, nil))
+			t.Run("ts (0-1]", assertEqualKVs(e, localMax, keyMax, tsMin, ts1, latest, kvs(kv1_1_1)))
+			t.Run("ts (0-∞]", assertEqualKVs(e, localMax, keyMax, tsMin, tsMax, latest, kvs(kv1_2_2, kv2_2_2)))
+			t.Run("ts (1-1]", assertEqualKVs(e, localMax, keyMax, ts1, ts1, latest, nil))
+			t.Run("ts (1-2]", assertEqualKVs(e, localMax, keyMax, ts1, ts2, latest, kvs(kv1_2_2, kv2_2_2)))
+			t.Run("ts (2-2]", assertEqualKVs(e, localMax, keyMax, ts2, ts2, latest, nil))
 
 			// Exercise key ranges.
 			t.Run("kv [1-1)", assertEqualKVs(e, testKey1, testKey1, tsMin, tsMax, latest, nil))
@@ -251,7 +251,7 @@ func TestMVCCIncrementalIterator(t *testing.T) {
 			if err := MVCCDelete(ctx, e, nil, testKey1, ts3, nil); err != nil {
 				t.Fatal(err)
 			}
-			t.Run("del", assertEqualKVs(e, keyMin, keyMax, ts1, tsMax, latest, kvs(kv1_3Deleted, kv2_2_2)))
+			t.Run("del", assertEqualKVs(e, localMax, keyMax, ts1, tsMax, latest, kvs(kv1_3Deleted, kv2_2_2)))
 
 			// Exercise intent handling.
 			txn1ID := uuid.MakeV4()
@@ -287,13 +287,13 @@ func TestMVCCIncrementalIterator(t *testing.T) {
 			t.Run("intents",
 				iterateExpectErr(e, testKey2, testKey2.PrefixEnd(), tsMin, tsMax, latest, "conflicting intents"))
 			t.Run("intents",
-				iterateExpectErr(e, keyMin, keyMax, tsMin, ts4, latest, "conflicting intents"))
+				iterateExpectErr(e, localMax, keyMax, tsMin, ts4, latest, "conflicting intents"))
 			// Intents above the upper time bound or beneath the lower time bound must
 			// be ignored (#28358). Note that the lower time bound is exclusive while
 			// the upper time bound is inclusive.
-			t.Run("intents", assertEqualKVs(e, keyMin, keyMax, tsMin, ts3, latest, kvs(kv1_3Deleted, kv2_2_2)))
-			t.Run("intents", assertEqualKVs(e, keyMin, keyMax, ts4, tsMax, latest, kvs()))
-			t.Run("intents", assertEqualKVs(e, keyMin, keyMax, ts4.Next(), tsMax, latest, kvs()))
+			t.Run("intents", assertEqualKVs(e, localMax, keyMax, tsMin, ts3, latest, kvs(kv1_3Deleted, kv2_2_2)))
+			t.Run("intents", assertEqualKVs(e, localMax, keyMax, ts4, tsMax, latest, kvs()))
+			t.Run("intents", assertEqualKVs(e, localMax, keyMax, ts4.Next(), tsMax, latest, kvs()))
 
 			intent1 := roachpb.MakeLockUpdate(&txn1, roachpb.Span{Key: testKey1})
 			intent1.Status = roachpb.COMMITTED
@@ -305,7 +305,7 @@ func TestMVCCIncrementalIterator(t *testing.T) {
 			if _, err := MVCCResolveWriteIntent(ctx, e, nil, intent2); err != nil {
 				t.Fatal(err)
 			}
-			t.Run("intents", assertEqualKVs(e, keyMin, keyMax, tsMin, tsMax, latest, kvs(kv1_4_4, kv2_2_2)))
+			t.Run("intents", assertEqualKVs(e, localMax, keyMax, tsMin, tsMax, latest, kvs(kv1_4_4, kv2_2_2)))
 		})
 	}
 
@@ -314,7 +314,7 @@ func TestMVCCIncrementalIterator(t *testing.T) {
 			e := engineImpl.create()
 			defer e.Close()
 
-			t.Run("empty", assertEqualKVs(e, keyMin, keyMax, tsMin, ts3, all, nil))
+			t.Run("empty", assertEqualKVs(e, localMax, keyMax, tsMin, ts3, all, nil))
 
 			for _, kv := range kvs(kv1_1_1, kv1_2_2, kv2_2_2) {
 				v := roachpb.Value{RawBytes: kv.Value}
@@ -324,12 +324,12 @@ func TestMVCCIncrementalIterator(t *testing.T) {
 			}
 
 			// Exercise time ranges.
-			t.Run("ts (0-0]", assertEqualKVs(e, keyMin, keyMax, tsMin, tsMin, all, nil))
-			t.Run("ts (0-1]", assertEqualKVs(e, keyMin, keyMax, tsMin, ts1, all, kvs(kv1_1_1)))
-			t.Run("ts (0-∞]", assertEqualKVs(e, keyMin, keyMax, tsMin, tsMax, all, kvs(kv1_2_2, kv1_1_1, kv2_2_2)))
-			t.Run("ts (1-1]", assertEqualKVs(e, keyMin, keyMax, ts1, ts1, all, nil))
-			t.Run("ts (1-2]", assertEqualKVs(e, keyMin, keyMax, ts1, ts2, all, kvs(kv1_2_2, kv2_2_2)))
-			t.Run("ts (2-2]", assertEqualKVs(e, keyMin, keyMax, ts2, ts2, all, nil))
+			t.Run("ts (0-0]", assertEqualKVs(e, localMax, keyMax, tsMin, tsMin, all, nil))
+			t.Run("ts (0-1]", assertEqualKVs(e, localMax, keyMax, tsMin, ts1, all, kvs(kv1_1_1)))
+			t.Run("ts (0-∞]", assertEqualKVs(e, localMax, keyMax, tsMin, tsMax, all, kvs(kv1_2_2, kv1_1_1, kv2_2_2)))
+			t.Run("ts (1-1]", assertEqualKVs(e, localMax, keyMax, ts1, ts1, all, nil))
+			t.Run("ts (1-2]", assertEqualKVs(e, localMax, keyMax, ts1, ts2, all, kvs(kv1_2_2, kv2_2_2)))
+			t.Run("ts (2-2]", assertEqualKVs(e, localMax, keyMax, ts2, ts2, all, nil))
 
 			// Exercise key ranges.
 			t.Run("kv [1-1)", assertEqualKVs(e, testKey1, testKey1, tsMin, tsMax, all, nil))
@@ -339,7 +339,7 @@ func TestMVCCIncrementalIterator(t *testing.T) {
 			if err := MVCCDelete(ctx, e, nil, testKey1, ts3, nil); err != nil {
 				t.Fatal(err)
 			}
-			t.Run("del", assertEqualKVs(e, keyMin, keyMax, ts1, tsMax, all, kvs(kv1_3Deleted, kv1_2_2, kv2_2_2)))
+			t.Run("del", assertEqualKVs(e, localMax, keyMax, ts1, tsMax, all, kvs(kv1_3Deleted, kv1_2_2, kv2_2_2)))
 
 			// Exercise intent handling.
 			txn1ID := uuid.MakeV4()
@@ -375,13 +375,13 @@ func TestMVCCIncrementalIterator(t *testing.T) {
 			t.Run("intents",
 				iterateExpectErr(e, testKey2, testKey2.PrefixEnd(), tsMin, tsMax, all, "conflicting intents"))
 			t.Run("intents",
-				iterateExpectErr(e, keyMin, keyMax, tsMin, ts4, all, "conflicting intents"))
+				iterateExpectErr(e, localMax, keyMax, tsMin, ts4, all, "conflicting intents"))
 			// Intents above the upper time bound or beneath the lower time bound must
 			// be ignored (#28358). Note that the lower time bound is exclusive while
 			// the upper time bound is inclusive.
-			t.Run("intents", assertEqualKVs(e, keyMin, keyMax, tsMin, ts3, all, kvs(kv1_3Deleted, kv1_2_2, kv1_1_1, kv2_2_2)))
-			t.Run("intents", assertEqualKVs(e, keyMin, keyMax, ts4, tsMax, all, kvs()))
-			t.Run("intents", assertEqualKVs(e, keyMin, keyMax, ts4.Next(), tsMax, all, kvs()))
+			t.Run("intents", assertEqualKVs(e, localMax, keyMax, tsMin, ts3, all, kvs(kv1_3Deleted, kv1_2_2, kv1_1_1, kv2_2_2)))
+			t.Run("intents", assertEqualKVs(e, localMax, keyMax, ts4, tsMax, all, kvs()))
+			t.Run("intents", assertEqualKVs(e, localMax, keyMax, ts4.Next(), tsMax, all, kvs()))
 
 			intent1 := roachpb.MakeLockUpdate(&txn1, roachpb.Span{Key: testKey1})
 			intent1.Status = roachpb.COMMITTED
@@ -393,7 +393,7 @@ func TestMVCCIncrementalIterator(t *testing.T) {
 			if _, err := MVCCResolveWriteIntent(ctx, e, nil, intent2); err != nil {
 				t.Fatal(err)
 			}
-			t.Run("intents", assertEqualKVs(e, keyMin, keyMax, tsMin, tsMax, all, kvs(kv1_4_4, kv1_3Deleted, kv1_2_2, kv1_1_1, kv2_2_2)))
+			t.Run("intents", assertEqualKVs(e, localMax, keyMax, tsMin, tsMax, all, kvs(kv1_4_4, kv1_3Deleted, kv1_2_2, kv1_1_1, kv2_2_2)))
 		})
 	}
 }
@@ -651,6 +651,11 @@ func TestMVCCIncrementalIteratorIntentStraddlesSStables(t *testing.T) {
 	db2 := NewInMem(ctx, roachpb.Attributes{}, 10<<20)
 	defer db2.Close()
 
+	// NB: If the original intent was separated, iterating using an interleaving
+	// iterator, as done below, and writing to an sst, transforms the separated
+	// intent to an interleaved intent. This is ok for now since both kinds of
+	// intents are supported.
+	// TODO(sumeer): change this test before interleaved intents are disallowed.
 	ingest := func(it MVCCIterator, count int) {
 		memFile := &MemFile{}
 		sst := MakeIngestionSSTWriter(memFile)
@@ -687,7 +692,7 @@ func TestMVCCIncrementalIteratorIntentStraddlesSStables(t *testing.T) {
 			UpperBound: keys.MaxKey,
 		})
 		defer it.Close()
-		it.SeekGE(MVCCKey{Key: keys.MinKey})
+		it.SeekGE(MVCCKey{Key: keys.LocalMax})
 		ingest(it, 2)
 		ingest(it, 1)
 	}
@@ -703,7 +708,7 @@ func TestMVCCIncrementalIteratorIntentStraddlesSStables(t *testing.T) {
 			EndTime:     hlc.Timestamp{WallTime: 2},
 		})
 		defer it.Close()
-		for it.SeekGE(MVCCKey{Key: keys.MinKey}); ; it.Next() {
+		for it.SeekGE(MVCCKey{Key: keys.LocalMax}); ; it.Next() {
 			ok, err := it.Valid()
 			if err != nil {
 				if errors.HasType(err, (*roachpb.WriteIntentError)(nil)) {
@@ -786,7 +791,7 @@ func TestMVCCIterateTimeBound(t *testing.T) {
 				t.Fatalf("source of truth had no expected KVs; likely a bug in the test itself")
 			}
 
-			assertEqualKVs(eng, keys.MinKey, keys.MaxKey, testCase.start, testCase.end, latest, expectedKVs)(t)
+			assertEqualKVs(eng, keys.LocalMax, keys.MaxKey, testCase.start, testCase.end, latest, expectedKVs)(t)
 		})
 	}
 }

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -45,7 +45,7 @@ import (
 
 // Constants for system-reserved keys in the KV map.
 var (
-	keyMin       = roachpb.KeyMin
+	localMax     = keys.LocalMax
 	keyMax       = roachpb.KeyMax
 	testKey1     = roachpb.Key("/db1")
 	testKey2     = roachpb.Key("/db2")
@@ -1034,10 +1034,11 @@ func TestMVCCPutAfterBatchIterCreate(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			// Should Next() from key2/5 to key2/3 first, then Seek to key3, and see
-			// the intent.
-			iter.NextKey()
-
+			iter.SeekGE(MVCCKey{Key: testKey3})
+			if ok, err := iter.Valid(); !ok || err != nil {
+				t.Fatalf("expected valid iter: ok %t, err %s", ok, err.Error())
+			}
+			// Should see the intent.
 			if iter.UnsafeKey().IsValue() {
 				t.Fatalf("expected iterator to land on an intent, got a value: %v", iter.UnsafeKey())
 			}
@@ -1129,7 +1130,7 @@ func mvccScanTest(ctx context.Context, t *testing.T, engine Engine) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	res, err = MVCCScan(ctx, engine, keyMin, testKey2,
+	res, err = MVCCScan(ctx, engine, localMax, testKey2,
 		hlc.Timestamp{WallTime: 1}, MVCCScanOptions{})
 	if err != nil {
 		t.Fatal(err)
@@ -1351,7 +1352,7 @@ func TestMVCCScanInconsistent(t *testing.T) {
 
 			// A scan with consistent=false should fail in a txn.
 			if _, err := MVCCScan(
-				ctx, engine, keyMin, keyMax, hlc.Timestamp{WallTime: 1},
+				ctx, engine, localMax, keyMax, hlc.Timestamp{WallTime: 1},
 				MVCCScanOptions{Inconsistent: true, Txn: txn1},
 			); err == nil {
 				t.Error("expected an error scanning with consistent=false in txn")
@@ -1476,7 +1477,7 @@ func TestMVCCDeleteRange(t *testing.T) {
 			if expected := (roachpb.Span{Key: testKey4, EndKey: testKey6}); !resumeSpan.EqualValue(expected) {
 				t.Fatalf("expected = %+v, resumeSpan = %+v", expected, resumeSpan)
 			}
-			res, _ := MVCCScan(ctx, engine, keyMin, keyMax,
+			res, _ := MVCCScan(ctx, engine, localMax, keyMax,
 				hlc.Timestamp{WallTime: 2}, MVCCScanOptions{})
 			if len(res.KVs) != 4 ||
 				!bytes.Equal(res.KVs[0].Key, testKey1) ||
@@ -1493,7 +1494,7 @@ func TestMVCCDeleteRange(t *testing.T) {
 			// Try again, but with tombstones set to true to fetch the deleted keys as well.
 			kvs := []roachpb.KeyValue{}
 			if _, err = MVCCIterate(
-				ctx, engine, keyMin, keyMax, hlc.Timestamp{WallTime: 2}, MVCCScanOptions{Tombstones: true},
+				ctx, engine, localMax, keyMax, hlc.Timestamp{WallTime: 2}, MVCCScanOptions{Tombstones: true},
 				func(kv roachpb.KeyValue) error {
 					kvs = append(kvs, kv)
 					return nil
@@ -1532,7 +1533,7 @@ func TestMVCCDeleteRange(t *testing.T) {
 			if expected := (roachpb.Span{Key: testKey2, EndKey: testKey6}); !resumeSpan.EqualValue(expected) {
 				t.Fatalf("expected = %+v, resumeSpan = %+v", expected, resumeSpan)
 			}
-			res, _ = MVCCScan(ctx, engine, keyMin, keyMax, hlc.Timestamp{WallTime: 2},
+			res, _ = MVCCScan(ctx, engine, localMax, keyMax, hlc.Timestamp{WallTime: 2},
 				MVCCScanOptions{})
 			if len(res.KVs) != 4 ||
 				!bytes.Equal(res.KVs[0].Key, testKey1) ||
@@ -1560,7 +1561,7 @@ func TestMVCCDeleteRange(t *testing.T) {
 			if resumeSpan != nil {
 				t.Fatalf("wrong resume key: expected nil, found %v", resumeSpan)
 			}
-			res, err = MVCCScan(ctx, engine, keyMin, keyMax, hlc.Timestamp{WallTime: 2},
+			res, err = MVCCScan(ctx, engine, localMax, keyMax, hlc.Timestamp{WallTime: 2},
 				MVCCScanOptions{})
 			if err != nil {
 				t.Fatal(err)
@@ -1572,7 +1573,7 @@ func TestMVCCDeleteRange(t *testing.T) {
 			}
 
 			deleted, resumeSpan, num, err = MVCCDeleteRange(
-				ctx, engine, nil, keyMin, testKey2, 0, hlc.Timestamp{WallTime: 2}, nil, false)
+				ctx, engine, nil, localMax, testKey2, 0, hlc.Timestamp{WallTime: 2}, nil, false)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1585,7 +1586,7 @@ func TestMVCCDeleteRange(t *testing.T) {
 			if resumeSpan != nil {
 				t.Fatalf("wrong resume key: expected nil, found %v", resumeSpan)
 			}
-			res, _ = MVCCScan(ctx, engine, keyMin, keyMax, hlc.Timestamp{WallTime: 2},
+			res, _ = MVCCScan(ctx, engine, localMax, keyMax, hlc.Timestamp{WallTime: 2},
 				MVCCScanOptions{})
 			if err != nil {
 				t.Fatal(err)
@@ -1647,7 +1648,7 @@ func TestMVCCDeleteRangeReturnKeys(t *testing.T) {
 			if expected := (roachpb.Span{Key: testKey4, EndKey: testKey6}); !resumeSpan.EqualValue(expected) {
 				t.Fatalf("expected = %+v, resumeSpan = %+v", expected, resumeSpan)
 			}
-			res, _ := MVCCScan(ctx, engine, keyMin, keyMax, hlc.Timestamp{WallTime: 2},
+			res, _ := MVCCScan(ctx, engine, localMax, keyMax, hlc.Timestamp{WallTime: 2},
 				MVCCScanOptions{})
 			if len(res.KVs) != 4 ||
 				!bytes.Equal(res.KVs[0].Key, testKey1) ||
@@ -1676,7 +1677,7 @@ func TestMVCCDeleteRangeReturnKeys(t *testing.T) {
 			if expected := (roachpb.Span{Key: testKey2, EndKey: testKey6}); !resumeSpan.EqualValue(expected) {
 				t.Fatalf("expected = %+v, resumeSpan = %+v", expected, resumeSpan)
 			}
-			res, _ = MVCCScan(ctx, engine, keyMin, keyMax, hlc.Timestamp{WallTime: 2},
+			res, _ = MVCCScan(ctx, engine, localMax, keyMax, hlc.Timestamp{WallTime: 2},
 				MVCCScanOptions{})
 			if len(res.KVs) != 4 ||
 				!bytes.Equal(res.KVs[0].Key, testKey1) ||
@@ -1713,7 +1714,7 @@ func TestMVCCDeleteRangeReturnKeys(t *testing.T) {
 			if resumeSpan != nil {
 				t.Fatalf("wrong resume key: expected nil, found %v", resumeSpan)
 			}
-			res, _ = MVCCScan(ctx, engine, keyMin, keyMax, hlc.Timestamp{WallTime: 2},
+			res, _ = MVCCScan(ctx, engine, localMax, keyMax, hlc.Timestamp{WallTime: 2},
 				MVCCScanOptions{})
 			if len(res.KVs) != 1 ||
 				!bytes.Equal(res.KVs[0].Key, testKey1) ||
@@ -1722,7 +1723,7 @@ func TestMVCCDeleteRangeReturnKeys(t *testing.T) {
 			}
 
 			deleted, resumeSpan, num, err = MVCCDeleteRange(
-				ctx, engine, nil, keyMin, testKey2, math.MaxInt64, hlc.Timestamp{WallTime: 2}, nil, true)
+				ctx, engine, nil, localMax, testKey2, math.MaxInt64, hlc.Timestamp{WallTime: 2}, nil, true)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1738,7 +1739,7 @@ func TestMVCCDeleteRangeReturnKeys(t *testing.T) {
 			if resumeSpan != nil {
 				t.Fatalf("wrong resume key: %v", resumeSpan)
 			}
-			res, _ = MVCCScan(ctx, engine, keyMin, keyMax, hlc.Timestamp{WallTime: 2},
+			res, _ = MVCCScan(ctx, engine, localMax, keyMax, hlc.Timestamp{WallTime: 2},
 				MVCCScanOptions{})
 			if len(res.KVs) != 0 {
 				t.Fatal("the value should be empty")
@@ -2028,7 +2029,7 @@ func TestMVCCDeleteRangeInline(t *testing.T) {
 					Value: value6,
 				},
 			}
-			res, err := MVCCScan(ctx, engine, keyMin, keyMax, hlc.Timestamp{WallTime: 2},
+			res, err := MVCCScan(ctx, engine, localMax, keyMax, hlc.Timestamp{WallTime: 2},
 				MVCCScanOptions{})
 			if err != nil {
 				t.Fatal(err)
@@ -2111,7 +2112,7 @@ func TestMVCCClearTimeRange(t *testing.T) {
 
 			assertKVs := func(t *testing.T, reader Reader, at hlc.Timestamp, expected []roachpb.KeyValue) {
 				t.Helper()
-				res, err := MVCCScan(ctx, reader, keyMin, keyMax, at, MVCCScanOptions{})
+				res, err := MVCCScan(ctx, reader, localMax, keyMax, at, MVCCScanOptions{})
 				require.NoError(t, err)
 				require.Equal(t, expected, res.KVs)
 			}
@@ -2119,7 +2120,7 @@ func TestMVCCClearTimeRange(t *testing.T) {
 			t.Run("clear > ts0", func(t *testing.T) {
 				e := setupKVs(t)
 				defer e.Close()
-				_, err := MVCCClearTimeRange(ctx, e, nil, keyMin, keyMax, ts0, ts5, 10)
+				_, err := MVCCClearTimeRange(ctx, e, nil, localMax, keyMax, ts0, ts5, 10)
 				require.NoError(t, err)
 				assertKVs(t, e, ts0, ts0Content)
 				assertKVs(t, e, ts1, ts0Content)
@@ -2129,7 +2130,7 @@ func TestMVCCClearTimeRange(t *testing.T) {
 			t.Run("clear > ts1 ", func(t *testing.T) {
 				e := setupKVs(t)
 				defer e.Close()
-				_, err := MVCCClearTimeRange(ctx, e, nil, keyMin, keyMax, ts1, ts5, 10)
+				_, err := MVCCClearTimeRange(ctx, e, nil, localMax, keyMax, ts1, ts5, 10)
 				require.NoError(t, err)
 				assertKVs(t, e, ts1, ts1Content)
 				assertKVs(t, e, ts2, ts1Content)
@@ -2139,7 +2140,7 @@ func TestMVCCClearTimeRange(t *testing.T) {
 			t.Run("clear > ts2", func(t *testing.T) {
 				e := setupKVs(t)
 				defer e.Close()
-				_, err := MVCCClearTimeRange(ctx, e, nil, keyMin, keyMax, ts2, ts5, 10)
+				_, err := MVCCClearTimeRange(ctx, e, nil, localMax, keyMax, ts2, ts5, 10)
 				require.NoError(t, err)
 				assertKVs(t, e, ts2, ts2Content)
 				assertKVs(t, e, ts5, ts2Content)
@@ -2148,7 +2149,7 @@ func TestMVCCClearTimeRange(t *testing.T) {
 			t.Run("clear > ts3", func(t *testing.T) {
 				e := setupKVs(t)
 				defer e.Close()
-				_, err := MVCCClearTimeRange(ctx, e, nil, keyMin, keyMax, ts3, ts5, 10)
+				_, err := MVCCClearTimeRange(ctx, e, nil, localMax, keyMax, ts3, ts5, 10)
 				require.NoError(t, err)
 				assertKVs(t, e, ts3, ts3Content)
 				assertKVs(t, e, ts5, ts3Content)
@@ -2157,7 +2158,7 @@ func TestMVCCClearTimeRange(t *testing.T) {
 			t.Run("clear > ts4 (nothing) ", func(t *testing.T) {
 				e := setupKVs(t)
 				defer e.Close()
-				_, err := MVCCClearTimeRange(ctx, e, nil, keyMin, keyMax, ts4, ts5, 10)
+				_, err := MVCCClearTimeRange(ctx, e, nil, localMax, keyMax, ts4, ts5, 10)
 				require.NoError(t, err)
 				assertKVs(t, e, ts4, ts4Content)
 				assertKVs(t, e, ts5, ts4Content)
@@ -2166,7 +2167,7 @@ func TestMVCCClearTimeRange(t *testing.T) {
 			t.Run("clear > ts5 (nothing)", func(t *testing.T) {
 				e := setupKVs(t)
 				defer e.Close()
-				_, err := MVCCClearTimeRange(ctx, e, nil, keyMin, keyMax, ts5, ts5, 10)
+				_, err := MVCCClearTimeRange(ctx, e, nil, localMax, keyMax, ts5, ts5, 10)
 				require.NoError(t, err)
 				assertKVs(t, e, ts4, ts4Content)
 				assertKVs(t, e, ts5, ts4Content)
@@ -2218,7 +2219,7 @@ func TestMVCCClearTimeRange(t *testing.T) {
 			t.Run("clear everything hitting intent fails", func(t *testing.T) {
 				e := setupKVsWithIntent(t)
 				defer e.Close()
-				_, err := MVCCClearTimeRange(ctx, e, nil, keyMin, keyMax, ts0, ts5, 10)
+				_, err := MVCCClearTimeRange(ctx, e, nil, localMax, keyMax, ts0, ts5, 10)
 				require.EqualError(t, err, "conflicting intents on \"/db3\"")
 			})
 
@@ -2232,13 +2233,13 @@ func TestMVCCClearTimeRange(t *testing.T) {
 			t.Run("clear everything above intent", func(t *testing.T) {
 				e := setupKVsWithIntent(t)
 				defer e.Close()
-				_, err := MVCCClearTimeRange(ctx, e, nil, keyMin, keyMax, ts3, ts5, 10)
+				_, err := MVCCClearTimeRange(ctx, e, nil, localMax, keyMax, ts3, ts5, 10)
 				require.NoError(t, err)
 				assertKVs(t, e, ts2, ts2Content)
 
 				// Scan (< k3 to avoid intent) to confirm that k2 was indeed reverted to
 				// value as of ts3 (i.e. v4 was cleared to expose v2).
-				res, err := MVCCScan(ctx, e, keyMin, testKey3, ts5, MVCCScanOptions{})
+				res, err := MVCCScan(ctx, e, localMax, testKey3, ts5, MVCCScanOptions{})
 				require.NoError(t, err)
 				require.Equal(t, ts3Content[:2], res.KVs)
 
@@ -2257,7 +2258,7 @@ func TestMVCCClearTimeRange(t *testing.T) {
 				e := setupKVsWithIntent(t)
 				defer e.Close()
 				assertKVs(t, e, ts2, ts2Content)
-				_, err := MVCCClearTimeRange(ctx, e, nil, keyMin, keyMax, ts1, ts2, 10)
+				_, err := MVCCClearTimeRange(ctx, e, nil, localMax, keyMax, ts1, ts2, 10)
 				require.NoError(t, err)
 				assertKVs(t, e, ts2, ts1Content)
 			})
@@ -2347,7 +2348,7 @@ func TestMVCCClearTimeRangeOnRandomData(t *testing.T) {
 			ms.AgeTo(2000)
 
 			// Sanity check starting stats.
-			require.Equal(t, computeStats(t, e, keyMin, keyMax, 2000), ms)
+			require.Equal(t, computeStats(t, e, localMax, keyMax, 2000), ms)
 
 			// Pick timestamps to which we'll revert, and sort them so we can go back
 			// though them in order. The largest will still be less than randTimeRange so
@@ -2363,11 +2364,11 @@ func TestMVCCClearTimeRangeOnRandomData(t *testing.T) {
 				t.Run(fmt.Sprintf("revert-%d", i), func(t *testing.T) {
 					revertTo := hlc.Timestamp{WallTime: int64(reverts[i])}
 					// MVCC-Scan at the revert time.
-					resBefore, err := MVCCScan(ctx, e, keyMin, keyMax, revertTo, MVCCScanOptions{MaxKeys: numKVs})
+					resBefore, err := MVCCScan(ctx, e, localMax, keyMax, revertTo, MVCCScanOptions{MaxKeys: numKVs})
 					require.NoError(t, err)
 
 					// Revert to the revert time.
-					startKey := keyMin
+					startKey := localMax
 					for {
 						resume, err := MVCCClearTimeRange(ctx, e, &ms, startKey, keyMax, revertTo, now, 100)
 						require.NoError(t, err)
@@ -2377,10 +2378,10 @@ func TestMVCCClearTimeRangeOnRandomData(t *testing.T) {
 						startKey = resume.Key
 					}
 
-					require.Equal(t, computeStats(t, e, keyMin, keyMax, 2000), ms)
+					require.Equal(t, computeStats(t, e, localMax, keyMax, 2000), ms)
 					// Scanning at "now" post-revert should yield the same result as scanning
 					// at revert-time pre-revert.
-					resAfter, err := MVCCScan(ctx, e, keyMin, keyMax, now, MVCCScanOptions{MaxKeys: numKVs})
+					resAfter, err := MVCCScan(ctx, e, localMax, keyMax, now, MVCCScanOptions{MaxKeys: numKVs})
 					require.NoError(t, err)
 					require.Equal(t, resBefore.KVs, resAfter.KVs)
 				})
@@ -4527,7 +4528,7 @@ func TestMVCCGarbageCollect(t *testing.T) {
 				}
 			}
 			if log.V(1) {
-				kvsn, err := Scan(engine, keyMin, keyMax, 0)
+				kvsn, err := Scan(engine, localMax, keyMax, 0)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -4558,7 +4559,7 @@ func TestMVCCGarbageCollect(t *testing.T) {
 				mvccVersionKey(roachpb.Key("b"), ts2),
 				mvccVersionKey(roachpb.Key("b-del"), ts3),
 			}
-			kvs, err := Scan(engine, keyMin, keyMax, 0)
+			kvs, err := Scan(engine, localMax, keyMax, 0)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/storage/pebble_iterator.go
+++ b/pkg/storage/pebble_iterator.go
@@ -47,6 +47,15 @@ type pebbleIterator struct {
 	// iterator, but simply marks it as not inuse. Used by pebbleReadOnly.
 	reusable bool
 	inuse    bool
+	// mvccDirIsReverse and mvccDone are used only for the methods implementing
+	// MVCCIterator. They are used to prevent the iterator from iterating into
+	// the lock table key space.
+	//
+	// The current direction. false for forward, true for reverse.
+	mvccDirIsReverse bool
+	// True iff the iterator is exhausted in the current direction. There is
+	// no error to report when it is true.
+	mvccDone bool
 	// Stat tracking the number of sstables encountered during time-bound
 	// iteration. Only used for MVCCIterator.
 	timeBoundNumSSTables int
@@ -190,6 +199,8 @@ func (p *pebbleIterator) Close() {
 
 // SeekGE implements the MVCCIterator interface.
 func (p *pebbleIterator) SeekGE(key MVCCKey) {
+	p.mvccDirIsReverse = false
+	p.mvccDone = false
 	p.keyBuf = EncodeKeyToBuf(p.keyBuf[:0], key)
 	if p.prefix {
 		p.iter.SeekPrefixGE(p.keyBuf)
@@ -215,11 +226,33 @@ func (p *pebbleIterator) SeekEngineKeyGE(key EngineKey) (valid bool, err error) 
 	return false, p.iter.Error()
 }
 
-// Valid implements the MVCCIterator interface.
+// Valid implements the MVCCIterator interface. Must not be called from
+// methods of EngineIterator.
 func (p *pebbleIterator) Valid() (bool, error) {
+	if p.mvccDone {
+		return false, nil
+	}
 	// NB: A Pebble Iterator always returns Valid()==false when an error is
 	// present. If Valid() is true, there is no error.
 	if ok := p.iter.Valid(); ok {
+		// The MVCCIterator interface is broken in that it silently discards
+		// the error when UnsafeKey(), Key() are unable to parse the key as
+		// an MVCCKey. This is especially problematic if the caller is
+		// accidentally iterating into the lock table key space, since that
+		// parsing will fail. We do a cheap check here to make sure we are
+		// not in the lock table key space.
+		//
+		// TODO(sumeer): fix this properly by changing those method signatures.
+		k := p.iter.Key()
+		if len(k) == 0 {
+			return false, errors.Errorf("iterator encountered 0 length key")
+		}
+		// Last byte is the version length + 1 or 0.
+		versionLen := int(k[len(k)-1])
+		if versionLen == engineKeyVersionLockTableLen+1 {
+			p.mvccDone = true
+			return false, nil
+		}
 		return ok, nil
 	}
 	return false, p.iter.Error()
@@ -227,6 +260,14 @@ func (p *pebbleIterator) Valid() (bool, error) {
 
 // Next implements the MVCCIterator interface.
 func (p *pebbleIterator) Next() {
+	if p.mvccDirIsReverse {
+		// Switching directions.
+		p.mvccDirIsReverse = false
+		p.mvccDone = false
+	}
+	if p.mvccDone {
+		return
+	}
 	p.iter.Next()
 }
 
@@ -243,6 +284,17 @@ func (p *pebbleIterator) NextEngineKey() (valid bool, err error) {
 
 // NextKey implements the MVCCIterator interface.
 func (p *pebbleIterator) NextKey() {
+	// Even though NextKey() is not allowed for switching direction by the
+	// MVCCIterator interface, pebbleIterator works correctly even when
+	// switching direction. So we set mvccDirIsReverse = false.
+	if p.mvccDirIsReverse {
+		// Switching directions.
+		p.mvccDirIsReverse = false
+		p.mvccDone = false
+	}
+	if p.mvccDone {
+		return
+	}
 	if valid, err := p.Valid(); err != nil || !valid {
 		return
 	}
@@ -297,7 +349,7 @@ func (p *pebbleIterator) UnsafeRawEngineKey() []byte {
 
 // UnsafeValue implements the MVCCIterator and EngineIterator interfaces.
 func (p *pebbleIterator) UnsafeValue() []byte {
-	if valid, err := p.Valid(); err != nil || !valid {
+	if ok := p.iter.Valid(); !ok {
 		return nil
 	}
 	return p.iter.Value()
@@ -305,6 +357,8 @@ func (p *pebbleIterator) UnsafeValue() []byte {
 
 // SeekLT implements the MVCCIterator interface.
 func (p *pebbleIterator) SeekLT(key MVCCKey) {
+	p.mvccDirIsReverse = true
+	p.mvccDone = false
 	p.keyBuf = EncodeKeyToBuf(p.keyBuf[:0], key)
 	p.iter.SeekLT(p.keyBuf)
 }
@@ -323,6 +377,14 @@ func (p *pebbleIterator) SeekEngineKeyLT(key EngineKey) (valid bool, err error) 
 
 // Prev implements the MVCCIterator interface.
 func (p *pebbleIterator) Prev() {
+	if !p.mvccDirIsReverse {
+		// Switching directions.
+		p.mvccDirIsReverse = true
+		p.mvccDone = false
+	}
+	if p.mvccDone {
+		return
+	}
 	p.iter.Prev()
 }
 

--- a/pkg/storage/testdata/intent_interleaving_iter/basic
+++ b/pkg/storage/testdata/intent_interleaving_iter/basic
@@ -89,7 +89,9 @@ next: output: value k=a ts=20 v=a20
 next: output: value k=a ts=10 v=a10
 next: output: meta k=b ts=30 txn=2
 
-# More forward and reverse iteration.
+# More forward and reverse iteration. This confirms that the underlying
+# MVCCIterator does not iterate into the lock table key space despite no lower
+# bound.
 iter upper=b
 seek-ge k=a
 next
@@ -98,6 +100,9 @@ next
 prev
 prev
 prev
+prev
+prev
+next
 ----
 seek-ge "a"/0,0: output: meta k=a ts=20 txn=1
 next: output: value k=a ts=20 v=a20
@@ -106,6 +111,9 @@ next: output: .
 prev: output: value k=a ts=10 v=a10
 prev: output: value k=a ts=20 v=a20
 prev: output: meta k=a ts=20 txn=1
+prev: output: .
+prev: output: .
+next: output: meta k=a ts=20 txn=1
 
 # Prefix iteration.
 iter prefix=true
@@ -414,6 +422,64 @@ prev: output: meta k=Lb ts=20 txn=2
 prev: output: value k=La ts=10 v=a10
 prev: output: meta k=La ts=10 txn=1
 prev: output: .
+
+# Confirm that the lock table iterator does not step out of the lock table
+# keys space despite no lower bound.
+iter upper=Lc
+seek-ge k=La
+next
+prev
+prev
+prev
+next
+next
+next
+----
+seek-ge "La"/0,0: output: meta k=La ts=10 txn=1
+next: output: value k=La ts=10 v=a10
+prev: output: meta k=La ts=10 txn=1
+prev: output: .
+prev: output: .
+next: output: meta k=La ts=10 txn=1
+next: output: value k=La ts=10 v=a10
+next: output: meta k=Lb ts=20 txn=2
+
+# Confirm that the underlying MVCCIterator does not iterate into the lock
+# table key space despite no upper bound.
+iter lower=La
+seek-lt k=Ld
+prev
+prev
+prev
+prev
+prev
+prev
+next
+next
+next
+next
+next
+next
+next
+next
+prev
+----
+seek-lt "Ld"/0,0: output: value k=Lc ts=30 v=c30
+prev: output: meta k=Lc ts=30 txn=4
+prev: output: value k=Lb ts=20 v=b20
+prev: output: meta k=Lb ts=20 txn=2
+prev: output: value k=La ts=10 v=a10
+prev: output: meta k=La ts=10 txn=1
+prev: output: .
+next: output: meta k=La ts=10 txn=1
+next: output: value k=La ts=10 v=a10
+next: output: meta k=Lb ts=20 txn=2
+next: output: value k=Lb ts=20 v=b20
+next: output: meta k=Lc ts=30 txn=4
+next: output: value k=Lc ts=30 v=c30
+next: output: .
+next: output: .
+prev: output: value k=Lc ts=30 v=c30
 
 iter prefix=true
 seek-ge k=Lb

--- a/pkg/storage/testdata/mvcc_histories/intent_history_allow_separated
+++ b/pkg/storage/testdata/mvcc_histories/intent_history_allow_separated
@@ -53,6 +53,6 @@ meta: "a"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000002,0
 data: "a"/0.000000002,0 -> /BYTES/first
 data: "a"/0.000000001,0 -> /BYTES/default
 >> resolve_intent k=a t=A
-called ClearIntent("a", ExistingIntentInterleaved, TDNUM(false), 00000000-0000-0000-0000-000000000000)
+called ClearIntent("a", ExistingIntentInterleaved, TDNUM(false), 00000000-0000-0000-0000-000000000002)
 data: "a"/0.000000002,0 -> /BYTES/first
 data: "a"/0.000000001,0 -> /BYTES/default

--- a/pkg/storage/testdata/mvcc_histories/intent_history_disallow_separated
+++ b/pkg/storage/testdata/mvcc_histories/intent_history_disallow_separated
@@ -53,6 +53,6 @@ meta: "a"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000002,0
 data: "a"/0.000000002,0 -> /BYTES/first
 data: "a"/0.000000001,0 -> /BYTES/default
 >> resolve_intent k=a t=A
-called ClearIntent("a", ExistingIntentInterleaved, TDNUM(false), 00000000-0000-0000-0000-000000000000)
+called ClearIntent("a", ExistingIntentInterleaved, TDNUM(false), 00000000-0000-0000-0000-000000000002)
 data: "a"/0.000000002,0 -> /BYTES/first
 data: "a"/0.000000001,0 -> /BYTES/default

--- a/pkg/storage/testdata/mvcc_histories/intent_with_write_tracing_allow_separated
+++ b/pkg/storage/testdata/mvcc_histories/intent_with_write_tracing_allow_separated
@@ -67,7 +67,7 @@ with t=A
   txn_remove
 ----
 >> resolve_intent k=k1 t=A
-called ClearIntent("k1", ExistingIntentInterleaved, TDNUM(false), 00000000-0000-0000-0000-000000000000)
+called ClearIntent("k1", ExistingIntentInterleaved, TDNUM(false), 00000000-0000-0000-0000-000000000001)
 data: "k1"/0.000000003,0 -> /BYTES/v1
 meta: "k2"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000003,0 min=0,0 seq=1} ts=0.000000003,0 del=false klen=12 vlen=7
 data: "k2"/0.000000003,0 -> /BYTES/v2
@@ -75,13 +75,13 @@ meta: "k3"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000003,
 data: "k3"/0.000000003,0 -> /BYTES/v33
 data: "k3"/0.000000001,0 -> /BYTES/v3
 >> resolve_intent k=k2 status=ABORTED t=A
-called ClearIntent("k2", ExistingIntentInterleaved, TDNUM(true), 00000000-0000-0000-0000-000000000000)
+called ClearIntent("k2", ExistingIntentInterleaved, TDNUM(true), 00000000-0000-0000-0000-000000000001)
 data: "k1"/0.000000003,0 -> /BYTES/v1
 meta: "k3"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000003,0 min=0,0 seq=1} ts=0.000000003,0 del=false klen=12 vlen=8
 data: "k3"/0.000000003,0 -> /BYTES/v33
 data: "k3"/0.000000001,0 -> /BYTES/v3
 >> resolve_intent k=k3 status=ABORTED t=A
-called ClearIntent("k3", ExistingIntentInterleaved, TDNUM(true), 00000000-0000-0000-0000-000000000000)
+called ClearIntent("k3", ExistingIntentInterleaved, TDNUM(true), 00000000-0000-0000-0000-000000000001)
 data: "k1"/0.000000003,0 -> /BYTES/v1
 data: "k3"/0.000000001,0 -> /BYTES/v3
 >> txn_remove t=A

--- a/pkg/storage/testdata/mvcc_histories/intent_with_write_tracing_disallow_separated
+++ b/pkg/storage/testdata/mvcc_histories/intent_with_write_tracing_disallow_separated
@@ -67,7 +67,7 @@ with t=A
   txn_remove
 ----
 >> resolve_intent k=k1 t=A
-called ClearIntent("k1", ExistingIntentInterleaved, TDNUM(false), 00000000-0000-0000-0000-000000000000)
+called ClearIntent("k1", ExistingIntentInterleaved, TDNUM(false), 00000000-0000-0000-0000-000000000001)
 data: "k1"/0.000000003,0 -> /BYTES/v1
 meta: "k2"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000003,0 min=0,0 seq=1} ts=0.000000003,0 del=false klen=12 vlen=7
 data: "k2"/0.000000003,0 -> /BYTES/v2
@@ -75,13 +75,13 @@ meta: "k3"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000003,
 data: "k3"/0.000000003,0 -> /BYTES/v33
 data: "k3"/0.000000001,0 -> /BYTES/v3
 >> resolve_intent k=k2 status=ABORTED t=A
-called ClearIntent("k2", ExistingIntentInterleaved, TDNUM(false), 00000000-0000-0000-0000-000000000000)
+called ClearIntent("k2", ExistingIntentInterleaved, TDNUM(false), 00000000-0000-0000-0000-000000000001)
 data: "k1"/0.000000003,0 -> /BYTES/v1
 meta: "k3"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000003,0 min=0,0 seq=1} ts=0.000000003,0 del=false klen=12 vlen=8
 data: "k3"/0.000000003,0 -> /BYTES/v33
 data: "k3"/0.000000001,0 -> /BYTES/v3
 >> resolve_intent k=k3 status=ABORTED t=A
-called ClearIntent("k3", ExistingIntentInterleaved, TDNUM(false), 00000000-0000-0000-0000-000000000000)
+called ClearIntent("k3", ExistingIntentInterleaved, TDNUM(false), 00000000-0000-0000-0000-000000000001)
 data: "k1"/0.000000003,0 -> /BYTES/v1
 data: "k3"/0.000000001,0 -> /BYTES/v3
 >> txn_remove t=A

--- a/pkg/storage/testdata/mvcc_histories/no_read_after_abort_allow_separated
+++ b/pkg/storage/testdata/mvcc_histories/no_read_after_abort_allow_separated
@@ -14,7 +14,7 @@ called PutIntent("a", _, NoExistingIntent, TDNUM(true), 00000000-0000-0000-0000-
 meta: "a"/0,0 -> txn={id=00000000 key="a" pri=0.00000000 epo=0 ts=0.000000022,0 min=0,0 seq=0} ts=0.000000022,0 del=false klen=12 vlen=8
 data: "a"/0.000000022,0 -> /BYTES/cde
 >> resolve_intent status=ABORTED t=A k=a
-called ClearIntent("a", ExistingIntentInterleaved, TDNUM(true), 00000000-0000-0000-0000-000000000000)
+called ClearIntent("a", ExistingIntentInterleaved, TDNUM(true), 00000000-0000-0000-0000-000000000001)
 <no data>
 >> txn_remove t=A k=a
 

--- a/pkg/storage/testdata/mvcc_histories/no_read_after_abort_disallow_separated
+++ b/pkg/storage/testdata/mvcc_histories/no_read_after_abort_disallow_separated
@@ -14,7 +14,7 @@ called PutIntent("a", _, NoExistingIntent, TDNUM(true), 00000000-0000-0000-0000-
 meta: "a"/0,0 -> txn={id=00000000 key="a" pri=0.00000000 epo=0 ts=0.000000022,0 min=0,0 seq=0} ts=0.000000022,0 del=false klen=12 vlen=8
 data: "a"/0.000000022,0 -> /BYTES/cde
 >> resolve_intent status=ABORTED t=A k=a
-called ClearIntent("a", ExistingIntentInterleaved, TDNUM(false), 00000000-0000-0000-0000-000000000000)
+called ClearIntent("a", ExistingIntentInterleaved, TDNUM(false), 00000000-0000-0000-0000-000000000001)
 <no data>
 >> txn_remove t=A k=a
 

--- a/pkg/storage/testdata/mvcc_histories/read_after_write_allow_separated
+++ b/pkg/storage/testdata/mvcc_histories/read_after_write_allow_separated
@@ -17,7 +17,7 @@ data: "a"/0.000000011,0 -> /BYTES/abc
 >> get k=a t=A
 get: "a" -> /BYTES/abc @0.000000011,0
 >> resolve_intent k=a t=A
-called ClearIntent("a", ExistingIntentInterleaved, TDNUM(true), 00000000-0000-0000-0000-000000000000)
+called ClearIntent("a", ExistingIntentInterleaved, TDNUM(true), 00000000-0000-0000-0000-000000000001)
 data: "a"/0.000000011,0 -> /BYTES/abc
 
 run ok

--- a/pkg/storage/testdata/mvcc_histories/read_after_write_disallow_separated
+++ b/pkg/storage/testdata/mvcc_histories/read_after_write_disallow_separated
@@ -17,7 +17,7 @@ data: "a"/0.000000011,0 -> /BYTES/abc
 >> get k=a t=A
 get: "a" -> /BYTES/abc @0.000000011,0
 >> resolve_intent k=a t=A
-called ClearIntent("a", ExistingIntentInterleaved, TDNUM(false), 00000000-0000-0000-0000-000000000000)
+called ClearIntent("a", ExistingIntentInterleaved, TDNUM(false), 00000000-0000-0000-0000-000000000001)
 data: "a"/0.000000011,0 -> /BYTES/abc
 
 run ok


### PR DESCRIPTION
- ClearIntent calls now pass the txn UUID.
- MVCC iteration is prevented from crossing into
  the lock table key space.
  pebbleIterator tracks the direction of iteration
  and cheaply checks whether it has crossed into
  the lock table key space, and if so, marks itself
  done.
  There is additional testing using intentInterleavingIter
  that exercises this code.
- The MVCCIterator interface is not properly designed
  for propagating errors, and it eats the error if the
  MVCCKey cannot be parsed. There is now a TODO to fix
  this.
- storage and kvserver test fixes.

Separated intents are not enabled in this PR. They were
temporarily enabled only to fix bugs and tests.

Informs #41720

Release note: None