### PR TITLE
release-20.2: opt: fix bug in TryDecorrelateSemiJoin rule

### DIFF
--- a/pkg/sql/opt/norm/rules/decorrelate.opt
+++ b/pkg/sql/opt/norm/rules/decorrelate.opt
@@ -526,7 +526,7 @@
         (MakeGrouping (KeyCols $newLeft) (EmptyOrdering))
     )
     []
-    (OutputCols2 $left $right)
+    (OutputCols $left)
 )
 
 # TryDecorrelateLimitOne "pushes down" a Join into a Limit 1 operator, in an


### PR DESCRIPTION
Backport 1/1 commits from #57501.

/cc @cockroachdb/release

---

This rule creates an incorrect Project which tries to pass through
columns that are not in the input. I am guessing that in practice,
those columns get pruned by other rules so it may not lead to
user-visible problems.

Notes: this was introduced in #48037; I am adding an assertion in
CheckExpr for this Project condition in a separate PR.

Release notes: None
