### PR TITLE
release-20.1: opt: disallow aggregate/window functions in ORDER BY for UNION

### DIFF
--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -268,7 +268,7 @@ func (mb *mutationBuilder) buildInputForUpdate(
 	// SELECT + ORDER BY (which may add projected expressions)
 	projectionsScope := mb.outScope.replace()
 	projectionsScope.appendColumnsFromScope(mb.outScope)
-	orderByScope := mb.b.analyzeOrderBy(orderBy, mb.outScope, projectionsScope)
+	orderByScope := mb.b.analyzeOrderBy(orderBy, mb.outScope, projectionsScope, tree.RejectGenerators)
 	mb.b.buildOrderBy(mb.outScope, projectionsScope, orderByScope)
 	mb.b.constructProjectForScope(mb.outScope, projectionsScope)
 
@@ -354,7 +354,7 @@ func (mb *mutationBuilder) buildInputForDelete(
 	// SELECT + ORDER BY (which may add projected expressions)
 	projectionsScope := mb.outScope.replace()
 	projectionsScope.appendColumnsFromScope(mb.outScope)
-	orderByScope := mb.b.analyzeOrderBy(orderBy, mb.outScope, projectionsScope)
+	orderByScope := mb.b.analyzeOrderBy(orderBy, mb.outScope, projectionsScope, tree.RejectGenerators)
 	mb.b.buildOrderBy(mb.outScope, projectionsScope, orderByScope)
 	mb.b.constructProjectForScope(mb.outScope, projectionsScope)
 

--- a/pkg/sql/opt/optbuilder/orderby.go
+++ b/pkg/sql/opt/optbuilder/orderby.go
@@ -23,7 +23,7 @@ import (
 // analyzeOrderBy analyzes an Ordering physical property from the ORDER BY
 // clause and adds the resulting typed expressions to orderByScope.
 func (b *Builder) analyzeOrderBy(
-	orderBy tree.OrderBy, inScope, projectionsScope *scope,
+	orderBy tree.OrderBy, inScope, projectionsScope *scope, rejectFlags tree.SemaRejectFlags,
 ) (orderByScope *scope) {
 	if orderBy == nil {
 		return nil
@@ -36,7 +36,7 @@ func (b *Builder) analyzeOrderBy(
 	// semaCtx in case we are recursively called within a subquery
 	// context.
 	defer b.semaCtx.Properties.Restore(b.semaCtx.Properties)
-	b.semaCtx.Properties.Require(exprKindOrderBy.String(), tree.RejectGenerators)
+	b.semaCtx.Properties.Require(exprKindOrderBy.String(), rejectFlags)
 	inScope.context = exprKindOrderBy
 
 	for i := range orderBy {

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -1478,6 +1478,12 @@ func (s *scope) String() string {
 		}
 		fmt.Fprintf(&buf, "%s:%d", c.name.String(), c.id)
 	}
+	for i, c := range s.extraCols {
+		if i > 0 || len(s.cols) > 0 {
+			buf.WriteByte(',')
+		}
+		fmt.Fprintf(&buf, "%s:%d!extra", c.name.String(), c.id)
+	}
 	buf.WriteByte(')')
 
 	return buf.String()

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -887,7 +887,7 @@ func (b *Builder) buildSelectStmtWithoutParens(
 			col := b.addColumn(projectionsScope, "" /* alias */, expr)
 			b.buildScalar(expr, outScope, projectionsScope, col, nil)
 		}
-		orderByScope := b.analyzeOrderBy(orderBy, outScope, projectionsScope)
+		orderByScope := b.analyzeOrderBy(orderBy, outScope, projectionsScope, tree.RejectGenerators|tree.RejectAggregates|tree.RejectWindowApplications)
 		b.buildOrderBy(outScope, projectionsScope, orderByScope)
 		b.constructProjectForScope(outScope, projectionsScope)
 		outScope = projectionsScope
@@ -931,7 +931,7 @@ func (b *Builder) buildSelectClause(
 	// Any aggregates in the HAVING, ORDER BY and DISTINCT ON clauses (if they
 	// exist) will be added here.
 	havingExpr := b.analyzeHaving(sel.Having, fromScope)
-	orderByScope := b.analyzeOrderBy(orderBy, fromScope, projectionsScope)
+	orderByScope := b.analyzeOrderBy(orderBy, fromScope, projectionsScope, tree.RejectGenerators)
 	distinctOnScope := b.analyzeDistinctOnArgs(sel.DistinctOn, fromScope, projectionsScope)
 
 	var having opt.ScalarExpr

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -3861,3 +3861,14 @@ build
 SELECT max((SELECT jsonb_agg(v))) FROM kv
 ----
 error (42803): aggregate function calls cannot be nested
+
+# Regression test for #57441.
+build
+SELECT v FROM kv UNION ALL SELECT count(1) FROM kv ORDER BY count(1)
+----
+error (42803): count(): aggregate functions are not allowed in ORDER BY
+
+build
+SELECT count(1) FROM kv UNION ALL SELECT v FROM kv ORDER BY count(1)
+----
+error (42803): count(): aggregate functions are not allowed in ORDER BY

--- a/pkg/sql/opt/optbuilder/testdata/values
+++ b/pkg/sql/opt/optbuilder/testdata/values
@@ -158,3 +158,9 @@ values
                      │    └── ()
                      └── projections
                           └── 2 [as=a:1]
+
+# Regression test for #57441.
+build
+VALUES (1) ORDER BY count(1)
+----
+error (42803): count(): aggregate functions are not allowed in ORDER BY

--- a/pkg/sql/opt/optbuilder/testdata/window
+++ b/pkg/sql/opt/optbuilder/testdata/window
@@ -1464,3 +1464,12 @@ GROUP BY
     tab_536191.col8, tab_536191.col5
 ----
 error (42P10): argument of ROWS must not contain variables
+
+# Regression test for #57441.
+build
+SELECT rank() OVER w FROM kv WINDOW w AS (ORDER BY v)
+UNION ALL SELECT rank() OVER w FROM kv WINDOW w AS (ORDER BY v)
+ORDER BY
+  rank() OVER()
+----
+error (42P20): rank(): window functions are not allowed in ORDER BY


### PR DESCRIPTION
Backport 1/1 commits from #57498.

/cc @cockroachdb/release

---

We support aggregates in ORDER BY, but only in the context of a
SELECT. If we have an ORDER BY clause outside a UNION or VALUES, this
results in an internal error (caused by a Project that tries to pass
through columns not in input).

This change presents a proper error for this case. Note that pg also
errors out in these cases.

Note: I am adding a CheckExpr assertion for Project in a separate PR
(it found more issues).

Fixes #57441.

Release note (bug fix): fixed an internal error when using aggregates
and window functions in an ORDER BY for a UNION or VALUES clause.
