### PR TITLE
opt: fix bug in ExtractJoinEqualities rule

### DIFF
--- a/pkg/sql/opt/norm/join_funcs.go
+++ b/pkg/sql/opt/norm/join_funcs.go
@@ -553,7 +553,13 @@ func (c *CustomFuncs) ExtractJoinEquality(
 	)
 
 	// Project away the synthesized columns.
-	return c.f.ConstructProject(join, memo.EmptyProjectionsExpr, leftCols.Union(rightCols))
+	outputCols := leftCols
+	if joinOp != opt.SemiJoinOp && joinOp != opt.AntiJoinOp {
+		// Semi/Anti join only produce the left side columns. All other join types
+		// produce columns from both sides.
+		outputCols = leftCols.Union(rightCols)
+	}
+	return c.f.ConstructProject(join, memo.EmptyProjectionsExpr, outputCols)
 }
 
 // CommuteJoinFlags returns a join private for the commuted join (where the left


### PR DESCRIPTION
If the join is semi/anti, this rule generates an incorrect projection
(which passes through columns not in input).

Similar to #57501. Other normalization rules prune the columns so this
doesn't lead to a bad outcome (at least in most cases).

I will add an assertion in CheckExpr for this condition in a separate
PR - without this fix, the assertion fires on an existing test.

Release note: None