### PR TITLE
ts, ui, sql, ccl: add metrics, timeseries graph for feature flags

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -683,8 +683,8 @@ func backupPlanHook(
 
 	if err := featureflag.CheckEnabled(
 		ctx,
+		p.ExecCfg(),
 		featureBackupEnabled,
-		&p.ExecCfg().Settings.SV,
 		"BACKUP",
 	); err != nil {
 		return nil, nil, nil, false, err

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -1278,8 +1278,8 @@ func restorePlanHook(
 
 	if err := featureflag.CheckEnabled(
 		ctx,
+		p.ExecCfg(),
 		featureRestoreEnabled,
-		&p.ExecCfg().Settings.SV,
 		"RESTORE",
 	); err != nil {
 		return nil, nil, nil, false, err

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -80,8 +80,8 @@ func changefeedPlanHook(
 
 	if err := featureflag.CheckEnabled(
 		ctx,
+		p.ExecCfg(),
 		featureChangefeedEnabled,
-		&p.ExecCfg().Settings.SV,
 		"CHANGEFEED",
 	); err != nil {
 		return nil, nil, nil, false, err

--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -270,8 +270,8 @@ func importPlanHook(
 
 	if err := featureflag.CheckEnabled(
 		ctx,
+		p.ExecCfg(),
 		featureImportEnabled,
-		&p.ExecCfg().Settings.SV,
 		"IMPORT",
 	); err != nil {
 		return nil, nil, nil, false, err

--- a/pkg/featureflag/BUILD.bazel
+++ b/pkg/featureflag/BUILD.bazel
@@ -12,5 +12,6 @@ go_library(
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/sqltelemetry",
         "//pkg/util/log",
+        "//pkg/util/metric",
     ],
 )

--- a/pkg/featureflag/feature_flags.go
+++ b/pkg/featureflag/feature_flags.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
 )
 
 // FeatureFlagEnabledDefault is used for the default value of all feature flag
@@ -30,10 +31,29 @@ const FeatureFlagEnabledDefault = true
 // increments a telemetry counter for any feature flag that is denied and logs
 // the feature and category that was denied.
 func CheckEnabled(
-	ctx context.Context, s *settings.BoolSetting, sv *settings.Values, featureName string,
+	ctx context.Context, config Config, s *settings.BoolSetting, featureName string,
 ) error {
+	sv := config.SV()
+
 	if enabled := s.Get(sv); !enabled {
+		// Increment telemetry counter for feature flag denial.
 		telemetry.Inc(sqltelemetry.FeatureDeniedByFeatureFlagCounter)
+
+		// Increment metrics counter for feature flag denial.
+		if config.GetFeatureFlagMetrics() == nil {
+			log.Warningf(
+				ctx,
+				"executorConfig.FeatureFlagMetrics is uninitiated; feature %s was attempted but disabled via cluster settings",
+				featureName,
+			)
+			return pgerror.Newf(
+				pgcode.OperatorIntervention,
+				"feature %s was disabled by the database administrator",
+				featureName,
+			)
+		}
+		config.GetFeatureFlagMetrics().FeatureDenialMetric.Inc(1)
+
 		if log.V(2) {
 			log.Warningf(
 				ctx,
@@ -49,4 +69,39 @@ func CheckEnabled(
 		)
 	}
 	return nil
+}
+
+// metaFeatureDenialMetric is a metric counting the statements denied by a
+//feature flag.
+var metaFeatureDenialMetric = metric.Metadata{
+	Name:        "sql.feature_flag_denial",
+	Help:        "Counter of the number of statements denied by a feature flag",
+	Measurement: "Statements",
+	Unit:        metric.Unit_COUNT,
+}
+
+// DenialMetrics is a struct corresponding to any metrics related to feature
+// flag denials. Future metrics related to feature flags should be added to
+// this struct.
+type DenialMetrics struct {
+	FeatureDenialMetric *metric.Counter
+}
+
+// MetricStruct makes FeatureFlagMetrics a metric.Struct.
+func (s *DenialMetrics) MetricStruct() {}
+
+var _ metric.Struct = (*DenialMetrics)(nil)
+
+// NewFeatureFlagMetrics constructs a new FeatureFlagMetrics metric.Struct.
+func NewFeatureFlagMetrics() *DenialMetrics {
+	return &DenialMetrics{
+		FeatureDenialMetric: metric.NewCounter(metaFeatureDenialMetric),
+	}
+}
+
+// Config is an interface used to pass required values from ExecutorConfig to
+// check if a feature flag is enabled.
+type Config interface {
+	SV() *settings.Values
+	GetFeatureFlagMetrics() *DenialMetrics
 }

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -49,6 +49,7 @@ go_library(
         "//pkg/config",
         "//pkg/config/zonepb",
         "//pkg/docs",
+        "//pkg/featureflag",
         "//pkg/gossip",
         "//pkg/gossip/resolver",
         "//pkg/jobs",

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/blobs/blobspb"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/config"
+	"github.com/cockroachdb/cockroach/pkg/featureflag"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/keys"
@@ -518,6 +519,9 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*sqlServer, error) {
 	}
 	execCfg.SchemaChangerMetrics = sql.NewSchemaChangerMetrics()
 	cfg.registry.AddMetricStruct(execCfg.SchemaChangerMetrics)
+
+	execCfg.FeatureFlagMetrics = featureflag.NewFeatureFlagMetrics()
+	cfg.registry.AddMetricStruct(execCfg.FeatureFlagMetrics)
 
 	if gcJobTestingKnobs := cfg.TestingKnobs.GCJob; gcJobTestingKnobs != nil {
 		execCfg.GCJobTestingKnobs = gcJobTestingKnobs.(*sql.GCJobTestingKnobs)

--- a/pkg/sql/alter_database.go
+++ b/pkg/sql/alter_database.go
@@ -33,7 +33,7 @@ func (p *planner) AlterDatabaseOwner(
 ) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
 		ctx,
-		&p.ExecCfg().Settings.SV,
+		p.ExecCfg(),
 		"ALTER DATABASE",
 	); err != nil {
 		return nil, err
@@ -105,7 +105,7 @@ func (p *planner) AlterDatabaseAddRegion(
 ) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
 		ctx,
-		&p.ExecCfg().Settings.SV,
+		p.ExecCfg(),
 		"ALTER DATABASE",
 	); err != nil {
 		return nil, err
@@ -119,7 +119,7 @@ func (p *planner) AlterDatabaseDropRegion(
 ) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
 		ctx,
-		&p.ExecCfg().Settings.SV,
+		p.ExecCfg(),
 		"ALTER DATABASE",
 	); err != nil {
 		return nil, err
@@ -140,7 +140,7 @@ func (p *planner) AlterDatabaseSurvivalGoal(
 ) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
 		ctx,
-		&p.ExecCfg().Settings.SV,
+		p.ExecCfg(),
 		"ALTER DATABASE",
 	); err != nil {
 		return nil, err

--- a/pkg/sql/alter_index.go
+++ b/pkg/sql/alter_index.go
@@ -34,7 +34,7 @@ type alterIndexNode struct {
 func (p *planner) AlterIndex(ctx context.Context, n *tree.AlterIndex) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
 		ctx,
-		&p.ExecCfg().Settings.SV,
+		p.ExecCfg(),
 		"ALTER INDEX",
 	); err != nil {
 		return nil, err

--- a/pkg/sql/alter_schema.go
+++ b/pkg/sql/alter_schema.go
@@ -42,7 +42,7 @@ var _ planNode = &alterSchemaNode{n: nil}
 func (p *planner) AlterSchema(ctx context.Context, n *tree.AlterSchema) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
 		ctx,
-		&p.ExecCfg().Settings.SV,
+		p.ExecCfg(),
 		"ALTER SCHEMA",
 	); err != nil {
 		return nil, err

--- a/pkg/sql/alter_sequence.go
+++ b/pkg/sql/alter_sequence.go
@@ -31,7 +31,7 @@ type alterSequenceNode struct {
 func (p *planner) AlterSequence(ctx context.Context, n *tree.AlterSequence) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
 		ctx,
-		&p.ExecCfg().Settings.SV,
+		p.ExecCfg(),
 		"ALTER SEQUENCE",
 	); err != nil {
 		return nil, err

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -56,7 +56,7 @@ type alterTableNode struct {
 func (p *planner) AlterTable(ctx context.Context, n *tree.AlterTable) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
 		ctx,
-		&p.ExecCfg().Settings.SV,
+		p.ExecCfg(),
 		"ALTER TABLE",
 	); err != nil {
 		return nil, err

--- a/pkg/sql/alter_table_locality.go
+++ b/pkg/sql/alter_table_locality.go
@@ -23,7 +23,7 @@ func (p *planner) AlterTableLocality(
 ) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
 		ctx,
-		&p.ExecCfg().Settings.SV,
+		p.ExecCfg(),
 		"ALTER TABLE",
 	); err != nil {
 		return nil, err

--- a/pkg/sql/alter_table_set_schema.go
+++ b/pkg/sql/alter_table_set_schema.go
@@ -35,7 +35,7 @@ func (p *planner) AlterTableSetSchema(
 ) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
 		ctx,
-		&p.ExecCfg().Settings.SV,
+		p.ExecCfg(),
 		"ALTER TABLE/VIEW/SEQUENCE SET SCHEMA",
 	); err != nil {
 		return nil, err

--- a/pkg/sql/alter_type.go
+++ b/pkg/sql/alter_type.go
@@ -39,7 +39,7 @@ var _ planNode = &alterTypeNode{n: nil}
 func (p *planner) AlterType(ctx context.Context, n *tree.AlterType) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
 		ctx,
-		&p.ExecCfg().Settings.SV,
+		p.ExecCfg(),
 		"ALTER TYPE",
 	); err != nil {
 		return nil, err

--- a/pkg/sql/comment_on_column.go
+++ b/pkg/sql/comment_on_column.go
@@ -32,7 +32,7 @@ type commentOnColumnNode struct {
 func (p *planner) CommentOnColumn(ctx context.Context, n *tree.CommentOnColumn) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
 		ctx,
-		&p.ExecCfg().Settings.SV,
+		p.ExecCfg(),
 		"COMMENT ON COLUMN",
 	); err != nil {
 		return nil, err

--- a/pkg/sql/comment_on_database.go
+++ b/pkg/sql/comment_on_database.go
@@ -35,7 +35,7 @@ func (p *planner) CommentOnDatabase(
 ) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
 		ctx,
-		&p.ExecCfg().Settings.SV,
+		p.ExecCfg(),
 		"COMMENT ON DATABASE",
 	); err != nil {
 		return nil, err

--- a/pkg/sql/comment_on_index.go
+++ b/pkg/sql/comment_on_index.go
@@ -34,7 +34,7 @@ type commentOnIndexNode struct {
 func (p *planner) CommentOnIndex(ctx context.Context, n *tree.CommentOnIndex) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
 		ctx,
-		&p.ExecCfg().Settings.SV,
+		p.ExecCfg(),
 		"COMMENT ON INDEX",
 	); err != nil {
 		return nil, err

--- a/pkg/sql/comment_on_table.go
+++ b/pkg/sql/comment_on_table.go
@@ -34,7 +34,7 @@ type commentOnTableNode struct {
 func (p *planner) CommentOnTable(ctx context.Context, n *tree.CommentOnTable) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
 		ctx,
-		&p.ExecCfg().Settings.SV,
+		p.ExecCfg(),
 		"COMMENT ON TABLE",
 	); err != nil {
 		return nil, err

--- a/pkg/sql/create_database.go
+++ b/pkg/sql/create_database.go
@@ -33,7 +33,7 @@ type createDatabaseNode struct {
 func (p *planner) CreateDatabase(ctx context.Context, n *tree.CreateDatabase) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
 		ctx,
-		&p.ExecCfg().Settings.SV,
+		p.ExecCfg(),
 		"CREATE DATABASE",
 	); err != nil {
 		return nil, err

--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -47,7 +47,7 @@ type createIndexNode struct {
 func (p *planner) CreateIndex(ctx context.Context, n *tree.CreateIndex) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
 		ctx,
-		&p.ExecCfg().Settings.SV,
+		p.ExecCfg(),
 		"CREATE INDEX",
 	); err != nil {
 		return nil, err

--- a/pkg/sql/create_schema.go
+++ b/pkg/sql/create_schema.go
@@ -40,7 +40,7 @@ func (n *createSchemaNode) startExec(params runParams) error {
 func (p *planner) createUserDefinedSchema(params runParams, n *tree.CreateSchema) error {
 	if err := checkSchemaChangeEnabled(
 		p.EvalContext().Context,
-		&p.ExecCfg().Settings.SV,
+		p.ExecCfg(),
 		"CREATE SCHEMA",
 	); err != nil {
 		return err
@@ -184,7 +184,7 @@ func (n *createSchemaNode) Close(ctx context.Context)  {}
 func (p *planner) CreateSchema(ctx context.Context, n *tree.CreateSchema) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
 		ctx,
-		&p.ExecCfg().Settings.SV,
+		p.ExecCfg(),
 		"CREATE SCHEMA",
 	); err != nil {
 		return nil, err

--- a/pkg/sql/create_sequence.go
+++ b/pkg/sql/create_sequence.go
@@ -37,7 +37,7 @@ type createSequenceNode struct {
 func (p *planner) CreateSequence(ctx context.Context, n *tree.CreateSequence) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
 		ctx,
-		&p.ExecCfg().Settings.SV,
+		p.ExecCfg(),
 		"CREATE SEQUENCE",
 	); err != nil {
 		return nil, err

--- a/pkg/sql/create_type.go
+++ b/pkg/sql/create_type.go
@@ -55,7 +55,7 @@ var _ planNode = &createTypeNode{n: nil}
 func (p *planner) CreateType(ctx context.Context, n *tree.CreateType) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
 		ctx,
-		&p.ExecCfg().Settings.SV,
+		p.ExecCfg(),
 		"CREATE TYPE",
 	); err != nil {
 		return nil, err

--- a/pkg/sql/drop_database.go
+++ b/pkg/sql/drop_database.go
@@ -47,7 +47,7 @@ type dropDatabaseNode struct {
 func (p *planner) DropDatabase(ctx context.Context, n *tree.DropDatabase) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
 		ctx,
-		&p.ExecCfg().Settings.SV,
+		p.ExecCfg(),
 		"DROP DATABASE",
 	); err != nil {
 		return nil, err

--- a/pkg/sql/drop_index.go
+++ b/pkg/sql/drop_index.go
@@ -45,7 +45,7 @@ type dropIndexNode struct {
 func (p *planner) DropIndex(ctx context.Context, n *tree.DropIndex) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
 		ctx,
-		&p.ExecCfg().Settings.SV,
+		p.ExecCfg(),
 		"DROP INDEX",
 	); err != nil {
 		return nil, err

--- a/pkg/sql/drop_owned_by.go
+++ b/pkg/sql/drop_owned_by.go
@@ -28,7 +28,7 @@ type dropOwnedByNode struct {
 func (p *planner) DropOwnedBy(ctx context.Context) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
 		ctx,
-		&p.ExecCfg().Settings.SV,
+		p.ExecCfg(),
 		"DROP OWNED BY",
 	); err != nil {
 		return nil, err

--- a/pkg/sql/drop_schema.go
+++ b/pkg/sql/drop_schema.go
@@ -42,7 +42,7 @@ var _ planNode = &dropSchemaNode{n: nil}
 func (p *planner) DropSchema(ctx context.Context, n *tree.DropSchema) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
 		ctx,
-		&p.ExecCfg().Settings.SV,
+		p.ExecCfg(),
 		"DROP SCHEMA",
 	); err != nil {
 		return nil, err

--- a/pkg/sql/drop_sequence.go
+++ b/pkg/sql/drop_sequence.go
@@ -35,7 +35,7 @@ type dropSequenceNode struct {
 func (p *planner) DropSequence(ctx context.Context, n *tree.DropSequence) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
 		ctx,
-		&p.ExecCfg().Settings.SV,
+		p.ExecCfg(),
 		"DROP SEQUENCE",
 	); err != nil {
 		return nil, err

--- a/pkg/sql/drop_table.go
+++ b/pkg/sql/drop_table.go
@@ -50,7 +50,7 @@ type toDelete struct {
 func (p *planner) DropTable(ctx context.Context, n *tree.DropTable) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
 		ctx,
-		&p.ExecCfg().Settings.SV,
+		p.ExecCfg(),
 		"DROP TABLE",
 	); err != nil {
 		return nil, err

--- a/pkg/sql/drop_type.go
+++ b/pkg/sql/drop_type.go
@@ -39,7 +39,7 @@ var _ planNode = &dropTypeNode{n: nil}
 func (p *planner) DropType(ctx context.Context, n *tree.DropType) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
 		ctx,
-		&p.ExecCfg().Settings.SV,
+		p.ExecCfg(),
 		"DROP TYPE",
 	); err != nil {
 		return nil, err

--- a/pkg/sql/drop_view.go
+++ b/pkg/sql/drop_view.go
@@ -38,7 +38,7 @@ type dropViewNode struct {
 func (p *planner) DropView(ctx context.Context, n *tree.DropView) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
 		ctx,
-		&p.ExecCfg().Settings.SV,
+		p.ExecCfg(),
 		"DROP VIEW",
 	); err != nil {
 		return nil, err

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
+	"github.com/cockroachdb/cockroach/pkg/featureflag"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/keys"
@@ -724,6 +725,7 @@ type ExecutorConfig struct {
 	QueryCache        *querycache.C
 
 	SchemaChangerMetrics *SchemaChangerMetrics
+	FeatureFlagMetrics   *featureflag.DenialMetrics
 
 	TestingKnobs                  ExecutorTestingKnobs
 	PGWireTestingKnobs            *PGWireTestingKnobs
@@ -767,6 +769,16 @@ type ExecutorConfig struct {
 // Organization returns the value of cluster.organization.
 func (cfg *ExecutorConfig) Organization() string {
 	return ClusterOrganization.Get(&cfg.Settings.SV)
+}
+
+// GetFeatureFlagMetrics returns the value of the FeatureFlagMetrics struct.
+func (cfg *ExecutorConfig) GetFeatureFlagMetrics() *featureflag.DenialMetrics {
+	return cfg.FeatureFlagMetrics
+}
+
+// SV returns the setting values.
+func (cfg *ExecutorConfig) SV() *settings.Values {
+	return &cfg.Settings.SV
 }
 
 var _ base.ModuleTestingKnobs = &ExecutorTestingKnobs{}

--- a/pkg/sql/export.go
+++ b/pkg/sql/export.go
@@ -101,8 +101,8 @@ func (ef *execFactory) ConstructExport(
 
 	if err := featureflag.CheckEnabled(
 		ef.planner.EvalContext().Context,
+		ef.planner.execCfg,
 		featureExportEnabled,
-		&ef.planner.ExecCfg().Settings.SV,
 		"EXPORT",
 	); err != nil {
 		return nil, err

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1606,7 +1606,7 @@ func (ef *execFactory) ConstructCreateTable(
 ) (exec.Node, error) {
 	if err := checkSchemaChangeEnabled(
 		ef.planner.EvalContext().Context,
-		&ef.planner.ExecCfg().Settings.SV,
+		ef.planner.ExecCfg(),
 		"CREATE TABLE",
 	); err != nil {
 		return nil, err
@@ -1623,7 +1623,7 @@ func (ef *execFactory) ConstructCreateTableAs(
 ) (exec.Node, error) {
 	if err := checkSchemaChangeEnabled(
 		ef.planner.EvalContext().Context,
-		&ef.planner.ExecCfg().Settings.SV,
+		ef.planner.ExecCfg(),
 		"CREATE TABLE",
 	); err != nil {
 		return nil, err
@@ -1651,7 +1651,7 @@ func (ef *execFactory) ConstructCreateView(
 
 	if err := checkSchemaChangeEnabled(
 		ef.planner.EvalContext().Context,
-		&ef.planner.ExecCfg().Settings.SV,
+		ef.planner.ExecCfg(),
 		"CREATE VIEW",
 	); err != nil {
 		return nil, err
@@ -1726,7 +1726,7 @@ func (ef *execFactory) ConstructAlterTableSplit(
 ) (exec.Node, error) {
 	if err := checkSchemaChangeEnabled(
 		ef.planner.EvalContext().Context,
-		&ef.planner.ExecCfg().Settings.SV,
+		ef.planner.ExecCfg(),
 		"ALTER TABLE/INDEX SPLIT AT",
 	); err != nil {
 		return nil, err
@@ -1755,7 +1755,7 @@ func (ef *execFactory) ConstructAlterTableUnsplit(
 ) (exec.Node, error) {
 	if err := checkSchemaChangeEnabled(
 		ef.planner.EvalContext().Context,
-		&ef.planner.ExecCfg().Settings.SV,
+		ef.planner.ExecCfg(),
 		"ALTER TABLE/INDEX UNSPLIT AT",
 	); err != nil {
 		return nil, err
@@ -1776,7 +1776,7 @@ func (ef *execFactory) ConstructAlterTableUnsplit(
 func (ef *execFactory) ConstructAlterTableUnsplitAll(index cat.Index) (exec.Node, error) {
 	if err := checkSchemaChangeEnabled(
 		ef.planner.EvalContext().Context,
-		&ef.planner.ExecCfg().Settings.SV,
+		ef.planner.ExecCfg(),
 		"ALTER TABLE/INDEX UNSPLIT ALL",
 	); err != nil {
 		return nil, err
@@ -1849,8 +1849,8 @@ func (ef *execFactory) ConstructCreateStatistics(cs *tree.CreateStats) (exec.Nod
 	ctx := ef.planner.extendedEvalCtx.Context
 	if err := featureflag.CheckEnabled(
 		ctx,
+		ef.planner.ExecCfg(),
 		featureStatsEnabled,
-		&ef.planner.ExecCfg().Settings.SV,
 		"ANALYZE/CREATE STATISTICS",
 	); err != nil {
 		return nil, err

--- a/pkg/sql/reassign_owned_by.go
+++ b/pkg/sql/reassign_owned_by.go
@@ -33,7 +33,7 @@ type reassignOwnedByNode struct {
 func (p *planner) ReassignOwnedBy(ctx context.Context, n *tree.ReassignOwnedBy) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
 		ctx,
-		&p.ExecCfg().Settings.SV,
+		p.ExecCfg(),
 		"REASSIGN OWNED BY",
 	); err != nil {
 		return nil, err

--- a/pkg/sql/rename_column.go
+++ b/pkg/sql/rename_column.go
@@ -39,7 +39,7 @@ type renameColumnNode struct {
 func (p *planner) RenameColumn(ctx context.Context, n *tree.RenameColumn) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
 		ctx,
-		&p.ExecCfg().Settings.SV,
+		p.ExecCfg(),
 		"RENAME COLUMN",
 	); err != nil {
 		return nil, err

--- a/pkg/sql/rename_database.go
+++ b/pkg/sql/rename_database.go
@@ -45,7 +45,7 @@ type renameDatabaseNode struct {
 func (p *planner) RenameDatabase(ctx context.Context, n *tree.RenameDatabase) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
 		ctx,
-		&p.ExecCfg().Settings.SV,
+		p.ExecCfg(),
 		"ALTER DATABASE",
 	); err != nil {
 		return nil, err

--- a/pkg/sql/rename_index.go
+++ b/pkg/sql/rename_index.go
@@ -37,7 +37,7 @@ type renameIndexNode struct {
 func (p *planner) RenameIndex(ctx context.Context, n *tree.RenameIndex) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
 		ctx,
-		&p.ExecCfg().Settings.SV,
+		p.ExecCfg(),
 		"RENAME INDEX",
 	); err != nil {
 		return nil, err

--- a/pkg/sql/rename_table.go
+++ b/pkg/sql/rename_table.go
@@ -44,7 +44,7 @@ type renameTableNode struct {
 func (p *planner) RenameTable(ctx context.Context, n *tree.RenameTable) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
 		ctx,
-		&p.ExecCfg().Settings.SV,
+		p.ExecCfg(),
 		"RENAME TABLE/VIEW/SEQUENCE",
 	); err != nil {
 		return nil, err

--- a/pkg/sql/reparent_database.go
+++ b/pkg/sql/reparent_database.go
@@ -44,7 +44,7 @@ func (p *planner) ReparentDatabase(
 ) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
 		ctx,
-		&p.ExecCfg().Settings.SV,
+		p.ExecCfg(),
 		"REPARENT DATABASE",
 	); err != nil {
 		return nil, err

--- a/pkg/sql/schema_change_cluster_setting.go
+++ b/pkg/sql/schema_change_cluster_setting.go
@@ -18,7 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings"
 )
 
-// featureSchemaChangeEnabled is the cluste rsetting used to enable and disable
+// featureSchemaChangeEnabled is the cluster setting used to enable and disable
 // any features that require schema changes. Documentation for which features
 // are covered TBD.
 var featureSchemaChangeEnabled = settings.RegisterPublicBoolSetting(
@@ -29,12 +29,12 @@ var featureSchemaChangeEnabled = settings.RegisterPublicBoolSetting(
 // checkSchemaChangeEnabled is a method that wraps the featureflag.CheckEnabled
 // method specifically for all features that are categorized as schema changes.
 func checkSchemaChangeEnabled(
-	ctx context.Context, sv *settings.Values, schemaFeatureName string,
+	ctx context.Context, execCfg *ExecutorConfig, schemaFeatureName string,
 ) error {
 	if err := featureflag.CheckEnabled(
 		ctx,
+		execCfg,
 		featureSchemaChangeEnabled,
-		sv,
 		fmt.Sprintf("%s is part of the schema change category, which", schemaFeatureName),
 	); err != nil {
 		return err

--- a/pkg/sql/set_zone_config.go
+++ b/pkg/sql/set_zone_config.go
@@ -106,7 +106,7 @@ func loadYAML(dst interface{}, yamlString string) {
 func (p *planner) SetZoneConfig(ctx context.Context, n *tree.SetZoneConfig) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
 		ctx,
-		&p.ExecCfg().Settings.SV,
+		p.ExecCfg(),
 		"CONFIGURE ZONE",
 	); err != nil {
 		return nil, err

--- a/pkg/ts/catalog/catalog_generator.go
+++ b/pkg/ts/catalog/catalog_generator.go
@@ -369,19 +369,19 @@ func (ic *IndividualChart) addMetrics(
 // addNames sets the IndividualChart's Title, Longname, and CollectionName.
 func (ic *IndividualChart) addNames(organization []string) {
 
-	// Find string delimeters that are not dashes, including spaces, slashes, and
+	// Find string delimiters that are not dashes, including spaces, slashes, and
 	// commas.
-	nondashDelimeters := regexp.MustCompile("( )|/|,")
+	nondashDelimiters := regexp.MustCompile("( )|/|,")
 
-	// Longnames look like "SQL Layer | SQL | Connections".
-	// CollectionNames look like "sql-layer-sql-connections".
+	// LongTitles look like "SQL Layer | SQL | Connections".
+	// CollectionTitless look like "sql-layer-sql-connections".
 	for _, n := range organization {
 		ic.LongTitle += n + string(" | ")
-		ic.CollectionTitle += nondashDelimeters.ReplaceAllString(strings.ToLower(n), "-") + "-"
+		ic.CollectionTitle += nondashDelimiters.ReplaceAllString(strings.ToLower(n), "-") + "-"
 	}
 
 	ic.LongTitle += ic.Title
-	ic.CollectionTitle += nondashDelimeters.ReplaceAllString(strings.ToLower(ic.Title), "-")
+	ic.CollectionTitle += nondashDelimiters.ReplaceAllString(strings.ToLower(ic.Title), "-")
 
 }
 
@@ -495,29 +495,29 @@ func (cs *ChartSection) addChartAndSubsections(organization []string, ics []*Ind
 	// If not found, create a new ChartSection and append it as a subsection.
 	if subsection == nil {
 
-		// Find string delimeters that are not dashes, including spaces, slashes, and
+		// Find string delimiters that are not dashes, including spaces, slashes, and
 		// commas.
-		nondashDelimeters := regexp.MustCompile("( )|/|,")
+		nondashDelimiters := regexp.MustCompile("( )|/|,")
 
 		subsection = &ChartSection{
 			Title: organization[subsectionLevel],
-			// Longnames look like "SQL Layer | SQL".
+			// LongTitles look like "SQL Layer | SQL".
 			LongTitle: "All",
-			// CollectionNames look like "sql-layer-sql".
-			CollectionTitle: nondashDelimeters.ReplaceAllString(strings.ToLower(organization[0]), "-"),
+			// CollectionTitles look like "sql-layer-sql".
+			CollectionTitle: nondashDelimiters.ReplaceAllString(strings.ToLower(organization[0]), "-"),
 			Level:           int32(subsectionLevel),
 		}
 
-		// Complete Longname and Colectionname values.
+		// Complete LongTitle and CollectionTitle values.
 		for i := 1; i <= subsectionLevel; i++ {
 			subsection.LongTitle += " " + organization[i]
-			subsection.CollectionTitle += "-" + nondashDelimeters.ReplaceAllString(strings.ToLower(organization[i]), "-")
+			subsection.CollectionTitle += "-" + nondashDelimiters.ReplaceAllString(strings.ToLower(organization[i]), "-")
 		}
 
 		cs.Subsections = append(cs.Subsections, subsection)
 	}
 
-	// If this is the last level of the organization, add the IndividualChart here. Otheriwse, recurse.
+	// If this is the last level of the organization, add the IndividualChart here. Otherwise, recurse.
 	if subsectionLevel == (len(organization) - 1) {
 		subsection.Charts = append(subsection.Charts, ics...)
 	} else {

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -2029,6 +2029,17 @@ var charts = []sectionDescription{
 		},
 	},
 	{
+		Organization: [][]string{{SQLLayer, "SQL", "Feature Flag"}},
+		Charts: []chartDescription{
+			{
+				Title: "Feature Flag Denials",
+				Metrics: []string{
+					"sql.feature_flag_denial",
+				},
+			},
+		},
+	},
+	{
 		Organization: [][]string{{StorageLayer, "RocksDB", "Block Cache"}},
 		Charts: []chartDescription{
 			{

--- a/pkg/ui/src/util/docs.ts
+++ b/pkg/ui/src/util/docs.ts
@@ -48,6 +48,7 @@ export const nodeLivenessIssues = docsURL("cluster-setup-troubleshooting.html#no
 export const howItWork = docsURL("cockroach-quit.html#how-it-works");
 export const clusterStore = docsURL("cockroach-start.html#store");
 export const clusterGlossary = docsURL("architecture/overview.html#glossary");
+export const clusterSettings = docsURL("cluster-settings.html");
 export const reviewOfCockroachTerminology = docsURL("admin-ui-replication-dashboard.html#review-of-cockroachdb-terminology");
 export const privileges = docsURL("authorization.html#privileges");
 export const showSessions = docsURL("show-sessions.html");

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/graphTooltips.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/graphTooltips.tsx
@@ -105,3 +105,10 @@ export const LiveBytesGraphTooltip: React.FC<{ tooltipSelection?: string }> =
       </dd>
     </dl>
   </div>);
+
+export const StatementDenialsClusterSettingsTooltip: React.FC<{tooltipSelection?: string }> =
+  ({ tooltipSelection }) => (<div>
+    The total number of statements denied per second {tooltipSelection} due to a
+    <Anchor href={docsURL.clusterSettings}> cluster setting </Anchor>
+    in the format feature.statement_type.enabled = FALSE.
+  </div>);

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
@@ -15,6 +15,7 @@ import { LineGraph } from "src/views/cluster/components/linegraph";
 import { Metric, Axis, AxisUnits } from "src/views/shared/components/metricQuery";
 
 import { GraphDashboardProps, nodeDisplayName } from "./dashboardUtils";
+import { StatementDenialsClusterSettingsTooltip } from "src/views/cluster/containers/nodeGraphs/dashboards/graphTooltips";
 
 export default function (props: GraphDashboardProps) {
   const { nodeIDs, nodesSummary, nodeSources, tooltipSelection } = props;
@@ -290,6 +291,16 @@ export default function (props: GraphDashboardProps) {
     >
       <Axis label="statements">
         <Metric name="cr.node.sql.ddl.count" title="DDL Statements" nonNegativeRate />
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph
+      title="Statement Denials: Cluster Settings"
+      sources={nodeSources}
+      tooltip={< StatementDenialsClusterSettingsTooltip tooltipSelection={tooltipSelection} />}
+    >
+      <Axis label="statements">
+        <Metric name="cr.node.sql.feature_flag_denial" title="Statements Denied" nonNegativeRate />
       </Axis>
     </LineGraph>,
   ];


### PR DESCRIPTION
This change adds metrics for statement denials due to feature
flags set via cluster settings, and displays a timeseries graph
tracking this metric on the SQL Dashboard of DB Console.

![Feature Flag Denials Timeseries Graph on DB Console](https://user-images.githubusercontent.com/39155301/102151816-8a9b9c80-3e28-11eb-9193-0e9fb7b1796d.png)

Release note (ui change): Adds a timeseries graph indicating
statement denials due to feature flags on the SQL Dashboard of DB
Console.