### PR TITLE
catalogkv: use in-memory descriptors to validate in GetAllDescriptors

### DIFF
--- a/pkg/bench/ddl_analysis/BUILD.bazel
+++ b/pkg/bench/ddl_analysis/BUILD.bazel
@@ -27,6 +27,7 @@ go_test(
         "grant_revoke_bench_test.go",
         "grant_revoke_role_bench_test.go",
         "truncate_bench_test.go",
+        "virtual_table_bench_test.go",
     ],
     embed = [":ddl_analysis"],
     deps = [

--- a/pkg/bench/ddl_analysis/virtual_table_bench_test.go
+++ b/pkg/bench/ddl_analysis/virtual_table_bench_test.go
@@ -1,0 +1,44 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package bench
+
+import "testing"
+
+func BenchmarkVirtualTableQueries(b *testing.B) {
+	tests := []RoundTripBenchTestCase{
+		// This benchmark should perform exactly one kv operation to fetch all of
+		// the descriptors.
+		{
+			name: "select crdb_internal.tables with 1 fk",
+			setup: `
+CREATE TABLE t1 (i INT PRIMARY KEY);
+CREATE TABLE t2 (i INT PRIMARY KEY, j INT REFERENCES t1(i));
+`,
+			stmt: `SELECT * FROM "".crdb_internal.tables`,
+		},
+		{
+			// We expect this to perform, somewhat surprisingly, 8 kv operations.
+			// It performs one to fetch all of the descriptors initially. Then it
+			// gets all of the databases which is 3 reads, one for each namespace
+			// table and one to fetch all of the descriptors. Then it checks to see
+			// if any of the databases have descriptors (system, defaultdb, postgres,
+			// and test) schemas which is another 4, leaving 8.
+			name: "select crdb_internal.invalid_objects with 1 fk",
+			setup: `
+CREATE TABLE t1 (i INT PRIMARY KEY);
+CREATE TABLE t2 (i INT PRIMARY KEY, j INT REFERENCES t1(i));
+`,
+			stmt: `SELECT * FROM "".crdb_internal.invalid_objects`,
+		},
+	}
+
+	RunRoundTripBenchmark(b, tests)
+}

--- a/pkg/sql/catalog/descriptor.go
+++ b/pkg/sql/catalog/descriptor.go
@@ -86,6 +86,7 @@ type DatabaseDescriptor interface {
 	Regions() (descpb.Regions, error)
 	IsMultiRegion() bool
 	PrimaryRegion() (descpb.Region, error)
+	Validate() error
 }
 
 // SchemaDescriptor will eventually be called schemadesc.Descriptor.


### PR DESCRIPTION
In 20.2 we added logic to validate descriptors on the read path for getting
all descriptors and introduced a performance regression. In particular, we'd
now retrieve all databases and cross references for all tables. This stricter
validation has proven to be somewhat handy and has become utilized in some
tests to ensure that descriptors indeed are valid. Eliminating this validation
would thus be problematic. This is fortunately easy to resolve as we already
have all of the descriptors sitting in memory. With this change, we use them.
    
Fixes #57249.
    
In the previously added benchmark tracking the number of KV calls, the code
used to perform 32 reads and now perform 1 (the 32 mostly has to do with
resolving the system database when validating system tables).
    
Release note (bug fix): Fixed performance regression introduced in v20.2 to
reading virtual tables which introspect the schema.
