### PR TITLE
sql,catalogkv: cleanup to virtual table descriptor resolution

### DIFF
--- a/pkg/bench/ddl_analysis/virtual_table_bench_test.go
+++ b/pkg/bench/ddl_analysis/virtual_table_bench_test.go
@@ -25,12 +25,8 @@ CREATE TABLE t2 (i INT PRIMARY KEY, j INT REFERENCES t1(i));
 			stmt: `SELECT * FROM "".crdb_internal.tables`,
 		},
 		{
-			// We expect this to perform, somewhat surprisingly, 8 kv operations.
-			// It performs one to fetch all of the descriptors initially. Then it
-			// gets all of the databases which is 3 reads, one for each namespace
-			// table and one to fetch all of the descriptors. Then it checks to see
-			// if any of the databases have descriptors (system, defaultdb, postgres,
-			// and test) schemas which is another 4, leaving 8.
+			// We expect this to perform exactly one kv operation to fetch all of
+			// the descriptors.
 			name: "select crdb_internal.invalid_objects with 1 fk",
 			setup: `
 CREATE TABLE t1 (i INT PRIMARY KEY);

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -1660,7 +1660,7 @@ func (r *restoreResumer) dropDescriptors(
 	for _, schema := range details.SchemaDescs {
 		ignoredChildDescIDs[schema.ID] = struct{}{}
 	}
-	allDescs, err := descsCol.GetAllDescriptors(ctx, txn, true /* validate */)
+	allDescs, err := descsCol.GetAllDescriptors(ctx, txn)
 	if err != nil {
 		return err
 	}

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -1182,7 +1182,7 @@ func errOnMissingRange(span covering.Range, start, end hlc.Timestamp) error {
 func getUserDescriptorNames(
 	ctx context.Context, txn *kv.Txn, codec keys.SQLCodec,
 ) ([]string, error) {
-	allDescs, err := catalogkv.GetAllDescriptors(ctx, txn, codec, true /* validate */)
+	allDescs, err := catalogkv.GetAllDescriptors(ctx, txn, codec)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ccl/backupccl/targets.go
+++ b/pkg/ccl/backupccl/targets.go
@@ -701,7 +701,7 @@ func loadAllDescs(
 		ctx,
 		func(ctx context.Context, txn *kv.Txn) (err error) {
 			txn.SetFixedTimestamp(ctx, asOf)
-			allDescs, err = catalogkv.GetAllDescriptors(ctx, txn, codec, true /* validate */)
+			allDescs, err = catalogkv.GetAllDescriptors(ctx, txn, codec)
 			return err
 		}); err != nil {
 		return nil, err

--- a/pkg/sql/catalog/catalogkv/catalogkv.go
+++ b/pkg/sql/catalog/catalogkv/catalogkv.go
@@ -373,7 +373,7 @@ func unwrapDescriptorMutable(
 // CountUserDescriptors returns the number of descriptors present that were
 // created by the user (i.e. not present when the cluster started).
 func CountUserDescriptors(ctx context.Context, txn *kv.Txn, codec keys.SQLCodec) (int, error) {
-	allDescs, err := GetAllDescriptors(ctx, txn, codec, true /* validate */)
+	allDescs, err := GetAllDescriptors(ctx, txn, codec)
 	if err != nil {
 		return 0, err
 	}
@@ -388,7 +388,10 @@ func CountUserDescriptors(ctx context.Context, txn *kv.Txn, codec keys.SQLCodec)
 	return count, nil
 }
 
-func getAllDescriptorsUnvalidated(
+// GetAllDescriptorsUnvalidated looks up and returns all available descriptors
+// but does not validate them. It is exported solely to be used by functions
+// which want to perform explicit validation to detect corruption.
+func GetAllDescriptorsUnvalidated(
 	ctx context.Context, txn *kv.Txn, codec keys.SQLCodec,
 ) ([]catalog.Descriptor, error) {
 	log.Eventf(ctx, "fetching all descriptors")
@@ -419,21 +422,19 @@ func getAllDescriptorsUnvalidated(
 // GetAllDescriptors looks up and returns all available descriptors. If validate
 // is set to true, it will also validate them.
 func GetAllDescriptors(
-	ctx context.Context, txn *kv.Txn, codec keys.SQLCodec, validate bool,
+	ctx context.Context, txn *kv.Txn, codec keys.SQLCodec,
 ) ([]catalog.Descriptor, error) {
-	descs, err := getAllDescriptorsUnvalidated(ctx, txn, codec)
+	descs, err := GetAllDescriptorsUnvalidated(ctx, txn, codec)
 	if err != nil {
 		return nil, err
 	}
-	if validate {
-		dg := make(catalog.MapDescGetter, len(descs))
-		for _, desc := range descs {
-			dg[desc.GetID()] = desc
-		}
-		for _, desc := range descs {
-			if err := validateDescriptor(ctx, dg, desc); err != nil {
-				return nil, err
-			}
+	dg := make(catalog.MapDescGetter, len(descs))
+	for _, desc := range descs {
+		dg[desc.GetID()] = desc
+	}
+	for _, desc := range descs {
+		if err := validateDescriptor(ctx, dg, desc); err != nil {
+			return nil, err
 		}
 	}
 	return descs, nil
@@ -593,7 +594,7 @@ func MustGetSchemaDescByID(
 }
 
 func getDescriptorsFromIDs(
-	ctx context.Context, txn *kv.Txn, codec keys.SQLCodec, ids []descpb.ID, allowMissingDesc bool,
+	ctx context.Context, txn *kv.Txn, codec keys.SQLCodec, ids []descpb.ID,
 ) ([]catalog.Descriptor, error) {
 	b := txn.NewBatch()
 	for _, id := range ids {
@@ -630,7 +631,7 @@ func getDescriptorsFromIDs(
 			}
 		}
 
-		if catalogDesc == nil && !allowMissingDesc {
+		if catalogDesc == nil {
 			return nil, catalog.ErrDescriptorNotFound
 		}
 		results = append(results, catalogDesc)
@@ -645,9 +646,9 @@ func getDescriptorsFromIDs(
 // If the argument allowMissingDesc is true the function will tolerate nil
 // descriptors otherwise it will throw an error.
 func GetDatabaseDescriptorsFromIDs(
-	ctx context.Context, txn *kv.Txn, codec keys.SQLCodec, ids []descpb.ID, allowMissingDesc bool,
+	ctx context.Context, txn *kv.Txn, codec keys.SQLCodec, ids []descpb.ID,
 ) ([]*dbdesc.Immutable, error) {
-	descs, err := getDescriptorsFromIDs(ctx, txn, codec, ids, allowMissingDesc)
+	descs, err := getDescriptorsFromIDs(ctx, txn, codec, ids)
 	if err != nil {
 		return nil, err
 	}
@@ -655,9 +656,6 @@ func GetDatabaseDescriptorsFromIDs(
 	for i := range descs {
 		desc := descs[i]
 		if desc == nil {
-			if allowMissingDesc {
-				continue
-			}
 			return nil, catalog.ErrDescriptorNotFound
 		}
 		db, ok := desc.(*dbdesc.Immutable)
@@ -675,7 +673,7 @@ func GetDatabaseDescriptorsFromIDs(
 func GetSchemaDescriptorsFromIDs(
 	ctx context.Context, txn *kv.Txn, codec keys.SQLCodec, ids []descpb.ID,
 ) ([]*schemadesc.Immutable, error) {
-	descs, err := getDescriptorsFromIDs(ctx, txn, codec, ids, false /* allowMissingDesc */)
+	descs, err := getDescriptorsFromIDs(ctx, txn, codec, ids)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/catalog/catalogkv/catalogkv.go
+++ b/pkg/sql/catalog/catalogkv/catalogkv.go
@@ -287,8 +287,7 @@ func validateDescriptor(ctx context.Context, dg catalog.DescGetter, desc catalog
 	case catalog.DatabaseDescriptor:
 		return desc.Validate()
 	case catalog.TypeDescriptor:
-		// TODO(ajwerner): Validate type descriptor.
-		return nil
+		return desc.Validate(ctx, dg)
 	case catalog.SchemaDescriptor:
 		return nil
 	default:

--- a/pkg/sql/catalog/descriptor.go
+++ b/pkg/sql/catalog/descriptor.go
@@ -190,6 +190,7 @@ type TypeDescriptor interface {
 	GetIDClosure() map[descpb.ID]struct{}
 
 	PrimaryRegion() (descpb.Region, error)
+	Validate(ctx context.Context, dg DescGetter) error
 }
 
 // TypeDescriptorResolver is an interface used during hydration of type

--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -1215,10 +1215,10 @@ func (tc *Collection) getUncommittedDescriptorByID(id descpb.ID) catalog.Mutable
 // first checking the Collection's cached descriptors for validity if validate
 // is set to true before defaulting to a key-value scan, if necessary.
 func (tc *Collection) GetAllDescriptors(
-	ctx context.Context, txn *kv.Txn, validate bool,
+	ctx context.Context, txn *kv.Txn,
 ) ([]catalog.Descriptor, error) {
 	if tc.allDescriptors == nil {
-		descs, err := catalogkv.GetAllDescriptors(ctx, txn, tc.codec(), validate)
+		descs, err := catalogkv.GetAllDescriptors(ctx, txn, tc.codec())
 		if err != nil {
 			return nil, err
 		}
@@ -1314,7 +1314,7 @@ func HydrateGivenDescriptors(ctx context.Context, descs []catalog.Descriptor) er
 // If the argument allowMissingDesc is true, the function will return nil-s for
 // missing database descriptors.
 func (tc *Collection) GetAllDatabaseDescriptors(
-	ctx context.Context, txn *kv.Txn, allowMissingDesc bool,
+	ctx context.Context, txn *kv.Txn,
 ) ([]*dbdesc.Immutable, error) {
 	if tc.allDatabaseDescriptors == nil {
 		dbDescIDs, err := catalogkv.GetAllDatabaseDescriptorIDs(ctx, txn, tc.codec())
@@ -1322,7 +1322,7 @@ func (tc *Collection) GetAllDatabaseDescriptors(
 			return nil, err
 		}
 		dbDescs, err := catalogkv.GetDatabaseDescriptorsFromIDs(
-			ctx, txn, tc.codec(), dbDescIDs, allowMissingDesc,
+			ctx, txn, tc.codec(), dbDescIDs,
 		)
 		if err != nil {
 			return nil, err

--- a/pkg/sql/catalog/typedesc/type_desc.go
+++ b/pkg/sql/catalog/typedesc/type_desc.go
@@ -457,6 +457,11 @@ func (desc *Immutable) Validate(ctx context.Context, dg catalog.DescGetter) erro
 		}
 	}
 
+	// Don't validate cross-references for dropped descriptors.
+	if desc.Dropped() {
+		return nil
+	}
+
 	// Validate all cross references on the descriptor.
 
 	// Buffer all the requested requests and error checks together to run at once.

--- a/pkg/sql/drop_role.go
+++ b/pkg/sql/drop_role.go
@@ -150,7 +150,7 @@ func (n *DropRoleNode) startExec(params runParams) error {
 	// the predefined forEachTableAll() function because we need to look
 	// at all _visible_ descriptors, not just those on which the current
 	// user has permission.
-	descs, err := params.p.Descriptors().GetAllDescriptors(params.ctx, params.p.txn, true /* validate */)
+	descs, err := params.p.Descriptors().GetAllDescriptors(params.ctx, params.p.txn)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -1685,7 +1685,7 @@ https://www.postgresql.org/docs/current/infoschema-collation-character-set-appli
 func forEachSchema(
 	ctx context.Context, p *planner, db *dbdesc.Immutable, fn func(sc catalog.ResolvedSchema) error,
 ) error {
-	schemaNames, err := getSchemaNames(ctx, p, db, false /* allowMissingDesc */)
+	schemaNames, err := getSchemaNames(ctx, p, db)
 	if err != nil {
 		return err
 	}
@@ -1764,9 +1764,7 @@ func forEachDatabaseDesc(
 ) error {
 	var dbDescs []*dbdesc.Immutable
 	if dbContext == nil {
-		allDbDescs, err := p.Descriptors().GetAllDatabaseDescriptors(
-			ctx, p.txn, false, /* allowMissingDesc */
-		)
+		allDbDescs, err := p.Descriptors().GetAllDatabaseDescriptors(ctx, p.txn)
 		if err != nil {
 			return err
 		}
@@ -1775,7 +1773,7 @@ func forEachDatabaseDesc(
 		// We can't just use dbContext here because we need to fetch the descriptor
 		// with privileges from kv.
 		fetchedDbDesc, err := catalogkv.GetDatabaseDescriptorsFromIDs(
-			ctx, p.txn, p.ExecCfg().Codec, []descpb.ID{dbContext.GetID()}, false, /* allowMissingDesc */
+			ctx, p.txn, p.ExecCfg().Codec, []descpb.ID{dbContext.GetID()},
 		)
 		if err != nil {
 			if errors.Is(err, catalog.ErrDescriptorNotFound) {
@@ -1807,11 +1805,11 @@ func forEachTypeDesc(
 	dbContext *dbdesc.Immutable,
 	fn func(db *dbdesc.Immutable, sc string, typ *typedesc.Immutable) error,
 ) error {
-	descs, err := p.Descriptors().GetAllDescriptors(ctx, p.txn, true /* validate */)
+	descs, err := p.Descriptors().GetAllDescriptors(ctx, p.txn)
 	if err != nil {
 		return err
 	}
-	schemaNames, err := getSchemaNames(ctx, p, dbContext, false /* allowMissingDesc */)
+	schemaNames, err := getSchemaNames(ctx, p, dbContext)
 	if err != nil {
 		return err
 	}
@@ -1886,16 +1884,14 @@ func forEachTableDescAll(
 	virtualOpts virtualOpts,
 	fn func(*dbdesc.Immutable, string, catalog.TableDescriptor) error,
 ) error {
-	return forEachTableDescAllWithTableLookup(ctx,
-		p, dbContext, virtualOpts, true, /* validate */
-		func(
-			db *dbdesc.Immutable,
-			scName string,
-			table catalog.TableDescriptor,
-			_ tableLookupFn,
-		) error {
-			return fn(db, scName, table)
-		})
+	return forEachTableDescAllWithTableLookup(ctx, p, dbContext, virtualOpts, func(
+		db *dbdesc.Immutable,
+		scName string,
+		table catalog.TableDescriptor,
+		_ tableLookupFn,
+	) error {
+		return fn(db, scName, table)
+	})
 }
 
 // forEachTableDescAllWithTableLookup is like forEachTableDescAll, but it also
@@ -1907,11 +1903,11 @@ func forEachTableDescAllWithTableLookup(
 	p *planner,
 	dbContext *dbdesc.Immutable,
 	virtualOpts virtualOpts,
-	validate bool,
 	fn func(*dbdesc.Immutable, string, catalog.TableDescriptor, tableLookupFn) error,
 ) error {
-	return forEachTableDescWithTableLookupInternal(ctx,
-		p, dbContext, virtualOpts, true /* allowAdding */, validate, fn)
+	return forEachTableDescWithTableLookupInternal(
+		ctx, p, dbContext, virtualOpts, true /* allowAdding */, fn,
+	)
 }
 
 // forEachTableDescWithTableLookup acts like forEachTableDesc, except it also provides a
@@ -1931,26 +1927,23 @@ func forEachTableDescWithTableLookup(
 	fn func(*dbdesc.Immutable, string, catalog.TableDescriptor, tableLookupFn) error,
 ) error {
 	return forEachTableDescWithTableLookupInternal(
-		ctx, p, dbContext, virtualOpts, false /* allowAdding */, true, fn,
+		ctx, p, dbContext, virtualOpts, false /* allowAdding */, fn,
 	)
 }
 
 func getSchemaNames(
-	ctx context.Context, p *planner, dbContext *dbdesc.Immutable, allowMissingDesc bool,
+	ctx context.Context, p *planner, dbContext *dbdesc.Immutable,
 ) (map[descpb.ID]string, error) {
 	if dbContext != nil {
 		return p.Descriptors().GetSchemasForDatabase(ctx, p.txn, dbContext.GetID())
 	}
 	ret := make(map[descpb.ID]string)
-	dbs, err := p.Descriptors().GetAllDatabaseDescriptors(ctx, p.txn, allowMissingDesc)
+	dbs, err := p.Descriptors().GetAllDatabaseDescriptors(ctx, p.txn)
 	if err != nil {
 		return nil, err
 	}
 	for _, db := range dbs {
 		if db == nil {
-			if allowMissingDesc {
-				continue
-			}
 			return nil, catalog.ErrDescriptorNotFound
 		}
 		schemas, err := p.Descriptors().GetSchemasForDatabase(ctx, p.txn, db.GetID())
@@ -1977,13 +1970,25 @@ func forEachTableDescWithTableLookupInternal(
 	dbContext *dbdesc.Immutable,
 	virtualOpts virtualOpts,
 	allowAdding bool,
-	validate bool,
 	fn func(*dbdesc.Immutable, string, catalog.TableDescriptor, tableLookupFn) error,
 ) error {
-	descs, err := p.Descriptors().GetAllDescriptors(ctx, p.txn, validate)
+	descs, err := p.Descriptors().GetAllDescriptors(ctx, p.txn)
 	if err != nil {
 		return err
 	}
+	return forEachTableDescWithTableLookupInternalFromDescriptors(
+		ctx, p, dbContext, virtualOpts, allowAdding, descs, fn)
+}
+
+func forEachTableDescWithTableLookupInternalFromDescriptors(
+	ctx context.Context,
+	p *planner,
+	dbContext *dbdesc.Immutable,
+	virtualOpts virtualOpts,
+	allowAdding bool,
+	descs []catalog.Descriptor,
+	fn func(*dbdesc.Immutable, string, catalog.TableDescriptor, tableLookupFn) error,
+) error {
 	lCtx := newInternalLookupCtx(ctx, descs, dbContext,
 		catalogkv.NewOneLevelUncachedDescGetter(p.txn, p.execCfg.Codec))
 
@@ -2021,7 +2026,7 @@ func forEachTableDescWithTableLookupInternal(
 	}
 
 	// Generate all schema names, and keep a mapping.
-	schemaNames, err := getSchemaNames(ctx, p, dbContext, !validate)
+	schemaNames, err := getSchemaNames(ctx, p, dbContext)
 	if err != nil {
 		return err
 	}
@@ -2037,7 +2042,7 @@ func forEachTableDescWithTableLookupInternal(
 		if parentExists {
 			var ok bool
 			scName, ok = schemaNames[table.GetParentSchemaID()]
-			if !ok && validate {
+			if !ok {
 				return errors.AssertionFailedf("schema id %d not found", table.GetParentSchemaID())
 			}
 		}

--- a/pkg/sql/reassign_owned_by.go
+++ b/pkg/sql/reassign_owned_by.go
@@ -56,7 +56,7 @@ func (p *planner) ReassignOwnedBy(ctx context.Context, n *tree.ReassignOwnedBy) 
 func (n *reassignOwnedByNode) startExec(params runParams) error {
 	telemetry.Inc(sqltelemetry.CreateReassignOwnedByCounter())
 
-	allDescs, err := params.p.Descriptors().GetAllDescriptors(params.ctx, params.p.txn, true /* validate */)
+	allDescs, err := params.p.Descriptors().GetAllDescriptors(params.ctx, params.p.txn)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -657,6 +657,7 @@ type internalLookupCtx struct {
 	dbIDs       []descpb.ID
 	dbDescs     map[descpb.ID]*dbdesc.Immutable
 	schemaDescs map[descpb.ID]*schemadesc.Immutable
+	schemaNames map[descpb.ID]string
 	schemaIDs   []descpb.ID
 	tbDescs     map[descpb.ID]*tabledesc.Immutable
 	tbIDs       []descpb.ID
@@ -743,6 +744,9 @@ func newInternalLookupCtx(
 	dbNames := make(map[descpb.ID]string)
 	dbDescs := make(map[descpb.ID]*dbdesc.Immutable)
 	schemaDescs := make(map[descpb.ID]*schemadesc.Immutable)
+	schemaNames := map[descpb.ID]string{
+		keys.PublicSchemaID: tree.PublicSchema,
+	}
 	tbDescs := make(map[descpb.ID]*tabledesc.Immutable)
 	typDescs := make(map[descpb.ID]*typedesc.Immutable)
 	var tbIDs, typIDs, dbIDs, schemaIDs []descpb.ID
@@ -773,6 +777,7 @@ func newInternalLookupCtx(
 			if prefix == nil || prefix.GetID() == desc.ParentID {
 				// Only make the schema visible for iteration if the prefix was included.
 				schemaIDs = append(schemaIDs, desc.GetID())
+				schemaNames[desc.GetID()] = desc.GetName()
 			}
 		}
 	}
@@ -781,6 +786,7 @@ func newInternalLookupCtx(
 		dbNames:     dbNames,
 		dbDescs:     dbDescs,
 		schemaDescs: schemaDescs,
+		schemaNames: schemaNames,
 		schemaIDs:   schemaIDs,
 		tbDescs:     tbDescs,
 		typDescs:    typDescs,


### PR DESCRIPTION
See individual commits. Enables validation of type descriptors (a rather wild oversight). Before this PR we didn't validate type descriptors on read the way we validate the other descriptors.