### PR TITLE
jobs: quiet logging an error when context is canceled

### DIFF
--- a/pkg/jobs/adopt.go
+++ b/pkg/jobs/adopt.go
@@ -251,7 +251,10 @@ func (r *Registry) runJob(
 
 	// Run the actual job.
 	err := r.stepThroughStateMachine(ctx, execCtx, resumer, resultsCh, job, status, finalResumeError)
-	if err != nil {
+	// If the context has been canceled, disregard errors for the sake of logging
+	// as presumably they are due to the context cancellation which commonly
+	// happens during shutdown.
+	if err != nil && ctx.Err() == nil {
 		log.Errorf(ctx, "job %d: adoption completed with error %v", *job.ID(), err)
 	}
 	r.unregister(*job.ID())


### PR DESCRIPTION
This was showing up during shutdown. Presumably this indicates that we should
be waiting for these jobs to terminate and is a hint that there's a graceful
shutdown problem, however, we already know that we have these.

Release note: None