### PR TITLE
sql: fix CREATE TEMP TABLE AS to preserve temp

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/create_as
+++ b/pkg/sql/logictest/testdata/logic_test/create_as
@@ -362,3 +362,16 @@ SELECT * FROM t
 ----
 1  1  false
 2  2  true
+
+# Regression test for TEMP in CREATE ... AS (#56733)
+statement ok
+SET experimental_enable_temp_tables = 'on';
+CREATE TEMP TABLE abcd_tmp AS SELECT a from abcd;
+
+query TT
+SHOW CREATE TABLE abcd_tmp
+----
+abcd_tmp  CREATE TEMP TABLE abcd_tmp (
+          a INT8 NULL,
+          FAMILY "primary" (a, rowid)
+)

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -4432,6 +4432,7 @@ create_table_as_stmt:
       AsSource: $8.slct(),
       StorageParams: $6.storageParams(),
       OnCommit: $10.createTableOnCommitSetting(),
+      Temporary: $2.persistenceType(),
     }
   }
 | CREATE opt_temp_create_table TABLE IF NOT EXISTS table_name create_as_opt_col_list opt_table_with AS select_stmt opt_create_as_data opt_create_table_on_commit
@@ -4445,6 +4446,7 @@ create_table_as_stmt:
       AsSource: $11.slct(),
       StorageParams: $9.storageParams(),
       OnCommit: $13.createTableOnCommitSetting(),
+      Temporary: $2.persistenceType(),
     }
   }
 


### PR DESCRIPTION
fixes #56733 

Release note (bug fix): The CREATE TEMP TABLE AS statement previously
created a non-temporary table. Now it makes a temporary one.
