### PR TITLE
build: tweak the TC test runner to detect package fails

### DIFF
--- a/build/teamcity-support.sh
+++ b/build/teamcity-support.sh
@@ -35,9 +35,6 @@ run_counter=-1
 function run_json_test() {
   run_counter=$((run_counter+1))
   tc_start_block "prep"
-  # TODO(tbg): better to go through builder for all of this.
-  go install github.com/cockroachdb/cockroach/pkg/cmd/testfilter
-  go install github.com/cockroachdb/cockroach/pkg/cmd/github-post
   mkdir -p artifacts
   tmpfile="artifacts/raw.${run_counter}.json.txt"
   tc_end_block "prep"
@@ -46,7 +43,7 @@ function run_json_test() {
   set +e
   run "$@" 2>&1 \
     | tee "${tmpfile}" \
-    | testfilter -mode=strip \
+    | (cd "$root"/pkg/cmd/testfilter && go run main.go -mode=strip) \
     | tee artifacts/stripped.txt
   status=$?
   set -e
@@ -77,7 +74,8 @@ function run_json_test() {
 
   tc_start_block "artifacts"
   # Create (or append to) failures.txt artifact and delete stripped.txt.
-  testfilter -mode=omit < artifacts/stripped.txt | testfilter -mode convert >> artifacts/failures.txt
+  (cd "$root"/pkg/cmd/testfilter && go run main.go -mode=omit) < artifacts/stripped.txt | \
+      (cd "$root"/pkg/cmd/testfilter && go run main.go -mode=convert) >> artifacts/failures.txt
 
   if [ $status -ne 0 ]; then
     # Keep the debug file around for failed builds. Compress it to avoid
@@ -89,7 +87,7 @@ function run_json_test() {
     # around in $tmpfile itself when anything else we don't handle well happens,
     # whatever that may be.
     fullfile=artifacts/full_output.txt
-    testfilter -mode convert < "${tmpfile}" >> "${fullfile}"
+    (cd "$root"/pkg/cmd/testfilter && go run main.go -mode=convert) < "${tmpfile}" >> "${fullfile}"
     tar --strip-components 1 -czf "${tmpfile}.tgz" "${tmpfile}" "${fullfile}"
     rm -f "${fullfile}"
   fi

--- a/pkg/cmd/testfilter/testdata/omit.txt
+++ b/pkg/cmd/testfilter/testdata/omit.txt
@@ -57,6 +57,8 @@ omit
 {"Time":"2019-11-29T14:21:47.595977+01:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"TestFaker","Output":"--- FAIL: TestFaker (0.00s)\n"}
 {"Time":"2019-11-29T14:21:47.595982+01:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"TestFaker","Output":"    stopper_test.go:379: failed\n"}
 {"Time":"2019-11-29T14:21:47.595991+01:00","Action":"fail","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"TestFaker","Elapsed":0}
+{"Time":"2019-11-29T14:21:47.596863+01:00","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"PackageLevel","Elapsed":1.593,"Output":""}
+{"Time":"2019-11-29T14:21:47.596863+01:00","Action":"fail","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"PackageLevel","Elapsed":1.593,"Output":"\nCheck full_output.txt in artifacts for stray panics or other errors that broke the test process."}
 
 # Keeps panicking test.
 omit

--- a/pkg/cmd/testfilter/testdata/strip.txt
+++ b/pkg/cmd/testfilter/testdata/strip.txt
@@ -36,8 +36,8 @@ and
 this
 {"Time":"2019-11-29T14:20:13.25826+01:00","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"TestFaker"}
 {"Time":"2019-11-29T14:20:13.258508+01:00","Action":"pass","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"TestFaker","Elapsed":0}
-{"Time":"2019-11-29T14:20:13.258518+01:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Output":"PASS\n"}
-{"Time":"2019-11-29T14:20:13.258539+01:00","Action":"pass","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Elapsed":0}
+{"Time":"2019-11-29T14:20:13.258518+01:00","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"PackageLevel","Elapsed":0,"Output":""}
+{"Time":"2019-11-29T14:20:13.258539+01:00","Action":"pass","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"PackageLevel","Elapsed":0,"Output":""}
 too
 the following test is unterminated and thus kept:
 {"Time":"2019-11-29T14:20:13.25826+01:00","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"TestFaker"}
@@ -63,9 +63,10 @@ strip
 {"Time":"2019-11-29T14:21:47.595977+01:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"TestFaker","Output":"--- FAIL: TestFaker (0.00s)\n"}
 {"Time":"2019-11-29T14:21:47.595982+01:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"TestFaker","Output":"    stopper_test.go:379: failed\n"}
 {"Time":"2019-11-29T14:21:47.595991+01:00","Action":"fail","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"TestFaker","Elapsed":0}
-{"Time":"2019-11-29T14:21:47.596002+01:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Output":"FAIL\n"}
-{"Time":"2019-11-29T14:21:47.59685+01:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Output":"FAIL\tgithub.com/cockroachdb/cockroach/pkg/util/stop\t1.593s\n"}
-{"Time":"2019-11-29T14:21:47.596863+01:00","Action":"fail","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Elapsed":1.593}
+{"Time":"2019-11-29T14:21:47.596002+01:00","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"PackageLevel","Elapsed":0,"Output":""}
+{"Time":"2019-11-29T14:21:47.596002+01:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"PackageLevel","Elapsed":0,"Output":"FAIL\n"}
+{"Time":"2019-11-29T14:21:47.59685+01:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"PackageLevel","Elapsed":0,"Output":"FAIL\tgithub.com/cockroachdb/cockroach/pkg/util/stop\t1.593s\n"}
+{"Time":"2019-11-29T14:21:47.596863+01:00","Action":"fail","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"PackageLevel","Elapsed":1.593,"Output":"\nCheck full_output.txt in artifacts for stray panics or other errors that broke the test process."}
 
 # Keeps panicking test.
 strip
@@ -100,3 +101,32 @@ strip
 {"Time":"2019-11-29T14:16:10.379153+01:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"TestFaker","Output":"\t/usr/local/Cellar/go/1.13.4/libexec/src/runtime/panic.go:679 +0x1b2\n"}
 {"Time":"2019-11-29T14:16:10.38139+01:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"TestFaker","Output":"FAIL\tgithub.com/cockroachdb/cockroach/pkg/util/stop\t1.421s\n"}
 {"Time":"2019-11-29T14:16:10.381438+01:00","Action":"fail","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"TestFaker","Elapsed":1.421}
+
+# Keeps panicking package.
+strip
+{"Time":"2019-11-29T14:16:10.376429+01:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/stop"}
+{"Time":"2019-11-29T14:16:10.381438+01:00","Action":"fail","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Elapsed":1.421}
+----
+{"Time":"2019-11-29T14:16:10.376429+01:00","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"PackageLevel","Elapsed":0,"Output":""}
+{"Time":"2019-11-29T14:16:10.376429+01:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"PackageLevel","Elapsed":0,"Output":""}
+{"Time":"2019-11-29T14:16:10.381438+01:00","Action":"fail","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"PackageLevel","Elapsed":1.421,"Output":"\nCheck full_output.txt in artifacts for stray panics or other errors that broke the test process."}
+
+# Keeps panicking package, and include unfinished tests, but not sub-tests.
+strip
+{"Time":"2019-11-29T14:16:10.376429+01:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/stop"}
+{"Time":"2019-11-29T14:16:10.376429+01:00","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"TestFaker"}
+{"Time":"2019-11-29T14:16:10.37671+01:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"TestFaker","Output":"=== RUN   TestFaker\n"}
+{"Time":"2019-11-29T14:16:10.376429+01:00","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"TestFaker/subtest"}
+{"Time":"2019-11-29T14:16:10.37671+01:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"TestFaker/subtest","Output":"=== RUN   TestFaker/subtest\n"}
+{"Time":"2019-11-29T14:16:10.381438+01:00","Action":"fail","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Elapsed":1.421}
+----
+----
+{"Time":"2019-11-29T14:16:10.376429+01:00","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"TestFaker"}
+{"Time":"2019-11-29T14:16:10.37671+01:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"TestFaker","Output":"=== RUN   TestFaker\n"}
+{"Time":"2019-11-29T14:16:10.381438+01:00","Action":"skip","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"TestFaker","Elapsed":0,"Output":"unfinished due to package-level failure\nCheck full_output.txt in artifacts for stray panics or other errors that broke the test process."}
+
+{"Time":"2019-11-29T14:16:10.376429+01:00","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"PackageLevel","Elapsed":0,"Output":""}
+{"Time":"2019-11-29T14:16:10.376429+01:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"PackageLevel","Elapsed":0,"Output":""}
+{"Time":"2019-11-29T14:16:10.381438+01:00","Action":"fail","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"PackageLevel","Elapsed":1.421,"Output":"\nCheck full_output.txt in artifacts for stray panics or other errors that broke the test process.\nThe following tests have not completed and could be the cause of the failure:\nTestFaker"}
+----
+----


### PR DESCRIPTION
Workaround for the issue identified in #57516

(I'm including the "panic" logic test to exercise this, I'll remove it before merging if it works)