### PR TITLE
sql: remove `local` option to `SET TRACING`

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender_server_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender_server_test.go
@@ -152,7 +152,7 @@ func TestNoDuplicateHeartbeatLoops(t *testing.T) {
 
 	tracer := tracing.NewTracer()
 	sp := tracer.StartSpan("test", tracing.WithForceRealSpan())
-	sp.StartRecording(tracing.SingleNodeRecording)
+	sp.StartRecording(tracing.SnowballRecording)
 	txnCtx := tracing.ContextWithSpan(context.Background(), sp)
 
 	push := func(ctx context.Context, key roachpb.Key) error {

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -12570,7 +12570,7 @@ func TestLaterReproposalsDoNotReuseContext(t *testing.T) {
 	tracedCtx := tracing.ContextWithSpan(ctx, sp)
 	// Go out of our way to enable recording so that expensive logging is enabled
 	// for this context.
-	sp.StartRecording(tracing.SingleNodeRecording)
+	sp.StartRecording(tracing.SnowballRecording)
 	ch, _, _, pErr := tc.repl.evalAndPropose(tracedCtx, &ba, allSpansGuard(), &lease)
 	if pErr != nil {
 		t.Fatal(pErr)

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -1287,8 +1287,6 @@ func (ex *connExecutor) enableTracing(modes []string) error {
 			enableMode = false
 		case "kv":
 			traceKV = true
-		case "local":
-			recordingType = tracing.SingleNodeRecording
 		case "cluster":
 			recordingType = tracing.SnowballRecording
 		default:

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1375,8 +1375,8 @@ func WithAnonymizedStatement(err error, stmt tree.Statement) error {
 		"while executing: %s", errors.Safe(anonStmtStr))
 }
 
-// SessionTracing holds the state used by SET TRACING {ON,OFF,LOCAL} statements in
-// the context of one SQL session.
+// SessionTracing holds the state used by SET TRACING statements in the context
+// of one SQL session.
 // It holds the current trace being collected (or the last trace collected, if
 // tracing is not currently ongoing).
 //
@@ -1474,9 +1474,6 @@ func (st *SessionTracing) StartTracing(
 				comma = ", "
 			}
 			recOption := "cluster"
-			if recType == tracing.SingleNodeRecording {
-				recOption = "local"
-			}
 			fmt.Fprintf(&desiredOptions, "%s%s", comma, recOption)
 
 			err := pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
@@ -1563,11 +1560,6 @@ func (st *SessionTracing) StopTracing() error {
 	var err error
 	st.lastRecording, err = generateSessionTraceVTable(spans)
 	return err
-}
-
-// RecordingType returns which type of tracing is currently being done.
-func (st *SessionTracing) RecordingType() tracing.RecordingType {
-	return st.recordingType
 }
 
 // KVTracingEnabled checks whether KV tracing is currently enabled.

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -4119,7 +4119,7 @@ set_exprs_internal:
 // SET [SESSION] <var> { TO | = } <values...>
 // SET [SESSION] TIME ZONE <tz>
 // SET [SESSION] CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL { SNAPSHOT | SERIALIZABLE }
-// SET [SESSION] TRACING { TO | = } { on | off | cluster | local | kv | results } [,...]
+// SET [SESSION] TRACING { TO | = } { on | off | cluster | kv | results } [,...]
 //
 // %SeeAlso: SHOW SESSION, RESET, DISCARD, SHOW, SET CLUSTER SETTING, SET TRANSACTION,
 // WEBDOCS/set-vars.html

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -34,7 +34,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
-	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 )
 
@@ -1012,9 +1011,6 @@ var varGen = map[string]sessionVar{
 			sessTracing := evalCtx.Tracing
 			if sessTracing.Enabled() {
 				val := "on"
-				if sessTracing.RecordingType() == tracing.SingleNodeRecording {
-					val += ", local"
-				}
 				if sessTracing.KVTracingEnabled() {
 					val += ", kv"
 				}

--- a/pkg/util/log/ambient_context_test.go
+++ b/pkg/util/log/ambient_context_test.go
@@ -48,7 +48,7 @@ func TestAnnotateCtxSpan(t *testing.T) {
 	// Annotate a context that has an open span.
 
 	sp1 := tracer.StartSpan("root", tracing.WithForceRealSpan())
-	sp1.StartRecording(tracing.SingleNodeRecording)
+	sp1.StartRecording(tracing.SnowballRecording)
 	ctx1 := tracing.ContextWithSpan(context.Background(), sp1)
 	Event(ctx1, "a")
 
@@ -61,10 +61,11 @@ func TestAnnotateCtxSpan(t *testing.T) {
 
 	if err := tracing.TestingCheckRecordedSpans(sp1.GetRecording(), `
 		Span root:
+			tags: sb=1
 			event: a
 			event: c
 		Span child:
-			tags: ambient=
+			tags: ambient= sb=1
 			event: [ambient] b
 	`); err != nil {
 		t.Fatal(err)

--- a/pkg/util/log/trace_test.go
+++ b/pkg/util/log/trace_test.go
@@ -66,7 +66,7 @@ func TestTrace(t *testing.T) {
 
 	tracer := tracing.NewTracer()
 	sp := tracer.StartSpan("s", tracing.WithForceRealSpan())
-	sp.StartRecording(tracing.SingleNodeRecording)
+	sp.StartRecording(tracing.SnowballRecording)
 	ctxWithSpan := tracing.ContextWithSpan(ctx, sp)
 	Event(ctxWithSpan, "test1")
 	VEvent(ctxWithSpan, noLogV(), "test2")
@@ -80,6 +80,7 @@ func TestTrace(t *testing.T) {
 
 	if err := tracing.TestingCheckRecordedSpans(sp.GetRecording(), `
 		Span s:
+		  tags: sb=1
 		  event: test1
 		  event: test2
 		  event: testerr
@@ -96,7 +97,7 @@ func TestTraceWithTags(t *testing.T) {
 	tracer := tracing.NewTracer()
 	sp := tracer.StartSpan("s", tracing.WithForceRealSpan())
 	ctxWithSpan := tracing.ContextWithSpan(ctx, sp)
-	sp.StartRecording(tracing.SingleNodeRecording)
+	sp.StartRecording(tracing.SnowballRecording)
 
 	Event(ctxWithSpan, "test1")
 	VEvent(ctxWithSpan, noLogV(), "test2")
@@ -106,6 +107,7 @@ func TestTraceWithTags(t *testing.T) {
 	sp.Finish()
 	if err := tracing.TestingCheckRecordedSpans(sp.GetRecording(), `
 		Span s:
+		  tags: sb=1
 		  event: [tag=1] test1
 		  event: [tag=1] test2
 		  event: [tag=1] testerr
@@ -181,7 +183,7 @@ func TestEventLogAndTrace(t *testing.T) {
 
 	tracer := tracing.NewTracer()
 	sp := tracer.StartSpan("s", tracing.WithForceRealSpan())
-	sp.StartRecording(tracing.SingleNodeRecording)
+	sp.StartRecording(tracing.SnowballRecording)
 	ctxWithBoth := tracing.ContextWithSpan(ctxWithEventLog, sp)
 	// Events should only go to the trace.
 	Event(ctxWithBoth, "test3")
@@ -196,6 +198,7 @@ func TestEventLogAndTrace(t *testing.T) {
 
 	if err := tracing.TestingCheckRecordedSpans(sp.GetRecording(), `
 		Span s:
+		  tags: sb=1
 		  event: test3
 		  event: test4
 		  event: test5err

--- a/pkg/util/tracing/recording.go
+++ b/pkg/util/tracing/recording.go
@@ -40,12 +40,6 @@ const (
 	// their own recording, and this recording will be included in that of
 	// any local parent spans.
 	SnowballRecording
-	// SingleNodeRecording means that the Span is recording and that locally
-	// derived spans will as well (i.e. a remote Span typically won't be
-	// recording by default, in contrast to SnowballRecording). Similar to
-	// SnowballRecording, children have their own recording which is also
-	// included in that of their parents.
-	SingleNodeRecording
 )
 
 type traceLogData struct {

--- a/pkg/util/tracing/tags_test.go
+++ b/pkg/util/tracing/tags_test.go
@@ -25,11 +25,11 @@ func TestLogTags(t *testing.T) {
 	l := logtags.SingleTagBuffer("tag1", "val1")
 	l = l.Add("tag2", "val2")
 	sp1 := tr.StartSpan("foo", WithForceRealSpan(), WithLogTags(l))
-	sp1.StartRecording(SingleNodeRecording)
+	sp1.StartRecording(SnowballRecording)
 	sp1.Finish()
 	require.NoError(t, TestingCheckRecordedSpans(sp1.GetRecording(), `
 		Span foo:
-		  tags: tag1=val1 tag2=val2
+		  tags: sb=1 tag1=val1 tag2=val2
 	`))
 	require.NoError(t, shadowTracer.expectSingleSpanWithTags("tag1", "tag2"))
 	shadowTracer.clear()
@@ -38,21 +38,21 @@ func TestLogTags(t *testing.T) {
 	RegisterTagRemapping("tag2", "two")
 
 	sp2 := tr.StartSpan("bar", WithForceRealSpan(), WithLogTags(l))
-	sp2.StartRecording(SingleNodeRecording)
+	sp2.StartRecording(SnowballRecording)
 	sp2.Finish()
 	require.NoError(t, TestingCheckRecordedSpans(sp2.GetRecording(), `
 		Span bar:
-			tags: one=val1 two=val2
+			tags: one=val1 sb=1 two=val2
 	`))
 	require.NoError(t, shadowTracer.expectSingleSpanWithTags("one", "two"))
 	shadowTracer.clear()
 
 	sp3 := tr.StartSpan("baz", WithLogTags(l), WithForceRealSpan())
-	sp3.StartRecording(SingleNodeRecording)
+	sp3.StartRecording(SnowballRecording)
 	sp3.Finish()
 	require.NoError(t, TestingCheckRecordedSpans(sp3.GetRecording(), `
 		Span baz:
-			tags: one=val1 two=val2
+			tags: one=val1 sb=1 two=val2
 	`))
 	require.NoError(t, shadowTracer.expectSingleSpanWithTags("one", "two"))
 }


### PR DESCRIPTION
The `local` option creates a recording span whose child spans
are not recording. We weren't meaningfully using it, and it
adds cognitive overhead, so remove it.

Closes #55585.
Closes #55586.

Release note (sql change): The "local" option to `SET TRACING` was
removed.
