### PR TITLE
sql: disallow admins from dropping system tables

### DIFF
--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -626,7 +626,13 @@ func (p *planner) checkCanAlterToNewOwner(
 // HasOwnershipOnSchema checks if the current user has ownership on the schema.
 // For schemas, we cannot always use HasOwnership as not every schema has a
 // descriptor.
-func (p *planner) HasOwnershipOnSchema(ctx context.Context, schemaID descpb.ID) (bool, error) {
+func (p *planner) HasOwnershipOnSchema(
+	ctx context.Context, schemaID descpb.ID, dbID descpb.ID,
+) (bool, error) {
+	if dbID == keys.SystemDatabaseID {
+		// Only the node user has ownership over the system database.
+		return p.User().IsNodeUser(), nil
+	}
 	resolvedSchema, err := p.Descriptors().ResolveSchemaByID(
 		ctx, p.Txn(), schemaID,
 	)

--- a/pkg/sql/drop_table.go
+++ b/pkg/sql/drop_table.go
@@ -199,7 +199,8 @@ func (p *planner) canDropTable(
 	// error if we tried to check for ownership on the schema.
 	if checkOwnership {
 		// If the user owns the schema the table is part of, they can drop the table.
-		hasOwnership, err = p.HasOwnershipOnSchema(ctx, tableDesc.GetParentSchemaID())
+		hasOwnership, err = p.HasOwnershipOnSchema(
+			ctx, tableDesc.GetParentSchemaID(), tableDesc.GetParentID())
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/logictest/testdata/logic_test/system
+++ b/pkg/sql/logictest/testdata/logic_test/system
@@ -448,6 +448,9 @@ ALTER DATABASE system RENAME TO not_system
 statement error user root does not have DROP privilege on database system
 DROP DATABASE system
 
+statement error user root does not have DROP privilege on relation users
+DROP TABLE system.users
+
 statement error user root does not have ALL privilege on database system
 GRANT ALL ON DATABASE system TO testuser
 


### PR DESCRIPTION
Release note (bug fix): In the v20.2.0 release we mistakenly permitted
users with the admin role to drop tables in the system database. This
commit revokes that privilege.