### PR TITLE
rowenc: don't panic during EncDatum creation

### DIFF
--- a/pkg/ccl/changefeedccl/avro.go
+++ b/pkg/ccl/changefeedccl/avro.go
@@ -545,7 +545,10 @@ func (r *avroDataRecord) rowFromNative(native interface{}) (rowenc.EncDatumRow, 
 		if err != nil {
 			return nil, err
 		}
-		row[r.colIdxByFieldIdx[fieldIdx]] = rowenc.DatumToEncDatum(field.typ, decoded)
+		row[r.colIdxByFieldIdx[fieldIdx]], err = rowenc.DatumToEncDatum(field.typ, decoded)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return row, nil
 }

--- a/pkg/sql/colexec/types_integration_test.go
+++ b/pkg/sql/colexec/types_integration_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -69,9 +70,11 @@ func TestSQLTypesIntegration(t *testing.T) {
 			coldata.BatchSize() + 1,
 		} {
 			rows := make(rowenc.EncDatumRows, numRows)
+			var err error
 			for i := 0; i < numRows; i++ {
 				rows[i] = make(rowenc.EncDatumRow, 1)
-				rows[i][0] = rowenc.DatumToEncDatum(typ, rowenc.RandDatum(rng, typ, true /* nullOk */))
+				rows[i][0], err = rowenc.DatumToEncDatum(typ, rowenc.RandDatum(rng, typ, true /* nullOk */))
+				assert.NoError(t, err)
 			}
 			typs := []*types.T{typ}
 			source := execinfra.NewRepeatableRowSource(typs, rows)

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -2915,7 +2915,10 @@ func (dsp *DistSQLPlanner) createValuesSpecFromTuples(
 			if err != nil {
 				return nil, err
 			}
-			encDatum := rowenc.DatumToEncDatum(resultTypes[colIdx], datum)
+			encDatum, err := rowenc.DatumToEncDatum(resultTypes[colIdx], datum)
+			if err != nil {
+				return nil, err
+			}
 			buf, err = encDatum.Encode(resultTypes[colIdx], &a, descpb.DatumEncoding_VALUE, buf)
 			if err != nil {
 				return nil, err

--- a/pkg/sql/execinfra/processorsbase.go
+++ b/pkg/sql/execinfra/processorsbase.go
@@ -283,7 +283,10 @@ func (h *ProcOutputHelper) ProcessRow(
 			if err != nil {
 				return nil, false, err
 			}
-			h.outputRow[i] = rowenc.DatumToEncDatum(h.OutputTypes[i], datum)
+			h.outputRow[i], err = rowenc.DatumToEncDatum(h.OutputTypes[i], datum)
+			if err != nil {
+				return nil, false, err
+			}
 		}
 	} else if h.outputCols != nil {
 		// Projection.

--- a/pkg/sql/execinfrapb/processors.go
+++ b/pkg/sql/execinfrapb/processors.go
@@ -317,7 +317,10 @@ func (spec *WindowerSpec_Frame_Bounds) initFromAST(
 			spec.Start.OffsetType = DatumInfo{Encoding: descpb.DatumEncoding_VALUE, Type: typ}
 			var buf []byte
 			var a rowenc.DatumAlloc
-			datum := rowenc.DatumToEncDatum(typ, dStartOffset)
+			datum, err := rowenc.DatumToEncDatum(typ, dStartOffset)
+			if err != nil {
+				return err
+			}
 			buf, err = datum.Encode(typ, &a, descpb.DatumEncoding_VALUE, buf)
 			if err != nil {
 				return err
@@ -361,7 +364,10 @@ func (spec *WindowerSpec_Frame_Bounds) initFromAST(
 				spec.End.OffsetType = DatumInfo{Encoding: descpb.DatumEncoding_VALUE, Type: typ}
 				var buf []byte
 				var a rowenc.DatumAlloc
-				datum := rowenc.DatumToEncDatum(typ, dEndOffset)
+				datum, err := rowenc.DatumToEncDatum(typ, dEndOffset)
+				if err != nil {
+					return err
+				}
 				buf, err = datum.Encode(typ, &a, descpb.DatumEncoding_VALUE, buf)
 				if err != nil {
 					return err

--- a/pkg/sql/flowinfra/cluster_test.go
+++ b/pkg/sql/flowinfra/cluster_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -381,8 +382,10 @@ func TestLimitedBufferingDeadlock(t *testing.T) {
 	// The left values rows are consecutive values.
 	leftRows := make(rowenc.EncDatumRows, 20)
 	for i := range leftRows {
+		encDatum, err := rowenc.DatumToEncDatum(typs[0], tree.NewDInt(tree.DInt(i)))
+		assert.NoError(t, err)
 		leftRows[i] = rowenc.EncDatumRow{
-			rowenc.DatumToEncDatum(typs[0], tree.NewDInt(tree.DInt(i))),
+			encDatum,
 		}
 	}
 	leftValuesSpec, err := execinfra.GenerateValuesSpec(typs, leftRows, 10 /* rows per chunk */)
@@ -395,8 +398,10 @@ func TestLimitedBufferingDeadlock(t *testing.T) {
 	rightRows := make(rowenc.EncDatumRows, 0)
 	for i := 1; i <= 20; i++ {
 		for j := 1; j <= 4*execinfra.RowChannelBufSize; j++ {
+			datum, err := rowenc.DatumToEncDatum(typs[0], tree.NewDInt(tree.DInt(i)))
+			assert.NoError(t, err)
 			rightRows = append(rightRows, rowenc.EncDatumRow{
-				rowenc.DatumToEncDatum(typs[0], tree.NewDInt(tree.DInt(i))),
+				datum,
 			})
 		}
 	}
@@ -695,9 +700,13 @@ func BenchmarkInfrastructure(b *testing.B) {
 						for j := 0; j < numRows; j++ {
 							row := make(rowenc.EncDatumRow, 3)
 							lastVal += rng.Intn(10)
-							row[0] = rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(lastVal)))
-							row[1] = rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(rng.Intn(100000))))
-							row[2] = rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(rng.Intn(100000))))
+							var err error
+							row[0], err = rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(lastVal)))
+							assert.NoError(b, err)
+							row[1], err = rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(rng.Intn(100000))))
+							assert.NoError(b, err)
+							row[2], err = rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(rng.Intn(100000))))
+							assert.NoError(b, err)
 							if err := se.AddRow(row); err != nil {
 								b.Fatal(err)
 							}

--- a/pkg/sql/flowinfra/stream_data_test.go
+++ b/pkg/sql/flowinfra/stream_data_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/stretchr/testify/assert"
 )
 
 // The encoder/decoder don't maintain the ordering between rows and metadata
@@ -116,9 +117,11 @@ func TestStreamEncodeDecode(t *testing.T) {
 		for i := range rows {
 			if rng.Intn(10) != 0 {
 				rows[i].row = make(rowenc.EncDatumRow, rowLen)
+				var err error
 				for j := range rows[i].row {
-					rows[i].row[j] = rowenc.DatumToEncDatum(info[j].Type,
+					rows[i].row[j], err = rowenc.DatumToEncDatum(info[j].Type,
 						rowenc.RandDatum(rng, info[j].Type, true))
+					assert.NoError(t, err)
 				}
 			} else {
 				rows[i].meta.Err = fmt.Errorf("test error %d", i)

--- a/pkg/sql/plan_node_to_row_source.go
+++ b/pkg/sql/plan_node_to_row_source.go
@@ -178,7 +178,11 @@ func (p *planNodeToRowSource) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerM
 
 		for i, datum := range p.node.Values() {
 			if datum != nil {
-				p.row[i] = rowenc.DatumToEncDatum(p.outputTypes[i], datum)
+				p.row[i], err = rowenc.DatumToEncDatum(p.outputTypes[i], datum)
+				if err != nil {
+					p.MoveToDraining(err)
+					return nil, p.DrainHelper()
+				}
 			}
 		}
 		// ProcessRow here is required to deal with projections, which won't be

--- a/pkg/sql/row/fetcher.go
+++ b/pkg/sql/row/fetcher.go
@@ -1132,7 +1132,10 @@ func (rf *Fetcher) processValueSingle(
 			if rf.traceKV {
 				prettyValue = value.String()
 			}
-			table.row[idx] = rowenc.DatumToEncDatum(typ, value)
+			table.row[idx], err = rowenc.DatumToEncDatum(typ, value)
+			if err != nil {
+				return "", "", err
+			}
 			if DebugRowFetch {
 				log.Infof(ctx, "Scan %s -> %v", kv.Key, value)
 			}

--- a/pkg/sql/rowcontainer/numbered_row_container.go
+++ b/pkg/sql/rowcontainer/numbered_row_container.go
@@ -182,7 +182,7 @@ func (d *DiskBackedNumberedRowContainer) GetRow(
 		if skip {
 			return nil, nil
 		}
-		return d.rc.mrc.EncRow(idx), nil
+		return d.rc.mrc.EncRow(idx)
 	}
 	return d.rowIter.getRow(ctx, idx, skip)
 }

--- a/pkg/sql/rowcontainer/numbered_row_container_test.go
+++ b/pkg/sql/rowcontainer/numbered_row_container_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -560,7 +561,8 @@ func BenchmarkNumberedContainerIteratorCaching(b *testing.B) {
 	for i := 0; i < numRows; i++ {
 		rows[i] = make([]rowenc.EncDatum, len(typs))
 		for j := range typs {
-			rows[i][j] = rowenc.DatumToEncDatum(typs[j], rowenc.RandDatum(rng, typs[j], false))
+			rows[i][j], err = rowenc.DatumToEncDatum(typs[j], rowenc.RandDatum(rng, typs[j], false))
+			assert.NoError(b, err)
 		}
 	}
 

--- a/pkg/sql/rowenc/encoded_datum_test.go
+++ b/pkg/sql/rowenc/encoded_datum_test.go
@@ -115,6 +115,19 @@ func columnTypeCompatibleWithEncoding(typ *types.T, enc descpb.DatumEncoding) bo
 	return enc == descpb.DatumEncoding_VALUE || colinfo.ColumnTypeIsIndexable(typ)
 }
 
+func BenchmarkDatumToEncDatum(b *testing.B) {
+	d := tree.NewDInt(0)
+	s := 0
+	for i := 0; i < b.N; i++ {
+		ed := DatumToEncDatum(types.Int, d)
+		s += int(*(ed.Datum.(*tree.DInt)))
+	}
+	b.Log(s)
+}
+
+func BenchmarkEncDatumFromEncoded(b *testing.B) {
+}
+
 func TestEncDatumNull(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 

--- a/pkg/sql/rowenc/testutils.go
+++ b/pkg/sql/rowenc/testutils.go
@@ -931,7 +931,11 @@ func RandEncodableColumnTypes(rng *rand.Rand, numCols int) []*types.T {
 func RandEncDatum(rng *rand.Rand) (EncDatum, *types.T) {
 	typ := RandEncodableType(rng)
 	datum := RandDatum(rng, typ, true /* nullOk */)
-	return DatumToEncDatum(typ, datum), typ
+	encDatum, err := DatumToEncDatum(typ, datum)
+	if err != nil {
+		panic(errors.NewAssertionErrorWithWrappedErrf(err, "can't generate random enc datum"))
+	}
+	return encDatum, typ
 }
 
 // RandSortingEncDatumSlice generates a slice of random EncDatum values of the
@@ -939,8 +943,12 @@ func RandEncDatum(rng *rand.Rand) (EncDatum, *types.T) {
 func RandSortingEncDatumSlice(rng *rand.Rand, numVals int) ([]EncDatum, *types.T) {
 	typ := RandSortingType(rng)
 	vals := make([]EncDatum, numVals)
+	var err error
 	for i := range vals {
-		vals[i] = DatumToEncDatum(typ, RandDatum(rng, typ, true))
+		vals[i], err = DatumToEncDatum(typ, RandDatum(rng, typ, true))
+		if err != nil {
+			panic(errors.NewAssertionErrorWithWrappedErrf(err, "can't generate random enc datum"))
+		}
 	}
 	return vals, typ
 }
@@ -964,7 +972,11 @@ func RandSortingEncDatumSlices(
 func RandEncDatumRowOfTypes(rng *rand.Rand, types []*types.T) EncDatumRow {
 	vals := make([]EncDatum, len(types))
 	for i := range types {
-		vals[i] = DatumToEncDatum(types[i], RandDatum(rng, types[i], true))
+		var err error
+		vals[i], err = DatumToEncDatum(types[i], RandDatum(rng, types[i], true))
+		if err != nil {
+			panic(errors.NewAssertionErrorWithWrappedErrf(err, "can't generate random enc datum"))
+		}
 	}
 	return vals
 }

--- a/pkg/sql/rowexec/aggregator.go
+++ b/pkg/sql/rowexec/aggregator.go
@@ -547,7 +547,11 @@ func (ag *aggregatorBase) getAggResults(
 			// We can't encode nil into an EncDatum, so we represent it with DNull.
 			result = tree.DNull
 		}
-		ag.row[i] = rowenc.DatumToEncDatum(ag.outputTypes[i], result)
+		ag.row[i], err = rowenc.DatumToEncDatum(ag.outputTypes[i], result)
+		if err != nil {
+			ag.MoveToDraining(err)
+			return aggStateUnknown, nil, nil
+		}
 	}
 
 	if outRow := ag.ProcessRowHelper(ag.row); outRow != nil {

--- a/pkg/sql/rowexec/aggregator_test.go
+++ b/pkg/sql/rowexec/aggregator_test.go
@@ -633,12 +633,19 @@ func makeGroupedIntRows(groupSize, numCols int, groupedCols []int) rowenc.EncDat
 
 	for i := range rows {
 		rows[i] = make(rowenc.EncDatumRow, numCols)
+		var err error
 		for j := 0; j < numCols; j++ {
 			if groupColSet.Contains(j) {
-				rows[i][j] = rowenc.DatumToEncDatum(
+				rows[i][j], err = rowenc.DatumToEncDatum(
 					types.Int, tree.NewDInt(tree.DInt(getGroupedColVal(i, j))))
+				if err != nil {
+					panic(err)
+				}
 			} else {
-				rows[i][j] = rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(i+j)))
+				rows[i][j], err = rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(i+j)))
+				if err != nil {
+					panic(err)
+				}
 			}
 		}
 	}

--- a/pkg/sql/rowexec/bulk_row_writer.go
+++ b/pkg/sql/rowexec/bulk_row_writer.go
@@ -90,8 +90,13 @@ func (sp *bulkRowWriter) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMetada
 		sp.MoveToDraining(marshalErr)
 		if marshalErr == nil {
 			// Output the summary.
+			ed, err := rowenc.DatumToEncDatum(types.Bytes, tree.NewDBytes(tree.DBytes(countsBytes)))
+			if err != nil {
+				sp.MoveToDraining(err)
+				return nil, sp.DrainHelper()
+			}
 			return rowenc.EncDatumRow{
-				rowenc.DatumToEncDatum(types.Bytes, tree.NewDBytes(tree.DBytes(countsBytes))),
+				ed,
 			}, nil
 		}
 	}

--- a/pkg/sql/rowexec/distinct_test.go
+++ b/pkg/sql/rowexec/distinct_test.go
@@ -23,16 +23,20 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils/distsqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestDistinct(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	v := [15]rowenc.EncDatum{}
+	var err error
 	for i := range v {
-		v[i] = rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(i)))
+		v[i], err = rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(i)))
+		assert.NoError(t, err)
 	}
-	vNull := rowenc.DatumToEncDatum(types.Unknown, tree.DNull)
+	vNull, err := rowenc.DatumToEncDatum(types.Unknown, tree.DNull)
+	assert.NoError(t, err)
 
 	testCases := []struct {
 		spec     execinfrapb.DistinctSpec

--- a/pkg/sql/rowexec/filterer_test.go
+++ b/pkg/sql/rowexec/filterer_test.go
@@ -23,13 +23,16 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils/distsqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestFilterer(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	v := [10]rowenc.EncDatum{}
+	var err error
 	for i := range v {
-		v[i] = rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(i)))
+		v[i], err = rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(i)))
+		assert.NoError(t, err)
 	}
 
 	// We run the same input rows through various PostProcessSpecs.

--- a/pkg/sql/rowexec/hashjoiner_test.go
+++ b/pkg/sql/rowexec/hashjoiner_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/distsqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/assert"
 )
 
 type hashJoinerTestCase struct {
@@ -45,10 +46,12 @@ type hashJoinerTestCase struct {
 	expected    rowenc.EncDatumRows
 }
 
-func hashJoinerTestCases() []hashJoinerTestCase {
+func hashJoinerTestCases(t *testing.T) []hashJoinerTestCase {
 	v := [10]rowenc.EncDatum{}
+	var err error
 	for i := range v {
-		v[i] = rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(i)))
+		v[i], err = rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(i)))
+		assert.NoError(t, err)
 	}
 	null := rowenc.EncDatum{Datum: tree.DNull}
 
@@ -843,10 +846,12 @@ type hashJoinerErrorTestCase struct {
 	expectedErr error
 }
 
-func hashJoinerErrorTestCases() []hashJoinerErrorTestCase {
+func hashJoinerErrorTestCases(t *testing.T) []hashJoinerErrorTestCase {
 	v := [10]rowenc.EncDatum{}
+	var err error
 	for i := range v {
-		v[i] = rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(i)))
+		v[i], err = rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(i)))
+		assert.NoError(t, err)
 	}
 
 	testCases := []hashJoinerErrorTestCase{
@@ -989,7 +994,7 @@ func mirrorJoinTypeAndOnExpr(
 func TestHashJoiner(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	testCases := hashJoinerTestCases()
+	testCases := hashJoinerTestCases(t)
 
 	for _, c := range testCases {
 		if c.joinType == descpb.LeftSemiJoin || c.joinType == descpb.LeftAntiJoin {
@@ -1007,12 +1012,12 @@ func TestHashJoiner(t *testing.T) {
 	}
 
 	// Add INTERSECT ALL cases with HashJoinerSpecs.
-	for _, tc := range intersectAllTestCases() {
+	for _, tc := range intersectAllTestCases(t) {
 		testCases = append(testCases, setOpTestCaseToHashJoinerTestCase(tc))
 	}
 
 	// Add EXCEPT ALL cases with HashJoinerSpecs.
-	for _, tc := range exceptAllTestCases() {
+	for _, tc := range exceptAllTestCases(t) {
 		testCases = append(testCases, setOpTestCaseToHashJoinerTestCase(tc))
 	}
 
@@ -1099,11 +1104,13 @@ func TestHashJoinerError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	v := [10]rowenc.EncDatum{}
+	var err error
 	for i := range v {
-		v[i] = rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(i)))
+		v[i], err = rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(i)))
+		assert.NoError(t, err)
 	}
 
-	testCases := hashJoinerErrorTestCases()
+	testCases := hashJoinerErrorTestCases(t)
 
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
@@ -1207,8 +1214,10 @@ func checkExpectedRows(
 func TestHashJoinerDrain(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	v := [10]rowenc.EncDatum{}
+	var err error
 	for i := range v {
-		v[i] = rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(i)))
+		v[i], err = rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(i)))
+		assert.NoError(t, err)
 	}
 	spec := execinfrapb.HashJoinerSpec{
 		LeftEqColumns:  []uint32{0},
@@ -1315,8 +1324,10 @@ func TestHashJoinerDrainAfterBuildPhaseError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	v := [10]rowenc.EncDatum{}
+	var err error
 	for i := range v {
-		v[i] = rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(i)))
+		v[i], err = rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(i)))
+		assert.NoError(t, err)
 	}
 	spec := execinfrapb.HashJoinerSpec{
 		LeftEqColumns:  []uint32{0},

--- a/pkg/sql/rowexec/inverted_joiner.go
+++ b/pkg/sql/rowexec/inverted_joiner.go
@@ -486,8 +486,8 @@ func (ij *invertedJoiner) performScan() (invertedJoinerState, *execinfrapb.Produ
 	return ijEmittingRows, nil
 }
 
-var trueEncDatum = rowenc.DatumToEncDatum(types.Bool, tree.DBoolTrue)
-var falseEncDatum = rowenc.DatumToEncDatum(types.Bool, tree.DBoolFalse)
+var trueEncDatum, _ = rowenc.DatumToEncDatum(types.Bool, tree.DBoolTrue)
+var falseEncDatum, _ = rowenc.DatumToEncDatum(types.Bool, tree.DBoolFalse)
 
 // emitRow returns the next row from ij.emitCursor, if present. Otherwise it
 // prepares for another input batch.

--- a/pkg/sql/rowexec/inverted_joiner_test.go
+++ b/pkg/sql/rowexec/inverted_joiner_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -485,7 +486,8 @@ func TestInvertedJoiner(t *testing.T) {
 				for rowIdx, row := range c.input {
 					encRow := make(rowenc.EncDatumRow, len(row))
 					for i, d := range row {
-						encRow[i] = rowenc.DatumToEncDatum(c.inputTypes[i], d)
+						encRow[i], err = rowenc.DatumToEncDatum(c.inputTypes[i], d)
+						assert.NoError(t, err)
 					}
 					encRows[rowIdx] = encRow
 				}

--- a/pkg/sql/rowexec/joinerbase.go
+++ b/pkg/sql/rowexec/joinerbase.go
@@ -64,12 +64,19 @@ func (jb *joinerBase) init(
 	}
 
 	jb.emptyLeft = make(rowenc.EncDatumRow, len(leftTypes))
+	var err error
 	for i := range jb.emptyLeft {
-		jb.emptyLeft[i] = rowenc.DatumToEncDatum(leftTypes[i], tree.DNull)
+		jb.emptyLeft[i], err = rowenc.DatumToEncDatum(leftTypes[i], tree.DNull)
+		if err != nil {
+			return err
+		}
 	}
 	jb.emptyRight = make(rowenc.EncDatumRow, len(rightTypes))
 	for i := range jb.emptyRight {
-		jb.emptyRight[i] = rowenc.DatumToEncDatum(rightTypes[i], tree.DNull)
+		jb.emptyRight[i], err = rowenc.DatumToEncDatum(rightTypes[i], tree.DNull)
+		if err != nil {
+			return err
+		}
 	}
 
 	jb.eqCols[leftSide] = leftEqColumns

--- a/pkg/sql/rowexec/joinreader_test.go
+++ b/pkg/sql/rowexec/joinreader_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -690,7 +691,8 @@ func TestJoinReader(t *testing.T) {
 							for rowIdx, row := range c.input {
 								encRow := make(rowenc.EncDatumRow, len(row))
 								for i, d := range row {
-									encRow[i] = rowenc.DatumToEncDatum(c.inputTypes[i], d)
+									encRow[i], err = rowenc.DatumToEncDatum(c.inputTypes[i], d)
+									assert.NoError(t, err)
 								}
 								encRows[rowIdx] = encRow
 							}
@@ -947,7 +949,8 @@ func TestJoinReaderDrain(t *testing.T) {
 	}
 
 	encRow := make(rowenc.EncDatumRow, 1)
-	encRow[0] = rowenc.DatumToEncDatum(types.Int, tree.NewDInt(1))
+	encRow[0], err = rowenc.DatumToEncDatum(types.Int, tree.NewDInt(1))
+	assert.NoError(t, err)
 
 	testReaderProcessorDrain(ctx, t, func(out execinfra.RowReceiver) (execinfra.Processor, error) {
 		return newJoinReader(

--- a/pkg/sql/rowexec/mergejoiner_test.go
+++ b/pkg/sql/rowexec/mergejoiner_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/distsqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/assert"
 )
 
 type mergeJoinerTestCase struct {
@@ -44,8 +45,10 @@ func TestMergeJoiner(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	v := [10]rowenc.EncDatum{}
+	var err error
 	for i := range v {
-		v[i] = rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(i)))
+		v[i], err = rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(i)))
+		assert.NoError(t, err)
 	}
 	null := rowenc.EncDatum{Datum: tree.DNull}
 
@@ -701,12 +704,12 @@ func TestMergeJoiner(t *testing.T) {
 	}
 
 	// Add INTERSECT ALL cases with MergeJoinerSpecs.
-	for _, tc := range intersectAllTestCases() {
+	for _, tc := range intersectAllTestCases(t) {
 		testCases = append(testCases, setOpTestCaseToMergeJoinerTestCase(tc))
 	}
 
 	// Add EXCEPT ALL cases with MergeJoinerSpecs.
-	for _, tc := range exceptAllTestCases() {
+	for _, tc := range exceptAllTestCases(t) {
 		testCases = append(testCases, setOpTestCaseToMergeJoinerTestCase(tc))
 	}
 
@@ -759,8 +762,10 @@ func TestConsumerClosed(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	v := [10]rowenc.EncDatum{}
+	var err error
 	for i := range v {
-		v[i] = rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(i)))
+		v[i], err = rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(i)))
+		assert.NoError(t, err)
 	}
 
 	spec := execinfrapb.MergeJoinerSpec{

--- a/pkg/sql/rowexec/ordinality.go
+++ b/pkg/sql/rowexec/ordinality.go
@@ -98,7 +98,12 @@ func (o *ordinalityProcessor) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerM
 		}
 
 		// The ordinality should increment even if the row gets filtered out.
-		row = append(row, rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(o.curCnt))))
+		ed, err := rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(o.curCnt)))
+		if err != nil {
+			o.MoveToDraining(err)
+			break
+		}
+		row = append(row, ed)
 		o.curCnt++
 		if outRow := o.ProcessRowHelper(row); outRow != nil {
 			return outRow, nil

--- a/pkg/sql/rowexec/ordinality_test.go
+++ b/pkg/sql/rowexec/ordinality_test.go
@@ -23,14 +23,17 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils/distsqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestOrdinality(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	v := [15]rowenc.EncDatum{}
+	var err error
 	for i := range v {
-		v[i] = rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(i)))
+		v[i], err = rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(i)))
+		assert.NoError(t, err)
 	}
 
 	testCases := []struct {

--- a/pkg/sql/rowexec/processor_utils_test.go
+++ b/pkg/sql/rowexec/processor_utils_test.go
@@ -78,7 +78,10 @@ func toEncDatum(datumType *types.T, v interface{}) rowenc.EncDatum {
 	if err != nil {
 		panic(err)
 	}
-	encodedDatum := rowenc.EncDatumFromEncoded(descpb.DatumEncoding_ASCENDING_KEY, encoded)
+	encodedDatum, err := rowenc.EncDatumFromEncoded(descpb.DatumEncoding_ASCENDING_KEY, encoded)
+	if err != nil {
+		panic(err)
+	}
 	encodedDatum.Datum = d
 	return encodedDatum
 }

--- a/pkg/sql/rowexec/processors_test.go
+++ b/pkg/sql/rowexec/processors_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/jackc/pgx"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -51,8 +52,10 @@ func TestPostProcess(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	v := [10]rowenc.EncDatum{}
+	var err error
 	for i := range v {
-		v[i] = rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(i)))
+		v[i], err = rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(i)))
+		assert.NoError(t, err)
 	}
 
 	// We run the same input rows through various PostProcessSpecs.

--- a/pkg/sql/rowexec/project_set.go
+++ b/pkg/sql/rowexec/project_set.go
@@ -183,7 +183,10 @@ func (ps *projectSetProcessor) nextGeneratorValues() (newValAvail bool, err erro
 						return false, err
 					}
 					for _, value := range values {
-						ps.rowBuffer[colIdx] = ps.toEncDatum(value, colIdx)
+						ps.rowBuffer[colIdx], err = ps.toEncDatum(value, colIdx)
+						if err != nil {
+							return false, err
+						}
 						colIdx++
 					}
 					newValAvail = true
@@ -191,7 +194,10 @@ func (ps *projectSetProcessor) nextGeneratorValues() (newValAvail bool, err erro
 					ps.done[i] = true
 					// No values left. Fill the buffer with NULLs for future results.
 					for j := 0; j < numCols; j++ {
-						ps.rowBuffer[colIdx] = ps.toEncDatum(tree.DNull, colIdx)
+						ps.rowBuffer[colIdx], err = ps.toEncDatum(tree.DNull, colIdx)
+						if err != nil {
+							return false, err
+						}
 						colIdx++
 					}
 				}
@@ -208,13 +214,19 @@ func (ps *projectSetProcessor) nextGeneratorValues() (newValAvail bool, err erro
 				if err != nil {
 					return false, err
 				}
-				ps.rowBuffer[colIdx] = ps.toEncDatum(value, colIdx)
+				ps.rowBuffer[colIdx], err = ps.toEncDatum(value, colIdx)
+				if err != nil {
+					return false, err
+				}
 				colIdx++
 				newValAvail = true
 				ps.done[i] = true
 			} else {
 				// Ensure that every row after the first returns a NULL value.
-				ps.rowBuffer[colIdx] = ps.toEncDatum(tree.DNull, colIdx)
+				ps.rowBuffer[colIdx], err = ps.toEncDatum(tree.DNull, colIdx)
+				if err != nil {
+					return false, err
+				}
 				colIdx++
 			}
 		}
@@ -273,7 +285,7 @@ func (ps *projectSetProcessor) Next() (rowenc.EncDatumRow, *execinfrapb.Producer
 	return nil, ps.DrainHelper()
 }
 
-func (ps *projectSetProcessor) toEncDatum(d tree.Datum, colIdx int) rowenc.EncDatum {
+func (ps *projectSetProcessor) toEncDatum(d tree.Datum, colIdx int) (rowenc.EncDatum, error) {
 	generatedColIdx := colIdx - len(ps.input.OutputTypes())
 	ctyp := ps.spec.GeneratedColumns[generatedColIdx]
 	return rowenc.DatumToEncDatum(ctyp, d)

--- a/pkg/sql/rowexec/sampler.go
+++ b/pkg/sql/rowexec/sampler.go
@@ -364,7 +364,10 @@ func (s *samplerProcessor) mainLoop(ctx context.Context) (earlyExit bool, err er
 	outRow := make(rowenc.EncDatumRow, len(s.outTypes))
 	// Emit the sampled rows.
 	for i := range outRow {
-		outRow[i] = rowenc.DatumToEncDatum(s.outTypes[i], tree.DNull)
+		outRow[i], err = rowenc.DatumToEncDatum(s.outTypes[i], tree.DNull)
+		if err != nil {
+			return earlyExit, err
+		}
 	}
 	for _, sample := range s.sr.Get() {
 		copy(outRow, sample.Row)
@@ -375,7 +378,10 @@ func (s *samplerProcessor) mainLoop(ctx context.Context) (earlyExit bool, err er
 	}
 	// Emit the inverted sample rows.
 	for i := range outRow {
-		outRow[i] = rowenc.DatumToEncDatum(s.outTypes[i], tree.DNull)
+		outRow[i], err = rowenc.DatumToEncDatum(s.outTypes[i], tree.DNull)
+		if err != nil {
+			return earlyExit, err
+		}
 	}
 	for col, invSr := range s.invSr {
 		outRow[s.invColIdxCol] = rowenc.EncDatum{Datum: tree.NewDInt(tree.DInt(col))}
@@ -394,7 +400,10 @@ func (s *samplerProcessor) mainLoop(ctx context.Context) (earlyExit bool, err er
 
 	// Emit the sketch rows.
 	for i := range outRow {
-		outRow[i] = rowenc.DatumToEncDatum(s.outTypes[i], tree.DNull)
+		outRow[i], err = rowenc.DatumToEncDatum(s.outTypes[i], tree.DNull)
+		if err != nil {
+			return earlyExit, err
+		}
 	}
 	for i, si := range s.sketches {
 		outRow[s.sketchIdxCol] = rowenc.EncDatum{Datum: tree.NewDInt(tree.DInt(i))}
@@ -405,7 +414,10 @@ func (s *samplerProcessor) mainLoop(ctx context.Context) (earlyExit bool, err er
 
 	// Emit the inverted sketch rows.
 	for i := range outRow {
-		outRow[i] = rowenc.DatumToEncDatum(s.outTypes[i], tree.DNull)
+		outRow[i], err = rowenc.DatumToEncDatum(s.outTypes[i], tree.DNull)
+		if err != nil {
+			return earlyExit, err
+		}
 	}
 	for col, invSketch := range s.invSketch {
 		outRow[s.invColIdxCol] = rowenc.EncDatum{Datum: tree.NewDInt(tree.DInt(col))}

--- a/pkg/sql/rowexec/scrub_tablereader.go
+++ b/pkg/sql/rowexec/scrub_tablereader.go
@@ -172,20 +172,20 @@ func (tr *scrubTableReader) generateScrubErrorRow(
 	}
 
 	primaryKeyValues := tr.prettyPrimaryKeyValues(row, tr.tableDesc.TableDesc())
-	return rowenc.EncDatumRow{
-		rowenc.DatumToEncDatum(
-			ScrubTypes[0],
-			tree.NewDString(scrubErr.Code),
-		),
-		rowenc.DatumToEncDatum(
-			ScrubTypes[1],
-			tree.NewDString(primaryKeyValues),
-		),
-		rowenc.DatumToEncDatum(
-			ScrubTypes[2],
-			detailsJSON,
-		),
-	}, nil
+	ret := make(rowenc.EncDatumRow, 3)
+	ret[0], err = rowenc.DatumToEncDatum(ScrubTypes[0], tree.NewDString(scrubErr.Code))
+	if err != nil {
+		return nil, err
+	}
+	ret[1], err = rowenc.DatumToEncDatum(ScrubTypes[1], tree.NewDString(primaryKeyValues))
+	if err != nil {
+		return nil, err
+	}
+	ret[2], err = rowenc.DatumToEncDatum(ScrubTypes[2], detailsJSON)
+	if err != nil {
+		return nil, err
+	}
+	return ret, nil
 }
 
 func (tr *scrubTableReader) prettyPrimaryKeyValues(

--- a/pkg/sql/rowexec/set_op_test.go
+++ b/pkg/sql/rowexec/set_op_test.go
@@ -11,6 +11,8 @@
 package rowexec
 
 import (
+	"testing"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
@@ -18,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/stretchr/testify/assert"
 )
 
 type setOpTestCase struct {
@@ -78,11 +81,13 @@ func setOpTestCaseToHashJoinerTestCase(tc setOpTestCase) hashJoinerTestCase {
 	}
 }
 
-func intersectAllTestCases() []setOpTestCase {
+func intersectAllTestCases(t *testing.T) []setOpTestCase {
 	null := rowenc.EncDatum{Datum: tree.DNull}
 	var v = [10]rowenc.EncDatum{}
+	var err error
 	for i := range v {
-		v[i] = rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(i)))
+		v[i], err = rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(i)))
+		assert.NoError(t, err)
 	}
 
 	return []setOpTestCase{
@@ -211,11 +216,13 @@ func intersectAllTestCases() []setOpTestCase {
 	}
 }
 
-func exceptAllTestCases() []setOpTestCase {
+func exceptAllTestCases(t *testing.T) []setOpTestCase {
 	null := rowenc.EncDatum{Datum: tree.DNull}
 	var v = [10]rowenc.EncDatum{}
+	var err error
 	for i := range v {
-		v[i] = rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(i)))
+		v[i], err = rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(i)))
+		assert.NoError(t, err)
 	}
 
 	return []setOpTestCase{

--- a/pkg/sql/rowexec/utils_test.go
+++ b/pkg/sql/rowexec/utils_test.go
@@ -128,8 +128,12 @@ func (r *rowGeneratingSource) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerM
 		r.scratchEncDatumRow = r.scratchEncDatumRow[:len(datumRow)]
 	}
 
+	var err error
 	for i := range r.scratchEncDatumRow {
-		r.scratchEncDatumRow[i] = rowenc.DatumToEncDatum(r.types[i], datumRow[i])
+		r.scratchEncDatumRow[i], err = rowenc.DatumToEncDatum(r.types[i], datumRow[i])
+		if err != nil {
+			return nil, &execinfrapb.ProducerMetadata{Err: err}
+		}
 	}
 	r.rowIdx++
 	return r.scratchEncDatumRow, nil

--- a/pkg/sql/rowexec/windower.go
+++ b/pkg/sql/rowexec/windower.go
@@ -743,7 +743,10 @@ func (w *windower) populateNextOutputRow() (bool, error) {
 		copy(w.outputRow, inputRow[:len(w.inputTypes)])
 		for windowFnIdx, windowFn := range w.windowFns {
 			windowFnRes := w.windowValues[w.partitionIdx][windowFnIdx][rowIdx]
-			encWindowFnRes := rowenc.DatumToEncDatum(w.outputTypes[windowFn.outputColIdx], windowFnRes)
+			encWindowFnRes, err := rowenc.DatumToEncDatum(w.outputTypes[windowFn.outputColIdx], windowFnRes)
+			if err != nil {
+				return false, err
+			}
 			w.outputRow[windowFn.outputColIdx] = encWindowFnRes
 		}
 		w.rowsInBucketEmitted++

--- a/pkg/sql/rowexec/zigzagjoiner_test.go
+++ b/pkg/sql/rowexec/zigzagjoiner_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -51,7 +52,11 @@ func intCols(numCols int) []*types.T {
 }
 
 func encInt(i int) rowenc.EncDatum {
-	return rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(i)))
+	datum, err := rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(i)))
+	if err != nil {
+		panic(err)
+	}
+	return datum
 }
 
 func TestZigzagJoiner(t *testing.T) {
@@ -558,8 +563,10 @@ func TestZigzagJoinerDrain(t *testing.T) {
 	for i := range v {
 		v[i] = tree.NewDInt(tree.DInt(i))
 	}
-	encThree := rowenc.DatumToEncDatum(types.Int, v[3])
-	encSeven := rowenc.DatumToEncDatum(types.Int, v[7])
+	encThree, err := rowenc.DatumToEncDatum(types.Int, v[3])
+	assert.NoError(t, err)
+	encSeven, err := rowenc.DatumToEncDatum(types.Int, v[7])
+	assert.NoError(t, err)
 
 	sqlutils.CreateTable(
 		t,

--- a/pkg/sql/rowflow/input_sync_test.go
+++ b/pkg/sql/rowflow/input_sync_test.go
@@ -26,14 +26,17 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestOrderedSync(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	v := [6]rowenc.EncDatum{}
+	var err error
 	for i := range v {
-		v[i] = rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(i)))
+		v[i], err = rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(i)))
+		assert.NoError(t, err)
 	}
 
 	asc := encoding.Ascending
@@ -191,8 +194,10 @@ func TestUnorderedSync(t *testing.T) {
 	for i := 1; i <= 5; i++ {
 		go func(i int) {
 			for j := 1; j <= 100; j++ {
-				a := rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(i)))
-				b := rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(j)))
+				a, err := rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(i)))
+				assert.NoError(t, err)
+				b, err := rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(j)))
+				assert.NoError(t, err)
 				row := rowenc.EncDatumRow{a, b}
 				if status := mrc.Push(row, nil /* meta */); status != execinfra.NeedMoreRows {
 					producerErr <- errors.Errorf("producer error: unexpected response: %d", status)
@@ -239,8 +244,10 @@ func TestUnorderedSync(t *testing.T) {
 	for i := 1; i <= 5; i++ {
 		go func(i int) {
 			for j := 1; j <= 100; j++ {
-				a := rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(i)))
-				b := rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(j)))
+				a, err := rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(i)))
+				assert.NoError(t, err)
+				b, err := rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(j)))
+				assert.NoError(t, err)
 				row := rowenc.EncDatumRow{a, b}
 				if status := mrc.Push(row, nil /* meta */); status != execinfra.NeedMoreRows {
 					producerErr <- errors.Errorf("producer error: unexpected response: %d", status)

--- a/pkg/sql/span/span_builder.go
+++ b/pkg/sql/span/span_builder.go
@@ -386,7 +386,11 @@ func (s *Builder) SpansFromInvertedSpans(
 			scratchRows[i] = make(rowenc.EncDatumRow, keyLength+1)
 			for j := 0; j < keyLength; j++ {
 				val := span.StartKey().Value(j)
-				scratchRows[i][j] = rowenc.DatumToEncDatum(val.ResolvedType(), val)
+				var err error
+				scratchRows[i][j], err = rowenc.DatumToEncDatum(val.ResolvedType(), val)
+				if err != nil {
+					return nil, err
+				}
 			}
 		}
 	} else {
@@ -429,7 +433,10 @@ func (s *Builder) generateInvertedSpanKey(
 		// true, since JSON inverted columns use a custom encoding. But since we
 		// are providing an already encoded Datum, the following will eventually
 		// fall through to EncDatum.Encode() which will reuse the encoded bytes.
-		encDatum := rowenc.EncDatumFromEncoded(descpb.DatumEncoding_ASCENDING_KEY, enc)
+		encDatum, err := rowenc.EncDatumFromEncoded(descpb.DatumEncoding_ASCENDING_KEY, enc)
+		if err != nil {
+			return nil, err
+		}
 		scratchRow = append(scratchRow, encDatum)
 		keyLen++
 	}

--- a/pkg/sql/stats/row_sampling.go
+++ b/pkg/sql/stats/row_sampling.go
@@ -153,7 +153,11 @@ func (sr *SampleReservoir) copyRow(
 			return err
 		}
 		beforeSize := dst[i].Size()
-		dst[i] = rowenc.DatumToEncDatum(sr.colTypes[i], src[i].Datum)
+		var err error
+		dst[i], err = rowenc.DatumToEncDatum(sr.colTypes[i], src[i].Datum)
+		if err != nil {
+			return err
+		}
 		afterSize := dst[i].Size()
 
 		// If the datum is too large, truncate it (this also performs a copy).

--- a/pkg/sql/stats/row_sampling_test.go
+++ b/pkg/sql/stats/row_sampling_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/stretchr/testify/assert"
 )
 
 // runSampleTest feeds rows with the given ranks through a reservoir
@@ -32,7 +33,8 @@ func runSampleTest(t *testing.T, evalCtx *tree.EvalContext, numSamples int, rank
 	var sr SampleReservoir
 	sr.Init(numSamples, []*types.T{types.Int}, nil /* memAcc */, util.MakeFastIntSet(0))
 	for _, r := range ranks {
-		d := rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(r)))
+		d, err := rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(r)))
+		assert.NoError(t, err)
 		if err := sr.SampleRow(ctx, evalCtx, rowenc.EncDatumRow{d}, uint64(r)); err != nil {
 			t.Errorf("%v", err)
 		}


### PR DESCRIPTION
Previously, EncDatum creation could panic in exceptional conditions.
Now, we return errors instead.

Release note (sql change): don't panic on some rare error cases in datum
decode.