### PR TITLE
colexec: make unordered distinct streaming-like

### DIFF
--- a/pkg/sql/colexec/hashjoiner.go
+++ b/pkg/sql/colexec/hashjoiner.go
@@ -314,7 +314,7 @@ func (hj *hashJoiner) Next(ctx context.Context) coldata.Batch {
 }
 
 func (hj *hashJoiner) build(ctx context.Context) {
-	hj.ht.build(ctx, hj.inputTwo)
+	hj.ht.fullBuild(ctx, hj.inputTwo)
 
 	// We might have duplicates in the hash table, so we need to set up
 	// same and visited slices for the prober.

--- a/pkg/sql/colexec/unordered_distinct.go
+++ b/pkg/sql/colexec/unordered_distinct.go
@@ -51,25 +51,21 @@ func NewUnorderedDistinct(
 	}
 }
 
-// unorderedDistinct performs a DISTINCT operation using a hashTable. Once the
-// building of the hashTable is completed, this operator iterates over all of
-// the tuples to check whether the tuple is the "head" of a linked list that
-// contain all of the tuples that are equal on distinct columns. Only the
-// "head" is included into the big selection vector. Once the big selection
-// vector is populated, the operator proceeds to returning the batches
-// according to a chunk of the selection vector.
+// unorderedDistinct performs a DISTINCT operation using a hashTable. It
+// populates the hash table in an iterative fashion by appending only the
+// distinct tuples from each input batch. Once at least one tuple is appended,
+// all of the distinct tuples from the batch are emitted in the output.
 type unorderedDistinct struct {
 	OneInputNode
 
-	allocator     *colmem.Allocator
-	ht            *hashTable
-	typs          []*types.T
-	buildFinished bool
+	allocator *colmem.Allocator
+	ht        *hashTable
+	typs      []*types.T
 
-	distinctCount int
-
-	output           coldata.Batch
-	outputBatchStart int
+	output coldata.Batch
+	// htIdx indicates the number of tuples from ht we have already emitted in
+	// the output.
+	htIdx int
 }
 
 var _ colexecbase.Operator = &unorderedDistinct{}
@@ -79,48 +75,36 @@ func (op *unorderedDistinct) Init() {
 }
 
 func (op *unorderedDistinct) Next(ctx context.Context) coldata.Batch {
-	// First, build the hash table and populate the selection vector that
-	// includes only distinct tuples.
-	if !op.buildFinished {
-		op.buildFinished = true
-		op.ht.build(ctx, op.input)
-
-		// We're using the hashTable in distinct mode, so it buffers only distinct
-		// tuples, as a result, we will be simply returning all buffered tuples.
-		op.distinctCount = op.ht.vals.Length()
-	}
-	if op.outputBatchStart == op.distinctCount {
-		return coldata.ZeroBatch
-	}
-	op.output, _ = op.allocator.ResetMaybeReallocate(op.typs, op.output, op.distinctCount-op.outputBatchStart)
-
-	// Create and return the next batch of input to a maximum size equal to the
-	// capacity of the output batch.
-	nSelected := 0
-	batchEnd := op.outputBatchStart + op.output.Capacity()
-	if batchEnd > op.distinctCount {
-		batchEnd = op.distinctCount
-	}
-	nSelected = batchEnd - op.outputBatchStart
-
-	op.allocator.PerformOperation(op.output.ColVecs(), func() {
-		for colIdx, fromCol := range op.ht.vals.ColVecs() {
-			toCol := op.output.ColVec(colIdx)
-			toCol.Copy(
-				coldata.CopySliceArgs{
-					SliceArgs: coldata.SliceArgs{
-						Src:         fromCol,
-						SrcStartIdx: op.outputBatchStart,
-						SrcEndIdx:   batchEnd,
-					},
-				},
-			)
+	for {
+		batch := op.input.Next(ctx)
+		if batch.Length() == 0 {
+			return coldata.ZeroBatch
 		}
-	})
-
-	op.outputBatchStart = batchEnd
-	op.output.SetLength(nSelected)
-	return op.output
+		op.ht.distinctBuild(ctx, batch)
+		if op.ht.vals.Length() > op.htIdx {
+			// We've just appended some distinct tuples to the hash table, so we
+			// will emit all of them as the output.
+			outputLength := op.ht.vals.Length() - op.htIdx
+			op.output, _ = op.allocator.ResetMaybeReallocate(op.typs, op.output, outputLength)
+			op.allocator.PerformOperation(op.output.ColVecs(), func() {
+				for colIdx, fromCol := range op.ht.vals.ColVecs() {
+					toCol := op.output.ColVec(colIdx)
+					toCol.Copy(
+						coldata.CopySliceArgs{
+							SliceArgs: coldata.SliceArgs{
+								Src:         fromCol,
+								SrcStartIdx: op.htIdx,
+								SrcEndIdx:   op.htIdx + outputLength,
+							},
+						},
+					)
+				}
+				op.output.SetLength(outputLength)
+			})
+			op.htIdx += outputLength
+			return op.output
+		}
+	}
 }
 
 // reset resets the unorderedDistinct.
@@ -128,10 +112,6 @@ func (op *unorderedDistinct) reset(ctx context.Context) {
 	if r, ok := op.input.(resetter); ok {
 		r.reset(ctx)
 	}
-	op.ht.vals.ResetInternalBatch()
-	op.ht.vals.SetLength(0)
-	op.buildFinished = false
 	op.ht.reset(ctx)
-	op.distinctCount = 0
-	op.outputBatchStart = 0
+	op.htIdx = 0
 }


### PR DESCRIPTION
Previously, when executing an unordered distinct, we would build the
whole hash table and consume the input source entirely before emitting
any output. This is a suboptimal behavior when the query has a limit -
we're likely to reach the limit long time before consuming the whole
input source.

This commit makes the unordered distinct more streaming-like - it builds
the hash table one batch at a time, and whenever some distinct tuples
are appended to the hash table, all of them are emitted in the output.

Fixes: #57566.

Release note (performance improvement): Previously, CockroachDB when
performing an unordered DISTINCT operation via the vectorized execution
engine would buffer up all tuples from the input which is a suboptimal
behavior when the query has a LIMIT clause, and this has now been fixed.
This behavior was introduced in 20.1. Note that the old row-by-row
engine doesn't have this issue.