### PR TITLE
sql: lift multi-region functions on to immutable descriptors

### DIFF
--- a/pkg/sql/catalog/dbdesc/database_desc.go
+++ b/pkg/sql/catalog/dbdesc/database_desc.go
@@ -206,6 +206,30 @@ func (desc *Immutable) DescriptorProto() *descpb.Descriptor {
 	}
 }
 
+// IsMultiRegion returns whether the database has multi-region properties
+// configured. If so, desc.RegionConfig can be used.
+func (desc *Immutable) IsMultiRegion() bool {
+	return desc.RegionConfig != nil
+}
+
+// Regions returns the multi-region regions that have been added to a database.
+func (desc *Immutable) Regions() (descpb.Regions, error) {
+	if !desc.IsMultiRegion() {
+		return nil, errors.AssertionFailedf(
+			"can not get regions of a non multi-region database")
+	}
+	return desc.RegionConfig.Regions, nil
+}
+
+// PrimaryRegion returns the primary region for a multi-region database.
+func (desc *Immutable) PrimaryRegion() (descpb.Region, error) {
+	if !desc.IsMultiRegion() {
+		return "", errors.AssertionFailedf(
+			"can not get the primary region of a non multi-region database")
+	}
+	return desc.RegionConfig.PrimaryRegion, nil
+}
+
 // SetName sets the name on the descriptor.
 func (desc *Mutable) SetName(name string) {
 	desc.Name = name

--- a/pkg/sql/catalog/descpb/structured.go
+++ b/pkg/sql/catalog/descpb/structured.go
@@ -324,36 +324,3 @@ func (DescriptorState) SafeValue() {}
 
 // SafeValue implements the redact.SafeValue interface.
 func (ConstraintType) SafeValue() {}
-
-// IsMultiRegion returns whether the database has multi-region properties
-// configured. If so, desc.RegionConfig can be used.
-func (desc *DatabaseDescriptor) IsMultiRegion() bool {
-	return desc.RegionConfig != nil
-}
-
-// Regions returns the multi-region regions that have been added to a database.
-func (desc *DatabaseDescriptor) Regions() (Regions, error) {
-	if !desc.IsMultiRegion() {
-		return nil, errors.AssertionFailedf(
-			"can not get regions of a non multi-region database")
-	}
-	return desc.RegionConfig.Regions, nil
-}
-
-// PrimaryRegion returns the primary region for a multi-region database.
-func (desc *DatabaseDescriptor) PrimaryRegion() (Region, error) {
-	if !desc.IsMultiRegion() {
-		return "", errors.AssertionFailedf(
-			"can not get the primary region of a non multi-region database")
-	}
-	return desc.RegionConfig.PrimaryRegion, nil
-}
-
-// PrimaryRegion returns the primary region for a multi-region type descriptor.
-func (desc *TypeDescriptor) PrimaryRegion() (Region, error) {
-	if desc.Kind != TypeDescriptor_MULTIREGION_ENUM {
-		return "", errors.AssertionFailedf(
-			"can not get primary region of a non multi-region type desc")
-	}
-	return desc.RegionConfig.PrimaryRegion, nil
-}

--- a/pkg/sql/catalog/typedesc/type_desc.go
+++ b/pkg/sql/catalog/typedesc/type_desc.go
@@ -201,6 +201,15 @@ func (desc *Immutable) DescriptorProto() *descpb.Descriptor {
 	}
 }
 
+// PrimaryRegion returns the primary region for a multi-region type descriptor.
+func (desc *Immutable) PrimaryRegion() (descpb.Region, error) {
+	if desc.Kind != descpb.TypeDescriptor_MULTIREGION_ENUM {
+		return "", errors.AssertionFailedf(
+			"can not get primary region of a non multi-region type desc")
+	}
+	return desc.RegionConfig.PrimaryRegion, nil
+}
+
 // SetDrainingNames implements the MutableDescriptor interface.
 func (desc *Mutable) SetDrainingNames(names []descpb.NameInfo) {
 	desc.DrainingNames = names


### PR DESCRIPTION
Previously, we added some accessors on type and database descriptors
that operated on the raw proto. Since, I've learned that this stuff
should really be on immutable types instead, as we're moving to a new
world where we move away from raw proto accesses. This patch lifts
accessors from the raw proto and on to the immutable types.

Release note: None