### PR TITLE
kv/kvserver: skip TestLeaseExpirationBasedDrainTransferWithExtension

### DIFF
--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -875,6 +875,7 @@ func TestLeaseExpirationBasedDrainTransfer(t *testing.T) {
 // complete before transferring away the new lease.
 func TestLeaseExpirationBasedDrainTransferWithExtension(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 57547, "flaky test")
 	defer log.Scope(t).Close(t)
 
 	l := setupLeaseTransferTest(t)


### PR DESCRIPTION
Refs: #57547

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes

Release note: None