### PR TITLE
jobs: invert status predicate to improve query plan

### DIFF
--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -630,11 +630,9 @@ func (r *Registry) Start(
 UPDATE system.jobs
    SET claim_session_id = NULL
  WHERE claim_session_id <> $1
-   AND status NOT IN ($2, $3, $4)
+   AND status IN `+claimableStatusTupleString+`
    AND NOT crdb_internal.sql_liveness_is_alive(claim_session_id)`,
 			s.ID().UnsafeBytes(),
-			// Don't touch terminal jobs.
-			StatusSucceeded, StatusCanceled, StatusFailed,
 		); err != nil {
 			log.Errorf(ctx, "error expiring job sessions: %s", err)
 		}


### PR DESCRIPTION
The jobs code regularly scans the set of adoptable jobs (generally small) to
find if there are abandoned jobs in need of adoption. In #56864 we added a
predicate to improve these loops to stop touching already terminal jobs. This
was a big improvement in what data is written but not as big of an improvement
in what data was read. When the jobs table is large, the queries, prior to this
patch, performed expensive full table scans. With this patch the query plan is
improved to utilize the index. Were there a check constraint indicating the
allowable values of status, then the optimizer could have created the same
plan. However, there isn't.

Release note (bug fix): Remove system.jobs full table scan which is
expensive in the face of many completed jobs.