### PR TITLE
[wip] roachtest: add backup/during-upgrade

### DIFF
--- a/pkg/cmd/roachtest/registry.go
+++ b/pkg/cmd/roachtest/registry.go
@@ -21,6 +21,7 @@ func registerTests(r *testRegistry) {
 	registerAlterPK(r)
 	registerAutoUpgrade(r)
 	registerBackup(r)
+	registerBackupDuringUpgrade(r)
 	registerCancel(r)
 	registerCDC(r)
 	registerClearRange(r)


### PR DESCRIPTION
This roachtest tests if a BACKUP job can successfully run during a
rolling upgrade of a cluster.

Release note: None