### PR TITLE
colexec: native type comparison optimization for Bytes

### DIFF
--- a/pkg/col/coldata/native_types.go
+++ b/pkg/col/coldata/native_types.go
@@ -29,6 +29,9 @@ type Int32s []int32
 // Int64s is a slice of int64.
 type Int64s []int64
 
+// Uint64s is a slice of uint64.
+type Uint64s []uint64
+
 // Float64s is a slice of float64.
 type Float64s []float64
 
@@ -60,6 +63,11 @@ func (c Int32s) Get(idx int) int32 { return c[idx] }
 // used anymore once the vector is modified.
 //gcassert:inline
 func (c Int64s) Get(idx int) int64 { return c[idx] }
+
+// Get returns the element at index idx of the vector. The element cannot be
+// used anymore once the vector is modified.
+//gcassert:inline
+func (c Uint64s) Get(idx int) uint64 { return c[idx] }
 
 // Get returns the element at index idx of the vector. The element cannot be
 // used anymore once the vector is modified.

--- a/pkg/sql/colexec/execgen/cmd/execgen/overloads_base.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/overloads_base.go
@@ -451,6 +451,31 @@ func (b *argWidthOverloadBase) GoTypeSliceName() string {
 	return goTypeSliceName(b.CanonicalTypeFamily, b.Width)
 }
 
+func abbreviatedGoTypeSliceName(canonicalTypeFamily types.Family, width int32) string {
+	switch canonicalTypeFamily {
+	case types.BytesFamily:
+		return "coldata.Uint64s"
+	}
+	colexecerror.InternalError(errors.AssertionFailedf("unsupported abbreviated canonical type family %s", canonicalTypeFamily))
+	return ""
+}
+
+func (b *argWidthOverloadBase) AbbreviatedGoTypeSliceName() string {
+	return abbreviatedGoTypeSliceName(b.CanonicalTypeFamily, b.Width)
+}
+
+func canAbbreviate(canonicalTypeFamily types.Family, width int32) bool {
+	switch canonicalTypeFamily {
+	case types.BytesFamily:
+		return true
+	}
+	return false
+}
+
+func (b *argWidthOverloadBase) CanAbbreviate() bool {
+	return canAbbreviate(b.CanonicalTypeFamily, b.Width)
+}
+
 func copyVal(canonicalTypeFamily types.Family, dest, src string) string {
 	switch canonicalTypeFamily {
 	case types.BytesFamily:

--- a/pkg/sql/colexec/execgen/cmd/execgen/sort_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/sort_gen.go
@@ -40,6 +40,7 @@ func genSortOps(inputFileContents string, wr io.Writer) error {
 		"_TYPE_WIDTH", typeWidthReplacement,
 		"_GOTYPESLICE", "{{.GoTypeSliceName}}",
 		"_GOTYPE", "{{.GoType}}",
+		"_ABBREVIATED_GOTYPESLICE", "{{.AbbreviatedGoTypeSliceName}}",
 		"_TYPE", "{{.VecMethod}}",
 		"TemplateType", "{{.VecMethod}}",
 

--- a/pkg/sql/colexec/sort.eg.go
+++ b/pkg/sql/colexec/sort.eg.go
@@ -431,6 +431,7 @@ func (s *sortBoolAscWithNullsOp) Less(i, j int) bool {
 		return false
 	}
 	var lt bool
+
 	// We always indirect via the order vector.
 	arg1 := s.sortCol.Get(s.order[i])
 	arg2 := s.sortCol.Get(s.order[j])
@@ -462,15 +463,17 @@ func (s *sortBoolAscWithNullsOp) Len() int {
 }
 
 type sortBytesAscWithNullsOp struct {
-	sortCol       *coldata.Bytes
-	nulls         *coldata.Nulls
-	order         []int
-	cancelChecker CancelChecker
+	sortCol            *coldata.Bytes
+	abbreviatedSortCol coldata.Uint64s
+	nulls              *coldata.Nulls
+	order              []int
+	cancelChecker      CancelChecker
 }
 
 func (s *sortBytesAscWithNullsOp) init(col coldata.Vec, order []int) {
 	s.sortCol = col.Bytes()
 	s.nulls = col.Nulls()
+	s.abbreviatedSortCol = col.AbbreviatedBytes()
 	s.order = order
 }
 
@@ -509,6 +512,17 @@ func (s *sortBytesAscWithNullsOp) Less(i, j int) bool {
 		return false
 	}
 	var lt bool
+
+	{
+		a := uint64(s.abbreviatedSortCol.Get(s.order[i]))
+		b := uint64(s.abbreviatedSortCol.Get(s.order[j]))
+		if a < b {
+			return true
+		} else if a > b {
+			return false
+		}
+	}
+
 	// We always indirect via the order vector.
 	arg1 := s.sortCol.Get(s.order[i])
 	arg2 := s.sortCol.Get(s.order[j])
@@ -579,6 +593,7 @@ func (s *sortDecimalAscWithNullsOp) Less(i, j int) bool {
 		return false
 	}
 	var lt bool
+
 	// We always indirect via the order vector.
 	arg1 := s.sortCol.Get(s.order[i])
 	arg2 := s.sortCol.Get(s.order[j])
@@ -649,6 +664,7 @@ func (s *sortInt16AscWithNullsOp) Less(i, j int) bool {
 		return false
 	}
 	var lt bool
+
 	// We always indirect via the order vector.
 	arg1 := s.sortCol.Get(s.order[i])
 	arg2 := s.sortCol.Get(s.order[j])
@@ -730,6 +746,7 @@ func (s *sortInt32AscWithNullsOp) Less(i, j int) bool {
 		return false
 	}
 	var lt bool
+
 	// We always indirect via the order vector.
 	arg1 := s.sortCol.Get(s.order[i])
 	arg2 := s.sortCol.Get(s.order[j])
@@ -811,6 +828,7 @@ func (s *sortInt64AscWithNullsOp) Less(i, j int) bool {
 		return false
 	}
 	var lt bool
+
 	// We always indirect via the order vector.
 	arg1 := s.sortCol.Get(s.order[i])
 	arg2 := s.sortCol.Get(s.order[j])
@@ -892,6 +910,7 @@ func (s *sortFloat64AscWithNullsOp) Less(i, j int) bool {
 		return false
 	}
 	var lt bool
+
 	// We always indirect via the order vector.
 	arg1 := s.sortCol.Get(s.order[i])
 	arg2 := s.sortCol.Get(s.order[j])
@@ -981,6 +1000,7 @@ func (s *sortTimestampAscWithNullsOp) Less(i, j int) bool {
 		return false
 	}
 	var lt bool
+
 	// We always indirect via the order vector.
 	arg1 := s.sortCol.Get(s.order[i])
 	arg2 := s.sortCol.Get(s.order[j])
@@ -1058,6 +1078,7 @@ func (s *sortIntervalAscWithNullsOp) Less(i, j int) bool {
 		return false
 	}
 	var lt bool
+
 	// We always indirect via the order vector.
 	arg1 := s.sortCol.Get(s.order[i])
 	arg2 := s.sortCol.Get(s.order[j])
@@ -1128,6 +1149,7 @@ func (s *sortDatumAscWithNullsOp) Less(i, j int) bool {
 		return false
 	}
 	var lt bool
+
 	// We always indirect via the order vector.
 	arg1 := s.sortCol.Get(s.order[i])
 	arg2 := s.sortCol.Get(s.order[j])
@@ -1200,6 +1222,7 @@ func (s *sortBoolDescWithNullsOp) Less(i, j int) bool {
 		return true
 	}
 	var lt bool
+
 	// We always indirect via the order vector.
 	arg1 := s.sortCol.Get(s.order[i])
 	arg2 := s.sortCol.Get(s.order[j])
@@ -1231,15 +1254,17 @@ func (s *sortBoolDescWithNullsOp) Len() int {
 }
 
 type sortBytesDescWithNullsOp struct {
-	sortCol       *coldata.Bytes
-	nulls         *coldata.Nulls
-	order         []int
-	cancelChecker CancelChecker
+	sortCol            *coldata.Bytes
+	abbreviatedSortCol coldata.Uint64s
+	nulls              *coldata.Nulls
+	order              []int
+	cancelChecker      CancelChecker
 }
 
 func (s *sortBytesDescWithNullsOp) init(col coldata.Vec, order []int) {
 	s.sortCol = col.Bytes()
 	s.nulls = col.Nulls()
+	s.abbreviatedSortCol = col.AbbreviatedBytes()
 	s.order = order
 }
 
@@ -1278,6 +1303,17 @@ func (s *sortBytesDescWithNullsOp) Less(i, j int) bool {
 		return true
 	}
 	var lt bool
+
+	{
+		a := uint64(s.abbreviatedSortCol.Get(s.order[i]))
+		b := uint64(s.abbreviatedSortCol.Get(s.order[j]))
+		if a < b {
+			return true
+		} else if a > b {
+			return false
+		}
+	}
+
 	// We always indirect via the order vector.
 	arg1 := s.sortCol.Get(s.order[i])
 	arg2 := s.sortCol.Get(s.order[j])
@@ -1348,6 +1384,7 @@ func (s *sortDecimalDescWithNullsOp) Less(i, j int) bool {
 		return true
 	}
 	var lt bool
+
 	// We always indirect via the order vector.
 	arg1 := s.sortCol.Get(s.order[i])
 	arg2 := s.sortCol.Get(s.order[j])
@@ -1418,6 +1455,7 @@ func (s *sortInt16DescWithNullsOp) Less(i, j int) bool {
 		return true
 	}
 	var lt bool
+
 	// We always indirect via the order vector.
 	arg1 := s.sortCol.Get(s.order[i])
 	arg2 := s.sortCol.Get(s.order[j])
@@ -1499,6 +1537,7 @@ func (s *sortInt32DescWithNullsOp) Less(i, j int) bool {
 		return true
 	}
 	var lt bool
+
 	// We always indirect via the order vector.
 	arg1 := s.sortCol.Get(s.order[i])
 	arg2 := s.sortCol.Get(s.order[j])
@@ -1580,6 +1619,7 @@ func (s *sortInt64DescWithNullsOp) Less(i, j int) bool {
 		return true
 	}
 	var lt bool
+
 	// We always indirect via the order vector.
 	arg1 := s.sortCol.Get(s.order[i])
 	arg2 := s.sortCol.Get(s.order[j])
@@ -1661,6 +1701,7 @@ func (s *sortFloat64DescWithNullsOp) Less(i, j int) bool {
 		return true
 	}
 	var lt bool
+
 	// We always indirect via the order vector.
 	arg1 := s.sortCol.Get(s.order[i])
 	arg2 := s.sortCol.Get(s.order[j])
@@ -1750,6 +1791,7 @@ func (s *sortTimestampDescWithNullsOp) Less(i, j int) bool {
 		return true
 	}
 	var lt bool
+
 	// We always indirect via the order vector.
 	arg1 := s.sortCol.Get(s.order[i])
 	arg2 := s.sortCol.Get(s.order[j])
@@ -1827,6 +1869,7 @@ func (s *sortIntervalDescWithNullsOp) Less(i, j int) bool {
 		return true
 	}
 	var lt bool
+
 	// We always indirect via the order vector.
 	arg1 := s.sortCol.Get(s.order[i])
 	arg2 := s.sortCol.Get(s.order[j])
@@ -1897,6 +1940,7 @@ func (s *sortDatumDescWithNullsOp) Less(i, j int) bool {
 		return true
 	}
 	var lt bool
+
 	// We always indirect via the order vector.
 	arg1 := s.sortCol.Get(s.order[i])
 	arg2 := s.sortCol.Get(s.order[j])
@@ -1959,6 +2003,7 @@ func (s *sortBoolAscOp) sortPartitions(ctx context.Context, partitions []int) {
 
 func (s *sortBoolAscOp) Less(i, j int) bool {
 	var lt bool
+
 	// We always indirect via the order vector.
 	arg1 := s.sortCol.Get(s.order[i])
 	arg2 := s.sortCol.Get(s.order[j])
@@ -1990,15 +2035,17 @@ func (s *sortBoolAscOp) Len() int {
 }
 
 type sortBytesAscOp struct {
-	sortCol       *coldata.Bytes
-	nulls         *coldata.Nulls
-	order         []int
-	cancelChecker CancelChecker
+	sortCol            *coldata.Bytes
+	abbreviatedSortCol coldata.Uint64s
+	nulls              *coldata.Nulls
+	order              []int
+	cancelChecker      CancelChecker
 }
 
 func (s *sortBytesAscOp) init(col coldata.Vec, order []int) {
 	s.sortCol = col.Bytes()
 	s.nulls = col.Nulls()
+	s.abbreviatedSortCol = col.AbbreviatedBytes()
 	s.order = order
 }
 
@@ -2027,6 +2074,17 @@ func (s *sortBytesAscOp) sortPartitions(ctx context.Context, partitions []int) {
 
 func (s *sortBytesAscOp) Less(i, j int) bool {
 	var lt bool
+
+	{
+		a := uint64(s.abbreviatedSortCol.Get(s.order[i]))
+		b := uint64(s.abbreviatedSortCol.Get(s.order[j]))
+		if a < b {
+			return true
+		} else if a > b {
+			return false
+		}
+	}
+
 	// We always indirect via the order vector.
 	arg1 := s.sortCol.Get(s.order[i])
 	arg2 := s.sortCol.Get(s.order[j])
@@ -2087,6 +2145,7 @@ func (s *sortDecimalAscOp) sortPartitions(ctx context.Context, partitions []int)
 
 func (s *sortDecimalAscOp) Less(i, j int) bool {
 	var lt bool
+
 	// We always indirect via the order vector.
 	arg1 := s.sortCol.Get(s.order[i])
 	arg2 := s.sortCol.Get(s.order[j])
@@ -2147,6 +2206,7 @@ func (s *sortInt16AscOp) sortPartitions(ctx context.Context, partitions []int) {
 
 func (s *sortInt16AscOp) Less(i, j int) bool {
 	var lt bool
+
 	// We always indirect via the order vector.
 	arg1 := s.sortCol.Get(s.order[i])
 	arg2 := s.sortCol.Get(s.order[j])
@@ -2218,6 +2278,7 @@ func (s *sortInt32AscOp) sortPartitions(ctx context.Context, partitions []int) {
 
 func (s *sortInt32AscOp) Less(i, j int) bool {
 	var lt bool
+
 	// We always indirect via the order vector.
 	arg1 := s.sortCol.Get(s.order[i])
 	arg2 := s.sortCol.Get(s.order[j])
@@ -2289,6 +2350,7 @@ func (s *sortInt64AscOp) sortPartitions(ctx context.Context, partitions []int) {
 
 func (s *sortInt64AscOp) Less(i, j int) bool {
 	var lt bool
+
 	// We always indirect via the order vector.
 	arg1 := s.sortCol.Get(s.order[i])
 	arg2 := s.sortCol.Get(s.order[j])
@@ -2360,6 +2422,7 @@ func (s *sortFloat64AscOp) sortPartitions(ctx context.Context, partitions []int)
 
 func (s *sortFloat64AscOp) Less(i, j int) bool {
 	var lt bool
+
 	// We always indirect via the order vector.
 	arg1 := s.sortCol.Get(s.order[i])
 	arg2 := s.sortCol.Get(s.order[j])
@@ -2439,6 +2502,7 @@ func (s *sortTimestampAscOp) sortPartitions(ctx context.Context, partitions []in
 
 func (s *sortTimestampAscOp) Less(i, j int) bool {
 	var lt bool
+
 	// We always indirect via the order vector.
 	arg1 := s.sortCol.Get(s.order[i])
 	arg2 := s.sortCol.Get(s.order[j])
@@ -2506,6 +2570,7 @@ func (s *sortIntervalAscOp) sortPartitions(ctx context.Context, partitions []int
 
 func (s *sortIntervalAscOp) Less(i, j int) bool {
 	var lt bool
+
 	// We always indirect via the order vector.
 	arg1 := s.sortCol.Get(s.order[i])
 	arg2 := s.sortCol.Get(s.order[j])
@@ -2566,6 +2631,7 @@ func (s *sortDatumAscOp) sortPartitions(ctx context.Context, partitions []int) {
 
 func (s *sortDatumAscOp) Less(i, j int) bool {
 	var lt bool
+
 	// We always indirect via the order vector.
 	arg1 := s.sortCol.Get(s.order[i])
 	arg2 := s.sortCol.Get(s.order[j])
@@ -2628,6 +2694,7 @@ func (s *sortBoolDescOp) sortPartitions(ctx context.Context, partitions []int) {
 
 func (s *sortBoolDescOp) Less(i, j int) bool {
 	var lt bool
+
 	// We always indirect via the order vector.
 	arg1 := s.sortCol.Get(s.order[i])
 	arg2 := s.sortCol.Get(s.order[j])
@@ -2659,15 +2726,17 @@ func (s *sortBoolDescOp) Len() int {
 }
 
 type sortBytesDescOp struct {
-	sortCol       *coldata.Bytes
-	nulls         *coldata.Nulls
-	order         []int
-	cancelChecker CancelChecker
+	sortCol            *coldata.Bytes
+	abbreviatedSortCol coldata.Uint64s
+	nulls              *coldata.Nulls
+	order              []int
+	cancelChecker      CancelChecker
 }
 
 func (s *sortBytesDescOp) init(col coldata.Vec, order []int) {
 	s.sortCol = col.Bytes()
 	s.nulls = col.Nulls()
+	s.abbreviatedSortCol = col.AbbreviatedBytes()
 	s.order = order
 }
 
@@ -2696,6 +2765,17 @@ func (s *sortBytesDescOp) sortPartitions(ctx context.Context, partitions []int) 
 
 func (s *sortBytesDescOp) Less(i, j int) bool {
 	var lt bool
+
+	{
+		a := uint64(s.abbreviatedSortCol.Get(s.order[i]))
+		b := uint64(s.abbreviatedSortCol.Get(s.order[j]))
+		if a < b {
+			return true
+		} else if a > b {
+			return false
+		}
+	}
+
 	// We always indirect via the order vector.
 	arg1 := s.sortCol.Get(s.order[i])
 	arg2 := s.sortCol.Get(s.order[j])
@@ -2756,6 +2836,7 @@ func (s *sortDecimalDescOp) sortPartitions(ctx context.Context, partitions []int
 
 func (s *sortDecimalDescOp) Less(i, j int) bool {
 	var lt bool
+
 	// We always indirect via the order vector.
 	arg1 := s.sortCol.Get(s.order[i])
 	arg2 := s.sortCol.Get(s.order[j])
@@ -2816,6 +2897,7 @@ func (s *sortInt16DescOp) sortPartitions(ctx context.Context, partitions []int) 
 
 func (s *sortInt16DescOp) Less(i, j int) bool {
 	var lt bool
+
 	// We always indirect via the order vector.
 	arg1 := s.sortCol.Get(s.order[i])
 	arg2 := s.sortCol.Get(s.order[j])
@@ -2887,6 +2969,7 @@ func (s *sortInt32DescOp) sortPartitions(ctx context.Context, partitions []int) 
 
 func (s *sortInt32DescOp) Less(i, j int) bool {
 	var lt bool
+
 	// We always indirect via the order vector.
 	arg1 := s.sortCol.Get(s.order[i])
 	arg2 := s.sortCol.Get(s.order[j])
@@ -2958,6 +3041,7 @@ func (s *sortInt64DescOp) sortPartitions(ctx context.Context, partitions []int) 
 
 func (s *sortInt64DescOp) Less(i, j int) bool {
 	var lt bool
+
 	// We always indirect via the order vector.
 	arg1 := s.sortCol.Get(s.order[i])
 	arg2 := s.sortCol.Get(s.order[j])
@@ -3029,6 +3113,7 @@ func (s *sortFloat64DescOp) sortPartitions(ctx context.Context, partitions []int
 
 func (s *sortFloat64DescOp) Less(i, j int) bool {
 	var lt bool
+
 	// We always indirect via the order vector.
 	arg1 := s.sortCol.Get(s.order[i])
 	arg2 := s.sortCol.Get(s.order[j])
@@ -3108,6 +3193,7 @@ func (s *sortTimestampDescOp) sortPartitions(ctx context.Context, partitions []i
 
 func (s *sortTimestampDescOp) Less(i, j int) bool {
 	var lt bool
+
 	// We always indirect via the order vector.
 	arg1 := s.sortCol.Get(s.order[i])
 	arg2 := s.sortCol.Get(s.order[j])
@@ -3175,6 +3261,7 @@ func (s *sortIntervalDescOp) sortPartitions(ctx context.Context, partitions []in
 
 func (s *sortIntervalDescOp) Less(i, j int) bool {
 	var lt bool
+
 	// We always indirect via the order vector.
 	arg1 := s.sortCol.Get(s.order[i])
 	arg2 := s.sortCol.Get(s.order[j])
@@ -3235,6 +3322,7 @@ func (s *sortDatumDescOp) sortPartitions(ctx context.Context, partitions []int) 
 
 func (s *sortDatumDescOp) Less(i, j int) bool {
 	var lt bool
+
 	// We always indirect via the order vector.
 	arg1 := s.sortCol.Get(s.order[i])
 	arg2 := s.sortCol.Get(s.order[j])


### PR DESCRIPTION
**NOTE: This is a super rough Flex Friday proof-of-concept.**

I recently read about "SortSupport" in Postgres. The TLDR is that
Postgres creates a 64-bit abbreviated key for sorting datums larger than
64-bits (or a 32-bit abbreviated key on 32-bit architectures). The
abbreviated key is packed with the most significant parts of the datum
it represents. As a result, the abbreviated keys can be natively
compared to each other. If the abbreviated keys are not equal, then
comparison is done. If the abbreviated keys are equal, then the system
must fall-back to comparing the entire datum. This leads to faster
comparison when the abbreviated keys have high cardinality.

In theory, this approach could speed up sorting for the following types,
though the packing of the 64-bit integer for comparison is non-trivial
for some:

  - BYTES
  - NUMERIC
  - STRING
  - INET
  - UUID

This commit is a **very** rough proof-of-concept to determine if we'd
benefit from a similar optimization. I've hacked the vectorized sorter
to create and compare abbreviate keys for the bytes type. This was the
minimum effort I could make in order to began to measure this
optimization. It's broken in many ways, including:

  - Hard-coding the fast-path comparison in `sort_tmpl.go` means that
    sorting by DESC order is broken. I tried not to get too bogged down
    mucking with execgen templates. There'll be a lot of tedious work
    in the templating logic to make this work correctly.
  - Strings are converted to Bytes in the vectorized engine but they
    cannot use such a simple abbreviate key to support different
    locales.

These huge caveats aside, it appears that this optimization could be
beneficial. **A simple ad-hoc test on my laptop of sorting 1 million
UUIDs (UUIDs are converted to Bytes in the vectorized engine) shows a
1.5x speedup, from ~1250ms to ~820ms.** I've pasted the "benchmark" I
ran below.

I'm leaving this open as a draft for discussion and feedback. I haven't
thought much about next steps and how to make this, you know, *actually
work*.

**References**

- [SortSupport: Sorting in Postgres at Speed](https://brandur.org/sortsupport)
- [Abbreviated keys: exploiting locality to improve PostgreSQL's text sort performance](http://pgeoghegan.blogspot.com/2015/01/abbreviated-keys-exploiting-locality-to.html?m=1)

**Benchmark I Ran**

I ran the last `EXPLAIN ANALYZE` statement several times for to "warm things up".

```sql
create table t (k int primary key, u uuid not null);
insert into t select i, gen_random_uuid() from generate_series(0, 1000000) as s(i);
explain analyze select k from t order by u;
```