### PR TITLE
release-20.2: importccl: support IMPORT in mixed-version cluster

### DIFF
--- a/pkg/ccl/backupccl/backup_processor_planning.go
+++ b/pkg/ccl/backupccl/backup_processor_planning.go
@@ -47,6 +47,8 @@ func distBackup(
 	dsp := phs.DistSQLPlanner()
 	evalCtx := phs.ExtendedEvalContext()
 
+	// We don't return the compatible nodes here since PartitionSpans will
+	// filter out incompatible nodes.
 	planCtx, _, err := dsp.SetupAllNodesPlanning(ctx, evalCtx, phs.ExecCfg())
 	if err != nil {
 		return err

--- a/pkg/cmd/roachtest/import.go
+++ b/pkg/cmd/roachtest/import.go
@@ -219,3 +219,37 @@ func registerImportMixedVersion(r *testRegistry) {
 		},
 	})
 }
+
+func registerImportDecommissioned(r *testRegistry) {
+	runImportDecommissioned := func(ctx context.Context, t *test, c *cluster) {
+		warehouses := 100
+		if local {
+			warehouses = 10
+		}
+
+		c.Put(ctx, cockroach, "./cockroach")
+		c.Put(ctx, workload, "./workload")
+		t.Status("starting csv servers")
+		c.Start(ctx, t)
+		c.Run(ctx, c.All(), `./workload csv-server --port=8081 &> logs/workload-csv-server.log < /dev/null &`)
+
+		// Decommission a node.
+		nodeToDecommission := 2
+		t.Status(fmt.Sprintf("decommissioning node %d", nodeToDecommission))
+		c.Run(ctx, c.Node(nodeToDecommission), `./cockroach node decommission --insecure --self --wait=all`)
+
+		// Wait for a bit for node liveness leases to expire.
+		time.Sleep(10 * time.Second)
+
+		t.Status("running workload")
+		c.Run(ctx, c.Node(1), tpccImportCmd(warehouses))
+	}
+
+	r.Add(testSpec{
+		Name:       "import/decommissioned",
+		Owner:      OwnerBulkIO,
+		MinVersion: "v20.2.3",
+		Cluster:    makeClusterSpec(4),
+		Run:        runImportDecommissioned,
+	})
+}

--- a/pkg/cmd/roachtest/import.go
+++ b/pkg/cmd/roachtest/import.go
@@ -168,3 +168,54 @@ func registerImportTPCH(r *testRegistry) {
 		})
 	}
 }
+
+func successfulImportStep(warehouses, nodeID int) versionStep {
+	return func(ctx context.Context, t *test, u *versionUpgradeTest) {
+		u.c.Run(ctx, u.c.Node(nodeID), tpccImportCmd(warehouses))
+	}
+}
+
+func runImportMixedVersion(
+	ctx context.Context, t *test, c *cluster, warehouses int, predecessorVersion string,
+) {
+	// An empty string means that the cockroach binary specified by flag
+	// `cockroach` will be used.
+	const mainVersion = ""
+	roachNodes := c.All()
+
+	t.Status("starting csv servers")
+
+	u := newVersionUpgradeTest(c,
+		uploadAndStartFromCheckpointFixture(roachNodes, predecessorVersion),
+		waitForUpgradeStep(roachNodes),
+		preventAutoUpgradeStep(1),
+
+		// Upgrade some of the nodes.
+		binaryUpgradeStep(c.Node(1), mainVersion),
+		binaryUpgradeStep(c.Node(2), mainVersion),
+
+		successfulImportStep(warehouses, 1 /* nodeID */),
+	)
+	u.run(ctx, t)
+}
+
+func registerImportMixedVersion(r *testRegistry) {
+	r.Add(testSpec{
+		Name:  "import/mixed-versions",
+		Owner: OwnerBulkIO,
+		// Mixed-version support was added in 20.2.3 on the release-20.2 branch.
+		MinVersion: "v20.2.3",
+		Cluster:    makeClusterSpec(4),
+		Run: func(ctx context.Context, t *test, c *cluster) {
+			predV, err := PredecessorVersion(r.buildVersion)
+			if err != nil {
+				t.Fatal(err)
+			}
+			warehouses := 100
+			if local {
+				warehouses = 10
+			}
+			runImportMixedVersion(ctx, t, c, warehouses, predV)
+		},
+	})
+}

--- a/pkg/cmd/roachtest/registry.go
+++ b/pkg/cmd/roachtest/registry.go
@@ -42,6 +42,7 @@ func registerTests(r *testRegistry) {
 	registerGossip(r)
 	registerHibernate(r)
 	registerHotSpotSplits(r)
+	registerImportDecommissioned(r)
 	registerImportMixedVersion(r)
 	registerImportTPCC(r)
 	registerImportTPCH(r)

--- a/pkg/cmd/roachtest/registry.go
+++ b/pkg/cmd/roachtest/registry.go
@@ -42,6 +42,7 @@ func registerTests(r *testRegistry) {
 	registerGossip(r)
 	registerHibernate(r)
 	registerHotSpotSplits(r)
+	registerImportMixedVersion(r)
 	registerImportTPCC(r)
 	registerImportTPCH(r)
 	registerInconsistency(r)

--- a/pkg/sql/distsql_plan_bulk.go
+++ b/pkg/sql/distsql_plan_bulk.go
@@ -19,7 +19,7 @@ import (
 )
 
 // SetupAllNodesPlanning creates a planCtx and sets up the planCtx.NodeStatuses
-// map for all nodes.
+// map for all nodes. It returns all nodes that can be used for planning.
 func (dsp *DistSQLPlanner) SetupAllNodesPlanning(
 	ctx context.Context, evalCtx *extendedEvalContext, execCfg *ExecutorConfig,
 ) (*PlanningCtx, []roachpb.NodeID, error) {
@@ -40,8 +40,10 @@ func (dsp *DistSQLPlanner) SetupAllNodesPlanning(
 		_ /* NodeStatus */ = dsp.CheckNodeHealthAndVersion(planCtx, node.Desc.NodeID)
 	}
 	nodes := make([]roachpb.NodeID, 0, len(planCtx.NodeStatuses))
-	for nodeID := range planCtx.NodeStatuses {
-		nodes = append(nodes, nodeID)
+	for nodeID, status := range planCtx.NodeStatuses {
+		if status == NodeOK {
+			nodes = append(nodes, nodeID)
+		}
 	}
 	// Shuffle node order so that multiple IMPORTs done in parallel will not
 	// identically schedule CSV reading. For example, if there are 3 nodes and 4


### PR DESCRIPTION
Backport 3/3 commits from #57382.

/cc @cockroachdb/release

---

This commit adds support for running IMPORT in a mixed-version cluster.
Note, that it does not add support for running an IMPORT during the
upgrade of a node however. The IMPORT job would need to be restarted in
that case.

Release note (sql change): Add support for running IMPORT in a
mixed-version cluster.
