### PR TITLE
bulkio: Do not close GCS storage prematurely.

### DIFF
--- a/pkg/ccl/backupccl/create_scheduled_backup.go
+++ b/pkg/ccl/backupccl/create_scheduled_backup.go
@@ -406,7 +406,7 @@ func checkForExistingBackupsInCollection(
 	if err != nil {
 		return err
 	}
-	defaultStore.Close()
+	defer defaultStore.Close()
 
 	r, err := defaultStore.ReadFile(ctx, latestFileName)
 	if err == nil {


### PR DESCRIPTION
Fixes #57611

Fix a crash when creating backup schedules to GCS bucket due
to nil pointer.

Release Notes: Do not crash when creating backup schedules writing
to GCS buckets.