### PR TITLE
opt: parser, test catalog, query support for virtual columns

### DIFF
--- a/docs/generated/sql/bnf/col_qualification.bnf
+++ b/docs/generated/sql/bnf/col_qualification.bnf
@@ -9,6 +9,8 @@ col_qualification ::=
 	| 'CONSTRAINT' constraint_name 'REFERENCES' table_name opt_name_parens key_match reference_actions
 	| 'CONSTRAINT' constraint_name 'AS' '(' a_expr ')' 'STORED'
 	| 'CONSTRAINT' constraint_name 'GENERATED_ALWAYS' 'ALWAYS' 'AS' '(' a_expr ')' 'STORED'
+	| 'CONSTRAINT' constraint_name 'AS' '(' a_expr ')' 'VIRTUAL'
+	| 'CONSTRAINT' constraint_name 'GENERATED_ALWAYS' 'ALWAYS' 'AS' '(' a_expr ')' 'VIRTUAL'
 	| 'NOT' 'NULL'
 	| 'NULL'
 	| 'UNIQUE' opt_without_index
@@ -19,6 +21,8 @@ col_qualification ::=
 	| 'REFERENCES' table_name opt_name_parens key_match reference_actions
 	| 'AS' '(' a_expr ')' 'STORED'
 	| 'GENERATED_ALWAYS' 'ALWAYS' 'AS' '(' a_expr ')' 'STORED'
+	| 'AS' '(' a_expr ')' 'VIRTUAL'
+	| 'GENERATED_ALWAYS' 'ALWAYS' 'AS' '(' a_expr ')' 'VIRTUAL'
 	| 'COLLATE' collation_name
 	| 'FAMILY' family_name
 	| 'CREATE' 'FAMILY' family_name

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -2872,6 +2872,7 @@ col_qualification_elem ::=
 	| 'DEFAULT' b_expr
 	| 'REFERENCES' table_name opt_name_parens key_match reference_actions
 	| generated_as '(' a_expr ')' 'STORED'
+	| generated_as '(' a_expr ')' 'VIRTUAL'
 
 family_name ::=
 	name

--- a/pkg/sql/add_column.go
+++ b/pkg/sql/add_column.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
+	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/errors"
 )
 
@@ -142,6 +143,9 @@ func (p *planner) addColumnImpl(
 	}
 
 	if d.IsComputed() {
+		if d.IsVirtual() {
+			return unimplemented.NewWithIssue(57608, "virtual computed columns")
+		}
 		computedColValidator := schemaexpr.MakeComputedColumnValidator(
 			params.ctx,
 			n.tableDesc,

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1297,6 +1297,10 @@ func NewTableDesc(
 				n.Defs = append(n.Defs, checkConstraint)
 				columnDefaultExprs = append(columnDefaultExprs, nil)
 			}
+			if d.IsVirtual() {
+				return nil, unimplemented.NewWithIssue(57608, "virtual computed columns")
+			}
+
 			col, idx, expr, err := tabledesc.MakeColumnDefDescs(ctx, d, semaCtx, evalCtx)
 			if err != nil {
 				return nil, err

--- a/pkg/sql/logictest/testdata/logic_test/computed
+++ b/pkg/sql/logictest/testdata/logic_test/computed
@@ -271,10 +271,19 @@ CREATE TABLE y (
   a INT AS (3)
 )
 
-statement error at or near "virtual": syntax error: unimplemented
+statement error unimplemented: virtual computed columns
 CREATE TABLE y (
   a INT AS (3) VIRTUAL
 )
+
+statement ok
+CREATE TABLE tmp (x INT)
+
+statement error unimplemented: virtual computed columns
+ALTER TABLE tmp ADD COLUMN y INT AS (x+1) VIRTUAL
+
+statement ok
+DROP TABLE tmp
 
 statement error expected computed column expression to have type int, but .* has type string
 CREATE TABLE y (

--- a/pkg/sql/opt/cat/column.go
+++ b/pkg/sql/opt/cat/column.go
@@ -161,8 +161,7 @@ const (
 	// VirtualInverted columns are implicit columns that are used by inverted
 	// indexes.
 	VirtualInverted
-	// VirtualComputed columns are non-stored computed columns that are used by
-	// expression-based indexes.
+	// VirtualComputed columns are non-stored computed columns.
 	VirtualComputed
 )
 
@@ -228,15 +227,21 @@ func (c *Column) InitVirtualInverted(
 // InitVirtualComputed is used by catalog implementations to populate a
 // VirtualComputed Column. It should not be used anywhere else.
 func (c *Column) InitVirtualComputed(
-	ordinal int, name tree.Name, datumType *types.T, nullable bool, computedExpr string,
+	ordinal int,
+	stableID StableID,
+	name tree.Name,
+	datumType *types.T,
+	nullable bool,
+	hidden bool,
+	computedExpr string,
 ) {
 	c.ordinal = ordinal
-	c.stableID = 0
+	c.stableID = stableID
 	c.name = name
 	c.kind = VirtualComputed
 	c.datumType = datumType
 	c.nullable = nullable
-	c.hidden = true
+	c.hidden = hidden
 	c.defaultExpr = ""
 	c.computedExpr = computedExpr
 	c.invertedSourceColumnOrdinal = -1

--- a/pkg/sql/opt/cat/utils.go
+++ b/pkg/sql/opt/cat/utils.go
@@ -306,7 +306,11 @@ func formatColumn(col *Column, buf *bytes.Buffer) {
 		fmt.Fprintf(buf, " not null")
 	}
 	if col.IsComputed() {
-		fmt.Fprintf(buf, " as (%s) stored", col.ComputedExprStr())
+		if col.Kind() == VirtualComputed {
+			fmt.Fprintf(buf, " as (%s) virtual", col.ComputedExprStr())
+		} else {
+			fmt.Fprintf(buf, " as (%s) stored", col.ComputedExprStr())
+		}
 	}
 	if col.HasDefault() {
 		fmt.Fprintf(buf, " default (%s)", col.DefaultExprStr())
@@ -322,7 +326,7 @@ func formatColumn(col *Column, buf *bytes.Buffer) {
 	case VirtualInverted:
 		fmt.Fprintf(buf, " [virtual-inverted]")
 	case VirtualComputed:
-		fmt.Fprintf(buf, " [virtual-computed]")
+		// No need to show anything more (it already shows up as virtual).
 	}
 }
 

--- a/pkg/sql/opt/optbuilder/testdata/virtual-columns
+++ b/pkg/sql/opt/optbuilder/testdata/virtual-columns
@@ -1,0 +1,37 @@
+exec-ddl
+CREATE TABLE t (
+  a INT PRIMARY KEY,
+  b INT,
+  c INT AS (a+b) VIRTUAL
+)
+----
+
+build
+SELECT * FROM t
+----
+project
+ ├── columns: a:1!null b:2 c:3
+ └── project
+      ├── columns: c:3 a:1!null b:2 crdb_internal_mvcc_timestamp:4
+      ├── scan t
+      │    ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:4
+      │    └── computed column expressions
+      │         └── c:3
+      │              └── a:1 + b:2
+      └── projections
+           └── a:1 + b:2 [as=c:3]
+
+build
+SELECT c FROM t
+----
+project
+ ├── columns: c:3
+ └── project
+      ├── columns: c:3 a:1!null b:2 crdb_internal_mvcc_timestamp:4
+      ├── scan t
+      │    ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:4
+      │    └── computed column expressions
+      │         └── c:3
+      │              └── a:1 + b:2
+      └── projections
+           └── a:1 + b:2 [as=c:3]

--- a/pkg/sql/opt/testutils/testcat/create_table.go
+++ b/pkg/sql/opt/testutils/testcat/create_table.go
@@ -514,17 +514,29 @@ func (tt *Table) addColumn(def *tree.ColumnTableDef) {
 	}
 
 	var col cat.Column
-	col.InitNonVirtual(
-		ordinal,
-		cat.StableID(1+ordinal),
-		name,
-		kind,
-		typ,
-		nullable,
-		false, /* hidden */
-		defaultExpr,
-		computedExpr,
-	)
+	if def.Computed.Virtual {
+		col.InitVirtualComputed(
+			ordinal,
+			cat.StableID(1+ordinal),
+			name,
+			typ,
+			nullable,
+			false, /* hidden */
+			*computedExpr,
+		)
+	} else {
+		col.InitNonVirtual(
+			ordinal,
+			cat.StableID(1+ordinal),
+			name,
+			kind,
+			typ,
+			nullable,
+			false, /* hidden */
+			defaultExpr,
+			computedExpr,
+		)
+	}
 	tt.Columns = append(tt.Columns, col)
 }
 
@@ -820,9 +832,11 @@ func columnForIndexElemExpr(tt *Table, expr tree.Expr) cat.Column {
 	var col cat.Column
 	col.InitVirtualComputed(
 		len(tt.Columns),
+		cat.StableID(1+len(tt.Columns)),
 		name,
 		typ,
 		true, /* nullable */
+		true, /* hidden */
 		exprStr,
 	)
 	tt.Columns = append(tt.Columns, col)

--- a/pkg/sql/opt/testutils/testcat/testdata/index
+++ b/pkg/sql/opt/testutils/testcat/testdata/index
@@ -122,24 +122,24 @@ TABLE xyz
  ├── y int
  ├── z string
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
- ├── idx_expr_1 string as (lower(z)) stored [hidden] [virtual-computed]
- ├── idx_expr_2 int as (y + 1) stored [hidden] [virtual-computed]
- ├── idx_expr_3 int as (x + y) stored [hidden] [virtual-computed]
+ ├── idx_expr_1 string as (lower(z)) virtual [hidden]
+ ├── idx_expr_2 int as (y + 1) virtual [hidden]
+ ├── idx_expr_3 int as (x + y) virtual [hidden]
  ├── INDEX primary
  │    └── x int not null
  ├── INDEX idx1
- │    ├── idx_expr_1 string as (lower(z)) stored [hidden] [virtual-computed]
+ │    ├── idx_expr_1 string as (lower(z)) virtual [hidden]
  │    └── x int not null
  ├── INDEX idx2
- │    ├── idx_expr_1 string as (lower(z)) stored [hidden] [virtual-computed]
+ │    ├── idx_expr_1 string as (lower(z)) virtual [hidden]
  │    ├── y int
  │    └── x int not null
  ├── INDEX idx3
- │    ├── idx_expr_2 int as (y + 1) stored [hidden] [virtual-computed]
- │    ├── idx_expr_1 string as (lower(z)) stored [hidden] [virtual-computed]
+ │    ├── idx_expr_2 int as (y + 1) virtual [hidden]
+ │    ├── idx_expr_1 string as (lower(z)) virtual [hidden]
  │    └── x int not null
  ├── INDEX idx4
- │    ├── idx_expr_3 int as (x + y) stored [hidden] [virtual-computed]
+ │    ├── idx_expr_3 int as (x + y) virtual [hidden]
  │    ├── y int
  │    ├── x int not null
  │    ├── z string (storing)

--- a/pkg/sql/opt/testutils/testcat/testdata/table
+++ b/pkg/sql/opt/testutils/testcat/testdata/table
@@ -23,7 +23,8 @@ CREATE TABLE abcdef (
     c INT DEFAULT (10),
     d INT AS (b + c + 1) STORED,
     e INT AS (a) STORED,
-    f INT CHECK (f > 2)
+    f INT CHECK (f > 2),
+    g INT AS (a+b) VIRTUAL
 )
 ----
 
@@ -37,6 +38,7 @@ TABLE abcdef
  ├── d int as ((b + c) + 1) stored
  ├── e int as (a) stored
  ├── f int
+ ├── g int as (a + b) virtual
  ├── rowid int not null default (unique_rowid()) [hidden]
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
  ├── CHECK (f > 2)

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -280,6 +280,7 @@ func TestParse(t *testing.T) {
 		{`CREATE TABLE a.b (b INT8)`},
 		{`CREATE TABLE IF NOT EXISTS a (b INT8)`},
 		{`CREATE TABLE a (b INT8 AS (a + b) STORED)`},
+		{`CREATE TABLE a (b INT8 AS (a + b) VIRTUAL)`},
 		{`CREATE TABLE view (view INT8)`},
 
 		{`CREATE TABLE a (b INT8 CONSTRAINT c PRIMARY KEY)`},
@@ -2720,6 +2721,7 @@ SKIP_MISSING_FOREIGN_KEYS, SKIP_MISSING_SEQUENCES, SKIP_MISSING_SEQUENCE_OWNERS,
 			`CREATE TABLE a (b INT8, c STRING, FOREIGN KEY (b, c) REFERENCES other (x, y) ON DELETE CASCADE ON UPDATE SET NULL)`,
 		},
 		{`CREATE TABLE a (b INT8 GENERATED ALWAYS AS (a + b) STORED)`, `CREATE TABLE a (b INT8 AS (a + b) STORED)`},
+		{`CREATE TABLE a (b INT8 GENERATED ALWAYS AS (a + b) VIRTUAL)`, `CREATE TABLE a (b INT8 AS (a + b) VIRTUAL)`},
 
 		{`ALTER TABLE a ALTER b DROP STORED`, `ALTER TABLE a ALTER COLUMN b DROP STORED`},
 		{`ALTER TABLE a ADD b INT8`, `ALTER TABLE a ADD COLUMN b INT8`},
@@ -3186,7 +3188,6 @@ func TestUnimplementedSyntax(t *testing.T) {
 
 		{`CREATE TABLE a AS SELECT b WITH NO DATA`, 0, `create table as with no data`, ``},
 
-		{`CREATE TABLE a(b INT8 AS (123) VIRTUAL)`, 0, `virtual computed columns`, ``},
 		{`CREATE TABLE a(b INT8 REFERENCES c(x) MATCH PARTIAL`, 20305, `match partial`, ``},
 		{`CREATE TABLE a(b INT8, FOREIGN KEY (b) REFERENCES c(x) MATCH PARTIAL)`, 20305, `match partial`, ``},
 

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -6104,11 +6104,11 @@ col_qualification_elem:
  }
 | generated_as '(' a_expr ')' STORED
  {
-    $$.val = &tree.ColumnComputedDef{Expr: $3.expr()}
+    $$.val = &tree.ColumnComputedDef{Expr: $3.expr(), Virtual: false}
  }
 | generated_as '(' a_expr ')' VIRTUAL
  {
-    return unimplemented(sqllex, "virtual computed columns")
+    $$.val = &tree.ColumnComputedDef{Expr: $3.expr(), Virtual: true}
  }
 | generated_as error
  {

--- a/pkg/sql/sem/tree/pretty.go
+++ b/pkg/sql/sem/tree/pretty.go
@@ -1819,8 +1819,19 @@ func (node *ColumnTableDef) docRow(p *PrettyCfg) pretty.TableRow {
 
 	// Compute expression (for computed columns).
 	if node.IsComputed() {
-		clauses = append(clauses, pretty.ConcatSpace(pretty.Keyword("AS"),
-			p.bracket("(", p.Doc(node.Computed.Expr), ") STORED"),
+		var typ string
+		if node.Computed.Virtual {
+			typ = "VIRTUAL"
+		} else {
+			typ = "STORED"
+		}
+
+		clauses = append(clauses, pretty.ConcatSpace(
+			pretty.Keyword("AS"),
+			pretty.ConcatSpace(
+				p.bracket("(", p.Doc(node.Computed.Expr), ")"),
+				pretty.Keyword(typ),
+			),
 		))
 	}
 

--- a/pkg/sql/sem/tree/testdata/pretty/create_table.align-deindent.golden.short
+++ b/pkg/sql/sem/tree/testdata/pretty/create_table.align-deindent.golden.short
@@ -42,6 +42,11 @@ CREATE TABLE product_information (
 								last_name
 							)
 	                    ) STORED,
+	virt_col            INT8
+	                    AS (
+							product_id
+							* 10
+	                    ) VIRTUAL,
 	INDEX date_added_idx (date_added),
 	INDEX supp_id_prod_status_idx (
 		supplier_id,

--- a/pkg/sql/sem/tree/testdata/pretty/create_table.align-only.golden.short
+++ b/pkg/sql/sem/tree/testdata/pretty/create_table.align-only.golden.short
@@ -42,6 +42,11 @@ CREATE TABLE product_information (
 								last_name
 							)
 	                    ) STORED,
+	virt_col            INT8
+	                    AS (
+							product_id
+							* 10
+	                    ) VIRTUAL,
 	INDEX date_added_idx (date_added),
 	INDEX supp_id_prod_status_idx (
 		supplier_id,

--- a/pkg/sql/sem/tree/testdata/pretty/create_table.ref.golden.short
+++ b/pkg/sql/sem/tree/testdata/pretty/create_table.ref.golden.short
@@ -46,6 +46,9 @@ CREATE TABLE product_information (
 				last_name
 			)
 		) STORED,
+	virt_col
+		INT8
+		AS (product_id * 10) VIRTUAL,
 	INDEX date_added_idx (date_added),
 	INDEX supp_id_prod_status_idx (
 		supplier_id,

--- a/pkg/sql/sem/tree/testdata/pretty/create_table.sql
+++ b/pkg/sql/sem/tree/testdata/pretty/create_table.sql
@@ -13,6 +13,7 @@ CREATE TABLE product_information (
     date_added           DATE DEFAULT current_date(),
     misc                 JSONB,
     full_name STRING AS (concat(first_name, ' ', last_name)) STORED,
+    virt_col INT AS (product_id * 10) VIRTUAL,
     INDEX date_added_idx (date_added),
     INDEX supp_id_prod_status_idx (supplier_id, product_status),
     customer_id INT REFERENCES customers_2(id) MATCH FULL ON UPDATE CASCADE ON DELETE CASCADE,


### PR DESCRIPTION
This set of changes add parser, testcat, and query support for virtual columns. I have come full circle and realized that even though user-defined virtual columns don't help with the optimizer-side work for expression-based indexes, they help with integrating with the existing sql code. In particular, we can carve out pieces of work and write more targeted tests related to virtual columns, without having to define them through an expression-based index.

Informs #57608.

#### sql: support virtual columns in parser

Support VIRTUAL keyword in the parser. We still error out if it is
ever used.

Release note: None

#### opt: clean up hack in test catalog

To ensure that PK columns are non-nullable, the test catalog
reinitializes them to override the nullable flag. We replace this
hacky mechanism with figuring out the PK columns beforehand and
marking them as non-nullable in the definition before creating the
table columns.

Release note: None

#### opt: test catalog support for virtual columns

Release note: None

#### opt: optbuilder support for scanning virtual columns

This change adds support for scanning tables with virtual columns. The
virtual columns are projected on top of the Scan.

Release note: None