### PR TITLE
colexec: improve unordered distinct

### DIFF
--- a/pkg/sql/colexec/hash_aggregator.go
+++ b/pkg/sql/colexec/hash_aggregator.go
@@ -179,12 +179,6 @@ func NewHashAggregator(
 
 func (op *hashAggregator) Init() {
 	op.input.Init()
-	// The hash table only needs to store the grouping columns to be able to
-	// perform the equality check.
-	colsToStore := make([]int, len(op.spec.GroupCols))
-	for i := range colsToStore {
-		colsToStore[i] = int(op.spec.GroupCols[i])
-	}
 	// These numbers were chosen after running the micro-benchmarks and relevant
 	// TPCH queries using tpchvec/bench.
 	const hashTableLoadFactor = 0.1
@@ -195,7 +189,6 @@ func (op *hashAggregator) Init() {
 		hashTableNumBuckets,
 		op.inputTypes,
 		op.spec.GroupCols,
-		colsToStore,
 		true, /* allowNullEquality */
 		hashTableDistinctBuildMode,
 		hashTableDefaultProbeMode,

--- a/pkg/sql/colexec/hashjoiner.go
+++ b/pkg/sql/colexec/hashjoiner.go
@@ -257,10 +257,6 @@ func (hj *hashJoiner) Init() {
 		hj.hashTableInitialNumBuckets,
 		hj.spec.right.sourceTypes,
 		hj.spec.right.eqCols,
-		// Store all columns from the right source since we need to be able to
-		// export the full batches when falling back to the external hash
-		// joiner.
-		nil, /* colsToStore */
 		allowNullEquality,
 		hashTableFullBuildMode,
 		probeMode,


### PR DESCRIPTION
This commit significantly simplifies and optimizes the unordered
distinct operator by making an observation that during `distinctBuild`
method of the hash table the input batch is updated in-place to include
only the distinct tuples. This allows us to simply return the batch
which avoids an unnecessary copy into the output batch. Additionally,
this commit adjusts the hash table instantiation to only store the
distinct columns.

Release note: None