### PR TITLE
sql: add force flag overloads to crdb_internal.unsafe_.* builtins

### DIFF
--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -89,13 +89,15 @@ type DummyEvalPlanner struct{}
 
 // UnsafeUpsertDescriptor is part of the EvalPlanner interface.
 func (ep *DummyEvalPlanner) UnsafeUpsertDescriptor(
-	ctx context.Context, descID int64, encodedDescriptor []byte,
+	ctx context.Context, descID int64, encodedDescriptor []byte, force bool,
 ) error {
 	return errors.WithStack(errEvalPlanner)
 }
 
 // UnsafeDeleteDescriptor is part of the EvalPlanner interface.
-func (ep *DummyEvalPlanner) UnsafeDeleteDescriptor(ctx context.Context, descID int64) error {
+func (ep *DummyEvalPlanner) UnsafeDeleteDescriptor(
+	ctx context.Context, descID int64, force bool,
+) error {
 	return errors.WithStack(errEvalPlanner)
 }
 
@@ -108,7 +110,7 @@ func (ep *DummyEvalPlanner) UnsafeUpsertNamespaceEntry(
 
 // UnsafeDeleteNamespaceEntry is part of the EvalPlanner interface.
 func (ep *DummyEvalPlanner) UnsafeDeleteNamespaceEntry(
-	ctx context.Context, parentID, parentSchemaID int64, name string, descID int64,
+	ctx context.Context, parentID, parentSchemaID int64, name string, descID int64, force bool,
 ) error {
 	return errors.WithStack(errEvalPlanner)
 }

--- a/pkg/sql/repair.go
+++ b/pkg/sql/repair.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/errors"
 )
@@ -55,7 +56,7 @@ import (
 // all descriptors at the end of the transaction to ensure that this operation
 // didn't break a reference to this descriptor.
 func (p *planner) UnsafeUpsertDescriptor(
-	ctx context.Context, descID int64, encodedDesc []byte,
+	ctx context.Context, descID int64, encodedDesc []byte, force bool,
 ) error {
 	const method = "crdb_internal.unsafe_upsert_descriptor()"
 	if err := checkPlannerStateForRepairFunctions(ctx, p, method); err != nil {
@@ -69,9 +70,18 @@ func (p *planner) UnsafeUpsertDescriptor(
 	}
 
 	// Fetch the existing descriptor.
+
 	existing, err := p.Descriptors().GetMutableDescriptorByID(ctx, id, p.txn)
+	var forceNoticeString string // for the event
 	if !errors.Is(err, catalog.ErrDescriptorNotFound) && err != nil {
-		return err
+		if force {
+			notice := pgnotice.NewWithSeverityf("WARNING",
+				"failed to retrieve existing descriptor, continuing with force flag: %v", err)
+			p.BufferClientNotice(ctx, notice)
+			forceNoticeString = notice.Error()
+		} else {
+			return err
+		}
 	}
 
 	// Validate that existing is sane and store its hex serialization into
@@ -130,6 +140,7 @@ func (p *planner) UnsafeUpsertDescriptor(
 			return err
 		}
 	}
+
 	return MakeEventLogger(p.execCfg).InsertEventRecord(
 		ctx,
 		p.txn,
@@ -140,10 +151,14 @@ func (p *planner) UnsafeUpsertDescriptor(
 			ID                 descpb.ID `json:"id"`
 			ExistingDescriptor string    `json:"existing_descriptor,omitempty"`
 			Descriptor         string    `json:"descriptor,omitempty"`
+			Force              bool      `json:"force,omitempty"`
+			ValidationErrors   string    `json:"validation_errors,omitempty"`
 		}{
 			ID:                 id,
 			ExistingDescriptor: existingStr,
 			Descriptor:         hex.EncodeToString(encodedDesc),
+			Force:              force,
+			ValidationErrors:   forceNoticeString,
 		})
 }
 
@@ -308,7 +323,11 @@ func (p *planner) UnsafeUpsertNamespaceEntry(
 // will ensure that the entry does not correspond to a non-dropped descriptor
 // and that the entry exists with the provided ID.
 func (p *planner) UnsafeDeleteNamespaceEntry(
-	ctx context.Context, parentIDInt, parentSchemaIDInt int64, name string, descIDInt int64,
+	ctx context.Context,
+	parentIDInt, parentSchemaIDInt int64,
+	name string,
+	descIDInt int64,
+	force bool,
 ) error {
 	const method = "crdb_internal.unsafe_delete_namespace_entry()"
 	if err := checkPlannerStateForRepairFunctions(ctx, p, method); err != nil {
@@ -336,8 +355,16 @@ func (p *planner) UnsafeDeleteNamespaceEntry(
 		}
 	}
 	desc, err := p.Descriptors().GetMutableDescriptorByID(ctx, descID, p.txn)
+	var forceNoticeString string // for the event
 	if err != nil && !errors.Is(err, catalog.ErrDescriptorNotFound) {
-		return errors.Wrapf(err, "failed to retrieve descriptor %d", descID)
+		if force {
+			notice := pgnotice.NewWithSeverityf("WARNING",
+				"failed to retrieve existing descriptor, continuing with force flag: %v", err)
+			p.BufferClientNotice(ctx, notice)
+			forceNoticeString = notice.Error()
+		} else {
+			return errors.Wrapf(err, "failed to retrieve descriptor %d", descID)
+		}
 	}
 	if err == nil && !desc.Dropped() {
 		return pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
@@ -353,16 +380,20 @@ func (p *planner) UnsafeDeleteNamespaceEntry(
 		int32(descID),
 		int32(p.EvalContext().NodeID.SQLInstanceID()),
 		&struct {
-			ParentID       descpb.ID `json:"parent_id,omitempty"`
-			ParentSchemaID descpb.ID `json:"parent_schema_id,omitempty"`
-			Name           string    `json:"name"`
-			ID             descpb.ID `json:"id"`
-			ExistingID     descpb.ID `json:"existing_id,omitempty"`
+			ParentID         descpb.ID `json:"parent_id,omitempty"`
+			ParentSchemaID   descpb.ID `json:"parent_schema_id,omitempty"`
+			Name             string    `json:"name"`
+			ID               descpb.ID `json:"id"`
+			ExistingID       descpb.ID `json:"existing_id,omitempty"`
+			Force            bool      `json:"force,omitempty"`
+			ValidationErrors string    `json:"validation_errors,omitempty"`
 		}{
-			ParentID:       parentID,
-			ParentSchemaID: parentSchemaID,
-			ID:             descID,
-			Name:           name,
+			ParentID:         parentID,
+			ParentSchemaID:   parentSchemaID,
+			ID:               descID,
+			Name:             name,
+			Force:            force,
+			ValidationErrors: forceNoticeString,
 		})
 }
 
@@ -373,19 +404,44 @@ func (p *planner) UnsafeDeleteNamespaceEntry(
 // This method will perform very minimal validation. An error will be returned
 // if no such descriptor exists. This method can very easily introduce
 // corruption, beware.
-func (p *planner) UnsafeDeleteDescriptor(ctx context.Context, descID int64) error {
+func (p *planner) UnsafeDeleteDescriptor(ctx context.Context, descID int64, force bool) error {
 	const method = "crdb_internal.unsafe_delete_descriptor()"
 	if err := checkPlannerStateForRepairFunctions(ctx, p, method); err != nil {
 		return err
 	}
 	id := descpb.ID(descID)
 	mut, err := p.Descriptors().GetMutableDescriptorByID(ctx, id, p.txn)
+	var forceNoticeString string // for the event
 	if err != nil {
-		return err
+		if !errors.Is(err, catalog.ErrDescriptorNotFound) && force {
+			notice := pgnotice.NewWithSeverityf("WARNING",
+				"failed to retrieve existing descriptor, continuing with force flag: %v", err)
+			p.BufferClientNotice(ctx, notice)
+			forceNoticeString = notice.Error()
+		} else {
+			return err
+		}
 	}
 	descKey := catalogkeys.MakeDescMetadataKey(p.execCfg.Codec, id)
 	if err := p.txn.Del(ctx, descKey); err != nil {
 		return err
+	}
+	ev := struct {
+		ParentID         descpb.ID `json:"parent_id,omitempty"`
+		ParentSchemaID   descpb.ID `json:"parent_schema_id,omitempty"`
+		Name             string    `json:"name"`
+		ID               descpb.ID `json:"id"`
+		Force            bool      `json:"force,omitempty"`
+		ValidationErrors string    `json:"validation_errors,omitempty"`
+	}{
+		ID:               id,
+		Force:            force,
+		ValidationErrors: forceNoticeString,
+	}
+	if mut != nil {
+		ev.ParentID = mut.GetParentID()
+		ev.ParentSchemaID = mut.GetParentSchemaID()
+		ev.Name = mut.GetName()
 	}
 	return MakeEventLogger(p.execCfg).InsertEventRecord(
 		ctx,
@@ -393,17 +449,8 @@ func (p *planner) UnsafeDeleteDescriptor(ctx context.Context, descID int64) erro
 		EventLogUnsafeDeleteDescriptor,
 		int32(descID),
 		int32(p.EvalContext().NodeID.SQLInstanceID()),
-		&struct {
-			ParentID       descpb.ID `json:"parent_id,omitempty"`
-			ParentSchemaID descpb.ID `json:"parent_schema_id,omitempty"`
-			Name           string    `json:"name"`
-			ID             descpb.ID `json:"id"`
-		}{
-			ParentID:       mut.GetParentID(),
-			ParentSchemaID: mut.GetParentSchemaID(),
-			ID:             mut.GetID(),
-			Name:           mut.GetName(),
-		})
+		ev,
+	)
 }
 
 func checkPlannerStateForRepairFunctions(ctx context.Context, p *planner, method string) error {

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -4293,7 +4293,27 @@ may increase either contention or retry errors, or both.`,
 			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
 				if err := ctx.Planner.UnsafeUpsertDescriptor(ctx.Context,
 					int64(*args[0].(*tree.DInt)),
-					[]byte(*args[1].(*tree.DBytes))); err != nil {
+					[]byte(*args[1].(*tree.DBytes)),
+					false /* force */); err != nil {
+					return nil, err
+				}
+				return tree.DBoolTrue, nil
+			},
+			Info:       "This function is used only by CockroachDB's developers for testing purposes.",
+			Volatility: tree.VolatilityVolatile,
+		},
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"id", types.Int},
+				{"desc", types.Bytes},
+				{"force", types.Bool},
+			},
+			ReturnType: tree.FixedReturnType(types.Bool),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				if err := ctx.Planner.UnsafeUpsertDescriptor(ctx.Context,
+					int64(*args[0].(*tree.DInt)),
+					[]byte(*args[1].(*tree.DBytes)),
+					bool(*args[2].(*tree.DBool))); err != nil {
 					return nil, err
 				}
 				return tree.DBoolTrue, nil
@@ -4316,6 +4336,25 @@ may increase either contention or retry errors, or both.`,
 			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
 				if err := ctx.Planner.UnsafeDeleteDescriptor(ctx.Context,
 					int64(*args[0].(*tree.DInt)),
+					false, /* force */
+				); err != nil {
+					return nil, err
+				}
+				return tree.DBoolTrue, nil
+			},
+			Info:       "This function is used only by CockroachDB's developers for testing purposes.",
+			Volatility: tree.VolatilityVolatile,
+		},
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"id", types.Int},
+				{"force", types.Bool},
+			},
+			ReturnType: tree.FixedReturnType(types.Bool),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				if err := ctx.Planner.UnsafeDeleteDescriptor(ctx.Context,
+					int64(*args[0].(*tree.DInt)),
+					bool(*args[1].(*tree.DBool)),
 				); err != nil {
 					return nil, err
 				}
@@ -4401,7 +4440,33 @@ may increase either contention or retry errors, or both.`,
 					int64(*args[0].(*tree.DInt)),     // parentID
 					int64(*args[1].(*tree.DInt)),     // parentSchemaID
 					string(*args[2].(*tree.DString)), // name
-					int64(*args[3].(*tree.DInt)),     // descID
+					int64(*args[3].(*tree.DInt)),     // id
+					false,                            // force
+				); err != nil {
+					return nil, err
+				}
+				return tree.DBoolTrue, nil
+			},
+			Info:       "This function is used only by CockroachDB's developers for testing purposes.",
+			Volatility: tree.VolatilityVolatile,
+		},
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"parent_id", types.Int},
+				{"parent_schema_id", types.Int},
+				{"name", types.String},
+				{"desc_id", types.Int},
+				{"force", types.Bool},
+			},
+			ReturnType: tree.FixedReturnType(types.Bool),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				if err := ctx.Planner.UnsafeDeleteNamespaceEntry(
+					ctx.Context,
+					int64(*args[0].(*tree.DInt)),     // parentID
+					int64(*args[1].(*tree.DInt)),     // parentSchemaID
+					string(*args[2].(*tree.DString)), // name
+					int64(*args[3].(*tree.DInt)),     // id
+					bool(*args[4].(*tree.DBool)),     // force
 				); err != nil {
 					return nil, err
 				}

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3037,19 +3037,33 @@ type EvalPlanner interface {
 
 	// UnsafeUpsertDescriptor is a used to repair descriptors in dire
 	// circumstances. See the comment on the planner implementation.
-	UnsafeUpsertDescriptor(ctx context.Context, descID int64, encodedDescriptor []byte) error
+	UnsafeUpsertDescriptor(
+		ctx context.Context, descID int64, encodedDescriptor []byte, force bool,
+	) error
 
 	// UnsafeDeleteDescriptor is a used to repair descriptors in dire
 	// circumstances. See the comment on the planner implementation.
-	UnsafeDeleteDescriptor(ctx context.Context, descID int64) error
+	UnsafeDeleteDescriptor(ctx context.Context, descID int64, force bool) error
 
 	// UnsafeUpsertNamespaceEntry is a used to repair namespace entries in dire
 	// circumstances. See the comment on the planner implementation.
-	UnsafeUpsertNamespaceEntry(ctx context.Context, parentID, parentSchemaID int64, name string, descID int64, force bool) error
+	UnsafeUpsertNamespaceEntry(
+		ctx context.Context,
+		parentID, parentSchemaID int64,
+		name string,
+		descID int64,
+		force bool,
+	) error
 
 	// UnsafeDeleteNamespaceEntry is a used to repair namespace entries in dire
 	// circumstances. See the comment on the planner implementation.
-	UnsafeDeleteNamespaceEntry(ctx context.Context, parentID, parentSchemaID int64, name string, descID int64) error
+	UnsafeDeleteNamespaceEntry(
+		ctx context.Context,
+		parentID, parentSchemaID int64,
+		name string,
+		descID int64,
+		force bool,
+	) error
 }
 
 // EvalSessionAccessor is a limited interface to access session variables.

--- a/pkg/sql/tests/repair_test.go
+++ b/pkg/sql/tests/repair_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/cockroachdb/cockroach-go/crdb"
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -250,6 +251,7 @@ func TestDescriptorRepair(t *testing.T) {
 		typ  string
 		info string
 	}
+
 	for _, tc := range []struct {
 		before             []string
 		op                 string
@@ -318,6 +320,104 @@ SELECT crdb_internal.unsafe_delete_namespace_entry("parentID", 0, 'foo', id)
 `,
 			expErrRE: `crdb_internal.unsafe_delete_namespace_entry\(\): refusing to delete namespace entry for non-dropped descriptor`,
 		},
+		{
+			// Upsert a descriptor which is invalid, then try to upsert a namespace
+			// entry for it and show that it fails.
+			before: []string{
+				upsertInvalidateDuplicateColumnDescriptor,
+			},
+			op:       `SELECT crdb_internal.unsafe_upsert_namespace_entry(50, 29, 'foo', 52);`,
+			expErrRE: `failed to retrieve descriptor 52: duplicate column name: "i"`,
+		},
+		{
+			// Upsert a descriptor which is invalid, then try to upsert a namespace
+			// entry for it and show that it succeeds with the force flag.
+			before: []string{
+				upsertInvalidateDuplicateColumnDescriptor,
+			},
+			op: `SELECT crdb_internal.unsafe_upsert_namespace_entry(50, 29, 'foo', 52, true);`,
+			expEventLogEntries: []eventLogPattern{
+				{
+					typ:  string(sql.EventLogUnsafeUpsertNamespaceEntry),
+					info: `"force":true,"validation_errors":"failed to retrieve descriptor 52: duplicate column name: \\"i\\""`,
+				},
+			},
+		},
+		{
+			// Upsert a descriptor which is invalid, upsert a namespace entry for it,
+			// then show that deleting the descriptor fails without the force flag.
+			before: []string{
+				upsertInvalidateDuplicateColumnDescriptor,
+				`SELECT crdb_internal.unsafe_upsert_namespace_entry(50, 29, 'foo', 52, true);`,
+			},
+			op:       `SELECT crdb_internal.unsafe_delete_descriptor(52);`,
+			expErrRE: `duplicate column name: "i"`,
+		},
+		{
+			// Upsert a descriptor which is invalid, upsert a namespace entry for it,
+			// then show that deleting the descriptor succeeds with the force flag.
+			before: []string{
+				upsertInvalidateDuplicateColumnDescriptor,
+				`SELECT crdb_internal.unsafe_upsert_namespace_entry(50, 29, 'foo', 52, true);`,
+			},
+			op: `SELECT crdb_internal.unsafe_delete_descriptor(52, true);`,
+			expEventLogEntries: []eventLogPattern{
+				{
+					typ:  string(sql.EventLogUnsafeDeleteDescriptor),
+					info: `"force":true,"validation_errors":"[^"]*duplicate column name: \\"i\\""`,
+				},
+			},
+		},
+		{
+			// Upsert a descriptor which is invalid, upsert a namespace entry for it,
+			// then show that updating the descriptor fails without the force flag.
+			before: []string{
+				upsertInvalidateDuplicateColumnDescriptor,
+				`SELECT crdb_internal.unsafe_upsert_namespace_entry(50, 29, 'foo', 52, true);`,
+			},
+			op:       updateInvalidateDuplicateColumnDescriptorNoForce,
+			expErrRE: `duplicate column name: "i"`,
+		},
+		{
+			// Upsert a descriptor which is invalid, upsert a namespace entry for it,
+			// then show that updating the descriptor succeeds the force flag.
+			before: []string{
+				upsertInvalidateDuplicateColumnDescriptor,
+				`SELECT crdb_internal.unsafe_upsert_namespace_entry(50, 29, 'foo', 52, true);`,
+			},
+			op: updateInvalidateDuplicateColumnDescriptorForce,
+			expEventLogEntries: []eventLogPattern{
+				{
+					typ:  string(sql.EventLogUnsafeUpsertDescriptor),
+					info: `"force":true,"validation_errors":"[^"]*duplicate column name: \\"i\\""`,
+				},
+			},
+		},
+		{
+			// Upsert a descriptor which is invalid, upsert a namespace entry for it,
+			// then show that deleting the namespace entry fails without the force flag.
+			before: []string{
+				upsertInvalidateDuplicateColumnDescriptor,
+				`SELECT crdb_internal.unsafe_upsert_namespace_entry(50, 29, 'foo', 52, true);`,
+			},
+			op:       `SELECT crdb_internal.unsafe_delete_namespace_entry(50, 29, 'foo', 52);`,
+			expErrRE: `duplicate column name: "i"`,
+		},
+		{
+			// Upsert a descriptor which is invalid, upsert a namespace entry for it,
+			// then show that deleting the namespace entry succeeds with the force flag.
+			before: []string{
+				upsertInvalidateDuplicateColumnDescriptor,
+				`SELECT crdb_internal.unsafe_upsert_namespace_entry(50, 29, 'foo', 52, true);`,
+			},
+			op: `SELECT crdb_internal.unsafe_delete_namespace_entry(50, 29, 'foo', 52, true);`,
+			expEventLogEntries: []eventLogPattern{
+				{
+					typ:  string(sql.EventLogUnsafeDeleteNamespaceEntry),
+					info: `"force":true,"validation_errors":"[^"]*duplicate column name: \\"i\\""`,
+				},
+			},
+		},
 	} {
 		t.Run(tc.op, func(t *testing.T) {
 			s, db, cleanup := setup(t)
@@ -354,3 +454,130 @@ SELECT crdb_internal.unsafe_delete_namespace_entry("parentID", 0, 'foo', id)
 		})
 	}
 }
+
+const (
+
+	// This is the json representation of a descriptor which has duplicate
+	// columns i and will subsequently fail validation.
+	invalidDuplicateColumnDescriptor = `'{
+  "table": {
+    "auditMode": "DISABLED",
+    "columns": [
+      {
+        "id": 1,
+        "name": "i"
+      },
+      {
+        "id": 1,
+        "name": "i"
+      }
+    ],
+    "families": [
+      {
+        "columnIds": [
+          1
+        ],
+        "columnNames": [
+          "i"
+        ],
+        "defaultColumnId": 0,
+        "id": 0,
+        "name": "primary"
+      }
+    ],
+    "formatVersion": 3,
+    "id": 52,
+    "name": "foo",
+    "nextColumnId": 2,
+    "nextFamilyId": 1,
+    "nextIndexId": 2,
+    "nextMutationId": 2,
+    "parentId": 50,
+    "primaryIndex": {
+      "columnDirections": [
+        "ASC"
+      ],
+      "columnIds": [
+        1
+      ],
+      "columnNames": [
+        "i"
+      ],
+      "compositeColumnIds": [],
+      "createdExplicitly": false,
+      "encodingType": 0,
+      "id": 1,
+      "name": "primary",
+      "type": "FORWARD",
+      "unique": true,
+      "version": 2
+    },
+    "privileges": {
+      "ownerProto": "root",
+      "users": [
+        {
+          "privileges": 2,
+          "userProto": "admin"
+        },
+        {
+          "privileges": 2,
+          "userProto": "root"
+        }
+      ],
+      "version": 1
+    },
+    "state": "PUBLIC",
+    "unexposedParentSchemaId": 29,
+    "version": 1
+  }
+}'`
+
+	// This is a statement to insert the invalid descriptor above using
+	// crdb_internal.unsafe_upsert_descriptor.
+	upsertInvalidateDuplicateColumnDescriptor = `
+SELECT crdb_internal.unsafe_upsert_descriptor(52,
+    crdb_internal.json_to_pb('cockroach.sql.sqlbase.Descriptor', ` +
+		invalidDuplicateColumnDescriptor + `))`
+
+	// These are CTEs for the below statements to update the above descriptor
+	// and fix its validation problems.
+	updateInvalidateDuplicateColumnDescriptorCTEs = `
+  WITH as_json AS (
+                SELECT crdb_internal.pb_to_json(
+                            'cockroach.sql.sqlbase.Descriptor',
+                            descriptor
+                        ) AS descriptor
+                  FROM system.descriptor
+                 WHERE id = 52
+               ),
+       updated AS (
+                SELECT crdb_internal.json_to_pb(
+                        'cockroach.sql.sqlbase.Descriptor',
+                        json_set(
+                            descriptor,
+                            ARRAY['table', 'columns'],
+                            json_build_array(
+                                descriptor->'table'->'columns'->0
+                            )
+                        )
+                       ) AS descriptor
+                  FROM as_json
+               )
+`
+
+	// This is a statement to update the above descriptor fixing its validity
+	// problems without the force flag.
+	updateInvalidateDuplicateColumnDescriptorNoForce = `` +
+		updateInvalidateDuplicateColumnDescriptorCTEs + `
+SELECT crdb_internal.unsafe_upsert_descriptor(52, descriptor)
+  FROM updated;
+`
+
+	// This is a statement to update the above descriptor fixing its validity
+	// problems with the force flag.
+	updateInvalidateDuplicateColumnDescriptorForce = `` +
+		updateInvalidateDuplicateColumnDescriptorCTEs + `
+SELECT crdb_internal.unsafe_upsert_descriptor(52, descriptor, true)
+  FROM updated;
+`
+)


### PR DESCRIPTION
This commit adds the ability to force the crdb_internal.unsafe_.* builtins to
allow them to work even when the existing descriptor is invalid.

Fixes #57061.

Release note: None