### PR TITLE
sql: display locality in SHOW TABLES

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -11,51 +11,51 @@ CREATE TABLE crdb_internal.t (x INT)
 query error database "crdb_internal" does not exist
 DROP DATABASE crdb_internal
 
-query TTTTI
+query TTTTIT
 SHOW TABLES FROM crdb_internal
 ----
-crdb_internal  backward_dependencies        table  NULL  NULL
-crdb_internal  builtin_functions            table  NULL  NULL
-crdb_internal  cluster_queries              table  NULL  NULL
-crdb_internal  cluster_sessions             table  NULL  NULL
-crdb_internal  cluster_settings             table  NULL  NULL
-crdb_internal  cluster_transactions         table  NULL  NULL
-crdb_internal  create_statements            table  NULL  NULL
-crdb_internal  create_type_statements       table  NULL  NULL
-crdb_internal  databases                    table  NULL  NULL
-crdb_internal  feature_usage                table  NULL  NULL
-crdb_internal  forward_dependencies         table  NULL  NULL
-crdb_internal  gossip_alerts                table  NULL  NULL
-crdb_internal  gossip_liveness              table  NULL  NULL
-crdb_internal  gossip_network               table  NULL  NULL
-crdb_internal  gossip_nodes                 table  NULL  NULL
-crdb_internal  index_columns                table  NULL  NULL
-crdb_internal  invalid_objects              table  NULL  NULL
-crdb_internal  jobs                         table  NULL  NULL
-crdb_internal  kv_node_status               table  NULL  NULL
-crdb_internal  kv_store_status              table  NULL  NULL
-crdb_internal  leases                       table  NULL  NULL
-crdb_internal  node_build_info              table  NULL  NULL
-crdb_internal  node_metrics                 table  NULL  NULL
-crdb_internal  node_queries                 table  NULL  NULL
-crdb_internal  node_runtime_info            table  NULL  NULL
-crdb_internal  node_sessions                table  NULL  NULL
-crdb_internal  node_statement_statistics    table  NULL  NULL
-crdb_internal  node_transaction_statistics  table  NULL  NULL
-crdb_internal  node_transactions            table  NULL  NULL
-crdb_internal  node_txn_stats               table  NULL  NULL
-crdb_internal  partitions                   table  NULL  NULL
-crdb_internal  predefined_comments          table  NULL  NULL
-crdb_internal  ranges                       view   NULL  NULL
-crdb_internal  ranges_no_leases             table  NULL  NULL
-crdb_internal  schema_changes               table  NULL  NULL
-crdb_internal  session_trace                table  NULL  NULL
-crdb_internal  session_variables            table  NULL  NULL
-crdb_internal  table_columns                table  NULL  NULL
-crdb_internal  table_indexes                table  NULL  NULL
-crdb_internal  table_row_statistics         table  NULL  NULL
-crdb_internal  tables                       table  NULL  NULL
-crdb_internal  zones                        table  NULL  NULL
+crdb_internal  backward_dependencies        table  NULL  NULL  NULL
+crdb_internal  builtin_functions            table  NULL  NULL  NULL
+crdb_internal  cluster_queries              table  NULL  NULL  NULL
+crdb_internal  cluster_sessions             table  NULL  NULL  NULL
+crdb_internal  cluster_settings             table  NULL  NULL  NULL
+crdb_internal  cluster_transactions         table  NULL  NULL  NULL
+crdb_internal  create_statements            table  NULL  NULL  NULL
+crdb_internal  create_type_statements       table  NULL  NULL  NULL
+crdb_internal  databases                    table  NULL  NULL  NULL
+crdb_internal  feature_usage                table  NULL  NULL  NULL
+crdb_internal  forward_dependencies         table  NULL  NULL  NULL
+crdb_internal  gossip_alerts                table  NULL  NULL  NULL
+crdb_internal  gossip_liveness              table  NULL  NULL  NULL
+crdb_internal  gossip_network               table  NULL  NULL  NULL
+crdb_internal  gossip_nodes                 table  NULL  NULL  NULL
+crdb_internal  index_columns                table  NULL  NULL  NULL
+crdb_internal  invalid_objects              table  NULL  NULL  NULL
+crdb_internal  jobs                         table  NULL  NULL  NULL
+crdb_internal  kv_node_status               table  NULL  NULL  NULL
+crdb_internal  kv_store_status              table  NULL  NULL  NULL
+crdb_internal  leases                       table  NULL  NULL  NULL
+crdb_internal  node_build_info              table  NULL  NULL  NULL
+crdb_internal  node_metrics                 table  NULL  NULL  NULL
+crdb_internal  node_queries                 table  NULL  NULL  NULL
+crdb_internal  node_runtime_info            table  NULL  NULL  NULL
+crdb_internal  node_sessions                table  NULL  NULL  NULL
+crdb_internal  node_statement_statistics    table  NULL  NULL  NULL
+crdb_internal  node_transaction_statistics  table  NULL  NULL  NULL
+crdb_internal  node_transactions            table  NULL  NULL  NULL
+crdb_internal  node_txn_stats               table  NULL  NULL  NULL
+crdb_internal  partitions                   table  NULL  NULL  NULL
+crdb_internal  predefined_comments          table  NULL  NULL  NULL
+crdb_internal  ranges                       view   NULL  NULL  NULL
+crdb_internal  ranges_no_leases             table  NULL  NULL  NULL
+crdb_internal  schema_changes               table  NULL  NULL  NULL
+crdb_internal  session_trace                table  NULL  NULL  NULL
+crdb_internal  session_variables            table  NULL  NULL  NULL
+crdb_internal  table_columns                table  NULL  NULL  NULL
+crdb_internal  table_indexes                table  NULL  NULL  NULL
+crdb_internal  table_row_statistics         table  NULL  NULL  NULL
+crdb_internal  tables                       table  NULL  NULL  NULL
+crdb_internal  zones                        table  NULL  NULL  NULL
 
 statement ok
 CREATE DATABASE testdb; CREATE TABLE testdb.foo(x INT)

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal_tenant
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal_tenant
@@ -20,51 +20,51 @@ CREATE TABLE crdb_internal.t (x INT)
 query error database "crdb_internal" does not exist
 DROP DATABASE crdb_internal
 
-query TTTTI
+query TTTTIT
 SHOW TABLES FROM crdb_internal
 ----
-crdb_internal  backward_dependencies        table  NULL  NULL
-crdb_internal  builtin_functions            table  NULL  NULL
-crdb_internal  cluster_queries              table  NULL  NULL
-crdb_internal  cluster_sessions             table  NULL  NULL
-crdb_internal  cluster_settings             table  NULL  NULL
-crdb_internal  cluster_transactions         table  NULL  NULL
-crdb_internal  create_statements            table  NULL  NULL
-crdb_internal  create_type_statements       table  NULL  NULL
-crdb_internal  databases                    table  NULL  NULL
-crdb_internal  feature_usage                table  NULL  NULL
-crdb_internal  forward_dependencies         table  NULL  NULL
-crdb_internal  gossip_alerts                table  NULL  NULL
-crdb_internal  gossip_liveness              table  NULL  NULL
-crdb_internal  gossip_network               table  NULL  NULL
-crdb_internal  gossip_nodes                 table  NULL  NULL
-crdb_internal  index_columns                table  NULL  NULL
-crdb_internal  invalid_objects              table  NULL  NULL
-crdb_internal  jobs                         table  NULL  NULL
-crdb_internal  kv_node_status               table  NULL  NULL
-crdb_internal  kv_store_status              table  NULL  NULL
-crdb_internal  leases                       table  NULL  NULL
-crdb_internal  node_build_info              table  NULL  NULL
-crdb_internal  node_metrics                 table  NULL  NULL
-crdb_internal  node_queries                 table  NULL  NULL
-crdb_internal  node_runtime_info            table  NULL  NULL
-crdb_internal  node_sessions                table  NULL  NULL
-crdb_internal  node_statement_statistics    table  NULL  NULL
-crdb_internal  node_transaction_statistics  table  NULL  NULL
-crdb_internal  node_transactions            table  NULL  NULL
-crdb_internal  node_txn_stats               table  NULL  NULL
-crdb_internal  partitions                   table  NULL  NULL
-crdb_internal  predefined_comments          table  NULL  NULL
-crdb_internal  ranges                       view   NULL  NULL
-crdb_internal  ranges_no_leases             table  NULL  NULL
-crdb_internal  schema_changes               table  NULL  NULL
-crdb_internal  session_trace                table  NULL  NULL
-crdb_internal  session_variables            table  NULL  NULL
-crdb_internal  table_columns                table  NULL  NULL
-crdb_internal  table_indexes                table  NULL  NULL
-crdb_internal  table_row_statistics         table  NULL  NULL
-crdb_internal  tables                       table  NULL  NULL
-crdb_internal  zones                        table  NULL  NULL
+crdb_internal  backward_dependencies        table  NULL  NULL  NULL
+crdb_internal  builtin_functions            table  NULL  NULL  NULL
+crdb_internal  cluster_queries              table  NULL  NULL  NULL
+crdb_internal  cluster_sessions             table  NULL  NULL  NULL
+crdb_internal  cluster_settings             table  NULL  NULL  NULL
+crdb_internal  cluster_transactions         table  NULL  NULL  NULL
+crdb_internal  create_statements            table  NULL  NULL  NULL
+crdb_internal  create_type_statements       table  NULL  NULL  NULL
+crdb_internal  databases                    table  NULL  NULL  NULL
+crdb_internal  feature_usage                table  NULL  NULL  NULL
+crdb_internal  forward_dependencies         table  NULL  NULL  NULL
+crdb_internal  gossip_alerts                table  NULL  NULL  NULL
+crdb_internal  gossip_liveness              table  NULL  NULL  NULL
+crdb_internal  gossip_network               table  NULL  NULL  NULL
+crdb_internal  gossip_nodes                 table  NULL  NULL  NULL
+crdb_internal  index_columns                table  NULL  NULL  NULL
+crdb_internal  invalid_objects              table  NULL  NULL  NULL
+crdb_internal  jobs                         table  NULL  NULL  NULL
+crdb_internal  kv_node_status               table  NULL  NULL  NULL
+crdb_internal  kv_store_status              table  NULL  NULL  NULL
+crdb_internal  leases                       table  NULL  NULL  NULL
+crdb_internal  node_build_info              table  NULL  NULL  NULL
+crdb_internal  node_metrics                 table  NULL  NULL  NULL
+crdb_internal  node_queries                 table  NULL  NULL  NULL
+crdb_internal  node_runtime_info            table  NULL  NULL  NULL
+crdb_internal  node_sessions                table  NULL  NULL  NULL
+crdb_internal  node_statement_statistics    table  NULL  NULL  NULL
+crdb_internal  node_transaction_statistics  table  NULL  NULL  NULL
+crdb_internal  node_transactions            table  NULL  NULL  NULL
+crdb_internal  node_txn_stats               table  NULL  NULL  NULL
+crdb_internal  partitions                   table  NULL  NULL  NULL
+crdb_internal  predefined_comments          table  NULL  NULL  NULL
+crdb_internal  ranges                       view   NULL  NULL  NULL
+crdb_internal  ranges_no_leases             table  NULL  NULL  NULL
+crdb_internal  schema_changes               table  NULL  NULL  NULL
+crdb_internal  session_trace                table  NULL  NULL  NULL
+crdb_internal  session_variables            table  NULL  NULL  NULL
+crdb_internal  table_columns                table  NULL  NULL  NULL
+crdb_internal  table_indexes                table  NULL  NULL  NULL
+crdb_internal  table_row_statistics         table  NULL  NULL  NULL
+crdb_internal  tables                       table  NULL  NULL  NULL
+crdb_internal  zones                        table  NULL  NULL  NULL
 
 statement ok
 CREATE DATABASE testdb; CREATE TABLE testdb.foo(x INT)

--- a/pkg/sql/logictest/testdata/logic_test/drop_index
+++ b/pkg/sql/logictest/testdata/logic_test/drop_index
@@ -168,12 +168,12 @@ users       foo         true        2             id           ASC        false 
 statement ok
 CREATE VIEW v2 AS SELECT name FROM v
 
-query TTTTI
+query TTTTIT
 SHOW TABLES
 ----
-public  users  table  root  0
-public  v      view   root  0
-public  v2     view   root  0
+public  users  table  root  0  NULL
+public  v      view   root  0  NULL
+public  v2     view   root  0  NULL
 
 statement ok
 GRANT ALL ON users to testuser
@@ -197,10 +197,10 @@ SHOW INDEXES FROM users
 table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit
 users       primary     false       1             id           ASC        false    false
 
-query TTTTI
+query TTTTIT
 SHOW TABLES
 ----
-public  users  table  root  0
+public  users  table  root  0  NULL
 
 # Test the syntax without a '@'
 

--- a/pkg/sql/logictest/testdata/logic_test/drop_table
+++ b/pkg/sql/logictest/testdata/logic_test/drop_table
@@ -4,11 +4,11 @@ CREATE TABLE a (id INT PRIMARY KEY)
 statement ok
 CREATE TABLE b (id INT PRIMARY KEY)
 
-query TTTTI
+query TTTTIT
 SHOW TABLES FROM test
 ----
-public  a  table  root  0
-public  b  table  root  0
+public  a  table  root  0  NULL
+public  b  table  root  0  NULL
 
 statement ok
 INSERT INTO a VALUES (3),(7),(2)
@@ -33,10 +33,10 @@ SELECT job_type, status FROM [SHOW JOBS] WHERE user_name = 'root' AND (job_type 
 SCHEMA CHANGE     succeeded
 SCHEMA CHANGE GC  running
 
-query TTTTI
+query TTTTIT
 SHOW TABLES FROM test
 ----
-public  b  table  root  0
+public  b  table  root  0  NULL
 
 statement error pgcode 42P01 relation "a" does not exist
 SELECT * FROM a

--- a/pkg/sql/logictest/testdata/logic_test/drop_view
+++ b/pkg/sql/logictest/testdata/logic_test/drop_view
@@ -10,12 +10,12 @@ CREATE VIEW b AS SELECT k,v from a
 statement ok
 CREATE VIEW c AS SELECT k,v from b
 
-query TTTTI
+query TTTTIT
 SHOW TABLES FROM test
 ----
-public  a  table  root  0
-public  b  view   root  0
-public  c  view   root  0
+public  a  table  root  0  NULL
+public  b  view   root  0  NULL
+public  c  view   root  0  NULL
 
 statement error cannot drop relation "a" because view "b" depends on it
 DROP TABLE a
@@ -38,14 +38,14 @@ DROP VIEW d
 statement ok
 GRANT ALL ON d TO testuser
 
-query TTTTI
+query TTTTIT
 SHOW TABLES FROM test
 ----
-public  a        table  root  0
-public  b        view   root  0
-public  c        view   root  0
-public  d        view   root  0
-public  diamond  view   root  0
+public  a        table  root  0  NULL
+public  b        view   root  0  NULL
+public  c        view   root  0  NULL
+public  d        view   root  0  NULL
+public  diamond  view   root  0  NULL
 
 user testuser
 
@@ -75,24 +75,24 @@ GRANT ALL ON testuser2 to testuser
 statement ok
 GRANT ALL ON testuser3 to testuser
 
-query TTTTI
+query TTTTIT
 SHOW TABLES FROM test
 ----
-public  a          table  root  0
-public  b          view   root  0
-public  c          view   root  0
-public  d          view   root  0
-public  diamond    view   root  0
-public  testuser1  view   root  0
-public  testuser2  view   root  0
-public  testuser3  view   root  0
+public  a          table  root  0  NULL
+public  b          view   root  0  NULL
+public  c          view   root  0  NULL
+public  d          view   root  0  NULL
+public  diamond    view   root  0  NULL
+public  testuser1  view   root  0  NULL
+public  testuser2  view   root  0  NULL
+public  testuser3  view   root  0  NULL
 
 user testuser
 
 statement ok
 DROP VIEW testuser3
 
-query TTTTI
+query TTTTIT
 SHOW TABLES FROM test
 ----
 
@@ -105,7 +105,7 @@ DROP VIEW testuser1 RESTRICT
 statement ok
 DROP VIEW testuser1 CASCADE
 
-query TTTTI
+query TTTTIT
 SHOW TABLES FROM test
 ----
 
@@ -136,7 +136,7 @@ user root
 statement ok
 DROP TABLE a CASCADE
 
-query TTTTI
+query TTTTIT
 SHOW TABLES FROM test
 ----
 

--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -1033,26 +1033,26 @@ statement ok
 DROP INDEX refers@another_idx
 
 # refers is not visible because it is in the ADD state.
-query TTTTI
+query TTTTIT
 SHOW TABLES FROM test
 ----
-public  bar                   table  root  0
-public  child                 table  root  0
-public  customers             table  root  0
-public  delivery              table  root  0
-public  domain_modules        table  root  0
-public  domains               table  root  0
-public  foo                   table  root  0
-public  grandchild            table  root  0
-public  modules               table  root  0
-public  pairs                 table  root  0
-public  referee               table  root  0
-public  refpairs              table  root  0
-public  refpairs_c_between    table  root  0
-public  refpairs_wrong_order  table  root  0
-public  tx                    table  root  0
-public  tx_leg                table  root  0
-public  unindexed             table  root  0
+public  bar                   table  root  0  NULL
+public  child                 table  root  0  NULL
+public  customers             table  root  0  NULL
+public  delivery              table  root  0  NULL
+public  domain_modules        table  root  0  NULL
+public  domains               table  root  0  NULL
+public  foo                   table  root  0  NULL
+public  grandchild            table  root  0  NULL
+public  modules               table  root  0  NULL
+public  pairs                 table  root  0  NULL
+public  referee               table  root  0  NULL
+public  refpairs              table  root  0  NULL
+public  refpairs_c_between    table  root  0  NULL
+public  refpairs_wrong_order  table  root  0  NULL
+public  tx                    table  root  0  NULL
+public  tx_leg                table  root  0  NULL
+public  unindexed             table  root  0  NULL
 
 statement ok
 COMMIT

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -13,35 +13,35 @@ CREATE TABLE information_schema.t (x INT)
 query error database "information_schema" does not exist
 DROP DATABASE information_schema
 
-query TTTTI
+query TTTTIT
 SHOW TABLES FROM information_schema
 ----
-information_schema  administrable_role_authorizations      table  NULL  NULL
-information_schema  applicable_roles                       table  NULL  NULL
-information_schema  character_sets                         table  NULL  NULL
-information_schema  check_constraints                      table  NULL  NULL
-information_schema  collation_character_set_applicability  table  NULL  NULL
-information_schema  collations                             table  NULL  NULL
-information_schema  column_privileges                      table  NULL  NULL
-information_schema  column_udt_usage                       table  NULL  NULL
-information_schema  columns                                table  NULL  NULL
-information_schema  constraint_column_usage                table  NULL  NULL
-information_schema  enabled_roles                          table  NULL  NULL
-information_schema  key_column_usage                       table  NULL  NULL
-information_schema  parameters                             table  NULL  NULL
-information_schema  referential_constraints                table  NULL  NULL
-information_schema  role_table_grants                      table  NULL  NULL
-information_schema  routines                               table  NULL  NULL
-information_schema  schema_privileges                      table  NULL  NULL
-information_schema  schemata                               table  NULL  NULL
-information_schema  sequences                              table  NULL  NULL
-information_schema  statistics                             table  NULL  NULL
-information_schema  table_constraints                      table  NULL  NULL
-information_schema  table_privileges                       table  NULL  NULL
-information_schema  tables                                 table  NULL  NULL
-information_schema  type_privileges                        table  NULL  NULL
-information_schema  user_privileges                        table  NULL  NULL
-information_schema  views                                  table  NULL  NULL
+information_schema  administrable_role_authorizations      table  NULL  NULL  NULL
+information_schema  applicable_roles                       table  NULL  NULL  NULL
+information_schema  character_sets                         table  NULL  NULL  NULL
+information_schema  check_constraints                      table  NULL  NULL  NULL
+information_schema  collation_character_set_applicability  table  NULL  NULL  NULL
+information_schema  collations                             table  NULL  NULL  NULL
+information_schema  column_privileges                      table  NULL  NULL  NULL
+information_schema  column_udt_usage                       table  NULL  NULL  NULL
+information_schema  columns                                table  NULL  NULL  NULL
+information_schema  constraint_column_usage                table  NULL  NULL  NULL
+information_schema  enabled_roles                          table  NULL  NULL  NULL
+information_schema  key_column_usage                       table  NULL  NULL  NULL
+information_schema  parameters                             table  NULL  NULL  NULL
+information_schema  referential_constraints                table  NULL  NULL  NULL
+information_schema  role_table_grants                      table  NULL  NULL  NULL
+information_schema  routines                               table  NULL  NULL  NULL
+information_schema  schema_privileges                      table  NULL  NULL  NULL
+information_schema  schemata                               table  NULL  NULL  NULL
+information_schema  sequences                              table  NULL  NULL  NULL
+information_schema  statistics                             table  NULL  NULL  NULL
+information_schema  table_constraints                      table  NULL  NULL  NULL
+information_schema  table_privileges                       table  NULL  NULL  NULL
+information_schema  tables                                 table  NULL  NULL  NULL
+information_schema  type_privileges                        table  NULL  NULL  NULL
+information_schema  user_privileges                        table  NULL  NULL  NULL
+information_schema  views                                  table  NULL  NULL  NULL
 
 # Verify that the name is not special for databases.
 
@@ -158,35 +158,35 @@ postgres   root  NULL  {}  NULL
 system     node  NULL  {}  NULL
 test       root  NULL  {}  NULL
 
-query TTTTI
+query TTTTIT
 SHOW TABLES FROM test.information_schema
 ----
-information_schema  administrable_role_authorizations      table  NULL  NULL
-information_schema  applicable_roles                       table  NULL  NULL
-information_schema  character_sets                         table  NULL  NULL
-information_schema  check_constraints                      table  NULL  NULL
-information_schema  collation_character_set_applicability  table  NULL  NULL
-information_schema  collations                             table  NULL  NULL
-information_schema  column_privileges                      table  NULL  NULL
-information_schema  column_udt_usage                       table  NULL  NULL
-information_schema  columns                                table  NULL  NULL
-information_schema  constraint_column_usage                table  NULL  NULL
-information_schema  enabled_roles                          table  NULL  NULL
-information_schema  key_column_usage                       table  NULL  NULL
-information_schema  parameters                             table  NULL  NULL
-information_schema  referential_constraints                table  NULL  NULL
-information_schema  role_table_grants                      table  NULL  NULL
-information_schema  routines                               table  NULL  NULL
-information_schema  schema_privileges                      table  NULL  NULL
-information_schema  schemata                               table  NULL  NULL
-information_schema  sequences                              table  NULL  NULL
-information_schema  statistics                             table  NULL  NULL
-information_schema  table_constraints                      table  NULL  NULL
-information_schema  table_privileges                       table  NULL  NULL
-information_schema  tables                                 table  NULL  NULL
-information_schema  type_privileges                        table  NULL  NULL
-information_schema  user_privileges                        table  NULL  NULL
-information_schema  views                                  table  NULL  NULL
+information_schema  administrable_role_authorizations      table  NULL  NULL  NULL
+information_schema  applicable_roles                       table  NULL  NULL  NULL
+information_schema  character_sets                         table  NULL  NULL  NULL
+information_schema  check_constraints                      table  NULL  NULL  NULL
+information_schema  collation_character_set_applicability  table  NULL  NULL  NULL
+information_schema  collations                             table  NULL  NULL  NULL
+information_schema  column_privileges                      table  NULL  NULL  NULL
+information_schema  column_udt_usage                       table  NULL  NULL  NULL
+information_schema  columns                                table  NULL  NULL  NULL
+information_schema  constraint_column_usage                table  NULL  NULL  NULL
+information_schema  enabled_roles                          table  NULL  NULL  NULL
+information_schema  key_column_usage                       table  NULL  NULL  NULL
+information_schema  parameters                             table  NULL  NULL  NULL
+information_schema  referential_constraints                table  NULL  NULL  NULL
+information_schema  role_table_grants                      table  NULL  NULL  NULL
+information_schema  routines                               table  NULL  NULL  NULL
+information_schema  schema_privileges                      table  NULL  NULL  NULL
+information_schema  schemata                               table  NULL  NULL  NULL
+information_schema  sequences                              table  NULL  NULL  NULL
+information_schema  statistics                             table  NULL  NULL  NULL
+information_schema  table_constraints                      table  NULL  NULL  NULL
+information_schema  table_privileges                       table  NULL  NULL  NULL
+information_schema  tables                                 table  NULL  NULL  NULL
+information_schema  type_privileges                        table  NULL  NULL  NULL
+information_schema  user_privileges                        table  NULL  NULL  NULL
+information_schema  views                                  table  NULL  NULL  NULL
 
 query TT colnames
 SHOW CREATE TABLE information_schema.tables

--- a/pkg/sql/logictest/testdata/logic_test/multiregion
+++ b/pkg/sql/logictest/testdata/logic_test/multiregion
@@ -236,6 +236,16 @@ CREATE TABLE public.global_table (
                    FAMILY "primary" (a, rowid)
 ) LOCALITY GLOBAL
 
+query TTTTIT colnames
+SHOW TABLES
+----
+schema_name  table_name                              type   owner  estimated_row_count  locality
+public       global_table                            table  root   0                    GLOBAL
+public       regional_by_row_table                   table  root   0                    REGIONAL BY ROW
+public       regional_implicit_primary_region_table  table  root   0                    REGIONAL BY TABLE IN PRIMARY REGION
+public       regional_primary_region_table           table  root   0                    REGIONAL BY TABLE IN PRIMARY REGION
+public       regional_test3_table                    table  root   0                    REGIONAL BY TABLE IN test3
+
 statement ok
 CREATE DATABASE new_db
 

--- a/pkg/sql/logictest/testdata/logic_test/namespace
+++ b/pkg/sql/logictest/testdata/logic_test/namespace
@@ -5,27 +5,27 @@ statement ok
 CREATE DATABASE public; CREATE TABLE public.public.t(a INT)
 
 # "public" with the current database designates the public schema
-query TTTTI
+query TTTTIT
 SHOW TABLES FROM public
 ----
-public  a  table  root  0
+public  a  table  root  0  NULL
 
 # To access all tables in database "public", one must specify
 # its public schema explicitly.
-query TTTTI
+query TTTTIT
 SHOW TABLES FROM public.public
 ----
-public  t  table  root  NULL
+public  t  table  root  NULL  NULL
 
 # Of course one can also list the tables in "public" by making it the
 # current database.
 statement ok
 SET database = public
 
-query TTTTI
+query TTTTIT
 SHOW TABLES
 ----
-public  t  table  root  0
+public  t  table  root  0  NULL
 
 statement ok
 SET database = test; DROP DATABASE public

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -14,61 +14,61 @@ CREATE TABLE pg_catalog.t (x INT)
 query error database "pg_catalog" does not exist
 DROP DATABASE pg_catalog
 
-query TTTTI
+query TTTTIT
 SHOW TABLES FROM pg_catalog
 ----
-pg_catalog  pg_aggregate             table  NULL  NULL
-pg_catalog  pg_am                    table  NULL  NULL
-pg_catalog  pg_attrdef               table  NULL  NULL
-pg_catalog  pg_attribute             table  NULL  NULL
-pg_catalog  pg_auth_members          table  NULL  NULL
-pg_catalog  pg_authid                table  NULL  NULL
-pg_catalog  pg_available_extensions  table  NULL  NULL
-pg_catalog  pg_cast                  table  NULL  NULL
-pg_catalog  pg_class                 table  NULL  NULL
-pg_catalog  pg_collation             table  NULL  NULL
-pg_catalog  pg_constraint            table  NULL  NULL
-pg_catalog  pg_conversion            table  NULL  NULL
-pg_catalog  pg_database              table  NULL  NULL
-pg_catalog  pg_default_acl           table  NULL  NULL
-pg_catalog  pg_depend                table  NULL  NULL
-pg_catalog  pg_description           table  NULL  NULL
-pg_catalog  pg_enum                  table  NULL  NULL
-pg_catalog  pg_event_trigger         table  NULL  NULL
-pg_catalog  pg_extension             table  NULL  NULL
-pg_catalog  pg_foreign_data_wrapper  table  NULL  NULL
-pg_catalog  pg_foreign_server        table  NULL  NULL
-pg_catalog  pg_foreign_table         table  NULL  NULL
-pg_catalog  pg_index                 table  NULL  NULL
-pg_catalog  pg_indexes               table  NULL  NULL
-pg_catalog  pg_inherits              table  NULL  NULL
-pg_catalog  pg_language              table  NULL  NULL
-pg_catalog  pg_locks                 table  NULL  NULL
-pg_catalog  pg_matviews              table  NULL  NULL
-pg_catalog  pg_namespace             table  NULL  NULL
-pg_catalog  pg_opclass               table  NULL  NULL
-pg_catalog  pg_operator              table  NULL  NULL
-pg_catalog  pg_prepared_statements   table  NULL  NULL
-pg_catalog  pg_prepared_xacts        table  NULL  NULL
-pg_catalog  pg_proc                  table  NULL  NULL
-pg_catalog  pg_range                 table  NULL  NULL
-pg_catalog  pg_rewrite               table  NULL  NULL
-pg_catalog  pg_roles                 table  NULL  NULL
-pg_catalog  pg_seclabel              table  NULL  NULL
-pg_catalog  pg_seclabels             table  NULL  NULL
-pg_catalog  pg_sequence              table  NULL  NULL
-pg_catalog  pg_settings              table  NULL  NULL
-pg_catalog  pg_shdepend              table  NULL  NULL
-pg_catalog  pg_shdescription         table  NULL  NULL
-pg_catalog  pg_shseclabel            table  NULL  NULL
-pg_catalog  pg_stat_activity         table  NULL  NULL
-pg_catalog  pg_tables                table  NULL  NULL
-pg_catalog  pg_tablespace            table  NULL  NULL
-pg_catalog  pg_trigger               table  NULL  NULL
-pg_catalog  pg_type                  table  NULL  NULL
-pg_catalog  pg_user                  table  NULL  NULL
-pg_catalog  pg_user_mapping          table  NULL  NULL
-pg_catalog  pg_views                 table  NULL  NULL
+pg_catalog  pg_aggregate             table  NULL  NULL  NULL
+pg_catalog  pg_am                    table  NULL  NULL  NULL
+pg_catalog  pg_attrdef               table  NULL  NULL  NULL
+pg_catalog  pg_attribute             table  NULL  NULL  NULL
+pg_catalog  pg_auth_members          table  NULL  NULL  NULL
+pg_catalog  pg_authid                table  NULL  NULL  NULL
+pg_catalog  pg_available_extensions  table  NULL  NULL  NULL
+pg_catalog  pg_cast                  table  NULL  NULL  NULL
+pg_catalog  pg_class                 table  NULL  NULL  NULL
+pg_catalog  pg_collation             table  NULL  NULL  NULL
+pg_catalog  pg_constraint            table  NULL  NULL  NULL
+pg_catalog  pg_conversion            table  NULL  NULL  NULL
+pg_catalog  pg_database              table  NULL  NULL  NULL
+pg_catalog  pg_default_acl           table  NULL  NULL  NULL
+pg_catalog  pg_depend                table  NULL  NULL  NULL
+pg_catalog  pg_description           table  NULL  NULL  NULL
+pg_catalog  pg_enum                  table  NULL  NULL  NULL
+pg_catalog  pg_event_trigger         table  NULL  NULL  NULL
+pg_catalog  pg_extension             table  NULL  NULL  NULL
+pg_catalog  pg_foreign_data_wrapper  table  NULL  NULL  NULL
+pg_catalog  pg_foreign_server        table  NULL  NULL  NULL
+pg_catalog  pg_foreign_table         table  NULL  NULL  NULL
+pg_catalog  pg_index                 table  NULL  NULL  NULL
+pg_catalog  pg_indexes               table  NULL  NULL  NULL
+pg_catalog  pg_inherits              table  NULL  NULL  NULL
+pg_catalog  pg_language              table  NULL  NULL  NULL
+pg_catalog  pg_locks                 table  NULL  NULL  NULL
+pg_catalog  pg_matviews              table  NULL  NULL  NULL
+pg_catalog  pg_namespace             table  NULL  NULL  NULL
+pg_catalog  pg_opclass               table  NULL  NULL  NULL
+pg_catalog  pg_operator              table  NULL  NULL  NULL
+pg_catalog  pg_prepared_statements   table  NULL  NULL  NULL
+pg_catalog  pg_prepared_xacts        table  NULL  NULL  NULL
+pg_catalog  pg_proc                  table  NULL  NULL  NULL
+pg_catalog  pg_range                 table  NULL  NULL  NULL
+pg_catalog  pg_rewrite               table  NULL  NULL  NULL
+pg_catalog  pg_roles                 table  NULL  NULL  NULL
+pg_catalog  pg_seclabel              table  NULL  NULL  NULL
+pg_catalog  pg_seclabels             table  NULL  NULL  NULL
+pg_catalog  pg_sequence              table  NULL  NULL  NULL
+pg_catalog  pg_settings              table  NULL  NULL  NULL
+pg_catalog  pg_shdepend              table  NULL  NULL  NULL
+pg_catalog  pg_shdescription         table  NULL  NULL  NULL
+pg_catalog  pg_shseclabel            table  NULL  NULL  NULL
+pg_catalog  pg_stat_activity         table  NULL  NULL  NULL
+pg_catalog  pg_tables                table  NULL  NULL  NULL
+pg_catalog  pg_tablespace            table  NULL  NULL  NULL
+pg_catalog  pg_trigger               table  NULL  NULL  NULL
+pg_catalog  pg_type                  table  NULL  NULL  NULL
+pg_catalog  pg_user                  table  NULL  NULL  NULL
+pg_catalog  pg_user_mapping          table  NULL  NULL  NULL
+pg_catalog  pg_views                 table  NULL  NULL  NULL
 
 # Verify "pg_catalog" is a regular db name
 
@@ -92,61 +92,61 @@ SELECT * FROM pg_catalog.pg_class c WHERE nonexistent_function()
 
 # Verify pg_catalog handles reflection correctly.
 
-query TTTTI
+query TTTTIT
 SHOW TABLES FROM test.pg_catalog
 ----
-pg_catalog  pg_aggregate             table  NULL  NULL
-pg_catalog  pg_am                    table  NULL  NULL
-pg_catalog  pg_attrdef               table  NULL  NULL
-pg_catalog  pg_attribute             table  NULL  NULL
-pg_catalog  pg_auth_members          table  NULL  NULL
-pg_catalog  pg_authid                table  NULL  NULL
-pg_catalog  pg_available_extensions  table  NULL  NULL
-pg_catalog  pg_cast                  table  NULL  NULL
-pg_catalog  pg_class                 table  NULL  NULL
-pg_catalog  pg_collation             table  NULL  NULL
-pg_catalog  pg_constraint            table  NULL  NULL
-pg_catalog  pg_conversion            table  NULL  NULL
-pg_catalog  pg_database              table  NULL  NULL
-pg_catalog  pg_default_acl           table  NULL  NULL
-pg_catalog  pg_depend                table  NULL  NULL
-pg_catalog  pg_description           table  NULL  NULL
-pg_catalog  pg_enum                  table  NULL  NULL
-pg_catalog  pg_event_trigger         table  NULL  NULL
-pg_catalog  pg_extension             table  NULL  NULL
-pg_catalog  pg_foreign_data_wrapper  table  NULL  NULL
-pg_catalog  pg_foreign_server        table  NULL  NULL
-pg_catalog  pg_foreign_table         table  NULL  NULL
-pg_catalog  pg_index                 table  NULL  NULL
-pg_catalog  pg_indexes               table  NULL  NULL
-pg_catalog  pg_inherits              table  NULL  NULL
-pg_catalog  pg_language              table  NULL  NULL
-pg_catalog  pg_locks                 table  NULL  NULL
-pg_catalog  pg_matviews              table  NULL  NULL
-pg_catalog  pg_namespace             table  NULL  NULL
-pg_catalog  pg_opclass               table  NULL  NULL
-pg_catalog  pg_operator              table  NULL  NULL
-pg_catalog  pg_prepared_statements   table  NULL  NULL
-pg_catalog  pg_prepared_xacts        table  NULL  NULL
-pg_catalog  pg_proc                  table  NULL  NULL
-pg_catalog  pg_range                 table  NULL  NULL
-pg_catalog  pg_rewrite               table  NULL  NULL
-pg_catalog  pg_roles                 table  NULL  NULL
-pg_catalog  pg_seclabel              table  NULL  NULL
-pg_catalog  pg_seclabels             table  NULL  NULL
-pg_catalog  pg_sequence              table  NULL  NULL
-pg_catalog  pg_settings              table  NULL  NULL
-pg_catalog  pg_shdepend              table  NULL  NULL
-pg_catalog  pg_shdescription         table  NULL  NULL
-pg_catalog  pg_shseclabel            table  NULL  NULL
-pg_catalog  pg_stat_activity         table  NULL  NULL
-pg_catalog  pg_tables                table  NULL  NULL
-pg_catalog  pg_tablespace            table  NULL  NULL
-pg_catalog  pg_trigger               table  NULL  NULL
-pg_catalog  pg_type                  table  NULL  NULL
-pg_catalog  pg_user                  table  NULL  NULL
-pg_catalog  pg_user_mapping          table  NULL  NULL
-pg_catalog  pg_views                 table  NULL  NULL
+pg_catalog  pg_aggregate             table  NULL  NULL  NULL
+pg_catalog  pg_am                    table  NULL  NULL  NULL
+pg_catalog  pg_attrdef               table  NULL  NULL  NULL
+pg_catalog  pg_attribute             table  NULL  NULL  NULL
+pg_catalog  pg_auth_members          table  NULL  NULL  NULL
+pg_catalog  pg_authid                table  NULL  NULL  NULL
+pg_catalog  pg_available_extensions  table  NULL  NULL  NULL
+pg_catalog  pg_cast                  table  NULL  NULL  NULL
+pg_catalog  pg_class                 table  NULL  NULL  NULL
+pg_catalog  pg_collation             table  NULL  NULL  NULL
+pg_catalog  pg_constraint            table  NULL  NULL  NULL
+pg_catalog  pg_conversion            table  NULL  NULL  NULL
+pg_catalog  pg_database              table  NULL  NULL  NULL
+pg_catalog  pg_default_acl           table  NULL  NULL  NULL
+pg_catalog  pg_depend                table  NULL  NULL  NULL
+pg_catalog  pg_description           table  NULL  NULL  NULL
+pg_catalog  pg_enum                  table  NULL  NULL  NULL
+pg_catalog  pg_event_trigger         table  NULL  NULL  NULL
+pg_catalog  pg_extension             table  NULL  NULL  NULL
+pg_catalog  pg_foreign_data_wrapper  table  NULL  NULL  NULL
+pg_catalog  pg_foreign_server        table  NULL  NULL  NULL
+pg_catalog  pg_foreign_table         table  NULL  NULL  NULL
+pg_catalog  pg_index                 table  NULL  NULL  NULL
+pg_catalog  pg_indexes               table  NULL  NULL  NULL
+pg_catalog  pg_inherits              table  NULL  NULL  NULL
+pg_catalog  pg_language              table  NULL  NULL  NULL
+pg_catalog  pg_locks                 table  NULL  NULL  NULL
+pg_catalog  pg_matviews              table  NULL  NULL  NULL
+pg_catalog  pg_namespace             table  NULL  NULL  NULL
+pg_catalog  pg_opclass               table  NULL  NULL  NULL
+pg_catalog  pg_operator              table  NULL  NULL  NULL
+pg_catalog  pg_prepared_statements   table  NULL  NULL  NULL
+pg_catalog  pg_prepared_xacts        table  NULL  NULL  NULL
+pg_catalog  pg_proc                  table  NULL  NULL  NULL
+pg_catalog  pg_range                 table  NULL  NULL  NULL
+pg_catalog  pg_rewrite               table  NULL  NULL  NULL
+pg_catalog  pg_roles                 table  NULL  NULL  NULL
+pg_catalog  pg_seclabel              table  NULL  NULL  NULL
+pg_catalog  pg_seclabels             table  NULL  NULL  NULL
+pg_catalog  pg_sequence              table  NULL  NULL  NULL
+pg_catalog  pg_settings              table  NULL  NULL  NULL
+pg_catalog  pg_shdepend              table  NULL  NULL  NULL
+pg_catalog  pg_shdescription         table  NULL  NULL  NULL
+pg_catalog  pg_shseclabel            table  NULL  NULL  NULL
+pg_catalog  pg_stat_activity         table  NULL  NULL  NULL
+pg_catalog  pg_tables                table  NULL  NULL  NULL
+pg_catalog  pg_tablespace            table  NULL  NULL  NULL
+pg_catalog  pg_trigger               table  NULL  NULL  NULL
+pg_catalog  pg_type                  table  NULL  NULL  NULL
+pg_catalog  pg_user                  table  NULL  NULL  NULL
+pg_catalog  pg_user_mapping          table  NULL  NULL  NULL
+pg_catalog  pg_views                 table  NULL  NULL  NULL
 
 query TT colnames
 SHOW CREATE TABLE pg_catalog.pg_namespace

--- a/pkg/sql/logictest/testdata/logic_test/rename_database
+++ b/pkg/sql/logictest/testdata/logic_test/rename_database
@@ -154,10 +154,10 @@ DROP DATABASE testuserdb2
 statement ok
 CREATE VIEW t.v AS SELECT k,v FROM u.kv
 
-query TTTTI
+query TTTTIT
 SHOW TABLES FROM u
 ----
-public  kv  table  root  0
+public  kv  table  root  0  NULL
 
 statement error cannot rename database because relation "t.public.v" depends on relation "u.public.kv"
 ALTER DATABASE u RENAME TO v

--- a/pkg/sql/logictest/testdata/logic_test/rename_table
+++ b/pkg/sql/logictest/testdata/logic_test/rename_table
@@ -19,10 +19,10 @@ SELECT * FROM kv
 1 2
 3 4
 
-query TTTTI
+query TTTTIT
 SHOW TABLES
 ----
-public  kv  table  root  0
+public  kv  table  root  0  NULL
 
 statement ok
 ALTER TABLE kv RENAME TO new_kv
@@ -36,10 +36,10 @@ SELECT * FROM new_kv
 1 2
 3 4
 
-query TTTTI
+query TTTTIT
 SHOW TABLES
 ----
-public  new_kv  table  root  0
+public  new_kv  table  root  0  NULL
 
 # check the name in the descriptor, which is used by SHOW GRANTS, is also changed
 query TTTTT
@@ -95,11 +95,11 @@ GRANT CREATE ON DATABASE test TO testuser
 statement ok
 ALTER TABLE test.t RENAME TO t2
 
-query TTTTI
+query TTTTIT
 SHOW TABLES
 ----
-public  new_kv  table  root  0
-public  t2      table  root  0
+public  new_kv  table  root  0  NULL
+public  t2      table  root  0  NULL
 
 user testuser
 
@@ -122,15 +122,15 @@ ALTER TABLE test.new_kv RENAME TO test2.t
 statement ok
 ALTER TABLE test.t2 RENAME TO test2.t2
 
-query TTTTI
+query TTTTIT
 SHOW TABLES
 ----
 
-query TTTTI
+query TTTTIT
 SHOW TABLES FROM test2
 ----
-public  t   table  root  NULL
-public  t2  table  root  NULL
+public  t   table  root  NULL  NULL
+public  t2  table  root  NULL  NULL
 
 user root
 
@@ -244,10 +244,10 @@ INSERT INTO d.kv2 (k,v) VALUES ('c', 'd')
 statement ok
 USE d
 
-query TTTTI
+query TTTTIT
 SHOW TABLES
 ----
-public  kv  table  root  0
+public  kv  table  root  0  NULL
 
 query T
 EXPLAIN ALTER TABLE kv RENAME TO kv2
@@ -258,10 +258,10 @@ vectorized: false
 • rename table
 
 # Verify that the EXPLAIN above does not actually rename the table (#30543)
-query TTTTI
+query TTTTIT
 SHOW TABLES
 ----
-public  kv  table  root  0
+public  kv  table  root  0  NULL
 
 # Test that tables can't be renamed to a different database unless both the
 # old and new schemas are in the public schema.

--- a/pkg/sql/logictest/testdata/logic_test/rename_view
+++ b/pkg/sql/logictest/testdata/logic_test/rename_view
@@ -25,11 +25,11 @@ SELECT * FROM v
 1 2
 3 4
 
-query TTTTI
+query TTTTIT
 SHOW TABLES
 ----
-public  kv  table  root  0
-public  v   view   root  0
+public  kv  table  root  0  NULL
+public  v   view   root  0  NULL
 
 statement error pgcode 42809 "kv" is not a view
 ALTER VIEW kv RENAME TO new_kv
@@ -47,11 +47,11 @@ SELECT * FROM new_v
 1 2
 3 4
 
-query TTTTI
+query TTTTIT
 SHOW TABLES
 ----
-public  kv     table  root  0
-public  new_v  view   root  0
+public  kv     table  root  0  NULL
+public  new_v  view   root  0  NULL
 
 # check the name in the descriptor, which is used by SHOW GRANTS, is also changed
 query TTTTT
@@ -110,13 +110,13 @@ GRANT CREATE ON DATABASE test TO testuser
 statement ok
 ALTER VIEW test.v RENAME TO v2
 
-query TTTTI
+query TTTTIT
 SHOW TABLES FROM test
 ----
-public  kv     table  root  0
-public  new_v  view   root  0
-public  t      table  root  0
-public  v2     view   root  0
+public  kv     table  root  0  NULL
+public  new_v  view   root  0  NULL
+public  t      table  root  0  NULL
+public  v2     view   root  0  NULL
 
 user testuser
 
@@ -139,15 +139,15 @@ ALTER VIEW test.new_v RENAME TO test2.v
 statement ok
 ALTER VIEW test.v2 RENAME TO test2.v2
 
-query TTTTI
+query TTTTIT
 SHOW TABLES FROM test
 ----
 
-query TTTTI
+query TTTTIT
 SHOW TABLES FROM test2
 ----
-public  v   view  root  NULL
-public  v2  view  root  NULL
+public  v   view  root  NULL  NULL
+public  v2  view  root  NULL  NULL
 
 user root
 

--- a/pkg/sql/logictest/testdata/logic_test/role
+++ b/pkg/sql/logictest/testdata/logic_test/role
@@ -1113,12 +1113,12 @@ SHOW DATABASES
 ----
 publicdb  root  NULL  {}  NULL
 
-query TTTTI
+query TTTTIT
 SHOW TABLES FROM publicdb
 ----
-public  publictable  table  root  NULL
+public  publictable  table  root  NULL  NULL
 
-query TTTTI
+query TTTTIT
 SHOW TABLES FROM privatedb
 ----
 
@@ -1161,7 +1161,7 @@ SELECT * FROM publicdb.publictable
 statement error user testuser does not have INSERT privilege on relation publictable
 INSERT INTO publicdb.publictable VALUES (1)
 
-query TTTTI
+query TTTTIT
 SHOW TABLES FROM publicdb
 ----
 

--- a/pkg/sql/logictest/testdata/logic_test/save_table
+++ b/pkg/sql/logictest/testdata/logic_test/save_table
@@ -75,20 +75,20 @@ key  val
 9    nine
 10   one-zero
 
-query TTTTI rowsort
+query TTTTIT rowsort
 SHOW TABLES
 ----
-public  save_table_test_scan_1  table  root  0
-public  st_lookup_join_2        table  root  0
-public  st_project_1            table  root  0
-public  st_scan_4               table  root  0
-public  st_select_3             table  root  0
-public  st_test_merge_join_2    table  root  0
-public  st_test_project_1       table  root  0
-public  st_test_scan_3          table  root  0
-public  st_test_scan_4          table  root  0
-public  t                       table  root  0
-public  u                       table  root  0
+public  save_table_test_scan_1  table  root  0  NULL
+public  st_lookup_join_2        table  root  0  NULL
+public  st_project_1            table  root  0  NULL
+public  st_scan_4               table  root  0  NULL
+public  st_select_3             table  root  0  NULL
+public  st_test_merge_join_2    table  root  0  NULL
+public  st_test_project_1       table  root  0  NULL
+public  st_test_scan_3          table  root  0  NULL
+public  st_test_scan_4          table  root  0  NULL
+public  t                       table  root  0  NULL
+public  u                       table  root  0  NULL
 
 # Only root may use the saveTableNode.
 

--- a/pkg/sql/logictest/testdata/logic_test/select_search_path
+++ b/pkg/sql/logictest/testdata/logic_test/select_search_path
@@ -1,7 +1,7 @@
 # Test that pg_catalog tables are accessible without qualifying table/view
 # names.
 
-query TTTTI
+query TTTTIT
 SHOW TABLES
 ----
 

--- a/pkg/sql/logictest/testdata/logic_test/set
+++ b/pkg/sql/logictest/testdata/logic_test/set
@@ -25,10 +25,10 @@ statement ok
 CREATE TABLE bar (k INT PRIMARY KEY)
 
 # Verify that the table is indeed in "foo".
-query TTTTI
+query TTTTIT
 SHOW TABLES FROM foo
 ----
-public  bar  table  root  0
+public  bar  table  root  0  NULL
 
 # Verify set to empty string.
 statement ok
@@ -44,10 +44,10 @@ statement error no database or schema specified
 SHOW TABLES
 
 # Verify SHOW TABLES FROM works when there is no current database.
-query TTTTI
+query TTTTIT
 SHOW TABLES FROM foo
 ----
-public  bar  table  root  0
+public  bar  table  root  0  NULL
 
 # SET statement succeeds, CREATE TABLE fails.
 statement error pgcode 42P07 relation \"bar\" already exists
@@ -60,10 +60,10 @@ database
 foo
 
 # SET succeeds
-query TTTTI
+query TTTTIT
 SHOW TABLES from foo
 ----
-public  bar  table  root  0
+public  bar  table  root  0  NULL
 
 statement error invalid variable name: ""
 SET ROW (1, TRUE, NULL)

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -186,73 +186,73 @@ SELECT * FROM [SHOW SEQUENCES FROM system]
 ----
 sequence_schema  sequence_name
 
-query TTTTI colnames,rowsort
+query TTTTIT colnames,rowsort
 SELECT * FROM [SHOW TABLES FROM system]
 ----
-schema_name  table_name                       type   owner  estimated_row_count
-public       namespace                        table  NULL   NULL
-public       descriptor                       table  NULL   NULL
-public       users                            table  NULL   NULL
-public       zones                            table  NULL   NULL
-public       settings                         table  NULL   NULL
-public       tenants                          table  NULL   NULL
-public       lease                            table  NULL   NULL
-public       eventlog                         table  NULL   NULL
-public       rangelog                         table  NULL   NULL
-public       ui                               table  NULL   NULL
-public       jobs                             table  NULL   NULL
-public       web_sessions                     table  NULL   NULL
-public       table_statistics                 table  NULL   NULL
-public       locations                        table  NULL   NULL
-public       role_members                     table  NULL   NULL
-public       comments                         table  NULL   NULL
-public       replication_constraint_stats     table  NULL   NULL
-public       replication_critical_localities  table  NULL   NULL
-public       replication_stats                table  NULL   NULL
-public       reports_meta                     table  NULL   NULL
-public       namespace2                       table  NULL   NULL
-public       protected_ts_meta                table  NULL   NULL
-public       protected_ts_records             table  NULL   NULL
-public       role_options                     table  NULL   NULL
-public       statement_bundle_chunks          table  NULL   NULL
-public       statement_diagnostics_requests   table  NULL   NULL
-public       statement_diagnostics            table  NULL   NULL
-public       scheduled_jobs                   table  NULL   NULL
-public       sqlliveness                      table  NULL   NULL
+schema_name  table_name                       type   owner  estimated_row_count  locality
+public       namespace                        table  NULL   NULL                 NULL
+public       descriptor                       table  NULL   NULL                 NULL
+public       users                            table  NULL   NULL                 NULL
+public       zones                            table  NULL   NULL                 NULL
+public       settings                         table  NULL   NULL                 NULL
+public       tenants                          table  NULL   NULL                 NULL
+public       lease                            table  NULL   NULL                 NULL
+public       eventlog                         table  NULL   NULL                 NULL
+public       rangelog                         table  NULL   NULL                 NULL
+public       ui                               table  NULL   NULL                 NULL
+public       jobs                             table  NULL   NULL                 NULL
+public       web_sessions                     table  NULL   NULL                 NULL
+public       table_statistics                 table  NULL   NULL                 NULL
+public       locations                        table  NULL   NULL                 NULL
+public       role_members                     table  NULL   NULL                 NULL
+public       comments                         table  NULL   NULL                 NULL
+public       replication_constraint_stats     table  NULL   NULL                 NULL
+public       replication_critical_localities  table  NULL   NULL                 NULL
+public       replication_stats                table  NULL   NULL                 NULL
+public       reports_meta                     table  NULL   NULL                 NULL
+public       namespace2                       table  NULL   NULL                 NULL
+public       protected_ts_meta                table  NULL   NULL                 NULL
+public       protected_ts_records             table  NULL   NULL                 NULL
+public       role_options                     table  NULL   NULL                 NULL
+public       statement_bundle_chunks          table  NULL   NULL                 NULL
+public       statement_diagnostics_requests   table  NULL   NULL                 NULL
+public       statement_diagnostics            table  NULL   NULL                 NULL
+public       scheduled_jobs                   table  NULL   NULL                 NULL
+public       sqlliveness                      table  NULL   NULL                 NULL
 
-query TTTTTT colnames,rowsort
+query TTTTTTT colnames,rowsort
 SELECT * FROM [SHOW TABLES FROM system WITH COMMENT]
 ----
-schema_name  table_name                       type   owner  estimated_row_count  comment
-public       namespace                        table  NULL   NULL                 ·
-public       descriptor                       table  NULL   NULL                 ·
-public       users                            table  NULL   NULL                 ·
-public       zones                            table  NULL   NULL                 ·
-public       settings                         table  NULL   NULL                 ·
-public       tenants                          table  NULL   NULL                 ·
-public       lease                            table  NULL   NULL                 ·
-public       eventlog                         table  NULL   NULL                 ·
-public       rangelog                         table  NULL   NULL                 ·
-public       ui                               table  NULL   NULL                 ·
-public       jobs                             table  NULL   NULL                 ·
-public       web_sessions                     table  NULL   NULL                 ·
-public       table_statistics                 table  NULL   NULL                 ·
-public       locations                        table  NULL   NULL                 ·
-public       role_members                     table  NULL   NULL                 ·
-public       comments                         table  NULL   NULL                 ·
-public       replication_constraint_stats     table  NULL   NULL                 ·
-public       replication_critical_localities  table  NULL   NULL                 ·
-public       replication_stats                table  NULL   NULL                 ·
-public       reports_meta                     table  NULL   NULL                 ·
-public       namespace2                       table  NULL   NULL                 ·
-public       protected_ts_meta                table  NULL   NULL                 ·
-public       protected_ts_records             table  NULL   NULL                 ·
-public       role_options                     table  NULL   NULL                 ·
-public       statement_bundle_chunks          table  NULL   NULL                 ·
-public       statement_diagnostics_requests   table  NULL   NULL                 ·
-public       statement_diagnostics            table  NULL   NULL                 ·
-public       scheduled_jobs                   table  NULL   NULL                 ·
-public       sqlliveness                      table  NULL   NULL                 ·
+schema_name  table_name                       type   owner  estimated_row_count  locality  comment
+public       namespace                        table  NULL   NULL                 NULL      ·
+public       descriptor                       table  NULL   NULL                 NULL      ·
+public       users                            table  NULL   NULL                 NULL      ·
+public       zones                            table  NULL   NULL                 NULL      ·
+public       settings                         table  NULL   NULL                 NULL      ·
+public       tenants                          table  NULL   NULL                 NULL      ·
+public       lease                            table  NULL   NULL                 NULL      ·
+public       eventlog                         table  NULL   NULL                 NULL      ·
+public       rangelog                         table  NULL   NULL                 NULL      ·
+public       ui                               table  NULL   NULL                 NULL      ·
+public       jobs                             table  NULL   NULL                 NULL      ·
+public       web_sessions                     table  NULL   NULL                 NULL      ·
+public       table_statistics                 table  NULL   NULL                 NULL      ·
+public       locations                        table  NULL   NULL                 NULL      ·
+public       role_members                     table  NULL   NULL                 NULL      ·
+public       comments                         table  NULL   NULL                 NULL      ·
+public       replication_constraint_stats     table  NULL   NULL                 NULL      ·
+public       replication_critical_localities  table  NULL   NULL                 NULL      ·
+public       replication_stats                table  NULL   NULL                 NULL      ·
+public       reports_meta                     table  NULL   NULL                 NULL      ·
+public       namespace2                       table  NULL   NULL                 NULL      ·
+public       protected_ts_meta                table  NULL   NULL                 NULL      ·
+public       protected_ts_records             table  NULL   NULL                 NULL      ·
+public       role_options                     table  NULL   NULL                 NULL      ·
+public       statement_bundle_chunks          table  NULL   NULL                 NULL      ·
+public       statement_diagnostics_requests   table  NULL   NULL                 NULL      ·
+public       statement_diagnostics            table  NULL   NULL                 NULL      ·
+public       scheduled_jobs                   table  NULL   NULL                 NULL      ·
+public       sqlliveness                      table  NULL   NULL                 NULL      ·
 
 query ITTT colnames
 SELECT node_id, user_name, application_name, active_queries
@@ -279,11 +279,11 @@ pg_catalog          NULL
 pg_extension        NULL
 public              admin
 
-query TTTTI colnames
+query TTTTIT colnames
 CREATE TABLE foo(x INT); SELECT * FROM [SHOW TABLES]
 ----
-schema_name  table_name  type   owner  estimated_row_count
-public       foo         table  root   0
+schema_name  table_name  type   owner  estimated_row_count  locality
+public       foo         table  root   0                    NULL
 
 
 query T colnames

--- a/pkg/sql/logictest/testdata/logic_test/system
+++ b/pkg/sql/logictest/testdata/logic_test/system
@@ -7,38 +7,38 @@ postgres   root  NULL  {}  NULL
 system     node  NULL  {}  NULL
 test       root  NULL  {}  NULL
 
-query TTTTI
+query TTTTIT
 SHOW TABLES FROM system
 ----
-public  comments                         table  NULL  NULL
-public  descriptor                       table  NULL  NULL
-public  eventlog                         table  NULL  NULL
-public  jobs                             table  NULL  NULL
-public  lease                            table  NULL  NULL
-public  locations                        table  NULL  NULL
-public  namespace                        table  NULL  NULL
-public  namespace2                       table  NULL  NULL
-public  protected_ts_meta                table  NULL  NULL
-public  protected_ts_records             table  NULL  NULL
-public  rangelog                         table  NULL  NULL
-public  replication_constraint_stats     table  NULL  NULL
-public  replication_critical_localities  table  NULL  NULL
-public  replication_stats                table  NULL  NULL
-public  reports_meta                     table  NULL  NULL
-public  role_members                     table  NULL  NULL
-public  role_options                     table  NULL  NULL
-public  scheduled_jobs                   table  NULL  NULL
-public  settings                         table  NULL  NULL
-public  sqlliveness                      table  NULL  NULL
-public  statement_bundle_chunks          table  NULL  NULL
-public  statement_diagnostics            table  NULL  NULL
-public  statement_diagnostics_requests   table  NULL  NULL
-public  table_statistics                 table  NULL  NULL
-public  tenants                          table  NULL  NULL
-public  ui                               table  NULL  NULL
-public  users                            table  NULL  NULL
-public  web_sessions                     table  NULL  NULL
-public  zones                            table  NULL  NULL
+public  comments                         table  NULL  NULL  NULL
+public  descriptor                       table  NULL  NULL  NULL
+public  eventlog                         table  NULL  NULL  NULL
+public  jobs                             table  NULL  NULL  NULL
+public  lease                            table  NULL  NULL  NULL
+public  locations                        table  NULL  NULL  NULL
+public  namespace                        table  NULL  NULL  NULL
+public  namespace2                       table  NULL  NULL  NULL
+public  protected_ts_meta                table  NULL  NULL  NULL
+public  protected_ts_records             table  NULL  NULL  NULL
+public  rangelog                         table  NULL  NULL  NULL
+public  replication_constraint_stats     table  NULL  NULL  NULL
+public  replication_critical_localities  table  NULL  NULL  NULL
+public  replication_stats                table  NULL  NULL  NULL
+public  reports_meta                     table  NULL  NULL  NULL
+public  role_members                     table  NULL  NULL  NULL
+public  role_options                     table  NULL  NULL  NULL
+public  scheduled_jobs                   table  NULL  NULL  NULL
+public  settings                         table  NULL  NULL  NULL
+public  sqlliveness                      table  NULL  NULL  NULL
+public  statement_bundle_chunks          table  NULL  NULL  NULL
+public  statement_diagnostics            table  NULL  NULL  NULL
+public  statement_diagnostics_requests   table  NULL  NULL  NULL
+public  table_statistics                 table  NULL  NULL  NULL
+public  tenants                          table  NULL  NULL  NULL
+public  ui                               table  NULL  NULL  NULL
+public  users                            table  NULL  NULL  NULL
+public  web_sessions                     table  NULL  NULL  NULL
+public  zones                            table  NULL  NULL  NULL
 
 query I rowsort
 SELECT id FROM system.descriptor

--- a/pkg/sql/logictest/testdata/logic_test/table
+++ b/pkg/sql/logictest/testdata/logic_test/table
@@ -40,11 +40,11 @@ CREATE TABLE IF NOT EXISTS a (id INT PRIMARY KEY)
 statement ok
 COMMENT ON TABLE a IS 'a_comment'
 
-query TTTTI colnames
+query TTTTIT colnames
 SHOW TABLES FROM test
 ----
-schema_name  table_name  type   owner  estimated_row_count
-public       a           table  root   0
+schema_name  table_name  type   owner  estimated_row_count  locality
+public       a           table  root   0                    NULL
 
 statement ok
 CREATE TABLE b (id INT PRIMARY KEY)
@@ -133,15 +133,16 @@ a            INT8       false        NULL            ·                      {pr
 b            INT8       false        NULL            ·                      {primary}  false
 c            INT8       false        NULL            ·                      {primary}  false
 
-query TTTTIT
+query TTTTITT colnames
 SHOW TABLES FROM test WITH COMMENT
 ----
-public  a  table  root  0  a_comment
-public  b  table  root  0  ·
-public  c  table  root  0  ·
-public  d  table  root  0  ·
-public  e  table  root  0  ·
-public  f  table  root  0  ·
+schema_name  table_name  type   owner  estimated_row_count  locality  comment
+public       a           table  root   0                    NULL      a_comment
+public       b           table  root   0                    NULL      ·
+public       c           table  root   0                    NULL      ·
+public       d           table  root   0                    NULL      ·
+public       e           table  root   0                    NULL      ·
+public       f           table  root   0                    NULL      ·
 
 statement ok
 SET DATABASE = ""
@@ -522,10 +523,10 @@ statement ok
 INSERT INTO t1 SELECT a FROM generate_series(1, 1024) AS a(a)
 
 # only tables from current database
-query TTTTI
+query TTTTIT
 SHOW TABLES
 ----
-public  t1  table  testuser  0
+public  t1  table  testuser  0  NULL
 
 # see only virtual tables (estimated_row_count is NULL)
 # and tables testuser has access to (estimated_row_count >= 0)

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -208,42 +208,41 @@ vectorized: false
 └── • render
     │
     └── • hash join (left outer)
-        │ equality: (column59) = (table_id)
+        │ equality: (column72) = (table_id)
         │
         ├── • render
         │   │
-        │   └── • hash join (right outer)
-        │       │ equality: (oid) = (relowner)
+        │   └── • hash join (left outer)
+        │       │ equality: (column54) = (table_id)
         │       │
-        │       ├── • virtual table
-        │       │     table: pg_roles@primary
+        │       ├── • render
+        │       │   │
+        │       │   └── • hash join (right outer)
+        │       │       │ equality: (oid) = (relowner)
+        │       │       │
+        │       │       ├── • virtual table
+        │       │       │     table: pg_roles@primary
+        │       │       │
+        │       │       └── • hash join
+        │       │           │ equality: (oid) = (relnamespace)
+        │       │           │
+        │       │           ├── • filter
+        │       │           │   │ filter: nspname NOT IN ('crdb_internal', 'information_schema', 'pg_catalog', 'pg_extension')
+        │       │           │   │
+        │       │           │   └── • virtual table
+        │       │           │         table: pg_namespace@primary
+        │       │           │
+        │       │           └── • filter
+        │       │               │ filter: relkind IN ('S', 'm', 'r', 'v')
+        │       │               │
+        │       │               └── • virtual table
+        │       │                     table: pg_class@primary
         │       │
-        │       └── • hash join
-        │           │ equality: (oid) = (relnamespace)
-        │           │
-        │           ├── • filter
-        │           │   │ filter: nspname NOT IN ('crdb_internal', 'information_schema', 'pg_catalog', 'pg_extension')
-        │           │   │
-        │           │   └── • virtual table
-        │           │         table: pg_namespace@primary
-        │           │
-        │           └── • hash join (left outer)
-        │               │ equality: (oid) = (objoid)
-        │               │
-        │               ├── • filter
-        │               │   │ filter: relkind IN ('S', 'm', 'r', 'v')
-        │               │   │
-        │               │   └── • virtual table
-        │               │         table: pg_class@primary
-        │               │
-        │               └── • filter
-        │                   │ filter: objsubid = 0
-        │                   │
-        │                   └── • virtual table
-        │                         table: pg_description@primary
+        │       └── • virtual table
+        │             table: table_row_statistics@primary
         │
         └── • virtual table
-              table: table_row_statistics@primary
+              table: tables@primary
 
 
 query T
@@ -258,42 +257,50 @@ vectorized: false
 └── • render
     │
     └── • hash join (left outer)
-        │ equality: (column59) = (table_id)
+        │ equality: (column77) = (table_id)
         │
         ├── • render
         │   │
-        │   └── • hash join (right outer)
-        │       │ equality: (oid) = (relowner)
+        │   └── • hash join (left outer)
+        │       │ equality: (column59) = (table_id)
         │       │
-        │       ├── • virtual table
-        │       │     table: pg_roles@primary
+        │       ├── • render
+        │       │   │
+        │       │   └── • hash join (right outer)
+        │       │       │ equality: (oid) = (relowner)
+        │       │       │
+        │       │       ├── • virtual table
+        │       │       │     table: pg_roles@primary
+        │       │       │
+        │       │       └── • hash join
+        │       │           │ equality: (oid) = (relnamespace)
+        │       │           │
+        │       │           ├── • filter
+        │       │           │   │ filter: nspname NOT IN ('crdb_internal', 'information_schema', 'pg_catalog', 'pg_extension')
+        │       │           │   │
+        │       │           │   └── • virtual table
+        │       │           │         table: pg_namespace@primary
+        │       │           │
+        │       │           └── • hash join (left outer)
+        │       │               │ equality: (oid) = (objoid)
+        │       │               │
+        │       │               ├── • filter
+        │       │               │   │ filter: relkind IN ('S', 'm', 'r', 'v')
+        │       │               │   │
+        │       │               │   └── • virtual table
+        │       │               │         table: pg_class@primary
+        │       │               │
+        │       │               └── • filter
+        │       │                   │ filter: objsubid = 0
+        │       │                   │
+        │       │                   └── • virtual table
+        │       │                         table: pg_description@primary
         │       │
-        │       └── • hash join
-        │           │ equality: (oid) = (relnamespace)
-        │           │
-        │           ├── • filter
-        │           │   │ filter: nspname NOT IN ('crdb_internal', 'information_schema', 'pg_catalog', 'pg_extension')
-        │           │   │
-        │           │   └── • virtual table
-        │           │         table: pg_namespace@primary
-        │           │
-        │           └── • hash join (left outer)
-        │               │ equality: (oid) = (objoid)
-        │               │
-        │               ├── • filter
-        │               │   │ filter: relkind IN ('S', 'm', 'r', 'v')
-        │               │   │
-        │               │   └── • virtual table
-        │               │         table: pg_class@primary
-        │               │
-        │               └── • filter
-        │                   │ filter: objsubid = 0
-        │                   │
-        │                   └── • virtual table
-        │                         table: pg_description@primary
+        │       └── • virtual table
+        │             table: table_row_statistics@primary
         │
         └── • virtual table
-              table: table_row_statistics@primary
+              table: tables@primary
 
 query T
 SELECT * FROM [EXPLAIN SHOW DATABASE] WHERE info NOT LIKE '%size%'

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -556,7 +556,7 @@ func TestPGPreparedQuery(t *testing.T) {
 			baseTest.Results("users", "primary", false, 1, "username", "ASC", false, false),
 		}},
 		{"SHOW TABLES FROM system", []preparedQueryTest{
-			baseTest.Results("public", "comments", "table", gosql.NullString{}, gosql.NullString{}).Others(28),
+			baseTest.Results("public", "comments", "table", gosql.NullString{}, gosql.NullString{}, gosql.NullString{}).Others(28),
 		}},
 		{"SHOW SCHEMAS FROM system", []preparedQueryTest{
 			baseTest.Results("crdb_internal", gosql.NullString{}).Others(4),

--- a/pkg/sql/show_create_clauses.go
+++ b/pkg/sql/show_create_clauses.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemaexpr"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
@@ -268,25 +269,9 @@ func showFamilyClause(desc catalog.TableDescriptor, f *tree.FmtCtx) {
 // showCreateLocality creates the LOCALITY clauses for a CREATE statement, writing them
 // to tree.FmtCtx f.
 func showCreateLocality(desc catalog.TableDescriptor, f *tree.FmtCtx) error {
-	c := desc.TableDesc().LocalityConfig
-	if c != nil {
+	if c := desc.TableDesc().LocalityConfig; c != nil {
 		f.WriteString(" LOCALITY ")
-		switch v := c.Locality.(type) {
-		case *descpb.TableDescriptor_LocalityConfig_Global_:
-			f.WriteString("GLOBAL")
-		case *descpb.TableDescriptor_LocalityConfig_RegionalByTable_:
-			f.WriteString("REGIONAL BY TABLE IN ")
-			if v.RegionalByTable.Region != nil {
-				region := tree.Name(*v.RegionalByTable.Region)
-				f.FormatNode(&region)
-			} else {
-				f.WriteString("PRIMARY REGION")
-			}
-		case *descpb.TableDescriptor_LocalityConfig_RegionalByRow_:
-			f.WriteString("REGIONAL BY ROW")
-		default:
-			return errors.Newf("unknown locality: %T", v)
-		}
+		return tabledesc.FormatTableLocalityConfig(c, f)
 	}
 	return nil
 }


### PR DESCRIPTION
Also reduced the number of joins required on the comments table whilst
I was cleaning around it.

Release note (sql change): crdb_internal.tables and SHOW TABLES now
shows locality data on the tables.