### PR TITLE
sql: partially implement CONFIGURE ZONE logic during CREATE TABLE

### DIFF
--- a/pkg/sql/descriptor.go
+++ b/pkg/sql/descriptor.go
@@ -126,7 +126,7 @@ func (p *planner) createDatabase(
 		); err != nil {
 			return nil, false, err
 		}
-		if err := p.applyZoneConfigFromRegionConfigForDatabase(ctx, database.Name, *regionConfig); err != nil {
+		if err := p.applyZoneConfigFromDatabaseRegionConfig(ctx, database.Name, *regionConfig); err != nil {
 			return nil, true, err
 		}
 	}

--- a/pkg/sql/logictest/testdata/logic_test/multiregion
+++ b/pkg/sql/logictest/testdata/logic_test/multiregion
@@ -189,6 +189,17 @@ CREATE TABLE public.regional_primary_region_table (
                                                 FAMILY "primary" (a, rowid)
 ) LOCALITY REGIONAL BY TABLE IN PRIMARY REGION
 
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE regional_primary_region_table
+----
+DATABASE multi_region_test_db  ALTER DATABASE multi_region_test_db CONFIGURE ZONE USING
+                               range_min_bytes = 134217728,
+                               range_max_bytes = 536870912,
+                               gc.ttlseconds = 90000,
+                               num_replicas = 3,
+                               constraints = '{+region=test1: 1, +region=test2: 1, +region=test3: 1}',
+                               lease_preferences = '[[+region=test2]]'
+
 statement ok
 CREATE TABLE regional_implicit_primary_region_table (a int) LOCALITY REGIONAL BY TABLE
 
@@ -200,6 +211,17 @@ CREATE TABLE public.regional_implicit_primary_region_table (
                                                 FAMILY "primary" (a, rowid)
 ) LOCALITY REGIONAL BY TABLE IN PRIMARY REGION
 
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE regional_implicit_primary_region_table
+----
+DATABASE multi_region_test_db  ALTER DATABASE multi_region_test_db CONFIGURE ZONE USING
+                               range_min_bytes = 134217728,
+                               range_max_bytes = 536870912,
+                               gc.ttlseconds = 90000,
+                               num_replicas = 3,
+                               constraints = '{+region=test1: 1, +region=test2: 1, +region=test3: 1}',
+                               lease_preferences = '[[+region=test2]]'
+
 statement ok
 CREATE TABLE regional_test3_table (a int) LOCALITY REGIONAL BY TABLE IN "test3"
 
@@ -210,6 +232,17 @@ CREATE TABLE public.regional_test3_table (
                                        a INT8 NULL,
                                        FAMILY "primary" (a, rowid)
 ) LOCALITY REGIONAL BY TABLE IN test3
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE regional_test3_table
+----
+TABLE regional_test3_table  ALTER TABLE regional_test3_table CONFIGURE ZONE USING
+                            range_min_bytes = 134217728,
+                            range_max_bytes = 536870912,
+                            gc.ttlseconds = 90000,
+                            num_replicas = 3,
+                            constraints = '{+region=test3: 1}',
+                            lease_preferences = '[[+region=test3]]'
 
 statement error region "test4" has not been added to database "multi_region_test_db"\nHINT: available regions: test1, test2, test3
 CREATE TABLE regional_test4_table (a int) LOCALITY REGIONAL BY TABLE IN "test4"
@@ -225,6 +258,17 @@ CREATE TABLE public.regional_by_row_table (
                             FAMILY "primary" (a, rowid)
 ) LOCALITY REGIONAL BY ROW
 
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE regional_by_row_table
+----
+TABLE regional_by_row_table  ALTER TABLE regional_by_row_table CONFIGURE ZONE USING
+                             range_min_bytes = 134217728,
+                             range_max_bytes = 536870912,
+                             gc.ttlseconds = 90000,
+                             num_replicas = 3,
+                             constraints = '[]',
+                             lease_preferences = '[]'
+
 statement ok
 CREATE TABLE global_table (a int) LOCALITY GLOBAL
 
@@ -235,6 +279,17 @@ CREATE TABLE public.global_table (
                    a INT8 NULL,
                    FAMILY "primary" (a, rowid)
 ) LOCALITY GLOBAL
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE global_table
+----
+TABLE global_table  ALTER TABLE global_table CONFIGURE ZONE USING
+                    range_min_bytes = 134217728,
+                    range_max_bytes = 536870912,
+                    gc.ttlseconds = 90000,
+                    num_replicas = 3,
+                    constraints = '{+region=test1: 1, +region=test2: 1, +region=test3: 1}',
+                    lease_preferences = '[[+region=test2]]'
 
 query TTTTIT colnames
 SHOW TABLES

--- a/pkg/sql/region_util.go
+++ b/pkg/sql/region_util.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/errors"
+	"github.com/gogo/protobuf/proto"
 )
 
 type liveClusterRegions map[descpb.Region]struct{}
@@ -87,17 +88,14 @@ func makeRequiredZoneConstraintForRegion(r descpb.Region) zonepb.Constraint {
 	}
 }
 
-// genZoneConfigFromRegionConfigForDatabase generates a desired ZoneConfig based
+// zoneConfigFromRegionConfigForDatabase generates a desired ZoneConfig based
 // on the region config.
-// TODO(aayushshah15): properly configure this for region survivability and leaseholder
+// TODO(#multiregion,aayushshah15): properly configure this for region survivability and leaseholder
 // preferences when new zone configuration parameters merge.
-func genZoneConfigFromRegionConfigForDatabase(
+func zoneConfigFromRegionConfigForDatabase(
 	regionConfig descpb.DatabaseDescriptor_RegionConfig,
 ) *zonepb.ZoneConfig {
-	numReplicas := int32(len(regionConfig.Regions))
-	if numReplicas < 3 {
-		numReplicas = 3
-	}
+	numReplicas := zoneConfigNumReplicasFromRegionConfig(regionConfig)
 	conjunctions := []zonepb.ConstraintsConjunction{}
 	for _, region := range regionConfig.Regions {
 		conjunctions = append(
@@ -117,24 +115,99 @@ func genZoneConfigFromRegionConfigForDatabase(
 	}
 }
 
-func (p *planner) applyZoneConfigFromRegionConfigForDatabase(
-	ctx context.Context, dbName tree.Name, regionConfig descpb.DatabaseDescriptor_RegionConfig,
+// zoneConfigNumReplicasFromRegionConfig generates the number of replicas needed given a region config.
+func zoneConfigNumReplicasFromRegionConfig(
+	regionConfig descpb.DatabaseDescriptor_RegionConfig,
+) int32 {
+	// TODO(#multiregion): do we want 5 in the case of region failure?
+	numReplicas := int32(len(regionConfig.Regions))
+	if numReplicas < 3 {
+		numReplicas = 3
+	}
+	return numReplicas
+}
+
+// constraintsConjunctionForRegionalLocality generates a ConstraintsConjunction clause
+// to be set for a given locality.
+// TODO(#multiregion,aayushshah15): properly configure constraints and replicas for
+// region survivability and leaseholder preferences when new zone configuration parameters merge.
+func constraintsConjunctionForRegionalLocality(
+	region descpb.Region, regionConfig descpb.DatabaseDescriptor_RegionConfig,
+) ([]zonepb.ConstraintsConjunction, error) {
+	switch regionConfig.SurvivalGoal {
+	case descpb.SurvivalGoal_ZONE_FAILURE:
+		return []zonepb.ConstraintsConjunction{
+			{
+				NumReplicas: zoneConfigNumReplicasFromRegionConfig(regionConfig),
+				Constraints: []zonepb.Constraint{makeRequiredZoneConstraintForRegion(region)},
+			},
+		}, nil
+	case descpb.SurvivalGoal_REGION_FAILURE:
+		return []zonepb.ConstraintsConjunction{
+			{
+				NumReplicas: 1,
+				Constraints: []zonepb.Constraint{makeRequiredZoneConstraintForRegion(region)},
+			},
+		}, nil
+	default:
+		return nil, errors.AssertionFailedf("unknown survival goal: %v", regionConfig.SurvivalGoal)
+	}
+}
+
+// zoneConfigFromTableLocalityConfig generates a desired ZoneConfig based
+// on the locality config for the database.
+// This function can return a nil zonepb.ZoneConfig, meaning no update is required
+// to any zone config.
+// TODO(#multiregion,aayushshah15): properly configure this for region survivability and leaseholder
+// preferences when new zone configuration parameters merge.
+func zoneConfigFromTableLocalityConfig(
+	localityConfig descpb.TableDescriptor_LocalityConfig,
+	regionConfig descpb.DatabaseDescriptor_RegionConfig,
+) (*zonepb.ZoneConfig, error) {
+	ret := zonepb.ZoneConfig{
+		NumReplicas: proto.Int32(zoneConfigNumReplicasFromRegionConfig(regionConfig)),
+	}
+
+	switch l := localityConfig.Locality.(type) {
+	case *descpb.TableDescriptor_LocalityConfig_Global_:
+		// Inherit everything from the database.
+		ret.InheritedConstraints = true
+		ret.InheritedLeasePreferences = true
+	case *descpb.TableDescriptor_LocalityConfig_RegionalByTable_:
+		// Use the same configuration as the database and return nil here.
+		if l.RegionalByTable.Region == nil {
+			return nil, nil
+		}
+		preferredRegion := *l.RegionalByTable.Region
+		var err error
+		if ret.Constraints, err = constraintsConjunctionForRegionalLocality(preferredRegion, regionConfig); err != nil {
+			return nil, err
+		}
+		ret.LeasePreferences = []zonepb.LeasePreference{
+			{Constraints: []zonepb.Constraint{makeRequiredZoneConstraintForRegion(preferredRegion)}},
+		}
+	case *descpb.TableDescriptor_LocalityConfig_RegionalByRow_:
+		// TODO(#multiregion): figure out correct partition/subzone fields to make this work.
+		// We need to fill the table with PARTITION BY to get the ball rolling on this.
+		// For now, return a dummy field for now so that other tests relying on this path of code to
+		// exercise other functionality (i.e. SHOW) pass.
+	}
+	return &ret, nil
+}
+
+func (p *planner) applyZoneConfigForMultiRegion(
+	ctx context.Context, zs tree.ZoneSpecifier, zc *zonepb.ZoneConfig, desc string,
 ) error {
 	// Convert the partially filled zone config to re-run as a SQL command.
 	// This avoid us having to modularize planNode logic from set_zone_config
 	// and the optimizer.
-	sql, err := zoneConfigToSQL(
-		&tree.ZoneSpecifier{
-			Database: dbName,
-		},
-		genZoneConfigFromRegionConfigForDatabase(regionConfig),
-	)
+	sql, err := zoneConfigToSQL(&zs, zc)
 	if err != nil {
 		return err
 	}
 	if _, err := p.ExtendedEvalContext().ExecCfg.InternalExecutor.ExecEx(
 		ctx,
-		"apply-database-multiregion-set-zone-config",
+		desc,
 		p.Txn(),
 		sessiondata.InternalExecutorOverride{
 			User: p.SessionData().User(),
@@ -144,4 +217,47 @@ func (p *planner) applyZoneConfigFromRegionConfigForDatabase(
 		return err
 	}
 	return nil
+}
+
+func (p *planner) applyZoneConfigFromTableLocalityConfig(
+	ctx context.Context,
+	tblName tree.TableName,
+	localityConfig descpb.TableDescriptor_LocalityConfig,
+	regionConfig descpb.DatabaseDescriptor_RegionConfig,
+) error {
+	localityZoneConfig, err := zoneConfigFromTableLocalityConfig(localityConfig, regionConfig)
+	if err != nil {
+		return err
+	}
+	// If we do not have to configure anything, exit early.
+	if localityZoneConfig == nil {
+		return nil
+	}
+	// Construct an explicit name so that CONFIGURE ZONE has the fully qualified name.
+	// Without this, the table may fail to resolve.
+	explicitTblName := tree.MakeTableNameWithSchema(
+		tblName.CatalogName,
+		tblName.SchemaName,
+		tblName.ObjectName,
+	)
+	return p.applyZoneConfigForMultiRegion(
+		ctx,
+		tree.ZoneSpecifier{TableOrIndex: tree.TableIndexName{Table: explicitTblName}},
+		localityZoneConfig,
+		"table-multiregion-set-zone-config",
+	)
+}
+
+func (p *planner) applyZoneConfigFromDatabaseRegionConfig(
+	ctx context.Context, dbName tree.Name, regionConfig descpb.DatabaseDescriptor_RegionConfig,
+) error {
+	// Convert the partially filled zone config to re-run as a SQL command.
+	// This avoid us having to modularize planNode logic from set_zone_config
+	// and the optimizer.
+	return p.applyZoneConfigForMultiRegion(
+		ctx,
+		tree.ZoneSpecifier{Database: dbName},
+		zoneConfigFromRegionConfigForDatabase(regionConfig),
+		"database-multiregion-set-zone-config",
+	)
 }


### PR DESCRIPTION
Release note (sql change): CREATE TABLE ... LOCALITY ... statements now
modify the zone configs to be in line with the desired locality.