### PR TITLE
backupccl: properly support restoring cluster backups from collections

### DIFF
--- a/docs/generated/sql/bnf/restore.bnf
+++ b/docs/generated/sql/bnf/restore.bnf
@@ -5,6 +5,12 @@ restore_stmt ::=
 	| 'RESTORE' 'FROM' full_backup_location ( | partitioned_backup_location ( ',' partitioned_backup_location )*)  'WITH' restore_options_list
 	| 'RESTORE' 'FROM' full_backup_location ( | partitioned_backup_location ( ',' partitioned_backup_location )*)  'WITH' 'OPTIONS' '(' restore_options_list ')'
 	| 'RESTORE' 'FROM' full_backup_location ( | partitioned_backup_location ( ',' partitioned_backup_location )*)  
+	| 'RESTORE' 'FROM' subdirectory 'IN' full_backup_location ( | partitioned_backup_location ( ',' partitioned_backup_location )*) 'AS' 'OF' 'SYSTEM' 'TIME' timestamp 'WITH' restore_options_list
+	| 'RESTORE' 'FROM' subdirectory 'IN' full_backup_location ( | partitioned_backup_location ( ',' partitioned_backup_location )*) 'AS' 'OF' 'SYSTEM' 'TIME' timestamp 'WITH' 'OPTIONS' '(' restore_options_list ')'
+	| 'RESTORE' 'FROM' subdirectory 'IN' full_backup_location ( | partitioned_backup_location ( ',' partitioned_backup_location )*) 'AS' 'OF' 'SYSTEM' 'TIME' timestamp 
+	| 'RESTORE' 'FROM' subdirectory 'IN' full_backup_location ( | partitioned_backup_location ( ',' partitioned_backup_location )*)  'WITH' restore_options_list
+	| 'RESTORE' 'FROM' subdirectory 'IN' full_backup_location ( | partitioned_backup_location ( ',' partitioned_backup_location )*)  'WITH' 'OPTIONS' '(' restore_options_list ')'
+	| 'RESTORE' 'FROM' subdirectory 'IN' full_backup_location ( | partitioned_backup_location ( ',' partitioned_backup_location )*)  
 	| 'RESTORE' ( ( 'TABLE' | ) table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'FROM' full_backup_location ( | partitioned_backup_location ( ',' partitioned_backup_location )*) 'AS' 'OF' 'SYSTEM' 'TIME' timestamp 'WITH' restore_options_list
 	| 'RESTORE' ( ( 'TABLE' | ) table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'FROM' full_backup_location ( | partitioned_backup_location ( ',' partitioned_backup_location )*) 'AS' 'OF' 'SYSTEM' 'TIME' timestamp 'WITH' 'OPTIONS' '(' restore_options_list ')'
 	| 'RESTORE' ( ( 'TABLE' | ) table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'FROM' full_backup_location ( | partitioned_backup_location ( ',' partitioned_backup_location )*) 'AS' 'OF' 'SYSTEM' 'TIME' timestamp 

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -175,6 +175,7 @@ reset_stmt ::=
 
 restore_stmt ::=
 	'RESTORE' 'FROM' list_of_string_or_placeholder_opt_list opt_as_of_clause opt_with_restore_options
+	| 'RESTORE' 'FROM' string_or_placeholder 'IN' list_of_string_or_placeholder_opt_list opt_as_of_clause opt_with_restore_options
 	| 'RESTORE' targets 'FROM' list_of_string_or_placeholder_opt_list opt_as_of_clause opt_with_restore_options
 	| 'RESTORE' targets 'FROM' string_or_placeholder 'IN' list_of_string_or_placeholder_opt_list opt_as_of_clause opt_with_restore_options
 

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -620,6 +620,16 @@ func TestBackupRestoreAppend(t *testing.T) {
 
 			sqlDB.Exec(t, "DROP DATABASE data CASCADE")
 			sqlDB.Exec(t, "RESTORE DATABASE data FROM $4 IN ($1, $2, $3) AS OF SYSTEM TIME "+ts2, append(collections, fullBackup2)...)
+
+			if test.name != "userfile" {
+				// Cluster restores from userfile are not supported yet since the
+				// restoring cluster needs to be empty, which means it can't contain any
+				// userfile tables.
+
+				_, _, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(t, MultiNode, tmpDir, InitNone, base.TestClusterArgs{})
+				defer cleanupEmptyCluster()
+				sqlDBRestore.Exec(t, "RESTORE FROM $4 IN ($1, $2, $3) AS OF SYSTEM TIME "+ts2, append(collections, fullBackup2)...)
+			}
 		}
 
 		if test.name == "userfile" {

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -1700,6 +1700,14 @@ func TestParse(t *testing.T) {
 		{`RESTORE DATABASE foo FROM ($1, $2), ($3, $4)`},
 		{`RESTORE DATABASE foo FROM ($1, $2), ($3, $4) AS OF SYSTEM TIME '1'`},
 
+		{`RESTORE FROM ($1, $2)`},
+		{`RESTORE FROM ($1, $2), $3`},
+		{`RESTORE FROM $1, ($2, $3)`},
+		{`RESTORE FROM ($1, $2), ($3, $4)`},
+		{`RESTORE FROM ($1, $2), ($3, $4) AS OF SYSTEM TIME '1'`},
+		{`RESTORE FROM $4 IN $1, $2, 'bar'`},
+		{`RESTORE FROM $4 IN $1, $2, 'bar' AS OF SYSTEM TIME '1' WITH skip_missing_foreign_keys`},
+
 		{`RESTORE TENANT 36 FROM ($1, $2) AS OF SYSTEM TIME '1'`},
 
 		{`BACKUP TABLE foo TO 'bar' WITH revision_history, detached`},

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -2574,6 +2574,16 @@ restore_stmt:
     Options: *($5.restoreOptions()),
     }
   }
+| RESTORE FROM string_or_placeholder IN list_of_string_or_placeholder_opt_list opt_as_of_clause opt_with_restore_options
+  {
+    $$.val = &tree.Restore{
+    DescriptorCoverage: tree.AllDescriptors,
+		Subdir: $3.expr(),
+		From: $5.listOfStringOrPlaceholderOptList(),
+		AsOf: $6.asOfClause(),
+		Options: *($7.restoreOptions()),
+    }
+  }
 | RESTORE targets FROM list_of_string_or_placeholder_opt_list opt_as_of_clause opt_with_restore_options
   {
     $$.val = &tree.Restore{


### PR DESCRIPTION
Previously, cluster restores could not use the `RESTORE FROM ... IN ...`
syntax. This PR fixes that bug.

Fixes https://github.com/cockroachdb/cockroach/issues/57657.

Release note (bug fix): Previously, users could not perform a cluster
restore from old backup chains (incrementals on top of fulls), when
using the BACKUP INTO syntax.