### PR TITLE
release-20.2: sql: add force flag overloads to crdb_internal.unsafe_.* builtins

### DIFF
--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -88,13 +88,15 @@ type DummyEvalPlanner struct{}
 
 // UnsafeUpsertDescriptor is part of the EvalPlanner interface.
 func (ep *DummyEvalPlanner) UnsafeUpsertDescriptor(
-	ctx context.Context, descID int64, encodedDescriptor []byte,
+	ctx context.Context, descID int64, encodedDescriptor []byte, force bool,
 ) error {
 	return errors.WithStack(errEvalPlanner)
 }
 
 // UnsafeDeleteDescriptor is part of the EvalPlanner interface.
-func (ep *DummyEvalPlanner) UnsafeDeleteDescriptor(ctx context.Context, descID int64) error {
+func (ep *DummyEvalPlanner) UnsafeDeleteDescriptor(
+	ctx context.Context, descID int64, force bool,
+) error {
 	return errors.WithStack(errEvalPlanner)
 }
 
@@ -107,7 +109,7 @@ func (ep *DummyEvalPlanner) UnsafeUpsertNamespaceEntry(
 
 // UnsafeDeleteNamespaceEntry is part of the EvalPlanner interface.
 func (ep *DummyEvalPlanner) UnsafeDeleteNamespaceEntry(
-	ctx context.Context, parentID, parentSchemaID int64, name string, descID int64,
+	ctx context.Context, parentID, parentSchemaID int64, name string, descID int64, force bool,
 ) error {
 	return errors.WithStack(errEvalPlanner)
 }

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -4248,7 +4248,27 @@ may increase either contention or retry errors, or both.`,
 			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
 				if err := ctx.Planner.UnsafeUpsertDescriptor(ctx.Context,
 					int64(*args[0].(*tree.DInt)),
-					[]byte(*args[1].(*tree.DBytes))); err != nil {
+					[]byte(*args[1].(*tree.DBytes)),
+					false /* force */); err != nil {
+					return nil, err
+				}
+				return tree.DBoolTrue, nil
+			},
+			Info:       "This function is used only by CockroachDB's developers for testing purposes.",
+			Volatility: tree.VolatilityVolatile,
+		},
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"id", types.Int},
+				{"desc", types.Bytes},
+				{"force", types.Bool},
+			},
+			ReturnType: tree.FixedReturnType(types.Bool),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				if err := ctx.Planner.UnsafeUpsertDescriptor(ctx.Context,
+					int64(*args[0].(*tree.DInt)),
+					[]byte(*args[1].(*tree.DBytes)),
+					bool(*args[2].(*tree.DBool))); err != nil {
 					return nil, err
 				}
 				return tree.DBoolTrue, nil
@@ -4271,6 +4291,25 @@ may increase either contention or retry errors, or both.`,
 			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
 				if err := ctx.Planner.UnsafeDeleteDescriptor(ctx.Context,
 					int64(*args[0].(*tree.DInt)),
+					false, /* force */
+				); err != nil {
+					return nil, err
+				}
+				return tree.DBoolTrue, nil
+			},
+			Info:       "This function is used only by CockroachDB's developers for testing purposes.",
+			Volatility: tree.VolatilityVolatile,
+		},
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"id", types.Int},
+				{"force", types.Bool},
+			},
+			ReturnType: tree.FixedReturnType(types.Bool),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				if err := ctx.Planner.UnsafeDeleteDescriptor(ctx.Context,
+					int64(*args[0].(*tree.DInt)),
+					bool(*args[1].(*tree.DBool)),
 				); err != nil {
 					return nil, err
 				}
@@ -4356,7 +4395,33 @@ may increase either contention or retry errors, or both.`,
 					int64(*args[0].(*tree.DInt)),     // parentID
 					int64(*args[1].(*tree.DInt)),     // parentSchemaID
 					string(*args[2].(*tree.DString)), // name
-					int64(*args[3].(*tree.DInt)),     // descID
+					int64(*args[3].(*tree.DInt)),     // id
+					false,                            // force
+				); err != nil {
+					return nil, err
+				}
+				return tree.DBoolTrue, nil
+			},
+			Info:       "This function is used only by CockroachDB's developers for testing purposes.",
+			Volatility: tree.VolatilityVolatile,
+		},
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"parent_id", types.Int},
+				{"parent_schema_id", types.Int},
+				{"name", types.String},
+				{"desc_id", types.Int},
+				{"force", types.Bool},
+			},
+			ReturnType: tree.FixedReturnType(types.Bool),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				if err := ctx.Planner.UnsafeDeleteNamespaceEntry(
+					ctx.Context,
+					int64(*args[0].(*tree.DInt)),     // parentID
+					int64(*args[1].(*tree.DInt)),     // parentSchemaID
+					string(*args[2].(*tree.DString)), // name
+					int64(*args[3].(*tree.DInt)),     // id
+					bool(*args[4].(*tree.DBool)),     // force
 				); err != nil {
 					return nil, err
 				}

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -2990,19 +2990,33 @@ type EvalPlanner interface {
 
 	// UnsafeUpsertDescriptor is a used to repair descriptors in dire
 	// circumstances. See the comment on the planner implementation.
-	UnsafeUpsertDescriptor(ctx context.Context, descID int64, encodedDescriptor []byte) error
+	UnsafeUpsertDescriptor(
+		ctx context.Context, descID int64, encodedDescriptor []byte, force bool,
+	) error
 
 	// UnsafeDeleteDescriptor is a used to repair descriptors in dire
 	// circumstances. See the comment on the planner implementation.
-	UnsafeDeleteDescriptor(ctx context.Context, descID int64) error
+	UnsafeDeleteDescriptor(ctx context.Context, descID int64, force bool) error
 
 	// UnsafeUpsertNamespaceEntry is a used to repair namespace entries in dire
 	// circumstances. See the comment on the planner implementation.
-	UnsafeUpsertNamespaceEntry(ctx context.Context, parentID, parentSchemaID int64, name string, descID int64, force bool) error
+	UnsafeUpsertNamespaceEntry(
+		ctx context.Context,
+		parentID, parentSchemaID int64,
+		name string,
+		descID int64,
+		force bool,
+	) error
 
 	// UnsafeDeleteNamespaceEntry is a used to repair namespace entries in dire
 	// circumstances. See the comment on the planner implementation.
-	UnsafeDeleteNamespaceEntry(ctx context.Context, parentID, parentSchemaID int64, name string, descID int64) error
+	UnsafeDeleteNamespaceEntry(
+		ctx context.Context,
+		parentID, parentSchemaID int64,
+		name string,
+		descID int64,
+		force bool,
+	) error
 }
 
 // EvalSessionAccessor is a limited interface to access session variables.


### PR DESCRIPTION
Backport 1/1 commits from #57648.

/cc @cockroachdb/release

---

This commit adds the ability to force the crdb_internal.unsafe_.* builtins to
allow them to work even when the existing descriptor is invalid.

Fixes #57061.

Release note: None
