### PR TITLE
kvserver: fix two broken retry loops

### DIFF
--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -1348,7 +1348,7 @@ func (r *Replica) atomicReplicationChange(
 	descriptorOK := false
 	start := timeutil.Now()
 	retOpts := retry.Options{InitialBackoff: time.Second, MaxBackoff: time.Second, MaxRetries: 10}
-	for re := retry.StartWithCtx(ctx, retOpts); ; re.Next() {
+	for re := retry.StartWithCtx(ctx, retOpts); re.Next(); {
 		rDesc := r.Desc()
 		if rDesc.Generation >= desc.Generation {
 			descriptorOK = true
@@ -2275,7 +2275,7 @@ func (s *Store) AdminRelocateRange(
 	// out.
 	every := log.Every(time.Minute)
 	for {
-		for re := retry.StartWithCtx(ctx, retry.Options{MaxBackoff: 5 * time.Second}); ; re.Next() {
+		for re := retry.StartWithCtx(ctx, retry.Options{MaxBackoff: 5 * time.Second}); re.Next(); {
 			if err := ctx.Err(); err != nil {
 				return err
 			}


### PR DESCRIPTION
Found thanks to a linter warning on #57564.
I went through all callers of the method; the rest were doing the right
thing already.

Release note: None
