### PR TITLE
kv: fix a snapshot error test matcher

### DIFF
--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -2165,10 +2165,8 @@ func TestConcurrentAdminChangeReplicasRequests(t *testing.T) {
 		"expected one of racing AdminChangeReplicasRequests to fail but neither did")
 	// It is possible that an error can occur due to a rejected snapshot from the
 	// target range. We don't want to fail the test if we got one of those.
-	isSnapshotErr := func(err error) bool {
-		return testutils.IsError(err, "snapshot failed:")
-	}
-	atLeastOneIsSnapshotErr := isSnapshotErr(err1) || isSnapshotErr(err2)
+	atLeastOneIsSnapshotErr := kvserver.IsRetriableReplicationChangeError(err1) ||
+		kvserver.IsRetriableReplicationChangeError(err2)
 	assert.Falsef(t, err1 != nil && err2 != nil && !atLeastOneIsSnapshotErr,
 		"expected only one of racing AdminChangeReplicasRequests to fail but both "+
 			"had errors and neither were snapshot: %v %v", err1, err2)

--- a/pkg/kv/test_utils.go
+++ b/pkg/kv/test_utils.go
@@ -53,7 +53,7 @@ func IsExpectedRelocateError(err error) bool {
 		"unable to add replica .* which is already present",
 		"received invalid ChangeReplicasTrigger .* to remove self",
 		"failed to apply snapshot: raft group deleted",
-		"snapshot failed:",
+		"snapshot failed",
 		"breaker open",
 		"unable to select removal target", // https://github.com/cockroachdb/cockroach/issues/49513
 		"cannot up-replicate to .*; missing gossiped StoreDescriptor",


### PR DESCRIPTION
This had rotted slightly since the `:` is no longer present as of
51785591b469d590861536737009e2145726eb21.

Closes #57605.

Release note: None
