### PR TITLE
kv/kvserver: skip TestReplicateRange

### DIFF
--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -268,6 +268,7 @@ func TestStoreRecoverWithErrors(t *testing.T) {
 // and a range, replicating the range to the second store, and reading its data there.
 func TestReplicateRange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 57560, "flaky test")
 	defer log.Scope(t).Close(t)
 	mtc := &multiTestContext{
 		// This test was written before the multiTestContext started creating many


### PR DESCRIPTION
Refs: #57560

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes

Release note: None