### PR TITLE
kvserver: skip unnecessary hlc.Clock update in Store.Send()

### DIFF
--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -2245,7 +2245,7 @@ func TestQuotaPool(t *testing.T) {
 		value := bytes.Repeat([]byte("v"), (3*quota)/4)
 		var ba roachpb.BatchRequest
 		ba.Add(putArgs(key, value))
-		if err := ba.SetActiveTimestamp(mtc.clock().Now); err != nil {
+		if _, err := ba.SetActiveTimestamp(mtc.clock().Now); err != nil {
 			t.Fatal(err)
 		}
 		if _, pErr := leaderRepl.Send(ctx, ba); pErr != nil {
@@ -2266,7 +2266,7 @@ func TestQuotaPool(t *testing.T) {
 		go func() {
 			var ba roachpb.BatchRequest
 			ba.Add(putArgs(key, value))
-			if err := ba.SetActiveTimestamp(mtc.clock().Now); err != nil {
+			if _, err := ba.SetActiveTimestamp(mtc.clock().Now); err != nil {
 				ch <- roachpb.NewError(err)
 				return
 			}
@@ -2358,7 +2358,7 @@ func TestWedgedReplicaDetection(t *testing.T) {
 	value := []byte("value")
 	var ba roachpb.BatchRequest
 	ba.Add(putArgs(key, value))
-	if err := ba.SetActiveTimestamp(mtc.clock().Now); err != nil {
+	if _, err := ba.SetActiveTimestamp(mtc.clock().Now); err != nil {
 		t.Fatal(err)
 	}
 	if _, pErr := leaderRepl.Send(ctx, ba); pErr != nil {

--- a/pkg/kv/kvserver/closed_timestamp_test.go
+++ b/pkg/kv/kvserver/closed_timestamp_test.go
@@ -90,7 +90,7 @@ func TestClosedTimestampCanServe(t *testing.T) {
 		baWrite.Txn = &txn
 		baWrite.Add(r)
 		baWrite.RangeID = repls[0].RangeID
-		if err := baWrite.SetActiveTimestamp(tc.Server(0).Clock().Now); err != nil {
+		if _, err := baWrite.SetActiveTimestamp(tc.Server(0).Clock().Now); err != nil {
 			t.Fatal(err)
 		}
 


### PR DESCRIPTION
Previously, `Store.Send()` updated `hlc.Clock` using
`BatchRequest.Timestamp` even when this timestamp was originally empty
and subsequently set to `Clock.Now()`. This unnecessary update
contributes to HLC lock contention as described in #37277.

This commit skips updating the HLC when the request timestamp is set to
`Clock.Now()`, to reduce HLC contention.

Release note: None

Resolves #37277.

I'd be curious to see what effect, if any, this has on HLC contention -- particularly after #56708. Is there a good way to inspect this?