### PR TITLE
optbuilder: add ST_Collect/ST_MakeLine to isOrderingSensitive

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -5015,6 +5015,11 @@ SELECT ST_AsEWKT(ST_MakeLine(g::geometry)) FROM ( VALUES
 NULL
 
 query T
+SELECT ST_AsText(ST_MakeLine(geom ORDER BY geom)) FROM geo_table
+----
+LINESTRING (1 1, 2 2, 2.22 -2.445)
+
+query T
 SELECT ST_Extent(g::geometry) FROM ( VALUES
   (NULL),
   ('POINT(-10.5 10.5)'),
@@ -5090,6 +5095,16 @@ query T
 SELECT ST_AsEWKT(ST_Collect(g::geometry)) FROM ( VALUES ('GEOMETRYCOLLECTION (POINT (1 1))'), ('GEOMETRYCOLLECTION (POINT (2 2))')) tbl(g)
 ----
 GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (1 1)), GEOMETRYCOLLECTION (POINT (2 2)))
+
+query T
+SELECT ST_AsText(ST_Collect(geom ORDER BY geom)) FROM geo_table
+----
+MULTIPOINT (1 1, 2 2, 2.22 -2.445)
+
+query T
+SELECT ST_AsText(ST_MemCollect(geom ORDER BY geom)) FROM geo_table
+----
+MULTIPOINT (1 1, 2 2, 2.22 -2.445)
 
 query T
 SELECT ST_AsEWKT(ST_MemCollect(g::geometry)) FROM ( VALUES (NULL), ('POINT (1 1)'), ('POINT EMPTY'), ('POINT (2 2)')) tbl(g)

--- a/pkg/sql/opt/optbuilder/groupby.go
+++ b/pkg/sql/opt/optbuilder/groupby.go
@@ -252,7 +252,8 @@ func (a aggregateInfo) isOrderingSensitive() bool {
 		return true
 	}
 	switch a.def.Name {
-	case "array_agg", "concat_agg", "string_agg", "json_agg", "jsonb_agg", "json_object_agg", "jsonb_object_agg":
+	case "array_agg", "concat_agg", "string_agg", "json_agg", "jsonb_agg", "json_object_agg", "jsonb_object_agg",
+		"st_makeline", "st_collect", "st_memcollect":
 		return true
 	default:
 		return false


### PR DESCRIPTION
Release note (bug fix): Fix a bug where ST_MakeLine and ST_Collect
did not respect ordering when used over a window clause.