### PR TITLE
backupccl: fix range accounting in backup progress logger

### DIFF
--- a/pkg/ccl/backupccl/backup_processor_planning.go
+++ b/pkg/ccl/backupccl/backup_processor_planning.go
@@ -26,12 +26,10 @@ import (
 	"github.com/cockroachdb/logtags"
 )
 
-// distBackup is used to plan the processors for a distributed backup. It
-// streams back progress updates over progCh, which is used to incrementally
-// build up the BulkOpSummary.
-func distBackup(
-	ctx context.Context,
+func distBackupPlanSpecs(
+	planCtx *sql.PlanningCtx,
 	execCtx sql.JobExecContext,
+	dsp *sql.DistSQLPlanner,
 	spans roachpb.Spans,
 	introducedSpans roachpb.Spans,
 	pkIDs map[uint64]bool,
@@ -40,22 +38,8 @@ func distBackup(
 	encryption *jobspb.BackupEncryptionOptions,
 	mvccFilter roachpb.MVCCFilter,
 	startTime, endTime hlc.Timestamp,
-	progCh chan *execinfrapb.RemoteProducerMetadata_BulkProcessorProgress,
-) error {
-	ctx = logtags.AddTag(ctx, "backup-distsql", nil)
-	var noTxn *kv.Txn
-
-	dsp := execCtx.DistSQLPlanner()
-	evalCtx := execCtx.ExtendedEvalContext()
-
-	// We don't return the compatible nodes here since PartitionSpans will
-	// filter out incompatible nodes.
-	planCtx, _, err := dsp.SetupAllNodesPlanning(ctx, evalCtx, execCtx.ExecCfg())
-	if err != nil {
-		return errors.Wrap(err, "failed to determine nodes on which to run")
-	}
-
-	backupSpecs, err := makeBackupDataProcessorSpecs(
+) (map[roachpb.NodeID]*execinfrapb.BackupDataSpec, error) {
+	return makeBackupDataProcessorSpecs(
 		planCtx,
 		dsp,
 		spans,
@@ -69,16 +53,27 @@ func distBackup(
 		execCtx.User(),
 		execCtx.ExecCfg(),
 	)
-	if err != nil {
-		return errors.Wrap(err, "failed to determine backup execution plan")
-	}
+}
+
+// distBackup is used to plan the processors for a distributed backup. It
+// streams back progress updates over progCh, which is used to incrementally
+// build up the BulkOpSummary.
+func distBackup(
+	ctx context.Context,
+	execCtx sql.JobExecContext,
+	planCtx *sql.PlanningCtx,
+	dsp *sql.DistSQLPlanner,
+	progCh chan *execinfrapb.RemoteProducerMetadata_BulkProcessorProgress,
+	backupSpecs map[roachpb.NodeID]*execinfrapb.BackupDataSpec,
+) error {
+	ctx = logtags.AddTag(ctx, "backup-distsql", nil)
+	evalCtx := execCtx.ExtendedEvalContext()
+	var noTxn *kv.Txn
 
 	if len(backupSpecs) == 0 {
 		close(progCh)
 		return nil
 	}
-
-	p := planCtx.NewPhysicalPlan()
 
 	// Setup a one-stage plan with one proc per input spec.
 	corePlacement := make([]physicalplan.ProcessorCorePlacement, len(backupSpecs))
@@ -89,6 +84,7 @@ func distBackup(
 		i++
 	}
 
+	p := planCtx.NewPhysicalPlan()
 	// All of the progress information is sent through the metadata stream, so we
 	// have an empty result stream.
 	p.AddNoInputStage(corePlacement, execinfrapb.PostProcessSpec{}, []*types.T{}, execinfrapb.Ordering{})


### PR DESCRIPTION
This commit moves code around so that the progress logger has the same
capacity as the number of export requests we expect to send. It first
plans the distsql backup specs, which partitions the spans, and then
uses the specs to determine the size of the progress channel.

Release note: None