### PR TITLE
sql/contention: add contention registry for global contention observability

### DIFF
--- a/pkg/sql/contention/BUILD.bazel
+++ b/pkg/sql/contention/BUILD.bazel
@@ -1,0 +1,31 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "contention",
+    srcs = ["registry.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/sql/contention",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/keys",
+        "//pkg/roachpb",
+        "//pkg/sql/catalog/descpb",
+        "//pkg/util/cache",
+        "//pkg/util/uuid",
+        "//vendor/github.com/biogo/store/llrb",
+    ],
+)
+
+go_test(
+    name = "contention_test",
+    srcs = ["registry_test.go"],
+    data = glob(["testdata/**"]),
+    embed = [":contention"],
+    deps = [
+        "//pkg/keys",
+        "//pkg/roachpb",
+        "//pkg/storage/enginepb",
+        "//pkg/util/encoding",
+        "//pkg/util/uuid",
+        "//vendor/github.com/cockroachdb/datadriven",
+    ],
+)

--- a/pkg/sql/contention/registry.go
+++ b/pkg/sql/contention/registry.go
@@ -1,0 +1,238 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package contention
+
+import (
+	"fmt"
+	"strings"
+	"time"
+	"unsafe"
+
+	"github.com/biogo/store/llrb"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/util/cache"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+)
+
+// Registry is an object that keeps track of aggregated contention information.
+// It can be thought of as three maps:
+// 1) The top-level map is a mapping from a tableID/indexID which uniquely
+// describes an index to that index's contention information.
+// 2) The contention information is itself a map from keys in that index
+// (maintained in sorted order for better observability) to a list of
+// transactions that caused contention events on the keys.
+// 3) These transactions map the transaction ID to the number of times that
+// transaction was observed (i.e. how many contention events that txn
+// generated).
+// The datadriven test contains string representations of this struct which make
+// it easier to visualize.
+// TODO(asubiotto): Make this thread-safe once it's used.
+type Registry struct {
+	// indexMap is an LRU cache that keeps track of up to indexMapMaxSize
+	// contended indexes.
+	indexMap *indexMap
+}
+
+const (
+	// indexMapMaxSize specifies the maximum number of indexes a Registry should
+	// keep track of contention events for.
+	indexMapMaxSize = 50
+	// orderedKeyMapMaxSize specifies the maximum number of keys in a given table
+	// to keep track of contention events for.
+	orderedKeyMapMaxSize = 50
+	// maxNumTxns specifies the maximum number of txns that caused contention
+	// events to keep track of.
+	maxNumTxns = 10
+)
+
+// TODO(asubiotto): Remove once used.
+var _ = GetRegistryEstimatedMaxMemoryFootprintInBytes
+
+// GetRegistryEstimatedMaxMemoryFootprintInBytes returns the estimated memory
+// footprint of a contention.Registry given an average key size of
+// estimatedAverageKeySize bytes.
+// Serves to reserve a reasonable amount of memory for this object.
+// Around ~4.5MB at the time of writing.
+func GetRegistryEstimatedMaxMemoryFootprintInBytes() uintptr {
+	const estimatedAverageKeySize = 64
+	txnsMapSize := maxNumTxns * (unsafe.Sizeof(uuid.UUID{}) + unsafe.Sizeof(int(0)))
+	orderedKeyMapSize := orderedKeyMapMaxSize * ((unsafe.Sizeof(comparableKey{}) * estimatedAverageKeySize) + txnsMapSize)
+	return indexMapMaxSize * (unsafe.Sizeof(indexMapKey{}) + unsafe.Sizeof(indexMapValue{}) + orderedKeyMapSize)
+}
+
+var orderedKeyMapCfg = cache.Config{
+	Policy: cache.CacheLRU,
+	ShouldEvict: func(size int, _, _ interface{}) bool {
+		return size > orderedKeyMapMaxSize
+	},
+}
+
+var txnCacheCfg = cache.Config{
+	Policy: cache.CacheLRU,
+	ShouldEvict: func(size int, _, _ interface{}) bool {
+		return size > maxNumTxns
+	},
+}
+
+type comparableKey roachpb.Key
+
+// Compare implements llrb.Comparable.
+func (c comparableKey) Compare(other llrb.Comparable) int {
+	return roachpb.Key(c).Compare(roachpb.Key(other.(comparableKey)))
+}
+
+type indexMapKey struct {
+	tableID descpb.ID
+	indexID descpb.IndexID
+}
+
+// indexMapValue is the value associated with an indexMapKey. It contains
+// contention information about the tableID/indexID pair.
+type indexMapValue struct {
+	// numContentionEvents is the number of contention events that have happened.
+	numContentionEvents uint64
+	// cumulativeContentionTime is the total duration that transactions touching
+	// this index have spent contended.
+	cumulativeContentionTime time.Duration
+	// orderedKeyMap is an LRU cache that keeps track of up to
+	// orderedKeyMapMaxSize keys that were the subject of contention in the given
+	// index. The keys are roachpb.Keys and the values are *cache.UnorderedCaches,
+	// which in turn is a cache of txn IDs of txns that caused contention events
+	// and the number of times that each txn ID was observed.
+	orderedKeyMap *cache.OrderedCache
+}
+
+// newIndexMapValue creates a new indexMapValue for a contention event
+// initialized with that event's data.
+func newIndexMapValue(c roachpb.ContentionEvent) *indexMapValue {
+	txnCache := cache.NewUnorderedCache(txnCacheCfg)
+	txnCache.Add(c.Txn.TxnMeta.ID, 1)
+	keyMap := cache.NewOrderedCache(orderedKeyMapCfg)
+	keyMap.Add(comparableKey(c.Key), txnCache)
+	return &indexMapValue{
+		numContentionEvents:      1,
+		cumulativeContentionTime: c.Duration,
+		orderedKeyMap:            keyMap,
+	}
+}
+
+// addContentionEvent adds the given contention event to previously aggregated
+// contention data.
+func (v *indexMapValue) addContentionEvent(c roachpb.ContentionEvent) {
+	v.numContentionEvents++
+	v.cumulativeContentionTime += c.Duration
+	var numTimesThisTxnWasEncountered int
+	txnCache, ok := v.orderedKeyMap.Get(comparableKey(c.Key))
+	if ok {
+		if txnVal, ok := txnCache.(*cache.UnorderedCache).Get(c.Txn.TxnMeta.ID); ok {
+			numTimesThisTxnWasEncountered = txnVal.(int)
+		}
+	} else {
+		// This key was not found in the map. Create a new txn cache for this key.
+		txnCache = cache.NewUnorderedCache(txnCacheCfg)
+		v.orderedKeyMap.Add(comparableKey(c.Key), txnCache)
+	}
+	txnCache.(*cache.UnorderedCache).Add(c.Txn.TxnMeta.ID, numTimesThisTxnWasEncountered+1)
+}
+
+// indexMap is a helper struct that wraps an LRU cache sized up to
+// indexMapMaxSize and maps tableID/indexID pairs to indexMapValues.
+type indexMap struct {
+	internalCache *cache.UnorderedCache
+	scratchKey    indexMapKey
+}
+
+func newIndexMap() *indexMap {
+	return &indexMap{
+		internalCache: cache.NewUnorderedCache(cache.Config{
+			Policy: cache.CacheLRU,
+			ShouldEvict: func(size int, _, _ interface{}) bool {
+				return size > indexMapMaxSize
+			},
+		}),
+	}
+}
+
+// get gets the indexMapValue keyed by the tableID/indexID pair and returns it
+// and true if it exists, nil and false if not. This counts as a cache access.
+func (m *indexMap) get(tableID descpb.ID, indexID descpb.IndexID) (*indexMapValue, bool) {
+	m.scratchKey.tableID = tableID
+	m.scratchKey.indexID = indexID
+	v, ok := m.internalCache.Get(m.scratchKey)
+	if !ok {
+		return nil, false
+	}
+	return v.(*indexMapValue), true
+}
+
+// add adds the indexMapValue keyed by the tableID/indexID pair. This counts as
+// a cache access.
+func (m *indexMap) add(tableID descpb.ID, indexID descpb.IndexID, v *indexMapValue) {
+	m.scratchKey.tableID = tableID
+	m.scratchKey.indexID = indexID
+	m.internalCache.Add(m.scratchKey, v)
+}
+
+// NewRegistry creates a new Registry.
+func NewRegistry() *Registry {
+	r := &Registry{
+		indexMap: newIndexMap(),
+	}
+	return r
+}
+
+// AddContentionEvent adds a new ContentionEvent to the Registry.
+func (r *Registry) AddContentionEvent(c roachpb.ContentionEvent) error {
+	_, rawTableID, rawIndexID, err := keys.DecodeTableIDIndexID(c.Key)
+	if err != nil {
+		return err
+	}
+	tableID := descpb.ID(rawTableID)
+	indexID := descpb.IndexID(rawIndexID)
+	if v, ok := r.indexMap.get(tableID, indexID); !ok {
+		// This is the first contention event seen for the given tableID/indexID
+		// pair.
+		r.indexMap.add(tableID, indexID, newIndexMapValue(c))
+	} else {
+		v.addContentionEvent(c)
+	}
+	return nil
+}
+
+// String returns a string representation of the Registry.
+func (r *Registry) String() string {
+	var b strings.Builder
+	r.indexMap.internalCache.Do(func(e *cache.Entry) {
+		key := e.Key.(indexMapKey)
+		b.WriteString(fmt.Sprintf("tableID=%d indexID=%d\n", key.tableID, key.indexID))
+		writeChild := func(prefix, s string) {
+			b.WriteString(prefix + s)
+		}
+		const prefixString = "  "
+		prefix := prefixString
+		v := e.Value.(*indexMapValue)
+		writeChild(prefix, fmt.Sprintf("num contention events: %d\n", v.numContentionEvents))
+		writeChild(prefix, fmt.Sprintf("cumulative contention time: %s\n", v.cumulativeContentionTime))
+		writeChild(prefix, "keys:\n")
+		keyPrefix := prefix + prefixString
+		v.orderedKeyMap.Do(func(k, txnCache interface{}) bool {
+			writeChild(keyPrefix, fmt.Sprintf("%s contending txns:\n", roachpb.Key(k.(comparableKey))))
+			txnPrefix := keyPrefix + prefixString
+			txnCache.(*cache.UnorderedCache).Do(func(e *cache.Entry) {
+				writeChild(txnPrefix, fmt.Sprintf("id=%s count=%d\n", e.Key.(uuid.UUID), e.Value.(int)))
+			})
+			return false
+		})
+	})
+	return b.String()
+}

--- a/pkg/sql/contention/registry_test.go
+++ b/pkg/sql/contention/registry_test.go
@@ -1,0 +1,127 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package contention
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"github.com/cockroachdb/datadriven"
+)
+
+// TestRegistry runs the datadriven test found in testdata/contention_registry.
+// The format of these tests is:
+// # Use and create if nonexistent a registry named "a".
+// use registry=a
+// ----
+//
+// # Add a contention event to the registry but don't verify state.
+// # tableid is the table ID.
+// # indexid is the index ID.
+// # key is a string key that a contention event was generated for.
+// # txnid is an id that represents the contending transaction.
+// # duration is the duration of ns the contention event lasted for.
+// ev tableid=1 indexid=1 key=key txnid=a duration=1
+// ----
+//
+// use registry=b
+// ----
+//
+// # Add a contention event to the registry and verify state.
+// evcheck tableid=1 indexid=1 key=key txnid=b duration=2
+// ----
+// < Registry b as string >
+func TestRegistry(t *testing.T) {
+	uuidMap := make(map[string]uuid.UUID)
+	testFriendlyRegistryString := func(r *Registry) string {
+		stringRepresentation := r.String()
+		// Swap out all UUIDs for corresponding test-friendly IDs.
+		for friendlyID, txnID := range uuidMap {
+			stringRepresentation = strings.Replace(stringRepresentation, txnID.String(), friendlyID, -1)
+		}
+		return stringRepresentation
+	}
+	registryMap := make(map[string]*Registry)
+	// registry is the current registry.
+	var registry *Registry
+	datadriven.RunTest(t, "testdata/contention_registry", func(t *testing.T, d *datadriven.TestData) string {
+		switch d.Cmd {
+		case "use":
+			var registryKey string
+			d.ScanArgs(t, "registry", &registryKey)
+			var ok bool
+			registry, ok = registryMap[registryKey]
+			if !ok {
+				registry = NewRegistry()
+				registryMap[registryKey] = registry
+			}
+			return d.Expected
+		case "ev", "evcheck":
+			var (
+				tableIDStr string
+				indexIDStr string
+				key        string
+				id         string
+				duration   string
+			)
+			d.ScanArgs(t, "tableid", &tableIDStr)
+			tableID, err := strconv.Atoi(tableIDStr)
+			if err != nil {
+				return fmt.Sprintf("could not parse table ID %s as int: %v", tableIDStr, err)
+			}
+			d.ScanArgs(t, "indexid", &indexIDStr)
+			indexID, err := strconv.Atoi(indexIDStr)
+			if err != nil {
+				return fmt.Sprintf("could not parse index ID %s as int: %v", indexIDStr, err)
+			}
+			d.ScanArgs(t, "key", &key)
+			d.ScanArgs(t, "id", &id)
+			contendingTxnID, ok := uuidMap[id]
+			if !ok {
+				// If a UUID wasn't created, create it and keep it for future reference.
+				contendingTxnID = uuid.MakeV4()
+				uuidMap[id] = contendingTxnID
+			}
+			d.ScanArgs(t, "duration", &duration)
+			contentionDuration, err := strconv.Atoi(duration)
+			if err != nil {
+				return fmt.Sprintf("could not parse duration %s as int: %v", duration, err)
+			}
+			keyBytes := keys.MakeTableIDIndexID(nil, uint32(tableID), uint32(indexID))
+			keyBytes = encoding.EncodeStringAscending(keyBytes, key)
+			if err := registry.AddContentionEvent(roachpb.ContentionEvent{
+				Key: keyBytes,
+				Txn: roachpb.Transaction{
+					TxnMeta: enginepb.TxnMeta{
+						ID: contendingTxnID,
+					},
+				},
+				Duration: time.Duration(contentionDuration),
+			}); err != nil {
+				return err.Error()
+			}
+			if d.Cmd == "evcheck" {
+				return testFriendlyRegistryString(registry)
+			}
+			return d.Expected
+		default:
+			return fmt.Sprintf("unknown command: %s", d.Cmd)
+		}
+	})
+}

--- a/pkg/sql/contention/testdata/contention_registry
+++ b/pkg/sql/contention/testdata/contention_registry
@@ -1,0 +1,111 @@
+use registry=a
+----
+
+evcheck tableid=1 indexid=1 key=key id=a duration=1
+----
+tableID=1 indexID=1
+  num contention events: 1
+  cumulative contention time: 1ns
+  keys:
+    /Table/1/1/"key" contending txns:
+      id=a count=1
+
+# Add another event to the same key contending with a different txn and ensure
+# correct aggregation.
+evcheck tableid=1 indexid=1 key=key id=b duration=3
+----
+tableID=1 indexID=1
+  num contention events: 2
+  cumulative contention time: 4ns
+  keys:
+    /Table/1/1/"key" contending txns:
+      id=b count=1
+      id=a count=1
+
+# Add txn with an ID that was already encountered.
+evcheck tableid=1 indexid=1 key=key id=a duration=5
+----
+tableID=1 indexID=1
+  num contention events: 3
+  cumulative contention time: 9ns
+  keys:
+    /Table/1/1/"key" contending txns:
+      id=a count=2
+      id=b count=1
+
+# Add txn on another key.
+evcheck tableid=1 indexid=1 key=keyc id=a duration=11
+----
+tableID=1 indexID=1
+  num contention events: 4
+  cumulative contention time: 20ns
+  keys:
+    /Table/1/1/"key" contending txns:
+      id=a count=2
+      id=b count=1
+    /Table/1/1/"keyc" contending txns:
+      id=a count=1
+
+# Ensure keys are in sorted order.
+evcheck tableid=1 indexid=1 key=keyb id=a duration=1
+----
+tableID=1 indexID=1
+  num contention events: 5
+  cumulative contention time: 21ns
+  keys:
+    /Table/1/1/"key" contending txns:
+      id=a count=2
+      id=b count=1
+    /Table/1/1/"keyb" contending txns:
+      id=a count=1
+    /Table/1/1/"keyc" contending txns:
+      id=a count=1
+
+# Add another index on the same table.
+evcheck tableid=1 indexid=2 key=key id=a duration=1
+----
+tableID=1 indexID=2
+  num contention events: 1
+  cumulative contention time: 1ns
+  keys:
+    /Table/1/2/"key" contending txns:
+      id=a count=1
+tableID=1 indexID=1
+  num contention events: 5
+  cumulative contention time: 21ns
+  keys:
+    /Table/1/1/"key" contending txns:
+      id=a count=2
+      id=b count=1
+    /Table/1/1/"keyb" contending txns:
+      id=a count=1
+    /Table/1/1/"keyc" contending txns:
+      id=a count=1
+
+
+# Add another table.
+evcheck tableid=2 indexid=1 key=key id=a duration=1
+----
+tableID=2 indexID=1
+  num contention events: 1
+  cumulative contention time: 1ns
+  keys:
+    /Table/2/1/"key" contending txns:
+      id=a count=1
+tableID=1 indexID=2
+  num contention events: 1
+  cumulative contention time: 1ns
+  keys:
+    /Table/1/2/"key" contending txns:
+      id=a count=1
+tableID=1 indexID=1
+  num contention events: 5
+  cumulative contention time: 21ns
+  keys:
+    /Table/1/1/"key" contending txns:
+      id=a count=2
+      id=b count=1
+    /Table/1/1/"keyb" contending txns:
+      id=a count=1
+    /Table/1/1/"keyc" contending txns:
+      id=a count=1

--- a/pkg/util/cache/cache.go
+++ b/pkg/util/cache/cache.go
@@ -286,6 +286,13 @@ func (bc *baseCache) Len() int {
 	return bc.store.length()
 }
 
+// Do iterates over all entries in the cache and calls fn with each entry.
+func (bc *baseCache) Do(fn func(e *Entry)) {
+	for e := bc.ll.root.next; e != &bc.ll.root; e = e.next {
+		fn(e)
+	}
+}
+
 func (bc *baseCache) access(e *Entry) {
 	if bc.Policy == CacheLRU {
 		bc.ll.moveToFront(e)


### PR DESCRIPTION
This PR adds a contention registry that groups roachpb.ContentionEvents by
tableID/indexID pair and collects metadata about them. This data structure is
backed by an LRU cache.

Release note: None

Addresses #57114

My goal here is to discuss the basic structure of the registry and get this basic version in. Once that's done, I'll work on:
1) Add a pointer to a global registry in the distsql receiver and add thread safety.
2) Adding a serialized version so registries can be sent between nodes and merged as well as sent back to the admin UI.
3) Implement a virtual table and status server endpoint that will merge and return these serialized versions.

cc @tbg 