### PR TITLE
jobs: update jobs.Update() to use SELECT FOR UPDATE

### DIFF
--- a/pkg/jobs/update.go
+++ b/pkg/jobs/update.go
@@ -106,9 +106,10 @@ func (j *Job) Update(ctx context.Context, updateFn UpdateFn) error {
 	var payload *jobspb.Payload
 	var progress *jobspb.Progress
 	if err := j.runInTxn(ctx, func(ctx context.Context, txn *kv.Txn) error {
-		stmt := "SELECT status, payload, progress FROM system.jobs WHERE id = $1"
+		stmt := "SELECT status, payload, progress FROM system.jobs WHERE id = $1 FOR UPDATE"
 		if j.sessionID != "" {
-			stmt = "SELECT status, payload, progress, claim_session_id FROM system.jobs WHERE id = $1"
+			stmt = "SELECT status, payload, progress, claim_session_id FROM system." +
+				"jobs WHERE id = $1 FOR UPDATE"
 		}
 		var err error
 		var row tree.Datums


### PR DESCRIPTION
The Update() method first reads the row corresponding to a particular
job from the system.jobs table via a SELECT query. It then runs a user
specified function which will update the contents of that in the same
txn as the row was read.

This seems like a good candidate to utilize the SELECT FOR UPDATE
functionality added to CRDB to prevent thrashing.

Release note: None