### PR TITLE
build: install pass, gnupg2 in teamcity agents

### DIFF
--- a/build/packer/teamcity-agent.sh
+++ b/build/packer/teamcity-agent.sh
@@ -34,9 +34,11 @@ apt-get install --yes \
   docker-ce \
   docker-compose \
   gnome-keyring \
+  gnupg2 \
   git \
   golang-go \
   openjdk-11-jre-headless \
+  pass \
   unzip
 # Installing gnome-keyring prevents the error described in
 # https://github.com/moby/moby/issues/34048


### PR DESCRIPTION
It's necessary to `docker login` our TeamCity build agents as a service
account so they can push new `build/builder` images (see #56987), but in
the absence of this change, attempting to do that fails with an error
like this:

```
Error saving credentials: error storing credentials - err: exit status
1, out: Cannot autolaunch D-Bus without X11 $DISPLAY
```

This is apparently because the `secretservice` binary has an X11
dependency, and `docker login` on Linux [falls back on `secretservice`](
https://docs.docker.com/engine/reference/commandline/login/#credentials-store)
if it can't find the `pass` binary.

To address this, just install the `pass` binary, which doesn't depend on
X11.

Release note: None