### PR TITLE
ccl/changefeedccl: skip TestChangefeedInitialScan under race

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -374,6 +374,7 @@ func TestChangefeedResolvedFrequency(t *testing.T) {
 // operation.
 func TestChangefeedInitialScan(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.UnderRaceWithIssue(t, 57754, "flaky test")
 	defer log.Scope(t).Close(t)
 
 	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {


### PR DESCRIPTION
Refs: #57754

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes

Release note: None