### PR TITLE
colexec: make aggregators resettable and other improvements

### DIFF
--- a/pkg/sql/colexec/aggregators_test.go
+++ b/pkg/sql/colexec/aggregators_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecagg"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase"
-	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -30,7 +29,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeofday"
 	"github.com/stretchr/testify/require"
@@ -69,39 +67,13 @@ type aggregatorTestCase struct {
 // aggType is a helper struct that allows tests to test both the ordered and
 // hash aggregators at the same time.
 type aggType struct {
-	new func(
-		allocator *colmem.Allocator,
-		memAccount *mon.BoundAccount,
-		input colexecbase.Operator,
-		inputTypes []*types.T,
-		spec *execinfrapb.AggregatorSpec,
-		evalCtx *tree.EvalContext,
-		constructors []execinfrapb.AggregateConstructor,
-		constArguments []tree.Datums,
-		outputTypes []*types.T,
-		isScalar bool,
-	) (colexecbase.Operator, error)
+	new  func(*colexecagg.NewAggregatorArgs) (colexecbase.Operator, error)
 	name string
 }
 
 var aggTypes = []aggType{
 	{
-		// This is a wrapper around NewHashAggregator so its signature is compatible
-		// with orderedAggregator.
-		new: func(
-			allocator *colmem.Allocator,
-			memAccount *mon.BoundAccount,
-			input colexecbase.Operator,
-			inputTypes []*types.T,
-			spec *execinfrapb.AggregatorSpec,
-			evalCtx *tree.EvalContext,
-			constructors []execinfrapb.AggregateConstructor,
-			constArguments []tree.Datums,
-			outputTypes []*types.T,
-			_ bool,
-		) (colexecbase.Operator, error) {
-			return NewHashAggregator(allocator, memAccount, input, inputTypes, spec, evalCtx, constructors, constArguments, outputTypes)
-		},
+		new:  NewHashAggregator,
 		name: "hash",
 	},
 	{
@@ -341,7 +313,6 @@ func TestAggregatorOneFunc(t *testing.T) {
 
 	evalCtx := tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
 	defer evalCtx.Stop(context.Background())
-	// Run tests with deliberate batch sizes and no selection vectors.
 	ctx := context.Background()
 	for _, tc := range testCases {
 		if err := tc.init(); err != nil {
@@ -360,10 +331,17 @@ func TestAggregatorOneFunc(t *testing.T) {
 			log.Infof(ctx, "%s/%s", tc.name, agg.name)
 			runTestsWithTyps(t, []tuples{tc.input}, [][]*types.T{tc.typs}, tc.expected, unorderedVerifier,
 				func(input []colexecbase.Operator) (colexecbase.Operator, error) {
-					return agg.new(
-						testAllocator, testMemAcc, input[0], tc.typs, tc.spec, &evalCtx,
-						constructors, constArguments, outputTypes, false, /* isScalar */
-					)
+					return agg.new(&colexecagg.NewAggregatorArgs{
+						Allocator:      testAllocator,
+						MemAccount:     testMemAcc,
+						Input:          input[0],
+						InputTypes:     tc.typs,
+						Spec:           tc.spec,
+						EvalCtx:        &evalCtx,
+						Constructors:   constructors,
+						ConstArguments: constArguments,
+						OutputTypes:    outputTypes,
+					})
 				})
 		}
 	}
@@ -582,10 +560,17 @@ func TestAggregatorMultiFunc(t *testing.T) {
 			require.NoError(t, err)
 			runTestsWithTyps(t, []tuples{tc.input}, [][]*types.T{tc.typs}, tc.expected, unorderedVerifier,
 				func(input []colexecbase.Operator) (colexecbase.Operator, error) {
-					return agg.new(
-						testAllocator, testMemAcc, input[0], tc.typs, tc.spec, &evalCtx,
-						constructors, constArguments, outputTypes, false, /* isScalar */
-					)
+					return agg.new(&colexecagg.NewAggregatorArgs{
+						Allocator:      testAllocator,
+						MemAccount:     testMemAcc,
+						Input:          input[0],
+						InputTypes:     tc.typs,
+						Spec:           tc.spec,
+						EvalCtx:        &evalCtx,
+						Constructors:   constructors,
+						ConstArguments: constArguments,
+						OutputTypes:    outputTypes,
+					})
 				})
 		}
 	}
@@ -807,10 +792,17 @@ func TestAggregatorAllFunctions(t *testing.T) {
 				tc.expected,
 				verifier,
 				func(input []colexecbase.Operator) (colexecbase.Operator, error) {
-					return agg.new(
-						testAllocator, testMemAcc, input[0], tc.typs, tc.spec, &evalCtx,
-						constructors, constArguments, outputTypes, false, /* isScalar */
-					)
+					return agg.new(&colexecagg.NewAggregatorArgs{
+						Allocator:      testAllocator,
+						MemAccount:     testMemAcc,
+						Input:          input[0],
+						InputTypes:     tc.typs,
+						Spec:           tc.spec,
+						EvalCtx:        &evalCtx,
+						Constructors:   constructors,
+						ConstArguments: constArguments,
+						OutputTypes:    outputTypes,
+					})
 				})
 		}
 	}
@@ -919,10 +911,17 @@ func TestAggregatorRandom(t *testing.T) {
 						&evalCtx, nil /* semaCtx */, tc.spec.Aggregations, tc.typs,
 					)
 					require.NoError(t, err)
-					a, err := agg.new(
-						testAllocator, testMemAcc, source, tc.typs, tc.spec, &evalCtx,
-						constructors, constArguments, outputTypes, false, /* isScalar */
-					)
+					a, err := agg.new(&colexecagg.NewAggregatorArgs{
+						Allocator:      testAllocator,
+						MemAccount:     testMemAcc,
+						Input:          source,
+						InputTypes:     tc.typs,
+						Spec:           tc.spec,
+						EvalCtx:        &evalCtx,
+						Constructors:   constructors,
+						ConstArguments: constArguments,
+						OutputTypes:    outputTypes,
+					})
 					if err != nil {
 						t.Fatal(err)
 					}
@@ -1070,10 +1069,17 @@ func benchmarkAggregateFunction(
 			b.SetBytes(int64(argumentsSize * numInputRows))
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				a, err := agg.new(
-					testAllocator, testMemAcc, source, typs, tc.spec, &evalCtx,
-					constructors, constArguments, outputTypes, false, /* isScalar */
-				)
+				a, err := agg.new(&colexecagg.NewAggregatorArgs{
+					Allocator:      testAllocator,
+					MemAccount:     testMemAcc,
+					Input:          source,
+					InputTypes:     tc.typs,
+					Spec:           tc.spec,
+					EvalCtx:        &evalCtx,
+					Constructors:   constructors,
+					ConstArguments: constArguments,
+					OutputTypes:    outputTypes,
+				})
 				if err != nil {
 					b.Fatal(err)
 				}
@@ -1295,10 +1301,17 @@ func TestHashAggregator(t *testing.T) {
 		)
 		require.NoError(t, err)
 		runTests(t, []tuples{tc.input}, tc.expected, unorderedVerifier, func(sources []colexecbase.Operator) (colexecbase.Operator, error) {
-			return NewHashAggregator(
-				testAllocator, testMemAcc, sources[0], tc.typs, tc.spec,
-				&evalCtx, constructors, constArguments, outputTypes,
-			)
+			return NewHashAggregator(&colexecagg.NewAggregatorArgs{
+				Allocator:      testAllocator,
+				MemAccount:     testMemAcc,
+				Input:          sources[0],
+				InputTypes:     tc.typs,
+				Spec:           tc.spec,
+				EvalCtx:        &evalCtx,
+				Constructors:   constructors,
+				ConstArguments: constArguments,
+				OutputTypes:    outputTypes,
+			})
 		})
 	}
 }

--- a/pkg/sql/colexec/aggregators_test.go
+++ b/pkg/sql/colexec/aggregators_test.go
@@ -67,7 +67,7 @@ type aggregatorTestCase struct {
 // aggType is a helper struct that allows tests to test both the ordered and
 // hash aggregators at the same time.
 type aggType struct {
-	new  func(*colexecagg.NewAggregatorArgs) (colexecbase.Operator, error)
+	new  func(*colexecagg.NewAggregatorArgs) (ResettableOperator, error)
 	name string
 }
 

--- a/pkg/sql/colexec/colexecagg/aggregate_funcs.go
+++ b/pkg/sql/colexec/colexecagg/aggregate_funcs.go
@@ -191,20 +191,12 @@ type AggregateFuncsAlloc struct {
 
 // NewAggregateFuncsAlloc returns a new AggregateFuncsAlloc.
 func NewAggregateFuncsAlloc(
-	allocator *colmem.Allocator,
-	inputTypes []*types.T,
-	spec *execinfrapb.AggregatorSpec,
-	evalCtx *tree.EvalContext,
-	constructors []execinfrapb.AggregateConstructor,
-	constArguments []tree.Datums,
-	outputTypes []*types.T,
-	allocSize int64,
-	isHashAgg bool,
+	args *NewAggregatorArgs, allocSize int64, isHashAgg bool,
 ) (*AggregateFuncsAlloc, *colconv.VecToDatumConverter, colexecbase.Closers, error) {
-	funcAllocs := make([]aggregateFuncAlloc, len(spec.Aggregations))
+	funcAllocs := make([]aggregateFuncAlloc, len(args.Spec.Aggregations))
 	var toClose colexecbase.Closers
 	var vecIdxsToConvert []int
-	for _, aggFn := range spec.Aggregations {
+	for _, aggFn := range args.Spec.Aggregations {
 		if !IsAggOptimized(aggFn.Func) {
 			for _, vecIdx := range aggFn.ColIdx {
 				found := false
@@ -220,75 +212,75 @@ func NewAggregateFuncsAlloc(
 			}
 		}
 	}
-	inputArgsConverter := colconv.NewVecToDatumConverter(len(inputTypes), vecIdxsToConvert)
-	for i, aggFn := range spec.Aggregations {
+	inputArgsConverter := colconv.NewVecToDatumConverter(len(args.InputTypes), vecIdxsToConvert)
+	for i, aggFn := range args.Spec.Aggregations {
 		var err error
 		switch aggFn.Func {
 		case execinfrapb.AggregatorSpec_ANY_NOT_NULL:
 			if isHashAgg {
-				funcAllocs[i], err = newAnyNotNullHashAggAlloc(allocator, inputTypes[aggFn.ColIdx[0]], allocSize)
+				funcAllocs[i], err = newAnyNotNullHashAggAlloc(args.Allocator, args.InputTypes[aggFn.ColIdx[0]], allocSize)
 			} else {
-				funcAllocs[i], err = newAnyNotNullOrderedAggAlloc(allocator, inputTypes[aggFn.ColIdx[0]], allocSize)
+				funcAllocs[i], err = newAnyNotNullOrderedAggAlloc(args.Allocator, args.InputTypes[aggFn.ColIdx[0]], allocSize)
 			}
 		case execinfrapb.AggregatorSpec_AVG:
 			if isHashAgg {
-				funcAllocs[i], err = newAvgHashAggAlloc(allocator, inputTypes[aggFn.ColIdx[0]], allocSize)
+				funcAllocs[i], err = newAvgHashAggAlloc(args.Allocator, args.InputTypes[aggFn.ColIdx[0]], allocSize)
 			} else {
-				funcAllocs[i], err = newAvgOrderedAggAlloc(allocator, inputTypes[aggFn.ColIdx[0]], allocSize)
+				funcAllocs[i], err = newAvgOrderedAggAlloc(args.Allocator, args.InputTypes[aggFn.ColIdx[0]], allocSize)
 			}
 		case execinfrapb.AggregatorSpec_SUM:
 			if isHashAgg {
-				funcAllocs[i], err = newSumHashAggAlloc(allocator, inputTypes[aggFn.ColIdx[0]], allocSize)
+				funcAllocs[i], err = newSumHashAggAlloc(args.Allocator, args.InputTypes[aggFn.ColIdx[0]], allocSize)
 			} else {
-				funcAllocs[i], err = newSumOrderedAggAlloc(allocator, inputTypes[aggFn.ColIdx[0]], allocSize)
+				funcAllocs[i], err = newSumOrderedAggAlloc(args.Allocator, args.InputTypes[aggFn.ColIdx[0]], allocSize)
 			}
 		case execinfrapb.AggregatorSpec_SUM_INT:
 			if isHashAgg {
-				funcAllocs[i], err = newSumIntHashAggAlloc(allocator, inputTypes[aggFn.ColIdx[0]], allocSize)
+				funcAllocs[i], err = newSumIntHashAggAlloc(args.Allocator, args.InputTypes[aggFn.ColIdx[0]], allocSize)
 			} else {
-				funcAllocs[i], err = newSumIntOrderedAggAlloc(allocator, inputTypes[aggFn.ColIdx[0]], allocSize)
+				funcAllocs[i], err = newSumIntOrderedAggAlloc(args.Allocator, args.InputTypes[aggFn.ColIdx[0]], allocSize)
 			}
 		case execinfrapb.AggregatorSpec_CONCAT_AGG:
 			if isHashAgg {
-				funcAllocs[i] = newConcatHashAggAlloc(allocator, allocSize)
+				funcAllocs[i] = newConcatHashAggAlloc(args.Allocator, allocSize)
 			} else {
-				funcAllocs[i] = newConcatOrderedAggAlloc(allocator, allocSize)
+				funcAllocs[i] = newConcatOrderedAggAlloc(args.Allocator, allocSize)
 			}
 		case execinfrapb.AggregatorSpec_COUNT_ROWS:
 			if isHashAgg {
-				funcAllocs[i] = newCountRowsHashAggAlloc(allocator, allocSize)
+				funcAllocs[i] = newCountRowsHashAggAlloc(args.Allocator, allocSize)
 			} else {
-				funcAllocs[i] = newCountRowsOrderedAggAlloc(allocator, allocSize)
+				funcAllocs[i] = newCountRowsOrderedAggAlloc(args.Allocator, allocSize)
 			}
 		case execinfrapb.AggregatorSpec_COUNT:
 			if isHashAgg {
-				funcAllocs[i] = newCountHashAggAlloc(allocator, allocSize)
+				funcAllocs[i] = newCountHashAggAlloc(args.Allocator, allocSize)
 			} else {
-				funcAllocs[i] = newCountOrderedAggAlloc(allocator, allocSize)
+				funcAllocs[i] = newCountOrderedAggAlloc(args.Allocator, allocSize)
 			}
 		case execinfrapb.AggregatorSpec_MIN:
 			if isHashAgg {
-				funcAllocs[i] = newMinHashAggAlloc(allocator, inputTypes[aggFn.ColIdx[0]], allocSize)
+				funcAllocs[i] = newMinHashAggAlloc(args.Allocator, args.InputTypes[aggFn.ColIdx[0]], allocSize)
 			} else {
-				funcAllocs[i] = newMinOrderedAggAlloc(allocator, inputTypes[aggFn.ColIdx[0]], allocSize)
+				funcAllocs[i] = newMinOrderedAggAlloc(args.Allocator, args.InputTypes[aggFn.ColIdx[0]], allocSize)
 			}
 		case execinfrapb.AggregatorSpec_MAX:
 			if isHashAgg {
-				funcAllocs[i] = newMaxHashAggAlloc(allocator, inputTypes[aggFn.ColIdx[0]], allocSize)
+				funcAllocs[i] = newMaxHashAggAlloc(args.Allocator, args.InputTypes[aggFn.ColIdx[0]], allocSize)
 			} else {
-				funcAllocs[i] = newMaxOrderedAggAlloc(allocator, inputTypes[aggFn.ColIdx[0]], allocSize)
+				funcAllocs[i] = newMaxOrderedAggAlloc(args.Allocator, args.InputTypes[aggFn.ColIdx[0]], allocSize)
 			}
 		case execinfrapb.AggregatorSpec_BOOL_AND:
 			if isHashAgg {
-				funcAllocs[i] = newBoolAndHashAggAlloc(allocator, allocSize)
+				funcAllocs[i] = newBoolAndHashAggAlloc(args.Allocator, allocSize)
 			} else {
-				funcAllocs[i] = newBoolAndOrderedAggAlloc(allocator, allocSize)
+				funcAllocs[i] = newBoolAndOrderedAggAlloc(args.Allocator, allocSize)
 			}
 		case execinfrapb.AggregatorSpec_BOOL_OR:
 			if isHashAgg {
-				funcAllocs[i] = newBoolOrHashAggAlloc(allocator, allocSize)
+				funcAllocs[i] = newBoolOrHashAggAlloc(args.Allocator, allocSize)
 			} else {
-				funcAllocs[i] = newBoolOrOrderedAggAlloc(allocator, allocSize)
+				funcAllocs[i] = newBoolOrOrderedAggAlloc(args.Allocator, allocSize)
 			}
 		// NOTE: if you're adding an implementation of a new aggregate
 		// function, make sure to account for the memory under that struct in
@@ -296,13 +288,13 @@ func NewAggregateFuncsAlloc(
 		default:
 			if isHashAgg {
 				funcAllocs[i] = newDefaultHashAggAlloc(
-					allocator, constructors[i], evalCtx, inputArgsConverter,
-					len(aggFn.ColIdx), constArguments[i], outputTypes[i], allocSize,
+					args.Allocator, args.Constructors[i], args.EvalCtx, inputArgsConverter,
+					len(aggFn.ColIdx), args.ConstArguments[i], args.OutputTypes[i], allocSize,
 				)
 			} else {
 				funcAllocs[i] = newDefaultOrderedAggAlloc(
-					allocator, constructors[i], evalCtx, inputArgsConverter,
-					len(aggFn.ColIdx), constArguments[i], outputTypes[i], allocSize,
+					args.Allocator, args.Constructors[i], args.EvalCtx, inputArgsConverter,
+					len(aggFn.ColIdx), args.ConstArguments[i], args.OutputTypes[i], allocSize,
 				)
 			}
 			toClose = append(toClose, funcAllocs[i].(colexecbase.Closer))
@@ -313,7 +305,7 @@ func NewAggregateFuncsAlloc(
 		}
 	}
 	return &AggregateFuncsAlloc{
-		allocator:     allocator,
+		allocator:     args.Allocator,
 		allocSize:     allocSize,
 		aggFuncAllocs: funcAllocs,
 	}, inputArgsConverter, toClose, nil

--- a/pkg/sql/colexec/colexecagg/aggregate_funcs.go
+++ b/pkg/sql/colexec/colexecagg/aggregate_funcs.go
@@ -91,6 +91,10 @@ type AggregateFunc interface {
 	// when the aggregate function is in scalar context. The output must always
 	// be a single value (either null or zero, depending on the function).
 	HandleEmptyInputScalar()
+
+	// Reset resets the aggregate function which allows for reusing the same
+	// instance for computation without the need to create a new instance.
+	Reset()
 }
 
 type orderedAggregateFuncBase struct {
@@ -109,7 +113,7 @@ type orderedAggregateFuncBase struct {
 
 func (o *orderedAggregateFuncBase) Init(groups []bool) {
 	o.groups = groups
-	o.isFirstGroup = true
+	o.Reset()
 }
 
 func (o *orderedAggregateFuncBase) SetOutput(vec coldata.Vec) {
@@ -130,6 +134,11 @@ func (o *orderedAggregateFuncBase) HandleEmptyInputScalar() {
 	// in the scalar context (the exceptions are COUNT aggregates which need
 	// to overwrite this method).
 	o.nulls.SetNull(0)
+}
+
+func (o *orderedAggregateFuncBase) Reset() {
+	o.curIdx = 0
+	o.isFirstGroup = true
 }
 
 type hashAggregateFuncBase struct {

--- a/pkg/sql/colexec/colexecagg/aggregators_util.go
+++ b/pkg/sql/colexec/colexecagg/aggregators_util.go
@@ -1,0 +1,34 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package colexecagg
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
+)
+
+// NewAggregatorArgs encompasses all arguments necessary to instantiate either
+// of the aggregators.
+type NewAggregatorArgs struct {
+	Allocator      *colmem.Allocator
+	MemAccount     *mon.BoundAccount
+	Input          colexecbase.Operator
+	InputTypes     []*types.T
+	Spec           *execinfrapb.AggregatorSpec
+	EvalCtx        *tree.EvalContext
+	Constructors   []execinfrapb.AggregateConstructor
+	ConstArguments []tree.Datums
+	OutputTypes    []*types.T
+}

--- a/pkg/sql/colexec/colexecagg/any_not_null_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/any_not_null_agg_tmpl.go
@@ -178,6 +178,13 @@ func (a *anyNotNull_TYPE_AGGKINDAgg) Flush(outputIdx int) {
 	// {{end}}
 }
 
+func (a *anyNotNull_TYPE_AGGKINDAgg) Reset() {
+	// {{if eq "_AGGKIND" "Ordered"}}
+	a.orderedAggregateFuncBase.Reset()
+	// {{end}}
+	a.foundNonNullForCurrentGroup = false
+}
+
 type anyNotNull_TYPE_AGGKINDAggAlloc struct {
 	aggAllocBase
 	aggFuncs []anyNotNull_TYPE_AGGKINDAgg

--- a/pkg/sql/colexec/colexecagg/avg_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/avg_agg_tmpl.go
@@ -192,6 +192,15 @@ func (a *avg_TYPE_AGGKINDAgg) Flush(outputIdx int) {
 	}
 }
 
+func (a *avg_TYPE_AGGKINDAgg) Reset() {
+	// {{if eq "_AGGKIND" "Ordered"}}
+	a.orderedAggregateFuncBase.Reset()
+	// {{end}}
+	a.curSum = zero_RET_TYPEValue
+	a.curCount = 0
+	a.foundNonNullForCurrentGroup = false
+}
+
 type avg_TYPE_AGGKINDAggAlloc struct {
 	aggAllocBase
 	aggFuncs []avg_TYPE_AGGKINDAgg

--- a/pkg/sql/colexec/colexecagg/bool_and_or_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/bool_and_or_agg_tmpl.go
@@ -138,6 +138,18 @@ func (a *bool_OP_TYPE_AGGKINDAgg) Flush(outputIdx int) {
 	}
 }
 
+func (a *bool_OP_TYPE_AGGKINDAgg) Reset() {
+	// {{if eq "_AGGKIND" "Ordered"}}
+	a.orderedAggregateFuncBase.Reset()
+	// {{end}}
+	// {{/*
+	// _DEFAULT_VAL indicates whether we are doing an AND aggregate or OR
+	// aggregate. For bool_and the _DEFAULT_VAL is true and for bool_or the
+	// _DEFAULT_VAL is false.
+	// */}}
+	a.curAgg = _DEFAULT_VAL
+}
+
 type bool_OP_TYPE_AGGKINDAggAlloc struct {
 	aggAllocBase
 	aggFuncs []bool_OP_TYPE_AGGKINDAgg
@@ -155,13 +167,8 @@ func (a *bool_OP_TYPE_AGGKINDAggAlloc) newAggFunc() AggregateFunc {
 	}
 	f := &a.aggFuncs[0]
 	f.allocator = a.allocator
+	f.Reset()
 	a.aggFuncs = a.aggFuncs[1:]
-	// {{/*
-	// _DEFAULT_VAL indicates whether we are doing an AND aggregate or OR
-	// aggregate. For bool_and the _DEFAULT_VAL is true and for bool_or the
-	// _DEFAULT_VAL is false.
-	// */}}
-	f.curAgg = _DEFAULT_VAL
 	return f
 }
 

--- a/pkg/sql/colexec/colexecagg/concat_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/concat_agg_tmpl.go
@@ -122,6 +122,14 @@ func (a *concat_AGGKINDAgg) Flush(outputIdx int) {
 	a.curAgg = nil
 }
 
+func (a *concat_AGGKINDAgg) Reset() {
+	// {{if eq "_AGGKIND" "Ordered"}}
+	a.orderedAggregateFuncBase.Reset()
+	// {{end}}
+	a.curAgg = nil
+	a.foundNonNullForCurrentGroup = false
+}
+
 type concat_AGGKINDAggAlloc struct {
 	aggAllocBase
 	aggFuncs []concat_AGGKINDAgg

--- a/pkg/sql/colexec/colexecagg/count_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/count_agg_tmpl.go
@@ -143,6 +143,13 @@ func (a *count_COUNTKIND_AGGKINDAgg) HandleEmptyInputScalar() {
 
 // {{end}}
 
+func (a *count_COUNTKIND_AGGKINDAgg) Reset() {
+	// {{if eq "_AGGKIND" "Ordered"}}
+	a.orderedAggregateFuncBase.Reset()
+	// {{end}}
+	a.curAgg = 0
+}
+
 type count_COUNTKIND_AGGKINDAggAlloc struct {
 	aggAllocBase
 	aggFuncs []count_COUNTKIND_AGGKINDAgg

--- a/pkg/sql/colexec/colexecagg/default_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/default_agg_tmpl.go
@@ -110,6 +110,13 @@ func (a *default_AGGKINDAgg) HandleEmptyInputScalar() {
 
 // {{end}}
 
+func (a *default_AGGKINDAgg) Reset() {
+	// {{if eq "_AGGKIND" "Ordered"}}
+	a.orderedAggregateFuncBase.Reset()
+	// {{end}}
+	a.fn.Reset(a.ctx)
+}
+
 func newDefault_AGGKINDAggAlloc(
 	allocator *colmem.Allocator,
 	constructor execinfrapb.AggregateConstructor,

--- a/pkg/sql/colexec/colexecagg/hash_any_not_null_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_any_not_null_agg.eg.go
@@ -177,6 +177,10 @@ func (a *anyNotNullBoolHashAgg) Flush(outputIdx int) {
 	}
 }
 
+func (a *anyNotNullBoolHashAgg) Reset() {
+	a.foundNonNullForCurrentGroup = false
+}
+
 type anyNotNullBoolHashAggAlloc struct {
 	aggAllocBase
 	aggFuncs []anyNotNullBoolHashAgg
@@ -293,6 +297,10 @@ func (a *anyNotNullBytesHashAgg) Flush(outputIdx int) {
 	a.curAgg = nil
 }
 
+func (a *anyNotNullBytesHashAgg) Reset() {
+	a.foundNonNullForCurrentGroup = false
+}
+
 type anyNotNullBytesHashAggAlloc struct {
 	aggAllocBase
 	aggFuncs []anyNotNullBytesHashAgg
@@ -404,6 +412,10 @@ func (a *anyNotNullDecimalHashAgg) Flush(outputIdx int) {
 	} else {
 		a.col[outputIdx].Set(&a.curAgg)
 	}
+}
+
+func (a *anyNotNullDecimalHashAgg) Reset() {
+	a.foundNonNullForCurrentGroup = false
 }
 
 type anyNotNullDecimalHashAggAlloc struct {
@@ -519,6 +531,10 @@ func (a *anyNotNullInt16HashAgg) Flush(outputIdx int) {
 	}
 }
 
+func (a *anyNotNullInt16HashAgg) Reset() {
+	a.foundNonNullForCurrentGroup = false
+}
+
 type anyNotNullInt16HashAggAlloc struct {
 	aggAllocBase
 	aggFuncs []anyNotNullInt16HashAgg
@@ -630,6 +646,10 @@ func (a *anyNotNullInt32HashAgg) Flush(outputIdx int) {
 	} else {
 		a.col[outputIdx] = a.curAgg
 	}
+}
+
+func (a *anyNotNullInt32HashAgg) Reset() {
+	a.foundNonNullForCurrentGroup = false
 }
 
 type anyNotNullInt32HashAggAlloc struct {
@@ -745,6 +765,10 @@ func (a *anyNotNullInt64HashAgg) Flush(outputIdx int) {
 	}
 }
 
+func (a *anyNotNullInt64HashAgg) Reset() {
+	a.foundNonNullForCurrentGroup = false
+}
+
 type anyNotNullInt64HashAggAlloc struct {
 	aggAllocBase
 	aggFuncs []anyNotNullInt64HashAgg
@@ -856,6 +880,10 @@ func (a *anyNotNullFloat64HashAgg) Flush(outputIdx int) {
 	} else {
 		a.col[outputIdx] = a.curAgg
 	}
+}
+
+func (a *anyNotNullFloat64HashAgg) Reset() {
+	a.foundNonNullForCurrentGroup = false
 }
 
 type anyNotNullFloat64HashAggAlloc struct {
@@ -971,6 +999,10 @@ func (a *anyNotNullTimestampHashAgg) Flush(outputIdx int) {
 	}
 }
 
+func (a *anyNotNullTimestampHashAgg) Reset() {
+	a.foundNonNullForCurrentGroup = false
+}
+
 type anyNotNullTimestampHashAggAlloc struct {
 	aggAllocBase
 	aggFuncs []anyNotNullTimestampHashAgg
@@ -1082,6 +1114,10 @@ func (a *anyNotNullIntervalHashAgg) Flush(outputIdx int) {
 	} else {
 		a.col[outputIdx] = a.curAgg
 	}
+}
+
+func (a *anyNotNullIntervalHashAgg) Reset() {
+	a.foundNonNullForCurrentGroup = false
 }
 
 type anyNotNullIntervalHashAggAlloc struct {
@@ -1207,6 +1243,10 @@ func (a *anyNotNullDatumHashAgg) Flush(outputIdx int) {
 		a.allocator.AdjustMemoryUsage(-int64(d.Size()))
 	}
 	a.curAgg = nil
+}
+
+func (a *anyNotNullDatumHashAgg) Reset() {
+	a.foundNonNullForCurrentGroup = false
 }
 
 type anyNotNullDatumHashAggAlloc struct {

--- a/pkg/sql/colexec/colexecagg/hash_avg_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_avg_agg.eg.go
@@ -152,6 +152,12 @@ func (a *avgInt16HashAgg) Flush(outputIdx int) {
 	}
 }
 
+func (a *avgInt16HashAgg) Reset() {
+	a.curSum = zeroDecimalValue
+	a.curCount = 0
+	a.foundNonNullForCurrentGroup = false
+}
+
 type avgInt16HashAggAlloc struct {
 	aggAllocBase
 	aggFuncs []avgInt16HashAgg
@@ -275,6 +281,12 @@ func (a *avgInt32HashAgg) Flush(outputIdx int) {
 			colexecerror.InternalError(err)
 		}
 	}
+}
+
+func (a *avgInt32HashAgg) Reset() {
+	a.curSum = zeroDecimalValue
+	a.curCount = 0
+	a.foundNonNullForCurrentGroup = false
 }
 
 type avgInt32HashAggAlloc struct {
@@ -402,6 +414,12 @@ func (a *avgInt64HashAgg) Flush(outputIdx int) {
 	}
 }
 
+func (a *avgInt64HashAgg) Reset() {
+	a.curSum = zeroDecimalValue
+	a.curCount = 0
+	a.foundNonNullForCurrentGroup = false
+}
+
 type avgInt64HashAggAlloc struct {
 	aggAllocBase
 	aggFuncs []avgInt64HashAgg
@@ -521,6 +539,12 @@ func (a *avgDecimalHashAgg) Flush(outputIdx int) {
 	}
 }
 
+func (a *avgDecimalHashAgg) Reset() {
+	a.curSum = zeroDecimalValue
+	a.curCount = 0
+	a.foundNonNullForCurrentGroup = false
+}
+
 type avgDecimalHashAggAlloc struct {
 	aggAllocBase
 	aggFuncs []avgDecimalHashAgg
@@ -630,6 +654,12 @@ func (a *avgFloat64HashAgg) Flush(outputIdx int) {
 	}
 }
 
+func (a *avgFloat64HashAgg) Reset() {
+	a.curSum = zeroFloat64Value
+	a.curCount = 0
+	a.foundNonNullForCurrentGroup = false
+}
+
 type avgFloat64HashAggAlloc struct {
 	aggAllocBase
 	aggFuncs []avgFloat64HashAgg
@@ -727,6 +757,12 @@ func (a *avgIntervalHashAgg) Flush(outputIdx int) {
 	} else {
 		a.col[outputIdx] = a.curSum.Div(int64(a.curCount))
 	}
+}
+
+func (a *avgIntervalHashAgg) Reset() {
+	a.curSum = zeroIntervalValue
+	a.curCount = 0
+	a.foundNonNullForCurrentGroup = false
 }
 
 type avgIntervalHashAggAlloc struct {

--- a/pkg/sql/colexec/colexecagg/hash_bool_and_or_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_bool_and_or_agg.eg.go
@@ -92,6 +92,10 @@ func (a *boolAndHashAgg) Flush(outputIdx int) {
 	}
 }
 
+func (a *boolAndHashAgg) Reset() {
+	a.curAgg = true
+}
+
 type boolAndHashAggAlloc struct {
 	aggAllocBase
 	aggFuncs []boolAndHashAgg
@@ -109,8 +113,8 @@ func (a *boolAndHashAggAlloc) newAggFunc() AggregateFunc {
 	}
 	f := &a.aggFuncs[0]
 	f.allocator = a.allocator
+	f.Reset()
 	a.aggFuncs = a.aggFuncs[1:]
-	f.curAgg = true
 	return f
 }
 
@@ -186,6 +190,10 @@ func (a *boolOrHashAgg) Flush(outputIdx int) {
 	}
 }
 
+func (a *boolOrHashAgg) Reset() {
+	a.curAgg = false
+}
+
 type boolOrHashAggAlloc struct {
 	aggAllocBase
 	aggFuncs []boolOrHashAgg
@@ -203,7 +211,7 @@ func (a *boolOrHashAggAlloc) newAggFunc() AggregateFunc {
 	}
 	f := &a.aggFuncs[0]
 	f.allocator = a.allocator
+	f.Reset()
 	a.aggFuncs = a.aggFuncs[1:]
-	f.curAgg = false
 	return f
 }

--- a/pkg/sql/colexec/colexecagg/hash_concat_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_concat_agg.eg.go
@@ -89,6 +89,11 @@ func (a *concatHashAgg) Flush(outputIdx int) {
 	a.curAgg = nil
 }
 
+func (a *concatHashAgg) Reset() {
+	a.curAgg = nil
+	a.foundNonNullForCurrentGroup = false
+}
+
 type concatHashAggAlloc struct {
 	aggAllocBase
 	aggFuncs []concatHashAgg

--- a/pkg/sql/colexec/colexecagg/hash_count_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_count_agg.eg.go
@@ -65,6 +65,10 @@ func (a *countRowsHashAgg) Flush(outputIdx int) {
 	a.col[outputIdx] = a.curAgg
 }
 
+func (a *countRowsHashAgg) Reset() {
+	a.curAgg = 0
+}
+
 type countRowsHashAggAlloc struct {
 	aggAllocBase
 	aggFuncs []countRowsHashAgg
@@ -147,6 +151,10 @@ func (a *countHashAgg) Compute(
 
 func (a *countHashAgg) Flush(outputIdx int) {
 	a.col[outputIdx] = a.curAgg
+}
+
+func (a *countHashAgg) Reset() {
+	a.curAgg = 0
 }
 
 type countHashAggAlloc struct {

--- a/pkg/sql/colexec/colexecagg/hash_default_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_default_agg.eg.go
@@ -86,6 +86,10 @@ func (a *defaultHashAgg) Flush(outputIdx int) {
 	}
 }
 
+func (a *defaultHashAgg) Reset() {
+	a.fn.Reset(a.ctx)
+}
+
 func newDefaultHashAggAlloc(
 	allocator *colmem.Allocator,
 	constructor execinfrapb.AggregateConstructor,

--- a/pkg/sql/colexec/colexecagg/hash_min_max_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_min_max_agg.eg.go
@@ -212,6 +212,10 @@ func (a *minBoolHashAgg) Flush(outputIdx int) {
 	}
 }
 
+func (a *minBoolHashAgg) Reset() {
+	a.foundNonNullForCurrentGroup = false
+}
+
 type minBoolHashAggAlloc struct {
 	aggAllocBase
 	aggFuncs []minBoolHashAgg
@@ -341,6 +345,10 @@ func (a *minBytesHashAgg) Flush(outputIdx int) {
 	a.curAgg = nil
 }
 
+func (a *minBytesHashAgg) Reset() {
+	a.foundNonNullForCurrentGroup = false
+}
+
 type minBytesHashAggAlloc struct {
 	aggAllocBase
 	aggFuncs []minBytesHashAgg
@@ -465,6 +473,10 @@ func (a *minDecimalHashAgg) Flush(outputIdx int) {
 	} else {
 		a.col[outputIdx].Set(&a.curAgg)
 	}
+}
+
+func (a *minDecimalHashAgg) Reset() {
+	a.foundNonNullForCurrentGroup = false
 }
 
 type minDecimalHashAggAlloc struct {
@@ -615,6 +627,10 @@ func (a *minInt16HashAgg) Flush(outputIdx int) {
 	}
 }
 
+func (a *minInt16HashAgg) Reset() {
+	a.foundNonNullForCurrentGroup = false
+}
+
 type minInt16HashAggAlloc struct {
 	aggAllocBase
 	aggFuncs []minInt16HashAgg
@@ -763,6 +779,10 @@ func (a *minInt32HashAgg) Flush(outputIdx int) {
 	}
 }
 
+func (a *minInt32HashAgg) Reset() {
+	a.foundNonNullForCurrentGroup = false
+}
+
 type minInt32HashAggAlloc struct {
 	aggAllocBase
 	aggFuncs []minInt32HashAgg
@@ -909,6 +929,10 @@ func (a *minInt64HashAgg) Flush(outputIdx int) {
 	} else {
 		a.col[outputIdx] = a.curAgg
 	}
+}
+
+func (a *minInt64HashAgg) Reset() {
+	a.foundNonNullForCurrentGroup = false
 }
 
 type minInt64HashAggAlloc struct {
@@ -1075,6 +1099,10 @@ func (a *minFloat64HashAgg) Flush(outputIdx int) {
 	}
 }
 
+func (a *minFloat64HashAgg) Reset() {
+	a.foundNonNullForCurrentGroup = false
+}
+
 type minFloat64HashAggAlloc struct {
 	aggAllocBase
 	aggFuncs []minFloat64HashAgg
@@ -1215,6 +1243,10 @@ func (a *minTimestampHashAgg) Flush(outputIdx int) {
 	}
 }
 
+func (a *minTimestampHashAgg) Reset() {
+	a.foundNonNullForCurrentGroup = false
+}
+
 type minTimestampHashAggAlloc struct {
 	aggAllocBase
 	aggFuncs []minTimestampHashAgg
@@ -1339,6 +1371,10 @@ func (a *minIntervalHashAgg) Flush(outputIdx int) {
 	} else {
 		a.col[outputIdx] = a.curAgg
 	}
+}
+
+func (a *minIntervalHashAgg) Reset() {
+	a.foundNonNullForCurrentGroup = false
 }
 
 type minIntervalHashAggAlloc struct {
@@ -1484,6 +1520,10 @@ func (a *minDatumHashAgg) Flush(outputIdx int) {
 	a.curAgg = nil
 }
 
+func (a *minDatumHashAgg) Reset() {
+	a.foundNonNullForCurrentGroup = false
+}
+
 type minDatumHashAggAlloc struct {
 	aggAllocBase
 	aggFuncs []minDatumHashAgg
@@ -1626,6 +1666,10 @@ func (a *maxBoolHashAgg) Flush(outputIdx int) {
 	}
 }
 
+func (a *maxBoolHashAgg) Reset() {
+	a.foundNonNullForCurrentGroup = false
+}
+
 type maxBoolHashAggAlloc struct {
 	aggAllocBase
 	aggFuncs []maxBoolHashAgg
@@ -1755,6 +1799,10 @@ func (a *maxBytesHashAgg) Flush(outputIdx int) {
 	a.curAgg = nil
 }
 
+func (a *maxBytesHashAgg) Reset() {
+	a.foundNonNullForCurrentGroup = false
+}
+
 type maxBytesHashAggAlloc struct {
 	aggAllocBase
 	aggFuncs []maxBytesHashAgg
@@ -1879,6 +1927,10 @@ func (a *maxDecimalHashAgg) Flush(outputIdx int) {
 	} else {
 		a.col[outputIdx].Set(&a.curAgg)
 	}
+}
+
+func (a *maxDecimalHashAgg) Reset() {
+	a.foundNonNullForCurrentGroup = false
 }
 
 type maxDecimalHashAggAlloc struct {
@@ -2029,6 +2081,10 @@ func (a *maxInt16HashAgg) Flush(outputIdx int) {
 	}
 }
 
+func (a *maxInt16HashAgg) Reset() {
+	a.foundNonNullForCurrentGroup = false
+}
+
 type maxInt16HashAggAlloc struct {
 	aggAllocBase
 	aggFuncs []maxInt16HashAgg
@@ -2177,6 +2233,10 @@ func (a *maxInt32HashAgg) Flush(outputIdx int) {
 	}
 }
 
+func (a *maxInt32HashAgg) Reset() {
+	a.foundNonNullForCurrentGroup = false
+}
+
 type maxInt32HashAggAlloc struct {
 	aggAllocBase
 	aggFuncs []maxInt32HashAgg
@@ -2323,6 +2383,10 @@ func (a *maxInt64HashAgg) Flush(outputIdx int) {
 	} else {
 		a.col[outputIdx] = a.curAgg
 	}
+}
+
+func (a *maxInt64HashAgg) Reset() {
+	a.foundNonNullForCurrentGroup = false
 }
 
 type maxInt64HashAggAlloc struct {
@@ -2489,6 +2553,10 @@ func (a *maxFloat64HashAgg) Flush(outputIdx int) {
 	}
 }
 
+func (a *maxFloat64HashAgg) Reset() {
+	a.foundNonNullForCurrentGroup = false
+}
+
 type maxFloat64HashAggAlloc struct {
 	aggAllocBase
 	aggFuncs []maxFloat64HashAgg
@@ -2629,6 +2697,10 @@ func (a *maxTimestampHashAgg) Flush(outputIdx int) {
 	}
 }
 
+func (a *maxTimestampHashAgg) Reset() {
+	a.foundNonNullForCurrentGroup = false
+}
+
 type maxTimestampHashAggAlloc struct {
 	aggAllocBase
 	aggFuncs []maxTimestampHashAgg
@@ -2753,6 +2825,10 @@ func (a *maxIntervalHashAgg) Flush(outputIdx int) {
 	} else {
 		a.col[outputIdx] = a.curAgg
 	}
+}
+
+func (a *maxIntervalHashAgg) Reset() {
+	a.foundNonNullForCurrentGroup = false
 }
 
 type maxIntervalHashAggAlloc struct {
@@ -2896,6 +2972,10 @@ func (a *maxDatumHashAgg) Flush(outputIdx int) {
 		a.allocator.AdjustMemoryUsage(-int64(d.Size()))
 	}
 	a.curAgg = nil
+}
+
+func (a *maxDatumHashAgg) Reset() {
+	a.foundNonNullForCurrentGroup = false
 }
 
 type maxDatumHashAggAlloc struct {

--- a/pkg/sql/colexec/colexecagg/hash_sum_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_sum_agg.eg.go
@@ -143,6 +143,11 @@ func (a *sumInt16HashAgg) Flush(outputIdx int) {
 	}
 }
 
+func (a *sumInt16HashAgg) Reset() {
+	a.curAgg = zeroDecimalValue
+	a.foundNonNullForCurrentGroup = false
+}
+
 type sumInt16HashAggAlloc struct {
 	aggAllocBase
 	aggFuncs []sumInt16HashAgg
@@ -256,6 +261,11 @@ func (a *sumInt32HashAgg) Flush(outputIdx int) {
 	} else {
 		a.col[outputIdx] = a.curAgg
 	}
+}
+
+func (a *sumInt32HashAgg) Reset() {
+	a.curAgg = zeroDecimalValue
+	a.foundNonNullForCurrentGroup = false
 }
 
 type sumInt32HashAggAlloc struct {
@@ -373,6 +383,11 @@ func (a *sumInt64HashAgg) Flush(outputIdx int) {
 	}
 }
 
+func (a *sumInt64HashAgg) Reset() {
+	a.curAgg = zeroDecimalValue
+	a.foundNonNullForCurrentGroup = false
+}
+
 type sumInt64HashAggAlloc struct {
 	aggAllocBase
 	aggFuncs []sumInt64HashAgg
@@ -482,6 +497,11 @@ func (a *sumDecimalHashAgg) Flush(outputIdx int) {
 	}
 }
 
+func (a *sumDecimalHashAgg) Reset() {
+	a.curAgg = zeroDecimalValue
+	a.foundNonNullForCurrentGroup = false
+}
+
 type sumDecimalHashAggAlloc struct {
 	aggAllocBase
 	aggFuncs []sumDecimalHashAgg
@@ -585,6 +605,11 @@ func (a *sumFloat64HashAgg) Flush(outputIdx int) {
 	}
 }
 
+func (a *sumFloat64HashAgg) Reset() {
+	a.curAgg = zeroFloat64Value
+	a.foundNonNullForCurrentGroup = false
+}
+
 type sumFloat64HashAggAlloc struct {
 	aggAllocBase
 	aggFuncs []sumFloat64HashAgg
@@ -676,6 +701,11 @@ func (a *sumIntervalHashAgg) Flush(outputIdx int) {
 	} else {
 		a.col[outputIdx] = a.curAgg
 	}
+}
+
+func (a *sumIntervalHashAgg) Reset() {
+	a.curAgg = zeroIntervalValue
+	a.foundNonNullForCurrentGroup = false
 }
 
 type sumIntervalHashAggAlloc struct {

--- a/pkg/sql/colexec/colexecagg/hash_sum_int_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_sum_int_agg.eg.go
@@ -128,6 +128,11 @@ func (a *sumIntInt16HashAgg) Flush(outputIdx int) {
 	}
 }
 
+func (a *sumIntInt16HashAgg) Reset() {
+	a.curAgg = zeroInt64Value
+	a.foundNonNullForCurrentGroup = false
+}
+
 type sumIntInt16HashAggAlloc struct {
 	aggAllocBase
 	aggFuncs []sumIntInt16HashAgg
@@ -237,6 +242,11 @@ func (a *sumIntInt32HashAgg) Flush(outputIdx int) {
 	}
 }
 
+func (a *sumIntInt32HashAgg) Reset() {
+	a.curAgg = zeroInt64Value
+	a.foundNonNullForCurrentGroup = false
+}
+
 type sumIntInt32HashAggAlloc struct {
 	aggAllocBase
 	aggFuncs []sumIntInt32HashAgg
@@ -344,6 +354,11 @@ func (a *sumIntInt64HashAgg) Flush(outputIdx int) {
 	} else {
 		a.col[outputIdx] = a.curAgg
 	}
+}
+
+func (a *sumIntInt64HashAgg) Reset() {
+	a.curAgg = zeroInt64Value
+	a.foundNonNullForCurrentGroup = false
 }
 
 type sumIntInt64HashAggAlloc struct {

--- a/pkg/sql/colexec/colexecagg/min_max_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/min_max_agg_tmpl.go
@@ -222,6 +222,13 @@ func (a *_AGG_TYPE_AGGKINDAgg) Flush(outputIdx int) {
 	// {{end}}
 }
 
+func (a *_AGG_TYPE_AGGKINDAgg) Reset() {
+	// {{if eq "_AGGKIND" "Ordered"}}
+	a.orderedAggregateFuncBase.Reset()
+	// {{end}}
+	a.foundNonNullForCurrentGroup = false
+}
+
 type _AGG_TYPE_AGGKINDAggAlloc struct {
 	aggAllocBase
 	aggFuncs []_AGG_TYPE_AGGKINDAgg

--- a/pkg/sql/colexec/colexecagg/ordered_any_not_null_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_any_not_null_agg.eg.go
@@ -255,6 +255,11 @@ func (a *anyNotNullBoolOrderedAgg) Flush(outputIdx int) {
 	}
 }
 
+func (a *anyNotNullBoolOrderedAgg) Reset() {
+	a.orderedAggregateFuncBase.Reset()
+	a.foundNonNullForCurrentGroup = false
+}
+
 type anyNotNullBoolOrderedAggAlloc struct {
 	aggAllocBase
 	aggFuncs []anyNotNullBoolOrderedAgg
@@ -449,6 +454,11 @@ func (a *anyNotNullBytesOrderedAgg) Flush(outputIdx int) {
 	a.curAgg = nil
 }
 
+func (a *anyNotNullBytesOrderedAgg) Reset() {
+	a.orderedAggregateFuncBase.Reset()
+	a.foundNonNullForCurrentGroup = false
+}
+
 type anyNotNullBytesOrderedAggAlloc struct {
 	aggAllocBase
 	aggFuncs []anyNotNullBytesOrderedAgg
@@ -638,6 +648,11 @@ func (a *anyNotNullDecimalOrderedAgg) Flush(outputIdx int) {
 	} else {
 		a.col[outputIdx].Set(&a.curAgg)
 	}
+}
+
+func (a *anyNotNullDecimalOrderedAgg) Reset() {
+	a.orderedAggregateFuncBase.Reset()
+	a.foundNonNullForCurrentGroup = false
 }
 
 type anyNotNullDecimalOrderedAggAlloc struct {
@@ -831,6 +846,11 @@ func (a *anyNotNullInt16OrderedAgg) Flush(outputIdx int) {
 	}
 }
 
+func (a *anyNotNullInt16OrderedAgg) Reset() {
+	a.orderedAggregateFuncBase.Reset()
+	a.foundNonNullForCurrentGroup = false
+}
+
 type anyNotNullInt16OrderedAggAlloc struct {
 	aggAllocBase
 	aggFuncs []anyNotNullInt16OrderedAgg
@@ -1020,6 +1040,11 @@ func (a *anyNotNullInt32OrderedAgg) Flush(outputIdx int) {
 	} else {
 		a.col[outputIdx] = a.curAgg
 	}
+}
+
+func (a *anyNotNullInt32OrderedAgg) Reset() {
+	a.orderedAggregateFuncBase.Reset()
+	a.foundNonNullForCurrentGroup = false
 }
 
 type anyNotNullInt32OrderedAggAlloc struct {
@@ -1213,6 +1238,11 @@ func (a *anyNotNullInt64OrderedAgg) Flush(outputIdx int) {
 	}
 }
 
+func (a *anyNotNullInt64OrderedAgg) Reset() {
+	a.orderedAggregateFuncBase.Reset()
+	a.foundNonNullForCurrentGroup = false
+}
+
 type anyNotNullInt64OrderedAggAlloc struct {
 	aggAllocBase
 	aggFuncs []anyNotNullInt64OrderedAgg
@@ -1402,6 +1432,11 @@ func (a *anyNotNullFloat64OrderedAgg) Flush(outputIdx int) {
 	} else {
 		a.col[outputIdx] = a.curAgg
 	}
+}
+
+func (a *anyNotNullFloat64OrderedAgg) Reset() {
+	a.orderedAggregateFuncBase.Reset()
+	a.foundNonNullForCurrentGroup = false
 }
 
 type anyNotNullFloat64OrderedAggAlloc struct {
@@ -1595,6 +1630,11 @@ func (a *anyNotNullTimestampOrderedAgg) Flush(outputIdx int) {
 	}
 }
 
+func (a *anyNotNullTimestampOrderedAgg) Reset() {
+	a.orderedAggregateFuncBase.Reset()
+	a.foundNonNullForCurrentGroup = false
+}
+
 type anyNotNullTimestampOrderedAggAlloc struct {
 	aggAllocBase
 	aggFuncs []anyNotNullTimestampOrderedAgg
@@ -1784,6 +1824,11 @@ func (a *anyNotNullIntervalOrderedAgg) Flush(outputIdx int) {
 	} else {
 		a.col[outputIdx] = a.curAgg
 	}
+}
+
+func (a *anyNotNullIntervalOrderedAgg) Reset() {
+	a.orderedAggregateFuncBase.Reset()
+	a.foundNonNullForCurrentGroup = false
 }
 
 type anyNotNullIntervalOrderedAggAlloc struct {
@@ -1987,6 +2032,11 @@ func (a *anyNotNullDatumOrderedAgg) Flush(outputIdx int) {
 		a.allocator.AdjustMemoryUsage(-int64(d.Size()))
 	}
 	a.curAgg = nil
+}
+
+func (a *anyNotNullDatumOrderedAgg) Reset() {
+	a.orderedAggregateFuncBase.Reset()
+	a.foundNonNullForCurrentGroup = false
 }
 
 type anyNotNullDatumOrderedAggAlloc struct {

--- a/pkg/sql/colexec/colexecagg/ordered_avg_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_avg_agg.eg.go
@@ -287,6 +287,13 @@ func (a *avgInt16OrderedAgg) Flush(outputIdx int) {
 	}
 }
 
+func (a *avgInt16OrderedAgg) Reset() {
+	a.orderedAggregateFuncBase.Reset()
+	a.curSum = zeroDecimalValue
+	a.curCount = 0
+	a.foundNonNullForCurrentGroup = false
+}
+
 type avgInt16OrderedAggAlloc struct {
 	aggAllocBase
 	aggFuncs []avgInt16OrderedAgg
@@ -545,6 +552,13 @@ func (a *avgInt32OrderedAgg) Flush(outputIdx int) {
 			colexecerror.InternalError(err)
 		}
 	}
+}
+
+func (a *avgInt32OrderedAgg) Reset() {
+	a.orderedAggregateFuncBase.Reset()
+	a.curSum = zeroDecimalValue
+	a.curCount = 0
+	a.foundNonNullForCurrentGroup = false
 }
 
 type avgInt32OrderedAggAlloc struct {
@@ -807,6 +821,13 @@ func (a *avgInt64OrderedAgg) Flush(outputIdx int) {
 	}
 }
 
+func (a *avgInt64OrderedAgg) Reset() {
+	a.orderedAggregateFuncBase.Reset()
+	a.curSum = zeroDecimalValue
+	a.curCount = 0
+	a.foundNonNullForCurrentGroup = false
+}
+
 type avgInt64OrderedAggAlloc struct {
 	aggAllocBase
 	aggFuncs []avgInt64OrderedAgg
@@ -1059,6 +1080,13 @@ func (a *avgDecimalOrderedAgg) Flush(outputIdx int) {
 	}
 }
 
+func (a *avgDecimalOrderedAgg) Reset() {
+	a.orderedAggregateFuncBase.Reset()
+	a.curSum = zeroDecimalValue
+	a.curCount = 0
+	a.foundNonNullForCurrentGroup = false
+}
+
 type avgDecimalOrderedAggAlloc struct {
 	aggAllocBase
 	aggFuncs []avgDecimalOrderedAgg
@@ -1279,6 +1307,13 @@ func (a *avgFloat64OrderedAgg) Flush(outputIdx int) {
 	}
 }
 
+func (a *avgFloat64OrderedAgg) Reset() {
+	a.orderedAggregateFuncBase.Reset()
+	a.curSum = zeroFloat64Value
+	a.curCount = 0
+	a.foundNonNullForCurrentGroup = false
+}
+
 type avgFloat64OrderedAggAlloc struct {
 	aggAllocBase
 	aggFuncs []avgFloat64OrderedAgg
@@ -1477,6 +1512,13 @@ func (a *avgIntervalOrderedAgg) Flush(outputIdx int) {
 	} else {
 		a.col[outputIdx] = a.curSum.Div(int64(a.curCount))
 	}
+}
+
+func (a *avgIntervalOrderedAgg) Reset() {
+	a.orderedAggregateFuncBase.Reset()
+	a.curSum = zeroIntervalValue
+	a.curCount = 0
+	a.foundNonNullForCurrentGroup = false
 }
 
 type avgIntervalOrderedAggAlloc struct {

--- a/pkg/sql/colexec/colexecagg/ordered_bool_and_or_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_bool_and_or_agg.eg.go
@@ -175,6 +175,11 @@ func (a *boolAndOrderedAgg) Flush(outputIdx int) {
 	}
 }
 
+func (a *boolAndOrderedAgg) Reset() {
+	a.orderedAggregateFuncBase.Reset()
+	a.curAgg = true
+}
+
 type boolAndOrderedAggAlloc struct {
 	aggAllocBase
 	aggFuncs []boolAndOrderedAgg
@@ -192,8 +197,8 @@ func (a *boolAndOrderedAggAlloc) newAggFunc() AggregateFunc {
 	}
 	f := &a.aggFuncs[0]
 	f.allocator = a.allocator
+	f.Reset()
 	a.aggFuncs = a.aggFuncs[1:]
-	f.curAgg = true
 	return f
 }
 
@@ -352,6 +357,11 @@ func (a *boolOrOrderedAgg) Flush(outputIdx int) {
 	}
 }
 
+func (a *boolOrOrderedAgg) Reset() {
+	a.orderedAggregateFuncBase.Reset()
+	a.curAgg = false
+}
+
 type boolOrOrderedAggAlloc struct {
 	aggAllocBase
 	aggFuncs []boolOrOrderedAgg
@@ -369,7 +379,7 @@ func (a *boolOrOrderedAggAlloc) newAggFunc() AggregateFunc {
 	}
 	f := &a.aggFuncs[0]
 	f.allocator = a.allocator
+	f.Reset()
 	a.aggFuncs = a.aggFuncs[1:]
-	f.curAgg = false
 	return f
 }

--- a/pkg/sql/colexec/colexecagg/ordered_concat_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_concat_agg.eg.go
@@ -183,6 +183,12 @@ func (a *concatOrderedAgg) Flush(outputIdx int) {
 	a.curAgg = nil
 }
 
+func (a *concatOrderedAgg) Reset() {
+	a.orderedAggregateFuncBase.Reset()
+	a.curAgg = nil
+	a.foundNonNullForCurrentGroup = false
+}
+
 type concatOrderedAggAlloc struct {
 	aggAllocBase
 	aggFuncs []concatOrderedAgg

--- a/pkg/sql/colexec/colexecagg/ordered_count_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_count_agg.eg.go
@@ -103,6 +103,11 @@ func (a *countRowsOrderedAgg) HandleEmptyInputScalar() {
 	a.col[0] = 0
 }
 
+func (a *countRowsOrderedAgg) Reset() {
+	a.orderedAggregateFuncBase.Reset()
+	a.curAgg = 0
+}
+
 type countRowsOrderedAggAlloc struct {
 	aggAllocBase
 	aggFuncs []countRowsOrderedAgg
@@ -249,6 +254,11 @@ func (a *countOrderedAgg) HandleEmptyInputScalar() {
 	// COUNT aggregates are special because they return zero in case of an
 	// empty input in the scalar context.
 	a.col[0] = 0
+}
+
+func (a *countOrderedAgg) Reset() {
+	a.orderedAggregateFuncBase.Reset()
+	a.curAgg = 0
 }
 
 type countOrderedAggAlloc struct {

--- a/pkg/sql/colexec/colexecagg/ordered_default_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_default_agg.eg.go
@@ -145,6 +145,11 @@ func (a *defaultOrderedAgg) HandleEmptyInputScalar() {
 	}
 }
 
+func (a *defaultOrderedAgg) Reset() {
+	a.orderedAggregateFuncBase.Reset()
+	a.fn.Reset(a.ctx)
+}
+
 func newDefaultOrderedAggAlloc(
 	allocator *colmem.Allocator,
 	constructor execinfrapb.AggregateConstructor,

--- a/pkg/sql/colexec/colexecagg/ordered_min_max_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_min_max_agg.eg.go
@@ -349,6 +349,11 @@ func (a *minBoolOrderedAgg) Flush(outputIdx int) {
 	}
 }
 
+func (a *minBoolOrderedAgg) Reset() {
+	a.orderedAggregateFuncBase.Reset()
+	a.foundNonNullForCurrentGroup = false
+}
+
 type minBoolOrderedAggAlloc struct {
 	aggAllocBase
 	aggFuncs []minBoolOrderedAgg
@@ -601,6 +606,11 @@ func (a *minBytesOrderedAgg) Flush(outputIdx int) {
 	a.curAgg = nil
 }
 
+func (a *minBytesOrderedAgg) Reset() {
+	a.orderedAggregateFuncBase.Reset()
+	a.foundNonNullForCurrentGroup = false
+}
+
 type minBytesOrderedAggAlloc struct {
 	aggAllocBase
 	aggFuncs []minBytesOrderedAgg
@@ -846,6 +856,11 @@ func (a *minDecimalOrderedAgg) Flush(outputIdx int) {
 	} else {
 		a.col[outputIdx].Set(&a.curAgg)
 	}
+}
+
+func (a *minDecimalOrderedAgg) Reset() {
+	a.orderedAggregateFuncBase.Reset()
+	a.foundNonNullForCurrentGroup = false
 }
 
 type minDecimalOrderedAggAlloc struct {
@@ -1139,6 +1154,11 @@ func (a *minInt16OrderedAgg) Flush(outputIdx int) {
 	}
 }
 
+func (a *minInt16OrderedAgg) Reset() {
+	a.orderedAggregateFuncBase.Reset()
+	a.foundNonNullForCurrentGroup = false
+}
+
 type minInt16OrderedAggAlloc struct {
 	aggAllocBase
 	aggFuncs []minInt16OrderedAgg
@@ -1430,6 +1450,11 @@ func (a *minInt32OrderedAgg) Flush(outputIdx int) {
 	}
 }
 
+func (a *minInt32OrderedAgg) Reset() {
+	a.orderedAggregateFuncBase.Reset()
+	a.foundNonNullForCurrentGroup = false
+}
+
 type minInt32OrderedAggAlloc struct {
 	aggAllocBase
 	aggFuncs []minInt32OrderedAgg
@@ -1719,6 +1744,11 @@ func (a *minInt64OrderedAgg) Flush(outputIdx int) {
 	} else {
 		a.col[outputIdx] = a.curAgg
 	}
+}
+
+func (a *minInt64OrderedAgg) Reset() {
+	a.orderedAggregateFuncBase.Reset()
+	a.foundNonNullForCurrentGroup = false
 }
 
 type minInt64OrderedAggAlloc struct {
@@ -2044,6 +2074,11 @@ func (a *minFloat64OrderedAgg) Flush(outputIdx int) {
 	}
 }
 
+func (a *minFloat64OrderedAgg) Reset() {
+	a.orderedAggregateFuncBase.Reset()
+	a.foundNonNullForCurrentGroup = false
+}
+
 type minFloat64OrderedAggAlloc struct {
 	aggAllocBase
 	aggFuncs []minFloat64OrderedAgg
@@ -2319,6 +2354,11 @@ func (a *minTimestampOrderedAgg) Flush(outputIdx int) {
 	}
 }
 
+func (a *minTimestampOrderedAgg) Reset() {
+	a.orderedAggregateFuncBase.Reset()
+	a.foundNonNullForCurrentGroup = false
+}
+
 type minTimestampOrderedAggAlloc struct {
 	aggAllocBase
 	aggFuncs []minTimestampOrderedAgg
@@ -2564,6 +2604,11 @@ func (a *minIntervalOrderedAgg) Flush(outputIdx int) {
 	} else {
 		a.col[outputIdx] = a.curAgg
 	}
+}
+
+func (a *minIntervalOrderedAgg) Reset() {
+	a.orderedAggregateFuncBase.Reset()
+	a.foundNonNullForCurrentGroup = false
 }
 
 type minIntervalOrderedAggAlloc struct {
@@ -2832,6 +2877,11 @@ func (a *minDatumOrderedAgg) Flush(outputIdx int) {
 		a.allocator.AdjustMemoryUsage(-int64(d.Size()))
 	}
 	a.curAgg = nil
+}
+
+func (a *minDatumOrderedAgg) Reset() {
+	a.orderedAggregateFuncBase.Reset()
+	a.foundNonNullForCurrentGroup = false
 }
 
 type minDatumOrderedAggAlloc struct {
@@ -3113,6 +3163,11 @@ func (a *maxBoolOrderedAgg) Flush(outputIdx int) {
 	}
 }
 
+func (a *maxBoolOrderedAgg) Reset() {
+	a.orderedAggregateFuncBase.Reset()
+	a.foundNonNullForCurrentGroup = false
+}
+
 type maxBoolOrderedAggAlloc struct {
 	aggAllocBase
 	aggFuncs []maxBoolOrderedAgg
@@ -3365,6 +3420,11 @@ func (a *maxBytesOrderedAgg) Flush(outputIdx int) {
 	a.curAgg = nil
 }
 
+func (a *maxBytesOrderedAgg) Reset() {
+	a.orderedAggregateFuncBase.Reset()
+	a.foundNonNullForCurrentGroup = false
+}
+
 type maxBytesOrderedAggAlloc struct {
 	aggAllocBase
 	aggFuncs []maxBytesOrderedAgg
@@ -3610,6 +3670,11 @@ func (a *maxDecimalOrderedAgg) Flush(outputIdx int) {
 	} else {
 		a.col[outputIdx].Set(&a.curAgg)
 	}
+}
+
+func (a *maxDecimalOrderedAgg) Reset() {
+	a.orderedAggregateFuncBase.Reset()
+	a.foundNonNullForCurrentGroup = false
 }
 
 type maxDecimalOrderedAggAlloc struct {
@@ -3903,6 +3968,11 @@ func (a *maxInt16OrderedAgg) Flush(outputIdx int) {
 	}
 }
 
+func (a *maxInt16OrderedAgg) Reset() {
+	a.orderedAggregateFuncBase.Reset()
+	a.foundNonNullForCurrentGroup = false
+}
+
 type maxInt16OrderedAggAlloc struct {
 	aggAllocBase
 	aggFuncs []maxInt16OrderedAgg
@@ -4194,6 +4264,11 @@ func (a *maxInt32OrderedAgg) Flush(outputIdx int) {
 	}
 }
 
+func (a *maxInt32OrderedAgg) Reset() {
+	a.orderedAggregateFuncBase.Reset()
+	a.foundNonNullForCurrentGroup = false
+}
+
 type maxInt32OrderedAggAlloc struct {
 	aggAllocBase
 	aggFuncs []maxInt32OrderedAgg
@@ -4483,6 +4558,11 @@ func (a *maxInt64OrderedAgg) Flush(outputIdx int) {
 	} else {
 		a.col[outputIdx] = a.curAgg
 	}
+}
+
+func (a *maxInt64OrderedAgg) Reset() {
+	a.orderedAggregateFuncBase.Reset()
+	a.foundNonNullForCurrentGroup = false
 }
 
 type maxInt64OrderedAggAlloc struct {
@@ -4808,6 +4888,11 @@ func (a *maxFloat64OrderedAgg) Flush(outputIdx int) {
 	}
 }
 
+func (a *maxFloat64OrderedAgg) Reset() {
+	a.orderedAggregateFuncBase.Reset()
+	a.foundNonNullForCurrentGroup = false
+}
+
 type maxFloat64OrderedAggAlloc struct {
 	aggAllocBase
 	aggFuncs []maxFloat64OrderedAgg
@@ -5083,6 +5168,11 @@ func (a *maxTimestampOrderedAgg) Flush(outputIdx int) {
 	}
 }
 
+func (a *maxTimestampOrderedAgg) Reset() {
+	a.orderedAggregateFuncBase.Reset()
+	a.foundNonNullForCurrentGroup = false
+}
+
 type maxTimestampOrderedAggAlloc struct {
 	aggAllocBase
 	aggFuncs []maxTimestampOrderedAgg
@@ -5328,6 +5418,11 @@ func (a *maxIntervalOrderedAgg) Flush(outputIdx int) {
 	} else {
 		a.col[outputIdx] = a.curAgg
 	}
+}
+
+func (a *maxIntervalOrderedAgg) Reset() {
+	a.orderedAggregateFuncBase.Reset()
+	a.foundNonNullForCurrentGroup = false
 }
 
 type maxIntervalOrderedAggAlloc struct {
@@ -5596,6 +5691,11 @@ func (a *maxDatumOrderedAgg) Flush(outputIdx int) {
 		a.allocator.AdjustMemoryUsage(-int64(d.Size()))
 	}
 	a.curAgg = nil
+}
+
+func (a *maxDatumOrderedAgg) Reset() {
+	a.orderedAggregateFuncBase.Reset()
+	a.foundNonNullForCurrentGroup = false
 }
 
 type maxDatumOrderedAggAlloc struct {

--- a/pkg/sql/colexec/colexecagg/ordered_sum_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_sum_agg.eg.go
@@ -256,6 +256,12 @@ func (a *sumInt16OrderedAgg) Flush(outputIdx int) {
 	}
 }
 
+func (a *sumInt16OrderedAgg) Reset() {
+	a.orderedAggregateFuncBase.Reset()
+	a.curAgg = zeroDecimalValue
+	a.foundNonNullForCurrentGroup = false
+}
+
 type sumInt16OrderedAggAlloc struct {
 	aggAllocBase
 	aggFuncs []sumInt16OrderedAgg
@@ -482,6 +488,12 @@ func (a *sumInt32OrderedAgg) Flush(outputIdx int) {
 	} else {
 		a.col[outputIdx] = a.curAgg
 	}
+}
+
+func (a *sumInt32OrderedAgg) Reset() {
+	a.orderedAggregateFuncBase.Reset()
+	a.curAgg = zeroDecimalValue
+	a.foundNonNullForCurrentGroup = false
 }
 
 type sumInt32OrderedAggAlloc struct {
@@ -712,6 +724,12 @@ func (a *sumInt64OrderedAgg) Flush(outputIdx int) {
 	}
 }
 
+func (a *sumInt64OrderedAgg) Reset() {
+	a.orderedAggregateFuncBase.Reset()
+	a.curAgg = zeroDecimalValue
+	a.foundNonNullForCurrentGroup = false
+}
+
 type sumInt64OrderedAggAlloc struct {
 	aggAllocBase
 	aggFuncs []sumInt64OrderedAgg
@@ -932,6 +950,12 @@ func (a *sumDecimalOrderedAgg) Flush(outputIdx int) {
 	}
 }
 
+func (a *sumDecimalOrderedAgg) Reset() {
+	a.orderedAggregateFuncBase.Reset()
+	a.curAgg = zeroDecimalValue
+	a.foundNonNullForCurrentGroup = false
+}
+
 type sumDecimalOrderedAggAlloc struct {
 	aggAllocBase
 	aggFuncs []sumDecimalOrderedAgg
@@ -1140,6 +1164,12 @@ func (a *sumFloat64OrderedAgg) Flush(outputIdx int) {
 	}
 }
 
+func (a *sumFloat64OrderedAgg) Reset() {
+	a.orderedAggregateFuncBase.Reset()
+	a.curAgg = zeroFloat64Value
+	a.foundNonNullForCurrentGroup = false
+}
+
 type sumFloat64OrderedAggAlloc struct {
 	aggAllocBase
 	aggFuncs []sumFloat64OrderedAgg
@@ -1326,6 +1356,12 @@ func (a *sumIntervalOrderedAgg) Flush(outputIdx int) {
 	} else {
 		a.col[outputIdx] = a.curAgg
 	}
+}
+
+func (a *sumIntervalOrderedAgg) Reset() {
+	a.orderedAggregateFuncBase.Reset()
+	a.curAgg = zeroIntervalValue
+	a.foundNonNullForCurrentGroup = false
 }
 
 type sumIntervalOrderedAggAlloc struct {

--- a/pkg/sql/colexec/colexecagg/ordered_sum_int_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_sum_int_agg.eg.go
@@ -239,6 +239,12 @@ func (a *sumIntInt16OrderedAgg) Flush(outputIdx int) {
 	}
 }
 
+func (a *sumIntInt16OrderedAgg) Reset() {
+	a.orderedAggregateFuncBase.Reset()
+	a.curAgg = zeroInt64Value
+	a.foundNonNullForCurrentGroup = false
+}
+
 type sumIntInt16OrderedAggAlloc struct {
 	aggAllocBase
 	aggFuncs []sumIntInt16OrderedAgg
@@ -459,6 +465,12 @@ func (a *sumIntInt32OrderedAgg) Flush(outputIdx int) {
 	}
 }
 
+func (a *sumIntInt32OrderedAgg) Reset() {
+	a.orderedAggregateFuncBase.Reset()
+	a.curAgg = zeroInt64Value
+	a.foundNonNullForCurrentGroup = false
+}
+
 type sumIntInt32OrderedAggAlloc struct {
 	aggAllocBase
 	aggFuncs []sumIntInt32OrderedAgg
@@ -677,6 +689,12 @@ func (a *sumIntInt64OrderedAgg) Flush(outputIdx int) {
 	} else {
 		a.col[outputIdx] = a.curAgg
 	}
+}
+
+func (a *sumIntInt64OrderedAgg) Reset() {
+	a.orderedAggregateFuncBase.Reset()
+	a.curAgg = zeroInt64Value
+	a.foundNonNullForCurrentGroup = false
 }
 
 type sumIntInt64OrderedAggAlloc struct {

--- a/pkg/sql/colexec/colexecagg/sum_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/sum_agg_tmpl.go
@@ -186,6 +186,14 @@ func (a *sum_SUMKIND_TYPE_AGGKINDAgg) Flush(outputIdx int) {
 	}
 }
 
+func (a *sum_SUMKIND_TYPE_AGGKINDAgg) Reset() {
+	// {{if eq "_AGGKIND" "Ordered"}}
+	a.orderedAggregateFuncBase.Reset()
+	// {{end}}
+	a.curAgg = zero_RET_TYPEValue
+	a.foundNonNullForCurrentGroup = false
+}
+
 type sum_SUMKIND_TYPE_AGGKINDAggAlloc struct {
 	aggAllocBase
 	aggFuncs []sum_SUMKIND_TYPE_AGGKINDAgg

--- a/pkg/sql/colexec/default_agg_test.go
+++ b/pkg/sql/colexec/default_agg_test.go
@@ -147,10 +147,17 @@ func TestDefaultAggregateFunc(t *testing.T) {
 				require.NoError(t, err)
 				runTestsWithTyps(t, []tuples{tc.input}, [][]*types.T{tc.typs}, tc.expected, unorderedVerifier,
 					func(input []colexecbase.Operator) (colexecbase.Operator, error) {
-						return agg.new(
-							testAllocator, testMemAcc, input[0], tc.typs, tc.spec, &evalCtx,
-							constructors, constArguments, outputTypes, false, /* isScalar */
-						)
+						return agg.new(&colexecagg.NewAggregatorArgs{
+							Allocator:      testAllocator,
+							MemAccount:     testMemAcc,
+							Input:          input[0],
+							InputTypes:     tc.typs,
+							Spec:           tc.spec,
+							EvalCtx:        &evalCtx,
+							Constructors:   constructors,
+							ConstArguments: constArguments,
+							OutputTypes:    outputTypes,
+						})
 					})
 			})
 		}

--- a/pkg/sql/colexec/operator.go
+++ b/pkg/sql/colexec/operator.go
@@ -109,6 +109,20 @@ type ResettableOperator interface {
 	resetter
 }
 
+// isOperatorChainResettable traverses the whole operator tree rooted at op and
+// returns true if all nodes are resetters.
+func isOperatorChainResettable(op execinfra.OpNode) bool {
+	if _, resettable := op.(resetter); !resettable {
+		return false
+	}
+	for i := 0; i < op.ChildCount(true /* verbose */); i++ {
+		if !isOperatorChainResettable(op.Child(i, true /* verbose */)) {
+			return false
+		}
+	}
+	return true
+}
+
 // CallbackCloser is a utility struct that implements the Closer interface by
 // calling a provided callback.
 type CallbackCloser struct {


### PR DESCRIPTION
**colexec: more nulls randomization in the test harness**

Previously, when deciding whether to inject a random null into the
input, we were using a rand object created with a constant seed. This
reduces our possible test coverage, and this commit fixes that. It
uncovered a few omissions which are now fixed too.

Release note: None

**colexec: extract arguments to New*Aggregator into a helper struct**

This commit is a mechanical change to extract the long list of arguments
that the constructors of both aggregators take into a helper struct.
This was prompted by the fact that the work on the external hash
aggregator will be adding even more arguments, so the function signature
becomes way too long.

Release note: None

**colexec: make aggregators resettable**

This commit makes both the ordered and the hash aggregators resettable
(this is a prerequisite for the external hash aggregator). This required
bringing back `Reset` method into the `AggregateFunc` interface.

Additionally, this commit modifies the test harness to check that the
operator trees that can be fully reset return the expected output once
they are reset. This increases our test coverage of the many operators
that are reused by the external ones.

Addresses: #42485.

Release note: None