### PR TITLE
tracing: simplify recording state

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -96,7 +96,7 @@
 <tr><td><code>timeseries.storage.enabled</code></td><td>boolean</td><td><code>true</code></td><td>if set, periodic timeseries data is stored within the cluster; disabling is not recommended unless you are storing the data elsewhere</td></tr>
 <tr><td><code>timeseries.storage.resolution_10s.ttl</code></td><td>duration</td><td><code>240h0m0s</code></td><td>the maximum age of time series data stored at the 10 second resolution. Data older than this is subject to rollup and deletion.</td></tr>
 <tr><td><code>timeseries.storage.resolution_30m.ttl</code></td><td>duration</td><td><code>2160h0m0s</code></td><td>the maximum age of time series data stored at the 30 minute resolution. Data older than this is subject to deletion.</td></tr>
-<tr><td><code>trace.debug.enable</code></td><td>boolean</td><td><code>false</code></td><td>if set, traces for recent requests can be seen in the /debug page</td></tr>
+<tr><td><code>trace.debug.enable</code></td><td>boolean</td><td><code>false</code></td><td>if set, traces for recent requests can be seen at https://<ui>/debug/requests</td></tr>
 <tr><td><code>trace.lightstep.token</code></td><td>string</td><td><code></code></td><td>if set, traces go to Lightstep using this token</td></tr>
 <tr><td><code>trace.zipkin.collector</code></td><td>string</td><td><code></code></td><td>if set, traces go to the given Zipkin instance (example: '127.0.0.1:9411'); ignored if trace.lightstep.token is set</td></tr>
 <tr><td><code>version</code></td><td>version</td><td><code>20.2-6</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>

--- a/pkg/cli/debug_reset_quorum.go
+++ b/pkg/cli/debug_reset_quorum.go
@@ -62,7 +62,7 @@ func runDebugResetQuorum(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	fmt.Printf("ok; please verify https://<ui>/#/reports/range/%d", rangeID)
+	fmt.Printf("ok; please verify https://<console>/#/reports/range/%d", rangeID)
 
 	return nil
 }

--- a/pkg/util/tracing/recording.go
+++ b/pkg/util/tracing/recording.go
@@ -28,7 +28,7 @@ import (
 )
 
 // RecordingType is the type of recording that a Span might be performing.
-type RecordingType int
+type RecordingType int32
 
 const (
 	// NoRecording means that the Span isn't recording. Child spans created from

--- a/pkg/util/tracing/span_options.go
+++ b/pkg/util/tracing/span_options.go
@@ -49,7 +49,7 @@ func (opts *spanOptions) parentSpanID() uint64 {
 func (opts *spanOptions) recordingType() RecordingType {
 	recordingType := NoRecording
 	if opts.Parent != nil && !opts.Parent.isNoop() {
-		recordingType = opts.Parent.crdb.getRecordingType()
+		recordingType = opts.Parent.crdb.recordingType()
 	} else if opts.RemoteParent != nil {
 		recordingType = opts.RemoteParent.recordingType
 	}

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -50,7 +50,7 @@ const (
 
 var enableNetTrace = settings.RegisterPublicBoolSetting(
 	"trace.debug.enable",
-	"if set, traces for recent requests can be seen in the /debug page",
+	"if set, traces for recent requests can be seen at https://<ui>/debug/requests",
 	false,
 )
 


### PR DESCRIPTION
We were previously keeping an authoritative recordingType under
`crdbSpanMu` and had a cheap atomic boolean outside of the mutex
that was checked in the hot path.

This unifies the two: we put an atomic under the mutex which can
be read without acquiring the mutex.

Additionally, we return the recording mode instead of just a bool
because with the introduction of always-on tracing (#55584) spans
will always be recording at least something, and so all of the
callers that have received a bool now will have to think harder
about what they actually want.

Release note: None
