### PR TITLE
vendor: bump Pebble to 024096017eda

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -440,8 +440,8 @@ def go_deps():
         name = "com_github_cockroachdb_pebble",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/cockroachdb/pebble",
-        sum = "h1:W2qQOIPTgHOPrCK/8CSHGfPc3jX8XIvvuWYKlcq55oE=",
-        version = "v0.0.0-20201119153812-62f2e316b532",
+        sum = "h1:LBXMPU1E/LWlT0t2SQkEgXZHX3t1SxHi86yn9ST0BgE=",
+        version = "v0.0.0-20201210152317-024096017eda",
     )
     go_repository(
         name = "com_github_cockroachdb_redact",

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/cockroachdb/go-test-teamcity v0.0.0-20191211140407-cff980ad0a55
 	github.com/cockroachdb/gostdlib v1.13.0
 	github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f
-	github.com/cockroachdb/pebble v0.0.0-20201119153812-62f2e316b532
+	github.com/cockroachdb/pebble v0.0.0-20201210152317-024096017eda
 	github.com/cockroachdb/redact v1.0.8
 	github.com/cockroachdb/returncheck v0.0.0-20200612231554-92cdbca611dd
 	github.com/cockroachdb/sentry-go v0.6.1-cockroachdb.2

--- a/go.sum
+++ b/go.sum
@@ -158,8 +158,8 @@ github.com/cockroachdb/grpc-gateway v1.14.6-0.20200519165156-52697fc4a249 h1:pZu
 github.com/cockroachdb/grpc-gateway v1.14.6-0.20200519165156-52697fc4a249/go.mod h1:UJ0EZAp832vCd54Wev9N1BMKEyvcZ5+IM0AwDrnlkEc=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f h1:o/kfcElHqOiXqcou5a3rIlMc7oJbMQkeLk0VQJ7zgqY=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
-github.com/cockroachdb/pebble v0.0.0-20201119153812-62f2e316b532 h1:W2qQOIPTgHOPrCK/8CSHGfPc3jX8XIvvuWYKlcq55oE=
-github.com/cockroachdb/pebble v0.0.0-20201119153812-62f2e316b532/go.mod h1:c3G8ud5zF3+nYHCWmVmtsA8eEtjrDSa6qeLtcRZyevE=
+github.com/cockroachdb/pebble v0.0.0-20201210152317-024096017eda h1:LBXMPU1E/LWlT0t2SQkEgXZHX3t1SxHi86yn9ST0BgE=
+github.com/cockroachdb/pebble v0.0.0-20201210152317-024096017eda/go.mod h1:c3G8ud5zF3+nYHCWmVmtsA8eEtjrDSa6qeLtcRZyevE=
 github.com/cockroachdb/redact v1.0.8 h1:8QG/764wK+vmEYoOlfobpe12EQcS81ukx/a4hdVMxNw=
 github.com/cockroachdb/redact v1.0.8/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/returncheck v0.0.0-20200612231554-92cdbca611dd h1:KFOt5I9nEKZgCnOSmy8r4Oykh8BYQO8bFOTgHDS8YZA=

--- a/pkg/cli/debug_test.go
+++ b/pkg/cli/debug_test.go
@@ -99,14 +99,6 @@ func TestOpenExistingStore(t *testing.T) {
 func TestOpenReadOnlyStore(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	stopper := stop.NewStopper()
-	defer stopper.Stop(context.Background())
-
-	baseDir, dirCleanupFn := testutils.TempDir(t)
-	defer dirCleanupFn()
-
-	storePath := filepath.Join(baseDir, "store")
-	createStore(t, storePath)
 
 	for _, test := range []struct {
 		readOnly bool
@@ -122,6 +114,15 @@ func TestOpenReadOnlyStore(t *testing.T) {
 		},
 	} {
 		t.Run(fmt.Sprintf("readOnly=%t", test.readOnly), func(t *testing.T) {
+			baseDir, dirCleanupFn := testutils.TempDir(t)
+			defer dirCleanupFn()
+
+			stopper := stop.NewStopper()
+			defer stopper.Stop(context.Background())
+
+			storePath := filepath.Join(baseDir, "store")
+			createStore(t, storePath)
+
 			db, err := OpenExistingStore(storePath, stopper, test.readOnly)
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -335,7 +335,6 @@ func DefaultPebbleOptions() *pebble.Options {
 		Merger:                      MVCCMerger,
 		TablePropertyCollectors:     PebbleTablePropertyCollectors,
 	}
-	opts.Experimental.L0SublevelCompactions = true
 	// Automatically flush 10s after the first range tombstone is added to a
 	// memtable. This ensures that we can reclaim space even when there's no
 	// activity on the database generating flushes.
@@ -356,12 +355,6 @@ func DefaultPebbleOptions() *pebble.Options {
 		}
 		l.EnsureDefaults()
 	}
-
-	// Set the value for FlushSplitBytes to 2x the L0 TargetFileSize. This
-	// should generally create flush split keys after every pair of
-	// L0 files. The 2x factor helps to reduce some cases of excessive flush
-	// splitting, and the overhead that comes with that.
-	opts.Experimental.FlushSplitBytes = 2 * opts.Levels[0].TargetFileSize
 
 	// Do not create bloom filters for the last level (i.e. the largest level
 	// which contains data in the LSM store). This configuration reduces the size


### PR DESCRIPTION
```
02409601 db: scale point tombstone averages according to file size
4a61407a db: add point tombstone compensation
2a2e77e3 cmd/pebble: add tombstone benchmark
f19faf85 vfs: prevent double locking from the same process
14c6e927 internal/base: provide more context in MustExist
e6d62a79 db: deflake TestRollManifest
a5e0a7ab db: heuristic to prevent tiny flushed files due to Lbase
c2b05f12 internal/cache: fix memory corruption when CGO_ENABLED=0
e325d9d1 *: Fix spurious race detection by adding flag to disable Compacting check
32a5180f *: Make sublevel compactions default, remove legacy code
2da62788 manifest: small optimizations to NewL0Sublevels
e3fe3566 internal/arenaskl: remove mention of arena.extValues
ef457c89 sstable: fix doc comment to remove reference to Reader.Get
6f1c9b11 db: fix flaky TestCompactionTombstoneElisionOnly
```

Release note: None