### PR TITLE
streaming: add mock streaming client

### DIFF
--- a/pkg/ccl/streamingccl/BUILD.bazel
+++ b/pkg/ccl/streamingccl/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "streamingccl",
+    srcs = ["stream_ingestion_job.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/ccl/streamingccl",
+    visibility = ["//visibility:public"],
+)

--- a/pkg/ccl/streamingccl/stream_ingestion_job.go
+++ b/pkg/ccl/streamingccl/stream_ingestion_job.go
@@ -1,0 +1,13 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package streamingccl
+
+func init() {
+	// TODO: Implement me.
+}

--- a/pkg/ccl/streamingccl/streamclient/BUILD.bazel
+++ b/pkg/ccl/streamingccl/streamclient/BUILD.bazel
@@ -1,0 +1,24 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "streamclient",
+    srcs = [
+        "client.go",
+        "event.go",
+    ],
+    importpath = "github.com/cockroachdb/cockroach/pkg/ccl/streamingccl/streamclient",
+    visibility = ["//visibility:public"],
+    deps = ["//pkg/roachpb"],
+)
+
+go_test(
+    name = "streamclient_test",
+    srcs = ["client_test.go"],
+    embed = [":streamclient"],
+    deps = [
+        "//pkg/roachpb",
+        "//pkg/util/hlc",
+        "//pkg/util/timeutil",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/pkg/ccl/streamingccl/streamclient/client.go
+++ b/pkg/ccl/streamingccl/streamclient/client.go
@@ -1,0 +1,42 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package streamclient
+
+import "time"
+
+// StreamAddress is the location of the stream. The topology of a stream should
+// be resolvable given a stream address.
+type StreamAddress string
+
+// PartitionAddress is the address where the stream client should be able to
+// read the events produced by a partition of a stream.
+//
+// Each partition will emit events for a fixed span of keys.
+type PartitionAddress string
+
+// Topology is a configuration of stream partitions. These are particular to a
+// stream. It specifies the number and addresses of partitions of the stream.
+//
+// There are a fixed number of Partitions in a Topology.
+type Topology struct {
+	Partitions []PartitionAddress
+}
+
+// Client provides a way for the stream ingestion job to consume a
+// specified stream.
+// TODO(57427): The stream client does not yet support the concept of
+//  generations in a stream.
+type Client interface {
+	// GetTopology returns the Topology of a stream.
+	GetTopology(address StreamAddress) (Topology, error)
+
+	// ConsumePartition returns a channel on which we can start listening for
+	// events from a given partition that occur after a startTime.
+	ConsumePartition(address PartitionAddress, startTime time.Time) (chan Event, error)
+}

--- a/pkg/ccl/streamingccl/streamclient/client_test.go
+++ b/pkg/ccl/streamingccl/streamclient/client_test.go
@@ -1,0 +1,80 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package streamclient
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/stretchr/testify/require"
+)
+
+type mockStreamClient struct{}
+
+var _ Client = mockStreamClient{}
+
+// GetTopology implements the Client interface.
+func (sc mockStreamClient) GetTopology(_ StreamAddress) (Topology, error) {
+	return Topology{Partitions: []PartitionAddress{
+		"s3://my_bucket/my_stream/partition_1",
+		"s3://my_bucket/my_stream/partition_2",
+	}}, nil
+}
+
+// ConsumePartition implements the Client interface.
+func (sc mockStreamClient) ConsumePartition(_ PartitionAddress, _ time.Time) (chan Event, error) {
+	sampleKV := roachpb.KeyValue{
+		Key: []byte("key_1"),
+		Value: roachpb.Value{
+			RawBytes:  []byte("value 1"),
+			Timestamp: hlc.Timestamp{WallTime: 1},
+		},
+	}
+
+	events := make(chan Event, 100)
+	events <- MakeKVEvent(sampleKV)
+	events <- MakeCheckpointEvent(timeutil.Now())
+	close(events)
+
+	return events, nil
+}
+
+// TestExampleClientUsage serves as documentation to indicate how a stream
+// client could be used.
+func TestExampleClientUsage(t *testing.T) {
+	client := mockStreamClient{}
+	sa := StreamAddress("s3://my_bucket/my_stream")
+	topology, err := client.GetTopology(sa)
+	require.NoError(t, err)
+
+	startTimestamp := timeutil.Now()
+	numReceivedEvents := 0
+
+	for _, partition := range topology.Partitions {
+		eventCh, err := client.ConsumePartition(partition, startTimestamp)
+		require.NoError(t, err)
+
+		// This example looks for the closing of the channel to terminate the test,
+		// but an ingestion job should look for another event such as the user
+		// cutting over to the new cluster to move to the next stage.
+		for {
+			_, ok := <-eventCh
+			if !ok {
+				break
+			}
+			numReceivedEvents++
+		}
+	}
+
+	// We expect 4 events, 2 from each partition.
+	require.Equal(t, 4, numReceivedEvents)
+}

--- a/pkg/ccl/streamingccl/streamclient/event.go
+++ b/pkg/ccl/streamingccl/streamclient/event.go
@@ -1,0 +1,96 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package streamclient
+
+import (
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+)
+
+// EventType enumerates all possible events emitted over a cluster stream.
+type EventType int
+
+const (
+	// KVEvent indicates that the KV field of an event holds an updated KV which
+	// needs to be ingested.
+	KVEvent EventType = iota
+	// CheckpointEvent indicates that GetResolved will be meaningful. The resolved
+	// timestamp indicates that all KVs have been emitted up to this timestamp.
+	CheckpointEvent
+)
+
+// Event describes an event emitted by a cluster to cluster stream.  Its Type
+// field indicates which other fields are meaningful.
+type Event interface {
+	// Type specifies which accessor will be meaningful.
+	Type() EventType
+
+	// GetKV returns a KV event if the EventType is KVEvent.
+	GetKV() *roachpb.KeyValue
+	// GetResolved returns a resolved timestamp if the EventType is
+	// CheckpointEvent. The resolved timestamp indicates that all KV events until
+	// this time have been emitted.
+	GetResolved() *time.Time
+}
+
+// kvEvent is a key value pair that needs to be ingested.
+type kvEvent struct {
+	kv roachpb.KeyValue
+}
+
+var _ Event = kvEvent{}
+
+// Type implements the Event interface.
+func (kve kvEvent) Type() EventType {
+	return KVEvent
+}
+
+// GetKV implements the Event interface.
+func (kve kvEvent) GetKV() *roachpb.KeyValue {
+	return &kve.kv
+}
+
+// GetResolved implements the Event interface.
+func (kve kvEvent) GetResolved() *time.Time {
+	return nil
+}
+
+// checkpointEvent indicates that the stream has emitted every change for all
+// keys in the span it is responsible for up until this timestamp.
+type checkpointEvent struct {
+	resolvedTimestamp time.Time
+}
+
+var _ Event = checkpointEvent{}
+
+// Type implements the Event interface.
+func (ce checkpointEvent) Type() EventType {
+	return CheckpointEvent
+}
+
+// GetKV implements the Event interface.
+func (ce checkpointEvent) GetKV() *roachpb.KeyValue {
+	return nil
+}
+
+// GetResolved implements the Event interface.
+func (ce checkpointEvent) GetResolved() *time.Time {
+	return &ce.resolvedTimestamp
+}
+
+// MakeKVEvent creates an Event from a KV.
+func MakeKVEvent(kv roachpb.KeyValue) Event {
+	return kvEvent{kv: kv}
+}
+
+// MakeCheckpointEvent creates an Event from a resolved timestamp.
+func MakeCheckpointEvent(resolvedTimestamp time.Time) Event {
+	return checkpointEvent{resolvedTimestamp: resolvedTimestamp}
+}


### PR DESCRIPTION
This commit adds a mock implementation of the most basic version of a
streaming client for cluster to cluster streaming in a new
`streamingccl` and `stream_client` packages.

This change is intended to get the foundations in place to define the
v0.1 version of the interface between components that reads the stream
with the job that will ingest the data.

Closes https://github.com/cockroachdb/cockroach/issues/57416.

Release note: None