### PR TITLE
kvserver: reduce hlc.Clock.Now() calls during Raft replica ticks

### DIFF
--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -424,7 +424,7 @@ func (r *Replica) leasePostApply(ctx context.Context, newLease roachpb.Lease, pe
 	// If we're the current raft leader, may want to transfer the leadership to
 	// the new leaseholder. Note that this condition is also checked periodically
 	// when ticking the replica.
-	r.maybeTransferRaftLeadershipToLeaseholder(ctx)
+	r.maybeTransferRaftLeadershipToLeaseholder(ctx, r.store.Clock().Now())
 
 	// Notify the store that a lease change occurred and it may need to
 	// gossip the updated store descriptor (with updated capacity).


### PR DESCRIPTION
Previously, the Raft `Replica.tick()` method fetched the current HLC
time twice: once during `maybeQuiesceLocked()` and again during
`maybeTransferRaftLeadershipToLeaseholderLocked()`. This contributed to
HLC contention, and also to `Replica.raftMu` lock contention since it is
held while making these calls.

According to #37278, both of these calls can tolerate a stale timestamp,
so this commit obtains the HLC timestamp before grabbing the `raftMu`
lock and passes it to both methods.

Release note: None

Resolves #37278.

I'd like some extra eyes on obtaining the time before grabbing the mutex. This intuitively makes sense to me, since a Raft tick necessarily must happen between the previous and next tick, and the precise time shouldn't really matter as long as it's between the previous/next time. However, the `raftMu` wait duration can in principle be arbitrarily long, and time can be tricky.