### PR TITLE
sql: use an unsafe []byte -> string cast to avoid allocations

### DIFF
--- a/pkg/sql/rowenc/column_type_encoding.go
+++ b/pkg/sql/rowenc/column_type_encoding.go
@@ -521,11 +521,13 @@ func DecodeTableValue(a *DatumAlloc, valType *types.T, b []byte) (tree.Datum, []
 	return DecodeUntaggedDatum(a, valType, b)
 }
 
-// DecodeUntaggedDatum is used to decode a Datum whose type is known,
-// and which doesn't have a value tag (either due to it having been
-// consumed already or not having one in the first place).
+// DecodeUntaggedDatum is used to decode a Datum whose type is known, and which
+// doesn't have a value tag (either due to it having been consumed already or
+// not having one in the first place).
 //
-// This is used to decode datums encoded using value encoding.
+// This is used to decode datums encoded using value encoding. The caller
+// relinquishes ownership over the portion of the byte slice that isn't returned
+// back to it.
 //
 // If t is types.Bool, the value tag must be present, as its value is encoded in
 // the tag directly.
@@ -542,7 +544,7 @@ func DecodeUntaggedDatum(a *DatumAlloc, t *types.T, buf []byte) (tree.Datum, []b
 		if err != nil {
 			return nil, b, err
 		}
-		return a.NewDString(tree.DString(data)), b, nil
+		return a.NewDString(tree.DString(encoding.UnsafeConvertBytesToString(data))), b, nil
 	case types.CollatedStringFamily:
 		b, data, err := encoding.DecodeUntaggedBytesValue(buf)
 		if err != nil {
@@ -578,7 +580,7 @@ func DecodeUntaggedDatum(a *DatumAlloc, t *types.T, buf []byte) (tree.Datum, []b
 		if err != nil {
 			return nil, b, err
 		}
-		return a.NewDBytes(tree.DBytes(data)), b, nil
+		return a.NewDBytes(tree.DBytes(encoding.UnsafeConvertBytesToString(data))), b, nil
 	case types.DateFamily:
 		b, data, err := encoding.DecodeUntaggedIntValue(buf)
 		if err != nil {

--- a/pkg/util/encoding/encoding.go
+++ b/pkg/util/encoding/encoding.go
@@ -687,7 +687,7 @@ func prettyPrintInvertedIndexKey(b []byte) (string, []byte, error) {
 		switch tempB[i+1] {
 		case escapedTerm:
 			if len(tempB[:i]) > 0 {
-				outBytes = outBytes + strconv.Quote(unsafeString(tempB[:i]))
+				outBytes = outBytes + strconv.Quote(UnsafeConvertBytesToString(tempB[:i]))
 			} else {
 				lenOut := len(outBytes)
 				if lenOut > 1 && outBytes[lenOut-1] == '/' {
@@ -696,7 +696,7 @@ func prettyPrintInvertedIndexKey(b []byte) (string, []byte, error) {
 			}
 			return outBytes, tempB[i+escapeLength:], nil
 		case escapedJSONObjectKeyTerm:
-			outBytes = outBytes + strconv.Quote(unsafeString(tempB[:i])) + "/"
+			outBytes = outBytes + strconv.Quote(UnsafeConvertBytesToString(tempB[:i])) + "/"
 		case escapedJSONArray:
 			outBytes = outBytes + "Arr/"
 		default:
@@ -795,11 +795,12 @@ func EncodeStringDescending(b []byte, s string) []byte {
 	return EncodeBytesDescending(b, arg)
 }
 
-// unsafeString performs an unsafe conversion from a []byte to a string. The
-// returned string will share the underlying memory with the []byte which thus
-// allows the string to be mutable through the []byte. We're careful to use
-// this method only in situations in which the []byte will not be modified.
-func unsafeString(b []byte) string {
+// UnsafeConvertBytesToString performs an unsafe conversion from a []byte to a
+// string. The returned string will share the underlying memory with the []byte
+// which thus allows the string to be mutable through the []byte. We're careful
+// to use this method only in situations in which the []byte will not be
+// modified. It's the parallel to UnsafeConvertStringToBytes.
+func UnsafeConvertBytesToString(b []byte) string {
 	return *(*string)(unsafe.Pointer(&b))
 }
 
@@ -810,7 +811,7 @@ func unsafeString(b []byte) string {
 // string may share storage with the input buffer.
 func DecodeUnsafeStringAscending(b []byte, r []byte) ([]byte, string, error) {
 	b, r, err := DecodeBytesAscending(b, r)
-	return b, unsafeString(r), err
+	return b, UnsafeConvertBytesToString(r), err
 }
 
 // DecodeUnsafeStringDescending decodes a string value from the input buffer which
@@ -821,7 +822,7 @@ func DecodeUnsafeStringAscending(b []byte, r []byte) ([]byte, string, error) {
 // buffer.
 func DecodeUnsafeStringDescending(b []byte, r []byte) ([]byte, string, error) {
 	b, r, err := DecodeBytesDescending(b, r)
-	return b, unsafeString(r), err
+	return b, UnsafeConvertBytesToString(r), err
 }
 
 // EncodeNullAscending encodes a NULL value. The encodes bytes are appended to the


### PR DESCRIPTION
See #50117, this particular cast was a major contributor to overall
GC impact from some earlier TPCC runs.

```
 Total:     2126197    2662867 (flat, cum)  15.39%
    507            .          .           	case types.IntFamily:
    508            .          .           		b, i, err := encoding.DecodeUntaggedIntValue(buf)
    509            .          .           		if err != nil {
    510            .          .           			return nil, b, err
    511            .          .           		}
    512            .      36867           		return a.NewDInt(tree.DInt(i)), b, nil
    513            .          .           	case types.StringFamily:
    514            .          .           		b, data, err := encoding.DecodeUntaggedBytesValue(buf)
    515            .          .           		if err != nil {
    516            .          .           			return nil, b, err
    517            .          .           		}
    518      2126197    2318755           		return a.NewDString(tree.DString(data)), b, nil
    519            .          .           	case types.CollatedStringFamily:
    520            .          .           		b, data, err := encoding.DecodeUntaggedBytesValue(buf)
```

Any []byte -> string cast allocates because strings are meant to be
immutable, but with the byte slice the caller still has the potential to
mutate it after the cast. In this particular codepath (like many others
within pkg/sql where we do the same), we already guarantee that the
input buffer provided is immutable.

Fixes #50117 (at least the biggest offender, all others seem minor and
probably have changed since we generated the report).

Release note: None