### PR TITLE
release-20.2: sql: fix bugs in adding foreign keys

### DIFF
--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -549,6 +549,14 @@ func (sc *SchemaChanger) addConstraints(
 					if err != nil {
 						return err
 					}
+					// Check that a unique constraint for the FK still exists on the
+					// referenced table. It's possible for the unique index found during
+					// planning to have been dropped in the meantime, since only the
+					// presence of the backreference prevents it.
+					_, err = tabledesc.FindFKReferencedIndex(backrefTable, constraint.ForeignKey.ReferencedColumnIDs)
+					if err != nil {
+						return err
+					}
 					backrefTable.InboundFKs = append(backrefTable.InboundFKs, constraint.ForeignKey)
 
 					// Note that this code may add the same descriptor to the batch

--- a/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
@@ -1897,3 +1897,28 @@ query TTTTB
 SHOW CONSTRAINTS FROM child_54265
 ----
 child_54265  fk_a_ref_parent_54265  FOREIGN KEY  FOREIGN KEY (a) REFERENCES parent_54265(a)  false
+
+# Test that dropping a unique index used by a foreign key reference causes the
+# foreign key addition to fail.
+subtest 57592
+
+statement ok
+CREATE TABLE t1_57592(a INT)
+
+statement ok
+CREATE UNIQUE INDEX idx ON t1_57592(a)
+
+statement ok
+CREATE TABLE t2_57592(a INT)
+
+statement ok
+BEGIN
+
+statement ok
+ALTER TABLE t2_57592 ADD FOREIGN KEY (a) REFERENCES t1_57592(a);
+
+statement ok
+DROP INDEX t1_57592@idx;
+
+statement error pgcode XXA00 there is no unique constraint matching given keys for referenced table t1_57592
+COMMIT


### PR DESCRIPTION
Backport 2/2 commits from #57598.

/cc @cockroachdb/release

---

See individual commits for details.

Fixes #57592.
Fixes #57596.
