### PR TITLE
release-20.1: sql: fix bugs in adding foreign keys

### DIFF
--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -466,6 +466,14 @@ func (sc *SchemaChanger) addConstraints(
 					if !ok {
 						return errors.AssertionFailedf("required table with ID %d not provided to update closure", sc.tableID)
 					}
+					// Check that a unique constraint for the FK still exists on the
+					// referenced table. It's possible for the unique index found during
+					// planning to have been dropped in the meantime, since only the
+					// presence of the backreference prevents it.
+					_, err := sqlbase.FindFKReferencedIndex(backrefTable.TableDesc(), constraint.ForeignKey.ReferencedColumnIDs)
+					if err != nil {
+						return err
+					}
 					backrefTable.InboundFKs = append(backrefTable.InboundFKs, constraint.ForeignKey)
 				}
 			}

--- a/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
@@ -1922,3 +1922,28 @@ query TTTTB
 SHOW CONSTRAINTS FROM child_54265
 ----
 child_54265  fk_a_ref_parent_54265  FOREIGN KEY  FOREIGN KEY (a) REFERENCES parent_54265(a)  false
+
+# Test that dropping a unique index used by a foreign key reference causes the
+# foreign key addition to fail.
+subtest 57592
+
+statement ok
+CREATE TABLE t1_57592(a INT)
+
+statement ok
+CREATE UNIQUE INDEX idx ON t1_57592(a)
+
+statement ok
+CREATE TABLE t2_57592(a INT)
+
+statement ok
+BEGIN
+
+statement ok
+ALTER TABLE t2_57592 ADD FOREIGN KEY (a) REFERENCES t1_57592(a);
+
+statement ok
+DROP INDEX t1_57592@idx;
+
+statement error pgcode XXA00 there is no unique constraint matching given keys for referenced table t1_57592
+COMMIT

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -6033,3 +6033,70 @@ CREATE UNIQUE INDEX i ON t.test(v);
 		runTest(params)
 	})
 }
+
+// TestRollbackForeignKeyAddition tests that rolling back a schema change to add
+// a foreign key before the backreference on the other table has been installed
+// works correctly (#57596).
+func TestRollbackForeignKeyAddition(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer setTestJobsAdoptInterval()()
+	ctx := context.Background()
+
+	// Track whether we've attempted the backfill already, since there's a second
+	// backfill during the schema change rollback.
+	attemptedBackfill := false
+	// Closed when we enter the RunBeforeBackfill knob (which is before
+	// backreferences for foreign keys are added).
+	beforeBackfillNotification := make(chan struct{})
+	// Closed when we're ready to continue with the schema change.
+	continueNotification := make(chan struct{})
+	params, _ := tests.CreateTestServerParams()
+	params.Knobs = base.TestingKnobs{
+		SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
+			RunBeforeBackfill: func() error {
+				if !attemptedBackfill {
+					attemptedBackfill = true
+					close(beforeBackfillNotification)
+					<-continueNotification
+				}
+				return nil
+			},
+		},
+	}
+	s, sqlDB, _ := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop(ctx)
+
+	tdb := sqlutils.MakeSQLRunner(sqlDB)
+	tdb.Exec(t, `CREATE DATABASE db`)
+	tdb.Exec(t, `CREATE TABLE db.t (a INT PRIMARY KEY)`)
+	tdb.Exec(t, `CREATE TABLE db.t2 (a INT)`)
+
+	g := ctxgroup.WithContext(ctx)
+	g.GoCtx(func(ctx context.Context) error {
+		_, err := sqlDB.ExecContext(ctx, `ALTER TABLE db.t2 ADD FOREIGN KEY (a) REFERENCES db.t`)
+		require.Regexp(t, "job canceled by user", err)
+		return nil
+	})
+
+	<-beforeBackfillNotification
+
+	var jobID int64
+
+	// We filter by descriptor_ids because there's a bug where we create an extra
+	// no-op job for the referenced table (#57624).
+	require.NoError(t, sqlDB.QueryRow(`
+SELECT job_id FROM crdb_internal.jobs WHERE description LIKE '%ALTER TABLE%'
+AND descriptor_ids[1] = 'db.t2'::regclass::int`,
+	).Scan(&jobID))
+	tdb.Exec(t, "CANCEL JOB $1", jobID)
+
+	close(continueNotification)
+	require.NoError(t, g.Wait())
+
+	var status jobs.Status
+	var error string
+	tdb.QueryRow(t, "SELECT status, error FROM crdb_internal.jobs WHERE job_id = $1", jobID).
+		Scan(&status, &error)
+	require.Equal(t, status, jobs.StatusCanceled)
+	require.Equal(t, error, "job canceled by user")
+}


### PR DESCRIPTION
Backport 2/2 commits from #57598.

/cc @cockroachdb/release

---

See individual commits for details.

Fixes #57592.
Fixes #57596.
