### PR TITLE
server: fix decomm status replica overcounting for r1

### DIFF
--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -1682,7 +1682,7 @@ func (s *adminServer) DecommissionStatus(
 		for _, nodeID := range nodeIDs {
 			replicaCounts[nodeID] = 0
 		}
-		return txn.Iterate(ctx, keys.MetaMin, keys.MetaMax, pageSize,
+		return txn.Iterate(ctx, keys.Meta2Prefix, keys.MetaMax, pageSize,
 			func(rows []kv.KeyValue) error {
 				rangeDesc := roachpb.RangeDescriptor{}
 				for _, row := range rows {


### PR DESCRIPTION
When scanning the KV keyspace for all range descriptors, we want to scan
from Meta2Prefix to MetaMax (see meta2RangeIter for other usages of
this). In our decomm status codepaths we were erroneously starting off
our scan at MetaMin, so including meta1 in our scans as well. This has
the effect of iterating over the range descriptor for r1 twice (first
observed in #57650 where we cargo-culted these bounds).

Release note (bug fix): When displaying replica counts during the
decommissioning process, previously we were overcounting the
replicas displayed for r1. This is no longer the case.