### PR TITLE
release-20.2: sql: fix bug in SHOW TABLES FROM <db> hiding non-public tables

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/schema
+++ b/pkg/sql/logictest/testdata/logic_test/schema
@@ -569,3 +569,45 @@ SELECT privilege_type FROM [SHOW GRANTS ON schema s FOR testuser]
 ----
 CREATE
 USAGE
+
+subtest show_tables
+
+statement ok
+CREATE DATABASE for_show;
+
+statement ok;
+USE for_show;
+
+statement ok;
+CREATE TABLE t1 (i INT PRIMARY KEY);
+
+statement ok;
+CREATE SCHEMA sc1;
+
+statement ok;
+CREATE TABLE sc1.t1 (i INT PRIMARY KEY);
+
+query TT
+SELECT schema_name, table_name FROM [SHOW TABLES]
+----
+public t1
+sc1    t1
+
+query TT
+SELECT schema_name, table_name FROM [SHOW TABLES FROM sc1]
+----
+sc1    t1
+
+statement ok
+USE test
+
+query TT
+SELECT schema_name, table_name FROM [SHOW TABLES FROM for_show]
+----
+public t1
+sc1    t1
+
+query TT
+SELECT schema_name, table_name FROM [SHOW TABLES FROM for_show.sc1]
+----
+sc1    t1


### PR DESCRIPTION
Backport 1/1 commits from #57749.

/cc @cockroachdb/release

---

The name resolution logic was hiding tables from schemas other than `public`
when using an explicit database name in `SHOW TABLES`.

Release note (bug fix): Fixed a bug whereby tables in schemas other than
"public" would not be displayed when running `SHOW TABLES FROM <db>`.
