### PR TITLE
kvserver: avoid multiTestContext racing replicate queue

### DIFF
--- a/pkg/kv/kvserver/client_metrics_test.go
+++ b/pkg/kv/kvserver/client_metrics_test.go
@@ -252,6 +252,7 @@ func TestStoreMetrics(t *testing.T) {
 
 	storeCfg := kvserver.TestStoreConfig(nil /* clock */)
 	storeCfg.TestingKnobs.DisableMergeQueue = true
+	storeCfg.TestingKnobs.DisableReplicateQueue = true
 	mtc := &multiTestContext{
 		storeConfig: &storeCfg,
 		// This test was written before the multiTestContext started creating many

--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -449,6 +449,7 @@ func TestFailedReplicaChange(t *testing.T) {
 	runFilter.Store(true)
 
 	sc := kvserver.TestStoreConfig(nil)
+	sc.TestingKnobs.DisableReplicateQueue = true
 	sc.Clock = nil // manual clock
 	sc.TestingKnobs.EvalKnobs.TestingEvalFilter = func(filterArgs kvserverbase.FilterArgs) *roachpb.Error {
 		if runFilter.Load().(bool) {
@@ -513,7 +514,10 @@ func TestFailedReplicaChange(t *testing.T) {
 func TestReplicateAfterTruncation(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	cfg := kvserver.TestStoreConfig(nil)
+	cfg.TestingKnobs.DisableReplicateQueue = true
 	mtc := &multiTestContext{
+		storeConfig: &cfg,
 		// This test was written before the multiTestContext started creating many
 		// system ranges at startup, and hasn't been update to take that into
 		// account.
@@ -687,14 +691,17 @@ func TestSnapshotAfterTruncation(t *testing.T) {
 			name = "differentTerm"
 		}
 		t.Run(name, func(t *testing.T) {
+			storeCfg := kvserver.TestStoreConfig(nil)
+			storeCfg.TestingKnobs.DisableReplicateQueue = true
 			mtc := &multiTestContext{
+				storeConfig: &storeCfg,
 				// This test was written before the multiTestContext started creating many
 				// system ranges at startup, and hasn't been update to take that into
 				// account.
 				startWithSingleRange: true,
 			}
-			defer mtc.Stop()
 			mtc.Start(t, 3)
+			defer mtc.Stop()
 			const stoppedStore = 1
 			repl0, err := mtc.stores[0].GetReplica(1)
 			if err != nil {
@@ -851,7 +858,12 @@ func TestSnapshotAfterTruncationWithUncommittedTail(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
+
+	cfg := kvserver.TestStoreConfig(nil)
+	cfg.TestingKnobs.DisableReplicateQueue = true
+	cfg.Clock = nil // using manual clock
 	mtc := &multiTestContext{
+		storeConfig: &cfg,
 		// This test was written before the multiTestContext started creating many
 		// system ranges at startup, and hasn't been update to take that into
 		// account.
@@ -1345,7 +1357,11 @@ func TestFailedSnapshotFillsReservation(t *testing.T) {
 func TestConcurrentRaftSnapshots(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	cfg := kvserver.TestStoreConfig(nil)
+	cfg.TestingKnobs.DisableReplicateQueue = true
 	mtc := &multiTestContext{
+		storeConfig: &cfg,
 		// This test was written before the multiTestContext started creating many
 		// system ranges at startup, and hasn't been update to take that into
 		// account.
@@ -1499,6 +1515,7 @@ func TestLogGrowthWhenRefreshingPendingCommands(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	sc := kvserver.TestStoreConfig(nil)
+	sc.TestingKnobs.DisableReplicateQueue = true
 	// Drop the raft tick interval so the Raft group is ticked more.
 	sc.RaftTickInterval = 10 * time.Millisecond
 	// Don't timeout raft leader. We don't want leadership moving.
@@ -1728,7 +1745,9 @@ func TestUnreplicateFirstRange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	mtc := &multiTestContext{}
+	cfg := kvserver.TestStoreConfig(nil)
+	cfg.TestingKnobs.DisableReplicateQueue = true
+	mtc := &multiTestContext{storeConfig: &cfg}
 	defer mtc.Stop()
 	mtc.Start(t, 3)
 
@@ -1750,7 +1769,10 @@ func TestUnreplicateFirstRange(t *testing.T) {
 func TestChangeReplicasDescriptorInvariant(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	storeCfg := kvserver.TestStoreConfig(nil)
+	storeCfg.TestingKnobs.DisableReplicateQueue = true
 	mtc := &multiTestContext{
+		storeConfig: &storeCfg,
 		// This test was written before the multiTestContext started creating many
 		// system ranges at startup, and hasn't been update to take that into
 		// account.
@@ -1831,7 +1853,11 @@ func TestChangeReplicasDescriptorInvariant(t *testing.T) {
 func TestProgressWithDownNode(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	cfg := kvserver.TestStoreConfig(nil)
+	cfg.TestingKnobs.DisableReplicateQueue = true
 	mtc := &multiTestContext{
+		storeConfig: &cfg,
 		// This test was written before the multiTestContext started creating many
 		// system ranges at startup, and hasn't been update to take that into
 		// account.
@@ -1914,6 +1940,7 @@ func runReplicateRestartAfterTruncation(t *testing.T, removeBeforeTruncateAndReA
 	// RaftElectionTimeoutTicks and RangeLeaseActiveDuration). This test expects
 	// mtc.stores[0] to hold the range lease for range 1.
 	sc.RaftElectionTimeoutTicks = 1000000
+	sc.TestingKnobs.DisableReplicateQueue = true
 	sc.Clock = nil // manual clock
 	mtc := &multiTestContext{
 		storeConfig: &sc,
@@ -2152,6 +2179,7 @@ func TestQuotaPool(t *testing.T) {
 	const rangeID = 1
 	ctx := context.Background()
 	sc := kvserver.TestStoreConfig(nil)
+	sc.TestingKnobs.DisableReplicateQueue = true
 	// Suppress timeout-based elections to avoid leadership changes in ways
 	// this test doesn't expect.
 	sc.RaftElectionTimeoutTicks = 100000
@@ -2301,6 +2329,7 @@ func TestWedgedReplicaDetection(t *testing.T) {
 	const rangeID = 1
 
 	sc := kvserver.TestStoreConfig(nil)
+	sc.TestingKnobs.DisableReplicateQueue = true
 	// Suppress timeout-based elections to avoid leadership changes in ways
 	// this test doesn't expect.
 	sc.RaftElectionTimeoutTicks = 100000
@@ -2396,7 +2425,9 @@ func TestRaftHeartbeats(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	mtc := &multiTestContext{}
+	cfg := kvserver.TestStoreConfig(nil)
+	cfg.TestingKnobs.DisableReplicateQueue = true
+	mtc := &multiTestContext{storeConfig: &cfg}
 	defer mtc.Stop()
 	mtc.Start(t, 3)
 
@@ -2434,8 +2465,10 @@ func TestRaftHeartbeats(t *testing.T) {
 func TestReportUnreachableHeartbeats(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-
+	cfg := kvserver.TestStoreConfig(nil)
+	cfg.TestingKnobs.DisableReplicateQueue = true
 	mtc := &multiTestContext{
+		storeConfig: &cfg,
 		// This test was written before the multiTestContext started creating many
 		// system ranges at startup, and hasn't been update to take that into
 		// account.
@@ -2505,7 +2538,9 @@ func TestReportUnreachableRemoveRace(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	mtc := &multiTestContext{}
+	sc := kvserver.TestStoreConfig(nil)
+	sc.TestingKnobs.DisableReplicateQueue = true
+	mtc := &multiTestContext{storeConfig: &sc}
 	defer mtc.Stop()
 	mtc.Start(t, 3)
 
@@ -2553,6 +2588,7 @@ func TestReplicateAfterSplit(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	storeCfg := kvserver.TestStoreConfig(nil /* clock */)
 	storeCfg.TestingKnobs.DisableMergeQueue = true
+	storeCfg.TestingKnobs.DisableReplicateQueue = true
 	mtc := &multiTestContext{
 		storeConfig: &storeCfg,
 	}
@@ -2631,6 +2667,7 @@ func TestReplicaRemovalCampaign(t *testing.T) {
 		func() {
 			storeCfg := kvserver.TestStoreConfig(nil /* clock */)
 			storeCfg.TestingKnobs.DisableMergeQueue = true
+			storeCfg.TestingKnobs.DisableReplicateQueue = true
 			mtc := &multiTestContext{
 				storeConfig: &storeCfg,
 			}
@@ -2713,6 +2750,7 @@ func TestRaftAfterRemoveRange(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	storeCfg := kvserver.TestStoreConfig(nil /* clock */)
 	storeCfg.TestingKnobs.DisableMergeQueue = true
+	storeCfg.TestingKnobs.DisableReplicateQueue = true
 	storeCfg.Clock = nil // manual clock
 	mtc := &multiTestContext{
 		storeConfig: &storeCfg,
@@ -2779,7 +2817,10 @@ func TestRaftAfterRemoveRange(t *testing.T) {
 func TestRaftRemoveRace(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	mtc := &multiTestContext{}
+
+	cfg := kvserver.TestStoreConfig(nil)
+	cfg.TestingKnobs.DisableReplicateQueue = true
+	mtc := &multiTestContext{storeConfig: &cfg}
 	defer mtc.Stop()
 	const rangeID = roachpb.RangeID(1)
 
@@ -2826,7 +2867,9 @@ func TestRaftRemoveRace(t *testing.T) {
 func TestRemovePlaceholderRace(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	mtc := &multiTestContext{}
+	cfg := kvserver.TestStoreConfig(nil)
+	cfg.TestingKnobs.DisableReplicateQueue = true
+	mtc := &multiTestContext{storeConfig: &cfg}
 	defer mtc.Stop()
 	mtc.Start(t, 3)
 
@@ -2913,7 +2956,9 @@ func TestReplicaGCRace(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	mtc := &multiTestContext{}
+	cfg := kvserver.TestStoreConfig(nil)
+	cfg.TestingKnobs.DisableReplicateQueue = true
+	mtc := &multiTestContext{storeConfig: &cfg}
 	defer mtc.Stop()
 	mtc.Start(t, 3)
 
@@ -3207,6 +3252,7 @@ func TestReplicateRogueRemovedNode(t *testing.T) {
 	// Newly-started stores (including the "rogue" one) should not GC
 	// their replicas. We'll turn this back on when needed.
 	sc.TestingKnobs.DisableReplicaGCQueue = true
+	sc.TestingKnobs.DisableReplicateQueue = true
 	sc.Clock = nil // manual clock
 	mtc := &multiTestContext{
 		storeConfig: &sc,
@@ -3384,7 +3430,10 @@ func TestReplicateRemovedNodeDisruptiveElection(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	cfg := kvserver.TestStoreConfig(nil)
+	cfg.TestingKnobs.DisableReplicateQueue = true
 	mtc := &multiTestContext{
+		storeConfig: &cfg,
 		// This test was written before the multiTestContext started creating many
 		// system ranges at startup, and hasn't been update to take that into
 		// account.
@@ -3520,6 +3569,7 @@ func TestReplicaTooOldGC(t *testing.T) {
 
 	sc := kvserver.TestStoreConfig(nil)
 	sc.TestingKnobs.DisableScanner = true
+	sc.TestingKnobs.DisableReplicateQueue = true
 	mtc := &multiTestContext{
 		storeConfig: &sc,
 		// This test was written before the multiTestContext started creating many
@@ -3647,7 +3697,10 @@ func TestReplicateReAddAfterDown(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	cfg := kvserver.TestStoreConfig(nil)
+	cfg.TestingKnobs.DisableReplicateQueue = true
 	mtc := &multiTestContext{
+		storeConfig: &cfg,
 		// This test was written before the multiTestContext started creating many
 		// system ranges at startup, and hasn't been update to take that into
 		// account.
@@ -3703,7 +3756,9 @@ func TestLeaseHolderRemoveSelf(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	mtc := &multiTestContext{}
+	cfg := kvserver.TestStoreConfig(nil)
+	cfg.TestingKnobs.DisableReplicateQueue = true
+	mtc := &multiTestContext{storeConfig: &cfg}
 	defer mtc.Stop()
 	mtc.Start(t, 2)
 
@@ -3733,14 +3788,18 @@ func TestRemovedReplicaError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	cfg := kvserver.TestStoreConfig(nil)
+	cfg.Clock = nil // using manual clock
+	cfg.TestingKnobs.DisableReplicateQueue = true
 	mtc := &multiTestContext{
+		storeConfig: &cfg,
 		// This test was written before the multiTestContext started creating many
 		// system ranges at startup, and hasn't been update to take that into
 		// account.
 		startWithSingleRange: true,
 	}
-	defer mtc.Stop()
 	mtc.Start(t, 2)
+	defer mtc.Stop()
 
 	// Disable the replica GC queues. This verifies that the replica is
 	// considered removed even before the gc queue has run, and also
@@ -3876,6 +3935,7 @@ func TestRaftBlockedReplica(t *testing.T) {
 
 	sc := kvserver.TestStoreConfig(nil)
 	sc.TestingKnobs.DisableMergeQueue = true
+	sc.TestingKnobs.DisableReplicateQueue = true
 	sc.TestingKnobs.DisableScanner = true
 	mtc := &multiTestContext{
 		storeConfig: &sc,
@@ -3940,6 +4000,7 @@ func TestRangeQuiescence(t *testing.T) {
 	sc := kvserver.TestStoreConfig(nil)
 	sc.TestingKnobs.DisableScanner = true
 	sc.TestingKnobs.DisablePeriodicGossips = true
+	sc.TestingKnobs.DisableReplicateQueue = true
 	mtc := &multiTestContext{
 		storeConfig: &sc,
 		// This test was written before the multiTestContext started creating many
@@ -4015,6 +4076,7 @@ func TestInitRaftGroupOnRequest(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	storeCfg := kvserver.TestStoreConfig(nil /* clock */)
+	storeCfg.TestingKnobs.DisableReplicateQueue = true
 	storeCfg.TestingKnobs.DisableMergeQueue = true
 	// Don't timeout range leases (see the relation between
 	// RaftElectionTimeoutTicks and RangeLeaseActiveDuration). This test expects
@@ -4099,6 +4161,7 @@ func TestFailedConfChange(t *testing.T) {
 	// followers.
 	var filterActive int32
 	sc := kvserver.TestStoreConfig(nil)
+	sc.TestingKnobs.DisableReplicateQueue = true
 	sc.TestingKnobs.TestingApplyFilter = func(filterArgs kvserverbase.ApplyFilterArgs) (int, *roachpb.Error) {
 		if atomic.LoadInt32(&filterActive) == 1 && filterArgs.ChangeReplicas != nil {
 			return 0, roachpb.NewErrorf("boom")
@@ -4526,6 +4589,7 @@ func TestDefaultConnectionDisruptionDoesNotInterfereWithSystemTraffic(t *testing
 	// Prevent the split queue from creating additional ranges while we're
 	// waiting for replication.
 	sc := kvserver.TestStoreConfig(nil)
+	sc.TestingKnobs.DisableReplicateQueue = true
 	mtc := &multiTestContext{
 		storeConfig:     &sc,
 		rpcTestingKnobs: knobs,
@@ -4641,6 +4705,7 @@ func TestAckWriteBeforeApplication(t *testing.T) {
 			tsc := kvserver.TestStoreConfig(nil)
 			tsc.TestingKnobs.TestingApplyFilter = applyFilterFn(blockPreApplication)
 			tsc.TestingKnobs.TestingPostApplyFilter = applyFilterFn(blockPostApplication)
+			tsc.TestingKnobs.DisableReplicateQueue = true
 
 			mtc := &multiTestContext{storeConfig: &tsc}
 			defer mtc.Stop()

--- a/pkg/kv/kvserver/client_split_test.go
+++ b/pkg/kv/kvserver/client_split_test.go
@@ -2098,6 +2098,7 @@ func TestLeaderAfterSplit(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	storeConfig := kvserver.TestStoreConfig(nil)
+	storeConfig.TestingKnobs.DisableReplicateQueue = true
 	storeConfig.TestingKnobs.DisableMergeQueue = true
 	storeConfig.RaftElectionTimeoutTicks = 1000000
 	mtc := &multiTestContext{

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -934,7 +934,7 @@ func (r *Replica) ChangeReplicas(
 	// replication queue is active. Such tests are often flaky.
 	if knobs := r.store.TestingKnobs(); knobs != nil &&
 		!knobs.DisableReplicateQueue &&
-		!knobs.AllowDangerousReplicationChanges {
+		!knobs.AllowUnsynchronizedReplicationChanges {
 		bq := r.store.replicateQueue.baseQueue
 		bq.mu.Lock()
 		disabled := bq.mu.disabled

--- a/pkg/kv/kvserver/testing_knobs.go
+++ b/pkg/kv/kvserver/testing_knobs.go
@@ -259,6 +259,10 @@ type StoreTestingKnobs struct {
 	// in execChangeReplicasTxn that prevent moving
 	// to a configuration that cannot make progress.
 	AllowDangerousReplicationChanges bool
+	// AllowUnsynchronizedReplicationChanges allows calls to ChangeReplicas
+	// even when the replicate queue is enabled. This often results in flaky
+	// tests, so by default, it is prevented.
+	AllowUnsynchronizedReplicationChanges bool
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.


### PR DESCRIPTION
The check added in #57564 to error out on manual changes that could
race the replicate ueue was imperfect: the multiTestContext is always
setting the `AllowDangerousReplicationChanges` knob and was thus
disabling the check.

Use a separate knob for the check that forces mtc through the check as
well and fix the fallout (many dozens of tests).

I pondered chosing a safer default (i.e. replication queue off unless
opted in to), but ultimately we are trying to move off the mtc and
`TestStoreConfig` is used in other places, so that without a very
time-consuming review, there would've been a good chance I would've
inadvertently changed tests in undesirable ways. Instead, I simply
went through the failing tests and disabled their replicate queues;
they still pass and hopefully are less flaky than before.

Release note: None
