### PR TITLE
tracing: rename "snowball" tracing to verbose tracing

### DIFF
--- a/docs/tech-notes/contexts.md
+++ b/docs/tech-notes/contexts.md
@@ -197,19 +197,18 @@ allows embedding a `trace.EventLog` in a `Context` ; events go to that
 `EventLog` automatically unless a span is also embedded in the
 context.
 
-There’s also `SET TRACING = on` that uses “snowball tracing” for
+There’s also `SET TRACING = on` that enables verbose tracing for
 collecting the distributed trace of one query and displaying it as SQL
-result rows. Snowball tracing is trace mode where trace information is
-stored in-memory, instead of being sent to a trace collector, so that
-the application can inspect its own trace later; this is the
-mechanism used by session tracing to present the execution
+result rows. In verbose tracing, the span picks up a number of messages
+as it traverses the system, which are propagated back to the root span;
+this is the mechanism used by session tracing to present the execution
 trace back to the SQL client.
 
 There’s also the
 `COCKROACH_TRACE_SQL` env var, which causes the distributed traces
 of all queries taking longer than a set time to be collected in memory
 and then dumped into the
-logs. This is expensive because it enables snowball tracing for all queries,
+logs. This is expensive because it enables verbose tracing for all queries,
 and may flood the logs. As of 03/2017, I (Andrei) am working on a new
 mechanism allowing a user to enable/disable tracing on a SQL session
 by issuing special SQL statements, and then making the collected
@@ -353,11 +352,8 @@ env var.
 Besides LightStep, CockroachDB also has its own tracer which, together
 with custom code around our RPC boundaries, enables marshalling spans
 from an RPC server to the RPC client by serializing them in the gRPC
-response protos. We call this **“snowball tracing”** (a high-level
-client enables it by marking a request as “traced”, and then lower
-level rpc clients propagate this marker with their calls, and the
-trace grows like a snowball… Or something.). This mechanism enables
-session tracing and all the other trace collection features.
+response protos. This mechanism enables session tracing and all the
+other trace collection features.
 
 If the Lightstep integration is enabled, crdb uses both the Lightstep
 and the internal tracers simultaneously - through a

--- a/pkg/kv/kvclient/kvcoord/transport_test.go
+++ b/pkg/kv/kvclient/kvcoord/transport_test.go
@@ -97,7 +97,7 @@ func TestTransportMoveToFront(t *testing.T) {
 }
 
 // TestSpanImport tests that the gRPC transport ingests trace information that
-// came from gRPC responses (through the "snowball tracing" mechanism).
+// came from gRPC responses (via tracingpb.RecordedSpan on the batch responses).
 func TestSpanImport(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)

--- a/pkg/kv/kvclient/kvcoord/transport_test.go
+++ b/pkg/kv/kvclient/kvcoord/transport_test.go
@@ -152,7 +152,7 @@ func (m *mockInternalClient) Batch(
 ) (*roachpb.BatchResponse, error) {
 	sp := m.tr.StartSpan("mock", tracing.WithForceRealSpan())
 	defer sp.Finish()
-	sp.StartRecording(tracing.SnowballRecording)
+	sp.SetVerbose(true)
 	ctx = tracing.ContextWithSpan(ctx, sp)
 
 	log.Eventf(ctx, "mockInternalClient processing batch")

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender_server_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender_server_test.go
@@ -152,7 +152,7 @@ func TestNoDuplicateHeartbeatLoops(t *testing.T) {
 
 	tracer := tracing.NewTracer()
 	sp := tracer.StartSpan("test", tracing.WithForceRealSpan())
-	sp.StartRecording(tracing.SnowballRecording)
+	sp.SetVerbose(true)
 	txnCtx := tracing.ContextWithSpan(context.Background(), sp)
 
 	push := func(ctx context.Context, key roachpb.Key) error {

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -12577,7 +12577,7 @@ func TestLaterReproposalsDoNotReuseContext(t *testing.T) {
 	tracedCtx := tracing.ContextWithSpan(ctx, sp)
 	// Go out of our way to enable recording so that expensive logging is enabled
 	// for this context.
-	sp.StartRecording(tracing.SnowballRecording)
+	sp.SetVerbose(true)
 	ch, _, _, pErr := tc.repl.evalAndPropose(tracedCtx, &ba, allSpansGuard(), &lease)
 	if pErr != nil {
 		t.Fatal(pErr)

--- a/pkg/kv/txn_test.go
+++ b/pkg/kv/txn_test.go
@@ -42,7 +42,7 @@ func TestTxnSnowballTrace(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	tracer := tracing.NewTracer()
-	ctx, sp := tracing.StartSnowballTrace(context.Background(), tracer, "test-txn")
+	ctx, sp := tracing.StartVerboseTrace(context.Background(), tracer, "test-txn")
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)

--- a/pkg/kv/txn_test.go
+++ b/pkg/kv/txn_test.go
@@ -34,10 +34,10 @@ var (
 	testPutResp = roachpb.PutResponse{}
 )
 
-// An example of snowball tracing being used to dump a trace around a
+// An example of verbose tracing being used to dump a trace around a
 // transaction. Use something similar whenever you cannot use
 // sql.trace.txn.threshold.
-func TestTxnSnowballTrace(t *testing.T) {
+func TestTxnVerboseTrace(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
@@ -61,7 +61,7 @@ func TestTxnSnowballTrace(t *testing.T) {
 	// dump:
 	//    0.105ms      0.000ms    event:inside txn
 	//    0.275ms      0.171ms    event:client.Txn did AutoCommit. err: <nil>
-	//txn: "internal/client/txn_test.go:67 TestTxnSnowballTrace" id=<nil> key=/Min lock=false pri=0.00000000 iso=SERIALIZABLE stat=COMMITTED epo=0 ts=0.000000000,0 orig=0.000000000,0 max=0.000000000,0 wto=false rop=false
+	//txn: "internal/client/txn_test.go:67 TestTxnVerboseTrace" id=<nil> key=/Min lock=false pri=0.00000000 iso=SERIALIZABLE stat=COMMITTED epo=0 ts=0.000000000,0 orig=0.000000000,0 max=0.000000000,0 wto=false rop=false
 	//    0.278ms      0.173ms    event:txn complete
 	found, err := regexp.MatchString(
 		// The (?s) makes "." match \n. This makes the test resilient to other log

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -196,7 +196,7 @@ func (f *vectorizedFlow) Setup(
 		log.Infof(ctx, "setting up vectorize flow %s", f.ID.Short())
 	}
 	recordingStats := false
-	if sp := tracing.SpanFromContext(ctx); sp != nil && sp.IsRecording() {
+	if sp := tracing.SpanFromContext(ctx); sp != nil && sp.IsVerbose() {
 		recordingStats = true
 	}
 	helper := newVectorizedFlowCreatorHelper(f.FlowBase)

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -635,7 +635,7 @@ func (ex *connExecutor) execStmtInOpenState(
 	stmtTraceThreshold := traceStmtThreshold.Get(&ex.planner.execCfg.Settings.SV)
 	if !alreadyRecording && stmtTraceThreshold > 0 {
 		ctx, stmtThresholdSpan = createRootOrChildSpan(ctx, "trace-stmt-threshold", ex.transitionCtx.tracer)
-		stmtThresholdSpan.StartRecording(tracing.SnowballRecording)
+		stmtThresholdSpan.SetVerbose(true)
 	}
 
 	if err := ex.dispatchToExecutionEngine(ctx, p, res); err != nil {
@@ -1303,7 +1303,7 @@ func (ex *connExecutor) runSetTracing(
 
 func (ex *connExecutor) enableTracing(modes []string) error {
 	traceKV := false
-	recordingType := tracing.SnowballRecording
+	recordingType := tracing.RecordingVerbose
 	enableMode := true
 	showResults := false
 
@@ -1318,7 +1318,7 @@ func (ex *connExecutor) enableTracing(modes []string) error {
 		case "kv":
 			traceKV = true
 		case "cluster":
-			recordingType = tracing.SnowballRecording
+			recordingType = tracing.RecordingVerbose
 		default:
 			return pgerror.Newf(pgcode.Syntax,
 				"set tracing: unknown mode %q", s)

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1528,7 +1528,7 @@ func (st *SessionTracing) StartTracing(
 		if sp == nil {
 			return errors.Errorf("no txn span for SessionTracing")
 		}
-		sp.StartRecording(recType)
+		sp.SetVerbose(true)
 		st.firstTxnSpan = sp
 	}
 
@@ -1558,7 +1558,7 @@ func (st *SessionTracing) StartTracing(
 			tracing.WithCtxLogTags(connCtx),
 		)
 	}
-	sp.StartRecording(recType)
+	sp.SetVerbose(true)
 	st.connSpan = sp
 
 	// Hijack the connections context.
@@ -1578,20 +1578,20 @@ func (st *SessionTracing) StopTracing() error {
 	st.enabled = false
 	st.kvTracingEnabled = false
 	st.showResults = false
-	st.recordingType = tracing.NoRecording
+	st.recordingType = tracing.RecordingOff
 
 	var spans []tracingpb.RecordedSpan
 
 	if st.firstTxnSpan != nil {
 		spans = append(spans, st.firstTxnSpan.GetRecording()...)
-		st.firstTxnSpan.StopRecording()
+		st.firstTxnSpan.SetVerbose(false)
 	}
 	st.connSpan.Finish()
 	spans = append(spans, st.connSpan.GetRecording()...)
 	// NOTE: We're stopping recording on the connection's ctx only; the stopping
 	// is not inherited by children. If we are inside of a txn, that span will
 	// continue recording, even though nobody will collect its recording again.
-	st.connSpan.StopRecording()
+	st.connSpan.SetVerbose(false)
 	st.ex.ctxHolder.unhijack()
 
 	var err error

--- a/pkg/sql/execinfra/processorsbase.go
+++ b/pkg/sql/execinfra/processorsbase.go
@@ -860,7 +860,7 @@ func ProcessorSpan(ctx context.Context, name string) (context.Context, *tracing.
 func (pb *ProcessorBase) StartInternal(ctx context.Context, name string) context.Context {
 	pb.origCtx = ctx
 	pb.Ctx, pb.span = ProcessorSpan(ctx, name)
-	if pb.span != nil && pb.span.IsRecording() {
+	if pb.span != nil && pb.span.IsVerbose() {
 		pb.span.SetTag(execinfrapb.FlowIDTagKey, pb.FlowCtx.ID.String())
 		pb.span.SetTag(execinfrapb.ProcessorIDTagKey, pb.processorID)
 	}

--- a/pkg/sql/execinfrapb/data.go
+++ b/pkg/sql/execinfrapb/data.go
@@ -178,7 +178,7 @@ type ProducerMetadata struct {
 	Ranges []roachpb.RangeInfo
 	// TODO(vivek): change to type Error
 	Err error
-	// TraceData is sent if snowball tracing is enabled.
+	// TraceData is sent if tracing is enabled.
 	TraceData []tracingpb.RecordedSpan
 	// LeafTxnFinalState contains the final state of the LeafTxn to be
 	// sent from leaf flows to the RootTxn held by the flow's ultimate

--- a/pkg/sql/execstats/traceanalyzer_test.go
+++ b/pkg/sql/execstats/traceanalyzer_test.go
@@ -98,7 +98,7 @@ func TestTraceAnalyzer(t *testing.T) {
 	)
 	for _, vectorizeMode := range []sessiondatapb.VectorizeExecMode{sessiondatapb.VectorizeOff, sessiondatapb.VectorizeOn} {
 		var sp *tracing.Span
-		ctx, sp = tracing.StartSnowballTrace(ctx, execCfg.AmbientCtx.Tracer, t.Name())
+		ctx, sp = tracing.StartVerboseTrace(ctx, execCfg.AmbientCtx.Tracer, t.Name())
 		ie := execCfg.InternalExecutor
 		ie.SetSessionData(
 			&sessiondata.SessionData{

--- a/pkg/sql/flowinfra/outbox.go
+++ b/pkg/sql/flowinfra/outbox.go
@@ -211,7 +211,7 @@ func (m *Outbox) mainLoop(ctx context.Context) error {
 
 	var span *tracing.Span
 	ctx, span = execinfra.ProcessorSpan(ctx, "outbox")
-	if span != nil && span.IsRecording() {
+	if span != nil && span.IsVerbose() {
 		m.statsCollectionEnabled = true
 		span.SetTag(execinfrapb.FlowIDTagKey, m.flowCtx.ID.String())
 		span.SetTag(execinfrapb.StreamIDTagKey, m.streamID)

--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -106,7 +106,7 @@ func (ih *instrumentationHelper) SetOutputMode(outputMode outputMode, explainFla
 	ih.explainFlags = explainFlags
 }
 
-// Setup potentially enables snowball tracing for the statement, depending on
+// Setup potentially enables verbose tracing for the statement, depending on
 // output mode or statement diagnostic activation requests. Finish() must be
 // called after the statement finishes execution (unless needFinish=false, in
 // which case Finish() is a no-op).

--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -151,7 +151,7 @@ func (ih *instrumentationHelper) Setup(
 	ih.traceMetadata = make(execNodeTraceMetadata)
 	ih.origCtx = ctx
 	ih.evalCtx = p.EvalContext()
-	newCtx, ih.sp = tracing.StartSnowballTrace(ctx, cfg.AmbientCtx.Tracer, "traced statement")
+	newCtx, ih.sp = tracing.StartVerboseTrace(ctx, cfg.AmbientCtx.Tracer, "traced statement")
 	return newCtx, true
 }
 

--- a/pkg/sql/rowexec/aggregator.go
+++ b/pkg/sql/rowexec/aggregator.go
@@ -94,7 +94,7 @@ func (ag *aggregatorBase) init(
 ) error {
 	ctx := flowCtx.EvalCtx.Ctx()
 	memMonitor := execinfra.NewMonitor(ctx, flowCtx.EvalCtx.Mon, "aggregator-mem")
-	if sp := tracing.SpanFromContext(ctx); sp != nil && sp.IsRecording() {
+	if sp := tracing.SpanFromContext(ctx); sp != nil && sp.IsVerbose() {
 		input = newInputStatCollector(input)
 		ag.ExecStatsForTrace = ag.execStatsForTrace
 	}

--- a/pkg/sql/rowexec/countrows.go
+++ b/pkg/sql/rowexec/countrows.go
@@ -45,7 +45,7 @@ func newCountAggregator(
 	ag := &countAggregator{}
 	ag.input = input
 
-	if sp := tracing.SpanFromContext(flowCtx.EvalCtx.Ctx()); sp != nil && sp.IsRecording() {
+	if sp := tracing.SpanFromContext(flowCtx.EvalCtx.Ctx()); sp != nil && sp.IsVerbose() {
 		ag.input = newInputStatCollector(input)
 		ag.ExecStatsForTrace = ag.execStatsForTrace
 	}

--- a/pkg/sql/rowexec/distinct.go
+++ b/pkg/sql/rowexec/distinct.go
@@ -133,7 +133,7 @@ func newDistinct(
 	// So we have to set up the account here.
 	d.arena = stringarena.Make(&d.memAcc)
 
-	if sp := tracing.SpanFromContext(ctx); sp != nil && sp.IsRecording() {
+	if sp := tracing.SpanFromContext(ctx); sp != nil && sp.IsVerbose() {
 		d.input = newInputStatCollector(d.input)
 		d.ExecStatsForTrace = d.execStatsForTrace
 	}

--- a/pkg/sql/rowexec/filterer.go
+++ b/pkg/sql/rowexec/filterer.go
@@ -63,7 +63,7 @@ func newFiltererProcessor(
 	}
 
 	ctx := flowCtx.EvalCtx.Ctx()
-	if sp := tracing.SpanFromContext(ctx); sp != nil && sp.IsRecording() {
+	if sp := tracing.SpanFromContext(ctx); sp != nil && sp.IsVerbose() {
 		f.input = newInputStatCollector(f.input)
 		f.ExecStatsForTrace = f.execStatsForTrace
 	}

--- a/pkg/sql/rowexec/hashjoiner.go
+++ b/pkg/sql/rowexec/hashjoiner.go
@@ -142,7 +142,7 @@ func newHashJoiner(
 	)
 
 	// If the trace is recording, instrument the hashJoiner to collect stats.
-	if sp := tracing.SpanFromContext(ctx); sp != nil && sp.IsRecording() {
+	if sp := tracing.SpanFromContext(ctx); sp != nil && sp.IsVerbose() {
 		h.leftSource = newInputStatCollector(h.leftSource)
 		h.rightSource = newInputStatCollector(h.rightSource)
 		h.ExecStatsForTrace = h.execStatsForTrace

--- a/pkg/sql/rowexec/inverted_filterer.go
+++ b/pkg/sql/rowexec/inverted_filterer.go
@@ -124,7 +124,7 @@ func newInvertedFilterer(
 		ifr.diskMonitor,
 	)
 
-	if sp := tracing.SpanFromContext(flowCtx.EvalCtx.Ctx()); sp != nil && sp.IsRecording() {
+	if sp := tracing.SpanFromContext(flowCtx.EvalCtx.Ctx()); sp != nil && sp.IsVerbose() {
 		ifr.input = newInputStatCollector(ifr.input)
 		ifr.ExecStatsForTrace = ifr.execStatsForTrace
 	}

--- a/pkg/sql/rowexec/inverted_joiner.go
+++ b/pkg/sql/rowexec/inverted_joiner.go
@@ -285,7 +285,7 @@ func newInvertedJoiner(
 	}
 
 	collectingStats := false
-	if sp := tracing.SpanFromContext(flowCtx.EvalCtx.Ctx()); sp != nil && sp.IsRecording() {
+	if sp := tracing.SpanFromContext(flowCtx.EvalCtx.Ctx()); sp != nil && sp.IsVerbose() {
 		collectingStats = true
 	}
 	if collectingStats {

--- a/pkg/sql/rowexec/inverted_joiner_test.go
+++ b/pkg/sql/rowexec/inverted_joiner_test.go
@@ -570,7 +570,7 @@ func TestInvertedJoinerDrain(t *testing.T) {
 	td := catalogkv.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, "test", "t")
 
 	tracer := tracing.NewTracer()
-	ctx, sp := tracing.StartSnowballTrace(context.Background(), tracer, "test flow ctx")
+	ctx, sp := tracing.StartVerboseTrace(context.Background(), tracer, "test flow ctx")
 	defer sp.Finish()
 	st := cluster.MakeTestingClusterSettings()
 	tempEngine, _, err := storage.NewTempEngine(ctx, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -272,7 +272,7 @@ func newJoinReader(
 	}
 
 	collectingStats := false
-	if sp := tracing.SpanFromContext(flowCtx.EvalCtx.Ctx()); sp != nil && sp.IsRecording() {
+	if sp := tracing.SpanFromContext(flowCtx.EvalCtx.Ctx()); sp != nil && sp.IsVerbose() {
 		collectingStats = true
 	}
 

--- a/pkg/sql/rowexec/joinreader_test.go
+++ b/pkg/sql/rowexec/joinreader_test.go
@@ -924,7 +924,7 @@ func TestJoinReaderDrain(t *testing.T) {
 
 	// Run the flow in a snowball trace so that we can test for tracing info.
 	tracer := tracing.NewTracer()
-	ctx, sp := tracing.StartSnowballTrace(context.Background(), tracer, "test flow ctx")
+	ctx, sp := tracing.StartVerboseTrace(context.Background(), tracer, "test flow ctx")
 	defer sp.Finish()
 
 	evalCtx := tree.MakeTestingEvalContext(st)

--- a/pkg/sql/rowexec/joinreader_test.go
+++ b/pkg/sql/rowexec/joinreader_test.go
@@ -922,7 +922,7 @@ func TestJoinReaderDrain(t *testing.T) {
 	}
 	defer tempEngine.Close()
 
-	// Run the flow in a snowball trace so that we can test for tracing info.
+	// Run the flow in a verbose trace so that we can test for tracing info.
 	tracer := tracing.NewTracer()
 	ctx, sp := tracing.StartVerboseTrace(context.Background(), tracer, "test flow ctx")
 	defer sp.Finish()

--- a/pkg/sql/rowexec/mergejoiner.go
+++ b/pkg/sql/rowexec/mergejoiner.go
@@ -75,7 +75,7 @@ func newMergeJoiner(
 		trackMatchedRight: shouldEmitUnmatchedRow(rightSide, spec.Type) || spec.Type == descpb.RightSemiJoin,
 	}
 
-	if sp := tracing.SpanFromContext(flowCtx.EvalCtx.Ctx()); sp != nil && sp.IsRecording() {
+	if sp := tracing.SpanFromContext(flowCtx.EvalCtx.Ctx()); sp != nil && sp.IsVerbose() {
 		m.leftSource = newInputStatCollector(m.leftSource)
 		m.rightSource = newInputStatCollector(m.rightSource)
 		m.ExecStatsForTrace = m.execStatsForTrace

--- a/pkg/sql/rowexec/noop.go
+++ b/pkg/sql/rowexec/noop.go
@@ -56,7 +56,7 @@ func newNoopProcessor(
 		return nil, err
 	}
 	ctx := flowCtx.EvalCtx.Ctx()
-	if sp := tracing.SpanFromContext(ctx); sp != nil && sp.IsRecording() {
+	if sp := tracing.SpanFromContext(ctx); sp != nil && sp.IsVerbose() {
 		n.input = newInputStatCollector(n.input)
 		n.ExecStatsForTrace = n.execStatsForTrace
 	}

--- a/pkg/sql/rowexec/ordinality.go
+++ b/pkg/sql/rowexec/ordinality.go
@@ -67,7 +67,7 @@ func newOrdinalityProcessor(
 		return nil, err
 	}
 
-	if sp := tracing.SpanFromContext(ctx); sp != nil && sp.IsRecording() {
+	if sp := tracing.SpanFromContext(ctx); sp != nil && sp.IsVerbose() {
 		o.input = newInputStatCollector(o.input)
 		o.ExecStatsForTrace = o.execStatsForTrace
 	}

--- a/pkg/sql/rowexec/sample_aggregator.go
+++ b/pkg/sql/rowexec/sample_aggregator.go
@@ -382,7 +382,7 @@ func (s *sampleAggregator) sampleRow(
 func (s *sampleAggregator) writeResults(ctx context.Context) error {
 	// Turn off tracing so these writes don't affect the results of EXPLAIN
 	// ANALYZE.
-	if span := tracing.SpanFromContext(ctx); span != nil && span.IsRecording() {
+	if span := tracing.SpanFromContext(ctx); span != nil && span.IsVerbose() {
 		// TODO(rytaft): this also hides writes in this function from SQL session
 		// traces.
 		ctx = tracing.ContextWithSpan(ctx, nil)

--- a/pkg/sql/rowexec/sorter.go
+++ b/pkg/sql/rowexec/sorter.go
@@ -54,7 +54,7 @@ func (s *sorterBase) init(
 	opts execinfra.ProcStateOpts,
 ) error {
 	ctx := flowCtx.EvalCtx.Ctx()
-	if sp := tracing.SpanFromContext(ctx); sp != nil && sp.IsRecording() {
+	if sp := tracing.SpanFromContext(ctx); sp != nil && sp.IsVerbose() {
 		input = newInputStatCollector(input)
 		s.ExecStatsForTrace = s.execStatsForTrace
 	}

--- a/pkg/sql/rowexec/tablereader.go
+++ b/pkg/sql/rowexec/tablereader.go
@@ -158,7 +158,7 @@ func newTableReader(
 		tr.spans[i] = s.Span
 	}
 
-	if sp := tracing.SpanFromContext(flowCtx.EvalCtx.Ctx()); sp != nil && sp.IsRecording() {
+	if sp := tracing.SpanFromContext(flowCtx.EvalCtx.Ctx()); sp != nil && sp.IsVerbose() {
 		tr.fetcher = newRowFetcherStatCollector(&fetcher)
 		tr.ExecStatsForTrace = tr.execStatsForTrace
 	} else {

--- a/pkg/sql/rowexec/tablereader_test.go
+++ b/pkg/sql/rowexec/tablereader_test.go
@@ -313,7 +313,7 @@ func TestTableReaderDrain(t *testing.T) {
 
 	td := catalogkv.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, "test", "t")
 
-	// Run the flow in a snowball trace so that we can test for tracing info.
+	// Run the flow in a verbose trace so that we can test for tracing info.
 	tracer := tracing.NewTracer()
 	ctx, sp := tracing.StartVerboseTrace(context.Background(), tracer, "test flow ctx")
 	defer sp.Finish()

--- a/pkg/sql/rowexec/tablereader_test.go
+++ b/pkg/sql/rowexec/tablereader_test.go
@@ -315,7 +315,7 @@ func TestTableReaderDrain(t *testing.T) {
 
 	// Run the flow in a snowball trace so that we can test for tracing info.
 	tracer := tracing.NewTracer()
-	ctx, sp := tracing.StartSnowballTrace(context.Background(), tracer, "test flow ctx")
+	ctx, sp := tracing.StartVerboseTrace(context.Background(), tracer, "test flow ctx")
 	defer sp.Finish()
 	st := s.ClusterSettings()
 	evalCtx := tree.MakeTestingEvalContext(st)

--- a/pkg/sql/rowexec/tablereader_test.go
+++ b/pkg/sql/rowexec/tablereader_test.go
@@ -391,7 +391,7 @@ func TestLimitScans(t *testing.T) {
 	// Now we're going to run the tableReader and trace it.
 	tracer := tracing.NewTracer()
 	sp := tracer.StartSpan("root", tracing.WithForceRealSpan())
-	sp.StartRecording(tracing.SnowballRecording)
+	sp.SetVerbose(true)
 	ctx = tracing.ContextWithSpan(ctx, sp)
 	flowCtx.EvalCtx.Context = ctx
 

--- a/pkg/sql/rowexec/windower.go
+++ b/pkg/sql/rowexec/windower.go
@@ -201,7 +201,7 @@ func newWindower(
 	// them to reuse the same shared memory account with the windower.
 	evalCtx.SingleDatumAggMemAccount = &w.acc
 
-	if sp := tracing.SpanFromContext(ctx); sp != nil && sp.IsRecording() {
+	if sp := tracing.SpanFromContext(ctx); sp != nil && sp.IsVerbose() {
 		w.input = newInputStatCollector(w.input)
 		w.ExecStatsForTrace = w.execStatsForTrace
 	}

--- a/pkg/sql/rowexec/zigzagjoiner_test.go
+++ b/pkg/sql/rowexec/zigzagjoiner_test.go
@@ -573,7 +573,7 @@ func TestZigzagJoinerDrain(t *testing.T) {
 
 	// Run the flow in a snowball trace so that we can test for tracing info.
 	tracer := tracing.NewTracer()
-	ctx, sp := tracing.StartSnowballTrace(context.Background(), tracer, "test flow ctx")
+	ctx, sp := tracing.StartVerboseTrace(context.Background(), tracer, "test flow ctx")
 	defer sp.Finish()
 	evalCtx := tree.MakeTestingEvalContext(s.ClusterSettings())
 	defer evalCtx.Stop(ctx)

--- a/pkg/sql/rowexec/zigzagjoiner_test.go
+++ b/pkg/sql/rowexec/zigzagjoiner_test.go
@@ -571,7 +571,7 @@ func TestZigzagJoinerDrain(t *testing.T) {
 	)
 	td := catalogkv.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, "test", "t").TableDesc()
 
-	// Run the flow in a snowball trace so that we can test for tracing info.
+	// Run the flow in a verbose trace so that we can test for tracing info.
 	tracer := tracing.NewTracer()
 	ctx, sp := tracing.StartVerboseTrace(context.Background(), tracer, "test flow ctx")
 	defer sp.Finish()

--- a/pkg/sql/rowflow/routers.go
+++ b/pkg/sql/rowflow/routers.go
@@ -260,7 +260,7 @@ func (rb *routerBase) setupStreams(
 // init must be called after setupStreams but before Start.
 func (rb *routerBase) init(ctx context.Context, flowCtx *execinfra.FlowCtx, types []*types.T) {
 	// Check if we're recording stats.
-	if s := tracing.SpanFromContext(ctx); s != nil && s.IsRecording() {
+	if s := tracing.SpanFromContext(ctx); s != nil && s.IsVerbose() {
 		rb.statsCollectionEnabled = true
 	}
 

--- a/pkg/sql/rowflow/routers_test.go
+++ b/pkg/sql/rowflow/routers_test.go
@@ -753,7 +753,7 @@ func TestRouterDiskSpill(t *testing.T) {
 	// Enable stats recording.
 	tracer := tracing.NewTracer()
 	sp := tracer.StartSpan("root", tracing.WithForceRealSpan())
-	sp.StartRecording(tracing.SnowballRecording)
+	sp.SetVerbose(true)
 	ctx := tracing.ContextWithSpan(context.Background(), sp)
 
 	st := cluster.MakeTestingClusterSettings()

--- a/pkg/sql/txn_state.go
+++ b/pkg/sql/txn_state.go
@@ -165,7 +165,7 @@ func (ts *txnState) resetForNewSQLTxn(
 	alreadyRecording := tranCtx.sessionTracing.Enabled()
 	duration := traceTxnThreshold.Get(&tranCtx.settings.SV)
 	if !alreadyRecording && (duration > 0) {
-		sp.StartRecording(tracing.SnowballRecording)
+		sp.SetVerbose(true)
 		ts.recordingThreshold = duration
 		ts.recordingStart = timeutil.Now()
 	}

--- a/pkg/util/log/ambient_context_test.go
+++ b/pkg/util/log/ambient_context_test.go
@@ -61,11 +61,11 @@ func TestAnnotateCtxSpan(t *testing.T) {
 
 	if err := tracing.TestingCheckRecordedSpans(sp1.GetRecording(), `
 		Span root:
-			tags: sb=1
+			tags: _verbose=1
 			event: a
 			event: c
 		Span child:
-			tags: ambient= sb=1
+			tags: _verbose=1 ambient=
 			event: [ambient] b
 	`); err != nil {
 		t.Fatal(err)

--- a/pkg/util/log/ambient_context_test.go
+++ b/pkg/util/log/ambient_context_test.go
@@ -48,7 +48,7 @@ func TestAnnotateCtxSpan(t *testing.T) {
 	// Annotate a context that has an open span.
 
 	sp1 := tracer.StartSpan("root", tracing.WithForceRealSpan())
-	sp1.StartRecording(tracing.SnowballRecording)
+	sp1.SetVerbose(true)
 	ctx1 := tracing.ContextWithSpan(context.Background(), sp1)
 	Event(ctx1, "a")
 

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -68,7 +68,7 @@ func V(level Level) bool {
 //
 func ExpensiveLogEnabled(ctx context.Context, level Level) bool {
 	if sp := tracing.SpanFromContext(ctx); sp != nil {
-		if sp.IsRecording() {
+		if sp.IsVerbose() {
 			return true
 		}
 	}

--- a/pkg/util/log/trace_test.go
+++ b/pkg/util/log/trace_test.go
@@ -80,7 +80,7 @@ func TestTrace(t *testing.T) {
 
 	if err := tracing.TestingCheckRecordedSpans(sp.GetRecording(), `
 		Span s:
-		  tags: sb=1
+		  tags: _verbose=1
 		  event: test1
 		  event: test2
 		  event: testerr
@@ -107,7 +107,7 @@ func TestTraceWithTags(t *testing.T) {
 	sp.Finish()
 	if err := tracing.TestingCheckRecordedSpans(sp.GetRecording(), `
 		Span s:
-		  tags: sb=1
+		  tags: _verbose=1
 		  event: [tag=1] test1
 		  event: [tag=1] test2
 		  event: [tag=1] testerr
@@ -198,7 +198,7 @@ func TestEventLogAndTrace(t *testing.T) {
 
 	if err := tracing.TestingCheckRecordedSpans(sp.GetRecording(), `
 		Span s:
-		  tags: sb=1
+		  tags: _verbose=1
 		  event: test3
 		  event: test4
 		  event: test5err

--- a/pkg/util/log/trace_test.go
+++ b/pkg/util/log/trace_test.go
@@ -66,7 +66,7 @@ func TestTrace(t *testing.T) {
 
 	tracer := tracing.NewTracer()
 	sp := tracer.StartSpan("s", tracing.WithForceRealSpan())
-	sp.StartRecording(tracing.SnowballRecording)
+	sp.SetVerbose(true)
 	ctxWithSpan := tracing.ContextWithSpan(ctx, sp)
 	Event(ctxWithSpan, "test1")
 	VEvent(ctxWithSpan, noLogV(), "test2")
@@ -97,7 +97,7 @@ func TestTraceWithTags(t *testing.T) {
 	tracer := tracing.NewTracer()
 	sp := tracer.StartSpan("s", tracing.WithForceRealSpan())
 	ctxWithSpan := tracing.ContextWithSpan(ctx, sp)
-	sp.StartRecording(tracing.SnowballRecording)
+	sp.SetVerbose(true)
 
 	Event(ctxWithSpan, "test1")
 	VEvent(ctxWithSpan, noLogV(), "test2")
@@ -183,7 +183,7 @@ func TestEventLogAndTrace(t *testing.T) {
 
 	tracer := tracing.NewTracer()
 	sp := tracer.StartSpan("s", tracing.WithForceRealSpan())
-	sp.StartRecording(tracing.SnowballRecording)
+	sp.SetVerbose(true)
 	ctxWithBoth := tracing.ContextWithSpan(ctxWithEventLog, sp)
 	// Events should only go to the trace.
 	Event(ctxWithBoth, "test3")

--- a/pkg/util/tracing/recording.go
+++ b/pkg/util/tracing/recording.go
@@ -31,15 +31,14 @@ import (
 type RecordingType int32
 
 const (
-	// NoRecording means that the Span isn't recording. Child spans created from
-	// it similarly won't be recording by default.
-	NoRecording RecordingType = iota
-	// SnowballRecording means that the Span is recording and that derived
-	// spans will be as well, in the same mode (this includes remote spans,
-	// i.e. this mode crosses RPC boundaries). Derived spans will maintain
-	// their own recording, and this recording will be included in that of
-	// any local parent spans.
-	SnowballRecording
+	// RecordingOff means that the Span discards all events handed to it.
+	// Child spans created from it similarly won't be recording by default.
+	RecordingOff RecordingType = iota
+	// RecordingVerbose means that the Span is adding events passed in via LogKV
+	// and LogData to its recording and that derived spans will do so as well.
+	RecordingVerbose
+
+	// TODO(tbg): add RecordingBackground for always-on tracing.
 )
 
 type traceLogData struct {

--- a/pkg/util/tracing/span.go
+++ b/pkg/util/tracing/span.go
@@ -256,7 +256,7 @@ func (s *Span) SetVerbose(to bool) {
 	// caveat that SetVerbose(true) is a panic on a noop span because there will be no
 	// noop span.
 	if s.isNoop() {
-		panic("SetVerbose called on NoopSpan; use the WithForceRealSpan option for StartSpan")
+		panic(errors.AssertionFailedf("SetVerbose called on NoopSpan; use the WithForceRealSpan option for StartSpan"))
 	}
 	if to {
 		// If we're already recording (perhaps because the parent was recording when

--- a/pkg/util/tracing/span.go
+++ b/pkg/util/tracing/span.go
@@ -56,7 +56,7 @@ type SpanMeta struct {
 	// If set, all spans derived from this context are being recorded.
 	//
 	// NB: at the time of writing, this is only ever set to SnowballTracing
-	// and only if Baggage[Snowball] is set.
+	// and only if Baggage[verboseTracingBaggageKey] is set.
 	recordingType RecordingType
 
 	// The Span's associated baggage.
@@ -227,7 +227,7 @@ func (s *crdbSpan) enableRecording(parent *crdbSpan, recType RecordingType) {
 		parent.addChild(s)
 	}
 	if recType == SnowballRecording {
-		s.setBaggageItemLocked(Snowball, "1")
+		s.setBaggageItemLocked(verboseTracingBaggageKey, "1")
 	}
 	// Clear any previously recorded info. This is needed by SQL SessionTracing,
 	// who likes to start and stop recording repeatedly on the same Span, and
@@ -286,9 +286,9 @@ func (s *crdbSpan) disableRecording() {
 	// has, we don't want to do the call below as it might crash (at least if
 	// there's a netTr).
 	if (s.mu.duration == -1) && (oldRecType == SnowballRecording) {
-		// Clear the Snowball baggage item, assuming that it was set by
+		// Clear the verboseTracingBaggageKey baggage item, assuming that it was set by
 		// enableRecording().
-		s.setBaggageItemLocked(Snowball, "")
+		s.setBaggageItemLocked(verboseTracingBaggageKey, "")
 	}
 }
 

--- a/pkg/util/tracing/span.go
+++ b/pkg/util/tracing/span.go
@@ -55,7 +55,7 @@ type SpanMeta struct {
 
 	// If set, all spans derived from this context are being recorded.
 	//
-	// NB: at the time of writing, this is only ever set to SnowballTracing
+	// NB: at the time of writing, this is only ever set to RecordingVerbose
 	// and only if Baggage[verboseTracingBaggageKey] is set.
 	recordingType RecordingType
 

--- a/pkg/util/tracing/span.go
+++ b/pkg/util/tracing/span.go
@@ -147,7 +147,7 @@ type crdbSpan struct {
 
 func (s *crdbSpan) recordingType() RecordingType {
 	if s == nil {
-		return NoRecording
+		return RecordingOff
 	}
 	return s.mu.recording.recordingType.load()
 }
@@ -200,7 +200,7 @@ type Span struct {
 }
 
 func (s *Span) isBlackHole() bool {
-	return s.crdb.recordingType() == NoRecording && s.netTr == nil && s.ot == (otSpan{})
+	return s.crdb.recordingType() == RecordingOff && s.netTr == nil && s.ot == (otSpan{})
 }
 
 func (s *Span) isNoop() bool {
@@ -209,7 +209,7 @@ func (s *Span) isNoop() bool {
 
 // IsRecording returns true if the Span is recording its events.
 func (s *Span) IsRecording() bool {
-	return s.crdb.recordingType() != NoRecording
+	return s.crdb.recordingType() != RecordingOff
 }
 
 // enableRecording start recording on the Span. From now on, log events and child spans
@@ -226,7 +226,7 @@ func (s *crdbSpan) enableRecording(parent *crdbSpan, recType RecordingType) {
 	if parent != nil {
 		parent.addChild(s)
 	}
-	if recType == SnowballRecording {
+	if recType == RecordingVerbose {
 		s.setBaggageItemLocked(verboseTracingBaggageKey, "1")
 	}
 	// Clear any previously recorded info. This is needed by SQL SessionTracing,
@@ -237,55 +237,48 @@ func (s *crdbSpan) enableRecording(parent *crdbSpan, recType RecordingType) {
 	s.mu.recording.remoteSpans = nil
 }
 
-// StartRecording enables recording on the Span. Events from this point forward
-// are recorded; also, all direct and indirect child spans started from now on
-// will be part of the same recording.
+// SetVerbose toggles verbose recording on the Span, which must not be a noop span
+// (see the WithForceRealSpan option).
 //
-// Recording is not supported by noop spans; to ensure a real Span is always
-// created, use the WithForceRealSpan option to StartSpan.
+// With 'true', future calls to LogFields and LogKV are recorded, and any future
+// descendants of this Span will do so automatically as well. This does not apply
+// to past derived Spans, which may in fact be noop spans.
 //
-// If recording was already started on this Span (either directly or because a
-// parent Span is recording), the old recording is lost.
+// As a side effect, calls to `SetVerbose(true)` on a span that was not already
+// verbose will reset any past recording stored on this Span.
 //
-// Children spans created from the Span while it is *not* recording will not
-// necessarily be recordable.
-func (s *Span) StartRecording(recType RecordingType) {
-	if recType == NoRecording {
-		panic("StartRecording called with NoRecording")
-	}
+// When passed 'false', LogFields and LogKV will cede to add data to the recording
+// (though they may still be collected, should the Span have been set up with an
+// auxiliary trace sink). This does not apply to Spans derived from this one when
+// it was verbose.
+func (s *Span) SetVerbose(to bool) {
+	// TODO(tbg): when always-on tracing is firmly established, we can remove the ugly
+	// caveat that SetVerbose(true) is a panic on a noop span because there will be no
+	// noop span.
 	if s.isNoop() {
-		panic("StartRecording called on NoopSpan; use the WithForceRealSpan option for StartSpan")
+		panic("SetVerbose called on NoopSpan; use the WithForceRealSpan option for StartSpan")
 	}
-
-	// If we're already recording (perhaps because the parent was recording when
-	// this Span was created), there's nothing to do.
-	if recType != s.crdb.recordingType() {
-		s.crdb.enableRecording(nil /* parent */, recType)
+	if to {
+		// If we're already recording (perhaps because the parent was recording when
+		// this Span was created), there's nothing to do. Avoid the call to enableRecording
+		// because it would clear the existing recording.
+		recType := RecordingVerbose
+		if recType != s.crdb.recordingType() {
+			s.crdb.enableRecording(nil /* parent */, recType)
+		}
+	} else {
+		s.crdb.disableRecording()
 	}
-}
-
-// StopRecording disables recording on this Span. Child spans that were created
-// since recording was started will continue to record until they finish.
-//
-// Calling this after StartRecording is not required; the recording will go away
-// when all the spans finish.
-//
-// StopRecording() can be called on a Finish()ed Span.
-func (s *Span) StopRecording() {
-	if s.isNoop() {
-		panic("can't disable recording a noop Span")
-	}
-	s.crdb.disableRecording()
 }
 
 func (s *crdbSpan) disableRecording() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	oldRecType := s.mu.recording.recordingType.swap(NoRecording)
+	oldRecType := s.mu.recording.recordingType.swap(RecordingOff)
 	// We test the duration as a way to check if the Span has been finished. If it
 	// has, we don't want to do the call below as it might crash (at least if
 	// there's a netTr).
-	if (s.mu.duration == -1) && (oldRecType == SnowballRecording) {
+	if (s.mu.duration == -1) && (oldRecType == RecordingVerbose) {
 		// Clear the verboseTracingBaggageKey baggage item, assuming that it was set by
 		// enableRecording().
 		s.setBaggageItemLocked(verboseTracingBaggageKey, "")
@@ -300,7 +293,7 @@ func (s *Span) GetRecording() Recording {
 }
 
 func (s *crdbSpan) getRecording() Recording {
-	if s.recordingType() == NoRecording {
+	if s.recordingType() == RecordingOff {
 		// TODO(tbg): is this desired? If a span is not currently recording,
 		// it can still hold a recording.
 		return nil
@@ -336,7 +329,7 @@ func (s *Span) ImportRemoteSpans(remoteSpans []tracingpb.RecordedSpan) error {
 }
 
 func (s *crdbSpan) ImportRemoteSpans(remoteSpans []tracingpb.RecordedSpan) error {
-	if s.recordingType() == NoRecording {
+	if s.recordingType() == RecordingOff {
 		return errors.AssertionFailedf("adding Raw Spans to a Span that isn't recording")
 	}
 	// Change the root of the remote recording to be a child of this Span. This is
@@ -366,7 +359,7 @@ func (s *Span) IsBlackHole() bool {
 // or corresponds to a "no-op" Span. If this is true, any Span
 // derived from this context will be a "black hole Span".
 func (sc *SpanMeta) isNilOrNoop() bool {
-	return sc == nil || (sc.recordingType == NoRecording && sc.shadowTracerType == "")
+	return sc == nil || (sc.recordingType == RecordingOff && sc.shadowTracerType == "")
 }
 
 // SetSpanStats sets the stats on a Span. stats.Stats() will also be added to
@@ -526,7 +519,7 @@ func (s *Span) LogFields(fields ...otlog.Field) {
 }
 
 func (s *crdbSpan) LogFields(fields ...otlog.Field) {
-	if s.recordingType() != SnowballRecording {
+	if s.recordingType() != RecordingVerbose {
 		return
 	}
 	s.mu.Lock()
@@ -543,7 +536,7 @@ func (s *crdbSpan) LogFields(fields ...otlog.Field) {
 // reason to even evaluate LogKV and LogData calls
 // because the result wouldn't be used for anything.
 func (s *Span) hasVerboseSink() bool {
-	if s.netTr == nil && s.ot == (otSpan{}) && s.crdb.recordingType() != SnowballRecording {
+	if s.netTr == nil && s.ot == (otSpan{}) && s.crdb.recordingType() != RecordingVerbose {
 		return false
 	}
 	return true

--- a/pkg/util/tracing/span.go
+++ b/pkg/util/tracing/span.go
@@ -207,11 +207,6 @@ func (s *Span) isNoop() bool {
 	return s.crdb == nil && s.netTr == nil && s.ot == (otSpan{})
 }
 
-// IsRecording returns true if the Span is recording its events.
-func (s *Span) IsRecording() bool {
-	return s.crdb.recordingType() != RecordingOff
-}
-
 // enableRecording start recording on the Span. From now on, log events and child spans
 // will be stored.
 //
@@ -235,6 +230,11 @@ func (s *crdbSpan) enableRecording(parent *crdbSpan, recType RecordingType) {
 	s.mu.recording.recordedLogs = nil
 	s.mu.recording.children = nil
 	s.mu.recording.remoteSpans = nil
+}
+
+// IsVerbose returns true if the Span is verbose. See SetVerbose for details.
+func (s *Span) IsVerbose() bool {
+	return s.crdb.recordingType() == RecordingVerbose
 }
 
 // SetVerbose toggles verbose recording on the Span, which must not be a noop span

--- a/pkg/util/tracing/span_options.go
+++ b/pkg/util/tracing/span_options.go
@@ -47,7 +47,7 @@ func (opts *spanOptions) parentSpanID() uint64 {
 }
 
 func (opts *spanOptions) recordingType() RecordingType {
-	recordingType := NoRecording
+	recordingType := RecordingOff
 	if opts.Parent != nil && !opts.Parent.isNoop() {
 		recordingType = opts.Parent.crdb.recordingType()
 	} else if opts.RemoteParent != nil {

--- a/pkg/util/tracing/span_test.go
+++ b/pkg/util/tracing/span_test.go
@@ -66,28 +66,28 @@ func TestRecordingString(t *testing.T) {
 	// its String() representation; this just list all the spans in order.
 	err = TestingCheckRecordedSpans(rec, `
 Span root:
-	tags: sb=1
+	tags: _verbose=1
 	event: root 1
 	event: root 2
 	event: root 3
 	event: root 4
 	event: root 5
 Span remote child:
-	tags: sb=1
+	tags: _verbose=1
 	event: remote child 1
 Span local child:
-	tags: sb=1
+	tags: _verbose=1
 	event: local child 1
 `)
 	require.NoError(t, err)
 
-	exp := `=== operation:root sb:1
+	exp := `=== operation:root _verbose:1
 event:root 1
-    === operation:remote child sb:1
+    === operation:remote child _verbose:1
     event:remote child 1
 event:root 2
 event:root 3
-    === operation:local child sb:1
+    === operation:local child _verbose:1
     event:local child 1
 event:root 4
 event:root 5
@@ -101,7 +101,7 @@ event:root 5
 	require.Equal(t, traceLine{
 		timeSinceTraceStart: "0.000ms",
 		timeSincePrev:       "0.000ms",
-		text:                "=== operation:root sb:1",
+		text:                "=== operation:root _verbose:1",
 	}, l)
 	l, err = parseLine(lines[1])
 	require.Equal(t, traceLine{
@@ -162,23 +162,23 @@ func TestRecordingInRecording(t *testing.T) {
 	rootRec := root.GetRecording()
 	require.NoError(t, TestingCheckRecordedSpans(rootRec, `
 Span root:
-	tags: sb=1
+	tags: _verbose=1
 Span child:
-	tags: sb=1
+	tags: _verbose=1
 Span grandchild:
-	tags: sb=1
+	tags: _verbose=1
 `))
 
 	childRec := child.GetRecording()
 	require.NoError(t, TestingCheckRecordedSpans(childRec, `
 Span child:
-	tags: sb=1
+	tags: _verbose=1
 Span grandchild:
-	tags: sb=1
+	tags: _verbose=1
 `))
 
-	exp := `=== operation:child sb:1
-    === operation:grandchild sb:1
+	exp := `=== operation:child _verbose:1
+    === operation:grandchild _verbose:1
 `
 	require.Equal(t, exp, recToStrippedString(childRec))
 }

--- a/pkg/util/tracing/span_test.go
+++ b/pkg/util/tracing/span_test.go
@@ -29,7 +29,7 @@ func TestRecordingString(t *testing.T) {
 	tr2 := NewTracer()
 
 	root := tr.StartSpan("root", WithForceRealSpan())
-	root.StartRecording(SnowballRecording)
+	root.SetVerbose(true)
 	root.LogFields(otlog.String(tracingpb.LogMessageField, "root 1"))
 	// Hackily fix the timing on the first log message, so that we can check it later.
 	root.crdb.mu.recording.recordedLogs[0].Timestamp = root.crdb.startTime.Add(time.Millisecond)
@@ -147,9 +147,9 @@ func TestRecordingInRecording(t *testing.T) {
 	tr := NewTracer()
 
 	root := tr.StartSpan("root", WithForceRealSpan())
-	root.StartRecording(SnowballRecording)
+	root.SetVerbose(true)
 	child := tr.StartSpan("child", WithParentAndAutoCollection(root), WithForceRealSpan())
-	child.StartRecording(SnowballRecording)
+	child.SetVerbose(true)
 	// The remote grandchild is also recording, however since it's remote the spans
 	// have to be imported into the parent manually (this would usually happen via
 	// code at the RPC boundaries).

--- a/pkg/util/tracing/tags_test.go
+++ b/pkg/util/tracing/tags_test.go
@@ -29,7 +29,7 @@ func TestLogTags(t *testing.T) {
 	sp1.Finish()
 	require.NoError(t, TestingCheckRecordedSpans(sp1.GetRecording(), `
 		Span foo:
-		  tags: sb=1 tag1=val1 tag2=val2
+		  tags: _verbose=1 tag1=val1 tag2=val2
 	`))
 	require.NoError(t, shadowTracer.expectSingleSpanWithTags("tag1", "tag2"))
 	shadowTracer.clear()
@@ -42,7 +42,7 @@ func TestLogTags(t *testing.T) {
 	sp2.Finish()
 	require.NoError(t, TestingCheckRecordedSpans(sp2.GetRecording(), `
 		Span bar:
-			tags: one=val1 sb=1 two=val2
+			tags: _verbose=1 one=val1 two=val2
 	`))
 	require.NoError(t, shadowTracer.expectSingleSpanWithTags("one", "two"))
 	shadowTracer.clear()
@@ -52,7 +52,7 @@ func TestLogTags(t *testing.T) {
 	sp3.Finish()
 	require.NoError(t, TestingCheckRecordedSpans(sp3.GetRecording(), `
 		Span baz:
-			tags: one=val1 sb=1 two=val2
+			tags: _verbose=1 one=val1 two=val2
 	`))
 	require.NoError(t, shadowTracer.expectSingleSpanWithTags("one", "two"))
 }

--- a/pkg/util/tracing/tags_test.go
+++ b/pkg/util/tracing/tags_test.go
@@ -25,7 +25,7 @@ func TestLogTags(t *testing.T) {
 	l := logtags.SingleTagBuffer("tag1", "val1")
 	l = l.Add("tag2", "val2")
 	sp1 := tr.StartSpan("foo", WithForceRealSpan(), WithLogTags(l))
-	sp1.StartRecording(SnowballRecording)
+	sp1.SetVerbose(true)
 	sp1.Finish()
 	require.NoError(t, TestingCheckRecordedSpans(sp1.GetRecording(), `
 		Span foo:
@@ -38,7 +38,7 @@ func TestLogTags(t *testing.T) {
 	RegisterTagRemapping("tag2", "two")
 
 	sp2 := tr.StartSpan("bar", WithForceRealSpan(), WithLogTags(l))
-	sp2.StartRecording(SnowballRecording)
+	sp2.SetVerbose(true)
 	sp2.Finish()
 	require.NoError(t, TestingCheckRecordedSpans(sp2.GetRecording(), `
 		Span bar:
@@ -48,7 +48,7 @@ func TestLogTags(t *testing.T) {
 	shadowTracer.clear()
 
 	sp3 := tr.StartSpan("baz", WithLogTags(l), WithForceRealSpan())
-	sp3.StartRecording(SnowballRecording)
+	sp3.SetVerbose(true)
 	sp3.Finish()
 	require.NoError(t, TestingCheckRecordedSpans(sp3.GetRecording(), `
 		Span baz:

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -83,8 +83,8 @@ var zipkinCollector = settings.RegisterPublicStringSetting(
 //    Span inside each of our spans.
 //
 // Even when tracing is disabled, we still use this Tracer (with x/net/trace and
-// lightstep disabled) because of its recording capability (snowball
-// tracing needs to work in all cases).
+// lightstep disabled) because of its recording capability (verbose tracing needs
+// to work in all cases).
 //
 // Tracer is currently stateless so we could have a single instance; however,
 // this won't be the case if the cluster settings move away from using global

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -616,13 +616,12 @@ func ContextWithSpan(ctx context.Context, sp *Span) context.Context {
 	return context.WithValue(ctx, activeSpanKey{}, sp)
 }
 
-// StartSnowballTrace takes in a context and returns a derived one with a
-// "snowball Span" in it. The caller takes ownership of this Span from the
-// returned context and is in charge of Finish()ing it. The Span has recording
-// enabled.
+// StartVerboseTrace takes in a context and returns a derived one with a
+// Span in it that is recording verbosely. The caller takes ownership of
+// this Span from the returned context and is in charge of Finish()ing it.
 //
 // TODO(andrei): remove this method once EXPLAIN(TRACE) is gone.
-func StartSnowballTrace(
+func StartVerboseTrace(
 	ctx context.Context, tracer *Tracer, opName string,
 ) (context.Context, *Span) {
 	var span *Span

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -27,8 +27,13 @@ import (
 	"golang.org/x/net/trace"
 )
 
-// Snowball is set as Baggage on traces which are used for snowball tracing.
-const Snowball = "sb"
+// verboseTracingBaggageKey is set as Baggage on traces which are used for verbose tracing,
+// meaning that a) spans derived from this one will not be no-op spans and b) they will
+// start recording.
+//
+// This is "sb" for historical reasons; this concept used to be called "[S]now[b]all" tracing
+// and since this string goes on the wire, it's a hassle to change it now.
+const verboseTracingBaggageKey = "sb"
 
 // maxLogsPerSpan limits the number of logs in a Span; use a comfortable limit.
 const maxLogsPerSpan = 1000
@@ -71,7 +76,7 @@ var zipkinCollector = settings.RegisterPublicStringSetting(
 //  - forwarding events to x/net/trace instances
 //
 //  - recording traces. Recording is started automatically for spans that have
-//    the Snowball baggage and can be started explicitly as well. Recorded
+//    the verboseTracingBaggageKey baggage and can be started explicitly as well. Recorded
 //    events can be retrieved at any time.
 //
 //  - lightstep traces. This is implemented by maintaining a "shadow" lightstep
@@ -465,7 +470,7 @@ func (t *Tracer) Extract(format interface{}, carrier interface{}) (*SpanMeta, er
 	}
 
 	var recordingType RecordingType
-	if baggage[Snowball] != "" {
+	if baggage[verboseTracingBaggageKey] != "" {
 		recordingType = SnowballRecording
 	}
 

--- a/pkg/util/tracing/tracer_test.go
+++ b/pkg/util/tracing/tracer_test.go
@@ -67,7 +67,7 @@ func TestTracerRecording(t *testing.T) {
 	noop3.Finish()
 
 	s1.LogKV("x", 1)
-	s1.StartRecording(SnowballRecording)
+	s1.SetVerbose(true)
 	s1.LogKV("x", 2)
 	s2 := tr.StartSpan("b", WithParentAndAutoCollection(s1))
 	if s2.IsBlackHole() {
@@ -127,7 +127,7 @@ func TestTracerRecording(t *testing.T) {
 	`); err != nil {
 		t.Fatal(err)
 	}
-	s1.StopRecording()
+	s1.SetVerbose(false)
 	s1.LogKV("x", 100)
 	if err := TestingCheckRecordedSpans(s1.GetRecording(), ``); err != nil {
 		t.Fatal(err)
@@ -149,7 +149,7 @@ func TestTracerRecording(t *testing.T) {
 func TestStartChildSpan(t *testing.T) {
 	tr := NewTracer()
 	sp1 := tr.StartSpan("parent", WithForceRealSpan())
-	sp1.StartRecording(SnowballRecording)
+	sp1.SetVerbose(true)
 	sp2 := tr.StartSpan("child", WithParentAndAutoCollection(sp1))
 	sp2.Finish()
 	sp1.Finish()
@@ -166,7 +166,7 @@ Span parent:
 	}
 
 	sp1 = tr.StartSpan("parent", WithForceRealSpan())
-	sp1.StartRecording(SnowballRecording)
+	sp1.SetVerbose(true)
 	sp2 = tr.StartSpan("child", WithParentAndManualCollection(sp1.Meta()))
 	sp2.Finish()
 	sp1.Finish()
@@ -184,7 +184,7 @@ Span parent:
 	}
 
 	sp1 = tr.StartSpan("parent", WithForceRealSpan())
-	sp1.StartRecording(SnowballRecording)
+	sp1.SetVerbose(true)
 	sp2 = tr.StartSpan("child", WithParentAndAutoCollection(sp1),
 		WithLogTags(logtags.SingleTagBuffer("key", "val")))
 	sp2.Finish()
@@ -235,7 +235,7 @@ func TestTracerInjectExtract(t *testing.T) {
 	// remote side.
 
 	s1 := tr.StartSpan("a", WithForceRealSpan())
-	s1.StartRecording(SnowballRecording)
+	s1.SetVerbose(true)
 
 	carrier = make(opentracing.HTTPHeadersCarrier)
 	if err := tr.Inject(s1.Meta(), opentracing.HTTPHeaders, carrier); err != nil {

--- a/pkg/util/tracing/tracer_test.go
+++ b/pkg/util/tracing/tracer_test.go
@@ -231,7 +231,7 @@ func TestTracerInjectExtract(t *testing.T) {
 	noop1.Finish()
 	noop2.Finish()
 
-	// Verify that snowball tracing is propagated and triggers recording on the
+	// Verify that verbose tracing is propagated and triggers verbosity on the
 	// remote side.
 
 	s1 := tr.StartSpan("a", WithForceRealSpan())

--- a/pkg/util/tracing/tracer_test.go
+++ b/pkg/util/tracing/tracer_test.go
@@ -77,10 +77,10 @@ func TestTracerRecording(t *testing.T) {
 
 	if err := TestingCheckRecordedSpans(s1.GetRecording(), `
 		Span a:
-			tags: sb=1 unfinished=
+			tags: _unfinished=1 _verbose=1
 			x: 2
 		Span b:
-			tags: sb=1 unfinished=
+			tags: _unfinished=1 _verbose=1
 			x: 3
 	`); err != nil {
 		t.Fatal(err)
@@ -88,7 +88,7 @@ func TestTracerRecording(t *testing.T) {
 
 	if err := TestingCheckRecordedSpans(s2.GetRecording(), `
 		Span b:
-			tags: sb=1 unfinished=
+			tags: _unfinished=1 _verbose=1
 			x: 3
 	`); err != nil {
 		t.Fatal(err)
@@ -102,13 +102,13 @@ func TestTracerRecording(t *testing.T) {
 
 	if err := TestingCheckRecordedSpans(s1.GetRecording(), `
 		Span a:
-			tags: sb=1 unfinished=
+			tags: _unfinished=1 _verbose=1
 			x: 2
 		Span b:
-			tags: sb=1
+			tags: _verbose=1
 			x: 3
 		Span c:
-			tags: sb=1 tag=val unfinished=
+			tags: _unfinished=1 _verbose=1 tag=val
 			x: 4
 	`); err != nil {
 		t.Fatal(err)
@@ -116,13 +116,13 @@ func TestTracerRecording(t *testing.T) {
 	s3.Finish()
 	if err := TestingCheckRecordedSpans(s1.GetRecording(), `
 		Span a:
-      tags: sb=1 unfinished=
+      tags: _unfinished=1 _verbose=1
 			x: 2
 		Span b:
-      tags: sb=1
+      tags: _verbose=1
 			x: 3
 		Span c:
-			tags: sb=1 tag=val
+			tags: _verbose=1 tag=val
 			x: 4
 	`); err != nil {
 		t.Fatal(err)
@@ -137,7 +137,7 @@ func TestTracerRecording(t *testing.T) {
 	s3.LogKV("x", 5)
 	if err := TestingCheckRecordedSpans(s3.GetRecording(), `
 		Span c:
-			tags: sb=1 tag=val
+			tags: _verbose=1 tag=val
 			x: 4
 			x: 5
 	`); err != nil {
@@ -156,9 +156,9 @@ func TestStartChildSpan(t *testing.T) {
 
 	var exp = `
 Span parent:
-      tags: sb=1
+      tags: _verbose=1
     Span child:
-      tags: sb=1
+      tags: _verbose=1
 `
 
 	if err := TestingCheckRecordedSpans(sp1.GetRecording(), exp); err != nil {
@@ -172,13 +172,13 @@ Span parent:
 	sp1.Finish()
 	if err := TestingCheckRecordedSpans(sp1.GetRecording(), `
 		Span parent:
-			tags: sb=1
+			tags: _verbose=1
 	`); err != nil {
 		t.Fatal(err)
 	}
 	if err := TestingCheckRecordedSpans(sp2.GetRecording(), `
 		Span child:
-			tags: sb=1
+			tags: _verbose=1
 	`); err != nil {
 		t.Fatal(err)
 	}
@@ -191,9 +191,9 @@ Span parent:
 	sp1.Finish()
 	if err := TestingCheckRecordedSpans(sp1.GetRecording(), `
 		Span parent:
-			tags: sb=1
+			tags: _verbose=1
 			Span child:
-				tags: key=val sb=1
+				tags: _verbose=1 key=val
 	`); err != nil {
 		t.Fatal(err)
 	}
@@ -261,7 +261,7 @@ func TestTracerInjectExtract(t *testing.T) {
 	rec := s2.GetRecording()
 	if err := TestingCheckRecordedSpans(rec, `
 		Span remote op:
-			tags: sb=1
+			tags: _verbose=1
 			x: 1
 	`); err != nil {
 		t.Fatal(err)
@@ -269,7 +269,7 @@ func TestTracerInjectExtract(t *testing.T) {
 
 	if err := TestingCheckRecordedSpans(s1.GetRecording(), `
 		Span a:
-			tags: sb=1 unfinished=
+			tags: _unfinished=1 _verbose=1
 	`); err != nil {
 		t.Fatal(err)
 	}
@@ -281,9 +281,9 @@ func TestTracerInjectExtract(t *testing.T) {
 
 	if err := TestingCheckRecordedSpans(s1.GetRecording(), `
 		Span a:
-			tags: sb=1
+			tags: _verbose=1
 		Span remote op:
-			tags: sb=1
+			tags: _verbose=1
 			x: 1
 	`); err != nil {
 		t.Fatal(err)

--- a/pkg/util/tracing/tracingpb/recorded_span.pb.go
+++ b/pkg/util/tracing/tracingpb/recorded_span.pb.go
@@ -39,7 +39,7 @@ func (m *LogRecord) Reset()         { *m = LogRecord{} }
 func (m *LogRecord) String() string { return proto.CompactTextString(m) }
 func (*LogRecord) ProtoMessage()    {}
 func (*LogRecord) Descriptor() ([]byte, []int) {
-	return fileDescriptor_recorded_span_cdc6b364ab4d9de8, []int{0}
+	return fileDescriptor_recorded_span_ac7a781f9ecf6725, []int{0}
 }
 func (m *LogRecord) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -73,7 +73,7 @@ func (m *LogRecord_Field) Reset()         { *m = LogRecord_Field{} }
 func (m *LogRecord_Field) String() string { return proto.CompactTextString(m) }
 func (*LogRecord_Field) ProtoMessage()    {}
 func (*LogRecord_Field) Descriptor() ([]byte, []int) {
-	return fileDescriptor_recorded_span_cdc6b364ab4d9de8, []int{0, 0}
+	return fileDescriptor_recorded_span_ac7a781f9ecf6725, []int{0, 0}
 }
 func (m *LogRecord_Field) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -98,8 +98,9 @@ func (m *LogRecord_Field) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_LogRecord_Field proto.InternalMessageInfo
 
-// RecordedSpan is a span that is part of a recording. It can be transferred
-// over the wire for snowball tracing.
+// RecordedSpan is the data recorded by a trace span. It
+// needs to be able to cross RPC boundaries so that the
+// complete recording of the trace can be constructed.
 type RecordedSpan struct {
 	// ID of the trace; spans that are part of the same hierarchy share
 	// the same trace ID.
@@ -111,7 +112,7 @@ type RecordedSpan struct {
 	// Operation name.
 	Operation string `protobuf:"bytes,4,opt,name=operation,proto3" json:"operation,omitempty"`
 	// Baggage items get passed from parent to child spans (even through gRPC).
-	// Notably, snowball tracing uses a special `sb` baggage item.
+	// Notably, verbose tracing uses a special baggage item.
 	Baggage map[string]string `protobuf:"bytes,5,rep,name=baggage,proto3" json:"baggage,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 	// Tags associated with the span.
 	Tags map[string]string `protobuf:"bytes,6,rep,name=tags,proto3" json:"tags,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
@@ -132,7 +133,7 @@ type RecordedSpan struct {
 func (m *RecordedSpan) Reset()      { *m = RecordedSpan{} }
 func (*RecordedSpan) ProtoMessage() {}
 func (*RecordedSpan) Descriptor() ([]byte, []int) {
-	return fileDescriptor_recorded_span_cdc6b364ab4d9de8, []int{1}
+	return fileDescriptor_recorded_span_ac7a781f9ecf6725, []int{1}
 }
 func (m *RecordedSpan) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -175,7 +176,7 @@ func (m *NormalizedSpan) Reset()         { *m = NormalizedSpan{} }
 func (m *NormalizedSpan) String() string { return proto.CompactTextString(m) }
 func (*NormalizedSpan) ProtoMessage()    {}
 func (*NormalizedSpan) Descriptor() ([]byte, []int) {
-	return fileDescriptor_recorded_span_cdc6b364ab4d9de8, []int{2}
+	return fileDescriptor_recorded_span_ac7a781f9ecf6725, []int{2}
 }
 func (m *NormalizedSpan) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1769,10 +1770,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("util/tracing/tracingpb/recorded_span.proto", fileDescriptor_recorded_span_cdc6b364ab4d9de8)
+	proto.RegisterFile("util/tracing/tracingpb/recorded_span.proto", fileDescriptor_recorded_span_ac7a781f9ecf6725)
 }
 
-var fileDescriptor_recorded_span_cdc6b364ab4d9de8 = []byte{
+var fileDescriptor_recorded_span_ac7a781f9ecf6725 = []byte{
 	// 626 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xa4, 0x53, 0xcd, 0x6a, 0xdb, 0x4c,
 	0x14, 0xb5, 0x6c, 0xf9, 0x47, 0x37, 0x26, 0x84, 0x21, 0x0b, 0xc5, 0x7c, 0x48, 0x21, 0x1f, 0x94,

--- a/pkg/util/tracing/tracingpb/recorded_span.proto
+++ b/pkg/util/tracing/tracingpb/recorded_span.proto
@@ -30,8 +30,9 @@ message LogRecord {
   repeated Field fields = 2 [(gogoproto.nullable) = false];
 }
 
-// RecordedSpan is a span that is part of a recording. It can be transferred
-// over the wire for snowball tracing.
+// RecordedSpan is the data recorded by a trace span. It
+// needs to be able to cross RPC boundaries so that the
+// complete recording of the trace can be constructed.
 message RecordedSpan {
   option (gogoproto.goproto_stringer) = false;
 
@@ -45,7 +46,7 @@ message RecordedSpan {
   // Operation name.
   string operation = 4;
   // Baggage items get passed from parent to child spans (even through gRPC).
-  // Notably, snowball tracing uses a special `sb` baggage item.
+  // Notably, verbose tracing uses a special baggage item.
   map<string, string> baggage = 5;
   // Tags associated with the span.
   map<string, string> tags = 6;


### PR DESCRIPTION
First two commits are #57781

----

Today, we have either

- a Span that was optimized out (noop span)
- a non-recording Span
- a recording Span (snowball span)

In the always-on tracing world (which does not yet exist but should soon), we
have:

- a Span
- a verbose Span

The recording Span from the old world is really the verbose Span in the new
world. This PR realizes this change in naming and removes the word "snowball"
from all tracing-related contexts throughout the codebase.

Release note: None
