### PR TITLE
sql: Add information_schema.session_variables table

### DIFF
--- a/pkg/sql/catalog/catconstants/constants.go
+++ b/pkg/sql/catalog/catconstants/constants.go
@@ -95,6 +95,7 @@ const (
 	InformationSchemaRoutineTableID
 	InformationSchemaSchemataTableID
 	InformationSchemaSchemataTablePrivilegesID
+	InformationSchemaSessionVariables
 	InformationSchemaSequencesID
 	InformationSchemaStatisticsTableID
 	InformationSchemaTableConstraintTableID

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -143,6 +143,7 @@ var informationSchema = virtualSchema{
 		catconstants.InformationSchemaRoutineTableID:                     informationSchemaRoutineTable,
 		catconstants.InformationSchemaSchemataTableID:                    informationSchemaSchemataTable,
 		catconstants.InformationSchemaSchemataTablePrivilegesID:          informationSchemaSchemataTablePrivileges,
+		catconstants.InformationSchemaSessionVariables:                   informationSchemaSessionVariables,
 		catconstants.InformationSchemaSequencesID:                        informationSchemaSequences,
 		catconstants.InformationSchemaStatisticsTableID:                  informationSchemaStatisticsTable,
 		catconstants.InformationSchemaTableConstraintTableID:             informationSchemaTableConstraintTable,
@@ -1674,6 +1675,24 @@ https://www.postgresql.org/docs/current/infoschema-collation-character-set-appli
 		for _, tag := range collate.Supported() {
 			collName := tag.String()
 			if err := add(collName); err != nil {
+				return err
+			}
+		}
+		return nil
+	},
+}
+
+var informationSchemaSessionVariables = virtualSchemaTable{
+	comment: `exposes the session variables.`,
+	schema:  vtable.InformationSchemaSessionVariables,
+	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
+		for _, vName := range varNames {
+			gen := varGen[vName]
+			value := gen.Get(&p.extendedEvalCtx)
+			if err := addRow(
+				tree.NewDString(vName),
+				tree.NewDString(value),
+			); err != nil {
 				return err
 			}
 		}

--- a/pkg/sql/logictest/testdata/logic_test/grant_table
+++ b/pkg/sql/logictest/testdata/logic_test/grant_table
@@ -90,6 +90,7 @@ test           information_schema  routines                               public
 test           information_schema  schema_privileges                      public   SELECT
 test           information_schema  schemata                               public   SELECT
 test           information_schema  sequences                              public   SELECT
+test           information_schema  session_variables                      public   SELECT
 test           information_schema  statistics                             public   SELECT
 test           information_schema  table_constraints                      public   SELECT
 test           information_schema  table_privileges                       public   SELECT

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -35,6 +35,7 @@ information_schema  routines                               table  NULL  NULL  NU
 information_schema  schema_privileges                      table  NULL  NULL  NULL
 information_schema  schemata                               table  NULL  NULL  NULL
 information_schema  sequences                              table  NULL  NULL  NULL
+information_schema  session_variables                      table  NULL  NULL  NULL
 information_schema  statistics                             table  NULL  NULL  NULL
 information_schema  table_constraints                      table  NULL  NULL  NULL
 information_schema  table_privileges                       table  NULL  NULL  NULL
@@ -105,6 +106,8 @@ GRANT CREATE ON information_schema.tables TO root
 statement error tables is a virtual object and cannot be modified
 REVOKE CREATE ON information_schema.tables FROM root
 
+statement error session_variables is a virtual object and cannot be modified
+ALTER TABLE information_schema.session_variables ALTER x DROP NOT NULL
 
 # Verify information_schema tables handles read-only property correctly.
 
@@ -148,6 +151,20 @@ UPDATE information_schema.collations SET a = 'abc'
 statement error collations is a virtual object and cannot be modified
 TRUNCATE TABLE information_schema.collations
 
+# Verify information_schema session_variables handles read-only property correctly.
+
+query error user root does not have DELETE privilege on relation session_variables
+DELETE FROM information_schema.session_variables
+
+query error user root does not have INSERT privilege on relation session_variables
+INSERT INTO information_schema.session_variables VALUES ('abc')
+
+statement error user root does not have UPDATE privilege on relation session_variables
+UPDATE information_schema.session_variables SET a = 'abc'
+
+statement error session_variables is a virtual object and cannot be modified
+TRUNCATE TABLE information_schema.session_variables
+
 # Verify information_schema handles reflection correctly.
 
 query TTTTT
@@ -180,6 +197,7 @@ information_schema  routines                               table  NULL  NULL  NU
 information_schema  schema_privileges                      table  NULL  NULL  NULL
 information_schema  schemata                               table  NULL  NULL  NULL
 information_schema  sequences                              table  NULL  NULL  NULL
+information_schema  session_variables                      table  NULL  NULL  NULL
 information_schema  statistics                             table  NULL  NULL  NULL
 information_schema  table_constraints                      table  NULL  NULL  NULL
 information_schema  table_privileges                       table  NULL  NULL  NULL
@@ -322,6 +340,7 @@ information_schema  routines
 information_schema  schema_privileges
 information_schema  schemata
 information_schema  sequences
+information_schema  session_variables
 information_schema  statistics
 information_schema  table_constraints
 information_schema  table_privileges
@@ -481,6 +500,7 @@ routines
 schema_privileges
 schemata
 sequences
+session_variables
 statistics
 table_constraints
 table_privileges
@@ -659,6 +679,7 @@ system         information_schema  routines                               SYSTEM
 system         information_schema  schema_privileges                      SYSTEM VIEW  NO                  1
 system         information_schema  schemata                               SYSTEM VIEW  NO                  1
 system         information_schema  sequences                              SYSTEM VIEW  NO                  1
+system         information_schema  session_variables                      SYSTEM VIEW  NO                  1
 system         information_schema  statistics                             SYSTEM VIEW  NO                  1
 system         information_schema  table_constraints                      SYSTEM VIEW  NO                  1
 system         information_schema  table_privileges                       SYSTEM VIEW  NO                  1
@@ -1823,6 +1844,7 @@ NULL     public   system         information_schema  routines                   
 NULL     public   system         information_schema  schema_privileges                      SELECT          NULL          YES
 NULL     public   system         information_schema  schemata                               SELECT          NULL          YES
 NULL     public   system         information_schema  sequences                              SELECT          NULL          YES
+NULL     public   system         information_schema  session_variables                      SELECT          NULL          YES
 NULL     public   system         information_schema  statistics                             SELECT          NULL          YES
 NULL     public   system         information_schema  table_constraints                      SELECT          NULL          YES
 NULL     public   system         information_schema  table_privileges                       SELECT          NULL          YES
@@ -2207,6 +2229,7 @@ NULL     public   system         information_schema  routines                   
 NULL     public   system         information_schema  schema_privileges                      SELECT          NULL          YES
 NULL     public   system         information_schema  schemata                               SELECT          NULL          YES
 NULL     public   system         information_schema  sequences                              SELECT          NULL          YES
+NULL     public   system         information_schema  session_variables                      SELECT          NULL          YES
 NULL     public   system         information_schema  statistics                             SELECT          NULL          YES
 NULL     public   system         information_schema  table_constraints                      SELECT          NULL          YES
 NULL     public   system         information_schema  table_privileges                       SELECT          NULL          YES
@@ -3064,6 +3087,7 @@ test         public      typ2      test           public        tb_enum_cols  z
 test         public      typ2      test           public        tb_enum_cols  w
 
 ## information_schema.collations
+subtest collations
 
 query TTTT colnames
 SELECT * FROM information_schema.collations
@@ -3168,6 +3192,7 @@ test               pg_catalog        zh-Hant              NO PAD
 
 
 ## information_schema.collation_character_set_applicability
+subtest collation_character_set_applicability
 
 query TTTTTT colnames
 SELECT * FROM information_schema.collation_character_set_applicability
@@ -3269,3 +3294,82 @@ test               pg_catalog        zh                   NULL                  
 test               pg_catalog        zh-u-co-stroke       NULL                   NULL                  UTF8
 test               pg_catalog        zh-Hant-u-co-pinyin  NULL                   NULL                  UTF8
 test               pg_catalog        zh-Hant              NULL                   NULL                  UTF8
+
+
+## information_schema.session_variables
+subtest variables
+
+## excluding crdb_version and session_id variables as they are generated on each
+## commit/session; distsql, experimental_distsql_planning and vectorize as they
+## depend on distsql and vectorization turned on/off.
+query TT colnames
+SELECT * FROM information_schema.session_variables where variable not in ('crdb_version', 'session_id', 'distsql', 'vectorize', 'experimental_distsql_planning')
+----
+variable                                              value
+allow_prepare_as_opt_plan                             off
+application_name                                      ·
+bytea_output                                          hex
+client_encoding                                       UTF8
+client_min_messages                                   notice
+database                                              test
+datestyle                                             ISO, MDY
+default_int_size                                      8
+default_tablespace                                    ·
+default_transaction_isolation                         serializable
+default_transaction_priority                          normal
+default_transaction_read_only                         off
+default_transaction_use_follower_reads                off
+disable_partially_distributed_plans                   off
+disallow_full_table_scans                             off
+enable_experimental_alter_column_type_general         off
+enable_implicit_select_for_update                     on
+enable_insert_fast_path                               on
+enable_seqscan                                        on
+enable_zigzag_join                                    on
+experimental_enable_hash_sharded_indexes              off
+experimental_enable_multi_column_inverted_indexes     off
+experimental_enable_temp_tables                       off
+experimental_enable_unique_without_index_constraints  off
+experimental_enable_virtual_columns                   off
+extra_float_digits                                    0
+force_savepoint_restart                               off
+foreign_key_cascades_limit                            10000
+idle_in_session_timeout                               0
+idle_in_transaction_session_timeout                   0
+integer_datetimes                                     on
+intervalstyle                                         postgres
+locality                                              region=test,dc=dc1
+lock_timeout                                          0
+max_identifier_length                                 128
+max_index_keys                                        32
+node_id                                               1
+optimizer                                             on
+optimizer_use_histograms                              on
+optimizer_use_multicol_stats                          on
+prefer_lookup_joins_for_fks                           off
+reorder_joins_limit                                   8
+require_explicit_primary_keys                         off
+results_buffer_size                                   16384
+row_security                                          off
+save_tables_prefix                                    ·
+search_path                                           $user,public
+serial_normalization                                  rowid
+server_encoding                                       UTF8
+server_version                                        13.0.0
+server_version_num                                    130000
+session_authorization                                 root
+session_user                                          root
+sql_safe_updates                                      off
+ssl_renegotiation_limit                               0
+standard_conforming_strings                           on
+statement_timeout                                     0
+synchronize_seqscans                                  on
+synchronous_commit                                    on
+testing_vectorize_inject_panics                       off
+timezone                                              UTC
+tracing                                               off
+transaction_isolation                                 serializable
+transaction_priority                                  normal
+transaction_read_only                                 off
+transaction_status                                    NoTxn
+vectorize_row_count_threshold                         0

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -952,12 +952,12 @@ FROM pg_catalog.pg_depend
 ORDER BY objid
 ----
 classid     objid       objsubid  refclassid  refobjid   refobjsubid  deptype
-4294967215  58          0         4294967215  55         1            n
-4294967215  58          0         4294967215  55         2            n
-4294967215  58          0         4294967215  55         3            n
-4294967215  58          0         4294967215  55         4            n
-4294967213  2143281868  0         4294967215  450499961  0            n
-4294967213  4089604113  0         4294967215  450499960  0            n
+4294967214  58          0         4294967214  55         1            n
+4294967214  58          0         4294967214  55         2            n
+4294967214  58          0         4294967214  55         3            n
+4294967214  58          0         4294967214  55         4            n
+4294967212  2143281868  0         4294967214  450499961  0            n
+4294967212  4089604113  0         4294967214  450499960  0            n
 
 # Some entries in pg_depend are dependency links from the pg_constraint system
 # table to the pg_class system table. Other entries are links to pg_class when it is
@@ -970,8 +970,8 @@ JOIN pg_class cla ON classid=cla.oid
 JOIN pg_class refcla ON refclassid=refcla.oid
 ----
 classid     refclassid  tablename      reftablename
-4294967215  4294967215  pg_class       pg_class
-4294967213  4294967215  pg_constraint  pg_class
+4294967214  4294967214  pg_class       pg_class
+4294967212  4294967214  pg_constraint  pg_class
 
 # Some entries in pg_depend are foreign key constraints that reference an index
 # in pg_class. Other entries are table-view dependencies
@@ -1679,129 +1679,130 @@ SELECT objoid, classoid, objsubid, regexp_replace(description, e'\n.*', '') AS d
   FROM pg_catalog.pg_description
 ----
 objoid      classoid    objsubid  description
-4294967294  4294967215  0         backward inter-descriptor dependencies starting from tables accessible by current user in current database (KV scan)
-4294967292  4294967215  0         built-in functions (RAM/static)
-4294967252  4294967215  0         virtual table with database privileges
-4294967291  4294967215  0         running queries visible by current user (cluster RPC; expensive!)
-4294967289  4294967215  0         running sessions visible to current user (cluster RPC; expensive!)
-4294967288  4294967215  0         cluster settings (RAM)
-4294967290  4294967215  0         running user transactions visible by the current user (cluster RPC; expensive!)
-4294967287  4294967215  0         CREATE and ALTER statements for all tables accessible by current user in current database (KV scan)
-4294967286  4294967215  0         CREATE statements for all user defined types accessible by the current user in current database (KV scan)
-4294967285  4294967215  0         databases accessible by the current user (KV scan)
-4294967284  4294967215  0         telemetry counters (RAM; local node only)
-4294967283  4294967215  0         forward inter-descriptor dependencies starting from tables accessible by current user in current database (KV scan)
-4294967281  4294967215  0         locally known gossiped health alerts (RAM; local node only)
-4294967280  4294967215  0         locally known gossiped node liveness (RAM; local node only)
-4294967279  4294967215  0         locally known edges in the gossip network (RAM; local node only)
-4294967282  4294967215  0         locally known gossiped node details (RAM; local node only)
-4294967278  4294967215  0         index columns for all indexes accessible by current user in current database (KV scan)
-4294967253  4294967215  0         virtual table to validate descriptors
-4294967277  4294967215  0         decoded job metadata from system.jobs (KV scan)
-4294967276  4294967215  0         node details across the entire cluster (cluster RPC; expensive!)
-4294967275  4294967215  0         store details and status (cluster RPC; expensive!)
-4294967274  4294967215  0         acquired table leases (RAM; local node only)
-4294967293  4294967215  0         detailed identification strings (RAM, local node only)
-4294967270  4294967215  0         current values for metrics (RAM; local node only)
-4294967273  4294967215  0         running queries visible by current user (RAM; local node only)
-4294967265  4294967215  0         server parameters, useful to construct connection URLs (RAM, local node only)
-4294967271  4294967215  0         running sessions visible by current user (RAM; local node only)
-4294967261  4294967215  0         statement statistics (in-memory, not durable; local node only). This table is wiped periodically (by default, at least every two hours)
-4294967256  4294967215  0         finer-grained transaction statistics (in-memory, not durable; local node only). This table is wiped periodically (by default, at least every two hours)
-4294967272  4294967215  0         running user transactions visible by the current user (RAM; local node only)
-4294967255  4294967215  0         per-application transaction statistics (in-memory, not durable; local node only). This table is wiped periodically (by default, at least every two hours)
-4294967269  4294967215  0         defined partitions for all tables/indexes accessible by the current user in the current database (KV scan)
-4294967268  4294967215  0         comments for predefined virtual tables (RAM/static)
-4294967267  4294967215  0         range metadata without leaseholder details (KV join; expensive!)
-4294967264  4294967215  0         ongoing schema changes, across all descriptors accessible by current user (KV scan; expensive!)
-4294967263  4294967215  0         session trace accumulated so far (RAM)
-4294967262  4294967215  0         session variables (RAM)
-4294967260  4294967215  0         details for all columns accessible by current user in current database (KV scan)
-4294967259  4294967215  0         indexes accessible by current user in current database (KV scan)
-4294967257  4294967215  0         the latest stats for all tables accessible by current user in current database (KV scan)
-4294967258  4294967215  0         table descriptors accessible by current user, including non-public and virtual (KV scan; expensive!)
-4294967254  4294967215  0         decoded zone configurations from system.zones (KV scan)
-4294967250  4294967215  0         roles for which the current user has admin option
-4294967249  4294967215  0         roles available to the current user
-4294967248  4294967215  0         character sets available in the current database
-4294967247  4294967215  0         check constraints
-4294967246  4294967215  0         identifies which character set the available collations are
-4294967245  4294967215  0         shows the collations available in the current database
-4294967244  4294967215  0         column privilege grants (incomplete)
-4294967242  4294967215  0         columns with user defined types
-4294967243  4294967215  0         table and view columns (incomplete)
-4294967241  4294967215  0         columns usage by constraints
-4294967240  4294967215  0         roles for the current user
-4294967239  4294967215  0         column usage by indexes and key constraints
-4294967238  4294967215  0         built-in function parameters (empty - introspection not yet supported)
-4294967237  4294967215  0         foreign key constraints
-4294967236  4294967215  0         privileges granted on table or views (incomplete; see also information_schema.table_privileges; may contain excess users or roles)
-4294967235  4294967215  0         built-in functions (empty - introspection not yet supported)
-4294967233  4294967215  0         schema privileges (incomplete; may contain excess users or roles)
-4294967234  4294967215  0         database schemas (may contain schemata without permission)
-4294967232  4294967215  0         sequences
-4294967231  4294967215  0         index metadata and statistics (incomplete)
-4294967230  4294967215  0         table constraints
-4294967229  4294967215  0         privileges granted on table or views (incomplete; may contain excess users or roles)
-4294967228  4294967215  0         tables and views
-4294967227  4294967215  0         type privileges (incomplete; may contain excess users or roles)
-4294967225  4294967215  0         grantable privileges (incomplete)
-4294967226  4294967215  0         views (incomplete)
-4294967223  4294967215  0         aggregated built-in functions (incomplete)
-4294967222  4294967215  0         index access methods (incomplete)
-4294967221  4294967215  0         column default values
-4294967220  4294967215  0         table columns (incomplete - see also information_schema.columns)
-4294967218  4294967215  0         role membership
-4294967219  4294967215  0         authorization identifiers - differs from postgres as we do not display passwords,
-4294967217  4294967215  0         available extensions
-4294967216  4294967215  0         casts (empty - needs filling out)
-4294967215  4294967215  0         tables and relation-like objects (incomplete - see also information_schema.tables/sequences/views)
-4294967214  4294967215  0         available collations (incomplete)
-4294967213  4294967215  0         table constraints (incomplete - see also information_schema.table_constraints)
-4294967212  4294967215  0         encoding conversions (empty - unimplemented)
-4294967211  4294967215  0         available databases (incomplete)
-4294967210  4294967215  0         default ACLs (empty - unimplemented)
-4294967209  4294967215  0         dependency relationships (incomplete)
-4294967208  4294967215  0         object comments
-4294967206  4294967215  0         enum types and labels (empty - feature does not exist)
-4294967205  4294967215  0         event triggers (empty - feature does not exist)
-4294967204  4294967215  0         installed extensions (empty - feature does not exist)
-4294967203  4294967215  0         foreign data wrappers (empty - feature does not exist)
-4294967202  4294967215  0         foreign servers (empty - feature does not exist)
-4294967201  4294967215  0         foreign tables (empty  - feature does not exist)
-4294967200  4294967215  0         indexes (incomplete)
-4294967199  4294967215  0         index creation statements
-4294967198  4294967215  0         table inheritance hierarchy (empty - feature does not exist)
-4294967197  4294967215  0         available languages (empty - feature does not exist)
-4294967196  4294967215  0         locks held by active processes (empty - feature does not exist)
-4294967195  4294967215  0         available materialized views (empty - feature does not exist)
-4294967194  4294967215  0         available namespaces (incomplete; namespaces and databases are congruent in CockroachDB)
-4294967193  4294967215  0         opclass (empty - Operator classes not supported yet)
-4294967192  4294967215  0         operators (incomplete)
-4294967191  4294967215  0         prepared statements
-4294967190  4294967215  0         prepared transactions (empty - feature does not exist)
-4294967189  4294967215  0         built-in functions (incomplete)
-4294967188  4294967215  0         range types (empty - feature does not exist)
-4294967187  4294967215  0         rewrite rules (empty - feature does not exist)
-4294967186  4294967215  0         database roles
-4294967173  4294967215  0         security labels (empty - feature does not exist)
-4294967185  4294967215  0         security labels (empty)
-4294967184  4294967215  0         sequences (see also information_schema.sequences)
-4294967183  4294967215  0         session variables (incomplete)
-4294967182  4294967215  0         shared dependencies (empty - not implemented)
-4294967207  4294967215  0         shared object comments
-4294967172  4294967215  0         shared security labels (empty - feature not supported)
-4294967174  4294967215  0         backend access statistics (empty - monitoring works differently in CockroachDB)
-4294967179  4294967215  0         tables summary (see also information_schema.tables, pg_catalog.pg_class)
-4294967178  4294967215  0         available tablespaces (incomplete; concept inapplicable to CockroachDB)
-4294967177  4294967215  0         triggers (empty - feature does not exist)
-4294967176  4294967215  0         scalar types (incomplete)
-4294967181  4294967215  0         database users
-4294967180  4294967215  0         local to remote user mapping (empty - feature does not exist)
-4294967175  4294967215  0         view definitions (incomplete - see also information_schema.views)
-4294967170  4294967215  0         Shows all defined geography columns. Matches PostGIS' geography_columns functionality.
-4294967169  4294967215  0         Shows all defined geometry columns. Matches PostGIS' geometry_columns functionality.
-4294967168  4294967215  0         Shows all defined Spatial Reference Identifiers (SRIDs). Matches PostGIS' spatial_ref_sys table.
+4294967294  4294967214  0         backward inter-descriptor dependencies starting from tables accessible by current user in current database (KV scan)
+4294967292  4294967214  0         built-in functions (RAM/static)
+4294967252  4294967214  0         virtual table with database privileges
+4294967291  4294967214  0         running queries visible by current user (cluster RPC; expensive!)
+4294967289  4294967214  0         running sessions visible to current user (cluster RPC; expensive!)
+4294967288  4294967214  0         cluster settings (RAM)
+4294967290  4294967214  0         running user transactions visible by the current user (cluster RPC; expensive!)
+4294967287  4294967214  0         CREATE and ALTER statements for all tables accessible by current user in current database (KV scan)
+4294967286  4294967214  0         CREATE statements for all user defined types accessible by the current user in current database (KV scan)
+4294967285  4294967214  0         databases accessible by the current user (KV scan)
+4294967284  4294967214  0         telemetry counters (RAM; local node only)
+4294967283  4294967214  0         forward inter-descriptor dependencies starting from tables accessible by current user in current database (KV scan)
+4294967281  4294967214  0         locally known gossiped health alerts (RAM; local node only)
+4294967280  4294967214  0         locally known gossiped node liveness (RAM; local node only)
+4294967279  4294967214  0         locally known edges in the gossip network (RAM; local node only)
+4294967282  4294967214  0         locally known gossiped node details (RAM; local node only)
+4294967278  4294967214  0         index columns for all indexes accessible by current user in current database (KV scan)
+4294967253  4294967214  0         virtual table to validate descriptors
+4294967277  4294967214  0         decoded job metadata from system.jobs (KV scan)
+4294967276  4294967214  0         node details across the entire cluster (cluster RPC; expensive!)
+4294967275  4294967214  0         store details and status (cluster RPC; expensive!)
+4294967274  4294967214  0         acquired table leases (RAM; local node only)
+4294967293  4294967214  0         detailed identification strings (RAM, local node only)
+4294967270  4294967214  0         current values for metrics (RAM; local node only)
+4294967273  4294967214  0         running queries visible by current user (RAM; local node only)
+4294967265  4294967214  0         server parameters, useful to construct connection URLs (RAM, local node only)
+4294967271  4294967214  0         running sessions visible by current user (RAM; local node only)
+4294967261  4294967214  0         statement statistics (in-memory, not durable; local node only). This table is wiped periodically (by default, at least every two hours)
+4294967256  4294967214  0         finer-grained transaction statistics (in-memory, not durable; local node only). This table is wiped periodically (by default, at least every two hours)
+4294967272  4294967214  0         running user transactions visible by the current user (RAM; local node only)
+4294967255  4294967214  0         per-application transaction statistics (in-memory, not durable; local node only). This table is wiped periodically (by default, at least every two hours)
+4294967269  4294967214  0         defined partitions for all tables/indexes accessible by the current user in the current database (KV scan)
+4294967268  4294967214  0         comments for predefined virtual tables (RAM/static)
+4294967267  4294967214  0         range metadata without leaseholder details (KV join; expensive!)
+4294967264  4294967214  0         ongoing schema changes, across all descriptors accessible by current user (KV scan; expensive!)
+4294967263  4294967214  0         session trace accumulated so far (RAM)
+4294967262  4294967214  0         session variables (RAM)
+4294967260  4294967214  0         details for all columns accessible by current user in current database (KV scan)
+4294967259  4294967214  0         indexes accessible by current user in current database (KV scan)
+4294967257  4294967214  0         the latest stats for all tables accessible by current user in current database (KV scan)
+4294967258  4294967214  0         table descriptors accessible by current user, including non-public and virtual (KV scan; expensive!)
+4294967254  4294967214  0         decoded zone configurations from system.zones (KV scan)
+4294967250  4294967214  0         roles for which the current user has admin option
+4294967249  4294967214  0         roles available to the current user
+4294967248  4294967214  0         character sets available in the current database
+4294967247  4294967214  0         check constraints
+4294967246  4294967214  0         identifies which character set the available collations are
+4294967245  4294967214  0         shows the collations available in the current database
+4294967244  4294967214  0         column privilege grants (incomplete)
+4294967242  4294967214  0         columns with user defined types
+4294967243  4294967214  0         table and view columns (incomplete)
+4294967241  4294967214  0         columns usage by constraints
+4294967240  4294967214  0         roles for the current user
+4294967239  4294967214  0         column usage by indexes and key constraints
+4294967238  4294967214  0         built-in function parameters (empty - introspection not yet supported)
+4294967237  4294967214  0         foreign key constraints
+4294967236  4294967214  0         privileges granted on table or views (incomplete; see also information_schema.table_privileges; may contain excess users or roles)
+4294967235  4294967214  0         built-in functions (empty - introspection not yet supported)
+4294967233  4294967214  0         schema privileges (incomplete; may contain excess users or roles)
+4294967234  4294967214  0         database schemas (may contain schemata without permission)
+4294967231  4294967214  0         sequences
+4294967232  4294967214  0         exposes the session variables.
+4294967230  4294967214  0         index metadata and statistics (incomplete)
+4294967229  4294967214  0         table constraints
+4294967228  4294967214  0         privileges granted on table or views (incomplete; may contain excess users or roles)
+4294967227  4294967214  0         tables and views
+4294967226  4294967214  0         type privileges (incomplete; may contain excess users or roles)
+4294967224  4294967214  0         grantable privileges (incomplete)
+4294967225  4294967214  0         views (incomplete)
+4294967222  4294967214  0         aggregated built-in functions (incomplete)
+4294967221  4294967214  0         index access methods (incomplete)
+4294967220  4294967214  0         column default values
+4294967219  4294967214  0         table columns (incomplete - see also information_schema.columns)
+4294967217  4294967214  0         role membership
+4294967218  4294967214  0         authorization identifiers - differs from postgres as we do not display passwords,
+4294967216  4294967214  0         available extensions
+4294967215  4294967214  0         casts (empty - needs filling out)
+4294967214  4294967214  0         tables and relation-like objects (incomplete - see also information_schema.tables/sequences/views)
+4294967213  4294967214  0         available collations (incomplete)
+4294967212  4294967214  0         table constraints (incomplete - see also information_schema.table_constraints)
+4294967211  4294967214  0         encoding conversions (empty - unimplemented)
+4294967210  4294967214  0         available databases (incomplete)
+4294967209  4294967214  0         default ACLs (empty - unimplemented)
+4294967208  4294967214  0         dependency relationships (incomplete)
+4294967207  4294967214  0         object comments
+4294967205  4294967214  0         enum types and labels (empty - feature does not exist)
+4294967204  4294967214  0         event triggers (empty - feature does not exist)
+4294967203  4294967214  0         installed extensions (empty - feature does not exist)
+4294967202  4294967214  0         foreign data wrappers (empty - feature does not exist)
+4294967201  4294967214  0         foreign servers (empty - feature does not exist)
+4294967200  4294967214  0         foreign tables (empty  - feature does not exist)
+4294967199  4294967214  0         indexes (incomplete)
+4294967198  4294967214  0         index creation statements
+4294967197  4294967214  0         table inheritance hierarchy (empty - feature does not exist)
+4294967196  4294967214  0         available languages (empty - feature does not exist)
+4294967195  4294967214  0         locks held by active processes (empty - feature does not exist)
+4294967194  4294967214  0         available materialized views (empty - feature does not exist)
+4294967193  4294967214  0         available namespaces (incomplete; namespaces and databases are congruent in CockroachDB)
+4294967192  4294967214  0         opclass (empty - Operator classes not supported yet)
+4294967191  4294967214  0         operators (incomplete)
+4294967190  4294967214  0         prepared statements
+4294967189  4294967214  0         prepared transactions (empty - feature does not exist)
+4294967188  4294967214  0         built-in functions (incomplete)
+4294967187  4294967214  0         range types (empty - feature does not exist)
+4294967186  4294967214  0         rewrite rules (empty - feature does not exist)
+4294967185  4294967214  0         database roles
+4294967172  4294967214  0         security labels (empty - feature does not exist)
+4294967184  4294967214  0         security labels (empty)
+4294967183  4294967214  0         sequences (see also information_schema.sequences)
+4294967182  4294967214  0         session variables (incomplete)
+4294967181  4294967214  0         shared dependencies (empty - not implemented)
+4294967206  4294967214  0         shared object comments
+4294967171  4294967214  0         shared security labels (empty - feature not supported)
+4294967173  4294967214  0         backend access statistics (empty - monitoring works differently in CockroachDB)
+4294967178  4294967214  0         tables summary (see also information_schema.tables, pg_catalog.pg_class)
+4294967177  4294967214  0         available tablespaces (incomplete; concept inapplicable to CockroachDB)
+4294967176  4294967214  0         triggers (empty - feature does not exist)
+4294967175  4294967214  0         scalar types (incomplete)
+4294967180  4294967214  0         database users
+4294967179  4294967214  0         local to remote user mapping (empty - feature does not exist)
+4294967174  4294967214  0         view definitions (incomplete - see also information_schema.views)
+4294967169  4294967214  0         Shows all defined geography columns. Matches PostGIS' geography_columns functionality.
+4294967168  4294967214  0         Shows all defined geometry columns. Matches PostGIS' geometry_columns functionality.
+4294967167  4294967214  0         Shows all defined Spatial Reference Identifiers (SRIDs). Matches PostGIS' spatial_ref_sys table.
 
 ## pg_catalog.pg_shdescription
 

--- a/pkg/sql/logictest/testdata/logic_test/table
+++ b/pkg/sql/logictest/testdata/logic_test/table
@@ -595,6 +595,7 @@ routines                               NULL
 schema_privileges                      NULL
 schemata                               NULL
 sequences                              NULL
+session_variables                      NULL
 statistics                             NULL
 table_constraints                      NULL
 table_privileges                       NULL

--- a/pkg/sql/vtable/information_schema.go
+++ b/pkg/sql/vtable/information_schema.go
@@ -195,3 +195,11 @@ CREATE TABLE information_schema.collations (
 	COLLATION_NAME    STRING NOT NULL,
 	PAD_ATTRIBUTE     STRING NOT NULL
 )`
+
+// InformationSchemaSessionVariables describes the schema of the
+// information_schema.session_variables table.
+const InformationSchemaSessionVariables = `
+CREATE TABLE information_schema.session_variables (
+	VARIABLE STRING NOT NULL,
+	VALUE STRING NOT NULL
+)`


### PR DESCRIPTION
sql: Add information_schema.session_variables table

The `session_variables` table exposes the session variables.
Related to: #8675

Release note (sql change): Added session_variables table to the information_schema.