### PR TITLE
colexec: remove almost all usages of execgen.SLICE

### DIFF
--- a/pkg/sql/colexec/cast.eg.go
+++ b/pkg/sql/colexec/cast.eg.go
@@ -558,7 +558,6 @@ func (c *castBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol[0:n]
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int
@@ -589,7 +588,6 @@ func (c *castBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol[0:n]
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int
@@ -666,7 +664,6 @@ func (c *castBoolFloat64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol[0:n]
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int
@@ -707,7 +704,6 @@ func (c *castBoolFloat64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol[0:n]
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int
@@ -789,7 +785,6 @@ func (c *castBoolInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol[0:n]
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int
@@ -830,7 +825,6 @@ func (c *castBoolInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol[0:n]
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int
@@ -912,7 +906,6 @@ func (c *castBoolInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol[0:n]
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int
@@ -953,7 +946,6 @@ func (c *castBoolInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol[0:n]
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int
@@ -1035,7 +1027,6 @@ func (c *castBoolInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol[0:n]
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int
@@ -1076,7 +1067,6 @@ func (c *castBoolInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol[0:n]
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int
@@ -1153,7 +1143,6 @@ func (c *castDecimalBoolOp) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol[0:n]
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int
@@ -1184,7 +1173,6 @@ func (c *castDecimalBoolOp) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol[0:n]
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int
@@ -1261,7 +1249,6 @@ func (c *castDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol[0:n]
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int
@@ -1302,7 +1289,6 @@ func (c *castDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol[0:n]
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int
@@ -1379,7 +1365,6 @@ func (c *castInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol[0:n]
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int
@@ -1410,7 +1395,6 @@ func (c *castInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol[0:n]
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int
@@ -1484,7 +1468,6 @@ func (c *castInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol[0:n]
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int
@@ -1519,7 +1502,6 @@ func (c *castInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol[0:n]
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int
@@ -1595,7 +1577,6 @@ func (c *castInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol[0:n]
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int
@@ -1630,7 +1611,6 @@ func (c *castInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol[0:n]
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int
@@ -1706,7 +1686,6 @@ func (c *castInt16BoolOp) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol[0:n]
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int
@@ -1741,7 +1720,6 @@ func (c *castInt16BoolOp) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol[0:n]
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int
@@ -1821,7 +1799,6 @@ func (c *castInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol[0:n]
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int
@@ -1864,7 +1841,6 @@ func (c *castInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol[0:n]
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int
@@ -1944,7 +1920,6 @@ func (c *castInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol[0:n]
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int
@@ -1979,7 +1954,6 @@ func (c *castInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol[0:n]
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int
@@ -2055,7 +2029,6 @@ func (c *castInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol[0:n]
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int
@@ -2090,7 +2063,6 @@ func (c *castInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol[0:n]
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int
@@ -2164,7 +2136,6 @@ func (c *castInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol[0:n]
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int
@@ -2195,7 +2166,6 @@ func (c *castInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol[0:n]
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int
@@ -2269,7 +2239,6 @@ func (c *castInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol[0:n]
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int
@@ -2304,7 +2273,6 @@ func (c *castInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol[0:n]
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int
@@ -2380,7 +2348,6 @@ func (c *castInt32BoolOp) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol[0:n]
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int
@@ -2415,7 +2382,6 @@ func (c *castInt32BoolOp) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol[0:n]
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int
@@ -2495,7 +2461,6 @@ func (c *castInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol[0:n]
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int
@@ -2538,7 +2503,6 @@ func (c *castInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol[0:n]
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int
@@ -2618,7 +2582,6 @@ func (c *castInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol[0:n]
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int
@@ -2653,7 +2616,6 @@ func (c *castInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol[0:n]
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int
@@ -2729,7 +2691,6 @@ func (c *castInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol[0:n]
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int
@@ -2764,7 +2725,6 @@ func (c *castInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol[0:n]
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int
@@ -2840,7 +2800,6 @@ func (c *castInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol[0:n]
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int
@@ -2875,7 +2834,6 @@ func (c *castInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol[0:n]
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int
@@ -2949,7 +2907,6 @@ func (c *castInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol[0:n]
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int
@@ -2980,7 +2937,6 @@ func (c *castInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol[0:n]
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int
@@ -3054,7 +3010,6 @@ func (c *castInt64BoolOp) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol[0:n]
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int
@@ -3089,7 +3044,6 @@ func (c *castInt64BoolOp) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol[0:n]
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int
@@ -3169,7 +3123,6 @@ func (c *castInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol[0:n]
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int
@@ -3212,7 +3165,6 @@ func (c *castInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol[0:n]
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int
@@ -3292,7 +3244,6 @@ func (c *castInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol[0:n]
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int
@@ -3327,7 +3278,6 @@ func (c *castInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol[0:n]
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int
@@ -3401,7 +3351,6 @@ func (c *castFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol[0:n]
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int
@@ -3432,7 +3381,6 @@ func (c *castFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol[0:n]
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int
@@ -3506,7 +3454,6 @@ func (c *castFloat64BoolOp) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol[0:n]
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int
@@ -3541,7 +3488,6 @@ func (c *castFloat64BoolOp) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol[0:n]
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int
@@ -3623,7 +3569,6 @@ func (c *castFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol[0:n]
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int
@@ -3670,7 +3615,6 @@ func (c *castFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol[0:n]
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int
@@ -3755,7 +3699,6 @@ func (c *castFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol[0:n]
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int
@@ -3796,7 +3739,6 @@ func (c *castFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol[0:n]
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int
@@ -3878,7 +3820,6 @@ func (c *castFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol[0:n]
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int
@@ -3919,7 +3860,6 @@ func (c *castFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol[0:n]
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int
@@ -4001,7 +3941,6 @@ func (c *castFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol[0:n]
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int
@@ -4042,7 +3981,6 @@ func (c *castFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol[0:n]
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int
@@ -4127,7 +4065,6 @@ func (c *castDatumBoolOp) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol.Slice(0, n)
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int
@@ -4174,7 +4111,6 @@ func (c *castDatumBoolOp) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol.Slice(0, n)
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int
@@ -4268,7 +4204,6 @@ func (c *castDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol.Slice(0, n)
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int
@@ -4327,7 +4262,6 @@ func (c *castDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
-					inputCol = inputCol.Slice(0, n)
 					_ = inputCol.Get(n - 1)
 					_ = outputCol.Get(n - 1)
 					var tupleIdx int

--- a/pkg/sql/colexec/cast_tmpl.go
+++ b/pkg/sql/colexec/cast_tmpl.go
@@ -69,11 +69,6 @@ func _R_SET(to, from interface{}) {
 	colexecerror.InternalError(errors.AssertionFailedf(""))
 }
 
-// This will be replaced with execgen.SLICE.
-func _L_SLICE(col, i, j interface{}) interface{} {
-	colexecerror.InternalError(errors.AssertionFailedf(""))
-}
-
 // */}}
 
 func GetCastOperator(
@@ -259,7 +254,6 @@ func _CAST_TUPLES(_HAS_NULLS, _HAS_SEL bool) { // */}}
 	sel = sel[:n]
 	// {{else}}
 	// Remove bounds checks for inputCol[i] and outputCol[i].
-	inputCol = _L_SLICE(inputCol, 0, n)
 	_ = inputCol.Get(n - 1)
 	_ = outputCol.Get(n - 1)
 	// {{end}}

--- a/pkg/sql/colexec/colexecagg/min_max_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/min_max_agg_tmpl.go
@@ -162,7 +162,7 @@ func (a *_AGG_TYPE_AGGKINDAgg) Compute(
 		// */}}
 		if sel == nil {
 			_ = groups[inputLen-1]
-			col = execgen.SLICE(col, 0, inputLen)
+			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
 				for i := 0; i < inputLen; i++ {
 					_ACCUMULATE_MINMAX(a, nulls, i, true)

--- a/pkg/sql/colexec/colexecagg/ordered_min_max_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_min_max_agg.eg.go
@@ -124,7 +124,7 @@ func (a *minBoolOrderedAgg) Compute(
 		groups := a.groups
 		if sel == nil {
 			_ = groups[inputLen-1]
-			col = col[0:inputLen]
+			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
 				for i := 0; i < inputLen; i++ {
 
@@ -403,9 +403,7 @@ func (a *minBytesOrderedAgg) Compute(
 		groups := a.groups
 		if sel == nil {
 			_ = groups[inputLen-1]
-			col = col
-			_ = 0
-			_ = inputLen
+			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
 				for i := 0; i < inputLen; i++ {
 
@@ -655,7 +653,7 @@ func (a *minDecimalOrderedAgg) Compute(
 		groups := a.groups
 		if sel == nil {
 			_ = groups[inputLen-1]
-			col = col[0:inputLen]
+			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
 				for i := 0; i < inputLen; i++ {
 
@@ -902,7 +900,7 @@ func (a *minInt16OrderedAgg) Compute(
 		groups := a.groups
 		if sel == nil {
 			_ = groups[inputLen-1]
-			col = col[0:inputLen]
+			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
 				for i := 0; i < inputLen; i++ {
 
@@ -1193,7 +1191,7 @@ func (a *minInt32OrderedAgg) Compute(
 		groups := a.groups
 		if sel == nil {
 			_ = groups[inputLen-1]
-			col = col[0:inputLen]
+			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
 				for i := 0; i < inputLen; i++ {
 
@@ -1484,7 +1482,7 @@ func (a *minInt64OrderedAgg) Compute(
 		groups := a.groups
 		if sel == nil {
 			_ = groups[inputLen-1]
-			col = col[0:inputLen]
+			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
 				for i := 0; i < inputLen; i++ {
 
@@ -1775,7 +1773,7 @@ func (a *minFloat64OrderedAgg) Compute(
 		groups := a.groups
 		if sel == nil {
 			_ = groups[inputLen-1]
-			col = col[0:inputLen]
+			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
 				for i := 0; i < inputLen; i++ {
 
@@ -2098,7 +2096,7 @@ func (a *minTimestampOrderedAgg) Compute(
 		groups := a.groups
 		if sel == nil {
 			_ = groups[inputLen-1]
-			col = col[0:inputLen]
+			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
 				for i := 0; i < inputLen; i++ {
 
@@ -2373,7 +2371,7 @@ func (a *minIntervalOrderedAgg) Compute(
 		groups := a.groups
 		if sel == nil {
 			_ = groups[inputLen-1]
-			col = col[0:inputLen]
+			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
 				for i := 0; i < inputLen; i++ {
 
@@ -2624,7 +2622,7 @@ func (a *minDatumOrderedAgg) Compute(
 		groups := a.groups
 		if sel == nil {
 			_ = groups[inputLen-1]
-			col = col.Slice(0, inputLen)
+			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
 				for i := 0; i < inputLen; i++ {
 
@@ -2888,7 +2886,7 @@ func (a *maxBoolOrderedAgg) Compute(
 		groups := a.groups
 		if sel == nil {
 			_ = groups[inputLen-1]
-			col = col[0:inputLen]
+			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
 				for i := 0; i < inputLen; i++ {
 
@@ -3167,9 +3165,7 @@ func (a *maxBytesOrderedAgg) Compute(
 		groups := a.groups
 		if sel == nil {
 			_ = groups[inputLen-1]
-			col = col
-			_ = 0
-			_ = inputLen
+			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
 				for i := 0; i < inputLen; i++ {
 
@@ -3419,7 +3415,7 @@ func (a *maxDecimalOrderedAgg) Compute(
 		groups := a.groups
 		if sel == nil {
 			_ = groups[inputLen-1]
-			col = col[0:inputLen]
+			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
 				for i := 0; i < inputLen; i++ {
 
@@ -3666,7 +3662,7 @@ func (a *maxInt16OrderedAgg) Compute(
 		groups := a.groups
 		if sel == nil {
 			_ = groups[inputLen-1]
-			col = col[0:inputLen]
+			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
 				for i := 0; i < inputLen; i++ {
 
@@ -3957,7 +3953,7 @@ func (a *maxInt32OrderedAgg) Compute(
 		groups := a.groups
 		if sel == nil {
 			_ = groups[inputLen-1]
-			col = col[0:inputLen]
+			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
 				for i := 0; i < inputLen; i++ {
 
@@ -4248,7 +4244,7 @@ func (a *maxInt64OrderedAgg) Compute(
 		groups := a.groups
 		if sel == nil {
 			_ = groups[inputLen-1]
-			col = col[0:inputLen]
+			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
 				for i := 0; i < inputLen; i++ {
 
@@ -4539,7 +4535,7 @@ func (a *maxFloat64OrderedAgg) Compute(
 		groups := a.groups
 		if sel == nil {
 			_ = groups[inputLen-1]
-			col = col[0:inputLen]
+			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
 				for i := 0; i < inputLen; i++ {
 
@@ -4862,7 +4858,7 @@ func (a *maxTimestampOrderedAgg) Compute(
 		groups := a.groups
 		if sel == nil {
 			_ = groups[inputLen-1]
-			col = col[0:inputLen]
+			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
 				for i := 0; i < inputLen; i++ {
 
@@ -5137,7 +5133,7 @@ func (a *maxIntervalOrderedAgg) Compute(
 		groups := a.groups
 		if sel == nil {
 			_ = groups[inputLen-1]
-			col = col[0:inputLen]
+			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
 				for i := 0; i < inputLen; i++ {
 
@@ -5388,7 +5384,7 @@ func (a *maxDatumOrderedAgg) Compute(
 		groups := a.groups
 		if sel == nil {
 			_ = groups[inputLen-1]
-			col = col.Slice(0, inputLen)
+			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
 				for i := 0; i < inputLen; i++ {
 

--- a/pkg/sql/colexec/const.eg.go
+++ b/pkg/sql/colexec/const.eg.go
@@ -184,7 +184,6 @@ func (c constBoolOp) Next(ctx context.Context) coldata.Batch {
 					col[i] = c.constVal
 				}
 			} else {
-				col = col[0:n]
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					col[i] = c.constVal
@@ -232,9 +231,6 @@ func (c constBytesOp) Next(ctx context.Context) coldata.Batch {
 					col.Set(i, c.constVal)
 				}
 			} else {
-				col = col
-				_ = 0
-				_ = n
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					col.Set(i, c.constVal)
@@ -282,7 +278,6 @@ func (c constDecimalOp) Next(ctx context.Context) coldata.Batch {
 					col[i].Set(&c.constVal)
 				}
 			} else {
-				col = col[0:n]
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					col[i].Set(&c.constVal)
@@ -330,7 +325,6 @@ func (c constInt16Op) Next(ctx context.Context) coldata.Batch {
 					col[i] = c.constVal
 				}
 			} else {
-				col = col[0:n]
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					col[i] = c.constVal
@@ -378,7 +372,6 @@ func (c constInt32Op) Next(ctx context.Context) coldata.Batch {
 					col[i] = c.constVal
 				}
 			} else {
-				col = col[0:n]
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					col[i] = c.constVal
@@ -426,7 +419,6 @@ func (c constInt64Op) Next(ctx context.Context) coldata.Batch {
 					col[i] = c.constVal
 				}
 			} else {
-				col = col[0:n]
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					col[i] = c.constVal
@@ -474,7 +466,6 @@ func (c constFloat64Op) Next(ctx context.Context) coldata.Batch {
 					col[i] = c.constVal
 				}
 			} else {
-				col = col[0:n]
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					col[i] = c.constVal
@@ -522,7 +513,6 @@ func (c constTimestampOp) Next(ctx context.Context) coldata.Batch {
 					col[i] = c.constVal
 				}
 			} else {
-				col = col[0:n]
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					col[i] = c.constVal
@@ -570,7 +560,6 @@ func (c constIntervalOp) Next(ctx context.Context) coldata.Batch {
 					col[i] = c.constVal
 				}
 			} else {
-				col = col[0:n]
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					col[i] = c.constVal
@@ -618,7 +607,6 @@ func (c constDatumOp) Next(ctx context.Context) coldata.Batch {
 					col.Set(i, c.constVal)
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					col.Set(i, c.constVal)

--- a/pkg/sql/colexec/const_tmpl.go
+++ b/pkg/sql/colexec/const_tmpl.go
@@ -124,7 +124,6 @@ func (c const_TYPEOp) Next(ctx context.Context) coldata.Batch {
 					execgen.SET(col, i, c.constVal)
 				}
 			} else {
-				col = execgen.SLICE(col, 0, n)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					execgen.SET(col, i, c.constVal)

--- a/pkg/sql/colexec/distinct.eg.go
+++ b/pkg/sql/colexec/distinct.eg.go
@@ -550,15 +550,13 @@ func (p partitionerBool) partitionWithOrder(
 	}
 
 	col := colVec.Bool()
-	col = col[0:n]
-	outputCol = outputCol[:n]
-	// Eliminate bounds checks for outputcol[outputIdx].
-	_ = outputCol[len(order)-1]
-	// Eliminate bounds checks for col[outputIdx].
-	_ = col.Get(len(order) - 1)
+	// Eliminate bounds checks.
+	_ = col.Get(n - 1)
+	_ = outputCol[n-1]
 	outputCol[0] = true
 	if nulls != nil {
-		for outputIdx, checkIdx := range order {
+		for outputIdx := 0; outputIdx < n; outputIdx++ {
+			checkIdx := order[outputIdx]
 			{
 				var (
 					__retval_lastVal     bool
@@ -607,7 +605,8 @@ func (p partitionerBool) partitionWithOrder(
 			}
 		}
 	} else {
-		for outputIdx, checkIdx := range order {
+		for outputIdx := 0; outputIdx < n; outputIdx++ {
+			checkIdx := order[outputIdx]
 			{
 				var __retval_0 bool
 				{
@@ -998,17 +997,13 @@ func (p partitionerBytes) partitionWithOrder(
 	}
 
 	col := colVec.Bytes()
-	col = col
-	_ = 0
-	_ = n
-	outputCol = outputCol[:n]
-	// Eliminate bounds checks for outputcol[outputIdx].
-	_ = outputCol[len(order)-1]
-	// Eliminate bounds checks for col[outputIdx].
-	_ = col.Get(len(order) - 1)
+	// Eliminate bounds checks.
+	_ = col.Get(n - 1)
+	_ = outputCol[n-1]
 	outputCol[0] = true
 	if nulls != nil {
-		for outputIdx, checkIdx := range order {
+		for outputIdx := 0; outputIdx < n; outputIdx++ {
+			checkIdx := order[outputIdx]
 			{
 				var (
 					__retval_lastVal     []byte
@@ -1049,7 +1044,8 @@ func (p partitionerBytes) partitionWithOrder(
 			}
 		}
 	} else {
-		for outputIdx, checkIdx := range order {
+		for outputIdx := 0; outputIdx < n; outputIdx++ {
+			checkIdx := order[outputIdx]
 			{
 				var __retval_0 []byte
 				{
@@ -1416,15 +1412,13 @@ func (p partitionerDecimal) partitionWithOrder(
 	}
 
 	col := colVec.Decimal()
-	col = col[0:n]
-	outputCol = outputCol[:n]
-	// Eliminate bounds checks for outputcol[outputIdx].
-	_ = outputCol[len(order)-1]
-	// Eliminate bounds checks for col[outputIdx].
-	_ = col.Get(len(order) - 1)
+	// Eliminate bounds checks.
+	_ = col.Get(n - 1)
+	_ = outputCol[n-1]
 	outputCol[0] = true
 	if nulls != nil {
-		for outputIdx, checkIdx := range order {
+		for outputIdx := 0; outputIdx < n; outputIdx++ {
+			checkIdx := order[outputIdx]
 			{
 				var (
 					__retval_lastVal     apd.Decimal
@@ -1465,7 +1459,8 @@ func (p partitionerDecimal) partitionWithOrder(
 			}
 		}
 	} else {
-		for outputIdx, checkIdx := range order {
+		for outputIdx := 0; outputIdx < n; outputIdx++ {
+			checkIdx := order[outputIdx]
 			{
 				var __retval_0 apd.Decimal
 				{
@@ -1876,15 +1871,13 @@ func (p partitionerInt16) partitionWithOrder(
 	}
 
 	col := colVec.Int16()
-	col = col[0:n]
-	outputCol = outputCol[:n]
-	// Eliminate bounds checks for outputcol[outputIdx].
-	_ = outputCol[len(order)-1]
-	// Eliminate bounds checks for col[outputIdx].
-	_ = col.Get(len(order) - 1)
+	// Eliminate bounds checks.
+	_ = col.Get(n - 1)
+	_ = outputCol[n-1]
 	outputCol[0] = true
 	if nulls != nil {
-		for outputIdx, checkIdx := range order {
+		for outputIdx := 0; outputIdx < n; outputIdx++ {
+			checkIdx := order[outputIdx]
 			{
 				var (
 					__retval_lastVal     int16
@@ -1936,7 +1929,8 @@ func (p partitionerInt16) partitionWithOrder(
 			}
 		}
 	} else {
-		for outputIdx, checkIdx := range order {
+		for outputIdx := 0; outputIdx < n; outputIdx++ {
+			checkIdx := order[outputIdx]
 			{
 				var __retval_0 int16
 				{
@@ -2380,15 +2374,13 @@ func (p partitionerInt32) partitionWithOrder(
 	}
 
 	col := colVec.Int32()
-	col = col[0:n]
-	outputCol = outputCol[:n]
-	// Eliminate bounds checks for outputcol[outputIdx].
-	_ = outputCol[len(order)-1]
-	// Eliminate bounds checks for col[outputIdx].
-	_ = col.Get(len(order) - 1)
+	// Eliminate bounds checks.
+	_ = col.Get(n - 1)
+	_ = outputCol[n-1]
 	outputCol[0] = true
 	if nulls != nil {
-		for outputIdx, checkIdx := range order {
+		for outputIdx := 0; outputIdx < n; outputIdx++ {
+			checkIdx := order[outputIdx]
 			{
 				var (
 					__retval_lastVal     int32
@@ -2440,7 +2432,8 @@ func (p partitionerInt32) partitionWithOrder(
 			}
 		}
 	} else {
-		for outputIdx, checkIdx := range order {
+		for outputIdx := 0; outputIdx < n; outputIdx++ {
+			checkIdx := order[outputIdx]
 			{
 				var __retval_0 int32
 				{
@@ -2884,15 +2877,13 @@ func (p partitionerInt64) partitionWithOrder(
 	}
 
 	col := colVec.Int64()
-	col = col[0:n]
-	outputCol = outputCol[:n]
-	// Eliminate bounds checks for outputcol[outputIdx].
-	_ = outputCol[len(order)-1]
-	// Eliminate bounds checks for col[outputIdx].
-	_ = col.Get(len(order) - 1)
+	// Eliminate bounds checks.
+	_ = col.Get(n - 1)
+	_ = outputCol[n-1]
 	outputCol[0] = true
 	if nulls != nil {
-		for outputIdx, checkIdx := range order {
+		for outputIdx := 0; outputIdx < n; outputIdx++ {
+			checkIdx := order[outputIdx]
 			{
 				var (
 					__retval_lastVal     int64
@@ -2944,7 +2935,8 @@ func (p partitionerInt64) partitionWithOrder(
 			}
 		}
 	} else {
-		for outputIdx, checkIdx := range order {
+		for outputIdx := 0; outputIdx < n; outputIdx++ {
+			checkIdx := order[outputIdx]
 			{
 				var __retval_0 int64
 				{
@@ -3420,15 +3412,13 @@ func (p partitionerFloat64) partitionWithOrder(
 	}
 
 	col := colVec.Float64()
-	col = col[0:n]
-	outputCol = outputCol[:n]
-	// Eliminate bounds checks for outputcol[outputIdx].
-	_ = outputCol[len(order)-1]
-	// Eliminate bounds checks for col[outputIdx].
-	_ = col.Get(len(order) - 1)
+	// Eliminate bounds checks.
+	_ = col.Get(n - 1)
+	_ = outputCol[n-1]
 	outputCol[0] = true
 	if nulls != nil {
-		for outputIdx, checkIdx := range order {
+		for outputIdx := 0; outputIdx < n; outputIdx++ {
+			checkIdx := order[outputIdx]
 			{
 				var (
 					__retval_lastVal     float64
@@ -3488,7 +3478,8 @@ func (p partitionerFloat64) partitionWithOrder(
 			}
 		}
 	} else {
-		for outputIdx, checkIdx := range order {
+		for outputIdx := 0; outputIdx < n; outputIdx++ {
+			checkIdx := order[outputIdx]
 			{
 				var __retval_0 float64
 				{
@@ -3940,15 +3931,13 @@ func (p partitionerTimestamp) partitionWithOrder(
 	}
 
 	col := colVec.Timestamp()
-	col = col[0:n]
-	outputCol = outputCol[:n]
-	// Eliminate bounds checks for outputcol[outputIdx].
-	_ = outputCol[len(order)-1]
-	// Eliminate bounds checks for col[outputIdx].
-	_ = col.Get(len(order) - 1)
+	// Eliminate bounds checks.
+	_ = col.Get(n - 1)
+	_ = outputCol[n-1]
 	outputCol[0] = true
 	if nulls != nil {
-		for outputIdx, checkIdx := range order {
+		for outputIdx := 0; outputIdx < n; outputIdx++ {
+			checkIdx := order[outputIdx]
 			{
 				var (
 					__retval_lastVal     time.Time
@@ -3996,7 +3985,8 @@ func (p partitionerTimestamp) partitionWithOrder(
 			}
 		}
 	} else {
-		for outputIdx, checkIdx := range order {
+		for outputIdx := 0; outputIdx < n; outputIdx++ {
+			checkIdx := order[outputIdx]
 			{
 				var __retval_0 time.Time
 				{
@@ -4384,15 +4374,13 @@ func (p partitionerInterval) partitionWithOrder(
 	}
 
 	col := colVec.Interval()
-	col = col[0:n]
-	outputCol = outputCol[:n]
-	// Eliminate bounds checks for outputcol[outputIdx].
-	_ = outputCol[len(order)-1]
-	// Eliminate bounds checks for col[outputIdx].
-	_ = col.Get(len(order) - 1)
+	// Eliminate bounds checks.
+	_ = col.Get(n - 1)
+	_ = outputCol[n-1]
 	outputCol[0] = true
 	if nulls != nil {
-		for outputIdx, checkIdx := range order {
+		for outputIdx := 0; outputIdx < n; outputIdx++ {
+			checkIdx := order[outputIdx]
 			{
 				var (
 					__retval_lastVal     duration.Duration
@@ -4433,7 +4421,8 @@ func (p partitionerInterval) partitionWithOrder(
 			}
 		}
 	} else {
-		for outputIdx, checkIdx := range order {
+		for outputIdx := 0; outputIdx < n; outputIdx++ {
+			checkIdx := order[outputIdx]
 			{
 				var __retval_0 duration.Duration
 				{
@@ -4808,15 +4797,13 @@ func (p partitionerDatum) partitionWithOrder(
 	}
 
 	col := colVec.Datum()
-	col = col.Slice(0, n)
-	outputCol = outputCol[:n]
-	// Eliminate bounds checks for outputcol[outputIdx].
-	_ = outputCol[len(order)-1]
-	// Eliminate bounds checks for col[outputIdx].
-	_ = col.Get(len(order) - 1)
+	// Eliminate bounds checks.
+	_ = col.Get(n - 1)
+	_ = outputCol[n-1]
 	outputCol[0] = true
 	if nulls != nil {
-		for outputIdx, checkIdx := range order {
+		for outputIdx := 0; outputIdx < n; outputIdx++ {
+			checkIdx := order[outputIdx]
 			{
 				var (
 					__retval_lastVal     interface{}
@@ -4859,7 +4846,8 @@ func (p partitionerDatum) partitionWithOrder(
 			}
 		}
 	} else {
-		for outputIdx, checkIdx := range order {
+		for outputIdx := 0; outputIdx < n; outputIdx++ {
+			checkIdx := order[outputIdx]
 			{
 				var __retval_0 interface{}
 				{

--- a/pkg/sql/colexec/distinct_tmpl.go
+++ b/pkg/sql/colexec/distinct_tmpl.go
@@ -303,19 +303,18 @@ func (p partitioner_TYPE) partitionWithOrder(
 	}
 
 	col := colVec.TemplateType()
-	col = execgen.SLICE(col, 0, n)
-	outputCol = outputCol[:n]
-	// Eliminate bounds checks for outputcol[outputIdx].
-	_ = outputCol[len(order)-1]
-	// Eliminate bounds checks for col[outputIdx].
-	_ = col.Get(len(order) - 1)
+	// Eliminate bounds checks.
+	_ = col.Get(n - 1)
+	_ = outputCol[n-1]
 	outputCol[0] = true
 	if nulls != nil {
-		for outputIdx, checkIdx := range order {
+		for outputIdx := 0; outputIdx < n; outputIdx++ {
+			checkIdx := order[outputIdx]
 			lastVal, lastValNull = checkDistinctWithNulls(checkIdx, outputIdx, lastVal, nulls, lastValNull, col, outputCol)
 		}
 	} else {
-		for outputIdx, checkIdx := range order {
+		for outputIdx := 0; outputIdx < n; outputIdx++ {
+			checkIdx := order[outputIdx]
 			lastVal = checkDistinct(checkIdx, outputIdx, lastVal, col, outputCol)
 		}
 	}

--- a/pkg/sql/colexec/execgen/cmd/execgen/cast_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/cast_gen.go
@@ -37,7 +37,6 @@ func genCastOperators(inputFileContents string, wr io.Writer) error {
 	castRe := makeFunctionRegex("_CAST", 4)
 	s = castRe.ReplaceAllString(s, makeTemplateFunctionCall("Right.Cast", 4))
 
-	s = strings.ReplaceAll(s, "_L_SLICE", "execgen.SLICE")
 	s = strings.ReplaceAll(s, "_L_UNSAFEGET", "execgen.UNSAFEGET")
 	s = replaceManipulationFuncsAmbiguous(".Left", s)
 

--- a/pkg/sql/colexec/execgen/cmd/execgen/selection_ops_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/selection_ops_gen.go
@@ -40,7 +40,6 @@ func getSelectionOpsTmpl(inputFileContents string) (*template.Template, error) {
 	s = strings.ReplaceAll(s, "_L_UNSAFEGET", "execgen.UNSAFEGET")
 	s = replaceManipulationFuncsAmbiguous(".Left", s)
 	s = strings.ReplaceAll(s, "_R_UNSAFEGET", "execgen.UNSAFEGET")
-	s = strings.ReplaceAll(s, "_R_SLICE", "execgen.SLICE")
 	s = replaceManipulationFuncsAmbiguous(".Right", s)
 
 	s = strings.ReplaceAll(s, "_HAS_NULLS", "$hasNulls")

--- a/pkg/sql/colexec/like_ops.eg.go
+++ b/pkg/sql/colexec/like_ops.eg.go
@@ -147,10 +147,8 @@ func (p projPrefixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col
-				_ = 0
-				_ = n
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -173,10 +171,8 @@ func (p projPrefixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 					projCol[i] = bytes.HasPrefix(arg, p.constArg)
 				}
 			} else {
-				col = col
-				_ = 0
-				_ = n
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 					projCol[i] = bytes.HasPrefix(arg, p.constArg)
@@ -336,10 +332,8 @@ func (p projSuffixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col
-				_ = 0
-				_ = n
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -362,10 +356,8 @@ func (p projSuffixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 					projCol[i] = bytes.HasSuffix(arg, p.constArg)
 				}
 			} else {
-				col = col
-				_ = 0
-				_ = n
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 					projCol[i] = bytes.HasSuffix(arg, p.constArg)
@@ -525,10 +517,8 @@ func (p projContainsBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col
-				_ = 0
-				_ = n
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -551,10 +541,8 @@ func (p projContainsBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 					projCol[i] = bytes.Contains(arg, p.constArg)
 				}
 			} else {
-				col = col
-				_ = 0
-				_ = n
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 					projCol[i] = bytes.Contains(arg, p.constArg)
@@ -714,10 +702,8 @@ func (p projRegexpBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col
-				_ = 0
-				_ = n
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -740,10 +726,8 @@ func (p projRegexpBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 					projCol[i] = p.constArg.Match(arg)
 				}
 			} else {
-				col = col
-				_ = 0
-				_ = n
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 					projCol[i] = p.constArg.Match(arg)
@@ -903,10 +887,8 @@ func (p projNotPrefixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch 
 					}
 				}
 			} else {
-				col = col
-				_ = 0
-				_ = n
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -929,10 +911,8 @@ func (p projNotPrefixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch 
 					projCol[i] = !bytes.HasPrefix(arg, p.constArg)
 				}
 			} else {
-				col = col
-				_ = 0
-				_ = n
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 					projCol[i] = !bytes.HasPrefix(arg, p.constArg)
@@ -1092,10 +1072,8 @@ func (p projNotSuffixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch 
 					}
 				}
 			} else {
-				col = col
-				_ = 0
-				_ = n
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -1118,10 +1096,8 @@ func (p projNotSuffixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch 
 					projCol[i] = !bytes.HasSuffix(arg, p.constArg)
 				}
 			} else {
-				col = col
-				_ = 0
-				_ = n
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 					projCol[i] = !bytes.HasSuffix(arg, p.constArg)
@@ -1281,10 +1257,8 @@ func (p projNotContainsBytesBytesConstOp) Next(ctx context.Context) coldata.Batc
 					}
 				}
 			} else {
-				col = col
-				_ = 0
-				_ = n
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -1307,10 +1281,8 @@ func (p projNotContainsBytesBytesConstOp) Next(ctx context.Context) coldata.Batc
 					projCol[i] = !bytes.Contains(arg, p.constArg)
 				}
 			} else {
-				col = col
-				_ = 0
-				_ = n
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 					projCol[i] = !bytes.Contains(arg, p.constArg)
@@ -1470,10 +1442,8 @@ func (p projNotRegexpBytesBytesConstOp) Next(ctx context.Context) coldata.Batch 
 					}
 				}
 			} else {
-				col = col
-				_ = 0
-				_ = n
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -1496,10 +1466,8 @@ func (p projNotRegexpBytesBytesConstOp) Next(ctx context.Context) coldata.Batch 
 					projCol[i] = !p.constArg.Match(arg)
 				}
 			} else {
-				col = col
-				_ = 0
-				_ = n
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 					projCol[i] = !p.constArg.Match(arg)

--- a/pkg/sql/colexec/proj_const_left_ops.eg.go
+++ b/pkg/sql/colexec/proj_const_left_ops.eg.go
@@ -87,8 +87,8 @@ func (p projBitandInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -115,8 +115,8 @@ func (p projBitandInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -188,8 +188,8 @@ func (p projBitandInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -216,8 +216,8 @@ func (p projBitandInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -289,8 +289,8 @@ func (p projBitandInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -317,8 +317,8 @@ func (p projBitandInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -390,8 +390,8 @@ func (p projBitandInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -418,8 +418,8 @@ func (p projBitandInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -491,8 +491,8 @@ func (p projBitandInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -519,8 +519,8 @@ func (p projBitandInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -592,8 +592,8 @@ func (p projBitandInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -620,8 +620,8 @@ func (p projBitandInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -693,8 +693,8 @@ func (p projBitandInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -721,8 +721,8 @@ func (p projBitandInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -794,8 +794,8 @@ func (p projBitandInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -822,8 +822,8 @@ func (p projBitandInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -895,8 +895,8 @@ func (p projBitandInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -923,8 +923,8 @@ func (p projBitandInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -1003,8 +1003,8 @@ func (p projBitandDatumConstDatumOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -1045,8 +1045,8 @@ func (p projBitandDatumConstDatumOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -1125,8 +1125,8 @@ func (p projBitorInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -1153,8 +1153,8 @@ func (p projBitorInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -1226,8 +1226,8 @@ func (p projBitorInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -1254,8 +1254,8 @@ func (p projBitorInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -1327,8 +1327,8 @@ func (p projBitorInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -1355,8 +1355,8 @@ func (p projBitorInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -1428,8 +1428,8 @@ func (p projBitorInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -1456,8 +1456,8 @@ func (p projBitorInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -1529,8 +1529,8 @@ func (p projBitorInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -1557,8 +1557,8 @@ func (p projBitorInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -1630,8 +1630,8 @@ func (p projBitorInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -1658,8 +1658,8 @@ func (p projBitorInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -1731,8 +1731,8 @@ func (p projBitorInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -1759,8 +1759,8 @@ func (p projBitorInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -1832,8 +1832,8 @@ func (p projBitorInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -1860,8 +1860,8 @@ func (p projBitorInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -1933,8 +1933,8 @@ func (p projBitorInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -1961,8 +1961,8 @@ func (p projBitorInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -2041,8 +2041,8 @@ func (p projBitorDatumConstDatumOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -2083,8 +2083,8 @@ func (p projBitorDatumConstDatumOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -2163,8 +2163,8 @@ func (p projBitxorInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -2191,8 +2191,8 @@ func (p projBitxorInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -2264,8 +2264,8 @@ func (p projBitxorInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -2292,8 +2292,8 @@ func (p projBitxorInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -2365,8 +2365,8 @@ func (p projBitxorInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -2393,8 +2393,8 @@ func (p projBitxorInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -2466,8 +2466,8 @@ func (p projBitxorInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -2494,8 +2494,8 @@ func (p projBitxorInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -2567,8 +2567,8 @@ func (p projBitxorInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -2595,8 +2595,8 @@ func (p projBitxorInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -2668,8 +2668,8 @@ func (p projBitxorInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -2696,8 +2696,8 @@ func (p projBitxorInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -2769,8 +2769,8 @@ func (p projBitxorInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -2797,8 +2797,8 @@ func (p projBitxorInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -2870,8 +2870,8 @@ func (p projBitxorInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -2898,8 +2898,8 @@ func (p projBitxorInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -2971,8 +2971,8 @@ func (p projBitxorInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -2999,8 +2999,8 @@ func (p projBitxorInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -3079,8 +3079,8 @@ func (p projBitxorDatumConstDatumOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -3121,8 +3121,8 @@ func (p projBitxorDatumConstDatumOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -3208,8 +3208,8 @@ func (p projPlusDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -3250,8 +3250,8 @@ func (p projPlusDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -3337,8 +3337,8 @@ func (p projPlusDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -3379,8 +3379,8 @@ func (p projPlusDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -3466,8 +3466,8 @@ func (p projPlusDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -3508,8 +3508,8 @@ func (p projPlusDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -3594,8 +3594,8 @@ func (p projPlusDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -3634,8 +3634,8 @@ func (p projPlusDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -3719,8 +3719,8 @@ func (p projPlusInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -3759,8 +3759,8 @@ func (p projPlusInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -3844,8 +3844,8 @@ func (p projPlusInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -3884,8 +3884,8 @@ func (p projPlusInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -3969,8 +3969,8 @@ func (p projPlusInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -4009,8 +4009,8 @@ func (p projPlusInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -4096,8 +4096,8 @@ func (p projPlusInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -4140,8 +4140,8 @@ func (p projPlusInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -4234,8 +4234,8 @@ func (p projPlusInt16ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -4288,8 +4288,8 @@ func (p projPlusInt16ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -4380,8 +4380,8 @@ func (p projPlusInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -4420,8 +4420,8 @@ func (p projPlusInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -4505,8 +4505,8 @@ func (p projPlusInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -4545,8 +4545,8 @@ func (p projPlusInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -4630,8 +4630,8 @@ func (p projPlusInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -4670,8 +4670,8 @@ func (p projPlusInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -4757,8 +4757,8 @@ func (p projPlusInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -4801,8 +4801,8 @@ func (p projPlusInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -4895,8 +4895,8 @@ func (p projPlusInt32ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -4949,8 +4949,8 @@ func (p projPlusInt32ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -5041,8 +5041,8 @@ func (p projPlusInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -5081,8 +5081,8 @@ func (p projPlusInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -5166,8 +5166,8 @@ func (p projPlusInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -5206,8 +5206,8 @@ func (p projPlusInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -5291,8 +5291,8 @@ func (p projPlusInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -5331,8 +5331,8 @@ func (p projPlusInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -5418,8 +5418,8 @@ func (p projPlusInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -5462,8 +5462,8 @@ func (p projPlusInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -5556,8 +5556,8 @@ func (p projPlusInt64ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -5610,8 +5610,8 @@ func (p projPlusInt64ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -5699,8 +5699,8 @@ func (p projPlusFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -5733,8 +5733,8 @@ func (p projPlusFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -5807,8 +5807,8 @@ func (p projPlusTimestampConstIntervalOp) Next(ctx context.Context) coldata.Batc
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -5831,8 +5831,8 @@ func (p projPlusTimestampConstIntervalOp) Next(ctx context.Context) coldata.Batc
 					projCol[i] = duration.Add(p.constArg, arg)
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 					projCol[i] = duration.Add(p.constArg, arg)
@@ -5900,8 +5900,8 @@ func (p projPlusIntervalConstTimestampOp) Next(ctx context.Context) coldata.Batc
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -5924,8 +5924,8 @@ func (p projPlusIntervalConstTimestampOp) Next(ctx context.Context) coldata.Batc
 					projCol[i] = duration.Add(arg, p.constArg)
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 					projCol[i] = duration.Add(arg, p.constArg)
@@ -5993,8 +5993,8 @@ func (p projPlusIntervalConstIntervalOp) Next(ctx context.Context) coldata.Batch
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -6017,8 +6017,8 @@ func (p projPlusIntervalConstIntervalOp) Next(ctx context.Context) coldata.Batch
 					projCol[i] = p.constArg.Add(arg)
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 					projCol[i] = p.constArg.Add(arg)
@@ -6101,8 +6101,8 @@ func (p projPlusIntervalConstDatumOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -6155,8 +6155,8 @@ func (p projPlusIntervalConstDatumOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -6252,8 +6252,8 @@ func (p projPlusDatumConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -6302,8 +6302,8 @@ func (p projPlusDatumConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -6397,8 +6397,8 @@ func (p projPlusDatumConstInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -6447,8 +6447,8 @@ func (p projPlusDatumConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -6542,8 +6542,8 @@ func (p projPlusDatumConstInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -6592,8 +6592,8 @@ func (p projPlusDatumConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -6687,8 +6687,8 @@ func (p projPlusDatumConstInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -6737,8 +6737,8 @@ func (p projPlusDatumConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -6828,8 +6828,8 @@ func (p projMinusDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -6870,8 +6870,8 @@ func (p projMinusDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -6957,8 +6957,8 @@ func (p projMinusDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -6999,8 +6999,8 @@ func (p projMinusDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -7086,8 +7086,8 @@ func (p projMinusDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -7128,8 +7128,8 @@ func (p projMinusDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -7214,8 +7214,8 @@ func (p projMinusDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch 
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -7254,8 +7254,8 @@ func (p projMinusDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch 
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -7339,8 +7339,8 @@ func (p projMinusInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -7379,8 +7379,8 @@ func (p projMinusInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -7464,8 +7464,8 @@ func (p projMinusInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -7504,8 +7504,8 @@ func (p projMinusInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -7589,8 +7589,8 @@ func (p projMinusInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -7629,8 +7629,8 @@ func (p projMinusInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -7716,8 +7716,8 @@ func (p projMinusInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -7760,8 +7760,8 @@ func (p projMinusInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -7854,8 +7854,8 @@ func (p projMinusInt16ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -7908,8 +7908,8 @@ func (p projMinusInt16ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -8000,8 +8000,8 @@ func (p projMinusInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -8040,8 +8040,8 @@ func (p projMinusInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -8125,8 +8125,8 @@ func (p projMinusInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -8165,8 +8165,8 @@ func (p projMinusInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -8250,8 +8250,8 @@ func (p projMinusInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -8290,8 +8290,8 @@ func (p projMinusInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -8377,8 +8377,8 @@ func (p projMinusInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -8421,8 +8421,8 @@ func (p projMinusInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -8515,8 +8515,8 @@ func (p projMinusInt32ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -8569,8 +8569,8 @@ func (p projMinusInt32ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -8661,8 +8661,8 @@ func (p projMinusInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -8701,8 +8701,8 @@ func (p projMinusInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -8786,8 +8786,8 @@ func (p projMinusInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -8826,8 +8826,8 @@ func (p projMinusInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -8911,8 +8911,8 @@ func (p projMinusInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -8951,8 +8951,8 @@ func (p projMinusInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -9038,8 +9038,8 @@ func (p projMinusInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -9082,8 +9082,8 @@ func (p projMinusInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -9176,8 +9176,8 @@ func (p projMinusInt64ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -9230,8 +9230,8 @@ func (p projMinusInt64ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -9319,8 +9319,8 @@ func (p projMinusFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch 
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -9353,8 +9353,8 @@ func (p projMinusFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch 
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -9430,8 +9430,8 @@ func (p projMinusTimestampConstTimestampOp) Next(ctx context.Context) coldata.Ba
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -9460,8 +9460,8 @@ func (p projMinusTimestampConstTimestampOp) Next(ctx context.Context) coldata.Ba
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -9532,8 +9532,8 @@ func (p projMinusTimestampConstIntervalOp) Next(ctx context.Context) coldata.Bat
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -9556,8 +9556,8 @@ func (p projMinusTimestampConstIntervalOp) Next(ctx context.Context) coldata.Bat
 					projCol[i] = duration.Add(p.constArg, arg.Mul(-1))
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 					projCol[i] = duration.Add(p.constArg, arg.Mul(-1))
@@ -9625,8 +9625,8 @@ func (p projMinusIntervalConstIntervalOp) Next(ctx context.Context) coldata.Batc
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -9649,8 +9649,8 @@ func (p projMinusIntervalConstIntervalOp) Next(ctx context.Context) coldata.Batc
 					projCol[i] = p.constArg.Sub(arg)
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 					projCol[i] = p.constArg.Sub(arg)
@@ -9733,8 +9733,8 @@ func (p projMinusIntervalConstDatumOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -9787,8 +9787,8 @@ func (p projMinusIntervalConstDatumOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -9880,8 +9880,8 @@ func (p projMinusDatumConstDatumOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -9922,8 +9922,8 @@ func (p projMinusDatumConstDatumOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -10013,8 +10013,8 @@ func (p projMinusDatumConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -10063,8 +10063,8 @@ func (p projMinusDatumConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -10158,10 +10158,8 @@ func (p projMinusDatumConstBytesOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col
-				_ = 0
-				_ = n
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -10210,10 +10208,8 @@ func (p projMinusDatumConstBytesOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col
-				_ = 0
-				_ = n
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -10307,8 +10303,8 @@ func (p projMinusDatumConstInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -10357,8 +10353,8 @@ func (p projMinusDatumConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -10452,8 +10448,8 @@ func (p projMinusDatumConstInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -10502,8 +10498,8 @@ func (p projMinusDatumConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -10597,8 +10593,8 @@ func (p projMinusDatumConstInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -10647,8 +10643,8 @@ func (p projMinusDatumConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -10738,8 +10734,8 @@ func (p projMultDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -10780,8 +10776,8 @@ func (p projMultDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -10867,8 +10863,8 @@ func (p projMultDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -10909,8 +10905,8 @@ func (p projMultDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -10996,8 +10992,8 @@ func (p projMultDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -11038,8 +11034,8 @@ func (p projMultDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -11124,8 +11120,8 @@ func (p projMultDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -11164,8 +11160,8 @@ func (p projMultDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -11246,8 +11242,8 @@ func (p projMultDecimalConstIntervalOp) Next(ctx context.Context) coldata.Batch 
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -11280,8 +11276,8 @@ func (p projMultDecimalConstIntervalOp) Next(ctx context.Context) coldata.Batch 
 					projCol[i] = arg.MulFloat(f)
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -11370,8 +11366,8 @@ func (p projMultInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -11426,8 +11422,8 @@ func (p projMultInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -11527,8 +11523,8 @@ func (p projMultInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -11583,8 +11579,8 @@ func (p projMultInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -11684,8 +11680,8 @@ func (p projMultInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -11740,8 +11736,8 @@ func (p projMultInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -11835,8 +11831,8 @@ func (p projMultInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -11879,8 +11875,8 @@ func (p projMultInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -11958,8 +11954,8 @@ func (p projMultInt16ConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -11982,8 +11978,8 @@ func (p projMultInt16ConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 					projCol[i] = arg.Mul(int64(p.constArg))
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 					projCol[i] = arg.Mul(int64(p.constArg))
@@ -12067,8 +12063,8 @@ func (p projMultInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -12123,8 +12119,8 @@ func (p projMultInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -12224,8 +12220,8 @@ func (p projMultInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -12280,8 +12276,8 @@ func (p projMultInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -12381,8 +12377,8 @@ func (p projMultInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -12437,8 +12433,8 @@ func (p projMultInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -12532,8 +12528,8 @@ func (p projMultInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -12576,8 +12572,8 @@ func (p projMultInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -12655,8 +12651,8 @@ func (p projMultInt32ConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -12679,8 +12675,8 @@ func (p projMultInt32ConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 					projCol[i] = arg.Mul(int64(p.constArg))
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 					projCol[i] = arg.Mul(int64(p.constArg))
@@ -12764,8 +12760,8 @@ func (p projMultInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -12820,8 +12816,8 @@ func (p projMultInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -12921,8 +12917,8 @@ func (p projMultInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -12977,8 +12973,8 @@ func (p projMultInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -13078,8 +13074,8 @@ func (p projMultInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -13134,8 +13130,8 @@ func (p projMultInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -13229,8 +13225,8 @@ func (p projMultInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -13273,8 +13269,8 @@ func (p projMultInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -13352,8 +13348,8 @@ func (p projMultInt64ConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -13376,8 +13372,8 @@ func (p projMultInt64ConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 					projCol[i] = arg.Mul(int64(p.constArg))
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 					projCol[i] = arg.Mul(int64(p.constArg))
@@ -13450,8 +13446,8 @@ func (p projMultFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -13484,8 +13480,8 @@ func (p projMultFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -13558,8 +13554,8 @@ func (p projMultFloat64ConstIntervalOp) Next(ctx context.Context) coldata.Batch 
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -13582,8 +13578,8 @@ func (p projMultFloat64ConstIntervalOp) Next(ctx context.Context) coldata.Batch 
 					projCol[i] = arg.MulFloat(float64(p.constArg))
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 					projCol[i] = arg.MulFloat(float64(p.constArg))
@@ -13651,8 +13647,8 @@ func (p projMultIntervalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -13675,8 +13671,8 @@ func (p projMultIntervalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 					projCol[i] = p.constArg.Mul(int64(arg))
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 					projCol[i] = p.constArg.Mul(int64(arg))
@@ -13744,8 +13740,8 @@ func (p projMultIntervalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -13768,8 +13764,8 @@ func (p projMultIntervalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 					projCol[i] = p.constArg.Mul(int64(arg))
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 					projCol[i] = p.constArg.Mul(int64(arg))
@@ -13837,8 +13833,8 @@ func (p projMultIntervalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -13861,8 +13857,8 @@ func (p projMultIntervalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 					projCol[i] = p.constArg.Mul(int64(arg))
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 					projCol[i] = p.constArg.Mul(int64(arg))
@@ -13930,8 +13926,8 @@ func (p projMultIntervalConstFloat64Op) Next(ctx context.Context) coldata.Batch 
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -13954,8 +13950,8 @@ func (p projMultIntervalConstFloat64Op) Next(ctx context.Context) coldata.Batch 
 					projCol[i] = p.constArg.MulFloat(float64(arg))
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 					projCol[i] = p.constArg.MulFloat(float64(arg))
@@ -14028,8 +14024,8 @@ func (p projMultIntervalConstDecimalOp) Next(ctx context.Context) coldata.Batch 
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -14062,8 +14058,8 @@ func (p projMultIntervalConstDecimalOp) Next(ctx context.Context) coldata.Batch 
 					projCol[i] = p.constArg.MulFloat(f)
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -14149,8 +14145,8 @@ func (p projDivDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -14199,8 +14195,8 @@ func (p projDivDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -14294,8 +14290,8 @@ func (p projDivDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -14344,8 +14340,8 @@ func (p projDivDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -14439,8 +14435,8 @@ func (p projDivDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -14489,8 +14485,8 @@ func (p projDivDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -14583,8 +14579,8 @@ func (p projDivDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -14631,8 +14627,8 @@ func (p projDivDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -14724,8 +14720,8 @@ func (p projDivInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -14772,8 +14768,8 @@ func (p projDivInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -14865,8 +14861,8 @@ func (p projDivInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -14913,8 +14909,8 @@ func (p projDivInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -15006,8 +15002,8 @@ func (p projDivInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -15054,8 +15050,8 @@ func (p projDivInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -15149,8 +15145,8 @@ func (p projDivInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -15201,8 +15197,8 @@ func (p projDivInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -15296,8 +15292,8 @@ func (p projDivInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -15344,8 +15340,8 @@ func (p projDivInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -15437,8 +15433,8 @@ func (p projDivInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -15485,8 +15481,8 @@ func (p projDivInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -15578,8 +15574,8 @@ func (p projDivInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -15626,8 +15622,8 @@ func (p projDivInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -15721,8 +15717,8 @@ func (p projDivInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -15773,8 +15769,8 @@ func (p projDivInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -15868,8 +15864,8 @@ func (p projDivInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -15916,8 +15912,8 @@ func (p projDivInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -16009,8 +16005,8 @@ func (p projDivInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -16057,8 +16053,8 @@ func (p projDivInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -16150,8 +16146,8 @@ func (p projDivInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -16198,8 +16194,8 @@ func (p projDivInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -16293,8 +16289,8 @@ func (p projDivInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -16345,8 +16341,8 @@ func (p projDivInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -16437,8 +16433,8 @@ func (p projDivFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -16479,8 +16475,8 @@ func (p projDivFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -16561,8 +16557,8 @@ func (p projDivIntervalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -16593,8 +16589,8 @@ func (p projDivIntervalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 					projCol[i] = p.constArg.Div(int64(arg))
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -16670,8 +16666,8 @@ func (p projDivIntervalConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -16702,8 +16698,8 @@ func (p projDivIntervalConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 					projCol[i] = p.constArg.DivFloat(float64(arg))
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -16788,8 +16784,8 @@ func (p projFloorDivDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -16838,8 +16834,8 @@ func (p projFloorDivDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -16933,8 +16929,8 @@ func (p projFloorDivDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -16983,8 +16979,8 @@ func (p projFloorDivDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -17078,8 +17074,8 @@ func (p projFloorDivDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -17128,8 +17124,8 @@ func (p projFloorDivDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -17222,8 +17218,8 @@ func (p projFloorDivDecimalConstDecimalOp) Next(ctx context.Context) coldata.Bat
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -17270,8 +17266,8 @@ func (p projFloorDivDecimalConstDecimalOp) Next(ctx context.Context) coldata.Bat
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -17358,8 +17354,8 @@ func (p projFloorDivInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -17396,8 +17392,8 @@ func (p projFloorDivInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -17479,8 +17475,8 @@ func (p projFloorDivInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -17517,8 +17513,8 @@ func (p projFloorDivInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -17600,8 +17596,8 @@ func (p projFloorDivInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -17638,8 +17634,8 @@ func (p projFloorDivInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -17728,8 +17724,8 @@ func (p projFloorDivInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -17780,8 +17776,8 @@ func (p projFloorDivInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -17870,8 +17866,8 @@ func (p projFloorDivInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -17908,8 +17904,8 @@ func (p projFloorDivInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -17991,8 +17987,8 @@ func (p projFloorDivInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -18029,8 +18025,8 @@ func (p projFloorDivInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -18112,8 +18108,8 @@ func (p projFloorDivInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -18150,8 +18146,8 @@ func (p projFloorDivInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -18240,8 +18236,8 @@ func (p projFloorDivInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -18292,8 +18288,8 @@ func (p projFloorDivInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -18382,8 +18378,8 @@ func (p projFloorDivInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -18420,8 +18416,8 @@ func (p projFloorDivInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -18503,8 +18499,8 @@ func (p projFloorDivInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -18541,8 +18537,8 @@ func (p projFloorDivInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -18624,8 +18620,8 @@ func (p projFloorDivInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -18662,8 +18658,8 @@ func (p projFloorDivInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -18752,8 +18748,8 @@ func (p projFloorDivInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -18804,8 +18800,8 @@ func (p projFloorDivInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -18896,8 +18892,8 @@ func (p projFloorDivFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Bat
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -18938,8 +18934,8 @@ func (p projFloorDivFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Bat
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -19029,8 +19025,8 @@ func (p projModDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -19079,8 +19075,8 @@ func (p projModDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -19174,8 +19170,8 @@ func (p projModDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -19224,8 +19220,8 @@ func (p projModDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -19319,8 +19315,8 @@ func (p projModDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -19369,8 +19365,8 @@ func (p projModDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -19463,8 +19459,8 @@ func (p projModDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -19511,8 +19507,8 @@ func (p projModDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -19599,8 +19595,8 @@ func (p projModInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -19637,8 +19633,8 @@ func (p projModInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -19720,8 +19716,8 @@ func (p projModInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -19758,8 +19754,8 @@ func (p projModInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -19841,8 +19837,8 @@ func (p projModInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -19879,8 +19875,8 @@ func (p projModInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -19969,8 +19965,8 @@ func (p projModInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -20021,8 +20017,8 @@ func (p projModInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -20111,8 +20107,8 @@ func (p projModInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -20149,8 +20145,8 @@ func (p projModInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -20232,8 +20228,8 @@ func (p projModInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -20270,8 +20266,8 @@ func (p projModInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -20353,8 +20349,8 @@ func (p projModInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -20391,8 +20387,8 @@ func (p projModInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -20481,8 +20477,8 @@ func (p projModInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -20533,8 +20529,8 @@ func (p projModInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -20623,8 +20619,8 @@ func (p projModInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -20661,8 +20657,8 @@ func (p projModInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -20744,8 +20740,8 @@ func (p projModInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -20782,8 +20778,8 @@ func (p projModInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -20865,8 +20861,8 @@ func (p projModInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -20903,8 +20899,8 @@ func (p projModInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -20993,8 +20989,8 @@ func (p projModInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -21045,8 +21041,8 @@ func (p projModInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -21137,8 +21133,8 @@ func (p projModFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -21179,8 +21175,8 @@ func (p projModFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -21266,8 +21262,8 @@ func (p projPowDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -21308,8 +21304,8 @@ func (p projPowDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -21395,8 +21391,8 @@ func (p projPowDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -21437,8 +21433,8 @@ func (p projPowDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -21524,8 +21520,8 @@ func (p projPowDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -21566,8 +21562,8 @@ func (p projPowDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -21652,8 +21648,8 @@ func (p projPowDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -21692,8 +21688,8 @@ func (p projPowDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -21783,8 +21779,8 @@ func (p projPowInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -21835,8 +21831,8 @@ func (p projPowInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -21932,8 +21928,8 @@ func (p projPowInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -21984,8 +21980,8 @@ func (p projPowInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -22081,8 +22077,8 @@ func (p projPowInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -22133,8 +22129,8 @@ func (p projPowInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -22226,8 +22222,8 @@ func (p projPowInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -22270,8 +22266,8 @@ func (p projPowInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -22363,8 +22359,8 @@ func (p projPowInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -22415,8 +22411,8 @@ func (p projPowInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -22512,8 +22508,8 @@ func (p projPowInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -22564,8 +22560,8 @@ func (p projPowInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -22661,8 +22657,8 @@ func (p projPowInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -22713,8 +22709,8 @@ func (p projPowInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -22806,8 +22802,8 @@ func (p projPowInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -22850,8 +22846,8 @@ func (p projPowInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -22943,8 +22939,8 @@ func (p projPowInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -22995,8 +22991,8 @@ func (p projPowInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -23092,8 +23088,8 @@ func (p projPowInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -23144,8 +23140,8 @@ func (p projPowInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -23241,8 +23237,8 @@ func (p projPowInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -23293,8 +23289,8 @@ func (p projPowInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -23386,8 +23382,8 @@ func (p projPowInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -23430,8 +23426,8 @@ func (p projPowInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -23514,8 +23510,8 @@ func (p projPowFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -23548,8 +23544,8 @@ func (p projPowFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -23629,10 +23625,8 @@ func (p projConcatBytesConstBytesOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col
-				_ = 0
-				_ = n
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -23669,10 +23663,8 @@ func (p projConcatBytesConstBytesOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col
-				_ = 0
-				_ = n
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -23756,8 +23748,8 @@ func (p projConcatDatumConstDatumOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -23798,8 +23790,8 @@ func (p projConcatDatumConstDatumOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -23884,8 +23876,8 @@ func (p projLShiftInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -23924,8 +23916,8 @@ func (p projLShiftInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -24009,8 +24001,8 @@ func (p projLShiftInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -24049,8 +24041,8 @@ func (p projLShiftInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -24134,8 +24126,8 @@ func (p projLShiftInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -24174,8 +24166,8 @@ func (p projLShiftInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -24259,8 +24251,8 @@ func (p projLShiftInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -24299,8 +24291,8 @@ func (p projLShiftInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -24384,8 +24376,8 @@ func (p projLShiftInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -24424,8 +24416,8 @@ func (p projLShiftInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -24509,8 +24501,8 @@ func (p projLShiftInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -24549,8 +24541,8 @@ func (p projLShiftInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -24634,8 +24626,8 @@ func (p projLShiftInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -24674,8 +24666,8 @@ func (p projLShiftInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -24759,8 +24751,8 @@ func (p projLShiftInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -24799,8 +24791,8 @@ func (p projLShiftInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -24884,8 +24876,8 @@ func (p projLShiftInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -24924,8 +24916,8 @@ func (p projLShiftInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -25014,8 +25006,8 @@ func (p projLShiftDatumConstInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -25064,8 +25056,8 @@ func (p projLShiftDatumConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -25159,8 +25151,8 @@ func (p projLShiftDatumConstInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -25209,8 +25201,8 @@ func (p projLShiftDatumConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -25304,8 +25296,8 @@ func (p projLShiftDatumConstInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -25354,8 +25346,8 @@ func (p projLShiftDatumConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -25444,8 +25436,8 @@ func (p projRShiftInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -25484,8 +25476,8 @@ func (p projRShiftInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -25569,8 +25561,8 @@ func (p projRShiftInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -25609,8 +25601,8 @@ func (p projRShiftInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -25694,8 +25686,8 @@ func (p projRShiftInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -25734,8 +25726,8 @@ func (p projRShiftInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -25819,8 +25811,8 @@ func (p projRShiftInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -25859,8 +25851,8 @@ func (p projRShiftInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -25944,8 +25936,8 @@ func (p projRShiftInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -25984,8 +25976,8 @@ func (p projRShiftInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -26069,8 +26061,8 @@ func (p projRShiftInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -26109,8 +26101,8 @@ func (p projRShiftInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -26194,8 +26186,8 @@ func (p projRShiftInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -26234,8 +26226,8 @@ func (p projRShiftInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -26319,8 +26311,8 @@ func (p projRShiftInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -26359,8 +26351,8 @@ func (p projRShiftInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -26444,8 +26436,8 @@ func (p projRShiftInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -26484,8 +26476,8 @@ func (p projRShiftInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -26574,8 +26566,8 @@ func (p projRShiftDatumConstInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -26624,8 +26616,8 @@ func (p projRShiftDatumConstInt16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -26719,8 +26711,8 @@ func (p projRShiftDatumConstInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -26769,8 +26761,8 @@ func (p projRShiftDatumConstInt32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -26864,8 +26856,8 @@ func (p projRShiftDatumConstInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -26914,8 +26906,8 @@ func (p projRShiftDatumConstInt64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -27009,10 +27001,8 @@ func (p projJSONFetchValDatumConstBytesOp) Next(ctx context.Context) coldata.Bat
 					}
 				}
 			} else {
-				col = col
-				_ = 0
-				_ = n
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -27061,10 +27051,8 @@ func (p projJSONFetchValDatumConstBytesOp) Next(ctx context.Context) coldata.Bat
 
 				}
 			} else {
-				col = col
-				_ = 0
-				_ = n
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -27158,8 +27146,8 @@ func (p projJSONFetchValDatumConstInt16Op) Next(ctx context.Context) coldata.Bat
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -27208,8 +27196,8 @@ func (p projJSONFetchValDatumConstInt16Op) Next(ctx context.Context) coldata.Bat
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -27303,8 +27291,8 @@ func (p projJSONFetchValDatumConstInt32Op) Next(ctx context.Context) coldata.Bat
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -27353,8 +27341,8 @@ func (p projJSONFetchValDatumConstInt32Op) Next(ctx context.Context) coldata.Bat
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -27448,8 +27436,8 @@ func (p projJSONFetchValDatumConstInt64Op) Next(ctx context.Context) coldata.Bat
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -27498,8 +27486,8 @@ func (p projJSONFetchValDatumConstInt64Op) Next(ctx context.Context) coldata.Bat
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -27589,8 +27577,8 @@ func (p projJSONFetchValPathDatumConstDatumOp) Next(ctx context.Context) coldata
 					}
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -27631,8 +27619,8 @@ func (p projJSONFetchValPathDatumConstDatumOp) Next(ctx context.Context) coldata
 
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 

--- a/pkg/sql/colexec/proj_const_ops_tmpl.go
+++ b/pkg/sql/colexec/proj_const_ops_tmpl.go
@@ -150,8 +150,8 @@ func _SET_PROJECTION(_HAS_NULLS bool) {
 			_SET_SINGLE_TUPLE_PROJECTION(_HAS_NULLS)
 		}
 	} else {
-		col = execgen.SLICE(col, 0, n)
 		_ = projCol.Get(n - 1)
+		_ = col.Get(n - 1)
 		for i := 0; i < n; i++ {
 			_SET_SINGLE_TUPLE_PROJECTION(_HAS_NULLS)
 		}

--- a/pkg/sql/colexec/proj_const_right_ops.eg.go
+++ b/pkg/sql/colexec/proj_const_right_ops.eg.go
@@ -88,8 +88,8 @@ func (p projBitandInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -116,8 +116,8 @@ func (p projBitandInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -189,8 +189,8 @@ func (p projBitandInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -217,8 +217,8 @@ func (p projBitandInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -290,8 +290,8 @@ func (p projBitandInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -318,8 +318,8 @@ func (p projBitandInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -391,8 +391,8 @@ func (p projBitandInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -419,8 +419,8 @@ func (p projBitandInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -492,8 +492,8 @@ func (p projBitandInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -520,8 +520,8 @@ func (p projBitandInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -593,8 +593,8 @@ func (p projBitandInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -621,8 +621,8 @@ func (p projBitandInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -694,8 +694,8 @@ func (p projBitandInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -722,8 +722,8 @@ func (p projBitandInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -795,8 +795,8 @@ func (p projBitandInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -823,8 +823,8 @@ func (p projBitandInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -896,8 +896,8 @@ func (p projBitandInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -924,8 +924,8 @@ func (p projBitandInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -1004,8 +1004,8 @@ func (p projBitandDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -1046,8 +1046,8 @@ func (p projBitandDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -1126,8 +1126,8 @@ func (p projBitorInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -1154,8 +1154,8 @@ func (p projBitorInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -1227,8 +1227,8 @@ func (p projBitorInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -1255,8 +1255,8 @@ func (p projBitorInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -1328,8 +1328,8 @@ func (p projBitorInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -1356,8 +1356,8 @@ func (p projBitorInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -1429,8 +1429,8 @@ func (p projBitorInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -1457,8 +1457,8 @@ func (p projBitorInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -1530,8 +1530,8 @@ func (p projBitorInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -1558,8 +1558,8 @@ func (p projBitorInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -1631,8 +1631,8 @@ func (p projBitorInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -1659,8 +1659,8 @@ func (p projBitorInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -1732,8 +1732,8 @@ func (p projBitorInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -1760,8 +1760,8 @@ func (p projBitorInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -1833,8 +1833,8 @@ func (p projBitorInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -1861,8 +1861,8 @@ func (p projBitorInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -1934,8 +1934,8 @@ func (p projBitorInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -1962,8 +1962,8 @@ func (p projBitorInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -2042,8 +2042,8 @@ func (p projBitorDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -2084,8 +2084,8 @@ func (p projBitorDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -2164,8 +2164,8 @@ func (p projBitxorInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -2192,8 +2192,8 @@ func (p projBitxorInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -2265,8 +2265,8 @@ func (p projBitxorInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -2293,8 +2293,8 @@ func (p projBitxorInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -2366,8 +2366,8 @@ func (p projBitxorInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -2394,8 +2394,8 @@ func (p projBitxorInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -2467,8 +2467,8 @@ func (p projBitxorInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -2495,8 +2495,8 @@ func (p projBitxorInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -2568,8 +2568,8 @@ func (p projBitxorInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -2596,8 +2596,8 @@ func (p projBitxorInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -2669,8 +2669,8 @@ func (p projBitxorInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -2697,8 +2697,8 @@ func (p projBitxorInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -2770,8 +2770,8 @@ func (p projBitxorInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -2798,8 +2798,8 @@ func (p projBitxorInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -2871,8 +2871,8 @@ func (p projBitxorInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -2899,8 +2899,8 @@ func (p projBitxorInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -2972,8 +2972,8 @@ func (p projBitxorInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -3000,8 +3000,8 @@ func (p projBitxorInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -3080,8 +3080,8 @@ func (p projBitxorDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -3122,8 +3122,8 @@ func (p projBitxorDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -3209,8 +3209,8 @@ func (p projPlusDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -3251,8 +3251,8 @@ func (p projPlusDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -3338,8 +3338,8 @@ func (p projPlusDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -3380,8 +3380,8 @@ func (p projPlusDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -3467,8 +3467,8 @@ func (p projPlusDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -3509,8 +3509,8 @@ func (p projPlusDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -3595,8 +3595,8 @@ func (p projPlusDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -3635,8 +3635,8 @@ func (p projPlusDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -3720,8 +3720,8 @@ func (p projPlusInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -3760,8 +3760,8 @@ func (p projPlusInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -3845,8 +3845,8 @@ func (p projPlusInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -3885,8 +3885,8 @@ func (p projPlusInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -3970,8 +3970,8 @@ func (p projPlusInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -4010,8 +4010,8 @@ func (p projPlusInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -4097,8 +4097,8 @@ func (p projPlusInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -4141,8 +4141,8 @@ func (p projPlusInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -4235,8 +4235,8 @@ func (p projPlusInt16DatumConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -4289,8 +4289,8 @@ func (p projPlusInt16DatumConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -4381,8 +4381,8 @@ func (p projPlusInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -4421,8 +4421,8 @@ func (p projPlusInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -4506,8 +4506,8 @@ func (p projPlusInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -4546,8 +4546,8 @@ func (p projPlusInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -4631,8 +4631,8 @@ func (p projPlusInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -4671,8 +4671,8 @@ func (p projPlusInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -4758,8 +4758,8 @@ func (p projPlusInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -4802,8 +4802,8 @@ func (p projPlusInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -4896,8 +4896,8 @@ func (p projPlusInt32DatumConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -4950,8 +4950,8 @@ func (p projPlusInt32DatumConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -5042,8 +5042,8 @@ func (p projPlusInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -5082,8 +5082,8 @@ func (p projPlusInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -5167,8 +5167,8 @@ func (p projPlusInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -5207,8 +5207,8 @@ func (p projPlusInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -5292,8 +5292,8 @@ func (p projPlusInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -5332,8 +5332,8 @@ func (p projPlusInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -5419,8 +5419,8 @@ func (p projPlusInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -5463,8 +5463,8 @@ func (p projPlusInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -5557,8 +5557,8 @@ func (p projPlusInt64DatumConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -5611,8 +5611,8 @@ func (p projPlusInt64DatumConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -5700,8 +5700,8 @@ func (p projPlusFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -5734,8 +5734,8 @@ func (p projPlusFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -5808,8 +5808,8 @@ func (p projPlusTimestampIntervalConstOp) Next(ctx context.Context) coldata.Batc
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -5832,8 +5832,8 @@ func (p projPlusTimestampIntervalConstOp) Next(ctx context.Context) coldata.Batc
 					projCol[i] = duration.Add(arg, p.constArg)
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 					projCol[i] = duration.Add(arg, p.constArg)
@@ -5901,8 +5901,8 @@ func (p projPlusIntervalTimestampConstOp) Next(ctx context.Context) coldata.Batc
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -5925,8 +5925,8 @@ func (p projPlusIntervalTimestampConstOp) Next(ctx context.Context) coldata.Batc
 					projCol[i] = duration.Add(p.constArg, arg)
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 					projCol[i] = duration.Add(p.constArg, arg)
@@ -5994,8 +5994,8 @@ func (p projPlusIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -6018,8 +6018,8 @@ func (p projPlusIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch
 					projCol[i] = arg.Add(p.constArg)
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 					projCol[i] = arg.Add(p.constArg)
@@ -6102,8 +6102,8 @@ func (p projPlusIntervalDatumConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -6156,8 +6156,8 @@ func (p projPlusIntervalDatumConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -6253,8 +6253,8 @@ func (p projPlusDatumIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -6303,8 +6303,8 @@ func (p projPlusDatumIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -6398,8 +6398,8 @@ func (p projPlusDatumInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -6448,8 +6448,8 @@ func (p projPlusDatumInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -6543,8 +6543,8 @@ func (p projPlusDatumInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -6593,8 +6593,8 @@ func (p projPlusDatumInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -6688,8 +6688,8 @@ func (p projPlusDatumInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -6738,8 +6738,8 @@ func (p projPlusDatumInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -6829,8 +6829,8 @@ func (p projMinusDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -6871,8 +6871,8 @@ func (p projMinusDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -6958,8 +6958,8 @@ func (p projMinusDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -7000,8 +7000,8 @@ func (p projMinusDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -7087,8 +7087,8 @@ func (p projMinusDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -7129,8 +7129,8 @@ func (p projMinusDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -7215,8 +7215,8 @@ func (p projMinusDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch 
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -7255,8 +7255,8 @@ func (p projMinusDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch 
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -7340,8 +7340,8 @@ func (p projMinusInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -7380,8 +7380,8 @@ func (p projMinusInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -7465,8 +7465,8 @@ func (p projMinusInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -7505,8 +7505,8 @@ func (p projMinusInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -7590,8 +7590,8 @@ func (p projMinusInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -7630,8 +7630,8 @@ func (p projMinusInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -7717,8 +7717,8 @@ func (p projMinusInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -7761,8 +7761,8 @@ func (p projMinusInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -7855,8 +7855,8 @@ func (p projMinusInt16DatumConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -7909,8 +7909,8 @@ func (p projMinusInt16DatumConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -8001,8 +8001,8 @@ func (p projMinusInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -8041,8 +8041,8 @@ func (p projMinusInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -8126,8 +8126,8 @@ func (p projMinusInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -8166,8 +8166,8 @@ func (p projMinusInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -8251,8 +8251,8 @@ func (p projMinusInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -8291,8 +8291,8 @@ func (p projMinusInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -8378,8 +8378,8 @@ func (p projMinusInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -8422,8 +8422,8 @@ func (p projMinusInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -8516,8 +8516,8 @@ func (p projMinusInt32DatumConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -8570,8 +8570,8 @@ func (p projMinusInt32DatumConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -8662,8 +8662,8 @@ func (p projMinusInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -8702,8 +8702,8 @@ func (p projMinusInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -8787,8 +8787,8 @@ func (p projMinusInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -8827,8 +8827,8 @@ func (p projMinusInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -8912,8 +8912,8 @@ func (p projMinusInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -8952,8 +8952,8 @@ func (p projMinusInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -9039,8 +9039,8 @@ func (p projMinusInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -9083,8 +9083,8 @@ func (p projMinusInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -9177,8 +9177,8 @@ func (p projMinusInt64DatumConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -9231,8 +9231,8 @@ func (p projMinusInt64DatumConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -9320,8 +9320,8 @@ func (p projMinusFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch 
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -9354,8 +9354,8 @@ func (p projMinusFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch 
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -9431,8 +9431,8 @@ func (p projMinusTimestampTimestampConstOp) Next(ctx context.Context) coldata.Ba
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -9461,8 +9461,8 @@ func (p projMinusTimestampTimestampConstOp) Next(ctx context.Context) coldata.Ba
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -9533,8 +9533,8 @@ func (p projMinusTimestampIntervalConstOp) Next(ctx context.Context) coldata.Bat
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -9557,8 +9557,8 @@ func (p projMinusTimestampIntervalConstOp) Next(ctx context.Context) coldata.Bat
 					projCol[i] = duration.Add(arg, p.constArg.Mul(-1))
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 					projCol[i] = duration.Add(arg, p.constArg.Mul(-1))
@@ -9626,8 +9626,8 @@ func (p projMinusIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batc
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -9650,8 +9650,8 @@ func (p projMinusIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batc
 					projCol[i] = arg.Sub(p.constArg)
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 					projCol[i] = arg.Sub(p.constArg)
@@ -9734,8 +9734,8 @@ func (p projMinusIntervalDatumConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -9788,8 +9788,8 @@ func (p projMinusIntervalDatumConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -9881,8 +9881,8 @@ func (p projMinusDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -9923,8 +9923,8 @@ func (p projMinusDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -10014,8 +10014,8 @@ func (p projMinusDatumIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -10064,8 +10064,8 @@ func (p projMinusDatumIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -10159,8 +10159,8 @@ func (p projMinusDatumBytesConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -10209,8 +10209,8 @@ func (p projMinusDatumBytesConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -10304,8 +10304,8 @@ func (p projMinusDatumInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -10354,8 +10354,8 @@ func (p projMinusDatumInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -10449,8 +10449,8 @@ func (p projMinusDatumInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -10499,8 +10499,8 @@ func (p projMinusDatumInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -10594,8 +10594,8 @@ func (p projMinusDatumInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -10644,8 +10644,8 @@ func (p projMinusDatumInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -10735,8 +10735,8 @@ func (p projMultDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -10777,8 +10777,8 @@ func (p projMultDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -10864,8 +10864,8 @@ func (p projMultDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -10906,8 +10906,8 @@ func (p projMultDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -10993,8 +10993,8 @@ func (p projMultDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -11035,8 +11035,8 @@ func (p projMultDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -11121,8 +11121,8 @@ func (p projMultDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -11161,8 +11161,8 @@ func (p projMultDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -11243,8 +11243,8 @@ func (p projMultDecimalIntervalConstOp) Next(ctx context.Context) coldata.Batch 
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -11277,8 +11277,8 @@ func (p projMultDecimalIntervalConstOp) Next(ctx context.Context) coldata.Batch 
 					projCol[i] = p.constArg.MulFloat(f)
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -11367,8 +11367,8 @@ func (p projMultInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -11423,8 +11423,8 @@ func (p projMultInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -11524,8 +11524,8 @@ func (p projMultInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -11580,8 +11580,8 @@ func (p projMultInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -11681,8 +11681,8 @@ func (p projMultInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -11737,8 +11737,8 @@ func (p projMultInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -11832,8 +11832,8 @@ func (p projMultInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -11876,8 +11876,8 @@ func (p projMultInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -11955,8 +11955,8 @@ func (p projMultInt16IntervalConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -11979,8 +11979,8 @@ func (p projMultInt16IntervalConstOp) Next(ctx context.Context) coldata.Batch {
 					projCol[i] = p.constArg.Mul(int64(arg))
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 					projCol[i] = p.constArg.Mul(int64(arg))
@@ -12064,8 +12064,8 @@ func (p projMultInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -12120,8 +12120,8 @@ func (p projMultInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -12221,8 +12221,8 @@ func (p projMultInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -12277,8 +12277,8 @@ func (p projMultInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -12378,8 +12378,8 @@ func (p projMultInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -12434,8 +12434,8 @@ func (p projMultInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -12529,8 +12529,8 @@ func (p projMultInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -12573,8 +12573,8 @@ func (p projMultInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -12652,8 +12652,8 @@ func (p projMultInt32IntervalConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -12676,8 +12676,8 @@ func (p projMultInt32IntervalConstOp) Next(ctx context.Context) coldata.Batch {
 					projCol[i] = p.constArg.Mul(int64(arg))
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 					projCol[i] = p.constArg.Mul(int64(arg))
@@ -12761,8 +12761,8 @@ func (p projMultInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -12817,8 +12817,8 @@ func (p projMultInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -12918,8 +12918,8 @@ func (p projMultInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -12974,8 +12974,8 @@ func (p projMultInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -13075,8 +13075,8 @@ func (p projMultInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -13131,8 +13131,8 @@ func (p projMultInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -13226,8 +13226,8 @@ func (p projMultInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -13270,8 +13270,8 @@ func (p projMultInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -13349,8 +13349,8 @@ func (p projMultInt64IntervalConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -13373,8 +13373,8 @@ func (p projMultInt64IntervalConstOp) Next(ctx context.Context) coldata.Batch {
 					projCol[i] = p.constArg.Mul(int64(arg))
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 					projCol[i] = p.constArg.Mul(int64(arg))
@@ -13447,8 +13447,8 @@ func (p projMultFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -13481,8 +13481,8 @@ func (p projMultFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -13555,8 +13555,8 @@ func (p projMultFloat64IntervalConstOp) Next(ctx context.Context) coldata.Batch 
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -13579,8 +13579,8 @@ func (p projMultFloat64IntervalConstOp) Next(ctx context.Context) coldata.Batch 
 					projCol[i] = p.constArg.MulFloat(float64(arg))
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 					projCol[i] = p.constArg.MulFloat(float64(arg))
@@ -13648,8 +13648,8 @@ func (p projMultIntervalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -13672,8 +13672,8 @@ func (p projMultIntervalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 					projCol[i] = arg.Mul(int64(p.constArg))
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 					projCol[i] = arg.Mul(int64(p.constArg))
@@ -13741,8 +13741,8 @@ func (p projMultIntervalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -13765,8 +13765,8 @@ func (p projMultIntervalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 					projCol[i] = arg.Mul(int64(p.constArg))
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 					projCol[i] = arg.Mul(int64(p.constArg))
@@ -13834,8 +13834,8 @@ func (p projMultIntervalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -13858,8 +13858,8 @@ func (p projMultIntervalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 					projCol[i] = arg.Mul(int64(p.constArg))
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 					projCol[i] = arg.Mul(int64(p.constArg))
@@ -13927,8 +13927,8 @@ func (p projMultIntervalFloat64ConstOp) Next(ctx context.Context) coldata.Batch 
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -13951,8 +13951,8 @@ func (p projMultIntervalFloat64ConstOp) Next(ctx context.Context) coldata.Batch 
 					projCol[i] = arg.MulFloat(float64(p.constArg))
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 					projCol[i] = arg.MulFloat(float64(p.constArg))
@@ -14025,8 +14025,8 @@ func (p projMultIntervalDecimalConstOp) Next(ctx context.Context) coldata.Batch 
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -14059,8 +14059,8 @@ func (p projMultIntervalDecimalConstOp) Next(ctx context.Context) coldata.Batch 
 					projCol[i] = arg.MulFloat(f)
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -14146,8 +14146,8 @@ func (p projDivDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -14196,8 +14196,8 @@ func (p projDivDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -14291,8 +14291,8 @@ func (p projDivDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -14341,8 +14341,8 @@ func (p projDivDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -14436,8 +14436,8 @@ func (p projDivDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -14486,8 +14486,8 @@ func (p projDivDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -14580,8 +14580,8 @@ func (p projDivDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -14628,8 +14628,8 @@ func (p projDivDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -14721,8 +14721,8 @@ func (p projDivInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -14769,8 +14769,8 @@ func (p projDivInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -14862,8 +14862,8 @@ func (p projDivInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -14910,8 +14910,8 @@ func (p projDivInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -15003,8 +15003,8 @@ func (p projDivInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -15051,8 +15051,8 @@ func (p projDivInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -15146,8 +15146,8 @@ func (p projDivInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -15198,8 +15198,8 @@ func (p projDivInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -15293,8 +15293,8 @@ func (p projDivInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -15341,8 +15341,8 @@ func (p projDivInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -15434,8 +15434,8 @@ func (p projDivInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -15482,8 +15482,8 @@ func (p projDivInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -15575,8 +15575,8 @@ func (p projDivInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -15623,8 +15623,8 @@ func (p projDivInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -15718,8 +15718,8 @@ func (p projDivInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -15770,8 +15770,8 @@ func (p projDivInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -15865,8 +15865,8 @@ func (p projDivInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -15913,8 +15913,8 @@ func (p projDivInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -16006,8 +16006,8 @@ func (p projDivInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -16054,8 +16054,8 @@ func (p projDivInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -16147,8 +16147,8 @@ func (p projDivInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -16195,8 +16195,8 @@ func (p projDivInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -16290,8 +16290,8 @@ func (p projDivInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -16342,8 +16342,8 @@ func (p projDivInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -16434,8 +16434,8 @@ func (p projDivFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -16476,8 +16476,8 @@ func (p projDivFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -16558,8 +16558,8 @@ func (p projDivIntervalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -16590,8 +16590,8 @@ func (p projDivIntervalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 					projCol[i] = arg.Div(int64(p.constArg))
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -16667,8 +16667,8 @@ func (p projDivIntervalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -16699,8 +16699,8 @@ func (p projDivIntervalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 					projCol[i] = arg.DivFloat(float64(p.constArg))
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -16785,8 +16785,8 @@ func (p projFloorDivDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -16835,8 +16835,8 @@ func (p projFloorDivDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -16930,8 +16930,8 @@ func (p projFloorDivDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -16980,8 +16980,8 @@ func (p projFloorDivDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -17075,8 +17075,8 @@ func (p projFloorDivDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -17125,8 +17125,8 @@ func (p projFloorDivDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -17219,8 +17219,8 @@ func (p projFloorDivDecimalDecimalConstOp) Next(ctx context.Context) coldata.Bat
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -17267,8 +17267,8 @@ func (p projFloorDivDecimalDecimalConstOp) Next(ctx context.Context) coldata.Bat
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -17355,8 +17355,8 @@ func (p projFloorDivInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -17393,8 +17393,8 @@ func (p projFloorDivInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -17476,8 +17476,8 @@ func (p projFloorDivInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -17514,8 +17514,8 @@ func (p projFloorDivInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -17597,8 +17597,8 @@ func (p projFloorDivInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -17635,8 +17635,8 @@ func (p projFloorDivInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -17725,8 +17725,8 @@ func (p projFloorDivInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -17777,8 +17777,8 @@ func (p projFloorDivInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -17867,8 +17867,8 @@ func (p projFloorDivInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -17905,8 +17905,8 @@ func (p projFloorDivInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -17988,8 +17988,8 @@ func (p projFloorDivInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -18026,8 +18026,8 @@ func (p projFloorDivInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -18109,8 +18109,8 @@ func (p projFloorDivInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -18147,8 +18147,8 @@ func (p projFloorDivInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -18237,8 +18237,8 @@ func (p projFloorDivInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -18289,8 +18289,8 @@ func (p projFloorDivInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -18379,8 +18379,8 @@ func (p projFloorDivInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -18417,8 +18417,8 @@ func (p projFloorDivInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -18500,8 +18500,8 @@ func (p projFloorDivInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -18538,8 +18538,8 @@ func (p projFloorDivInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -18621,8 +18621,8 @@ func (p projFloorDivInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -18659,8 +18659,8 @@ func (p projFloorDivInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -18749,8 +18749,8 @@ func (p projFloorDivInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -18801,8 +18801,8 @@ func (p projFloorDivInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -18893,8 +18893,8 @@ func (p projFloorDivFloat64Float64ConstOp) Next(ctx context.Context) coldata.Bat
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -18935,8 +18935,8 @@ func (p projFloorDivFloat64Float64ConstOp) Next(ctx context.Context) coldata.Bat
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -19026,8 +19026,8 @@ func (p projModDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -19076,8 +19076,8 @@ func (p projModDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -19171,8 +19171,8 @@ func (p projModDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -19221,8 +19221,8 @@ func (p projModDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -19316,8 +19316,8 @@ func (p projModDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -19366,8 +19366,8 @@ func (p projModDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -19460,8 +19460,8 @@ func (p projModDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -19508,8 +19508,8 @@ func (p projModDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -19596,8 +19596,8 @@ func (p projModInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -19634,8 +19634,8 @@ func (p projModInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -19717,8 +19717,8 @@ func (p projModInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -19755,8 +19755,8 @@ func (p projModInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -19838,8 +19838,8 @@ func (p projModInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -19876,8 +19876,8 @@ func (p projModInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -19966,8 +19966,8 @@ func (p projModInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -20018,8 +20018,8 @@ func (p projModInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -20108,8 +20108,8 @@ func (p projModInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -20146,8 +20146,8 @@ func (p projModInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -20229,8 +20229,8 @@ func (p projModInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -20267,8 +20267,8 @@ func (p projModInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -20350,8 +20350,8 @@ func (p projModInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -20388,8 +20388,8 @@ func (p projModInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -20478,8 +20478,8 @@ func (p projModInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -20530,8 +20530,8 @@ func (p projModInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -20620,8 +20620,8 @@ func (p projModInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -20658,8 +20658,8 @@ func (p projModInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -20741,8 +20741,8 @@ func (p projModInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -20779,8 +20779,8 @@ func (p projModInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -20862,8 +20862,8 @@ func (p projModInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -20900,8 +20900,8 @@ func (p projModInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -20990,8 +20990,8 @@ func (p projModInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -21042,8 +21042,8 @@ func (p projModInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -21134,8 +21134,8 @@ func (p projModFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -21176,8 +21176,8 @@ func (p projModFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -21263,8 +21263,8 @@ func (p projPowDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -21305,8 +21305,8 @@ func (p projPowDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -21392,8 +21392,8 @@ func (p projPowDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -21434,8 +21434,8 @@ func (p projPowDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -21521,8 +21521,8 @@ func (p projPowDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -21563,8 +21563,8 @@ func (p projPowDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -21649,8 +21649,8 @@ func (p projPowDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -21689,8 +21689,8 @@ func (p projPowDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -21780,8 +21780,8 @@ func (p projPowInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -21832,8 +21832,8 @@ func (p projPowInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -21929,8 +21929,8 @@ func (p projPowInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -21981,8 +21981,8 @@ func (p projPowInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -22078,8 +22078,8 @@ func (p projPowInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -22130,8 +22130,8 @@ func (p projPowInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -22223,8 +22223,8 @@ func (p projPowInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -22267,8 +22267,8 @@ func (p projPowInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -22360,8 +22360,8 @@ func (p projPowInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -22412,8 +22412,8 @@ func (p projPowInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -22509,8 +22509,8 @@ func (p projPowInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -22561,8 +22561,8 @@ func (p projPowInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -22658,8 +22658,8 @@ func (p projPowInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -22710,8 +22710,8 @@ func (p projPowInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -22803,8 +22803,8 @@ func (p projPowInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -22847,8 +22847,8 @@ func (p projPowInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -22940,8 +22940,8 @@ func (p projPowInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -22992,8 +22992,8 @@ func (p projPowInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -23089,8 +23089,8 @@ func (p projPowInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -23141,8 +23141,8 @@ func (p projPowInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -23238,8 +23238,8 @@ func (p projPowInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -23290,8 +23290,8 @@ func (p projPowInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -23383,8 +23383,8 @@ func (p projPowInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -23427,8 +23427,8 @@ func (p projPowInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -23511,8 +23511,8 @@ func (p projPowFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -23545,8 +23545,8 @@ func (p projPowFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -23626,10 +23626,8 @@ func (p projConcatBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col
-				_ = 0
-				_ = n
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -23666,10 +23664,8 @@ func (p projConcatBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col
-				_ = 0
-				_ = n
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -23753,8 +23749,8 @@ func (p projConcatDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -23795,8 +23791,8 @@ func (p projConcatDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -23881,8 +23877,8 @@ func (p projLShiftInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -23921,8 +23917,8 @@ func (p projLShiftInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -24006,8 +24002,8 @@ func (p projLShiftInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -24046,8 +24042,8 @@ func (p projLShiftInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -24131,8 +24127,8 @@ func (p projLShiftInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -24171,8 +24167,8 @@ func (p projLShiftInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -24256,8 +24252,8 @@ func (p projLShiftInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -24296,8 +24292,8 @@ func (p projLShiftInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -24381,8 +24377,8 @@ func (p projLShiftInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -24421,8 +24417,8 @@ func (p projLShiftInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -24506,8 +24502,8 @@ func (p projLShiftInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -24546,8 +24542,8 @@ func (p projLShiftInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -24631,8 +24627,8 @@ func (p projLShiftInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -24671,8 +24667,8 @@ func (p projLShiftInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -24756,8 +24752,8 @@ func (p projLShiftInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -24796,8 +24792,8 @@ func (p projLShiftInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -24881,8 +24877,8 @@ func (p projLShiftInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -24921,8 +24917,8 @@ func (p projLShiftInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -25011,8 +25007,8 @@ func (p projLShiftDatumInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -25061,8 +25057,8 @@ func (p projLShiftDatumInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -25156,8 +25152,8 @@ func (p projLShiftDatumInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -25206,8 +25202,8 @@ func (p projLShiftDatumInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -25301,8 +25297,8 @@ func (p projLShiftDatumInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -25351,8 +25347,8 @@ func (p projLShiftDatumInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -25441,8 +25437,8 @@ func (p projRShiftInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -25481,8 +25477,8 @@ func (p projRShiftInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -25566,8 +25562,8 @@ func (p projRShiftInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -25606,8 +25602,8 @@ func (p projRShiftInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -25691,8 +25687,8 @@ func (p projRShiftInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -25731,8 +25727,8 @@ func (p projRShiftInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -25816,8 +25812,8 @@ func (p projRShiftInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -25856,8 +25852,8 @@ func (p projRShiftInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -25941,8 +25937,8 @@ func (p projRShiftInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -25981,8 +25977,8 @@ func (p projRShiftInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -26066,8 +26062,8 @@ func (p projRShiftInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -26106,8 +26102,8 @@ func (p projRShiftInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -26191,8 +26187,8 @@ func (p projRShiftInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -26231,8 +26227,8 @@ func (p projRShiftInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -26316,8 +26312,8 @@ func (p projRShiftInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -26356,8 +26352,8 @@ func (p projRShiftInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -26441,8 +26437,8 @@ func (p projRShiftInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -26481,8 +26477,8 @@ func (p projRShiftInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -26571,8 +26567,8 @@ func (p projRShiftDatumInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -26621,8 +26617,8 @@ func (p projRShiftDatumInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -26716,8 +26712,8 @@ func (p projRShiftDatumInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -26766,8 +26762,8 @@ func (p projRShiftDatumInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -26861,8 +26857,8 @@ func (p projRShiftDatumInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -26911,8 +26907,8 @@ func (p projRShiftDatumInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -27006,8 +27002,8 @@ func (p projJSONFetchValDatumBytesConstOp) Next(ctx context.Context) coldata.Bat
 					}
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -27056,8 +27052,8 @@ func (p projJSONFetchValDatumBytesConstOp) Next(ctx context.Context) coldata.Bat
 
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -27151,8 +27147,8 @@ func (p projJSONFetchValDatumInt16ConstOp) Next(ctx context.Context) coldata.Bat
 					}
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -27201,8 +27197,8 @@ func (p projJSONFetchValDatumInt16ConstOp) Next(ctx context.Context) coldata.Bat
 
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -27296,8 +27292,8 @@ func (p projJSONFetchValDatumInt32ConstOp) Next(ctx context.Context) coldata.Bat
 					}
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -27346,8 +27342,8 @@ func (p projJSONFetchValDatumInt32ConstOp) Next(ctx context.Context) coldata.Bat
 
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -27441,8 +27437,8 @@ func (p projJSONFetchValDatumInt64ConstOp) Next(ctx context.Context) coldata.Bat
 					}
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -27491,8 +27487,8 @@ func (p projJSONFetchValDatumInt64ConstOp) Next(ctx context.Context) coldata.Bat
 
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -27582,8 +27578,8 @@ func (p projJSONFetchValPathDatumDatumConstOp) Next(ctx context.Context) coldata
 					}
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -27624,8 +27620,8 @@ func (p projJSONFetchValPathDatumDatumConstOp) Next(ctx context.Context) coldata
 
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -27716,8 +27712,8 @@ func (p projEQBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -27768,8 +27764,8 @@ func (p projEQBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -27857,10 +27853,8 @@ func (p projEQBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col
-				_ = 0
-				_ = n
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -27895,10 +27889,8 @@ func (p projEQBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col
-				_ = 0
-				_ = n
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -27984,8 +27976,8 @@ func (p projEQDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -28032,8 +28024,8 @@ func (p projEQDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -28125,8 +28117,8 @@ func (p projEQDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -28173,8 +28165,8 @@ func (p projEQDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -28266,8 +28258,8 @@ func (p projEQDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -28314,8 +28306,8 @@ func (p projEQDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -28409,8 +28401,8 @@ func (p projEQDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -28461,8 +28453,8 @@ func (p projEQDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -28550,8 +28542,8 @@ func (p projEQDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -28586,8 +28578,8 @@ func (p projEQDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -28678,8 +28670,8 @@ func (p projEQInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -28736,8 +28728,8 @@ func (p projEQInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -28839,8 +28831,8 @@ func (p projEQInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -28897,8 +28889,8 @@ func (p projEQInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -29000,8 +28992,8 @@ func (p projEQInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -29058,8 +29050,8 @@ func (p projEQInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -29169,8 +29161,8 @@ func (p projEQInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -29243,8 +29235,8 @@ func (p projEQInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -29349,8 +29341,8 @@ func (p projEQInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -29397,8 +29389,8 @@ func (p projEQInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -29495,8 +29487,8 @@ func (p projEQInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -29553,8 +29545,8 @@ func (p projEQInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -29656,8 +29648,8 @@ func (p projEQInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -29714,8 +29706,8 @@ func (p projEQInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -29817,8 +29809,8 @@ func (p projEQInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -29875,8 +29867,8 @@ func (p projEQInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -29986,8 +29978,8 @@ func (p projEQInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -30060,8 +30052,8 @@ func (p projEQInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -30166,8 +30158,8 @@ func (p projEQInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -30214,8 +30206,8 @@ func (p projEQInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -30312,8 +30304,8 @@ func (p projEQInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -30370,8 +30362,8 @@ func (p projEQInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -30473,8 +30465,8 @@ func (p projEQInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -30531,8 +30523,8 @@ func (p projEQInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -30634,8 +30626,8 @@ func (p projEQInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -30692,8 +30684,8 @@ func (p projEQInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -30803,8 +30795,8 @@ func (p projEQInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -30877,8 +30869,8 @@ func (p projEQInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -30983,8 +30975,8 @@ func (p projEQInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -31031,8 +31023,8 @@ func (p projEQInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -31137,8 +31129,8 @@ func (p projEQFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -31211,8 +31203,8 @@ func (p projEQFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -31330,8 +31322,8 @@ func (p projEQFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -31404,8 +31396,8 @@ func (p projEQFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -31523,8 +31515,8 @@ func (p projEQFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -31597,8 +31589,8 @@ func (p projEQFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -31716,8 +31708,8 @@ func (p projEQFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -31790,8 +31782,8 @@ func (p projEQFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -31898,8 +31890,8 @@ func (p projEQFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -31950,8 +31942,8 @@ func (p projEQFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -32046,8 +32038,8 @@ func (p projEQTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -32096,8 +32088,8 @@ func (p projEQTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -32184,8 +32176,8 @@ func (p projEQIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -32220,8 +32212,8 @@ func (p projEQIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -32303,8 +32295,8 @@ func (p projEQDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -32343,8 +32335,8 @@ func (p projEQDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -32434,8 +32426,8 @@ func (p projNEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -32486,8 +32478,8 @@ func (p projNEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -32575,10 +32567,8 @@ func (p projNEBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col
-				_ = 0
-				_ = n
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -32613,10 +32603,8 @@ func (p projNEBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col
-				_ = 0
-				_ = n
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -32702,8 +32690,8 @@ func (p projNEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -32750,8 +32738,8 @@ func (p projNEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -32843,8 +32831,8 @@ func (p projNEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -32891,8 +32879,8 @@ func (p projNEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -32984,8 +32972,8 @@ func (p projNEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -33032,8 +33020,8 @@ func (p projNEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -33127,8 +33115,8 @@ func (p projNEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -33179,8 +33167,8 @@ func (p projNEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -33268,8 +33256,8 @@ func (p projNEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -33304,8 +33292,8 @@ func (p projNEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -33396,8 +33384,8 @@ func (p projNEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -33454,8 +33442,8 @@ func (p projNEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -33557,8 +33545,8 @@ func (p projNEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -33615,8 +33603,8 @@ func (p projNEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -33718,8 +33706,8 @@ func (p projNEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -33776,8 +33764,8 @@ func (p projNEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -33887,8 +33875,8 @@ func (p projNEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -33961,8 +33949,8 @@ func (p projNEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -34067,8 +34055,8 @@ func (p projNEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -34115,8 +34103,8 @@ func (p projNEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -34213,8 +34201,8 @@ func (p projNEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -34271,8 +34259,8 @@ func (p projNEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -34374,8 +34362,8 @@ func (p projNEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -34432,8 +34420,8 @@ func (p projNEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -34535,8 +34523,8 @@ func (p projNEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -34593,8 +34581,8 @@ func (p projNEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -34704,8 +34692,8 @@ func (p projNEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -34778,8 +34766,8 @@ func (p projNEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -34884,8 +34872,8 @@ func (p projNEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -34932,8 +34920,8 @@ func (p projNEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -35030,8 +35018,8 @@ func (p projNEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -35088,8 +35076,8 @@ func (p projNEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -35191,8 +35179,8 @@ func (p projNEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -35249,8 +35237,8 @@ func (p projNEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -35352,8 +35340,8 @@ func (p projNEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -35410,8 +35398,8 @@ func (p projNEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -35521,8 +35509,8 @@ func (p projNEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -35595,8 +35583,8 @@ func (p projNEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -35701,8 +35689,8 @@ func (p projNEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -35749,8 +35737,8 @@ func (p projNEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -35855,8 +35843,8 @@ func (p projNEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -35929,8 +35917,8 @@ func (p projNEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -36048,8 +36036,8 @@ func (p projNEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -36122,8 +36110,8 @@ func (p projNEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -36241,8 +36229,8 @@ func (p projNEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -36315,8 +36303,8 @@ func (p projNEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -36434,8 +36422,8 @@ func (p projNEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -36508,8 +36496,8 @@ func (p projNEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -36616,8 +36604,8 @@ func (p projNEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -36668,8 +36656,8 @@ func (p projNEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -36764,8 +36752,8 @@ func (p projNETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -36814,8 +36802,8 @@ func (p projNETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -36902,8 +36890,8 @@ func (p projNEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -36938,8 +36926,8 @@ func (p projNEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -37021,8 +37009,8 @@ func (p projNEDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -37061,8 +37049,8 @@ func (p projNEDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -37152,8 +37140,8 @@ func (p projLTBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -37204,8 +37192,8 @@ func (p projLTBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -37293,10 +37281,8 @@ func (p projLTBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col
-				_ = 0
-				_ = n
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -37331,10 +37317,8 @@ func (p projLTBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col
-				_ = 0
-				_ = n
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -37420,8 +37404,8 @@ func (p projLTDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -37468,8 +37452,8 @@ func (p projLTDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -37561,8 +37545,8 @@ func (p projLTDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -37609,8 +37593,8 @@ func (p projLTDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -37702,8 +37686,8 @@ func (p projLTDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -37750,8 +37734,8 @@ func (p projLTDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -37845,8 +37829,8 @@ func (p projLTDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -37897,8 +37881,8 @@ func (p projLTDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -37986,8 +37970,8 @@ func (p projLTDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -38022,8 +38006,8 @@ func (p projLTDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -38114,8 +38098,8 @@ func (p projLTInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -38172,8 +38156,8 @@ func (p projLTInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -38275,8 +38259,8 @@ func (p projLTInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -38333,8 +38317,8 @@ func (p projLTInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -38436,8 +38420,8 @@ func (p projLTInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -38494,8 +38478,8 @@ func (p projLTInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -38605,8 +38589,8 @@ func (p projLTInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -38679,8 +38663,8 @@ func (p projLTInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -38785,8 +38769,8 @@ func (p projLTInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -38833,8 +38817,8 @@ func (p projLTInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -38931,8 +38915,8 @@ func (p projLTInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -38989,8 +38973,8 @@ func (p projLTInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -39092,8 +39076,8 @@ func (p projLTInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -39150,8 +39134,8 @@ func (p projLTInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -39253,8 +39237,8 @@ func (p projLTInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -39311,8 +39295,8 @@ func (p projLTInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -39422,8 +39406,8 @@ func (p projLTInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -39496,8 +39480,8 @@ func (p projLTInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -39602,8 +39586,8 @@ func (p projLTInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -39650,8 +39634,8 @@ func (p projLTInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -39748,8 +39732,8 @@ func (p projLTInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -39806,8 +39790,8 @@ func (p projLTInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -39909,8 +39893,8 @@ func (p projLTInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -39967,8 +39951,8 @@ func (p projLTInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -40070,8 +40054,8 @@ func (p projLTInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -40128,8 +40112,8 @@ func (p projLTInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -40239,8 +40223,8 @@ func (p projLTInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -40313,8 +40297,8 @@ func (p projLTInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -40419,8 +40403,8 @@ func (p projLTInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -40467,8 +40451,8 @@ func (p projLTInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -40573,8 +40557,8 @@ func (p projLTFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -40647,8 +40631,8 @@ func (p projLTFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -40766,8 +40750,8 @@ func (p projLTFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -40840,8 +40824,8 @@ func (p projLTFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -40959,8 +40943,8 @@ func (p projLTFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -41033,8 +41017,8 @@ func (p projLTFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -41152,8 +41136,8 @@ func (p projLTFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -41226,8 +41210,8 @@ func (p projLTFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -41334,8 +41318,8 @@ func (p projLTFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -41386,8 +41370,8 @@ func (p projLTFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -41482,8 +41466,8 @@ func (p projLTTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -41532,8 +41516,8 @@ func (p projLTTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -41620,8 +41604,8 @@ func (p projLTIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -41656,8 +41640,8 @@ func (p projLTIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -41739,8 +41723,8 @@ func (p projLTDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -41779,8 +41763,8 @@ func (p projLTDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -41870,8 +41854,8 @@ func (p projLEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -41922,8 +41906,8 @@ func (p projLEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -42011,10 +41995,8 @@ func (p projLEBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col
-				_ = 0
-				_ = n
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -42049,10 +42031,8 @@ func (p projLEBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col
-				_ = 0
-				_ = n
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -42138,8 +42118,8 @@ func (p projLEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -42186,8 +42166,8 @@ func (p projLEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -42279,8 +42259,8 @@ func (p projLEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -42327,8 +42307,8 @@ func (p projLEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -42420,8 +42400,8 @@ func (p projLEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -42468,8 +42448,8 @@ func (p projLEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -42563,8 +42543,8 @@ func (p projLEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -42615,8 +42595,8 @@ func (p projLEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -42704,8 +42684,8 @@ func (p projLEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -42740,8 +42720,8 @@ func (p projLEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -42832,8 +42812,8 @@ func (p projLEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -42890,8 +42870,8 @@ func (p projLEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -42993,8 +42973,8 @@ func (p projLEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -43051,8 +43031,8 @@ func (p projLEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -43154,8 +43134,8 @@ func (p projLEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -43212,8 +43192,8 @@ func (p projLEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -43323,8 +43303,8 @@ func (p projLEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -43397,8 +43377,8 @@ func (p projLEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -43503,8 +43483,8 @@ func (p projLEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -43551,8 +43531,8 @@ func (p projLEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -43649,8 +43629,8 @@ func (p projLEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -43707,8 +43687,8 @@ func (p projLEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -43810,8 +43790,8 @@ func (p projLEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -43868,8 +43848,8 @@ func (p projLEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -43971,8 +43951,8 @@ func (p projLEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -44029,8 +44009,8 @@ func (p projLEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -44140,8 +44120,8 @@ func (p projLEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -44214,8 +44194,8 @@ func (p projLEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -44320,8 +44300,8 @@ func (p projLEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -44368,8 +44348,8 @@ func (p projLEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -44466,8 +44446,8 @@ func (p projLEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -44524,8 +44504,8 @@ func (p projLEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -44627,8 +44607,8 @@ func (p projLEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -44685,8 +44665,8 @@ func (p projLEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -44788,8 +44768,8 @@ func (p projLEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -44846,8 +44826,8 @@ func (p projLEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -44957,8 +44937,8 @@ func (p projLEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -45031,8 +45011,8 @@ func (p projLEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -45137,8 +45117,8 @@ func (p projLEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -45185,8 +45165,8 @@ func (p projLEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -45291,8 +45271,8 @@ func (p projLEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -45365,8 +45345,8 @@ func (p projLEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -45484,8 +45464,8 @@ func (p projLEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -45558,8 +45538,8 @@ func (p projLEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -45677,8 +45657,8 @@ func (p projLEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -45751,8 +45731,8 @@ func (p projLEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -45870,8 +45850,8 @@ func (p projLEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -45944,8 +45924,8 @@ func (p projLEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -46052,8 +46032,8 @@ func (p projLEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -46104,8 +46084,8 @@ func (p projLEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -46200,8 +46180,8 @@ func (p projLETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -46250,8 +46230,8 @@ func (p projLETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -46338,8 +46318,8 @@ func (p projLEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -46374,8 +46354,8 @@ func (p projLEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -46457,8 +46437,8 @@ func (p projLEDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -46497,8 +46477,8 @@ func (p projLEDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -46588,8 +46568,8 @@ func (p projGTBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -46640,8 +46620,8 @@ func (p projGTBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -46729,10 +46709,8 @@ func (p projGTBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col
-				_ = 0
-				_ = n
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -46767,10 +46745,8 @@ func (p projGTBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col
-				_ = 0
-				_ = n
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -46856,8 +46832,8 @@ func (p projGTDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -46904,8 +46880,8 @@ func (p projGTDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -46997,8 +46973,8 @@ func (p projGTDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -47045,8 +47021,8 @@ func (p projGTDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -47138,8 +47114,8 @@ func (p projGTDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -47186,8 +47162,8 @@ func (p projGTDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -47281,8 +47257,8 @@ func (p projGTDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -47333,8 +47309,8 @@ func (p projGTDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -47422,8 +47398,8 @@ func (p projGTDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -47458,8 +47434,8 @@ func (p projGTDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -47550,8 +47526,8 @@ func (p projGTInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -47608,8 +47584,8 @@ func (p projGTInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -47711,8 +47687,8 @@ func (p projGTInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -47769,8 +47745,8 @@ func (p projGTInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -47872,8 +47848,8 @@ func (p projGTInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -47930,8 +47906,8 @@ func (p projGTInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -48041,8 +48017,8 @@ func (p projGTInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -48115,8 +48091,8 @@ func (p projGTInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -48221,8 +48197,8 @@ func (p projGTInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -48269,8 +48245,8 @@ func (p projGTInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -48367,8 +48343,8 @@ func (p projGTInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -48425,8 +48401,8 @@ func (p projGTInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -48528,8 +48504,8 @@ func (p projGTInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -48586,8 +48562,8 @@ func (p projGTInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -48689,8 +48665,8 @@ func (p projGTInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -48747,8 +48723,8 @@ func (p projGTInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -48858,8 +48834,8 @@ func (p projGTInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -48932,8 +48908,8 @@ func (p projGTInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -49038,8 +49014,8 @@ func (p projGTInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -49086,8 +49062,8 @@ func (p projGTInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -49184,8 +49160,8 @@ func (p projGTInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -49242,8 +49218,8 @@ func (p projGTInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -49345,8 +49321,8 @@ func (p projGTInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -49403,8 +49379,8 @@ func (p projGTInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -49506,8 +49482,8 @@ func (p projGTInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -49564,8 +49540,8 @@ func (p projGTInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -49675,8 +49651,8 @@ func (p projGTInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -49749,8 +49725,8 @@ func (p projGTInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -49855,8 +49831,8 @@ func (p projGTInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -49903,8 +49879,8 @@ func (p projGTInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -50009,8 +49985,8 @@ func (p projGTFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -50083,8 +50059,8 @@ func (p projGTFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -50202,8 +50178,8 @@ func (p projGTFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -50276,8 +50252,8 @@ func (p projGTFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -50395,8 +50371,8 @@ func (p projGTFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -50469,8 +50445,8 @@ func (p projGTFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -50588,8 +50564,8 @@ func (p projGTFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -50662,8 +50638,8 @@ func (p projGTFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -50770,8 +50746,8 @@ func (p projGTFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -50822,8 +50798,8 @@ func (p projGTFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -50918,8 +50894,8 @@ func (p projGTTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -50968,8 +50944,8 @@ func (p projGTTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -51056,8 +51032,8 @@ func (p projGTIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -51092,8 +51068,8 @@ func (p projGTIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -51175,8 +51151,8 @@ func (p projGTDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -51215,8 +51191,8 @@ func (p projGTDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -51306,8 +51282,8 @@ func (p projGEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -51358,8 +51334,8 @@ func (p projGEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -51447,10 +51423,8 @@ func (p projGEBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col
-				_ = 0
-				_ = n
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -51485,10 +51459,8 @@ func (p projGEBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col
-				_ = 0
-				_ = n
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -51574,8 +51546,8 @@ func (p projGEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -51622,8 +51594,8 @@ func (p projGEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -51715,8 +51687,8 @@ func (p projGEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -51763,8 +51735,8 @@ func (p projGEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -51856,8 +51828,8 @@ func (p projGEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -51904,8 +51876,8 @@ func (p projGEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -51999,8 +51971,8 @@ func (p projGEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -52051,8 +52023,8 @@ func (p projGEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -52140,8 +52112,8 @@ func (p projGEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -52176,8 +52148,8 @@ func (p projGEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -52268,8 +52240,8 @@ func (p projGEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -52326,8 +52298,8 @@ func (p projGEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -52429,8 +52401,8 @@ func (p projGEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -52487,8 +52459,8 @@ func (p projGEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -52590,8 +52562,8 @@ func (p projGEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -52648,8 +52620,8 @@ func (p projGEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -52759,8 +52731,8 @@ func (p projGEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -52833,8 +52805,8 @@ func (p projGEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -52939,8 +52911,8 @@ func (p projGEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -52987,8 +52959,8 @@ func (p projGEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -53085,8 +53057,8 @@ func (p projGEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -53143,8 +53115,8 @@ func (p projGEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -53246,8 +53218,8 @@ func (p projGEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -53304,8 +53276,8 @@ func (p projGEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -53407,8 +53379,8 @@ func (p projGEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -53465,8 +53437,8 @@ func (p projGEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -53576,8 +53548,8 @@ func (p projGEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -53650,8 +53622,8 @@ func (p projGEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -53756,8 +53728,8 @@ func (p projGEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -53804,8 +53776,8 @@ func (p projGEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -53902,8 +53874,8 @@ func (p projGEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -53960,8 +53932,8 @@ func (p projGEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -54063,8 +54035,8 @@ func (p projGEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -54121,8 +54093,8 @@ func (p projGEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -54224,8 +54196,8 @@ func (p projGEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -54282,8 +54254,8 @@ func (p projGEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -54393,8 +54365,8 @@ func (p projGEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -54467,8 +54439,8 @@ func (p projGEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -54573,8 +54545,8 @@ func (p projGEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -54621,8 +54593,8 @@ func (p projGEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -54727,8 +54699,8 @@ func (p projGEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -54801,8 +54773,8 @@ func (p projGEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -54920,8 +54892,8 @@ func (p projGEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -54994,8 +54966,8 @@ func (p projGEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -55113,8 +55085,8 @@ func (p projGEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -55187,8 +55159,8 @@ func (p projGEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -55306,8 +55278,8 @@ func (p projGEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -55380,8 +55352,8 @@ func (p projGEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -55488,8 +55460,8 @@ func (p projGEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -55540,8 +55512,8 @@ func (p projGEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -55636,8 +55608,8 @@ func (p projGETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -55686,8 +55658,8 @@ func (p projGETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -55774,8 +55746,8 @@ func (p projGEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -55810,8 +55782,8 @@ func (p projGEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col[0:n]
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
@@ -55893,8 +55865,8 @@ func (p projGEDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
@@ -55933,8 +55905,8 @@ func (p projGEDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col = col.Slice(0, n)
 				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 

--- a/pkg/sql/colexec/proj_non_const_ops.eg.go
+++ b/pkg/sql/colexec/proj_non_const_ops.eg.go
@@ -112,10 +112,9 @@ func (p projBitandInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -145,10 +144,9 @@ func (p projBitandInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -224,10 +222,9 @@ func (p projBitandInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -257,10 +254,9 @@ func (p projBitandInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -336,10 +332,9 @@ func (p projBitandInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -369,10 +364,9 @@ func (p projBitandInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -448,10 +442,9 @@ func (p projBitandInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -481,10 +474,9 @@ func (p projBitandInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -560,10 +552,9 @@ func (p projBitandInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -593,10 +584,9 @@ func (p projBitandInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -672,10 +662,9 @@ func (p projBitandInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -705,10 +694,9 @@ func (p projBitandInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -784,10 +772,9 @@ func (p projBitandInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -817,10 +804,9 @@ func (p projBitandInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -896,10 +882,9 @@ func (p projBitandInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -929,10 +914,9 @@ func (p projBitandInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -1008,10 +992,9 @@ func (p projBitandInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -1041,10 +1024,9 @@ func (p projBitandInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -1127,10 +1109,9 @@ func (p projBitandDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1.Slice(0, n)
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -1174,10 +1155,9 @@ func (p projBitandDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1.Slice(0, n)
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -1260,10 +1240,9 @@ func (p projBitorInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -1293,10 +1272,9 @@ func (p projBitorInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -1372,10 +1350,9 @@ func (p projBitorInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -1405,10 +1382,9 @@ func (p projBitorInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -1484,10 +1460,9 @@ func (p projBitorInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -1517,10 +1492,9 @@ func (p projBitorInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -1596,10 +1570,9 @@ func (p projBitorInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -1629,10 +1602,9 @@ func (p projBitorInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -1708,10 +1680,9 @@ func (p projBitorInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -1741,10 +1712,9 @@ func (p projBitorInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -1820,10 +1790,9 @@ func (p projBitorInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -1853,10 +1822,9 @@ func (p projBitorInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -1932,10 +1900,9 @@ func (p projBitorInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -1965,10 +1932,9 @@ func (p projBitorInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -2044,10 +2010,9 @@ func (p projBitorInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -2077,10 +2042,9 @@ func (p projBitorInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -2156,10 +2120,9 @@ func (p projBitorInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -2189,10 +2152,9 @@ func (p projBitorInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -2275,10 +2237,9 @@ func (p projBitorDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1.Slice(0, n)
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -2322,10 +2283,9 @@ func (p projBitorDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1.Slice(0, n)
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -2408,10 +2368,9 @@ func (p projBitxorInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -2441,10 +2400,9 @@ func (p projBitxorInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -2520,10 +2478,9 @@ func (p projBitxorInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -2553,10 +2510,9 @@ func (p projBitxorInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -2632,10 +2588,9 @@ func (p projBitxorInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -2665,10 +2620,9 @@ func (p projBitxorInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -2744,10 +2698,9 @@ func (p projBitxorInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -2777,10 +2730,9 @@ func (p projBitxorInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -2856,10 +2808,9 @@ func (p projBitxorInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -2889,10 +2840,9 @@ func (p projBitxorInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -2968,10 +2918,9 @@ func (p projBitxorInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -3001,10 +2950,9 @@ func (p projBitxorInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -3080,10 +3028,9 @@ func (p projBitxorInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -3113,10 +3060,9 @@ func (p projBitxorInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -3192,10 +3138,9 @@ func (p projBitxorInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -3225,10 +3170,9 @@ func (p projBitxorInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -3304,10 +3248,9 @@ func (p projBitxorInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -3337,10 +3280,9 @@ func (p projBitxorInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -3423,10 +3365,9 @@ func (p projBitxorDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1.Slice(0, n)
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -3470,10 +3411,9 @@ func (p projBitxorDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1.Slice(0, n)
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -3563,10 +3503,9 @@ func (p projPlusDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -3610,10 +3549,9 @@ func (p projPlusDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -3703,10 +3641,9 @@ func (p projPlusDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -3750,10 +3687,9 @@ func (p projPlusDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -3843,10 +3779,9 @@ func (p projPlusDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -3890,10 +3825,9 @@ func (p projPlusDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -3982,10 +3916,9 @@ func (p projPlusDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -4027,10 +3960,9 @@ func (p projPlusDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -4118,10 +4050,9 @@ func (p projPlusInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -4163,10 +4094,9 @@ func (p projPlusInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -4254,10 +4184,9 @@ func (p projPlusInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -4299,10 +4228,9 @@ func (p projPlusInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -4390,10 +4318,9 @@ func (p projPlusInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -4435,10 +4362,9 @@ func (p projPlusInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -4528,10 +4454,9 @@ func (p projPlusInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -4577,10 +4502,9 @@ func (p projPlusInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -4677,10 +4601,9 @@ func (p projPlusInt16DatumOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -4736,10 +4659,9 @@ func (p projPlusInt16DatumOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -4834,10 +4756,9 @@ func (p projPlusInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -4879,10 +4800,9 @@ func (p projPlusInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -4970,10 +4890,9 @@ func (p projPlusInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -5015,10 +4934,9 @@ func (p projPlusInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -5106,10 +5024,9 @@ func (p projPlusInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -5151,10 +5068,9 @@ func (p projPlusInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -5244,10 +5160,9 @@ func (p projPlusInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -5293,10 +5208,9 @@ func (p projPlusInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -5393,10 +5307,9 @@ func (p projPlusInt32DatumOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -5452,10 +5365,9 @@ func (p projPlusInt32DatumOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -5550,10 +5462,9 @@ func (p projPlusInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -5595,10 +5506,9 @@ func (p projPlusInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -5686,10 +5596,9 @@ func (p projPlusInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -5731,10 +5640,9 @@ func (p projPlusInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -5822,10 +5730,9 @@ func (p projPlusInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -5867,10 +5774,9 @@ func (p projPlusInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -5960,10 +5866,9 @@ func (p projPlusInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -6009,10 +5914,9 @@ func (p projPlusInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -6109,10 +6013,9 @@ func (p projPlusInt64DatumOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -6168,10 +6071,9 @@ func (p projPlusInt64DatumOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -6263,10 +6165,9 @@ func (p projPlusFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -6302,10 +6203,9 @@ func (p projPlusFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -6382,10 +6282,9 @@ func (p projPlusTimestampIntervalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -6411,10 +6310,9 @@ func (p projPlusTimestampIntervalOp) Next(ctx context.Context) coldata.Batch {
 					projCol[i] = duration.Add(arg1, arg2)
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -6486,10 +6384,9 @@ func (p projPlusIntervalTimestampOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -6515,10 +6412,9 @@ func (p projPlusIntervalTimestampOp) Next(ctx context.Context) coldata.Batch {
 					projCol[i] = duration.Add(arg2, arg1)
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -6590,10 +6486,9 @@ func (p projPlusIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -6619,10 +6514,9 @@ func (p projPlusIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 					projCol[i] = arg1.Add(arg2)
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -6709,10 +6603,9 @@ func (p projPlusIntervalDatumOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -6768,10 +6661,9 @@ func (p projPlusIntervalDatumOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -6871,10 +6763,9 @@ func (p projPlusDatumIntervalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1.Slice(0, n)
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -6926,10 +6817,9 @@ func (p projPlusDatumIntervalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1.Slice(0, n)
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -7027,10 +6917,9 @@ func (p projPlusDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1.Slice(0, n)
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -7082,10 +6971,9 @@ func (p projPlusDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1.Slice(0, n)
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -7183,10 +7071,9 @@ func (p projPlusDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1.Slice(0, n)
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -7238,10 +7125,9 @@ func (p projPlusDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1.Slice(0, n)
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -7339,10 +7225,9 @@ func (p projPlusDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1.Slice(0, n)
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -7394,10 +7279,9 @@ func (p projPlusDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1.Slice(0, n)
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -7491,10 +7375,9 @@ func (p projMinusDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -7538,10 +7421,9 @@ func (p projMinusDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -7631,10 +7513,9 @@ func (p projMinusDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -7678,10 +7559,9 @@ func (p projMinusDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -7771,10 +7651,9 @@ func (p projMinusDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -7818,10 +7697,9 @@ func (p projMinusDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -7910,10 +7788,9 @@ func (p projMinusDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -7955,10 +7832,9 @@ func (p projMinusDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -8046,10 +7922,9 @@ func (p projMinusInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -8091,10 +7966,9 @@ func (p projMinusInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -8182,10 +8056,9 @@ func (p projMinusInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -8227,10 +8100,9 @@ func (p projMinusInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -8318,10 +8190,9 @@ func (p projMinusInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -8363,10 +8234,9 @@ func (p projMinusInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -8456,10 +8326,9 @@ func (p projMinusInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -8505,10 +8374,9 @@ func (p projMinusInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -8605,10 +8473,9 @@ func (p projMinusInt16DatumOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -8664,10 +8531,9 @@ func (p projMinusInt16DatumOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -8762,10 +8628,9 @@ func (p projMinusInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -8807,10 +8672,9 @@ func (p projMinusInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -8898,10 +8762,9 @@ func (p projMinusInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -8943,10 +8806,9 @@ func (p projMinusInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -9034,10 +8896,9 @@ func (p projMinusInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -9079,10 +8940,9 @@ func (p projMinusInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -9172,10 +9032,9 @@ func (p projMinusInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -9221,10 +9080,9 @@ func (p projMinusInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -9321,10 +9179,9 @@ func (p projMinusInt32DatumOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -9380,10 +9237,9 @@ func (p projMinusInt32DatumOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -9478,10 +9334,9 @@ func (p projMinusInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -9523,10 +9378,9 @@ func (p projMinusInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -9614,10 +9468,9 @@ func (p projMinusInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -9659,10 +9512,9 @@ func (p projMinusInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -9750,10 +9602,9 @@ func (p projMinusInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -9795,10 +9646,9 @@ func (p projMinusInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -9888,10 +9738,9 @@ func (p projMinusInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -9937,10 +9786,9 @@ func (p projMinusInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -10037,10 +9885,9 @@ func (p projMinusInt64DatumOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -10096,10 +9943,9 @@ func (p projMinusInt64DatumOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -10191,10 +10037,9 @@ func (p projMinusFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -10230,10 +10075,9 @@ func (p projMinusFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -10313,10 +10157,9 @@ func (p projMinusTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -10348,10 +10191,9 @@ func (p projMinusTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -10426,10 +10268,9 @@ func (p projMinusTimestampIntervalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -10455,10 +10296,9 @@ func (p projMinusTimestampIntervalOp) Next(ctx context.Context) coldata.Batch {
 					projCol[i] = duration.Add(arg1, arg2.Mul(-1))
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -10530,10 +10370,9 @@ func (p projMinusIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -10559,10 +10398,9 @@ func (p projMinusIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 					projCol[i] = arg1.Sub(arg2)
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -10649,10 +10487,9 @@ func (p projMinusIntervalDatumOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -10708,10 +10545,9 @@ func (p projMinusIntervalDatumOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -10807,10 +10643,9 @@ func (p projMinusDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1.Slice(0, n)
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -10854,10 +10689,9 @@ func (p projMinusDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1.Slice(0, n)
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -10951,10 +10785,9 @@ func (p projMinusDatumIntervalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1.Slice(0, n)
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -11006,10 +10839,9 @@ func (p projMinusDatumIntervalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1.Slice(0, n)
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -11107,10 +10939,9 @@ func (p projMinusDatumBytesOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1.Slice(0, n)
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -11162,10 +10993,9 @@ func (p projMinusDatumBytesOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1.Slice(0, n)
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -11263,10 +11093,9 @@ func (p projMinusDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1.Slice(0, n)
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -11318,10 +11147,9 @@ func (p projMinusDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1.Slice(0, n)
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -11419,10 +11247,9 @@ func (p projMinusDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1.Slice(0, n)
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -11474,10 +11301,9 @@ func (p projMinusDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1.Slice(0, n)
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -11575,10 +11401,9 @@ func (p projMinusDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1.Slice(0, n)
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -11630,10 +11455,9 @@ func (p projMinusDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1.Slice(0, n)
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -11727,10 +11551,9 @@ func (p projMultDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -11774,10 +11597,9 @@ func (p projMultDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -11867,10 +11689,9 @@ func (p projMultDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -11914,10 +11735,9 @@ func (p projMultDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -12007,10 +11827,9 @@ func (p projMultDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -12054,10 +11873,9 @@ func (p projMultDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -12146,10 +11964,9 @@ func (p projMultDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -12191,10 +12008,9 @@ func (p projMultDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -12279,10 +12095,9 @@ func (p projMultDecimalIntervalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -12318,10 +12133,9 @@ func (p projMultDecimalIntervalOp) Next(ctx context.Context) coldata.Batch {
 					projCol[i] = arg2.MulFloat(f)
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -12414,10 +12228,9 @@ func (p projMultInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -12475,10 +12288,9 @@ func (p projMultInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -12582,10 +12394,9 @@ func (p projMultInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -12643,10 +12454,9 @@ func (p projMultInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -12750,10 +12560,9 @@ func (p projMultInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -12811,10 +12620,9 @@ func (p projMultInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -12912,10 +12720,9 @@ func (p projMultInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -12961,10 +12768,9 @@ func (p projMultInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -13046,10 +12852,9 @@ func (p projMultInt16IntervalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -13075,10 +12880,9 @@ func (p projMultInt16IntervalOp) Next(ctx context.Context) coldata.Batch {
 					projCol[i] = arg2.Mul(int64(arg1))
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -13166,10 +12970,9 @@ func (p projMultInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -13227,10 +13030,9 @@ func (p projMultInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -13334,10 +13136,9 @@ func (p projMultInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -13395,10 +13196,9 @@ func (p projMultInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -13502,10 +13302,9 @@ func (p projMultInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -13563,10 +13362,9 @@ func (p projMultInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -13664,10 +13462,9 @@ func (p projMultInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -13713,10 +13510,9 @@ func (p projMultInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -13798,10 +13594,9 @@ func (p projMultInt32IntervalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -13827,10 +13622,9 @@ func (p projMultInt32IntervalOp) Next(ctx context.Context) coldata.Batch {
 					projCol[i] = arg2.Mul(int64(arg1))
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -13918,10 +13712,9 @@ func (p projMultInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -13979,10 +13772,9 @@ func (p projMultInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -14086,10 +13878,9 @@ func (p projMultInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -14147,10 +13938,9 @@ func (p projMultInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -14254,10 +14044,9 @@ func (p projMultInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -14315,10 +14104,9 @@ func (p projMultInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -14416,10 +14204,9 @@ func (p projMultInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -14465,10 +14252,9 @@ func (p projMultInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -14550,10 +14336,9 @@ func (p projMultInt64IntervalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -14579,10 +14364,9 @@ func (p projMultInt64IntervalOp) Next(ctx context.Context) coldata.Batch {
 					projCol[i] = arg2.Mul(int64(arg1))
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -14659,10 +14443,9 @@ func (p projMultFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -14698,10 +14481,9 @@ func (p projMultFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -14778,10 +14560,9 @@ func (p projMultFloat64IntervalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -14807,10 +14588,9 @@ func (p projMultFloat64IntervalOp) Next(ctx context.Context) coldata.Batch {
 					projCol[i] = arg2.MulFloat(float64(arg1))
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -14882,10 +14662,9 @@ func (p projMultIntervalInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -14911,10 +14690,9 @@ func (p projMultIntervalInt16Op) Next(ctx context.Context) coldata.Batch {
 					projCol[i] = arg1.Mul(int64(arg2))
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -14986,10 +14764,9 @@ func (p projMultIntervalInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -15015,10 +14792,9 @@ func (p projMultIntervalInt32Op) Next(ctx context.Context) coldata.Batch {
 					projCol[i] = arg1.Mul(int64(arg2))
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -15090,10 +14866,9 @@ func (p projMultIntervalInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -15119,10 +14894,9 @@ func (p projMultIntervalInt64Op) Next(ctx context.Context) coldata.Batch {
 					projCol[i] = arg1.Mul(int64(arg2))
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -15194,10 +14968,9 @@ func (p projMultIntervalFloat64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -15223,10 +14996,9 @@ func (p projMultIntervalFloat64Op) Next(ctx context.Context) coldata.Batch {
 					projCol[i] = arg1.MulFloat(float64(arg2))
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -15303,10 +15075,9 @@ func (p projMultIntervalDecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -15342,10 +15113,9 @@ func (p projMultIntervalDecimalOp) Next(ctx context.Context) coldata.Batch {
 					projCol[i] = arg1.MulFloat(f)
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -15435,10 +15205,9 @@ func (p projDivDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -15490,10 +15259,9 @@ func (p projDivDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -15591,10 +15359,9 @@ func (p projDivDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -15646,10 +15413,9 @@ func (p projDivDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -15747,10 +15513,9 @@ func (p projDivDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -15802,10 +15567,9 @@ func (p projDivDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -15902,10 +15666,9 @@ func (p projDivDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -15955,10 +15718,9 @@ func (p projDivDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -16054,10 +15816,9 @@ func (p projDivInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -16107,10 +15868,9 @@ func (p projDivInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -16206,10 +15966,9 @@ func (p projDivInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -16259,10 +16018,9 @@ func (p projDivInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -16358,10 +16116,9 @@ func (p projDivInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -16411,10 +16168,9 @@ func (p projDivInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -16512,10 +16268,9 @@ func (p projDivInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -16569,10 +16324,9 @@ func (p projDivInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -16670,10 +16424,9 @@ func (p projDivInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -16723,10 +16476,9 @@ func (p projDivInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -16822,10 +16574,9 @@ func (p projDivInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -16875,10 +16626,9 @@ func (p projDivInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -16974,10 +16724,9 @@ func (p projDivInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -17027,10 +16776,9 @@ func (p projDivInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -17128,10 +16876,9 @@ func (p projDivInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -17185,10 +16932,9 @@ func (p projDivInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -17286,10 +17032,9 @@ func (p projDivInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -17339,10 +17084,9 @@ func (p projDivInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -17438,10 +17182,9 @@ func (p projDivInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -17491,10 +17234,9 @@ func (p projDivInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -17590,10 +17332,9 @@ func (p projDivInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -17643,10 +17384,9 @@ func (p projDivInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -17744,10 +17484,9 @@ func (p projDivInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -17801,10 +17540,9 @@ func (p projDivInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -17899,10 +17637,9 @@ func (p projDivFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -17946,10 +17683,9 @@ func (p projDivFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -18034,10 +17770,9 @@ func (p projDivIntervalInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -18071,10 +17806,9 @@ func (p projDivIntervalInt64Op) Next(ctx context.Context) coldata.Batch {
 					projCol[i] = arg1.Div(int64(arg2))
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -18154,10 +17888,9 @@ func (p projDivIntervalFloat64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -18191,10 +17924,9 @@ func (p projDivIntervalFloat64Op) Next(ctx context.Context) coldata.Batch {
 					projCol[i] = arg1.DivFloat(float64(arg2))
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -18283,10 +18015,9 @@ func (p projFloorDivDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -18338,10 +18069,9 @@ func (p projFloorDivDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -18439,10 +18169,9 @@ func (p projFloorDivDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -18494,10 +18223,9 @@ func (p projFloorDivDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -18595,10 +18323,9 @@ func (p projFloorDivDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -18650,10 +18377,9 @@ func (p projFloorDivDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -18750,10 +18476,9 @@ func (p projFloorDivDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -18803,10 +18528,9 @@ func (p projFloorDivDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -18897,10 +18621,9 @@ func (p projFloorDivInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -18940,10 +18663,9 @@ func (p projFloorDivInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -19029,10 +18751,9 @@ func (p projFloorDivInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -19072,10 +18793,9 @@ func (p projFloorDivInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -19161,10 +18881,9 @@ func (p projFloorDivInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -19204,10 +18923,9 @@ func (p projFloorDivInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -19300,10 +19018,9 @@ func (p projFloorDivInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -19357,10 +19074,9 @@ func (p projFloorDivInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -19453,10 +19169,9 @@ func (p projFloorDivInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -19496,10 +19211,9 @@ func (p projFloorDivInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -19585,10 +19299,9 @@ func (p projFloorDivInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -19628,10 +19341,9 @@ func (p projFloorDivInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -19717,10 +19429,9 @@ func (p projFloorDivInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -19760,10 +19471,9 @@ func (p projFloorDivInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -19856,10 +19566,9 @@ func (p projFloorDivInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -19913,10 +19622,9 @@ func (p projFloorDivInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -20009,10 +19717,9 @@ func (p projFloorDivInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -20052,10 +19759,9 @@ func (p projFloorDivInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -20141,10 +19847,9 @@ func (p projFloorDivInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -20184,10 +19889,9 @@ func (p projFloorDivInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -20273,10 +19977,9 @@ func (p projFloorDivInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -20316,10 +20019,9 @@ func (p projFloorDivInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -20412,10 +20114,9 @@ func (p projFloorDivInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -20469,10 +20170,9 @@ func (p projFloorDivInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -20567,10 +20267,9 @@ func (p projFloorDivFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -20614,10 +20313,9 @@ func (p projFloorDivFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -20711,10 +20409,9 @@ func (p projModDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -20766,10 +20463,9 @@ func (p projModDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -20867,10 +20563,9 @@ func (p projModDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -20922,10 +20617,9 @@ func (p projModDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -21023,10 +20717,9 @@ func (p projModDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -21078,10 +20771,9 @@ func (p projModDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -21178,10 +20870,9 @@ func (p projModDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -21231,10 +20922,9 @@ func (p projModDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -21325,10 +21015,9 @@ func (p projModInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -21368,10 +21057,9 @@ func (p projModInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -21457,10 +21145,9 @@ func (p projModInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -21500,10 +21187,9 @@ func (p projModInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -21589,10 +21275,9 @@ func (p projModInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -21632,10 +21317,9 @@ func (p projModInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -21728,10 +21412,9 @@ func (p projModInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -21785,10 +21468,9 @@ func (p projModInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -21881,10 +21563,9 @@ func (p projModInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -21924,10 +21605,9 @@ func (p projModInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -22013,10 +21693,9 @@ func (p projModInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -22056,10 +21735,9 @@ func (p projModInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -22145,10 +21823,9 @@ func (p projModInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -22188,10 +21865,9 @@ func (p projModInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -22284,10 +21960,9 @@ func (p projModInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -22341,10 +22016,9 @@ func (p projModInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -22437,10 +22111,9 @@ func (p projModInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -22480,10 +22153,9 @@ func (p projModInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -22569,10 +22241,9 @@ func (p projModInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -22612,10 +22283,9 @@ func (p projModInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -22701,10 +22371,9 @@ func (p projModInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -22744,10 +22413,9 @@ func (p projModInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -22840,10 +22508,9 @@ func (p projModInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -22897,10 +22564,9 @@ func (p projModInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -22995,10 +22661,9 @@ func (p projModFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -23042,10 +22707,9 @@ func (p projModFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -23135,10 +22799,9 @@ func (p projPowDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -23182,10 +22845,9 @@ func (p projPowDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -23275,10 +22937,9 @@ func (p projPowDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -23322,10 +22983,9 @@ func (p projPowDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -23415,10 +23075,9 @@ func (p projPowDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -23462,10 +23121,9 @@ func (p projPowDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -23554,10 +23212,9 @@ func (p projPowDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -23599,10 +23256,9 @@ func (p projPowDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -23696,10 +23352,9 @@ func (p projPowInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -23753,10 +23408,9 @@ func (p projPowInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -23856,10 +23510,9 @@ func (p projPowInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -23913,10 +23566,9 @@ func (p projPowInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -24016,10 +23668,9 @@ func (p projPowInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -24073,10 +23724,9 @@ func (p projPowInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -24172,10 +23822,9 @@ func (p projPowInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -24221,10 +23870,9 @@ func (p projPowInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -24320,10 +23968,9 @@ func (p projPowInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -24377,10 +24024,9 @@ func (p projPowInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -24480,10 +24126,9 @@ func (p projPowInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -24537,10 +24182,9 @@ func (p projPowInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -24640,10 +24284,9 @@ func (p projPowInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -24697,10 +24340,9 @@ func (p projPowInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -24796,10 +24438,9 @@ func (p projPowInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -24845,10 +24486,9 @@ func (p projPowInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -24944,10 +24584,9 @@ func (p projPowInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -25001,10 +24640,9 @@ func (p projPowInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -25104,10 +24742,9 @@ func (p projPowInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -25161,10 +24798,9 @@ func (p projPowInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -25264,10 +24900,9 @@ func (p projPowInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -25321,10 +24956,9 @@ func (p projPowInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -25420,10 +25054,9 @@ func (p projPowInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -25469,10 +25102,9 @@ func (p projPowInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -25559,10 +25191,9 @@ func (p projPowFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -25598,10 +25229,9 @@ func (p projPowFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -25685,6 +25315,9 @@ func (p projConcatBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -25724,6 +25357,9 @@ func (p projConcatBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -25811,10 +25447,9 @@ func (p projConcatDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1.Slice(0, n)
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -25858,10 +25493,9 @@ func (p projConcatDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1.Slice(0, n)
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -25950,10 +25584,9 @@ func (p projLShiftInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -25995,10 +25628,9 @@ func (p projLShiftInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -26086,10 +25718,9 @@ func (p projLShiftInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -26131,10 +25762,9 @@ func (p projLShiftInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -26222,10 +25852,9 @@ func (p projLShiftInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -26267,10 +25896,9 @@ func (p projLShiftInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -26358,10 +25986,9 @@ func (p projLShiftInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -26403,10 +26030,9 @@ func (p projLShiftInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -26494,10 +26120,9 @@ func (p projLShiftInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -26539,10 +26164,9 @@ func (p projLShiftInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -26630,10 +26254,9 @@ func (p projLShiftInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -26675,10 +26298,9 @@ func (p projLShiftInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -26766,10 +26388,9 @@ func (p projLShiftInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -26811,10 +26432,9 @@ func (p projLShiftInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -26902,10 +26522,9 @@ func (p projLShiftInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -26947,10 +26566,9 @@ func (p projLShiftInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -27038,10 +26656,9 @@ func (p projLShiftInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -27083,10 +26700,9 @@ func (p projLShiftInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -27179,10 +26795,9 @@ func (p projLShiftDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1.Slice(0, n)
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -27234,10 +26849,9 @@ func (p projLShiftDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1.Slice(0, n)
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -27335,10 +26949,9 @@ func (p projLShiftDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1.Slice(0, n)
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -27390,10 +27003,9 @@ func (p projLShiftDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1.Slice(0, n)
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -27491,10 +27103,9 @@ func (p projLShiftDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1.Slice(0, n)
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -27546,10 +27157,9 @@ func (p projLShiftDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1.Slice(0, n)
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -27642,10 +27252,9 @@ func (p projRShiftInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -27687,10 +27296,9 @@ func (p projRShiftInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -27778,10 +27386,9 @@ func (p projRShiftInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -27823,10 +27430,9 @@ func (p projRShiftInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -27914,10 +27520,9 @@ func (p projRShiftInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -27959,10 +27564,9 @@ func (p projRShiftInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -28050,10 +27654,9 @@ func (p projRShiftInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -28095,10 +27698,9 @@ func (p projRShiftInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -28186,10 +27788,9 @@ func (p projRShiftInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -28231,10 +27832,9 @@ func (p projRShiftInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -28322,10 +27922,9 @@ func (p projRShiftInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -28367,10 +27966,9 @@ func (p projRShiftInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -28458,10 +28056,9 @@ func (p projRShiftInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -28503,10 +28100,9 @@ func (p projRShiftInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -28594,10 +28190,9 @@ func (p projRShiftInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -28639,10 +28234,9 @@ func (p projRShiftInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -28730,10 +28324,9 @@ func (p projRShiftInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -28775,10 +28368,9 @@ func (p projRShiftInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -28871,10 +28463,9 @@ func (p projRShiftDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1.Slice(0, n)
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -28926,10 +28517,9 @@ func (p projRShiftDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1.Slice(0, n)
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -29027,10 +28617,9 @@ func (p projRShiftDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1.Slice(0, n)
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -29082,10 +28671,9 @@ func (p projRShiftDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1.Slice(0, n)
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -29183,10 +28771,9 @@ func (p projRShiftDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1.Slice(0, n)
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -29238,10 +28825,9 @@ func (p projRShiftDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1.Slice(0, n)
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -29339,10 +28925,9 @@ func (p projJSONFetchValDatumBytesOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1.Slice(0, n)
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -29394,10 +28979,9 @@ func (p projJSONFetchValDatumBytesOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1.Slice(0, n)
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -29495,10 +29079,9 @@ func (p projJSONFetchValDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1.Slice(0, n)
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -29550,10 +29133,9 @@ func (p projJSONFetchValDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1.Slice(0, n)
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -29651,10 +29233,9 @@ func (p projJSONFetchValDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1.Slice(0, n)
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -29706,10 +29287,9 @@ func (p projJSONFetchValDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1.Slice(0, n)
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -29807,10 +29387,9 @@ func (p projJSONFetchValDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1.Slice(0, n)
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -29862,10 +29441,9 @@ func (p projJSONFetchValDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1.Slice(0, n)
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -29959,10 +29537,9 @@ func (p projJSONFetchValPathDatumDatumOp) Next(ctx context.Context) coldata.Batc
 					}
 				}
 			} else {
-				col1 = col1.Slice(0, n)
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -30006,10 +29583,9 @@ func (p projJSONFetchValPathDatumDatumOp) Next(ctx context.Context) coldata.Batc
 
 				}
 			} else {
-				col1 = col1.Slice(0, n)
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -30104,10 +29680,9 @@ func (p projEQBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -30161,10 +29736,9 @@ func (p projEQBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -30256,6 +29830,9 @@ func (p projEQBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -30293,6 +29870,9 @@ func (p projEQBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -30382,10 +29962,9 @@ func (p projEQDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -30435,10 +30014,9 @@ func (p projEQDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -30534,10 +30112,9 @@ func (p projEQDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -30587,10 +30164,9 @@ func (p projEQDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -30686,10 +30262,9 @@ func (p projEQDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -30739,10 +30314,9 @@ func (p projEQDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -30840,10 +30414,9 @@ func (p projEQDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -30897,10 +30470,9 @@ func (p projEQDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -30992,10 +30564,9 @@ func (p projEQDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -31033,10 +30604,9 @@ func (p projEQDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -31131,10 +30701,9 @@ func (p projEQInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -31194,10 +30763,9 @@ func (p projEQInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -31303,10 +30871,9 @@ func (p projEQInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -31366,10 +30933,9 @@ func (p projEQInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -31475,10 +31041,9 @@ func (p projEQInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -31538,10 +31103,9 @@ func (p projEQInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -31655,10 +31219,9 @@ func (p projEQInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -31734,10 +31297,9 @@ func (p projEQInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -31846,10 +31408,9 @@ func (p projEQInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -31899,10 +31460,9 @@ func (p projEQInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -32003,10 +31563,9 @@ func (p projEQInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -32066,10 +31625,9 @@ func (p projEQInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -32175,10 +31733,9 @@ func (p projEQInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -32238,10 +31795,9 @@ func (p projEQInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -32347,10 +31903,9 @@ func (p projEQInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -32410,10 +31965,9 @@ func (p projEQInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -32527,10 +32081,9 @@ func (p projEQInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -32606,10 +32159,9 @@ func (p projEQInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -32718,10 +32270,9 @@ func (p projEQInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -32771,10 +32322,9 @@ func (p projEQInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -32875,10 +32425,9 @@ func (p projEQInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -32938,10 +32487,9 @@ func (p projEQInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -33047,10 +32595,9 @@ func (p projEQInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -33110,10 +32657,9 @@ func (p projEQInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -33219,10 +32765,9 @@ func (p projEQInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -33282,10 +32827,9 @@ func (p projEQInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -33399,10 +32943,9 @@ func (p projEQInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -33478,10 +33021,9 @@ func (p projEQInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -33590,10 +33132,9 @@ func (p projEQInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -33643,10 +33184,9 @@ func (p projEQInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -33755,10 +33295,9 @@ func (p projEQFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -33834,10 +33373,9 @@ func (p projEQFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -33959,10 +33497,9 @@ func (p projEQFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -34038,10 +33575,9 @@ func (p projEQFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -34163,10 +33699,9 @@ func (p projEQFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -34242,10 +33777,9 @@ func (p projEQFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -34367,10 +33901,9 @@ func (p projEQFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -34446,10 +33979,9 @@ func (p projEQFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -34560,10 +34092,9 @@ func (p projEQFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -34617,10 +34148,9 @@ func (p projEQFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -34719,10 +34249,9 @@ func (p projEQTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -34774,10 +34303,9 @@ func (p projEQTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -34868,10 +34396,9 @@ func (p projEQIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -34909,10 +34436,9 @@ func (p projEQIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -34998,10 +34524,9 @@ func (p projEQDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1.Slice(0, n)
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -35043,10 +34568,9 @@ func (p projEQDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1.Slice(0, n)
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -35140,10 +34664,9 @@ func (p projNEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -35197,10 +34720,9 @@ func (p projNEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -35292,6 +34814,9 @@ func (p projNEBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -35329,6 +34854,9 @@ func (p projNEBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -35418,10 +34946,9 @@ func (p projNEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -35471,10 +34998,9 @@ func (p projNEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -35570,10 +35096,9 @@ func (p projNEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -35623,10 +35148,9 @@ func (p projNEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -35722,10 +35246,9 @@ func (p projNEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -35775,10 +35298,9 @@ func (p projNEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -35876,10 +35398,9 @@ func (p projNEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -35933,10 +35454,9 @@ func (p projNEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -36028,10 +35548,9 @@ func (p projNEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -36069,10 +35588,9 @@ func (p projNEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -36167,10 +35685,9 @@ func (p projNEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -36230,10 +35747,9 @@ func (p projNEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -36339,10 +35855,9 @@ func (p projNEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -36402,10 +35917,9 @@ func (p projNEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -36511,10 +36025,9 @@ func (p projNEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -36574,10 +36087,9 @@ func (p projNEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -36691,10 +36203,9 @@ func (p projNEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -36770,10 +36281,9 @@ func (p projNEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -36882,10 +36392,9 @@ func (p projNEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -36935,10 +36444,9 @@ func (p projNEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -37039,10 +36547,9 @@ func (p projNEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -37102,10 +36609,9 @@ func (p projNEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -37211,10 +36717,9 @@ func (p projNEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -37274,10 +36779,9 @@ func (p projNEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -37383,10 +36887,9 @@ func (p projNEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -37446,10 +36949,9 @@ func (p projNEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -37563,10 +37065,9 @@ func (p projNEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -37642,10 +37143,9 @@ func (p projNEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -37754,10 +37254,9 @@ func (p projNEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -37807,10 +37306,9 @@ func (p projNEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -37911,10 +37409,9 @@ func (p projNEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -37974,10 +37471,9 @@ func (p projNEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -38083,10 +37579,9 @@ func (p projNEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -38146,10 +37641,9 @@ func (p projNEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -38255,10 +37749,9 @@ func (p projNEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -38318,10 +37811,9 @@ func (p projNEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -38435,10 +37927,9 @@ func (p projNEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -38514,10 +38005,9 @@ func (p projNEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -38626,10 +38116,9 @@ func (p projNEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -38679,10 +38168,9 @@ func (p projNEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -38791,10 +38279,9 @@ func (p projNEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -38870,10 +38357,9 @@ func (p projNEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -38995,10 +38481,9 @@ func (p projNEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -39074,10 +38559,9 @@ func (p projNEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -39199,10 +38683,9 @@ func (p projNEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -39278,10 +38761,9 @@ func (p projNEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -39403,10 +38885,9 @@ func (p projNEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -39482,10 +38963,9 @@ func (p projNEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -39596,10 +39076,9 @@ func (p projNEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -39653,10 +39132,9 @@ func (p projNEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -39755,10 +39233,9 @@ func (p projNETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -39810,10 +39287,9 @@ func (p projNETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -39904,10 +39380,9 @@ func (p projNEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -39945,10 +39420,9 @@ func (p projNEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -40034,10 +39508,9 @@ func (p projNEDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1.Slice(0, n)
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -40079,10 +39552,9 @@ func (p projNEDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1.Slice(0, n)
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -40176,10 +39648,9 @@ func (p projLTBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -40233,10 +39704,9 @@ func (p projLTBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -40328,6 +39798,9 @@ func (p projLTBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -40365,6 +39838,9 @@ func (p projLTBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -40454,10 +39930,9 @@ func (p projLTDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -40507,10 +39982,9 @@ func (p projLTDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -40606,10 +40080,9 @@ func (p projLTDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -40659,10 +40132,9 @@ func (p projLTDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -40758,10 +40230,9 @@ func (p projLTDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -40811,10 +40282,9 @@ func (p projLTDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -40912,10 +40382,9 @@ func (p projLTDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -40969,10 +40438,9 @@ func (p projLTDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -41064,10 +40532,9 @@ func (p projLTDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -41105,10 +40572,9 @@ func (p projLTDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -41203,10 +40669,9 @@ func (p projLTInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -41266,10 +40731,9 @@ func (p projLTInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -41375,10 +40839,9 @@ func (p projLTInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -41438,10 +40901,9 @@ func (p projLTInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -41547,10 +41009,9 @@ func (p projLTInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -41610,10 +41071,9 @@ func (p projLTInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -41727,10 +41187,9 @@ func (p projLTInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -41806,10 +41265,9 @@ func (p projLTInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -41918,10 +41376,9 @@ func (p projLTInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -41971,10 +41428,9 @@ func (p projLTInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -42075,10 +41531,9 @@ func (p projLTInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -42138,10 +41593,9 @@ func (p projLTInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -42247,10 +41701,9 @@ func (p projLTInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -42310,10 +41763,9 @@ func (p projLTInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -42419,10 +41871,9 @@ func (p projLTInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -42482,10 +41933,9 @@ func (p projLTInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -42599,10 +42049,9 @@ func (p projLTInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -42678,10 +42127,9 @@ func (p projLTInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -42790,10 +42238,9 @@ func (p projLTInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -42843,10 +42290,9 @@ func (p projLTInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -42947,10 +42393,9 @@ func (p projLTInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -43010,10 +42455,9 @@ func (p projLTInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -43119,10 +42563,9 @@ func (p projLTInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -43182,10 +42625,9 @@ func (p projLTInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -43291,10 +42733,9 @@ func (p projLTInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -43354,10 +42795,9 @@ func (p projLTInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -43471,10 +42911,9 @@ func (p projLTInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -43550,10 +42989,9 @@ func (p projLTInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -43662,10 +43100,9 @@ func (p projLTInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -43715,10 +43152,9 @@ func (p projLTInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -43827,10 +43263,9 @@ func (p projLTFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -43906,10 +43341,9 @@ func (p projLTFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -44031,10 +43465,9 @@ func (p projLTFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -44110,10 +43543,9 @@ func (p projLTFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -44235,10 +43667,9 @@ func (p projLTFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -44314,10 +43745,9 @@ func (p projLTFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -44439,10 +43869,9 @@ func (p projLTFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -44518,10 +43947,9 @@ func (p projLTFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -44632,10 +44060,9 @@ func (p projLTFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -44689,10 +44116,9 @@ func (p projLTFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -44791,10 +44217,9 @@ func (p projLTTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -44846,10 +44271,9 @@ func (p projLTTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -44940,10 +44364,9 @@ func (p projLTIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -44981,10 +44404,9 @@ func (p projLTIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -45070,10 +44492,9 @@ func (p projLTDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1.Slice(0, n)
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -45115,10 +44536,9 @@ func (p projLTDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1.Slice(0, n)
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -45212,10 +44632,9 @@ func (p projLEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -45269,10 +44688,9 @@ func (p projLEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -45364,6 +44782,9 @@ func (p projLEBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -45401,6 +44822,9 @@ func (p projLEBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -45490,10 +44914,9 @@ func (p projLEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -45543,10 +44966,9 @@ func (p projLEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -45642,10 +45064,9 @@ func (p projLEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -45695,10 +45116,9 @@ func (p projLEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -45794,10 +45214,9 @@ func (p projLEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -45847,10 +45266,9 @@ func (p projLEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -45948,10 +45366,9 @@ func (p projLEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -46005,10 +45422,9 @@ func (p projLEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -46100,10 +45516,9 @@ func (p projLEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -46141,10 +45556,9 @@ func (p projLEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -46239,10 +45653,9 @@ func (p projLEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -46302,10 +45715,9 @@ func (p projLEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -46411,10 +45823,9 @@ func (p projLEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -46474,10 +45885,9 @@ func (p projLEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -46583,10 +45993,9 @@ func (p projLEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -46646,10 +46055,9 @@ func (p projLEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -46763,10 +46171,9 @@ func (p projLEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -46842,10 +46249,9 @@ func (p projLEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -46954,10 +46360,9 @@ func (p projLEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -47007,10 +46412,9 @@ func (p projLEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -47111,10 +46515,9 @@ func (p projLEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -47174,10 +46577,9 @@ func (p projLEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -47283,10 +46685,9 @@ func (p projLEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -47346,10 +46747,9 @@ func (p projLEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -47455,10 +46855,9 @@ func (p projLEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -47518,10 +46917,9 @@ func (p projLEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -47635,10 +47033,9 @@ func (p projLEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -47714,10 +47111,9 @@ func (p projLEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -47826,10 +47222,9 @@ func (p projLEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -47879,10 +47274,9 @@ func (p projLEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -47983,10 +47377,9 @@ func (p projLEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -48046,10 +47439,9 @@ func (p projLEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -48155,10 +47547,9 @@ func (p projLEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -48218,10 +47609,9 @@ func (p projLEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -48327,10 +47717,9 @@ func (p projLEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -48390,10 +47779,9 @@ func (p projLEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -48507,10 +47895,9 @@ func (p projLEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -48586,10 +47973,9 @@ func (p projLEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -48698,10 +48084,9 @@ func (p projLEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -48751,10 +48136,9 @@ func (p projLEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -48863,10 +48247,9 @@ func (p projLEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -48942,10 +48325,9 @@ func (p projLEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -49067,10 +48449,9 @@ func (p projLEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -49146,10 +48527,9 @@ func (p projLEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -49271,10 +48651,9 @@ func (p projLEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -49350,10 +48729,9 @@ func (p projLEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -49475,10 +48853,9 @@ func (p projLEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -49554,10 +48931,9 @@ func (p projLEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -49668,10 +49044,9 @@ func (p projLEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -49725,10 +49100,9 @@ func (p projLEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -49827,10 +49201,9 @@ func (p projLETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -49882,10 +49255,9 @@ func (p projLETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -49976,10 +49348,9 @@ func (p projLEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -50017,10 +49388,9 @@ func (p projLEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -50106,10 +49476,9 @@ func (p projLEDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1.Slice(0, n)
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -50151,10 +49520,9 @@ func (p projLEDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1.Slice(0, n)
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -50248,10 +49616,9 @@ func (p projGTBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -50305,10 +49672,9 @@ func (p projGTBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -50400,6 +49766,9 @@ func (p projGTBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -50437,6 +49806,9 @@ func (p projGTBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -50526,10 +49898,9 @@ func (p projGTDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -50579,10 +49950,9 @@ func (p projGTDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -50678,10 +50048,9 @@ func (p projGTDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -50731,10 +50100,9 @@ func (p projGTDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -50830,10 +50198,9 @@ func (p projGTDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -50883,10 +50250,9 @@ func (p projGTDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -50984,10 +50350,9 @@ func (p projGTDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -51041,10 +50406,9 @@ func (p projGTDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -51136,10 +50500,9 @@ func (p projGTDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -51177,10 +50540,9 @@ func (p projGTDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -51275,10 +50637,9 @@ func (p projGTInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -51338,10 +50699,9 @@ func (p projGTInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -51447,10 +50807,9 @@ func (p projGTInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -51510,10 +50869,9 @@ func (p projGTInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -51619,10 +50977,9 @@ func (p projGTInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -51682,10 +51039,9 @@ func (p projGTInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -51799,10 +51155,9 @@ func (p projGTInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -51878,10 +51233,9 @@ func (p projGTInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -51990,10 +51344,9 @@ func (p projGTInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -52043,10 +51396,9 @@ func (p projGTInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -52147,10 +51499,9 @@ func (p projGTInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -52210,10 +51561,9 @@ func (p projGTInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -52319,10 +51669,9 @@ func (p projGTInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -52382,10 +51731,9 @@ func (p projGTInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -52491,10 +51839,9 @@ func (p projGTInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -52554,10 +51901,9 @@ func (p projGTInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -52671,10 +52017,9 @@ func (p projGTInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -52750,10 +52095,9 @@ func (p projGTInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -52862,10 +52206,9 @@ func (p projGTInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -52915,10 +52258,9 @@ func (p projGTInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -53019,10 +52361,9 @@ func (p projGTInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -53082,10 +52423,9 @@ func (p projGTInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -53191,10 +52531,9 @@ func (p projGTInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -53254,10 +52593,9 @@ func (p projGTInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -53363,10 +52701,9 @@ func (p projGTInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -53426,10 +52763,9 @@ func (p projGTInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -53543,10 +52879,9 @@ func (p projGTInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -53622,10 +52957,9 @@ func (p projGTInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -53734,10 +53068,9 @@ func (p projGTInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -53787,10 +53120,9 @@ func (p projGTInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -53899,10 +53231,9 @@ func (p projGTFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -53978,10 +53309,9 @@ func (p projGTFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -54103,10 +53433,9 @@ func (p projGTFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -54182,10 +53511,9 @@ func (p projGTFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -54307,10 +53635,9 @@ func (p projGTFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -54386,10 +53713,9 @@ func (p projGTFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -54511,10 +53837,9 @@ func (p projGTFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -54590,10 +53915,9 @@ func (p projGTFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -54704,10 +54028,9 @@ func (p projGTFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -54761,10 +54084,9 @@ func (p projGTFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -54863,10 +54185,9 @@ func (p projGTTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -54918,10 +54239,9 @@ func (p projGTTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -55012,10 +54332,9 @@ func (p projGTIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -55053,10 +54372,9 @@ func (p projGTIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -55142,10 +54460,9 @@ func (p projGTDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1.Slice(0, n)
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -55187,10 +54504,9 @@ func (p projGTDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1.Slice(0, n)
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -55284,10 +54600,9 @@ func (p projGEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -55341,10 +54656,9 @@ func (p projGEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -55436,6 +54750,9 @@ func (p projGEBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -55473,6 +54790,9 @@ func (p projGEBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -55562,10 +54882,9 @@ func (p projGEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -55615,10 +54934,9 @@ func (p projGEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -55714,10 +55032,9 @@ func (p projGEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -55767,10 +55084,9 @@ func (p projGEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -55866,10 +55182,9 @@ func (p projGEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -55919,10 +55234,9 @@ func (p projGEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -56020,10 +55334,9 @@ func (p projGEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -56077,10 +55390,9 @@ func (p projGEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -56172,10 +55484,9 @@ func (p projGEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -56213,10 +55524,9 @@ func (p projGEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -56311,10 +55621,9 @@ func (p projGEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -56374,10 +55683,9 @@ func (p projGEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -56483,10 +55791,9 @@ func (p projGEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -56546,10 +55853,9 @@ func (p projGEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -56655,10 +55961,9 @@ func (p projGEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -56718,10 +56023,9 @@ func (p projGEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -56835,10 +56139,9 @@ func (p projGEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -56914,10 +56217,9 @@ func (p projGEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -57026,10 +56328,9 @@ func (p projGEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -57079,10 +56380,9 @@ func (p projGEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -57183,10 +56483,9 @@ func (p projGEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -57246,10 +56545,9 @@ func (p projGEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -57355,10 +56653,9 @@ func (p projGEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -57418,10 +56715,9 @@ func (p projGEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -57527,10 +56823,9 @@ func (p projGEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -57590,10 +56885,9 @@ func (p projGEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -57707,10 +57001,9 @@ func (p projGEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -57786,10 +57079,9 @@ func (p projGEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -57898,10 +57190,9 @@ func (p projGEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -57951,10 +57242,9 @@ func (p projGEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -58055,10 +57345,9 @@ func (p projGEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -58118,10 +57407,9 @@ func (p projGEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -58227,10 +57515,9 @@ func (p projGEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -58290,10 +57577,9 @@ func (p projGEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -58399,10 +57685,9 @@ func (p projGEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -58462,10 +57747,9 @@ func (p projGEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -58579,10 +57863,9 @@ func (p projGEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -58658,10 +57941,9 @@ func (p projGEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -58770,10 +58052,9 @@ func (p projGEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -58823,10 +58104,9 @@ func (p projGEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -58935,10 +58215,9 @@ func (p projGEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -59014,10 +58293,9 @@ func (p projGEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -59139,10 +58417,9 @@ func (p projGEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -59218,10 +58495,9 @@ func (p projGEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -59343,10 +58619,9 @@ func (p projGEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -59422,10 +58697,9 @@ func (p projGEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -59547,10 +58821,9 @@ func (p projGEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -59626,10 +58899,9 @@ func (p projGEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -59740,10 +59012,9 @@ func (p projGEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -59797,10 +59068,9 @@ func (p projGEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -59899,10 +59169,9 @@ func (p projGETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -59954,10 +59223,9 @@ func (p projGETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -60048,10 +59316,9 @@ func (p projGEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -60089,10 +59356,9 @@ func (p projGEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1[0:n]
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
@@ -60178,10 +59444,9 @@ func (p projGEDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 			} else {
-				col1 = col1.Slice(0, n)
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
@@ -60223,10 +59488,9 @@ func (p projGEDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 
 				}
 			} else {
-				col1 = col1.Slice(0, n)
-				colLen := col1.Len()
-				_ = projCol.Get(colLen - 1)
-				_ = col2.Get(colLen - 1)
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)

--- a/pkg/sql/colexec/proj_non_const_ops_tmpl.go
+++ b/pkg/sql/colexec/proj_non_const_ops_tmpl.go
@@ -162,15 +162,9 @@ func _SET_PROJECTION(_HAS_NULLS bool) {
 			_SET_SINGLE_TUPLE_PROJECTION(_HAS_NULLS)
 		}
 	} else {
-		// {{if not (eq .Left.VecMethod "Bytes")}}
-		// {{/* Slice is a noop for Bytes type, so colLen below might contain an
-		// incorrect value. In order to keep bounds check elimination for all other
-		// types, we simply omit this code snippet for Bytes. */}}
-		col1 = execgen.SLICE(col1, 0, n)
-		colLen := col1.Len()
-		_ = projCol.Get(colLen - 1)
-		_ = col2.Get(colLen - 1)
-		// {{end}}
+		_ = projCol.Get(n - 1)
+		_ = col1.Get(n - 1)
+		_ = col2.Get(n - 1)
 		for i := 0; i < n; i++ {
 			_SET_SINGLE_TUPLE_PROJECTION(_HAS_NULLS)
 		}

--- a/pkg/sql/colexec/select_in.eg.go
+++ b/pkg/sql/colexec/select_in.eg.go
@@ -513,7 +513,7 @@ func (pi *projectInOpBool) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		} else {
-			col = col[0:n]
+			_ = col.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if nulls.NullAt(i) {
 					projNulls.SetNull(i)
@@ -541,7 +541,7 @@ func (pi *projectInOpBool) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		} else {
-			col = col[0:n]
+			_ = col.Get(n - 1)
 			for i := 0; i < n; i++ {
 				v := col.Get(i)
 				cmpRes := cmpInBool(v, col, pi.filterRow, pi.hasNulls)
@@ -743,9 +743,7 @@ func (pi *projectInOpBytes) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		} else {
-			col = col
-			_ = 0
-			_ = n
+			_ = col.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if nulls.NullAt(i) {
 					projNulls.SetNull(i)
@@ -773,9 +771,7 @@ func (pi *projectInOpBytes) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		} else {
-			col = col
-			_ = 0
-			_ = n
+			_ = col.Get(n - 1)
 			for i := 0; i < n; i++ {
 				v := col.Get(i)
 				cmpRes := cmpInBytes(v, col, pi.filterRow, pi.hasNulls)
@@ -977,7 +973,7 @@ func (pi *projectInOpDecimal) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		} else {
-			col = col[0:n]
+			_ = col.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if nulls.NullAt(i) {
 					projNulls.SetNull(i)
@@ -1005,7 +1001,7 @@ func (pi *projectInOpDecimal) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		} else {
-			col = col[0:n]
+			_ = col.Get(n - 1)
 			for i := 0; i < n; i++ {
 				v := col.Get(i)
 				cmpRes := cmpInDecimal(v, col, pi.filterRow, pi.hasNulls)
@@ -1218,7 +1214,7 @@ func (pi *projectInOpInt16) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		} else {
-			col = col[0:n]
+			_ = col.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if nulls.NullAt(i) {
 					projNulls.SetNull(i)
@@ -1246,7 +1242,7 @@ func (pi *projectInOpInt16) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		} else {
-			col = col[0:n]
+			_ = col.Get(n - 1)
 			for i := 0; i < n; i++ {
 				v := col.Get(i)
 				cmpRes := cmpInInt16(v, col, pi.filterRow, pi.hasNulls)
@@ -1459,7 +1455,7 @@ func (pi *projectInOpInt32) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		} else {
-			col = col[0:n]
+			_ = col.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if nulls.NullAt(i) {
 					projNulls.SetNull(i)
@@ -1487,7 +1483,7 @@ func (pi *projectInOpInt32) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		} else {
-			col = col[0:n]
+			_ = col.Get(n - 1)
 			for i := 0; i < n; i++ {
 				v := col.Get(i)
 				cmpRes := cmpInInt32(v, col, pi.filterRow, pi.hasNulls)
@@ -1700,7 +1696,7 @@ func (pi *projectInOpInt64) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		} else {
-			col = col[0:n]
+			_ = col.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if nulls.NullAt(i) {
 					projNulls.SetNull(i)
@@ -1728,7 +1724,7 @@ func (pi *projectInOpInt64) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		} else {
-			col = col[0:n]
+			_ = col.Get(n - 1)
 			for i := 0; i < n; i++ {
 				v := col.Get(i)
 				cmpRes := cmpInInt64(v, col, pi.filterRow, pi.hasNulls)
@@ -1949,7 +1945,7 @@ func (pi *projectInOpFloat64) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		} else {
-			col = col[0:n]
+			_ = col.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if nulls.NullAt(i) {
 					projNulls.SetNull(i)
@@ -1977,7 +1973,7 @@ func (pi *projectInOpFloat64) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		} else {
-			col = col[0:n]
+			_ = col.Get(n - 1)
 			for i := 0; i < n; i++ {
 				v := col.Get(i)
 				cmpRes := cmpInFloat64(v, col, pi.filterRow, pi.hasNulls)
@@ -2186,7 +2182,7 @@ func (pi *projectInOpTimestamp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		} else {
-			col = col[0:n]
+			_ = col.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if nulls.NullAt(i) {
 					projNulls.SetNull(i)
@@ -2214,7 +2210,7 @@ func (pi *projectInOpTimestamp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		} else {
-			col = col[0:n]
+			_ = col.Get(n - 1)
 			for i := 0; i < n; i++ {
 				v := col.Get(i)
 				cmpRes := cmpInTimestamp(v, col, pi.filterRow, pi.hasNulls)
@@ -2416,7 +2412,7 @@ func (pi *projectInOpInterval) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		} else {
-			col = col[0:n]
+			_ = col.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if nulls.NullAt(i) {
 					projNulls.SetNull(i)
@@ -2444,7 +2440,7 @@ func (pi *projectInOpInterval) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		} else {
-			col = col[0:n]
+			_ = col.Get(n - 1)
 			for i := 0; i < n; i++ {
 				v := col.Get(i)
 				cmpRes := cmpInInterval(v, col, pi.filterRow, pi.hasNulls)
@@ -2648,7 +2644,7 @@ func (pi *projectInOpDatum) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		} else {
-			col = col.Slice(0, n)
+			_ = col.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if nulls.NullAt(i) {
 					projNulls.SetNull(i)
@@ -2676,7 +2672,7 @@ func (pi *projectInOpDatum) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		} else {
-			col = col.Slice(0, n)
+			_ = col.Get(n - 1)
 			for i := 0; i < n; i++ {
 				v := col.Get(i)
 				cmpRes := cmpInDatum(v, col, pi.filterRow, pi.hasNulls)

--- a/pkg/sql/colexec/select_in_tmpl.go
+++ b/pkg/sql/colexec/select_in_tmpl.go
@@ -27,7 +27,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coldataext"
 	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/colconv"
-	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
@@ -322,7 +321,7 @@ func (pi *projectInOp_TYPE) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		} else {
-			col = execgen.SLICE(col, 0, n)
+			_ = col.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if nulls.NullAt(i) {
 					projNulls.SetNull(i)
@@ -350,7 +349,7 @@ func (pi *projectInOp_TYPE) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		} else {
-			col = execgen.SLICE(col, 0, n)
+			_ = col.Get(n - 1)
 			for i := 0; i < n; i++ {
 				v := col.Get(i)
 				cmpRes := cmpIn_TYPE(v, col, pi.filterRow, pi.hasNulls)


### PR DESCRIPTION
In several places we are using `execgen.SLICE` to eliminate some bounds
checks. This commit refactors most of those callsites to use `Get`
instead. I confirmed that the number of BCEs doesn't change because of
this commit in `colexec` and `colexecagg` packages.

Note that in all affected places actually bounds checks didn't work
before nor after this commit. That is left to be figured out later.

Release note: None