### PR TITLE
sql: introduce connection/session variable to enable follower reads

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/as_of
+++ b/pkg/ccl/logictestccl/testdata/logic_test/as_of
@@ -11,3 +11,84 @@ SELECT * FROM t AS OF SYSTEM TIME follower_read_timestamp()
 
 statement error pq: relation "t" does not exist
 SELECT * FROM t AS OF SYSTEM TIME experimental_follower_read_timestamp()
+
+statement error pq: relation "t" does not exist
+BEGIN; SET TRANSACTION AS OF SYSTEM TIME follower_read_timestamp(); SELECT * FROM t
+
+statement ok
+ROLLBACK
+
+statement error pq: relation "t" does not exist
+BEGIN AS OF SYSTEM TIME follower_read_timestamp(); SELECT * FROM t
+
+statement ok
+ROLLBACK
+
+statement ok
+SET DEFAULT_TRANSACTION_USE_FOLLOWER_READS TO TRUE
+
+statement error pq: relation "t" does not exist
+SELECT * FROM t
+
+statement error pq: cannot execute CREATE DATABASE in a read-only transaction
+CREATE DATABASE IF NOT EXISTS d2
+
+statement error pq: relation "t" does not exist
+BEGIN; SELECT * FROM t
+
+statement ok
+ROLLBACK
+
+statement error pq: AS OF SYSTEM TIME specified with READ WRITE mode
+BEGIN READ WRITE
+
+statement error pq: cannot execute CREATE DATABASE in a read-only transaction
+BEGIN; CREATE DATABASE IF NOT EXISTS d2
+
+statement ok
+ROLLBACK
+
+statement ok
+SET DEFAULT_TRANSACTION_USE_FOLLOWER_READS TO FALSE
+
+statement ok
+SELECT * FROM t
+
+statement ok
+CREATE DATABASE IF NOT EXISTS d2
+
+statement ok
+BEGIN; SELECT * FROM t; COMMIT
+
+statement ok
+BEGIN READ WRITE; COMMIT
+
+statement ok
+BEGIN; CREATE DATABASE IF NOT EXISTS d2; COMMIT
+
+statement ok
+SET SESSION CHARACTERISTICS AS TRANSACTION AS OF SYSTEM TIME follower_read_timestamp()
+
+statement error pq: relation "t" does not exist
+SELECT * FROM t
+
+statement error pq: cannot execute CREATE DATABASE in a read-only transaction
+CREATE DATABASE IF NOT EXISTS d2
+
+statement error pq: relation "t" does not exist
+BEGIN; SELECT * FROM t
+
+statement ok
+ROLLBACK
+
+statement error pq: AS OF SYSTEM TIME specified with READ WRITE mode
+BEGIN READ WRITE
+
+statement error pq: cannot execute CREATE DATABASE in a read-only transaction
+BEGIN; CREATE DATABASE IF NOT EXISTS d2
+
+statement ok
+ROLLBACK
+
+statement ok
+SET DEFAULT_TRANSACTION_USE_FOLLOWER_READS TO FALSE

--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_enum
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_enum
@@ -55,4 +55,3 @@ ALTER TABLE partitioned_table_3 PARTITION BY RANGE (place)
 
 statement ok
 SELECT * FROM crdb_internal.tables
-

--- a/pkg/cmd/roachtest/follower_reads.go
+++ b/pkg/cmd/roachtest/follower_reads.go
@@ -116,7 +116,7 @@ func runFollowerReadsTest(ctx context.Context, t *test, c *cluster) {
 		return func() error {
 			nodeDB := conns[node-1]
 			r := nodeDB.QueryRowContext(ctx, "SELECT v FROM test.test AS OF SYSTEM "+
-				"TIME experimental_follower_read_timestamp() WHERE k = $1", k)
+				"TIME follower_read_timestamp() WHERE k = $1", k)
 			var got int64
 			if err := r.Scan(&got); err != nil {
 				// Ignore errors due to cancellation.

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -2069,6 +2069,25 @@ func (ex *connExecutor) readWriteModeWithSessionDefault(
 	return mode
 }
 
+// followerReadTimestampExpr is the function which can be used with AOST clauses
+// to generate a timestamp likely to be safe for follower reads.
+//
+// NOTE: this cannot live in pkg/sql/sem/tree due to the call to WrapFunction,
+// which fails before the pkg/sql/sem/builtins package has been initialized.
+var followerReadTimestampExpr = &tree.FuncExpr{
+	Func: tree.WrapFunction(tree.FollowerReadTimestampFunctionName),
+}
+
+func (ex *connExecutor) asOfClauseWithSessionDefault(expr tree.AsOfClause) tree.AsOfClause {
+	if expr.Expr == nil {
+		if ex.sessionData.DefaultTxnUseFollowerReads {
+			return tree.AsOfClause{Expr: followerReadTimestampExpr}
+		}
+		return tree.AsOfClause{}
+	}
+	return expr
+}
+
 // initEvalCtx initializes the fields of an extendedEvalContext that stay the
 // same across multiple statements. resetEvalCtx must also be called before each
 // statement, to reinitialize other fields.

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -2061,7 +2061,7 @@ func (ex *connExecutor) readWriteModeWithSessionDefault(
 	mode tree.ReadWriteMode,
 ) tree.ReadWriteMode {
 	if mode == tree.UnspecifiedReadWriteMode {
-		if ex.sessionData.DefaultReadOnly {
+		if ex.sessionData.DefaultTxnReadOnly {
 			return tree.ReadOnly
 		}
 		return tree.ReadWrite

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -2057,6 +2057,10 @@ func (m *sessionDataMutator) SetDefaultTransactionReadOnly(val bool) {
 	m.data.DefaultTxnReadOnly = val
 }
 
+func (m *sessionDataMutator) SetDefaultTransactionUseFollowerReads(val bool) {
+	m.data.DefaultTxnUseFollowerReads = val
+}
+
 func (m *sessionDataMutator) SetEnableSeqScan(val bool) {
 	m.data.EnableSeqScan = val
 }

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -2053,8 +2053,8 @@ func (m *sessionDataMutator) SetDefaultTransactionPriority(val tree.UserPriority
 	m.data.DefaultTxnPriority = int(val)
 }
 
-func (m *sessionDataMutator) SetDefaultReadOnly(val bool) {
-	m.data.DefaultReadOnly = val
+func (m *sessionDataMutator) SetDefaultTransactionReadOnly(val bool) {
+	m.data.DefaultTxnReadOnly = val
 }
 
 func (m *sessionDataMutator) SetEnableSeqScan(val bool) {

--- a/pkg/sql/logictest/testdata/logic_test/fuzzystrmatch
+++ b/pkg/sql/logictest/testdata/logic_test/fuzzystrmatch
@@ -54,4 +54,3 @@ query TTT
 SELECT soundex('Anne'), soundex(NULL), difference('Anne', NULL);
 ----
 A500 · ·
-

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1882,6 +1882,7 @@ default_tablespace                                    ·                   NULL 
 default_transaction_isolation                         serializable        NULL      NULL        NULL        string
 default_transaction_priority                          normal              NULL      NULL        NULL        string
 default_transaction_read_only                         off                 NULL      NULL        NULL        string
+default_transaction_use_follower_reads                off                 NULL      NULL        NULL        string
 disable_partially_distributed_plans                   off                 NULL      NULL        NULL        string
 disallow_full_table_scans                             off                 NULL      NULL        NULL        string
 distsql                                               off                 NULL      NULL        NULL        string
@@ -1956,6 +1957,7 @@ default_tablespace                                    ·                   NULL 
 default_transaction_isolation                         serializable        NULL  user     NULL      default             default
 default_transaction_priority                          normal              NULL  user     NULL      normal              normal
 default_transaction_read_only                         off                 NULL  user     NULL      off                 off
+default_transaction_use_follower_reads                off                 NULL  user     NULL      off                 off
 disable_partially_distributed_plans                   off                 NULL  user     NULL      off                 off
 disallow_full_table_scans                             off                 NULL  user     NULL      off                 off
 distsql                                               off                 NULL  user     NULL      off                 off
@@ -2026,6 +2028,7 @@ default_tablespace                                    NULL    NULL     NULL     
 default_transaction_isolation                         NULL    NULL     NULL     NULL        NULL
 default_transaction_priority                          NULL    NULL     NULL     NULL        NULL
 default_transaction_read_only                         NULL    NULL     NULL     NULL        NULL
+default_transaction_use_follower_reads                NULL    NULL     NULL     NULL        NULL
 disable_partially_distributed_plans                   NULL    NULL     NULL     NULL        NULL
 disallow_full_table_scans                             NULL    NULL     NULL     NULL        NULL
 distsql                                               NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -37,6 +37,7 @@ default_tablespace                                    ·
 default_transaction_isolation                         serializable
 default_transaction_priority                          normal
 default_transaction_read_only                         off
+default_transaction_use_follower_reads                off
 disable_partially_distributed_plans                   off
 disallow_full_table_scans                             off
 distsql                                               off

--- a/pkg/sql/logictest/testdata/logic_test/txn
+++ b/pkg/sql/logictest/testdata/logic_test/txn
@@ -1038,3 +1038,52 @@ ROLLBACK
 # restore the default
 statement ok
 SET default_transaction_read_only = false
+
+# Transaction AS OF SYSTEM TIME clauses can be assigned a default value.
+
+query T
+SHOW DEFAULT_TRANSACTION_USE_FOLLOWER_READS
+----
+off
+
+statement ok
+SET DEFAULT_TRANSACTION_USE_FOLLOWER_READS TO TRUE
+
+# NOTE: run SHOW statement at different AS OF SYSTEM TIME time to avoid schema
+# resolution complications.
+query T
+BEGIN AS OF SYSTEM TIME '-1us'; SHOW DEFAULT_TRANSACTION_USE_FOLLOWER_READS; COMMIT
+----
+on
+
+statement ok
+SET DEFAULT_TRANSACTION_USE_FOLLOWER_READS TO FALSE
+
+query T
+SHOW DEFAULT_TRANSACTION_USE_FOLLOWER_READS
+----
+off
+
+statement ok
+SET SESSION CHARACTERISTICS AS TRANSACTION AS OF SYSTEM TIME follower_read_timestamp()
+
+# NOTE: run SHOW statement at different AS OF SYSTEM TIME time to avoid schema
+# resolution complications.
+query T
+BEGIN AS OF SYSTEM TIME '-1us'; SHOW DEFAULT_TRANSACTION_USE_FOLLOWER_READS; COMMIT
+----
+on
+
+statement error pgcode 22023 unsupported default as of system time expression, only follower_read_timestamp\(\) allowed
+SET SESSION CHARACTERISTICS AS TRANSACTION AS OF SYSTEM TIME now()
+
+statement error pgcode 22023 unsupported default as of system time expression, only follower_read_timestamp\(\) allowed
+SET SESSION CHARACTERISTICS AS TRANSACTION AS OF SYSTEM TIME '-1m'
+
+statement ok
+SET DEFAULT_TRANSACTION_USE_FOLLOWER_READS TO FALSE
+
+query T
+SHOW DEFAULT_TRANSACTION_USE_FOLLOWER_READS
+----
+off

--- a/pkg/sql/logictest/testdata/logic_test/txn
+++ b/pkg/sql/logictest/testdata/logic_test/txn
@@ -1087,3 +1087,11 @@ query T
 SHOW DEFAULT_TRANSACTION_USE_FOLLOWER_READS
 ----
 off
+
+# Transaction deferrability can be assigned a default value.
+
+statement ok
+SET SESSION CHARACTERISTICS AS TRANSACTION NOT DEFERRABLE
+
+statement error pq: unimplemented: DEFERRABLE transactions
+SET SESSION CHARACTERISTICS AS TRANSACTION DEFERRABLE

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -378,6 +378,18 @@ vectorized: false
       table: session_variables@primary
 
 query T
+SELECT * FROM [EXPLAIN SHOW DEFAULT_TRANSACTION_USE_FOLLOWER_READS] WHERE info NOT LIKE '%size%'
+----
+distribution: local
+vectorized: false
+·
+• filter
+│ filter: variable = 'default_transaction_use_follower_reads'
+│
+└── • virtual table
+      table: session_variables@primary
+
+query T
 SELECT * FROM [EXPLAIN SHOW TRANSACTION ISOLATION LEVEL] WHERE info NOT LIKE '%size%'
 ----
 distribution: local

--- a/pkg/sql/sessiondata/session_data.go
+++ b/pkg/sql/sessiondata/session_data.go
@@ -158,9 +158,9 @@ type LocalOnlySessionData struct {
 	// NOTE: we'd prefer to use tree.UserPriority here, but doing so would
 	// introduce a package dependency cycle.
 	DefaultTxnPriority int
-	// DefaultReadOnly indicates the default read-only status of newly created
-	// transactions.
-	DefaultReadOnly bool
+	// DefaultTxnReadOnly indicates the default read-only status of newly
+	// created transactions.
+	DefaultTxnReadOnly bool
 	// PartiallyDistributedPlansDisabled indicates whether the partially
 	// distributed plans produced by distSQLSpecExecFactory are disabled. It
 	// should be set to 'true' only in tests that verify that the old and the

--- a/pkg/sql/sessiondata/session_data.go
+++ b/pkg/sql/sessiondata/session_data.go
@@ -161,6 +161,11 @@ type LocalOnlySessionData struct {
 	// DefaultTxnReadOnly indicates the default read-only status of newly
 	// created transactions.
 	DefaultTxnReadOnly bool
+	// DefaultTxnUseFollowerReads indicates whether transactions should be
+	// created by default using an AS OF SYSTEM TIME clause far enough in the
+	// past to facilitate reads against followers. If true, transactions will
+	// also default to being read-only.
+	DefaultTxnUseFollowerReads bool
 	// PartiallyDistributedPlansDisabled indicates whether the partially
 	// distributed plans produced by distSQLSpecExecFactory are disabled. It
 	// should be set to 'true' only in tests that verify that the old and the

--- a/pkg/sql/set_default_isolation.go
+++ b/pkg/sql/set_default_isolation.go
@@ -35,9 +35,9 @@ func (p *planner) SetSessionCharacteristics(n *tree.SetSessionCharacteristics) (
 	// Note: We also support SET DEFAULT_TRANSACTION_READ_ONLY TO ' .... '.
 	switch n.Modes.ReadWriteMode {
 	case tree.ReadOnly:
-		p.sessionDataMutator.SetDefaultReadOnly(true)
+		p.sessionDataMutator.SetDefaultTransactionReadOnly(true)
 	case tree.ReadWrite:
-		p.sessionDataMutator.SetDefaultReadOnly(false)
+		p.sessionDataMutator.SetDefaultTransactionReadOnly(false)
 	case tree.UnspecifiedReadWriteMode:
 	default:
 		return nil, fmt.Errorf("unsupported default read write mode: %s", n.Modes.ReadWriteMode)

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -369,6 +369,23 @@ var varGen = map[string]sessionVar{
 	},
 
 	// CockroachDB extension.
+	`default_transaction_use_follower_reads`: {
+		GetStringVal: makePostgresBoolGetStringValFn("default_transaction_use_follower_reads"),
+		Set: func(_ context.Context, m *sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("default_transaction_use_follower_reads", s)
+			if err != nil {
+				return err
+			}
+			m.SetDefaultTransactionUseFollowerReads(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext) string {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData.DefaultTxnUseFollowerReads)
+		},
+		GlobalDefault: globalFalse,
+	},
+
+	// CockroachDB extension.
 	`distsql`: {
 		Set: func(_ context.Context, m *sessionDataMutator, s string) error {
 			mode, ok := sessiondata.DistSQLExecModeFromString(s)

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -359,11 +359,11 @@ var varGen = map[string]sessionVar{
 			if err != nil {
 				return err
 			}
-			m.SetDefaultReadOnly(b)
+			m.SetDefaultTransactionReadOnly(b)
 			return nil
 		},
 		Get: func(evalCtx *extendedEvalContext) string {
-			return formatBoolAsPostgresSetting(evalCtx.SessionData.DefaultReadOnly)
+			return formatBoolAsPostgresSetting(evalCtx.SessionData.DefaultTxnReadOnly)
 		},
 		GlobalDefault: globalFalse,
 	},


### PR DESCRIPTION
Fixes #44514.

This commit introduces a new `default_transaction_use_follower_reads` session variable, along with support for the `SET SESSION CHARACTERISTICS AS TRANSACTION AS OF SYSTEM TIME follower_read_timestamp()` statement. These can be used to set a default AS OF SYSTEM TIME clause for all implicit and explicit transactions such that the transaction operates far enough in the past to facilitate reads against followers. When enabled, these settings also default transactions to being read-only.

Because this is implemented as a session variable, it can be provided as a session parameter in the PG connection URL.

I'm happy to bikeshed the name of this setting if people would like to. Other options I considered were:
- `default_transaction_use_follower_read_timestamp`
- `default_transaction_read_from_followers`

I also considered making the setting only impact transactions that are already READ ONLY, instead of having it also mandate that all transactions become READ ONLY. This would mean that a client would need to set this option and `default_transaction_read_only` in its connection string if it didn't want to configure anything else per-txn and wanted all txns to read from followers. The benefit of this is that a user could then opt-out of this default by running a READ WRITE transaction when `default_transaction_read_only` is set to READ ONLY. Or they could opt-in to follower read behavior by running a READ ONLY transaction when default_transaction_read_from_followers is not set.

Release note (sql change): A new default_transaction_use_follower_reads session variable is now supported, which configures SQL transactions to perform stale reads from follower replicas.