### PR TITLE
opt: support INSERT with virtual columns

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/virtual_columns
+++ b/pkg/sql/logictest/testdata/logic_test/virtual_columns
@@ -37,9 +37,35 @@ INSERT INTO t(a,b) VALUES (2, 2)
 statement error cannot write directly to computed column
 INSERT INTO t(a,b,v) VALUES (2, 2, 0)
 
+# Ensure that the virtual column is produced.
 query III colnames,rowsort
 SELECT * FROM t
 ----
 a  b  v
 1  1  2
 2  2  4
+
+statement ok
+CREATE TABLE t_idx (
+  a INT PRIMARY KEY,
+  b INT,
+  v INT AS (a+b) VIRTUAL,
+  INDEX (v)
+)
+
+statement ok
+INSERT INTO t_idx VALUES (1, 1), (2, 8), (3, 3), (4, 6), (5, 2)
+
+# Queries which should use the index on v. Note that there are corresponding
+# execbuilder tests which verify the query plans.
+query I rowsort
+SELECT a FROM t_idx WHERE a+b=10
+----
+2
+4
+
+query I rowsort
+SELECT a FROM t_idx WHERE v=10
+----
+2
+4

--- a/pkg/sql/opt/cat/utils.go
+++ b/pkg/sql/opt/cat/utils.go
@@ -306,7 +306,7 @@ func formatColumn(col *Column, buf *bytes.Buffer) {
 		fmt.Fprintf(buf, " not null")
 	}
 	if col.IsComputed() {
-		if col.Kind() == VirtualComputed {
+		if col.IsVirtualComputed() {
 			fmt.Fprintf(buf, " as (%s) virtual", col.ComputedExprStr())
 		} else {
 			fmt.Fprintf(buf, " as (%s) stored", col.ComputedExprStr())
@@ -325,8 +325,6 @@ func formatColumn(col *Column, buf *bytes.Buffer) {
 		fmt.Fprintf(buf, " [system]")
 	case VirtualInverted:
 		fmt.Fprintf(buf, " [virtual-inverted]")
-	case VirtualComputed:
-		// No need to show anything more (it already shows up as virtual).
 	}
 }
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/virtual_columns
+++ b/pkg/sql/opt/exec/execbuilder/testdata/virtual_columns
@@ -64,3 +64,115 @@ vectorized: true
       estimated row count: 1,000 (missing stats)
       table: t@primary
       spans: FULL SCAN
+
+statement ok
+CREATE TABLE t_idx (
+  a INT PRIMARY KEY,
+  b INT,
+  v INT AS (a+b) VIRTUAL,
+  INDEX (v),
+  FAMILY (a),
+  FAMILY (b)
+)
+
+query T
+EXPLAIN (VERBOSE) SELECT a FROM t_idx WHERE a+b=1
+----
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a)
+  estimated row count: 10 (missing stats)
+  table: t_idx@t_idx_v_idx
+  spans: /1-/2
+
+query T
+EXPLAIN (VERBOSE) SELECT a FROM t_idx WHERE v=1
+----
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a)
+  estimated row count: 10 (missing stats)
+  table: t_idx@t_idx_v_idx
+  spans: /1-/2
+
+# TODO(radu): allow retrieving the virtual column from the index.
+query T
+EXPLAIN (VERBOSE) SELECT a, v FROM t_idx WHERE v=1
+----
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (a, v)
+│ estimated row count: 333 (missing stats)
+│ render 0: a + b
+│ render 1: a
+│
+└── • index join
+    │ columns: (a, b)
+    │ estimated row count: 333 (missing stats)
+    │ table: t_idx@primary
+    │ key columns: a
+    │
+    └── • scan
+          columns: (a)
+          estimated row count: 10 (missing stats)
+          table: t_idx@t_idx_v_idx
+          spans: /1-/2
+
+# TODO(radu): we shouldn't need to synthesize v here.
+query T
+EXPLAIN (VERBOSE) INSERT INTO t VALUES (1, 1)
+----
+distribution: local
+vectorized: false
+·
+• insert fast path
+  columns: ()
+  estimated row count: 0 (missing stats)
+  into: t(a, b, v)
+  auto commit
+  size: 3 columns, 1 row
+  row 0, expr 0: 1
+  row 0, expr 1: 1
+  row 0, expr 2: 2
+
+query T
+EXPLAIN (VERBOSE) INSERT INTO t VALUES (1, 1) RETURNING v
+----
+distribution: local
+vectorized: false
+·
+• project
+│ columns: (v)
+│ estimated row count: 1
+│
+└── • insert fast path
+      columns: (a, v)
+      estimated row count: 1
+      into: t(a, b, v)
+      auto commit
+      size: 3 columns, 1 row
+      row 0, expr 0: 1
+      row 0, expr 1: 1
+      row 0, expr 2: 2
+
+query T
+EXPLAIN (VERBOSE) INSERT INTO t_idx VALUES (1, 1)
+----
+distribution: local
+vectorized: false
+·
+• insert fast path
+  columns: ()
+  estimated row count: 0 (missing stats)
+  into: t_idx(a, b, v)
+  auto commit
+  size: 3 columns, 1 row
+  row 0, expr 0: 1
+  row 0, expr 1: 1
+  row 0, expr 2: 2

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -373,8 +373,8 @@ func (mb *mutationBuilder) needExistingRows() bool {
 			// #1: Don't consider key columns.
 			continue
 		}
-		if kind := mb.tab.Column(i).Kind(); kind == cat.System || kind.IsVirtual() {
-			// #2: Don't consider system or virtual columns.
+		if kind := mb.tab.Column(i).Kind(); kind == cat.System || kind == cat.VirtualInverted {
+			// #2: Don't consider system or virtual inverted columns.
 			continue
 		}
 		insertColID := mb.insertColIDs[i]
@@ -617,7 +617,7 @@ func (mb *mutationBuilder) addSynthesizedColsForInsert() {
 	// may depend on non-computed columns.
 	mb.addSynthesizedCols(
 		mb.insertColIDs,
-		func(colOrd int) bool { return !mb.tab.Column(colOrd).IsComputed() },
+		func(col *cat.Column) bool { return !col.IsComputed() },
 	)
 
 	// Possibly round DECIMAL-related columns containing insertion values (whether
@@ -627,7 +627,7 @@ func (mb *mutationBuilder) addSynthesizedColsForInsert() {
 	// Now add all computed columns.
 	mb.addSynthesizedCols(
 		mb.insertColIDs,
-		func(colOrd int) bool { return mb.tab.Column(colOrd).IsComputed() },
+		func(col *cat.Column) bool { return col.IsComputed() },
 	)
 
 	// Possibly round DECIMAL-related computed columns.

--- a/pkg/sql/opt/optbuilder/testdata/virtual-columns
+++ b/pkg/sql/opt/optbuilder/testdata/virtual-columns
@@ -2,36 +2,145 @@ exec-ddl
 CREATE TABLE t (
   a INT PRIMARY KEY,
   b INT,
-  c INT AS (a+b) VIRTUAL
+  v INT AS (a+b) VIRTUAL
 )
 ----
 
+exec-ddl
+CREATE TABLE t_idx (
+  a INT PRIMARY KEY,
+  b INT,
+  v INT AS (a+b) VIRTUAL,
+  INDEX (v)
+)
+----
+
+# Column v should be produced.
 build
 SELECT * FROM t
 ----
 project
- ├── columns: a:1!null b:2 c:3
+ ├── columns: a:1!null b:2 v:3
  └── project
-      ├── columns: c:3 a:1!null b:2 crdb_internal_mvcc_timestamp:4
+      ├── columns: v:3 a:1!null b:2 crdb_internal_mvcc_timestamp:4
       ├── scan t
       │    ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:4
       │    └── computed column expressions
-      │         └── c:3
+      │         └── v:3
       │              └── a:1 + b:2
       └── projections
-           └── a:1 + b:2 [as=c:3]
+           └── a:1 + b:2 [as=v:3]
 
+# Column v can be selected explicitly.
 build
-SELECT c FROM t
+SELECT v FROM t
 ----
 project
- ├── columns: c:3
+ ├── columns: v:3
  └── project
-      ├── columns: c:3 a:1!null b:2 crdb_internal_mvcc_timestamp:4
+      ├── columns: v:3 a:1!null b:2 crdb_internal_mvcc_timestamp:4
       ├── scan t
       │    ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:4
       │    └── computed column expressions
-      │         └── c:3
+      │         └── v:3
       │              └── a:1 + b:2
       └── projections
-           └── a:1 + b:2 [as=c:3]
+           └── a:1 + b:2 [as=v:3]
+
+# The projection for v will be removed by norm rules.
+build
+SELECT b FROM t
+----
+project
+ ├── columns: b:2
+ └── project
+      ├── columns: v:3 a:1!null b:2 crdb_internal_mvcc_timestamp:4
+      ├── scan t
+      │    ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:4
+      │    └── computed column expressions
+      │         └── v:3
+      │              └── a:1 + b:2
+      └── projections
+           └── a:1 + b:2 [as=v:3]
+
+# TODO(radu): we should remove the virtual column from the insert mapping if it
+# is not used by any indexes (so that it can be pruned in the input). This is
+# not trivial because it can still be used by a RETURNING clause.
+build
+INSERT INTO t VALUES (1, 1)
+----
+insert t
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:5 => a:1
+ │    ├── column2:6 => b:2
+ │    └── column7:7 => v:3
+ └── project
+      ├── columns: column7:7!null column1:5!null column2:6!null
+      ├── values
+      │    ├── columns: column1:5!null column2:6!null
+      │    └── (1, 1)
+      └── projections
+           └── column1:5 + column2:6 [as=column7:7]
+
+build
+INSERT INTO t(a) VALUES (1)
+----
+insert t
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:5 => a:1
+ │    ├── column6:6 => b:2
+ │    └── column7:7 => v:3
+ └── project
+      ├── columns: column7:7 column1:5!null column6:6
+      ├── project
+      │    ├── columns: column6:6 column1:5!null
+      │    ├── values
+      │    │    ├── columns: column1:5!null
+      │    │    └── (1,)
+      │    └── projections
+      │         └── NULL::INT8 [as=column6:6]
+      └── projections
+           └── column1:5 + column6:6 [as=column7:7]
+
+build
+INSERT INTO t(a, b, v) VALUES (1, 1, 1)
+----
+error (55000): cannot write directly to computed column "v"
+
+build
+INSERT INTO t VALUES (1, 1) RETURNING v
+----
+project
+ ├── columns: v:3!null
+ └── insert t
+      ├── columns: a:1!null b:2!null v:3!null
+      ├── insert-mapping:
+      │    ├── column1:5 => a:1
+      │    ├── column2:6 => b:2
+      │    └── column7:7 => v:3
+      └── project
+           ├── columns: column7:7!null column1:5!null column2:6!null
+           ├── values
+           │    ├── columns: column1:5!null column2:6!null
+           │    └── (1, 1)
+           └── projections
+                └── column1:5 + column2:6 [as=column7:7]
+
+build
+INSERT INTO t_idx VALUES (1, 1)
+----
+insert t_idx
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:5 => a:1
+ │    ├── column2:6 => b:2
+ │    └── column7:7 => v:3
+ └── project
+      ├── columns: column7:7!null column1:5!null column2:6!null
+      ├── values
+      │    ├── columns: column1:5!null column2:6!null
+      │    └── (1, 1)
+      └── projections
+           └── column1:5 + column2:6 [as=column7:7]

--- a/pkg/sql/opt/optbuilder/update.go
+++ b/pkg/sql/opt/optbuilder/update.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -306,8 +307,7 @@ func (mb *mutationBuilder) addSynthesizedColsForUpdate() {
 	// set by the backfiller.
 	mb.addSynthesizedCols(
 		mb.updateColIDs,
-		func(colOrd int) bool {
-			col := mb.tab.Column(colOrd)
+		func(col *cat.Column) bool {
 			return !col.IsComputed() && col.IsMutation()
 		},
 	)
@@ -324,7 +324,7 @@ func (mb *mutationBuilder) addSynthesizedColsForUpdate() {
 	// Add all computed columns in case their values have changed.
 	mb.addSynthesizedCols(
 		mb.updateColIDs,
-		func(colOrd int) bool { return mb.tab.Column(colOrd).IsComputed() },
+		func(col *cat.Column) bool { return col.IsComputed() },
 	)
 
 	// Possibly round DECIMAL-related computed columns.

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -704,11 +704,11 @@ func tableOrdinals(tab cat.Table, k columnKinds) []int {
 		cat.DeleteOnly:      k.includeMutations,
 		cat.System:          k.includeSystem,
 		cat.VirtualInverted: k.includeVirtualInverted,
-		cat.VirtualComputed: k.includeVirtualComputed,
 	}
 	ordinals := make([]int, 0, n)
 	for i := 0; i < n; i++ {
-		if shouldInclude[tab.Column(i).Kind()] {
+		col := tab.Column(i)
+		if shouldInclude[col.Kind()] && (k.includeVirtualComputed || !col.IsVirtualComputed()) {
 			ordinals = append(ordinals, i)
 		}
 	}

--- a/pkg/sql/opt/testutils/testcat/create_table.go
+++ b/pkg/sql/opt/testutils/testcat/create_table.go
@@ -625,7 +625,7 @@ func (tt *Table) addIndexWithVersion(
 		}
 		// Add the rest of the columns in the table.
 		for i, col := range tt.Columns {
-			if !pkOrdinals.Contains(i) && !col.Kind().IsVirtual() {
+			if !pkOrdinals.Contains(i) && col.Kind() != cat.VirtualInverted && !col.IsVirtualComputed() {
 				idx.addColumnByOrdinal(tt, i, tree.Ascending, nonKeyCol)
 			}
 		}
@@ -810,8 +810,7 @@ func columnForIndexElemExpr(tt *Table, expr tree.Expr) cat.Column {
 	exprStr := serializeTableDefExpr(expr)
 	// Find an existing virtual computed column with the same expression.
 	for _, col := range tt.Columns {
-		if col.Kind() == cat.VirtualComputed &&
-			col.ComputedExprStr() == exprStr {
+		if col.IsVirtualComputed() && col.ComputedExprStr() == exprStr {
 			return col
 		}
 	}

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -1137,7 +1137,7 @@ func (oi *optIndex) init(
 			pkCols.Add(int(desc.ColumnIDs[i]))
 		}
 		for i, n := 0, tab.ColumnCount(); i < n; i++ {
-			if col := tab.Column(i); !col.Kind().IsVirtual() {
+			if col := tab.Column(i); col.Kind() != cat.VirtualInverted && !col.IsVirtualComputed() {
 				if id := col.ColID(); !pkCols.Contains(int(id)) {
 					oi.storedCols = append(oi.storedCols, descpb.ColumnID(id))
 				}


### PR DESCRIPTION
This commit adds support for INSERT with virtual columns, by allowing
virtual computed columns to be synthesized. No changes were necessary
in the execution path.

Note that we always synthesize the value for the virtual column for an
Insert. Pruning it when it is not used in any indexes is left as a
TODO; the difficulty is that we still want to be able to refer to it
using a RETURNING clause. In practice, the main motivation to create a
virtual column is to use it in an index, so this optimization may not
matter.

In this same commit, we also backtrack on having a separate `ColumnKind`
for virtual computed columns. They are very close in behavior to ordinary
columns in most cases; the main difference is just that they are not
stored by the PK index. This change replaces the separate kind with a
`IsVirtualComputed()` method.

Release note: None