### PR TITLE
colexec: audit BCE of Gets and Sets and add assertions in multiple places

### DIFF
--- a/pkg/sql/colconv/vec_to_datum.eg.go
+++ b/pkg/sql/colconv/vec_to_datum.eg.go
@@ -205,13 +205,17 @@ func (c *VecToDatumConverter) GetDatumColumn(colIdx int) tree.Datums {
 func ColVecToDatumAndDeselect(
 	converted []tree.Datum, col coldata.Vec, length int, sel []int, da *rowenc.DatumAlloc,
 ) {
+	if length == 0 {
+		return
+	}
 	if sel == nil {
 		ColVecToDatum(converted, col, length, sel, da)
 		return
 	}
 	if col.MaybeHasNulls() {
 		nulls := col.Nulls()
-		sel = sel[:length]
+		_ = converted[length-1]
+		_ = sel[length-1]
 		var idx, destIdx, srcIdx int
 		switch ct := col.Type(); ct.Family() {
 		case types.StringFamily:
@@ -221,23 +225,31 @@ func ColVecToDatumAndDeselect(
 			if ct.Oid() == oid.T_name {
 				for idx = 0; idx < length; idx++ {
 					destIdx = idx
+					//gcassert:bce
 					srcIdx = sel[idx]
 					if nulls.NullAt(srcIdx) {
+						//gcassert:bce
 						converted[destIdx] = tree.DNull
 						continue
 					}
-					converted[destIdx] = da.NewDName(tree.DString(bytes.Get(srcIdx)))
+					v := da.NewDName(tree.DString(bytes.Get(srcIdx)))
+					//gcassert:bce
+					converted[destIdx] = v
 				}
 				return
 			}
 			for idx = 0; idx < length; idx++ {
 				destIdx = idx
+				//gcassert:bce
 				srcIdx = sel[idx]
 				if nulls.NullAt(srcIdx) {
+					//gcassert:bce
 					converted[destIdx] = tree.DNull
 					continue
 				}
-				converted[destIdx] = da.NewDString(tree.DString(bytes.Get(srcIdx)))
+				v := da.NewDString(tree.DString(bytes.Get(srcIdx)))
+				//gcassert:bce
+				converted[destIdx] = v
 			}
 		case types.BoolFamily:
 			switch ct.Width() {
@@ -246,12 +258,17 @@ func ColVecToDatumAndDeselect(
 				typedCol := col.Bool()
 				for idx = 0; idx < length; idx++ {
 					destIdx = idx
+					//gcassert:bce
 					srcIdx = sel[idx]
 					if nulls.NullAt(srcIdx) {
+						//gcassert:bce
 						converted[destIdx] = tree.DNull
 						continue
 					}
-					converted[destIdx] = tree.MakeDBool(tree.DBool(typedCol[srcIdx]))
+					v := typedCol.Get(srcIdx)
+					_converted := tree.MakeDBool(tree.DBool(v))
+					//gcassert:bce
+					converted[destIdx] = _converted
 				}
 			}
 		case types.IntFamily:
@@ -260,35 +277,50 @@ func ColVecToDatumAndDeselect(
 				typedCol := col.Int16()
 				for idx = 0; idx < length; idx++ {
 					destIdx = idx
+					//gcassert:bce
 					srcIdx = sel[idx]
 					if nulls.NullAt(srcIdx) {
+						//gcassert:bce
 						converted[destIdx] = tree.DNull
 						continue
 					}
-					converted[destIdx] = da.NewDInt(tree.DInt(typedCol[srcIdx]))
+					v := typedCol.Get(srcIdx)
+					_converted := da.NewDInt(tree.DInt(v))
+					//gcassert:bce
+					converted[destIdx] = _converted
 				}
 			case 32:
 				typedCol := col.Int32()
 				for idx = 0; idx < length; idx++ {
 					destIdx = idx
+					//gcassert:bce
 					srcIdx = sel[idx]
 					if nulls.NullAt(srcIdx) {
+						//gcassert:bce
 						converted[destIdx] = tree.DNull
 						continue
 					}
-					converted[destIdx] = da.NewDInt(tree.DInt(typedCol[srcIdx]))
+					v := typedCol.Get(srcIdx)
+					_converted := da.NewDInt(tree.DInt(v))
+					//gcassert:bce
+					converted[destIdx] = _converted
 				}
 			case -1:
 			default:
 				typedCol := col.Int64()
 				for idx = 0; idx < length; idx++ {
 					destIdx = idx
+					//gcassert:bce
 					srcIdx = sel[idx]
 					if nulls.NullAt(srcIdx) {
+						//gcassert:bce
 						converted[destIdx] = tree.DNull
 						continue
 					}
-					converted[destIdx] = da.NewDInt(tree.DInt(typedCol[srcIdx]))
+					v := typedCol.Get(srcIdx)
+					_converted := da.NewDInt(tree.DInt(v))
+					//gcassert:bce
+					converted[destIdx] = _converted
 				}
 			}
 		case types.FloatFamily:
@@ -298,12 +330,17 @@ func ColVecToDatumAndDeselect(
 				typedCol := col.Float64()
 				for idx = 0; idx < length; idx++ {
 					destIdx = idx
+					//gcassert:bce
 					srcIdx = sel[idx]
 					if nulls.NullAt(srcIdx) {
+						//gcassert:bce
 						converted[destIdx] = tree.DNull
 						continue
 					}
-					converted[destIdx] = da.NewDFloat(tree.DFloat(typedCol[srcIdx]))
+					v := typedCol.Get(srcIdx)
+					_converted := da.NewDFloat(tree.DFloat(v))
+					//gcassert:bce
+					converted[destIdx] = _converted
 				}
 			}
 		case types.DecimalFamily:
@@ -313,17 +350,21 @@ func ColVecToDatumAndDeselect(
 				typedCol := col.Decimal()
 				for idx = 0; idx < length; idx++ {
 					destIdx = idx
+					//gcassert:bce
 					srcIdx = sel[idx]
 					if nulls.NullAt(srcIdx) {
+						//gcassert:bce
 						converted[destIdx] = tree.DNull
 						continue
 					}
-					d := da.NewDDecimal(tree.DDecimal{Decimal: typedCol[srcIdx]})
+					v := typedCol.Get(srcIdx)
+					_converted := da.NewDDecimal(tree.DDecimal{Decimal: v})
 					// Clear the Coeff so that the Set below allocates a new slice for the
 					// Coeff.abs field.
-					d.Coeff = big.Int{}
-					d.Coeff.Set(&typedCol[srcIdx].Coeff)
-					converted[destIdx] = d
+					_converted.Coeff = big.Int{}
+					_converted.Coeff.Set(&v.Coeff)
+					//gcassert:bce
+					converted[destIdx] = _converted
 				}
 			}
 		case types.DateFamily:
@@ -333,12 +374,17 @@ func ColVecToDatumAndDeselect(
 				typedCol := col.Int64()
 				for idx = 0; idx < length; idx++ {
 					destIdx = idx
+					//gcassert:bce
 					srcIdx = sel[idx]
 					if nulls.NullAt(srcIdx) {
+						//gcassert:bce
 						converted[destIdx] = tree.DNull
 						continue
 					}
-					converted[destIdx] = da.NewDDate(tree.DDate{Date: pgdate.MakeCompatibleDateFromDisk(typedCol[srcIdx])})
+					v := typedCol.Get(srcIdx)
+					_converted := da.NewDDate(tree.DDate{Date: pgdate.MakeCompatibleDateFromDisk(v)})
+					//gcassert:bce
+					converted[destIdx] = _converted
 				}
 			}
 		case types.BytesFamily:
@@ -348,14 +394,19 @@ func ColVecToDatumAndDeselect(
 				typedCol := col.Bytes()
 				for idx = 0; idx < length; idx++ {
 					destIdx = idx
+					//gcassert:bce
 					srcIdx = sel[idx]
 					if nulls.NullAt(srcIdx) {
+						//gcassert:bce
 						converted[destIdx] = tree.DNull
 						continue
 					}
+					v := typedCol.Get(srcIdx)
 					// Note that there is no need for a copy since DBytes uses a string
 					// as underlying storage, which will perform the copy for us.
-					converted[destIdx] = da.NewDBytes(tree.DBytes(typedCol.Get(srcIdx)))
+					_converted := da.NewDBytes(tree.DBytes(v))
+					//gcassert:bce
+					converted[destIdx] = _converted
 				}
 			}
 		case types.UuidFamily:
@@ -365,18 +416,23 @@ func ColVecToDatumAndDeselect(
 				typedCol := col.Bytes()
 				for idx = 0; idx < length; idx++ {
 					destIdx = idx
+					//gcassert:bce
 					srcIdx = sel[idx]
 					if nulls.NullAt(srcIdx) {
+						//gcassert:bce
 						converted[destIdx] = tree.DNull
 						continue
 					}
+					v := typedCol.Get(srcIdx)
 					// Note that there is no need for a copy because uuid.FromBytes
 					// will perform a copy.
-					id, err := uuid.FromBytes(typedCol.Get(srcIdx))
+					id, err := uuid.FromBytes(v)
 					if err != nil {
 						colexecerror.InternalError(err)
 					}
-					converted[destIdx] = da.NewDUuid(tree.DUuid{UUID: id})
+					_converted := da.NewDUuid(tree.DUuid{UUID: id})
+					//gcassert:bce
+					converted[destIdx] = _converted
 				}
 			}
 		case types.TimestampFamily:
@@ -386,12 +442,17 @@ func ColVecToDatumAndDeselect(
 				typedCol := col.Timestamp()
 				for idx = 0; idx < length; idx++ {
 					destIdx = idx
+					//gcassert:bce
 					srcIdx = sel[idx]
 					if nulls.NullAt(srcIdx) {
+						//gcassert:bce
 						converted[destIdx] = tree.DNull
 						continue
 					}
-					converted[destIdx] = da.NewDTimestamp(tree.DTimestamp{Time: typedCol[srcIdx]})
+					v := typedCol.Get(srcIdx)
+					_converted := da.NewDTimestamp(tree.DTimestamp{Time: v})
+					//gcassert:bce
+					converted[destIdx] = _converted
 				}
 			}
 		case types.TimestampTZFamily:
@@ -401,12 +462,17 @@ func ColVecToDatumAndDeselect(
 				typedCol := col.Timestamp()
 				for idx = 0; idx < length; idx++ {
 					destIdx = idx
+					//gcassert:bce
 					srcIdx = sel[idx]
 					if nulls.NullAt(srcIdx) {
+						//gcassert:bce
 						converted[destIdx] = tree.DNull
 						continue
 					}
-					converted[destIdx] = da.NewDTimestampTZ(tree.DTimestampTZ{Time: typedCol[srcIdx]})
+					v := typedCol.Get(srcIdx)
+					_converted := da.NewDTimestampTZ(tree.DTimestampTZ{Time: v})
+					//gcassert:bce
+					converted[destIdx] = _converted
 				}
 			}
 		case types.IntervalFamily:
@@ -416,12 +482,17 @@ func ColVecToDatumAndDeselect(
 				typedCol := col.Interval()
 				for idx = 0; idx < length; idx++ {
 					destIdx = idx
+					//gcassert:bce
 					srcIdx = sel[idx]
 					if nulls.NullAt(srcIdx) {
+						//gcassert:bce
 						converted[destIdx] = tree.DNull
 						continue
 					}
-					converted[destIdx] = da.NewDInterval(tree.DInterval{Duration: typedCol[srcIdx]})
+					v := typedCol.Get(srcIdx)
+					_converted := da.NewDInterval(tree.DInterval{Duration: v})
+					//gcassert:bce
+					converted[destIdx] = _converted
 				}
 			}
 		case typeconv.DatumVecCanonicalTypeFamily:
@@ -432,17 +503,23 @@ func ColVecToDatumAndDeselect(
 				typedCol := col.Datum()
 				for idx = 0; idx < length; idx++ {
 					destIdx = idx
+					//gcassert:bce
 					srcIdx = sel[idx]
 					if nulls.NullAt(srcIdx) {
+						//gcassert:bce
 						converted[destIdx] = tree.DNull
 						continue
 					}
-					converted[destIdx] = typedCol.Get(srcIdx).(*coldataext.Datum).Datum
+					v := typedCol.Get(srcIdx)
+					_converted := v.(*coldataext.Datum).Datum
+					//gcassert:bce
+					converted[destIdx] = _converted
 				}
 			}
 		}
 	} else {
-		sel = sel[:length]
+		_ = converted[length-1]
+		_ = sel[length-1]
 		var idx, destIdx, srcIdx int
 		switch ct := col.Type(); ct.Family() {
 		case types.StringFamily:
@@ -452,15 +529,21 @@ func ColVecToDatumAndDeselect(
 			if ct.Oid() == oid.T_name {
 				for idx = 0; idx < length; idx++ {
 					destIdx = idx
+					//gcassert:bce
 					srcIdx = sel[idx]
-					converted[destIdx] = da.NewDName(tree.DString(bytes.Get(srcIdx)))
+					v := da.NewDName(tree.DString(bytes.Get(srcIdx)))
+					//gcassert:bce
+					converted[destIdx] = v
 				}
 				return
 			}
 			for idx = 0; idx < length; idx++ {
 				destIdx = idx
+				//gcassert:bce
 				srcIdx = sel[idx]
-				converted[destIdx] = da.NewDString(tree.DString(bytes.Get(srcIdx)))
+				v := da.NewDString(tree.DString(bytes.Get(srcIdx)))
+				//gcassert:bce
+				converted[destIdx] = v
 			}
 		case types.BoolFamily:
 			switch ct.Width() {
@@ -469,8 +552,12 @@ func ColVecToDatumAndDeselect(
 				typedCol := col.Bool()
 				for idx = 0; idx < length; idx++ {
 					destIdx = idx
+					//gcassert:bce
 					srcIdx = sel[idx]
-					converted[destIdx] = tree.MakeDBool(tree.DBool(typedCol[srcIdx]))
+					v := typedCol.Get(srcIdx)
+					_converted := tree.MakeDBool(tree.DBool(v))
+					//gcassert:bce
+					converted[destIdx] = _converted
 				}
 			}
 		case types.IntFamily:
@@ -479,23 +566,35 @@ func ColVecToDatumAndDeselect(
 				typedCol := col.Int16()
 				for idx = 0; idx < length; idx++ {
 					destIdx = idx
+					//gcassert:bce
 					srcIdx = sel[idx]
-					converted[destIdx] = da.NewDInt(tree.DInt(typedCol[srcIdx]))
+					v := typedCol.Get(srcIdx)
+					_converted := da.NewDInt(tree.DInt(v))
+					//gcassert:bce
+					converted[destIdx] = _converted
 				}
 			case 32:
 				typedCol := col.Int32()
 				for idx = 0; idx < length; idx++ {
 					destIdx = idx
+					//gcassert:bce
 					srcIdx = sel[idx]
-					converted[destIdx] = da.NewDInt(tree.DInt(typedCol[srcIdx]))
+					v := typedCol.Get(srcIdx)
+					_converted := da.NewDInt(tree.DInt(v))
+					//gcassert:bce
+					converted[destIdx] = _converted
 				}
 			case -1:
 			default:
 				typedCol := col.Int64()
 				for idx = 0; idx < length; idx++ {
 					destIdx = idx
+					//gcassert:bce
 					srcIdx = sel[idx]
-					converted[destIdx] = da.NewDInt(tree.DInt(typedCol[srcIdx]))
+					v := typedCol.Get(srcIdx)
+					_converted := da.NewDInt(tree.DInt(v))
+					//gcassert:bce
+					converted[destIdx] = _converted
 				}
 			}
 		case types.FloatFamily:
@@ -505,8 +604,12 @@ func ColVecToDatumAndDeselect(
 				typedCol := col.Float64()
 				for idx = 0; idx < length; idx++ {
 					destIdx = idx
+					//gcassert:bce
 					srcIdx = sel[idx]
-					converted[destIdx] = da.NewDFloat(tree.DFloat(typedCol[srcIdx]))
+					v := typedCol.Get(srcIdx)
+					_converted := da.NewDFloat(tree.DFloat(v))
+					//gcassert:bce
+					converted[destIdx] = _converted
 				}
 			}
 		case types.DecimalFamily:
@@ -516,13 +619,16 @@ func ColVecToDatumAndDeselect(
 				typedCol := col.Decimal()
 				for idx = 0; idx < length; idx++ {
 					destIdx = idx
+					//gcassert:bce
 					srcIdx = sel[idx]
-					d := da.NewDDecimal(tree.DDecimal{Decimal: typedCol[srcIdx]})
+					v := typedCol.Get(srcIdx)
+					_converted := da.NewDDecimal(tree.DDecimal{Decimal: v})
 					// Clear the Coeff so that the Set below allocates a new slice for the
 					// Coeff.abs field.
-					d.Coeff = big.Int{}
-					d.Coeff.Set(&typedCol[srcIdx].Coeff)
-					converted[destIdx] = d
+					_converted.Coeff = big.Int{}
+					_converted.Coeff.Set(&v.Coeff)
+					//gcassert:bce
+					converted[destIdx] = _converted
 				}
 			}
 		case types.DateFamily:
@@ -532,8 +638,12 @@ func ColVecToDatumAndDeselect(
 				typedCol := col.Int64()
 				for idx = 0; idx < length; idx++ {
 					destIdx = idx
+					//gcassert:bce
 					srcIdx = sel[idx]
-					converted[destIdx] = da.NewDDate(tree.DDate{Date: pgdate.MakeCompatibleDateFromDisk(typedCol[srcIdx])})
+					v := typedCol.Get(srcIdx)
+					_converted := da.NewDDate(tree.DDate{Date: pgdate.MakeCompatibleDateFromDisk(v)})
+					//gcassert:bce
+					converted[destIdx] = _converted
 				}
 			}
 		case types.BytesFamily:
@@ -543,10 +653,14 @@ func ColVecToDatumAndDeselect(
 				typedCol := col.Bytes()
 				for idx = 0; idx < length; idx++ {
 					destIdx = idx
+					//gcassert:bce
 					srcIdx = sel[idx]
+					v := typedCol.Get(srcIdx)
 					// Note that there is no need for a copy since DBytes uses a string
 					// as underlying storage, which will perform the copy for us.
-					converted[destIdx] = da.NewDBytes(tree.DBytes(typedCol.Get(srcIdx)))
+					_converted := da.NewDBytes(tree.DBytes(v))
+					//gcassert:bce
+					converted[destIdx] = _converted
 				}
 			}
 		case types.UuidFamily:
@@ -556,14 +670,18 @@ func ColVecToDatumAndDeselect(
 				typedCol := col.Bytes()
 				for idx = 0; idx < length; idx++ {
 					destIdx = idx
+					//gcassert:bce
 					srcIdx = sel[idx]
+					v := typedCol.Get(srcIdx)
 					// Note that there is no need for a copy because uuid.FromBytes
 					// will perform a copy.
-					id, err := uuid.FromBytes(typedCol.Get(srcIdx))
+					id, err := uuid.FromBytes(v)
 					if err != nil {
 						colexecerror.InternalError(err)
 					}
-					converted[destIdx] = da.NewDUuid(tree.DUuid{UUID: id})
+					_converted := da.NewDUuid(tree.DUuid{UUID: id})
+					//gcassert:bce
+					converted[destIdx] = _converted
 				}
 			}
 		case types.TimestampFamily:
@@ -573,8 +691,12 @@ func ColVecToDatumAndDeselect(
 				typedCol := col.Timestamp()
 				for idx = 0; idx < length; idx++ {
 					destIdx = idx
+					//gcassert:bce
 					srcIdx = sel[idx]
-					converted[destIdx] = da.NewDTimestamp(tree.DTimestamp{Time: typedCol[srcIdx]})
+					v := typedCol.Get(srcIdx)
+					_converted := da.NewDTimestamp(tree.DTimestamp{Time: v})
+					//gcassert:bce
+					converted[destIdx] = _converted
 				}
 			}
 		case types.TimestampTZFamily:
@@ -584,8 +706,12 @@ func ColVecToDatumAndDeselect(
 				typedCol := col.Timestamp()
 				for idx = 0; idx < length; idx++ {
 					destIdx = idx
+					//gcassert:bce
 					srcIdx = sel[idx]
-					converted[destIdx] = da.NewDTimestampTZ(tree.DTimestampTZ{Time: typedCol[srcIdx]})
+					v := typedCol.Get(srcIdx)
+					_converted := da.NewDTimestampTZ(tree.DTimestampTZ{Time: v})
+					//gcassert:bce
+					converted[destIdx] = _converted
 				}
 			}
 		case types.IntervalFamily:
@@ -595,8 +721,12 @@ func ColVecToDatumAndDeselect(
 				typedCol := col.Interval()
 				for idx = 0; idx < length; idx++ {
 					destIdx = idx
+					//gcassert:bce
 					srcIdx = sel[idx]
-					converted[destIdx] = da.NewDInterval(tree.DInterval{Duration: typedCol[srcIdx]})
+					v := typedCol.Get(srcIdx)
+					_converted := da.NewDInterval(tree.DInterval{Duration: v})
+					//gcassert:bce
+					converted[destIdx] = _converted
 				}
 			}
 		case typeconv.DatumVecCanonicalTypeFamily:
@@ -607,8 +737,12 @@ func ColVecToDatumAndDeselect(
 				typedCol := col.Datum()
 				for idx = 0; idx < length; idx++ {
 					destIdx = idx
+					//gcassert:bce
 					srcIdx = sel[idx]
-					converted[destIdx] = typedCol.Get(srcIdx).(*coldataext.Datum).Datum
+					v := typedCol.Get(srcIdx)
+					_converted := v.(*coldataext.Datum).Datum
+					//gcassert:bce
+					converted[destIdx] = _converted
 				}
 			}
 		}
@@ -622,10 +756,13 @@ func ColVecToDatumAndDeselect(
 func ColVecToDatum(
 	converted []tree.Datum, col coldata.Vec, length int, sel []int, da *rowenc.DatumAlloc,
 ) {
+	if length == 0 {
+		return
+	}
 	if col.MaybeHasNulls() {
 		nulls := col.Nulls()
 		if sel != nil {
-			sel = sel[:length]
+			_ = sel[length-1]
 			var idx, destIdx, srcIdx int
 			switch ct := col.Type(); ct.Family() {
 			case types.StringFamily:
@@ -634,24 +771,30 @@ func ColVecToDatum(
 				bytes := col.Bytes()
 				if ct.Oid() == oid.T_name {
 					for idx = 0; idx < length; idx++ {
+						//gcassert:bce
 						destIdx = sel[idx]
+						//gcassert:bce
 						srcIdx = sel[idx]
 						if nulls.NullAt(srcIdx) {
 							converted[destIdx] = tree.DNull
 							continue
 						}
-						converted[destIdx] = da.NewDName(tree.DString(bytes.Get(srcIdx)))
+						v := da.NewDName(tree.DString(bytes.Get(srcIdx)))
+						converted[destIdx] = v
 					}
 					return
 				}
 				for idx = 0; idx < length; idx++ {
+					//gcassert:bce
 					destIdx = sel[idx]
+					//gcassert:bce
 					srcIdx = sel[idx]
 					if nulls.NullAt(srcIdx) {
 						converted[destIdx] = tree.DNull
 						continue
 					}
-					converted[destIdx] = da.NewDString(tree.DString(bytes.Get(srcIdx)))
+					v := da.NewDString(tree.DString(bytes.Get(srcIdx)))
+					converted[destIdx] = v
 				}
 			case types.BoolFamily:
 				switch ct.Width() {
@@ -659,13 +802,17 @@ func ColVecToDatum(
 				default:
 					typedCol := col.Bool()
 					for idx = 0; idx < length; idx++ {
+						//gcassert:bce
 						destIdx = sel[idx]
+						//gcassert:bce
 						srcIdx = sel[idx]
 						if nulls.NullAt(srcIdx) {
 							converted[destIdx] = tree.DNull
 							continue
 						}
-						converted[destIdx] = tree.MakeDBool(tree.DBool(typedCol[srcIdx]))
+						v := typedCol.Get(srcIdx)
+						_converted := tree.MakeDBool(tree.DBool(v))
+						converted[destIdx] = _converted
 					}
 				}
 			case types.IntFamily:
@@ -673,36 +820,48 @@ func ColVecToDatum(
 				case 16:
 					typedCol := col.Int16()
 					for idx = 0; idx < length; idx++ {
+						//gcassert:bce
 						destIdx = sel[idx]
+						//gcassert:bce
 						srcIdx = sel[idx]
 						if nulls.NullAt(srcIdx) {
 							converted[destIdx] = tree.DNull
 							continue
 						}
-						converted[destIdx] = da.NewDInt(tree.DInt(typedCol[srcIdx]))
+						v := typedCol.Get(srcIdx)
+						_converted := da.NewDInt(tree.DInt(v))
+						converted[destIdx] = _converted
 					}
 				case 32:
 					typedCol := col.Int32()
 					for idx = 0; idx < length; idx++ {
+						//gcassert:bce
 						destIdx = sel[idx]
+						//gcassert:bce
 						srcIdx = sel[idx]
 						if nulls.NullAt(srcIdx) {
 							converted[destIdx] = tree.DNull
 							continue
 						}
-						converted[destIdx] = da.NewDInt(tree.DInt(typedCol[srcIdx]))
+						v := typedCol.Get(srcIdx)
+						_converted := da.NewDInt(tree.DInt(v))
+						converted[destIdx] = _converted
 					}
 				case -1:
 				default:
 					typedCol := col.Int64()
 					for idx = 0; idx < length; idx++ {
+						//gcassert:bce
 						destIdx = sel[idx]
+						//gcassert:bce
 						srcIdx = sel[idx]
 						if nulls.NullAt(srcIdx) {
 							converted[destIdx] = tree.DNull
 							continue
 						}
-						converted[destIdx] = da.NewDInt(tree.DInt(typedCol[srcIdx]))
+						v := typedCol.Get(srcIdx)
+						_converted := da.NewDInt(tree.DInt(v))
+						converted[destIdx] = _converted
 					}
 				}
 			case types.FloatFamily:
@@ -711,13 +870,17 @@ func ColVecToDatum(
 				default:
 					typedCol := col.Float64()
 					for idx = 0; idx < length; idx++ {
+						//gcassert:bce
 						destIdx = sel[idx]
+						//gcassert:bce
 						srcIdx = sel[idx]
 						if nulls.NullAt(srcIdx) {
 							converted[destIdx] = tree.DNull
 							continue
 						}
-						converted[destIdx] = da.NewDFloat(tree.DFloat(typedCol[srcIdx]))
+						v := typedCol.Get(srcIdx)
+						_converted := da.NewDFloat(tree.DFloat(v))
+						converted[destIdx] = _converted
 					}
 				}
 			case types.DecimalFamily:
@@ -726,18 +889,21 @@ func ColVecToDatum(
 				default:
 					typedCol := col.Decimal()
 					for idx = 0; idx < length; idx++ {
+						//gcassert:bce
 						destIdx = sel[idx]
+						//gcassert:bce
 						srcIdx = sel[idx]
 						if nulls.NullAt(srcIdx) {
 							converted[destIdx] = tree.DNull
 							continue
 						}
-						d := da.NewDDecimal(tree.DDecimal{Decimal: typedCol[srcIdx]})
+						v := typedCol.Get(srcIdx)
+						_converted := da.NewDDecimal(tree.DDecimal{Decimal: v})
 						// Clear the Coeff so that the Set below allocates a new slice for the
 						// Coeff.abs field.
-						d.Coeff = big.Int{}
-						d.Coeff.Set(&typedCol[srcIdx].Coeff)
-						converted[destIdx] = d
+						_converted.Coeff = big.Int{}
+						_converted.Coeff.Set(&v.Coeff)
+						converted[destIdx] = _converted
 					}
 				}
 			case types.DateFamily:
@@ -746,13 +912,17 @@ func ColVecToDatum(
 				default:
 					typedCol := col.Int64()
 					for idx = 0; idx < length; idx++ {
+						//gcassert:bce
 						destIdx = sel[idx]
+						//gcassert:bce
 						srcIdx = sel[idx]
 						if nulls.NullAt(srcIdx) {
 							converted[destIdx] = tree.DNull
 							continue
 						}
-						converted[destIdx] = da.NewDDate(tree.DDate{Date: pgdate.MakeCompatibleDateFromDisk(typedCol[srcIdx])})
+						v := typedCol.Get(srcIdx)
+						_converted := da.NewDDate(tree.DDate{Date: pgdate.MakeCompatibleDateFromDisk(v)})
+						converted[destIdx] = _converted
 					}
 				}
 			case types.BytesFamily:
@@ -761,15 +931,19 @@ func ColVecToDatum(
 				default:
 					typedCol := col.Bytes()
 					for idx = 0; idx < length; idx++ {
+						//gcassert:bce
 						destIdx = sel[idx]
+						//gcassert:bce
 						srcIdx = sel[idx]
 						if nulls.NullAt(srcIdx) {
 							converted[destIdx] = tree.DNull
 							continue
 						}
+						v := typedCol.Get(srcIdx)
 						// Note that there is no need for a copy since DBytes uses a string
 						// as underlying storage, which will perform the copy for us.
-						converted[destIdx] = da.NewDBytes(tree.DBytes(typedCol.Get(srcIdx)))
+						_converted := da.NewDBytes(tree.DBytes(v))
+						converted[destIdx] = _converted
 					}
 				}
 			case types.UuidFamily:
@@ -778,19 +952,23 @@ func ColVecToDatum(
 				default:
 					typedCol := col.Bytes()
 					for idx = 0; idx < length; idx++ {
+						//gcassert:bce
 						destIdx = sel[idx]
+						//gcassert:bce
 						srcIdx = sel[idx]
 						if nulls.NullAt(srcIdx) {
 							converted[destIdx] = tree.DNull
 							continue
 						}
+						v := typedCol.Get(srcIdx)
 						// Note that there is no need for a copy because uuid.FromBytes
 						// will perform a copy.
-						id, err := uuid.FromBytes(typedCol.Get(srcIdx))
+						id, err := uuid.FromBytes(v)
 						if err != nil {
 							colexecerror.InternalError(err)
 						}
-						converted[destIdx] = da.NewDUuid(tree.DUuid{UUID: id})
+						_converted := da.NewDUuid(tree.DUuid{UUID: id})
+						converted[destIdx] = _converted
 					}
 				}
 			case types.TimestampFamily:
@@ -799,13 +977,17 @@ func ColVecToDatum(
 				default:
 					typedCol := col.Timestamp()
 					for idx = 0; idx < length; idx++ {
+						//gcassert:bce
 						destIdx = sel[idx]
+						//gcassert:bce
 						srcIdx = sel[idx]
 						if nulls.NullAt(srcIdx) {
 							converted[destIdx] = tree.DNull
 							continue
 						}
-						converted[destIdx] = da.NewDTimestamp(tree.DTimestamp{Time: typedCol[srcIdx]})
+						v := typedCol.Get(srcIdx)
+						_converted := da.NewDTimestamp(tree.DTimestamp{Time: v})
+						converted[destIdx] = _converted
 					}
 				}
 			case types.TimestampTZFamily:
@@ -814,13 +996,17 @@ func ColVecToDatum(
 				default:
 					typedCol := col.Timestamp()
 					for idx = 0; idx < length; idx++ {
+						//gcassert:bce
 						destIdx = sel[idx]
+						//gcassert:bce
 						srcIdx = sel[idx]
 						if nulls.NullAt(srcIdx) {
 							converted[destIdx] = tree.DNull
 							continue
 						}
-						converted[destIdx] = da.NewDTimestampTZ(tree.DTimestampTZ{Time: typedCol[srcIdx]})
+						v := typedCol.Get(srcIdx)
+						_converted := da.NewDTimestampTZ(tree.DTimestampTZ{Time: v})
+						converted[destIdx] = _converted
 					}
 				}
 			case types.IntervalFamily:
@@ -829,13 +1015,17 @@ func ColVecToDatum(
 				default:
 					typedCol := col.Interval()
 					for idx = 0; idx < length; idx++ {
+						//gcassert:bce
 						destIdx = sel[idx]
+						//gcassert:bce
 						srcIdx = sel[idx]
 						if nulls.NullAt(srcIdx) {
 							converted[destIdx] = tree.DNull
 							continue
 						}
-						converted[destIdx] = da.NewDInterval(tree.DInterval{Duration: typedCol[srcIdx]})
+						v := typedCol.Get(srcIdx)
+						_converted := da.NewDInterval(tree.DInterval{Duration: v})
+						converted[destIdx] = _converted
 					}
 				}
 			case typeconv.DatumVecCanonicalTypeFamily:
@@ -845,17 +1035,22 @@ func ColVecToDatum(
 				default:
 					typedCol := col.Datum()
 					for idx = 0; idx < length; idx++ {
+						//gcassert:bce
 						destIdx = sel[idx]
+						//gcassert:bce
 						srcIdx = sel[idx]
 						if nulls.NullAt(srcIdx) {
 							converted[destIdx] = tree.DNull
 							continue
 						}
-						converted[destIdx] = typedCol.Get(srcIdx).(*coldataext.Datum).Datum
+						v := typedCol.Get(srcIdx)
+						_converted := v.(*coldataext.Datum).Datum
+						converted[destIdx] = _converted
 					}
 				}
 			}
 		} else {
+			_ = converted[length-1]
 			var idx, destIdx, srcIdx int
 			switch ct := col.Type(); ct.Family() {
 			case types.StringFamily:
@@ -867,10 +1062,13 @@ func ColVecToDatum(
 						destIdx = idx
 						srcIdx = idx
 						if nulls.NullAt(srcIdx) {
+							//gcassert:bce
 							converted[destIdx] = tree.DNull
 							continue
 						}
-						converted[destIdx] = da.NewDName(tree.DString(bytes.Get(srcIdx)))
+						v := da.NewDName(tree.DString(bytes.Get(srcIdx)))
+						//gcassert:bce
+						converted[destIdx] = v
 					}
 					return
 				}
@@ -878,61 +1076,88 @@ func ColVecToDatum(
 					destIdx = idx
 					srcIdx = idx
 					if nulls.NullAt(srcIdx) {
+						//gcassert:bce
 						converted[destIdx] = tree.DNull
 						continue
 					}
-					converted[destIdx] = da.NewDString(tree.DString(bytes.Get(srcIdx)))
+					v := da.NewDString(tree.DString(bytes.Get(srcIdx)))
+					//gcassert:bce
+					converted[destIdx] = v
 				}
 			case types.BoolFamily:
 				switch ct.Width() {
 				case -1:
 				default:
 					typedCol := col.Bool()
+					_ = typedCol.Get(length - 1)
 					for idx = 0; idx < length; idx++ {
 						destIdx = idx
 						srcIdx = idx
 						if nulls.NullAt(srcIdx) {
+							//gcassert:bce
 							converted[destIdx] = tree.DNull
 							continue
 						}
-						converted[destIdx] = tree.MakeDBool(tree.DBool(typedCol[srcIdx]))
+						//gcassert:bce
+						v := typedCol.Get(srcIdx)
+						_converted := tree.MakeDBool(tree.DBool(v))
+						//gcassert:bce
+						converted[destIdx] = _converted
 					}
 				}
 			case types.IntFamily:
 				switch ct.Width() {
 				case 16:
 					typedCol := col.Int16()
+					_ = typedCol.Get(length - 1)
 					for idx = 0; idx < length; idx++ {
 						destIdx = idx
 						srcIdx = idx
 						if nulls.NullAt(srcIdx) {
+							//gcassert:bce
 							converted[destIdx] = tree.DNull
 							continue
 						}
-						converted[destIdx] = da.NewDInt(tree.DInt(typedCol[srcIdx]))
+						//gcassert:bce
+						v := typedCol.Get(srcIdx)
+						_converted := da.NewDInt(tree.DInt(v))
+						//gcassert:bce
+						converted[destIdx] = _converted
 					}
 				case 32:
 					typedCol := col.Int32()
+					_ = typedCol.Get(length - 1)
 					for idx = 0; idx < length; idx++ {
 						destIdx = idx
 						srcIdx = idx
 						if nulls.NullAt(srcIdx) {
+							//gcassert:bce
 							converted[destIdx] = tree.DNull
 							continue
 						}
-						converted[destIdx] = da.NewDInt(tree.DInt(typedCol[srcIdx]))
+						//gcassert:bce
+						v := typedCol.Get(srcIdx)
+						_converted := da.NewDInt(tree.DInt(v))
+						//gcassert:bce
+						converted[destIdx] = _converted
 					}
 				case -1:
 				default:
 					typedCol := col.Int64()
+					_ = typedCol.Get(length - 1)
 					for idx = 0; idx < length; idx++ {
 						destIdx = idx
 						srcIdx = idx
 						if nulls.NullAt(srcIdx) {
+							//gcassert:bce
 							converted[destIdx] = tree.DNull
 							continue
 						}
-						converted[destIdx] = da.NewDInt(tree.DInt(typedCol[srcIdx]))
+						//gcassert:bce
+						v := typedCol.Get(srcIdx)
+						_converted := da.NewDInt(tree.DInt(v))
+						//gcassert:bce
+						converted[destIdx] = _converted
 					}
 				}
 			case types.FloatFamily:
@@ -940,14 +1165,20 @@ func ColVecToDatum(
 				case -1:
 				default:
 					typedCol := col.Float64()
+					_ = typedCol.Get(length - 1)
 					for idx = 0; idx < length; idx++ {
 						destIdx = idx
 						srcIdx = idx
 						if nulls.NullAt(srcIdx) {
+							//gcassert:bce
 							converted[destIdx] = tree.DNull
 							continue
 						}
-						converted[destIdx] = da.NewDFloat(tree.DFloat(typedCol[srcIdx]))
+						//gcassert:bce
+						v := typedCol.Get(srcIdx)
+						_converted := da.NewDFloat(tree.DFloat(v))
+						//gcassert:bce
+						converted[destIdx] = _converted
 					}
 				}
 			case types.DecimalFamily:
@@ -955,19 +1186,24 @@ func ColVecToDatum(
 				case -1:
 				default:
 					typedCol := col.Decimal()
+					_ = typedCol.Get(length - 1)
 					for idx = 0; idx < length; idx++ {
 						destIdx = idx
 						srcIdx = idx
 						if nulls.NullAt(srcIdx) {
+							//gcassert:bce
 							converted[destIdx] = tree.DNull
 							continue
 						}
-						d := da.NewDDecimal(tree.DDecimal{Decimal: typedCol[srcIdx]})
+						//gcassert:bce
+						v := typedCol.Get(srcIdx)
+						_converted := da.NewDDecimal(tree.DDecimal{Decimal: v})
 						// Clear the Coeff so that the Set below allocates a new slice for the
 						// Coeff.abs field.
-						d.Coeff = big.Int{}
-						d.Coeff.Set(&typedCol[srcIdx].Coeff)
-						converted[destIdx] = d
+						_converted.Coeff = big.Int{}
+						_converted.Coeff.Set(&v.Coeff)
+						//gcassert:bce
+						converted[destIdx] = _converted
 					}
 				}
 			case types.DateFamily:
@@ -975,14 +1211,20 @@ func ColVecToDatum(
 				case -1:
 				default:
 					typedCol := col.Int64()
+					_ = typedCol.Get(length - 1)
 					for idx = 0; idx < length; idx++ {
 						destIdx = idx
 						srcIdx = idx
 						if nulls.NullAt(srcIdx) {
+							//gcassert:bce
 							converted[destIdx] = tree.DNull
 							continue
 						}
-						converted[destIdx] = da.NewDDate(tree.DDate{Date: pgdate.MakeCompatibleDateFromDisk(typedCol[srcIdx])})
+						//gcassert:bce
+						v := typedCol.Get(srcIdx)
+						_converted := da.NewDDate(tree.DDate{Date: pgdate.MakeCompatibleDateFromDisk(v)})
+						//gcassert:bce
+						converted[destIdx] = _converted
 					}
 				}
 			case types.BytesFamily:
@@ -994,12 +1236,16 @@ func ColVecToDatum(
 						destIdx = idx
 						srcIdx = idx
 						if nulls.NullAt(srcIdx) {
+							//gcassert:bce
 							converted[destIdx] = tree.DNull
 							continue
 						}
+						v := typedCol.Get(srcIdx)
 						// Note that there is no need for a copy since DBytes uses a string
 						// as underlying storage, which will perform the copy for us.
-						converted[destIdx] = da.NewDBytes(tree.DBytes(typedCol.Get(srcIdx)))
+						_converted := da.NewDBytes(tree.DBytes(v))
+						//gcassert:bce
+						converted[destIdx] = _converted
 					}
 				}
 			case types.UuidFamily:
@@ -1011,16 +1257,20 @@ func ColVecToDatum(
 						destIdx = idx
 						srcIdx = idx
 						if nulls.NullAt(srcIdx) {
+							//gcassert:bce
 							converted[destIdx] = tree.DNull
 							continue
 						}
+						v := typedCol.Get(srcIdx)
 						// Note that there is no need for a copy because uuid.FromBytes
 						// will perform a copy.
-						id, err := uuid.FromBytes(typedCol.Get(srcIdx))
+						id, err := uuid.FromBytes(v)
 						if err != nil {
 							colexecerror.InternalError(err)
 						}
-						converted[destIdx] = da.NewDUuid(tree.DUuid{UUID: id})
+						_converted := da.NewDUuid(tree.DUuid{UUID: id})
+						//gcassert:bce
+						converted[destIdx] = _converted
 					}
 				}
 			case types.TimestampFamily:
@@ -1028,14 +1278,20 @@ func ColVecToDatum(
 				case -1:
 				default:
 					typedCol := col.Timestamp()
+					_ = typedCol.Get(length - 1)
 					for idx = 0; idx < length; idx++ {
 						destIdx = idx
 						srcIdx = idx
 						if nulls.NullAt(srcIdx) {
+							//gcassert:bce
 							converted[destIdx] = tree.DNull
 							continue
 						}
-						converted[destIdx] = da.NewDTimestamp(tree.DTimestamp{Time: typedCol[srcIdx]})
+						//gcassert:bce
+						v := typedCol.Get(srcIdx)
+						_converted := da.NewDTimestamp(tree.DTimestamp{Time: v})
+						//gcassert:bce
+						converted[destIdx] = _converted
 					}
 				}
 			case types.TimestampTZFamily:
@@ -1043,14 +1299,20 @@ func ColVecToDatum(
 				case -1:
 				default:
 					typedCol := col.Timestamp()
+					_ = typedCol.Get(length - 1)
 					for idx = 0; idx < length; idx++ {
 						destIdx = idx
 						srcIdx = idx
 						if nulls.NullAt(srcIdx) {
+							//gcassert:bce
 							converted[destIdx] = tree.DNull
 							continue
 						}
-						converted[destIdx] = da.NewDTimestampTZ(tree.DTimestampTZ{Time: typedCol[srcIdx]})
+						//gcassert:bce
+						v := typedCol.Get(srcIdx)
+						_converted := da.NewDTimestampTZ(tree.DTimestampTZ{Time: v})
+						//gcassert:bce
+						converted[destIdx] = _converted
 					}
 				}
 			case types.IntervalFamily:
@@ -1058,14 +1320,20 @@ func ColVecToDatum(
 				case -1:
 				default:
 					typedCol := col.Interval()
+					_ = typedCol.Get(length - 1)
 					for idx = 0; idx < length; idx++ {
 						destIdx = idx
 						srcIdx = idx
 						if nulls.NullAt(srcIdx) {
+							//gcassert:bce
 							converted[destIdx] = tree.DNull
 							continue
 						}
-						converted[destIdx] = da.NewDInterval(tree.DInterval{Duration: typedCol[srcIdx]})
+						//gcassert:bce
+						v := typedCol.Get(srcIdx)
+						_converted := da.NewDInterval(tree.DInterval{Duration: v})
+						//gcassert:bce
+						converted[destIdx] = _converted
 					}
 				}
 			case typeconv.DatumVecCanonicalTypeFamily:
@@ -1078,17 +1346,21 @@ func ColVecToDatum(
 						destIdx = idx
 						srcIdx = idx
 						if nulls.NullAt(srcIdx) {
+							//gcassert:bce
 							converted[destIdx] = tree.DNull
 							continue
 						}
-						converted[destIdx] = typedCol.Get(srcIdx).(*coldataext.Datum).Datum
+						v := typedCol.Get(srcIdx)
+						_converted := v.(*coldataext.Datum).Datum
+						//gcassert:bce
+						converted[destIdx] = _converted
 					}
 				}
 			}
 		}
 	} else {
 		if sel != nil {
-			sel = sel[:length]
+			_ = sel[length-1]
 			var idx, destIdx, srcIdx int
 			switch ct := col.Type(); ct.Family() {
 			case types.StringFamily:
@@ -1097,16 +1369,22 @@ func ColVecToDatum(
 				bytes := col.Bytes()
 				if ct.Oid() == oid.T_name {
 					for idx = 0; idx < length; idx++ {
+						//gcassert:bce
 						destIdx = sel[idx]
+						//gcassert:bce
 						srcIdx = sel[idx]
-						converted[destIdx] = da.NewDName(tree.DString(bytes.Get(srcIdx)))
+						v := da.NewDName(tree.DString(bytes.Get(srcIdx)))
+						converted[destIdx] = v
 					}
 					return
 				}
 				for idx = 0; idx < length; idx++ {
+					//gcassert:bce
 					destIdx = sel[idx]
+					//gcassert:bce
 					srcIdx = sel[idx]
-					converted[destIdx] = da.NewDString(tree.DString(bytes.Get(srcIdx)))
+					v := da.NewDString(tree.DString(bytes.Get(srcIdx)))
+					converted[destIdx] = v
 				}
 			case types.BoolFamily:
 				switch ct.Width() {
@@ -1114,9 +1392,13 @@ func ColVecToDatum(
 				default:
 					typedCol := col.Bool()
 					for idx = 0; idx < length; idx++ {
+						//gcassert:bce
 						destIdx = sel[idx]
+						//gcassert:bce
 						srcIdx = sel[idx]
-						converted[destIdx] = tree.MakeDBool(tree.DBool(typedCol[srcIdx]))
+						v := typedCol.Get(srcIdx)
+						_converted := tree.MakeDBool(tree.DBool(v))
+						converted[destIdx] = _converted
 					}
 				}
 			case types.IntFamily:
@@ -1124,24 +1406,36 @@ func ColVecToDatum(
 				case 16:
 					typedCol := col.Int16()
 					for idx = 0; idx < length; idx++ {
+						//gcassert:bce
 						destIdx = sel[idx]
+						//gcassert:bce
 						srcIdx = sel[idx]
-						converted[destIdx] = da.NewDInt(tree.DInt(typedCol[srcIdx]))
+						v := typedCol.Get(srcIdx)
+						_converted := da.NewDInt(tree.DInt(v))
+						converted[destIdx] = _converted
 					}
 				case 32:
 					typedCol := col.Int32()
 					for idx = 0; idx < length; idx++ {
+						//gcassert:bce
 						destIdx = sel[idx]
+						//gcassert:bce
 						srcIdx = sel[idx]
-						converted[destIdx] = da.NewDInt(tree.DInt(typedCol[srcIdx]))
+						v := typedCol.Get(srcIdx)
+						_converted := da.NewDInt(tree.DInt(v))
+						converted[destIdx] = _converted
 					}
 				case -1:
 				default:
 					typedCol := col.Int64()
 					for idx = 0; idx < length; idx++ {
+						//gcassert:bce
 						destIdx = sel[idx]
+						//gcassert:bce
 						srcIdx = sel[idx]
-						converted[destIdx] = da.NewDInt(tree.DInt(typedCol[srcIdx]))
+						v := typedCol.Get(srcIdx)
+						_converted := da.NewDInt(tree.DInt(v))
+						converted[destIdx] = _converted
 					}
 				}
 			case types.FloatFamily:
@@ -1150,9 +1444,13 @@ func ColVecToDatum(
 				default:
 					typedCol := col.Float64()
 					for idx = 0; idx < length; idx++ {
+						//gcassert:bce
 						destIdx = sel[idx]
+						//gcassert:bce
 						srcIdx = sel[idx]
-						converted[destIdx] = da.NewDFloat(tree.DFloat(typedCol[srcIdx]))
+						v := typedCol.Get(srcIdx)
+						_converted := da.NewDFloat(tree.DFloat(v))
+						converted[destIdx] = _converted
 					}
 				}
 			case types.DecimalFamily:
@@ -1161,14 +1459,17 @@ func ColVecToDatum(
 				default:
 					typedCol := col.Decimal()
 					for idx = 0; idx < length; idx++ {
+						//gcassert:bce
 						destIdx = sel[idx]
+						//gcassert:bce
 						srcIdx = sel[idx]
-						d := da.NewDDecimal(tree.DDecimal{Decimal: typedCol[srcIdx]})
+						v := typedCol.Get(srcIdx)
+						_converted := da.NewDDecimal(tree.DDecimal{Decimal: v})
 						// Clear the Coeff so that the Set below allocates a new slice for the
 						// Coeff.abs field.
-						d.Coeff = big.Int{}
-						d.Coeff.Set(&typedCol[srcIdx].Coeff)
-						converted[destIdx] = d
+						_converted.Coeff = big.Int{}
+						_converted.Coeff.Set(&v.Coeff)
+						converted[destIdx] = _converted
 					}
 				}
 			case types.DateFamily:
@@ -1177,9 +1478,13 @@ func ColVecToDatum(
 				default:
 					typedCol := col.Int64()
 					for idx = 0; idx < length; idx++ {
+						//gcassert:bce
 						destIdx = sel[idx]
+						//gcassert:bce
 						srcIdx = sel[idx]
-						converted[destIdx] = da.NewDDate(tree.DDate{Date: pgdate.MakeCompatibleDateFromDisk(typedCol[srcIdx])})
+						v := typedCol.Get(srcIdx)
+						_converted := da.NewDDate(tree.DDate{Date: pgdate.MakeCompatibleDateFromDisk(v)})
+						converted[destIdx] = _converted
 					}
 				}
 			case types.BytesFamily:
@@ -1188,11 +1493,15 @@ func ColVecToDatum(
 				default:
 					typedCol := col.Bytes()
 					for idx = 0; idx < length; idx++ {
+						//gcassert:bce
 						destIdx = sel[idx]
+						//gcassert:bce
 						srcIdx = sel[idx]
+						v := typedCol.Get(srcIdx)
 						// Note that there is no need for a copy since DBytes uses a string
 						// as underlying storage, which will perform the copy for us.
-						converted[destIdx] = da.NewDBytes(tree.DBytes(typedCol.Get(srcIdx)))
+						_converted := da.NewDBytes(tree.DBytes(v))
+						converted[destIdx] = _converted
 					}
 				}
 			case types.UuidFamily:
@@ -1201,15 +1510,19 @@ func ColVecToDatum(
 				default:
 					typedCol := col.Bytes()
 					for idx = 0; idx < length; idx++ {
+						//gcassert:bce
 						destIdx = sel[idx]
+						//gcassert:bce
 						srcIdx = sel[idx]
+						v := typedCol.Get(srcIdx)
 						// Note that there is no need for a copy because uuid.FromBytes
 						// will perform a copy.
-						id, err := uuid.FromBytes(typedCol.Get(srcIdx))
+						id, err := uuid.FromBytes(v)
 						if err != nil {
 							colexecerror.InternalError(err)
 						}
-						converted[destIdx] = da.NewDUuid(tree.DUuid{UUID: id})
+						_converted := da.NewDUuid(tree.DUuid{UUID: id})
+						converted[destIdx] = _converted
 					}
 				}
 			case types.TimestampFamily:
@@ -1218,9 +1531,13 @@ func ColVecToDatum(
 				default:
 					typedCol := col.Timestamp()
 					for idx = 0; idx < length; idx++ {
+						//gcassert:bce
 						destIdx = sel[idx]
+						//gcassert:bce
 						srcIdx = sel[idx]
-						converted[destIdx] = da.NewDTimestamp(tree.DTimestamp{Time: typedCol[srcIdx]})
+						v := typedCol.Get(srcIdx)
+						_converted := da.NewDTimestamp(tree.DTimestamp{Time: v})
+						converted[destIdx] = _converted
 					}
 				}
 			case types.TimestampTZFamily:
@@ -1229,9 +1546,13 @@ func ColVecToDatum(
 				default:
 					typedCol := col.Timestamp()
 					for idx = 0; idx < length; idx++ {
+						//gcassert:bce
 						destIdx = sel[idx]
+						//gcassert:bce
 						srcIdx = sel[idx]
-						converted[destIdx] = da.NewDTimestampTZ(tree.DTimestampTZ{Time: typedCol[srcIdx]})
+						v := typedCol.Get(srcIdx)
+						_converted := da.NewDTimestampTZ(tree.DTimestampTZ{Time: v})
+						converted[destIdx] = _converted
 					}
 				}
 			case types.IntervalFamily:
@@ -1240,9 +1561,13 @@ func ColVecToDatum(
 				default:
 					typedCol := col.Interval()
 					for idx = 0; idx < length; idx++ {
+						//gcassert:bce
 						destIdx = sel[idx]
+						//gcassert:bce
 						srcIdx = sel[idx]
-						converted[destIdx] = da.NewDInterval(tree.DInterval{Duration: typedCol[srcIdx]})
+						v := typedCol.Get(srcIdx)
+						_converted := da.NewDInterval(tree.DInterval{Duration: v})
+						converted[destIdx] = _converted
 					}
 				}
 			case typeconv.DatumVecCanonicalTypeFamily:
@@ -1252,13 +1577,18 @@ func ColVecToDatum(
 				default:
 					typedCol := col.Datum()
 					for idx = 0; idx < length; idx++ {
+						//gcassert:bce
 						destIdx = sel[idx]
+						//gcassert:bce
 						srcIdx = sel[idx]
-						converted[destIdx] = typedCol.Get(srcIdx).(*coldataext.Datum).Datum
+						v := typedCol.Get(srcIdx)
+						_converted := v.(*coldataext.Datum).Datum
+						converted[destIdx] = _converted
 					}
 				}
 			}
 		} else {
+			_ = converted[length-1]
 			var idx, destIdx, srcIdx int
 			switch ct := col.Type(); ct.Family() {
 			case types.StringFamily:
@@ -1269,49 +1599,73 @@ func ColVecToDatum(
 					for idx = 0; idx < length; idx++ {
 						destIdx = idx
 						srcIdx = idx
-						converted[destIdx] = da.NewDName(tree.DString(bytes.Get(srcIdx)))
+						v := da.NewDName(tree.DString(bytes.Get(srcIdx)))
+						//gcassert:bce
+						converted[destIdx] = v
 					}
 					return
 				}
 				for idx = 0; idx < length; idx++ {
 					destIdx = idx
 					srcIdx = idx
-					converted[destIdx] = da.NewDString(tree.DString(bytes.Get(srcIdx)))
+					v := da.NewDString(tree.DString(bytes.Get(srcIdx)))
+					//gcassert:bce
+					converted[destIdx] = v
 				}
 			case types.BoolFamily:
 				switch ct.Width() {
 				case -1:
 				default:
 					typedCol := col.Bool()
+					_ = typedCol.Get(length - 1)
 					for idx = 0; idx < length; idx++ {
 						destIdx = idx
 						srcIdx = idx
-						converted[destIdx] = tree.MakeDBool(tree.DBool(typedCol[srcIdx]))
+						//gcassert:bce
+						v := typedCol.Get(srcIdx)
+						_converted := tree.MakeDBool(tree.DBool(v))
+						//gcassert:bce
+						converted[destIdx] = _converted
 					}
 				}
 			case types.IntFamily:
 				switch ct.Width() {
 				case 16:
 					typedCol := col.Int16()
+					_ = typedCol.Get(length - 1)
 					for idx = 0; idx < length; idx++ {
 						destIdx = idx
 						srcIdx = idx
-						converted[destIdx] = da.NewDInt(tree.DInt(typedCol[srcIdx]))
+						//gcassert:bce
+						v := typedCol.Get(srcIdx)
+						_converted := da.NewDInt(tree.DInt(v))
+						//gcassert:bce
+						converted[destIdx] = _converted
 					}
 				case 32:
 					typedCol := col.Int32()
+					_ = typedCol.Get(length - 1)
 					for idx = 0; idx < length; idx++ {
 						destIdx = idx
 						srcIdx = idx
-						converted[destIdx] = da.NewDInt(tree.DInt(typedCol[srcIdx]))
+						//gcassert:bce
+						v := typedCol.Get(srcIdx)
+						_converted := da.NewDInt(tree.DInt(v))
+						//gcassert:bce
+						converted[destIdx] = _converted
 					}
 				case -1:
 				default:
 					typedCol := col.Int64()
+					_ = typedCol.Get(length - 1)
 					for idx = 0; idx < length; idx++ {
 						destIdx = idx
 						srcIdx = idx
-						converted[destIdx] = da.NewDInt(tree.DInt(typedCol[srcIdx]))
+						//gcassert:bce
+						v := typedCol.Get(srcIdx)
+						_converted := da.NewDInt(tree.DInt(v))
+						//gcassert:bce
+						converted[destIdx] = _converted
 					}
 				}
 			case types.FloatFamily:
@@ -1319,10 +1673,15 @@ func ColVecToDatum(
 				case -1:
 				default:
 					typedCol := col.Float64()
+					_ = typedCol.Get(length - 1)
 					for idx = 0; idx < length; idx++ {
 						destIdx = idx
 						srcIdx = idx
-						converted[destIdx] = da.NewDFloat(tree.DFloat(typedCol[srcIdx]))
+						//gcassert:bce
+						v := typedCol.Get(srcIdx)
+						_converted := da.NewDFloat(tree.DFloat(v))
+						//gcassert:bce
+						converted[destIdx] = _converted
 					}
 				}
 			case types.DecimalFamily:
@@ -1330,15 +1689,19 @@ func ColVecToDatum(
 				case -1:
 				default:
 					typedCol := col.Decimal()
+					_ = typedCol.Get(length - 1)
 					for idx = 0; idx < length; idx++ {
 						destIdx = idx
 						srcIdx = idx
-						d := da.NewDDecimal(tree.DDecimal{Decimal: typedCol[srcIdx]})
+						//gcassert:bce
+						v := typedCol.Get(srcIdx)
+						_converted := da.NewDDecimal(tree.DDecimal{Decimal: v})
 						// Clear the Coeff so that the Set below allocates a new slice for the
 						// Coeff.abs field.
-						d.Coeff = big.Int{}
-						d.Coeff.Set(&typedCol[srcIdx].Coeff)
-						converted[destIdx] = d
+						_converted.Coeff = big.Int{}
+						_converted.Coeff.Set(&v.Coeff)
+						//gcassert:bce
+						converted[destIdx] = _converted
 					}
 				}
 			case types.DateFamily:
@@ -1346,10 +1709,15 @@ func ColVecToDatum(
 				case -1:
 				default:
 					typedCol := col.Int64()
+					_ = typedCol.Get(length - 1)
 					for idx = 0; idx < length; idx++ {
 						destIdx = idx
 						srcIdx = idx
-						converted[destIdx] = da.NewDDate(tree.DDate{Date: pgdate.MakeCompatibleDateFromDisk(typedCol[srcIdx])})
+						//gcassert:bce
+						v := typedCol.Get(srcIdx)
+						_converted := da.NewDDate(tree.DDate{Date: pgdate.MakeCompatibleDateFromDisk(v)})
+						//gcassert:bce
+						converted[destIdx] = _converted
 					}
 				}
 			case types.BytesFamily:
@@ -1360,9 +1728,12 @@ func ColVecToDatum(
 					for idx = 0; idx < length; idx++ {
 						destIdx = idx
 						srcIdx = idx
+						v := typedCol.Get(srcIdx)
 						// Note that there is no need for a copy since DBytes uses a string
 						// as underlying storage, which will perform the copy for us.
-						converted[destIdx] = da.NewDBytes(tree.DBytes(typedCol.Get(srcIdx)))
+						_converted := da.NewDBytes(tree.DBytes(v))
+						//gcassert:bce
+						converted[destIdx] = _converted
 					}
 				}
 			case types.UuidFamily:
@@ -1373,13 +1744,16 @@ func ColVecToDatum(
 					for idx = 0; idx < length; idx++ {
 						destIdx = idx
 						srcIdx = idx
+						v := typedCol.Get(srcIdx)
 						// Note that there is no need for a copy because uuid.FromBytes
 						// will perform a copy.
-						id, err := uuid.FromBytes(typedCol.Get(srcIdx))
+						id, err := uuid.FromBytes(v)
 						if err != nil {
 							colexecerror.InternalError(err)
 						}
-						converted[destIdx] = da.NewDUuid(tree.DUuid{UUID: id})
+						_converted := da.NewDUuid(tree.DUuid{UUID: id})
+						//gcassert:bce
+						converted[destIdx] = _converted
 					}
 				}
 			case types.TimestampFamily:
@@ -1387,10 +1761,15 @@ func ColVecToDatum(
 				case -1:
 				default:
 					typedCol := col.Timestamp()
+					_ = typedCol.Get(length - 1)
 					for idx = 0; idx < length; idx++ {
 						destIdx = idx
 						srcIdx = idx
-						converted[destIdx] = da.NewDTimestamp(tree.DTimestamp{Time: typedCol[srcIdx]})
+						//gcassert:bce
+						v := typedCol.Get(srcIdx)
+						_converted := da.NewDTimestamp(tree.DTimestamp{Time: v})
+						//gcassert:bce
+						converted[destIdx] = _converted
 					}
 				}
 			case types.TimestampTZFamily:
@@ -1398,10 +1777,15 @@ func ColVecToDatum(
 				case -1:
 				default:
 					typedCol := col.Timestamp()
+					_ = typedCol.Get(length - 1)
 					for idx = 0; idx < length; idx++ {
 						destIdx = idx
 						srcIdx = idx
-						converted[destIdx] = da.NewDTimestampTZ(tree.DTimestampTZ{Time: typedCol[srcIdx]})
+						//gcassert:bce
+						v := typedCol.Get(srcIdx)
+						_converted := da.NewDTimestampTZ(tree.DTimestampTZ{Time: v})
+						//gcassert:bce
+						converted[destIdx] = _converted
 					}
 				}
 			case types.IntervalFamily:
@@ -1409,10 +1793,15 @@ func ColVecToDatum(
 				case -1:
 				default:
 					typedCol := col.Interval()
+					_ = typedCol.Get(length - 1)
 					for idx = 0; idx < length; idx++ {
 						destIdx = idx
 						srcIdx = idx
-						converted[destIdx] = da.NewDInterval(tree.DInterval{Duration: typedCol[srcIdx]})
+						//gcassert:bce
+						v := typedCol.Get(srcIdx)
+						_converted := da.NewDInterval(tree.DInterval{Duration: v})
+						//gcassert:bce
+						converted[destIdx] = _converted
 					}
 				}
 			case typeconv.DatumVecCanonicalTypeFamily:
@@ -1424,7 +1813,10 @@ func ColVecToDatum(
 					for idx = 0; idx < length; idx++ {
 						destIdx = idx
 						srcIdx = idx
-						converted[destIdx] = typedCol.Get(srcIdx).(*coldataext.Datum).Datum
+						v := typedCol.Get(srcIdx)
+						_converted := v.(*coldataext.Datum).Datum
+						//gcassert:bce
+						converted[destIdx] = _converted
 					}
 				}
 			}

--- a/pkg/sql/colexec/cast.eg.go
+++ b/pkg/sql/colexec/cast.eg.go
@@ -566,9 +566,11 @@ func (c *castBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 						if inputNulls.NullAt(tupleIdx) {
 							continue
 						}
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r bool
 						r = v
+						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
 				}
@@ -593,9 +595,11 @@ func (c *castBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 					var tupleIdx int
 					for i := 0; i < n; i++ {
 						tupleIdx = i
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r bool
 						r = v
+						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
 				}
@@ -672,6 +676,7 @@ func (c *castBoolFloat64Op) Next(ctx context.Context) coldata.Batch {
 						if inputNulls.NullAt(tupleIdx) {
 							continue
 						}
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r float64
 
@@ -680,6 +685,7 @@ func (c *castBoolFloat64Op) Next(ctx context.Context) coldata.Batch {
 							r = 1
 						}
 
+						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
 				}
@@ -709,6 +715,7 @@ func (c *castBoolFloat64Op) Next(ctx context.Context) coldata.Batch {
 					var tupleIdx int
 					for i := 0; i < n; i++ {
 						tupleIdx = i
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r float64
 
@@ -717,6 +724,7 @@ func (c *castBoolFloat64Op) Next(ctx context.Context) coldata.Batch {
 							r = 1
 						}
 
+						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
 				}
@@ -793,6 +801,7 @@ func (c *castBoolInt16Op) Next(ctx context.Context) coldata.Batch {
 						if inputNulls.NullAt(tupleIdx) {
 							continue
 						}
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r int16
 
@@ -801,6 +810,7 @@ func (c *castBoolInt16Op) Next(ctx context.Context) coldata.Batch {
 							r = 1
 						}
 
+						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
 				}
@@ -830,6 +840,7 @@ func (c *castBoolInt16Op) Next(ctx context.Context) coldata.Batch {
 					var tupleIdx int
 					for i := 0; i < n; i++ {
 						tupleIdx = i
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r int16
 
@@ -838,6 +849,7 @@ func (c *castBoolInt16Op) Next(ctx context.Context) coldata.Batch {
 							r = 1
 						}
 
+						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
 				}
@@ -914,6 +926,7 @@ func (c *castBoolInt32Op) Next(ctx context.Context) coldata.Batch {
 						if inputNulls.NullAt(tupleIdx) {
 							continue
 						}
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r int32
 
@@ -922,6 +935,7 @@ func (c *castBoolInt32Op) Next(ctx context.Context) coldata.Batch {
 							r = 1
 						}
 
+						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
 				}
@@ -951,6 +965,7 @@ func (c *castBoolInt32Op) Next(ctx context.Context) coldata.Batch {
 					var tupleIdx int
 					for i := 0; i < n; i++ {
 						tupleIdx = i
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r int32
 
@@ -959,6 +974,7 @@ func (c *castBoolInt32Op) Next(ctx context.Context) coldata.Batch {
 							r = 1
 						}
 
+						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
 				}
@@ -1035,6 +1051,7 @@ func (c *castBoolInt64Op) Next(ctx context.Context) coldata.Batch {
 						if inputNulls.NullAt(tupleIdx) {
 							continue
 						}
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r int64
 
@@ -1043,6 +1060,7 @@ func (c *castBoolInt64Op) Next(ctx context.Context) coldata.Batch {
 							r = 1
 						}
 
+						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
 				}
@@ -1072,6 +1090,7 @@ func (c *castBoolInt64Op) Next(ctx context.Context) coldata.Batch {
 					var tupleIdx int
 					for i := 0; i < n; i++ {
 						tupleIdx = i
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r int64
 
@@ -1080,6 +1099,7 @@ func (c *castBoolInt64Op) Next(ctx context.Context) coldata.Batch {
 							r = 1
 						}
 
+						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
 				}
@@ -1151,9 +1171,11 @@ func (c *castDecimalBoolOp) Next(ctx context.Context) coldata.Batch {
 						if inputNulls.NullAt(tupleIdx) {
 							continue
 						}
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r bool
 						r = v.Sign() != 0
+						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
 				}
@@ -1178,9 +1200,11 @@ func (c *castDecimalBoolOp) Next(ctx context.Context) coldata.Batch {
 					var tupleIdx int
 					for i := 0; i < n; i++ {
 						tupleIdx = i
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r bool
 						r = v.Sign() != 0
+						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
 				}
@@ -1257,6 +1281,7 @@ func (c *castDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 						if inputNulls.NullAt(tupleIdx) {
 							continue
 						}
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r apd.Decimal
 
@@ -1265,6 +1290,7 @@ func (c *castDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 							colexecerror.ExpectedError(err)
 						}
 
+						//gcassert:bce
 						outputCol[tupleIdx].Set(&r)
 					}
 				}
@@ -1294,6 +1320,7 @@ func (c *castDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 					var tupleIdx int
 					for i := 0; i < n; i++ {
 						tupleIdx = i
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r apd.Decimal
 
@@ -1302,6 +1329,7 @@ func (c *castDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 							colexecerror.ExpectedError(err)
 						}
 
+						//gcassert:bce
 						outputCol[tupleIdx].Set(&r)
 					}
 				}
@@ -1373,9 +1401,11 @@ func (c *castInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 						if inputNulls.NullAt(tupleIdx) {
 							continue
 						}
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r int16
 						r = v
+						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
 				}
@@ -1400,9 +1430,11 @@ func (c *castInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 					var tupleIdx int
 					for i := 0; i < n; i++ {
 						tupleIdx = i
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r int16
 						r = v
+						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
 				}
@@ -1476,11 +1508,13 @@ func (c *castInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 						if inputNulls.NullAt(tupleIdx) {
 							continue
 						}
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r int32
 
 						r = int32(v)
 
+						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
 				}
@@ -1507,11 +1541,13 @@ func (c *castInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 					var tupleIdx int
 					for i := 0; i < n; i++ {
 						tupleIdx = i
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r int32
 
 						r = int32(v)
 
+						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
 				}
@@ -1585,11 +1621,13 @@ func (c *castInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 						if inputNulls.NullAt(tupleIdx) {
 							continue
 						}
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r int64
 
 						r = int64(v)
 
+						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
 				}
@@ -1616,11 +1654,13 @@ func (c *castInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 					var tupleIdx int
 					for i := 0; i < n; i++ {
 						tupleIdx = i
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r int64
 
 						r = int64(v)
 
+						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
 				}
@@ -1694,11 +1734,13 @@ func (c *castInt16BoolOp) Next(ctx context.Context) coldata.Batch {
 						if inputNulls.NullAt(tupleIdx) {
 							continue
 						}
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r bool
 
 						r = v != 0
 
+						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
 				}
@@ -1725,11 +1767,13 @@ func (c *castInt16BoolOp) Next(ctx context.Context) coldata.Batch {
 					var tupleIdx int
 					for i := 0; i < n; i++ {
 						tupleIdx = i
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r bool
 
 						r = v != 0
 
+						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
 				}
@@ -1807,6 +1851,7 @@ func (c *castInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 						if inputNulls.NullAt(tupleIdx) {
 							continue
 						}
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r apd.Decimal
 
@@ -1816,6 +1861,7 @@ func (c *castInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 							colexecerror.ExpectedError(err)
 						}
 
+						//gcassert:bce
 						outputCol[tupleIdx].Set(&r)
 					}
 				}
@@ -1846,6 +1892,7 @@ func (c *castInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 					var tupleIdx int
 					for i := 0; i < n; i++ {
 						tupleIdx = i
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r apd.Decimal
 
@@ -1855,6 +1902,7 @@ func (c *castInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 							colexecerror.ExpectedError(err)
 						}
 
+						//gcassert:bce
 						outputCol[tupleIdx].Set(&r)
 					}
 				}
@@ -1928,11 +1976,13 @@ func (c *castInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 						if inputNulls.NullAt(tupleIdx) {
 							continue
 						}
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r float64
 
 						r = float64(v)
 
+						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
 				}
@@ -1959,11 +2009,13 @@ func (c *castInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 					var tupleIdx int
 					for i := 0; i < n; i++ {
 						tupleIdx = i
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r float64
 
 						r = float64(v)
 
+						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
 				}
@@ -2037,11 +2089,13 @@ func (c *castInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 						if inputNulls.NullAt(tupleIdx) {
 							continue
 						}
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r int16
 
 						r = int16(v)
 
+						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
 				}
@@ -2068,11 +2122,13 @@ func (c *castInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 					var tupleIdx int
 					for i := 0; i < n; i++ {
 						tupleIdx = i
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r int16
 
 						r = int16(v)
 
+						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
 				}
@@ -2144,9 +2200,11 @@ func (c *castInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 						if inputNulls.NullAt(tupleIdx) {
 							continue
 						}
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r int32
 						r = v
+						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
 				}
@@ -2171,9 +2229,11 @@ func (c *castInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 					var tupleIdx int
 					for i := 0; i < n; i++ {
 						tupleIdx = i
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r int32
 						r = v
+						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
 				}
@@ -2247,11 +2307,13 @@ func (c *castInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 						if inputNulls.NullAt(tupleIdx) {
 							continue
 						}
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r int64
 
 						r = int64(v)
 
+						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
 				}
@@ -2278,11 +2340,13 @@ func (c *castInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 					var tupleIdx int
 					for i := 0; i < n; i++ {
 						tupleIdx = i
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r int64
 
 						r = int64(v)
 
+						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
 				}
@@ -2356,11 +2420,13 @@ func (c *castInt32BoolOp) Next(ctx context.Context) coldata.Batch {
 						if inputNulls.NullAt(tupleIdx) {
 							continue
 						}
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r bool
 
 						r = v != 0
 
+						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
 				}
@@ -2387,11 +2453,13 @@ func (c *castInt32BoolOp) Next(ctx context.Context) coldata.Batch {
 					var tupleIdx int
 					for i := 0; i < n; i++ {
 						tupleIdx = i
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r bool
 
 						r = v != 0
 
+						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
 				}
@@ -2469,6 +2537,7 @@ func (c *castInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 						if inputNulls.NullAt(tupleIdx) {
 							continue
 						}
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r apd.Decimal
 
@@ -2478,6 +2547,7 @@ func (c *castInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 							colexecerror.ExpectedError(err)
 						}
 
+						//gcassert:bce
 						outputCol[tupleIdx].Set(&r)
 					}
 				}
@@ -2508,6 +2578,7 @@ func (c *castInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 					var tupleIdx int
 					for i := 0; i < n; i++ {
 						tupleIdx = i
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r apd.Decimal
 
@@ -2517,6 +2588,7 @@ func (c *castInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 							colexecerror.ExpectedError(err)
 						}
 
+						//gcassert:bce
 						outputCol[tupleIdx].Set(&r)
 					}
 				}
@@ -2590,11 +2662,13 @@ func (c *castInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 						if inputNulls.NullAt(tupleIdx) {
 							continue
 						}
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r float64
 
 						r = float64(v)
 
+						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
 				}
@@ -2621,11 +2695,13 @@ func (c *castInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 					var tupleIdx int
 					for i := 0; i < n; i++ {
 						tupleIdx = i
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r float64
 
 						r = float64(v)
 
+						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
 				}
@@ -2699,11 +2775,13 @@ func (c *castInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 						if inputNulls.NullAt(tupleIdx) {
 							continue
 						}
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r int16
 
 						r = int16(v)
 
+						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
 				}
@@ -2730,11 +2808,13 @@ func (c *castInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 					var tupleIdx int
 					for i := 0; i < n; i++ {
 						tupleIdx = i
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r int16
 
 						r = int16(v)
 
+						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
 				}
@@ -2808,11 +2888,13 @@ func (c *castInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 						if inputNulls.NullAt(tupleIdx) {
 							continue
 						}
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r int32
 
 						r = int32(v)
 
+						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
 				}
@@ -2839,11 +2921,13 @@ func (c *castInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 					var tupleIdx int
 					for i := 0; i < n; i++ {
 						tupleIdx = i
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r int32
 
 						r = int32(v)
 
+						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
 				}
@@ -2915,9 +2999,11 @@ func (c *castInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 						if inputNulls.NullAt(tupleIdx) {
 							continue
 						}
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r int64
 						r = v
+						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
 				}
@@ -2942,9 +3028,11 @@ func (c *castInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 					var tupleIdx int
 					for i := 0; i < n; i++ {
 						tupleIdx = i
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r int64
 						r = v
+						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
 				}
@@ -3018,11 +3106,13 @@ func (c *castInt64BoolOp) Next(ctx context.Context) coldata.Batch {
 						if inputNulls.NullAt(tupleIdx) {
 							continue
 						}
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r bool
 
 						r = v != 0
 
+						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
 				}
@@ -3049,11 +3139,13 @@ func (c *castInt64BoolOp) Next(ctx context.Context) coldata.Batch {
 					var tupleIdx int
 					for i := 0; i < n; i++ {
 						tupleIdx = i
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r bool
 
 						r = v != 0
 
+						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
 				}
@@ -3131,6 +3223,7 @@ func (c *castInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 						if inputNulls.NullAt(tupleIdx) {
 							continue
 						}
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r apd.Decimal
 
@@ -3140,6 +3233,7 @@ func (c *castInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 							colexecerror.ExpectedError(err)
 						}
 
+						//gcassert:bce
 						outputCol[tupleIdx].Set(&r)
 					}
 				}
@@ -3170,6 +3264,7 @@ func (c *castInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 					var tupleIdx int
 					for i := 0; i < n; i++ {
 						tupleIdx = i
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r apd.Decimal
 
@@ -3179,6 +3274,7 @@ func (c *castInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 							colexecerror.ExpectedError(err)
 						}
 
+						//gcassert:bce
 						outputCol[tupleIdx].Set(&r)
 					}
 				}
@@ -3252,11 +3348,13 @@ func (c *castInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 						if inputNulls.NullAt(tupleIdx) {
 							continue
 						}
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r float64
 
 						r = float64(v)
 
+						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
 				}
@@ -3283,11 +3381,13 @@ func (c *castInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 					var tupleIdx int
 					for i := 0; i < n; i++ {
 						tupleIdx = i
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r float64
 
 						r = float64(v)
 
+						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
 				}
@@ -3359,9 +3459,11 @@ func (c *castFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 						if inputNulls.NullAt(tupleIdx) {
 							continue
 						}
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r float64
 						r = v
+						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
 				}
@@ -3386,9 +3488,11 @@ func (c *castFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 					var tupleIdx int
 					for i := 0; i < n; i++ {
 						tupleIdx = i
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r float64
 						r = v
+						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
 				}
@@ -3462,11 +3566,13 @@ func (c *castFloat64BoolOp) Next(ctx context.Context) coldata.Batch {
 						if inputNulls.NullAt(tupleIdx) {
 							continue
 						}
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r bool
 
 						r = v != 0
 
+						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
 				}
@@ -3493,11 +3599,13 @@ func (c *castFloat64BoolOp) Next(ctx context.Context) coldata.Batch {
 					var tupleIdx int
 					for i := 0; i < n; i++ {
 						tupleIdx = i
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r bool
 
 						r = v != 0
 
+						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
 				}
@@ -3577,6 +3685,7 @@ func (c *castFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 						if inputNulls.NullAt(tupleIdx) {
 							continue
 						}
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r apd.Decimal
 
@@ -3588,6 +3697,7 @@ func (c *castFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 							colexecerror.ExpectedError(err)
 						}
 
+						//gcassert:bce
 						outputCol[tupleIdx].Set(&r)
 					}
 				}
@@ -3620,6 +3730,7 @@ func (c *castFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 					var tupleIdx int
 					for i := 0; i < n; i++ {
 						tupleIdx = i
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r apd.Decimal
 
@@ -3631,6 +3742,7 @@ func (c *castFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 							colexecerror.ExpectedError(err)
 						}
 
+						//gcassert:bce
 						outputCol[tupleIdx].Set(&r)
 					}
 				}
@@ -3707,6 +3819,7 @@ func (c *castFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 						if inputNulls.NullAt(tupleIdx) {
 							continue
 						}
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r int16
 
@@ -3715,6 +3828,7 @@ func (c *castFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 						}
 						r = int16(v)
 
+						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
 				}
@@ -3744,6 +3858,7 @@ func (c *castFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 					var tupleIdx int
 					for i := 0; i < n; i++ {
 						tupleIdx = i
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r int16
 
@@ -3752,6 +3867,7 @@ func (c *castFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 						}
 						r = int16(v)
 
+						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
 				}
@@ -3828,6 +3944,7 @@ func (c *castFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 						if inputNulls.NullAt(tupleIdx) {
 							continue
 						}
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r int32
 
@@ -3836,6 +3953,7 @@ func (c *castFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 						}
 						r = int32(v)
 
+						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
 				}
@@ -3865,6 +3983,7 @@ func (c *castFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 					var tupleIdx int
 					for i := 0; i < n; i++ {
 						tupleIdx = i
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r int32
 
@@ -3873,6 +3992,7 @@ func (c *castFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 						}
 						r = int32(v)
 
+						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
 				}
@@ -3949,6 +4069,7 @@ func (c *castFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 						if inputNulls.NullAt(tupleIdx) {
 							continue
 						}
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r int64
 
@@ -3957,6 +4078,7 @@ func (c *castFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 						}
 						r = int64(v)
 
+						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
 				}
@@ -3986,6 +4108,7 @@ func (c *castFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 					var tupleIdx int
 					for i := 0; i < n; i++ {
 						tupleIdx = i
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r int64
 
@@ -3994,6 +4117,7 @@ func (c *castFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 						}
 						r = int64(v)
 
+						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
 				}
@@ -4073,6 +4197,7 @@ func (c *castDatumBoolOp) Next(ctx context.Context) coldata.Batch {
 						if inputNulls.NullAt(tupleIdx) {
 							continue
 						}
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r bool
 
@@ -4084,6 +4209,7 @@ func (c *castDatumBoolOp) Next(ctx context.Context) coldata.Batch {
 							r = _castedDatum == tree.DBoolTrue
 						}
 
+						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
 				}
@@ -4116,6 +4242,7 @@ func (c *castDatumBoolOp) Next(ctx context.Context) coldata.Batch {
 					var tupleIdx int
 					for i := 0; i < n; i++ {
 						tupleIdx = i
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r bool
 
@@ -4127,6 +4254,7 @@ func (c *castDatumBoolOp) Next(ctx context.Context) coldata.Batch {
 							r = _castedDatum == tree.DBoolTrue
 						}
 
+						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
 				}
@@ -4212,6 +4340,7 @@ func (c *castDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 						if inputNulls.NullAt(tupleIdx) {
 							continue
 						}
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r interface{}
 
@@ -4267,6 +4396,7 @@ func (c *castDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 					var tupleIdx int
 					for i := 0; i < n; i++ {
 						tupleIdx = i
+						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r interface{}
 

--- a/pkg/sql/colexec/cast_tmpl.go
+++ b/pkg/sql/colexec/cast_tmpl.go
@@ -269,9 +269,15 @@ func _CAST_TUPLES(_HAS_NULLS, _HAS_SEL bool) { // */}}
 			continue
 		}
 		// {{end}}
+		// {{if not $hasSel}}
+		//gcassert:bce
+		// {{end}}
 		v := inputCol.Get(tupleIdx)
 		var r _R_GO_TYPE
 		_CAST(r, v, inputCol, c.toType)
+		// {{if and (.Right.Sliceable) (not $hasSel)}}
+		//gcassert:bce
+		// {{end}}
 		_R_SET(outputCol, tupleIdx, r)
 		// {{if eq .Right.VecMethod "Datum"}}
 		// Casting to datum-backed vector might produce a null value on

--- a/pkg/sql/colexec/colexecagg/bool_and_or_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/bool_and_or_agg_tmpl.go
@@ -84,7 +84,10 @@ func (a *bool_OP_TYPE_AGGKINDAgg) Compute(
 	col, nulls := vec.Bool(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
 		// {{if eq "_AGGKIND" "Ordered"}}
+		// Capture groups and col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
 		groups := a.groups
+		col := col
 		// {{/*
 		// We don't need to check whether sel is non-nil when performing
 		// hash aggregation because the hash aggregator always uses non-nil
@@ -92,14 +95,14 @@ func (a *bool_OP_TYPE_AGGKINDAgg) Compute(
 		// */}}
 		if sel == nil {
 			_ = groups[inputLen-1]
-			col = col[:inputLen]
+			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
-				for i := range col {
-					_ACCUMULATE_BOOLEAN(a, nulls, i, true)
+				for i := 0; i < inputLen; i++ {
+					_ACCUMULATE_BOOLEAN(a, nulls, i, true, false)
 				}
 			} else {
-				for i := range col {
-					_ACCUMULATE_BOOLEAN(a, nulls, i, false)
+				for i := 0; i < inputLen; i++ {
+					_ACCUMULATE_BOOLEAN(a, nulls, i, false, false)
 				}
 			}
 		} else
@@ -108,11 +111,11 @@ func (a *bool_OP_TYPE_AGGKINDAgg) Compute(
 			sel = sel[:inputLen]
 			if nulls.MaybeHasNulls() {
 				for _, i := range sel {
-					_ACCUMULATE_BOOLEAN(a, nulls, i, true)
+					_ACCUMULATE_BOOLEAN(a, nulls, i, true, true)
 				}
 			} else {
 				for _, i := range sel {
-					_ACCUMULATE_BOOLEAN(a, nulls, i, false)
+					_ACCUMULATE_BOOLEAN(a, nulls, i, false, true)
 				}
 			}
 		}
@@ -176,10 +179,15 @@ func (a *bool_OP_TYPE_AGGKINDAggAlloc) newAggFunc() AggregateFunc {
 
 // {{/*
 // _ACCUMULATE_BOOLEAN aggregates the boolean value at index i into the boolean aggregate.
-func _ACCUMULATE_BOOLEAN(a *bool_OP_TYPE_AGGKINDAgg, nulls *coldata.Nulls, i int, _HAS_NULLS bool) { // */}}
+func _ACCUMULATE_BOOLEAN(
+	a *bool_OP_TYPE_AGGKINDAgg, nulls *coldata.Nulls, i int, _HAS_NULLS bool, _HAS_SEL bool,
+) { // */}}
 	// {{define "accumulateBoolean" -}}
 
 	// {{if eq "_AGGKIND" "Ordered"}}
+	// {{if not .HasSel}}
+	//gcassert:bce
+	// {{end}}
 	if groups[i] {
 		if !a.isFirstGroup {
 			if !a.sawNonNull {
@@ -204,6 +212,9 @@ func _ACCUMULATE_BOOLEAN(a *bool_OP_TYPE_AGGKINDAgg, nulls *coldata.Nulls, i int
 	isNull = false
 	// {{end}}
 	if !isNull {
+		// {{if not .HasSel}}
+		//gcassert:bce
+		// {{end}}
 		// {{with .Global}}
 		_ASSIGN_BOOL_OP(a.curAgg, a.curAgg, col[i])
 		// {{end}}

--- a/pkg/sql/colexec/colexecagg/hash_any_not_null_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_any_not_null_agg.eg.go
@@ -115,10 +115,6 @@ func (a *anyNotNullBoolHashAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Bool(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
-		// https://github.com/golang/go/issues/39756
-		col := col
-		_ = col.Get(inputLen - 1)
 		{
 			sel = sel[:inputLen]
 			if nulls.MaybeHasNulls() {
@@ -232,10 +228,6 @@ func (a *anyNotNullBytesHashAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Bytes(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
-		// https://github.com/golang/go/issues/39756
-		col := col
-		_ = col.Get(inputLen - 1)
 		{
 			sel = sel[:inputLen]
 			if nulls.MaybeHasNulls() {
@@ -352,10 +344,6 @@ func (a *anyNotNullDecimalHashAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Decimal(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
-		// https://github.com/golang/go/issues/39756
-		col := col
-		_ = col.Get(inputLen - 1)
 		{
 			sel = sel[:inputLen]
 			if nulls.MaybeHasNulls() {
@@ -469,10 +457,6 @@ func (a *anyNotNullInt16HashAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int16(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
-		// https://github.com/golang/go/issues/39756
-		col := col
-		_ = col.Get(inputLen - 1)
 		{
 			sel = sel[:inputLen]
 			if nulls.MaybeHasNulls() {
@@ -586,10 +570,6 @@ func (a *anyNotNullInt32HashAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int32(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
-		// https://github.com/golang/go/issues/39756
-		col := col
-		_ = col.Get(inputLen - 1)
 		{
 			sel = sel[:inputLen]
 			if nulls.MaybeHasNulls() {
@@ -703,10 +683,6 @@ func (a *anyNotNullInt64HashAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int64(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
-		// https://github.com/golang/go/issues/39756
-		col := col
-		_ = col.Get(inputLen - 1)
 		{
 			sel = sel[:inputLen]
 			if nulls.MaybeHasNulls() {
@@ -820,10 +796,6 @@ func (a *anyNotNullFloat64HashAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Float64(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
-		// https://github.com/golang/go/issues/39756
-		col := col
-		_ = col.Get(inputLen - 1)
 		{
 			sel = sel[:inputLen]
 			if nulls.MaybeHasNulls() {
@@ -937,10 +909,6 @@ func (a *anyNotNullTimestampHashAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Timestamp(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
-		// https://github.com/golang/go/issues/39756
-		col := col
-		_ = col.Get(inputLen - 1)
 		{
 			sel = sel[:inputLen]
 			if nulls.MaybeHasNulls() {
@@ -1054,10 +1022,6 @@ func (a *anyNotNullIntervalHashAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Interval(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
-		// https://github.com/golang/go/issues/39756
-		col := col
-		_ = col.Get(inputLen - 1)
 		{
 			sel = sel[:inputLen]
 			if nulls.MaybeHasNulls() {
@@ -1174,10 +1138,6 @@ func (a *anyNotNullDatumHashAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Datum(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
-		// https://github.com/golang/go/issues/39756
-		col := col
-		_ = col.Get(inputLen - 1)
 		{
 			sel = sel[:inputLen]
 			if nulls.MaybeHasNulls() {

--- a/pkg/sql/colexec/colexecagg/hash_avg_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_avg_agg.eg.go
@@ -82,9 +82,6 @@ func (a *avgInt16HashAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int16(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
-		// https://github.com/golang/go/issues/39756
-		col := col
 		{
 			sel = sel[:inputLen]
 			if nulls.MaybeHasNulls() {
@@ -93,11 +90,12 @@ func (a *avgInt16HashAgg) Compute(
 					var isNull bool
 					isNull = nulls.NullAt(i)
 					if !isNull {
+						v := col.Get(i)
 
 						{
 
 							tmpDec := &_overloadHelper.TmpDec1
-							tmpDec.SetInt64(int64(col[i]))
+							tmpDec.SetInt64(int64(v))
 							if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -113,11 +111,12 @@ func (a *avgInt16HashAgg) Compute(
 					var isNull bool
 					isNull = false
 					if !isNull {
+						v := col.Get(i)
 
 						{
 
 							tmpDec := &_overloadHelper.TmpDec1
-							tmpDec.SetInt64(int64(col[i]))
+							tmpDec.SetInt64(int64(v))
 							if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -213,9 +212,6 @@ func (a *avgInt32HashAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int32(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
-		// https://github.com/golang/go/issues/39756
-		col := col
 		{
 			sel = sel[:inputLen]
 			if nulls.MaybeHasNulls() {
@@ -224,11 +220,12 @@ func (a *avgInt32HashAgg) Compute(
 					var isNull bool
 					isNull = nulls.NullAt(i)
 					if !isNull {
+						v := col.Get(i)
 
 						{
 
 							tmpDec := &_overloadHelper.TmpDec1
-							tmpDec.SetInt64(int64(col[i]))
+							tmpDec.SetInt64(int64(v))
 							if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -244,11 +241,12 @@ func (a *avgInt32HashAgg) Compute(
 					var isNull bool
 					isNull = false
 					if !isNull {
+						v := col.Get(i)
 
 						{
 
 							tmpDec := &_overloadHelper.TmpDec1
-							tmpDec.SetInt64(int64(col[i]))
+							tmpDec.SetInt64(int64(v))
 							if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -344,9 +342,6 @@ func (a *avgInt64HashAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int64(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
-		// https://github.com/golang/go/issues/39756
-		col := col
 		{
 			sel = sel[:inputLen]
 			if nulls.MaybeHasNulls() {
@@ -355,11 +350,12 @@ func (a *avgInt64HashAgg) Compute(
 					var isNull bool
 					isNull = nulls.NullAt(i)
 					if !isNull {
+						v := col.Get(i)
 
 						{
 
 							tmpDec := &_overloadHelper.TmpDec1
-							tmpDec.SetInt64(int64(col[i]))
+							tmpDec.SetInt64(int64(v))
 							if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -375,11 +371,12 @@ func (a *avgInt64HashAgg) Compute(
 					var isNull bool
 					isNull = false
 					if !isNull {
+						v := col.Get(i)
 
 						{
 
 							tmpDec := &_overloadHelper.TmpDec1
-							tmpDec.SetInt64(int64(col[i]))
+							tmpDec.SetInt64(int64(v))
 							if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -471,9 +468,6 @@ func (a *avgDecimalHashAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Decimal(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
-		// https://github.com/golang/go/issues/39756
-		col := col
 		{
 			sel = sel[:inputLen]
 			if nulls.MaybeHasNulls() {
@@ -482,10 +476,11 @@ func (a *avgDecimalHashAgg) Compute(
 					var isNull bool
 					isNull = nulls.NullAt(i)
 					if !isNull {
+						v := col.Get(i)
 
 						{
 
-							_, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, &col[i])
+							_, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, &v)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -501,10 +496,11 @@ func (a *avgDecimalHashAgg) Compute(
 					var isNull bool
 					isNull = false
 					if !isNull {
+						v := col.Get(i)
 
 						{
 
-							_, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, &col[i])
+							_, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, &v)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -596,9 +592,6 @@ func (a *avgFloat64HashAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Float64(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
-		// https://github.com/golang/go/issues/39756
-		col := col
 		{
 			sel = sel[:inputLen]
 			if nulls.MaybeHasNulls() {
@@ -607,10 +600,11 @@ func (a *avgFloat64HashAgg) Compute(
 					var isNull bool
 					isNull = nulls.NullAt(i)
 					if !isNull {
+						v := col.Get(i)
 
 						{
 
-							a.curSum = float64(a.curSum) + float64(col[i])
+							a.curSum = float64(a.curSum) + float64(v)
 						}
 
 						a.curCount++
@@ -623,10 +617,11 @@ func (a *avgFloat64HashAgg) Compute(
 					var isNull bool
 					isNull = false
 					if !isNull {
+						v := col.Get(i)
 
 						{
 
-							a.curSum = float64(a.curSum) + float64(col[i])
+							a.curSum = float64(a.curSum) + float64(v)
 						}
 
 						a.curCount++
@@ -711,9 +706,6 @@ func (a *avgIntervalHashAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Interval(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
-		// https://github.com/golang/go/issues/39756
-		col := col
 		{
 			sel = sel[:inputLen]
 			if nulls.MaybeHasNulls() {
@@ -722,7 +714,8 @@ func (a *avgIntervalHashAgg) Compute(
 					var isNull bool
 					isNull = nulls.NullAt(i)
 					if !isNull {
-						a.curSum = a.curSum.Add(col[i])
+						v := col.Get(i)
+						a.curSum = a.curSum.Add(v)
 						a.curCount++
 						a.foundNonNullForCurrentGroup = true
 					}
@@ -733,7 +726,8 @@ func (a *avgIntervalHashAgg) Compute(
 					var isNull bool
 					isNull = false
 					if !isNull {
-						a.curSum = a.curSum.Add(col[i])
+						v := col.Get(i)
+						a.curSum = a.curSum.Add(v)
 						a.curCount++
 						a.foundNonNullForCurrentGroup = true
 					}

--- a/pkg/sql/colexec/colexecagg/hash_min_max_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_min_max_agg.eg.go
@@ -118,9 +118,6 @@ func (a *minBoolHashAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Bool(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
-		// https://github.com/golang/go/issues/39756
-		col := col
 		{
 			sel = sel[:inputLen]
 			if nulls.MaybeHasNulls() {
@@ -264,9 +261,6 @@ func (a *minBytesHashAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Bytes(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
-		// https://github.com/golang/go/issues/39756
-		col := col
 		{
 			sel = sel[:inputLen]
 			if nulls.MaybeHasNulls() {
@@ -397,9 +391,6 @@ func (a *minDecimalHashAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Decimal(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
-		// https://github.com/golang/go/issues/39756
-		col := col
 		{
 			sel = sel[:inputLen]
 			if nulls.MaybeHasNulls() {
@@ -527,9 +518,6 @@ func (a *minInt16HashAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int16(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
-		// https://github.com/golang/go/issues/39756
-		col := col
 		{
 			sel = sel[:inputLen]
 			if nulls.MaybeHasNulls() {
@@ -679,9 +667,6 @@ func (a *minInt32HashAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int32(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
-		// https://github.com/golang/go/issues/39756
-		col := col
 		{
 			sel = sel[:inputLen]
 			if nulls.MaybeHasNulls() {
@@ -831,9 +816,6 @@ func (a *minInt64HashAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int64(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
-		// https://github.com/golang/go/issues/39756
-		col := col
 		{
 			sel = sel[:inputLen]
 			if nulls.MaybeHasNulls() {
@@ -983,9 +965,6 @@ func (a *minFloat64HashAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Float64(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
-		// https://github.com/golang/go/issues/39756
-		col := col
 		{
 			sel = sel[:inputLen]
 			if nulls.MaybeHasNulls() {
@@ -1151,9 +1130,6 @@ func (a *minTimestampHashAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Timestamp(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
-		// https://github.com/golang/go/issues/39756
-		col := col
 		{
 			sel = sel[:inputLen]
 			if nulls.MaybeHasNulls() {
@@ -1295,9 +1271,6 @@ func (a *minIntervalHashAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Interval(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
-		// https://github.com/golang/go/issues/39756
-		col := col
 		{
 			sel = sel[:inputLen]
 			if nulls.MaybeHasNulls() {
@@ -1429,9 +1402,6 @@ func (a *minDatumHashAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Datum(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
-		// https://github.com/golang/go/issues/39756
-		col := col
 		{
 			sel = sel[:inputLen]
 			if nulls.MaybeHasNulls() {
@@ -1572,9 +1542,6 @@ func (a *maxBoolHashAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Bool(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
-		// https://github.com/golang/go/issues/39756
-		col := col
 		{
 			sel = sel[:inputLen]
 			if nulls.MaybeHasNulls() {
@@ -1718,9 +1685,6 @@ func (a *maxBytesHashAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Bytes(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
-		// https://github.com/golang/go/issues/39756
-		col := col
 		{
 			sel = sel[:inputLen]
 			if nulls.MaybeHasNulls() {
@@ -1851,9 +1815,6 @@ func (a *maxDecimalHashAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Decimal(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
-		// https://github.com/golang/go/issues/39756
-		col := col
 		{
 			sel = sel[:inputLen]
 			if nulls.MaybeHasNulls() {
@@ -1981,9 +1942,6 @@ func (a *maxInt16HashAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int16(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
-		// https://github.com/golang/go/issues/39756
-		col := col
 		{
 			sel = sel[:inputLen]
 			if nulls.MaybeHasNulls() {
@@ -2133,9 +2091,6 @@ func (a *maxInt32HashAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int32(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
-		// https://github.com/golang/go/issues/39756
-		col := col
 		{
 			sel = sel[:inputLen]
 			if nulls.MaybeHasNulls() {
@@ -2285,9 +2240,6 @@ func (a *maxInt64HashAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int64(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
-		// https://github.com/golang/go/issues/39756
-		col := col
 		{
 			sel = sel[:inputLen]
 			if nulls.MaybeHasNulls() {
@@ -2437,9 +2389,6 @@ func (a *maxFloat64HashAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Float64(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
-		// https://github.com/golang/go/issues/39756
-		col := col
 		{
 			sel = sel[:inputLen]
 			if nulls.MaybeHasNulls() {
@@ -2605,9 +2554,6 @@ func (a *maxTimestampHashAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Timestamp(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
-		// https://github.com/golang/go/issues/39756
-		col := col
 		{
 			sel = sel[:inputLen]
 			if nulls.MaybeHasNulls() {
@@ -2749,9 +2695,6 @@ func (a *maxIntervalHashAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Interval(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
-		// https://github.com/golang/go/issues/39756
-		col := col
 		{
 			sel = sel[:inputLen]
 			if nulls.MaybeHasNulls() {
@@ -2883,9 +2826,6 @@ func (a *maxDatumHashAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Datum(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
-		// https://github.com/golang/go/issues/39756
-		col := col
 		{
 			sel = sel[:inputLen]
 			if nulls.MaybeHasNulls() {

--- a/pkg/sql/colexec/colexecagg/hash_sum_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_sum_agg.eg.go
@@ -79,9 +79,6 @@ func (a *sumInt16HashAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int16(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
-		// https://github.com/golang/go/issues/39756
-		col := col
 		{
 			sel = sel[:inputLen]
 			if nulls.MaybeHasNulls() {
@@ -90,11 +87,12 @@ func (a *sumInt16HashAgg) Compute(
 					var isNull bool
 					isNull = nulls.NullAt(i)
 					if !isNull {
+						v := col.Get(i)
 
 						{
 
 							tmpDec := &_overloadHelper.TmpDec1
-							tmpDec.SetInt64(int64(col[i]))
+							tmpDec.SetInt64(int64(v))
 							if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -109,11 +107,12 @@ func (a *sumInt16HashAgg) Compute(
 					var isNull bool
 					isNull = false
 					if !isNull {
+						v := col.Get(i)
 
 						{
 
 							tmpDec := &_overloadHelper.TmpDec1
-							tmpDec.SetInt64(int64(col[i]))
+							tmpDec.SetInt64(int64(v))
 							if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -199,9 +198,6 @@ func (a *sumInt32HashAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int32(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
-		// https://github.com/golang/go/issues/39756
-		col := col
 		{
 			sel = sel[:inputLen]
 			if nulls.MaybeHasNulls() {
@@ -210,11 +206,12 @@ func (a *sumInt32HashAgg) Compute(
 					var isNull bool
 					isNull = nulls.NullAt(i)
 					if !isNull {
+						v := col.Get(i)
 
 						{
 
 							tmpDec := &_overloadHelper.TmpDec1
-							tmpDec.SetInt64(int64(col[i]))
+							tmpDec.SetInt64(int64(v))
 							if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -229,11 +226,12 @@ func (a *sumInt32HashAgg) Compute(
 					var isNull bool
 					isNull = false
 					if !isNull {
+						v := col.Get(i)
 
 						{
 
 							tmpDec := &_overloadHelper.TmpDec1
-							tmpDec.SetInt64(int64(col[i]))
+							tmpDec.SetInt64(int64(v))
 							if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -319,9 +317,6 @@ func (a *sumInt64HashAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int64(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
-		// https://github.com/golang/go/issues/39756
-		col := col
 		{
 			sel = sel[:inputLen]
 			if nulls.MaybeHasNulls() {
@@ -330,11 +325,12 @@ func (a *sumInt64HashAgg) Compute(
 					var isNull bool
 					isNull = nulls.NullAt(i)
 					if !isNull {
+						v := col.Get(i)
 
 						{
 
 							tmpDec := &_overloadHelper.TmpDec1
-							tmpDec.SetInt64(int64(col[i]))
+							tmpDec.SetInt64(int64(v))
 							if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -349,11 +345,12 @@ func (a *sumInt64HashAgg) Compute(
 					var isNull bool
 					isNull = false
 					if !isNull {
+						v := col.Get(i)
 
 						{
 
 							tmpDec := &_overloadHelper.TmpDec1
-							tmpDec.SetInt64(int64(col[i]))
+							tmpDec.SetInt64(int64(v))
 							if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -435,9 +432,6 @@ func (a *sumDecimalHashAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Decimal(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
-		// https://github.com/golang/go/issues/39756
-		col := col
 		{
 			sel = sel[:inputLen]
 			if nulls.MaybeHasNulls() {
@@ -446,10 +440,11 @@ func (a *sumDecimalHashAgg) Compute(
 					var isNull bool
 					isNull = nulls.NullAt(i)
 					if !isNull {
+						v := col.Get(i)
 
 						{
 
-							_, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, &col[i])
+							_, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, &v)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -464,10 +459,11 @@ func (a *sumDecimalHashAgg) Compute(
 					var isNull bool
 					isNull = false
 					if !isNull {
+						v := col.Get(i)
 
 						{
 
-							_, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, &col[i])
+							_, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, &v)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -549,9 +545,6 @@ func (a *sumFloat64HashAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Float64(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
-		// https://github.com/golang/go/issues/39756
-		col := col
 		{
 			sel = sel[:inputLen]
 			if nulls.MaybeHasNulls() {
@@ -560,10 +553,11 @@ func (a *sumFloat64HashAgg) Compute(
 					var isNull bool
 					isNull = nulls.NullAt(i)
 					if !isNull {
+						v := col.Get(i)
 
 						{
 
-							a.curAgg = float64(a.curAgg) + float64(col[i])
+							a.curAgg = float64(a.curAgg) + float64(v)
 						}
 
 						a.foundNonNullForCurrentGroup = true
@@ -575,10 +569,11 @@ func (a *sumFloat64HashAgg) Compute(
 					var isNull bool
 					isNull = false
 					if !isNull {
+						v := col.Get(i)
 
 						{
 
-							a.curAgg = float64(a.curAgg) + float64(col[i])
+							a.curAgg = float64(a.curAgg) + float64(v)
 						}
 
 						a.foundNonNullForCurrentGroup = true
@@ -657,9 +652,6 @@ func (a *sumIntervalHashAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Interval(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
-		// https://github.com/golang/go/issues/39756
-		col := col
 		{
 			sel = sel[:inputLen]
 			if nulls.MaybeHasNulls() {
@@ -668,7 +660,8 @@ func (a *sumIntervalHashAgg) Compute(
 					var isNull bool
 					isNull = nulls.NullAt(i)
 					if !isNull {
-						a.curAgg = a.curAgg.Add(col[i])
+						v := col.Get(i)
+						a.curAgg = a.curAgg.Add(v)
 						a.foundNonNullForCurrentGroup = true
 					}
 				}
@@ -678,7 +671,8 @@ func (a *sumIntervalHashAgg) Compute(
 					var isNull bool
 					isNull = false
 					if !isNull {
-						a.curAgg = a.curAgg.Add(col[i])
+						v := col.Get(i)
+						a.curAgg = a.curAgg.Add(v)
 						a.foundNonNullForCurrentGroup = true
 					}
 				}

--- a/pkg/sql/colexec/colexecagg/hash_sum_int_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_sum_int_agg.eg.go
@@ -66,9 +66,6 @@ func (a *sumIntInt16HashAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int16(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
-		// https://github.com/golang/go/issues/39756
-		col := col
 		{
 			sel = sel[:inputLen]
 			if nulls.MaybeHasNulls() {
@@ -77,10 +74,11 @@ func (a *sumIntInt16HashAgg) Compute(
 					var isNull bool
 					isNull = nulls.NullAt(i)
 					if !isNull {
+						v := col.Get(i)
 
 						{
-							result := int64(a.curAgg) + int64(col[i])
-							if (result < int64(a.curAgg)) != (int64(col[i]) < 0) {
+							result := int64(a.curAgg) + int64(v)
+							if (result < int64(a.curAgg)) != (int64(v) < 0) {
 								colexecerror.ExpectedError(tree.ErrIntOutOfRange)
 							}
 							a.curAgg = result
@@ -95,10 +93,11 @@ func (a *sumIntInt16HashAgg) Compute(
 					var isNull bool
 					isNull = false
 					if !isNull {
+						v := col.Get(i)
 
 						{
-							result := int64(a.curAgg) + int64(col[i])
-							if (result < int64(a.curAgg)) != (int64(col[i]) < 0) {
+							result := int64(a.curAgg) + int64(v)
+							if (result < int64(a.curAgg)) != (int64(v) < 0) {
 								colexecerror.ExpectedError(tree.ErrIntOutOfRange)
 							}
 							a.curAgg = result
@@ -180,9 +179,6 @@ func (a *sumIntInt32HashAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int32(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
-		// https://github.com/golang/go/issues/39756
-		col := col
 		{
 			sel = sel[:inputLen]
 			if nulls.MaybeHasNulls() {
@@ -191,10 +187,11 @@ func (a *sumIntInt32HashAgg) Compute(
 					var isNull bool
 					isNull = nulls.NullAt(i)
 					if !isNull {
+						v := col.Get(i)
 
 						{
-							result := int64(a.curAgg) + int64(col[i])
-							if (result < int64(a.curAgg)) != (int64(col[i]) < 0) {
+							result := int64(a.curAgg) + int64(v)
+							if (result < int64(a.curAgg)) != (int64(v) < 0) {
 								colexecerror.ExpectedError(tree.ErrIntOutOfRange)
 							}
 							a.curAgg = result
@@ -209,10 +206,11 @@ func (a *sumIntInt32HashAgg) Compute(
 					var isNull bool
 					isNull = false
 					if !isNull {
+						v := col.Get(i)
 
 						{
-							result := int64(a.curAgg) + int64(col[i])
-							if (result < int64(a.curAgg)) != (int64(col[i]) < 0) {
+							result := int64(a.curAgg) + int64(v)
+							if (result < int64(a.curAgg)) != (int64(v) < 0) {
 								colexecerror.ExpectedError(tree.ErrIntOutOfRange)
 							}
 							a.curAgg = result
@@ -294,9 +292,6 @@ func (a *sumIntInt64HashAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int64(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
-		// https://github.com/golang/go/issues/39756
-		col := col
 		{
 			sel = sel[:inputLen]
 			if nulls.MaybeHasNulls() {
@@ -305,10 +300,11 @@ func (a *sumIntInt64HashAgg) Compute(
 					var isNull bool
 					isNull = nulls.NullAt(i)
 					if !isNull {
+						v := col.Get(i)
 
 						{
-							result := int64(a.curAgg) + int64(col[i])
-							if (result < int64(a.curAgg)) != (int64(col[i]) < 0) {
+							result := int64(a.curAgg) + int64(v)
+							if (result < int64(a.curAgg)) != (int64(v) < 0) {
 								colexecerror.ExpectedError(tree.ErrIntOutOfRange)
 							}
 							a.curAgg = result
@@ -323,10 +319,11 @@ func (a *sumIntInt64HashAgg) Compute(
 					var isNull bool
 					isNull = false
 					if !isNull {
+						v := col.Get(i)
 
 						{
-							result := int64(a.curAgg) + int64(col[i])
-							if (result < int64(a.curAgg)) != (int64(col[i]) < 0) {
+							result := int64(a.curAgg) + int64(v)
+							if (result < int64(a.curAgg)) != (int64(v) < 0) {
 								colexecerror.ExpectedError(tree.ErrIntOutOfRange)
 							}
 							a.curAgg = result

--- a/pkg/sql/colexec/colexecagg/ordered_any_not_null_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_any_not_null_agg.eg.go
@@ -109,15 +109,16 @@ func (a *anyNotNullBoolOrderedAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Bool(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
+		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
-		col := col
-		_ = col.Get(inputLen - 1)
 		groups := a.groups
+		col := col
 		if sel == nil {
 			_ = groups[inputLen-1]
+			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
 				for i := 0; i < inputLen; i++ {
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If this is a new group, check if any non-nulls have been found for the
@@ -146,6 +147,7 @@ func (a *anyNotNullBoolOrderedAgg) Compute(
 				}
 			} else {
 				for i := 0; i < inputLen; i++ {
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If this is a new group, check if any non-nulls have been found for the
@@ -305,15 +307,16 @@ func (a *anyNotNullBytesOrderedAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Bytes(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
+		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
-		col := col
-		_ = col.Get(inputLen - 1)
 		groups := a.groups
+		col := col
 		if sel == nil {
 			_ = groups[inputLen-1]
+			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
 				for i := 0; i < inputLen; i++ {
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If this is a new group, check if any non-nulls have been found for the
@@ -342,6 +345,7 @@ func (a *anyNotNullBytesOrderedAgg) Compute(
 				}
 			} else {
 				for i := 0; i < inputLen; i++ {
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If this is a new group, check if any non-nulls have been found for the
@@ -504,15 +508,16 @@ func (a *anyNotNullDecimalOrderedAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Decimal(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
+		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
-		col := col
-		_ = col.Get(inputLen - 1)
 		groups := a.groups
+		col := col
 		if sel == nil {
 			_ = groups[inputLen-1]
+			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
 				for i := 0; i < inputLen; i++ {
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If this is a new group, check if any non-nulls have been found for the
@@ -541,6 +546,7 @@ func (a *anyNotNullDecimalOrderedAgg) Compute(
 				}
 			} else {
 				for i := 0; i < inputLen; i++ {
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If this is a new group, check if any non-nulls have been found for the
@@ -700,15 +706,16 @@ func (a *anyNotNullInt16OrderedAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int16(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
+		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
-		col := col
-		_ = col.Get(inputLen - 1)
 		groups := a.groups
+		col := col
 		if sel == nil {
 			_ = groups[inputLen-1]
+			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
 				for i := 0; i < inputLen; i++ {
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If this is a new group, check if any non-nulls have been found for the
@@ -737,6 +744,7 @@ func (a *anyNotNullInt16OrderedAgg) Compute(
 				}
 			} else {
 				for i := 0; i < inputLen; i++ {
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If this is a new group, check if any non-nulls have been found for the
@@ -896,15 +904,16 @@ func (a *anyNotNullInt32OrderedAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int32(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
+		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
-		col := col
-		_ = col.Get(inputLen - 1)
 		groups := a.groups
+		col := col
 		if sel == nil {
 			_ = groups[inputLen-1]
+			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
 				for i := 0; i < inputLen; i++ {
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If this is a new group, check if any non-nulls have been found for the
@@ -933,6 +942,7 @@ func (a *anyNotNullInt32OrderedAgg) Compute(
 				}
 			} else {
 				for i := 0; i < inputLen; i++ {
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If this is a new group, check if any non-nulls have been found for the
@@ -1092,15 +1102,16 @@ func (a *anyNotNullInt64OrderedAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int64(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
+		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
-		col := col
-		_ = col.Get(inputLen - 1)
 		groups := a.groups
+		col := col
 		if sel == nil {
 			_ = groups[inputLen-1]
+			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
 				for i := 0; i < inputLen; i++ {
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If this is a new group, check if any non-nulls have been found for the
@@ -1129,6 +1140,7 @@ func (a *anyNotNullInt64OrderedAgg) Compute(
 				}
 			} else {
 				for i := 0; i < inputLen; i++ {
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If this is a new group, check if any non-nulls have been found for the
@@ -1288,15 +1300,16 @@ func (a *anyNotNullFloat64OrderedAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Float64(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
+		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
-		col := col
-		_ = col.Get(inputLen - 1)
 		groups := a.groups
+		col := col
 		if sel == nil {
 			_ = groups[inputLen-1]
+			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
 				for i := 0; i < inputLen; i++ {
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If this is a new group, check if any non-nulls have been found for the
@@ -1325,6 +1338,7 @@ func (a *anyNotNullFloat64OrderedAgg) Compute(
 				}
 			} else {
 				for i := 0; i < inputLen; i++ {
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If this is a new group, check if any non-nulls have been found for the
@@ -1484,15 +1498,16 @@ func (a *anyNotNullTimestampOrderedAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Timestamp(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
+		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
-		col := col
-		_ = col.Get(inputLen - 1)
 		groups := a.groups
+		col := col
 		if sel == nil {
 			_ = groups[inputLen-1]
+			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
 				for i := 0; i < inputLen; i++ {
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If this is a new group, check if any non-nulls have been found for the
@@ -1521,6 +1536,7 @@ func (a *anyNotNullTimestampOrderedAgg) Compute(
 				}
 			} else {
 				for i := 0; i < inputLen; i++ {
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If this is a new group, check if any non-nulls have been found for the
@@ -1680,15 +1696,16 @@ func (a *anyNotNullIntervalOrderedAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Interval(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
+		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
-		col := col
-		_ = col.Get(inputLen - 1)
 		groups := a.groups
+		col := col
 		if sel == nil {
 			_ = groups[inputLen-1]
+			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
 				for i := 0; i < inputLen; i++ {
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If this is a new group, check if any non-nulls have been found for the
@@ -1717,6 +1734,7 @@ func (a *anyNotNullIntervalOrderedAgg) Compute(
 				}
 			} else {
 				for i := 0; i < inputLen; i++ {
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If this is a new group, check if any non-nulls have been found for the
@@ -1879,15 +1897,16 @@ func (a *anyNotNullDatumOrderedAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Datum(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
+		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
-		col := col
-		_ = col.Get(inputLen - 1)
 		groups := a.groups
+		col := col
 		if sel == nil {
 			_ = groups[inputLen-1]
+			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
 				for i := 0; i < inputLen; i++ {
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If this is a new group, check if any non-nulls have been found for the
@@ -1916,6 +1935,7 @@ func (a *anyNotNullDatumOrderedAgg) Compute(
 				}
 			} else {
 				for i := 0; i < inputLen; i++ {
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If this is a new group, check if any non-nulls have been found for the

--- a/pkg/sql/colexec/colexecagg/ordered_avg_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_avg_agg.eg.go
@@ -82,16 +82,17 @@ func (a *avgInt16OrderedAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int16(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
+		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
-		col := col
 		groups := a.groups
+		col := col
 		if sel == nil {
 			_ = groups[inputLen-1]
-			col = col[:inputLen]
+			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
-				for i := range col {
+				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -117,11 +118,13 @@ func (a *avgInt16OrderedAgg) Compute(
 					var isNull bool
 					isNull = nulls.NullAt(i)
 					if !isNull {
+						//gcassert:bce
+						v := col.Get(i)
 
 						{
 
 							tmpDec := &_overloadHelper.TmpDec1
-							tmpDec.SetInt64(int64(col[i]))
+							tmpDec.SetInt64(int64(v))
 							if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -132,8 +135,9 @@ func (a *avgInt16OrderedAgg) Compute(
 					}
 				}
 			} else {
-				for i := range col {
+				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -158,11 +162,13 @@ func (a *avgInt16OrderedAgg) Compute(
 					var isNull bool
 					isNull = false
 					if !isNull {
+						//gcassert:bce
+						v := col.Get(i)
 
 						{
 
 							tmpDec := &_overloadHelper.TmpDec1
-							tmpDec.SetInt64(int64(col[i]))
+							tmpDec.SetInt64(int64(v))
 							if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -203,11 +209,12 @@ func (a *avgInt16OrderedAgg) Compute(
 					var isNull bool
 					isNull = nulls.NullAt(i)
 					if !isNull {
+						v := col.Get(i)
 
 						{
 
 							tmpDec := &_overloadHelper.TmpDec1
-							tmpDec.SetInt64(int64(col[i]))
+							tmpDec.SetInt64(int64(v))
 							if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -244,11 +251,12 @@ func (a *avgInt16OrderedAgg) Compute(
 					var isNull bool
 					isNull = false
 					if !isNull {
+						v := col.Get(i)
 
 						{
 
 							tmpDec := &_overloadHelper.TmpDec1
-							tmpDec.SetInt64(int64(col[i]))
+							tmpDec.SetInt64(int64(v))
 							if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -349,16 +357,17 @@ func (a *avgInt32OrderedAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int32(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
+		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
-		col := col
 		groups := a.groups
+		col := col
 		if sel == nil {
 			_ = groups[inputLen-1]
-			col = col[:inputLen]
+			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
-				for i := range col {
+				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -384,11 +393,13 @@ func (a *avgInt32OrderedAgg) Compute(
 					var isNull bool
 					isNull = nulls.NullAt(i)
 					if !isNull {
+						//gcassert:bce
+						v := col.Get(i)
 
 						{
 
 							tmpDec := &_overloadHelper.TmpDec1
-							tmpDec.SetInt64(int64(col[i]))
+							tmpDec.SetInt64(int64(v))
 							if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -399,8 +410,9 @@ func (a *avgInt32OrderedAgg) Compute(
 					}
 				}
 			} else {
-				for i := range col {
+				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -425,11 +437,13 @@ func (a *avgInt32OrderedAgg) Compute(
 					var isNull bool
 					isNull = false
 					if !isNull {
+						//gcassert:bce
+						v := col.Get(i)
 
 						{
 
 							tmpDec := &_overloadHelper.TmpDec1
-							tmpDec.SetInt64(int64(col[i]))
+							tmpDec.SetInt64(int64(v))
 							if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -470,11 +484,12 @@ func (a *avgInt32OrderedAgg) Compute(
 					var isNull bool
 					isNull = nulls.NullAt(i)
 					if !isNull {
+						v := col.Get(i)
 
 						{
 
 							tmpDec := &_overloadHelper.TmpDec1
-							tmpDec.SetInt64(int64(col[i]))
+							tmpDec.SetInt64(int64(v))
 							if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -511,11 +526,12 @@ func (a *avgInt32OrderedAgg) Compute(
 					var isNull bool
 					isNull = false
 					if !isNull {
+						v := col.Get(i)
 
 						{
 
 							tmpDec := &_overloadHelper.TmpDec1
-							tmpDec.SetInt64(int64(col[i]))
+							tmpDec.SetInt64(int64(v))
 							if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -616,16 +632,17 @@ func (a *avgInt64OrderedAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int64(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
+		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
-		col := col
 		groups := a.groups
+		col := col
 		if sel == nil {
 			_ = groups[inputLen-1]
-			col = col[:inputLen]
+			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
-				for i := range col {
+				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -651,11 +668,13 @@ func (a *avgInt64OrderedAgg) Compute(
 					var isNull bool
 					isNull = nulls.NullAt(i)
 					if !isNull {
+						//gcassert:bce
+						v := col.Get(i)
 
 						{
 
 							tmpDec := &_overloadHelper.TmpDec1
-							tmpDec.SetInt64(int64(col[i]))
+							tmpDec.SetInt64(int64(v))
 							if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -666,8 +685,9 @@ func (a *avgInt64OrderedAgg) Compute(
 					}
 				}
 			} else {
-				for i := range col {
+				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -692,11 +712,13 @@ func (a *avgInt64OrderedAgg) Compute(
 					var isNull bool
 					isNull = false
 					if !isNull {
+						//gcassert:bce
+						v := col.Get(i)
 
 						{
 
 							tmpDec := &_overloadHelper.TmpDec1
-							tmpDec.SetInt64(int64(col[i]))
+							tmpDec.SetInt64(int64(v))
 							if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -737,11 +759,12 @@ func (a *avgInt64OrderedAgg) Compute(
 					var isNull bool
 					isNull = nulls.NullAt(i)
 					if !isNull {
+						v := col.Get(i)
 
 						{
 
 							tmpDec := &_overloadHelper.TmpDec1
-							tmpDec.SetInt64(int64(col[i]))
+							tmpDec.SetInt64(int64(v))
 							if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -778,11 +801,12 @@ func (a *avgInt64OrderedAgg) Compute(
 					var isNull bool
 					isNull = false
 					if !isNull {
+						v := col.Get(i)
 
 						{
 
 							tmpDec := &_overloadHelper.TmpDec1
-							tmpDec.SetInt64(int64(col[i]))
+							tmpDec.SetInt64(int64(v))
 							if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -879,16 +903,17 @@ func (a *avgDecimalOrderedAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Decimal(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
+		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
-		col := col
 		groups := a.groups
+		col := col
 		if sel == nil {
 			_ = groups[inputLen-1]
-			col = col[:inputLen]
+			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
-				for i := range col {
+				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -914,10 +939,12 @@ func (a *avgDecimalOrderedAgg) Compute(
 					var isNull bool
 					isNull = nulls.NullAt(i)
 					if !isNull {
+						//gcassert:bce
+						v := col.Get(i)
 
 						{
 
-							_, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, &col[i])
+							_, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, &v)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -928,8 +955,9 @@ func (a *avgDecimalOrderedAgg) Compute(
 					}
 				}
 			} else {
-				for i := range col {
+				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -954,10 +982,12 @@ func (a *avgDecimalOrderedAgg) Compute(
 					var isNull bool
 					isNull = false
 					if !isNull {
+						//gcassert:bce
+						v := col.Get(i)
 
 						{
 
-							_, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, &col[i])
+							_, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, &v)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -998,10 +1028,11 @@ func (a *avgDecimalOrderedAgg) Compute(
 					var isNull bool
 					isNull = nulls.NullAt(i)
 					if !isNull {
+						v := col.Get(i)
 
 						{
 
-							_, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, &col[i])
+							_, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, &v)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -1038,10 +1069,11 @@ func (a *avgDecimalOrderedAgg) Compute(
 					var isNull bool
 					isNull = false
 					if !isNull {
+						v := col.Get(i)
 
 						{
 
-							_, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, &col[i])
+							_, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, &v)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -1138,16 +1170,17 @@ func (a *avgFloat64OrderedAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Float64(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
+		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
-		col := col
 		groups := a.groups
+		col := col
 		if sel == nil {
 			_ = groups[inputLen-1]
-			col = col[:inputLen]
+			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
-				for i := range col {
+				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -1169,10 +1202,12 @@ func (a *avgFloat64OrderedAgg) Compute(
 					var isNull bool
 					isNull = nulls.NullAt(i)
 					if !isNull {
+						//gcassert:bce
+						v := col.Get(i)
 
 						{
 
-							a.curSum = float64(a.curSum) + float64(col[i])
+							a.curSum = float64(a.curSum) + float64(v)
 						}
 
 						a.curCount++
@@ -1180,8 +1215,9 @@ func (a *avgFloat64OrderedAgg) Compute(
 					}
 				}
 			} else {
-				for i := range col {
+				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -1202,10 +1238,12 @@ func (a *avgFloat64OrderedAgg) Compute(
 					var isNull bool
 					isNull = false
 					if !isNull {
+						//gcassert:bce
+						v := col.Get(i)
 
 						{
 
-							a.curSum = float64(a.curSum) + float64(col[i])
+							a.curSum = float64(a.curSum) + float64(v)
 						}
 
 						a.curCount++
@@ -1239,10 +1277,11 @@ func (a *avgFloat64OrderedAgg) Compute(
 					var isNull bool
 					isNull = nulls.NullAt(i)
 					if !isNull {
+						v := col.Get(i)
 
 						{
 
-							a.curSum = float64(a.curSum) + float64(col[i])
+							a.curSum = float64(a.curSum) + float64(v)
 						}
 
 						a.curCount++
@@ -1272,10 +1311,11 @@ func (a *avgFloat64OrderedAgg) Compute(
 					var isNull bool
 					isNull = false
 					if !isNull {
+						v := col.Get(i)
 
 						{
 
-							a.curSum = float64(a.curSum) + float64(col[i])
+							a.curSum = float64(a.curSum) + float64(v)
 						}
 
 						a.curCount++
@@ -1365,16 +1405,17 @@ func (a *avgIntervalOrderedAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Interval(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
+		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
-		col := col
 		groups := a.groups
+		col := col
 		if sel == nil {
 			_ = groups[inputLen-1]
-			col = col[:inputLen]
+			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
-				for i := range col {
+				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -1396,14 +1437,17 @@ func (a *avgIntervalOrderedAgg) Compute(
 					var isNull bool
 					isNull = nulls.NullAt(i)
 					if !isNull {
-						a.curSum = a.curSum.Add(col[i])
+						//gcassert:bce
+						v := col.Get(i)
+						a.curSum = a.curSum.Add(v)
 						a.curCount++
 						a.foundNonNullForCurrentGroup = true
 					}
 				}
 			} else {
-				for i := range col {
+				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -1424,7 +1468,9 @@ func (a *avgIntervalOrderedAgg) Compute(
 					var isNull bool
 					isNull = false
 					if !isNull {
-						a.curSum = a.curSum.Add(col[i])
+						//gcassert:bce
+						v := col.Get(i)
+						a.curSum = a.curSum.Add(v)
 						a.curCount++
 						a.foundNonNullForCurrentGroup = true
 					}
@@ -1456,7 +1502,8 @@ func (a *avgIntervalOrderedAgg) Compute(
 					var isNull bool
 					isNull = nulls.NullAt(i)
 					if !isNull {
-						a.curSum = a.curSum.Add(col[i])
+						v := col.Get(i)
+						a.curSum = a.curSum.Add(v)
 						a.curCount++
 						a.foundNonNullForCurrentGroup = true
 					}
@@ -1484,7 +1531,8 @@ func (a *avgIntervalOrderedAgg) Compute(
 					var isNull bool
 					isNull = false
 					if !isNull {
-						a.curSum = a.curSum.Add(col[i])
+						v := col.Get(i)
+						a.curSum = a.curSum.Add(v)
 						a.curCount++
 						a.foundNonNullForCurrentGroup = true
 					}

--- a/pkg/sql/colexec/colexecagg/ordered_bool_and_or_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_bool_and_or_agg.eg.go
@@ -50,12 +50,16 @@ func (a *boolAndOrderedAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Bool(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+		// Capture groups and col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
 		groups := a.groups
+		col := col
 		if sel == nil {
 			_ = groups[inputLen-1]
-			col = col[:inputLen]
+			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
-				for i := range col {
+				for i := 0; i < inputLen; i++ {
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							if !a.sawNonNull {
@@ -73,13 +77,15 @@ func (a *boolAndOrderedAgg) Compute(
 					var isNull bool
 					isNull = nulls.NullAt(i)
 					if !isNull {
+						//gcassert:bce
 						a.curAgg = a.curAgg && col[i]
 						a.sawNonNull = true
 					}
 
 				}
 			} else {
-				for i := range col {
+				for i := 0; i < inputLen; i++ {
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							if !a.sawNonNull {
@@ -97,6 +103,7 @@ func (a *boolAndOrderedAgg) Compute(
 					var isNull bool
 					isNull = false
 					if !isNull {
+						//gcassert:bce
 						a.curAgg = a.curAgg && col[i]
 						a.sawNonNull = true
 					}
@@ -232,12 +239,16 @@ func (a *boolOrOrderedAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Bool(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+		// Capture groups and col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
 		groups := a.groups
+		col := col
 		if sel == nil {
 			_ = groups[inputLen-1]
-			col = col[:inputLen]
+			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
-				for i := range col {
+				for i := 0; i < inputLen; i++ {
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							if !a.sawNonNull {
@@ -255,13 +266,15 @@ func (a *boolOrOrderedAgg) Compute(
 					var isNull bool
 					isNull = nulls.NullAt(i)
 					if !isNull {
+						//gcassert:bce
 						a.curAgg = a.curAgg || col[i]
 						a.sawNonNull = true
 					}
 
 				}
 			} else {
-				for i := range col {
+				for i := 0; i < inputLen; i++ {
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							if !a.sawNonNull {
@@ -279,6 +292,7 @@ func (a *boolOrOrderedAgg) Compute(
 					var isNull bool
 					isNull = false
 					if !isNull {
+						//gcassert:bce
 						a.curAgg = a.curAgg || col[i]
 						a.sawNonNull = true
 					}

--- a/pkg/sql/colexec/colexecagg/ordered_concat_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_concat_agg.eg.go
@@ -46,12 +46,15 @@ func (a *concatOrderedAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Bytes(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+		// Capture groups to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
 		groups := a.groups
 		if sel == nil {
 			_ = groups[inputLen-1]
 			if nulls.MaybeHasNulls() {
 				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -79,6 +82,7 @@ func (a *concatOrderedAgg) Compute(
 			} else {
 				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the

--- a/pkg/sql/colexec/colexecagg/ordered_count_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_count_agg.eg.go
@@ -44,11 +44,14 @@ func (a *countRowsOrderedAgg) Compute(
 ) {
 	var oldCurAggSize uintptr
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+		// Capture groups to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
 		groups := a.groups
 		if sel == nil {
 			_ = groups[inputLen-1]
 			{
 				for i := 0; i < inputLen; i++ {
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							a.col[a.curIdx] = a.curAgg
@@ -161,11 +164,14 @@ func (a *countOrderedAgg) Compute(
 	// COUNT aggregate on a single column.
 	nulls := vecs[inputIdxs[0]].Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
+		// Capture groups to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
 		groups := a.groups
 		if sel == nil {
 			_ = groups[inputLen-1]
 			if nulls.MaybeHasNulls() {
 				for i := 0; i < inputLen; i++ {
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							a.col[a.curIdx] = a.curAgg
@@ -184,6 +190,7 @@ func (a *countOrderedAgg) Compute(
 				}
 			} else {
 				for i := 0; i < inputLen; i++ {
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							a.col[a.curIdx] = a.curAgg

--- a/pkg/sql/colexec/colexecagg/ordered_min_max_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_min_max_agg.eg.go
@@ -118,16 +118,17 @@ func (a *minBoolOrderedAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Bool(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
+		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
-		col := col
 		groups := a.groups
+		col := col
 		if sel == nil {
 			_ = groups[inputLen-1]
 			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
 				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -177,6 +178,7 @@ func (a *minBoolOrderedAgg) Compute(
 			} else {
 				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -402,16 +404,17 @@ func (a *minBytesOrderedAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Bytes(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
+		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
-		col := col
 		groups := a.groups
+		col := col
 		if sel == nil {
 			_ = groups[inputLen-1]
 			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
 				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -453,6 +456,7 @@ func (a *minBytesOrderedAgg) Compute(
 			} else {
 				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -657,16 +661,17 @@ func (a *minDecimalOrderedAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Decimal(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
+		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
-		col := col
 		groups := a.groups
+		col := col
 		if sel == nil {
 			_ = groups[inputLen-1]
 			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
 				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -708,6 +713,7 @@ func (a *minDecimalOrderedAgg) Compute(
 			} else {
 				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -909,16 +915,17 @@ func (a *minInt16OrderedAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int16(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
+		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
-		col := col
 		groups := a.groups
+		col := col
 		if sel == nil {
 			_ = groups[inputLen-1]
 			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
 				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -971,6 +978,7 @@ func (a *minInt16OrderedAgg) Compute(
 			} else {
 				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -1205,16 +1213,17 @@ func (a *minInt32OrderedAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int32(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
+		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
-		col := col
 		groups := a.groups
+		col := col
 		if sel == nil {
 			_ = groups[inputLen-1]
 			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
 				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -1267,6 +1276,7 @@ func (a *minInt32OrderedAgg) Compute(
 			} else {
 				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -1501,16 +1511,17 @@ func (a *minInt64OrderedAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int64(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
+		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
-		col := col
 		groups := a.groups
+		col := col
 		if sel == nil {
 			_ = groups[inputLen-1]
 			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
 				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -1563,6 +1574,7 @@ func (a *minInt64OrderedAgg) Compute(
 			} else {
 				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -1797,16 +1809,17 @@ func (a *minFloat64OrderedAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Float64(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
+		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
-		col := col
 		groups := a.groups
+		col := col
 		if sel == nil {
 			_ = groups[inputLen-1]
 			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
 				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -1867,6 +1880,7 @@ func (a *minFloat64OrderedAgg) Compute(
 			} else {
 				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -2125,16 +2139,17 @@ func (a *minTimestampOrderedAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Timestamp(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
+		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
-		col := col
 		groups := a.groups
+		col := col
 		if sel == nil {
 			_ = groups[inputLen-1]
 			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
 				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -2183,6 +2198,7 @@ func (a *minTimestampOrderedAgg) Compute(
 			} else {
 				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -2405,16 +2421,17 @@ func (a *minIntervalOrderedAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Interval(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
+		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
-		col := col
 		groups := a.groups
+		col := col
 		if sel == nil {
 			_ = groups[inputLen-1]
 			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
 				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -2456,6 +2473,7 @@ func (a *minIntervalOrderedAgg) Compute(
 			} else {
 				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -2661,16 +2679,17 @@ func (a *minDatumOrderedAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Datum(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
+		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
-		col := col
 		groups := a.groups
+		col := col
 		if sel == nil {
 			_ = groups[inputLen-1]
 			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
 				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -2714,6 +2733,7 @@ func (a *minDatumOrderedAgg) Compute(
 			} else {
 				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -2930,16 +2950,17 @@ func (a *maxBoolOrderedAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Bool(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
+		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
-		col := col
 		groups := a.groups
+		col := col
 		if sel == nil {
 			_ = groups[inputLen-1]
 			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
 				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -2989,6 +3010,7 @@ func (a *maxBoolOrderedAgg) Compute(
 			} else {
 				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -3214,16 +3236,17 @@ func (a *maxBytesOrderedAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Bytes(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
+		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
-		col := col
 		groups := a.groups
+		col := col
 		if sel == nil {
 			_ = groups[inputLen-1]
 			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
 				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -3265,6 +3288,7 @@ func (a *maxBytesOrderedAgg) Compute(
 			} else {
 				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -3469,16 +3493,17 @@ func (a *maxDecimalOrderedAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Decimal(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
+		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
-		col := col
 		groups := a.groups
+		col := col
 		if sel == nil {
 			_ = groups[inputLen-1]
 			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
 				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -3520,6 +3545,7 @@ func (a *maxDecimalOrderedAgg) Compute(
 			} else {
 				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -3721,16 +3747,17 @@ func (a *maxInt16OrderedAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int16(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
+		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
-		col := col
 		groups := a.groups
+		col := col
 		if sel == nil {
 			_ = groups[inputLen-1]
 			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
 				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -3783,6 +3810,7 @@ func (a *maxInt16OrderedAgg) Compute(
 			} else {
 				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -4017,16 +4045,17 @@ func (a *maxInt32OrderedAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int32(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
+		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
-		col := col
 		groups := a.groups
+		col := col
 		if sel == nil {
 			_ = groups[inputLen-1]
 			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
 				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -4079,6 +4108,7 @@ func (a *maxInt32OrderedAgg) Compute(
 			} else {
 				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -4313,16 +4343,17 @@ func (a *maxInt64OrderedAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int64(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
+		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
-		col := col
 		groups := a.groups
+		col := col
 		if sel == nil {
 			_ = groups[inputLen-1]
 			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
 				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -4375,6 +4406,7 @@ func (a *maxInt64OrderedAgg) Compute(
 			} else {
 				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -4609,16 +4641,17 @@ func (a *maxFloat64OrderedAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Float64(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
+		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
-		col := col
 		groups := a.groups
+		col := col
 		if sel == nil {
 			_ = groups[inputLen-1]
 			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
 				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -4679,6 +4712,7 @@ func (a *maxFloat64OrderedAgg) Compute(
 			} else {
 				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -4937,16 +4971,17 @@ func (a *maxTimestampOrderedAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Timestamp(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
+		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
-		col := col
 		groups := a.groups
+		col := col
 		if sel == nil {
 			_ = groups[inputLen-1]
 			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
 				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -4995,6 +5030,7 @@ func (a *maxTimestampOrderedAgg) Compute(
 			} else {
 				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -5217,16 +5253,17 @@ func (a *maxIntervalOrderedAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Interval(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
+		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
-		col := col
 		groups := a.groups
+		col := col
 		if sel == nil {
 			_ = groups[inputLen-1]
 			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
 				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -5268,6 +5305,7 @@ func (a *maxIntervalOrderedAgg) Compute(
 			} else {
 				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -5473,16 +5511,17 @@ func (a *maxDatumOrderedAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Datum(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
+		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
-		col := col
 		groups := a.groups
+		col := col
 		if sel == nil {
 			_ = groups[inputLen-1]
 			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
 				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -5526,6 +5565,7 @@ func (a *maxDatumOrderedAgg) Compute(
 			} else {
 				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the

--- a/pkg/sql/colexec/colexecagg/ordered_sum_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_sum_agg.eg.go
@@ -79,16 +79,17 @@ func (a *sumInt16OrderedAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int16(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
+		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
-		col := col
 		groups := a.groups
+		col := col
 		if sel == nil {
 			_ = groups[inputLen-1]
-			col = col[:inputLen]
+			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
-				for i := range col {
+				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -109,11 +110,13 @@ func (a *sumInt16OrderedAgg) Compute(
 					var isNull bool
 					isNull = nulls.NullAt(i)
 					if !isNull {
+						//gcassert:bce
+						v := col.Get(i)
 
 						{
 
 							tmpDec := &_overloadHelper.TmpDec1
-							tmpDec.SetInt64(int64(col[i]))
+							tmpDec.SetInt64(int64(v))
 							if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -123,8 +126,9 @@ func (a *sumInt16OrderedAgg) Compute(
 					}
 				}
 			} else {
-				for i := range col {
+				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -144,11 +148,13 @@ func (a *sumInt16OrderedAgg) Compute(
 					var isNull bool
 					isNull = false
 					if !isNull {
+						//gcassert:bce
+						v := col.Get(i)
 
 						{
 
 							tmpDec := &_overloadHelper.TmpDec1
-							tmpDec.SetInt64(int64(col[i]))
+							tmpDec.SetInt64(int64(v))
 							if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -183,11 +189,12 @@ func (a *sumInt16OrderedAgg) Compute(
 					var isNull bool
 					isNull = nulls.NullAt(i)
 					if !isNull {
+						v := col.Get(i)
 
 						{
 
 							tmpDec := &_overloadHelper.TmpDec1
-							tmpDec.SetInt64(int64(col[i]))
+							tmpDec.SetInt64(int64(v))
 							if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -218,11 +225,12 @@ func (a *sumInt16OrderedAgg) Compute(
 					var isNull bool
 					isNull = false
 					if !isNull {
+						v := col.Get(i)
 
 						{
 
 							tmpDec := &_overloadHelper.TmpDec1
-							tmpDec.SetInt64(int64(col[i]))
+							tmpDec.SetInt64(int64(v))
 							if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -313,16 +321,17 @@ func (a *sumInt32OrderedAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int32(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
+		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
-		col := col
 		groups := a.groups
+		col := col
 		if sel == nil {
 			_ = groups[inputLen-1]
-			col = col[:inputLen]
+			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
-				for i := range col {
+				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -343,11 +352,13 @@ func (a *sumInt32OrderedAgg) Compute(
 					var isNull bool
 					isNull = nulls.NullAt(i)
 					if !isNull {
+						//gcassert:bce
+						v := col.Get(i)
 
 						{
 
 							tmpDec := &_overloadHelper.TmpDec1
-							tmpDec.SetInt64(int64(col[i]))
+							tmpDec.SetInt64(int64(v))
 							if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -357,8 +368,9 @@ func (a *sumInt32OrderedAgg) Compute(
 					}
 				}
 			} else {
-				for i := range col {
+				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -378,11 +390,13 @@ func (a *sumInt32OrderedAgg) Compute(
 					var isNull bool
 					isNull = false
 					if !isNull {
+						//gcassert:bce
+						v := col.Get(i)
 
 						{
 
 							tmpDec := &_overloadHelper.TmpDec1
-							tmpDec.SetInt64(int64(col[i]))
+							tmpDec.SetInt64(int64(v))
 							if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -417,11 +431,12 @@ func (a *sumInt32OrderedAgg) Compute(
 					var isNull bool
 					isNull = nulls.NullAt(i)
 					if !isNull {
+						v := col.Get(i)
 
 						{
 
 							tmpDec := &_overloadHelper.TmpDec1
-							tmpDec.SetInt64(int64(col[i]))
+							tmpDec.SetInt64(int64(v))
 							if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -452,11 +467,12 @@ func (a *sumInt32OrderedAgg) Compute(
 					var isNull bool
 					isNull = false
 					if !isNull {
+						v := col.Get(i)
 
 						{
 
 							tmpDec := &_overloadHelper.TmpDec1
-							tmpDec.SetInt64(int64(col[i]))
+							tmpDec.SetInt64(int64(v))
 							if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -547,16 +563,17 @@ func (a *sumInt64OrderedAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int64(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
+		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
-		col := col
 		groups := a.groups
+		col := col
 		if sel == nil {
 			_ = groups[inputLen-1]
-			col = col[:inputLen]
+			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
-				for i := range col {
+				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -577,11 +594,13 @@ func (a *sumInt64OrderedAgg) Compute(
 					var isNull bool
 					isNull = nulls.NullAt(i)
 					if !isNull {
+						//gcassert:bce
+						v := col.Get(i)
 
 						{
 
 							tmpDec := &_overloadHelper.TmpDec1
-							tmpDec.SetInt64(int64(col[i]))
+							tmpDec.SetInt64(int64(v))
 							if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -591,8 +610,9 @@ func (a *sumInt64OrderedAgg) Compute(
 					}
 				}
 			} else {
-				for i := range col {
+				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -612,11 +632,13 @@ func (a *sumInt64OrderedAgg) Compute(
 					var isNull bool
 					isNull = false
 					if !isNull {
+						//gcassert:bce
+						v := col.Get(i)
 
 						{
 
 							tmpDec := &_overloadHelper.TmpDec1
-							tmpDec.SetInt64(int64(col[i]))
+							tmpDec.SetInt64(int64(v))
 							if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -651,11 +673,12 @@ func (a *sumInt64OrderedAgg) Compute(
 					var isNull bool
 					isNull = nulls.NullAt(i)
 					if !isNull {
+						v := col.Get(i)
 
 						{
 
 							tmpDec := &_overloadHelper.TmpDec1
-							tmpDec.SetInt64(int64(col[i]))
+							tmpDec.SetInt64(int64(v))
 							if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -686,11 +709,12 @@ func (a *sumInt64OrderedAgg) Compute(
 					var isNull bool
 					isNull = false
 					if !isNull {
+						v := col.Get(i)
 
 						{
 
 							tmpDec := &_overloadHelper.TmpDec1
-							tmpDec.SetInt64(int64(col[i]))
+							tmpDec.SetInt64(int64(v))
 							if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -777,16 +801,17 @@ func (a *sumDecimalOrderedAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Decimal(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
+		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
-		col := col
 		groups := a.groups
+		col := col
 		if sel == nil {
 			_ = groups[inputLen-1]
-			col = col[:inputLen]
+			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
-				for i := range col {
+				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -807,10 +832,12 @@ func (a *sumDecimalOrderedAgg) Compute(
 					var isNull bool
 					isNull = nulls.NullAt(i)
 					if !isNull {
+						//gcassert:bce
+						v := col.Get(i)
 
 						{
 
-							_, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, &col[i])
+							_, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, &v)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -820,8 +847,9 @@ func (a *sumDecimalOrderedAgg) Compute(
 					}
 				}
 			} else {
-				for i := range col {
+				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -841,10 +869,12 @@ func (a *sumDecimalOrderedAgg) Compute(
 					var isNull bool
 					isNull = false
 					if !isNull {
+						//gcassert:bce
+						v := col.Get(i)
 
 						{
 
-							_, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, &col[i])
+							_, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, &v)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -879,10 +909,11 @@ func (a *sumDecimalOrderedAgg) Compute(
 					var isNull bool
 					isNull = nulls.NullAt(i)
 					if !isNull {
+						v := col.Get(i)
 
 						{
 
-							_, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, &col[i])
+							_, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, &v)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -913,10 +944,11 @@ func (a *sumDecimalOrderedAgg) Compute(
 					var isNull bool
 					isNull = false
 					if !isNull {
+						v := col.Get(i)
 
 						{
 
-							_, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, &col[i])
+							_, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, &v)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -1003,16 +1035,17 @@ func (a *sumFloat64OrderedAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Float64(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
+		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
-		col := col
 		groups := a.groups
+		col := col
 		if sel == nil {
 			_ = groups[inputLen-1]
-			col = col[:inputLen]
+			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
-				for i := range col {
+				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -1033,18 +1066,21 @@ func (a *sumFloat64OrderedAgg) Compute(
 					var isNull bool
 					isNull = nulls.NullAt(i)
 					if !isNull {
+						//gcassert:bce
+						v := col.Get(i)
 
 						{
 
-							a.curAgg = float64(a.curAgg) + float64(col[i])
+							a.curAgg = float64(a.curAgg) + float64(v)
 						}
 
 						a.foundNonNullForCurrentGroup = true
 					}
 				}
 			} else {
-				for i := range col {
+				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -1064,10 +1100,12 @@ func (a *sumFloat64OrderedAgg) Compute(
 					var isNull bool
 					isNull = false
 					if !isNull {
+						//gcassert:bce
+						v := col.Get(i)
 
 						{
 
-							a.curAgg = float64(a.curAgg) + float64(col[i])
+							a.curAgg = float64(a.curAgg) + float64(v)
 						}
 
 						a.foundNonNullForCurrentGroup = true
@@ -1099,10 +1137,11 @@ func (a *sumFloat64OrderedAgg) Compute(
 					var isNull bool
 					isNull = nulls.NullAt(i)
 					if !isNull {
+						v := col.Get(i)
 
 						{
 
-							a.curAgg = float64(a.curAgg) + float64(col[i])
+							a.curAgg = float64(a.curAgg) + float64(v)
 						}
 
 						a.foundNonNullForCurrentGroup = true
@@ -1130,10 +1169,11 @@ func (a *sumFloat64OrderedAgg) Compute(
 					var isNull bool
 					isNull = false
 					if !isNull {
+						v := col.Get(i)
 
 						{
 
-							a.curAgg = float64(a.curAgg) + float64(col[i])
+							a.curAgg = float64(a.curAgg) + float64(v)
 						}
 
 						a.foundNonNullForCurrentGroup = true
@@ -1217,16 +1257,17 @@ func (a *sumIntervalOrderedAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Interval(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
+		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
-		col := col
 		groups := a.groups
+		col := col
 		if sel == nil {
 			_ = groups[inputLen-1]
-			col = col[:inputLen]
+			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
-				for i := range col {
+				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -1247,13 +1288,16 @@ func (a *sumIntervalOrderedAgg) Compute(
 					var isNull bool
 					isNull = nulls.NullAt(i)
 					if !isNull {
-						a.curAgg = a.curAgg.Add(col[i])
+						//gcassert:bce
+						v := col.Get(i)
+						a.curAgg = a.curAgg.Add(v)
 						a.foundNonNullForCurrentGroup = true
 					}
 				}
 			} else {
-				for i := range col {
+				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -1273,7 +1317,9 @@ func (a *sumIntervalOrderedAgg) Compute(
 					var isNull bool
 					isNull = false
 					if !isNull {
-						a.curAgg = a.curAgg.Add(col[i])
+						//gcassert:bce
+						v := col.Get(i)
+						a.curAgg = a.curAgg.Add(v)
 						a.foundNonNullForCurrentGroup = true
 					}
 				}
@@ -1303,7 +1349,8 @@ func (a *sumIntervalOrderedAgg) Compute(
 					var isNull bool
 					isNull = nulls.NullAt(i)
 					if !isNull {
-						a.curAgg = a.curAgg.Add(col[i])
+						v := col.Get(i)
+						a.curAgg = a.curAgg.Add(v)
 						a.foundNonNullForCurrentGroup = true
 					}
 				}
@@ -1329,7 +1376,8 @@ func (a *sumIntervalOrderedAgg) Compute(
 					var isNull bool
 					isNull = false
 					if !isNull {
-						a.curAgg = a.curAgg.Add(col[i])
+						v := col.Get(i)
+						a.curAgg = a.curAgg.Add(v)
 						a.foundNonNullForCurrentGroup = true
 					}
 				}

--- a/pkg/sql/colexec/colexecagg/ordered_sum_int_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_sum_int_agg.eg.go
@@ -66,16 +66,17 @@ func (a *sumIntInt16OrderedAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int16(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
+		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
-		col := col
 		groups := a.groups
+		col := col
 		if sel == nil {
 			_ = groups[inputLen-1]
-			col = col[:inputLen]
+			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
-				for i := range col {
+				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -96,10 +97,12 @@ func (a *sumIntInt16OrderedAgg) Compute(
 					var isNull bool
 					isNull = nulls.NullAt(i)
 					if !isNull {
+						//gcassert:bce
+						v := col.Get(i)
 
 						{
-							result := int64(a.curAgg) + int64(col[i])
-							if (result < int64(a.curAgg)) != (int64(col[i]) < 0) {
+							result := int64(a.curAgg) + int64(v)
+							if (result < int64(a.curAgg)) != (int64(v) < 0) {
 								colexecerror.ExpectedError(tree.ErrIntOutOfRange)
 							}
 							a.curAgg = result
@@ -109,8 +112,9 @@ func (a *sumIntInt16OrderedAgg) Compute(
 					}
 				}
 			} else {
-				for i := range col {
+				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -130,10 +134,12 @@ func (a *sumIntInt16OrderedAgg) Compute(
 					var isNull bool
 					isNull = false
 					if !isNull {
+						//gcassert:bce
+						v := col.Get(i)
 
 						{
-							result := int64(a.curAgg) + int64(col[i])
-							if (result < int64(a.curAgg)) != (int64(col[i]) < 0) {
+							result := int64(a.curAgg) + int64(v)
+							if (result < int64(a.curAgg)) != (int64(v) < 0) {
 								colexecerror.ExpectedError(tree.ErrIntOutOfRange)
 							}
 							a.curAgg = result
@@ -168,10 +174,11 @@ func (a *sumIntInt16OrderedAgg) Compute(
 					var isNull bool
 					isNull = nulls.NullAt(i)
 					if !isNull {
+						v := col.Get(i)
 
 						{
-							result := int64(a.curAgg) + int64(col[i])
-							if (result < int64(a.curAgg)) != (int64(col[i]) < 0) {
+							result := int64(a.curAgg) + int64(v)
+							if (result < int64(a.curAgg)) != (int64(v) < 0) {
 								colexecerror.ExpectedError(tree.ErrIntOutOfRange)
 							}
 							a.curAgg = result
@@ -202,10 +209,11 @@ func (a *sumIntInt16OrderedAgg) Compute(
 					var isNull bool
 					isNull = false
 					if !isNull {
+						v := col.Get(i)
 
 						{
-							result := int64(a.curAgg) + int64(col[i])
-							if (result < int64(a.curAgg)) != (int64(col[i]) < 0) {
+							result := int64(a.curAgg) + int64(v)
+							if (result < int64(a.curAgg)) != (int64(v) < 0) {
 								colexecerror.ExpectedError(tree.ErrIntOutOfRange)
 							}
 							a.curAgg = result
@@ -292,16 +300,17 @@ func (a *sumIntInt32OrderedAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int32(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
+		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
-		col := col
 		groups := a.groups
+		col := col
 		if sel == nil {
 			_ = groups[inputLen-1]
-			col = col[:inputLen]
+			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
-				for i := range col {
+				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -322,10 +331,12 @@ func (a *sumIntInt32OrderedAgg) Compute(
 					var isNull bool
 					isNull = nulls.NullAt(i)
 					if !isNull {
+						//gcassert:bce
+						v := col.Get(i)
 
 						{
-							result := int64(a.curAgg) + int64(col[i])
-							if (result < int64(a.curAgg)) != (int64(col[i]) < 0) {
+							result := int64(a.curAgg) + int64(v)
+							if (result < int64(a.curAgg)) != (int64(v) < 0) {
 								colexecerror.ExpectedError(tree.ErrIntOutOfRange)
 							}
 							a.curAgg = result
@@ -335,8 +346,9 @@ func (a *sumIntInt32OrderedAgg) Compute(
 					}
 				}
 			} else {
-				for i := range col {
+				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -356,10 +368,12 @@ func (a *sumIntInt32OrderedAgg) Compute(
 					var isNull bool
 					isNull = false
 					if !isNull {
+						//gcassert:bce
+						v := col.Get(i)
 
 						{
-							result := int64(a.curAgg) + int64(col[i])
-							if (result < int64(a.curAgg)) != (int64(col[i]) < 0) {
+							result := int64(a.curAgg) + int64(v)
+							if (result < int64(a.curAgg)) != (int64(v) < 0) {
 								colexecerror.ExpectedError(tree.ErrIntOutOfRange)
 							}
 							a.curAgg = result
@@ -394,10 +408,11 @@ func (a *sumIntInt32OrderedAgg) Compute(
 					var isNull bool
 					isNull = nulls.NullAt(i)
 					if !isNull {
+						v := col.Get(i)
 
 						{
-							result := int64(a.curAgg) + int64(col[i])
-							if (result < int64(a.curAgg)) != (int64(col[i]) < 0) {
+							result := int64(a.curAgg) + int64(v)
+							if (result < int64(a.curAgg)) != (int64(v) < 0) {
 								colexecerror.ExpectedError(tree.ErrIntOutOfRange)
 							}
 							a.curAgg = result
@@ -428,10 +443,11 @@ func (a *sumIntInt32OrderedAgg) Compute(
 					var isNull bool
 					isNull = false
 					if !isNull {
+						v := col.Get(i)
 
 						{
-							result := int64(a.curAgg) + int64(col[i])
-							if (result < int64(a.curAgg)) != (int64(col[i]) < 0) {
+							result := int64(a.curAgg) + int64(v)
+							if (result < int64(a.curAgg)) != (int64(v) < 0) {
 								colexecerror.ExpectedError(tree.ErrIntOutOfRange)
 							}
 							a.curAgg = result
@@ -518,16 +534,17 @@ func (a *sumIntInt64OrderedAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int64(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
+		// Capture groups and col to force bounds check to work. See
 		// https://github.com/golang/go/issues/39756
-		col := col
 		groups := a.groups
+		col := col
 		if sel == nil {
 			_ = groups[inputLen-1]
-			col = col[:inputLen]
+			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
-				for i := range col {
+				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -548,10 +565,12 @@ func (a *sumIntInt64OrderedAgg) Compute(
 					var isNull bool
 					isNull = nulls.NullAt(i)
 					if !isNull {
+						//gcassert:bce
+						v := col.Get(i)
 
 						{
-							result := int64(a.curAgg) + int64(col[i])
-							if (result < int64(a.curAgg)) != (int64(col[i]) < 0) {
+							result := int64(a.curAgg) + int64(v)
+							if (result < int64(a.curAgg)) != (int64(v) < 0) {
 								colexecerror.ExpectedError(tree.ErrIntOutOfRange)
 							}
 							a.curAgg = result
@@ -561,8 +580,9 @@ func (a *sumIntInt64OrderedAgg) Compute(
 					}
 				}
 			} else {
-				for i := range col {
+				for i := 0; i < inputLen; i++ {
 
+					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
 							// If we encounter a new group, and we haven't found any non-nulls for the
@@ -582,10 +602,12 @@ func (a *sumIntInt64OrderedAgg) Compute(
 					var isNull bool
 					isNull = false
 					if !isNull {
+						//gcassert:bce
+						v := col.Get(i)
 
 						{
-							result := int64(a.curAgg) + int64(col[i])
-							if (result < int64(a.curAgg)) != (int64(col[i]) < 0) {
+							result := int64(a.curAgg) + int64(v)
+							if (result < int64(a.curAgg)) != (int64(v) < 0) {
 								colexecerror.ExpectedError(tree.ErrIntOutOfRange)
 							}
 							a.curAgg = result
@@ -620,10 +642,11 @@ func (a *sumIntInt64OrderedAgg) Compute(
 					var isNull bool
 					isNull = nulls.NullAt(i)
 					if !isNull {
+						v := col.Get(i)
 
 						{
-							result := int64(a.curAgg) + int64(col[i])
-							if (result < int64(a.curAgg)) != (int64(col[i]) < 0) {
+							result := int64(a.curAgg) + int64(v)
+							if (result < int64(a.curAgg)) != (int64(v) < 0) {
 								colexecerror.ExpectedError(tree.ErrIntOutOfRange)
 							}
 							a.curAgg = result
@@ -654,10 +677,11 @@ func (a *sumIntInt64OrderedAgg) Compute(
 					var isNull bool
 					isNull = false
 					if !isNull {
+						v := col.Get(i)
 
 						{
-							result := int64(a.curAgg) + int64(col[i])
-							if (result < int64(a.curAgg)) != (int64(col[i]) < 0) {
+							result := int64(a.curAgg) + int64(v)
+							if (result < int64(a.curAgg)) != (int64(v) < 0) {
 								colexecerror.ExpectedError(tree.ErrIntOutOfRange)
 							}
 							a.curAgg = result

--- a/pkg/sql/colexec/colexecagg/sum_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/sum_agg_tmpl.go
@@ -125,11 +125,11 @@ func (a *sum_SUMKIND_TYPE_AGGKINDAgg) Compute(
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.TemplateType(), vec.Nulls()
 	a.allocator.PerformOperation([]coldata.Vec{a.vec}, func() {
-		// Capture col to force bounds check to work. See
-		// https://github.com/golang/go/issues/39756
-		col := col
 		// {{if eq "_AGGKIND" "Ordered"}}
+		// Capture groups and col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
 		groups := a.groups
+		col := col
 		// {{/*
 		// We don't need to check whether sel is non-nil when performing
 		// hash aggregation because the hash aggregator always uses non-nil
@@ -137,14 +137,14 @@ func (a *sum_SUMKIND_TYPE_AGGKINDAgg) Compute(
 		// */}}
 		if sel == nil {
 			_ = groups[inputLen-1]
-			col = col[:inputLen]
+			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
-				for i := range col {
-					_ACCUMULATE_SUM(a, nulls, i, true)
+				for i := 0; i < inputLen; i++ {
+					_ACCUMULATE_SUM(a, nulls, i, true, false)
 				}
 			} else {
-				for i := range col {
-					_ACCUMULATE_SUM(a, nulls, i, false)
+				for i := 0; i < inputLen; i++ {
+					_ACCUMULATE_SUM(a, nulls, i, false, false)
 				}
 			}
 		} else
@@ -153,11 +153,11 @@ func (a *sum_SUMKIND_TYPE_AGGKINDAgg) Compute(
 			sel = sel[:inputLen]
 			if nulls.MaybeHasNulls() {
 				for _, i := range sel {
-					_ACCUMULATE_SUM(a, nulls, i, true)
+					_ACCUMULATE_SUM(a, nulls, i, true, true)
 				}
 			} else {
 				for _, i := range sel {
-					_ACCUMULATE_SUM(a, nulls, i, false)
+					_ACCUMULATE_SUM(a, nulls, i, false, true)
 				}
 			}
 		}
@@ -222,10 +222,15 @@ func (a *sum_SUMKIND_TYPE_AGGKINDAggAlloc) newAggFunc() AggregateFunc {
 // group. If this is the first row of a new group, and no non-nulls have been
 // found for the current group, then the output for the current group is set to
 // null.
-func _ACCUMULATE_SUM(a *sum_SUMKIND_TYPE_AGGKINDAgg, nulls *coldata.Nulls, i int, _HAS_NULLS bool) { // */}}
+func _ACCUMULATE_SUM(
+	a *sum_SUMKIND_TYPE_AGGKINDAgg, nulls *coldata.Nulls, i int, _HAS_NULLS bool, _HAS_SEL bool,
+) { // */}}
 	// {{define "accumulateSum"}}
 
 	// {{if eq "_AGGKIND" "Ordered"}}
+	// {{if not .HasSel}}
+	//gcassert:bce
+	// {{end}}
 	if groups[i] {
 		if !a.isFirstGroup {
 			// If we encounter a new group, and we haven't found any non-nulls for the
@@ -259,7 +264,11 @@ func _ACCUMULATE_SUM(a *sum_SUMKIND_TYPE_AGGKINDAgg, nulls *coldata.Nulls, i int
 	isNull = false
 	// {{end}}
 	if !isNull {
-		_ASSIGN_ADD(a.curAgg, a.curAgg, col[i], _, _, col)
+		// {{if not .HasSel}}
+		//gcassert:bce
+		// {{end}}
+		v := col.Get(i)
+		_ASSIGN_ADD(a.curAgg, a.curAgg, v, _, _, col)
 		a.foundNonNullForCurrentGroup = true
 	}
 	// {{end}}

--- a/pkg/sql/colexec/const.eg.go
+++ b/pkg/sql/colexec/const.eg.go
@@ -186,6 +186,7 @@ func (c constBoolOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					col[i] = c.constVal
 				}
 			}
@@ -280,6 +281,7 @@ func (c constDecimalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					col[i].Set(&c.constVal)
 				}
 			}
@@ -327,6 +329,7 @@ func (c constInt16Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					col[i] = c.constVal
 				}
 			}
@@ -374,6 +377,7 @@ func (c constInt32Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					col[i] = c.constVal
 				}
 			}
@@ -421,6 +425,7 @@ func (c constInt64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					col[i] = c.constVal
 				}
 			}
@@ -468,6 +473,7 @@ func (c constFloat64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					col[i] = c.constVal
 				}
 			}
@@ -515,6 +521,7 @@ func (c constTimestampOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					col[i] = c.constVal
 				}
 			}
@@ -562,6 +569,7 @@ func (c constIntervalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					col[i] = c.constVal
 				}
 			}

--- a/pkg/sql/colexec/const_tmpl.go
+++ b/pkg/sql/colexec/const_tmpl.go
@@ -126,6 +126,9 @@ func (c const_TYPEOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					// {{if .Sliceable}}
+					//gcassert:bce
+					// {{end}}
 					execgen.SET(col, i, c.constVal)
 				}
 			}

--- a/pkg/sql/colexec/default_cmp_proj_ops.eg.go
+++ b/pkg/sql/colexec/default_cmp_proj_ops.eg.go
@@ -45,9 +45,15 @@ func (d *defaultCmpProjOp) Next(ctx context.Context) coldata.Batch {
 		d.toDatumConverter.ConvertBatchAndDeselect(batch)
 		leftColumn := d.toDatumConverter.GetDatumColumn(d.col1Idx)
 		rightColumn := d.toDatumConverter.GetDatumColumn(d.col2Idx)
+		_ = leftColumn[n-1]
+		_ = rightColumn[n-1]
+		if sel != nil {
+			_ = sel[n-1]
+		}
 		for i := 0; i < n; i++ {
 			// Note that we performed a conversion with deselection, so there
 			// is no need to check whether sel is non-nil.
+			//gcassert:bce
 			res, err := d.adapter.eval(leftColumn[i], rightColumn[i])
 			if err != nil {
 				colexecerror.ExpectedError(err)
@@ -99,9 +105,14 @@ func (d *defaultCmpRConstProjOp) Next(ctx context.Context) coldata.Batch {
 	d.allocator.PerformOperation([]coldata.Vec{output}, func() {
 		d.toDatumConverter.ConvertBatchAndDeselect(batch)
 		nonConstColumn := d.toDatumConverter.GetDatumColumn(d.colIdx)
+		_ = nonConstColumn[n-1]
+		if sel != nil {
+			_ = sel[n-1]
+		}
 		for i := 0; i < n; i++ {
 			// Note that we performed a conversion with deselection, so there
 			// is no need to check whether sel is non-nil.
+			//gcassert:bce
 			res, err := d.adapter.eval(nonConstColumn[i], d.constArg)
 			if err != nil {
 				colexecerror.ExpectedError(err)

--- a/pkg/sql/colexec/default_cmp_proj_ops_tmpl.go
+++ b/pkg/sql/colexec/default_cmp_proj_ops_tmpl.go
@@ -62,16 +62,24 @@ func (d *defaultCmp_KINDProjOp) Next(ctx context.Context) coldata.Batch {
 		d.toDatumConverter.ConvertBatchAndDeselect(batch)
 		// {{if .IsRightConst}}
 		nonConstColumn := d.toDatumConverter.GetDatumColumn(d.colIdx)
+		_ = nonConstColumn[n-1]
 		// {{else}}
 		leftColumn := d.toDatumConverter.GetDatumColumn(d.col1Idx)
 		rightColumn := d.toDatumConverter.GetDatumColumn(d.col2Idx)
+		_ = leftColumn[n-1]
+		_ = rightColumn[n-1]
 		// {{end}}
+		if sel != nil {
+			_ = sel[n-1]
+		}
 		for i := 0; i < n; i++ {
 			// Note that we performed a conversion with deselection, so there
 			// is no need to check whether sel is non-nil.
 			// {{if .IsRightConst}}
+			//gcassert:bce
 			res, err := d.adapter.eval(nonConstColumn[i], d.constArg)
 			// {{else}}
+			//gcassert:bce
 			res, err := d.adapter.eval(leftColumn[i], rightColumn[i])
 			// {{end}}
 			if err != nil {

--- a/pkg/sql/colexec/default_cmp_sel_ops.eg.go
+++ b/pkg/sql/colexec/default_cmp_sel_ops.eg.go
@@ -42,13 +42,17 @@ func (d *defaultCmpSelOp) Next(ctx context.Context) coldata.Batch {
 		d.toDatumConverter.ConvertBatchAndDeselect(batch)
 		leftColumn := d.toDatumConverter.GetDatumColumn(d.col1Idx)
 		rightColumn := d.toDatumConverter.GetDatumColumn(d.col2Idx)
+		_ = leftColumn[n-1]
+		_ = rightColumn[n-1]
 		var idx int
 		hasSel := batch.Selection() != nil
 		batch.SetSelection(true)
 		sel := batch.Selection()
+		_ = sel[n-1]
 		for i := 0; i < n; i++ {
 			// Note that we performed a conversion with deselection, so there
 			// is no need to check whether hasSel is true.
+			//gcassert:bce
 			res, err := d.adapter.eval(leftColumn[i], rightColumn[i])
 			if err != nil {
 				colexecerror.ExpectedError(err)
@@ -56,6 +60,7 @@ func (d *defaultCmpSelOp) Next(ctx context.Context) coldata.Batch {
 			if res == tree.DBoolTrue {
 				rowIdx := i
 				if hasSel {
+					//gcassert:bce
 					rowIdx = sel[i]
 				}
 				sel[idx] = rowIdx
@@ -92,13 +97,16 @@ func (d *defaultCmpConstSelOp) Next(ctx context.Context) coldata.Batch {
 		}
 		d.toDatumConverter.ConvertBatchAndDeselect(batch)
 		leftColumn := d.toDatumConverter.GetDatumColumn(d.colIdx)
+		_ = leftColumn[n-1]
 		var idx int
 		hasSel := batch.Selection() != nil
 		batch.SetSelection(true)
 		sel := batch.Selection()
+		_ = sel[n-1]
 		for i := 0; i < n; i++ {
 			// Note that we performed a conversion with deselection, so there
 			// is no need to check whether hasSel is true.
+			//gcassert:bce
 			res, err := d.adapter.eval(leftColumn[i], d.constArg)
 			if err != nil {
 				colexecerror.ExpectedError(err)
@@ -106,6 +114,7 @@ func (d *defaultCmpConstSelOp) Next(ctx context.Context) coldata.Batch {
 			if res == tree.DBoolTrue {
 				rowIdx := i
 				if hasSel {
+					//gcassert:bce
 					rowIdx = sel[i]
 				}
 				sel[idx] = rowIdx

--- a/pkg/sql/colexec/default_cmp_sel_ops_tmpl.go
+++ b/pkg/sql/colexec/default_cmp_sel_ops_tmpl.go
@@ -59,20 +59,26 @@ func (d *defaultCmp_KINDSelOp) Next(ctx context.Context) coldata.Batch {
 		d.toDatumConverter.ConvertBatchAndDeselect(batch)
 		// {{if .HasConst}}
 		leftColumn := d.toDatumConverter.GetDatumColumn(d.colIdx)
+		_ = leftColumn[n-1]
 		// {{else}}
 		leftColumn := d.toDatumConverter.GetDatumColumn(d.col1Idx)
 		rightColumn := d.toDatumConverter.GetDatumColumn(d.col2Idx)
+		_ = leftColumn[n-1]
+		_ = rightColumn[n-1]
 		// {{end}}
 		var idx int
 		hasSel := batch.Selection() != nil
 		batch.SetSelection(true)
 		sel := batch.Selection()
+		_ = sel[n-1]
 		for i := 0; i < n; i++ {
 			// Note that we performed a conversion with deselection, so there
 			// is no need to check whether hasSel is true.
 			// {{if .HasConst}}
+			//gcassert:bce
 			res, err := d.adapter.eval(leftColumn[i], d.constArg)
 			// {{else}}
+			//gcassert:bce
 			res, err := d.adapter.eval(leftColumn[i], rightColumn[i])
 			// {{end}}
 			if err != nil {
@@ -81,6 +87,7 @@ func (d *defaultCmp_KINDSelOp) Next(ctx context.Context) coldata.Batch {
 			if res == tree.DBoolTrue {
 				rowIdx := i
 				if hasSel {
+					//gcassert:bce
 					rowIdx = sel[i]
 				}
 				sel[idx] = rowIdx

--- a/pkg/sql/colexec/distinct.eg.go
+++ b/pkg/sql/colexec/distinct.eg.go
@@ -336,7 +336,6 @@ func (p *distinctBoolOp) Next(ctx context.Context) coldata.Batch {
 
 	n := batch.Length()
 	if sel != nil {
-		// Bounds check elimination.
 		sel = sel[:n]
 		if nulls != nil {
 			for _, idx := range sel {
@@ -392,10 +391,6 @@ func (p *distinctBoolOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		} else {
-			// Eliminate bounds checks for outputCol[idx].
-			_ = outputCol[n-1]
-			// Eliminate bounds checks for col[idx].
-			_ = col.Get(n - 1)
 			for _, idx := range sel {
 				{
 					var __retval_0 bool
@@ -432,6 +427,11 @@ func (p *distinctBoolOp) Next(ctx context.Context) coldata.Batch {
 			}
 		}
 	} else {
+		// Eliminate bounds checks for outputCol[idx].
+		_ = outputCol[n-1]
+		// Eliminate bounds checks for col[idx].
+		_ = col.Get(n - 1)
+		// TODO(yuzefovich): add BCE assertions for these.
 		if nulls != nil {
 			for idx := 0; idx < n; idx++ {
 				{
@@ -486,10 +486,6 @@ func (p *distinctBoolOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		} else {
-			// Eliminate bounds checks for outputCol[idx].
-			_ = outputCol[n-1]
-			// Eliminate bounds checks for col[idx].
-			_ = col.Get(n - 1)
 			for idx := 0; idx < n; idx++ {
 				{
 					var __retval_0 bool
@@ -553,6 +549,7 @@ func (p partitionerBool) partitionWithOrder(
 	// Eliminate bounds checks.
 	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
+	// TODO(yuzefovich): add BCE assertions for these.
 	outputCol[0] = true
 	if nulls != nil {
 		for outputIdx := 0; outputIdx < n; outputIdx++ {
@@ -652,6 +649,7 @@ func (p partitionerBool) partition(colVec coldata.Vec, outputCol []bool, n int) 
 	col := colVec.Bool()
 	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
+	// TODO(yuzefovich): add BCE assertions for these.
 	outputCol[0] = true
 	if nulls != nil {
 		for idx := 0; idx < n; idx++ {
@@ -815,7 +813,6 @@ func (p *distinctBytesOp) Next(ctx context.Context) coldata.Batch {
 
 	n := batch.Length()
 	if sel != nil {
-		// Bounds check elimination.
 		sel = sel[:n]
 		if nulls != nil {
 			for _, idx := range sel {
@@ -863,10 +860,6 @@ func (p *distinctBytesOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		} else {
-			// Eliminate bounds checks for outputCol[idx].
-			_ = outputCol[n-1]
-			// Eliminate bounds checks for col[idx].
-			_ = col.Get(n - 1)
 			for _, idx := range sel {
 				{
 					var __retval_0 []byte
@@ -895,6 +888,11 @@ func (p *distinctBytesOp) Next(ctx context.Context) coldata.Batch {
 			}
 		}
 	} else {
+		// Eliminate bounds checks for outputCol[idx].
+		_ = outputCol[n-1]
+		// Eliminate bounds checks for col[idx].
+		_ = col.Get(n - 1)
+		// TODO(yuzefovich): add BCE assertions for these.
 		if nulls != nil {
 			for idx := 0; idx < n; idx++ {
 				{
@@ -941,10 +939,6 @@ func (p *distinctBytesOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		} else {
-			// Eliminate bounds checks for outputCol[idx].
-			_ = outputCol[n-1]
-			// Eliminate bounds checks for col[idx].
-			_ = col.Get(n - 1)
 			for idx := 0; idx < n; idx++ {
 				{
 					var __retval_0 []byte
@@ -1000,6 +994,7 @@ func (p partitionerBytes) partitionWithOrder(
 	// Eliminate bounds checks.
 	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
+	// TODO(yuzefovich): add BCE assertions for these.
 	outputCol[0] = true
 	if nulls != nil {
 		for outputIdx := 0; outputIdx < n; outputIdx++ {
@@ -1083,6 +1078,7 @@ func (p partitionerBytes) partition(colVec coldata.Vec, outputCol []bool, n int)
 	col := colVec.Bytes()
 	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
+	// TODO(yuzefovich): add BCE assertions for these.
 	outputCol[0] = true
 	if nulls != nil {
 		for idx := 0; idx < n; idx++ {
@@ -1230,7 +1226,6 @@ func (p *distinctDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 	n := batch.Length()
 	if sel != nil {
-		// Bounds check elimination.
 		sel = sel[:n]
 		if nulls != nil {
 			for _, idx := range sel {
@@ -1278,10 +1273,6 @@ func (p *distinctDecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		} else {
-			// Eliminate bounds checks for outputCol[idx].
-			_ = outputCol[n-1]
-			// Eliminate bounds checks for col[idx].
-			_ = col.Get(n - 1)
 			for _, idx := range sel {
 				{
 					var __retval_0 apd.Decimal
@@ -1310,6 +1301,11 @@ func (p *distinctDecimalOp) Next(ctx context.Context) coldata.Batch {
 			}
 		}
 	} else {
+		// Eliminate bounds checks for outputCol[idx].
+		_ = outputCol[n-1]
+		// Eliminate bounds checks for col[idx].
+		_ = col.Get(n - 1)
+		// TODO(yuzefovich): add BCE assertions for these.
 		if nulls != nil {
 			for idx := 0; idx < n; idx++ {
 				{
@@ -1356,10 +1352,6 @@ func (p *distinctDecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		} else {
-			// Eliminate bounds checks for outputCol[idx].
-			_ = outputCol[n-1]
-			// Eliminate bounds checks for col[idx].
-			_ = col.Get(n - 1)
 			for idx := 0; idx < n; idx++ {
 				{
 					var __retval_0 apd.Decimal
@@ -1415,6 +1407,7 @@ func (p partitionerDecimal) partitionWithOrder(
 	// Eliminate bounds checks.
 	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
+	// TODO(yuzefovich): add BCE assertions for these.
 	outputCol[0] = true
 	if nulls != nil {
 		for outputIdx := 0; outputIdx < n; outputIdx++ {
@@ -1498,6 +1491,7 @@ func (p partitionerDecimal) partition(colVec coldata.Vec, outputCol []bool, n in
 	col := colVec.Decimal()
 	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
+	// TODO(yuzefovich): add BCE assertions for these.
 	outputCol[0] = true
 	if nulls != nil {
 		for idx := 0; idx < n; idx++ {
@@ -1645,7 +1639,6 @@ func (p *distinctInt16Op) Next(ctx context.Context) coldata.Batch {
 
 	n := batch.Length()
 	if sel != nil {
-		// Bounds check elimination.
 		sel = sel[:n]
 		if nulls != nil {
 			for _, idx := range sel {
@@ -1704,10 +1697,6 @@ func (p *distinctInt16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		} else {
-			// Eliminate bounds checks for outputCol[idx].
-			_ = outputCol[n-1]
-			// Eliminate bounds checks for col[idx].
-			_ = col.Get(n - 1)
 			for _, idx := range sel {
 				{
 					var __retval_0 int16
@@ -1747,6 +1736,11 @@ func (p *distinctInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		}
 	} else {
+		// Eliminate bounds checks for outputCol[idx].
+		_ = outputCol[n-1]
+		// Eliminate bounds checks for col[idx].
+		_ = col.Get(n - 1)
+		// TODO(yuzefovich): add BCE assertions for these.
 		if nulls != nil {
 			for idx := 0; idx < n; idx++ {
 				{
@@ -1804,10 +1798,6 @@ func (p *distinctInt16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		} else {
-			// Eliminate bounds checks for outputCol[idx].
-			_ = outputCol[n-1]
-			// Eliminate bounds checks for col[idx].
-			_ = col.Get(n - 1)
 			for idx := 0; idx < n; idx++ {
 				{
 					var __retval_0 int16
@@ -1874,6 +1864,7 @@ func (p partitionerInt16) partitionWithOrder(
 	// Eliminate bounds checks.
 	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
+	// TODO(yuzefovich): add BCE assertions for these.
 	outputCol[0] = true
 	if nulls != nil {
 		for outputIdx := 0; outputIdx < n; outputIdx++ {
@@ -1979,6 +1970,7 @@ func (p partitionerInt16) partition(colVec coldata.Vec, outputCol []bool, n int)
 	col := colVec.Int16()
 	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
+	// TODO(yuzefovich): add BCE assertions for these.
 	outputCol[0] = true
 	if nulls != nil {
 		for idx := 0; idx < n; idx++ {
@@ -2148,7 +2140,6 @@ func (p *distinctInt32Op) Next(ctx context.Context) coldata.Batch {
 
 	n := batch.Length()
 	if sel != nil {
-		// Bounds check elimination.
 		sel = sel[:n]
 		if nulls != nil {
 			for _, idx := range sel {
@@ -2207,10 +2198,6 @@ func (p *distinctInt32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		} else {
-			// Eliminate bounds checks for outputCol[idx].
-			_ = outputCol[n-1]
-			// Eliminate bounds checks for col[idx].
-			_ = col.Get(n - 1)
 			for _, idx := range sel {
 				{
 					var __retval_0 int32
@@ -2250,6 +2237,11 @@ func (p *distinctInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		}
 	} else {
+		// Eliminate bounds checks for outputCol[idx].
+		_ = outputCol[n-1]
+		// Eliminate bounds checks for col[idx].
+		_ = col.Get(n - 1)
+		// TODO(yuzefovich): add BCE assertions for these.
 		if nulls != nil {
 			for idx := 0; idx < n; idx++ {
 				{
@@ -2307,10 +2299,6 @@ func (p *distinctInt32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		} else {
-			// Eliminate bounds checks for outputCol[idx].
-			_ = outputCol[n-1]
-			// Eliminate bounds checks for col[idx].
-			_ = col.Get(n - 1)
 			for idx := 0; idx < n; idx++ {
 				{
 					var __retval_0 int32
@@ -2377,6 +2365,7 @@ func (p partitionerInt32) partitionWithOrder(
 	// Eliminate bounds checks.
 	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
+	// TODO(yuzefovich): add BCE assertions for these.
 	outputCol[0] = true
 	if nulls != nil {
 		for outputIdx := 0; outputIdx < n; outputIdx++ {
@@ -2482,6 +2471,7 @@ func (p partitionerInt32) partition(colVec coldata.Vec, outputCol []bool, n int)
 	col := colVec.Int32()
 	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
+	// TODO(yuzefovich): add BCE assertions for these.
 	outputCol[0] = true
 	if nulls != nil {
 		for idx := 0; idx < n; idx++ {
@@ -2651,7 +2641,6 @@ func (p *distinctInt64Op) Next(ctx context.Context) coldata.Batch {
 
 	n := batch.Length()
 	if sel != nil {
-		// Bounds check elimination.
 		sel = sel[:n]
 		if nulls != nil {
 			for _, idx := range sel {
@@ -2710,10 +2699,6 @@ func (p *distinctInt64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		} else {
-			// Eliminate bounds checks for outputCol[idx].
-			_ = outputCol[n-1]
-			// Eliminate bounds checks for col[idx].
-			_ = col.Get(n - 1)
 			for _, idx := range sel {
 				{
 					var __retval_0 int64
@@ -2753,6 +2738,11 @@ func (p *distinctInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		}
 	} else {
+		// Eliminate bounds checks for outputCol[idx].
+		_ = outputCol[n-1]
+		// Eliminate bounds checks for col[idx].
+		_ = col.Get(n - 1)
+		// TODO(yuzefovich): add BCE assertions for these.
 		if nulls != nil {
 			for idx := 0; idx < n; idx++ {
 				{
@@ -2810,10 +2800,6 @@ func (p *distinctInt64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		} else {
-			// Eliminate bounds checks for outputCol[idx].
-			_ = outputCol[n-1]
-			// Eliminate bounds checks for col[idx].
-			_ = col.Get(n - 1)
 			for idx := 0; idx < n; idx++ {
 				{
 					var __retval_0 int64
@@ -2880,6 +2866,7 @@ func (p partitionerInt64) partitionWithOrder(
 	// Eliminate bounds checks.
 	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
+	// TODO(yuzefovich): add BCE assertions for these.
 	outputCol[0] = true
 	if nulls != nil {
 		for outputIdx := 0; outputIdx < n; outputIdx++ {
@@ -2985,6 +2972,7 @@ func (p partitionerInt64) partition(colVec coldata.Vec, outputCol []bool, n int)
 	col := colVec.Int64()
 	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
+	// TODO(yuzefovich): add BCE assertions for these.
 	outputCol[0] = true
 	if nulls != nil {
 		for idx := 0; idx < n; idx++ {
@@ -3154,7 +3142,6 @@ func (p *distinctFloat64Op) Next(ctx context.Context) coldata.Batch {
 
 	n := batch.Length()
 	if sel != nil {
-		// Bounds check elimination.
 		sel = sel[:n]
 		if nulls != nil {
 			for _, idx := range sel {
@@ -3221,10 +3208,6 @@ func (p *distinctFloat64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		} else {
-			// Eliminate bounds checks for outputCol[idx].
-			_ = outputCol[n-1]
-			// Eliminate bounds checks for col[idx].
-			_ = col.Get(n - 1)
 			for _, idx := range sel {
 				{
 					var __retval_0 float64
@@ -3272,6 +3255,11 @@ func (p *distinctFloat64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		}
 	} else {
+		// Eliminate bounds checks for outputCol[idx].
+		_ = outputCol[n-1]
+		// Eliminate bounds checks for col[idx].
+		_ = col.Get(n - 1)
+		// TODO(yuzefovich): add BCE assertions for these.
 		if nulls != nil {
 			for idx := 0; idx < n; idx++ {
 				{
@@ -3337,10 +3325,6 @@ func (p *distinctFloat64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		} else {
-			// Eliminate bounds checks for outputCol[idx].
-			_ = outputCol[n-1]
-			// Eliminate bounds checks for col[idx].
-			_ = col.Get(n - 1)
 			for idx := 0; idx < n; idx++ {
 				{
 					var __retval_0 float64
@@ -3415,6 +3399,7 @@ func (p partitionerFloat64) partitionWithOrder(
 	// Eliminate bounds checks.
 	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
+	// TODO(yuzefovich): add BCE assertions for these.
 	outputCol[0] = true
 	if nulls != nil {
 		for outputIdx := 0; outputIdx < n; outputIdx++ {
@@ -3536,6 +3521,7 @@ func (p partitionerFloat64) partition(colVec coldata.Vec, outputCol []bool, n in
 	col := colVec.Float64()
 	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
+	// TODO(yuzefovich): add BCE assertions for these.
 	outputCol[0] = true
 	if nulls != nil {
 		for idx := 0; idx < n; idx++ {
@@ -3721,7 +3707,6 @@ func (p *distinctTimestampOp) Next(ctx context.Context) coldata.Batch {
 
 	n := batch.Length()
 	if sel != nil {
-		// Bounds check elimination.
 		sel = sel[:n]
 		if nulls != nil {
 			for _, idx := range sel {
@@ -3776,10 +3761,6 @@ func (p *distinctTimestampOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		} else {
-			// Eliminate bounds checks for outputCol[idx].
-			_ = outputCol[n-1]
-			// Eliminate bounds checks for col[idx].
-			_ = col.Get(n - 1)
 			for _, idx := range sel {
 				{
 					var __retval_0 time.Time
@@ -3815,6 +3796,11 @@ func (p *distinctTimestampOp) Next(ctx context.Context) coldata.Batch {
 			}
 		}
 	} else {
+		// Eliminate bounds checks for outputCol[idx].
+		_ = outputCol[n-1]
+		// Eliminate bounds checks for col[idx].
+		_ = col.Get(n - 1)
+		// TODO(yuzefovich): add BCE assertions for these.
 		if nulls != nil {
 			for idx := 0; idx < n; idx++ {
 				{
@@ -3868,10 +3854,6 @@ func (p *distinctTimestampOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		} else {
-			// Eliminate bounds checks for outputCol[idx].
-			_ = outputCol[n-1]
-			// Eliminate bounds checks for col[idx].
-			_ = col.Get(n - 1)
 			for idx := 0; idx < n; idx++ {
 				{
 					var __retval_0 time.Time
@@ -3934,6 +3916,7 @@ func (p partitionerTimestamp) partitionWithOrder(
 	// Eliminate bounds checks.
 	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
+	// TODO(yuzefovich): add BCE assertions for these.
 	outputCol[0] = true
 	if nulls != nil {
 		for outputIdx := 0; outputIdx < n; outputIdx++ {
@@ -4031,6 +4014,7 @@ func (p partitionerTimestamp) partition(colVec coldata.Vec, outputCol []bool, n 
 	col := colVec.Timestamp()
 	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
+	// TODO(yuzefovich): add BCE assertions for these.
 	outputCol[0] = true
 	if nulls != nil {
 		for idx := 0; idx < n; idx++ {
@@ -4192,7 +4176,6 @@ func (p *distinctIntervalOp) Next(ctx context.Context) coldata.Batch {
 
 	n := batch.Length()
 	if sel != nil {
-		// Bounds check elimination.
 		sel = sel[:n]
 		if nulls != nil {
 			for _, idx := range sel {
@@ -4240,10 +4223,6 @@ func (p *distinctIntervalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		} else {
-			// Eliminate bounds checks for outputCol[idx].
-			_ = outputCol[n-1]
-			// Eliminate bounds checks for col[idx].
-			_ = col.Get(n - 1)
 			for _, idx := range sel {
 				{
 					var __retval_0 duration.Duration
@@ -4272,6 +4251,11 @@ func (p *distinctIntervalOp) Next(ctx context.Context) coldata.Batch {
 			}
 		}
 	} else {
+		// Eliminate bounds checks for outputCol[idx].
+		_ = outputCol[n-1]
+		// Eliminate bounds checks for col[idx].
+		_ = col.Get(n - 1)
+		// TODO(yuzefovich): add BCE assertions for these.
 		if nulls != nil {
 			for idx := 0; idx < n; idx++ {
 				{
@@ -4318,10 +4302,6 @@ func (p *distinctIntervalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		} else {
-			// Eliminate bounds checks for outputCol[idx].
-			_ = outputCol[n-1]
-			// Eliminate bounds checks for col[idx].
-			_ = col.Get(n - 1)
 			for idx := 0; idx < n; idx++ {
 				{
 					var __retval_0 duration.Duration
@@ -4377,6 +4357,7 @@ func (p partitionerInterval) partitionWithOrder(
 	// Eliminate bounds checks.
 	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
+	// TODO(yuzefovich): add BCE assertions for these.
 	outputCol[0] = true
 	if nulls != nil {
 		for outputIdx := 0; outputIdx < n; outputIdx++ {
@@ -4460,6 +4441,7 @@ func (p partitionerInterval) partition(colVec coldata.Vec, outputCol []bool, n i
 	col := colVec.Interval()
 	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
+	// TODO(yuzefovich): add BCE assertions for these.
 	outputCol[0] = true
 	if nulls != nil {
 		for idx := 0; idx < n; idx++ {
@@ -4607,7 +4589,6 @@ func (p *distinctDatumOp) Next(ctx context.Context) coldata.Batch {
 
 	n := batch.Length()
 	if sel != nil {
-		// Bounds check elimination.
 		sel = sel[:n]
 		if nulls != nil {
 			for _, idx := range sel {
@@ -4657,10 +4638,6 @@ func (p *distinctDatumOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		} else {
-			// Eliminate bounds checks for outputCol[idx].
-			_ = outputCol[n-1]
-			// Eliminate bounds checks for col[idx].
-			_ = col.Get(n - 1)
 			for _, idx := range sel {
 				{
 					var __retval_0 interface{}
@@ -4691,6 +4668,11 @@ func (p *distinctDatumOp) Next(ctx context.Context) coldata.Batch {
 			}
 		}
 	} else {
+		// Eliminate bounds checks for outputCol[idx].
+		_ = outputCol[n-1]
+		// Eliminate bounds checks for col[idx].
+		_ = col.Get(n - 1)
+		// TODO(yuzefovich): add BCE assertions for these.
 		if nulls != nil {
 			for idx := 0; idx < n; idx++ {
 				{
@@ -4739,10 +4721,6 @@ func (p *distinctDatumOp) Next(ctx context.Context) coldata.Batch {
 				}
 			}
 		} else {
-			// Eliminate bounds checks for outputCol[idx].
-			_ = outputCol[n-1]
-			// Eliminate bounds checks for col[idx].
-			_ = col.Get(n - 1)
 			for idx := 0; idx < n; idx++ {
 				{
 					var __retval_0 interface{}
@@ -4800,6 +4778,7 @@ func (p partitionerDatum) partitionWithOrder(
 	// Eliminate bounds checks.
 	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
+	// TODO(yuzefovich): add BCE assertions for these.
 	outputCol[0] = true
 	if nulls != nil {
 		for outputIdx := 0; outputIdx < n; outputIdx++ {
@@ -4887,6 +4866,7 @@ func (p partitionerDatum) partition(colVec coldata.Vec, outputCol []bool, n int)
 	col := colVec.Datum()
 	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
+	// TODO(yuzefovich): add BCE assertions for these.
 	outputCol[0] = true
 	if nulls != nil {
 		for idx := 0; idx < n; idx++ {

--- a/pkg/sql/colexec/distinct_tmpl.go
+++ b/pkg/sql/colexec/distinct_tmpl.go
@@ -249,31 +249,27 @@ func (p *distinct_TYPEOp) Next(ctx context.Context) coldata.Batch {
 
 	n := batch.Length()
 	if sel != nil {
-		// Bounds check elimination.
 		sel = sel[:n]
 		if nulls != nil {
 			for _, idx := range sel {
 				lastVal, lastValNull = checkDistinctWithNulls(idx, idx, lastVal, nulls, lastValNull, col, outputCol)
 			}
 		} else {
-			// Eliminate bounds checks for outputCol[idx].
-			_ = outputCol[n-1]
-			// Eliminate bounds checks for col[idx].
-			_ = col.Get(n - 1)
 			for _, idx := range sel {
 				lastVal = checkDistinct(idx, idx, lastVal, col, outputCol)
 			}
 		}
 	} else {
+		// Eliminate bounds checks for outputCol[idx].
+		_ = outputCol[n-1]
+		// Eliminate bounds checks for col[idx].
+		_ = col.Get(n - 1)
+		// TODO(yuzefovich): add BCE assertions for these.
 		if nulls != nil {
 			for idx := 0; idx < n; idx++ {
 				lastVal, lastValNull = checkDistinctWithNulls(idx, idx, lastVal, nulls, lastValNull, col, outputCol)
 			}
 		} else {
-			// Eliminate bounds checks for outputCol[idx].
-			_ = outputCol[n-1]
-			// Eliminate bounds checks for col[idx].
-			_ = col.Get(n - 1)
 			for idx := 0; idx < n; idx++ {
 				lastVal = checkDistinct(idx, idx, lastVal, col, outputCol)
 			}
@@ -306,6 +302,7 @@ func (p partitioner_TYPE) partitionWithOrder(
 	// Eliminate bounds checks.
 	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
+	// TODO(yuzefovich): add BCE assertions for these.
 	outputCol[0] = true
 	if nulls != nil {
 		for outputIdx := 0; outputIdx < n; outputIdx++ {
@@ -333,6 +330,7 @@ func (p partitioner_TYPE) partition(colVec coldata.Vec, outputCol []bool, n int)
 	col := colVec.TemplateType()
 	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
+	// TODO(yuzefovich): add BCE assertions for these.
 	outputCol[0] = true
 	if nulls != nil {
 		for idx := 0; idx < n; idx++ {

--- a/pkg/sql/colexec/execgen/cmd/execgen/any_not_null_agg_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/any_not_null_agg_gen.go
@@ -31,8 +31,8 @@ func genAnyNotNullAgg(inputFileContents string, wr io.Writer) error {
 	)
 	s := r.Replace(inputFileContents)
 
-	findAnyNotNull := makeFunctionRegex("_FIND_ANY_NOT_NULL", 5)
-	s = findAnyNotNull.ReplaceAllString(s, `{{template "findAnyNotNull" buildDict "Global" . "HasNulls" $5}}`)
+	findAnyNotNull := makeFunctionRegex("_FIND_ANY_NOT_NULL", 6)
+	s = findAnyNotNull.ReplaceAllString(s, `{{template "findAnyNotNull" buildDict "Global" . "HasNulls" $5 "HasSel" $6}}`)
 
 	s = replaceManipulationFuncs(s)
 

--- a/pkg/sql/colexec/execgen/cmd/execgen/avg_agg_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/avg_agg_gen.go
@@ -87,8 +87,8 @@ func genAvgAgg(inputFileContents string, wr io.Writer) error {
 	assignAddRe := makeFunctionRegex("_ASSIGN_ADD", 6)
 	s = assignAddRe.ReplaceAllString(s, makeTemplateFunctionCall("Global.AssignAdd", 6))
 
-	accumulateAvg := makeFunctionRegex("_ACCUMULATE_AVG", 4)
-	s = accumulateAvg.ReplaceAllString(s, `{{template "accumulateAvg" buildDict "Global" . "HasNulls" $4}}`)
+	accumulateAvg := makeFunctionRegex("_ACCUMULATE_AVG", 5)
+	s = accumulateAvg.ReplaceAllString(s, `{{template "accumulateAvg" buildDict "Global" . "HasNulls" $4 "HasSel" $5}}`)
 
 	s = replaceManipulationFuncs(s)
 

--- a/pkg/sql/colexec/execgen/cmd/execgen/bool_and_or_agg_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/bool_and_or_agg_gen.go
@@ -69,8 +69,8 @@ func genBooleanAgg(inputFileContents string, wr io.Writer) error {
 	)
 	s := r.Replace(inputFileContents)
 
-	accumulateBoolean := makeFunctionRegex("_ACCUMULATE_BOOLEAN", 4)
-	s = accumulateBoolean.ReplaceAllString(s, `{{template "accumulateBoolean" buildDict "Global" . "HasNulls" $4}}`)
+	accumulateBoolean := makeFunctionRegex("_ACCUMULATE_BOOLEAN", 5)
+	s = accumulateBoolean.ReplaceAllString(s, `{{template "accumulateBoolean" buildDict "Global" . "HasNulls" $4 "HasSel" $5}}`)
 
 	assignBoolRe := makeFunctionRegex("_ASSIGN_BOOL_OP", 3)
 	s = assignBoolRe.ReplaceAllString(s, makeTemplateFunctionCall(`AssignBoolOp`, 3))

--- a/pkg/sql/colexec/execgen/cmd/execgen/concat_agg_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/concat_agg_gen.go
@@ -20,8 +20,8 @@ import (
 const concatAggTmpl = "pkg/sql/colexec/colexecagg/concat_agg_tmpl.go"
 
 func genConcatAgg(inputFileContents string, wr io.Writer) error {
-	accumulateConcatRe := makeFunctionRegex("_ACCUMULATE_CONCAT", 4)
-	s := accumulateConcatRe.ReplaceAllString(inputFileContents, `{{template "accumulateConcat" buildDict "HasNulls" $4}}`)
+	accumulateConcatRe := makeFunctionRegex("_ACCUMULATE_CONCAT", 5)
+	s := accumulateConcatRe.ReplaceAllString(inputFileContents, `{{template "accumulateConcat" buildDict "HasNulls" $4 "HasSel" $5}}`)
 
 	s = replaceManipulationFuncs(s)
 

--- a/pkg/sql/colexec/execgen/cmd/execgen/count_agg_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/count_agg_gen.go
@@ -23,8 +23,8 @@ const countAggTmpl = "pkg/sql/colexec/colexecagg/count_agg_tmpl.go"
 func genCountAgg(inputFileContents string, wr io.Writer) error {
 	s := strings.ReplaceAll(inputFileContents, "_COUNTKIND", "{{.CountKind}}")
 
-	accumulateSum := makeFunctionRegex("_ACCUMULATE_COUNT", 4)
-	s = accumulateSum.ReplaceAllString(s, `{{template "accumulateCount" buildDict "Global" . "ColWithNulls" $4}}`)
+	accumulateSum := makeFunctionRegex("_ACCUMULATE_COUNT", 5)
+	s = accumulateSum.ReplaceAllString(s, `{{template "accumulateCount" buildDict "Global" . "ColWithNulls" $4 "HasSel" $5}}`)
 
 	s = replaceManipulationFuncs(s)
 

--- a/pkg/sql/colexec/execgen/cmd/execgen/default_agg_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/default_agg_gen.go
@@ -18,13 +18,13 @@ import (
 const defaultAggTmpl = "pkg/sql/colexec/colexecagg/default_agg_tmpl.go"
 
 func genDefaultAgg(inputFileContents string, wr io.Writer) error {
-	addTuple := makeFunctionRegex("_ADD_TUPLE", 4)
-	s := addTuple.ReplaceAllString(inputFileContents, `{{template "addTuple"}}`)
+	addTuple := makeFunctionRegex("_ADD_TUPLE", 5)
+	s := addTuple.ReplaceAllString(inputFileContents, `{{template "addTuple" buildDict "HasSel" $5}}`)
 
 	setResult := makeFunctionRegex("_SET_RESULT", 2)
 	s = setResult.ReplaceAllString(s, `{{template "setResult"}}`)
 
-	tmpl, err := template.New("default_agg").Parse(s)
+	tmpl, err := template.New("default_agg").Funcs(template.FuncMap{"buildDict": buildDict}).Parse(s)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/colexec/execgen/cmd/execgen/min_max_agg_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/min_max_agg_gen.go
@@ -33,8 +33,8 @@ func genMinMaxAgg(inputFileContents string, wr io.Writer) error {
 	assignCmpRe := makeFunctionRegex("_ASSIGN_CMP", 6)
 	s = assignCmpRe.ReplaceAllString(s, makeTemplateFunctionCall("Assign", 6))
 
-	accumulateMinMax := makeFunctionRegex("_ACCUMULATE_MINMAX", 4)
-	s = accumulateMinMax.ReplaceAllString(s, `{{template "accumulateMinMax" buildDict "Global" . "HasNulls" $4}}`)
+	accumulateMinMax := makeFunctionRegex("_ACCUMULATE_MINMAX", 5)
+	s = accumulateMinMax.ReplaceAllString(s, `{{template "accumulateMinMax" buildDict "Global" . "HasNulls" $4 "HasSel" $5}}`)
 
 	s = replaceManipulationFuncs(s)
 

--- a/pkg/sql/colexec/execgen/cmd/execgen/projection_ops_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/projection_ops_gen.go
@@ -50,10 +50,11 @@ func replaceProjTmplVariables(tmpl string) string {
 	tmpl = assignRe.ReplaceAllString(tmpl, makeTemplateFunctionCall("Right.Assign", 6))
 
 	tmpl = strings.ReplaceAll(tmpl, "_HAS_NULLS", "$hasNulls")
+	tmpl = strings.ReplaceAll(tmpl, "_HAS_SEL", "$hasSel")
 	setProjectionRe := makeFunctionRegex("_SET_PROJECTION", 1)
 	tmpl = setProjectionRe.ReplaceAllString(tmpl, `{{template "setProjection" buildDict "Global" $ "HasNulls" $1 "Overload" .}}`)
-	setSingleTupleProjectionRe := makeFunctionRegex("_SET_SINGLE_TUPLE_PROJECTION", 1)
-	tmpl = setSingleTupleProjectionRe.ReplaceAllString(tmpl, `{{template "setSingleTupleProjection" buildDict "Global" $ "HasNulls" $1 "Overload" .}}`)
+	setSingleTupleProjectionRe := makeFunctionRegex("_SET_SINGLE_TUPLE_PROJECTION", 2)
+	tmpl = setSingleTupleProjectionRe.ReplaceAllString(tmpl, `{{template "setSingleTupleProjection" buildDict "Global" $ "HasNulls" $1 "HasSel" $2 "Overload" .}}`)
 
 	return tmpl
 }

--- a/pkg/sql/colexec/execgen/cmd/execgen/rank_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/rank_gen.go
@@ -54,8 +54,8 @@ const rankTmpl = "pkg/sql/colexec/rank_tmpl.go"
 func genRankOps(inputFileContents string, wr io.Writer) error {
 	s := strings.ReplaceAll(inputFileContents, "_RANK_STRING", "{{.String}}")
 
-	computeRankRe := makeFunctionRegex("_COMPUTE_RANK", 0)
-	s = computeRankRe.ReplaceAllString(s, `{{template "computeRank" buildDict "Global" . "HasPartition" .HasPartition}}`)
+	computeRankRe := makeFunctionRegex("_COMPUTE_RANK", 1)
+	s = computeRankRe.ReplaceAllString(s, `{{template "computeRank" buildDict "Global" . "HasPartition" .HasPartition "HasSel" $1}}`)
 	updateRankRe := makeFunctionRegex("_UPDATE_RANK", 0)
 	s = updateRankRe.ReplaceAllString(s, makeTemplateFunctionCall("Global.UpdateRank", 0))
 	updateRankIncrementRe := makeFunctionRegex("_UPDATE_RANK_INCREMENT", 0)

--- a/pkg/sql/colexec/execgen/cmd/execgen/relative_rank_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/relative_rank_gen.go
@@ -28,13 +28,13 @@ const relativeRankTmpl = "pkg/sql/colexec/relative_rank_tmpl.go"
 func genRelativeRankOps(inputFileContents string, wr io.Writer) error {
 	s := strings.ReplaceAll(inputFileContents, "_RELATIVE_RANK_STRING", "{{.String}}")
 
-	computePartitionsSizesRe := makeFunctionRegex("_COMPUTE_PARTITIONS_SIZES", 0)
-	s = computePartitionsSizesRe.ReplaceAllString(s, `{{template "computePartitionsSizes"}}`)
-	computePeerGroupsSizesRe := makeFunctionRegex("_COMPUTE_PEER_GROUPS_SIZES", 0)
-	s = computePeerGroupsSizesRe.ReplaceAllString(s, `{{template "computePeerGroupsSizes"}}`)
+	computePartitionsSizesRe := makeFunctionRegex("_COMPUTE_PARTITIONS_SIZES", 1)
+	s = computePartitionsSizesRe.ReplaceAllString(s, `{{template "computePartitionsSizes" buildDict "HasSel" $1}}`)
+	computePeerGroupsSizesRe := makeFunctionRegex("_COMPUTE_PEER_GROUPS_SIZES", 1)
+	s = computePeerGroupsSizesRe.ReplaceAllString(s, `{{template "computePeerGroupsSizes" buildDict "HasSel" $1}}`)
 
 	// Now, generate the op, from the template.
-	tmpl, err := template.New("relative_rank_op").Parse(s)
+	tmpl, err := template.New("relative_rank_op").Funcs(template.FuncMap{"buildDict": buildDict}).Parse(s)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/colexec/execgen/cmd/execgen/row_number_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/row_number_gen.go
@@ -26,8 +26,8 @@ const rowNumberTmpl = "pkg/sql/colexec/row_number_tmpl.go"
 func genRowNumberOp(inputFileContents string, wr io.Writer) error {
 	s := strings.ReplaceAll(inputFileContents, "_ROW_NUMBER_STRING", "{{.String}}")
 
-	computeRowNumberRe := makeFunctionRegex("_COMPUTE_ROW_NUMBER", 0)
-	s = computeRowNumberRe.ReplaceAllString(s, `{{template "computeRowNumber" buildDict "HasPartition" .HasPartition}}`)
+	computeRowNumberRe := makeFunctionRegex("_COMPUTE_ROW_NUMBER", 1)
+	s = computeRowNumberRe.ReplaceAllString(s, `{{template "computeRowNumber" buildDict "HasPartition" .HasPartition "HasSel" $1}}`)
 
 	// Now, generate the op, from the template.
 	tmpl, err := template.New("row_number_op").Funcs(template.FuncMap{"buildDict": buildDict}).Parse(s)

--- a/pkg/sql/colexec/execgen/cmd/execgen/rowstovec_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/rowstovec_gen.go
@@ -62,10 +62,15 @@ func (i rowsToVecWidthTmplInfo) Set(col, idx, castV string) string {
 	return set(i.canonicalTypeFamily, col, idx, castV)
 }
 
+func (i rowsToVecWidthTmplInfo) Sliceable() bool {
+	return sliceable(i.canonicalTypeFamily)
+}
+
 // Remove unused warnings.
 var _ = rowsToVecWidthTmplInfo{}.Prelude
 var _ = rowsToVecWidthTmplInfo{}.Convert
 var _ = rowsToVecWidthTmplInfo{}.Set
+var _ = rowsToVecWidthTmplInfo{}.Sliceable
 
 type familyWidthPair struct {
 	family types.Family

--- a/pkg/sql/colexec/execgen/cmd/execgen/sort_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/sort_gen.go
@@ -12,7 +12,6 @@ package main
 
 import (
 	"io"
-	"io/ioutil"
 	"strings"
 	"text/template"
 
@@ -67,16 +66,12 @@ func genSortOps(inputFileContents string, wr io.Writer) error {
 const quickSortTmpl = "pkg/sql/colexec/quicksort_tmpl.go"
 
 func genQuickSortOps(inputFileContents string, wr io.Writer) error {
-	d, err := ioutil.ReadFile(quickSortTmpl)
-	if err != nil {
-		return err
-	}
-
-	s := string(d)
-
-	s = strings.ReplaceAll(s, "_TYPE", "{{.VecMethod}}")
-	s = strings.ReplaceAll(s, "_DIR", "{{$dir}}")
-	s = strings.ReplaceAll(s, "_HANDLES_NULLS", "{{if $nulls}}WithNulls{{else}}{{end}}")
+	r := strings.NewReplacer(
+		"_TYPE", "{{.VecMethod}}",
+		"_DIR", "{{$dir}}",
+		"_HANDLES_NULLS", "{{if $nulls}}WithNulls{{else}}{{end}}",
+	)
+	s := r.Replace(inputFileContents)
 
 	// Now, generate the op, from the template.
 	tmpl, err := template.New("quicksort").Parse(s)

--- a/pkg/sql/colexec/execgen/cmd/execgen/sum_agg_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/sum_agg_gen.go
@@ -90,8 +90,8 @@ func genSumAgg(inputFileContents string, wr io.Writer, isSumInt bool) error {
 	assignAddRe := makeFunctionRegex("_ASSIGN_ADD", 6)
 	s = assignAddRe.ReplaceAllString(s, makeTemplateFunctionCall("Global.AssignAdd", 6))
 
-	accumulateSum := makeFunctionRegex("_ACCUMULATE_SUM", 4)
-	s = accumulateSum.ReplaceAllString(s, `{{template "accumulateSum" buildDict "Global" . "HasNulls" $4}}`)
+	accumulateSum := makeFunctionRegex("_ACCUMULATE_SUM", 5)
+	s = accumulateSum.ReplaceAllString(s, `{{template "accumulateSum" buildDict "Global" . "HasNulls" $4 "HasSel" $5}}`)
 
 	s = replaceManipulationFuncs(s)
 

--- a/pkg/sql/colexec/hash_utils.eg.go
+++ b/pkg/sql/colexec/hash_utils.eg.go
@@ -61,11 +61,13 @@ func rehash(
 					_ = sel[nKeys-1]
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
+						//gcassert:bce
 						selIdx = sel[i]
 						if nulls.NullAt(selIdx) {
 							continue
 						}
 						v := keys.Get(selIdx)
+						//gcassert:bce
 						p := uintptr(buckets[i])
 
 						x := 0
@@ -74,13 +76,13 @@ func rehash(
 						}
 						p = p*31 + uintptr(x)
 
+						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
 					cancelChecker.checkEveryCall(ctx)
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
-					_ = keys.Get(nKeys - 1)
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
 						selIdx = i
@@ -88,6 +90,7 @@ func rehash(
 							continue
 						}
 						v := keys.Get(selIdx)
+						//gcassert:bce
 						p := uintptr(buckets[i])
 
 						x := 0
@@ -96,6 +99,7 @@ func rehash(
 						}
 						p = p*31 + uintptr(x)
 
+						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
 					cancelChecker.checkEveryCall(ctx)
@@ -107,8 +111,10 @@ func rehash(
 					_ = sel[nKeys-1]
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
+						//gcassert:bce
 						selIdx = sel[i]
 						v := keys.Get(selIdx)
+						//gcassert:bce
 						p := uintptr(buckets[i])
 
 						x := 0
@@ -117,17 +123,18 @@ func rehash(
 						}
 						p = p*31 + uintptr(x)
 
+						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
 					cancelChecker.checkEveryCall(ctx)
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
-					_ = keys.Get(nKeys - 1)
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
 						selIdx = i
 						v := keys.Get(selIdx)
+						//gcassert:bce
 						p := uintptr(buckets[i])
 
 						x := 0
@@ -136,6 +143,7 @@ func rehash(
 						}
 						p = p*31 + uintptr(x)
 
+						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
 					cancelChecker.checkEveryCall(ctx)
@@ -154,23 +162,25 @@ func rehash(
 					_ = sel[nKeys-1]
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
+						//gcassert:bce
 						selIdx = sel[i]
 						if nulls.NullAt(selIdx) {
 							continue
 						}
 						v := keys.Get(selIdx)
+						//gcassert:bce
 						p := uintptr(buckets[i])
 
 						sh := (*reflect.SliceHeader)(unsafe.Pointer(&v))
 						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(v)))
 
+						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
 					cancelChecker.checkEveryCall(ctx)
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
-					_ = keys.Get(nKeys - 1)
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
 						selIdx = i
@@ -178,11 +188,13 @@ func rehash(
 							continue
 						}
 						v := keys.Get(selIdx)
+						//gcassert:bce
 						p := uintptr(buckets[i])
 
 						sh := (*reflect.SliceHeader)(unsafe.Pointer(&v))
 						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(v)))
 
+						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
 					cancelChecker.checkEveryCall(ctx)
@@ -194,29 +206,33 @@ func rehash(
 					_ = sel[nKeys-1]
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
+						//gcassert:bce
 						selIdx = sel[i]
 						v := keys.Get(selIdx)
+						//gcassert:bce
 						p := uintptr(buckets[i])
 
 						sh := (*reflect.SliceHeader)(unsafe.Pointer(&v))
 						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(v)))
 
+						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
 					cancelChecker.checkEveryCall(ctx)
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
-					_ = keys.Get(nKeys - 1)
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
 						selIdx = i
 						v := keys.Get(selIdx)
+						//gcassert:bce
 						p := uintptr(buckets[i])
 
 						sh := (*reflect.SliceHeader)(unsafe.Pointer(&v))
 						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(v)))
 
+						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
 					cancelChecker.checkEveryCall(ctx)
@@ -235,11 +251,13 @@ func rehash(
 					_ = sel[nKeys-1]
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
+						//gcassert:bce
 						selIdx = sel[i]
 						if nulls.NullAt(selIdx) {
 							continue
 						}
 						v := keys.Get(selIdx)
+						//gcassert:bce
 						p := uintptr(buckets[i])
 
 						// In order for equal decimals to hash to the same value we need to
@@ -250,13 +268,13 @@ func rehash(
 						sh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(b)))
 
+						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
 					cancelChecker.checkEveryCall(ctx)
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
-					_ = keys.Get(nKeys - 1)
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
 						selIdx = i
@@ -264,6 +282,7 @@ func rehash(
 							continue
 						}
 						v := keys.Get(selIdx)
+						//gcassert:bce
 						p := uintptr(buckets[i])
 
 						// In order for equal decimals to hash to the same value we need to
@@ -274,6 +293,7 @@ func rehash(
 						sh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(b)))
 
+						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
 					cancelChecker.checkEveryCall(ctx)
@@ -285,8 +305,10 @@ func rehash(
 					_ = sel[nKeys-1]
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
+						//gcassert:bce
 						selIdx = sel[i]
 						v := keys.Get(selIdx)
+						//gcassert:bce
 						p := uintptr(buckets[i])
 
 						// In order for equal decimals to hash to the same value we need to
@@ -297,17 +319,18 @@ func rehash(
 						sh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(b)))
 
+						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
 					cancelChecker.checkEveryCall(ctx)
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
-					_ = keys.Get(nKeys - 1)
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
 						selIdx = i
 						v := keys.Get(selIdx)
+						//gcassert:bce
 						p := uintptr(buckets[i])
 
 						// In order for equal decimals to hash to the same value we need to
@@ -318,6 +341,7 @@ func rehash(
 						sh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(b)))
 
+						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
 					cancelChecker.checkEveryCall(ctx)
@@ -335,24 +359,26 @@ func rehash(
 					_ = sel[nKeys-1]
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
+						//gcassert:bce
 						selIdx = sel[i]
 						if nulls.NullAt(selIdx) {
 							continue
 						}
 						v := keys.Get(selIdx)
+						//gcassert:bce
 						p := uintptr(buckets[i])
 
 						// In order for integers with different widths but of the same value to
 						// to hash to the same value, we upcast all of them to int64.
 						asInt64 := int64(v)
 						p = memhash64(noescape(unsafe.Pointer(&asInt64)), p)
+						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
 					cancelChecker.checkEveryCall(ctx)
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
-					_ = keys.Get(nKeys - 1)
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
 						selIdx = i
@@ -360,12 +386,14 @@ func rehash(
 							continue
 						}
 						v := keys.Get(selIdx)
+						//gcassert:bce
 						p := uintptr(buckets[i])
 
 						// In order for integers with different widths but of the same value to
 						// to hash to the same value, we upcast all of them to int64.
 						asInt64 := int64(v)
 						p = memhash64(noescape(unsafe.Pointer(&asInt64)), p)
+						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
 					cancelChecker.checkEveryCall(ctx)
@@ -377,31 +405,35 @@ func rehash(
 					_ = sel[nKeys-1]
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
+						//gcassert:bce
 						selIdx = sel[i]
 						v := keys.Get(selIdx)
+						//gcassert:bce
 						p := uintptr(buckets[i])
 
 						// In order for integers with different widths but of the same value to
 						// to hash to the same value, we upcast all of them to int64.
 						asInt64 := int64(v)
 						p = memhash64(noescape(unsafe.Pointer(&asInt64)), p)
+						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
 					cancelChecker.checkEveryCall(ctx)
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
-					_ = keys.Get(nKeys - 1)
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
 						selIdx = i
 						v := keys.Get(selIdx)
+						//gcassert:bce
 						p := uintptr(buckets[i])
 
 						// In order for integers with different widths but of the same value to
 						// to hash to the same value, we upcast all of them to int64.
 						asInt64 := int64(v)
 						p = memhash64(noescape(unsafe.Pointer(&asInt64)), p)
+						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
 					cancelChecker.checkEveryCall(ctx)
@@ -416,24 +448,26 @@ func rehash(
 					_ = sel[nKeys-1]
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
+						//gcassert:bce
 						selIdx = sel[i]
 						if nulls.NullAt(selIdx) {
 							continue
 						}
 						v := keys.Get(selIdx)
+						//gcassert:bce
 						p := uintptr(buckets[i])
 
 						// In order for integers with different widths but of the same value to
 						// to hash to the same value, we upcast all of them to int64.
 						asInt64 := int64(v)
 						p = memhash64(noescape(unsafe.Pointer(&asInt64)), p)
+						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
 					cancelChecker.checkEveryCall(ctx)
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
-					_ = keys.Get(nKeys - 1)
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
 						selIdx = i
@@ -441,12 +475,14 @@ func rehash(
 							continue
 						}
 						v := keys.Get(selIdx)
+						//gcassert:bce
 						p := uintptr(buckets[i])
 
 						// In order for integers with different widths but of the same value to
 						// to hash to the same value, we upcast all of them to int64.
 						asInt64 := int64(v)
 						p = memhash64(noescape(unsafe.Pointer(&asInt64)), p)
+						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
 					cancelChecker.checkEveryCall(ctx)
@@ -458,31 +494,35 @@ func rehash(
 					_ = sel[nKeys-1]
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
+						//gcassert:bce
 						selIdx = sel[i]
 						v := keys.Get(selIdx)
+						//gcassert:bce
 						p := uintptr(buckets[i])
 
 						// In order for integers with different widths but of the same value to
 						// to hash to the same value, we upcast all of them to int64.
 						asInt64 := int64(v)
 						p = memhash64(noescape(unsafe.Pointer(&asInt64)), p)
+						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
 					cancelChecker.checkEveryCall(ctx)
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
-					_ = keys.Get(nKeys - 1)
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
 						selIdx = i
 						v := keys.Get(selIdx)
+						//gcassert:bce
 						p := uintptr(buckets[i])
 
 						// In order for integers with different widths but of the same value to
 						// to hash to the same value, we upcast all of them to int64.
 						asInt64 := int64(v)
 						p = memhash64(noescape(unsafe.Pointer(&asInt64)), p)
+						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
 					cancelChecker.checkEveryCall(ctx)
@@ -498,24 +538,26 @@ func rehash(
 					_ = sel[nKeys-1]
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
+						//gcassert:bce
 						selIdx = sel[i]
 						if nulls.NullAt(selIdx) {
 							continue
 						}
 						v := keys.Get(selIdx)
+						//gcassert:bce
 						p := uintptr(buckets[i])
 
 						// In order for integers with different widths but of the same value to
 						// to hash to the same value, we upcast all of them to int64.
 						asInt64 := int64(v)
 						p = memhash64(noescape(unsafe.Pointer(&asInt64)), p)
+						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
 					cancelChecker.checkEveryCall(ctx)
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
-					_ = keys.Get(nKeys - 1)
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
 						selIdx = i
@@ -523,12 +565,14 @@ func rehash(
 							continue
 						}
 						v := keys.Get(selIdx)
+						//gcassert:bce
 						p := uintptr(buckets[i])
 
 						// In order for integers with different widths but of the same value to
 						// to hash to the same value, we upcast all of them to int64.
 						asInt64 := int64(v)
 						p = memhash64(noescape(unsafe.Pointer(&asInt64)), p)
+						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
 					cancelChecker.checkEveryCall(ctx)
@@ -540,31 +584,35 @@ func rehash(
 					_ = sel[nKeys-1]
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
+						//gcassert:bce
 						selIdx = sel[i]
 						v := keys.Get(selIdx)
+						//gcassert:bce
 						p := uintptr(buckets[i])
 
 						// In order for integers with different widths but of the same value to
 						// to hash to the same value, we upcast all of them to int64.
 						asInt64 := int64(v)
 						p = memhash64(noescape(unsafe.Pointer(&asInt64)), p)
+						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
 					cancelChecker.checkEveryCall(ctx)
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
-					_ = keys.Get(nKeys - 1)
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
 						selIdx = i
 						v := keys.Get(selIdx)
+						//gcassert:bce
 						p := uintptr(buckets[i])
 
 						// In order for integers with different widths but of the same value to
 						// to hash to the same value, we upcast all of them to int64.
 						asInt64 := int64(v)
 						p = memhash64(noescape(unsafe.Pointer(&asInt64)), p)
+						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
 					cancelChecker.checkEveryCall(ctx)
@@ -583,11 +631,13 @@ func rehash(
 					_ = sel[nKeys-1]
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
+						//gcassert:bce
 						selIdx = sel[i]
 						if nulls.NullAt(selIdx) {
 							continue
 						}
 						v := keys.Get(selIdx)
+						//gcassert:bce
 						p := uintptr(buckets[i])
 
 						f := v
@@ -596,13 +646,13 @@ func rehash(
 						}
 						p = f64hash(noescape(unsafe.Pointer(&f)), p)
 
+						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
 					cancelChecker.checkEveryCall(ctx)
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
-					_ = keys.Get(nKeys - 1)
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
 						selIdx = i
@@ -610,6 +660,7 @@ func rehash(
 							continue
 						}
 						v := keys.Get(selIdx)
+						//gcassert:bce
 						p := uintptr(buckets[i])
 
 						f := v
@@ -618,6 +669,7 @@ func rehash(
 						}
 						p = f64hash(noescape(unsafe.Pointer(&f)), p)
 
+						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
 					cancelChecker.checkEveryCall(ctx)
@@ -629,8 +681,10 @@ func rehash(
 					_ = sel[nKeys-1]
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
+						//gcassert:bce
 						selIdx = sel[i]
 						v := keys.Get(selIdx)
+						//gcassert:bce
 						p := uintptr(buckets[i])
 
 						f := v
@@ -639,17 +693,18 @@ func rehash(
 						}
 						p = f64hash(noescape(unsafe.Pointer(&f)), p)
 
+						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
 					cancelChecker.checkEveryCall(ctx)
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
-					_ = keys.Get(nKeys - 1)
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
 						selIdx = i
 						v := keys.Get(selIdx)
+						//gcassert:bce
 						p := uintptr(buckets[i])
 
 						f := v
@@ -658,6 +713,7 @@ func rehash(
 						}
 						p = f64hash(noescape(unsafe.Pointer(&f)), p)
 
+						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
 					cancelChecker.checkEveryCall(ctx)
@@ -676,23 +732,25 @@ func rehash(
 					_ = sel[nKeys-1]
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
+						//gcassert:bce
 						selIdx = sel[i]
 						if nulls.NullAt(selIdx) {
 							continue
 						}
 						v := keys.Get(selIdx)
+						//gcassert:bce
 						p := uintptr(buckets[i])
 
 						s := v.UnixNano()
 						p = memhash64(noescape(unsafe.Pointer(&s)), p)
 
+						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
 					cancelChecker.checkEveryCall(ctx)
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
-					_ = keys.Get(nKeys - 1)
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
 						selIdx = i
@@ -700,11 +758,13 @@ func rehash(
 							continue
 						}
 						v := keys.Get(selIdx)
+						//gcassert:bce
 						p := uintptr(buckets[i])
 
 						s := v.UnixNano()
 						p = memhash64(noescape(unsafe.Pointer(&s)), p)
 
+						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
 					cancelChecker.checkEveryCall(ctx)
@@ -716,29 +776,33 @@ func rehash(
 					_ = sel[nKeys-1]
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
+						//gcassert:bce
 						selIdx = sel[i]
 						v := keys.Get(selIdx)
+						//gcassert:bce
 						p := uintptr(buckets[i])
 
 						s := v.UnixNano()
 						p = memhash64(noescape(unsafe.Pointer(&s)), p)
 
+						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
 					cancelChecker.checkEveryCall(ctx)
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
-					_ = keys.Get(nKeys - 1)
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
 						selIdx = i
 						v := keys.Get(selIdx)
+						//gcassert:bce
 						p := uintptr(buckets[i])
 
 						s := v.UnixNano()
 						p = memhash64(noescape(unsafe.Pointer(&s)), p)
 
+						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
 					cancelChecker.checkEveryCall(ctx)
@@ -757,11 +821,13 @@ func rehash(
 					_ = sel[nKeys-1]
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
+						//gcassert:bce
 						selIdx = sel[i]
 						if nulls.NullAt(selIdx) {
 							continue
 						}
 						v := keys.Get(selIdx)
+						//gcassert:bce
 						p := uintptr(buckets[i])
 
 						months, days, nanos := v.Months, v.Days, v.Nanos()
@@ -769,13 +835,13 @@ func rehash(
 						p = memhash64(noescape(unsafe.Pointer(&days)), p)
 						p = memhash64(noescape(unsafe.Pointer(&nanos)), p)
 
+						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
 					cancelChecker.checkEveryCall(ctx)
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
-					_ = keys.Get(nKeys - 1)
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
 						selIdx = i
@@ -783,6 +849,7 @@ func rehash(
 							continue
 						}
 						v := keys.Get(selIdx)
+						//gcassert:bce
 						p := uintptr(buckets[i])
 
 						months, days, nanos := v.Months, v.Days, v.Nanos()
@@ -790,6 +857,7 @@ func rehash(
 						p = memhash64(noescape(unsafe.Pointer(&days)), p)
 						p = memhash64(noescape(unsafe.Pointer(&nanos)), p)
 
+						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
 					cancelChecker.checkEveryCall(ctx)
@@ -801,8 +869,10 @@ func rehash(
 					_ = sel[nKeys-1]
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
+						//gcassert:bce
 						selIdx = sel[i]
 						v := keys.Get(selIdx)
+						//gcassert:bce
 						p := uintptr(buckets[i])
 
 						months, days, nanos := v.Months, v.Days, v.Nanos()
@@ -810,17 +880,18 @@ func rehash(
 						p = memhash64(noescape(unsafe.Pointer(&days)), p)
 						p = memhash64(noescape(unsafe.Pointer(&nanos)), p)
 
+						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
 					cancelChecker.checkEveryCall(ctx)
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
-					_ = keys.Get(nKeys - 1)
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
 						selIdx = i
 						v := keys.Get(selIdx)
+						//gcassert:bce
 						p := uintptr(buckets[i])
 
 						months, days, nanos := v.Months, v.Days, v.Nanos()
@@ -828,6 +899,7 @@ func rehash(
 						p = memhash64(noescape(unsafe.Pointer(&days)), p)
 						p = memhash64(noescape(unsafe.Pointer(&nanos)), p)
 
+						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
 					cancelChecker.checkEveryCall(ctx)
@@ -846,23 +918,25 @@ func rehash(
 					_ = sel[nKeys-1]
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
+						//gcassert:bce
 						selIdx = sel[i]
 						if nulls.NullAt(selIdx) {
 							continue
 						}
 						v := keys.Get(selIdx)
+						//gcassert:bce
 						p := uintptr(buckets[i])
 						b := v.(*coldataext.Datum).Hash(datumAlloc)
 						sh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(b)))
 
+						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
 					cancelChecker.checkEveryCall(ctx)
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
-					_ = keys.Get(nKeys - 1)
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
 						selIdx = i
@@ -870,11 +944,13 @@ func rehash(
 							continue
 						}
 						v := keys.Get(selIdx)
+						//gcassert:bce
 						p := uintptr(buckets[i])
 						b := v.(*coldataext.Datum).Hash(datumAlloc)
 						sh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(b)))
 
+						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
 					cancelChecker.checkEveryCall(ctx)
@@ -886,29 +962,33 @@ func rehash(
 					_ = sel[nKeys-1]
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
+						//gcassert:bce
 						selIdx = sel[i]
 						v := keys.Get(selIdx)
+						//gcassert:bce
 						p := uintptr(buckets[i])
 						b := v.(*coldataext.Datum).Hash(datumAlloc)
 						sh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(b)))
 
+						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
 					cancelChecker.checkEveryCall(ctx)
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
-					_ = keys.Get(nKeys - 1)
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
 						selIdx = i
 						v := keys.Get(selIdx)
+						//gcassert:bce
 						p := uintptr(buckets[i])
 						b := v.(*coldataext.Datum).Hash(datumAlloc)
 						sh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(b)))
 
+						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
 					cancelChecker.checkEveryCall(ctx)

--- a/pkg/sql/colexec/hash_utils_tmpl.go
+++ b/pkg/sql/colexec/hash_utils_tmpl.go
@@ -74,12 +74,13 @@ func _REHASH_BODY(
 	_ = buckets[nKeys-1]
 	// {{if .HasSel}}
 	_ = sel[nKeys-1]
-	// {{else}}
+	// {{else if .Sliceable}}
 	_ = keys.Get(nKeys - 1)
 	// {{end}}
 	var selIdx int
 	for i := 0; i < nKeys; i++ {
 		// {{if .HasSel}}
+		//gcassert:bce
 		selIdx = sel[i]
 		// {{else}}
 		selIdx = i
@@ -89,9 +90,14 @@ func _REHASH_BODY(
 			continue
 		}
 		// {{end}}
+		// {{if .Sliceable}}
+		//gcassert:bce
+		// {{end}}
 		v := keys.Get(selIdx)
+		//gcassert:bce
 		p := uintptr(buckets[i])
 		_ASSIGN_HASH(p, v, _, keys)
+		//gcassert:bce
 		buckets[i] = uint64(p)
 	}
 	cancelChecker.checkEveryCall(ctx)

--- a/pkg/sql/colexec/hashjoiner.eg.go
+++ b/pkg/sql/colexec/hashjoiner.eg.go
@@ -16,28 +16,39 @@ const _ = "template_collectProbeOuter"
 func collectProbeOuter_false(
 	hj *hashJoiner, batchSize int, nResults int, batch coldata.Batch, sel []int) int {
 	// Early bounds checks.
-	_ = hj.ht.probeScratch.headID[batchSize-1]
-	for i := hj.probeState.prevBatchResumeIdx; i < batchSize; i++ {
-		currentID := hj.ht.probeScratch.headID[i]
+	// Capture the slices in order for BCE to occur.
+	headIDs := hj.ht.probeScratch.headID
+	startIdx := hj.probeState.prevBatchResumeIdx
+	_ = headIDs[startIdx]
+	_ = headIDs[batchSize-1]
+	maxResults := len(hj.probeState.buildIdx)
+	buildIdx := hj.probeState.buildIdx
+	probeIdx := hj.probeState.probeIdx
+	_ = buildIdx[nResults]
+	_ = probeIdx[nResults]
+	_ = buildIdx[maxResults-1]
+	_ = probeIdx[maxResults-1]
+	for i := startIdx; i < batchSize; i++ {
+		//gcassert:bce
+		currentID := headIDs[i]
 
-		for {
-			if nResults == len(hj.probeState.buildIdx) {
-				hj.probeState.prevBatch = batch
-				hj.probeState.prevBatchResumeIdx = i
-				return nResults
-			}
-
+		for ; nResults < maxResults; nResults++ {
 			rowUnmatched := currentID == 0
+			// For some reason, BCE doesn't occur for probeRowUnmatched slice.
+			// TODO(yuzefovich): figure it out.
 			hj.probeState.probeRowUnmatched[nResults] = rowUnmatched
 			if rowUnmatched {
 				// The row is unmatched, and we set the corresponding buildIdx
 				// to zero so that (as long as the build hash table has at least
 				// one row) we can copy the values vector without paying
 				// attention to probeRowUnmatched.
-				hj.probeState.buildIdx[nResults] = 0
+				//gcassert:bce
+				buildIdx[nResults] = 0
 			} else {
-				hj.probeState.buildIdx[nResults] = int(currentID - 1)
+				//gcassert:bce
+				buildIdx[nResults] = int(currentID - 1)
 			}
+			var pIdx int
 			{
 				var __retval_0 int
 				{
@@ -45,15 +56,37 @@ func collectProbeOuter_false(
 						__retval_0 = i
 					}
 				}
-				hj.probeState.probeIdx[nResults] = __retval_0
+				pIdx = __retval_0
 			}
+			//gcassert:bce
+			probeIdx[nResults] = pIdx
 			currentID = hj.ht.same[currentID]
-			hj.ht.probeScratch.headID[i] = currentID
-			nResults++
+			//gcassert:bce
+			headIDs[i] = currentID
 
 			if currentID == 0 {
+				nResults++
 				break
 			}
+		}
+
+		if nResults == maxResults {
+			// We have collected the maximum number of results that fit into the
+			// current output batch.
+			if currentID != 0 {
+				// We haven't finished probing the ith tuple of the current
+				// probing batch, so we'll need to resume from the same state.
+				hj.probeState.prevBatch = batch
+				hj.probeState.prevBatchResumeIdx = i
+			} else {
+				// We're done probing the ith tuple.
+				if i+1 < batchSize {
+					// But we're not done probing the batch yet.
+					hj.probeState.prevBatch = batch
+					hj.probeState.prevBatchResumeIdx = i + 1
+				}
+			}
+			return nResults
 		}
 	}
 	return nResults
@@ -62,29 +95,40 @@ func collectProbeOuter_false(
 func collectProbeOuter_true(
 	hj *hashJoiner, batchSize int, nResults int, batch coldata.Batch, sel []int) int {
 	// Early bounds checks.
-	_ = hj.ht.probeScratch.headID[batchSize-1]
+	// Capture the slices in order for BCE to occur.
+	headIDs := hj.ht.probeScratch.headID
+	startIdx := hj.probeState.prevBatchResumeIdx
+	_ = headIDs[startIdx]
+	_ = headIDs[batchSize-1]
 	_ = sel[batchSize-1]
-	for i := hj.probeState.prevBatchResumeIdx; i < batchSize; i++ {
-		currentID := hj.ht.probeScratch.headID[i]
+	maxResults := len(hj.probeState.buildIdx)
+	buildIdx := hj.probeState.buildIdx
+	probeIdx := hj.probeState.probeIdx
+	_ = buildIdx[nResults]
+	_ = probeIdx[nResults]
+	_ = buildIdx[maxResults-1]
+	_ = probeIdx[maxResults-1]
+	for i := startIdx; i < batchSize; i++ {
+		//gcassert:bce
+		currentID := headIDs[i]
 
-		for {
-			if nResults == len(hj.probeState.buildIdx) {
-				hj.probeState.prevBatch = batch
-				hj.probeState.prevBatchResumeIdx = i
-				return nResults
-			}
-
+		for ; nResults < maxResults; nResults++ {
 			rowUnmatched := currentID == 0
+			// For some reason, BCE doesn't occur for probeRowUnmatched slice.
+			// TODO(yuzefovich): figure it out.
 			hj.probeState.probeRowUnmatched[nResults] = rowUnmatched
 			if rowUnmatched {
 				// The row is unmatched, and we set the corresponding buildIdx
 				// to zero so that (as long as the build hash table has at least
 				// one row) we can copy the values vector without paying
 				// attention to probeRowUnmatched.
-				hj.probeState.buildIdx[nResults] = 0
+				//gcassert:bce
+				buildIdx[nResults] = 0
 			} else {
-				hj.probeState.buildIdx[nResults] = int(currentID - 1)
+				//gcassert:bce
+				buildIdx[nResults] = int(currentID - 1)
 			}
+			var pIdx int
 			{
 				var __retval_0 int
 				{
@@ -92,15 +136,37 @@ func collectProbeOuter_true(
 						__retval_0 = sel[i]
 					}
 				}
-				hj.probeState.probeIdx[nResults] = __retval_0
+				pIdx = __retval_0
 			}
+			//gcassert:bce
+			probeIdx[nResults] = pIdx
 			currentID = hj.ht.same[currentID]
-			hj.ht.probeScratch.headID[i] = currentID
-			nResults++
+			//gcassert:bce
+			headIDs[i] = currentID
 
 			if currentID == 0 {
+				nResults++
 				break
 			}
+		}
+
+		if nResults == maxResults {
+			// We have collected the maximum number of results that fit into the
+			// current output batch.
+			if currentID != 0 {
+				// We haven't finished probing the ith tuple of the current
+				// probing batch, so we'll need to resume from the same state.
+				hj.probeState.prevBatch = batch
+				hj.probeState.prevBatchResumeIdx = i
+			} else {
+				// We're done probing the ith tuple.
+				if i+1 < batchSize {
+					// But we're not done probing the batch yet.
+					hj.probeState.prevBatch = batch
+					hj.probeState.prevBatchResumeIdx = i + 1
+				}
+			}
+			return nResults
 		}
 	}
 	return nResults
@@ -111,17 +177,23 @@ const _ = "template_collectProbeNoOuter"
 func collectProbeNoOuter_false(
 	hj *hashJoiner, batchSize int, nResults int, batch coldata.Batch, sel []int) int {
 	// Early bounds checks.
-	_ = hj.ht.probeScratch.headID[batchSize-1]
-	for i := hj.probeState.prevBatchResumeIdx; i < batchSize; i++ {
-		currentID := hj.ht.probeScratch.headID[i]
-		for currentID != 0 {
-			if nResults == len(hj.probeState.buildIdx) {
-				hj.probeState.prevBatch = batch
-				hj.probeState.prevBatchResumeIdx = i
-				return nResults
-			}
-
+	// Capture the slices in order for BCE to occur.
+	headIDs := hj.ht.probeScratch.headID
+	startIdx := hj.probeState.prevBatchResumeIdx
+	_ = headIDs[startIdx]
+	_ = headIDs[batchSize-1]
+	maxResults := len(hj.probeState.buildIdx)
+	probeIdx := hj.probeState.probeIdx
+	_ = probeIdx[nResults]
+	_ = probeIdx[maxResults-1]
+	for i := startIdx; i < batchSize; i++ {
+		//gcassert:bce
+		currentID := headIDs[i]
+		for ; currentID != 0 && nResults < maxResults; nResults++ {
+			// For some reason, BCE doesn't occur for buildIdx slice.
+			// TODO(yuzefovich): figure it out.
 			hj.probeState.buildIdx[nResults] = int(currentID - 1)
+			var pIdx int
 			{
 				var __retval_0 int
 				{
@@ -129,11 +201,32 @@ func collectProbeNoOuter_false(
 						__retval_0 = i
 					}
 				}
-				hj.probeState.probeIdx[nResults] = __retval_0
+				pIdx = __retval_0
 			}
+			//gcassert:bce
+			probeIdx[nResults] = pIdx
 			currentID = hj.ht.same[currentID]
-			hj.ht.probeScratch.headID[i] = currentID
-			nResults++
+			//gcassert:bce
+			headIDs[i] = currentID
+		}
+
+		if nResults == maxResults {
+			// We have collected the maximum number of results that fit into the
+			// current output batch.
+			if currentID != 0 {
+				// We haven't finished probing the ith tuple of the current
+				// probing batch, so we'll need to resume from the same state.
+				hj.probeState.prevBatch = batch
+				hj.probeState.prevBatchResumeIdx = i
+			} else {
+				// We're done probing the ith tuple.
+				if i+1 < batchSize {
+					// But we're not done probing the batch yet.
+					hj.probeState.prevBatch = batch
+					hj.probeState.prevBatchResumeIdx = i + 1
+				}
+			}
+			return nResults
 		}
 	}
 	return nResults
@@ -142,18 +235,24 @@ func collectProbeNoOuter_false(
 func collectProbeNoOuter_true(
 	hj *hashJoiner, batchSize int, nResults int, batch coldata.Batch, sel []int) int {
 	// Early bounds checks.
-	_ = hj.ht.probeScratch.headID[batchSize-1]
+	// Capture the slices in order for BCE to occur.
+	headIDs := hj.ht.probeScratch.headID
+	startIdx := hj.probeState.prevBatchResumeIdx
+	_ = headIDs[startIdx]
+	_ = headIDs[batchSize-1]
 	_ = sel[batchSize-1]
-	for i := hj.probeState.prevBatchResumeIdx; i < batchSize; i++ {
-		currentID := hj.ht.probeScratch.headID[i]
-		for currentID != 0 {
-			if nResults == len(hj.probeState.buildIdx) {
-				hj.probeState.prevBatch = batch
-				hj.probeState.prevBatchResumeIdx = i
-				return nResults
-			}
-
+	maxResults := len(hj.probeState.buildIdx)
+	probeIdx := hj.probeState.probeIdx
+	_ = probeIdx[nResults]
+	_ = probeIdx[maxResults-1]
+	for i := startIdx; i < batchSize; i++ {
+		//gcassert:bce
+		currentID := headIDs[i]
+		for ; currentID != 0 && nResults < maxResults; nResults++ {
+			// For some reason, BCE doesn't occur for buildIdx slice.
+			// TODO(yuzefovich): figure it out.
 			hj.probeState.buildIdx[nResults] = int(currentID - 1)
+			var pIdx int
 			{
 				var __retval_0 int
 				{
@@ -161,11 +260,32 @@ func collectProbeNoOuter_true(
 						__retval_0 = sel[i]
 					}
 				}
-				hj.probeState.probeIdx[nResults] = __retval_0
+				pIdx = __retval_0
 			}
+			//gcassert:bce
+			probeIdx[nResults] = pIdx
 			currentID = hj.ht.same[currentID]
-			hj.ht.probeScratch.headID[i] = currentID
-			nResults++
+			//gcassert:bce
+			headIDs[i] = currentID
+		}
+
+		if nResults == maxResults {
+			// We have collected the maximum number of results that fit into the
+			// current output batch.
+			if currentID != 0 {
+				// We haven't finished probing the ith tuple of the current
+				// probing batch, so we'll need to resume from the same state.
+				hj.probeState.prevBatch = batch
+				hj.probeState.prevBatchResumeIdx = i
+			} else {
+				// We're done probing the ith tuple.
+				if i+1 < batchSize {
+					// But we're not done probing the batch yet.
+					hj.probeState.prevBatch = batch
+					hj.probeState.prevBatchResumeIdx = i + 1
+				}
+			}
+			return nResults
 		}
 	}
 	return nResults
@@ -179,9 +299,12 @@ const _ = "template_collectLeftAnti"
 func collectLeftAnti_false(
 	hj *hashJoiner, batchSize int, nResults int, batch coldata.Batch, sel []int) int {
 	// Early bounds checks.
-	_ = hj.ht.probeScratch.headID[batchSize-1]
-	for i := int(0); i < batchSize; i++ {
-		currentID := hj.ht.probeScratch.headID[i]
+	// Capture the slice in order for BCE to occur.
+	headIDs := hj.ht.probeScratch.headID
+	_ = headIDs[batchSize-1]
+	for i := 0; i < batchSize; i++ {
+		//gcassert:bce
+		currentID := headIDs[i]
 		if currentID == 0 {
 			{
 				var __retval_0 int
@@ -203,10 +326,13 @@ func collectLeftAnti_false(
 func collectLeftAnti_true(
 	hj *hashJoiner, batchSize int, nResults int, batch coldata.Batch, sel []int) int {
 	// Early bounds checks.
-	_ = hj.ht.probeScratch.headID[batchSize-1]
+	// Capture the slice in order for BCE to occur.
+	headIDs := hj.ht.probeScratch.headID
+	_ = headIDs[batchSize-1]
 	_ = sel[batchSize-1]
-	for i := int(0); i < batchSize; i++ {
-		currentID := hj.ht.probeScratch.headID[i]
+	for i := 0; i < batchSize; i++ {
+		//gcassert:bce
+		currentID := headIDs[i]
 		if currentID == 0 {
 			{
 				var __retval_0 int
@@ -231,9 +357,12 @@ func collectLeftAnti_true(
 // populated when in hjEmittingRight state.
 func collectRightSemiAnti(hj *hashJoiner, batchSize int) {
 	// Early bounds checks.
-	_ = hj.ht.probeScratch.headID[batchSize-1]
-	for i := int(0); i < batchSize; i++ {
-		currentID := hj.ht.probeScratch.headID[i]
+	// Capture the slice in order for BCE to occur.
+	headIDs := hj.ht.probeScratch.headID
+	_ = headIDs[batchSize-1]
+	for i := 0; i < batchSize; i++ {
+		//gcassert:bce
+		currentID := headIDs[i]
 		for currentID != 0 {
 			hj.probeState.buildRowMatched[currentID-1] = true
 			currentID = hj.ht.same[currentID]
@@ -245,24 +374,34 @@ const _ = "template_distinctCollectProbeOuter"
 
 func distinctCollectProbeOuter_false(hj *hashJoiner, batchSize int, sel []int) {
 	// Early bounds checks.
-	_ = hj.ht.probeScratch.groupID[batchSize-1]
-	_ = hj.probeState.probeRowUnmatched[batchSize-1]
-	_ = hj.probeState.buildIdx[batchSize-1]
-	_ = hj.probeState.probeIdx[batchSize-1]
-	for i := int(0); i < batchSize; i++ {
+	// Capture the slices in order for BCE to occur.
+	groupIDs := hj.ht.probeScratch.groupID
+	probeRowUnmatched := hj.probeState.probeRowUnmatched
+	buildIdx := hj.probeState.buildIdx
+	probeIdx := hj.probeState.probeIdx
+	_ = groupIDs[batchSize-1]
+	_ = probeRowUnmatched[batchSize-1]
+	_ = buildIdx[batchSize-1]
+	_ = probeIdx[batchSize-1]
+	for i := 0; i < batchSize; i++ {
 		// Index of keys and outputs in the hash table is calculated as ID - 1.
-		id := hj.ht.probeScratch.groupID[i]
+		//gcassert:bce
+		id := groupIDs[i]
 		rowUnmatched := id == 0
-		hj.probeState.probeRowUnmatched[i] = rowUnmatched
+		//gcassert:bce
+		probeRowUnmatched[i] = rowUnmatched
 		if rowUnmatched {
 			// The row is unmatched, and we set the corresponding buildIdx
 			// to zero so that (as long as the build hash table has at least
 			// one row) we can copy the values vector without paying
 			// attention to probeRowUnmatched.
-			hj.probeState.buildIdx[i] = 0
+			//gcassert:bce
+			buildIdx[i] = 0
 		} else {
-			hj.probeState.buildIdx[i] = int(id - 1)
+			//gcassert:bce
+			buildIdx[i] = int(id - 1)
 		}
+		var pIdx int
 		{
 			var __retval_0 int
 			{
@@ -270,32 +409,44 @@ func distinctCollectProbeOuter_false(hj *hashJoiner, batchSize int, sel []int) {
 					__retval_0 = i
 				}
 			}
-			hj.probeState.probeIdx[i] = __retval_0
+			pIdx = __retval_0
 		}
+		//gcassert:bce
+		probeIdx[i] = pIdx
 	}
 }
 
 func distinctCollectProbeOuter_true(hj *hashJoiner, batchSize int, sel []int) {
 	// Early bounds checks.
-	_ = hj.ht.probeScratch.groupID[batchSize-1]
-	_ = hj.probeState.probeRowUnmatched[batchSize-1]
-	_ = hj.probeState.buildIdx[batchSize-1]
-	_ = hj.probeState.probeIdx[batchSize-1]
+	// Capture the slices in order for BCE to occur.
+	groupIDs := hj.ht.probeScratch.groupID
+	probeRowUnmatched := hj.probeState.probeRowUnmatched
+	buildIdx := hj.probeState.buildIdx
+	probeIdx := hj.probeState.probeIdx
+	_ = groupIDs[batchSize-1]
+	_ = probeRowUnmatched[batchSize-1]
+	_ = buildIdx[batchSize-1]
+	_ = probeIdx[batchSize-1]
 	_ = sel[batchSize-1]
-	for i := int(0); i < batchSize; i++ {
+	for i := 0; i < batchSize; i++ {
 		// Index of keys and outputs in the hash table is calculated as ID - 1.
-		id := hj.ht.probeScratch.groupID[i]
+		//gcassert:bce
+		id := groupIDs[i]
 		rowUnmatched := id == 0
-		hj.probeState.probeRowUnmatched[i] = rowUnmatched
+		//gcassert:bce
+		probeRowUnmatched[i] = rowUnmatched
 		if rowUnmatched {
 			// The row is unmatched, and we set the corresponding buildIdx
 			// to zero so that (as long as the build hash table has at least
 			// one row) we can copy the values vector without paying
 			// attention to probeRowUnmatched.
-			hj.probeState.buildIdx[i] = 0
+			//gcassert:bce
+			buildIdx[i] = 0
 		} else {
-			hj.probeState.buildIdx[i] = int(id - 1)
+			//gcassert:bce
+			buildIdx[i] = int(id - 1)
 		}
+		var pIdx int
 		{
 			var __retval_0 int
 			{
@@ -303,8 +454,10 @@ func distinctCollectProbeOuter_true(hj *hashJoiner, batchSize int, sel []int) {
 					__retval_0 = sel[i]
 				}
 			}
-			hj.probeState.probeIdx[i] = __retval_0
+			pIdx = __retval_0
 		}
+		//gcassert:bce
+		probeIdx[i] = pIdx
 	}
 }
 
@@ -313,13 +466,15 @@ const _ = "template_distinctCollectProbeNoOuter"
 func distinctCollectProbeNoOuter_false(
 	hj *hashJoiner, batchSize int, nResults int, sel []int) int {
 	// Early bounds checks.
-	_ = hj.ht.probeScratch.groupID[batchSize-1]
-	_ = hj.probeState.buildIdx[batchSize-1]
-	_ = hj.probeState.probeIdx[batchSize-1]
-	for i := int(0); i < batchSize; i++ {
-		if hj.ht.probeScratch.groupID[i] != 0 {
+	// Capture the slice in order for BCE to occur.
+	groupIDs := hj.ht.probeScratch.groupID
+	_ = groupIDs[batchSize-1]
+	for i := 0; i < batchSize; i++ {
+		//gcassert:bce
+		id := groupIDs[i]
+		if id != 0 {
 			// Index of keys and outputs in the hash table is calculated as ID - 1.
-			hj.probeState.buildIdx[nResults] = int(hj.ht.probeScratch.groupID[i] - 1)
+			hj.probeState.buildIdx[nResults] = int(id - 1)
 			{
 				var __retval_0 int
 				{
@@ -338,14 +493,16 @@ func distinctCollectProbeNoOuter_false(
 func distinctCollectProbeNoOuter_true(
 	hj *hashJoiner, batchSize int, nResults int, sel []int) int {
 	// Early bounds checks.
-	_ = hj.ht.probeScratch.groupID[batchSize-1]
-	_ = hj.probeState.buildIdx[batchSize-1]
-	_ = hj.probeState.probeIdx[batchSize-1]
+	// Capture the slice in order for BCE to occur.
+	groupIDs := hj.ht.probeScratch.groupID
+	_ = groupIDs[batchSize-1]
 	_ = sel[batchSize-1]
-	for i := int(0); i < batchSize; i++ {
-		if hj.ht.probeScratch.groupID[i] != 0 {
+	for i := 0; i < batchSize; i++ {
+		//gcassert:bce
+		id := groupIDs[i]
+		if id != 0 {
 			// Index of keys and outputs in the hash table is calculated as ID - 1.
-			hj.probeState.buildIdx[nResults] = int(hj.ht.probeScratch.groupID[i] - 1)
+			hj.probeState.buildIdx[nResults] = int(id - 1)
 			{
 				var __retval_0 int
 				{
@@ -365,7 +522,7 @@ func distinctCollectProbeNoOuter_true(
 // probeIdx at each index are joined to make an output row. The total number of
 // resulting rows is returned.
 func (hj *hashJoiner) collect(batch coldata.Batch, batchSize int, sel []int) int {
-	nResults := int(0)
+	nResults := 0
 
 	if hj.spec.joinType.IsRightSemiOrRightAnti() {
 		collectRightSemiAnti(hj, batchSize)
@@ -401,7 +558,7 @@ func (hj *hashJoiner) collect(batch coldata.Batch, batchSize int, sel []int) int
 // row index for each probe row is given in the groupID slice. This function
 // requires assumes a N-1 hash join.
 func (hj *hashJoiner) distinctCollect(batch coldata.Batch, batchSize int, sel []int) int {
-	nResults := int(0)
+	nResults := 0
 
 	if hj.spec.joinType.IsRightSemiOrRightAnti() {
 		collectRightSemiAnti(hj, batchSize)

--- a/pkg/sql/colexec/hashjoiner.go
+++ b/pkg/sql/colexec/hashjoiner.go
@@ -449,9 +449,8 @@ func (hj *hashJoiner) prepareForCollecting(batchSize int) {
 // right source columns as the last M elements.
 func (hj *hashJoiner) exec(ctx context.Context) coldata.Batch {
 	if batch := hj.probeState.prevBatch; batch != nil {
-		// The previous result was bigger than the maximum batch size, so we didn't
-		// finish outputting it in the last call to exec. Continue outputting the
-		// result from the previous batch.
+		// We didn't finish probing the last read batch on the previous call to
+		// exec, so we continue where we left off.
 		hj.probeState.prevBatch = nil
 		batchSize := batch.Length()
 		sel := batch.Selection()
@@ -462,94 +461,104 @@ func (hj *hashJoiner) exec(ctx context.Context) coldata.Batch {
 		// therefore, we use coldata.BatchSize() here.
 		hj.prepareForCollecting(coldata.BatchSize())
 		nResults := hj.collect(batch, batchSize, sel)
-		hj.congregate(nResults, batch)
-	} else {
-		for {
-			batch := hj.inputOne.Next(ctx)
-			batchSize := batch.Length()
+		if nResults > 0 {
+			hj.congregate(nResults, batch)
+			return hj.output
+		}
+		// There were no matches in that batch, so we move on to the next one.
+	}
+	for {
+		batch := hj.inputOne.Next(ctx)
+		batchSize := batch.Length()
 
-			if batchSize == 0 {
-				return coldata.ZeroBatch
-			}
+		if batchSize == 0 {
+			return coldata.ZeroBatch
+		}
 
-			for i, colIdx := range hj.spec.left.eqCols {
-				hj.ht.keys[i] = batch.ColVec(int(colIdx))
-			}
+		for i, colIdx := range hj.spec.left.eqCols {
+			hj.ht.keys[i] = batch.ColVec(int(colIdx))
+		}
 
-			sel := batch.Selection()
+		sel := batch.Selection()
 
-			// First, we compute the hash values for all tuples in the batch.
-			if cap(hj.probeState.buckets) < batchSize {
-				hj.probeState.buckets = make([]uint64, batchSize)
-			} else {
-				// Note that we don't need to clear old values from buckets
-				// because the correct values will be populated in
-				// computeBuckets.
-				hj.probeState.buckets = hj.probeState.buckets[:batchSize]
-			}
-			hj.ht.computeBuckets(
-				ctx, hj.probeState.buckets, hj.ht.keys, batchSize, sel,
-			)
+		// First, we compute the hash values for all tuples in the batch.
+		if cap(hj.probeState.buckets) < batchSize {
+			hj.probeState.buckets = make([]uint64, batchSize)
+		} else {
+			// Note that we don't need to clear old values from buckets
+			// because the correct values will be populated in
+			// computeBuckets.
+			hj.probeState.buckets = hj.probeState.buckets[:batchSize]
+		}
+		hj.ht.computeBuckets(
+			ctx, hj.probeState.buckets, hj.ht.keys, batchSize, sel,
+		)
 
-			// Then, we initialize groupID with the initial hash buckets and
-			// toCheck with all applicable indices.
-			hj.ht.probeScratch.setupLimitedSlices(batchSize, hj.ht.buildMode)
-			var nToCheck uint64
-			switch hj.spec.joinType {
-			case descpb.LeftAntiJoin, descpb.RightAntiJoin, descpb.ExceptAllJoin:
-				// The setup of probing for LEFT/RIGHT ANTI and EXCEPT ALL joins
-				// needs a special treatment in order to reuse the same "check"
-				// functions below.
-				for i, bucket := range hj.probeState.buckets[:batchSize] {
-					hj.ht.probeScratch.groupID[i] = hj.ht.buildScratch.first[bucket]
-					if hj.ht.buildScratch.first[bucket] != 0 {
-						// Non-zero "first" key indicates that there is a match of hashes
-						// and we need to include the current tuple to check whether it is
-						// an actual match.
-						hj.ht.probeScratch.toCheck[nToCheck] = uint64(i)
-						nToCheck++
-					}
+		// Then, we initialize groupID with the initial hash buckets and
+		// toCheck with all applicable indices.
+		hj.ht.probeScratch.setupLimitedSlices(batchSize, hj.ht.buildMode)
+		// Early bounds checks.
+		groupIDs := hj.ht.probeScratch.groupID
+		_ = groupIDs[batchSize-1]
+		var nToCheck uint64
+		switch hj.spec.joinType {
+		case descpb.LeftAntiJoin, descpb.RightAntiJoin, descpb.ExceptAllJoin:
+			// The setup of probing for LEFT/RIGHT ANTI and EXCEPT ALL joins
+			// needs a special treatment in order to reuse the same "check"
+			// functions below.
+			for i, bucket := range hj.probeState.buckets[:batchSize] {
+				f := hj.ht.buildScratch.first[bucket]
+				//gcassert:bce
+				groupIDs[i] = f
+				if hj.ht.buildScratch.first[bucket] != 0 {
+					// Non-zero "first" key indicates that there is a match of hashes
+					// and we need to include the current tuple to check whether it is
+					// an actual match.
+					hj.ht.probeScratch.toCheck[nToCheck] = uint64(i)
+					nToCheck++
 				}
-			default:
-				for i, bucket := range hj.probeState.buckets[:batchSize] {
-					hj.ht.probeScratch.groupID[i] = hj.ht.buildScratch.first[bucket]
-				}
-				copy(hj.ht.probeScratch.toCheck, hashTableInitialToCheck[:batchSize])
-				nToCheck = uint64(batchSize)
+			}
+		default:
+			for i, bucket := range hj.probeState.buckets[:batchSize] {
+				f := hj.ht.buildScratch.first[bucket]
+				//gcassert:bce
+				groupIDs[i] = f
+			}
+			copy(hj.ht.probeScratch.toCheck, hashTableInitialToCheck[:batchSize])
+			nToCheck = uint64(batchSize)
+		}
+
+		// Now we collect all matches that we can emit in the probing phase
+		// in a single batch.
+		hj.prepareForCollecting(batchSize)
+		var nResults int
+		if hj.spec.rightDistinct {
+			for nToCheck > 0 {
+				// Continue searching along the hash table next chains for the corresponding
+				// buckets. If the key is found or end of next chain is reached, the key is
+				// removed from the toCheck array.
+				nToCheck = hj.ht.distinctCheck(nToCheck, sel)
+				hj.ht.findNext(hj.ht.buildScratch.next, nToCheck)
 			}
 
-			// Now we collect all matches that we can emit in the probing phase
-			// in a single batch.
-			hj.prepareForCollecting(batchSize)
-			var nResults int
-			if hj.spec.rightDistinct {
-				for nToCheck > 0 {
-					// Continue searching along the hash table next chains for the corresponding
-					// buckets. If the key is found or end of next chain is reached, the key is
-					// removed from the toCheck array.
-					nToCheck = hj.ht.distinctCheck(nToCheck, sel)
-					hj.ht.findNext(hj.ht.buildScratch.next, nToCheck)
-				}
-
-				nResults = hj.distinctCollect(batch, batchSize, sel)
-			} else {
-				for nToCheck > 0 {
-					// Continue searching for the build table matching keys while the toCheck
-					// array is non-empty.
-					nToCheck = hj.ht.check(hj.ht.keys, nToCheck, sel)
-					hj.ht.findNext(hj.ht.buildScratch.next, nToCheck)
-				}
-
-				// We're processing a new batch, so we'll reset the index to start
-				// collecting from.
-				hj.probeState.prevBatchResumeIdx = 0
-				nResults = hj.collect(batch, batchSize, sel)
+			nResults = hj.distinctCollect(batch, batchSize, sel)
+		} else {
+			for nToCheck > 0 {
+				// Continue searching for the build table matching keys while the toCheck
+				// array is non-empty.
+				nToCheck = hj.ht.check(hj.ht.keys, nToCheck, sel)
+				hj.ht.findNext(hj.ht.buildScratch.next, nToCheck)
 			}
 
-			if nResults > 0 {
-				hj.congregate(nResults, batch)
-				break
-			}
+			// We're processing a new batch, so we'll reset the index to start
+			// collecting from.
+			hj.probeState.prevBatchResumeIdx = 0
+			nResults = hj.collect(batch, batchSize, sel)
+		}
+
+		if nResults > 0 {
+			hj.congregate(nResults, batch)
+			break
 		}
 	}
 	return hj.output
@@ -621,15 +630,26 @@ func (hj *hashJoiner) congregate(nResults int, batch coldata.Batch) {
 		}
 
 		if hj.spec.trackBuildMatches {
+			// Early bounds checks.
+			buildIdx := hj.probeState.buildIdx
+			_ = buildIdx[nResults-1]
 			if hj.spec.joinType.IsLeftOuterOrFullOuter() {
+				// Early bounds checks.
+				probeRowUnmatched := hj.probeState.probeRowUnmatched
+				_ = probeRowUnmatched[nResults-1]
 				for i := 0; i < nResults; i++ {
-					if !hj.probeState.probeRowUnmatched[i] {
-						hj.probeState.buildRowMatched[hj.probeState.buildIdx[i]] = true
+					//gcassert:bce
+					if !probeRowUnmatched[i] {
+						//gcassert:bce
+						bIdx := buildIdx[i]
+						hj.probeState.buildRowMatched[bIdx] = true
 					}
 				}
 			} else {
 				for i := 0; i < nResults; i++ {
-					hj.probeState.buildRowMatched[hj.probeState.buildIdx[i]] = true
+					//gcassert:bce
+					bIdx := buildIdx[i]
+					hj.probeState.buildRowMatched[bIdx] = true
 				}
 			}
 		}

--- a/pkg/sql/colexec/hashtable_full_deleting.eg.go
+++ b/pkg/sql/colexec/hashtable_full_deleting.eg.go
@@ -8835,7 +8835,11 @@ func (ht *hashTable) check(probeVecs []coldata.Vec, nToCheck uint64, probeSel []
 	switch ht.probeMode {
 	case hashTableDefaultProbeMode:
 		if ht.same != nil {
-			for _, toCheck := range ht.probeScratch.toCheck[:nToCheck] {
+			toCheckSlice := ht.probeScratch.toCheck
+			_ = toCheckSlice[nToCheck-1]
+			for toCheckPos := uint64(0); toCheckPos < nToCheck && nDiffers < nToCheck; toCheckPos++ {
+				//gcassert:bce
+				toCheck := toCheckSlice[toCheckPos]
 				if !ht.probeScratch.differs[toCheck] {
 					// If the current key matches with the probe key, we want to update headID
 					// with the current key if it has not been set yet.
@@ -8862,12 +8866,17 @@ func (ht *hashTable) check(probeVecs []coldata.Vec, nToCheck uint64, probeSel []
 				if ht.probeScratch.differs[toCheck] {
 					// Continue probing in this next chain for the probe key.
 					ht.probeScratch.differs[toCheck] = false
-					ht.probeScratch.toCheck[nDiffers] = toCheck
+					//gcassert:bce
+					toCheckSlice[nDiffers] = toCheck
 					nDiffers++
 				}
 			}
 		} else {
-			for _, toCheck := range ht.probeScratch.toCheck[:nToCheck] {
+			toCheckSlice := ht.probeScratch.toCheck
+			_ = toCheckSlice[nToCheck-1]
+			for toCheckPos := uint64(0); toCheckPos < nToCheck && nDiffers < nToCheck; toCheckPos++ {
+				//gcassert:bce
+				toCheck := toCheckSlice[toCheckPos]
 				if !ht.probeScratch.differs[toCheck] {
 					// If the current key matches with the probe key, we want to update headID
 					// with the current key if it has not been set yet.
@@ -8879,14 +8888,19 @@ func (ht *hashTable) check(probeVecs []coldata.Vec, nToCheck uint64, probeSel []
 				if ht.probeScratch.differs[toCheck] {
 					// Continue probing in this next chain for the probe key.
 					ht.probeScratch.differs[toCheck] = false
-					ht.probeScratch.toCheck[nDiffers] = toCheck
+					//gcassert:bce
+					toCheckSlice[nDiffers] = toCheck
 					nDiffers++
 				}
 			}
 		}
 	case hashTableDeletingProbeMode:
 		if ht.same != nil {
-			for _, toCheck := range ht.probeScratch.toCheck[:nToCheck] {
+			toCheckSlice := ht.probeScratch.toCheck
+			_ = toCheckSlice[nToCheck-1]
+			for toCheckPos := uint64(0); toCheckPos < nToCheck && nDiffers < nToCheck; toCheckPos++ {
+				//gcassert:bce
+				toCheck := toCheckSlice[toCheckPos]
 				if !ht.probeScratch.differs[toCheck] {
 					// If the current key matches with the probe key, we want to update headID
 					// with the current key if it has not been set yet.
@@ -8906,7 +8920,8 @@ func (ht *hashTable) check(probeVecs []coldata.Vec, nToCheck uint64, probeSel []
 						// It has been deleted, so we need to continue probing on the
 						// next chain if it's not the end of the chain already.
 						if keyID != 0 {
-							ht.probeScratch.toCheck[nDiffers] = toCheck
+							//gcassert:bce
+							toCheckSlice[nDiffers] = toCheck
 							nDiffers++
 						}
 					}
@@ -8915,12 +8930,17 @@ func (ht *hashTable) check(probeVecs []coldata.Vec, nToCheck uint64, probeSel []
 				if ht.probeScratch.differs[toCheck] {
 					// Continue probing in this next chain for the probe key.
 					ht.probeScratch.differs[toCheck] = false
-					ht.probeScratch.toCheck[nDiffers] = toCheck
+					//gcassert:bce
+					toCheckSlice[nDiffers] = toCheck
 					nDiffers++
 				}
 			}
 		} else {
-			for _, toCheck := range ht.probeScratch.toCheck[:nToCheck] {
+			toCheckSlice := ht.probeScratch.toCheck
+			_ = toCheckSlice[nToCheck-1]
+			for toCheckPos := uint64(0); toCheckPos < nToCheck && nDiffers < nToCheck; toCheckPos++ {
+				//gcassert:bce
+				toCheck := toCheckSlice[toCheckPos]
 				if !ht.probeScratch.differs[toCheck] {
 					// If the current key matches with the probe key, we want to update headID
 					// with the current key if it has not been set yet.
@@ -8940,7 +8960,8 @@ func (ht *hashTable) check(probeVecs []coldata.Vec, nToCheck uint64, probeSel []
 						// It has been deleted, so we need to continue probing on the
 						// next chain if it's not the end of the chain already.
 						if keyID != 0 {
-							ht.probeScratch.toCheck[nDiffers] = toCheck
+							//gcassert:bce
+							toCheckSlice[nDiffers] = toCheck
 							nDiffers++
 						}
 					}
@@ -8949,7 +8970,8 @@ func (ht *hashTable) check(probeVecs []coldata.Vec, nToCheck uint64, probeSel []
 				if ht.probeScratch.differs[toCheck] {
 					// Continue probing in this next chain for the probe key.
 					ht.probeScratch.differs[toCheck] = false
-					ht.probeScratch.toCheck[nDiffers] = toCheck
+					//gcassert:bce
+					toCheckSlice[nDiffers] = toCheck
 					nDiffers++
 				}
 			}

--- a/pkg/sql/colexec/hashtable_tmpl.go
+++ b/pkg/sql/colexec/hashtable_tmpl.go
@@ -380,7 +380,11 @@ func (ht *hashTable) checkColForDistinctTuples(
 // {{/*
 func _CHECK_BODY(_SELECT_SAME_TUPLES bool, _DELETING_PROBE_MODE bool) { // */}}
 	// {{define "checkBody" -}}
-	for _, toCheck := range ht.probeScratch.toCheck[:nToCheck] {
+	toCheckSlice := ht.probeScratch.toCheck
+	_ = toCheckSlice[nToCheck-1]
+	for toCheckPos := uint64(0); toCheckPos < nToCheck && nDiffers < nToCheck; toCheckPos++ {
+		//gcassert:bce
+		toCheck := toCheckSlice[toCheckPos]
 		if !ht.probeScratch.differs[toCheck] {
 			// If the current key matches with the probe key, we want to update headID
 			// with the current key if it has not been set yet.
@@ -401,7 +405,8 @@ func _CHECK_BODY(_SELECT_SAME_TUPLES bool, _DELETING_PROBE_MODE bool) { // */}}
 				// It has been deleted, so we need to continue probing on the
 				// next chain if it's not the end of the chain already.
 				if keyID != 0 {
-					ht.probeScratch.toCheck[nDiffers] = toCheck
+					//gcassert:bce
+					toCheckSlice[nDiffers] = toCheck
 					nDiffers++
 				}
 			}
@@ -432,7 +437,8 @@ func _CHECK_BODY(_SELECT_SAME_TUPLES bool, _DELETING_PROBE_MODE bool) { // */}}
 		if ht.probeScratch.differs[toCheck] {
 			// Continue probing in this next chain for the probe key.
 			ht.probeScratch.differs[toCheck] = false
-			ht.probeScratch.toCheck[nDiffers] = toCheck
+			//gcassert:bce
+			toCheckSlice[nDiffers] = toCheck
 			nDiffers++
 		}
 	}
@@ -497,10 +503,18 @@ func (ht *hashTable) checkProbeForDistinct(vecs []coldata.Vec, nToCheck uint64, 
 func _UPDATE_SEL_BODY(_USE_SEL bool) { // */}}
 	// {{define "updateSelBody" -}}
 	batchLength := b.Length()
+	// Capture the slices in order for BCE to occur.
+	headIDs := ht.probeScratch.headID
+	hashBuffer := ht.probeScratch.hashBuffer
+	_ = headIDs[batchLength-1]
+	_ = hashBuffer[batchLength-1]
 	// Reuse the buffer allocated for distinct.
 	visited := ht.probeScratch.distinct
 	copy(visited, zeroBoolColumn)
-	for i, headID := range ht.probeScratch.headID[:batchLength] {
+	distinctCount := 0
+	for i := 0; i < batchLength && distinctCount < batchLength; i++ {
+		//gcassert:bce
+		headID := headIDs[i]
 		if headID != 0 {
 			if hasVisited := visited[headID-1]; !hasVisited {
 				// {{if .UseSel}}
@@ -510,11 +524,13 @@ func _UPDATE_SEL_BODY(_USE_SEL bool) { // */}}
 				// {{end}}
 				visited[headID-1] = true
 				// Compacting and deduplicating hash buffer.
-				ht.probeScratch.hashBuffer[distinctCount] = ht.probeScratch.hashBuffer[i]
+				//gcassert:bce
+				hashBuffer[distinctCount] = hashBuffer[i]
 				distinctCount++
 			}
 		}
 	}
+	b.SetLength(distinctCount)
 	// {{end}}
 	// {{/*
 } // */}}
@@ -529,7 +545,9 @@ func _UPDATE_SEL_BODY(_USE_SEL bool) { // */}}
 // key index will be used. The duplicated keyIDs will be discarded. The
 // hashBuffer will also compact and discard hash values of duplicated keys.
 func (ht *hashTable) updateSel(b coldata.Batch) {
-	distinctCount := 0
+	if b.Length() == 0 {
+		return
+	}
 	if sel := b.Selection(); sel != nil {
 		_UPDATE_SEL_BODY(true)
 	} else {
@@ -537,7 +555,6 @@ func (ht *hashTable) updateSel(b coldata.Batch) {
 		sel = b.Selection()
 		_UPDATE_SEL_BODY(false)
 	}
-	b.SetLength(distinctCount)
 }
 
 // distinctCheck determines if the current key in the groupID bucket matches the
@@ -549,10 +566,15 @@ func (ht *hashTable) distinctCheck(nToCheck uint64, probeSel []int) uint64 {
 	ht.checkCols(ht.keys, nToCheck, probeSel)
 	// Select the indices that differ and put them into toCheck.
 	nDiffers := uint64(0)
-	for _, toCheck := range ht.probeScratch.toCheck[:nToCheck] {
+	toCheckSlice := ht.probeScratch.toCheck
+	_ = toCheckSlice[nToCheck-1]
+	for toCheckPos := uint64(0); toCheckPos < nToCheck && nDiffers < nToCheck; toCheckPos++ {
+		//gcassert:bce
+		toCheck := toCheckSlice[toCheckPos]
 		if ht.probeScratch.differs[toCheck] {
 			ht.probeScratch.differs[toCheck] = false
-			ht.probeScratch.toCheck[nDiffers] = toCheck
+			//gcassert:bce
+			toCheckSlice[nDiffers] = toCheck
 			nDiffers++
 		}
 	}

--- a/pkg/sql/colexec/like_ops.eg.go
+++ b/pkg/sql/colexec/like_ops.eg.go
@@ -124,6 +124,9 @@ func (p projPrefixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Bytes()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -309,6 +312,9 @@ func (p projSuffixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Bytes()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -494,6 +500,9 @@ func (p projContainsBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Bytes()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -679,6 +688,9 @@ func (p projRegexpBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Bytes()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -864,6 +876,9 @@ func (p projNotPrefixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch 
 	col = vec.Bytes()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -1049,6 +1064,9 @@ func (p projNotSuffixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch 
 	col = vec.Bytes()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -1234,6 +1252,9 @@ func (p projNotContainsBytesBytesConstOp) Next(ctx context.Context) coldata.Batc
 	col = vec.Bytes()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -1419,6 +1440,9 @@ func (p projNotRegexpBytesBytesConstOp) Next(ctx context.Context) coldata.Batch 
 	col = vec.Bytes()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.

--- a/pkg/sql/colexec/proj_const_left_ops.eg.go
+++ b/pkg/sql/colexec/proj_const_left_ops.eg.go
@@ -62,6 +62,9 @@ func (p projBitandInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -92,6 +95,7 @@ func (p projBitandInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						projCol[i] = int64(p.constArg) & int64(arg)
@@ -118,6 +122,7 @@ func (p projBitandInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) & int64(arg)
@@ -163,6 +168,9 @@ func (p projBitandInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -193,6 +201,7 @@ func (p projBitandInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						projCol[i] = int64(p.constArg) & int64(arg)
@@ -219,6 +228,7 @@ func (p projBitandInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) & int64(arg)
@@ -264,6 +274,9 @@ func (p projBitandInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -294,6 +307,7 @@ func (p projBitandInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						projCol[i] = int64(p.constArg) & int64(arg)
@@ -320,6 +334,7 @@ func (p projBitandInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) & int64(arg)
@@ -365,6 +380,9 @@ func (p projBitandInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -395,6 +413,7 @@ func (p projBitandInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						projCol[i] = int64(p.constArg) & int64(arg)
@@ -421,6 +440,7 @@ func (p projBitandInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) & int64(arg)
@@ -466,6 +486,9 @@ func (p projBitandInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -496,6 +519,7 @@ func (p projBitandInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						projCol[i] = int64(p.constArg) & int64(arg)
@@ -522,6 +546,7 @@ func (p projBitandInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) & int64(arg)
@@ -567,6 +592,9 @@ func (p projBitandInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -597,6 +625,7 @@ func (p projBitandInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						projCol[i] = int64(p.constArg) & int64(arg)
@@ -623,6 +652,7 @@ func (p projBitandInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) & int64(arg)
@@ -668,6 +698,9 @@ func (p projBitandInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -698,6 +731,7 @@ func (p projBitandInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						projCol[i] = int64(p.constArg) & int64(arg)
@@ -724,6 +758,7 @@ func (p projBitandInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) & int64(arg)
@@ -769,6 +804,9 @@ func (p projBitandInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -799,6 +837,7 @@ func (p projBitandInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						projCol[i] = int64(p.constArg) & int64(arg)
@@ -825,6 +864,7 @@ func (p projBitandInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) & int64(arg)
@@ -870,6 +910,9 @@ func (p projBitandInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -900,6 +943,7 @@ func (p projBitandInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						projCol[i] = int64(p.constArg) & int64(arg)
@@ -926,6 +970,7 @@ func (p projBitandInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) & int64(arg)
@@ -971,6 +1016,9 @@ func (p projBitandDatumConstDatumOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -1100,6 +1148,9 @@ func (p projBitorInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -1130,6 +1181,7 @@ func (p projBitorInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						projCol[i] = int64(p.constArg) | int64(arg)
@@ -1156,6 +1208,7 @@ func (p projBitorInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) | int64(arg)
@@ -1201,6 +1254,9 @@ func (p projBitorInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -1231,6 +1287,7 @@ func (p projBitorInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						projCol[i] = int64(p.constArg) | int64(arg)
@@ -1257,6 +1314,7 @@ func (p projBitorInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) | int64(arg)
@@ -1302,6 +1360,9 @@ func (p projBitorInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -1332,6 +1393,7 @@ func (p projBitorInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						projCol[i] = int64(p.constArg) | int64(arg)
@@ -1358,6 +1420,7 @@ func (p projBitorInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) | int64(arg)
@@ -1403,6 +1466,9 @@ func (p projBitorInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -1433,6 +1499,7 @@ func (p projBitorInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						projCol[i] = int64(p.constArg) | int64(arg)
@@ -1459,6 +1526,7 @@ func (p projBitorInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) | int64(arg)
@@ -1504,6 +1572,9 @@ func (p projBitorInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -1534,6 +1605,7 @@ func (p projBitorInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						projCol[i] = int64(p.constArg) | int64(arg)
@@ -1560,6 +1632,7 @@ func (p projBitorInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) | int64(arg)
@@ -1605,6 +1678,9 @@ func (p projBitorInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -1635,6 +1711,7 @@ func (p projBitorInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						projCol[i] = int64(p.constArg) | int64(arg)
@@ -1661,6 +1738,7 @@ func (p projBitorInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) | int64(arg)
@@ -1706,6 +1784,9 @@ func (p projBitorInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -1736,6 +1817,7 @@ func (p projBitorInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						projCol[i] = int64(p.constArg) | int64(arg)
@@ -1762,6 +1844,7 @@ func (p projBitorInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) | int64(arg)
@@ -1807,6 +1890,9 @@ func (p projBitorInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -1837,6 +1923,7 @@ func (p projBitorInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						projCol[i] = int64(p.constArg) | int64(arg)
@@ -1863,6 +1950,7 @@ func (p projBitorInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) | int64(arg)
@@ -1908,6 +1996,9 @@ func (p projBitorInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -1938,6 +2029,7 @@ func (p projBitorInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						projCol[i] = int64(p.constArg) | int64(arg)
@@ -1964,6 +2056,7 @@ func (p projBitorInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) | int64(arg)
@@ -2009,6 +2102,9 @@ func (p projBitorDatumConstDatumOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -2138,6 +2234,9 @@ func (p projBitxorInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -2168,6 +2267,7 @@ func (p projBitxorInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						projCol[i] = int64(p.constArg) ^ int64(arg)
@@ -2194,6 +2294,7 @@ func (p projBitxorInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) ^ int64(arg)
@@ -2239,6 +2340,9 @@ func (p projBitxorInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -2269,6 +2373,7 @@ func (p projBitxorInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						projCol[i] = int64(p.constArg) ^ int64(arg)
@@ -2295,6 +2400,7 @@ func (p projBitxorInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) ^ int64(arg)
@@ -2340,6 +2446,9 @@ func (p projBitxorInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -2370,6 +2479,7 @@ func (p projBitxorInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						projCol[i] = int64(p.constArg) ^ int64(arg)
@@ -2396,6 +2506,7 @@ func (p projBitxorInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) ^ int64(arg)
@@ -2441,6 +2552,9 @@ func (p projBitxorInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -2471,6 +2585,7 @@ func (p projBitxorInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						projCol[i] = int64(p.constArg) ^ int64(arg)
@@ -2497,6 +2612,7 @@ func (p projBitxorInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) ^ int64(arg)
@@ -2542,6 +2658,9 @@ func (p projBitxorInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -2572,6 +2691,7 @@ func (p projBitxorInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						projCol[i] = int64(p.constArg) ^ int64(arg)
@@ -2598,6 +2718,7 @@ func (p projBitxorInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) ^ int64(arg)
@@ -2643,6 +2764,9 @@ func (p projBitxorInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -2673,6 +2797,7 @@ func (p projBitxorInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						projCol[i] = int64(p.constArg) ^ int64(arg)
@@ -2699,6 +2824,7 @@ func (p projBitxorInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) ^ int64(arg)
@@ -2744,6 +2870,9 @@ func (p projBitxorInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -2774,6 +2903,7 @@ func (p projBitxorInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						projCol[i] = int64(p.constArg) ^ int64(arg)
@@ -2800,6 +2930,7 @@ func (p projBitxorInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) ^ int64(arg)
@@ -2845,6 +2976,9 @@ func (p projBitxorInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -2875,6 +3009,7 @@ func (p projBitxorInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						projCol[i] = int64(p.constArg) ^ int64(arg)
@@ -2901,6 +3036,7 @@ func (p projBitxorInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) ^ int64(arg)
@@ -2946,6 +3082,9 @@ func (p projBitxorInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -2976,6 +3115,7 @@ func (p projBitxorInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						projCol[i] = int64(p.constArg) ^ int64(arg)
@@ -3002,6 +3142,7 @@ func (p projBitxorInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) ^ int64(arg)
@@ -3047,6 +3188,9 @@ func (p projBitxorDatumConstDatumOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -3176,6 +3320,9 @@ func (p projPlusDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -3213,6 +3360,7 @@ func (p projPlusDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -3253,6 +3401,7 @@ func (p projPlusDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -3305,6 +3454,9 @@ func (p projPlusDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -3342,6 +3494,7 @@ func (p projPlusDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -3382,6 +3535,7 @@ func (p projPlusDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -3434,6 +3588,9 @@ func (p projPlusDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -3471,6 +3628,7 @@ func (p projPlusDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -3511,6 +3669,7 @@ func (p projPlusDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -3563,6 +3722,9 @@ func (p projPlusDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -3599,6 +3761,7 @@ func (p projPlusDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -3637,6 +3800,7 @@ func (p projPlusDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -3688,6 +3852,9 @@ func (p projPlusInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -3724,6 +3891,7 @@ func (p projPlusInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -3762,6 +3930,7 @@ func (p projPlusInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -3813,6 +3982,9 @@ func (p projPlusInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -3849,6 +4021,7 @@ func (p projPlusInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -3887,6 +4060,7 @@ func (p projPlusInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -3938,6 +4112,9 @@ func (p projPlusInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -3974,6 +4151,7 @@ func (p projPlusInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -4012,6 +4190,7 @@ func (p projPlusInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -4063,6 +4242,9 @@ func (p projPlusInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -4101,6 +4283,7 @@ func (p projPlusInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -4143,6 +4326,7 @@ func (p projPlusInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -4196,6 +4380,9 @@ func (p projPlusInt16ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -4239,6 +4426,7 @@ func (p projPlusInt16ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						_convertedNativeElem := tree.DInt(p.constArg)
@@ -4291,6 +4479,7 @@ func (p projPlusInt16ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInt(p.constArg)
@@ -4349,6 +4538,9 @@ func (p projPlusInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -4385,6 +4577,7 @@ func (p projPlusInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -4423,6 +4616,7 @@ func (p projPlusInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -4474,6 +4668,9 @@ func (p projPlusInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -4510,6 +4707,7 @@ func (p projPlusInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -4548,6 +4746,7 @@ func (p projPlusInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -4599,6 +4798,9 @@ func (p projPlusInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -4635,6 +4837,7 @@ func (p projPlusInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -4673,6 +4876,7 @@ func (p projPlusInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -4724,6 +4928,9 @@ func (p projPlusInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -4762,6 +4969,7 @@ func (p projPlusInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -4804,6 +5012,7 @@ func (p projPlusInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -4857,6 +5066,9 @@ func (p projPlusInt32ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -4900,6 +5112,7 @@ func (p projPlusInt32ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						_convertedNativeElem := tree.DInt(p.constArg)
@@ -4952,6 +5165,7 @@ func (p projPlusInt32ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInt(p.constArg)
@@ -5010,6 +5224,9 @@ func (p projPlusInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -5046,6 +5263,7 @@ func (p projPlusInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -5084,6 +5302,7 @@ func (p projPlusInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -5135,6 +5354,9 @@ func (p projPlusInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -5171,6 +5393,7 @@ func (p projPlusInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -5209,6 +5432,7 @@ func (p projPlusInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -5260,6 +5484,9 @@ func (p projPlusInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -5296,6 +5523,7 @@ func (p projPlusInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -5334,6 +5562,7 @@ func (p projPlusInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -5385,6 +5614,9 @@ func (p projPlusInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -5423,6 +5655,7 @@ func (p projPlusInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -5465,6 +5698,7 @@ func (p projPlusInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -5518,6 +5752,9 @@ func (p projPlusInt64ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -5561,6 +5798,7 @@ func (p projPlusInt64ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						_convertedNativeElem := tree.DInt(p.constArg)
@@ -5613,6 +5851,7 @@ func (p projPlusInt64ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInt(p.constArg)
@@ -5671,6 +5910,9 @@ func (p projPlusFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -5704,6 +5946,7 @@ func (p projPlusFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -5736,6 +5979,7 @@ func (p projPlusFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -5784,6 +6028,9 @@ func (p projPlusTimestampConstIntervalOp) Next(ctx context.Context) coldata.Batc
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -5812,6 +6059,7 @@ func (p projPlusTimestampConstIntervalOp) Next(ctx context.Context) coldata.Batc
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 						projCol[i] = duration.Add(p.constArg, arg)
 					}
@@ -5834,6 +6082,7 @@ func (p projPlusTimestampConstIntervalOp) Next(ctx context.Context) coldata.Batc
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 					projCol[i] = duration.Add(p.constArg, arg)
 				}
@@ -5877,6 +6126,9 @@ func (p projPlusIntervalConstTimestampOp) Next(ctx context.Context) coldata.Batc
 	col = vec.Timestamp()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -5905,6 +6157,7 @@ func (p projPlusIntervalConstTimestampOp) Next(ctx context.Context) coldata.Batc
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 						projCol[i] = duration.Add(arg, p.constArg)
 					}
@@ -5927,6 +6180,7 @@ func (p projPlusIntervalConstTimestampOp) Next(ctx context.Context) coldata.Batc
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 					projCol[i] = duration.Add(arg, p.constArg)
 				}
@@ -5970,6 +6224,9 @@ func (p projPlusIntervalConstIntervalOp) Next(ctx context.Context) coldata.Batch
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -5998,6 +6255,7 @@ func (p projPlusIntervalConstIntervalOp) Next(ctx context.Context) coldata.Batch
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 						projCol[i] = p.constArg.Add(arg)
 					}
@@ -6020,6 +6278,7 @@ func (p projPlusIntervalConstIntervalOp) Next(ctx context.Context) coldata.Batch
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 					projCol[i] = p.constArg.Add(arg)
 				}
@@ -6063,6 +6322,9 @@ func (p projPlusIntervalConstDatumOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -6106,6 +6368,7 @@ func (p projPlusIntervalConstDatumOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						_convertedNativeElem := tree.DInterval{Duration: p.constArg}
@@ -6158,6 +6421,7 @@ func (p projPlusIntervalConstDatumOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInterval{Duration: p.constArg}
@@ -6216,6 +6480,9 @@ func (p projPlusDatumConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -6361,6 +6628,9 @@ func (p projPlusDatumConstInt16Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -6506,6 +6776,9 @@ func (p projPlusDatumConstInt32Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -6651,6 +6924,9 @@ func (p projPlusDatumConstInt64Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -6796,6 +7072,9 @@ func (p projMinusDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -6833,6 +7112,7 @@ func (p projMinusDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -6873,6 +7153,7 @@ func (p projMinusDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -6925,6 +7206,9 @@ func (p projMinusDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -6962,6 +7246,7 @@ func (p projMinusDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -7002,6 +7287,7 @@ func (p projMinusDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -7054,6 +7340,9 @@ func (p projMinusDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -7091,6 +7380,7 @@ func (p projMinusDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -7131,6 +7421,7 @@ func (p projMinusDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -7183,6 +7474,9 @@ func (p projMinusDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch 
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -7219,6 +7513,7 @@ func (p projMinusDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch 
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -7257,6 +7552,7 @@ func (p projMinusDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch 
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -7308,6 +7604,9 @@ func (p projMinusInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -7344,6 +7643,7 @@ func (p projMinusInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -7382,6 +7682,7 @@ func (p projMinusInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -7433,6 +7734,9 @@ func (p projMinusInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -7469,6 +7773,7 @@ func (p projMinusInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -7507,6 +7812,7 @@ func (p projMinusInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -7558,6 +7864,9 @@ func (p projMinusInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -7594,6 +7903,7 @@ func (p projMinusInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -7632,6 +7942,7 @@ func (p projMinusInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -7683,6 +7994,9 @@ func (p projMinusInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -7721,6 +8035,7 @@ func (p projMinusInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -7763,6 +8078,7 @@ func (p projMinusInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -7816,6 +8132,9 @@ func (p projMinusInt16ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -7859,6 +8178,7 @@ func (p projMinusInt16ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						_convertedNativeElem := tree.DInt(p.constArg)
@@ -7911,6 +8231,7 @@ func (p projMinusInt16ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInt(p.constArg)
@@ -7969,6 +8290,9 @@ func (p projMinusInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -8005,6 +8329,7 @@ func (p projMinusInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -8043,6 +8368,7 @@ func (p projMinusInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -8094,6 +8420,9 @@ func (p projMinusInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -8130,6 +8459,7 @@ func (p projMinusInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -8168,6 +8498,7 @@ func (p projMinusInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -8219,6 +8550,9 @@ func (p projMinusInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -8255,6 +8589,7 @@ func (p projMinusInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -8293,6 +8628,7 @@ func (p projMinusInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -8344,6 +8680,9 @@ func (p projMinusInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -8382,6 +8721,7 @@ func (p projMinusInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -8424,6 +8764,7 @@ func (p projMinusInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -8477,6 +8818,9 @@ func (p projMinusInt32ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -8520,6 +8864,7 @@ func (p projMinusInt32ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						_convertedNativeElem := tree.DInt(p.constArg)
@@ -8572,6 +8917,7 @@ func (p projMinusInt32ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInt(p.constArg)
@@ -8630,6 +8976,9 @@ func (p projMinusInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -8666,6 +9015,7 @@ func (p projMinusInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -8704,6 +9054,7 @@ func (p projMinusInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -8755,6 +9106,9 @@ func (p projMinusInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -8791,6 +9145,7 @@ func (p projMinusInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -8829,6 +9184,7 @@ func (p projMinusInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -8880,6 +9236,9 @@ func (p projMinusInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -8916,6 +9275,7 @@ func (p projMinusInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -8954,6 +9314,7 @@ func (p projMinusInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -9005,6 +9366,9 @@ func (p projMinusInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -9043,6 +9407,7 @@ func (p projMinusInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -9085,6 +9450,7 @@ func (p projMinusInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -9138,6 +9504,9 @@ func (p projMinusInt64ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -9181,6 +9550,7 @@ func (p projMinusInt64ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						_convertedNativeElem := tree.DInt(p.constArg)
@@ -9233,6 +9603,7 @@ func (p projMinusInt64ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInt(p.constArg)
@@ -9291,6 +9662,9 @@ func (p projMinusFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch 
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -9324,6 +9698,7 @@ func (p projMinusFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch 
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -9356,6 +9731,7 @@ func (p projMinusFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch 
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -9404,6 +9780,9 @@ func (p projMinusTimestampConstTimestampOp) Next(ctx context.Context) coldata.Ba
 	col = vec.Timestamp()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -9435,6 +9814,7 @@ func (p projMinusTimestampConstTimestampOp) Next(ctx context.Context) coldata.Ba
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						nanos := p.constArg.Sub(arg).Nanoseconds()
@@ -9463,6 +9843,7 @@ func (p projMinusTimestampConstTimestampOp) Next(ctx context.Context) coldata.Ba
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					nanos := p.constArg.Sub(arg).Nanoseconds()
@@ -9509,6 +9890,9 @@ func (p projMinusTimestampConstIntervalOp) Next(ctx context.Context) coldata.Bat
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -9537,6 +9921,7 @@ func (p projMinusTimestampConstIntervalOp) Next(ctx context.Context) coldata.Bat
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 						projCol[i] = duration.Add(p.constArg, arg.Mul(-1))
 					}
@@ -9559,6 +9944,7 @@ func (p projMinusTimestampConstIntervalOp) Next(ctx context.Context) coldata.Bat
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 					projCol[i] = duration.Add(p.constArg, arg.Mul(-1))
 				}
@@ -9602,6 +9988,9 @@ func (p projMinusIntervalConstIntervalOp) Next(ctx context.Context) coldata.Batc
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -9630,6 +10019,7 @@ func (p projMinusIntervalConstIntervalOp) Next(ctx context.Context) coldata.Batc
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 						projCol[i] = p.constArg.Sub(arg)
 					}
@@ -9652,6 +10042,7 @@ func (p projMinusIntervalConstIntervalOp) Next(ctx context.Context) coldata.Batc
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 					projCol[i] = p.constArg.Sub(arg)
 				}
@@ -9695,6 +10086,9 @@ func (p projMinusIntervalConstDatumOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -9738,6 +10132,7 @@ func (p projMinusIntervalConstDatumOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						_convertedNativeElem := tree.DInterval{Duration: p.constArg}
@@ -9790,6 +10185,7 @@ func (p projMinusIntervalConstDatumOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInterval{Duration: p.constArg}
@@ -9848,6 +10244,9 @@ func (p projMinusDatumConstDatumOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -9977,6 +10376,9 @@ func (p projMinusDatumConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -10122,6 +10524,9 @@ func (p projMinusDatumConstBytesOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Bytes()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -10267,6 +10672,9 @@ func (p projMinusDatumConstInt16Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -10412,6 +10820,9 @@ func (p projMinusDatumConstInt32Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -10557,6 +10968,9 @@ func (p projMinusDatumConstInt64Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -10702,6 +11116,9 @@ func (p projMultDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -10739,6 +11156,7 @@ func (p projMultDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -10779,6 +11197,7 @@ func (p projMultDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -10831,6 +11250,9 @@ func (p projMultDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -10868,6 +11290,7 @@ func (p projMultDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -10908,6 +11331,7 @@ func (p projMultDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -10960,6 +11384,9 @@ func (p projMultDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -10997,6 +11424,7 @@ func (p projMultDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -11037,6 +11465,7 @@ func (p projMultDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -11089,6 +11518,9 @@ func (p projMultDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -11125,6 +11557,7 @@ func (p projMultDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -11163,6 +11596,7 @@ func (p projMultDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -11214,6 +11648,9 @@ func (p projMultDecimalConstIntervalOp) Next(ctx context.Context) coldata.Batch 
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -11247,6 +11684,7 @@ func (p projMultDecimalConstIntervalOp) Next(ctx context.Context) coldata.Batch 
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						f, err := p.constArg.Float64()
@@ -11279,6 +11717,7 @@ func (p projMultDecimalConstIntervalOp) Next(ctx context.Context) coldata.Batch 
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					f, err := p.constArg.Float64()
@@ -11327,6 +11766,9 @@ func (p projMultInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -11371,6 +11813,7 @@ func (p projMultInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -11425,6 +11868,7 @@ func (p projMultInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -11484,6 +11928,9 @@ func (p projMultInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -11528,6 +11975,7 @@ func (p projMultInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -11582,6 +12030,7 @@ func (p projMultInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -11641,6 +12090,9 @@ func (p projMultInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -11685,6 +12137,7 @@ func (p projMultInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -11739,6 +12192,7 @@ func (p projMultInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -11798,6 +12252,9 @@ func (p projMultInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -11836,6 +12293,7 @@ func (p projMultInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -11878,6 +12336,7 @@ func (p projMultInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -11931,6 +12390,9 @@ func (p projMultInt16ConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -11959,6 +12421,7 @@ func (p projMultInt16ConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 						projCol[i] = arg.Mul(int64(p.constArg))
 					}
@@ -11981,6 +12444,7 @@ func (p projMultInt16ConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 					projCol[i] = arg.Mul(int64(p.constArg))
 				}
@@ -12024,6 +12488,9 @@ func (p projMultInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -12068,6 +12535,7 @@ func (p projMultInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -12122,6 +12590,7 @@ func (p projMultInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -12181,6 +12650,9 @@ func (p projMultInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -12225,6 +12697,7 @@ func (p projMultInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -12279,6 +12752,7 @@ func (p projMultInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -12338,6 +12812,9 @@ func (p projMultInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -12382,6 +12859,7 @@ func (p projMultInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -12436,6 +12914,7 @@ func (p projMultInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -12495,6 +12974,9 @@ func (p projMultInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -12533,6 +13015,7 @@ func (p projMultInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -12575,6 +13058,7 @@ func (p projMultInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -12628,6 +13112,9 @@ func (p projMultInt32ConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -12656,6 +13143,7 @@ func (p projMultInt32ConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 						projCol[i] = arg.Mul(int64(p.constArg))
 					}
@@ -12678,6 +13166,7 @@ func (p projMultInt32ConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 					projCol[i] = arg.Mul(int64(p.constArg))
 				}
@@ -12721,6 +13210,9 @@ func (p projMultInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -12765,6 +13257,7 @@ func (p projMultInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -12819,6 +13312,7 @@ func (p projMultInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -12878,6 +13372,9 @@ func (p projMultInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -12922,6 +13419,7 @@ func (p projMultInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -12976,6 +13474,7 @@ func (p projMultInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -13035,6 +13534,9 @@ func (p projMultInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -13079,6 +13581,7 @@ func (p projMultInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -13133,6 +13636,7 @@ func (p projMultInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -13192,6 +13696,9 @@ func (p projMultInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -13230,6 +13737,7 @@ func (p projMultInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -13272,6 +13780,7 @@ func (p projMultInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -13325,6 +13834,9 @@ func (p projMultInt64ConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -13353,6 +13865,7 @@ func (p projMultInt64ConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 						projCol[i] = arg.Mul(int64(p.constArg))
 					}
@@ -13375,6 +13888,7 @@ func (p projMultInt64ConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 					projCol[i] = arg.Mul(int64(p.constArg))
 				}
@@ -13418,6 +13932,9 @@ func (p projMultFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -13451,6 +13968,7 @@ func (p projMultFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -13483,6 +14001,7 @@ func (p projMultFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -13531,6 +14050,9 @@ func (p projMultFloat64ConstIntervalOp) Next(ctx context.Context) coldata.Batch 
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -13559,6 +14081,7 @@ func (p projMultFloat64ConstIntervalOp) Next(ctx context.Context) coldata.Batch 
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 						projCol[i] = arg.MulFloat(float64(p.constArg))
 					}
@@ -13581,6 +14104,7 @@ func (p projMultFloat64ConstIntervalOp) Next(ctx context.Context) coldata.Batch 
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 					projCol[i] = arg.MulFloat(float64(p.constArg))
 				}
@@ -13624,6 +14148,9 @@ func (p projMultIntervalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -13652,6 +14179,7 @@ func (p projMultIntervalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 						projCol[i] = p.constArg.Mul(int64(arg))
 					}
@@ -13674,6 +14202,7 @@ func (p projMultIntervalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 					projCol[i] = p.constArg.Mul(int64(arg))
 				}
@@ -13717,6 +14246,9 @@ func (p projMultIntervalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -13745,6 +14277,7 @@ func (p projMultIntervalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 						projCol[i] = p.constArg.Mul(int64(arg))
 					}
@@ -13767,6 +14300,7 @@ func (p projMultIntervalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 					projCol[i] = p.constArg.Mul(int64(arg))
 				}
@@ -13810,6 +14344,9 @@ func (p projMultIntervalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -13838,6 +14375,7 @@ func (p projMultIntervalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 						projCol[i] = p.constArg.Mul(int64(arg))
 					}
@@ -13860,6 +14398,7 @@ func (p projMultIntervalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 					projCol[i] = p.constArg.Mul(int64(arg))
 				}
@@ -13903,6 +14442,9 @@ func (p projMultIntervalConstFloat64Op) Next(ctx context.Context) coldata.Batch 
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -13931,6 +14473,7 @@ func (p projMultIntervalConstFloat64Op) Next(ctx context.Context) coldata.Batch 
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 						projCol[i] = p.constArg.MulFloat(float64(arg))
 					}
@@ -13953,6 +14496,7 @@ func (p projMultIntervalConstFloat64Op) Next(ctx context.Context) coldata.Batch 
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 					projCol[i] = p.constArg.MulFloat(float64(arg))
 				}
@@ -13996,6 +14540,9 @@ func (p projMultIntervalConstDecimalOp) Next(ctx context.Context) coldata.Batch 
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -14029,6 +14576,7 @@ func (p projMultIntervalConstDecimalOp) Next(ctx context.Context) coldata.Batch 
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						f, err := arg.Float64()
@@ -14061,6 +14609,7 @@ func (p projMultIntervalConstDecimalOp) Next(ctx context.Context) coldata.Batch 
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					f, err := arg.Float64()
@@ -14109,6 +14658,9 @@ func (p projDivDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -14150,6 +14702,7 @@ func (p projDivDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -14198,6 +14751,7 @@ func (p projDivDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -14254,6 +14808,9 @@ func (p projDivDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -14295,6 +14852,7 @@ func (p projDivDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -14343,6 +14901,7 @@ func (p projDivDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -14399,6 +14958,9 @@ func (p projDivDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -14440,6 +15002,7 @@ func (p projDivDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -14488,6 +15051,7 @@ func (p projDivDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -14544,6 +15108,9 @@ func (p projDivDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -14584,6 +15151,7 @@ func (p projDivDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -14630,6 +15198,7 @@ func (p projDivDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -14685,6 +15254,9 @@ func (p projDivInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -14725,6 +15297,7 @@ func (p projDivInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -14771,6 +15344,7 @@ func (p projDivInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -14826,6 +15400,9 @@ func (p projDivInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -14866,6 +15443,7 @@ func (p projDivInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -14912,6 +15490,7 @@ func (p projDivInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -14967,6 +15546,9 @@ func (p projDivInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -15007,6 +15589,7 @@ func (p projDivInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -15053,6 +15636,7 @@ func (p projDivInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -15108,6 +15692,9 @@ func (p projDivInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -15150,6 +15737,7 @@ func (p projDivInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -15200,6 +15788,7 @@ func (p projDivInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -15257,6 +15846,9 @@ func (p projDivInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -15297,6 +15889,7 @@ func (p projDivInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -15343,6 +15936,7 @@ func (p projDivInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -15398,6 +15992,9 @@ func (p projDivInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -15438,6 +16035,7 @@ func (p projDivInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -15484,6 +16082,7 @@ func (p projDivInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -15539,6 +16138,9 @@ func (p projDivInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -15579,6 +16181,7 @@ func (p projDivInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -15625,6 +16228,7 @@ func (p projDivInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -15680,6 +16284,9 @@ func (p projDivInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -15722,6 +16329,7 @@ func (p projDivInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -15772,6 +16380,7 @@ func (p projDivInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -15829,6 +16438,9 @@ func (p projDivInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -15869,6 +16481,7 @@ func (p projDivInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -15915,6 +16528,7 @@ func (p projDivInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -15970,6 +16584,9 @@ func (p projDivInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -16010,6 +16627,7 @@ func (p projDivInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -16056,6 +16674,7 @@ func (p projDivInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -16111,6 +16730,9 @@ func (p projDivInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -16151,6 +16773,7 @@ func (p projDivInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -16197,6 +16820,7 @@ func (p projDivInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -16252,6 +16876,9 @@ func (p projDivInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -16294,6 +16921,7 @@ func (p projDivInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -16344,6 +16972,7 @@ func (p projDivInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -16401,6 +17030,9 @@ func (p projDivFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -16438,6 +17070,7 @@ func (p projDivFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -16478,6 +17111,7 @@ func (p projDivFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -16530,6 +17164,9 @@ func (p projDivIntervalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -16562,6 +17199,7 @@ func (p projDivIntervalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						if arg == 0 {
@@ -16592,6 +17230,7 @@ func (p projDivIntervalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					if arg == 0 {
@@ -16639,6 +17278,9 @@ func (p projDivIntervalConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -16671,6 +17313,7 @@ func (p projDivIntervalConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						if arg == 0.0 {
@@ -16701,6 +17344,7 @@ func (p projDivIntervalConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					if arg == 0.0 {
@@ -16748,6 +17392,9 @@ func (p projFloorDivDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -16789,6 +17436,7 @@ func (p projFloorDivDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -16837,6 +17485,7 @@ func (p projFloorDivDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -16893,6 +17542,9 @@ func (p projFloorDivDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -16934,6 +17586,7 @@ func (p projFloorDivDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -16982,6 +17635,7 @@ func (p projFloorDivDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -17038,6 +17692,9 @@ func (p projFloorDivDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -17079,6 +17736,7 @@ func (p projFloorDivDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -17127,6 +17785,7 @@ func (p projFloorDivDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -17183,6 +17842,9 @@ func (p projFloorDivDecimalConstDecimalOp) Next(ctx context.Context) coldata.Bat
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -17223,6 +17885,7 @@ func (p projFloorDivDecimalConstDecimalOp) Next(ctx context.Context) coldata.Bat
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -17269,6 +17932,7 @@ func (p projFloorDivDecimalConstDecimalOp) Next(ctx context.Context) coldata.Bat
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -17324,6 +17988,9 @@ func (p projFloorDivInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -17359,6 +18026,7 @@ func (p projFloorDivInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -17395,6 +18063,7 @@ func (p projFloorDivInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -17445,6 +18114,9 @@ func (p projFloorDivInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -17480,6 +18152,7 @@ func (p projFloorDivInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -17516,6 +18189,7 @@ func (p projFloorDivInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -17566,6 +18240,9 @@ func (p projFloorDivInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -17601,6 +18278,7 @@ func (p projFloorDivInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -17637,6 +18315,7 @@ func (p projFloorDivInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -17687,6 +18366,9 @@ func (p projFloorDivInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -17729,6 +18411,7 @@ func (p projFloorDivInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -17779,6 +18462,7 @@ func (p projFloorDivInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -17836,6 +18520,9 @@ func (p projFloorDivInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -17871,6 +18558,7 @@ func (p projFloorDivInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -17907,6 +18595,7 @@ func (p projFloorDivInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -17957,6 +18646,9 @@ func (p projFloorDivInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -17992,6 +18684,7 @@ func (p projFloorDivInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -18028,6 +18721,7 @@ func (p projFloorDivInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -18078,6 +18772,9 @@ func (p projFloorDivInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -18113,6 +18810,7 @@ func (p projFloorDivInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -18149,6 +18847,7 @@ func (p projFloorDivInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -18199,6 +18898,9 @@ func (p projFloorDivInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -18241,6 +18943,7 @@ func (p projFloorDivInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -18291,6 +18994,7 @@ func (p projFloorDivInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -18348,6 +19052,9 @@ func (p projFloorDivInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -18383,6 +19090,7 @@ func (p projFloorDivInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -18419,6 +19127,7 @@ func (p projFloorDivInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -18469,6 +19178,9 @@ func (p projFloorDivInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -18504,6 +19216,7 @@ func (p projFloorDivInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -18540,6 +19253,7 @@ func (p projFloorDivInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -18590,6 +19304,9 @@ func (p projFloorDivInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -18625,6 +19342,7 @@ func (p projFloorDivInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -18661,6 +19379,7 @@ func (p projFloorDivInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -18711,6 +19430,9 @@ func (p projFloorDivInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -18753,6 +19475,7 @@ func (p projFloorDivInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -18803,6 +19526,7 @@ func (p projFloorDivInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -18860,6 +19584,9 @@ func (p projFloorDivFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Bat
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -18897,6 +19624,7 @@ func (p projFloorDivFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Bat
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -18937,6 +19665,7 @@ func (p projFloorDivFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Bat
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -18989,6 +19718,9 @@ func (p projModDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -19030,6 +19762,7 @@ func (p projModDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -19078,6 +19811,7 @@ func (p projModDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -19134,6 +19868,9 @@ func (p projModDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -19175,6 +19912,7 @@ func (p projModDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -19223,6 +19961,7 @@ func (p projModDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -19279,6 +20018,9 @@ func (p projModDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -19320,6 +20062,7 @@ func (p projModDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -19368,6 +20111,7 @@ func (p projModDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -19424,6 +20168,9 @@ func (p projModDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -19464,6 +20211,7 @@ func (p projModDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -19510,6 +20258,7 @@ func (p projModDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -19565,6 +20314,9 @@ func (p projModInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -19600,6 +20352,7 @@ func (p projModInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -19636,6 +20389,7 @@ func (p projModInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -19686,6 +20440,9 @@ func (p projModInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -19721,6 +20478,7 @@ func (p projModInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -19757,6 +20515,7 @@ func (p projModInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -19807,6 +20566,9 @@ func (p projModInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -19842,6 +20604,7 @@ func (p projModInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -19878,6 +20641,7 @@ func (p projModInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -19928,6 +20692,9 @@ func (p projModInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -19970,6 +20737,7 @@ func (p projModInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -20020,6 +20788,7 @@ func (p projModInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -20077,6 +20846,9 @@ func (p projModInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -20112,6 +20884,7 @@ func (p projModInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -20148,6 +20921,7 @@ func (p projModInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -20198,6 +20972,9 @@ func (p projModInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -20233,6 +21010,7 @@ func (p projModInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -20269,6 +21047,7 @@ func (p projModInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -20319,6 +21098,9 @@ func (p projModInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -20354,6 +21136,7 @@ func (p projModInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -20390,6 +21173,7 @@ func (p projModInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -20440,6 +21224,9 @@ func (p projModInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -20482,6 +21269,7 @@ func (p projModInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -20532,6 +21320,7 @@ func (p projModInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -20589,6 +21378,9 @@ func (p projModInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -20624,6 +21416,7 @@ func (p projModInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -20660,6 +21453,7 @@ func (p projModInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -20710,6 +21504,9 @@ func (p projModInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -20745,6 +21542,7 @@ func (p projModInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -20781,6 +21579,7 @@ func (p projModInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -20831,6 +21630,9 @@ func (p projModInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -20866,6 +21668,7 @@ func (p projModInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -20902,6 +21705,7 @@ func (p projModInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -20952,6 +21756,9 @@ func (p projModInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -20994,6 +21801,7 @@ func (p projModInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -21044,6 +21852,7 @@ func (p projModInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -21101,6 +21910,9 @@ func (p projModFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -21138,6 +21950,7 @@ func (p projModFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -21178,6 +21991,7 @@ func (p projModFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -21230,6 +22044,9 @@ func (p projPowDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -21267,6 +22084,7 @@ func (p projPowDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -21307,6 +22125,7 @@ func (p projPowDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -21359,6 +22178,9 @@ func (p projPowDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -21396,6 +22218,7 @@ func (p projPowDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -21436,6 +22259,7 @@ func (p projPowDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -21488,6 +22312,9 @@ func (p projPowDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -21525,6 +22352,7 @@ func (p projPowDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -21565,6 +22393,7 @@ func (p projPowDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -21617,6 +22446,9 @@ func (p projPowDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -21653,6 +22485,7 @@ func (p projPowDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -21691,6 +22524,7 @@ func (p projPowDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -21742,6 +22576,9 @@ func (p projPowInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -21784,6 +22621,7 @@ func (p projPowInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -21834,6 +22672,7 @@ func (p projPowInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -21891,6 +22730,9 @@ func (p projPowInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -21933,6 +22775,7 @@ func (p projPowInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -21983,6 +22826,7 @@ func (p projPowInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -22040,6 +22884,9 @@ func (p projPowInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -22082,6 +22929,7 @@ func (p projPowInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -22132,6 +22980,7 @@ func (p projPowInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -22189,6 +23038,9 @@ func (p projPowInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -22227,6 +23079,7 @@ func (p projPowInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -22269,6 +23122,7 @@ func (p projPowInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -22322,6 +23176,9 @@ func (p projPowInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -22364,6 +23221,7 @@ func (p projPowInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -22414,6 +23272,7 @@ func (p projPowInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -22471,6 +23330,9 @@ func (p projPowInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -22513,6 +23375,7 @@ func (p projPowInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -22563,6 +23426,7 @@ func (p projPowInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -22620,6 +23484,9 @@ func (p projPowInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -22662,6 +23529,7 @@ func (p projPowInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -22712,6 +23580,7 @@ func (p projPowInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -22769,6 +23638,9 @@ func (p projPowInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -22807,6 +23679,7 @@ func (p projPowInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -22849,6 +23722,7 @@ func (p projPowInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -22902,6 +23776,9 @@ func (p projPowInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -22944,6 +23821,7 @@ func (p projPowInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -22994,6 +23872,7 @@ func (p projPowInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -23051,6 +23930,9 @@ func (p projPowInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -23093,6 +23975,7 @@ func (p projPowInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -23143,6 +24026,7 @@ func (p projPowInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -23200,6 +24084,9 @@ func (p projPowInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -23242,6 +24129,7 @@ func (p projPowInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -23292,6 +24180,7 @@ func (p projPowInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -23349,6 +24238,9 @@ func (p projPowInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -23387,6 +24279,7 @@ func (p projPowInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -23429,6 +24322,7 @@ func (p projPowInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -23482,6 +24376,9 @@ func (p projPowFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -23515,6 +24412,7 @@ func (p projPowFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -23547,6 +24445,7 @@ func (p projPowFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -23595,6 +24494,9 @@ func (p projConcatBytesConstBytesOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Bytes()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -23716,6 +24618,9 @@ func (p projConcatDatumConstDatumOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -23845,6 +24750,9 @@ func (p projLShiftInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -23881,6 +24789,7 @@ func (p projLShiftInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -23919,6 +24828,7 @@ func (p projLShiftInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -23970,6 +24880,9 @@ func (p projLShiftInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -24006,6 +24919,7 @@ func (p projLShiftInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -24044,6 +24958,7 @@ func (p projLShiftInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -24095,6 +25010,9 @@ func (p projLShiftInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -24131,6 +25049,7 @@ func (p projLShiftInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -24169,6 +25088,7 @@ func (p projLShiftInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -24220,6 +25140,9 @@ func (p projLShiftInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -24256,6 +25179,7 @@ func (p projLShiftInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -24294,6 +25218,7 @@ func (p projLShiftInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -24345,6 +25270,9 @@ func (p projLShiftInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -24381,6 +25309,7 @@ func (p projLShiftInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -24419,6 +25348,7 @@ func (p projLShiftInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -24470,6 +25400,9 @@ func (p projLShiftInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -24506,6 +25439,7 @@ func (p projLShiftInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -24544,6 +25478,7 @@ func (p projLShiftInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -24595,6 +25530,9 @@ func (p projLShiftInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -24631,6 +25569,7 @@ func (p projLShiftInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -24669,6 +25608,7 @@ func (p projLShiftInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -24720,6 +25660,9 @@ func (p projLShiftInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -24756,6 +25699,7 @@ func (p projLShiftInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -24794,6 +25738,7 @@ func (p projLShiftInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -24845,6 +25790,9 @@ func (p projLShiftInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -24881,6 +25829,7 @@ func (p projLShiftInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -24919,6 +25868,7 @@ func (p projLShiftInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -24970,6 +25920,9 @@ func (p projLShiftDatumConstInt16Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -25115,6 +26068,9 @@ func (p projLShiftDatumConstInt32Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -25260,6 +26216,9 @@ func (p projLShiftDatumConstInt64Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -25405,6 +26364,9 @@ func (p projRShiftInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -25441,6 +26403,7 @@ func (p projRShiftInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -25479,6 +26442,7 @@ func (p projRShiftInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -25530,6 +26494,9 @@ func (p projRShiftInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -25566,6 +26533,7 @@ func (p projRShiftInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -25604,6 +26572,7 @@ func (p projRShiftInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -25655,6 +26624,9 @@ func (p projRShiftInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -25691,6 +26663,7 @@ func (p projRShiftInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -25729,6 +26702,7 @@ func (p projRShiftInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -25780,6 +26754,9 @@ func (p projRShiftInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -25816,6 +26793,7 @@ func (p projRShiftInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -25854,6 +26832,7 @@ func (p projRShiftInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -25905,6 +26884,9 @@ func (p projRShiftInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -25941,6 +26923,7 @@ func (p projRShiftInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -25979,6 +26962,7 @@ func (p projRShiftInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -26030,6 +27014,9 @@ func (p projRShiftInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -26066,6 +27053,7 @@ func (p projRShiftInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -26104,6 +27092,7 @@ func (p projRShiftInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -26155,6 +27144,9 @@ func (p projRShiftInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -26191,6 +27183,7 @@ func (p projRShiftInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -26229,6 +27222,7 @@ func (p projRShiftInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -26280,6 +27274,9 @@ func (p projRShiftInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -26316,6 +27313,7 @@ func (p projRShiftInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -26354,6 +27352,7 @@ func (p projRShiftInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -26405,6 +27404,9 @@ func (p projRShiftInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -26441,6 +27443,7 @@ func (p projRShiftInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -26479,6 +27482,7 @@ func (p projRShiftInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -26530,6 +27534,9 @@ func (p projRShiftDatumConstInt16Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -26675,6 +27682,9 @@ func (p projRShiftDatumConstInt32Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -26820,6 +27830,9 @@ func (p projRShiftDatumConstInt64Op) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -26965,6 +27978,9 @@ func (p projJSONFetchValDatumConstBytesOp) Next(ctx context.Context) coldata.Bat
 	col = vec.Bytes()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -27110,6 +28126,9 @@ func (p projJSONFetchValDatumConstInt16Op) Next(ctx context.Context) coldata.Bat
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -27255,6 +28274,9 @@ func (p projJSONFetchValDatumConstInt32Op) Next(ctx context.Context) coldata.Bat
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -27400,6 +28422,9 @@ func (p projJSONFetchValDatumConstInt64Op) Next(ctx context.Context) coldata.Bat
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -27545,6 +28570,9 @@ func (p projJSONFetchValPathDatumConstDatumOp) Next(ctx context.Context) coldata
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.

--- a/pkg/sql/colexec/proj_const_right_ops.eg.go
+++ b/pkg/sql/colexec/proj_const_right_ops.eg.go
@@ -63,6 +63,9 @@ func (p projBitandInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -93,6 +96,7 @@ func (p projBitandInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						projCol[i] = int64(arg) & int64(p.constArg)
@@ -119,6 +123,7 @@ func (p projBitandInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					projCol[i] = int64(arg) & int64(p.constArg)
@@ -164,6 +169,9 @@ func (p projBitandInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -194,6 +202,7 @@ func (p projBitandInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						projCol[i] = int64(arg) & int64(p.constArg)
@@ -220,6 +229,7 @@ func (p projBitandInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					projCol[i] = int64(arg) & int64(p.constArg)
@@ -265,6 +275,9 @@ func (p projBitandInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -295,6 +308,7 @@ func (p projBitandInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						projCol[i] = int64(arg) & int64(p.constArg)
@@ -321,6 +335,7 @@ func (p projBitandInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					projCol[i] = int64(arg) & int64(p.constArg)
@@ -366,6 +381,9 @@ func (p projBitandInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -396,6 +414,7 @@ func (p projBitandInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						projCol[i] = int64(arg) & int64(p.constArg)
@@ -422,6 +441,7 @@ func (p projBitandInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					projCol[i] = int64(arg) & int64(p.constArg)
@@ -467,6 +487,9 @@ func (p projBitandInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -497,6 +520,7 @@ func (p projBitandInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						projCol[i] = int64(arg) & int64(p.constArg)
@@ -523,6 +547,7 @@ func (p projBitandInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					projCol[i] = int64(arg) & int64(p.constArg)
@@ -568,6 +593,9 @@ func (p projBitandInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -598,6 +626,7 @@ func (p projBitandInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						projCol[i] = int64(arg) & int64(p.constArg)
@@ -624,6 +653,7 @@ func (p projBitandInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					projCol[i] = int64(arg) & int64(p.constArg)
@@ -669,6 +699,9 @@ func (p projBitandInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -699,6 +732,7 @@ func (p projBitandInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						projCol[i] = int64(arg) & int64(p.constArg)
@@ -725,6 +759,7 @@ func (p projBitandInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					projCol[i] = int64(arg) & int64(p.constArg)
@@ -770,6 +805,9 @@ func (p projBitandInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -800,6 +838,7 @@ func (p projBitandInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						projCol[i] = int64(arg) & int64(p.constArg)
@@ -826,6 +865,7 @@ func (p projBitandInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					projCol[i] = int64(arg) & int64(p.constArg)
@@ -871,6 +911,9 @@ func (p projBitandInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -901,6 +944,7 @@ func (p projBitandInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						projCol[i] = int64(arg) & int64(p.constArg)
@@ -927,6 +971,7 @@ func (p projBitandInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					projCol[i] = int64(arg) & int64(p.constArg)
@@ -972,6 +1017,9 @@ func (p projBitandDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -1101,6 +1149,9 @@ func (p projBitorInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -1131,6 +1182,7 @@ func (p projBitorInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						projCol[i] = int64(arg) | int64(p.constArg)
@@ -1157,6 +1209,7 @@ func (p projBitorInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					projCol[i] = int64(arg) | int64(p.constArg)
@@ -1202,6 +1255,9 @@ func (p projBitorInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -1232,6 +1288,7 @@ func (p projBitorInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						projCol[i] = int64(arg) | int64(p.constArg)
@@ -1258,6 +1315,7 @@ func (p projBitorInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					projCol[i] = int64(arg) | int64(p.constArg)
@@ -1303,6 +1361,9 @@ func (p projBitorInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -1333,6 +1394,7 @@ func (p projBitorInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						projCol[i] = int64(arg) | int64(p.constArg)
@@ -1359,6 +1421,7 @@ func (p projBitorInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					projCol[i] = int64(arg) | int64(p.constArg)
@@ -1404,6 +1467,9 @@ func (p projBitorInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -1434,6 +1500,7 @@ func (p projBitorInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						projCol[i] = int64(arg) | int64(p.constArg)
@@ -1460,6 +1527,7 @@ func (p projBitorInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					projCol[i] = int64(arg) | int64(p.constArg)
@@ -1505,6 +1573,9 @@ func (p projBitorInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -1535,6 +1606,7 @@ func (p projBitorInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						projCol[i] = int64(arg) | int64(p.constArg)
@@ -1561,6 +1633,7 @@ func (p projBitorInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					projCol[i] = int64(arg) | int64(p.constArg)
@@ -1606,6 +1679,9 @@ func (p projBitorInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -1636,6 +1712,7 @@ func (p projBitorInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						projCol[i] = int64(arg) | int64(p.constArg)
@@ -1662,6 +1739,7 @@ func (p projBitorInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					projCol[i] = int64(arg) | int64(p.constArg)
@@ -1707,6 +1785,9 @@ func (p projBitorInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -1737,6 +1818,7 @@ func (p projBitorInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						projCol[i] = int64(arg) | int64(p.constArg)
@@ -1763,6 +1845,7 @@ func (p projBitorInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					projCol[i] = int64(arg) | int64(p.constArg)
@@ -1808,6 +1891,9 @@ func (p projBitorInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -1838,6 +1924,7 @@ func (p projBitorInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						projCol[i] = int64(arg) | int64(p.constArg)
@@ -1864,6 +1951,7 @@ func (p projBitorInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					projCol[i] = int64(arg) | int64(p.constArg)
@@ -1909,6 +1997,9 @@ func (p projBitorInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -1939,6 +2030,7 @@ func (p projBitorInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						projCol[i] = int64(arg) | int64(p.constArg)
@@ -1965,6 +2057,7 @@ func (p projBitorInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					projCol[i] = int64(arg) | int64(p.constArg)
@@ -2010,6 +2103,9 @@ func (p projBitorDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -2139,6 +2235,9 @@ func (p projBitxorInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -2169,6 +2268,7 @@ func (p projBitxorInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						projCol[i] = int64(arg) ^ int64(p.constArg)
@@ -2195,6 +2295,7 @@ func (p projBitxorInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					projCol[i] = int64(arg) ^ int64(p.constArg)
@@ -2240,6 +2341,9 @@ func (p projBitxorInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -2270,6 +2374,7 @@ func (p projBitxorInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						projCol[i] = int64(arg) ^ int64(p.constArg)
@@ -2296,6 +2401,7 @@ func (p projBitxorInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					projCol[i] = int64(arg) ^ int64(p.constArg)
@@ -2341,6 +2447,9 @@ func (p projBitxorInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -2371,6 +2480,7 @@ func (p projBitxorInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						projCol[i] = int64(arg) ^ int64(p.constArg)
@@ -2397,6 +2507,7 @@ func (p projBitxorInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					projCol[i] = int64(arg) ^ int64(p.constArg)
@@ -2442,6 +2553,9 @@ func (p projBitxorInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -2472,6 +2586,7 @@ func (p projBitxorInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						projCol[i] = int64(arg) ^ int64(p.constArg)
@@ -2498,6 +2613,7 @@ func (p projBitxorInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					projCol[i] = int64(arg) ^ int64(p.constArg)
@@ -2543,6 +2659,9 @@ func (p projBitxorInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -2573,6 +2692,7 @@ func (p projBitxorInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						projCol[i] = int64(arg) ^ int64(p.constArg)
@@ -2599,6 +2719,7 @@ func (p projBitxorInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					projCol[i] = int64(arg) ^ int64(p.constArg)
@@ -2644,6 +2765,9 @@ func (p projBitxorInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -2674,6 +2798,7 @@ func (p projBitxorInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						projCol[i] = int64(arg) ^ int64(p.constArg)
@@ -2700,6 +2825,7 @@ func (p projBitxorInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					projCol[i] = int64(arg) ^ int64(p.constArg)
@@ -2745,6 +2871,9 @@ func (p projBitxorInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -2775,6 +2904,7 @@ func (p projBitxorInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						projCol[i] = int64(arg) ^ int64(p.constArg)
@@ -2801,6 +2931,7 @@ func (p projBitxorInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					projCol[i] = int64(arg) ^ int64(p.constArg)
@@ -2846,6 +2977,9 @@ func (p projBitxorInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -2876,6 +3010,7 @@ func (p projBitxorInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						projCol[i] = int64(arg) ^ int64(p.constArg)
@@ -2902,6 +3037,7 @@ func (p projBitxorInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					projCol[i] = int64(arg) ^ int64(p.constArg)
@@ -2947,6 +3083,9 @@ func (p projBitxorInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -2977,6 +3116,7 @@ func (p projBitxorInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						projCol[i] = int64(arg) ^ int64(p.constArg)
@@ -3003,6 +3143,7 @@ func (p projBitxorInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					projCol[i] = int64(arg) ^ int64(p.constArg)
@@ -3048,6 +3189,9 @@ func (p projBitxorDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -3177,6 +3321,9 @@ func (p projPlusDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -3214,6 +3361,7 @@ func (p projPlusDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -3254,6 +3402,7 @@ func (p projPlusDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -3306,6 +3455,9 @@ func (p projPlusDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -3343,6 +3495,7 @@ func (p projPlusDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -3383,6 +3536,7 @@ func (p projPlusDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -3435,6 +3589,9 @@ func (p projPlusDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -3472,6 +3629,7 @@ func (p projPlusDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -3512,6 +3670,7 @@ func (p projPlusDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -3564,6 +3723,9 @@ func (p projPlusDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -3600,6 +3762,7 @@ func (p projPlusDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -3638,6 +3801,7 @@ func (p projPlusDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -3689,6 +3853,9 @@ func (p projPlusInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -3725,6 +3892,7 @@ func (p projPlusInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -3763,6 +3931,7 @@ func (p projPlusInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -3814,6 +3983,9 @@ func (p projPlusInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -3850,6 +4022,7 @@ func (p projPlusInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -3888,6 +4061,7 @@ func (p projPlusInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -3939,6 +4113,9 @@ func (p projPlusInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -3975,6 +4152,7 @@ func (p projPlusInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -4013,6 +4191,7 @@ func (p projPlusInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -4064,6 +4243,9 @@ func (p projPlusInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -4102,6 +4284,7 @@ func (p projPlusInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -4144,6 +4327,7 @@ func (p projPlusInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -4197,6 +4381,9 @@ func (p projPlusInt16DatumConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -4350,6 +4537,9 @@ func (p projPlusInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -4386,6 +4576,7 @@ func (p projPlusInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -4424,6 +4615,7 @@ func (p projPlusInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -4475,6 +4667,9 @@ func (p projPlusInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -4511,6 +4706,7 @@ func (p projPlusInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -4549,6 +4745,7 @@ func (p projPlusInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -4600,6 +4797,9 @@ func (p projPlusInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -4636,6 +4836,7 @@ func (p projPlusInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -4674,6 +4875,7 @@ func (p projPlusInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -4725,6 +4927,9 @@ func (p projPlusInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -4763,6 +4968,7 @@ func (p projPlusInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -4805,6 +5011,7 @@ func (p projPlusInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -4858,6 +5065,9 @@ func (p projPlusInt32DatumConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -5011,6 +5221,9 @@ func (p projPlusInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -5047,6 +5260,7 @@ func (p projPlusInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -5085,6 +5299,7 @@ func (p projPlusInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -5136,6 +5351,9 @@ func (p projPlusInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -5172,6 +5390,7 @@ func (p projPlusInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -5210,6 +5429,7 @@ func (p projPlusInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -5261,6 +5481,9 @@ func (p projPlusInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -5297,6 +5520,7 @@ func (p projPlusInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -5335,6 +5559,7 @@ func (p projPlusInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -5386,6 +5611,9 @@ func (p projPlusInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -5424,6 +5652,7 @@ func (p projPlusInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -5466,6 +5695,7 @@ func (p projPlusInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -5519,6 +5749,9 @@ func (p projPlusInt64DatumConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -5672,6 +5905,9 @@ func (p projPlusFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -5705,6 +5941,7 @@ func (p projPlusFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -5737,6 +5974,7 @@ func (p projPlusFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -5785,6 +6023,9 @@ func (p projPlusTimestampIntervalConstOp) Next(ctx context.Context) coldata.Batc
 	col = vec.Timestamp()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -5813,6 +6054,7 @@ func (p projPlusTimestampIntervalConstOp) Next(ctx context.Context) coldata.Batc
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 						projCol[i] = duration.Add(arg, p.constArg)
 					}
@@ -5835,6 +6077,7 @@ func (p projPlusTimestampIntervalConstOp) Next(ctx context.Context) coldata.Batc
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 					projCol[i] = duration.Add(arg, p.constArg)
 				}
@@ -5878,6 +6121,9 @@ func (p projPlusIntervalTimestampConstOp) Next(ctx context.Context) coldata.Batc
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -5906,6 +6152,7 @@ func (p projPlusIntervalTimestampConstOp) Next(ctx context.Context) coldata.Batc
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 						projCol[i] = duration.Add(p.constArg, arg)
 					}
@@ -5928,6 +6175,7 @@ func (p projPlusIntervalTimestampConstOp) Next(ctx context.Context) coldata.Batc
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 					projCol[i] = duration.Add(p.constArg, arg)
 				}
@@ -5971,6 +6219,9 @@ func (p projPlusIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -5999,6 +6250,7 @@ func (p projPlusIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 						projCol[i] = arg.Add(p.constArg)
 					}
@@ -6021,6 +6273,7 @@ func (p projPlusIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 					projCol[i] = arg.Add(p.constArg)
 				}
@@ -6064,6 +6317,9 @@ func (p projPlusIntervalDatumConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -6217,6 +6473,9 @@ func (p projPlusDatumIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -6258,6 +6517,7 @@ func (p projPlusDatumIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						_convertedNativeElem := tree.DInterval{Duration: p.constArg}
@@ -6306,6 +6566,7 @@ func (p projPlusDatumIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInterval{Duration: p.constArg}
@@ -6362,6 +6623,9 @@ func (p projPlusDatumInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -6403,6 +6667,7 @@ func (p projPlusDatumInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						_convertedNativeElem := tree.DInt(p.constArg)
@@ -6451,6 +6716,7 @@ func (p projPlusDatumInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInt(p.constArg)
@@ -6507,6 +6773,9 @@ func (p projPlusDatumInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -6548,6 +6817,7 @@ func (p projPlusDatumInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						_convertedNativeElem := tree.DInt(p.constArg)
@@ -6596,6 +6866,7 @@ func (p projPlusDatumInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInt(p.constArg)
@@ -6652,6 +6923,9 @@ func (p projPlusDatumInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -6693,6 +6967,7 @@ func (p projPlusDatumInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						_convertedNativeElem := tree.DInt(p.constArg)
@@ -6741,6 +7016,7 @@ func (p projPlusDatumInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInt(p.constArg)
@@ -6797,6 +7073,9 @@ func (p projMinusDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -6834,6 +7113,7 @@ func (p projMinusDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -6874,6 +7154,7 @@ func (p projMinusDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -6926,6 +7207,9 @@ func (p projMinusDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -6963,6 +7247,7 @@ func (p projMinusDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -7003,6 +7288,7 @@ func (p projMinusDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -7055,6 +7341,9 @@ func (p projMinusDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -7092,6 +7381,7 @@ func (p projMinusDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -7132,6 +7422,7 @@ func (p projMinusDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -7184,6 +7475,9 @@ func (p projMinusDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch 
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -7220,6 +7514,7 @@ func (p projMinusDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch 
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -7258,6 +7553,7 @@ func (p projMinusDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch 
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -7309,6 +7605,9 @@ func (p projMinusInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -7345,6 +7644,7 @@ func (p projMinusInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -7383,6 +7683,7 @@ func (p projMinusInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -7434,6 +7735,9 @@ func (p projMinusInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -7470,6 +7774,7 @@ func (p projMinusInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -7508,6 +7813,7 @@ func (p projMinusInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -7559,6 +7865,9 @@ func (p projMinusInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -7595,6 +7904,7 @@ func (p projMinusInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -7633,6 +7943,7 @@ func (p projMinusInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -7684,6 +7995,9 @@ func (p projMinusInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -7722,6 +8036,7 @@ func (p projMinusInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -7764,6 +8079,7 @@ func (p projMinusInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -7817,6 +8133,9 @@ func (p projMinusInt16DatumConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -7970,6 +8289,9 @@ func (p projMinusInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -8006,6 +8328,7 @@ func (p projMinusInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -8044,6 +8367,7 @@ func (p projMinusInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -8095,6 +8419,9 @@ func (p projMinusInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -8131,6 +8458,7 @@ func (p projMinusInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -8169,6 +8497,7 @@ func (p projMinusInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -8220,6 +8549,9 @@ func (p projMinusInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -8256,6 +8588,7 @@ func (p projMinusInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -8294,6 +8627,7 @@ func (p projMinusInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -8345,6 +8679,9 @@ func (p projMinusInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -8383,6 +8720,7 @@ func (p projMinusInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -8425,6 +8763,7 @@ func (p projMinusInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -8478,6 +8817,9 @@ func (p projMinusInt32DatumConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -8631,6 +8973,9 @@ func (p projMinusInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -8667,6 +9012,7 @@ func (p projMinusInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -8705,6 +9051,7 @@ func (p projMinusInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -8756,6 +9103,9 @@ func (p projMinusInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -8792,6 +9142,7 @@ func (p projMinusInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -8830,6 +9181,7 @@ func (p projMinusInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -8881,6 +9233,9 @@ func (p projMinusInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -8917,6 +9272,7 @@ func (p projMinusInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -8955,6 +9311,7 @@ func (p projMinusInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -9006,6 +9363,9 @@ func (p projMinusInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -9044,6 +9404,7 @@ func (p projMinusInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -9086,6 +9447,7 @@ func (p projMinusInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -9139,6 +9501,9 @@ func (p projMinusInt64DatumConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -9292,6 +9657,9 @@ func (p projMinusFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch 
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -9325,6 +9693,7 @@ func (p projMinusFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch 
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -9357,6 +9726,7 @@ func (p projMinusFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch 
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -9405,6 +9775,9 @@ func (p projMinusTimestampTimestampConstOp) Next(ctx context.Context) coldata.Ba
 	col = vec.Timestamp()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -9436,6 +9809,7 @@ func (p projMinusTimestampTimestampConstOp) Next(ctx context.Context) coldata.Ba
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						nanos := arg.Sub(p.constArg).Nanoseconds()
@@ -9464,6 +9838,7 @@ func (p projMinusTimestampTimestampConstOp) Next(ctx context.Context) coldata.Ba
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					nanos := arg.Sub(p.constArg).Nanoseconds()
@@ -9510,6 +9885,9 @@ func (p projMinusTimestampIntervalConstOp) Next(ctx context.Context) coldata.Bat
 	col = vec.Timestamp()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -9538,6 +9916,7 @@ func (p projMinusTimestampIntervalConstOp) Next(ctx context.Context) coldata.Bat
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 						projCol[i] = duration.Add(arg, p.constArg.Mul(-1))
 					}
@@ -9560,6 +9939,7 @@ func (p projMinusTimestampIntervalConstOp) Next(ctx context.Context) coldata.Bat
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 					projCol[i] = duration.Add(arg, p.constArg.Mul(-1))
 				}
@@ -9603,6 +9983,9 @@ func (p projMinusIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batc
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -9631,6 +10014,7 @@ func (p projMinusIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batc
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 						projCol[i] = arg.Sub(p.constArg)
 					}
@@ -9653,6 +10037,7 @@ func (p projMinusIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batc
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 					projCol[i] = arg.Sub(p.constArg)
 				}
@@ -9696,6 +10081,9 @@ func (p projMinusIntervalDatumConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -9849,6 +10237,9 @@ func (p projMinusDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -9978,6 +10369,9 @@ func (p projMinusDatumIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -10019,6 +10413,7 @@ func (p projMinusDatumIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						_convertedNativeElem := tree.DInterval{Duration: p.constArg}
@@ -10067,6 +10462,7 @@ func (p projMinusDatumIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInterval{Duration: p.constArg}
@@ -10123,6 +10519,9 @@ func (p projMinusDatumBytesConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -10268,6 +10667,9 @@ func (p projMinusDatumInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -10309,6 +10711,7 @@ func (p projMinusDatumInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						_convertedNativeElem := tree.DInt(p.constArg)
@@ -10357,6 +10760,7 @@ func (p projMinusDatumInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInt(p.constArg)
@@ -10413,6 +10817,9 @@ func (p projMinusDatumInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -10454,6 +10861,7 @@ func (p projMinusDatumInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						_convertedNativeElem := tree.DInt(p.constArg)
@@ -10502,6 +10910,7 @@ func (p projMinusDatumInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInt(p.constArg)
@@ -10558,6 +10967,9 @@ func (p projMinusDatumInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -10599,6 +11011,7 @@ func (p projMinusDatumInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						_convertedNativeElem := tree.DInt(p.constArg)
@@ -10647,6 +11060,7 @@ func (p projMinusDatumInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInt(p.constArg)
@@ -10703,6 +11117,9 @@ func (p projMultDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -10740,6 +11157,7 @@ func (p projMultDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -10780,6 +11198,7 @@ func (p projMultDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -10832,6 +11251,9 @@ func (p projMultDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -10869,6 +11291,7 @@ func (p projMultDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -10909,6 +11332,7 @@ func (p projMultDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -10961,6 +11385,9 @@ func (p projMultDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -10998,6 +11425,7 @@ func (p projMultDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -11038,6 +11466,7 @@ func (p projMultDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -11090,6 +11519,9 @@ func (p projMultDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -11126,6 +11558,7 @@ func (p projMultDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -11164,6 +11597,7 @@ func (p projMultDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -11215,6 +11649,9 @@ func (p projMultDecimalIntervalConstOp) Next(ctx context.Context) coldata.Batch 
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -11248,6 +11685,7 @@ func (p projMultDecimalIntervalConstOp) Next(ctx context.Context) coldata.Batch 
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						f, err := arg.Float64()
@@ -11280,6 +11718,7 @@ func (p projMultDecimalIntervalConstOp) Next(ctx context.Context) coldata.Batch 
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					f, err := arg.Float64()
@@ -11328,6 +11767,9 @@ func (p projMultInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -11372,6 +11814,7 @@ func (p projMultInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -11426,6 +11869,7 @@ func (p projMultInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -11485,6 +11929,9 @@ func (p projMultInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -11529,6 +11976,7 @@ func (p projMultInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -11583,6 +12031,7 @@ func (p projMultInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -11642,6 +12091,9 @@ func (p projMultInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -11686,6 +12138,7 @@ func (p projMultInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -11740,6 +12193,7 @@ func (p projMultInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -11799,6 +12253,9 @@ func (p projMultInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -11837,6 +12294,7 @@ func (p projMultInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -11879,6 +12337,7 @@ func (p projMultInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -11932,6 +12391,9 @@ func (p projMultInt16IntervalConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -11960,6 +12422,7 @@ func (p projMultInt16IntervalConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 						projCol[i] = p.constArg.Mul(int64(arg))
 					}
@@ -11982,6 +12445,7 @@ func (p projMultInt16IntervalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 					projCol[i] = p.constArg.Mul(int64(arg))
 				}
@@ -12025,6 +12489,9 @@ func (p projMultInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -12069,6 +12536,7 @@ func (p projMultInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -12123,6 +12591,7 @@ func (p projMultInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -12182,6 +12651,9 @@ func (p projMultInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -12226,6 +12698,7 @@ func (p projMultInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -12280,6 +12753,7 @@ func (p projMultInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -12339,6 +12813,9 @@ func (p projMultInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -12383,6 +12860,7 @@ func (p projMultInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -12437,6 +12915,7 @@ func (p projMultInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -12496,6 +12975,9 @@ func (p projMultInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -12534,6 +13016,7 @@ func (p projMultInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -12576,6 +13059,7 @@ func (p projMultInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -12629,6 +13113,9 @@ func (p projMultInt32IntervalConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -12657,6 +13144,7 @@ func (p projMultInt32IntervalConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 						projCol[i] = p.constArg.Mul(int64(arg))
 					}
@@ -12679,6 +13167,7 @@ func (p projMultInt32IntervalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 					projCol[i] = p.constArg.Mul(int64(arg))
 				}
@@ -12722,6 +13211,9 @@ func (p projMultInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -12766,6 +13258,7 @@ func (p projMultInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -12820,6 +13313,7 @@ func (p projMultInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -12879,6 +13373,9 @@ func (p projMultInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -12923,6 +13420,7 @@ func (p projMultInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -12977,6 +13475,7 @@ func (p projMultInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -13036,6 +13535,9 @@ func (p projMultInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -13080,6 +13582,7 @@ func (p projMultInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -13134,6 +13637,7 @@ func (p projMultInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -13193,6 +13697,9 @@ func (p projMultInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -13231,6 +13738,7 @@ func (p projMultInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -13273,6 +13781,7 @@ func (p projMultInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -13326,6 +13835,9 @@ func (p projMultInt64IntervalConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -13354,6 +13866,7 @@ func (p projMultInt64IntervalConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 						projCol[i] = p.constArg.Mul(int64(arg))
 					}
@@ -13376,6 +13889,7 @@ func (p projMultInt64IntervalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 					projCol[i] = p.constArg.Mul(int64(arg))
 				}
@@ -13419,6 +13933,9 @@ func (p projMultFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -13452,6 +13969,7 @@ func (p projMultFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -13484,6 +14002,7 @@ func (p projMultFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -13532,6 +14051,9 @@ func (p projMultFloat64IntervalConstOp) Next(ctx context.Context) coldata.Batch 
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -13560,6 +14082,7 @@ func (p projMultFloat64IntervalConstOp) Next(ctx context.Context) coldata.Batch 
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 						projCol[i] = p.constArg.MulFloat(float64(arg))
 					}
@@ -13582,6 +14105,7 @@ func (p projMultFloat64IntervalConstOp) Next(ctx context.Context) coldata.Batch 
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 					projCol[i] = p.constArg.MulFloat(float64(arg))
 				}
@@ -13625,6 +14149,9 @@ func (p projMultIntervalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -13653,6 +14180,7 @@ func (p projMultIntervalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 						projCol[i] = arg.Mul(int64(p.constArg))
 					}
@@ -13675,6 +14203,7 @@ func (p projMultIntervalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 					projCol[i] = arg.Mul(int64(p.constArg))
 				}
@@ -13718,6 +14247,9 @@ func (p projMultIntervalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -13746,6 +14278,7 @@ func (p projMultIntervalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 						projCol[i] = arg.Mul(int64(p.constArg))
 					}
@@ -13768,6 +14301,7 @@ func (p projMultIntervalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 					projCol[i] = arg.Mul(int64(p.constArg))
 				}
@@ -13811,6 +14345,9 @@ func (p projMultIntervalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -13839,6 +14376,7 @@ func (p projMultIntervalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 						projCol[i] = arg.Mul(int64(p.constArg))
 					}
@@ -13861,6 +14399,7 @@ func (p projMultIntervalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 					projCol[i] = arg.Mul(int64(p.constArg))
 				}
@@ -13904,6 +14443,9 @@ func (p projMultIntervalFloat64ConstOp) Next(ctx context.Context) coldata.Batch 
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -13932,6 +14474,7 @@ func (p projMultIntervalFloat64ConstOp) Next(ctx context.Context) coldata.Batch 
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 						projCol[i] = arg.MulFloat(float64(p.constArg))
 					}
@@ -13954,6 +14497,7 @@ func (p projMultIntervalFloat64ConstOp) Next(ctx context.Context) coldata.Batch 
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 					projCol[i] = arg.MulFloat(float64(p.constArg))
 				}
@@ -13997,6 +14541,9 @@ func (p projMultIntervalDecimalConstOp) Next(ctx context.Context) coldata.Batch 
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -14030,6 +14577,7 @@ func (p projMultIntervalDecimalConstOp) Next(ctx context.Context) coldata.Batch 
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						f, err := p.constArg.Float64()
@@ -14062,6 +14610,7 @@ func (p projMultIntervalDecimalConstOp) Next(ctx context.Context) coldata.Batch 
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					f, err := p.constArg.Float64()
@@ -14110,6 +14659,9 @@ func (p projDivDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -14151,6 +14703,7 @@ func (p projDivDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -14199,6 +14752,7 @@ func (p projDivDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -14255,6 +14809,9 @@ func (p projDivDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -14296,6 +14853,7 @@ func (p projDivDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -14344,6 +14902,7 @@ func (p projDivDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -14400,6 +14959,9 @@ func (p projDivDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -14441,6 +15003,7 @@ func (p projDivDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -14489,6 +15052,7 @@ func (p projDivDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -14545,6 +15109,9 @@ func (p projDivDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -14585,6 +15152,7 @@ func (p projDivDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -14631,6 +15199,7 @@ func (p projDivDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -14686,6 +15255,9 @@ func (p projDivInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -14726,6 +15298,7 @@ func (p projDivInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -14772,6 +15345,7 @@ func (p projDivInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -14827,6 +15401,9 @@ func (p projDivInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -14867,6 +15444,7 @@ func (p projDivInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -14913,6 +15491,7 @@ func (p projDivInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -14968,6 +15547,9 @@ func (p projDivInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -15008,6 +15590,7 @@ func (p projDivInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -15054,6 +15637,7 @@ func (p projDivInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -15109,6 +15693,9 @@ func (p projDivInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -15151,6 +15738,7 @@ func (p projDivInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -15201,6 +15789,7 @@ func (p projDivInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -15258,6 +15847,9 @@ func (p projDivInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -15298,6 +15890,7 @@ func (p projDivInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -15344,6 +15937,7 @@ func (p projDivInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -15399,6 +15993,9 @@ func (p projDivInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -15439,6 +16036,7 @@ func (p projDivInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -15485,6 +16083,7 @@ func (p projDivInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -15540,6 +16139,9 @@ func (p projDivInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -15580,6 +16182,7 @@ func (p projDivInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -15626,6 +16229,7 @@ func (p projDivInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -15681,6 +16285,9 @@ func (p projDivInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -15723,6 +16330,7 @@ func (p projDivInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -15773,6 +16381,7 @@ func (p projDivInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -15830,6 +16439,9 @@ func (p projDivInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -15870,6 +16482,7 @@ func (p projDivInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -15916,6 +16529,7 @@ func (p projDivInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -15971,6 +16585,9 @@ func (p projDivInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -16011,6 +16628,7 @@ func (p projDivInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -16057,6 +16675,7 @@ func (p projDivInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -16112,6 +16731,9 @@ func (p projDivInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -16152,6 +16774,7 @@ func (p projDivInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -16198,6 +16821,7 @@ func (p projDivInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -16253,6 +16877,9 @@ func (p projDivInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -16295,6 +16922,7 @@ func (p projDivInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -16345,6 +16973,7 @@ func (p projDivInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -16402,6 +17031,9 @@ func (p projDivFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -16439,6 +17071,7 @@ func (p projDivFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -16479,6 +17112,7 @@ func (p projDivFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -16531,6 +17165,9 @@ func (p projDivIntervalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -16563,6 +17200,7 @@ func (p projDivIntervalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						if p.constArg == 0 {
@@ -16593,6 +17231,7 @@ func (p projDivIntervalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					if p.constArg == 0 {
@@ -16640,6 +17279,9 @@ func (p projDivIntervalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -16672,6 +17314,7 @@ func (p projDivIntervalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						if p.constArg == 0.0 {
@@ -16702,6 +17345,7 @@ func (p projDivIntervalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					if p.constArg == 0.0 {
@@ -16749,6 +17393,9 @@ func (p projFloorDivDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -16790,6 +17437,7 @@ func (p projFloorDivDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -16838,6 +17486,7 @@ func (p projFloorDivDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -16894,6 +17543,9 @@ func (p projFloorDivDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -16935,6 +17587,7 @@ func (p projFloorDivDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -16983,6 +17636,7 @@ func (p projFloorDivDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -17039,6 +17693,9 @@ func (p projFloorDivDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -17080,6 +17737,7 @@ func (p projFloorDivDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -17128,6 +17786,7 @@ func (p projFloorDivDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -17184,6 +17843,9 @@ func (p projFloorDivDecimalDecimalConstOp) Next(ctx context.Context) coldata.Bat
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -17224,6 +17886,7 @@ func (p projFloorDivDecimalDecimalConstOp) Next(ctx context.Context) coldata.Bat
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -17270,6 +17933,7 @@ func (p projFloorDivDecimalDecimalConstOp) Next(ctx context.Context) coldata.Bat
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -17325,6 +17989,9 @@ func (p projFloorDivInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -17360,6 +18027,7 @@ func (p projFloorDivInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -17396,6 +18064,7 @@ func (p projFloorDivInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -17446,6 +18115,9 @@ func (p projFloorDivInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -17481,6 +18153,7 @@ func (p projFloorDivInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -17517,6 +18190,7 @@ func (p projFloorDivInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -17567,6 +18241,9 @@ func (p projFloorDivInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -17602,6 +18279,7 @@ func (p projFloorDivInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -17638,6 +18316,7 @@ func (p projFloorDivInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -17688,6 +18367,9 @@ func (p projFloorDivInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -17730,6 +18412,7 @@ func (p projFloorDivInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -17780,6 +18463,7 @@ func (p projFloorDivInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -17837,6 +18521,9 @@ func (p projFloorDivInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -17872,6 +18559,7 @@ func (p projFloorDivInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -17908,6 +18596,7 @@ func (p projFloorDivInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -17958,6 +18647,9 @@ func (p projFloorDivInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -17993,6 +18685,7 @@ func (p projFloorDivInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -18029,6 +18722,7 @@ func (p projFloorDivInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -18079,6 +18773,9 @@ func (p projFloorDivInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -18114,6 +18811,7 @@ func (p projFloorDivInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -18150,6 +18848,7 @@ func (p projFloorDivInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -18200,6 +18899,9 @@ func (p projFloorDivInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -18242,6 +18944,7 @@ func (p projFloorDivInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -18292,6 +18995,7 @@ func (p projFloorDivInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -18349,6 +19053,9 @@ func (p projFloorDivInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -18384,6 +19091,7 @@ func (p projFloorDivInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -18420,6 +19128,7 @@ func (p projFloorDivInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -18470,6 +19179,9 @@ func (p projFloorDivInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -18505,6 +19217,7 @@ func (p projFloorDivInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -18541,6 +19254,7 @@ func (p projFloorDivInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -18591,6 +19305,9 @@ func (p projFloorDivInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -18626,6 +19343,7 @@ func (p projFloorDivInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -18662,6 +19380,7 @@ func (p projFloorDivInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -18712,6 +19431,9 @@ func (p projFloorDivInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -18754,6 +19476,7 @@ func (p projFloorDivInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -18804,6 +19527,7 @@ func (p projFloorDivInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -18861,6 +19585,9 @@ func (p projFloorDivFloat64Float64ConstOp) Next(ctx context.Context) coldata.Bat
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -18898,6 +19625,7 @@ func (p projFloorDivFloat64Float64ConstOp) Next(ctx context.Context) coldata.Bat
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -18938,6 +19666,7 @@ func (p projFloorDivFloat64Float64ConstOp) Next(ctx context.Context) coldata.Bat
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -18990,6 +19719,9 @@ func (p projModDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -19031,6 +19763,7 @@ func (p projModDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -19079,6 +19812,7 @@ func (p projModDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -19135,6 +19869,9 @@ func (p projModDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -19176,6 +19913,7 @@ func (p projModDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -19224,6 +19962,7 @@ func (p projModDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -19280,6 +20019,9 @@ func (p projModDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -19321,6 +20063,7 @@ func (p projModDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -19369,6 +20112,7 @@ func (p projModDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -19425,6 +20169,9 @@ func (p projModDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -19465,6 +20212,7 @@ func (p projModDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -19511,6 +20259,7 @@ func (p projModDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -19566,6 +20315,9 @@ func (p projModInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -19601,6 +20353,7 @@ func (p projModInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -19637,6 +20390,7 @@ func (p projModInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -19687,6 +20441,9 @@ func (p projModInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -19722,6 +20479,7 @@ func (p projModInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -19758,6 +20516,7 @@ func (p projModInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -19808,6 +20567,9 @@ func (p projModInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -19843,6 +20605,7 @@ func (p projModInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -19879,6 +20642,7 @@ func (p projModInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -19929,6 +20693,9 @@ func (p projModInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -19971,6 +20738,7 @@ func (p projModInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -20021,6 +20789,7 @@ func (p projModInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -20078,6 +20847,9 @@ func (p projModInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -20113,6 +20885,7 @@ func (p projModInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -20149,6 +20922,7 @@ func (p projModInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -20199,6 +20973,9 @@ func (p projModInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -20234,6 +21011,7 @@ func (p projModInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -20270,6 +21048,7 @@ func (p projModInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -20320,6 +21099,9 @@ func (p projModInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -20355,6 +21137,7 @@ func (p projModInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -20391,6 +21174,7 @@ func (p projModInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -20441,6 +21225,9 @@ func (p projModInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -20483,6 +21270,7 @@ func (p projModInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -20533,6 +21321,7 @@ func (p projModInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -20590,6 +21379,9 @@ func (p projModInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -20625,6 +21417,7 @@ func (p projModInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -20661,6 +21454,7 @@ func (p projModInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -20711,6 +21505,9 @@ func (p projModInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -20746,6 +21543,7 @@ func (p projModInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -20782,6 +21580,7 @@ func (p projModInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -20832,6 +21631,9 @@ func (p projModInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -20867,6 +21669,7 @@ func (p projModInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -20903,6 +21706,7 @@ func (p projModInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -20953,6 +21757,9 @@ func (p projModInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -20995,6 +21802,7 @@ func (p projModInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -21045,6 +21853,7 @@ func (p projModInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -21102,6 +21911,9 @@ func (p projModFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -21139,6 +21951,7 @@ func (p projModFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -21179,6 +21992,7 @@ func (p projModFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -21231,6 +22045,9 @@ func (p projPowDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -21268,6 +22085,7 @@ func (p projPowDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -21308,6 +22126,7 @@ func (p projPowDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -21360,6 +22179,9 @@ func (p projPowDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -21397,6 +22219,7 @@ func (p projPowDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -21437,6 +22260,7 @@ func (p projPowDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -21489,6 +22313,9 @@ func (p projPowDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -21526,6 +22353,7 @@ func (p projPowDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -21566,6 +22394,7 @@ func (p projPowDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -21618,6 +22447,9 @@ func (p projPowDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -21654,6 +22486,7 @@ func (p projPowDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -21692,6 +22525,7 @@ func (p projPowDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -21743,6 +22577,9 @@ func (p projPowInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -21785,6 +22622,7 @@ func (p projPowInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -21835,6 +22673,7 @@ func (p projPowInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -21892,6 +22731,9 @@ func (p projPowInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -21934,6 +22776,7 @@ func (p projPowInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -21984,6 +22827,7 @@ func (p projPowInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -22041,6 +22885,9 @@ func (p projPowInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -22083,6 +22930,7 @@ func (p projPowInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -22133,6 +22981,7 @@ func (p projPowInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -22190,6 +23039,9 @@ func (p projPowInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -22228,6 +23080,7 @@ func (p projPowInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -22270,6 +23123,7 @@ func (p projPowInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -22323,6 +23177,9 @@ func (p projPowInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -22365,6 +23222,7 @@ func (p projPowInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -22415,6 +23273,7 @@ func (p projPowInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -22472,6 +23331,9 @@ func (p projPowInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -22514,6 +23376,7 @@ func (p projPowInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -22564,6 +23427,7 @@ func (p projPowInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -22621,6 +23485,9 @@ func (p projPowInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -22663,6 +23530,7 @@ func (p projPowInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -22713,6 +23581,7 @@ func (p projPowInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -22770,6 +23639,9 @@ func (p projPowInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -22808,6 +23680,7 @@ func (p projPowInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -22850,6 +23723,7 @@ func (p projPowInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -22903,6 +23777,9 @@ func (p projPowInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -22945,6 +23822,7 @@ func (p projPowInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -22995,6 +23873,7 @@ func (p projPowInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -23052,6 +23931,9 @@ func (p projPowInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -23094,6 +23976,7 @@ func (p projPowInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -23144,6 +24027,7 @@ func (p projPowInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -23201,6 +24085,9 @@ func (p projPowInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -23243,6 +24130,7 @@ func (p projPowInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -23293,6 +24181,7 @@ func (p projPowInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -23350,6 +24239,9 @@ func (p projPowInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -23388,6 +24280,7 @@ func (p projPowInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -23430,6 +24323,7 @@ func (p projPowInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -23483,6 +24377,9 @@ func (p projPowFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -23516,6 +24413,7 @@ func (p projPowFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -23548,6 +24446,7 @@ func (p projPowFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -23596,6 +24495,9 @@ func (p projConcatBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Bytes()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -23717,6 +24619,9 @@ func (p projConcatDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -23846,6 +24751,9 @@ func (p projLShiftInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -23882,6 +24790,7 @@ func (p projLShiftInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -23920,6 +24829,7 @@ func (p projLShiftInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -23971,6 +24881,9 @@ func (p projLShiftInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -24007,6 +24920,7 @@ func (p projLShiftInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -24045,6 +24959,7 @@ func (p projLShiftInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -24096,6 +25011,9 @@ func (p projLShiftInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -24132,6 +25050,7 @@ func (p projLShiftInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -24170,6 +25089,7 @@ func (p projLShiftInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -24221,6 +25141,9 @@ func (p projLShiftInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -24257,6 +25180,7 @@ func (p projLShiftInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -24295,6 +25219,7 @@ func (p projLShiftInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -24346,6 +25271,9 @@ func (p projLShiftInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -24382,6 +25310,7 @@ func (p projLShiftInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -24420,6 +25349,7 @@ func (p projLShiftInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -24471,6 +25401,9 @@ func (p projLShiftInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -24507,6 +25440,7 @@ func (p projLShiftInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -24545,6 +25479,7 @@ func (p projLShiftInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -24596,6 +25531,9 @@ func (p projLShiftInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -24632,6 +25570,7 @@ func (p projLShiftInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -24670,6 +25609,7 @@ func (p projLShiftInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -24721,6 +25661,9 @@ func (p projLShiftInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -24757,6 +25700,7 @@ func (p projLShiftInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -24795,6 +25739,7 @@ func (p projLShiftInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -24846,6 +25791,9 @@ func (p projLShiftInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -24882,6 +25830,7 @@ func (p projLShiftInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -24920,6 +25869,7 @@ func (p projLShiftInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -24971,6 +25921,9 @@ func (p projLShiftDatumInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -25012,6 +25965,7 @@ func (p projLShiftDatumInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						_convertedNativeElem := tree.DInt(p.constArg)
@@ -25060,6 +26014,7 @@ func (p projLShiftDatumInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInt(p.constArg)
@@ -25116,6 +26071,9 @@ func (p projLShiftDatumInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -25157,6 +26115,7 @@ func (p projLShiftDatumInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						_convertedNativeElem := tree.DInt(p.constArg)
@@ -25205,6 +26164,7 @@ func (p projLShiftDatumInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInt(p.constArg)
@@ -25261,6 +26221,9 @@ func (p projLShiftDatumInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -25302,6 +26265,7 @@ func (p projLShiftDatumInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						_convertedNativeElem := tree.DInt(p.constArg)
@@ -25350,6 +26314,7 @@ func (p projLShiftDatumInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInt(p.constArg)
@@ -25406,6 +26371,9 @@ func (p projRShiftInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -25442,6 +26410,7 @@ func (p projRShiftInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -25480,6 +26449,7 @@ func (p projRShiftInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -25531,6 +26501,9 @@ func (p projRShiftInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -25567,6 +26540,7 @@ func (p projRShiftInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -25605,6 +26579,7 @@ func (p projRShiftInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -25656,6 +26631,9 @@ func (p projRShiftInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -25692,6 +26670,7 @@ func (p projRShiftInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -25730,6 +26709,7 @@ func (p projRShiftInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -25781,6 +26761,9 @@ func (p projRShiftInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -25817,6 +26800,7 @@ func (p projRShiftInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -25855,6 +26839,7 @@ func (p projRShiftInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -25906,6 +26891,9 @@ func (p projRShiftInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -25942,6 +26930,7 @@ func (p projRShiftInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -25980,6 +26969,7 @@ func (p projRShiftInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -26031,6 +27021,9 @@ func (p projRShiftInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -26067,6 +27060,7 @@ func (p projRShiftInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -26105,6 +27099,7 @@ func (p projRShiftInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -26156,6 +27151,9 @@ func (p projRShiftInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -26192,6 +27190,7 @@ func (p projRShiftInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -26230,6 +27229,7 @@ func (p projRShiftInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -26281,6 +27281,9 @@ func (p projRShiftInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -26317,6 +27320,7 @@ func (p projRShiftInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -26355,6 +27359,7 @@ func (p projRShiftInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -26406,6 +27411,9 @@ func (p projRShiftInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -26442,6 +27450,7 @@ func (p projRShiftInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -26480,6 +27489,7 @@ func (p projRShiftInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -26531,6 +27541,9 @@ func (p projRShiftDatumInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -26572,6 +27585,7 @@ func (p projRShiftDatumInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						_convertedNativeElem := tree.DInt(p.constArg)
@@ -26620,6 +27634,7 @@ func (p projRShiftDatumInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInt(p.constArg)
@@ -26676,6 +27691,9 @@ func (p projRShiftDatumInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -26717,6 +27735,7 @@ func (p projRShiftDatumInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						_convertedNativeElem := tree.DInt(p.constArg)
@@ -26765,6 +27784,7 @@ func (p projRShiftDatumInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInt(p.constArg)
@@ -26821,6 +27841,9 @@ func (p projRShiftDatumInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -26862,6 +27885,7 @@ func (p projRShiftDatumInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						_convertedNativeElem := tree.DInt(p.constArg)
@@ -26910,6 +27934,7 @@ func (p projRShiftDatumInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInt(p.constArg)
@@ -26966,6 +27991,9 @@ func (p projJSONFetchValDatumBytesConstOp) Next(ctx context.Context) coldata.Bat
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -27111,6 +28139,9 @@ func (p projJSONFetchValDatumInt16ConstOp) Next(ctx context.Context) coldata.Bat
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -27152,6 +28183,7 @@ func (p projJSONFetchValDatumInt16ConstOp) Next(ctx context.Context) coldata.Bat
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						_convertedNativeElem := tree.DInt(p.constArg)
@@ -27200,6 +28232,7 @@ func (p projJSONFetchValDatumInt16ConstOp) Next(ctx context.Context) coldata.Bat
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInt(p.constArg)
@@ -27256,6 +28289,9 @@ func (p projJSONFetchValDatumInt32ConstOp) Next(ctx context.Context) coldata.Bat
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -27297,6 +28333,7 @@ func (p projJSONFetchValDatumInt32ConstOp) Next(ctx context.Context) coldata.Bat
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						_convertedNativeElem := tree.DInt(p.constArg)
@@ -27345,6 +28382,7 @@ func (p projJSONFetchValDatumInt32ConstOp) Next(ctx context.Context) coldata.Bat
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInt(p.constArg)
@@ -27401,6 +28439,9 @@ func (p projJSONFetchValDatumInt64ConstOp) Next(ctx context.Context) coldata.Bat
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -27442,6 +28483,7 @@ func (p projJSONFetchValDatumInt64ConstOp) Next(ctx context.Context) coldata.Bat
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						_convertedNativeElem := tree.DInt(p.constArg)
@@ -27490,6 +28532,7 @@ func (p projJSONFetchValDatumInt64ConstOp) Next(ctx context.Context) coldata.Bat
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInt(p.constArg)
@@ -27546,6 +28589,9 @@ func (p projJSONFetchValPathDatumDatumConstOp) Next(ctx context.Context) coldata
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -27675,6 +28721,9 @@ func (p projEQBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Bool()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -27717,6 +28766,7 @@ func (p projEQBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -27767,6 +28817,7 @@ func (p projEQBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -27824,6 +28875,9 @@ func (p projEQBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Bytes()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -27941,6 +28995,9 @@ func (p projEQDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -27981,6 +29038,7 @@ func (p projEQDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -28027,6 +29085,7 @@ func (p projEQDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -28082,6 +29141,9 @@ func (p projEQDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -28122,6 +29184,7 @@ func (p projEQDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -28168,6 +29231,7 @@ func (p projEQDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -28223,6 +29287,9 @@ func (p projEQDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -28263,6 +29330,7 @@ func (p projEQDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -28309,6 +29377,7 @@ func (p projEQDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -28364,6 +29433,9 @@ func (p projEQDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -28406,6 +29478,7 @@ func (p projEQDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -28456,6 +29529,7 @@ func (p projEQDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -28513,6 +29587,9 @@ func (p projEQDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -28547,6 +29624,7 @@ func (p projEQDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -28581,6 +29659,7 @@ func (p projEQDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -28630,6 +29709,9 @@ func (p projEQInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -28675,6 +29757,7 @@ func (p projEQInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -28731,6 +29814,7 @@ func (p projEQInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -28791,6 +29875,9 @@ func (p projEQInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -28836,6 +29923,7 @@ func (p projEQInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -28892,6 +29980,7 @@ func (p projEQInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -28952,6 +30041,9 @@ func (p projEQInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -28997,6 +30089,7 @@ func (p projEQInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -29053,6 +30146,7 @@ func (p projEQInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -29113,6 +30207,9 @@ func (p projEQInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -29166,6 +30263,7 @@ func (p projEQInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -29238,6 +30336,7 @@ func (p projEQInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -29306,6 +30405,9 @@ func (p projEQInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -29346,6 +30448,7 @@ func (p projEQInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -29392,6 +30495,7 @@ func (p projEQInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -29447,6 +30551,9 @@ func (p projEQInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -29492,6 +30599,7 @@ func (p projEQInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -29548,6 +30656,7 @@ func (p projEQInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -29608,6 +30717,9 @@ func (p projEQInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -29653,6 +30765,7 @@ func (p projEQInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -29709,6 +30822,7 @@ func (p projEQInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -29769,6 +30883,9 @@ func (p projEQInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -29814,6 +30931,7 @@ func (p projEQInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -29870,6 +30988,7 @@ func (p projEQInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -29930,6 +31049,9 @@ func (p projEQInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -29983,6 +31105,7 @@ func (p projEQInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -30055,6 +31178,7 @@ func (p projEQInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -30123,6 +31247,9 @@ func (p projEQInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -30163,6 +31290,7 @@ func (p projEQInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -30209,6 +31337,7 @@ func (p projEQInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -30264,6 +31393,9 @@ func (p projEQInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -30309,6 +31441,7 @@ func (p projEQInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -30365,6 +31498,7 @@ func (p projEQInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -30425,6 +31559,9 @@ func (p projEQInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -30470,6 +31607,7 @@ func (p projEQInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -30526,6 +31664,7 @@ func (p projEQInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -30586,6 +31725,9 @@ func (p projEQInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -30631,6 +31773,7 @@ func (p projEQInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -30687,6 +31830,7 @@ func (p projEQInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -30747,6 +31891,9 @@ func (p projEQInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -30800,6 +31947,7 @@ func (p projEQInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -30872,6 +32020,7 @@ func (p projEQInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -30940,6 +32089,9 @@ func (p projEQInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -30980,6 +32132,7 @@ func (p projEQInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -31026,6 +32179,7 @@ func (p projEQInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -31081,6 +32235,9 @@ func (p projEQFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -31134,6 +32291,7 @@ func (p projEQFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -31206,6 +32364,7 @@ func (p projEQFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -31274,6 +32433,9 @@ func (p projEQFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -31327,6 +32489,7 @@ func (p projEQFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -31399,6 +32562,7 @@ func (p projEQFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -31467,6 +32631,9 @@ func (p projEQFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -31520,6 +32687,7 @@ func (p projEQFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -31592,6 +32760,7 @@ func (p projEQFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -31660,6 +32829,9 @@ func (p projEQFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -31713,6 +32885,7 @@ func (p projEQFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -31785,6 +32958,7 @@ func (p projEQFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -31853,6 +33027,9 @@ func (p projEQFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -31895,6 +33072,7 @@ func (p projEQFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -31945,6 +33123,7 @@ func (p projEQFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -32002,6 +33181,9 @@ func (p projEQTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 	col = vec.Timestamp()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -32043,6 +33225,7 @@ func (p projEQTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -32091,6 +33274,7 @@ func (p projEQTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -32147,6 +33331,9 @@ func (p projEQIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -32181,6 +33368,7 @@ func (p projEQIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -32215,6 +33403,7 @@ func (p projEQIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -32264,6 +33453,9 @@ func (p projEQDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -32389,6 +33581,9 @@ func (p projNEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Bool()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -32431,6 +33626,7 @@ func (p projNEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -32481,6 +33677,7 @@ func (p projNEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -32538,6 +33735,9 @@ func (p projNEBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Bytes()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -32655,6 +33855,9 @@ func (p projNEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -32695,6 +33898,7 @@ func (p projNEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -32741,6 +33945,7 @@ func (p projNEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -32796,6 +34001,9 @@ func (p projNEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -32836,6 +34044,7 @@ func (p projNEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -32882,6 +34091,7 @@ func (p projNEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -32937,6 +34147,9 @@ func (p projNEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -32977,6 +34190,7 @@ func (p projNEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -33023,6 +34237,7 @@ func (p projNEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -33078,6 +34293,9 @@ func (p projNEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -33120,6 +34338,7 @@ func (p projNEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -33170,6 +34389,7 @@ func (p projNEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -33227,6 +34447,9 @@ func (p projNEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -33261,6 +34484,7 @@ func (p projNEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -33295,6 +34519,7 @@ func (p projNEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -33344,6 +34569,9 @@ func (p projNEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -33389,6 +34617,7 @@ func (p projNEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -33445,6 +34674,7 @@ func (p projNEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -33505,6 +34735,9 @@ func (p projNEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -33550,6 +34783,7 @@ func (p projNEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -33606,6 +34840,7 @@ func (p projNEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -33666,6 +34901,9 @@ func (p projNEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -33711,6 +34949,7 @@ func (p projNEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -33767,6 +35006,7 @@ func (p projNEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -33827,6 +35067,9 @@ func (p projNEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -33880,6 +35123,7 @@ func (p projNEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -33952,6 +35196,7 @@ func (p projNEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -34020,6 +35265,9 @@ func (p projNEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -34060,6 +35308,7 @@ func (p projNEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -34106,6 +35355,7 @@ func (p projNEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -34161,6 +35411,9 @@ func (p projNEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -34206,6 +35459,7 @@ func (p projNEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -34262,6 +35516,7 @@ func (p projNEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -34322,6 +35577,9 @@ func (p projNEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -34367,6 +35625,7 @@ func (p projNEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -34423,6 +35682,7 @@ func (p projNEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -34483,6 +35743,9 @@ func (p projNEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -34528,6 +35791,7 @@ func (p projNEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -34584,6 +35848,7 @@ func (p projNEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -34644,6 +35909,9 @@ func (p projNEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -34697,6 +35965,7 @@ func (p projNEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -34769,6 +36038,7 @@ func (p projNEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -34837,6 +36107,9 @@ func (p projNEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -34877,6 +36150,7 @@ func (p projNEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -34923,6 +36197,7 @@ func (p projNEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -34978,6 +36253,9 @@ func (p projNEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -35023,6 +36301,7 @@ func (p projNEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -35079,6 +36358,7 @@ func (p projNEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -35139,6 +36419,9 @@ func (p projNEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -35184,6 +36467,7 @@ func (p projNEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -35240,6 +36524,7 @@ func (p projNEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -35300,6 +36585,9 @@ func (p projNEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -35345,6 +36633,7 @@ func (p projNEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -35401,6 +36690,7 @@ func (p projNEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -35461,6 +36751,9 @@ func (p projNEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -35514,6 +36807,7 @@ func (p projNEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -35586,6 +36880,7 @@ func (p projNEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -35654,6 +36949,9 @@ func (p projNEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -35694,6 +36992,7 @@ func (p projNEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -35740,6 +37039,7 @@ func (p projNEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -35795,6 +37095,9 @@ func (p projNEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -35848,6 +37151,7 @@ func (p projNEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -35920,6 +37224,7 @@ func (p projNEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -35988,6 +37293,9 @@ func (p projNEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -36041,6 +37349,7 @@ func (p projNEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -36113,6 +37422,7 @@ func (p projNEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -36181,6 +37491,9 @@ func (p projNEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -36234,6 +37547,7 @@ func (p projNEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -36306,6 +37620,7 @@ func (p projNEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -36374,6 +37689,9 @@ func (p projNEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -36427,6 +37745,7 @@ func (p projNEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -36499,6 +37818,7 @@ func (p projNEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -36567,6 +37887,9 @@ func (p projNEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -36609,6 +37932,7 @@ func (p projNEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -36659,6 +37983,7 @@ func (p projNEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -36716,6 +38041,9 @@ func (p projNETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 	col = vec.Timestamp()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -36757,6 +38085,7 @@ func (p projNETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -36805,6 +38134,7 @@ func (p projNETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -36861,6 +38191,9 @@ func (p projNEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -36895,6 +38228,7 @@ func (p projNEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -36929,6 +38263,7 @@ func (p projNEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -36978,6 +38313,9 @@ func (p projNEDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -37103,6 +38441,9 @@ func (p projLTBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Bool()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -37145,6 +38486,7 @@ func (p projLTBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -37195,6 +38537,7 @@ func (p projLTBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -37252,6 +38595,9 @@ func (p projLTBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Bytes()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -37369,6 +38715,9 @@ func (p projLTDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -37409,6 +38758,7 @@ func (p projLTDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -37455,6 +38805,7 @@ func (p projLTDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -37510,6 +38861,9 @@ func (p projLTDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -37550,6 +38904,7 @@ func (p projLTDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -37596,6 +38951,7 @@ func (p projLTDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -37651,6 +39007,9 @@ func (p projLTDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -37691,6 +39050,7 @@ func (p projLTDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -37737,6 +39097,7 @@ func (p projLTDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -37792,6 +39153,9 @@ func (p projLTDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -37834,6 +39198,7 @@ func (p projLTDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -37884,6 +39249,7 @@ func (p projLTDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -37941,6 +39307,9 @@ func (p projLTDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -37975,6 +39344,7 @@ func (p projLTDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -38009,6 +39379,7 @@ func (p projLTDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -38058,6 +39429,9 @@ func (p projLTInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -38103,6 +39477,7 @@ func (p projLTInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -38159,6 +39534,7 @@ func (p projLTInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -38219,6 +39595,9 @@ func (p projLTInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -38264,6 +39643,7 @@ func (p projLTInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -38320,6 +39700,7 @@ func (p projLTInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -38380,6 +39761,9 @@ func (p projLTInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -38425,6 +39809,7 @@ func (p projLTInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -38481,6 +39866,7 @@ func (p projLTInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -38541,6 +39927,9 @@ func (p projLTInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -38594,6 +39983,7 @@ func (p projLTInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -38666,6 +40056,7 @@ func (p projLTInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -38734,6 +40125,9 @@ func (p projLTInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -38774,6 +40168,7 @@ func (p projLTInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -38820,6 +40215,7 @@ func (p projLTInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -38875,6 +40271,9 @@ func (p projLTInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -38920,6 +40319,7 @@ func (p projLTInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -38976,6 +40376,7 @@ func (p projLTInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -39036,6 +40437,9 @@ func (p projLTInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -39081,6 +40485,7 @@ func (p projLTInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -39137,6 +40542,7 @@ func (p projLTInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -39197,6 +40603,9 @@ func (p projLTInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -39242,6 +40651,7 @@ func (p projLTInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -39298,6 +40708,7 @@ func (p projLTInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -39358,6 +40769,9 @@ func (p projLTInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -39411,6 +40825,7 @@ func (p projLTInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -39483,6 +40898,7 @@ func (p projLTInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -39551,6 +40967,9 @@ func (p projLTInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -39591,6 +41010,7 @@ func (p projLTInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -39637,6 +41057,7 @@ func (p projLTInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -39692,6 +41113,9 @@ func (p projLTInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -39737,6 +41161,7 @@ func (p projLTInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -39793,6 +41218,7 @@ func (p projLTInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -39853,6 +41279,9 @@ func (p projLTInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -39898,6 +41327,7 @@ func (p projLTInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -39954,6 +41384,7 @@ func (p projLTInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -40014,6 +41445,9 @@ func (p projLTInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -40059,6 +41493,7 @@ func (p projLTInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -40115,6 +41550,7 @@ func (p projLTInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -40175,6 +41611,9 @@ func (p projLTInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -40228,6 +41667,7 @@ func (p projLTInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -40300,6 +41740,7 @@ func (p projLTInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -40368,6 +41809,9 @@ func (p projLTInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -40408,6 +41852,7 @@ func (p projLTInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -40454,6 +41899,7 @@ func (p projLTInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -40509,6 +41955,9 @@ func (p projLTFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -40562,6 +42011,7 @@ func (p projLTFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -40634,6 +42084,7 @@ func (p projLTFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -40702,6 +42153,9 @@ func (p projLTFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -40755,6 +42209,7 @@ func (p projLTFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -40827,6 +42282,7 @@ func (p projLTFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -40895,6 +42351,9 @@ func (p projLTFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -40948,6 +42407,7 @@ func (p projLTFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -41020,6 +42480,7 @@ func (p projLTFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -41088,6 +42549,9 @@ func (p projLTFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -41141,6 +42605,7 @@ func (p projLTFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -41213,6 +42678,7 @@ func (p projLTFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -41281,6 +42747,9 @@ func (p projLTFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -41323,6 +42792,7 @@ func (p projLTFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -41373,6 +42843,7 @@ func (p projLTFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -41430,6 +42901,9 @@ func (p projLTTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 	col = vec.Timestamp()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -41471,6 +42945,7 @@ func (p projLTTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -41519,6 +42994,7 @@ func (p projLTTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -41575,6 +43051,9 @@ func (p projLTIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -41609,6 +43088,7 @@ func (p projLTIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -41643,6 +43123,7 @@ func (p projLTIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -41692,6 +43173,9 @@ func (p projLTDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -41817,6 +43301,9 @@ func (p projLEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Bool()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -41859,6 +43346,7 @@ func (p projLEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -41909,6 +43397,7 @@ func (p projLEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -41966,6 +43455,9 @@ func (p projLEBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Bytes()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -42083,6 +43575,9 @@ func (p projLEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -42123,6 +43618,7 @@ func (p projLEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -42169,6 +43665,7 @@ func (p projLEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -42224,6 +43721,9 @@ func (p projLEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -42264,6 +43764,7 @@ func (p projLEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -42310,6 +43811,7 @@ func (p projLEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -42365,6 +43867,9 @@ func (p projLEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -42405,6 +43910,7 @@ func (p projLEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -42451,6 +43957,7 @@ func (p projLEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -42506,6 +44013,9 @@ func (p projLEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -42548,6 +44058,7 @@ func (p projLEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -42598,6 +44109,7 @@ func (p projLEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -42655,6 +44167,9 @@ func (p projLEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -42689,6 +44204,7 @@ func (p projLEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -42723,6 +44239,7 @@ func (p projLEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -42772,6 +44289,9 @@ func (p projLEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -42817,6 +44337,7 @@ func (p projLEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -42873,6 +44394,7 @@ func (p projLEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -42933,6 +44455,9 @@ func (p projLEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -42978,6 +44503,7 @@ func (p projLEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -43034,6 +44560,7 @@ func (p projLEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -43094,6 +44621,9 @@ func (p projLEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -43139,6 +44669,7 @@ func (p projLEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -43195,6 +44726,7 @@ func (p projLEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -43255,6 +44787,9 @@ func (p projLEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -43308,6 +44843,7 @@ func (p projLEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -43380,6 +44916,7 @@ func (p projLEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -43448,6 +44985,9 @@ func (p projLEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -43488,6 +45028,7 @@ func (p projLEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -43534,6 +45075,7 @@ func (p projLEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -43589,6 +45131,9 @@ func (p projLEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -43634,6 +45179,7 @@ func (p projLEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -43690,6 +45236,7 @@ func (p projLEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -43750,6 +45297,9 @@ func (p projLEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -43795,6 +45345,7 @@ func (p projLEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -43851,6 +45402,7 @@ func (p projLEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -43911,6 +45463,9 @@ func (p projLEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -43956,6 +45511,7 @@ func (p projLEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -44012,6 +45568,7 @@ func (p projLEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -44072,6 +45629,9 @@ func (p projLEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -44125,6 +45685,7 @@ func (p projLEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -44197,6 +45758,7 @@ func (p projLEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -44265,6 +45827,9 @@ func (p projLEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -44305,6 +45870,7 @@ func (p projLEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -44351,6 +45917,7 @@ func (p projLEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -44406,6 +45973,9 @@ func (p projLEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -44451,6 +46021,7 @@ func (p projLEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -44507,6 +46078,7 @@ func (p projLEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -44567,6 +46139,9 @@ func (p projLEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -44612,6 +46187,7 @@ func (p projLEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -44668,6 +46244,7 @@ func (p projLEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -44728,6 +46305,9 @@ func (p projLEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -44773,6 +46353,7 @@ func (p projLEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -44829,6 +46410,7 @@ func (p projLEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -44889,6 +46471,9 @@ func (p projLEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -44942,6 +46527,7 @@ func (p projLEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -45014,6 +46600,7 @@ func (p projLEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -45082,6 +46669,9 @@ func (p projLEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -45122,6 +46712,7 @@ func (p projLEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -45168,6 +46759,7 @@ func (p projLEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -45223,6 +46815,9 @@ func (p projLEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -45276,6 +46871,7 @@ func (p projLEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -45348,6 +46944,7 @@ func (p projLEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -45416,6 +47013,9 @@ func (p projLEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -45469,6 +47069,7 @@ func (p projLEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -45541,6 +47142,7 @@ func (p projLEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -45609,6 +47211,9 @@ func (p projLEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -45662,6 +47267,7 @@ func (p projLEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -45734,6 +47340,7 @@ func (p projLEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -45802,6 +47409,9 @@ func (p projLEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -45855,6 +47465,7 @@ func (p projLEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -45927,6 +47538,7 @@ func (p projLEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -45995,6 +47607,9 @@ func (p projLEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -46037,6 +47652,7 @@ func (p projLEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -46087,6 +47703,7 @@ func (p projLEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -46144,6 +47761,9 @@ func (p projLETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 	col = vec.Timestamp()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -46185,6 +47805,7 @@ func (p projLETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -46233,6 +47854,7 @@ func (p projLETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -46289,6 +47911,9 @@ func (p projLEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -46323,6 +47948,7 @@ func (p projLEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -46357,6 +47983,7 @@ func (p projLEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -46406,6 +48033,9 @@ func (p projLEDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -46531,6 +48161,9 @@ func (p projGTBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Bool()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -46573,6 +48206,7 @@ func (p projGTBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -46623,6 +48257,7 @@ func (p projGTBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -46680,6 +48315,9 @@ func (p projGTBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Bytes()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -46797,6 +48435,9 @@ func (p projGTDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -46837,6 +48478,7 @@ func (p projGTDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -46883,6 +48525,7 @@ func (p projGTDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -46938,6 +48581,9 @@ func (p projGTDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -46978,6 +48624,7 @@ func (p projGTDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -47024,6 +48671,7 @@ func (p projGTDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -47079,6 +48727,9 @@ func (p projGTDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -47119,6 +48770,7 @@ func (p projGTDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -47165,6 +48817,7 @@ func (p projGTDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -47220,6 +48873,9 @@ func (p projGTDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -47262,6 +48918,7 @@ func (p projGTDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -47312,6 +48969,7 @@ func (p projGTDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -47369,6 +49027,9 @@ func (p projGTDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -47403,6 +49064,7 @@ func (p projGTDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -47437,6 +49099,7 @@ func (p projGTDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -47486,6 +49149,9 @@ func (p projGTInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -47531,6 +49197,7 @@ func (p projGTInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -47587,6 +49254,7 @@ func (p projGTInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -47647,6 +49315,9 @@ func (p projGTInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -47692,6 +49363,7 @@ func (p projGTInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -47748,6 +49420,7 @@ func (p projGTInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -47808,6 +49481,9 @@ func (p projGTInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -47853,6 +49529,7 @@ func (p projGTInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -47909,6 +49586,7 @@ func (p projGTInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -47969,6 +49647,9 @@ func (p projGTInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -48022,6 +49703,7 @@ func (p projGTInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -48094,6 +49776,7 @@ func (p projGTInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -48162,6 +49845,9 @@ func (p projGTInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -48202,6 +49888,7 @@ func (p projGTInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -48248,6 +49935,7 @@ func (p projGTInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -48303,6 +49991,9 @@ func (p projGTInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -48348,6 +50039,7 @@ func (p projGTInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -48404,6 +50096,7 @@ func (p projGTInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -48464,6 +50157,9 @@ func (p projGTInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -48509,6 +50205,7 @@ func (p projGTInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -48565,6 +50262,7 @@ func (p projGTInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -48625,6 +50323,9 @@ func (p projGTInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -48670,6 +50371,7 @@ func (p projGTInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -48726,6 +50428,7 @@ func (p projGTInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -48786,6 +50489,9 @@ func (p projGTInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -48839,6 +50545,7 @@ func (p projGTInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -48911,6 +50618,7 @@ func (p projGTInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -48979,6 +50687,9 @@ func (p projGTInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -49019,6 +50730,7 @@ func (p projGTInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -49065,6 +50777,7 @@ func (p projGTInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -49120,6 +50833,9 @@ func (p projGTInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -49165,6 +50881,7 @@ func (p projGTInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -49221,6 +50938,7 @@ func (p projGTInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -49281,6 +50999,9 @@ func (p projGTInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -49326,6 +51047,7 @@ func (p projGTInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -49382,6 +51104,7 @@ func (p projGTInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -49442,6 +51165,9 @@ func (p projGTInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -49487,6 +51213,7 @@ func (p projGTInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -49543,6 +51270,7 @@ func (p projGTInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -49603,6 +51331,9 @@ func (p projGTInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -49656,6 +51387,7 @@ func (p projGTInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -49728,6 +51460,7 @@ func (p projGTInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -49796,6 +51529,9 @@ func (p projGTInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -49836,6 +51572,7 @@ func (p projGTInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -49882,6 +51619,7 @@ func (p projGTInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -49937,6 +51675,9 @@ func (p projGTFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -49990,6 +51731,7 @@ func (p projGTFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -50062,6 +51804,7 @@ func (p projGTFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -50130,6 +51873,9 @@ func (p projGTFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -50183,6 +51929,7 @@ func (p projGTFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -50255,6 +52002,7 @@ func (p projGTFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -50323,6 +52071,9 @@ func (p projGTFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -50376,6 +52127,7 @@ func (p projGTFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -50448,6 +52200,7 @@ func (p projGTFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -50516,6 +52269,9 @@ func (p projGTFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -50569,6 +52325,7 @@ func (p projGTFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -50641,6 +52398,7 @@ func (p projGTFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -50709,6 +52467,9 @@ func (p projGTFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -50751,6 +52512,7 @@ func (p projGTFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -50801,6 +52563,7 @@ func (p projGTFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -50858,6 +52621,9 @@ func (p projGTTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 	col = vec.Timestamp()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -50899,6 +52665,7 @@ func (p projGTTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -50947,6 +52714,7 @@ func (p projGTTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -51003,6 +52771,9 @@ func (p projGTIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -51037,6 +52808,7 @@ func (p projGTIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -51071,6 +52843,7 @@ func (p projGTIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -51120,6 +52893,9 @@ func (p projGTDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -51245,6 +53021,9 @@ func (p projGEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Bool()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -51287,6 +53066,7 @@ func (p projGEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -51337,6 +53117,7 @@ func (p projGEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -51394,6 +53175,9 @@ func (p projGEBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Bytes()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -51511,6 +53295,9 @@ func (p projGEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -51551,6 +53338,7 @@ func (p projGEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -51597,6 +53385,7 @@ func (p projGEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -51652,6 +53441,9 @@ func (p projGEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -51692,6 +53484,7 @@ func (p projGEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -51738,6 +53531,7 @@ func (p projGEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -51793,6 +53587,9 @@ func (p projGEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -51833,6 +53630,7 @@ func (p projGEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -51879,6 +53677,7 @@ func (p projGEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -51934,6 +53733,9 @@ func (p projGEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -51976,6 +53778,7 @@ func (p projGEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -52026,6 +53829,7 @@ func (p projGEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -52083,6 +53887,9 @@ func (p projGEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -52117,6 +53924,7 @@ func (p projGEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -52151,6 +53959,7 @@ func (p projGEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -52200,6 +54009,9 @@ func (p projGEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -52245,6 +54057,7 @@ func (p projGEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -52301,6 +54114,7 @@ func (p projGEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -52361,6 +54175,9 @@ func (p projGEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -52406,6 +54223,7 @@ func (p projGEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -52462,6 +54280,7 @@ func (p projGEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -52522,6 +54341,9 @@ func (p projGEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -52567,6 +54389,7 @@ func (p projGEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -52623,6 +54446,7 @@ func (p projGEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -52683,6 +54507,9 @@ func (p projGEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -52736,6 +54563,7 @@ func (p projGEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -52808,6 +54636,7 @@ func (p projGEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -52876,6 +54705,9 @@ func (p projGEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -52916,6 +54748,7 @@ func (p projGEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -52962,6 +54795,7 @@ func (p projGEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -53017,6 +54851,9 @@ func (p projGEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -53062,6 +54899,7 @@ func (p projGEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -53118,6 +54956,7 @@ func (p projGEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -53178,6 +55017,9 @@ func (p projGEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -53223,6 +55065,7 @@ func (p projGEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -53279,6 +55122,7 @@ func (p projGEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -53339,6 +55183,9 @@ func (p projGEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -53384,6 +55231,7 @@ func (p projGEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -53440,6 +55288,7 @@ func (p projGEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -53500,6 +55349,9 @@ func (p projGEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -53553,6 +55405,7 @@ func (p projGEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -53625,6 +55478,7 @@ func (p projGEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -53693,6 +55547,9 @@ func (p projGEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -53733,6 +55590,7 @@ func (p projGEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -53779,6 +55637,7 @@ func (p projGEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -53834,6 +55693,9 @@ func (p projGEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -53879,6 +55741,7 @@ func (p projGEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -53935,6 +55798,7 @@ func (p projGEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -53995,6 +55859,9 @@ func (p projGEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -54040,6 +55907,7 @@ func (p projGEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -54096,6 +55964,7 @@ func (p projGEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -54156,6 +56025,9 @@ func (p projGEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -54201,6 +56073,7 @@ func (p projGEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -54257,6 +56130,7 @@ func (p projGEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -54317,6 +56191,9 @@ func (p projGEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -54370,6 +56247,7 @@ func (p projGEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -54442,6 +56320,7 @@ func (p projGEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -54510,6 +56389,9 @@ func (p projGEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -54550,6 +56432,7 @@ func (p projGEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -54596,6 +56479,7 @@ func (p projGEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -54651,6 +56535,9 @@ func (p projGEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -54704,6 +56591,7 @@ func (p projGEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -54776,6 +56664,7 @@ func (p projGEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -54844,6 +56733,9 @@ func (p projGEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -54897,6 +56789,7 @@ func (p projGEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -54969,6 +56862,7 @@ func (p projGEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -55037,6 +56931,9 @@ func (p projGEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -55090,6 +56987,7 @@ func (p projGEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -55162,6 +57060,7 @@ func (p projGEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -55230,6 +57129,9 @@ func (p projGEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -55283,6 +57185,7 @@ func (p projGEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -55355,6 +57258,7 @@ func (p projGEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -55423,6 +57327,9 @@ func (p projGEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -55465,6 +57372,7 @@ func (p projGEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -55515,6 +57423,7 @@ func (p projGEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -55572,6 +57481,9 @@ func (p projGETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 	col = vec.Timestamp()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -55613,6 +57525,7 @@ func (p projGETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -55661,6 +57574,7 @@ func (p projGETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -55717,6 +57631,9 @@ func (p projGEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.
@@ -55751,6 +57668,7 @@ func (p projGEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 				for i := 0; i < n; i++ {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
 						arg := col.Get(i)
 
 						{
@@ -55785,6 +57703,7 @@ func (p projGEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -55834,6 +57753,9 @@ func (p projGEDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 	col = vec.Datum()
 	projVec := batch.ColVec(p.outputIdx)
 	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
 		if projVec.MaybeHasNulls() {
 			// We need to make sure that there are no left over null values in the
 			// output vector.

--- a/pkg/sql/colexec/proj_non_const_ops.eg.go
+++ b/pkg/sql/colexec/proj_non_const_ops.eg.go
@@ -119,7 +119,9 @@ func (p projBitandInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						projCol[i] = int64(arg1) & int64(arg2)
@@ -148,7 +150,9 @@ func (p projBitandInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) & int64(arg2)
@@ -229,7 +233,9 @@ func (p projBitandInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						projCol[i] = int64(arg1) & int64(arg2)
@@ -258,7 +264,9 @@ func (p projBitandInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) & int64(arg2)
@@ -339,7 +347,9 @@ func (p projBitandInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						projCol[i] = int64(arg1) & int64(arg2)
@@ -368,7 +378,9 @@ func (p projBitandInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) & int64(arg2)
@@ -449,7 +461,9 @@ func (p projBitandInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						projCol[i] = int64(arg1) & int64(arg2)
@@ -478,7 +492,9 @@ func (p projBitandInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) & int64(arg2)
@@ -559,7 +575,9 @@ func (p projBitandInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						projCol[i] = int64(arg1) & int64(arg2)
@@ -588,7 +606,9 @@ func (p projBitandInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) & int64(arg2)
@@ -669,7 +689,9 @@ func (p projBitandInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						projCol[i] = int64(arg1) & int64(arg2)
@@ -698,7 +720,9 @@ func (p projBitandInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) & int64(arg2)
@@ -779,7 +803,9 @@ func (p projBitandInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						projCol[i] = int64(arg1) & int64(arg2)
@@ -808,7 +834,9 @@ func (p projBitandInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) & int64(arg2)
@@ -889,7 +917,9 @@ func (p projBitandInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						projCol[i] = int64(arg1) & int64(arg2)
@@ -918,7 +948,9 @@ func (p projBitandInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) & int64(arg2)
@@ -999,7 +1031,9 @@ func (p projBitandInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						projCol[i] = int64(arg1) & int64(arg2)
@@ -1028,7 +1062,9 @@ func (p projBitandInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) & int64(arg2)
@@ -1247,7 +1283,9 @@ func (p projBitorInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						projCol[i] = int64(arg1) | int64(arg2)
@@ -1276,7 +1314,9 @@ func (p projBitorInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) | int64(arg2)
@@ -1357,7 +1397,9 @@ func (p projBitorInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						projCol[i] = int64(arg1) | int64(arg2)
@@ -1386,7 +1428,9 @@ func (p projBitorInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) | int64(arg2)
@@ -1467,7 +1511,9 @@ func (p projBitorInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						projCol[i] = int64(arg1) | int64(arg2)
@@ -1496,7 +1542,9 @@ func (p projBitorInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) | int64(arg2)
@@ -1577,7 +1625,9 @@ func (p projBitorInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						projCol[i] = int64(arg1) | int64(arg2)
@@ -1606,7 +1656,9 @@ func (p projBitorInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) | int64(arg2)
@@ -1687,7 +1739,9 @@ func (p projBitorInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						projCol[i] = int64(arg1) | int64(arg2)
@@ -1716,7 +1770,9 @@ func (p projBitorInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) | int64(arg2)
@@ -1797,7 +1853,9 @@ func (p projBitorInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						projCol[i] = int64(arg1) | int64(arg2)
@@ -1826,7 +1884,9 @@ func (p projBitorInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) | int64(arg2)
@@ -1907,7 +1967,9 @@ func (p projBitorInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						projCol[i] = int64(arg1) | int64(arg2)
@@ -1936,7 +1998,9 @@ func (p projBitorInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) | int64(arg2)
@@ -2017,7 +2081,9 @@ func (p projBitorInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						projCol[i] = int64(arg1) | int64(arg2)
@@ -2046,7 +2112,9 @@ func (p projBitorInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) | int64(arg2)
@@ -2127,7 +2195,9 @@ func (p projBitorInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						projCol[i] = int64(arg1) | int64(arg2)
@@ -2156,7 +2226,9 @@ func (p projBitorInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) | int64(arg2)
@@ -2375,7 +2447,9 @@ func (p projBitxorInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						projCol[i] = int64(arg1) ^ int64(arg2)
@@ -2404,7 +2478,9 @@ func (p projBitxorInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) ^ int64(arg2)
@@ -2485,7 +2561,9 @@ func (p projBitxorInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						projCol[i] = int64(arg1) ^ int64(arg2)
@@ -2514,7 +2592,9 @@ func (p projBitxorInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) ^ int64(arg2)
@@ -2595,7 +2675,9 @@ func (p projBitxorInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						projCol[i] = int64(arg1) ^ int64(arg2)
@@ -2624,7 +2706,9 @@ func (p projBitxorInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) ^ int64(arg2)
@@ -2705,7 +2789,9 @@ func (p projBitxorInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						projCol[i] = int64(arg1) ^ int64(arg2)
@@ -2734,7 +2820,9 @@ func (p projBitxorInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) ^ int64(arg2)
@@ -2815,7 +2903,9 @@ func (p projBitxorInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						projCol[i] = int64(arg1) ^ int64(arg2)
@@ -2844,7 +2934,9 @@ func (p projBitxorInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) ^ int64(arg2)
@@ -2925,7 +3017,9 @@ func (p projBitxorInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						projCol[i] = int64(arg1) ^ int64(arg2)
@@ -2954,7 +3048,9 @@ func (p projBitxorInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) ^ int64(arg2)
@@ -3035,7 +3131,9 @@ func (p projBitxorInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						projCol[i] = int64(arg1) ^ int64(arg2)
@@ -3064,7 +3162,9 @@ func (p projBitxorInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) ^ int64(arg2)
@@ -3145,7 +3245,9 @@ func (p projBitxorInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						projCol[i] = int64(arg1) ^ int64(arg2)
@@ -3174,7 +3276,9 @@ func (p projBitxorInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) ^ int64(arg2)
@@ -3255,7 +3359,9 @@ func (p projBitxorInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						projCol[i] = int64(arg1) ^ int64(arg2)
@@ -3284,7 +3390,9 @@ func (p projBitxorInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) ^ int64(arg2)
@@ -3510,7 +3618,9 @@ func (p projPlusDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -3553,7 +3663,9 @@ func (p projPlusDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -3648,7 +3760,9 @@ func (p projPlusDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -3691,7 +3805,9 @@ func (p projPlusDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -3786,7 +3902,9 @@ func (p projPlusDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -3829,7 +3947,9 @@ func (p projPlusDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -3923,7 +4043,9 @@ func (p projPlusDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -3964,7 +4086,9 @@ func (p projPlusDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -4057,7 +4181,9 @@ func (p projPlusInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -4098,7 +4224,9 @@ func (p projPlusInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -4191,7 +4319,9 @@ func (p projPlusInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -4232,7 +4362,9 @@ func (p projPlusInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -4325,7 +4457,9 @@ func (p projPlusInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -4366,7 +4500,9 @@ func (p projPlusInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -4461,7 +4597,9 @@ func (p projPlusInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -4506,7 +4644,9 @@ func (p projPlusInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -4608,6 +4748,7 @@ func (p projPlusInt16DatumOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
 						arg2 := col2.Get(i)
 
@@ -4663,6 +4804,7 @@ func (p projPlusInt16DatumOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
 
@@ -4763,7 +4905,9 @@ func (p projPlusInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -4804,7 +4948,9 @@ func (p projPlusInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -4897,7 +5043,9 @@ func (p projPlusInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -4938,7 +5086,9 @@ func (p projPlusInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -5031,7 +5181,9 @@ func (p projPlusInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -5072,7 +5224,9 @@ func (p projPlusInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -5167,7 +5321,9 @@ func (p projPlusInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -5212,7 +5368,9 @@ func (p projPlusInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -5314,6 +5472,7 @@ func (p projPlusInt32DatumOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
 						arg2 := col2.Get(i)
 
@@ -5369,6 +5528,7 @@ func (p projPlusInt32DatumOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
 
@@ -5469,7 +5629,9 @@ func (p projPlusInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -5510,7 +5672,9 @@ func (p projPlusInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -5603,7 +5767,9 @@ func (p projPlusInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -5644,7 +5810,9 @@ func (p projPlusInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -5737,7 +5905,9 @@ func (p projPlusInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -5778,7 +5948,9 @@ func (p projPlusInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -5873,7 +6045,9 @@ func (p projPlusInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -5918,7 +6092,9 @@ func (p projPlusInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -6020,6 +6196,7 @@ func (p projPlusInt64DatumOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
 						arg2 := col2.Get(i)
 
@@ -6075,6 +6252,7 @@ func (p projPlusInt64DatumOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
 
@@ -6172,7 +6350,9 @@ func (p projPlusFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -6207,7 +6387,9 @@ func (p projPlusFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -6289,7 +6471,9 @@ func (p projPlusTimestampIntervalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 						projCol[i] = duration.Add(arg1, arg2)
 					}
@@ -6314,7 +6498,9 @@ func (p projPlusTimestampIntervalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 					projCol[i] = duration.Add(arg1, arg2)
 				}
@@ -6391,7 +6577,9 @@ func (p projPlusIntervalTimestampOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 						projCol[i] = duration.Add(arg2, arg1)
 					}
@@ -6416,7 +6604,9 @@ func (p projPlusIntervalTimestampOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 					projCol[i] = duration.Add(arg2, arg1)
 				}
@@ -6493,7 +6683,9 @@ func (p projPlusIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 						projCol[i] = arg1.Add(arg2)
 					}
@@ -6518,7 +6710,9 @@ func (p projPlusIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 					projCol[i] = arg1.Add(arg2)
 				}
@@ -6610,6 +6804,7 @@ func (p projPlusIntervalDatumOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
 						arg2 := col2.Get(i)
 
@@ -6665,6 +6860,7 @@ func (p projPlusIntervalDatumOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
 
@@ -6771,6 +6967,7 @@ func (p projPlusDatumIntervalOp) Next(ctx context.Context) coldata.Batch {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						_convertedNativeElem := tree.DInterval{Duration: arg2}
@@ -6822,6 +7019,7 @@ func (p projPlusDatumIntervalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInterval{Duration: arg2}
@@ -6925,6 +7123,7 @@ func (p projPlusDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						_convertedNativeElem := tree.DInt(arg2)
@@ -6976,6 +7175,7 @@ func (p projPlusDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg2)
@@ -7079,6 +7279,7 @@ func (p projPlusDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						_convertedNativeElem := tree.DInt(arg2)
@@ -7130,6 +7331,7 @@ func (p projPlusDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg2)
@@ -7233,6 +7435,7 @@ func (p projPlusDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						_convertedNativeElem := tree.DInt(arg2)
@@ -7284,6 +7487,7 @@ func (p projPlusDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg2)
@@ -7382,7 +7586,9 @@ func (p projMinusDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -7425,7 +7631,9 @@ func (p projMinusDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -7520,7 +7728,9 @@ func (p projMinusDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -7563,7 +7773,9 @@ func (p projMinusDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -7658,7 +7870,9 @@ func (p projMinusDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -7701,7 +7915,9 @@ func (p projMinusDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -7795,7 +8011,9 @@ func (p projMinusDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -7836,7 +8054,9 @@ func (p projMinusDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -7929,7 +8149,9 @@ func (p projMinusInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -7970,7 +8192,9 @@ func (p projMinusInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -8063,7 +8287,9 @@ func (p projMinusInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -8104,7 +8330,9 @@ func (p projMinusInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -8197,7 +8425,9 @@ func (p projMinusInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -8238,7 +8468,9 @@ func (p projMinusInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -8333,7 +8565,9 @@ func (p projMinusInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -8378,7 +8612,9 @@ func (p projMinusInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -8480,6 +8716,7 @@ func (p projMinusInt16DatumOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
 						arg2 := col2.Get(i)
 
@@ -8535,6 +8772,7 @@ func (p projMinusInt16DatumOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
 
@@ -8635,7 +8873,9 @@ func (p projMinusInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -8676,7 +8916,9 @@ func (p projMinusInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -8769,7 +9011,9 @@ func (p projMinusInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -8810,7 +9054,9 @@ func (p projMinusInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -8903,7 +9149,9 @@ func (p projMinusInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -8944,7 +9192,9 @@ func (p projMinusInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -9039,7 +9289,9 @@ func (p projMinusInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -9084,7 +9336,9 @@ func (p projMinusInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -9186,6 +9440,7 @@ func (p projMinusInt32DatumOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
 						arg2 := col2.Get(i)
 
@@ -9241,6 +9496,7 @@ func (p projMinusInt32DatumOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
 
@@ -9341,7 +9597,9 @@ func (p projMinusInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -9382,7 +9640,9 @@ func (p projMinusInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -9475,7 +9735,9 @@ func (p projMinusInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -9516,7 +9778,9 @@ func (p projMinusInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -9609,7 +9873,9 @@ func (p projMinusInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -9650,7 +9916,9 @@ func (p projMinusInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -9745,7 +10013,9 @@ func (p projMinusInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -9790,7 +10060,9 @@ func (p projMinusInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -9892,6 +10164,7 @@ func (p projMinusInt64DatumOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
 						arg2 := col2.Get(i)
 
@@ -9947,6 +10220,7 @@ func (p projMinusInt64DatumOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
 
@@ -10044,7 +10318,9 @@ func (p projMinusFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -10079,7 +10355,9 @@ func (p projMinusFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -10164,7 +10442,9 @@ func (p projMinusTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						nanos := arg1.Sub(arg2).Nanoseconds()
@@ -10195,7 +10475,9 @@ func (p projMinusTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					nanos := arg1.Sub(arg2).Nanoseconds()
@@ -10275,7 +10557,9 @@ func (p projMinusTimestampIntervalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 						projCol[i] = duration.Add(arg1, arg2.Mul(-1))
 					}
@@ -10300,7 +10584,9 @@ func (p projMinusTimestampIntervalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 					projCol[i] = duration.Add(arg1, arg2.Mul(-1))
 				}
@@ -10377,7 +10663,9 @@ func (p projMinusIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 						projCol[i] = arg1.Sub(arg2)
 					}
@@ -10402,7 +10690,9 @@ func (p projMinusIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 					projCol[i] = arg1.Sub(arg2)
 				}
@@ -10494,6 +10784,7 @@ func (p projMinusIntervalDatumOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
 						arg2 := col2.Get(i)
 
@@ -10549,6 +10840,7 @@ func (p projMinusIntervalDatumOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
 
@@ -10793,6 +11085,7 @@ func (p projMinusDatumIntervalOp) Next(ctx context.Context) coldata.Batch {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						_convertedNativeElem := tree.DInterval{Duration: arg2}
@@ -10844,6 +11137,7 @@ func (p projMinusDatumIntervalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInterval{Duration: arg2}
@@ -11101,6 +11395,7 @@ func (p projMinusDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						_convertedNativeElem := tree.DInt(arg2)
@@ -11152,6 +11447,7 @@ func (p projMinusDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg2)
@@ -11255,6 +11551,7 @@ func (p projMinusDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						_convertedNativeElem := tree.DInt(arg2)
@@ -11306,6 +11603,7 @@ func (p projMinusDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg2)
@@ -11409,6 +11707,7 @@ func (p projMinusDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						_convertedNativeElem := tree.DInt(arg2)
@@ -11460,6 +11759,7 @@ func (p projMinusDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg2)
@@ -11558,7 +11858,9 @@ func (p projMultDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -11601,7 +11903,9 @@ func (p projMultDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -11696,7 +12000,9 @@ func (p projMultDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -11739,7 +12045,9 @@ func (p projMultDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -11834,7 +12142,9 @@ func (p projMultDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -11877,7 +12187,9 @@ func (p projMultDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -11971,7 +12283,9 @@ func (p projMultDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -12012,7 +12326,9 @@ func (p projMultDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -12102,7 +12418,9 @@ func (p projMultDecimalIntervalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						f, err := arg1.Float64()
@@ -12137,7 +12455,9 @@ func (p projMultDecimalIntervalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					f, err := arg1.Float64()
@@ -12235,7 +12555,9 @@ func (p projMultInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -12292,7 +12614,9 @@ func (p projMultInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -12401,7 +12725,9 @@ func (p projMultInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -12458,7 +12784,9 @@ func (p projMultInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -12567,7 +12895,9 @@ func (p projMultInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -12624,7 +12954,9 @@ func (p projMultInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -12727,7 +13059,9 @@ func (p projMultInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -12772,7 +13106,9 @@ func (p projMultInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -12859,7 +13195,9 @@ func (p projMultInt16IntervalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 						projCol[i] = arg2.Mul(int64(arg1))
 					}
@@ -12884,7 +13222,9 @@ func (p projMultInt16IntervalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 					projCol[i] = arg2.Mul(int64(arg1))
 				}
@@ -12977,7 +13317,9 @@ func (p projMultInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -13034,7 +13376,9 @@ func (p projMultInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -13143,7 +13487,9 @@ func (p projMultInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -13200,7 +13546,9 @@ func (p projMultInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -13309,7 +13657,9 @@ func (p projMultInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -13366,7 +13716,9 @@ func (p projMultInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -13469,7 +13821,9 @@ func (p projMultInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -13514,7 +13868,9 @@ func (p projMultInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -13601,7 +13957,9 @@ func (p projMultInt32IntervalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 						projCol[i] = arg2.Mul(int64(arg1))
 					}
@@ -13626,7 +13984,9 @@ func (p projMultInt32IntervalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 					projCol[i] = arg2.Mul(int64(arg1))
 				}
@@ -13719,7 +14079,9 @@ func (p projMultInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -13776,7 +14138,9 @@ func (p projMultInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -13885,7 +14249,9 @@ func (p projMultInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -13942,7 +14308,9 @@ func (p projMultInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -14051,7 +14419,9 @@ func (p projMultInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -14108,7 +14478,9 @@ func (p projMultInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -14211,7 +14583,9 @@ func (p projMultInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -14256,7 +14630,9 @@ func (p projMultInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -14343,7 +14719,9 @@ func (p projMultInt64IntervalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 						projCol[i] = arg2.Mul(int64(arg1))
 					}
@@ -14368,7 +14746,9 @@ func (p projMultInt64IntervalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 					projCol[i] = arg2.Mul(int64(arg1))
 				}
@@ -14450,7 +14830,9 @@ func (p projMultFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -14485,7 +14867,9 @@ func (p projMultFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -14567,7 +14951,9 @@ func (p projMultFloat64IntervalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 						projCol[i] = arg2.MulFloat(float64(arg1))
 					}
@@ -14592,7 +14978,9 @@ func (p projMultFloat64IntervalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 					projCol[i] = arg2.MulFloat(float64(arg1))
 				}
@@ -14669,7 +15057,9 @@ func (p projMultIntervalInt16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 						projCol[i] = arg1.Mul(int64(arg2))
 					}
@@ -14694,7 +15084,9 @@ func (p projMultIntervalInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 					projCol[i] = arg1.Mul(int64(arg2))
 				}
@@ -14771,7 +15163,9 @@ func (p projMultIntervalInt32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 						projCol[i] = arg1.Mul(int64(arg2))
 					}
@@ -14796,7 +15190,9 @@ func (p projMultIntervalInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 					projCol[i] = arg1.Mul(int64(arg2))
 				}
@@ -14873,7 +15269,9 @@ func (p projMultIntervalInt64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 						projCol[i] = arg1.Mul(int64(arg2))
 					}
@@ -14898,7 +15296,9 @@ func (p projMultIntervalInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 					projCol[i] = arg1.Mul(int64(arg2))
 				}
@@ -14975,7 +15375,9 @@ func (p projMultIntervalFloat64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 						projCol[i] = arg1.MulFloat(float64(arg2))
 					}
@@ -15000,7 +15402,9 @@ func (p projMultIntervalFloat64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 					projCol[i] = arg1.MulFloat(float64(arg2))
 				}
@@ -15082,7 +15486,9 @@ func (p projMultIntervalDecimalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						f, err := arg2.Float64()
@@ -15117,7 +15523,9 @@ func (p projMultIntervalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					f, err := arg2.Float64()
@@ -15212,7 +15620,9 @@ func (p projDivDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -15263,7 +15673,9 @@ func (p projDivDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -15366,7 +15778,9 @@ func (p projDivDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -15417,7 +15831,9 @@ func (p projDivDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -15520,7 +15936,9 @@ func (p projDivDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -15571,7 +15989,9 @@ func (p projDivDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -15673,7 +16093,9 @@ func (p projDivDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -15722,7 +16144,9 @@ func (p projDivDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -15823,7 +16247,9 @@ func (p projDivInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -15872,7 +16298,9 @@ func (p projDivInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -15973,7 +16401,9 @@ func (p projDivInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -16022,7 +16452,9 @@ func (p projDivInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -16123,7 +16555,9 @@ func (p projDivInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -16172,7 +16606,9 @@ func (p projDivInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -16275,7 +16711,9 @@ func (p projDivInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -16328,7 +16766,9 @@ func (p projDivInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -16431,7 +16871,9 @@ func (p projDivInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -16480,7 +16922,9 @@ func (p projDivInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -16581,7 +17025,9 @@ func (p projDivInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -16630,7 +17076,9 @@ func (p projDivInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -16731,7 +17179,9 @@ func (p projDivInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -16780,7 +17230,9 @@ func (p projDivInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -16883,7 +17335,9 @@ func (p projDivInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -16936,7 +17390,9 @@ func (p projDivInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -17039,7 +17495,9 @@ func (p projDivInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -17088,7 +17546,9 @@ func (p projDivInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -17189,7 +17649,9 @@ func (p projDivInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -17238,7 +17700,9 @@ func (p projDivInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -17339,7 +17803,9 @@ func (p projDivInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -17388,7 +17854,9 @@ func (p projDivInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -17491,7 +17959,9 @@ func (p projDivInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -17544,7 +18014,9 @@ func (p projDivInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -17644,7 +18116,9 @@ func (p projDivFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -17687,7 +18161,9 @@ func (p projDivFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -17777,7 +18253,9 @@ func (p projDivIntervalInt64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						if arg2 == 0 {
@@ -17810,7 +18288,9 @@ func (p projDivIntervalInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					if arg2 == 0 {
@@ -17895,7 +18375,9 @@ func (p projDivIntervalFloat64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						if arg2 == 0.0 {
@@ -17928,7 +18410,9 @@ func (p projDivIntervalFloat64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					if arg2 == 0.0 {
@@ -18022,7 +18506,9 @@ func (p projFloorDivDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -18073,7 +18559,9 @@ func (p projFloorDivDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -18176,7 +18664,9 @@ func (p projFloorDivDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -18227,7 +18717,9 @@ func (p projFloorDivDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -18330,7 +18822,9 @@ func (p projFloorDivDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -18381,7 +18875,9 @@ func (p projFloorDivDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -18483,7 +18979,9 @@ func (p projFloorDivDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -18532,7 +19030,9 @@ func (p projFloorDivDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -18628,7 +19128,9 @@ func (p projFloorDivInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -18667,7 +19169,9 @@ func (p projFloorDivInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -18758,7 +19262,9 @@ func (p projFloorDivInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -18797,7 +19303,9 @@ func (p projFloorDivInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -18888,7 +19396,9 @@ func (p projFloorDivInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -18927,7 +19437,9 @@ func (p projFloorDivInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -19025,7 +19537,9 @@ func (p projFloorDivInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -19078,7 +19592,9 @@ func (p projFloorDivInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -19176,7 +19692,9 @@ func (p projFloorDivInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -19215,7 +19733,9 @@ func (p projFloorDivInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -19306,7 +19826,9 @@ func (p projFloorDivInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -19345,7 +19867,9 @@ func (p projFloorDivInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -19436,7 +19960,9 @@ func (p projFloorDivInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -19475,7 +20001,9 @@ func (p projFloorDivInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -19573,7 +20101,9 @@ func (p projFloorDivInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -19626,7 +20156,9 @@ func (p projFloorDivInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -19724,7 +20256,9 @@ func (p projFloorDivInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -19763,7 +20297,9 @@ func (p projFloorDivInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -19854,7 +20390,9 @@ func (p projFloorDivInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -19893,7 +20431,9 @@ func (p projFloorDivInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -19984,7 +20524,9 @@ func (p projFloorDivInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -20023,7 +20565,9 @@ func (p projFloorDivInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -20121,7 +20665,9 @@ func (p projFloorDivInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -20174,7 +20720,9 @@ func (p projFloorDivInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -20274,7 +20822,9 @@ func (p projFloorDivFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -20317,7 +20867,9 @@ func (p projFloorDivFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -20416,7 +20968,9 @@ func (p projModDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -20467,7 +21021,9 @@ func (p projModDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -20570,7 +21126,9 @@ func (p projModDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -20621,7 +21179,9 @@ func (p projModDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -20724,7 +21284,9 @@ func (p projModDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -20775,7 +21337,9 @@ func (p projModDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -20877,7 +21441,9 @@ func (p projModDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -20926,7 +21492,9 @@ func (p projModDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -21022,7 +21590,9 @@ func (p projModInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -21061,7 +21631,9 @@ func (p projModInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -21152,7 +21724,9 @@ func (p projModInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -21191,7 +21765,9 @@ func (p projModInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -21282,7 +21858,9 @@ func (p projModInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -21321,7 +21899,9 @@ func (p projModInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -21419,7 +21999,9 @@ func (p projModInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -21472,7 +22054,9 @@ func (p projModInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -21570,7 +22154,9 @@ func (p projModInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -21609,7 +22195,9 @@ func (p projModInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -21700,7 +22288,9 @@ func (p projModInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -21739,7 +22329,9 @@ func (p projModInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -21830,7 +22422,9 @@ func (p projModInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -21869,7 +22463,9 @@ func (p projModInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -21967,7 +22563,9 @@ func (p projModInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -22020,7 +22618,9 @@ func (p projModInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -22118,7 +22718,9 @@ func (p projModInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -22157,7 +22759,9 @@ func (p projModInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -22248,7 +22852,9 @@ func (p projModInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -22287,7 +22893,9 @@ func (p projModInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -22378,7 +22986,9 @@ func (p projModInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -22417,7 +23027,9 @@ func (p projModInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -22515,7 +23127,9 @@ func (p projModInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -22568,7 +23182,9 @@ func (p projModInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -22668,7 +23284,9 @@ func (p projModFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -22711,7 +23329,9 @@ func (p projModFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -22806,7 +23426,9 @@ func (p projPowDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -22849,7 +23471,9 @@ func (p projPowDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -22944,7 +23568,9 @@ func (p projPowDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -22987,7 +23613,9 @@ func (p projPowDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -23082,7 +23710,9 @@ func (p projPowDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -23125,7 +23755,9 @@ func (p projPowDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -23219,7 +23851,9 @@ func (p projPowDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -23260,7 +23894,9 @@ func (p projPowDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -23359,7 +23995,9 @@ func (p projPowInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -23412,7 +24050,9 @@ func (p projPowInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -23517,7 +24157,9 @@ func (p projPowInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -23570,7 +24212,9 @@ func (p projPowInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -23675,7 +24319,9 @@ func (p projPowInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -23728,7 +24374,9 @@ func (p projPowInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -23829,7 +24477,9 @@ func (p projPowInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -23874,7 +24524,9 @@ func (p projPowInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -23975,7 +24627,9 @@ func (p projPowInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -24028,7 +24682,9 @@ func (p projPowInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -24133,7 +24789,9 @@ func (p projPowInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -24186,7 +24844,9 @@ func (p projPowInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -24291,7 +24951,9 @@ func (p projPowInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -24344,7 +25006,9 @@ func (p projPowInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -24445,7 +25109,9 @@ func (p projPowInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -24490,7 +25156,9 @@ func (p projPowInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -24591,7 +25259,9 @@ func (p projPowInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -24644,7 +25314,9 @@ func (p projPowInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -24749,7 +25421,9 @@ func (p projPowInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -24802,7 +25476,9 @@ func (p projPowInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -24907,7 +25583,9 @@ func (p projPowInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -24960,7 +25638,9 @@ func (p projPowInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -25061,7 +25741,9 @@ func (p projPowInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -25106,7 +25788,9 @@ func (p projPowInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -25198,7 +25882,9 @@ func (p projPowFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -25233,7 +25919,9 @@ func (p projPowFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -25591,7 +26279,9 @@ func (p projLShiftInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -25632,7 +26322,9 @@ func (p projLShiftInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -25725,7 +26417,9 @@ func (p projLShiftInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -25766,7 +26460,9 @@ func (p projLShiftInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -25859,7 +26555,9 @@ func (p projLShiftInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -25900,7 +26598,9 @@ func (p projLShiftInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -25993,7 +26693,9 @@ func (p projLShiftInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -26034,7 +26736,9 @@ func (p projLShiftInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -26127,7 +26831,9 @@ func (p projLShiftInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -26168,7 +26874,9 @@ func (p projLShiftInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -26261,7 +26969,9 @@ func (p projLShiftInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -26302,7 +27012,9 @@ func (p projLShiftInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -26395,7 +27107,9 @@ func (p projLShiftInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -26436,7 +27150,9 @@ func (p projLShiftInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -26529,7 +27245,9 @@ func (p projLShiftInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -26570,7 +27288,9 @@ func (p projLShiftInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -26663,7 +27383,9 @@ func (p projLShiftInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -26704,7 +27426,9 @@ func (p projLShiftInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -26803,6 +27527,7 @@ func (p projLShiftDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						_convertedNativeElem := tree.DInt(arg2)
@@ -26854,6 +27579,7 @@ func (p projLShiftDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg2)
@@ -26957,6 +27683,7 @@ func (p projLShiftDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						_convertedNativeElem := tree.DInt(arg2)
@@ -27008,6 +27735,7 @@ func (p projLShiftDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg2)
@@ -27111,6 +27839,7 @@ func (p projLShiftDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						_convertedNativeElem := tree.DInt(arg2)
@@ -27162,6 +27891,7 @@ func (p projLShiftDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg2)
@@ -27259,7 +27989,9 @@ func (p projRShiftInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -27300,7 +28032,9 @@ func (p projRShiftInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -27393,7 +28127,9 @@ func (p projRShiftInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -27434,7 +28170,9 @@ func (p projRShiftInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -27527,7 +28265,9 @@ func (p projRShiftInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -27568,7 +28308,9 @@ func (p projRShiftInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -27661,7 +28403,9 @@ func (p projRShiftInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -27702,7 +28446,9 @@ func (p projRShiftInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -27795,7 +28541,9 @@ func (p projRShiftInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -27836,7 +28584,9 @@ func (p projRShiftInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -27929,7 +28679,9 @@ func (p projRShiftInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -27970,7 +28722,9 @@ func (p projRShiftInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -28063,7 +28817,9 @@ func (p projRShiftInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -28104,7 +28860,9 @@ func (p projRShiftInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -28197,7 +28955,9 @@ func (p projRShiftInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -28238,7 +28998,9 @@ func (p projRShiftInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -28331,7 +29093,9 @@ func (p projRShiftInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -28372,7 +29136,9 @@ func (p projRShiftInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -28471,6 +29237,7 @@ func (p projRShiftDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						_convertedNativeElem := tree.DInt(arg2)
@@ -28522,6 +29289,7 @@ func (p projRShiftDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg2)
@@ -28625,6 +29393,7 @@ func (p projRShiftDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						_convertedNativeElem := tree.DInt(arg2)
@@ -28676,6 +29445,7 @@ func (p projRShiftDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg2)
@@ -28779,6 +29549,7 @@ func (p projRShiftDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						_convertedNativeElem := tree.DInt(arg2)
@@ -28830,6 +29601,7 @@ func (p projRShiftDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg2)
@@ -29087,6 +29859,7 @@ func (p projJSONFetchValDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						_convertedNativeElem := tree.DInt(arg2)
@@ -29138,6 +29911,7 @@ func (p projJSONFetchValDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg2)
@@ -29241,6 +30015,7 @@ func (p projJSONFetchValDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						_convertedNativeElem := tree.DInt(arg2)
@@ -29292,6 +30067,7 @@ func (p projJSONFetchValDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg2)
@@ -29395,6 +30171,7 @@ func (p projJSONFetchValDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						_convertedNativeElem := tree.DInt(arg2)
@@ -29446,6 +30223,7 @@ func (p projJSONFetchValDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg2)
@@ -29687,7 +30465,9 @@ func (p projEQBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -29740,7 +30520,9 @@ func (p projEQBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -29969,7 +30751,9 @@ func (p projEQDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -30018,7 +30802,9 @@ func (p projEQDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -30119,7 +30905,9 @@ func (p projEQDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -30168,7 +30956,9 @@ func (p projEQDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -30269,7 +31059,9 @@ func (p projEQDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -30318,7 +31110,9 @@ func (p projEQDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -30421,7 +31215,9 @@ func (p projEQDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -30474,7 +31270,9 @@ func (p projEQDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -30571,7 +31369,9 @@ func (p projEQDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -30608,7 +31408,9 @@ func (p projEQDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -30708,7 +31510,9 @@ func (p projEQInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -30767,7 +31571,9 @@ func (p projEQInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -30878,7 +31684,9 @@ func (p projEQInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -30937,7 +31745,9 @@ func (p projEQInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -31048,7 +31858,9 @@ func (p projEQInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -31107,7 +31919,9 @@ func (p projEQInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -31226,7 +32040,9 @@ func (p projEQInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -31301,7 +32117,9 @@ func (p projEQInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -31415,7 +32233,9 @@ func (p projEQInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -31464,7 +32284,9 @@ func (p projEQInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -31570,7 +32392,9 @@ func (p projEQInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -31629,7 +32453,9 @@ func (p projEQInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -31740,7 +32566,9 @@ func (p projEQInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -31799,7 +32627,9 @@ func (p projEQInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -31910,7 +32740,9 @@ func (p projEQInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -31969,7 +32801,9 @@ func (p projEQInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -32088,7 +32922,9 @@ func (p projEQInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -32163,7 +32999,9 @@ func (p projEQInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -32277,7 +33115,9 @@ func (p projEQInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -32326,7 +33166,9 @@ func (p projEQInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -32432,7 +33274,9 @@ func (p projEQInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -32491,7 +33335,9 @@ func (p projEQInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -32602,7 +33448,9 @@ func (p projEQInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -32661,7 +33509,9 @@ func (p projEQInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -32772,7 +33622,9 @@ func (p projEQInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -32831,7 +33683,9 @@ func (p projEQInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -32950,7 +33804,9 @@ func (p projEQInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -33025,7 +33881,9 @@ func (p projEQInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -33139,7 +33997,9 @@ func (p projEQInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -33188,7 +34048,9 @@ func (p projEQInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -33302,7 +34164,9 @@ func (p projEQFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -33377,7 +34241,9 @@ func (p projEQFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -33504,7 +34370,9 @@ func (p projEQFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -33579,7 +34447,9 @@ func (p projEQFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -33706,7 +34576,9 @@ func (p projEQFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -33781,7 +34653,9 @@ func (p projEQFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -33908,7 +34782,9 @@ func (p projEQFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -33983,7 +34859,9 @@ func (p projEQFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -34099,7 +34977,9 @@ func (p projEQFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -34152,7 +35032,9 @@ func (p projEQFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -34256,7 +35138,9 @@ func (p projEQTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -34307,7 +35191,9 @@ func (p projEQTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -34403,7 +35289,9 @@ func (p projEQIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -34440,7 +35328,9 @@ func (p projEQIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -34671,7 +35561,9 @@ func (p projNEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -34724,7 +35616,9 @@ func (p projNEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -34953,7 +35847,9 @@ func (p projNEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -35002,7 +35898,9 @@ func (p projNEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -35103,7 +36001,9 @@ func (p projNEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -35152,7 +36052,9 @@ func (p projNEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -35253,7 +36155,9 @@ func (p projNEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -35302,7 +36206,9 @@ func (p projNEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -35405,7 +36311,9 @@ func (p projNEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -35458,7 +36366,9 @@ func (p projNEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -35555,7 +36465,9 @@ func (p projNEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -35592,7 +36504,9 @@ func (p projNEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -35692,7 +36606,9 @@ func (p projNEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -35751,7 +36667,9 @@ func (p projNEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -35862,7 +36780,9 @@ func (p projNEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -35921,7 +36841,9 @@ func (p projNEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -36032,7 +36954,9 @@ func (p projNEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -36091,7 +37015,9 @@ func (p projNEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -36210,7 +37136,9 @@ func (p projNEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -36285,7 +37213,9 @@ func (p projNEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -36399,7 +37329,9 @@ func (p projNEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -36448,7 +37380,9 @@ func (p projNEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -36554,7 +37488,9 @@ func (p projNEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -36613,7 +37549,9 @@ func (p projNEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -36724,7 +37662,9 @@ func (p projNEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -36783,7 +37723,9 @@ func (p projNEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -36894,7 +37836,9 @@ func (p projNEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -36953,7 +37897,9 @@ func (p projNEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -37072,7 +38018,9 @@ func (p projNEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -37147,7 +38095,9 @@ func (p projNEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -37261,7 +38211,9 @@ func (p projNEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -37310,7 +38262,9 @@ func (p projNEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -37416,7 +38370,9 @@ func (p projNEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -37475,7 +38431,9 @@ func (p projNEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -37586,7 +38544,9 @@ func (p projNEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -37645,7 +38605,9 @@ func (p projNEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -37756,7 +38718,9 @@ func (p projNEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -37815,7 +38779,9 @@ func (p projNEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -37934,7 +38900,9 @@ func (p projNEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -38009,7 +38977,9 @@ func (p projNEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -38123,7 +39093,9 @@ func (p projNEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -38172,7 +39144,9 @@ func (p projNEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -38286,7 +39260,9 @@ func (p projNEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -38361,7 +39337,9 @@ func (p projNEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -38488,7 +39466,9 @@ func (p projNEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -38563,7 +39543,9 @@ func (p projNEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -38690,7 +39672,9 @@ func (p projNEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -38765,7 +39749,9 @@ func (p projNEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -38892,7 +39878,9 @@ func (p projNEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -38967,7 +39955,9 @@ func (p projNEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -39083,7 +40073,9 @@ func (p projNEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -39136,7 +40128,9 @@ func (p projNEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -39240,7 +40234,9 @@ func (p projNETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -39291,7 +40287,9 @@ func (p projNETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -39387,7 +40385,9 @@ func (p projNEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -39424,7 +40424,9 @@ func (p projNEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -39655,7 +40657,9 @@ func (p projLTBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -39708,7 +40712,9 @@ func (p projLTBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -39937,7 +40943,9 @@ func (p projLTDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -39986,7 +40994,9 @@ func (p projLTDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -40087,7 +41097,9 @@ func (p projLTDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -40136,7 +41148,9 @@ func (p projLTDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -40237,7 +41251,9 @@ func (p projLTDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -40286,7 +41302,9 @@ func (p projLTDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -40389,7 +41407,9 @@ func (p projLTDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -40442,7 +41462,9 @@ func (p projLTDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -40539,7 +41561,9 @@ func (p projLTDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -40576,7 +41600,9 @@ func (p projLTDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -40676,7 +41702,9 @@ func (p projLTInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -40735,7 +41763,9 @@ func (p projLTInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -40846,7 +41876,9 @@ func (p projLTInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -40905,7 +41937,9 @@ func (p projLTInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -41016,7 +42050,9 @@ func (p projLTInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -41075,7 +42111,9 @@ func (p projLTInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -41194,7 +42232,9 @@ func (p projLTInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -41269,7 +42309,9 @@ func (p projLTInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -41383,7 +42425,9 @@ func (p projLTInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -41432,7 +42476,9 @@ func (p projLTInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -41538,7 +42584,9 @@ func (p projLTInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -41597,7 +42645,9 @@ func (p projLTInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -41708,7 +42758,9 @@ func (p projLTInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -41767,7 +42819,9 @@ func (p projLTInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -41878,7 +42932,9 @@ func (p projLTInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -41937,7 +42993,9 @@ func (p projLTInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -42056,7 +43114,9 @@ func (p projLTInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -42131,7 +43191,9 @@ func (p projLTInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -42245,7 +43307,9 @@ func (p projLTInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -42294,7 +43358,9 @@ func (p projLTInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -42400,7 +43466,9 @@ func (p projLTInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -42459,7 +43527,9 @@ func (p projLTInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -42570,7 +43640,9 @@ func (p projLTInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -42629,7 +43701,9 @@ func (p projLTInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -42740,7 +43814,9 @@ func (p projLTInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -42799,7 +43875,9 @@ func (p projLTInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -42918,7 +43996,9 @@ func (p projLTInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -42993,7 +44073,9 @@ func (p projLTInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -43107,7 +44189,9 @@ func (p projLTInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -43156,7 +44240,9 @@ func (p projLTInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -43270,7 +44356,9 @@ func (p projLTFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -43345,7 +44433,9 @@ func (p projLTFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -43472,7 +44562,9 @@ func (p projLTFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -43547,7 +44639,9 @@ func (p projLTFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -43674,7 +44768,9 @@ func (p projLTFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -43749,7 +44845,9 @@ func (p projLTFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -43876,7 +44974,9 @@ func (p projLTFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -43951,7 +45051,9 @@ func (p projLTFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -44067,7 +45169,9 @@ func (p projLTFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -44120,7 +45224,9 @@ func (p projLTFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -44224,7 +45330,9 @@ func (p projLTTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -44275,7 +45383,9 @@ func (p projLTTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -44371,7 +45481,9 @@ func (p projLTIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -44408,7 +45520,9 @@ func (p projLTIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -44639,7 +45753,9 @@ func (p projLEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -44692,7 +45808,9 @@ func (p projLEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -44921,7 +46039,9 @@ func (p projLEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -44970,7 +46090,9 @@ func (p projLEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -45071,7 +46193,9 @@ func (p projLEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -45120,7 +46244,9 @@ func (p projLEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -45221,7 +46347,9 @@ func (p projLEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -45270,7 +46398,9 @@ func (p projLEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -45373,7 +46503,9 @@ func (p projLEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -45426,7 +46558,9 @@ func (p projLEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -45523,7 +46657,9 @@ func (p projLEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -45560,7 +46696,9 @@ func (p projLEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -45660,7 +46798,9 @@ func (p projLEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -45719,7 +46859,9 @@ func (p projLEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -45830,7 +46972,9 @@ func (p projLEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -45889,7 +47033,9 @@ func (p projLEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -46000,7 +47146,9 @@ func (p projLEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -46059,7 +47207,9 @@ func (p projLEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -46178,7 +47328,9 @@ func (p projLEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -46253,7 +47405,9 @@ func (p projLEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -46367,7 +47521,9 @@ func (p projLEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -46416,7 +47572,9 @@ func (p projLEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -46522,7 +47680,9 @@ func (p projLEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -46581,7 +47741,9 @@ func (p projLEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -46692,7 +47854,9 @@ func (p projLEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -46751,7 +47915,9 @@ func (p projLEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -46862,7 +48028,9 @@ func (p projLEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -46921,7 +48089,9 @@ func (p projLEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -47040,7 +48210,9 @@ func (p projLEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -47115,7 +48287,9 @@ func (p projLEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -47229,7 +48403,9 @@ func (p projLEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -47278,7 +48454,9 @@ func (p projLEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -47384,7 +48562,9 @@ func (p projLEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -47443,7 +48623,9 @@ func (p projLEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -47554,7 +48736,9 @@ func (p projLEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -47613,7 +48797,9 @@ func (p projLEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -47724,7 +48910,9 @@ func (p projLEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -47783,7 +48971,9 @@ func (p projLEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -47902,7 +49092,9 @@ func (p projLEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -47977,7 +49169,9 @@ func (p projLEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -48091,7 +49285,9 @@ func (p projLEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -48140,7 +49336,9 @@ func (p projLEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -48254,7 +49452,9 @@ func (p projLEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -48329,7 +49529,9 @@ func (p projLEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -48456,7 +49658,9 @@ func (p projLEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -48531,7 +49735,9 @@ func (p projLEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -48658,7 +49864,9 @@ func (p projLEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -48733,7 +49941,9 @@ func (p projLEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -48860,7 +50070,9 @@ func (p projLEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -48935,7 +50147,9 @@ func (p projLEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -49051,7 +50265,9 @@ func (p projLEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -49104,7 +50320,9 @@ func (p projLEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -49208,7 +50426,9 @@ func (p projLETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -49259,7 +50479,9 @@ func (p projLETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -49355,7 +50577,9 @@ func (p projLEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -49392,7 +50616,9 @@ func (p projLEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -49623,7 +50849,9 @@ func (p projGTBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -49676,7 +50904,9 @@ func (p projGTBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -49905,7 +51135,9 @@ func (p projGTDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -49954,7 +51186,9 @@ func (p projGTDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -50055,7 +51289,9 @@ func (p projGTDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -50104,7 +51340,9 @@ func (p projGTDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -50205,7 +51443,9 @@ func (p projGTDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -50254,7 +51494,9 @@ func (p projGTDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -50357,7 +51599,9 @@ func (p projGTDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -50410,7 +51654,9 @@ func (p projGTDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -50507,7 +51753,9 @@ func (p projGTDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -50544,7 +51792,9 @@ func (p projGTDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -50644,7 +51894,9 @@ func (p projGTInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -50703,7 +51955,9 @@ func (p projGTInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -50814,7 +52068,9 @@ func (p projGTInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -50873,7 +52129,9 @@ func (p projGTInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -50984,7 +52242,9 @@ func (p projGTInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -51043,7 +52303,9 @@ func (p projGTInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -51162,7 +52424,9 @@ func (p projGTInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -51237,7 +52501,9 @@ func (p projGTInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -51351,7 +52617,9 @@ func (p projGTInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -51400,7 +52668,9 @@ func (p projGTInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -51506,7 +52776,9 @@ func (p projGTInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -51565,7 +52837,9 @@ func (p projGTInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -51676,7 +52950,9 @@ func (p projGTInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -51735,7 +53011,9 @@ func (p projGTInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -51846,7 +53124,9 @@ func (p projGTInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -51905,7 +53185,9 @@ func (p projGTInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -52024,7 +53306,9 @@ func (p projGTInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -52099,7 +53383,9 @@ func (p projGTInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -52213,7 +53499,9 @@ func (p projGTInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -52262,7 +53550,9 @@ func (p projGTInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -52368,7 +53658,9 @@ func (p projGTInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -52427,7 +53719,9 @@ func (p projGTInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -52538,7 +53832,9 @@ func (p projGTInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -52597,7 +53893,9 @@ func (p projGTInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -52708,7 +54006,9 @@ func (p projGTInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -52767,7 +54067,9 @@ func (p projGTInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -52886,7 +54188,9 @@ func (p projGTInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -52961,7 +54265,9 @@ func (p projGTInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -53075,7 +54381,9 @@ func (p projGTInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -53124,7 +54432,9 @@ func (p projGTInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -53238,7 +54548,9 @@ func (p projGTFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -53313,7 +54625,9 @@ func (p projGTFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -53440,7 +54754,9 @@ func (p projGTFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -53515,7 +54831,9 @@ func (p projGTFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -53642,7 +54960,9 @@ func (p projGTFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -53717,7 +55037,9 @@ func (p projGTFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -53844,7 +55166,9 @@ func (p projGTFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -53919,7 +55243,9 @@ func (p projGTFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -54035,7 +55361,9 @@ func (p projGTFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -54088,7 +55416,9 @@ func (p projGTFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -54192,7 +55522,9 @@ func (p projGTTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -54243,7 +55575,9 @@ func (p projGTTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -54339,7 +55673,9 @@ func (p projGTIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -54376,7 +55712,9 @@ func (p projGTIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -54607,7 +55945,9 @@ func (p projGEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -54660,7 +56000,9 @@ func (p projGEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -54889,7 +56231,9 @@ func (p projGEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -54938,7 +56282,9 @@ func (p projGEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -55039,7 +56385,9 @@ func (p projGEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -55088,7 +56436,9 @@ func (p projGEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -55189,7 +56539,9 @@ func (p projGEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -55238,7 +56590,9 @@ func (p projGEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -55341,7 +56695,9 @@ func (p projGEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -55394,7 +56750,9 @@ func (p projGEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -55491,7 +56849,9 @@ func (p projGEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -55528,7 +56888,9 @@ func (p projGEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -55628,7 +56990,9 @@ func (p projGEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -55687,7 +57051,9 @@ func (p projGEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -55798,7 +57164,9 @@ func (p projGEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -55857,7 +57225,9 @@ func (p projGEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -55968,7 +57338,9 @@ func (p projGEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -56027,7 +57399,9 @@ func (p projGEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -56146,7 +57520,9 @@ func (p projGEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -56221,7 +57597,9 @@ func (p projGEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -56335,7 +57713,9 @@ func (p projGEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -56384,7 +57764,9 @@ func (p projGEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -56490,7 +57872,9 @@ func (p projGEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -56549,7 +57933,9 @@ func (p projGEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -56660,7 +58046,9 @@ func (p projGEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -56719,7 +58107,9 @@ func (p projGEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -56830,7 +58220,9 @@ func (p projGEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -56889,7 +58281,9 @@ func (p projGEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -57008,7 +58402,9 @@ func (p projGEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -57083,7 +58479,9 @@ func (p projGEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -57197,7 +58595,9 @@ func (p projGEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -57246,7 +58646,9 @@ func (p projGEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -57352,7 +58754,9 @@ func (p projGEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -57411,7 +58815,9 @@ func (p projGEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -57522,7 +58928,9 @@ func (p projGEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -57581,7 +58989,9 @@ func (p projGEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -57692,7 +59102,9 @@ func (p projGEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -57751,7 +59163,9 @@ func (p projGEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -57870,7 +59284,9 @@ func (p projGEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -57945,7 +59361,9 @@ func (p projGEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -58059,7 +59477,9 @@ func (p projGEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -58108,7 +59528,9 @@ func (p projGEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -58222,7 +59644,9 @@ func (p projGEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -58297,7 +59721,9 @@ func (p projGEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -58424,7 +59850,9 @@ func (p projGEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -58499,7 +59927,9 @@ func (p projGEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -58626,7 +60056,9 @@ func (p projGEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -58701,7 +60133,9 @@ func (p projGEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -58828,7 +60262,9 @@ func (p projGEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -58903,7 +60339,9 @@ func (p projGEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -59019,7 +60457,9 @@ func (p projGEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -59072,7 +60512,9 @@ func (p projGEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -59176,7 +60618,9 @@ func (p projGETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -59227,7 +60671,9 @@ func (p projGETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -59323,7 +60769,9 @@ func (p projGEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 						// We only want to perform the projection operation if both values are not
 						// null.
+						//gcassert:bce
 						arg1 := col1.Get(i)
+						//gcassert:bce
 						arg2 := col2.Get(i)
 
 						{
@@ -59360,7 +60808,9 @@ func (p projGEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{

--- a/pkg/sql/colexec/proj_non_const_ops_tmpl.go
+++ b/pkg/sql/colexec/proj_non_const_ops_tmpl.go
@@ -159,14 +159,14 @@ func _SET_PROJECTION(_HAS_NULLS bool) {
 	if sel := batch.Selection(); sel != nil {
 		sel = sel[:n]
 		for _, i := range sel {
-			_SET_SINGLE_TUPLE_PROJECTION(_HAS_NULLS)
+			_SET_SINGLE_TUPLE_PROJECTION(_HAS_NULLS, true)
 		}
 	} else {
 		_ = projCol.Get(n - 1)
 		_ = col1.Get(n - 1)
 		_ = col2.Get(n - 1)
 		for i := 0; i < n; i++ {
-			_SET_SINGLE_TUPLE_PROJECTION(_HAS_NULLS)
+			_SET_SINGLE_TUPLE_PROJECTION(_HAS_NULLS, false)
 		}
 	}
 	// _outNulls has been updated from within the _ASSIGN function to include
@@ -185,16 +185,23 @@ func _SET_PROJECTION(_HAS_NULLS bool) {
 // */}}
 
 // {{/*
-func _SET_SINGLE_TUPLE_PROJECTION(_HAS_NULLS bool) { // */}}
+func _SET_SINGLE_TUPLE_PROJECTION(_HAS_NULLS bool, _HAS_SEL bool) { // */}}
 	// {{define "setSingleTupleProjection" -}}
 	// {{$hasNulls := $.HasNulls}}
+	// {{$hasSel := $.HasSel}}
 	// {{with $.Overload}}
 	// {{if _HAS_NULLS}}
 	if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 		// We only want to perform the projection operation if both values are not
 		// null.
 		// {{end}}
+		// {{if and (.Left.Sliceable) (not _HAS_SEL)}}
+		//gcassert:bce
+		// {{end}}
 		arg1 := col1.Get(i)
+		// {{if and (.Right.Sliceable) (not _HAS_SEL)}}
+		//gcassert:bce
+		// {{end}}
 		arg2 := col2.Get(i)
 		_ASSIGN(projCol[i], arg1, arg2, projCol, col1, col2)
 		// {{if _HAS_NULLS}}

--- a/pkg/sql/colexec/rank.eg.go
+++ b/pkg/sql/colexec/rank.eg.go
@@ -124,12 +124,17 @@ func (r *rankNoPartitionOp) Next(ctx context.Context) coldata.Batch {
 			}
 		}
 	} else {
-		for i := range rankCol[:n] {
+		_ = peersCol[n-1]
+		_ = rankCol[n-1]
+		for i := 0; i < n; i++ {
+			//gcassert:bce
 			if peersCol[i] {
 				r.rank += r.rankIncrement
 				r.rankIncrement = 1
+				//gcassert:bce
 				rankCol[i] = r.rank
 			} else {
+				//gcassert:bce
 				rankCol[i] = r.rank
 				r.rankIncrement++
 			}
@@ -195,7 +200,11 @@ func (r *rankWithPartitionOp) Next(ctx context.Context) coldata.Batch {
 			}
 		}
 	} else {
-		for i := range rankCol[:n] {
+		_ = partitionCol[n-1]
+		_ = peersCol[n-1]
+		_ = rankCol[n-1]
+		for i := 0; i < n; i++ {
+			//gcassert:bce
 			if partitionCol[i] {
 				// We need to reset the internal state because of the new partition.
 				// Note that the beginning of new partition necessarily starts a new
@@ -204,11 +213,14 @@ func (r *rankWithPartitionOp) Next(ctx context.Context) coldata.Batch {
 				r.rank = 0
 				r.rankIncrement = 1
 			}
+			//gcassert:bce
 			if peersCol[i] {
 				r.rank += r.rankIncrement
 				r.rankIncrement = 1
+				//gcassert:bce
 				rankCol[i] = r.rank
 			} else {
+				//gcassert:bce
 				rankCol[i] = r.rank
 				r.rankIncrement++
 			}
@@ -264,11 +276,16 @@ func (r *denseRankNoPartitionOp) Next(ctx context.Context) coldata.Batch {
 			}
 		}
 	} else {
-		for i := range rankCol[:n] {
+		_ = peersCol[n-1]
+		_ = rankCol[n-1]
+		for i := 0; i < n; i++ {
+			//gcassert:bce
 			if peersCol[i] {
 				r.rank++
+				//gcassert:bce
 				rankCol[i] = r.rank
 			} else {
+				//gcassert:bce
 				rankCol[i] = r.rank
 
 			}
@@ -333,7 +350,11 @@ func (r *denseRankWithPartitionOp) Next(ctx context.Context) coldata.Batch {
 			}
 		}
 	} else {
-		for i := range rankCol[:n] {
+		_ = partitionCol[n-1]
+		_ = peersCol[n-1]
+		_ = rankCol[n-1]
+		for i := 0; i < n; i++ {
+			//gcassert:bce
 			if partitionCol[i] {
 				// We need to reset the internal state because of the new partition.
 				// Note that the beginning of new partition necessarily starts a new
@@ -342,10 +363,13 @@ func (r *denseRankWithPartitionOp) Next(ctx context.Context) coldata.Batch {
 				r.rank = 0
 				r.rankIncrement = 1
 			}
+			//gcassert:bce
 			if peersCol[i] {
 				r.rank++
+				//gcassert:bce
 				rankCol[i] = r.rank
 			} else {
+				//gcassert:bce
 				rankCol[i] = r.rank
 
 			}

--- a/pkg/sql/colexec/relative_rank.eg.go
+++ b/pkg/sql/colexec/relative_rank.eg.go
@@ -291,17 +291,20 @@ func (r *percentRankNoPartitionOp) Next(ctx context.Context) coldata.Batch {
 
 			// Now we will populate the output column.
 			relativeRankOutputCol := r.output.ColVec(r.outputColIdx).Float64()
+			_ = relativeRankOutputCol[n-1]
 			peersCol := r.scratch.ColVec(r.peersColIdx).Bool()
+			_ = peersCol[n-1]
 			// We don't need to think about the selection vector since all the
 			// buffered up tuples have been "deselected" during the buffering
 			// stage.
-			for i := range relativeRankOutputCol[:n] {
+			for i := 0; i < n; i++ {
 				// We need to set r.numTuplesInPartition to the size of the
 				// partition that i'th tuple belongs to (which we have already
 				// computed).
 				// There is a single partition in the whole input, and
 				// r.numTuplesInPartition already contains the correct number.
 
+				//gcassert:bce
 				if peersCol[i] {
 					r.rank += r.rankIncrement
 					r.rankIncrement = 0
@@ -311,8 +314,10 @@ func (r *percentRankNoPartitionOp) Next(ctx context.Context) coldata.Batch {
 				// tuple.
 				if r.numTuplesInPartition == 1 {
 					// There is a single tuple in the partition, so we return 0, per spec.
+					//gcassert:bce
 					relativeRankOutputCol[i] = 0
 				} else {
+					//gcassert:bce
 					relativeRankOutputCol[i] = float64(r.rank-1) / float64(r.numTuplesInPartition-1)
 				}
 				r.rankIncrement++
@@ -515,7 +520,9 @@ func (r *percentRankWithPartitionOp) Next(ctx context.Context) coldata.Batch {
 					r.numTuplesInPartition++
 				}
 			} else {
+				_ = partitionCol[n-1]
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					if partitionCol[i] {
 						// We have encountered a start of a new partition, so we
 						// need to save the computed size of the previous one
@@ -583,15 +590,19 @@ func (r *percentRankWithPartitionOp) Next(ctx context.Context) coldata.Batch {
 
 			// Now we will populate the output column.
 			relativeRankOutputCol := r.output.ColVec(r.outputColIdx).Float64()
+			_ = relativeRankOutputCol[n-1]
 			partitionCol := r.scratch.ColVec(r.partitionColIdx).Bool()
+			_ = partitionCol[n-1]
 			peersCol := r.scratch.ColVec(r.peersColIdx).Bool()
+			_ = peersCol[n-1]
 			// We don't need to think about the selection vector since all the
 			// buffered up tuples have been "deselected" during the buffering
 			// stage.
-			for i := range relativeRankOutputCol[:n] {
+			for i := 0; i < n; i++ {
 				// We need to set r.numTuplesInPartition to the size of the
 				// partition that i'th tuple belongs to (which we have already
 				// computed).
+				//gcassert:bce
 				if partitionCol[i] {
 					if r.partitionsState.idx == r.partitionsState.dequeuedSizes.Length() {
 						if r.partitionsState.dequeuedSizes, err = r.partitionsState.dequeue(ctx); err != nil {
@@ -607,6 +618,7 @@ func (r *percentRankWithPartitionOp) Next(ctx context.Context) coldata.Batch {
 					r.rankIncrement = 1
 				}
 
+				//gcassert:bce
 				if peersCol[i] {
 					r.rank += r.rankIncrement
 					r.rankIncrement = 0
@@ -616,8 +628,10 @@ func (r *percentRankWithPartitionOp) Next(ctx context.Context) coldata.Batch {
 				// tuple.
 				if r.numTuplesInPartition == 1 {
 					// There is a single tuple in the partition, so we return 0, per spec.
+					//gcassert:bce
 					relativeRankOutputCol[i] = 0
 				} else {
+					//gcassert:bce
 					relativeRankOutputCol[i] = float64(r.rank-1) / float64(r.numTuplesInPartition-1)
 				}
 				r.rankIncrement++
@@ -821,7 +835,9 @@ func (r *cumeDistNoPartitionOp) Next(ctx context.Context) coldata.Batch {
 					r.numPeers++
 				}
 			} else {
+				_ = peersCol[n-1]
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					if peersCol[i] {
 						// We have encountered a start of a new peer group, so we
 						// need to save the computed size of the previous one
@@ -888,17 +904,20 @@ func (r *cumeDistNoPartitionOp) Next(ctx context.Context) coldata.Batch {
 
 			// Now we will populate the output column.
 			relativeRankOutputCol := r.output.ColVec(r.outputColIdx).Float64()
+			_ = relativeRankOutputCol[n-1]
 			peersCol := r.scratch.ColVec(r.peersColIdx).Bool()
+			_ = peersCol[n-1]
 			// We don't need to think about the selection vector since all the
 			// buffered up tuples have been "deselected" during the buffering
 			// stage.
-			for i := range relativeRankOutputCol[:n] {
+			for i := 0; i < n; i++ {
 				// We need to set r.numTuplesInPartition to the size of the
 				// partition that i'th tuple belongs to (which we have already
 				// computed).
 				// There is a single partition in the whole input, and
 				// r.numTuplesInPartition already contains the correct number.
 
+				//gcassert:bce
 				if peersCol[i] {
 					// We have encountered a new peer group, and we need to update the
 					// number of preceding tuples and get the number of tuples in
@@ -916,6 +935,7 @@ func (r *cumeDistNoPartitionOp) Next(ctx context.Context) coldata.Batch {
 
 				// Now we can compute the value of the window function for i'th
 				// tuple.
+				//gcassert:bce
 				relativeRankOutputCol[i] = float64(r.numPrecedingTuples+r.numPeers) / float64(r.numTuplesInPartition)
 			}
 			r.output.SetLength(n)
@@ -1140,7 +1160,9 @@ func (r *cumeDistWithPartitionOp) Next(ctx context.Context) coldata.Batch {
 					r.numTuplesInPartition++
 				}
 			} else {
+				_ = partitionCol[n-1]
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					if partitionCol[i] {
 						// We have encountered a start of a new partition, so we
 						// need to save the computed size of the previous one
@@ -1208,7 +1230,9 @@ func (r *cumeDistWithPartitionOp) Next(ctx context.Context) coldata.Batch {
 					r.numPeers++
 				}
 			} else {
+				_ = peersCol[n-1]
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					if peersCol[i] {
 						// We have encountered a start of a new peer group, so we
 						// need to save the computed size of the previous one
@@ -1283,15 +1307,19 @@ func (r *cumeDistWithPartitionOp) Next(ctx context.Context) coldata.Batch {
 
 			// Now we will populate the output column.
 			relativeRankOutputCol := r.output.ColVec(r.outputColIdx).Float64()
+			_ = relativeRankOutputCol[n-1]
 			partitionCol := r.scratch.ColVec(r.partitionColIdx).Bool()
+			_ = partitionCol[n-1]
 			peersCol := r.scratch.ColVec(r.peersColIdx).Bool()
+			_ = peersCol[n-1]
 			// We don't need to think about the selection vector since all the
 			// buffered up tuples have been "deselected" during the buffering
 			// stage.
-			for i := range relativeRankOutputCol[:n] {
+			for i := 0; i < n; i++ {
 				// We need to set r.numTuplesInPartition to the size of the
 				// partition that i'th tuple belongs to (which we have already
 				// computed).
+				//gcassert:bce
 				if partitionCol[i] {
 					if r.partitionsState.idx == r.partitionsState.dequeuedSizes.Length() {
 						if r.partitionsState.dequeuedSizes, err = r.partitionsState.dequeue(ctx); err != nil {
@@ -1307,6 +1335,7 @@ func (r *cumeDistWithPartitionOp) Next(ctx context.Context) coldata.Batch {
 					r.numPeers = 0
 				}
 
+				//gcassert:bce
 				if peersCol[i] {
 					// We have encountered a new peer group, and we need to update the
 					// number of preceding tuples and get the number of tuples in
@@ -1324,6 +1353,7 @@ func (r *cumeDistWithPartitionOp) Next(ctx context.Context) coldata.Batch {
 
 				// Now we can compute the value of the window function for i'th
 				// tuple.
+				//gcassert:bce
 				relativeRankOutputCol[i] = float64(r.numPrecedingTuples+r.numPeers) / float64(r.numTuplesInPartition)
 			}
 			r.output.SetLength(n)

--- a/pkg/sql/colexec/row_number.eg.go
+++ b/pkg/sql/colexec/row_number.eg.go
@@ -82,8 +82,10 @@ func (r *rowNumberNoPartitionOp) Next(ctx context.Context) coldata.Batch {
 			rowNumberCol[i] = r.rowNumber
 		}
 	} else {
-		for i := range rowNumberCol[:n] {
+		_ = rowNumberCol[n-1]
+		for i := 0; i < n; i++ {
 			r.rowNumber++
+			//gcassert:bce
 			rowNumberCol[i] = r.rowNumber
 		}
 	}
@@ -121,11 +123,15 @@ func (r *rowNumberWithPartitionOp) Next(ctx context.Context) coldata.Batch {
 			rowNumberCol[i] = r.rowNumber
 		}
 	} else {
-		for i := range rowNumberCol[:n] {
+		_ = partitionCol[n-1]
+		_ = rowNumberCol[n-1]
+		for i := 0; i < n; i++ {
+			//gcassert:bce
 			if partitionCol[i] {
 				r.rowNumber = 0
 			}
 			r.rowNumber++
+			//gcassert:bce
 			rowNumberCol[i] = r.rowNumber
 		}
 	}

--- a/pkg/sql/colexec/rowstovec.eg.go
+++ b/pkg/sql/colexec/rowstovec.eg.go
@@ -52,22 +52,26 @@ func EncDatumRowsToColVec(
 				case -1:
 				default:
 					col := vec.Bool()
-					var v interface{}
-					for i := range rows {
-						row := rows[i]
-						if row[columnIdx].Datum == nil {
-							if err = row[columnIdx].EnsureDecoded(t, alloc); err != nil {
-								return
+					if len(rows) > 0 {
+						_ = col.Get(len(rows) - 1)
+						var v interface{}
+						for i := range rows {
+							row := rows[i]
+							if row[columnIdx].Datum == nil {
+								if err = row[columnIdx].EnsureDecoded(t, alloc); err != nil {
+									return
+								}
 							}
-						}
-						datum := row[columnIdx].Datum
-						if datum == tree.DNull {
-							vec.Nulls().SetNull(i)
-						} else {
+							datum := row[columnIdx].Datum
+							if datum == tree.DNull {
+								vec.Nulls().SetNull(i)
+							} else {
 
-							v = bool(*datum.(*tree.DBool))
-							castV := v.(bool)
-							col[i] = castV
+								v = bool(*datum.(*tree.DBool))
+								castV := v.(bool)
+								//gcassert:bce
+								col[i] = castV
+							}
 						}
 					}
 				}
@@ -75,63 +79,75 @@ func EncDatumRowsToColVec(
 				switch t.Width() {
 				case 16:
 					col := vec.Int16()
-					var v interface{}
-					for i := range rows {
-						row := rows[i]
-						if row[columnIdx].Datum == nil {
-							if err = row[columnIdx].EnsureDecoded(t, alloc); err != nil {
-								return
+					if len(rows) > 0 {
+						_ = col.Get(len(rows) - 1)
+						var v interface{}
+						for i := range rows {
+							row := rows[i]
+							if row[columnIdx].Datum == nil {
+								if err = row[columnIdx].EnsureDecoded(t, alloc); err != nil {
+									return
+								}
 							}
-						}
-						datum := row[columnIdx].Datum
-						if datum == tree.DNull {
-							vec.Nulls().SetNull(i)
-						} else {
+							datum := row[columnIdx].Datum
+							if datum == tree.DNull {
+								vec.Nulls().SetNull(i)
+							} else {
 
-							v = int16(*datum.(*tree.DInt))
-							castV := v.(int16)
-							col[i] = castV
+								v = int16(*datum.(*tree.DInt))
+								castV := v.(int16)
+								//gcassert:bce
+								col[i] = castV
+							}
 						}
 					}
 				case 32:
 					col := vec.Int32()
-					var v interface{}
-					for i := range rows {
-						row := rows[i]
-						if row[columnIdx].Datum == nil {
-							if err = row[columnIdx].EnsureDecoded(t, alloc); err != nil {
-								return
+					if len(rows) > 0 {
+						_ = col.Get(len(rows) - 1)
+						var v interface{}
+						for i := range rows {
+							row := rows[i]
+							if row[columnIdx].Datum == nil {
+								if err = row[columnIdx].EnsureDecoded(t, alloc); err != nil {
+									return
+								}
 							}
-						}
-						datum := row[columnIdx].Datum
-						if datum == tree.DNull {
-							vec.Nulls().SetNull(i)
-						} else {
+							datum := row[columnIdx].Datum
+							if datum == tree.DNull {
+								vec.Nulls().SetNull(i)
+							} else {
 
-							v = int32(*datum.(*tree.DInt))
-							castV := v.(int32)
-							col[i] = castV
+								v = int32(*datum.(*tree.DInt))
+								castV := v.(int32)
+								//gcassert:bce
+								col[i] = castV
+							}
 						}
 					}
 				case -1:
 				default:
 					col := vec.Int64()
-					var v interface{}
-					for i := range rows {
-						row := rows[i]
-						if row[columnIdx].Datum == nil {
-							if err = row[columnIdx].EnsureDecoded(t, alloc); err != nil {
-								return
+					if len(rows) > 0 {
+						_ = col.Get(len(rows) - 1)
+						var v interface{}
+						for i := range rows {
+							row := rows[i]
+							if row[columnIdx].Datum == nil {
+								if err = row[columnIdx].EnsureDecoded(t, alloc); err != nil {
+									return
+								}
 							}
-						}
-						datum := row[columnIdx].Datum
-						if datum == tree.DNull {
-							vec.Nulls().SetNull(i)
-						} else {
+							datum := row[columnIdx].Datum
+							if datum == tree.DNull {
+								vec.Nulls().SetNull(i)
+							} else {
 
-							v = int64(*datum.(*tree.DInt))
-							castV := v.(int64)
-							col[i] = castV
+								v = int64(*datum.(*tree.DInt))
+								castV := v.(int64)
+								//gcassert:bce
+								col[i] = castV
+							}
 						}
 					}
 				}
@@ -140,22 +156,26 @@ func EncDatumRowsToColVec(
 				case -1:
 				default:
 					col := vec.Float64()
-					var v interface{}
-					for i := range rows {
-						row := rows[i]
-						if row[columnIdx].Datum == nil {
-							if err = row[columnIdx].EnsureDecoded(t, alloc); err != nil {
-								return
+					if len(rows) > 0 {
+						_ = col.Get(len(rows) - 1)
+						var v interface{}
+						for i := range rows {
+							row := rows[i]
+							if row[columnIdx].Datum == nil {
+								if err = row[columnIdx].EnsureDecoded(t, alloc); err != nil {
+									return
+								}
 							}
-						}
-						datum := row[columnIdx].Datum
-						if datum == tree.DNull {
-							vec.Nulls().SetNull(i)
-						} else {
+							datum := row[columnIdx].Datum
+							if datum == tree.DNull {
+								vec.Nulls().SetNull(i)
+							} else {
 
-							v = float64(*datum.(*tree.DFloat))
-							castV := v.(float64)
-							col[i] = castV
+								v = float64(*datum.(*tree.DFloat))
+								castV := v.(float64)
+								//gcassert:bce
+								col[i] = castV
+							}
 						}
 					}
 				}
@@ -164,22 +184,25 @@ func EncDatumRowsToColVec(
 				case -1:
 				default:
 					col := vec.Decimal()
-					var v interface{}
-					for i := range rows {
-						row := rows[i]
-						if row[columnIdx].Datum == nil {
-							if err = row[columnIdx].EnsureDecoded(t, alloc); err != nil {
-								return
+					if len(rows) > 0 {
+						_ = col.Get(len(rows) - 1)
+						var v interface{}
+						for i := range rows {
+							row := rows[i]
+							if row[columnIdx].Datum == nil {
+								if err = row[columnIdx].EnsureDecoded(t, alloc); err != nil {
+									return
+								}
 							}
-						}
-						datum := row[columnIdx].Datum
-						if datum == tree.DNull {
-							vec.Nulls().SetNull(i)
-						} else {
+							datum := row[columnIdx].Datum
+							if datum == tree.DNull {
+								vec.Nulls().SetNull(i)
+							} else {
 
-							v = datum.(*tree.DDecimal).Decimal
-							castV := v.(apd.Decimal)
-							col[i].Set(&castV)
+								v = datum.(*tree.DDecimal).Decimal
+								castV := v.(apd.Decimal)
+								col[i].Set(&castV)
+							}
 						}
 					}
 				}
@@ -188,22 +211,26 @@ func EncDatumRowsToColVec(
 				case -1:
 				default:
 					col := vec.Int64()
-					var v interface{}
-					for i := range rows {
-						row := rows[i]
-						if row[columnIdx].Datum == nil {
-							if err = row[columnIdx].EnsureDecoded(t, alloc); err != nil {
-								return
+					if len(rows) > 0 {
+						_ = col.Get(len(rows) - 1)
+						var v interface{}
+						for i := range rows {
+							row := rows[i]
+							if row[columnIdx].Datum == nil {
+								if err = row[columnIdx].EnsureDecoded(t, alloc); err != nil {
+									return
+								}
 							}
-						}
-						datum := row[columnIdx].Datum
-						if datum == tree.DNull {
-							vec.Nulls().SetNull(i)
-						} else {
+							datum := row[columnIdx].Datum
+							if datum == tree.DNull {
+								vec.Nulls().SetNull(i)
+							} else {
 
-							v = datum.(*tree.DDate).UnixEpochDaysWithOrig()
-							castV := v.(int64)
-							col[i] = castV
+								v = datum.(*tree.DDate).UnixEpochDaysWithOrig()
+								castV := v.(int64)
+								//gcassert:bce
+								col[i] = castV
+							}
 						}
 					}
 				}
@@ -212,22 +239,26 @@ func EncDatumRowsToColVec(
 				case -1:
 				default:
 					col := vec.Timestamp()
-					var v interface{}
-					for i := range rows {
-						row := rows[i]
-						if row[columnIdx].Datum == nil {
-							if err = row[columnIdx].EnsureDecoded(t, alloc); err != nil {
-								return
+					if len(rows) > 0 {
+						_ = col.Get(len(rows) - 1)
+						var v interface{}
+						for i := range rows {
+							row := rows[i]
+							if row[columnIdx].Datum == nil {
+								if err = row[columnIdx].EnsureDecoded(t, alloc); err != nil {
+									return
+								}
 							}
-						}
-						datum := row[columnIdx].Datum
-						if datum == tree.DNull {
-							vec.Nulls().SetNull(i)
-						} else {
+							datum := row[columnIdx].Datum
+							if datum == tree.DNull {
+								vec.Nulls().SetNull(i)
+							} else {
 
-							v = datum.(*tree.DTimestamp).Time
-							castV := v.(time.Time)
-							col[i] = castV
+								v = datum.(*tree.DTimestamp).Time
+								castV := v.(time.Time)
+								//gcassert:bce
+								col[i] = castV
+							}
 						}
 					}
 				}
@@ -236,22 +267,26 @@ func EncDatumRowsToColVec(
 				case -1:
 				default:
 					col := vec.Interval()
-					var v interface{}
-					for i := range rows {
-						row := rows[i]
-						if row[columnIdx].Datum == nil {
-							if err = row[columnIdx].EnsureDecoded(t, alloc); err != nil {
-								return
+					if len(rows) > 0 {
+						_ = col.Get(len(rows) - 1)
+						var v interface{}
+						for i := range rows {
+							row := rows[i]
+							if row[columnIdx].Datum == nil {
+								if err = row[columnIdx].EnsureDecoded(t, alloc); err != nil {
+									return
+								}
 							}
-						}
-						datum := row[columnIdx].Datum
-						if datum == tree.DNull {
-							vec.Nulls().SetNull(i)
-						} else {
+							datum := row[columnIdx].Datum
+							if datum == tree.DNull {
+								vec.Nulls().SetNull(i)
+							} else {
 
-							v = datum.(*tree.DInterval).Duration
-							castV := v.(duration.Duration)
-							col[i] = castV
+								v = datum.(*tree.DInterval).Duration
+								castV := v.(duration.Duration)
+								//gcassert:bce
+								col[i] = castV
+							}
 						}
 					}
 				}
@@ -260,26 +295,29 @@ func EncDatumRowsToColVec(
 				case -1:
 				default:
 					col := vec.Bytes()
-					var v interface{}
-					for i := range rows {
-						row := rows[i]
-						if row[columnIdx].Datum == nil {
-							if err = row[columnIdx].EnsureDecoded(t, alloc); err != nil {
-								return
+					if len(rows) > 0 {
+						_ = col.Get(len(rows) - 1)
+						var v interface{}
+						for i := range rows {
+							row := rows[i]
+							if row[columnIdx].Datum == nil {
+								if err = row[columnIdx].EnsureDecoded(t, alloc); err != nil {
+									return
+								}
 							}
-						}
-						datum := row[columnIdx].Datum
-						if datum == tree.DNull {
-							vec.Nulls().SetNull(i)
-						} else {
-							// Handle other STRING-related OID types, like oid.T_name.
-							wrapper, ok := datum.(*tree.DOidWrapper)
-							if ok {
-								datum = wrapper.Wrapped
+							datum := row[columnIdx].Datum
+							if datum == tree.DNull {
+								vec.Nulls().SetNull(i)
+							} else {
+								// Handle other STRING-related OID types, like oid.T_name.
+								wrapper, ok := datum.(*tree.DOidWrapper)
+								if ok {
+									datum = wrapper.Wrapped
+								}
+								v = encoding.UnsafeConvertStringToBytes(string(*datum.(*tree.DString)))
+								castV := v.([]byte)
+								col.Set(i, castV)
 							}
-							v = encoding.UnsafeConvertStringToBytes(string(*datum.(*tree.DString)))
-							castV := v.([]byte)
-							col.Set(i, castV)
 						}
 					}
 				}
@@ -288,22 +326,25 @@ func EncDatumRowsToColVec(
 				case -1:
 				default:
 					col := vec.Bytes()
-					var v interface{}
-					for i := range rows {
-						row := rows[i]
-						if row[columnIdx].Datum == nil {
-							if err = row[columnIdx].EnsureDecoded(t, alloc); err != nil {
-								return
+					if len(rows) > 0 {
+						_ = col.Get(len(rows) - 1)
+						var v interface{}
+						for i := range rows {
+							row := rows[i]
+							if row[columnIdx].Datum == nil {
+								if err = row[columnIdx].EnsureDecoded(t, alloc); err != nil {
+									return
+								}
 							}
-						}
-						datum := row[columnIdx].Datum
-						if datum == tree.DNull {
-							vec.Nulls().SetNull(i)
-						} else {
+							datum := row[columnIdx].Datum
+							if datum == tree.DNull {
+								vec.Nulls().SetNull(i)
+							} else {
 
-							v = encoding.UnsafeConvertStringToBytes(string(*datum.(*tree.DBytes)))
-							castV := v.([]byte)
-							col.Set(i, castV)
+								v = encoding.UnsafeConvertStringToBytes(string(*datum.(*tree.DBytes)))
+								castV := v.([]byte)
+								col.Set(i, castV)
+							}
 						}
 					}
 				}
@@ -312,22 +353,26 @@ func EncDatumRowsToColVec(
 				case -1:
 				default:
 					col := vec.Timestamp()
-					var v interface{}
-					for i := range rows {
-						row := rows[i]
-						if row[columnIdx].Datum == nil {
-							if err = row[columnIdx].EnsureDecoded(t, alloc); err != nil {
-								return
+					if len(rows) > 0 {
+						_ = col.Get(len(rows) - 1)
+						var v interface{}
+						for i := range rows {
+							row := rows[i]
+							if row[columnIdx].Datum == nil {
+								if err = row[columnIdx].EnsureDecoded(t, alloc); err != nil {
+									return
+								}
 							}
-						}
-						datum := row[columnIdx].Datum
-						if datum == tree.DNull {
-							vec.Nulls().SetNull(i)
-						} else {
+							datum := row[columnIdx].Datum
+							if datum == tree.DNull {
+								vec.Nulls().SetNull(i)
+							} else {
 
-							v = datum.(*tree.DTimestampTZ).Time
-							castV := v.(time.Time)
-							col[i] = castV
+								v = datum.(*tree.DTimestampTZ).Time
+								castV := v.(time.Time)
+								//gcassert:bce
+								col[i] = castV
+							}
 						}
 					}
 				}
@@ -336,22 +381,25 @@ func EncDatumRowsToColVec(
 				case -1:
 				default:
 					col := vec.Bytes()
-					var v interface{}
-					for i := range rows {
-						row := rows[i]
-						if row[columnIdx].Datum == nil {
-							if err = row[columnIdx].EnsureDecoded(t, alloc); err != nil {
-								return
+					if len(rows) > 0 {
+						_ = col.Get(len(rows) - 1)
+						var v interface{}
+						for i := range rows {
+							row := rows[i]
+							if row[columnIdx].Datum == nil {
+								if err = row[columnIdx].EnsureDecoded(t, alloc); err != nil {
+									return
+								}
 							}
-						}
-						datum := row[columnIdx].Datum
-						if datum == tree.DNull {
-							vec.Nulls().SetNull(i)
-						} else {
+							datum := row[columnIdx].Datum
+							if datum == tree.DNull {
+								vec.Nulls().SetNull(i)
+							} else {
 
-							v = datum.(*tree.DUuid).UUID.GetBytesMut()
-							castV := v.([]byte)
-							col.Set(i, castV)
+								v = datum.(*tree.DUuid).UUID.GetBytesMut()
+								castV := v.([]byte)
+								col.Set(i, castV)
+							}
 						}
 					}
 				}
@@ -361,22 +409,25 @@ func EncDatumRowsToColVec(
 				case -1:
 				default:
 					col := vec.Datum()
-					var v interface{}
-					for i := range rows {
-						row := rows[i]
-						if row[columnIdx].Datum == nil {
-							if err = row[columnIdx].EnsureDecoded(t, alloc); err != nil {
-								return
+					if len(rows) > 0 {
+						_ = col.Get(len(rows) - 1)
+						var v interface{}
+						for i := range rows {
+							row := rows[i]
+							if row[columnIdx].Datum == nil {
+								if err = row[columnIdx].EnsureDecoded(t, alloc); err != nil {
+									return
+								}
 							}
-						}
-						datum := row[columnIdx].Datum
-						if datum == tree.DNull {
-							vec.Nulls().SetNull(i)
-						} else {
+							datum := row[columnIdx].Datum
+							if datum == tree.DNull {
+								vec.Nulls().SetNull(i)
+							} else {
 
-							v = datum
-							castV := v.(tree.Datum)
-							col.Set(i, castV)
+								v = datum
+								castV := v.(tree.Datum)
+								col.Set(i, castV)
+							}
 						}
 					}
 				}

--- a/pkg/sql/colexec/select_in.eg.go
+++ b/pkg/sql/colexec/select_in.eg.go
@@ -432,6 +432,7 @@ func (si *selectInOpBool) Next(ctx context.Context) coldata.Batch {
 				sel := batch.Selection()
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					v := col.Get(i)
 					if !nulls.NullAt(i) && cmpInBool(v, col, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = i
@@ -454,6 +455,7 @@ func (si *selectInOpBool) Next(ctx context.Context) coldata.Batch {
 				sel := batch.Selection()
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					v := col.Get(i)
 					if cmpInBool(v, col, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = i
@@ -518,6 +520,7 @@ func (pi *projectInOpBool) Next(ctx context.Context) coldata.Batch {
 				if nulls.NullAt(i) {
 					projNulls.SetNull(i)
 				} else {
+					//gcassert:bce
 					v := col.Get(i)
 					cmpRes := cmpInBool(v, col, pi.filterRow, pi.hasNulls)
 					if cmpRes == siNull {
@@ -543,6 +546,7 @@ func (pi *projectInOpBool) Next(ctx context.Context) coldata.Batch {
 		} else {
 			_ = col.Get(n - 1)
 			for i := 0; i < n; i++ {
+				//gcassert:bce
 				v := col.Get(i)
 				cmpRes := cmpInBool(v, col, pi.filterRow, pi.hasNulls)
 				if cmpRes == siNull {
@@ -892,6 +896,7 @@ func (si *selectInOpDecimal) Next(ctx context.Context) coldata.Batch {
 				sel := batch.Selection()
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					v := col.Get(i)
 					if !nulls.NullAt(i) && cmpInDecimal(v, col, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = i
@@ -914,6 +919,7 @@ func (si *selectInOpDecimal) Next(ctx context.Context) coldata.Batch {
 				sel := batch.Selection()
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					v := col.Get(i)
 					if cmpInDecimal(v, col, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = i
@@ -978,6 +984,7 @@ func (pi *projectInOpDecimal) Next(ctx context.Context) coldata.Batch {
 				if nulls.NullAt(i) {
 					projNulls.SetNull(i)
 				} else {
+					//gcassert:bce
 					v := col.Get(i)
 					cmpRes := cmpInDecimal(v, col, pi.filterRow, pi.hasNulls)
 					if cmpRes == siNull {
@@ -1003,6 +1010,7 @@ func (pi *projectInOpDecimal) Next(ctx context.Context) coldata.Batch {
 		} else {
 			_ = col.Get(n - 1)
 			for i := 0; i < n; i++ {
+				//gcassert:bce
 				v := col.Get(i)
 				cmpRes := cmpInDecimal(v, col, pi.filterRow, pi.hasNulls)
 				if cmpRes == siNull {
@@ -1133,6 +1141,7 @@ func (si *selectInOpInt16) Next(ctx context.Context) coldata.Batch {
 				sel := batch.Selection()
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					v := col.Get(i)
 					if !nulls.NullAt(i) && cmpInInt16(v, col, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = i
@@ -1155,6 +1164,7 @@ func (si *selectInOpInt16) Next(ctx context.Context) coldata.Batch {
 				sel := batch.Selection()
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					v := col.Get(i)
 					if cmpInInt16(v, col, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = i
@@ -1219,6 +1229,7 @@ func (pi *projectInOpInt16) Next(ctx context.Context) coldata.Batch {
 				if nulls.NullAt(i) {
 					projNulls.SetNull(i)
 				} else {
+					//gcassert:bce
 					v := col.Get(i)
 					cmpRes := cmpInInt16(v, col, pi.filterRow, pi.hasNulls)
 					if cmpRes == siNull {
@@ -1244,6 +1255,7 @@ func (pi *projectInOpInt16) Next(ctx context.Context) coldata.Batch {
 		} else {
 			_ = col.Get(n - 1)
 			for i := 0; i < n; i++ {
+				//gcassert:bce
 				v := col.Get(i)
 				cmpRes := cmpInInt16(v, col, pi.filterRow, pi.hasNulls)
 				if cmpRes == siNull {
@@ -1374,6 +1386,7 @@ func (si *selectInOpInt32) Next(ctx context.Context) coldata.Batch {
 				sel := batch.Selection()
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					v := col.Get(i)
 					if !nulls.NullAt(i) && cmpInInt32(v, col, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = i
@@ -1396,6 +1409,7 @@ func (si *selectInOpInt32) Next(ctx context.Context) coldata.Batch {
 				sel := batch.Selection()
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					v := col.Get(i)
 					if cmpInInt32(v, col, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = i
@@ -1460,6 +1474,7 @@ func (pi *projectInOpInt32) Next(ctx context.Context) coldata.Batch {
 				if nulls.NullAt(i) {
 					projNulls.SetNull(i)
 				} else {
+					//gcassert:bce
 					v := col.Get(i)
 					cmpRes := cmpInInt32(v, col, pi.filterRow, pi.hasNulls)
 					if cmpRes == siNull {
@@ -1485,6 +1500,7 @@ func (pi *projectInOpInt32) Next(ctx context.Context) coldata.Batch {
 		} else {
 			_ = col.Get(n - 1)
 			for i := 0; i < n; i++ {
+				//gcassert:bce
 				v := col.Get(i)
 				cmpRes := cmpInInt32(v, col, pi.filterRow, pi.hasNulls)
 				if cmpRes == siNull {
@@ -1615,6 +1631,7 @@ func (si *selectInOpInt64) Next(ctx context.Context) coldata.Batch {
 				sel := batch.Selection()
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					v := col.Get(i)
 					if !nulls.NullAt(i) && cmpInInt64(v, col, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = i
@@ -1637,6 +1654,7 @@ func (si *selectInOpInt64) Next(ctx context.Context) coldata.Batch {
 				sel := batch.Selection()
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					v := col.Get(i)
 					if cmpInInt64(v, col, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = i
@@ -1701,6 +1719,7 @@ func (pi *projectInOpInt64) Next(ctx context.Context) coldata.Batch {
 				if nulls.NullAt(i) {
 					projNulls.SetNull(i)
 				} else {
+					//gcassert:bce
 					v := col.Get(i)
 					cmpRes := cmpInInt64(v, col, pi.filterRow, pi.hasNulls)
 					if cmpRes == siNull {
@@ -1726,6 +1745,7 @@ func (pi *projectInOpInt64) Next(ctx context.Context) coldata.Batch {
 		} else {
 			_ = col.Get(n - 1)
 			for i := 0; i < n; i++ {
+				//gcassert:bce
 				v := col.Get(i)
 				cmpRes := cmpInInt64(v, col, pi.filterRow, pi.hasNulls)
 				if cmpRes == siNull {
@@ -1864,6 +1884,7 @@ func (si *selectInOpFloat64) Next(ctx context.Context) coldata.Batch {
 				sel := batch.Selection()
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					v := col.Get(i)
 					if !nulls.NullAt(i) && cmpInFloat64(v, col, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = i
@@ -1886,6 +1907,7 @@ func (si *selectInOpFloat64) Next(ctx context.Context) coldata.Batch {
 				sel := batch.Selection()
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					v := col.Get(i)
 					if cmpInFloat64(v, col, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = i
@@ -1950,6 +1972,7 @@ func (pi *projectInOpFloat64) Next(ctx context.Context) coldata.Batch {
 				if nulls.NullAt(i) {
 					projNulls.SetNull(i)
 				} else {
+					//gcassert:bce
 					v := col.Get(i)
 					cmpRes := cmpInFloat64(v, col, pi.filterRow, pi.hasNulls)
 					if cmpRes == siNull {
@@ -1975,6 +1998,7 @@ func (pi *projectInOpFloat64) Next(ctx context.Context) coldata.Batch {
 		} else {
 			_ = col.Get(n - 1)
 			for i := 0; i < n; i++ {
+				//gcassert:bce
 				v := col.Get(i)
 				cmpRes := cmpInFloat64(v, col, pi.filterRow, pi.hasNulls)
 				if cmpRes == siNull {
@@ -2101,6 +2125,7 @@ func (si *selectInOpTimestamp) Next(ctx context.Context) coldata.Batch {
 				sel := batch.Selection()
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					v := col.Get(i)
 					if !nulls.NullAt(i) && cmpInTimestamp(v, col, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = i
@@ -2123,6 +2148,7 @@ func (si *selectInOpTimestamp) Next(ctx context.Context) coldata.Batch {
 				sel := batch.Selection()
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					v := col.Get(i)
 					if cmpInTimestamp(v, col, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = i
@@ -2187,6 +2213,7 @@ func (pi *projectInOpTimestamp) Next(ctx context.Context) coldata.Batch {
 				if nulls.NullAt(i) {
 					projNulls.SetNull(i)
 				} else {
+					//gcassert:bce
 					v := col.Get(i)
 					cmpRes := cmpInTimestamp(v, col, pi.filterRow, pi.hasNulls)
 					if cmpRes == siNull {
@@ -2212,6 +2239,7 @@ func (pi *projectInOpTimestamp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			_ = col.Get(n - 1)
 			for i := 0; i < n; i++ {
+				//gcassert:bce
 				v := col.Get(i)
 				cmpRes := cmpInTimestamp(v, col, pi.filterRow, pi.hasNulls)
 				if cmpRes == siNull {
@@ -2331,6 +2359,7 @@ func (si *selectInOpInterval) Next(ctx context.Context) coldata.Batch {
 				sel := batch.Selection()
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					v := col.Get(i)
 					if !nulls.NullAt(i) && cmpInInterval(v, col, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = i
@@ -2353,6 +2382,7 @@ func (si *selectInOpInterval) Next(ctx context.Context) coldata.Batch {
 				sel := batch.Selection()
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					//gcassert:bce
 					v := col.Get(i)
 					if cmpInInterval(v, col, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = i
@@ -2417,6 +2447,7 @@ func (pi *projectInOpInterval) Next(ctx context.Context) coldata.Batch {
 				if nulls.NullAt(i) {
 					projNulls.SetNull(i)
 				} else {
+					//gcassert:bce
 					v := col.Get(i)
 					cmpRes := cmpInInterval(v, col, pi.filterRow, pi.hasNulls)
 					if cmpRes == siNull {
@@ -2442,6 +2473,7 @@ func (pi *projectInOpInterval) Next(ctx context.Context) coldata.Batch {
 		} else {
 			_ = col.Get(n - 1)
 			for i := 0; i < n; i++ {
+				//gcassert:bce
 				v := col.Get(i)
 				cmpRes := cmpInInterval(v, col, pi.filterRow, pi.hasNulls)
 				if cmpRes == siNull {

--- a/pkg/sql/colexec/select_in_tmpl.go
+++ b/pkg/sql/colexec/select_in_tmpl.go
@@ -240,6 +240,9 @@ func (si *selectInOp_TYPE) Next(ctx context.Context) coldata.Batch {
 				sel := batch.Selection()
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					// {{if .Sliceable}}
+					//gcassert:bce
+					// {{end}}
 					v := col.Get(i)
 					if !nulls.NullAt(i) && cmpIn_TYPE(v, col, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = i
@@ -262,6 +265,9 @@ func (si *selectInOp_TYPE) Next(ctx context.Context) coldata.Batch {
 				sel := batch.Selection()
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
+					// {{if .Sliceable}}
+					//gcassert:bce
+					// {{end}}
 					v := col.Get(i)
 					if cmpIn_TYPE(v, col, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = i
@@ -326,6 +332,9 @@ func (pi *projectInOp_TYPE) Next(ctx context.Context) coldata.Batch {
 				if nulls.NullAt(i) {
 					projNulls.SetNull(i)
 				} else {
+					// {{if .Sliceable}}
+					//gcassert:bce
+					// {{end}}
 					v := col.Get(i)
 					cmpRes := cmpIn_TYPE(v, col, pi.filterRow, pi.hasNulls)
 					if cmpRes == siNull {
@@ -351,6 +360,9 @@ func (pi *projectInOp_TYPE) Next(ctx context.Context) coldata.Batch {
 		} else {
 			_ = col.Get(n - 1)
 			for i := 0; i < n; i++ {
+				// {{if .Sliceable}}
+				//gcassert:bce
+				// {{end}}
 				v := col.Get(i)
 				cmpRes := cmpIn_TYPE(v, col, pi.filterRow, pi.hasNulls)
 				if cmpRes == siNull {

--- a/pkg/sql/colexec/selection_ops.eg.go
+++ b/pkg/sql/colexec/selection_ops.eg.go
@@ -109,6 +109,7 @@ func (p *selEQBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -165,6 +166,7 @@ func (p *selEQBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -261,7 +263,9 @@ func (p *selEQBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -320,7 +324,9 @@ func (p *selEQBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -651,6 +657,7 @@ func (p *selEQDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -703,6 +710,7 @@ func (p *selEQDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -795,7 +803,9 @@ func (p *selEQDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -850,7 +860,9 @@ func (p *selEQDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -939,6 +951,7 @@ func (p *selEQDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -991,6 +1004,7 @@ func (p *selEQDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -1083,7 +1097,9 @@ func (p *selEQDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -1138,7 +1154,9 @@ func (p *selEQDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -1227,6 +1245,7 @@ func (p *selEQDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -1279,6 +1298,7 @@ func (p *selEQDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -1371,7 +1391,9 @@ func (p *selEQDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -1426,7 +1448,9 @@ func (p *selEQDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -1517,6 +1541,7 @@ func (p *selEQDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -1573,6 +1598,7 @@ func (p *selEQDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -1669,7 +1695,9 @@ func (p *selEQDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -1728,7 +1756,9 @@ func (p *selEQDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -1813,6 +1843,7 @@ func (p *selEQDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -1853,6 +1884,7 @@ func (p *selEQDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -1933,7 +1965,9 @@ func (p *selEQDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -1976,7 +2010,9 @@ func (p *selEQDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -2064,6 +2100,7 @@ func (p *selEQInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -2126,6 +2163,7 @@ func (p *selEQInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -2228,7 +2266,9 @@ func (p *selEQInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -2293,7 +2333,9 @@ func (p *selEQInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -2392,6 +2434,7 @@ func (p *selEQInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -2454,6 +2497,7 @@ func (p *selEQInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -2556,7 +2600,9 @@ func (p *selEQInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -2621,7 +2667,9 @@ func (p *selEQInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -2720,6 +2768,7 @@ func (p *selEQInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -2782,6 +2831,7 @@ func (p *selEQInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -2884,7 +2934,9 @@ func (p *selEQInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -2949,7 +3001,9 @@ func (p *selEQInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -3056,6 +3110,7 @@ func (p *selEQInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -3134,6 +3189,7 @@ func (p *selEQInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -3252,7 +3308,9 @@ func (p *selEQInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -3333,7 +3391,9 @@ func (p *selEQInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -3435,6 +3495,7 @@ func (p *selEQInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -3487,6 +3548,7 @@ func (p *selEQInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -3579,7 +3641,9 @@ func (p *selEQInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -3634,7 +3698,9 @@ func (p *selEQInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -3728,6 +3794,7 @@ func (p *selEQInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -3790,6 +3857,7 @@ func (p *selEQInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -3892,7 +3960,9 @@ func (p *selEQInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -3957,7 +4027,9 @@ func (p *selEQInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -4056,6 +4128,7 @@ func (p *selEQInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -4118,6 +4191,7 @@ func (p *selEQInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -4220,7 +4294,9 @@ func (p *selEQInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -4285,7 +4361,9 @@ func (p *selEQInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -4384,6 +4462,7 @@ func (p *selEQInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -4446,6 +4525,7 @@ func (p *selEQInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -4548,7 +4628,9 @@ func (p *selEQInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -4613,7 +4695,9 @@ func (p *selEQInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -4720,6 +4804,7 @@ func (p *selEQInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -4798,6 +4883,7 @@ func (p *selEQInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -4916,7 +5002,9 @@ func (p *selEQInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -4997,7 +5085,9 @@ func (p *selEQInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -5099,6 +5189,7 @@ func (p *selEQInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -5151,6 +5242,7 @@ func (p *selEQInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -5243,7 +5335,9 @@ func (p *selEQInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -5298,7 +5392,9 @@ func (p *selEQInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -5392,6 +5488,7 @@ func (p *selEQInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -5454,6 +5551,7 @@ func (p *selEQInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -5556,7 +5654,9 @@ func (p *selEQInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -5621,7 +5721,9 @@ func (p *selEQInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -5720,6 +5822,7 @@ func (p *selEQInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -5782,6 +5885,7 @@ func (p *selEQInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -5884,7 +5988,9 @@ func (p *selEQInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -5949,7 +6055,9 @@ func (p *selEQInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -6048,6 +6156,7 @@ func (p *selEQInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -6110,6 +6219,7 @@ func (p *selEQInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -6212,7 +6322,9 @@ func (p *selEQInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -6277,7 +6389,9 @@ func (p *selEQInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -6384,6 +6498,7 @@ func (p *selEQInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -6462,6 +6577,7 @@ func (p *selEQInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -6580,7 +6696,9 @@ func (p *selEQInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -6661,7 +6779,9 @@ func (p *selEQInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -6763,6 +6883,7 @@ func (p *selEQInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -6815,6 +6936,7 @@ func (p *selEQInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -6907,7 +7029,9 @@ func (p *selEQInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -6962,7 +7086,9 @@ func (p *selEQInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -7064,6 +7190,7 @@ func (p *selEQFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -7142,6 +7269,7 @@ func (p *selEQFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -7260,7 +7388,9 @@ func (p *selEQFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -7341,7 +7471,9 @@ func (p *selEQFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -7456,6 +7588,7 @@ func (p *selEQFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -7534,6 +7667,7 @@ func (p *selEQFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -7652,7 +7786,9 @@ func (p *selEQFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -7733,7 +7869,9 @@ func (p *selEQFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -7848,6 +7986,7 @@ func (p *selEQFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -7926,6 +8065,7 @@ func (p *selEQFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -8044,7 +8184,9 @@ func (p *selEQFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -8125,7 +8267,9 @@ func (p *selEQFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -8240,6 +8384,7 @@ func (p *selEQFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -8318,6 +8463,7 @@ func (p *selEQFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -8436,7 +8582,9 @@ func (p *selEQFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -8517,7 +8665,9 @@ func (p *selEQFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -8621,6 +8771,7 @@ func (p *selEQFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -8677,6 +8828,7 @@ func (p *selEQFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -8773,7 +8925,9 @@ func (p *selEQFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -8832,7 +8986,9 @@ func (p *selEQFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -8924,6 +9080,7 @@ func (p *selEQTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -8978,6 +9135,7 @@ func (p *selEQTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -9072,7 +9230,9 @@ func (p *selEQTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -9129,7 +9289,9 @@ func (p *selEQTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -9213,6 +9375,7 @@ func (p *selEQIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -9253,6 +9416,7 @@ func (p *selEQIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -9333,7 +9497,9 @@ func (p *selEQIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -9376,7 +9542,9 @@ func (p *selEQIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -9717,6 +9885,7 @@ func (p *selNEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -9773,6 +9942,7 @@ func (p *selNEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -9869,7 +10039,9 @@ func (p *selNEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -9928,7 +10100,9 @@ func (p *selNEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -10259,6 +10433,7 @@ func (p *selNEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -10311,6 +10486,7 @@ func (p *selNEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -10403,7 +10579,9 @@ func (p *selNEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -10458,7 +10636,9 @@ func (p *selNEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -10547,6 +10727,7 @@ func (p *selNEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -10599,6 +10780,7 @@ func (p *selNEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -10691,7 +10873,9 @@ func (p *selNEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -10746,7 +10930,9 @@ func (p *selNEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -10835,6 +11021,7 @@ func (p *selNEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -10887,6 +11074,7 @@ func (p *selNEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -10979,7 +11167,9 @@ func (p *selNEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -11034,7 +11224,9 @@ func (p *selNEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -11125,6 +11317,7 @@ func (p *selNEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -11181,6 +11374,7 @@ func (p *selNEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -11277,7 +11471,9 @@ func (p *selNEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -11336,7 +11532,9 @@ func (p *selNEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -11421,6 +11619,7 @@ func (p *selNEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -11461,6 +11660,7 @@ func (p *selNEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -11541,7 +11741,9 @@ func (p *selNEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -11584,7 +11786,9 @@ func (p *selNEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -11672,6 +11876,7 @@ func (p *selNEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -11734,6 +11939,7 @@ func (p *selNEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -11836,7 +12042,9 @@ func (p *selNEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -11901,7 +12109,9 @@ func (p *selNEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -12000,6 +12210,7 @@ func (p *selNEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -12062,6 +12273,7 @@ func (p *selNEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -12164,7 +12376,9 @@ func (p *selNEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -12229,7 +12443,9 @@ func (p *selNEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -12328,6 +12544,7 @@ func (p *selNEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -12390,6 +12607,7 @@ func (p *selNEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -12492,7 +12710,9 @@ func (p *selNEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -12557,7 +12777,9 @@ func (p *selNEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -12664,6 +12886,7 @@ func (p *selNEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -12742,6 +12965,7 @@ func (p *selNEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -12860,7 +13084,9 @@ func (p *selNEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -12941,7 +13167,9 @@ func (p *selNEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -13043,6 +13271,7 @@ func (p *selNEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -13095,6 +13324,7 @@ func (p *selNEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -13187,7 +13417,9 @@ func (p *selNEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -13242,7 +13474,9 @@ func (p *selNEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -13336,6 +13570,7 @@ func (p *selNEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -13398,6 +13633,7 @@ func (p *selNEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -13500,7 +13736,9 @@ func (p *selNEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -13565,7 +13803,9 @@ func (p *selNEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -13664,6 +13904,7 @@ func (p *selNEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -13726,6 +13967,7 @@ func (p *selNEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -13828,7 +14070,9 @@ func (p *selNEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -13893,7 +14137,9 @@ func (p *selNEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -13992,6 +14238,7 @@ func (p *selNEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -14054,6 +14301,7 @@ func (p *selNEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -14156,7 +14404,9 @@ func (p *selNEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -14221,7 +14471,9 @@ func (p *selNEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -14328,6 +14580,7 @@ func (p *selNEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -14406,6 +14659,7 @@ func (p *selNEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -14524,7 +14778,9 @@ func (p *selNEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -14605,7 +14861,9 @@ func (p *selNEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -14707,6 +14965,7 @@ func (p *selNEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -14759,6 +15018,7 @@ func (p *selNEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -14851,7 +15111,9 @@ func (p *selNEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -14906,7 +15168,9 @@ func (p *selNEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -15000,6 +15264,7 @@ func (p *selNEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -15062,6 +15327,7 @@ func (p *selNEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -15164,7 +15430,9 @@ func (p *selNEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -15229,7 +15497,9 @@ func (p *selNEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -15328,6 +15598,7 @@ func (p *selNEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -15390,6 +15661,7 @@ func (p *selNEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -15492,7 +15764,9 @@ func (p *selNEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -15557,7 +15831,9 @@ func (p *selNEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -15656,6 +15932,7 @@ func (p *selNEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -15718,6 +15995,7 @@ func (p *selNEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -15820,7 +16098,9 @@ func (p *selNEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -15885,7 +16165,9 @@ func (p *selNEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -15992,6 +16274,7 @@ func (p *selNEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -16070,6 +16353,7 @@ func (p *selNEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -16188,7 +16472,9 @@ func (p *selNEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -16269,7 +16555,9 @@ func (p *selNEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -16371,6 +16659,7 @@ func (p *selNEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -16423,6 +16712,7 @@ func (p *selNEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -16515,7 +16805,9 @@ func (p *selNEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -16570,7 +16862,9 @@ func (p *selNEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -16672,6 +16966,7 @@ func (p *selNEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -16750,6 +17045,7 @@ func (p *selNEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -16868,7 +17164,9 @@ func (p *selNEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -16949,7 +17247,9 @@ func (p *selNEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -17064,6 +17364,7 @@ func (p *selNEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -17142,6 +17443,7 @@ func (p *selNEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -17260,7 +17562,9 @@ func (p *selNEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -17341,7 +17645,9 @@ func (p *selNEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -17456,6 +17762,7 @@ func (p *selNEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -17534,6 +17841,7 @@ func (p *selNEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -17652,7 +17960,9 @@ func (p *selNEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -17733,7 +18043,9 @@ func (p *selNEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -17848,6 +18160,7 @@ func (p *selNEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -17926,6 +18239,7 @@ func (p *selNEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -18044,7 +18358,9 @@ func (p *selNEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -18125,7 +18441,9 @@ func (p *selNEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -18229,6 +18547,7 @@ func (p *selNEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -18285,6 +18604,7 @@ func (p *selNEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -18381,7 +18701,9 @@ func (p *selNEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -18440,7 +18762,9 @@ func (p *selNEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -18532,6 +18856,7 @@ func (p *selNETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -18586,6 +18911,7 @@ func (p *selNETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -18680,7 +19006,9 @@ func (p *selNETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -18737,7 +19065,9 @@ func (p *selNETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -18821,6 +19151,7 @@ func (p *selNEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -18861,6 +19192,7 @@ func (p *selNEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -18941,7 +19273,9 @@ func (p *selNEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -18984,7 +19318,9 @@ func (p *selNEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -19325,6 +19661,7 @@ func (p *selLTBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -19381,6 +19718,7 @@ func (p *selLTBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -19477,7 +19815,9 @@ func (p *selLTBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -19536,7 +19876,9 @@ func (p *selLTBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -19867,6 +20209,7 @@ func (p *selLTDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -19919,6 +20262,7 @@ func (p *selLTDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -20011,7 +20355,9 @@ func (p *selLTDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -20066,7 +20412,9 @@ func (p *selLTDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -20155,6 +20503,7 @@ func (p *selLTDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -20207,6 +20556,7 @@ func (p *selLTDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -20299,7 +20649,9 @@ func (p *selLTDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -20354,7 +20706,9 @@ func (p *selLTDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -20443,6 +20797,7 @@ func (p *selLTDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -20495,6 +20850,7 @@ func (p *selLTDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -20587,7 +20943,9 @@ func (p *selLTDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -20642,7 +21000,9 @@ func (p *selLTDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -20733,6 +21093,7 @@ func (p *selLTDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -20789,6 +21150,7 @@ func (p *selLTDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -20885,7 +21247,9 @@ func (p *selLTDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -20944,7 +21308,9 @@ func (p *selLTDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -21029,6 +21395,7 @@ func (p *selLTDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -21069,6 +21436,7 @@ func (p *selLTDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -21149,7 +21517,9 @@ func (p *selLTDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -21192,7 +21562,9 @@ func (p *selLTDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -21280,6 +21652,7 @@ func (p *selLTInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -21342,6 +21715,7 @@ func (p *selLTInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -21444,7 +21818,9 @@ func (p *selLTInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -21509,7 +21885,9 @@ func (p *selLTInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -21608,6 +21986,7 @@ func (p *selLTInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -21670,6 +22049,7 @@ func (p *selLTInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -21772,7 +22152,9 @@ func (p *selLTInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -21837,7 +22219,9 @@ func (p *selLTInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -21936,6 +22320,7 @@ func (p *selLTInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -21998,6 +22383,7 @@ func (p *selLTInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -22100,7 +22486,9 @@ func (p *selLTInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -22165,7 +22553,9 @@ func (p *selLTInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -22272,6 +22662,7 @@ func (p *selLTInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -22350,6 +22741,7 @@ func (p *selLTInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -22468,7 +22860,9 @@ func (p *selLTInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -22549,7 +22943,9 @@ func (p *selLTInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -22651,6 +23047,7 @@ func (p *selLTInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -22703,6 +23100,7 @@ func (p *selLTInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -22795,7 +23193,9 @@ func (p *selLTInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -22850,7 +23250,9 @@ func (p *selLTInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -22944,6 +23346,7 @@ func (p *selLTInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -23006,6 +23409,7 @@ func (p *selLTInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -23108,7 +23512,9 @@ func (p *selLTInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -23173,7 +23579,9 @@ func (p *selLTInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -23272,6 +23680,7 @@ func (p *selLTInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -23334,6 +23743,7 @@ func (p *selLTInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -23436,7 +23846,9 @@ func (p *selLTInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -23501,7 +23913,9 @@ func (p *selLTInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -23600,6 +24014,7 @@ func (p *selLTInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -23662,6 +24077,7 @@ func (p *selLTInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -23764,7 +24180,9 @@ func (p *selLTInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -23829,7 +24247,9 @@ func (p *selLTInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -23936,6 +24356,7 @@ func (p *selLTInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -24014,6 +24435,7 @@ func (p *selLTInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -24132,7 +24554,9 @@ func (p *selLTInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -24213,7 +24637,9 @@ func (p *selLTInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -24315,6 +24741,7 @@ func (p *selLTInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -24367,6 +24794,7 @@ func (p *selLTInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -24459,7 +24887,9 @@ func (p *selLTInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -24514,7 +24944,9 @@ func (p *selLTInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -24608,6 +25040,7 @@ func (p *selLTInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -24670,6 +25103,7 @@ func (p *selLTInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -24772,7 +25206,9 @@ func (p *selLTInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -24837,7 +25273,9 @@ func (p *selLTInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -24936,6 +25374,7 @@ func (p *selLTInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -24998,6 +25437,7 @@ func (p *selLTInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -25100,7 +25540,9 @@ func (p *selLTInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -25165,7 +25607,9 @@ func (p *selLTInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -25264,6 +25708,7 @@ func (p *selLTInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -25326,6 +25771,7 @@ func (p *selLTInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -25428,7 +25874,9 @@ func (p *selLTInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -25493,7 +25941,9 @@ func (p *selLTInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -25600,6 +26050,7 @@ func (p *selLTInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -25678,6 +26129,7 @@ func (p *selLTInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -25796,7 +26248,9 @@ func (p *selLTInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -25877,7 +26331,9 @@ func (p *selLTInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -25979,6 +26435,7 @@ func (p *selLTInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -26031,6 +26488,7 @@ func (p *selLTInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -26123,7 +26581,9 @@ func (p *selLTInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -26178,7 +26638,9 @@ func (p *selLTInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -26280,6 +26742,7 @@ func (p *selLTFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -26358,6 +26821,7 @@ func (p *selLTFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -26476,7 +26940,9 @@ func (p *selLTFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -26557,7 +27023,9 @@ func (p *selLTFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -26672,6 +27140,7 @@ func (p *selLTFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -26750,6 +27219,7 @@ func (p *selLTFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -26868,7 +27338,9 @@ func (p *selLTFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -26949,7 +27421,9 @@ func (p *selLTFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -27064,6 +27538,7 @@ func (p *selLTFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -27142,6 +27617,7 @@ func (p *selLTFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -27260,7 +27736,9 @@ func (p *selLTFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -27341,7 +27819,9 @@ func (p *selLTFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -27456,6 +27936,7 @@ func (p *selLTFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -27534,6 +28015,7 @@ func (p *selLTFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -27652,7 +28134,9 @@ func (p *selLTFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -27733,7 +28217,9 @@ func (p *selLTFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -27837,6 +28323,7 @@ func (p *selLTFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -27893,6 +28380,7 @@ func (p *selLTFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -27989,7 +28477,9 @@ func (p *selLTFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -28048,7 +28538,9 @@ func (p *selLTFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -28140,6 +28632,7 @@ func (p *selLTTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -28194,6 +28687,7 @@ func (p *selLTTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -28288,7 +28782,9 @@ func (p *selLTTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -28345,7 +28841,9 @@ func (p *selLTTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -28429,6 +28927,7 @@ func (p *selLTIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -28469,6 +28968,7 @@ func (p *selLTIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -28549,7 +29049,9 @@ func (p *selLTIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -28592,7 +29094,9 @@ func (p *selLTIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -28933,6 +29437,7 @@ func (p *selLEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -28989,6 +29494,7 @@ func (p *selLEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -29085,7 +29591,9 @@ func (p *selLEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -29144,7 +29652,9 @@ func (p *selLEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -29475,6 +29985,7 @@ func (p *selLEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -29527,6 +30038,7 @@ func (p *selLEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -29619,7 +30131,9 @@ func (p *selLEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -29674,7 +30188,9 @@ func (p *selLEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -29763,6 +30279,7 @@ func (p *selLEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -29815,6 +30332,7 @@ func (p *selLEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -29907,7 +30425,9 @@ func (p *selLEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -29962,7 +30482,9 @@ func (p *selLEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -30051,6 +30573,7 @@ func (p *selLEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -30103,6 +30626,7 @@ func (p *selLEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -30195,7 +30719,9 @@ func (p *selLEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -30250,7 +30776,9 @@ func (p *selLEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -30341,6 +30869,7 @@ func (p *selLEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -30397,6 +30926,7 @@ func (p *selLEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -30493,7 +31023,9 @@ func (p *selLEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -30552,7 +31084,9 @@ func (p *selLEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -30637,6 +31171,7 @@ func (p *selLEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -30677,6 +31212,7 @@ func (p *selLEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -30757,7 +31293,9 @@ func (p *selLEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -30800,7 +31338,9 @@ func (p *selLEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -30888,6 +31428,7 @@ func (p *selLEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -30950,6 +31491,7 @@ func (p *selLEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -31052,7 +31594,9 @@ func (p *selLEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -31117,7 +31661,9 @@ func (p *selLEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -31216,6 +31762,7 @@ func (p *selLEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -31278,6 +31825,7 @@ func (p *selLEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -31380,7 +31928,9 @@ func (p *selLEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -31445,7 +31995,9 @@ func (p *selLEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -31544,6 +32096,7 @@ func (p *selLEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -31606,6 +32159,7 @@ func (p *selLEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -31708,7 +32262,9 @@ func (p *selLEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -31773,7 +32329,9 @@ func (p *selLEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -31880,6 +32438,7 @@ func (p *selLEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -31958,6 +32517,7 @@ func (p *selLEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -32076,7 +32636,9 @@ func (p *selLEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -32157,7 +32719,9 @@ func (p *selLEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -32259,6 +32823,7 @@ func (p *selLEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -32311,6 +32876,7 @@ func (p *selLEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -32403,7 +32969,9 @@ func (p *selLEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -32458,7 +33026,9 @@ func (p *selLEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -32552,6 +33122,7 @@ func (p *selLEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -32614,6 +33185,7 @@ func (p *selLEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -32716,7 +33288,9 @@ func (p *selLEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -32781,7 +33355,9 @@ func (p *selLEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -32880,6 +33456,7 @@ func (p *selLEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -32942,6 +33519,7 @@ func (p *selLEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -33044,7 +33622,9 @@ func (p *selLEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -33109,7 +33689,9 @@ func (p *selLEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -33208,6 +33790,7 @@ func (p *selLEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -33270,6 +33853,7 @@ func (p *selLEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -33372,7 +33956,9 @@ func (p *selLEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -33437,7 +34023,9 @@ func (p *selLEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -33544,6 +34132,7 @@ func (p *selLEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -33622,6 +34211,7 @@ func (p *selLEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -33740,7 +34330,9 @@ func (p *selLEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -33821,7 +34413,9 @@ func (p *selLEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -33923,6 +34517,7 @@ func (p *selLEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -33975,6 +34570,7 @@ func (p *selLEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -34067,7 +34663,9 @@ func (p *selLEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -34122,7 +34720,9 @@ func (p *selLEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -34216,6 +34816,7 @@ func (p *selLEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -34278,6 +34879,7 @@ func (p *selLEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -34380,7 +34982,9 @@ func (p *selLEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -34445,7 +35049,9 @@ func (p *selLEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -34544,6 +35150,7 @@ func (p *selLEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -34606,6 +35213,7 @@ func (p *selLEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -34708,7 +35316,9 @@ func (p *selLEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -34773,7 +35383,9 @@ func (p *selLEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -34872,6 +35484,7 @@ func (p *selLEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -34934,6 +35547,7 @@ func (p *selLEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -35036,7 +35650,9 @@ func (p *selLEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -35101,7 +35717,9 @@ func (p *selLEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -35208,6 +35826,7 @@ func (p *selLEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -35286,6 +35905,7 @@ func (p *selLEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -35404,7 +36024,9 @@ func (p *selLEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -35485,7 +36107,9 @@ func (p *selLEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -35587,6 +36211,7 @@ func (p *selLEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -35639,6 +36264,7 @@ func (p *selLEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -35731,7 +36357,9 @@ func (p *selLEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -35786,7 +36414,9 @@ func (p *selLEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -35888,6 +36518,7 @@ func (p *selLEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -35966,6 +36597,7 @@ func (p *selLEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -36084,7 +36716,9 @@ func (p *selLEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -36165,7 +36799,9 @@ func (p *selLEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -36280,6 +36916,7 @@ func (p *selLEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -36358,6 +36995,7 @@ func (p *selLEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -36476,7 +37114,9 @@ func (p *selLEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -36557,7 +37197,9 @@ func (p *selLEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -36672,6 +37314,7 @@ func (p *selLEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -36750,6 +37393,7 @@ func (p *selLEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -36868,7 +37512,9 @@ func (p *selLEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -36949,7 +37595,9 @@ func (p *selLEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -37064,6 +37712,7 @@ func (p *selLEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -37142,6 +37791,7 @@ func (p *selLEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -37260,7 +37910,9 @@ func (p *selLEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -37341,7 +37993,9 @@ func (p *selLEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -37445,6 +38099,7 @@ func (p *selLEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -37501,6 +38156,7 @@ func (p *selLEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -37597,7 +38253,9 @@ func (p *selLEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -37656,7 +38314,9 @@ func (p *selLEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -37748,6 +38408,7 @@ func (p *selLETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -37802,6 +38463,7 @@ func (p *selLETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -37896,7 +38558,9 @@ func (p *selLETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -37953,7 +38617,9 @@ func (p *selLETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -38037,6 +38703,7 @@ func (p *selLEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -38077,6 +38744,7 @@ func (p *selLEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -38157,7 +38825,9 @@ func (p *selLEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -38200,7 +38870,9 @@ func (p *selLEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -38541,6 +39213,7 @@ func (p *selGTBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -38597,6 +39270,7 @@ func (p *selGTBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -38693,7 +39367,9 @@ func (p *selGTBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -38752,7 +39428,9 @@ func (p *selGTBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -39083,6 +39761,7 @@ func (p *selGTDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -39135,6 +39814,7 @@ func (p *selGTDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -39227,7 +39907,9 @@ func (p *selGTDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -39282,7 +39964,9 @@ func (p *selGTDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -39371,6 +40055,7 @@ func (p *selGTDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -39423,6 +40108,7 @@ func (p *selGTDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -39515,7 +40201,9 @@ func (p *selGTDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -39570,7 +40258,9 @@ func (p *selGTDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -39659,6 +40349,7 @@ func (p *selGTDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -39711,6 +40402,7 @@ func (p *selGTDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -39803,7 +40495,9 @@ func (p *selGTDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -39858,7 +40552,9 @@ func (p *selGTDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -39949,6 +40645,7 @@ func (p *selGTDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -40005,6 +40702,7 @@ func (p *selGTDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -40101,7 +40799,9 @@ func (p *selGTDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -40160,7 +40860,9 @@ func (p *selGTDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -40245,6 +40947,7 @@ func (p *selGTDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -40285,6 +40988,7 @@ func (p *selGTDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -40365,7 +41069,9 @@ func (p *selGTDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -40408,7 +41114,9 @@ func (p *selGTDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -40496,6 +41204,7 @@ func (p *selGTInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -40558,6 +41267,7 @@ func (p *selGTInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -40660,7 +41370,9 @@ func (p *selGTInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -40725,7 +41437,9 @@ func (p *selGTInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -40824,6 +41538,7 @@ func (p *selGTInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -40886,6 +41601,7 @@ func (p *selGTInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -40988,7 +41704,9 @@ func (p *selGTInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -41053,7 +41771,9 @@ func (p *selGTInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -41152,6 +41872,7 @@ func (p *selGTInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -41214,6 +41935,7 @@ func (p *selGTInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -41316,7 +42038,9 @@ func (p *selGTInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -41381,7 +42105,9 @@ func (p *selGTInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -41488,6 +42214,7 @@ func (p *selGTInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -41566,6 +42293,7 @@ func (p *selGTInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -41684,7 +42412,9 @@ func (p *selGTInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -41765,7 +42495,9 @@ func (p *selGTInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -41867,6 +42599,7 @@ func (p *selGTInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -41919,6 +42652,7 @@ func (p *selGTInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -42011,7 +42745,9 @@ func (p *selGTInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -42066,7 +42802,9 @@ func (p *selGTInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -42160,6 +42898,7 @@ func (p *selGTInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -42222,6 +42961,7 @@ func (p *selGTInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -42324,7 +43064,9 @@ func (p *selGTInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -42389,7 +43131,9 @@ func (p *selGTInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -42488,6 +43232,7 @@ func (p *selGTInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -42550,6 +43295,7 @@ func (p *selGTInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -42652,7 +43398,9 @@ func (p *selGTInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -42717,7 +43465,9 @@ func (p *selGTInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -42816,6 +43566,7 @@ func (p *selGTInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -42878,6 +43629,7 @@ func (p *selGTInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -42980,7 +43732,9 @@ func (p *selGTInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -43045,7 +43799,9 @@ func (p *selGTInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -43152,6 +43908,7 @@ func (p *selGTInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -43230,6 +43987,7 @@ func (p *selGTInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -43348,7 +44106,9 @@ func (p *selGTInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -43429,7 +44189,9 @@ func (p *selGTInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -43531,6 +44293,7 @@ func (p *selGTInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -43583,6 +44346,7 @@ func (p *selGTInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -43675,7 +44439,9 @@ func (p *selGTInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -43730,7 +44496,9 @@ func (p *selGTInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -43824,6 +44592,7 @@ func (p *selGTInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -43886,6 +44655,7 @@ func (p *selGTInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -43988,7 +44758,9 @@ func (p *selGTInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -44053,7 +44825,9 @@ func (p *selGTInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -44152,6 +44926,7 @@ func (p *selGTInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -44214,6 +44989,7 @@ func (p *selGTInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -44316,7 +45092,9 @@ func (p *selGTInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -44381,7 +45159,9 @@ func (p *selGTInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -44480,6 +45260,7 @@ func (p *selGTInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -44542,6 +45323,7 @@ func (p *selGTInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -44644,7 +45426,9 @@ func (p *selGTInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -44709,7 +45493,9 @@ func (p *selGTInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -44816,6 +45602,7 @@ func (p *selGTInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -44894,6 +45681,7 @@ func (p *selGTInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -45012,7 +45800,9 @@ func (p *selGTInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -45093,7 +45883,9 @@ func (p *selGTInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -45195,6 +45987,7 @@ func (p *selGTInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -45247,6 +46040,7 @@ func (p *selGTInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -45339,7 +46133,9 @@ func (p *selGTInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -45394,7 +46190,9 @@ func (p *selGTInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -45496,6 +46294,7 @@ func (p *selGTFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -45574,6 +46373,7 @@ func (p *selGTFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -45692,7 +46492,9 @@ func (p *selGTFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -45773,7 +46575,9 @@ func (p *selGTFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -45888,6 +46692,7 @@ func (p *selGTFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -45966,6 +46771,7 @@ func (p *selGTFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -46084,7 +46890,9 @@ func (p *selGTFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -46165,7 +46973,9 @@ func (p *selGTFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -46280,6 +47090,7 @@ func (p *selGTFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -46358,6 +47169,7 @@ func (p *selGTFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -46476,7 +47288,9 @@ func (p *selGTFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -46557,7 +47371,9 @@ func (p *selGTFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -46672,6 +47488,7 @@ func (p *selGTFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -46750,6 +47567,7 @@ func (p *selGTFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -46868,7 +47686,9 @@ func (p *selGTFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -46949,7 +47769,9 @@ func (p *selGTFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -47053,6 +47875,7 @@ func (p *selGTFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -47109,6 +47932,7 @@ func (p *selGTFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -47205,7 +48029,9 @@ func (p *selGTFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -47264,7 +48090,9 @@ func (p *selGTFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -47356,6 +48184,7 @@ func (p *selGTTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -47410,6 +48239,7 @@ func (p *selGTTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -47504,7 +48334,9 @@ func (p *selGTTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -47561,7 +48393,9 @@ func (p *selGTTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -47645,6 +48479,7 @@ func (p *selGTIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -47685,6 +48520,7 @@ func (p *selGTIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -47765,7 +48601,9 @@ func (p *selGTIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -47808,7 +48646,9 @@ func (p *selGTIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -48149,6 +48989,7 @@ func (p *selGEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -48205,6 +49046,7 @@ func (p *selGEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -48301,7 +49143,9 @@ func (p *selGEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -48360,7 +49204,9 @@ func (p *selGEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -48691,6 +49537,7 @@ func (p *selGEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -48743,6 +49590,7 @@ func (p *selGEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -48835,7 +49683,9 @@ func (p *selGEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -48890,7 +49740,9 @@ func (p *selGEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -48979,6 +49831,7 @@ func (p *selGEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -49031,6 +49884,7 @@ func (p *selGEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -49123,7 +49977,9 @@ func (p *selGEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -49178,7 +50034,9 @@ func (p *selGEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -49267,6 +50125,7 @@ func (p *selGEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -49319,6 +50178,7 @@ func (p *selGEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -49411,7 +50271,9 @@ func (p *selGEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -49466,7 +50328,9 @@ func (p *selGEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -49557,6 +50421,7 @@ func (p *selGEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -49613,6 +50478,7 @@ func (p *selGEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -49709,7 +50575,9 @@ func (p *selGEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -49768,7 +50636,9 @@ func (p *selGEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -49853,6 +50723,7 @@ func (p *selGEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -49893,6 +50764,7 @@ func (p *selGEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -49973,7 +50845,9 @@ func (p *selGEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -50016,7 +50890,9 @@ func (p *selGEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -50104,6 +50980,7 @@ func (p *selGEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -50166,6 +51043,7 @@ func (p *selGEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -50268,7 +51146,9 @@ func (p *selGEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -50333,7 +51213,9 @@ func (p *selGEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -50432,6 +51314,7 @@ func (p *selGEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -50494,6 +51377,7 @@ func (p *selGEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -50596,7 +51480,9 @@ func (p *selGEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -50661,7 +51547,9 @@ func (p *selGEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -50760,6 +51648,7 @@ func (p *selGEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -50822,6 +51711,7 @@ func (p *selGEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -50924,7 +51814,9 @@ func (p *selGEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -50989,7 +51881,9 @@ func (p *selGEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -51096,6 +51990,7 @@ func (p *selGEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -51174,6 +52069,7 @@ func (p *selGEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -51292,7 +52188,9 @@ func (p *selGEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -51373,7 +52271,9 @@ func (p *selGEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -51475,6 +52375,7 @@ func (p *selGEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -51527,6 +52428,7 @@ func (p *selGEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -51619,7 +52521,9 @@ func (p *selGEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -51674,7 +52578,9 @@ func (p *selGEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -51768,6 +52674,7 @@ func (p *selGEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -51830,6 +52737,7 @@ func (p *selGEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -51932,7 +52840,9 @@ func (p *selGEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -51997,7 +52907,9 @@ func (p *selGEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -52096,6 +53008,7 @@ func (p *selGEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -52158,6 +53071,7 @@ func (p *selGEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -52260,7 +53174,9 @@ func (p *selGEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -52325,7 +53241,9 @@ func (p *selGEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -52424,6 +53342,7 @@ func (p *selGEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -52486,6 +53405,7 @@ func (p *selGEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -52588,7 +53508,9 @@ func (p *selGEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -52653,7 +53575,9 @@ func (p *selGEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -52760,6 +53684,7 @@ func (p *selGEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -52838,6 +53763,7 @@ func (p *selGEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -52956,7 +53882,9 @@ func (p *selGEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -53037,7 +53965,9 @@ func (p *selGEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -53139,6 +54069,7 @@ func (p *selGEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -53191,6 +54122,7 @@ func (p *selGEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -53283,7 +54215,9 @@ func (p *selGEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -53338,7 +54272,9 @@ func (p *selGEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -53432,6 +54368,7 @@ func (p *selGEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -53494,6 +54431,7 @@ func (p *selGEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -53596,7 +54534,9 @@ func (p *selGEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -53661,7 +54601,9 @@ func (p *selGEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -53760,6 +54702,7 @@ func (p *selGEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -53822,6 +54765,7 @@ func (p *selGEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -53924,7 +54868,9 @@ func (p *selGEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -53989,7 +54935,9 @@ func (p *selGEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -54088,6 +55036,7 @@ func (p *selGEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -54150,6 +55099,7 @@ func (p *selGEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -54252,7 +55202,9 @@ func (p *selGEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -54317,7 +55269,9 @@ func (p *selGEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -54424,6 +55378,7 @@ func (p *selGEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -54502,6 +55457,7 @@ func (p *selGEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -54620,7 +55576,9 @@ func (p *selGEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -54701,7 +55659,9 @@ func (p *selGEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -54803,6 +55763,7 @@ func (p *selGEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -54855,6 +55816,7 @@ func (p *selGEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -54947,7 +55909,9 @@ func (p *selGEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -55002,7 +55966,9 @@ func (p *selGEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -55104,6 +56070,7 @@ func (p *selGEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -55182,6 +56149,7 @@ func (p *selGEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -55300,7 +56268,9 @@ func (p *selGEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -55381,7 +56351,9 @@ func (p *selGEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -55496,6 +56468,7 @@ func (p *selGEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -55574,6 +56547,7 @@ func (p *selGEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -55692,7 +56666,9 @@ func (p *selGEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -55773,7 +56749,9 @@ func (p *selGEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -55888,6 +56866,7 @@ func (p *selGEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -55966,6 +56945,7 @@ func (p *selGEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -56084,7 +57064,9 @@ func (p *selGEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -56165,7 +57147,9 @@ func (p *selGEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -56280,6 +57264,7 @@ func (p *selGEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -56358,6 +57343,7 @@ func (p *selGEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -56476,7 +57462,9 @@ func (p *selGEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -56557,7 +57545,9 @@ func (p *selGEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -56661,6 +57651,7 @@ func (p *selGEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -56717,6 +57708,7 @@ func (p *selGEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -56813,7 +57805,9 @@ func (p *selGEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -56872,7 +57866,9 @@ func (p *selGEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -56964,6 +57960,7 @@ func (p *selGETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -57018,6 +58015,7 @@ func (p *selGETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -57112,7 +58110,9 @@ func (p *selGETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -57169,7 +58169,9 @@ func (p *selGETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -57253,6 +58255,7 @@ func (p *selGEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -57293,6 +58296,7 @@ func (p *selGEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg := col.Get(i)
 
 					{
@@ -57373,7 +58377,9 @@ func (p *selGEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{
@@ -57416,7 +58422,9 @@ func (p *selGEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
+					//gcassert:bce
 					arg1 := col1.Get(i)
+					//gcassert:bce
 					arg2 := col2.Get(i)
 
 					{

--- a/pkg/sql/colexec/selection_ops_tmpl.go
+++ b/pkg/sql/colexec/selection_ops_tmpl.go
@@ -94,6 +94,9 @@ func _SEL_CONST_LOOP(_HAS_NULLS bool) { // */}}
 		_ = col.Get(n - 1)
 		for i := 0; i < n; i++ {
 			var cmp bool
+			// {{if .Left.Sliceable}}
+			//gcassert:bce
+			// {{end}}
 			arg := col.Get(i)
 			_ASSIGN_CMP(cmp, arg, p.constArg, _, col, _)
 			// {{if _HAS_NULLS}}
@@ -141,7 +144,13 @@ func _SEL_LOOP(_HAS_NULLS bool) { // */}}
 		_ = col2.Get(n - 1)
 		for i := 0; i < n; i++ {
 			var cmp bool
+			// {{if .Left.Sliceable}}
+			//gcassert:bce
+			// {{end}}
 			arg1 := col1.Get(i)
+			// {{if .Right.Sliceable}}
+			//gcassert:bce
+			// {{end}}
 			arg2 := col2.Get(i)
 			_ASSIGN_CMP(cmp, arg1, arg2, _, col1, col2)
 			// {{if _HAS_NULLS}}

--- a/pkg/sql/colexec/substring.eg.go
+++ b/pkg/sql/colexec/substring.eg.go
@@ -117,6 +117,8 @@ func (s *substringInt64Int16Operator) Next(ctx context.Context) coldata.Batch {
 	s.allocator.PerformOperation(
 		[]coldata.Vec{outputVec},
 		func() {
+			// TODO(yuzefovich): refactor this loop so that BCE occurs when sel
+			// is nil.
 			for i := 0; i < n; i++ {
 				rowIdx := i
 				if sel != nil {
@@ -197,6 +199,8 @@ func (s *substringInt64Int32Operator) Next(ctx context.Context) coldata.Batch {
 	s.allocator.PerformOperation(
 		[]coldata.Vec{outputVec},
 		func() {
+			// TODO(yuzefovich): refactor this loop so that BCE occurs when sel
+			// is nil.
 			for i := 0; i < n; i++ {
 				rowIdx := i
 				if sel != nil {
@@ -277,6 +281,8 @@ func (s *substringInt64Int64Operator) Next(ctx context.Context) coldata.Batch {
 	s.allocator.PerformOperation(
 		[]coldata.Vec{outputVec},
 		func() {
+			// TODO(yuzefovich): refactor this loop so that BCE occurs when sel
+			// is nil.
 			for i := 0; i < n; i++ {
 				rowIdx := i
 				if sel != nil {
@@ -357,6 +363,8 @@ func (s *substringInt16Int16Operator) Next(ctx context.Context) coldata.Batch {
 	s.allocator.PerformOperation(
 		[]coldata.Vec{outputVec},
 		func() {
+			// TODO(yuzefovich): refactor this loop so that BCE occurs when sel
+			// is nil.
 			for i := 0; i < n; i++ {
 				rowIdx := i
 				if sel != nil {
@@ -437,6 +445,8 @@ func (s *substringInt16Int32Operator) Next(ctx context.Context) coldata.Batch {
 	s.allocator.PerformOperation(
 		[]coldata.Vec{outputVec},
 		func() {
+			// TODO(yuzefovich): refactor this loop so that BCE occurs when sel
+			// is nil.
 			for i := 0; i < n; i++ {
 				rowIdx := i
 				if sel != nil {
@@ -517,6 +527,8 @@ func (s *substringInt16Int64Operator) Next(ctx context.Context) coldata.Batch {
 	s.allocator.PerformOperation(
 		[]coldata.Vec{outputVec},
 		func() {
+			// TODO(yuzefovich): refactor this loop so that BCE occurs when sel
+			// is nil.
 			for i := 0; i < n; i++ {
 				rowIdx := i
 				if sel != nil {
@@ -597,6 +609,8 @@ func (s *substringInt32Int16Operator) Next(ctx context.Context) coldata.Batch {
 	s.allocator.PerformOperation(
 		[]coldata.Vec{outputVec},
 		func() {
+			// TODO(yuzefovich): refactor this loop so that BCE occurs when sel
+			// is nil.
 			for i := 0; i < n; i++ {
 				rowIdx := i
 				if sel != nil {
@@ -677,6 +691,8 @@ func (s *substringInt32Int32Operator) Next(ctx context.Context) coldata.Batch {
 	s.allocator.PerformOperation(
 		[]coldata.Vec{outputVec},
 		func() {
+			// TODO(yuzefovich): refactor this loop so that BCE occurs when sel
+			// is nil.
 			for i := 0; i < n; i++ {
 				rowIdx := i
 				if sel != nil {
@@ -757,6 +773,8 @@ func (s *substringInt32Int64Operator) Next(ctx context.Context) coldata.Batch {
 	s.allocator.PerformOperation(
 		[]coldata.Vec{outputVec},
 		func() {
+			// TODO(yuzefovich): refactor this loop so that BCE occurs when sel
+			// is nil.
 			for i := 0; i < n; i++ {
 				rowIdx := i
 				if sel != nil {

--- a/pkg/sql/colexec/substring_tmpl.go
+++ b/pkg/sql/colexec/substring_tmpl.go
@@ -118,6 +118,8 @@ func (s *substring_StartType_LengthTypeOperator) Next(ctx context.Context) colda
 	s.allocator.PerformOperation(
 		[]coldata.Vec{outputVec},
 		func() {
+			// TODO(yuzefovich): refactor this loop so that BCE occurs when sel
+			// is nil.
 			for i := 0; i < n; i++ {
 				rowIdx := i
 				if sel != nil {

--- a/pkg/sql/colexec/window_peer_grouper.eg.go
+++ b/pkg/sql/colexec/window_peer_grouper.eg.go
@@ -165,8 +165,14 @@ func (p *windowPeerGrouperWithPartitionOp) Next(ctx context.Context) coldata.Bat
 		// The new peer group begins either when a new partition begins (in which
 		// case partitionCol[i] is 'true') or when i'th tuple is different from
 		// i-1'th (in which case p.distinctCol[i] is 'true').
-		for i := range peersCol[:n] {
-			peersCol[i] = partitionCol[i] || p.distinctCol[i]
+		_ = peersCol[n-1]
+		_ = partitionCol[n-1]
+		// Capture the slice in order for BCE to occur.
+		distinctCol := p.distinctCol
+		_ = distinctCol[n-1]
+		for i := 0; i < n; i++ {
+			//gcassert:bce
+			peersCol[i] = partitionCol[i] || distinctCol[i]
 		}
 	}
 	return b

--- a/pkg/sql/colexec/window_peer_grouper_tmpl.go
+++ b/pkg/sql/colexec/window_peer_grouper_tmpl.go
@@ -176,8 +176,14 @@ func (p *_PEER_GROUPER_STRINGOp) Next(ctx context.Context) coldata.Batch {
 		// The new peer group begins either when a new partition begins (in which
 		// case partitionCol[i] is 'true') or when i'th tuple is different from
 		// i-1'th (in which case p.distinctCol[i] is 'true').
-		for i := range peersCol[:n] {
-			peersCol[i] = partitionCol[i] || p.distinctCol[i]
+		_ = peersCol[n-1]
+		_ = partitionCol[n-1]
+		// Capture the slice in order for BCE to occur.
+		distinctCol := p.distinctCol
+		_ = distinctCol[n-1]
+		for i := 0; i < n; i++ {
+			//gcassert:bce
+			peersCol[i] = partitionCol[i] || distinctCol[i]
 		}
 		// {{else}}
 		// The new peer group begins when i'th tuple is different from i-1'th (in

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1828,7 +1828,12 @@ func TestLint(t *testing.T) {
 
 		// t.Parallel() // Disabled due to CI not parsing failure from parallel tests correctly. Can be re-enabled on Go 1.15 (see: https://github.com/golang/go/issues/38458).
 		var buf strings.Builder
-		if err := gcassert.GCAssert(&buf, "../../col/coldata", "../../sql/colexec"); err != nil {
+		if err := gcassert.GCAssert(&buf,
+			"../../col/coldata",
+			"../../sql/colconv",
+			"../../sql/colexec",
+			"../../sql/colexec/colexecagg",
+		); err != nil {
 			t.Fatal(err)
 		}
 		output := buf.String()


### PR DESCRIPTION
**coldata: add BCE in Copy in some cases and in AppendSlice of decimals**

This commit audits the usage of slices in the `vec_tmpl` template and
improves `Copy` method with present selection vector for BCEs to occur
on sliceable types. This required introduction a separate path for
sliceable and non-sliceable types (which is a bit confusing, but the
performance improvement of 30-60% is worth it). Also, early bounds
checks are added to `AppendSlice` of decimals.

Additionally, this commit puts `gcassert:bce` in places where we expect
BCEs to occur. The caveat here that BCE works only on vectors that are
"sliceable", so this commit introduces a `Sliceable` method onto the
overload base struct.

Release note: None

**colconv: add early bounds checks and BCE assertions**

This commit reviews `vec_to_datum` template and introduces early bounds
checks where possible. Additionally, BCE assertions are added.

Release note: None

**colexecagg: enforce BCEs where possible**

This commit audits all aggregate functions to add BCE assertions where
we expect them to occur. The following issues were fixed:
- `bool_and_agg` missing the capture of `col`
- `default_agg` missing the capture and slicing of `groups`.

Release note: None

**colexec: improve hash utility methods with early bounds checks**

This commit adds early bounds checks to several hash utility methods
(enforced by the BCE assertions). This required a minor change to the
hash aggregator to avoid a scenario of aggregating over zero buffered
tuples.

Release note: None

**colexec: add early bounds checks in columnarizer and hashtable**

Release note: None

**colexec: audit most templates to add BCE assertions**

This commit reviews most templates in the colexec package to add BCE
assertions where we expect them to occur. The following problems were
fixed:
- `distinct_tmpl` had BCE in the wrong place so that it wasn't working
- `proj_const` missing the capture of `col`.

New early bounds checks are now applied in:
- multiple slices in window functions
- `rowstovec` template
- `hash_aggregator` template
- multiple functions in `hashtable` template
- `default_cmp` template.

Release note: None

**colexec: audit the hash joiner to get BCE**

This commit refactors the hash joiner code to allow for bounds checks
eliminations to occur. Previously, we tried to get them working, but
they didn't because we were missing the capture of the variables, so the
compiler couldn't prove that BCE was safe. This commit adds the early
bounds checks in almost all places in the template file (except for two
spots where I couldn't figure out how to get BCE to occur) which gives
us a modest performance improvement. This, however, required to adjust
the logic slightly.

Release note: None