### PR TITLE
kvserver: generalize setCorruptRaftMuLocked

### DIFF
--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -42,6 +42,7 @@ go_library(
         "replica_eval_context.go",
         "replica_eval_context_span.go",
         "replica_evaluate.go",
+        "replica_exit.go",
         "replica_follower_read.go",
         "replica_gc_queue.go",
         "replica_gossip.go",

--- a/pkg/kv/kvserver/replica_exit.go
+++ b/pkg/kv/kvserver/replica_exit.go
@@ -1,0 +1,42 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package kvserver
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/storage/fs"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+)
+
+func (r *Replica) exitAndPreventStartupMuLockedRaftMuLocked(
+	ctx context.Context, err error, preventStartupMsgBody string,
+) {
+	auxDir := r.store.engine.GetAuxiliaryDir()
+	_ = r.store.engine.MkdirAll(auxDir)
+	path := base.PreventedStartupFile(auxDir)
+
+	preventStartupMsg := fmt.Sprintf(`ATTENTION:
+
+%s
+
+A file preventing this node from restarting was placed at:
+%s
+`, preventStartupMsgBody, path)
+
+	if err := fs.WriteFile(r.store.engine, path, []byte(preventStartupMsg)); err != nil {
+		log.Warningf(ctx, "%v", err)
+	}
+
+	log.Fatalf(ctx, "replica is corrupted: %s", err)
+}


### PR DESCRIPTION
This relates to https://github.com/cockroachdb/cockroach/issues/57369
This is a small refactor of `setCorruptRaftMuLocked` in package
kvserver, with the intention of it the funcionality to be more widely
used. The functionality to write a file to the filesystem that
prevents cockroach from restarting is refactored into its own file
and the interface's parameter is widened to an `error`.

Release note: None.