### PR TITLE
testfilter: further cleanups

### DIFF
--- a/pkg/cmd/testfilter/testdata/omit.txt
+++ b/pkg/cmd/testfilter/testdata/omit.txt
@@ -28,7 +28,7 @@ omit
 {"Time":"2019-11-29T14:20:13.258539+01:00","Action":"pass","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Elapsed":0}
 ----
 
-# Skips unterminated tests.
+# Skips unterminated tests in single-package test binaries.
 omit
 {"Time":"2019-11-29T14:20:13.25826+01:00","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"TestFaker"}
 {"Time":"2019-11-29T14:20:13.258474+01:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"TestFaker","Output":"=== RUN   TestFaker\n"}
@@ -57,10 +57,8 @@ omit
 {"Time":"2019-11-29T14:21:47.595977+01:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"TestFaker","Output":"--- FAIL: TestFaker (0.00s)\n"}
 {"Time":"2019-11-29T14:21:47.595982+01:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"TestFaker","Output":"    stopper_test.go:379: failed\n"}
 {"Time":"2019-11-29T14:21:47.595991+01:00","Action":"fail","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"TestFaker","Elapsed":0}
-{"Time":"2019-11-29T14:21:47.596863+01:00","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"PackageLevel","Elapsed":1.593,"Output":""}
-{"Time":"2019-11-29T14:21:47.596863+01:00","Action":"fail","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"PackageLevel","Elapsed":1.593,"Output":"\nCheck full_output.txt in artifacts for stray panics or other errors that broke the test process."}
 
-# Keeps panicking test.
+# Keeps panicking test when the test is clearly marked as failed.
 omit
 {"Time":"2019-11-29T14:16:10.376429+01:00","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"TestFaker"}
 {"Time":"2019-11-29T14:16:10.37671+01:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"TestFaker","Output":"=== RUN   TestFaker\n"}
@@ -93,3 +91,44 @@ omit
 {"Time":"2019-11-29T14:16:10.379153+01:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"TestFaker","Output":"\t/usr/local/Cellar/go/1.13.4/libexec/src/runtime/panic.go:679 +0x1b2\n"}
 {"Time":"2019-11-29T14:16:10.38139+01:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"TestFaker","Output":"FAIL\tgithub.com/cockroachdb/cockroach/pkg/util/stop\t1.421s\n"}
 {"Time":"2019-11-29T14:16:10.381438+01:00","Action":"fail","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"TestFaker","Elapsed":1.421}
+
+# Keeps unterminated tests in multi-package runs when the package is marked as failed.
+# Also ensure that the "run" event for the pseudo-test coincides with the first test event encountered for the package.
+omit
+{"Time":"2019-11-29T14:21:47.595941+01:00","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"TestFaker","Output":"=== RUN   TestFaker\n"}
+{"Time":"2019-11-29T14:21:47.595957+01:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"TestFaker","Output":"foo\n"}
+{"Time":"2019-11-29T14:21:47.595964+01:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"TestFaker","Output":"bar\n"}
+{"Time":"2019-11-29T14:21:47.595991+01:00","Action":"fail","Package":"github.com/cockroachdb/cockroach/pkg/util/stop"}
+----
+{"Time":"2019-11-29T14:21:47.595941+01:00","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"PackageLevel","Elapsed":0,"Output":""}
+{"Time":"2019-11-29T14:21:47.595991+01:00","Action":"fail","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"PackageLevel","Elapsed":0,"Output":"\nCheck full_output.txt in artifacts for stray panics or other errors that broke the test process.\nThe following tests have not completed and could be the cause of the failure:\nTestFaker"}
+
+# Keep packages that are marked as failed but did not contain any tests.
+omit
+{"Time":"2019-11-29T14:21:43.595991+01:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Output":"foo"}
+{"Time":"2019-11-29T14:21:47.595991+01:00","Action":"fail","Package":"github.com/cockroachdb/cockroach/pkg/util/stop"}
+----
+{"Time":"2019-11-29T14:21:43.595991+01:00","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"PackageLevel","Elapsed":0,"Output":""}
+{"Time":"2019-11-29T14:21:43.595991+01:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"PackageLevel","Elapsed":0,"Output":"foo"}
+{"Time":"2019-11-29T14:21:47.595991+01:00","Action":"fail","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"PackageLevel","Elapsed":0,"Output":"\nCheck full_output.txt in artifacts for stray panics or other errors that broke the test process."}
+
+# Ditto, when the package did not report any output.
+omit
+{"Time":"2019-11-29T14:21:47.595991+01:00","Action":"fail","Package":"github.com/cockroachdb/cockroach/pkg/util/stop"}
+----
+{"Time":"2019-11-29T14:21:47.595991+01:00","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"PackageLevel","Elapsed":0,"Output":""}
+{"Time":"2019-11-29T14:21:47.595991+01:00","Action":"fail","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"PackageLevel","Elapsed":0,"Output":"\nCheck full_output.txt in artifacts for stray panics or other errors that broke the test process."}
+
+# Omit unterminated tests in multi-package runs when the package is marked as passed.
+omit
+{"Time":"2019-11-29T14:21:47.595941+01:00","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"TestFaker","Output":"=== RUN   TestFaker\n"}
+{"Time":"2019-11-29T14:21:47.595957+01:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"TestFaker","Output":"foo\n"}
+{"Time":"2019-11-29T14:21:47.595964+01:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"TestFaker","Output":"bar\n"}
+{"Time":"2019-11-29T14:21:47.595991+01:00","Action":"pass","Package":"github.com/cockroachdb/cockroach/pkg/util/stop"}
+----
+
+# Also omit the package if it passed and there were no tests at all.
+omit
+{"Time":"2019-11-29T14:21:43.595991+01:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Output":"foo"}
+{"Time":"2019-11-29T14:21:47.595991+01:00","Action":"pass","Package":"github.com/cockroachdb/cockroach/pkg/util/stop"}
+----

--- a/pkg/cmd/testfilter/testdata/strip.txt
+++ b/pkg/cmd/testfilter/testdata/strip.txt
@@ -36,7 +36,7 @@ and
 this
 {"Time":"2019-11-29T14:20:13.25826+01:00","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"TestFaker"}
 {"Time":"2019-11-29T14:20:13.258508+01:00","Action":"pass","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"TestFaker","Elapsed":0}
-{"Time":"2019-11-29T14:20:13.258518+01:00","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"PackageLevel","Elapsed":0,"Output":""}
+{"Time":"2019-11-29T14:20:13.25826+01:00","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"PackageLevel","Elapsed":0,"Output":""}
 {"Time":"2019-11-29T14:20:13.258539+01:00","Action":"pass","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"PackageLevel","Elapsed":0,"Output":""}
 too
 the following test is unterminated and thus kept:
@@ -63,10 +63,6 @@ strip
 {"Time":"2019-11-29T14:21:47.595977+01:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"TestFaker","Output":"--- FAIL: TestFaker (0.00s)\n"}
 {"Time":"2019-11-29T14:21:47.595982+01:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"TestFaker","Output":"    stopper_test.go:379: failed\n"}
 {"Time":"2019-11-29T14:21:47.595991+01:00","Action":"fail","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"TestFaker","Elapsed":0}
-{"Time":"2019-11-29T14:21:47.596002+01:00","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"PackageLevel","Elapsed":0,"Output":""}
-{"Time":"2019-11-29T14:21:47.596002+01:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"PackageLevel","Elapsed":0,"Output":"FAIL\n"}
-{"Time":"2019-11-29T14:21:47.59685+01:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"PackageLevel","Elapsed":0,"Output":"FAIL\tgithub.com/cockroachdb/cockroach/pkg/util/stop\t1.593s\n"}
-{"Time":"2019-11-29T14:21:47.596863+01:00","Action":"fail","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"PackageLevel","Elapsed":1.593,"Output":"\nCheck full_output.txt in artifacts for stray panics or other errors that broke the test process."}
 
 # Keeps panicking test.
 strip
@@ -102,7 +98,7 @@ strip
 {"Time":"2019-11-29T14:16:10.38139+01:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"TestFaker","Output":"FAIL\tgithub.com/cockroachdb/cockroach/pkg/util/stop\t1.421s\n"}
 {"Time":"2019-11-29T14:16:10.381438+01:00","Action":"fail","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"TestFaker","Elapsed":1.421}
 
-# Keeps panicking package.
+# Keeps panicking package, when there were no tests.
 strip
 {"Time":"2019-11-29T14:16:10.376429+01:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/stop"}
 {"Time":"2019-11-29T14:16:10.381438+01:00","Action":"fail","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Elapsed":1.421}
@@ -120,13 +116,17 @@ strip
 {"Time":"2019-11-29T14:16:10.37671+01:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"TestFaker/subtest","Output":"=== RUN   TestFaker/subtest\n"}
 {"Time":"2019-11-29T14:16:10.381438+01:00","Action":"fail","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Elapsed":1.421}
 ----
-----
 {"Time":"2019-11-29T14:16:10.376429+01:00","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"TestFaker"}
-{"Time":"2019-11-29T14:16:10.37671+01:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"TestFaker","Output":"=== RUN   TestFaker\n"}
 {"Time":"2019-11-29T14:16:10.381438+01:00","Action":"skip","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"TestFaker","Elapsed":0,"Output":"unfinished due to package-level failure\nCheck full_output.txt in artifacts for stray panics or other errors that broke the test process."}
-
 {"Time":"2019-11-29T14:16:10.376429+01:00","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"PackageLevel","Elapsed":0,"Output":""}
 {"Time":"2019-11-29T14:16:10.376429+01:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"PackageLevel","Elapsed":0,"Output":""}
 {"Time":"2019-11-29T14:16:10.381438+01:00","Action":"fail","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"PackageLevel","Elapsed":1.421,"Output":"\nCheck full_output.txt in artifacts for stray panics or other errors that broke the test process.\nThe following tests have not completed and could be the cause of the failure:\nTestFaker"}
+
+# Discard panicking package when there were tests and all tests are finished.
+strip
+{"Time":"2019-11-29T14:16:10.376429+01:00","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"TestFaker"}
+{"Time":"2019-11-29T14:16:11.37671+01:00","Action":"fail","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"TestFaker","Output":"FAIL"}
+{"Time":"2019-11-29T14:16:13.381438+01:00","Action":"fail","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Elapsed":1.421}
 ----
-----
+{"Time":"2019-11-29T14:16:10.376429+01:00","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"TestFaker"}
+{"Time":"2019-11-29T14:16:11.37671+01:00","Action":"fail","Package":"github.com/cockroachdb/cockroach/pkg/util/stop","Test":"TestFaker","Output":"FAIL"}


### PR DESCRIPTION
Since last week changes I noticed the following two non-useful
behaviors:

- the testfilter would emit a `PackageLevel` pseudo-entry every time a
  package failed, even when there were one or more tests in the package
  already marked as "failed". This creates noise in the output:
  once there is at least one test failed, we don't need to tell the
  user to "look at this package" (which `PackageLevel` does).

  This patch fixes this by omitting the package-level entry if the was
  at least a test failure and there were no non-terminated tests
  remaining.

- it discarded history of package-level outputs when reporting a
  package as failed, which makes the investigation harder.

  This patch fixes that by keeping the package-level output
  until it's definitely not needed any more.

The patch also simplifies the code and makes it somewhat easier to
read and maintain.

cc @rickystewart 

Release note: None