### PR TITLE
eventpb: document that CreateStatistics is only reported conditionally

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -506,6 +506,9 @@ An event of type `create_sequence` is recorded when a sequence is created.
 An event of type `create_statistics` is recorded when statistics are collected for a
 table.
 
+Events of this type are only collected when the cluster setting
+`sql.stats.post_events.enabled` is set.
+
 
 | Field | Description |
 |--|--|

--- a/pkg/util/log/eventpb/ddl_events.pb.go
+++ b/pkg/util/log/eventpb/ddl_events.pb.go
@@ -32,7 +32,7 @@ func (m *CreateDatabase) Reset()         { *m = CreateDatabase{} }
 func (m *CreateDatabase) String() string { return proto.CompactTextString(m) }
 func (*CreateDatabase) ProtoMessage()    {}
 func (*CreateDatabase) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_d882e643fa57a740, []int{0}
+	return fileDescriptor_ddl_events_c1d384ac3b923957, []int{0}
 }
 func (m *CreateDatabase) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -71,7 +71,7 @@ func (m *DropDatabase) Reset()         { *m = DropDatabase{} }
 func (m *DropDatabase) String() string { return proto.CompactTextString(m) }
 func (*DropDatabase) ProtoMessage()    {}
 func (*DropDatabase) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_d882e643fa57a740, []int{1}
+	return fileDescriptor_ddl_events_c1d384ac3b923957, []int{1}
 }
 func (m *DropDatabase) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -110,7 +110,7 @@ func (m *RenameDatabase) Reset()         { *m = RenameDatabase{} }
 func (m *RenameDatabase) String() string { return proto.CompactTextString(m) }
 func (*RenameDatabase) ProtoMessage()    {}
 func (*RenameDatabase) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_d882e643fa57a740, []int{2}
+	return fileDescriptor_ddl_events_c1d384ac3b923957, []int{2}
 }
 func (m *RenameDatabase) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -149,7 +149,7 @@ func (m *ConvertToSchema) Reset()         { *m = ConvertToSchema{} }
 func (m *ConvertToSchema) String() string { return proto.CompactTextString(m) }
 func (*ConvertToSchema) ProtoMessage()    {}
 func (*ConvertToSchema) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_d882e643fa57a740, []int{3}
+	return fileDescriptor_ddl_events_c1d384ac3b923957, []int{3}
 }
 func (m *ConvertToSchema) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -188,7 +188,7 @@ func (m *AlterDatabaseOwner) Reset()         { *m = AlterDatabaseOwner{} }
 func (m *AlterDatabaseOwner) String() string { return proto.CompactTextString(m) }
 func (*AlterDatabaseOwner) ProtoMessage()    {}
 func (*AlterDatabaseOwner) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_d882e643fa57a740, []int{4}
+	return fileDescriptor_ddl_events_c1d384ac3b923957, []int{4}
 }
 func (m *AlterDatabaseOwner) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -227,7 +227,7 @@ func (m *CreateSchema) Reset()         { *m = CreateSchema{} }
 func (m *CreateSchema) String() string { return proto.CompactTextString(m) }
 func (*CreateSchema) ProtoMessage()    {}
 func (*CreateSchema) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_d882e643fa57a740, []int{5}
+	return fileDescriptor_ddl_events_c1d384ac3b923957, []int{5}
 }
 func (m *CreateSchema) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -264,7 +264,7 @@ func (m *DropSchema) Reset()         { *m = DropSchema{} }
 func (m *DropSchema) String() string { return proto.CompactTextString(m) }
 func (*DropSchema) ProtoMessage()    {}
 func (*DropSchema) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_d882e643fa57a740, []int{6}
+	return fileDescriptor_ddl_events_c1d384ac3b923957, []int{6}
 }
 func (m *DropSchema) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -303,7 +303,7 @@ func (m *RenameSchema) Reset()         { *m = RenameSchema{} }
 func (m *RenameSchema) String() string { return proto.CompactTextString(m) }
 func (*RenameSchema) ProtoMessage()    {}
 func (*RenameSchema) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_d882e643fa57a740, []int{7}
+	return fileDescriptor_ddl_events_c1d384ac3b923957, []int{7}
 }
 func (m *RenameSchema) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -342,7 +342,7 @@ func (m *AlterSchemaOwner) Reset()         { *m = AlterSchemaOwner{} }
 func (m *AlterSchemaOwner) String() string { return proto.CompactTextString(m) }
 func (*AlterSchemaOwner) ProtoMessage()    {}
 func (*AlterSchemaOwner) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_d882e643fa57a740, []int{8}
+	return fileDescriptor_ddl_events_c1d384ac3b923957, []int{8}
 }
 func (m *AlterSchemaOwner) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -381,7 +381,7 @@ func (m *CreateTable) Reset()         { *m = CreateTable{} }
 func (m *CreateTable) String() string { return proto.CompactTextString(m) }
 func (*CreateTable) ProtoMessage()    {}
 func (*CreateTable) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_d882e643fa57a740, []int{9}
+	return fileDescriptor_ddl_events_c1d384ac3b923957, []int{9}
 }
 func (m *CreateTable) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -420,7 +420,7 @@ func (m *DropTable) Reset()         { *m = DropTable{} }
 func (m *DropTable) String() string { return proto.CompactTextString(m) }
 func (*DropTable) ProtoMessage()    {}
 func (*DropTable) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_d882e643fa57a740, []int{10}
+	return fileDescriptor_ddl_events_c1d384ac3b923957, []int{10}
 }
 func (m *DropTable) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -459,7 +459,7 @@ func (m *RenameTable) Reset()         { *m = RenameTable{} }
 func (m *RenameTable) String() string { return proto.CompactTextString(m) }
 func (*RenameTable) ProtoMessage()    {}
 func (*RenameTable) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_d882e643fa57a740, []int{11}
+	return fileDescriptor_ddl_events_c1d384ac3b923957, []int{11}
 }
 func (m *RenameTable) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -496,7 +496,7 @@ func (m *TruncateTable) Reset()         { *m = TruncateTable{} }
 func (m *TruncateTable) String() string { return proto.CompactTextString(m) }
 func (*TruncateTable) ProtoMessage()    {}
 func (*TruncateTable) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_d882e643fa57a740, []int{12}
+	return fileDescriptor_ddl_events_c1d384ac3b923957, []int{12}
 }
 func (m *TruncateTable) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -537,7 +537,7 @@ func (m *AlterTable) Reset()         { *m = AlterTable{} }
 func (m *AlterTable) String() string { return proto.CompactTextString(m) }
 func (*AlterTable) ProtoMessage()    {}
 func (*AlterTable) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_d882e643fa57a740, []int{13}
+	return fileDescriptor_ddl_events_c1d384ac3b923957, []int{13}
 }
 func (m *AlterTable) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -580,7 +580,7 @@ func (m *CommentOnColumn) Reset()         { *m = CommentOnColumn{} }
 func (m *CommentOnColumn) String() string { return proto.CompactTextString(m) }
 func (*CommentOnColumn) ProtoMessage()    {}
 func (*CommentOnColumn) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_d882e643fa57a740, []int{14}
+	return fileDescriptor_ddl_events_c1d384ac3b923957, []int{14}
 }
 func (m *CommentOnColumn) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -621,7 +621,7 @@ func (m *CommentOnDatabase) Reset()         { *m = CommentOnDatabase{} }
 func (m *CommentOnDatabase) String() string { return proto.CompactTextString(m) }
 func (*CommentOnDatabase) ProtoMessage()    {}
 func (*CommentOnDatabase) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_d882e643fa57a740, []int{15}
+	return fileDescriptor_ddl_events_c1d384ac3b923957, []int{15}
 }
 func (m *CommentOnDatabase) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -662,7 +662,7 @@ func (m *CommentOnTable) Reset()         { *m = CommentOnTable{} }
 func (m *CommentOnTable) String() string { return proto.CompactTextString(m) }
 func (*CommentOnTable) ProtoMessage()    {}
 func (*CommentOnTable) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_d882e643fa57a740, []int{16}
+	return fileDescriptor_ddl_events_c1d384ac3b923957, []int{16}
 }
 func (m *CommentOnTable) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -705,7 +705,7 @@ func (m *CommentOnIndex) Reset()         { *m = CommentOnIndex{} }
 func (m *CommentOnIndex) String() string { return proto.CompactTextString(m) }
 func (*CommentOnIndex) ProtoMessage()    {}
 func (*CommentOnIndex) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_d882e643fa57a740, []int{17}
+	return fileDescriptor_ddl_events_c1d384ac3b923957, []int{17}
 }
 func (m *CommentOnIndex) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -746,7 +746,7 @@ func (m *CreateIndex) Reset()         { *m = CreateIndex{} }
 func (m *CreateIndex) String() string { return proto.CompactTextString(m) }
 func (*CreateIndex) ProtoMessage()    {}
 func (*CreateIndex) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_d882e643fa57a740, []int{18}
+	return fileDescriptor_ddl_events_c1d384ac3b923957, []int{18}
 }
 func (m *CreateIndex) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -789,7 +789,7 @@ func (m *DropIndex) Reset()         { *m = DropIndex{} }
 func (m *DropIndex) String() string { return proto.CompactTextString(m) }
 func (*DropIndex) ProtoMessage()    {}
 func (*DropIndex) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_d882e643fa57a740, []int{19}
+	return fileDescriptor_ddl_events_c1d384ac3b923957, []int{19}
 }
 func (m *DropIndex) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -830,7 +830,7 @@ func (m *AlterIndex) Reset()         { *m = AlterIndex{} }
 func (m *AlterIndex) String() string { return proto.CompactTextString(m) }
 func (*AlterIndex) ProtoMessage()    {}
 func (*AlterIndex) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_d882e643fa57a740, []int{20}
+	return fileDescriptor_ddl_events_c1d384ac3b923957, []int{20}
 }
 func (m *AlterIndex) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -871,7 +871,7 @@ func (m *CreateView) Reset()         { *m = CreateView{} }
 func (m *CreateView) String() string { return proto.CompactTextString(m) }
 func (*CreateView) ProtoMessage()    {}
 func (*CreateView) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_d882e643fa57a740, []int{21}
+	return fileDescriptor_ddl_events_c1d384ac3b923957, []int{21}
 }
 func (m *CreateView) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -910,7 +910,7 @@ func (m *DropView) Reset()         { *m = DropView{} }
 func (m *DropView) String() string { return proto.CompactTextString(m) }
 func (*DropView) ProtoMessage()    {}
 func (*DropView) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_d882e643fa57a740, []int{22}
+	return fileDescriptor_ddl_events_c1d384ac3b923957, []int{22}
 }
 func (m *DropView) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -949,7 +949,7 @@ func (m *CreateSequence) Reset()         { *m = CreateSequence{} }
 func (m *CreateSequence) String() string { return proto.CompactTextString(m) }
 func (*CreateSequence) ProtoMessage()    {}
 func (*CreateSequence) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_d882e643fa57a740, []int{23}
+	return fileDescriptor_ddl_events_c1d384ac3b923957, []int{23}
 }
 func (m *CreateSequence) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -986,7 +986,7 @@ func (m *DropSequence) Reset()         { *m = DropSequence{} }
 func (m *DropSequence) String() string { return proto.CompactTextString(m) }
 func (*DropSequence) ProtoMessage()    {}
 func (*DropSequence) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_d882e643fa57a740, []int{24}
+	return fileDescriptor_ddl_events_c1d384ac3b923957, []int{24}
 }
 func (m *DropSequence) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1023,7 +1023,7 @@ func (m *AlterSequence) Reset()         { *m = AlterSequence{} }
 func (m *AlterSequence) String() string { return proto.CompactTextString(m) }
 func (*AlterSequence) ProtoMessage()    {}
 func (*AlterSequence) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_d882e643fa57a740, []int{25}
+	return fileDescriptor_ddl_events_c1d384ac3b923957, []int{25}
 }
 func (m *AlterSequence) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1071,7 +1071,7 @@ func (m *CommonSchemaChangeEventDetails) Reset()         { *m = CommonSchemaChan
 func (m *CommonSchemaChangeEventDetails) String() string { return proto.CompactTextString(m) }
 func (*CommonSchemaChangeEventDetails) ProtoMessage()    {}
 func (*CommonSchemaChangeEventDetails) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_d882e643fa57a740, []int{26}
+	return fileDescriptor_ddl_events_c1d384ac3b923957, []int{26}
 }
 func (m *CommonSchemaChangeEventDetails) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1112,7 +1112,7 @@ func (m *ReverseSchemaChange) Reset()         { *m = ReverseSchemaChange{} }
 func (m *ReverseSchemaChange) String() string { return proto.CompactTextString(m) }
 func (*ReverseSchemaChange) ProtoMessage()    {}
 func (*ReverseSchemaChange) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_d882e643fa57a740, []int{27}
+	return fileDescriptor_ddl_events_c1d384ac3b923957, []int{27}
 }
 func (m *ReverseSchemaChange) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1148,7 +1148,7 @@ func (m *FinishSchemaChange) Reset()         { *m = FinishSchemaChange{} }
 func (m *FinishSchemaChange) String() string { return proto.CompactTextString(m) }
 func (*FinishSchemaChange) ProtoMessage()    {}
 func (*FinishSchemaChange) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_d882e643fa57a740, []int{28}
+	return fileDescriptor_ddl_events_c1d384ac3b923957, []int{28}
 }
 func (m *FinishSchemaChange) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1184,7 +1184,7 @@ func (m *FinishSchemaChangeRollback) Reset()         { *m = FinishSchemaChangeRo
 func (m *FinishSchemaChangeRollback) String() string { return proto.CompactTextString(m) }
 func (*FinishSchemaChangeRollback) ProtoMessage()    {}
 func (*FinishSchemaChangeRollback) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_d882e643fa57a740, []int{29}
+	return fileDescriptor_ddl_events_c1d384ac3b923957, []int{29}
 }
 func (m *FinishSchemaChangeRollback) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1223,7 +1223,7 @@ func (m *CreateType) Reset()         { *m = CreateType{} }
 func (m *CreateType) String() string { return proto.CompactTextString(m) }
 func (*CreateType) ProtoMessage()    {}
 func (*CreateType) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_d882e643fa57a740, []int{30}
+	return fileDescriptor_ddl_events_c1d384ac3b923957, []int{30}
 }
 func (m *CreateType) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1260,7 +1260,7 @@ func (m *DropType) Reset()         { *m = DropType{} }
 func (m *DropType) String() string { return proto.CompactTextString(m) }
 func (*DropType) ProtoMessage()    {}
 func (*DropType) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_d882e643fa57a740, []int{31}
+	return fileDescriptor_ddl_events_c1d384ac3b923957, []int{31}
 }
 func (m *DropType) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1297,7 +1297,7 @@ func (m *AlterType) Reset()         { *m = AlterType{} }
 func (m *AlterType) String() string { return proto.CompactTextString(m) }
 func (*AlterType) ProtoMessage()    {}
 func (*AlterType) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_d882e643fa57a740, []int{32}
+	return fileDescriptor_ddl_events_c1d384ac3b923957, []int{32}
 }
 func (m *AlterType) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1336,7 +1336,7 @@ func (m *AlterTypeOwner) Reset()         { *m = AlterTypeOwner{} }
 func (m *AlterTypeOwner) String() string { return proto.CompactTextString(m) }
 func (*AlterTypeOwner) ProtoMessage()    {}
 func (*AlterTypeOwner) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_d882e643fa57a740, []int{33}
+	return fileDescriptor_ddl_events_c1d384ac3b923957, []int{33}
 }
 func (m *AlterTypeOwner) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1375,7 +1375,7 @@ func (m *RenameType) Reset()         { *m = RenameType{} }
 func (m *RenameType) String() string { return proto.CompactTextString(m) }
 func (*RenameType) ProtoMessage()    {}
 func (*RenameType) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_d882e643fa57a740, []int{34}
+	return fileDescriptor_ddl_events_c1d384ac3b923957, []int{34}
 }
 func (m *RenameType) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1414,7 +1414,7 @@ func (m *CommonZoneConfigDetails) Reset()         { *m = CommonZoneConfigDetails
 func (m *CommonZoneConfigDetails) String() string { return proto.CompactTextString(m) }
 func (*CommonZoneConfigDetails) ProtoMessage()    {}
 func (*CommonZoneConfigDetails) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_d882e643fa57a740, []int{35}
+	return fileDescriptor_ddl_events_c1d384ac3b923957, []int{35}
 }
 func (m *CommonZoneConfigDetails) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1450,7 +1450,7 @@ func (m *SetZoneConfig) Reset()         { *m = SetZoneConfig{} }
 func (m *SetZoneConfig) String() string { return proto.CompactTextString(m) }
 func (*SetZoneConfig) ProtoMessage()    {}
 func (*SetZoneConfig) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_d882e643fa57a740, []int{36}
+	return fileDescriptor_ddl_events_c1d384ac3b923957, []int{36}
 }
 func (m *SetZoneConfig) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1486,7 +1486,7 @@ func (m *RemoveZoneConfig) Reset()         { *m = RemoveZoneConfig{} }
 func (m *RemoveZoneConfig) String() string { return proto.CompactTextString(m) }
 func (*RemoveZoneConfig) ProtoMessage()    {}
 func (*RemoveZoneConfig) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_d882e643fa57a740, []int{37}
+	return fileDescriptor_ddl_events_c1d384ac3b923957, []int{37}
 }
 func (m *RemoveZoneConfig) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1513,6 +1513,9 @@ var xxx_messageInfo_RemoveZoneConfig proto.InternalMessageInfo
 
 // CreateStatistics is recorded when statistics are collected for a
 // table.
+//
+// Events of this type are only collected when the cluster setting
+// `sql.stats.post_events.enabled` is set.
 type CreateStatistics struct {
 	CommonEventDetails    `protobuf:"bytes,1,opt,name=common,proto3,embedded=common" json:""`
 	CommonSQLEventDetails `protobuf:"bytes,2,opt,name=sql,proto3,embedded=sql" json:""`
@@ -1524,7 +1527,7 @@ func (m *CreateStatistics) Reset()         { *m = CreateStatistics{} }
 func (m *CreateStatistics) String() string { return proto.CompactTextString(m) }
 func (*CreateStatistics) ProtoMessage()    {}
 func (*CreateStatistics) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_d882e643fa57a740, []int{38}
+	return fileDescriptor_ddl_events_c1d384ac3b923957, []int{38}
 }
 func (m *CreateStatistics) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1564,7 +1567,7 @@ func (m *UnsafeUpsertDescriptor) Reset()         { *m = UnsafeUpsertDescriptor{}
 func (m *UnsafeUpsertDescriptor) String() string { return proto.CompactTextString(m) }
 func (*UnsafeUpsertDescriptor) ProtoMessage()    {}
 func (*UnsafeUpsertDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_d882e643fa57a740, []int{39}
+	return fileDescriptor_ddl_events_c1d384ac3b923957, []int{39}
 }
 func (m *UnsafeUpsertDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1608,7 +1611,7 @@ func (m *UnsafeDeleteDescriptor) Reset()         { *m = UnsafeDeleteDescriptor{}
 func (m *UnsafeDeleteDescriptor) String() string { return proto.CompactTextString(m) }
 func (*UnsafeDeleteDescriptor) ProtoMessage()    {}
 func (*UnsafeDeleteDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_d882e643fa57a740, []int{40}
+	return fileDescriptor_ddl_events_c1d384ac3b923957, []int{40}
 }
 func (m *UnsafeDeleteDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1654,7 +1657,7 @@ func (m *UnsafeUpsertNamespaceEntry) Reset()         { *m = UnsafeUpsertNamespac
 func (m *UnsafeUpsertNamespaceEntry) String() string { return proto.CompactTextString(m) }
 func (*UnsafeUpsertNamespaceEntry) ProtoMessage()    {}
 func (*UnsafeUpsertNamespaceEntry) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_d882e643fa57a740, []int{41}
+	return fileDescriptor_ddl_events_c1d384ac3b923957, []int{41}
 }
 func (m *UnsafeUpsertNamespaceEntry) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1698,7 +1701,7 @@ func (m *UnsafeDeleteNamespaceEntry) Reset()         { *m = UnsafeDeleteNamespac
 func (m *UnsafeDeleteNamespaceEntry) String() string { return proto.CompactTextString(m) }
 func (*UnsafeDeleteNamespaceEntry) ProtoMessage()    {}
 func (*UnsafeDeleteNamespaceEntry) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_d882e643fa57a740, []int{42}
+	return fileDescriptor_ddl_events_c1d384ac3b923957, []int{42}
 }
 func (m *UnsafeDeleteNamespaceEntry) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -12194,10 +12197,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("util/log/eventpb/ddl_events.proto", fileDescriptor_ddl_events_d882e643fa57a740)
+	proto.RegisterFile("util/log/eventpb/ddl_events.proto", fileDescriptor_ddl_events_c1d384ac3b923957)
 }
 
-var fileDescriptor_ddl_events_d882e643fa57a740 = []byte{
+var fileDescriptor_ddl_events_c1d384ac3b923957 = []byte{
 	// 1554 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xec, 0x5b, 0x5d, 0x6f, 0x1b, 0x45,
 	0x17, 0xce, 0xae, 0xf3, 0x61, 0x1f, 0x7f, 0x34, 0xd9, 0xf4, 0xed, 0x6b, 0x45, 0xef, 0x6b, 0x87,

--- a/pkg/util/log/eventpb/ddl_events.proto
+++ b/pkg/util/log/eventpb/ddl_events.proto
@@ -432,6 +432,9 @@ message RemoveZoneConfig {
 
 // CreateStatistics is recorded when statistics are collected for a
 // table.
+//
+// Events of this type are only collected when the cluster setting
+// `sql.stats.post_events.enabled` is set.
 message CreateStatistics {
   CommonEventDetails common = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];
   CommonSQLEventDetails sql = 2 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];


### PR DESCRIPTION
Fixes #57739 

Release note (api change): The notable event `create_statistics` is
only reported when the cluster setting `sql.stats.post_events.enabled`
is enabled. This fact is now also reported in the event log reference
documentation. (Note this is not new behavior; this is mentioned in
this release note because I did not see it documented before.)