### PR TITLE
optbuilder: fix invalid projection wrapping scalar group by

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/aggregate
+++ b/pkg/sql/logictest/testdata/logic_test/aggregate
@@ -3084,12 +3084,11 @@ array_agg   array_agg   col3
 {-3,-2,-1}  {-1,-2,-3}  a
 {0,1,2}     {1,2,0}     b
 
-# This case is broken (#57496).
-#query TTII colnames
-#SELECT array_agg(col1 ORDER BY col1), array_agg(col1 ORDER BY col2, col1), count(col3), count(*) FROM tab
-#----
-#array_agg         array_agg         count  count
-#{-3,-2,-1,0,1,2}  {-1,1,-2,2,-3,0}  6      6
+query TTII colnames
+SELECT array_agg(col1 ORDER BY col1), array_agg(col1 ORDER BY col2, col1), count(col3), count(*) FROM tab
+----
+array_agg         array_agg         count  count
+{-3,-2,-1,0,1,2}  {-1,1,-2,2,-3,0}  6      6
 
 query TT colnames
 SELECT array_agg(col1 ORDER BY col1), array_agg(col1 ORDER BY col1) FILTER (WHERE col1 < 0) FROM tab
@@ -3103,11 +3102,10 @@ SELECT array_agg(col1 ORDER BY col3, col1) FILTER (WHERE col1 < 0), array_agg(co
 array_agg   array_agg
 {-3,-2,-1}  {-3,-2,-1,0,1,2}
 
-# This case is broken (#57496).
-#query IT
-#SELECT count(1), concat_agg(col3 ORDER BY col1) from tab
-#----
-#6  aaabbb
+query IT
+SELECT count(1), concat_agg(col3 ORDER BY col1) from tab
+----
+6  aaabbb
 
 # Testing pre-projections. Tests when the GroupBy clause has a projection.
 query IIIT colnames

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -3855,40 +3855,41 @@ project
       └── filters
            └── col2:2 > 1
 
-# This case is broken (#57496).
-## Add projection on top to ensure the default NULL values are set correctly.
-#build
-#SELECT count(DISTINCT col1), count(*), array_agg(col1 ORDER BY col2) FROM tab
-#----
-#project
-# ├── columns: count:6 count:7 array_agg:8
-# └── project
-#      ├── columns: count:6 count_rows:7 col1:1 col2:2 col3:3 rowid:4 crdb_internal_mvcc_timestamp:5 array_agg:8
-#      ├── scalar-group-by
-#      │    ├── columns: array_agg:8 count:9 count_rows:10
-#      │    ├── window partition=() ordering=+2
-#      │    │    ├── columns: col1:1!null col2:2!null col3:3 rowid:4!null crdb_internal_mvcc_timestamp:5 count:6 count_rows:7 array_agg:8
-#      │    │    ├── window partition=()
-#      │    │    │    ├── columns: col1:1!null col2:2!null col3:3 rowid:4!null crdb_internal_mvcc_timestamp:5 count:6 count_rows:7
-#      │    │    │    ├── scan tab
-#      │    │    │    │    └── columns: col1:1!null col2:2!null col3:3 rowid:4!null crdb_internal_mvcc_timestamp:5
-#      │    │    │    └── windows
-#      │    │    │         ├── count [as=count:6, frame="range from unbounded to unbounded"]
-#      │    │    │         │    └── col1:1
-#      │    │    │         └── count-rows [as=count_rows:7, frame="range from unbounded to unbounded"]
-#      │    │    └── windows
-#      │    │         └── array-agg [as=array_agg:8, frame="range from unbounded to unbounded"]
-#      │    │              └── col1:1
-#      │    └── aggregations
-#      │         ├── const-agg [as=count:9]
-#      │         │    └── count:6
-#      │         ├── const-agg [as=count_rows:10]
-#      │         │    └── count_rows:7
-#      │         └── const-agg [as=array_agg:8]
-#      │              └── array_agg:8
-#      └── projections
-#           ├── CASE WHEN count:9 IS NULL THEN 0 ELSE count:9 END [as=count:6]
-#           └── CASE WHEN count_rows:10 IS NULL THEN 0 ELSE count_rows:10 END [as=count_rows:7]
+# Add projection on top to ensure the default NULL values are set correctly.
+# Regression test for #57496: Ensure that non-input columns are not passed
+# through by the Project.
+build
+SELECT count(DISTINCT col1), count(*), array_agg(col1 ORDER BY col2) FROM tab
+----
+project
+ ├── columns: count:6 count:7 array_agg:8
+ └── project
+      ├── columns: count:6 count_rows:7 array_agg:8
+      ├── scalar-group-by
+      │    ├── columns: array_agg:8 count:9 count_rows:10
+      │    ├── window partition=() ordering=+2
+      │    │    ├── columns: col1:1!null col2:2!null col3:3 rowid:4!null crdb_internal_mvcc_timestamp:5 count:6 count_rows:7 array_agg:8
+      │    │    ├── window partition=()
+      │    │    │    ├── columns: col1:1!null col2:2!null col3:3 rowid:4!null crdb_internal_mvcc_timestamp:5 count:6 count_rows:7
+      │    │    │    ├── scan tab
+      │    │    │    │    └── columns: col1:1!null col2:2!null col3:3 rowid:4!null crdb_internal_mvcc_timestamp:5
+      │    │    │    └── windows
+      │    │    │         ├── count [as=count:6, frame="range from unbounded to unbounded"]
+      │    │    │         │    └── col1:1
+      │    │    │         └── count-rows [as=count_rows:7, frame="range from unbounded to unbounded"]
+      │    │    └── windows
+      │    │         └── array-agg [as=array_agg:8, frame="range from unbounded to unbounded"]
+      │    │              └── col1:1
+      │    └── aggregations
+      │         ├── const-agg [as=count:9]
+      │         │    └── count:6
+      │         ├── const-agg [as=count_rows:10]
+      │         │    └── count_rows:7
+      │         └── const-agg [as=array_agg:8]
+      │              └── array_agg:8
+      └── projections
+           ├── CASE WHEN count:9 IS NULL THEN 0 ELSE count:9 END [as=count:6]
+           └── CASE WHEN count_rows:10 IS NULL THEN 0 ELSE count_rows:10 END [as=count_rows:7]
 
 # Testing aggregations as window when group by has a projection.
 build


### PR DESCRIPTION
This commit fixes a bug in which some columns were incorrectly added as
passthrough columns to a proejct that was wrapping a scalar group by.
There is no release note as there are no known user-facing effects
of this bug (the invalid columns were always pruned during optimization).

Fixes #57496

Release note: None