### PR TITLE
ccl/backupccl: skip TestBackupRestoreSystemJobsProgress

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -1373,6 +1373,7 @@ func checkInProgressBackupRestore(
 
 func TestBackupRestoreSystemJobsProgress(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 57831, "flaky test")
 	defer log.Scope(t).Close(t)
 	defer jobs.TestingSetProgressThresholds()()
 


### PR DESCRIPTION
Refs: #57831

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes

Release note: None