### PR TITLE
release-20.2: optbuilder: fix invalid projection wrapping scalar group by

### DIFF
--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -3134,13 +3134,15 @@ project
            └── col2:2 > 1
 
 # Add projection on top to ensure the default NULL values are set correctly.
+# Regression test for #57496: Ensure that non-input columns are not passed
+# through by the Project.
 build
 SELECT count(DISTINCT col1), count(*), array_agg(col1 ORDER BY col2) FROM tab
 ----
 project
  ├── columns: count:6 count:7 array_agg:8
  └── project
-      ├── columns: count:6 count_rows:7 col1:1 col2:2 col3:3 rowid:4 crdb_internal_mvcc_timestamp:5 array_agg:8
+      ├── columns: count:6 count_rows:7 array_agg:8
       ├── scalar-group-by
       │    ├── columns: array_agg:8 count:9 count_rows:10
       │    ├── window partition=() ordering=+2


### PR DESCRIPTION
Backport 1/1 commits from #57911.

/cc @cockroachdb/release

---

This commit fixes a bug in which some columns were incorrectly added as
passthrough columns to a proejct that was wrapping a scalar group by.
There is no release note as there are no known user-facing effects
of this bug (the invalid columns were always pruned during optimization).

Fixes #57496

Release note: None
