### PR TITLE
release-20.1: optbuilder: fix invalid projection wrapping scalar group by

### DIFF
--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -3120,13 +3120,15 @@ project
            └── col2:2 > 1
 
 # Add projection on top to ensure the default NULL values are set correctly.
+# Regression test for #57496: Ensure that non-input columns are not passed
+# through by the Project.
 build
 SELECT count(DISTINCT col1), count(*), array_agg(col1 ORDER BY col2) FROM tab
 ----
 project
  ├── columns: count:5 count:6 array_agg:7
  └── project
-      ├── columns: count:5 count_rows:6 col1:1 col2:2 col3:3 rowid:4 array_agg:7
+      ├── columns: count:5 count_rows:6 array_agg:7
       ├── scalar-group-by
       │    ├── columns: array_agg:7 count:8 count_rows:9
       │    ├── window partition=() ordering=+2

--- a/pkg/sql/opt/optbuilder/window.go
+++ b/pkg/sql/opt/optbuilder/window.go
@@ -479,7 +479,7 @@ func (b *Builder) constructWindowGroup(
 ) memo.RelExpr {
 	if groupingColSet.Empty() {
 		// Construct a scalar GroupBy wrapped around the appropriate projections.
-		return b.constructScalarWindowGroup(input, groupingColSet, aggInfos, outScope)
+		return b.constructScalarWindowGroup(input, aggInfos, outScope)
 	}
 
 	// Construct a GroupBy using the groupingColSet. Use the ConstAgg aggregate for
@@ -531,10 +531,8 @@ func (b *Builder) overrideDefaultNullValue(agg aggregateInfo) (opt.ScalarExpr, b
 // The expression may be wrapped with a projection so ensure the default NULL
 // values of the aggregates are respected when no rows are returned.
 func (b *Builder) constructScalarWindowGroup(
-	input memo.RelExpr, groupingColSet opt.ColSet, aggInfos []aggregateInfo, outScope *scope,
+	input memo.RelExpr, aggInfos []aggregateInfo, outScope *scope,
 ) memo.RelExpr {
-	private := memo.GroupingPrivate{GroupingCols: groupingColSet}
-	private.Ordering.FromOrderingWithOptCols(nil, groupingColSet)
 	aggs := make(memo.AggregationsExpr, 0, len(aggInfos))
 
 	// Create a projection here to replace the NULL values with pre-defined
@@ -552,7 +550,7 @@ func (b *Builder) constructScalarWindowGroup(
 	projections := make(memo.ProjectionsExpr, 0, len(aggInfos))
 
 	// Create an appropriate passthrough for the projection.
-	passthrough := input.Relational().OutputCols.Copy()
+	var passthrough opt.ColSet
 	for i := range aggInfos {
 		varExpr := b.factory.ConstructConstAgg(b.factory.ConstructVariable(aggInfos[i].col.id))
 
@@ -565,10 +563,9 @@ func (b *Builder) constructScalarWindowGroup(
 		}
 
 		aggs = append(aggs, b.factory.ConstructAggregationsItem(varExpr, aggregateCol.id))
-		passthrough.Add(aggInfos[i].col.id)
 
-		// Add projection to replace default NULL value.
 		if requiresProjection {
+			// Add projection to replace default NULL value.
 			projections = append(projections, b.factory.ConstructProjectionsItem(
 				b.replaceDefaultReturn(
 					b.factory.ConstructVariable(aggregateCol.id),
@@ -576,11 +573,13 @@ func (b *Builder) constructScalarWindowGroup(
 					defaultNullVal),
 				aggInfos[i].col.id,
 			))
-			passthrough.Remove(aggInfos[i].col.id)
+		} else {
+			// Pass through the aggregate column directly.
+			passthrough.Add(aggInfos[i].col.id)
 		}
 	}
 
-	scalarAggExpr := b.factory.ConstructScalarGroupBy(input, aggs, &private)
+	scalarAggExpr := b.factory.ConstructScalarGroupBy(input, aggs, &memo.GroupingPrivate{})
 	if len(projections) != 0 {
 		return b.factory.ConstructProject(scalarAggExpr, projections, passthrough)
 	}


### PR DESCRIPTION
Backport 1/1 commits from #57911.

/cc @cockroachdb/release

---

This commit fixes a bug in which some columns were incorrectly added as
passthrough columns to a proejct that was wrapping a scalar group by.
There is no release note as there are no known user-facing effects
of this bug (the invalid columns were always pruned during optimization).

Fixes #57496

Release note: None
