### PR TITLE
settings, *: make NonNeg/Positive passed validators

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -83,10 +83,11 @@ type backupKMSEnv struct {
 var _ cloud.KMSEnv = &backupKMSEnv{}
 
 // featureBackupEnabled is used to enable and disable the BACKUP feature.
-var featureBackupEnabled = settings.RegisterPublicBoolSetting(
+var featureBackupEnabled = settings.RegisterBoolSetting(
 	"feature.backup.enabled",
 	"set to true to enable backups, false to disable; default is true",
-	featureflag.FeatureFlagEnabledDefault)
+	featureflag.FeatureFlagEnabledDefault,
+).WithPublic()
 
 func (p *backupKMSEnv) ClusterSettings() *cluster.Settings {
 	return p.settings

--- a/pkg/ccl/backupccl/backup_processor.go
+++ b/pkg/ccl/backupccl/backup_processor.go
@@ -40,15 +40,17 @@ var (
 		"use experimental time-bound file filter when exporting in BACKUP",
 		true,
 	)
-	priorityAfter = settings.RegisterNonNegativeDurationSetting(
+	priorityAfter = settings.RegisterDurationSetting(
 		"bulkio.backup.read_with_priority_after",
 		"age of read-as-of time above which a BACKUP should read with priority",
 		time.Minute,
+		settings.NonNegativeDuration,
 	)
-	delayPerAttmpt = settings.RegisterNonNegativeDurationSetting(
+	delayPerAttmpt = settings.RegisterDurationSetting(
 		"bulkio.backup.read_retry_delay",
 		"amount of time since the read-as-of time, per-prior attempt, to wait before making another attempt",
 		time.Second*5,
+		settings.NonNegativeDuration,
 	)
 )
 

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -71,10 +71,11 @@ const (
 )
 
 // featureRestoreEnabled is used to enable and disable the RESTORE feature.
-var featureRestoreEnabled = settings.RegisterPublicBoolSetting(
+var featureRestoreEnabled = settings.RegisterBoolSetting(
 	"feature.restore.enabled",
 	"set to true to enable restore, false to disable; default is true",
-	featureflag.FeatureFlagEnabledDefault)
+	featureflag.FeatureFlagEnabledDefault,
+).WithPublic()
 
 // rewriteViewQueryDBNames rewrites the passed table's ViewQuery replacing all
 // non-empty db qualifiers with `newDB`.

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -54,10 +54,11 @@ import (
 )
 
 // featureChangefeedEnabled is used to enable and disable the CHANGEFEED feature.
-var featureChangefeedEnabled = settings.RegisterPublicBoolSetting(
+var featureChangefeedEnabled = settings.RegisterBoolSetting(
 	"feature.changefeed.enabled",
 	"set to true to enable changefeeds, false to disable; default is true",
-	featureflag.FeatureFlagEnabledDefault)
+	featureflag.FeatureFlagEnabledDefault,
+).WithPublic()
 
 func init() {
 	sql.AddPlanHook(changefeedPlanHook)

--- a/pkg/ccl/changefeedccl/changefeedbase/settings.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/settings.go
@@ -19,8 +19,9 @@ import (
 //
 // NB: The more generic name of this setting precedes its current
 // interpretation. It used to control additional polling rates.
-var TableDescriptorPollInterval = settings.RegisterNonNegativeDurationSetting(
+var TableDescriptorPollInterval = settings.RegisterDurationSetting(
 	"changefeed.experimental_poll_interval",
 	"polling interval for the table descriptors",
 	1*time.Second,
+	settings.NonNegativeDuration,
 )

--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -177,10 +177,11 @@ var allowedIntoFormats = map[string]struct{}{
 }
 
 // featureImportEnabled is used to enable and disable the IMPORT feature.
-var featureImportEnabled = settings.RegisterPublicBoolSetting(
+var featureImportEnabled = settings.RegisterBoolSetting(
 	"feature.import.enabled",
 	"set to true to enable imports, false to disable; default is true",
-	featureflag.FeatureFlagEnabledDefault)
+	featureflag.FeatureFlagEnabledDefault,
+).WithPublic()
 
 func validateFormatOptions(
 	format string, specified map[string]string, formatAllowed map[string]struct{},

--- a/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads.go
+++ b/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads.go
@@ -34,7 +34,7 @@ import (
 // followerReadMultiple is the multiple of kv.closed_timestmap.target_duration
 // which the implementation of the follower read capable replica policy ought
 // to use to determine if a request can be used for reading.
-var followerReadMultiple = settings.RegisterValidatedFloatSetting(
+var followerReadMultiple = settings.RegisterFloatSetting(
 	"kv.follower_read.target_multiple",
 	"if above 1, encourages the distsender to perform a read against the "+
 		"closest replica if a request is older than kv.closed_timestamp.target_duration"+

--- a/pkg/ccl/oidcccl/settings.go
+++ b/pkg/ccl/oidcccl/settings.go
@@ -35,33 +35,33 @@ const (
 
 // OIDCEnabled enables or disabled OIDC login for the DB Console
 var OIDCEnabled = func() *settings.BoolSetting {
-	s := settings.RegisterPublicBoolSetting(
+	s := settings.RegisterBoolSetting(
 		OIDCEnabledSettingName,
 		"enables or disabled OIDC login for the DB Console (this feature is experimental)",
 		false,
-	)
+	).WithPublic()
 	s.SetReportable(true)
 	return s
 }()
 
 // OIDCClientID is the OIDC client id
 var OIDCClientID = func() *settings.StringSetting {
-	s := settings.RegisterPublicStringSetting(
+	s := settings.RegisterStringSetting(
 		OIDCClientIDSettingName,
 		"sets OIDC client id (this feature is experimental)",
 		"",
-	)
+	).WithPublic()
 	s.SetReportable(true)
 	return s
 }()
 
 // OIDCClientSecret is the OIDC client secret
 var OIDCClientSecret = func() *settings.StringSetting {
-	s := settings.RegisterPublicStringSetting(
+	s := settings.RegisterStringSetting(
 		OIDCClientSecretSettingName,
 		"sets OIDC client secret (this feature is experimental)",
 		"",
-	)
+	).WithPublic()
 	s.SetReportable(false)
 	return s
 }()
@@ -125,12 +125,12 @@ var OIDCScopes = func() *settings.StringSetting {
 
 // OIDCClaimJSONKey is the key of the claim to extract from the OIDC id_token
 var OIDCClaimJSONKey = func() *settings.StringSetting {
-	s := settings.RegisterPublicStringSetting(
+	s := settings.RegisterStringSetting(
 		OIDCClaimJSONKeySettingName,
 		"sets JSON key of principal to extract from payload after OIDC authentication completes "+
 			"(usually email or sid) (this feature is experimental)",
 		"",
-	)
+	).WithPublic()
 	return s
 }()
 
@@ -157,22 +157,22 @@ var OIDCPrincipalRegex = func() *settings.StringSetting {
 
 // OIDCButtonText is a string to display on the button in the DB Console to login with OIDC
 var OIDCButtonText = func() *settings.StringSetting {
-	s := settings.RegisterPublicStringSetting(
+	s := settings.RegisterStringSetting(
 		OIDCButtonTextSettingName,
 		"text to show on button on DB Console login page to login with your OIDC provider "+
 			"(only shown if OIDC is enabled) (this feature is experimental)",
 		"Login with your OIDC provider",
-	)
+	).WithPublic()
 	return s
 }()
 
 // OIDCAutoLogin is a boolean that enables automatic redirection to OIDC auth in the DB Console
 var OIDCAutoLogin = func() *settings.BoolSetting {
-	s := settings.RegisterPublicBoolSetting(
+	s := settings.RegisterBoolSetting(
 		OIDCAutoLoginSettingName,
 		"if true, logged-out visitors to the DB Console will be "+
 			"automatically redirected to the OIDC login endpoint (this feature is experimental)",
 		false,
-	)
+	).WithPublic()
 	return s
 }()

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -52,10 +52,11 @@ import (
 const defaultLeniencySetting = 60 * time.Second
 
 var (
-	gcSetting = settings.RegisterPublicDurationSetting(
+	gcSetting = settings.RegisterDurationSetting(
 		"jobs.retention_time",
 		"the amount of time to retain records for completed jobs before",
-		time.Hour*24*14)
+		time.Hour*24*14,
+	).WithPublic()
 )
 
 // adoptedJobs represents a the epoch and cancelation of a job id being run

--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -150,10 +150,11 @@ var rangeDescriptorCacheSize = settings.RegisterIntSetting(
 	1e6,
 )
 
-var senderConcurrencyLimit = settings.RegisterNonNegativeIntSetting(
+var senderConcurrencyLimit = settings.RegisterIntSetting(
 	"kv.dist_sender.concurrency_limit",
 	"maximum number of asynchronous send requests",
 	max(defaultSenderConcurrency, int64(64*runtime.NumCPU())),
+	settings.NonNegativeInt,
 )
 
 func max(a, b int64) int64 {

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_pipeliner.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_pipeliner.go
@@ -42,7 +42,7 @@ var pipelinedWritesMaxInFlightSize = settings.RegisterByteSizeSetting(
 	"maximum number of bytes used to track in-flight pipelined writes before disabling pipelining",
 	1<<18, /* 256 KB */
 )
-var pipelinedWritesMaxBatchSize = settings.RegisterNonNegativeIntSetting(
+var pipelinedWritesMaxBatchSize = settings.RegisterIntSetting(
 	"kv.transaction.write_pipelining_max_batch_size",
 	"if non-zero, defines that maximum size batch that will be pipelined through Raft consensus",
 	// NB: there is a tradeoff between the overhead of synchronously waiting for
@@ -54,6 +54,7 @@ var pipelinedWritesMaxBatchSize = settings.RegisterNonNegativeIntSetting(
 	// so implicit SQL txns should never pipeline their writes - they should either
 	// hit the 1PC fast-path or should have batches which exceed this limit.
 	128,
+	settings.NonNegativeInt,
 )
 
 // trackedWritesMaxSize is a threshold in bytes for lock spans stored on the
@@ -66,11 +67,11 @@ var pipelinedWritesMaxBatchSize = settings.RegisterNonNegativeIntSetting(
 // NB: this is called "max_intents_bytes" instead of "max_lock_bytes" because
 // it was created before the concept of intents were generalized to locks.
 // Switching it would require a migration which doesn't seem worth it.
-var trackedWritesMaxSize = settings.RegisterPublicIntSetting(
+var trackedWritesMaxSize = settings.RegisterIntSetting(
 	"kv.transaction.max_intents_bytes",
 	"maximum number of bytes used to track locks in transactions",
 	1<<18, /* 256 KB */
-)
+).WithPublic()
 
 // txnPipeliner is a txnInterceptor that pipelines transactional writes by using
 // asynchronous consensus. The interceptor then tracks all writes that have been

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_span_refresher.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_span_refresher.go
@@ -34,11 +34,11 @@ const (
 // MaxTxnRefreshSpansBytes is a threshold in bytes for refresh spans stored
 // on the coordinator during the lifetime of a transaction. Refresh spans
 // are used for SERIALIZABLE transactions to avoid client restarts.
-var MaxTxnRefreshSpansBytes = settings.RegisterPublicIntSetting(
+var MaxTxnRefreshSpansBytes = settings.RegisterIntSetting(
 	"kv.transaction.max_refresh_spans_bytes",
 	"maximum number of bytes used to track refresh spans in serializable transactions",
 	256*1000,
-)
+).WithPublic()
 
 // txnSpanRefresher is a txnInterceptor that collects the read spans of a
 // serializable transaction in the event it gets a serializable retry error. It

--- a/pkg/kv/kvserver/allocator.go
+++ b/pkg/kv/kvserver/allocator.go
@@ -69,11 +69,11 @@ var MinLeaseTransferStatsDuration = 30 * time.Second
 // enableLoadBasedLeaseRebalancing controls whether lease rebalancing is done
 // via the new heuristic based on request load and latency or via the simpler
 // approach that purely seeks to balance the number of leases per node evenly.
-var enableLoadBasedLeaseRebalancing = settings.RegisterPublicBoolSetting(
+var enableLoadBasedLeaseRebalancing = settings.RegisterBoolSetting(
 	"kv.allocator.load_based_lease_rebalancing.enabled",
 	"set to enable rebalancing of range leases based on load and latency",
 	true,
-)
+).WithPublic()
 
 // leaseRebalancingAggressiveness enables users to tweak how aggressive their
 // cluster is at moving leases towards the localities where the most requests
@@ -83,11 +83,12 @@ var enableLoadBasedLeaseRebalancing = settings.RegisterPublicBoolSetting(
 //
 // Setting this to 0 effectively disables load-based lease rebalancing, and
 // settings less than 0 are disallowed.
-var leaseRebalancingAggressiveness = settings.RegisterNonNegativeFloatSetting(
+var leaseRebalancingAggressiveness = settings.RegisterFloatSetting(
 	"kv.allocator.lease_rebalancing_aggressiveness",
 	"set greater than 1.0 to rebalance leases toward load more aggressively, "+
 		"or between 0 and 1.0 to be more conservative about rebalancing leases",
 	1.0,
+	settings.NonNegativeFloat,
 )
 
 // AllocatorAction enumerates the various replication adjustments that may be

--- a/pkg/kv/kvserver/allocator_scorer.go
+++ b/pkg/kv/kvserver/allocator_scorer.go
@@ -78,10 +78,11 @@ const (
 // the mean range count at which that store is considered overfull or underfull
 // of ranges.
 var rangeRebalanceThreshold = func() *settings.FloatSetting {
-	s := settings.RegisterNonNegativeFloatSetting(
+	s := settings.RegisterFloatSetting(
 		"kv.allocator.range_rebalance_threshold",
 		"minimum fraction away from the mean a store's range count can be before it is considered overfull or underfull",
 		0.05,
+		settings.NonNegativeFloat,
 	)
 	s.SetVisibility(settings.Public)
 	return s

--- a/pkg/kv/kvserver/closedts/setting.go
+++ b/pkg/kv/kvserver/closedts/setting.go
@@ -18,15 +18,16 @@ import (
 )
 
 // TargetDuration is the follower reads closed timestamp update target duration.
-var TargetDuration = settings.RegisterNonNegativeDurationSetting(
+var TargetDuration = settings.RegisterDurationSetting(
 	"kv.closed_timestamp.target_duration",
 	"if nonzero, attempt to provide closed timestamp notifications for timestamps trailing cluster time by approximately this duration",
 	3*time.Second,
+	settings.NonNegativeDuration,
 )
 
 // CloseFraction is the fraction of TargetDuration determining how often closed
 // timestamp updates are to be attempted.
-var CloseFraction = settings.RegisterValidatedFloatSetting(
+var CloseFraction = settings.RegisterFloatSetting(
 	"kv.closed_timestamp.close_fraction",
 	"fraction of closed timestamp target duration specifying how frequently the closed timestamp is advanced",
 	0.2,

--- a/pkg/kv/kvserver/consistency_queue.go
+++ b/pkg/kv/kvserver/consistency_queue.go
@@ -24,14 +24,15 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
-var consistencyCheckInterval = settings.RegisterNonNegativeDurationSetting(
+var consistencyCheckInterval = settings.RegisterDurationSetting(
 	"server.consistency_check.interval",
 	"the time between range consistency checks; set to 0 to disable consistency checking."+
 		" Note that intervals that are too short can negatively impact performance.",
 	24*time.Hour,
+	settings.NonNegativeDuration,
 )
 
-var consistencyCheckRate = settings.RegisterPublicValidatedByteSizeSetting(
+var consistencyCheckRate = settings.RegisterByteSizeSetting(
 	"server.consistency_check.max_rate",
 	"the rate limit (bytes/sec) to use for consistency checks; used in "+
 		"conjunction with server.consistency_check.interval to control the "+
@@ -39,7 +40,7 @@ var consistencyCheckRate = settings.RegisterPublicValidatedByteSizeSetting(
 		"negatively impact performance.",
 	8<<20, // 8MB
 	validatePositive,
-)
+).WithPublic()
 
 // consistencyCheckRateBurstFactor we use this to set the burst parameter on the
 // quotapool.RateLimiter. It seems overkill to provide a user setting for this,

--- a/pkg/kv/kvserver/merge_queue.go
+++ b/pkg/kv/kvserver/merge_queue.go
@@ -45,10 +45,11 @@ const (
 
 // MergeQueueInterval is a setting that controls how often the merge queue waits
 // between processing replicas.
-var MergeQueueInterval = settings.RegisterNonNegativeDurationSetting(
+var MergeQueueInterval = settings.RegisterDurationSetting(
 	"kv.range_merge.queue_interval",
 	"how long the merge queue waits between processing replicas",
 	time.Second,
+	settings.NonNegativeDuration,
 )
 
 // mergeQueue manages a queue of ranges slated to be merged with their right-

--- a/pkg/kv/kvserver/protectedts/ptreconcile/reconciler.go
+++ b/pkg/kv/kvserver/protectedts/ptreconcile/reconciler.go
@@ -33,11 +33,12 @@ import (
 
 // ReconcileInterval is the interval between two generations of the reports.
 // When set to zero - disables the report generation.
-var ReconcileInterval = settings.RegisterPublicNonNegativeDurationSetting(
+var ReconcileInterval = settings.RegisterDurationSetting(
 	"kv.protectedts.reconciliation.interval",
 	"the frequency for reconciling jobs with protected timestamp records",
 	5*time.Minute,
-)
+	settings.NonNegativeDuration,
+).WithPublic()
 
 // StatusFunc is used to check on the status of a Record based on its Meta
 // field.

--- a/pkg/kv/kvserver/protectedts/settings.go
+++ b/pkg/kv/kvserver/protectedts/settings.go
@@ -21,26 +21,29 @@ import (
 
 // MaxBytes controls the maximum number of bytes worth of spans and metadata
 // which can be protected by all protected timestamp records.
-var MaxBytes = settings.RegisterNonNegativeIntSetting(
+var MaxBytes = settings.RegisterIntSetting(
 	"kv.protectedts.max_bytes",
 	"if non-zero the limit of the number of bytes of spans and metadata which can be protected",
 	1<<20, // 1 MiB
+	settings.NonNegativeInt,
 )
 
 // MaxSpans controls the maximum number of spans which can be protected
 // by all protected timestamp records.
-var MaxSpans = settings.RegisterNonNegativeIntSetting(
+var MaxSpans = settings.RegisterIntSetting(
 	"kv.protectedts.max_spans",
 	"if non-zero the limit of the number of spans which can be protected",
-	4096)
+	4096,
+	settings.NonNegativeInt,
+)
 
 // PollInterval defines how frequently the protectedts state is polled by the
 // Tracker.
-var PollInterval = settings.RegisterNonNegativeDurationSetting(
+var PollInterval = settings.RegisterDurationSetting(
 	"kv.protectedts.poll_interval",
 	// TODO(ajwerner): better description.
 	"the interval at which the protectedts subsystem state is polled",
-	2*time.Minute)
+	2*time.Minute, settings.NonNegativeDuration)
 
 func init() {
 	MaxBytes.SetVisibility(settings.Reserved)

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -99,7 +99,7 @@ var UseAtomicReplicationChanges = settings.RegisterBoolSetting(
 const MaxCommandSizeFloor = 4 << 20 // 4MB
 
 // MaxCommandSize wraps "kv.raft.command.max_size".
-var MaxCommandSize = settings.RegisterValidatedByteSizeSetting(
+var MaxCommandSize = settings.RegisterByteSizeSetting(
 	"kv.raft.command.max_size",
 	"maximum size of a raft command",
 	64<<20,

--- a/pkg/kv/kvserver/replica_backpressure.go
+++ b/pkg/kv/kvserver/replica_backpressure.go
@@ -26,7 +26,7 @@ var backpressureLogLimiter = log.Every(500 * time.Millisecond)
 // backpressureRangeSizeMultiplier is the multiple of range_max_bytes that a
 // range's size must grow to before backpressure will be applied on writes. Set
 // to 0 to disable backpressure altogether.
-var backpressureRangeSizeMultiplier = settings.RegisterValidatedFloatSetting(
+var backpressureRangeSizeMultiplier = settings.RegisterFloatSetting(
 	"kv.range.backpressure_range_size_multiplier",
 	"multiple of range_max_bytes that a range is allowed to grow to without "+
 		"splitting before writes to that range are blocked, or 0 to disable",

--- a/pkg/kv/kvserver/replica_follower_read.go
+++ b/pkg/kv/kvserver/replica_follower_read.go
@@ -26,11 +26,11 @@ import (
 // reads. The closed timestamp machinery is unaffected by this, i.e. the same
 // information is collected and passed around, regardless of the value of this
 // setting.
-var FollowerReadsEnabled = settings.RegisterPublicBoolSetting(
+var FollowerReadsEnabled = settings.RegisterBoolSetting(
 	"kv.closed_timestamp.follower_reads_enabled",
 	"allow (all) replicas to serve consistent historical reads based on closed timestamp information",
 	true,
-)
+).WithPublic()
 
 // canServeFollowerRead tests, when a range lease could not be acquired, whether
 // the batch can be served as a follower read despite the error. Only

--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -35,11 +35,11 @@ import (
 )
 
 // RangefeedEnabled is a cluster setting that enables rangefeed requests.
-var RangefeedEnabled = settings.RegisterPublicBoolSetting(
+var RangefeedEnabled = settings.RegisterBoolSetting(
 	"kv.rangefeed.enabled",
 	"if set, rangefeed registration is enabled",
 	false,
-)
+).WithPublic()
 
 // lockedRangefeedStream is an implementation of rangefeed.Stream which provides
 // support for concurrent calls to Send. Note that the default implementation of

--- a/pkg/kv/kvserver/replica_split_load.go
+++ b/pkg/kv/kvserver/replica_split_load.go
@@ -21,24 +21,25 @@ import (
 )
 
 // SplitByLoadEnabled wraps "kv.range_split.by_load_enabled".
-var SplitByLoadEnabled = settings.RegisterPublicBoolSetting(
+var SplitByLoadEnabled = settings.RegisterBoolSetting(
 	"kv.range_split.by_load_enabled",
 	"allow automatic splits of ranges based on where load is concentrated",
 	true,
-)
+).WithPublic()
 
 // SplitByLoadQPSThreshold wraps "kv.range_split.load_qps_threshold".
-var SplitByLoadQPSThreshold = settings.RegisterPublicIntSetting(
+var SplitByLoadQPSThreshold = settings.RegisterIntSetting(
 	"kv.range_split.load_qps_threshold",
 	"the QPS over which, the range becomes a candidate for load based splitting",
 	2500, // 2500 req/s
-)
+).WithPublic()
 
 // SplitByLoadMergeDelay wraps "kv.range_split.by_load_merge_delay".
-var SplitByLoadMergeDelay = settings.RegisterNonNegativeDurationSetting(
+var SplitByLoadMergeDelay = settings.RegisterDurationSetting(
 	"kv.range_split.by_load_merge_delay",
 	"the delay that range splits created due to load will wait before considering being merged away",
 	5*time.Minute,
+	settings.NonNegativeDuration,
 )
 
 // SplitByLoadQPSThreshold returns the QPS request rate for a given replica.

--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -51,12 +51,13 @@ const (
 // minLeaseTransferInterval controls how frequently leases can be transferred
 // for rebalancing. It does not prevent transferring leases in order to allow
 // a replica to be removed from a range.
-var minLeaseTransferInterval = settings.RegisterNonNegativeDurationSetting(
+var minLeaseTransferInterval = settings.RegisterDurationSetting(
 	"kv.allocator.min_lease_transfer_interval",
 	"controls how frequently leases can be transferred for rebalancing. "+
 		"It does not prevent transferring leases in order to allow a "+
 		"replica to be removed from a range.",
 	1*time.Second,
+	settings.NonNegativeDuration,
 )
 
 // TODO(aayush): Expand this metric set to include metrics about non-voting replicas.

--- a/pkg/kv/kvserver/reports/reporter.go
+++ b/pkg/kv/kvserver/reports/reporter.go
@@ -42,12 +42,13 @@ import (
 
 // ReporterInterval is the interval between two generations of the reports.
 // When set to zero - disables the report generation.
-var ReporterInterval = settings.RegisterPublicNonNegativeDurationSetting(
+var ReporterInterval = settings.RegisterDurationSetting(
 	"kv.replication_reports.interval",
 	"the frequency for generating the replication_constraint_stats, replication_stats_report and "+
 		"replication_critical_localities reports (set to 0 to disable)",
 	time.Minute,
-)
+	settings.NonNegativeDuration,
+).WithPublic()
 
 // Reporter periodically produces a couple of reports on the cluster's data
 // distribution: the system tables: replication_constraint_stats,

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -114,52 +114,59 @@ var logSSTInfoTicks = envutil.EnvOrDefaultInt(
 	"COCKROACH_LOG_SST_INFO_TICKS_INTERVAL", 60)
 
 // bulkIOWriteLimit is defined here because it is used by BulkIOWriteLimiter.
-var bulkIOWriteLimit = settings.RegisterPublicByteSizeSetting(
+var bulkIOWriteLimit = settings.RegisterByteSizeSetting(
 	"kv.bulk_io_write.max_rate",
 	"the rate limit (bytes/sec) to use for writes to disk on behalf of bulk io ops",
 	1<<40,
-)
+).WithPublic()
 
 // importRequestsLimit limits concurrent import requests.
-var importRequestsLimit = settings.RegisterPositiveIntSetting(
+var importRequestsLimit = settings.RegisterIntSetting(
 	"kv.bulk_io_write.concurrent_import_requests",
 	"number of import requests a store will handle concurrently before queuing",
 	1,
+	settings.PositiveInt,
 )
 
 // addSSTableRequestLimit limits concurrent AddSSTable requests.
-var addSSTableRequestLimit = settings.RegisterPositiveIntSetting(
+var addSSTableRequestLimit = settings.RegisterIntSetting(
 	"kv.bulk_io_write.concurrent_addsstable_requests",
 	"number of AddSSTable requests a store will handle concurrently before queuing",
 	1,
+	settings.PositiveInt,
 )
 
 // concurrentRangefeedItersLimit limits concurrent rangefeed catchup iterators.
-var concurrentRangefeedItersLimit = settings.RegisterPositiveIntSetting(
+var concurrentRangefeedItersLimit = settings.RegisterIntSetting(
 	"kv.rangefeed.concurrent_catchup_iterators",
 	"number of rangefeeds catchup iterators a store will allow concurrently before queueing",
 	64,
+	settings.PositiveInt,
 )
 
 // Minimum time interval between system config updates which will lead to
 // enqueuing replicas.
-var queueAdditionOnSystemConfigUpdateRate = settings.RegisterNonNegativeFloatSetting(
+var queueAdditionOnSystemConfigUpdateRate = settings.RegisterFloatSetting(
 	"kv.store.system_config_update.queue_add_rate",
-	"the rate (per second) at which the store will add all replicas to the split and merge queue due to system config gossip",
-	.5)
+	"the rate (per second) at which the store will add, all replicas to the split and merge queue due to system config gossip",
+	.5,
+	settings.NonNegativeFloat,
+)
 
 // Minimum time interval between system config updates which will lead to
 // enqueuing replicas. The default is relatively high to deal with startup
 // scenarios.
-var queueAdditionOnSystemConfigUpdateBurst = settings.RegisterNonNegativeIntSetting(
+var queueAdditionOnSystemConfigUpdateBurst = settings.RegisterIntSetting(
 	"kv.store.system_config_update.queue_add_burst",
 	"the burst rate at which the store will add all replicas to the split and merge queue due to system config gossip",
-	32)
+	32,
+	settings.NonNegativeInt,
+)
 
 // leaseTransferWait limits the amount of time a drain command waits for lease
 // and Raft leadership transfers.
 var leaseTransferWait = func() *settings.DurationSetting {
-	s := settings.RegisterValidatedDurationSetting(
+	s := settings.RegisterDurationSetting(
 		leaseTransferWaitSettingName,
 		"the amount of time a server waits to transfer range leases before proceeding with the rest of the shutdown process",
 		5*time.Second,
@@ -184,10 +191,11 @@ const leaseTransferWaitSettingName = "server.shutdown.lease_transfer_wait"
 // by a guessing - it could be improved by more measured heuristics. Exported
 // here since we check it in in the caller to limit generated requests as well
 // to prevent excessive queuing.
-var ExportRequestsLimit = settings.RegisterPositiveIntSetting(
+var ExportRequestsLimit = settings.RegisterIntSetting(
 	"kv.bulk_io_write.concurrent_export_requests",
 	"number of export requests a store will handle concurrently before queuing",
 	3,
+	settings.PositiveInt,
 )
 
 // TestStoreConfig has some fields initialized with values relevant in tests.

--- a/pkg/kv/kvserver/store_pool.go
+++ b/pkg/kv/kvserver/store_pool.go
@@ -45,26 +45,28 @@ const (
 // DeclinedReservationsTimeout specifies a duration during which the local
 // replicate queue will not consider stores which have rejected a reservation a
 // viable target.
-var DeclinedReservationsTimeout = settings.RegisterNonNegativeDurationSetting(
+var DeclinedReservationsTimeout = settings.RegisterDurationSetting(
 	"server.declined_reservation_timeout",
 	"the amount of time to consider the store throttled for up-replication after a reservation was declined",
 	1*time.Second,
+	settings.NonNegativeDuration,
 )
 
 // FailedReservationsTimeout specifies a duration during which the local
 // replicate queue will not consider stores which have failed a reservation a
 // viable target.
-var FailedReservationsTimeout = settings.RegisterNonNegativeDurationSetting(
+var FailedReservationsTimeout = settings.RegisterDurationSetting(
 	"server.failed_reservation_timeout",
 	"the amount of time to consider the store throttled for up-replication after a failed reservation call",
 	5*time.Second,
+	settings.NonNegativeDuration,
 )
 
 const timeUntilStoreDeadSettingName = "server.time_until_store_dead"
 
 // TimeUntilStoreDead wraps "server.time_until_store_dead".
 var TimeUntilStoreDead = func() *settings.DurationSetting {
-	s := settings.RegisterValidatedDurationSetting(
+	s := settings.RegisterDurationSetting(
 		timeUntilStoreDeadSettingName,
 		"the time after which if there is no new gossiped information about a store, it is considered dead",
 		5*time.Minute,

--- a/pkg/kv/kvserver/store_rebalancer.go
+++ b/pkg/kv/kvserver/store_rebalancer.go
@@ -74,7 +74,7 @@ func makeStoreRebalancerMetrics() StoreRebalancerMetrics {
 // LoadBasedRebalancingMode controls whether range rebalancing takes
 // additional variables such as write load and disk usage into account.
 // If disabled, rebalancing is done purely based on replica count.
-var LoadBasedRebalancingMode = settings.RegisterPublicEnumSetting(
+var LoadBasedRebalancingMode = settings.RegisterEnumSetting(
 	"kv.allocator.load_based_rebalancing",
 	"whether to rebalance based on the distribution of QPS across stores",
 	"leases and replicas",
@@ -83,7 +83,7 @@ var LoadBasedRebalancingMode = settings.RegisterPublicEnumSetting(
 		int64(LBRebalancingLeasesOnly):        "leases",
 		int64(LBRebalancingLeasesAndReplicas): "leases and replicas",
 	},
-)
+).WithPublic()
 
 // qpsRebalanceThreshold is much like rangeRebalanceThreshold, but for
 // QPS rather than range count. This should be set higher than
@@ -91,10 +91,11 @@ var LoadBasedRebalancingMode = settings.RegisterPublicEnumSetting(
 // workloads change and clients come and go, so we need to be a little more
 // forgiving to avoid thrashing.
 var qpsRebalanceThreshold = func() *settings.FloatSetting {
-	s := settings.RegisterNonNegativeFloatSetting(
+	s := settings.RegisterFloatSetting(
 		"kv.allocator.qps_rebalance_threshold",
 		"minimum fraction away from the mean a store's QPS (such as queries per second) can be before it is considered overfull or underfull",
 		0.25,
+		settings.NonNegativeFloat,
 	)
 	s.SetVisibility(settings.Public)
 	return s

--- a/pkg/kv/kvserver/store_snapshot.go
+++ b/pkg/kv/kvserver/store_snapshot.go
@@ -839,12 +839,12 @@ func validatePositive(v int64) error {
 
 // rebalanceSnapshotRate is the rate at which preemptive snapshots can be sent.
 // This includes snapshots generated for upreplication or for rebalancing.
-var rebalanceSnapshotRate = settings.RegisterPublicValidatedByteSizeSetting(
+var rebalanceSnapshotRate = settings.RegisterByteSizeSetting(
 	"kv.snapshot_rebalance.max_rate",
 	"the rate limit (bytes/sec) to use for rebalance and upreplication snapshots",
 	envutil.EnvOrDefaultBytes("COCKROACH_PREEMPTIVE_SNAPSHOT_RATE", 8<<20),
 	validatePositive,
-)
+).WithPublic()
 
 // recoverySnapshotRate is the rate at which Raft-initiated spanshots can be
 // sent. Ideally, one would never see a Raft-initiated snapshot; we'd like all
@@ -852,18 +852,18 @@ var rebalanceSnapshotRate = settings.RegisterPublicValidatedByteSizeSetting(
 // completely get rid of them.
 // TODO(tbg): The existence of this rate, separate from rebalanceSnapshotRate,
 // does not make a whole lot of sense.
-var recoverySnapshotRate = settings.RegisterPublicValidatedByteSizeSetting(
+var recoverySnapshotRate = settings.RegisterByteSizeSetting(
 	"kv.snapshot_recovery.max_rate",
 	"the rate limit (bytes/sec) to use for recovery snapshots",
 	envutil.EnvOrDefaultBytes("COCKROACH_RAFT_SNAPSHOT_RATE", 8<<20),
 	validatePositive,
-)
+).WithPublic()
 
 // snapshotSenderBatchSize is the size that key-value batches are allowed to
 // grow to during Range snapshots before being sent to the receiver. This limit
 // places an upper-bound on the memory footprint of the sender of a Range
 // snapshot. It is also the granularity of rate limiting.
-var snapshotSenderBatchSize = settings.RegisterValidatedByteSizeSetting(
+var snapshotSenderBatchSize = settings.RegisterByteSizeSetting(
 	"kv.snapshot_sender.batch_size",
 	"size of key-value batches sent over the network during snapshots",
 	256<<10, // 256 KB
@@ -873,7 +873,7 @@ var snapshotSenderBatchSize = settings.RegisterValidatedByteSizeSetting(
 // snapshotSSTWriteSyncRate is the size of chunks to write before fsync-ing.
 // The default of 2 MiB was chosen to be in line with the behavior in bulk-io.
 // See sstWriteSyncRate.
-var snapshotSSTWriteSyncRate = settings.RegisterValidatedByteSizeSetting(
+var snapshotSSTWriteSyncRate = settings.RegisterByteSizeSetting(
 	"kv.snapshot_sst.sync_size",
 	"threshold after which snapshot SST writes must fsync",
 	bulkIOWriteBurst,

--- a/pkg/kv/kvserver/tenantrate/settings.go
+++ b/pkg/kv/kvserver/tenantrate/settings.go
@@ -58,25 +58,33 @@ func LimitConfigsFromSettings(settings *cluster.Settings) LimitConfigs {
 }
 
 var (
-	readRequestRateLimit = settings.RegisterPositiveFloatSetting(
+	readRequestRateLimit = settings.RegisterFloatSetting(
 		"kv.tenant_rate_limiter.read_requests.rate_limit",
 		"per-tenant read request rate limit in requests per second",
-		128)
+		128,
+		settings.PositiveFloat,
+	)
 
-	readRequestBurstLimit = settings.RegisterPositiveIntSetting(
+	readRequestBurstLimit = settings.RegisterIntSetting(
 		"kv.tenant_rate_limiter.read_requests.burst_limit",
 		"per-tenant read request burst limit in requests",
-		512)
+		512,
+		settings.PositiveInt,
+	)
 
-	writeRequestRateLimit = settings.RegisterPositiveFloatSetting(
+	writeRequestRateLimit = settings.RegisterFloatSetting(
 		"kv.tenant_rate_limiter.write_requests.rate_limit",
 		"per-tenant write request rate limit in requests per second",
-		128)
+		128,
+		settings.PositiveFloat,
+	)
 
-	writeRequestBurstLimit = settings.RegisterPositiveIntSetting(
+	writeRequestBurstLimit = settings.RegisterIntSetting(
 		"kv.tenant_rate_limiter.write_requests.burst_limit",
 		"per-tenant write request burst limit in requests",
-		512)
+		512,
+		settings.PositiveInt,
+	)
 
 	readRateLimit = settings.RegisterByteSizeSetting(
 		"kv.tenant_rate_limiter.read_bytes.rate_limit",

--- a/pkg/security/password.go
+++ b/pkg/security/password.go
@@ -84,11 +84,12 @@ func PromptForPassword() (string, error) {
 
 // MinPasswordLength is the cluster setting that configures the
 // minimum SQL password length.
-var MinPasswordLength = settings.RegisterNonNegativeIntSetting(
+var MinPasswordLength = settings.RegisterIntSetting(
 	"server.user_login.min_password_length",
 	"the minimum length accepted for passwords set in cleartext via SQL. "+
 		"Note that a value lower than 1 is ignored: passwords cannot be empty in any case.",
 	1,
+	settings.NonNegativeInt,
 )
 
 // GenerateRandomPassword generates a somewhat secure password

--- a/pkg/security/tls_settings.go
+++ b/pkg/security/tls_settings.go
@@ -33,17 +33,20 @@ type TLSSettings interface {
 	ocspTimeout() time.Duration
 }
 
-var ocspMode = settings.RegisterPublicEnumSetting("security.ocsp.mode",
+var ocspMode = settings.RegisterEnumSetting("security.ocsp.mode",
 	`use OCSP to check whether TLS certificates are revoked. If the OCSP
 server is unreachable, in strict mode all certificates will be rejected
 and in lax mode all certificates will be accepted.`,
-	"off", map[int64]string{ocspOff: "off", ocspLax: "lax", ocspStrict: "strict"})
+	"off", map[int64]string{ocspOff: "off", ocspLax: "lax", ocspStrict: "strict"}).WithPublic()
 
 // TODO(bdarnell): 3 seconds is the same as base.NetworkTimeout, but
 // we can't use it here due to import cycles. We need a real
 // no-dependencies base package for constants like this.
-var ocspTimeout = settings.RegisterPublicNonNegativeDurationSetting("security.ocsp.timeout",
-	"timeout before considering the OCSP server unreachable", 3*time.Second)
+var ocspTimeout = settings.RegisterDurationSetting("security.ocsp.timeout",
+	"timeout before considering the OCSP server unreachable",
+	3*time.Second,
+	settings.NonNegativeDuration,
+).WithPublic()
 
 type clusterTLSSettings struct {
 	settings *cluster.Settings

--- a/pkg/server/authentication.go
+++ b/pkg/server/authentication.go
@@ -80,11 +80,12 @@ var ConfigureOIDC = func(
 	return &noOIDCConfigured{}, nil
 }
 
-var webSessionTimeout = settings.RegisterPublicNonNegativeDurationSetting(
+var webSessionTimeout = settings.RegisterDurationSetting(
 	"server.web_session_timeout",
 	"the duration that a newly created web session will be valid",
 	7*24*time.Hour,
-)
+	settings.NonNegativeDuration,
+).WithPublic()
 
 type authenticationServer struct {
 	server *Server

--- a/pkg/server/drain.go
+++ b/pkg/server/drain.go
@@ -26,18 +26,18 @@ import (
 )
 
 var (
-	queryWait = settings.RegisterPublicDurationSetting(
+	queryWait = settings.RegisterDurationSetting(
 		"server.shutdown.query_wait",
 		"the server will wait for at least this amount of time for active queries to finish",
 		10*time.Second,
-	)
+	).WithPublic()
 
-	drainWait = settings.RegisterPublicDurationSetting(
+	drainWait = settings.RegisterDurationSetting(
 		"server.shutdown.drain_wait",
 		"the amount of time a server waits in an unready state before proceeding with the rest "+
 			"of the shutdown process",
 		0*time.Second,
-	)
+	).WithPublic()
 )
 
 // Drain puts the node into the specified drain mode(s) and optionally

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -98,18 +98,18 @@ var (
 // Cluster settings.
 var (
 	// graphiteEndpoint is host:port, if any, of Graphite metrics server.
-	graphiteEndpoint = settings.RegisterPublicStringSetting(
+	graphiteEndpoint = settings.RegisterStringSetting(
 		"external.graphite.endpoint",
 		"if nonempty, push server metrics to the Graphite or Carbon server at the specified host:port",
 		"",
-	)
+	).WithPublic()
 	// graphiteInterval is how often metrics are pushed to Graphite, if enabled.
-	graphiteInterval = settings.RegisterPublicNonNegativeDurationSettingWithMaximum(
+	graphiteInterval = settings.RegisterDurationSetting(
 		graphiteIntervalKey,
 		"the interval at which metrics are pushed to Graphite (if enabled)",
 		10*time.Second,
-		maxGraphiteInterval,
-	)
+		settings.NonNegativeDurationWithMaximum(maxGraphiteInterval),
+	).WithPublic()
 )
 
 type nodeMetrics struct {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -97,13 +97,13 @@ var (
 	// Allocation pool for gzipResponseWriters.
 	gzipResponseWriterPool sync.Pool
 
-	forwardClockJumpCheckEnabled = settings.RegisterPublicBoolSetting(
+	forwardClockJumpCheckEnabled = settings.RegisterBoolSetting(
 		"server.clock.forward_jump_check_enabled",
 		"if enabled, forward clock jumps > max_offset/2 will cause a panic",
 		false,
-	)
+	).WithPublic()
 
-	persistHLCUpperBoundInterval = settings.RegisterPublicDurationSetting(
+	persistHLCUpperBoundInterval = settings.RegisterDurationSetting(
 		"server.clock.persist_upper_bound_interval",
 		"the interval between persisting the wall time upper bound of the clock. The clock "+
 			"does not generate a wall time greater than the persisted timestamp and will panic if "+
@@ -112,7 +112,7 @@ var (
 			"time across server restarts. Not setting this or setting a value of 0 disables this "+
 			"feature.",
 		0,
-	)
+	).WithPublic()
 )
 
 // Server is the cockroach server node.

--- a/pkg/server/server_systemlog_gc.go
+++ b/pkg/server/server_systemlog_gc.go
@@ -35,7 +35,7 @@ const (
 var (
 	// rangeLogTTL is the TTL for rows in system.rangelog. If non zero, range log
 	// entries are periodically garbage collected.
-	rangeLogTTL = settings.RegisterPublicDurationSetting(
+	rangeLogTTL = settings.RegisterDurationSetting(
 		"server.rangelog.ttl",
 		fmt.Sprintf(
 			"if nonzero, range log entries older than this duration are deleted every %s. "+
@@ -43,11 +43,11 @@ var (
 			systemLogGCPeriod,
 		),
 		30*24*time.Hour, // 30 days
-	)
+	).WithPublic()
 
 	// eventLogTTL is the TTL for rows in system.eventlog. If non zero, event log
 	// entries are periodically garbage collected.
-	eventLogTTL = settings.RegisterPublicDurationSetting(
+	eventLogTTL = settings.RegisterDurationSetting(
 		"server.eventlog.ttl",
 		fmt.Sprintf(
 			"if nonzero, entries in system.eventlog older than this duration are deleted every %s. "+
@@ -55,7 +55,7 @@ var (
 			systemLogGCPeriod,
 		),
 		90*24*time.Hour, // 90 days
-	)
+	).WithPublic()
 )
 
 // gcSystemLog deletes entries in the given system log table between
@@ -83,7 +83,7 @@ func (s *Server) gcSystemLog(
 	}
 
 	deleteStmt := fmt.Sprintf(
-		`SELECT count(1), max(timestamp) FROM 
+		`SELECT count(1), max(timestamp) FROM
 [DELETE FROM system.%s WHERE timestamp >= $1 AND timestamp <= $2 LIMIT 1000 RETURNING timestamp]`,
 		table,
 	)

--- a/pkg/server/settingsworker_test.go
+++ b/pkg/server/settingsworker_test.go
@@ -39,20 +39,20 @@ var strA = settings.RegisterValidatedStringSetting(strKey, "desc", "<default>", 
 	}
 	return nil
 })
-var intA = settings.RegisterValidatedIntSetting(intKey, "desc", 1, func(v int64) error {
+var intA = settings.RegisterIntSetting(intKey, "desc", 1, func(v int64) error {
 	if v < 0 {
 		return errors.Errorf("can't set %s to a negative value: %d", intKey, v)
 	}
 	return nil
 
 })
-var durationA = settings.RegisterValidatedDurationSetting(durationKey, "desc", time.Minute, func(v time.Duration) error {
+var durationA = settings.RegisterDurationSetting(durationKey, "desc", time.Minute, func(v time.Duration) error {
 	if v < 0 {
 		return errors.Errorf("can't set %s to a negative duration: %s", durationKey, v)
 	}
 	return nil
 })
-var byteSizeA = settings.RegisterValidatedByteSizeSetting(byteSizeKey, "desc", 1024*1024, func(v int64) error {
+var byteSizeA = settings.RegisterByteSizeSetting(byteSizeKey, "desc", 1024*1024, func(v int64) error {
 	if v < 0 {
 		return errors.Errorf("can't set %s to a negative value: %d", byteSizeKey, v)
 	}

--- a/pkg/server/updates.go
+++ b/pkg/server/updates.go
@@ -60,11 +60,12 @@ const (
 	updateCheckJitterSeconds = 120
 )
 
-var diagnosticReportFrequency = settings.RegisterPublicNonNegativeDurationSetting(
+var diagnosticReportFrequency = settings.RegisterDurationSetting(
 	"diagnostics.reporting.interval",
 	"interval at which diagnostics data should be reported",
 	time.Hour,
-)
+	settings.NonNegativeDuration,
+).WithPublic()
 
 // randomly shift `d` to be up to `jitterSec` shorter or longer.
 func addJitter(d time.Duration, jitterSec int) time.Duration {

--- a/pkg/settings/bool.go
+++ b/pkg/settings/bool.go
@@ -76,16 +76,15 @@ func (b *BoolSetting) setToDefault(sv *Values) {
 	b.set(sv, b.defaultValue)
 }
 
+// WithPublic sets public visibility and can be chained.
+func (b *BoolSetting) WithPublic() *BoolSetting {
+	b.SetVisibility(Public)
+	return b
+}
+
 // RegisterBoolSetting defines a new setting with type bool.
 func RegisterBoolSetting(key, desc string, defaultValue bool) *BoolSetting {
 	setting := &BoolSetting{defaultValue: defaultValue}
 	register(key, desc, setting)
 	return setting
-}
-
-// RegisterPublicBoolSetting defines a new setting with type bool and makes it public.
-func RegisterPublicBoolSetting(key, desc string, defaultValue bool) *BoolSetting {
-	s := RegisterBoolSetting(key, desc, defaultValue)
-	s.SetVisibility(Public)
-	return s
 }

--- a/pkg/settings/byte_size.go
+++ b/pkg/settings/byte_size.go
@@ -33,23 +33,30 @@ func (b *ByteSizeSetting) String(sv *Values) string {
 	return humanizeutil.IBytes(b.Get(sv))
 }
 
-// RegisterByteSizeSetting defines a new setting with type bytesize.
-func RegisterByteSizeSetting(key, desc string, defaultValue int64) *ByteSizeSetting {
-	return RegisterValidatedByteSizeSetting(key, desc, defaultValue, nil)
+// WithPublic sets public visibility and can be chained.
+func (b *ByteSizeSetting) WithPublic() *ByteSizeSetting {
+	b.SetVisibility(Public)
+	return b
 }
 
-// RegisterPublicByteSizeSetting defines a new setting with type bytesize and makes it public.
-func RegisterPublicByteSizeSetting(key, desc string, defaultValue int64) *ByteSizeSetting {
-	s := RegisterValidatedByteSizeSetting(key, desc, defaultValue, nil)
-	s.SetVisibility(Public)
-	return s
-}
-
-// RegisterValidatedByteSizeSetting defines a new setting with type bytesize
-// with a validation function.
-func RegisterValidatedByteSizeSetting(
-	key, desc string, defaultValue int64, validateFn func(int64) error,
+// RegisterByteSizeSetting defines a new setting with type bytesize and any
+// supplied validation function(s).
+func RegisterByteSizeSetting(
+	key, desc string, defaultValue int64, validateFns ...func(int64) error,
 ) *ByteSizeSetting {
+
+	var validateFn func(int64) error
+	if len(validateFns) > 0 {
+		validateFn = func(v int64) error {
+			for _, fn := range validateFns {
+				if err := fn(v); err != nil {
+					return errors.Wrapf(err, "invalid value for %s", key)
+				}
+			}
+			return nil
+		}
+	}
+
 	if validateFn != nil {
 		if err := validateFn(defaultValue); err != nil {
 			panic(errors.Wrap(err, "invalid default"))
@@ -61,14 +68,4 @@ func RegisterValidatedByteSizeSetting(
 	}}
 	register(key, desc, setting)
 	return setting
-}
-
-// RegisterPublicValidatedByteSizeSetting defines a new setting with type
-// bytesize with a validation function and makes it public.
-func RegisterPublicValidatedByteSizeSetting(
-	key, desc string, defaultValue int64, validateFn func(int64) error,
-) *ByteSizeSetting {
-	s := RegisterValidatedByteSizeSetting(key, desc, defaultValue, validateFn)
-	s.SetVisibility(Public)
-	return s
 }

--- a/pkg/settings/duration.go
+++ b/pkg/settings/duration.go
@@ -105,64 +105,28 @@ func (d *DurationSetting) setToDefault(sv *Values) {
 	}
 }
 
+// WithPublic sets the visibility to public and can be chained.
+func (d *DurationSetting) WithPublic() *DurationSetting {
+	d.SetVisibility(Public)
+	return d
+}
+
 // RegisterDurationSetting defines a new setting with type duration.
-func RegisterDurationSetting(key, desc string, defaultValue time.Duration) *DurationSetting {
-	return RegisterValidatedDurationSetting(key, desc, defaultValue, nil)
-}
-
-// RegisterPublicDurationSetting defines a new setting with type
-// duration and makes it public.
-func RegisterPublicDurationSetting(key, desc string, defaultValue time.Duration) *DurationSetting {
-	s := RegisterValidatedDurationSetting(key, desc, defaultValue, nil)
-	s.SetVisibility(Public)
-	return s
-}
-
-// RegisterPublicNonNegativeDurationSetting defines a new setting with
-// type duration and makes it public.
-func RegisterPublicNonNegativeDurationSetting(
-	key, desc string, defaultValue time.Duration,
+func RegisterDurationSetting(
+	key, desc string, defaultValue time.Duration, validateFns ...func(time.Duration) error,
 ) *DurationSetting {
-	s := RegisterNonNegativeDurationSetting(key, desc, defaultValue)
-	s.SetVisibility(Public)
-	return s
-}
-
-// RegisterPublicNonNegativeDurationSettingWithMaximum defines a new setting with
-// type duration, makes it public, and sets a maximum value.
-// The maximum value is an allowed value.
-func RegisterPublicNonNegativeDurationSettingWithMaximum(
-	key, desc string, defaultValue time.Duration, maxValue time.Duration,
-) *DurationSetting {
-	s := RegisterValidatedDurationSetting(key, desc, defaultValue, func(v time.Duration) error {
-		if v < 0 {
-			return errors.Errorf("cannot set %s to a negative duration: %s", key, v)
+	var validateFn func(time.Duration) error
+	if len(validateFns) > 0 {
+		validateFn = func(v time.Duration) error {
+			for _, fn := range validateFns {
+				if err := fn(v); err != nil {
+					return errors.Wrapf(err, "invalid value for %s", key)
+				}
+			}
+			return nil
 		}
-		if v > maxValue {
-			return errors.Errorf("cannot set %s to a value larger than %s", key, maxValue)
-		}
-		return nil
-	})
-	s.SetVisibility(Public)
-	return s
-}
+	}
 
-// RegisterNonNegativeDurationSetting defines a new setting with type duration.
-func RegisterNonNegativeDurationSetting(
-	key, desc string, defaultValue time.Duration,
-) *DurationSetting {
-	return RegisterValidatedDurationSetting(key, desc, defaultValue, func(v time.Duration) error {
-		if v < 0 {
-			return errors.Errorf("cannot set %s to a negative duration: %s", key, v)
-		}
-		return nil
-	})
-}
-
-// RegisterValidatedDurationSetting defines a new setting with type duration.
-func RegisterValidatedDurationSetting(
-	key, desc string, defaultValue time.Duration, validateFn func(time.Duration) error,
-) *DurationSetting {
 	if validateFn != nil {
 		if err := validateFn(defaultValue); err != nil {
 			panic(errors.Wrap(err, "invalid default"))
@@ -176,24 +140,48 @@ func RegisterValidatedDurationSetting(
 	return setting
 }
 
-// RegisterPublicNonNegativeDurationSettingWithExplicitUnit defines a new
+// RegisterPublicDurationSettingWithExplicitUnit defines a new
 // public setting with type duration which requires an explicit unit when being
 // set.
-func RegisterPublicNonNegativeDurationSettingWithExplicitUnit(
-	key, desc string, defaultValue time.Duration,
+func RegisterPublicDurationSettingWithExplicitUnit(
+	key, desc string, defaultValue time.Duration, validateFn func(time.Duration) error,
 ) *DurationSettingWithExplicitUnit {
+	var fn func(time.Duration) error
+
+	if validateFn != nil {
+		fn = func(v time.Duration) error {
+			return errors.Wrapf(validateFn(v), "invalid value for %s", key)
+		}
+	}
+
 	setting := &DurationSettingWithExplicitUnit{
 		DurationSetting{
 			defaultValue: defaultValue,
-			validateFn: func(v time.Duration) error {
-				if v < 0 {
-					return errors.Errorf("cannot set %s to a negative duration: %s", key, v)
-				}
-				return nil
-			},
+			validateFn:   fn,
 		},
 	}
 	setting.SetVisibility(Public)
 	register(key, desc, setting)
 	return setting
+}
+
+// NonNegativeDuration can be passed to RegisterDurationSetting.
+func NonNegativeDuration(v time.Duration) error {
+	if v < 0 {
+		return errors.Errorf("cannot be set to a negative duration: %s", v)
+	}
+	return nil
+}
+
+// NonNegativeDurationWithMaximum can be passed to RegisterDurationSetting.
+func NonNegativeDurationWithMaximum(maxValue time.Duration) func(time.Duration) error {
+	return func(v time.Duration) error {
+		if v < 0 {
+			return errors.Errorf("cannot be set to a negative duration: %s", v)
+		}
+		if v > maxValue {
+			return errors.Errorf("cannot be set to a value larger than %s", maxValue)
+		}
+		return nil
+	}
 }

--- a/pkg/settings/enum.go
+++ b/pkg/settings/enum.go
@@ -103,13 +103,10 @@ func enumValuesToDesc(enumValues map[int64]string) string {
 	return buffer.String()
 }
 
-// RegisterPublicEnumSetting defines a new setting with type int and makes it public.
-func RegisterPublicEnumSetting(
-	key, desc string, defaultValue string, enumValues map[int64]string,
-) *EnumSetting {
-	s := RegisterEnumSetting(key, desc, defaultValue, enumValues)
-	s.SetVisibility(Public)
-	return s
+// WithPublic sets public visibility and can be chained.
+func (e *EnumSetting) WithPublic() *EnumSetting {
+	e.SetVisibility(Public)
+	return e
 }
 
 // RegisterEnumSetting defines a new setting with type int.

--- a/pkg/settings/settings_test.go
+++ b/pkg/settings/settings_test.go
@@ -145,8 +145,8 @@ var i1A = settings.RegisterIntSetting("i.1", "desc", 0)
 var i2A = settings.RegisterIntSetting("i.2", "desc", 5)
 var fA = settings.RegisterFloatSetting("f", "desc", 5.4)
 var dA = settings.RegisterDurationSetting("d", "desc", time.Second)
-var duA = settings.RegisterPublicNonNegativeDurationSettingWithExplicitUnit("d_with_explicit_unit", "desc", time.Second)
-var _ = settings.RegisterPublicNonNegativeDurationSettingWithMaximum("d_with_maximum", "desc", time.Second, time.Hour)
+var duA = settings.RegisterPublicDurationSettingWithExplicitUnit("d_with_explicit_unit", "desc", time.Second, settings.NonNegativeDuration)
+var _ = settings.RegisterDurationSetting("d_with_maximum", "desc", time.Second, settings.NonNegativeDurationWithMaximum(time.Hour))
 var eA = settings.RegisterEnumSetting("e", "desc", "foo", map[int64]string{1: "foo", 2: "bar", 3: "baz"})
 var byteSize = settings.RegisterByteSizeSetting("zzz", "desc", mb)
 var mA = settings.TestingRegisterVersionSetting("v.1", "desc", &dummyVersionSettingImpl{})
@@ -165,16 +165,16 @@ var strVal = settings.RegisterValidatedStringSetting(
 		}
 		return nil
 	})
-var dVal = settings.RegisterNonNegativeDurationSetting("dVal", "desc", time.Second)
-var fVal = settings.RegisterNonNegativeFloatSetting("fVal", "desc", 5.4)
-var byteSizeVal = settings.RegisterValidatedByteSizeSetting(
+var dVal = settings.RegisterDurationSetting("dVal", "desc", time.Second, settings.NonNegativeDuration)
+var fVal = settings.RegisterFloatSetting("fVal", "desc", 5.4, settings.NonNegativeFloat)
+var byteSizeVal = settings.RegisterByteSizeSetting(
 	"byteSize.Val", "desc", mb, func(v int64) error {
 		if v < 0 {
 			return errors.Errorf("bytesize cannot be negative")
 		}
 		return nil
 	})
-var iVal = settings.RegisterValidatedIntSetting(
+var iVal = settings.RegisterIntSetting(
 	"i.Val", "desc", 0, func(v int64) error {
 		if v < 0 {
 			return errors.Errorf("int cannot be negative")
@@ -606,7 +606,7 @@ func TestCache(t *testing.T) {
 		{
 			u := settings.NewUpdater(sv)
 			if err := u.Set("dVal", settings.EncodeDuration(-time.Hour), "d"); !testutils.IsError(err,
-				"cannot set dVal to a negative duration: -1h0m0s",
+				"cannot be set to a negative duration: -1h0m0s",
 			) {
 				t.Fatal(err)
 			}
@@ -634,7 +634,7 @@ func TestCache(t *testing.T) {
 		{
 			u := settings.NewUpdater(sv)
 			if err := u.Set("fVal", settings.EncodeFloat(-1.1), "f"); !testutils.IsError(err,
-				"cannot set fVal to a negative value: -1.1",
+				"cannot set to a negative value: -1.1",
 			) {
 				t.Fatal(err)
 			}
@@ -727,7 +727,7 @@ func batchRegisterSettings(t *testing.T, keyPrefix string, count int) (name stri
 	}()
 	for i := 0; i < count; i++ {
 		name = fmt.Sprintf("%s_%3d", keyPrefix, i)
-		settings.RegisterValidatedIntSetting(name, "desc", 0, nil)
+		settings.RegisterIntSetting(name, "desc", 0)
 	}
 	return name, err
 }

--- a/pkg/settings/string.go
+++ b/pkg/settings/string.go
@@ -77,16 +77,15 @@ func (s *StringSetting) setToDefault(sv *Values) {
 	}
 }
 
+// WithPublic sets public visibility and can be chained.
+func (s *StringSetting) WithPublic() *StringSetting {
+	s.SetVisibility(Public)
+	return s
+}
+
 // RegisterStringSetting defines a new setting with type string.
 func RegisterStringSetting(key, desc string, defaultValue string) *StringSetting {
 	return RegisterValidatedStringSetting(key, desc, defaultValue, nil)
-}
-
-// RegisterPublicStringSetting defines a new setting with type string and makes it public.
-func RegisterPublicStringSetting(key, desc string, defaultValue string) *StringSetting {
-	s := RegisterValidatedStringSetting(key, desc, defaultValue, nil)
-	s.SetVisibility(Public)
-	return s
 }
 
 // RegisterValidatedStringSetting defines a new setting with type string with a

--- a/pkg/sql/app_stats.go
+++ b/pkg/sql/app_stats.go
@@ -104,50 +104,53 @@ type transactionCounts struct {
 
 // stmtStatsEnable determines whether to collect per-statement
 // statistics.
-var stmtStatsEnable = settings.RegisterPublicBoolSetting(
+var stmtStatsEnable = settings.RegisterBoolSetting(
 	"sql.metrics.statement_details.enabled", "collect per-statement query statistics", true,
-)
+).WithPublic()
 
 // TxnStatsNumStmtIDsToRecord limits the number of statementIDs stored for in
 // transactions statistics for a single transaction. This defaults to 1000, and
 // currently is non-configurable (hidden setting).
-var TxnStatsNumStmtIDsToRecord = settings.RegisterPositiveIntSetting(
+var TxnStatsNumStmtIDsToRecord = settings.RegisterIntSetting(
 	"sql.metrics.transaction_details.max_statement_ids",
 	"max number of statement IDs to store for transaction statistics",
-	1000)
+	1000,
+	settings.PositiveInt,
+)
 
 // txnStatsEnable determines whether to collect per-application transaction
 // statistics.
-var txnStatsEnable = settings.RegisterPublicBoolSetting(
+var txnStatsEnable = settings.RegisterBoolSetting(
 	"sql.metrics.transaction_details.enabled", "collect per-application transaction statistics", true,
-)
+).WithPublic()
 
 // sqlStatsCollectionLatencyThreshold specifies the minimum amount of time
 // consumed by a SQL statement before it is collected for statistics reporting.
-var sqlStatsCollectionLatencyThreshold = settings.RegisterPublicDurationSetting(
+var sqlStatsCollectionLatencyThreshold = settings.RegisterDurationSetting(
 	"sql.metrics.statement_details.threshold",
 	"minimum execution time to cause statement statistics to be collected. "+
 		"If configured, no transaction stats are collected.",
 	0,
-)
+).WithPublic()
 
-var dumpStmtStatsToLogBeforeReset = settings.RegisterPublicBoolSetting(
+var dumpStmtStatsToLogBeforeReset = settings.RegisterBoolSetting(
 	"sql.metrics.statement_details.dump_to_logs",
 	"dump collected statement statistics to node logs when periodically cleared",
 	false,
-)
+).WithPublic()
 
-var sampleLogicalPlans = settings.RegisterPublicBoolSetting(
+var sampleLogicalPlans = settings.RegisterBoolSetting(
 	"sql.metrics.statement_details.plan_collection.enabled",
 	"periodically save a logical plan for each fingerprint",
 	true,
-)
+).WithPublic()
 
-var logicalPlanCollectionPeriod = settings.RegisterPublicNonNegativeDurationSetting(
+var logicalPlanCollectionPeriod = settings.RegisterDurationSetting(
 	"sql.metrics.statement_details.plan_collection.period",
 	"the time until a new logical plan is collected",
 	5*time.Minute,
-)
+	settings.NonNegativeDuration,
+).WithPublic()
 
 func (s stmtKey) String() string {
 	if s.failed {

--- a/pkg/sql/catalog/hydratedtables/hydratedcache.go
+++ b/pkg/sql/catalog/hydratedtables/hydratedcache.go
@@ -97,10 +97,12 @@ var (
 )
 
 // CacheSize controls the size of the LRU cache.
-var CacheSize = settings.RegisterNonNegativeIntSetting(
+var CacheSize = settings.RegisterIntSetting(
 	"sql.catalog.hydrated_tables.cache_size",
 	"number of table descriptor versions retained in the hydratedtables LRU cache",
-	128)
+	128,
+	settings.NonNegativeInt,
+)
 
 // NewCache constructs a new Cache.
 func NewCache(settings *cluster.Settings) *Cache {

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -706,23 +706,23 @@ func (s *Server) newConnExecutorWithTxn(
 
 // SQLStatReset is the cluster setting that controls at what interval SQL
 // statement statistics should be reset.
-var SQLStatReset = settings.RegisterPublicNonNegativeDurationSettingWithMaximum(
+var SQLStatReset = settings.RegisterDurationSetting(
 	"diagnostics.sql_stat_reset.interval",
 	"interval controlling how often SQL statement statistics should "+
 		"be reset (should be less than diagnostics.forced_sql_stat_reset.interval). It has a max value of 24H.",
 	time.Hour,
-	time.Hour*24,
-)
+	settings.NonNegativeDurationWithMaximum(time.Hour*24),
+).WithPublic()
 
 // MaxSQLStatReset is the cluster setting that controls at what interval SQL
 // statement statistics must be flushed within.
-var MaxSQLStatReset = settings.RegisterPublicNonNegativeDurationSettingWithMaximum(
+var MaxSQLStatReset = settings.RegisterDurationSetting(
 	"diagnostics.forced_sql_stat_reset.interval",
 	"interval after which SQL statement statistics are refreshed even "+
 		"if not collected (should be more than diagnostics.sql_stat_reset.interval). It has a max value of 24H.",
 	time.Hour*2, // 2 x diagnostics.sql_stat_reset.interval
-	time.Hour*24,
-)
+	settings.NonNegativeDurationWithMaximum(time.Hour*24),
+).WithPublic()
 
 // PeriodicallyClearSQLStats spawns a loop to reset stats based on the setting
 // of a given duration settings variable. We take in a function to actually do

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -44,18 +44,19 @@ import (
 
 // createStatsPostEvents controls the cluster setting for logging
 // automatic table statistics collection to the event log.
-var createStatsPostEvents = settings.RegisterPublicBoolSetting(
+var createStatsPostEvents = settings.RegisterBoolSetting(
 	"sql.stats.post_events.enabled",
 	"if set, an event is logged for every CREATE STATISTICS job",
 	false,
-)
+).WithPublic()
 
 // featureStatsEnabled is used to enable and disable the CREATE STATISTICS and
 // ANALYZE features.
-var featureStatsEnabled = settings.RegisterPublicBoolSetting(
+var featureStatsEnabled = settings.RegisterBoolSetting(
 	"feature.stats.enabled",
 	"set to true to enable CREATE STATISTICS/ANALYZE, false to disable; default is true",
-	featureflag.FeatureFlagEnabledDefault)
+	featureflag.FeatureFlagEnabledDefault,
+).WithPublic()
 
 const defaultHistogramBuckets = 200
 const nonIndexColHistogramBuckets = 2

--- a/pkg/sql/event_log.go
+++ b/pkg/sql/event_log.go
@@ -106,11 +106,11 @@ func logEventInternalForSQLStatements(
 		event)
 }
 
-var eventLogEnabled = settings.RegisterPublicBoolSetting(
+var eventLogEnabled = settings.RegisterBoolSetting(
 	"server.eventlog.enabled",
 	"if set, logged notable events are also stored in the table system.eventlog",
 	true,
-)
+).WithPublic()
 
 // InsertEventRecord inserts a single event into the event log as part
 // of the provided transaction, using the provided internal executor.

--- a/pkg/sql/exec_log.go
+++ b/pkg/sql/exec_log.go
@@ -83,34 +83,35 @@ import (
 
 // logStatementsExecuteEnabled causes the Executor to log executed
 // statements and, if any, resulting errors.
-var logStatementsExecuteEnabled = settings.RegisterPublicBoolSetting(
+var logStatementsExecuteEnabled = settings.RegisterBoolSetting(
 	"sql.trace.log_statement_execute",
 	"set to true to enable logging of executed statements",
 	false,
-)
+).WithPublic()
 
-var slowQueryLogThreshold = settings.RegisterPublicNonNegativeDurationSettingWithExplicitUnit(
+var slowQueryLogThreshold = settings.RegisterPublicDurationSettingWithExplicitUnit(
 	"sql.log.slow_query.latency_threshold",
 	"when set to non-zero, log statements whose service latency exceeds "+
 		"the threshold to a secondary logger on each node",
 	0,
+	settings.NonNegativeDuration,
 )
 
-var slowInternalQueryLogEnabled = settings.RegisterPublicBoolSetting(
+var slowInternalQueryLogEnabled = settings.RegisterBoolSetting(
 	"sql.log.slow_query.internal_queries.enabled",
 	"when set to true, internal queries which exceed the slow query log threshold "+
 		"are logged to a separate log. Must have the slow query log enabled for this "+
 		"setting to have any effect.",
 	false,
-)
+).WithPublic()
 
-var slowQueryLogFullTableScans = settings.RegisterPublicBoolSetting(
+var slowQueryLogFullTableScans = settings.RegisterBoolSetting(
 	"sql.log.slow_query.experimental_full_table_scans.enabled",
 	"when set to true, statements that perform a full table/index scan will be logged to the "+
 		"slow query log even if they do not meet the latency threshold. Must have the slow query "+
 		"log enabled for this setting to have any effect.",
 	false,
-)
+).WithPublic()
 
 type executorType int
 

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -80,11 +80,11 @@ import (
 )
 
 // ClusterOrganization is the organization name.
-var ClusterOrganization = settings.RegisterPublicStringSetting(
+var ClusterOrganization = settings.RegisterStringSetting(
 	"cluster.organization",
 	"organization name",
 	"",
-)
+).WithPublic()
 
 // ClusterIsInternal returns true if the cluster organization contains
 // "Cockroach Labs", indicating an internal cluster.
@@ -111,7 +111,7 @@ var ClusterSecret = func() *settings.StringSetting {
 // TODO(bob): Change this to 4 in v2.3; https://github.com/cockroachdb/cockroach/issues/32534
 // TODO(bob): Remove or n-op this in v2.4: https://github.com/cockroachdb/cockroach/issues/32844
 var defaultIntSize = func() *settings.IntSetting {
-	s := settings.RegisterValidatedIntSetting(
+	s := settings.RegisterIntSetting(
 		"sql.defaults.default_int_size",
 		"the size, in bytes, of an INT type", 8, func(i int64) error {
 			if i != 4 && i != 8 {
@@ -125,27 +125,27 @@ var defaultIntSize = func() *settings.IntSetting {
 
 const allowCrossDatabaseFKsSetting = "sql.cross_db_fks.enabled"
 
-var allowCrossDatabaseFKs = settings.RegisterPublicBoolSetting(
+var allowCrossDatabaseFKs = settings.RegisterBoolSetting(
 	allowCrossDatabaseFKsSetting,
 	"if true, creating foreign key references across databases is allowed",
 	false,
-)
+).WithPublic()
 
 const allowCrossDatabaseViewsSetting = "sql.cross_db_views.enabled"
 
-var allowCrossDatabaseViews = settings.RegisterPublicBoolSetting(
+var allowCrossDatabaseViews = settings.RegisterBoolSetting(
 	allowCrossDatabaseViewsSetting,
 	"if true, creating views that refer to other databases is allowed",
 	false,
-)
+).WithPublic()
 
 const allowCrossDatabaseSeqOwnerSetting = "sql.cross_db_sequence_owners.enabled"
 
-var allowCrossDatabaseSeqOwner = settings.RegisterPublicBoolSetting(
+var allowCrossDatabaseSeqOwner = settings.RegisterBoolSetting(
 	allowCrossDatabaseSeqOwnerSetting,
 	"if true, creating sequences owned by tables from other databases is allowed",
 	false,
-)
+).WithPublic()
 
 // traceTxnThreshold can be used to log SQL transactions that take
 // longer than duration to complete. For example, traceTxnThreshold=1s
@@ -154,36 +154,36 @@ var allowCrossDatabaseSeqOwner = settings.RegisterPublicBoolSetting(
 // that any positive duration will enable tracing and will slow down
 // all execution because traces are gathered for all transactions even
 // if they are not output.
-var traceTxnThreshold = settings.RegisterPublicDurationSetting(
+var traceTxnThreshold = settings.RegisterDurationSetting(
 	"sql.trace.txn.enable_threshold",
 	"duration beyond which all transactions are traced (set to 0 to "+
 		"disable). This setting is coarser grained than"+
 		"sql.trace.stmt.enable_threshold because it applies to all statements "+
 		"within a transaction as well as client communication (e.g. retries).", 0,
-)
+).WithPublic()
 
 // traceStmtThreshold is identical to traceTxnThreshold except it applies to
 // individual statements in a transaction. The motivation for this setting is
 // to be able to reduce the noise associated with a larger transaction (e.g.
 // round trips to client).
-var traceStmtThreshold = settings.RegisterPublicDurationSetting(
+var traceStmtThreshold = settings.RegisterDurationSetting(
 	"sql.trace.stmt.enable_threshold",
 	"duration beyond which all statements are traced (set to 0 to disable). "+
 		"This applies to individual statements within a transaction and is therefore "+
 		"finer-grained than sql.trace.txn.enable_threshold.",
 	0,
-)
+).WithPublic()
 
 // traceSessionEventLogEnabled can be used to enable the event log
 // that is normally kept for every SQL connection. The event log has a
 // non-trivial performance impact and also reveals SQL statements
 // which may be a privacy concern.
-var traceSessionEventLogEnabled = settings.RegisterPublicBoolSetting(
+var traceSessionEventLogEnabled = settings.RegisterBoolSetting(
 	"sql.trace.session_eventlog.enabled",
 	"set to true to enable session tracing. "+
 		"Note that enabling this may have a non-trivial negative performance impact.",
 	false,
-)
+).WithPublic()
 
 // ReorderJoinsLimitClusterSettingName is the name of the cluster setting for
 // the maximum number of joins to reorder.
@@ -191,7 +191,7 @@ const ReorderJoinsLimitClusterSettingName = "sql.defaults.reorder_joins_limit"
 
 // ReorderJoinsLimitClusterValue controls the cluster default for the maximum
 // number of joins reordered.
-var ReorderJoinsLimitClusterValue = settings.RegisterValidatedIntSetting(
+var ReorderJoinsLimitClusterValue = settings.RegisterIntSetting(
 	ReorderJoinsLimitClusterSettingName,
 	"default number of joins to reorder",
 	opt.DefaultJoinOrderLimit,
@@ -231,10 +231,11 @@ var zigzagJoinClusterMode = settings.RegisterBoolSetting(
 	true,
 )
 
-var optDrivenFKCascadesClusterLimit = settings.RegisterNonNegativeIntSetting(
+var optDrivenFKCascadesClusterLimit = settings.RegisterIntSetting(
 	"sql.defaults.foreign_key_cascades_limit",
 	"default value for foreign_key_cascades_limit session setting; limits the number of cascading operations that run as part of a single query",
 	10000,
+	settings.NonNegativeInt,
 )
 
 var preferLookupJoinsForFKs = settings.RegisterBoolSetting(
@@ -286,12 +287,13 @@ var experimentalAlterColumnTypeGeneralMode = settings.RegisterBoolSetting(
 	false,
 )
 
-var clusterIdleInSessionTimeout = settings.RegisterNonNegativeDurationSetting(
+var clusterIdleInSessionTimeout = settings.RegisterDurationSetting(
 	"sql.defaults.idle_in_session_timeout",
 	"default value for the idle_in_session_timeout; "+
 		"enables automatically killing sessions that exceed the "+
 		"idle_in_session_timeout threshold",
 	0,
+	settings.NonNegativeDuration,
 )
 
 // TODO(mgartner): remove this once multi-column inverted indexes are fully
@@ -348,7 +350,7 @@ var VectorizeClusterMode = settings.RegisterEnumSetting(
 // VectorizeRowCountThresholdClusterValue controls the cluster default for the
 // vectorize row count threshold. When it is met, the vectorized execution
 // engine will be used if possible.
-var VectorizeRowCountThresholdClusterValue = settings.RegisterValidatedIntSetting(
+var VectorizeRowCountThresholdClusterValue = settings.RegisterIntSetting(
 	"sql.defaults.vectorize_row_count_threshold",
 	"default vectorize row count threshold",
 	colexec.DefaultVectorizeRowCountThreshold,
@@ -375,7 +377,7 @@ var DistSQLClusterExecMode = settings.RegisterEnumSetting(
 
 // SerialNormalizationMode controls how the SERIAL type is interpreted in table
 // definitions.
-var SerialNormalizationMode = settings.RegisterPublicEnumSetting(
+var SerialNormalizationMode = settings.RegisterEnumSetting(
 	"sql.defaults.serial_normalization",
 	"default handling of SERIAL in table definitions",
 	"rowid",
@@ -384,13 +386,13 @@ var SerialNormalizationMode = settings.RegisterPublicEnumSetting(
 		int64(sessiondata.SerialUsesVirtualSequences): "virtual_sequence",
 		int64(sessiondata.SerialUsesSQLSequences):     "sql_sequence",
 	},
-)
+).WithPublic()
 
-var disallowFullTableScans = settings.RegisterPublicBoolSetting(
+var disallowFullTableScans = settings.RegisterBoolSetting(
 	`sql.defaults.disallow_full_table_scans.enabled`,
 	"setting to true rejects queries that have planned a full table scan",
 	false,
-)
+).WithPublic()
 
 var errNoTransactionInProgress = errors.New("there is no transaction in progress")
 var errTransactionInProgress = errors.New("there is already a transaction in progress")

--- a/pkg/sql/export.go
+++ b/pkg/sql/export.go
@@ -83,10 +83,11 @@ const exportFilePatternDefault = exportFilePatternPart + ".csv"
 const exportCompressionCodec = "gzip"
 
 // featureExportEnabled is used to enable and disable the EXPORT feature.
-var featureExportEnabled = settings.RegisterPublicBoolSetting(
+var featureExportEnabled = settings.RegisterBoolSetting(
 	"feature.export.enabled",
 	"set to true to enable exports, false to disable; default is true",
-	featureflag.FeatureFlagEnabledDefault)
+	featureflag.FeatureFlagEnabledDefault,
+).WithPublic()
 
 // ConstructExport is part of the exec.Factory interface.
 func (ef *execFactory) ConstructExport(

--- a/pkg/sql/flowinfra/flow_registry.go
+++ b/pkg/sql/flowinfra/flow_registry.go
@@ -32,10 +32,11 @@ var errNoInboundStreamConnection = errors.New("no inbound stream connection")
 
 // SettingFlowStreamTimeout is a cluster setting that sets the default flow
 // stream timeout.
-var SettingFlowStreamTimeout = settings.RegisterNonNegativeDurationSetting(
+var SettingFlowStreamTimeout = settings.RegisterDurationSetting(
 	"sql.distsql.flow_stream_timeout",
 	"amount of time incoming streams wait for a flow to be set up before erroring out",
 	10*time.Second,
+	settings.NonNegativeDuration,
 )
 
 // expectedConnectionTime is the expected time taken by a flow to connect to its

--- a/pkg/sql/flowinfra/flow_scheduler.go
+++ b/pkg/sql/flowinfra/flow_scheduler.go
@@ -27,11 +27,11 @@ import (
 
 const flowDoneChanSize = 8
 
-var settingMaxRunningFlows = settings.RegisterPublicIntSetting(
+var settingMaxRunningFlows = settings.RegisterIntSetting(
 	"sql.distsql.max_running_flows",
 	"maximum number of concurrent flows that can be run on a node",
 	500,
-)
+).WithPublic()
 
 // FlowScheduler manages running flows and decides when to queue and when to
 // start flows. The main interface it presents is ScheduleFlows, which passes a

--- a/pkg/sql/logictest/testdata/logic_test/cluster_settings
+++ b/pkg/sql/logictest/testdata/logic_test/cluster_settings
@@ -1,7 +1,7 @@
 statement ok
 SET CLUSTER SETTING sql.log.slow_query.latency_threshold = '1ms'
 
-statement error pq: cannot set sql.log.slow_query.latency_threshold to a negative duration
+statement error pq: invalid value for sql.log.slow_query.latency_threshold: cannot be set to a negative duration
 SET CLUSTER SETTING sql.log.slow_query.latency_threshold = '-1ms'
 
 statement error pq: invalid cluster setting argument type

--- a/pkg/sql/notice.go
+++ b/pkg/sql/notice.go
@@ -21,11 +21,11 @@ import (
 
 // NoticesEnabled is the cluster setting that allows users
 // to enable notices.
-var NoticesEnabled = settings.RegisterPublicBoolSetting(
+var NoticesEnabled = settings.RegisterBoolSetting(
 	"sql.notices.enabled",
 	"enable notices in the server/client protocol being sent",
 	true,
-)
+).WithPublic()
 
 // noticeSender is a subset of RestrictedCommandResult which allows
 // sending notices.

--- a/pkg/sql/pgwire/pgwirebase/encoding.go
+++ b/pkg/sql/pgwire/pgwirebase/encoding.go
@@ -51,7 +51,7 @@ const readBufferMaxMessageSizeClusterSettingName = "sql.conn.max_read_buffer_mes
 
 // ReadBufferMaxMessageSizeClusterSetting is the cluster setting for configuring
 // ReadBuffer default message sizes.
-var ReadBufferMaxMessageSizeClusterSetting = settings.RegisterValidatedByteSizeSetting(
+var ReadBufferMaxMessageSizeClusterSetting = settings.RegisterByteSizeSetting(
 	readBufferMaxMessageSizeClusterSettingName,
 	"maximum buffer size to allow for ingesting sql statements. Connections must be restarted for this to take effect.",
 	defaultMaxReadBufferMessageSize,

--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -51,7 +51,7 @@ import (
 //
 // The "results_buffer_size" connection parameter can be used to override this
 // default for an individual connection.
-var connResultsBufferSize = settings.RegisterPublicByteSizeSetting(
+var connResultsBufferSize = settings.RegisterByteSizeSetting(
 	"sql.defaults.results_buffer.size",
 	"default size of the buffer that accumulates results for a statement or a batch "+
 		"of statements before they are sent to the client. This can be overridden on "+
@@ -63,17 +63,17 @@ var connResultsBufferSize = settings.RegisterPublicByteSizeSetting(
 		"Updating the setting only affects new connections. "+
 		"Setting to 0 disables any buffering.",
 	16<<10, // 16 KiB
-)
+).WithPublic()
 
-var logConnAuth = settings.RegisterPublicBoolSetting(
+var logConnAuth = settings.RegisterBoolSetting(
 	sql.ConnAuditingClusterSettingName,
 	"if set, log SQL client connect and disconnect events (note: may hinder performance on loaded nodes)",
-	false)
+	false).WithPublic()
 
-var logSessionAuth = settings.RegisterPublicBoolSetting(
+var logSessionAuth = settings.RegisterBoolSetting(
 	sql.AuthAuditingClusterSettingName,
 	"if set, log SQL session login/disconnection events (note: may hinder performance on loaded nodes)",
-	false)
+	false).WithPublic()
 
 const (
 	// ErrSSLRequired is returned when a client attempts to connect to a

--- a/pkg/sql/schema_change_cluster_setting.go
+++ b/pkg/sql/schema_change_cluster_setting.go
@@ -21,10 +21,11 @@ import (
 // featureSchemaChangeEnabled is the cluster setting used to enable and disable
 // any features that require schema changes. Documentation for which features
 // are covered TBD.
-var featureSchemaChangeEnabled = settings.RegisterPublicBoolSetting(
+var featureSchemaChangeEnabled = settings.RegisterBoolSetting(
 	"feature.schema_change.enabled",
 	"set to true to enable schema changes, false to disable; default is true",
-	featureflag.FeatureFlagEnabledDefault)
+	featureflag.FeatureFlagEnabledDefault,
+).WithPublic()
 
 // checkSchemaChangeEnabled is a method that wraps the featureflag.CheckEnabled
 // method specifically for all features that are categorized as schema changes.

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -2570,11 +2570,11 @@ var CmpOps = cmpOpFixups(map[ComparisonOperator]cmpOpOverload{
 
 const experimentalBox2DClusterSettingName = "sql.spatial.experimental_box2d_comparison_operators.enabled"
 
-var experimentalBox2DClusterSetting = settings.RegisterPublicBoolSetting(
+var experimentalBox2DClusterSetting = settings.RegisterBoolSetting(
 	experimentalBox2DClusterSettingName,
 	"enables the use of certain experimental box2d comparison operators",
 	false,
-)
+).WithPublic()
 
 func checkExperimentalBox2DComparisonOperatorEnabled(ctx *EvalContext) error {
 	if !experimentalBox2DClusterSetting.Get(&ctx.Settings.SV) {

--- a/pkg/sql/sqlliveness/slinstance/slinstance.go
+++ b/pkg/sql/sqlliveness/slinstance/slinstance.go
@@ -32,16 +32,18 @@ import (
 
 var (
 	// DefaultTTL specifies the time to expiration when a session is created.
-	DefaultTTL = settings.RegisterNonNegativeDurationSetting(
+	DefaultTTL = settings.RegisterDurationSetting(
 		"server.sqlliveness.ttl",
 		"default sqlliveness session ttl",
 		40*time.Second,
+		settings.NonNegativeDuration,
 	)
 	// DefaultHeartBeat specifies the period between attempts to extend a session.
-	DefaultHeartBeat = settings.RegisterNonNegativeDurationSetting(
+	DefaultHeartBeat = settings.RegisterDurationSetting(
 		"server.sqlliveness.heartbeat",
 		"duration heart beats to push session expiration further out in time",
 		5*time.Second,
+		settings.NonNegativeDuration,
 	)
 )
 

--- a/pkg/sql/sqlliveness/slstorage/slstorage.go
+++ b/pkg/sql/sqlliveness/slstorage/slstorage.go
@@ -35,17 +35,18 @@ import (
 
 // GCInterval specifies duration between attempts to delete extant
 // sessions that have expired.
-var GCInterval = settings.RegisterNonNegativeDurationSetting(
+var GCInterval = settings.RegisterDurationSetting(
 	"server.sqlliveness.gc_interval",
 	"duration between attempts to delete extant sessions that have expired",
 	20*time.Second,
+	settings.NonNegativeDuration,
 )
 
 // GCJitter specifies the jitter fraction on the interval between attempts to
 // delete extant sessions that have expired.
 //
 // [(1-GCJitter) * GCInterval, (1+GCJitter) * GCInterval]
-var GCJitter = settings.RegisterValidatedFloatSetting(
+var GCJitter = settings.RegisterFloatSetting(
 	"server.sqlliveness.gc_jitter",
 	"jitter fraction on the duration between attempts to delete extant sessions that have expired",
 	.15,

--- a/pkg/sql/stats/automatic_stats.go
+++ b/pkg/sql/stats/automatic_stats.go
@@ -37,25 +37,25 @@ const AutoStatsClusterSettingName = "sql.stats.automatic_collection.enabled"
 
 // AutomaticStatisticsClusterMode controls the cluster setting for enabling
 // automatic table statistics collection.
-var AutomaticStatisticsClusterMode = settings.RegisterPublicBoolSetting(
+var AutomaticStatisticsClusterMode = settings.RegisterBoolSetting(
 	AutoStatsClusterSettingName,
 	"automatic statistics collection mode",
 	true,
-)
+).WithPublic()
 
 // MultiColumnStatisticsClusterMode controls the cluster setting for enabling
 // automatic collection of multi-column statistics.
-var MultiColumnStatisticsClusterMode = settings.RegisterPublicBoolSetting(
+var MultiColumnStatisticsClusterMode = settings.RegisterBoolSetting(
 	"sql.stats.multi_column_collection.enabled",
 	"multi-column statistics collection mode",
 	true,
-)
+).WithPublic()
 
 // AutomaticStatisticsMaxIdleTime controls the maximum fraction of time that
 // the sampler processors will be idle when scanning large tables for automatic
 // statistics (in high load scenarios). This value can be tuned to trade off
 // the runtime vs performance impact of automatic stats.
-var AutomaticStatisticsMaxIdleTime = settings.RegisterValidatedFloatSetting(
+var AutomaticStatisticsMaxIdleTime = settings.RegisterFloatSetting(
 	"sql.stats.automatic_collection.max_fraction_idle",
 	"maximum fraction of time that automatic statistics sampler processors are idle",
 	0.9,
@@ -73,10 +73,11 @@ var AutomaticStatisticsMaxIdleTime = settings.RegisterValidatedFloatSetting(
 // statistics on that table are refreshed, in addition to the constant value
 // AutomaticStatisticsMinStaleRows.
 var AutomaticStatisticsFractionStaleRows = func() *settings.FloatSetting {
-	s := settings.RegisterNonNegativeFloatSetting(
+	s := settings.RegisterFloatSetting(
 		"sql.stats.automatic_collection.fraction_stale_rows",
 		"target fraction of stale rows per table that will trigger a statistics refresh",
 		0.2,
+		settings.NonNegativeFloat,
 	)
 	s.SetVisibility(settings.Public)
 	return s
@@ -86,10 +87,11 @@ var AutomaticStatisticsFractionStaleRows = func() *settings.FloatSetting {
 // number of rows that should be updated before a table is refreshed, in
 // addition to the fraction AutomaticStatisticsFractionStaleRows.
 var AutomaticStatisticsMinStaleRows = func() *settings.IntSetting {
-	s := settings.RegisterNonNegativeIntSetting(
+	s := settings.RegisterIntSetting(
 		"sql.stats.automatic_collection.min_stale_rows",
 		"target minimum number of stale rows per table that will trigger a statistics refresh",
 		500,
+		settings.NonNegativeInt,
 	)
 	s.SetVisibility(settings.Public)
 	return s

--- a/pkg/sql/stats/histogram.go
+++ b/pkg/sql/stats/histogram.go
@@ -24,11 +24,11 @@ import (
 
 // HistogramClusterMode controls the cluster setting for enabling
 // histogram collection.
-var HistogramClusterMode = settings.RegisterPublicBoolSetting(
+var HistogramClusterMode = settings.RegisterBoolSetting(
 	"sql.stats.histogram_collection.enabled",
 	"histogram collection mode",
 	true,
-)
+).WithPublic()
 
 // EquiDepthHistogram creates a histogram where each bucket contains roughly
 // the same number of samples (though it can vary when a boundary value has

--- a/pkg/sql/stmtdiagnostics/statement_diagnostics.go
+++ b/pkg/sql/stmtdiagnostics/statement_diagnostics.go
@@ -38,7 +38,7 @@ var pollingInterval = settings.RegisterDurationSetting(
 	"rate at which the stmtdiagnostics.Registry polls for requests, set to zero to disable",
 	10*time.Second)
 
-var bundleChunkSize = settings.RegisterValidatedByteSizeSetting(
+var bundleChunkSize = settings.RegisterByteSizeSetting(
 	"sql.stmt_diagnostics.bundle_chunk_size",
 	"chunk size for statement diagnostic bundles",
 	1024*1024,

--- a/pkg/sql/temporary_schema.go
+++ b/pkg/sql/temporary_schema.go
@@ -51,11 +51,11 @@ import (
 
 // TempObjectCleanupInterval is a ClusterSetting controlling how often
 // temporary objects get cleaned up.
-var TempObjectCleanupInterval = settings.RegisterPublicDurationSetting(
+var TempObjectCleanupInterval = settings.RegisterDurationSetting(
 	"sql.temp_object_cleaner.cleanup_interval",
 	"how often to clean up orphaned temporary objects",
 	30*time.Minute,
-)
+).WithPublic()
 
 var (
 	temporaryObjectCleanerActiveCleanersMetric = metric.Metadata{

--- a/pkg/sql/user.go
+++ b/pkg/sql/user.go
@@ -181,11 +181,12 @@ func retrieveUserAndPassword(
 	return exists, canLogin, hashedPassword, validUntil, err
 }
 
-var userLoginTimeout = settings.RegisterPublicNonNegativeDurationSetting(
+var userLoginTimeout = settings.RegisterDurationSetting(
 	"server.user_login.timeout",
 	"timeout after which client authentication times out if some system range is unavailable (0 = no timeout)",
 	10*time.Second,
-)
+	settings.NonNegativeDuration,
+).WithPublic()
 
 // GetAllRoles returns a "set" (map) of Roles -> true.
 func (p *planner) GetAllRoles(ctx context.Context) (map[security.SQLUsername]bool, error) {

--- a/pkg/storage/cloudimpl/external_storage.go
+++ b/pkg/storage/cloudimpl/external_storage.go
@@ -405,20 +405,21 @@ func containsGlob(str string) bool {
 var (
 	// GcsDefault is the setting which defines the JSON key to use during GCS
 	// operations.
-	GcsDefault = settings.RegisterPublicStringSetting(
+	GcsDefault = settings.RegisterStringSetting(
 		CloudstorageGSDefaultKey,
 		"if set, JSON key to use during Google Cloud Storage operations",
 		"",
-	)
-	httpCustomCA = settings.RegisterPublicStringSetting(
+	).WithPublic()
+	httpCustomCA = settings.RegisterStringSetting(
 		CloudstorageHTTPCASetting,
 		"custom root CA (appended to system's default CAs) for verifying certificates when interacting with HTTPS storage",
 		"",
-	)
-	timeoutSetting = settings.RegisterPublicDurationSetting(
+	).WithPublic()
+	timeoutSetting = settings.RegisterDurationSetting(
 		cloudStorageTimeout,
 		"the timeout for import/export storage operations",
-		10*time.Minute)
+		10*time.Minute,
+	).WithPublic()
 )
 
 // delayedRetry runs fn and re-runs it a limited number of times if it

--- a/pkg/ts/db.go
+++ b/pkg/ts/db.go
@@ -37,22 +37,22 @@ var (
 )
 
 // TimeseriesStorageEnabled controls whether to store timeseries data to disk.
-var TimeseriesStorageEnabled = settings.RegisterPublicBoolSetting(
+var TimeseriesStorageEnabled = settings.RegisterBoolSetting(
 	"timeseries.storage.enabled",
 	"if set, periodic timeseries data is stored within the cluster; disabling is not recommended "+
 		"unless you are storing the data elsewhere",
 	true,
-)
+).WithPublic()
 
 // Resolution10sStorageTTL defines the maximum age of data that will be retained
 // at he 10 second resolution. Data older than this is subject to being "rolled
 // up" into the 30 minute resolution and then deleted.
-var Resolution10sStorageTTL = settings.RegisterPublicDurationSetting(
+var Resolution10sStorageTTL = settings.RegisterDurationSetting(
 	"timeseries.storage.resolution_10s.ttl",
 	"the maximum age of time series data stored at the 10 second resolution. Data older than this "+
 		"is subject to rollup and deletion.",
 	resolution10sDefaultRollupThreshold,
-)
+).WithPublic()
 
 // deprecatedResolution30StoreDuration is retained for backward compatibility during a version upgrade.
 var deprecatedResolution30StoreDuration = func() *settings.DurationSetting {
@@ -74,12 +74,12 @@ func init() {
 // Resolution30mStorageTTL defines the maximum age of data that will be
 // retained at he 30 minute resolution. Data older than this is subject to
 // deletion.
-var Resolution30mStorageTTL = settings.RegisterPublicDurationSetting(
+var Resolution30mStorageTTL = settings.RegisterDurationSetting(
 	"timeseries.storage.resolution_30m.ttl",
 	"the maximum age of time series data stored at the 30 minute resolution. Data older than this "+
 		"is subject to deletion.",
 	resolution30mDefaultPruneThreshold,
-)
+).WithPublic()
 
 // DB provides Cockroach's Time Series API.
 type DB struct {

--- a/pkg/util/log/logcrash/crash_reporting.go
+++ b/pkg/util/log/logcrash/crash_reporting.go
@@ -50,11 +50,11 @@ var (
 	//
 	// Doing this, rather than just using a default of `true`, means that a node
 	// will not errantly send a report using a default before loading settings.
-	DiagnosticsReportingEnabled = settings.RegisterPublicBoolSetting(
+	DiagnosticsReportingEnabled = settings.RegisterBoolSetting(
 		"diagnostics.reporting.enabled",
 		"enable reporting diagnostic metrics to cockroach labs",
 		false,
-	)
+	).WithPublic()
 
 	// CrashReports wraps "diagnostics.reporting.send_crash_reports".
 	CrashReports = settings.RegisterBoolSetting(

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -53,23 +53,23 @@ const (
 	fieldNameShadowType = prefixTracerState + "shadowtype"
 )
 
-var enableNetTrace = settings.RegisterPublicBoolSetting(
+var enableNetTrace = settings.RegisterBoolSetting(
 	"trace.debug.enable",
 	"if set, traces for recent requests can be seen at https://<ui>/debug/requests",
 	false,
-)
+).WithPublic()
 
-var lightstepToken = settings.RegisterPublicStringSetting(
+var lightstepToken = settings.RegisterStringSetting(
 	"trace.lightstep.token",
 	"if set, traces go to Lightstep using this token",
 	envutil.EnvOrDefaultString("COCKROACH_TEST_LIGHTSTEP_TOKEN", ""),
-)
+).WithPublic()
 
-var zipkinCollector = settings.RegisterPublicStringSetting(
+var zipkinCollector = settings.RegisterStringSetting(
 	"trace.zipkin.collector",
 	"if set, traces go to the given Zipkin instance (example: '127.0.0.1:9411'); ignored if trace.lightstep.token is set",
 	envutil.EnvOrDefaultString("COCKROACH_TEST_ZIPKIN_COLLECTOR", ""),
-)
+).WithPublic()
 
 // Tracer is our own custom implementation of opentracing.Tracer. It supports:
 //


### PR DESCRIPTION
The helpers to create and register settings with pre-defined validation
functions can sometimes lead to a proliferation or even combinatorial 
explosion of different register methods, like “RgisterPositiveDuration”, 
“RegisterNonNegativeDuration”, “RegisterPublicPostiveDuration”, 
“RegisterPublicNonNegativeDuration”, and then even “RegisterPublicNonNegativeDurationSettingWthMaxium”.

Reusable short-hands for common validations like “non-negative” or 
“positive” or “with maximum” are useful, but we cannot keep defining new
register methods for every combination.

Instead, this change makes common validations able to be passed as the
validation function argument to the regular registration method.

Release note: none.