### PR TITLE
tracing: fix child span optimization

### DIFF
--- a/pkg/util/tracing/span_test.go
+++ b/pkg/util/tracing/span_test.go
@@ -11,7 +11,6 @@
 package tracing
 
 import (
-	"context"
 	"regexp"
 	"strings"
 	"testing"
@@ -181,20 +180,4 @@ Span grandchild:
     === operation:grandchild _verbose:1
 `
 	require.Equal(t, exp, recToStrippedString(childRec))
-}
-
-func TestChildSpan(t *testing.T) {
-	tr := NewTracer()
-	// Set up non-recording span.
-	sp := tr.StartSpan("foo", WithForceRealSpan())
-	ctx := ContextWithSpan(context.Background(), sp)
-	// Since the parent span was not recording, we would expect the
-	// noop span back. However - we don't, we get our inputs instead.
-	// This is a performance optimization; there is a to-do in
-	// childSpan asking for its removal, but for now it's here to stay.
-	{
-		newCtx, newSp := ChildSpan(ctx, "foo")
-		require.Equal(t, ctx, newCtx)
-		require.Equal(t, sp, newSp)
-	}
 }


### PR DESCRIPTION
When given a context with a non-recording (but real) Span, we would
return the incoming context. This would lead to an extra premature
call to `Finish()` and subsequent use-after-Finish of the Span, which
can blow up and/or hang, most of the time within net/trace code.

Prior to this commit, the crash reproduced readily (within seconds) via

```
make stress PKG=./pkg/sql TESTS=TestTrace
```

and I had no issues for ~10 minutes with this commit.

Fixes #57875.

Release note: None
