### PR TITLE
release-20.2: opt: fix panic caused by some DDL statements and CTEs

### DIFF
--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -2278,8 +2278,10 @@ func deriveWithUses(r opt.Expr) props.WithUsesMap {
 
 	default:
 		if opt.IsMutationOp(e) {
-			// Note: this can still be 0.
-			excludedID = e.Private().(*MutationPrivate).WithID
+			if p, ok := e.Private().(*MutationPrivate); ok {
+				// Note: this can still be 0.
+				excludedID = p.WithID
+			}
 		}
 	}
 

--- a/pkg/sql/opt/memo/testdata/logprops/with
+++ b/pkg/sql/opt/memo/testdata/logprops/with
@@ -217,3 +217,36 @@ FROM
     LATERAL (SELECT * FROM (WITH foo AS (SELECT 1 + x) SELECT * FROM foo))
 ----
 error (0A000): CTEs may not be correlated
+
+# Regression test for #57821: error deriving WithUses caused by MutationOps
+# that don't use a MutationPrivate.
+norm
+WITH vals AS (VALUES (1), (2)),
+     cte AS (ALTER TABLE xy SPLIT AT (VALUES (1), (2)))
+SELECT * FROM cte
+----
+with &2 (cte)
+ ├── columns: key:9(bytes) pretty:10(string) split_enforced_until:11(timestamp)
+ ├── volatile, mutations
+ ├── prune: (9-11)
+ ├── alter-table-split xy
+ │    ├── columns: key:3(bytes) pretty:4(string) split_enforced_until:5(timestamp)
+ │    ├── volatile, mutations
+ │    ├── values
+ │    │    ├── columns: column1:2(int!null)
+ │    │    ├── cardinality: [2 - 2]
+ │    │    ├── prune: (2)
+ │    │    ├── tuple [type=tuple{int}]
+ │    │    │    └── const: 1 [type=int]
+ │    │    └── tuple [type=tuple{int}]
+ │    │         └── const: 2 [type=int]
+ │    └── null [type=string]
+ └── with-scan &2 (cte)
+      ├── columns: key:9(bytes) pretty:10(string) split_enforced_until:11(timestamp)
+      ├── mapping:
+      │    ├──  key:3(bytes) => key:9(bytes)
+      │    ├──  pretty:4(string) => pretty:10(string)
+      │    └──  split_enforced_until:5(timestamp) => split_enforced_until:11(timestamp)
+      ├── prune: (9-11)
+      └── cte-uses
+           └── &2: count=1 used-columns=(3-5)


### PR DESCRIPTION
Backport 1/1 commits from #57927.

/cc @cockroachdb/release

---

This piece of code assumed that all MutationOps have a
MutationPrivate, which is not the case (only the DMLs have it). It
causes a panic if we try to derive WithUses.

Fixes #57821.

Release note (bug fix): fixed assertion error caused by some DDL
statements used in conjunction with common table expressions (WITH).
