### PR TITLE
scripts: adjust release note script

### DIFF
--- a/scripts/release-notes.py
+++ b/scripts/release-notes.py
@@ -270,6 +270,8 @@ parser.add_option("--exclude-until", dest="exclude_until_commit",
                   help="exclude history ending at COMMIT", metavar="COMMIT")
 parser.add_option("--one-line", dest="one_line", action="store_true", default=False,
                   help="unwrap release notes on a single line")
+parser.add_option("--prod-release", dest="prod_release", action="store_true", default=False,
+                  help="identify release as production (e.g., v20.2.x) and omit '-unstable' from docker pull command")
 
 (options, args) = parser.parse_args()
 
@@ -833,6 +835,13 @@ if not hideheader:
 
 # Print the release notes sign-up and Downloads section.
 
+if options.prod_release:
+    print("""DOCS WRITER: PLEASE UPDATE THE VERSIONS AND LINKS IN THIS INTRO: This page lists additions and changes in <current release> since <previous_version>.
+
+- For a comprehensive summary of features in v20.2, see the [v20.2 GA release notes](v20.2.0.html).
+- To upgrade to v20.2, see [Upgrade to CockroachDB v20.2](../v20.2/upgrade-cockroach-version.html).
+""")
+
 if not hidedownloads:
     print("""Get future release notes emailed to you:
 
@@ -864,7 +873,7 @@ if not hidedownloads:
 
 {% include copy-clipboard.html %}
 ~~~shell
-$ docker pull cockroachdb/cockroach""" + ("-unstable:" if "-" in current_version else ":") + current_version + """
+$ docker pull cockroachdb/cockroach""" + (":" if options.prod_release else "-unstable:") + current_version + """
 ~~~
 """)
     print()


### PR DESCRIPTION
The generated docker pull command needs "-unstable" when it's not
a production release. The previous logic didn't always work.
That's been fixed by adding a new flag to indicate if the release
is production (e.g., v20.2.x) or testing (e.g., v21.1.0-alpha.x).
When the flag is passed, we also expand the intro with placeholder
text to link to the relevant GA release notes and upgrade doc.

Release note: None