### PR TITLE
geo/geomfn: fix SIGFPE in ST_FrechetDistance for very small densifyFrac

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -1681,6 +1681,7 @@ Bottom Left.</p>
 <p>This function utilizes the GEOS module.</p>
 </span></td></tr>
 <tr><td><a name="st_frechetdistance"></a><code>st_frechetdistance(geometry_a: geometry, geometry_b: geometry, densify_frac: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Returns the Frechet distance between the given geometries, with the given segment densification (range 0.0-1.0, -1 to disable).</p>
+<p>Smaller densify_frac gives a more accurate Fréchet distance. However, the computation time and memory usage increases with the square of the number of subsegments.</p>
 <p>This function utilizes the GEOS module.</p>
 </span></td></tr>
 <tr><td><a name="st_geogfromewkb"></a><code>st_geogfromewkb(val: <a href="bytes.html">bytes</a>) &rarr; geography</code></td><td><span class="funcdesc"><p>Returns the Geography from an EWKB representation.</p>

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -2991,8 +2991,10 @@ The azimuth is angle is referenced from north, and is positive clockwise: North 
 				return tree.NewDFloat(tree.DFloat(*ret)), nil
 			},
 			Info: infoBuilder{
-				info: `Returns the Frechet distance between the given geometries, with the given ` +
-					`segment densification (range 0.0-1.0, -1 to disable).`,
+				info: "Returns the Frechet distance between the given geometries, with the given " +
+					"segment densification (range 0.0-1.0, -1 to disable).\n\n" +
+					"Smaller densify_frac gives a more accurate Fréchet distance. However, the computation " +
+					"time and memory usage increases with the square of the number of subsegments.",
 				libraryUsage: usesGEOS,
 			}.String(),
 			Volatility: tree.VolatilityImmutable,


### PR DESCRIPTION
The geospatial builtin `ST_FrechetDistance` caused a division-by-zero
`SIGFPE` panic in GEOS with very small `densifyFrac` values (1e-20).
Slightly larger values (1e-19) result in `geos error: vector`.

This patch explicitly checks for `densifyFrac < 1e-19` and returns an
error, to avoid the `SIGFPE` panic.

Note that very small values of `densifyFrac` are prohibitively expensive
and likely to cause out-of-memory errors.

Release note (bug fix): `ST_FrechetDistance` no longer causes a `SIGFPE`
panic for very small values of `densifyFrac` (e.g. 1e-20), and returns
an error instead.

Resolves #57905.