### PR TITLE
memo: remove unused function arguments

### DIFF
--- a/pkg/sql/opt/memo/extract.go
+++ b/pkg/sql/opt/memo/extract.go
@@ -282,9 +282,7 @@ func ExtractRemainingJoinFilters(on FiltersExpr, leftEq, rightEq opt.ColList) Fi
 
 // ExtractConstColumns returns columns in the filters expression that have been
 // constrained to fixed values.
-func ExtractConstColumns(
-	on FiltersExpr, mem *Memo, evalCtx *tree.EvalContext,
-) (fixedCols opt.ColSet) {
+func ExtractConstColumns(on FiltersExpr, evalCtx *tree.EvalContext) (fixedCols opt.ColSet) {
 	for i := range on {
 		scalar := on[i]
 		scalarProps := scalar.ScalarProps()
@@ -298,7 +296,7 @@ func ExtractConstColumns(
 // ExtractValueForConstColumn returns the constant value of a column returned by
 // ExtractConstColumns.
 func ExtractValueForConstColumn(
-	on FiltersExpr, mem *Memo, evalCtx *tree.EvalContext, col opt.ColumnID,
+	on FiltersExpr, evalCtx *tree.EvalContext, col opt.ColumnID,
 ) tree.Datum {
 	for i := range on {
 		scalar := on[i]

--- a/pkg/sql/opt/xform/select_funcs.go
+++ b/pkg/sql/opt/xform/select_funcs.go
@@ -940,7 +940,7 @@ func (c *CustomFuncs) GenerateZigzagJoins(
 		return
 	}
 
-	fixedCols := memo.ExtractConstColumns(filters, c.e.mem, c.e.evalCtx)
+	fixedCols := memo.ExtractConstColumns(filters, c.e.evalCtx)
 
 	if fixedCols.Len() == 0 {
 		// Zigzagging isn't helpful in the absence of fixed columns.
@@ -1248,7 +1248,7 @@ func (c *CustomFuncs) fixedColsForZigzag(
 ) (fixedCols opt.ColList, vals memo.ScalarListExpr, typs []*types.T) {
 	for i, cnt := 0, index.ColumnCount(); i < cnt; i++ {
 		colID := tabID.IndexColumnID(index, i)
-		val := memo.ExtractValueForConstColumn(filters, c.e.mem, c.e.evalCtx, colID)
+		val := memo.ExtractValueForConstColumn(filters, c.e.evalCtx, colID)
 		if val == nil {
 			break
 		}


### PR DESCRIPTION
This commit removes the unused `mem *Memo` argument in
`ExtractConstColumns` and `ExtractValueForConstColumn`.

Release note: None