### PR TITLE
coldataext: propagate the encoding error as expected one

### DIFF
--- a/pkg/col/coldataext/datum_vec.go
+++ b/pkg/col/coldataext/datum_vec.go
@@ -87,7 +87,10 @@ func (d *Datum) Hash(da *rowenc.DatumAlloc) []byte {
 	// decode ed for fingerprinting, so we pass in nil memory account.
 	b, err := ed.Fingerprint(context.TODO(), d.ResolvedType(), da, nil /* appendTo */, nil /* acc */)
 	if err != nil {
-		colexecerror.InternalError(err)
+		// Since we know that the memory accounting error cannot occur in
+		// Fingerprint, we only can get an expected error (e.g. unable to encode
+		// JSON as a key), so we propagate all of them accordingly.
+		colexecerror.ExpectedError(err)
 	}
 	return b
 }

--- a/pkg/sql/logictest/testdata/logic_test/hash_join
+++ b/pkg/sql/logictest/testdata/logic_test/hash_join
@@ -216,3 +216,10 @@ SELECT * FROM t44797_2 WHERE EXISTS (SELECT * FROM t44797_2 AS l, t44797_3 AS r 
 ----
 1
 2
+
+# Regression test for incorrectly propagating an error in the vectorized engine.
+statement ok
+CREATE TABLE table57696(col_table TIME NOT NULL)
+
+statement error unable to encode JSON as a table key\nHINT:.*\n.*35706.*
+WITH cte (col_cte) AS ( SELECT * FROM ( VALUES ( ( 'false':::JSONB, '1970-01-05 16:57:40.000665+00:00':::TIMESTAMPTZ ) ) ) EXCEPT ALL SELECT * FROM ( VALUES ( ( ' [ [[true], [], {}, "b", {}], {"a": []}, {"c": 2.05750813403415} ] ':::JSONB, '1970-01-10 05:23:26.000428+00:00':::TIMESTAMPTZ ) ) ) ) SELECT * FROM cte, table57696

--- a/pkg/sql/rowenc/BUILD.bazel
+++ b/pkg/sql/rowenc/BUILD.bazel
@@ -31,6 +31,7 @@ go_library(
         "//pkg/util/bitarray",
         "//pkg/util/duration",
         "//pkg/util/encoding",
+        "//pkg/util/errorutil/unimplemented",
         "//pkg/util/ipaddr",
         "//pkg/util/json",
         "//pkg/util/log",

--- a/pkg/sql/rowenc/column_type_encoding.go
+++ b/pkg/sql/rowenc/column_type_encoding.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/bitarray"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/ipaddr"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
 	"github.com/cockroachdb/cockroach/pkg/util/timetz"
@@ -183,6 +184,8 @@ func EncodeTableKey(b []byte, val tree.Datum, dir encoding.Direction) ([]byte, e
 			return encoding.EncodeBytesAscending(b, t.PhysicalRep), nil
 		}
 		return encoding.EncodeBytesDescending(b, t.PhysicalRep), nil
+	case *tree.DJSON:
+		return nil, unimplemented.NewWithIssue(35706, "unable to encode JSON as a table key")
 	}
 	return nil, errors.Errorf("unable to encode table key: %T", val)
 }


### PR DESCRIPTION
Fixes: #57696.

Release note (bug fix): CockroachDB previously would return an internal
error when attempting to execute a hash join on a JSON column via the
vectorized engine. Now a more user-friendly error is returned.