### PR TITLE
kvserver: fix testing code that was accidentally in prod

### DIFF
--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -929,10 +930,10 @@ func (r *Replica) ChangeReplicas(
 		return nil, errors.Errorf("%s: the current RangeDescriptor must not be nil", r)
 	}
 
-	// If there are testing knobs, we're definitely in a test.
-	// Try to catch tests that use manual replication while the
-	// replication queue is active. Such tests are often flaky.
-	if knobs := r.store.TestingKnobs(); knobs != nil &&
+	// If in testing (for lack of a better mechanism, we restrict to race builds),
+	// try to catch tests that use manual replication while the replication queue
+	// is active. Such tests are often flaky.
+	if knobs := r.store.TestingKnobs(); util.RaceEnabled &&
 		!knobs.DisableReplicateQueue &&
 		!knobs.AllowUnsynchronizedReplicationChanges {
 		bq := r.store.replicateQueue.baseQueue


### PR DESCRIPTION
In 65df6fcf9a93bd68f32eda9bb01f398e2dd69944, I added code intended to
catch racy uses of manual replication in tests. Unfortunately, the
condition I used to check whether we were in a test was always true
(the return of `TestingKnobs()` is never nil).

I looked around for a better way to test whether we're running in
a test and it's not that straightforward, but we do get to find
out whether running as part of nightly stress, and that seems
like a good enough context in which to enable these checks.

Fixes #57863.

Release note: None
