### PR TITLE
sql: check use of virtual columns in indexes

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/virtual_columns
+++ b/pkg/sql/logictest/testdata/logic_test/virtual_columns
@@ -20,6 +20,22 @@ CREATE TABLE t (
   FAMILY (v)
 )
 
+statement error primary index column "v" cannot be virtual
+CREATE TABLE t (
+  a INT,
+  b INT,
+  v INT AS (a+b) VIRTUAL,
+  PRIMARY KEY (b,v)
+)
+
+statement error index "t_b_idx" cannot store virtual column "v"
+CREATE TABLE t (
+  a INT PRIMARY KEY,
+  b INT,
+  v INT AS (a+b) VIRTUAL,
+  INDEX (b) STORING (v)
+)
+
 statement ok
 CREATE TABLE t (
   a INT PRIMARY KEY,


### PR DESCRIPTION
This commit adds checks that disallow virtual columns being used as
primary key columns or stored columns in indexes.

Release note: None

Informs #57608.