### PR TITLE
colexec: fix spilling of unordered distinct

### DIFF
--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -878,6 +878,7 @@ func NewColOperator(
 							input,
 							result.ColumnTypes,
 							result.makeDiskBackedSorterConstructor(ctx, flowCtx, args, monitorNamePrefix, factory),
+							inMemoryUnorderedDistinct,
 							diskAccount,
 						)
 						result.ToClose = append(result.ToClose, ed.(colexecbase.Closer))

--- a/pkg/sql/colexec/external_distinct_test.go
+++ b/pkg/sql/colexec/external_distinct_test.go
@@ -13,8 +13,10 @@ package colexec
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/colcontainer"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase"
@@ -27,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/marusama/semaphore"
 	"github.com/stretchr/testify/require"
 )
@@ -80,7 +83,8 @@ func TestExternalDistinct(t *testing.T) {
 						outputOrdering = convertDistinctColsToOrdering(tc.distinctCols)
 					}
 					distinct, newAccounts, newMonitors, closers, err := createExternalDistinct(
-						ctx, flowCtx, input, tc.typs, tc.distinctCols, outputOrdering, queueCfg, sem,
+						ctx, flowCtx, input, tc.typs, tc.distinctCols,
+						outputOrdering, queueCfg, sem, nil, /* spillingCallbackFn */
 					)
 					// Check that the external distinct and the disk-backed sort
 					// were added as Closers.
@@ -107,6 +111,160 @@ func TestExternalDistinct(t *testing.T) {
 	for _, mon := range monitors {
 		mon.Stop(ctx)
 	}
+}
+
+// TestExternalDistinctSpilling verifies that the external distinct correctly
+// handles the scenario when spilling to disk occurs after some tuples have
+// been emitted in the output by the in-memory unordered distinct.
+func TestExternalDistinctSpilling(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
+	defer evalCtx.Stop(ctx)
+	flowCtx := &execinfra.FlowCtx{
+		EvalCtx: &evalCtx,
+		Cfg: &execinfra.ServerConfig{
+			Settings:    st,
+			DiskMonitor: testDiskMonitor,
+		},
+	}
+
+	queueCfg, cleanup := colcontainerutils.NewTestingDiskQueueCfg(t, true /* inMem */)
+	defer cleanup()
+
+	var (
+		accounts []*mon.BoundAccount
+		monitors []*mon.BytesMonitor
+	)
+
+	rng, _ := randutil.NewPseudoRand()
+	nCols := 1 + rng.Intn(3)
+	typs := make([]*types.T, nCols)
+	distinctCols := make([]uint32, nCols)
+	for i := range typs {
+		typs[i] = types.Int
+		distinctCols[i] = uint32(i)
+	}
+
+	batchMemEstimate := colmem.EstimateBatchSizeBytes(typs, coldata.BatchSize())
+	// Set the memory limit in such a manner that at least 2 batches of distinct
+	// tuples are emitted by the in-memory unordered distinct before the
+	// spilling occurs.
+	nBatchesOutputByInMemoryOp := 2 + rng.Intn(2)
+	memoryLimitBytes := int64(nBatchesOutputByInMemoryOp * batchMemEstimate)
+	if memoryLimitBytes < mon.DefaultPoolAllocationSize {
+		memoryLimitBytes = mon.DefaultPoolAllocationSize
+		nBatchesOutputByInMemoryOp = int(memoryLimitBytes) / batchMemEstimate
+	}
+	flowCtx.Cfg.TestingKnobs.MemoryLimitBytes = memoryLimitBytes
+
+	// Calculate the total number of distinct batches at least twice as large
+	// as for the in-memory operator in order to make sure that the external
+	// distinct has enough work to do.
+	nDistinctBatches := nBatchesOutputByInMemoryOp * (2 + rng.Intn(2))
+	newTupleProbability := rng.Float64()
+	nTuples := int(float64(nDistinctBatches*coldata.BatchSize()) / newTupleProbability)
+	const maxNumTuples = 25000
+	spillingMightNotHappen := false
+	if nTuples > maxNumTuples {
+		// If we happen to set a large value for coldata.BatchSize() and a small
+		// value for newTupleProbability, we might end up with huge number of
+		// tuples. Then, when runTests test harness uses small batch size, the
+		// test might take a while, so we'll limit the number of tuples.
+		nTuples = maxNumTuples
+		// Since we have limited the number of tuples, it is possible that the
+		// spilling will not occur because we have given too large of a memory
+		// limit to the in-memory distinct. In such (relatively rare) scenario
+		// we cannot check that we spilled every time, yet we might as well run
+		// the correctness check.
+		spillingMightNotHappen = true
+	}
+	tups, expected := generateRandomDataForUnorderedDistinct(rng, nTuples, nCols, newTupleProbability)
+
+	var numRuns, numSpills int
+	var semsToCheck []semaphore.Semaphore
+	runTestsWithoutAllNullsInjection(
+		t,
+		[]tuples{tups},
+		[][]*types.T{typs},
+		expected,
+		// tups and expected are in an arbitrary order, so we use an unordered
+		// verifier.
+		unorderedVerifier,
+		func(input []colexecbase.Operator) (colexecbase.Operator, error) {
+			// Since we're giving very low memory limit to the operator, in
+			// order to make the test run faster, we'll use an unlimited number
+			// of file descriptors.
+			sem := colexecbase.NewTestingSemaphore(0 /* limit */)
+			semsToCheck = append(semsToCheck, sem)
+			var outputOrdering execinfrapb.Ordering
+			distinct, newAccounts, newMonitors, closers, err := createExternalDistinct(
+				ctx, flowCtx, input, typs, distinctCols, outputOrdering, queueCfg,
+				sem, func() { numSpills++ },
+			)
+			require.NoError(t, err)
+			// Check that the external distinct and the disk-backed sort
+			// were added as Closers.
+			numExpectedClosers := 2
+			require.Equal(t, numExpectedClosers, len(closers))
+			accounts = append(accounts, newAccounts...)
+			monitors = append(monitors, newMonitors...)
+			numRuns++
+			return distinct, nil
+		},
+	)
+	for i, sem := range semsToCheck {
+		require.Equal(t, 0, sem.GetCount(), "sem still reports open FDs at index %d", i)
+	}
+	if !spillingMightNotHappen {
+		require.Equal(t, numRuns, numSpills, "the spilling didn't occur in all cases")
+	}
+
+	for _, acc := range accounts {
+		acc.Close(ctx)
+	}
+	for _, mon := range monitors {
+		mon.Stop(ctx)
+	}
+}
+
+// generateRandomDataForDistinct is a utility function that generates data to be
+// used in randomized unit test of an unordered distinct operation. Note that
+// tups and expected can be in an arbitrary order (meaning the former is
+// shuffled whereas the latter is not).
+func generateRandomDataForUnorderedDistinct(
+	rng *rand.Rand, nTups, nDistinctCols int, newTupleProbability float64,
+) (tups, expected tuples) {
+	tups = make(tuples, nTups)
+	expected = make(tuples, 1, nTups)
+	tups[0] = make(tuple, nDistinctCols)
+	for j := 0; j < nDistinctCols; j++ {
+		tups[0][j] = 0
+	}
+	expected[0] = tups[0]
+
+	// We will construct the data in an ordered manner, and we'll shuffle it so
+	// that duplicate tuples are distributed randomly and not consequently.
+	newValueProbability := getNewValueProbabilityForDistinct(newTupleProbability, nDistinctCols)
+	for i := 1; i < nTups; i++ {
+		tups[i] = make(tuple, nDistinctCols)
+		isDuplicate := true
+		for j := range tups[i] {
+			tups[i][j] = tups[i-1][j].(int)
+			if rng.Float64() < newValueProbability {
+				tups[i][j] = tups[i][j].(int) + 1
+				isDuplicate = false
+			}
+		}
+		if !isDuplicate {
+			expected = append(expected, tups[i])
+		}
+	}
+
+	rand.Shuffle(nTups, func(i, j int) { tups[i], tups[j] = tups[j], tups[i] })
+	return tups, expected
 }
 
 func convertDistinctColsToOrdering(distinctCols []uint32) execinfrapb.Ordering {
@@ -160,7 +318,8 @@ func BenchmarkExternalDistinct(b *testing.B) {
 					}
 					op, accs, mons, _, err := createExternalDistinct(
 						ctx, flowCtx, []colexecbase.Operator{input}, typs,
-						distinctCols, outputOrdering, queueCfg, &colexecbase.TestingSemaphore{},
+						distinctCols, outputOrdering, queueCfg,
+						&colexecbase.TestingSemaphore{}, nil, /* spillingCallbackFn */
 					)
 					memAccounts = append(memAccounts, accs...)
 					memMonitors = append(memMonitors, mons...)
@@ -195,6 +354,7 @@ func createExternalDistinct(
 	outputOrdering execinfrapb.Ordering,
 	diskQueueCfg colcontainer.DiskQueueCfg,
 	testingSemaphore semaphore.Semaphore,
+	spillingCallbackFn func(),
 ) (colexecbase.Operator, []*mon.BoundAccount, []*mon.BytesMonitor, []colexecbase.Closer, error) {
 	distinctSpec := &execinfrapb.DistinctSpec{
 		DistinctColumns: distinctCols,
@@ -215,6 +375,7 @@ func createExternalDistinct(
 		DiskQueueCfg:        diskQueueCfg,
 		FDSemaphore:         testingSemaphore,
 	}
+	args.TestingKnobs.SpillingCallbackFn = spillingCallbackFn
 	// External sorter relies on different memory accounts to
 	// understand when to start a new partition, so we will not use
 	// the streaming memory account.

--- a/pkg/sql/colexec/unordered_distinct.go
+++ b/pkg/sql/colexec/unordered_distinct.go
@@ -51,7 +51,11 @@ func NewUnorderedDistinct(
 type unorderedDistinct struct {
 	OneInputNode
 
-	ht             *hashTable
+	ht *hashTable
+	// lastInputBatch tracks the last input batch read from the input and not
+	// emitted into the output. It is the only batch that we need to export when
+	// spilling to disk, and it will contain only the distinct tuples that need
+	// to be emitted into the output.
 	lastInputBatch coldata.Batch
 }
 
@@ -68,11 +72,11 @@ func (op *unorderedDistinct) Next(ctx context.Context) coldata.Batch {
 		if op.lastInputBatch.Length() == 0 {
 			return coldata.ZeroBatch
 		}
-		// Note that distinctBuild might panic with a memory budget exceeded
-		// error, in which case no tuples from the last input batch are output.
-		// In such scenario, we don't know at which point of distinctBuild that
-		// happened, but it doesn't matter - we will export the last input batch
-		// when falling back to disk.
+		// distinctBuild call might result in an OOM error after lastInputBatch
+		// is updated in-place to include only the new distinct tuples. If an
+		// OOM occurs, we are careful not to filter them out (since the
+		// filtering has already been performed); if an OOM doesn't occur, we
+		// will emit the updated last input batch here.
 		op.ht.distinctBuild(ctx, op.lastInputBatch)
 		if op.lastInputBatch.Length() > 0 {
 			// We've just appended some distinct tuples to the hash table, so we
@@ -85,14 +89,14 @@ func (op *unorderedDistinct) Next(ctx context.Context) coldata.Batch {
 }
 
 func (op *unorderedDistinct) ExportBuffered(colexecbase.Operator) coldata.Batch {
-	// We have output all the distinct tuples except for the ones that are part
-	// of the last input batch, so we only need to export that batch, and then
-	// we're done exporting.
 	if op.lastInputBatch != nil {
 		batch := op.lastInputBatch
 		op.lastInputBatch = nil
 		return batch
 	}
+	// We only need to export the last input batch because the buffered in the
+	// hash table data is used by the unorderedDistinctFilterer (which is
+	// planned by the external distinct).
 	return coldata.ZeroBatch
 }
 
@@ -102,4 +106,63 @@ func (op *unorderedDistinct) reset(ctx context.Context) {
 		r.reset(ctx)
 	}
 	op.ht.reset(ctx)
+}
+
+// unorderedDistinctFilterer filters out tuples that are duplicates of the
+// tuples already emitted by the unordered distinct.
+type unorderedDistinctFilterer struct {
+	OneInputNode
+	NonExplainable
+
+	ht *hashTable
+	// seenBatch tracks whether the operator has already read at least one
+	// batch.
+	seenBatch bool
+}
+
+var _ colexecbase.Operator = &unorderedDistinctFilterer{}
+
+func (f *unorderedDistinctFilterer) Init() {
+	f.input.Init()
+}
+
+func (f *unorderedDistinctFilterer) Next(ctx context.Context) coldata.Batch {
+	if f.ht.vals.Length() == 0 {
+		// The hash table is empty, so there is nothing to filter against.
+		return f.input.Next(ctx)
+	}
+	for {
+		batch := f.input.Next(ctx)
+		if batch.Length() == 0 {
+			return coldata.ZeroBatch
+		}
+		if !f.seenBatch {
+			// This is the first batch we received from bufferExportingOperator
+			// and the hash table is not empty; therefore, this batch must be
+			// the last input batch coming from the in-memory unordered
+			// distinct.
+			//
+			// That batch has already been updated in-place to contain only
+			// distinct tuples all of which have been appended to the hash
+			// table, so we don't need to perform filtering on it. However, we
+			// might need to repair the hash table in case the OOM error
+			// occurred when tuples were being appended to f.ht.vals.
+			//
+			// See https://github.com/cockroachdb/cockroach/pull/58006#pullrequestreview-565859919
+			// for all the gory details.
+			f.ht.maybeRepairAfterDistinctBuild(ctx)
+			f.seenBatch = true
+			return batch
+		}
+		// The unordered distinct has emitted some tuples, so we need to check
+		// all tuples in batch against the hash table.
+		f.ht.computeHashAndBuildChains(ctx, batch)
+		// Remove the duplicates within batch itself.
+		f.ht.removeDuplicates(batch, f.ht.keys, f.ht.probeScratch.first, f.ht.probeScratch.next, f.ht.checkProbeForDistinct)
+		// Remove the duplicates of already emitted distinct tuples.
+		f.ht.removeDuplicates(batch, f.ht.keys, f.ht.buildScratch.first, f.ht.buildScratch.next, f.ht.checkBuildForDistinct)
+		if batch.Length() > 0 {
+			return batch
+		}
+	}
 }


### PR DESCRIPTION
In the recent addition of the external distinct we have a bug - we
completely ignored the in-memory state (the hash table) of the in-memory
unordered distinct when the spill occurs. This became problematic with
the recent change to make the unordered distinct streaming-like: we now
probe the hash table to remove all duplicates, add the distinct tuples
into the hash table and emit them into the output. So currently it is
possible for the external distinct to emit tuples that are duplicates of
already emitted ones by the in-memory operator before the spill
occurred.

To go around this issue, without changing the streaming-like behavior of
the in-memory unordered distinct, this commit introduces a special
filterer on the input to the external distinct which removes all
duplicates of tuples already emitted by the in-memory operator. (A side
bonus is that it also removes the duplicates within the batch itself.)

The complication here is that the last input batch read by the in-memory
unordered distinct has already been updated in-place to include only the
new distinct tuples and the tuples have been appended to the hash table
right before the OOM occurs. This required plumbing an assumption that
the first batch seen by the new filterer has already been filtered and
should be returned unchanged. Another detail is that the hash table
might be in an inconsistent state, so it'll need to be repaired before
used by the filterer.

Fixes: #57858.
Fixes: #58286.

Release note: None (no release with this bug)