### PR TITLE
ccl/sqlproxyccl: add context and tag with remote addr/db

### DIFF
--- a/pkg/ccl/sqlproxyccl/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "//vendor/github.com/cockroachdb/errors",
+        "//vendor/github.com/cockroachdb/logtags",
         "//vendor/github.com/jackc/pgproto3/v2:pgproto3",
     ],
 )

--- a/pkg/ccl/sqlproxyccl/backend_dialer.go
+++ b/pkg/ccl/sqlproxyccl/backend_dialer.go
@@ -9,6 +9,7 @@
 package sqlproxyccl
 
 import (
+	"context"
 	"crypto/tls"
 	"encoding/binary"
 	"io"
@@ -20,7 +21,7 @@ import (
 // BackendDial is an example backend dialer that does a TCP/IP connection
 // to a backend, SSL and forwards the start message.
 func BackendDial(
-	msg *pgproto3.StartupMessage, outgoingAddress string, tlsConfig *tls.Config,
+	ctx context.Context, msg *pgproto3.StartupMessage, outgoingAddress string, tlsConfig *tls.Config,
 ) (net.Conn, error) {
 	conn, err := net.Dial("tcp", outgoingAddress)
 	if err != nil {

--- a/pkg/ccl/sqlproxyccl/frontend_admitter.go
+++ b/pkg/ccl/sqlproxyccl/frontend_admitter.go
@@ -9,6 +9,7 @@
 package sqlproxyccl
 
 import (
+	"context"
 	"crypto/tls"
 	"net"
 
@@ -19,7 +20,7 @@ import (
 // upgrade to an optional SSL connection, and will handle and verify
 // the startup message received from the PG SQL client.
 func FrontendAdmit(
-	conn net.Conn, incomingTLSConfig *tls.Config,
+	ctx context.Context, conn net.Conn, incomingTLSConfig *tls.Config,
 ) (net.Conn, *pgproto3.StartupMessage, error) {
 	// `conn` could be replaced by `conn` embedded in a `tls.Conn` connection,
 	// hence it's important to close `conn` rather than `proxyConn` since closing

--- a/pkg/ccl/sqlproxyccl/frontend_admitter_test.go
+++ b/pkg/ccl/sqlproxyccl/frontend_admitter_test.go
@@ -58,7 +58,9 @@ func TestFrontendAdmitWithClientSSLDisableAndCustomParam(t *testing.T) {
 		fmt.Printf("Done\n")
 	}()
 
-	frontendCon, msg, err := FrontendAdmit(srv, nil)
+	frontendCon, msg, err := FrontendAdmit(
+		context.Background(), srv, nil,
+	)
 	require.NoError(t, err)
 	require.Equal(t, srv, frontendCon)
 	require.NotNil(t, msg)
@@ -88,7 +90,9 @@ func TestFrontendAdmitWithClientSSLRequire(t *testing.T) {
 
 	tlsConfig, err := tlsConfig()
 	require.NoError(t, err)
-	frontendCon, msg, err := FrontendAdmit(srv, tlsConfig)
+	frontendCon, msg, err := FrontendAdmit(
+		context.Background(), srv, tlsConfig,
+	)
 	require.NoError(t, err)
 	require.NotEqual(t, srv, frontendCon) // The connection was replaced by SSL
 	require.NotNil(t, msg)
@@ -107,7 +111,9 @@ func TestFrontendAdmitWithCancel(t *testing.T) {
 		require.NoError(t, err)
 	}()
 
-	frontendCon, msg, err := FrontendAdmit(srv, nil)
+	frontendCon, msg, err := FrontendAdmit(
+		context.Background(), srv, nil,
+	)
 	require.EqualError(t, err,
 		"CodeUnexpectedStartupMessage: "+
 			"unsupported post-TLS startup message: *pgproto3.CancelRequest",
@@ -139,7 +145,9 @@ func TestFrontendAdmitWithSSLAndCancel(t *testing.T) {
 
 	tlsConfig, err := tlsConfig()
 	require.NoError(t, err)
-	frontendCon, msg, err := FrontendAdmit(srv, tlsConfig)
+	frontendCon, msg, err := FrontendAdmit(
+		context.Background(), srv, tlsConfig,
+	)
 	require.EqualError(t, err,
 		"CodeUnexpectedStartupMessage: "+
 			"unsupported post-TLS startup message: *pgproto3.CancelRequest",


### PR DESCRIPTION
When logging from the proxy and the related code, it is
hard to figure out the connection to which the logging applies.
This PR now passes a context to the frontend admitter and
backend dialer so it can be used to decorate the log output.
The proxy itself adds a remote addr tag and database tag
once the startup message is available. Using the log
functions will show a prefix like this one (after db tag):
`[remote-addr=‹127.0.0.1:60820›,db=‹defaultdb_29›]`

This also changes the signature of the BackendDialer to
pass the incoming connection. This isn't currently used
but can be useful in the cases where the backend setup
or reporting depends on the incoming connection.

Release note: none