### PR TITLE
colexec: fix spilling queue

### DIFF
--- a/pkg/sql/colcontainer/partitionedqueue.go
+++ b/pkg/sql/colcontainer/partitionedqueue.go
@@ -27,6 +27,7 @@ type PartitionedQueue interface {
 	// partition at that index does not exist, a new one is created. Existing
 	// partitions may not be Enqueued to after calling
 	// CloseAllOpenWriteFileDescriptors.
+	// WARNING: Selection vectors are ignored.
 	Enqueue(ctx context.Context, partitionIdx int, batch coldata.Batch) error
 	// Dequeue removes and returns the batch from the front of the
 	// partitionIdx'th partition. If the partition is empty, or no partition at

--- a/pkg/sql/colexec/external_sort.go
+++ b/pkg/sql/colexec/external_sort.go
@@ -262,6 +262,9 @@ func (s *externalSorter) Next(ctx context.Context) coldata.Batch {
 			if s.partitioner == nil {
 				s.partitioner = s.partitionerCreator()
 			}
+			// Note that b will never have a selection vector set because the
+			// allSpooler performs a deselection when buffering up the tuples,
+			// and the in-memory sorter has allSpooler as its input.
 			if err := s.partitioner.Enqueue(ctx, newPartitionIdx, b); err != nil {
 				colexecerror.InternalError(err)
 			}

--- a/pkg/sql/colexec/routers.go
+++ b/pkg/sql/colexec/routers.go
@@ -37,10 +37,10 @@ type routerOutput interface {
 	// initWithHashRouter passes a reference to the HashRouter that will be
 	// pushing batches to this output.
 	initWithHashRouter(*HashRouter)
-	// addBatch adds the elements specified by the selection vector from batch to
-	// the output. It returns whether or not the output changed its state to
+	// addBatch adds the elements specified by the selection vector from batch
+	// to the output. It returns whether or not the output changed its state to
 	// blocked (see implementations).
-	addBatch(context.Context, coldata.Batch, []int) bool
+	addBatch(context.Context, coldata.Batch) bool
 	// cancel tells the output to stop producing batches. Optionally forwards an
 	// error if not nil.
 	cancel(context.Context, error)
@@ -66,10 +66,15 @@ type routerOutputOpState int
 
 const (
 	// routerOutputOpRunning is the state in which routerOutputOp operates
-	// normally. The router output transitions into the draining state when
-	// either it is finished (when a zero-length batch was added or when it was
-	// canceled) or it encounters an error.
+	// normally. The router output transitions into routerOutputDoneAdding when
+	// a zero-length batch was added or routerOutputOpDraining when it
+	// encounters an error or the drain is requested.
 	routerOutputOpRunning routerOutputOpState = iota
+	// routerOutputDoneAdding is the state in which a zero-length was batch was
+	// added to routerOutputOp and no more batches will be added. The router
+	// output transitions to routerOutputOpDraining when the output is canceled
+	// (either closed or the drain is requested).
+	routerOutputDoneAdding
 	// routerOutputOpDraining is the state in which routerOutputOp always
 	// returns zero-length batches on calls to Next.
 	routerOutputOpDraining
@@ -110,54 +115,12 @@ type routerOutputOp struct {
 		// forwardedErr is an error that was forwarded by the HashRouter. If set,
 		// any subsequent calls to Next will return this error.
 		forwardedErr error
-		// unlimitedAllocator tracks the memory usage of this router output,
-		// providing a signal for when it should spill to disk.
-		// The memory lifecycle is as follows:
-		//
-		// o.mu.pendingBatch is allocated as a "staging" area. Tuples are copied
-		// into it in addBatch.
-		// A read may come in in this state, in which case pendingBatch is returned
-		// and references to it are removed. Since batches are unsafe for reuse,
-		// the batch is also manually released from the allocator.
-		// If a read does not come in and the batch becomes full of tuples, that
-		// batch is stored in o.mu.data, which is a queue with an in-memory circular
-		// buffer backed by disk. If the batch fits in memory, a reference to it
-		// is retained and a new pendingBatch is allocated.
-		//
-		// If a read comes in at this point, the batch is dequeued from o.mu.data
-		// and returned, but the memory is still accounted for. In fact, memory use
-		// increases up to when o.mu.data is full and must spill to disk.
-		// Once it spills to disk, the spillingQueue (o.mu.data), will release
-		// batches it spills to disk to stop accounting for them.
-		// The tricky part comes when o.mu.data is dequeued from. In this case, the
-		// reference for a previously-returned batch is overwritten with an on-disk
-		// batch, so the memory for the overwritten batch is released, while the
-		// new batch's memory is retained. Note that if batches are being dequeued
-		// from disk, it must be the case that the circular buffer is now empty,
-		// holding references to batches that have been previously returned.
-		//
-		// In short, batches whose references are retained are also retained in the
-		// allocator, but if any references are overwritten or lost, those batches
-		// are released.
-		unlimitedAllocator *colmem.Allocator
-		cond               *sync.Cond
-		// pendingBatch is a partially-filled batch with data added through
-		// addBatch. Once this batch reaches capacity, it is flushed to data. The
-		// main use of pendingBatch is coalescing various fragmented batches into
-		// one.
-		pendingBatch coldata.Batch
+		cond         *sync.Cond
 		// data is a spillingQueue, a circular buffer backed by a disk queue.
 		data      *spillingQueue
 		numUnread int
 		blocked   bool
 	}
-
-	// pendingBatchCapacity indicates the capacity which the new mu.pendingBatch
-	// should be allocated with. It'll increase dynamically until
-	// coldata.BatchSize(). We need to track it ourselves since the pending
-	// batch ownership is given to the spillingQueue, so when using
-	// ResetMaybeReallocate, we don't the old batch to check the capacity of.
-	pendingBatchCapacity int
 
 	testingKnobs routerOutputOpTestingKnobs
 }
@@ -183,9 +146,6 @@ type routerOutputOpTestingKnobs struct {
 	// defaultRouterOutputBlockedThreshold but can be modified by tests to test
 	// edge cases.
 	blockedThreshold int
-	// alwaysFlush, if set to true, will always flush o.mu.pendingBatch to
-	// o.mu.data.
-	alwaysFlush bool
 	// addBatchTestInducedErrorCb is called after any function call that could
 	// produce an error if that error is nil. If the callback returns an error,
 	// the router output overwrites the nil error with the returned error.
@@ -233,7 +193,6 @@ func newRouterOutputOp(args routerOutputOpArgs) *routerOutputOp {
 		unblockedEventsChan: args.unblockedEventsChan,
 		testingKnobs:        args.testingKnobs,
 	}
-	o.mu.unlimitedAllocator = args.unlimitedAllocator
 	o.mu.cond = sync.NewCond(&o.mu)
 	o.mu.data = newSpillingQueue(
 		args.unlimitedAllocator,
@@ -266,7 +225,7 @@ func (o *routerOutputOp) nextErrorLocked(ctx context.Context, err error) {
 func (o *routerOutputOp) Next(ctx context.Context) coldata.Batch {
 	o.mu.Lock()
 	defer o.mu.Unlock()
-	for o.mu.forwardedErr == nil && o.mu.state == routerOutputOpRunning && o.mu.pendingBatch == nil && o.mu.data.empty() {
+	for o.mu.forwardedErr == nil && o.mu.state == routerOutputOpRunning && o.mu.data.empty() {
 		// Wait until there is data to read or the output is canceled.
 		o.mu.cond.Wait()
 	}
@@ -276,23 +235,12 @@ func (o *routerOutputOp) Next(ctx context.Context) coldata.Batch {
 	if o.mu.state == routerOutputOpDraining {
 		return coldata.ZeroBatch
 	}
-	var b coldata.Batch
-	if o.mu.pendingBatch != nil && o.mu.data.empty() {
-		// o.mu.data is empty (i.e. nothing has been flushed to the spillingQueue),
-		// but there is a o.mu.pendingBatch that has not been flushed yet. Return
-		// this batch directly.
-		b = o.mu.pendingBatch
-		o.mu.unlimitedAllocator.ReleaseBatch(b)
-		o.mu.pendingBatch = nil
-	} else {
-		var err error
-		b, err = o.mu.data.dequeue(ctx)
-		if err == nil && o.testingKnobs.nextTestInducedErrorCb != nil {
-			err = o.testingKnobs.nextTestInducedErrorCb()
-		}
-		if err != nil {
-			o.nextErrorLocked(ctx, err)
-		}
+	b, err := o.mu.data.dequeue(ctx)
+	if err == nil && o.testingKnobs.nextTestInducedErrorCb != nil {
+		err = o.testingKnobs.nextTestInducedErrorCb()
+	}
+	if err != nil {
+		o.nextErrorLocked(ctx, err)
 	}
 	o.mu.numUnread -= b.Length()
 	if o.mu.numUnread <= o.testingKnobs.blockedThreshold {
@@ -362,113 +310,38 @@ func (o *routerOutputOp) forwardErr(err error) {
 	o.mu.cond.Signal()
 }
 
-// addBatch copies the columns in batch according to selection into an internal
-// buffer.
-// The routerOutputOp only adds the elements specified by selection. Therefore,
-// an empty selection slice will add no elements. Note that the selection vector
-// on the batch is ignored. This is so that callers of addBatch can push the
-// same batch with different selection vectors to many different outputs.
-// True is returned if the output changes state to blocked (note: if the
-// output is already blocked, false is returned).
+// addBatch copies the batch (according to its selection vector) into an
+// internal buffer. Zero-length batch should be passed-in to indicate that no
+// more batches will be added.
 // TODO(asubiotto): We should explore pipelining addBatch if disk-spilling
 //  performance becomes a concern. The main router goroutine will be writing to
 //  disk as the code is written, meaning that we impact the performance of
 //  writing rows to a fast output if we have to write to disk for a single
 //  slow output.
-func (o *routerOutputOp) addBatch(ctx context.Context, batch coldata.Batch, selection []int) bool {
-	if len(selection) > batch.Length() {
-		selection = selection[:batch.Length()]
-	}
+func (o *routerOutputOp) addBatch(ctx context.Context, batch coldata.Batch) bool {
 	o.mu.Lock()
 	defer o.mu.Unlock()
-	if o.mu.state == routerOutputOpDraining {
+	switch o.mu.state {
+	case routerOutputDoneAdding:
+		colexecerror.InternalError(errors.AssertionFailedf("a batch was added to routerOutput in DoneAdding state"))
+	case routerOutputOpDraining:
 		// This output is draining, discard any data.
 		return false
 	}
 
+	o.mu.numUnread += batch.Length()
+	err := o.mu.data.enqueue(ctx, batch)
+	if err == nil && o.testingKnobs.addBatchTestInducedErrorCb != nil {
+		err = o.testingKnobs.addBatchTestInducedErrorCb()
+	}
+	if err != nil {
+		colexecerror.InternalError(err)
+	}
+
 	if batch.Length() == 0 {
-		if o.mu.pendingBatch != nil {
-			err := o.mu.data.enqueue(ctx, o.mu.pendingBatch)
-			if err == nil && o.testingKnobs.addBatchTestInducedErrorCb != nil {
-				err = o.testingKnobs.addBatchTestInducedErrorCb()
-			}
-			if err != nil {
-				colexecerror.InternalError(err)
-			}
-		} else if o.testingKnobs.addBatchTestInducedErrorCb != nil {
-			// This is the last chance to run addBatchTestInducedErorCb if it has
-			// been set.
-			if err := o.testingKnobs.addBatchTestInducedErrorCb(); err != nil {
-				colexecerror.InternalError(err)
-			}
-		}
-		o.mu.pendingBatch = coldata.ZeroBatch
+		o.mu.state = routerOutputDoneAdding
 		o.mu.cond.Signal()
 		return false
-	}
-
-	if len(selection) == 0 {
-		// Non-zero batch with no selection vector. Nothing to do.
-		return false
-	}
-
-	// Increment o.mu.numUnread before going into the loop, as we will consume
-	// selection.
-	o.mu.numUnread += len(selection)
-
-	for toAppend := len(selection); toAppend > 0; {
-		if o.mu.pendingBatch == nil {
-			if o.pendingBatchCapacity < coldata.BatchSize() {
-				// We still haven't reached the maximum capacity, so let's
-				// calculate the next capacity to use.
-				if o.pendingBatchCapacity == 0 {
-					// This is the first set of tuples that are added to this
-					// router output, so we'll allocate the batch with just
-					// enough capacity to fill all of these tuples.
-					o.pendingBatchCapacity = len(selection)
-				} else {
-					o.pendingBatchCapacity *= 2
-				}
-			}
-			// Note: we could have used NewMemBatchWithFixedCapacity here, but
-			// we choose not to in order to indicate that the capacity of the
-			// pending batches has dynamic behavior.
-			o.mu.pendingBatch, _ = o.mu.unlimitedAllocator.ResetMaybeReallocate(o.types, nil /* oldBatch */, o.pendingBatchCapacity)
-		}
-		available := o.mu.pendingBatch.Capacity() - o.mu.pendingBatch.Length()
-		numAppended := toAppend
-		if toAppend > available {
-			numAppended = available
-		}
-		o.mu.unlimitedAllocator.PerformOperation(o.mu.pendingBatch.ColVecs(), func() {
-			for i := range o.types {
-				o.mu.pendingBatch.ColVec(i).Copy(
-					coldata.CopySliceArgs{
-						SliceArgs: coldata.SliceArgs{
-							Src:       batch.ColVec(i),
-							Sel:       selection[:numAppended],
-							DestIdx:   o.mu.pendingBatch.Length(),
-							SrcEndIdx: numAppended,
-						},
-					},
-				)
-			}
-		})
-		newLength := o.mu.pendingBatch.Length() + numAppended
-		o.mu.pendingBatch.SetLength(newLength)
-		if o.testingKnobs.alwaysFlush || newLength >= o.mu.pendingBatch.Capacity() {
-			// The capacity in o.mu.pendingBatch has been filled.
-			err := o.mu.data.enqueue(ctx, o.mu.pendingBatch)
-			if err == nil && o.testingKnobs.addBatchTestInducedErrorCb != nil {
-				err = o.testingKnobs.addBatchTestInducedErrorCb()
-			}
-			if err != nil {
-				colexecerror.InternalError(err)
-			}
-			o.mu.pendingBatch = nil
-		}
-		toAppend -= numAppended
-		selection = selection[numAppended:]
 	}
 
 	stateChanged := false
@@ -500,7 +373,6 @@ func (o *routerOutputOp) resetForTests(ctx context.Context) {
 	o.mu.data.reset(ctx)
 	o.mu.numUnread = 0
 	o.mu.blocked = false
-	o.pendingBatchCapacity = 0
 }
 
 // hashRouterDrainState is a state that specifically describes the hashRouter's
@@ -752,16 +624,21 @@ func (r *HashRouter) processNextBatch(ctx context.Context) bool {
 		// Done. Push an empty batch to outputs to tell them the data is done as
 		// well.
 		for _, o := range r.outputs {
-			o.addBatch(ctx, b, nil)
+			o.addBatch(ctx, b)
 		}
 		return true
 	}
 
 	selections := r.tupleDistributor.distribute(ctx, b, r.hashCols)
 	for i, o := range r.outputs {
-		if o.addBatch(ctx, b, selections[i]) {
-			// This batch blocked the output.
-			r.numBlockedOutputs++
+		if len(selections[i]) > 0 {
+			b.SetSelection(true)
+			copy(b.Selection(), selections[i])
+			b.SetLength(len(selections[i]))
+			if o.addBatch(ctx, b) {
+				// This batch blocked the output.
+				r.numBlockedOutputs++
+			}
 		}
 	}
 	return false

--- a/pkg/sql/colexec/spilling_queue.go
+++ b/pkg/sql/colexec/spilling_queue.go
@@ -54,14 +54,32 @@ type spillingQueue struct {
 	numOnDiskItems   int
 	closed           bool
 
-	diskQueueCfg   colcontainer.DiskQueueCfg
-	diskQueue      colcontainer.Queue
-	fdSemaphore    semaphore.Semaphore
-	dequeueScratch coldata.Batch
+	// nextInMemBatchCapacity indicates the capacity which the new batch that
+	// we'll append to items should be allocated with. It'll increase
+	// dynamically until coldata.BatchSize().
+	nextInMemBatchCapacity int
+
+	diskQueueCfg                colcontainer.DiskQueueCfg
+	diskQueue                   colcontainer.Queue
+	diskQueueDeselectionScratch coldata.Batch
+	fdSemaphore                 semaphore.Semaphore
+	dequeueScratch              coldata.Batch
 
 	rewindable      bool
 	rewindableState struct {
 		numItemsDequeued int
+	}
+
+	testingKnobs struct {
+		// numEnqueues tracks the number of times enqueue() has been called with
+		// non-zero batch.
+		numEnqueues int
+		// maxNumBatchesEnqueuedInMemory, if greater than 0, indicates the
+		// maximum number of batches that are attempted to be enqueued to the
+		// in-memory buffer 'items' (other limiting conditions might occur
+		// earlier). Once numEnqueues reaches this limit, all consequent calls
+		// to enqueue() will use the disk queue.
+		maxNumBatchesEnqueuedInMemory int
 	}
 
 	diskAcc *mon.BoundAccount
@@ -134,8 +152,16 @@ func newRewindableSpillingQueue(
 	return q
 }
 
+// enqueue adds the provided batch to the queue. Zero-length batch needs to be
+// added as the last one.
+//
+// Passed-in batch is deeply copied, so it can safely reused by the caller. The
+// spilling queue coalesces all input tuples into the batches of dynamically
+// increasing capacity when those are kept in-memory. It also performs a
+// deselection step if necessary when adding the batch to the disk queue.
 func (q *spillingQueue) enqueue(ctx context.Context, batch coldata.Batch) error {
-	if batch.Length() == 0 {
+	n := batch.Length()
+	if n == 0 {
 		if q.diskQueue != nil {
 			if err := q.diskQueue.Enqueue(ctx, batch); err != nil {
 				return err
@@ -143,18 +169,49 @@ func (q *spillingQueue) enqueue(ctx context.Context, batch coldata.Batch) error 
 		}
 		return nil
 	}
+	q.testingKnobs.numEnqueues++
 
-	if q.numOnDiskItems > 0 || q.unlimitedAllocator.Used() > q.maxMemoryLimit ||
-		(q.numInMemoryItems == len(q.items) && q.numInMemoryItems == q.maxItemsLen) {
-		// In this case, there is not enough memory available to keep this batch in
-		// memory, or the in-memory circular buffer has no slots available (we do
-		// an initial estimate of how many batches would fit into the buffer, which
-		// might be wrong). The tail of the queue might also already be on disk, in
-		// which case that is where the batch must be enqueued to maintain order.
+	alreadySpilled := q.numOnDiskItems > 0
+	memoryLimitReached := q.unlimitedAllocator.Used() > q.maxMemoryLimit
+	maxItemsLenReached := q.numInMemoryItems == len(q.items) && q.numInMemoryItems == q.maxItemsLen
+	maxInMemEnqueuesExceeded := q.testingKnobs.maxNumBatchesEnqueuedInMemory != 0 && q.testingKnobs.numEnqueues > q.testingKnobs.maxNumBatchesEnqueuedInMemory
+	if alreadySpilled || memoryLimitReached || maxItemsLenReached || maxInMemEnqueuesExceeded {
+		// In this case, one of the following conditions is true:
+		// 1. the tail of the queue might also already be on disk, in which case
+		//    that is where the batch must be enqueued to maintain order
+		// 2. there is not enough memory available to keep this batch in memory
+		// 3. the in-memory circular buffer has no slots available (we do an
+		//    initial estimate of how many batches would fit into the buffer,
+		//    which might be wrong)
+		// 4. we reached the testing limit on the number of items added to the
+		//    in-memory buffer
+		// so we have to add batch to the disk queue.
 		if err := q.maybeSpillToDisk(ctx); err != nil {
 			return err
 		}
 		q.unlimitedAllocator.ReleaseBatch(batch)
+		if sel := batch.Selection(); sel != nil {
+			// We need to perform the deselection since the disk queue
+			// ignores the selection vectors.
+			q.diskQueueDeselectionScratch, _ = q.unlimitedAllocator.ResetMaybeReallocate(
+				q.typs, q.diskQueueDeselectionScratch, n,
+			)
+			q.unlimitedAllocator.PerformOperation(q.diskQueueDeselectionScratch.ColVecs(), func() {
+				for i := range q.typs {
+					q.diskQueueDeselectionScratch.ColVec(i).Copy(
+						coldata.CopySliceArgs{
+							SliceArgs: coldata.SliceArgs{
+								Src:       batch.ColVec(i),
+								Sel:       sel,
+								SrcEndIdx: n,
+							},
+						},
+					)
+				}
+				q.diskQueueDeselectionScratch.SetLength(n)
+			})
+			batch = q.diskQueueDeselectionScratch
+		}
 		if err := q.diskQueue.Enqueue(ctx, batch); err != nil {
 			return err
 		}
@@ -182,7 +239,78 @@ func (q *spillingQueue) enqueue(ctx context.Context, batch coldata.Batch) error 
 		q.items = newItems
 	}
 
-	q.items[q.curTailIdx] = batch
+	alreadyCopied := 0
+	if q.numInMemoryItems > 0 {
+		// If we have already enqueued at least one batch, let's try to append
+		// as many tuples to it as it has the capacity for.
+		tailBatchIdx := q.curTailIdx - 1
+		if tailBatchIdx < 0 {
+			tailBatchIdx = 0
+		}
+		tailBatch := q.items[tailBatchIdx]
+		if l, c := tailBatch.Length(), tailBatch.Capacity(); l < c {
+			alreadyCopied = c - l
+			if alreadyCopied > n {
+				alreadyCopied = n
+			}
+			q.unlimitedAllocator.PerformOperation(tailBatch.ColVecs(), func() {
+				for i := range q.typs {
+					tailBatch.ColVec(i).Append(
+						coldata.SliceArgs{
+							Src:         batch.ColVec(i),
+							Sel:         batch.Selection(),
+							DestIdx:     l,
+							SrcStartIdx: 0,
+							SrcEndIdx:   alreadyCopied,
+						},
+					)
+				}
+				tailBatch.SetLength(l + alreadyCopied)
+			})
+			if alreadyCopied == n {
+				// We were able to append all of the tuples, so we return early
+				// since we don't need to update any of the state.
+				return nil
+			}
+		}
+	}
+
+	var newBatchCapacity int
+	if q.nextInMemBatchCapacity == coldata.BatchSize() {
+		// At this point we only allocate batches with maximum capacity.
+		newBatchCapacity = coldata.BatchSize()
+	} else {
+		newBatchCapacity = n - alreadyCopied
+		if q.nextInMemBatchCapacity > newBatchCapacity {
+			newBatchCapacity = q.nextInMemBatchCapacity
+		}
+		q.nextInMemBatchCapacity = 2 * newBatchCapacity
+		if q.nextInMemBatchCapacity > coldata.BatchSize() {
+			q.nextInMemBatchCapacity = coldata.BatchSize()
+		}
+	}
+
+	// Note: we could have used NewMemBatchWithFixedCapacity here, but we choose
+	// not to in order to indicate that the capacity of the new batches has
+	// dynamic behavior.
+	newBatch, _ := q.unlimitedAllocator.ResetMaybeReallocate(q.typs, nil /* oldBatch */, newBatchCapacity)
+	q.unlimitedAllocator.PerformOperation(newBatch.ColVecs(), func() {
+		for i := range q.typs {
+			newBatch.ColVec(i).Copy(
+				coldata.CopySliceArgs{
+					SliceArgs: coldata.SliceArgs{
+						Src:         batch.ColVec(i),
+						Sel:         batch.Selection(),
+						SrcStartIdx: alreadyCopied,
+						SrcEndIdx:   n,
+					},
+				},
+			)
+		}
+		newBatch.SetLength(n - alreadyCopied)
+	})
+
+	q.items[q.curTailIdx] = newBatch
 	q.curTailIdx++
 	if q.curTailIdx == len(q.items) {
 		q.curTailIdx = 0
@@ -342,5 +470,7 @@ func (q *spillingQueue) reset(ctx context.Context) {
 	q.numOnDiskItems = 0
 	q.curHeadIdx = 0
 	q.curTailIdx = 0
+	q.nextInMemBatchCapacity = 0
 	q.rewindableState.numItemsDequeued = 0
+	q.testingKnobs.numEnqueues = 0
 }


### PR DESCRIPTION
This commit refactors `enqueue` method of the spilling queue to
deep-copy the passed-in batches if they are kept in memory. Previous
behavior was suboptimal because it was forcing the caller to always
allocate a new batch. Additionally, the spilling queue will now perform
a coalescing step by attempting to append as many tuples to the tail
in-memory batch as possible. The in-memory batches are allocated with
dynamically increasing capacity.

This allows us to significantly simplify the code of the router outputs
which were performing the coalescing step previously.

Additionally, this commit fixes a couple of uses of `enqueue` method
(the router outputs and the merge joiner) in which they forgot to
enqueue a zero-length batch which is necessary when the disk queue is
initialized.

Fixes: #47062.

Release note: None