### PR TITLE
backupccl: fix progress updating test

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -923,6 +923,10 @@ type BackupRestoreTestingKnobs struct {
 	// RunAfterProcessingRestoreSpanEntry allows blocking the RESTORE job after a
 	// single RestoreSpanEntry has been processed and added to the SSTBatcher.
 	RunAfterProcessingRestoreSpanEntry func(ctx context.Context)
+
+	// RunAfterExportingSpanEntry allows blocking the BACKUP job after a single
+	// span has been exported.
+	RunAfterExportingSpanEntry func(ctx context.Context)
 }
 
 var _ base.ModuleTestingKnobs = &BackupRestoreTestingKnobs{}


### PR DESCRIPTION
This test was previously flaky since it was assuming that backup would
issue the same number of requests as spans issued. This assumption was
incorrect, and fixing the progress accounting for backup revealed that
this test was faulty.

While planning the work distribution for backup worker nodes,
PartitionSpans automatically merges spans that are co-located on the
same node, therefore reducing the number of ExportRequests issued.
Before this commit, we used to block on the ExportRequest responses.
The blocking was triggered on a per-range-request level. However,
progress is only updated when the processor-level batch request is
returned. This meant that the test might block a batch request and
therefore the progress of the job would be less than what the test
expected.

This is now fixed by adjusting the blocking mechanism and range counting
to all be at the level of the merged ranges with which the backup
processor operates.

Fixes #57831.

This test would fail under stress pretty quickly (~40) -- I was able to get
over 600 runs without failure with this patch.

Release note: none