### PR TITLE
util/log: delay the formatting of log entries

### DIFF
--- a/pkg/cli/debug_merge_logs.go
+++ b/pkg/cli/debug_merge_logs.go
@@ -64,7 +64,7 @@ func writeLogStream(
 		if _, err = w.Write(prefixBytes); err != nil {
 			return err
 		}
-		return log.FormatEntry(ei.Entry, w)
+		return log.FormatLegacyEntry(ei.Entry, w)
 	}
 
 	g, ctx := errgroup.WithContext(context.Background())

--- a/pkg/cli/zip.go
+++ b/pkg/cli/zip.go
@@ -676,7 +676,7 @@ func runDebugZip(cmd *cobra.Command, args []string) (retErr error) {
 							// We're also going to print a warning at the end.
 							warnRedactLeak = true
 						}
-						if err := log.FormatEntry(e, logOut); err != nil {
+						if err := log.FormatLegacyEntry(e, logOut); err != nil {
 							return err
 						}
 					}

--- a/pkg/server/debug/logspy.go
+++ b/pkg/server/debug/logspy.go
@@ -160,11 +160,11 @@ func (spy *logSpy) run(ctx context.Context, w io.Writer, opts logSpyOptions) (er
 	defer func() {
 		if err == nil {
 			if dropped := atomic.LoadInt32(&countDropped); dropped > 0 {
-				entry := log.MakeEntry(
+				entry := log.MakeLegacyEntry(
 					ctx, severity.WARNING, channel.DEV,
-					0 /* depth */, false, /* redactable */
+					0 /* depth */, true, /* redactable */
 					"%d messages were dropped", log.Safe(dropped))
-				err = log.FormatEntry(entry, w) // modify return value
+				err = log.FormatLegacyEntry(entry, w) // modify return value
 			}
 		}
 	}()
@@ -176,9 +176,9 @@ func (spy *logSpy) run(ctx context.Context, w io.Writer, opts logSpyOptions) (er
 	entries := make(chan logpb.Entry, logSpyChanCap)
 
 	{
-		entry := log.MakeEntry(
+		entry := log.MakeLegacyEntry(
 			ctx, severity.INFO, channel.DEV,
-			0 /* depth */, false, /* redactable */
+			0 /* depth */, true, /* redactable */
 			"intercepting logs with options %+v", opts)
 		entries <- entry
 	}
@@ -218,7 +218,7 @@ func (spy *logSpy) run(ctx context.Context, w io.Writer, opts logSpyOptions) (er
 			return
 
 		case entry := <-entries:
-			if err := log.FormatEntry(entry, w); err != nil {
+			if err := log.FormatLegacyEntry(entry, w); err != nil {
 				return errors.Wrapf(err, "while writing entry %v", entry)
 			}
 			count++

--- a/pkg/testutils/lint/passes/fmtsafe/functions.go
+++ b/pkg/testutils/lint/passes/fmtsafe/functions.go
@@ -74,7 +74,8 @@ var requireConstFmt = map[string]bool{
 	// Note: More of the logging functions are populated here via the
 	// init() function below.
 
-	"github.com/cockroachdb/cockroach/pkg/util/log.MakeEntry":              true,
+	"github.com/cockroachdb/cockroach/pkg/util/log.MakeLegacyEntry":        true,
+	"github.com/cockroachdb/cockroach/pkg/util/log.makeUnstructuredEntry":  true,
 	"github.com/cockroachdb/cockroach/pkg/util/log.FormatWithContextTags":  true,
 	"github.com/cockroachdb/cockroach/pkg/util/log.renderArgsAsRedactable": true,
 	"github.com/cockroachdb/cockroach/pkg/util/log.formatArgs":             true,

--- a/pkg/util/log/channels.go
+++ b/pkg/util/log/channels.go
@@ -49,11 +49,11 @@ func logfDepth(
 	}
 
 	logger := logging.getLogger(ch)
-	entry := MakeEntry(
+	entry := makeUnstructuredEntry(
 		ctx, sev, ch,
 		depth+1, true /* redactable */, format, args...)
 	if sp, el, ok := getSpanOrEventLog(ctx); ok {
-		eventInternal(sp, el, (sev >= severity.ERROR), entry)
+		eventInternal(sp, el, (sev >= severity.ERROR), entry.convertToLegacy())
 	}
 	logger.outputLogEntry(entry)
 }

--- a/pkg/util/log/exit_override.go
+++ b/pkg/util/log/exit_override.go
@@ -77,9 +77,10 @@ func (l *loggerT) exitLocked(err error, code exit.Code) {
 // This assumes l.outputMu is held, but l.fileSink.mu is not held.
 func (l *loggerT) reportErrorEverywhereLocked(ctx context.Context, err error) {
 	// Make a valid log entry for this error.
-	entry := MakeEntry(
+	entry := makeUnstructuredEntry(
 		ctx, severity.ERROR, channel.OPS,
-		2 /* depth */, true, /* redactable */
+		2,    /* depth */
+		true, /* redactable */
 		"logging error: %v", err)
 
 	// Either stderr or our log file is broken. Try writing the error to both
@@ -96,7 +97,7 @@ func (l *loggerT) reportErrorEverywhereLocked(ctx context.Context, err error) {
 	for _, s := range l.sinkInfos {
 		sink := s.sink
 		if logpb.Severity_ERROR >= s.threshold && sink.active() {
-			buf := s.formatter.formatEntry(entry, nil /*stack*/)
+			buf := s.formatter.formatEntry(entry)
 			sink.emergencyOutput(buf.Bytes())
 			putBuffer(buf)
 		}

--- a/pkg/util/log/file_log_gc_test.go
+++ b/pkg/util/log/file_log_gc_test.go
@@ -67,7 +67,8 @@ func TestSecondaryGC(t *testing.T) {
 
 	testLogGC(t, logger,
 		func(ctx context.Context, format string, args ...interface{}) {
-			entry := MakeEntry(ctx, severity.INFO, channel.DEV, 1, si.redactable,
+			entry := makeUnstructuredEntry(ctx, severity.INFO, channel.DEV, 1,
+				true,   /* redactable */
 				format, /* nolint:fmtsafe */
 				args...)
 			logger.outputLogEntry(entry)

--- a/pkg/util/log/flags.go
+++ b/pkg/util/log/flags.go
@@ -191,7 +191,10 @@ func ApplyConfig(config logconfig.Config) (cleanupFn func(), err error) {
 
 		// Force a log entry. This does two things: it forces the creation
 		// of a file and it also introduces a timestamp marker.
-		entry := MakeEntry(secLoggersCtx, severity.INFO, channel.DEV, 0, false,
+		entry := makeUnstructuredEntry(secLoggersCtx, severity.INFO, channel.DEV, 0,
+			// Note: we need this entry to be marked as non-redactable since
+			// it's going to be followed by junk printed by the go runtime.
+			false, /* redactable */
 			"stderr capture started")
 		secLogger.outputLogEntry(entry)
 

--- a/pkg/util/log/formats.go
+++ b/pkg/util/log/formats.go
@@ -10,13 +10,11 @@
 
 package log
 
-import "github.com/cockroachdb/cockroach/pkg/util/log/logpb"
-
 type logFormatter interface {
 	formatterName() string
-	// formatEntry formats a logpb.Entry into a newly allocated *buffer.
+	// formatEntry formats a logEntry into a newly allocated *buffer.
 	// The caller is responsible for calling putBuffer() afterwards.
-	formatEntry(entry logpb.Entry, stacks []byte) *buffer
+	formatEntry(entry logEntry) *buffer
 }
 
 var formatters = func() map[string]logFormatter {

--- a/pkg/util/log/logpb/log.pb.go
+++ b/pkg/util/log/logpb/log.pb.go
@@ -77,7 +77,7 @@ func (x Severity) String() string {
 	return proto.EnumName(Severity_name, int32(x))
 }
 func (Severity) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_log_3af1d6be118bff01, []int{0}
+	return fileDescriptor_log_1138047630abb4e3, []int{0}
 }
 
 // Channel is the logical logging channel on which a message is sent.
@@ -234,10 +234,14 @@ func (x Channel) String() string {
 	return proto.EnumName(Channel_name, int32(x))
 }
 func (Channel) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_log_3af1d6be118bff01, []int{1}
+	return fileDescriptor_log_1138047630abb4e3, []int{1}
 }
 
-// Entry represents a cockroach structured log entry.
+// Entry represents a cockroach log entry in the following two cases:
+// - when reading a log file using the crdb-v1 format, entries
+//   are parsed into this struct.
+// - when injecting an interceptor into the logging package, the
+//   interceptor is fed entries using this structure.
 type Entry struct {
 	// Severity is the importance of the log entry. See the
 	// documentation for the Severity enum for more details.
@@ -279,7 +283,7 @@ func (m *Entry) Reset()         { *m = Entry{} }
 func (m *Entry) String() string { return proto.CompactTextString(m) }
 func (*Entry) ProtoMessage()    {}
 func (*Entry) Descriptor() ([]byte, []int) {
-	return fileDescriptor_log_3af1d6be118bff01, []int{0}
+	return fileDescriptor_log_1138047630abb4e3, []int{0}
 }
 func (m *Entry) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -318,7 +322,7 @@ func (m *FileDetails) Reset()         { *m = FileDetails{} }
 func (m *FileDetails) String() string { return proto.CompactTextString(m) }
 func (*FileDetails) ProtoMessage()    {}
 func (*FileDetails) Descriptor() ([]byte, []int) {
-	return fileDescriptor_log_3af1d6be118bff01, []int{1}
+	return fileDescriptor_log_1138047630abb4e3, []int{1}
 }
 func (m *FileDetails) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -354,7 +358,7 @@ func (m *FileInfo) Reset()         { *m = FileInfo{} }
 func (m *FileInfo) String() string { return proto.CompactTextString(m) }
 func (*FileInfo) ProtoMessage()    {}
 func (*FileInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_log_3af1d6be118bff01, []int{2}
+	return fileDescriptor_log_1138047630abb4e3, []int{2}
 }
 func (m *FileInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1360,9 +1364,9 @@ var (
 	ErrIntOverflowLog   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("util/log/logpb/log.proto", fileDescriptor_log_3af1d6be118bff01) }
+func init() { proto.RegisterFile("util/log/logpb/log.proto", fileDescriptor_log_1138047630abb4e3) }
 
-var fileDescriptor_log_3af1d6be118bff01 = []byte{
+var fileDescriptor_log_1138047630abb4e3 = []byte{
 	// 682 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x6c, 0x53, 0xd1, 0x6e, 0xf3, 0x34,
 	0x18, 0x6d, 0x9a, 0xa4, 0x49, 0xbe, 0xfe, 0x9a, 0x8c, 0x35, 0xa4, 0xc0, 0x46, 0x56, 0x4d, 0x48,

--- a/pkg/util/log/logpb/log.proto
+++ b/pkg/util/log/logpb/log.proto
@@ -176,7 +176,11 @@ enum Channel {
   SQL_INTERNAL_PERF = 11;
 }
 
-// Entry represents a cockroach structured log entry.
+// Entry represents a cockroach log entry in the following two cases:
+// - when reading a log file using the crdb-v1 format, entries
+//   are parsed into this struct.
+// - when injecting an interceptor into the logging package, the
+//   interceptor is fed entries using this structure.
 message Entry {
   // Severity is the importance of the log entry. See the
   // documentation for the Severity enum for more details.

--- a/pkg/util/log/redact_test.go
+++ b/pkg/util/log/redact_test.go
@@ -119,9 +119,9 @@ func TestRedactTags(t *testing.T) {
 	}
 
 	for _, tc := range testData {
-		var buf strings.Builder
-		renderTagsAsRedactable(tc.ctx, &buf)
-		assert.Equal(t, tc.expected, buf.String())
+		tags := logtags.FromContext(tc.ctx)
+		actual := renderTagsAsRedactable(tags)
+		assert.Equal(t, tc.expected, string(actual))
 	}
 }
 

--- a/pkg/util/log/structured.go
+++ b/pkg/util/log/structured.go
@@ -12,6 +12,7 @@ package log
 
 import (
 	"context"
+	"fmt"
 	"strings"
 )
 
@@ -25,4 +26,14 @@ func FormatWithContextTags(ctx context.Context, format string, args ...interface
 	formatTags(ctx, true /* brackets */, &buf)
 	formatArgs(&buf, format, args...)
 	return buf.String()
+}
+
+func formatArgs(buf *strings.Builder, format string, args ...interface{}) {
+	if len(args) == 0 {
+		buf.WriteString(format)
+	} else if len(format) == 0 {
+		fmt.Fprint(buf, args...)
+	} else {
+		fmt.Fprintf(buf, format, args...)
+	}
 }

--- a/pkg/util/log/trace.go
+++ b/pkg/util/log/trace.go
@@ -198,7 +198,7 @@ func Event(ctx context.Context, msg string) {
 	}
 
 	// Format the tracing event and add it to the trace.
-	entry := MakeEntry(ctx,
+	entry := MakeLegacyEntry(ctx,
 		severity.INFO, /* unused for trace events */
 		channel.DEV,   /* unused for trace events */
 		1,             /* depth */
@@ -221,7 +221,7 @@ func Eventf(ctx context.Context, format string, args ...interface{}) {
 	}
 
 	// Format the tracing event and add it to the trace.
-	entry := MakeEntry(ctx,
+	entry := MakeLegacyEntry(ctx,
 		severity.INFO, /* unused for trace events */
 		channel.DEV,   /* unused for trace events */
 		1,             /* depth */
@@ -248,7 +248,7 @@ func vEventf(
 			// Nothing to log. Skip the work.
 			return
 		}
-		entry := MakeEntry(ctx,
+		entry := MakeLegacyEntry(ctx,
 			severity.INFO, /* unused for trace events */
 			channel.DEV,   /* unused for trace events */
 			depth+1,


### PR DESCRIPTION
Needed for #58126

Prior to this patch, the logging events were converted to a
`logpb.Entry` very early in the logging pipeline. This was forcing the
conversion of the logging tags to a flat string too early, and making
it hard for (e.g.) a JSON formatter to preserve the structure of
logging tags.

This patch averts this by introducing a new `logEntry` type which has
more-or-less the same structure as `logpb.Entry` but keep the logging
tags structured until the point the entry is formatted.

Release note: None