### PR TITLE
roachtest: add test_9_6_diagnostics to psycopg blocklist

### DIFF
--- a/pkg/cmd/roachtest/psycopg_blocklist.go
+++ b/pkg/cmd/roachtest/psycopg_blocklist.go
@@ -29,7 +29,8 @@ var psycopgBlocklists = blocklistsForVersion{
 // After a failed run, an updated version of this blocklist should be available
 // in the test log.
 var psycopgBlockList21_1 = blocklist{
-	"tests.test_async_keyword.CancelTests.test_async_cancel": "41335",
+	"tests.test_async_keyword.CancelTests.test_async_cancel":    "41335",
+	"tests.test_module.ExceptionsTestCase.test_9_6_diagnostics": "58035",
 }
 
 var psycopgBlockList20_2 = blocklist{


### PR DESCRIPTION
Previously, this test was skipped as our pg server version (9.5) did
not meet the threshold (9.6) for this test to run. After the pg server
version bump to 13 this is no longer the case. A change to explicitly
skip this test for CRDB has been merged upstream, but it won't apply
until the next release (psycopg_2_8_7) comes out and we switch to
testing against that. Until then, this test lives in the blocklist.

Closes #57986

Release note: None