### PR TITLE
workload/schemachange: ensure unique column numbers upon table creation

### DIFF
--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -526,7 +526,7 @@ func (og *operationGenerator) createTable(tx *pgx.Tx) (string, error) {
 		return "", err
 	}
 
-	stmt := rowenc.RandCreateTable(og.params.rng, "table", tableIdx)
+	stmt := rowenc.RandCreateTableWithColumnIndexNumberGenerator(og.params.rng, "table", tableIdx, og.newUniqueSeqNum)
 	stmt.Table = *tableName
 	stmt.IfNotExists = og.randIntn(2) == 0
 


### PR DESCRIPTION
**workload/schemachange: ensure unique column numbers upon table creation**

Previously, the following behaviour would result in a seg fault:
First a table (eg. table1) gets created with col1_0, col1_1, col1_2
where thec column numbers (0,1,2) refer to their index in the table.
After table creation, the workload tries to intentionally cause an
error by altering the type of a column that does not exist. From the
perspective of the workload, the sequence numbers (0,1,2) have not
been used, so it may use one of the column names above (eg. col1_0)
while assuming the column name is unique compared to any column names
in the db. This assumption leads to a seg fault because it is not
correct. Specifically, a column variable representing a column that
does not exist will have a nil type. If the workload checks the database
for this column, sees that it exists, then tries to dereference the type,
a seg fault will occur.

This change ensures that table creation uses the workload's atomically
increasing global sequence number while naming columns. This ensures
that the assumption above holds true and prevents the seg fault from
occurring.

Closes: https://github.com/cockroachdb/cockroach/issues/58017

Release note: None