### PR TITLE
colexecagg: fix bazel build

### DIFF
--- a/pkg/sql/colexec/colexecagg/BUILD.bazel
+++ b/pkg/sql/colexec/colexecagg/BUILD.bazel
@@ -4,30 +4,30 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 # depends on execgen+templates from a parent package. Look towards colexec for
 # how this should be done. For now we just lazily depend on the already
 # generated+checked in file.
-#
-# keep
+
 go_library(
     name = "colexecagg",
     srcs = [
         "aggregate_funcs.go",
-        "hash_any_not_null_agg.eg.go",
-        "hash_avg_agg.eg.go",
-        "hash_bool_and_or_agg.eg.go",
-        "hash_concat_agg.eg.go",
-        "hash_count_agg.eg.go",
-        "hash_default_agg.eg.go",
-        "hash_min_max_agg.eg.go",
-        "hash_sum_agg.eg.go",
-        "hash_sum_int_agg.eg.go",
-        "ordered_any_not_null_agg.eg.go",
-        "ordered_avg_agg.eg.go",
-        "ordered_bool_and_or_agg.eg.go",
-        "ordered_concat_agg.eg.go",
-        "ordered_count_agg.eg.go",
-        "ordered_default_agg.eg.go",
-        "ordered_min_max_agg.eg.go",
-        "ordered_sum_agg.eg.go",
-        "ordered_sum_int_agg.eg.go",
+        "aggregators_util.go",
+        "hash_any_not_null_agg.eg.go",  # keep
+        "hash_avg_agg.eg.go",  # keep
+        "hash_bool_and_or_agg.eg.go",  # keep
+        "hash_concat_agg.eg.go",  # keep
+        "hash_count_agg.eg.go",  # keep
+        "hash_default_agg.eg.go",  # keep
+        "hash_min_max_agg.eg.go",  # keep
+        "hash_sum_agg.eg.go",  # keep
+        "hash_sum_int_agg.eg.go",  # keep
+        "ordered_any_not_null_agg.eg.go",  # keep
+        "ordered_avg_agg.eg.go",  # keep
+        "ordered_bool_and_or_agg.eg.go",  # keep
+        "ordered_concat_agg.eg.go",  # keep
+        "ordered_count_agg.eg.go",  # keep
+        "ordered_default_agg.eg.go",  # keep
+        "ordered_min_max_agg.eg.go",  # keep
+        "ordered_sum_agg.eg.go",  # keep
+        "ordered_sum_int_agg.eg.go",  # keep
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecagg",
     visibility = ["//visibility:public"],
@@ -45,6 +45,7 @@ go_library(
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",
         "//pkg/util/duration",
+        "//pkg/util/mon",
         "//vendor/github.com/cockroachdb/apd/v2:apd",
         "//vendor/github.com/cockroachdb/errors",
     ],


### PR DESCRIPTION
The BUILD.bazel file was pinned down because we still haven't
auto-generated eg.go files placed in this package within the sandbox
(see open TODO). A new file was added in #57769 which wasn't picked up
by bazel, we do that now (+ only selectively pin the eg.go files instead
of the entire go_library definition).

Release note: None