### PR TITLE
backupccl: re-parallelize restore data processor

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -351,7 +351,7 @@ func TestBackupRestoreSingleUserfile(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	const numAccounts = 1000
+	const numAccounts = 10
 	ctx, tc, _, _, cleanupFn := BackupRestoreTestSetup(t, singleNode, numAccounts, InitManualReplication)
 	defer cleanupFn()
 

--- a/pkg/ccl/backupccl/bench_test.go
+++ b/pkg/ccl/backupccl/bench_test.go
@@ -61,13 +61,15 @@ func BenchmarkDatabaseRestore(b *testing.B) {
 	defer cleanup()
 	sqlDB.Exec(b, `DROP TABLE data.bank`)
 
-	bankData := bank.FromRows(b.N).Tables()[0]
+	bankData := bank.FromRows(100000).Tables()[0]
 	if _, err := sampledataccl.ToBackup(b, bankData, dir, "foo"); err != nil {
-		b.Fatalf("%+v", err)
+		b.Fatalf("%+v", err	)
 	}
 
 	b.ResetTimer()
-	sqlDB.Exec(b, `RESTORE data.* FROM 'nodelocal://0/foo'`)
+	for i := 0; i < b.N; i++ {
+		sqlDB.Exec(b, fmt.Sprintf(`RESTORE data.* FROM 'nodelocal://0/foo' WITH into_db='data_%d'`, i))
+	}
 	b.StopTimer()
 }
 

--- a/pkg/ccl/backupccl/restore_data_processor.go
+++ b/pkg/ccl/backupccl/restore_data_processor.go
@@ -16,9 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
 	"github.com/cockroachdb/cockroach/pkg/kv/bulk"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
@@ -39,12 +37,6 @@ import (
 // Progress is streamed to the coordinator through metadata.
 var restoreDataOutputTypes = []*types.T{}
 
-var importLeadMultiplier = settings.RegisterIntSetting(
-	"bulkio.import_lead_multiplier",
-	"a description",
-	2,
-)
-
 type restoreDataProcessor struct {
 	execinfra.ProcessorBase
 
@@ -64,6 +56,11 @@ type restoreDataProcessor struct {
 	totalIngest map[int]time.Duration
 
 	totalProgSend map[int]time.Duration
+}
+
+type fetchedEntry struct {
+	entry execinfrapb.RestoreSpanEntry
+	iters []storage.SimpleMVCCIterator
 }
 
 var _ execinfra.Processor = &restoreDataProcessor{}
@@ -98,9 +95,7 @@ func newRestoreDataProcessor(
 		}); err != nil {
 		return nil, err
 	}
-	mult := int(importLeadMultiplier.Get(&rd.EvalCtx.Settings.SV))
-	numWorkers := int(kvserver.ImportRequestsLimit.Get(&rd.EvalCtx.Settings.SV)) * mult
-	rd.progCh = make(chan *RestoreProgress, numWorkers)
+	rd.progCh = make(chan *RestoreProgress, 2 /* TODO Evaluate this */)
 	return rd, nil
 }
 
@@ -110,7 +105,22 @@ func (rd *restoreDataProcessor) Start(ctx context.Context) context.Context {
 	ctx = rd.StartInternal(ctx, restoreDataProcName)
 	go func() {
 		defer close(rd.progCh)
-		rd.restoreErr = rd.runRestore()
+		entriesToFetch := make(chan execinfrapb.RestoreSpanEntry)
+		entriesToIngest := make(chan fetchedEntry)
+
+		g := ctxgroup.WithContext(ctx)
+		g.Go(func() error {
+			return rd.runRestore(entriesToFetch)
+		})
+		g.Go(func() error {
+			return rd.fetchWorker(entriesToFetch, entriesToIngest)
+		})
+		g.Go(func() error {
+			return rd.ingestWorker(entriesToIngest)
+		})
+		if err := g.Wait(); err != nil {
+			rd.restoreErr = err
+		}
 	}()
 	return ctx
 }
@@ -146,214 +156,232 @@ func (rd *restoreDataProcessor) ConsumerClosed() {
 	rd.InternalClose()
 }
 
-func (rd *restoreDataProcessor) runRestore() error {
-	mult := int(importLeadMultiplier.Get(&rd.EvalCtx.Settings.SV))
-	numWorkers := int(kvserver.ImportRequestsLimit.Get(&rd.EvalCtx.Settings.SV)) * mult
-	return ctxgroup.GroupWorkers(rd.Ctx, numWorkers, func(ctx context.Context, workerID int) error {
-		for {
-			// We read rows from the SplitAndScatter processor. We expect each row to
-			// contain 2 columns. The first is used to route the row to this processor,
-			// and the second contains the RestoreSpanEntry that we're interested in.
-			// beforeNext := timeutil.Now()
-			row, meta := rd.input.Next()
-			// rd.totalNext[workerID] += timeutil.Since(beforeNext)
-			if meta != nil {
-				if meta.Err != nil {
-					// We got an error.
-					return meta.Err
-				}
-
-				// TODO: This currently ignores all metadata.
-				// TODO: Should this be fwding metadata?
-			}
-			if row == nil {
-				// Done consuming rows.
-				return nil
+// TODO: Rename
+// runRestore reads the input and puts work on the spansToDownload channel.
+func (rd *restoreDataProcessor) runRestore(
+	entriesToDownload chan execinfrapb.RestoreSpanEntry,
+) error {
+	defer close(entriesToDownload)
+	for {
+		// We read rows from the SplitAndScatter processor. We expect each row to
+		// contain 2 columns. The first is used to route the row to this processor,
+		// and the second contains the RestoreSpanEntry that we're interested in.
+		// beforeNext := timeutil.Now()
+		row, meta := rd.input.Next()
+		// rd.totalNext[workerID] += timeutil.Since(beforeNext)
+		if meta != nil {
+			if meta.Err != nil {
+				// We got an error.
+				return meta.Err
 			}
 
-			if len(row) != 2 {
-				return errors.New("expected input rows to have exactly 2 columns")
-			}
-			if err := row[1].EnsureDecoded(types.Bytes, &rd.alloc); err != nil {
-				return err
-			}
-			datum := row[1].Datum
-			entryDatumBytes, ok := datum.(*tree.DBytes)
-			if !ok {
-				return errors.AssertionFailedf(`unexpected datum type %T: %+v`, datum, row)
-			}
-
-			var entry execinfrapb.RestoreSpanEntry
-			if err := protoutil.Unmarshal([]byte(*entryDatumBytes), &entry); err != nil {
-				return errors.Wrap(err, "un-marshaling restore span entry")
-			}
-
-			newSpanKey, err := rewriteBackupSpanKey(rd.flowCtx.Codec(), rd.kr, entry.Span.Key)
-			if err != nil {
-				return errors.Wrap(err, "re-writing span key to import")
-			}
-
-			// beforeImport := timeutil.Now()
-			log.VEventf(rd.Ctx, 1 /* level */, "importing span %v", newSpanKey)
-			summary, err := rd.processRestoreSpanEntry(entry, entry.Span.Key)
-			if err != nil {
-				return err
-			}
-			// rd.totalIngest[workerID] += timeutil.Since(beforeImport)
-
-			progDetails := &RestoreProgress{}
-			progDetails.Summary = countRows(summary, rd.spec.PKIDs)
-			progDetails.ProgressIdx = entry.ProgressIdx
-			progDetails.DataSpan = entry.Span
-
-			//beforeProgSend := timeutil.Now()
-			rd.progCh <- progDetails
-			// rd.totalProgSend[workerID] += timeutil.Since(beforeProgSend)
-
-			log.Infof(ctx, "restore timing: spent %+v on waiting for next row, %+v on processing the import and %+v on waiting for the progCh for worker %d", rd.totalNext[workerID], rd.totalIngest[workerID], rd.totalProgSend[workerID], workerID)
+			// TODO: This currently ignores all metadata.
+			// TODO: Should this be fwding metadata?
 		}
-	})
+		if row == nil {
+			// Done consuming rows.
+			return nil
+		}
+
+		if len(row) != 2 {
+			return errors.New("expected input rows to have exactly 2 columns")
+		}
+		if err := row[1].EnsureDecoded(types.Bytes, &rd.alloc); err != nil {
+			return err
+		}
+		datum := row[1].Datum
+		entryDatumBytes, ok := datum.(*tree.DBytes)
+		if !ok {
+			return errors.AssertionFailedf(`unexpected datum type %T: %+v`, datum, row)
+		}
+
+		var entry execinfrapb.RestoreSpanEntry
+		if err := protoutil.Unmarshal([]byte(*entryDatumBytes), &entry); err != nil {
+			return errors.Wrap(err, "un-marshaling restore span entry")
+		}
+
+		newSpanKey, err := rewriteBackupSpanKey(rd.flowCtx.Codec(), rd.kr, entry.Span.Key)
+		if err != nil {
+			return errors.Wrap(err, "re-writing span key to import")
+		}
+
+		// This should just pass work off to the first stage of the pipeline.
+		log.VEventf(rd.Ctx, 1 /* level */, "importing span %v", newSpanKey)
+		log.Infof(rd.Ctx, "adding entry %+v", entry)
+		entriesToDownload <- entry
+	}
 }
 
-func (rd *restoreDataProcessor) processRestoreSpanEntry(
-	entry execinfrapb.RestoreSpanEntry, newSpanKey roachpb.Key,
-) (roachpb.BulkOpSummary, error) {
+func (rd *restoreDataProcessor) fetchWorker(
+	entriesToFetch chan execinfrapb.RestoreSpanEntry, downloadedFiles chan fetchedEntry,
+) error {
+	defer close(downloadedFiles)
+
+	ctx := rd.Ctx
+	for entry := range entriesToFetch {
+		log.Infof(rd.Ctx, "getting entry %+v", entry)
+		newSpanKey := entry.Span.Key
+
+		// The sstables only contain MVCC data and no intents, so using an MVCC
+		// iterator is sufficient.
+		var iters []storage.SimpleMVCCIterator
+		for _, file := range entry.Files {
+			log.VEventf(ctx, 2, "import file %s %s", file.Path, newSpanKey)
+
+			dir, err := rd.flowCtx.Cfg.ExternalStorage(ctx, file.Dir)
+			if err != nil {
+				return err
+			}
+			defer func() {
+				if err := dir.Close(); err != nil {
+					log.Warningf(ctx, "close export storage failed %v", err)
+				}
+			}()
+
+			const maxAttempts = 3
+			var fileContents []byte
+			if err := retry.WithMaxAttempts(ctx, base.DefaultRetryOptions(), maxAttempts, func() error {
+				f, err := dir.ReadFile(ctx, file.Path)
+				if err != nil {
+					return err
+				}
+				defer f.Close()
+				fileContents, err = ioutil.ReadAll(f)
+				return err
+			}); err != nil {
+				return errors.Wrapf(err, "fetching %q", file.Path)
+			}
+			dataSize := int64(len(fileContents))
+			log.Eventf(ctx, "fetched file (%s)", humanizeutil.IBytes(dataSize))
+
+			if rd.spec.Encryption != nil {
+				fileContents, err = storageccl.DecryptFile(fileContents, rd.spec.Encryption.Key)
+				if err != nil {
+					return err
+				}
+			}
+
+			iter, err := storage.NewMemSSTIterator(fileContents, false)
+			if err != nil {
+				return err
+			}
+
+			iters = append(iters, iter)
+		}
+		log.Infof(rd.Ctx, "adding downloaded file %+v", entry)
+		downloadedFiles <- fetchedEntry{entry: entry, iters: iters}
+	}
+
+	return nil
+}
+
+func (rd *restoreDataProcessor) ingestWorker(entriesToIngest chan fetchedEntry) error {
 	db := rd.flowCtx.Cfg.DB
 	ctx := rd.Ctx
 	evalCtx := rd.EvalCtx
-	var summary roachpb.BulkOpSummary
-
-	// The sstables only contain MVCC data and no intents, so using an MVCC
-	// iterator is sufficient.
-	var iters []storage.SimpleMVCCIterator
-	for _, file := range entry.Files {
-		log.VEventf(ctx, 2, "import file %s %s", file.Path, newSpanKey)
-
-		dir, err := rd.flowCtx.Cfg.ExternalStorage(ctx, file.Dir)
-		if err != nil {
-			return summary, err
-		}
-		defer func() {
-			if err := dir.Close(); err != nil {
-				log.Warningf(ctx, "close export storage failed %v", err)
-			}
-		}()
-
-		const maxAttempts = 3
-		var fileContents []byte
-		if err := retry.WithMaxAttempts(ctx, base.DefaultRetryOptions(), maxAttempts, func() error {
-			f, err := dir.ReadFile(ctx, file.Path)
-			if err != nil {
-				return err
-			}
-			defer f.Close()
-			fileContents, err = ioutil.ReadAll(f)
-			return err
-		}); err != nil {
-			return summary, errors.Wrapf(err, "fetching %q", file.Path)
-		}
-		dataSize := int64(len(fileContents))
-		log.Eventf(ctx, "fetched file (%s)", humanizeutil.IBytes(dataSize))
-
-		if rd.spec.Encryption != nil {
-			fileContents, err = storageccl.DecryptFile(fileContents, rd.spec.Encryption.Key)
-			if err != nil {
-				return summary, err
-			}
-		}
-
-		iter, err := storage.NewMemSSTIterator(fileContents, false)
-		if err != nil {
-			return summary, err
-		}
-
-		defer iter.Close()
-		iters = append(iters, iter)
-	}
-
 	batcher, err := bulk.MakeSSTBatcher(ctx, db, evalCtx.Settings,
 		func() int64 { return storageccl.MaxImportBatchSize(evalCtx.Settings) })
 	if err != nil {
-		return summary, err
+		return err
 	}
 	defer batcher.Close()
 
-	startKeyMVCC, endKeyMVCC := storage.MVCCKey{Key: entry.Span.Key},
-		storage.MVCCKey{Key: entry.Span.EndKey}
-	iter := storage.MakeMultiIterator(iters)
-	defer iter.Close()
-	var keyScratch, valueScratch []byte
-
-	for iter.SeekGE(startKeyMVCC); ; {
-		ok, err := iter.Valid()
-		if err != nil {
-			return summary, err
-		}
-		if !ok {
-			break
+	for fetched := range entriesToIngest {
+		log.Infof(rd.Ctx, "getting downloaded file %+v", fetched)
+		entry := fetched.entry
+		iters := fetched.iters
+		for _, iter := range iters {
+			defer iter.Close()
 		}
 
-		if !rd.spec.RestoreTime.IsEmpty() {
-			// TODO(dan): If we have to skip past a lot of versions to find the
-			// latest one before args.EndTime, then this could be slow.
-			if rd.spec.RestoreTime.Less(iter.UnsafeKey().Timestamp) {
-				iter.Next()
+		startKeyMVCC, endKeyMVCC := storage.MVCCKey{Key: entry.Span.Key}, storage.MVCCKey{Key: entry.Span.EndKey}
+		iter := storage.MakeMultiIterator(iters)
+		defer iter.Close()
+		var keyScratch, valueScratch []byte
+
+		for iter.SeekGE(startKeyMVCC); ; {
+			ok, err := iter.Valid()
+			if err != nil {
+				return err
+			}
+			if !ok {
+				break
+			}
+
+			if !rd.spec.RestoreTime.IsEmpty() {
+				// TODO(dan): If we have to skip past a lot of versions to find the
+				// latest one before args.EndTime, then this could be slow.
+				if rd.spec.RestoreTime.Less(iter.UnsafeKey().Timestamp) {
+					iter.Next()
+					continue
+				}
+			}
+
+			if !ok || !iter.UnsafeKey().Less(endKeyMVCC) {
+				break
+			}
+			if len(iter.UnsafeValue()) == 0 {
+				// Value is deleted.
+				iter.NextKey()
 				continue
 			}
-		}
 
-		if !ok || !iter.UnsafeKey().Less(endKeyMVCC) {
-			break
-		}
-		if len(iter.UnsafeValue()) == 0 {
-			// Value is deleted.
+			keyScratch = append(keyScratch[:0], iter.UnsafeKey().Key...)
+			valueScratch = append(valueScratch[:0], iter.UnsafeValue()...)
+			key := storage.MVCCKey{Key: keyScratch, Timestamp: iter.UnsafeKey().Timestamp}
+			value := roachpb.Value{RawBytes: valueScratch}
 			iter.NextKey()
-			continue
-		}
 
-		keyScratch = append(keyScratch[:0], iter.UnsafeKey().Key...)
-		valueScratch = append(valueScratch[:0], iter.UnsafeValue()...)
-		key := storage.MVCCKey{Key: keyScratch, Timestamp: iter.UnsafeKey().Timestamp}
-		value := roachpb.Value{RawBytes: valueScratch}
-		iter.NextKey()
-
-		key.Key, ok, err = rd.kr.RewriteKey(key.Key, false /* isFromSpan */)
-		if err != nil {
-			return summary, err
-		}
-		if !ok {
-			// If the key rewriter didn't match this key, it's not data for the
-			// table(s) we're interested in.
-			if log.V(3) {
-				log.Infof(ctx, "skipping %s %s", key.Key, value.PrettyPrint())
+			key.Key, ok, err = rd.kr.RewriteKey(key.Key, false /* isFromSpan */)
+			if err != nil {
+				return err
 			}
-			continue
+			if !ok {
+				// If the key rewriter didn't match this key, it's not data for the
+				// table(s) we're interested in.
+				if log.V(3) {
+					log.Infof(ctx, "skipping %s %s", key.Key, value.PrettyPrint())
+				}
+				continue
+			}
+
+			// Rewriting the key means the checksum needs to be updated.
+			value.ClearChecksum()
+			value.InitChecksum(key.Key)
+
+			if log.V(3) {
+				log.Infof(ctx, "Put %s -> %s", key.Key, value.PrettyPrint())
+			}
+			if err := batcher.AddMVCCKey(ctx, key, value.RawBytes); err != nil {
+				return errors.Wrapf(err, "adding to batch: %s -> %s", key, value.PrettyPrint())
+			}
+		}
+		// Flush out the last batch.
+		if err := batcher.Flush(ctx); err != nil {
+			return err
+		}
+		log.Event(ctx, "done")
+
+		if restoreKnobs, ok := rd.flowCtx.TestingKnobs().BackupRestoreTestingKnobs.(*sql.BackupRestoreTestingKnobs); ok {
+			if restoreKnobs.RunAfterProcessingRestoreSpanEntry != nil {
+				restoreKnobs.RunAfterProcessingRestoreSpanEntry(ctx)
+			}
 		}
 
-		// Rewriting the key means the checksum needs to be updated.
-		value.ClearChecksum()
-		value.InitChecksum(key.Key)
+		summary := batcher.GetBatchSummary()
 
-		if log.V(3) {
-			log.Infof(ctx, "Put %s -> %s", key.Key, value.PrettyPrint())
-		}
-		if err := batcher.AddMVCCKey(ctx, key, value.RawBytes); err != nil {
-			return summary, errors.Wrapf(err, "adding to batch: %s -> %s", key, value.PrettyPrint())
+		progDetails := &RestoreProgress{}
+		progDetails.Summary = countRows(summary, rd.spec.PKIDs)
+		progDetails.ProgressIdx = entry.ProgressIdx
+		progDetails.DataSpan = entry.Span
+
+		rd.progCh <- progDetails
+		if err := batcher.Reset(ctx); err != nil {
+			return err
 		}
 	}
-	// Flush out the last batch.
-	if err := batcher.Flush(ctx); err != nil {
-		return summary, err
-	}
-	log.Event(ctx, "done")
 
-	if restoreKnobs, ok := rd.flowCtx.TestingKnobs().BackupRestoreTestingKnobs.(*sql.BackupRestoreTestingKnobs); ok {
-		if restoreKnobs.RunAfterProcessingRestoreSpanEntry != nil {
-			restoreKnobs.RunAfterProcessingRestoreSpanEntry(ctx)
-		}
-	}
-
-	return batcher.GetSummary(), nil
+	return nil
 }
 
 func init() {

--- a/pkg/ccl/backupccl/restore_data_processor.go
+++ b/pkg/ccl/backupccl/restore_data_processor.go
@@ -10,7 +10,12 @@ package backupccl
 
 import (
 	"context"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
+	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"io/ioutil"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
@@ -35,6 +40,12 @@ import (
 // Progress is streamed to the coordinator through metadata.
 var restoreDataOutputTypes = []*types.T{}
 
+var importLeadMultiplier = settings.RegisterIntSetting(
+	"bulkio.import_lead_multiplier",
+	"a description",
+	2,
+)
+
 type restoreDataProcessor struct {
 	execinfra.ProcessorBase
 
@@ -43,8 +54,20 @@ type restoreDataProcessor struct {
 	input   execinfra.RowSource
 	output  execinfra.RowReceiver
 
+	progCh chan *RestoreProgress
+	restoreErr error
+
 	alloc rowenc.DatumAlloc
 	kr    *storageccl.KeyRewriter
+
+	beforeNext map[int]time.Time
+	totalNext map[int]time.Duration
+
+	beforeIngest map[int]time.Time
+	totalIngest map[int]time.Duration
+
+	beforeProgSend map[int]time.Time
+	totalProgSend map[int]time.Duration
 }
 
 var _ execinfra.Processor = &restoreDataProcessor{}
@@ -79,13 +102,21 @@ func newRestoreDataProcessor(
 		}); err != nil {
 		return nil, err
 	}
+	mult := int(importLeadMultiplier.Get(&rd.EvalCtx.Settings.SV))
+	numWorkers := int(kvserver.ImportRequestsLimit.Get(&rd.EvalCtx.Settings.SV)) * mult
+	rd.progCh = make(chan *RestoreProgress, numWorkers)
 	return rd, nil
 }
 
 // Start is part of the RowSource interface.
 func (rd *restoreDataProcessor) Start(ctx context.Context) context.Context {
 	rd.input.Start(ctx)
-	return rd.StartInternal(ctx, restoreDataProcName)
+	ctx = rd.StartInternal(ctx, restoreDataProcName)
+	go func() {
+		defer close(rd.progCh)
+		rd.restoreErr = rd.runRestore()
+	}()
+	return ctx
 }
 
 // Next is part of the RowSource interface.
@@ -93,67 +124,25 @@ func (rd *restoreDataProcessor) Next() (rowenc.EncDatumRow, *execinfrapb.Produce
 	if rd.State != execinfra.StateRunning {
 		return nil, rd.DrainHelper()
 	}
-	// We read rows from the SplitAndScatter processor. We expect each row to
-	// contain 2 columns. The first is used to route the row to this processor,
-	// and the second contains the RestoreSpanEntry that we're interested in.
-	row, meta := rd.input.Next()
-	if meta != nil {
-		if meta.Err != nil {
-			rd.MoveToDraining(nil /* err */)
+
+	for progDetails := range rd.progCh {
+		var prog execinfrapb.RemoteProducerMetadata_BulkProcessorProgress
+		details, err := gogotypes.MarshalAny(progDetails)
+		if err != nil {
+			rd.MoveToDraining(err)
+			return nil, rd.DrainHelper()
 		}
-		return nil, meta
+		prog.ProgressDetails = *details
+		return nil, &execinfrapb.ProducerMetadata{BulkProcessorProgress: &prog}
 	}
-	if row == nil {
-		rd.MoveToDraining(nil /* err */)
+
+	if rd.restoreErr != nil {
+		rd.MoveToDraining(rd.restoreErr)
 		return nil, rd.DrainHelper()
 	}
 
-	if len(row) != 2 {
-		rd.MoveToDraining(errors.New("expected input rows to have exactly 2 columns"))
-		return nil, rd.DrainHelper()
-	}
-	if err := row[1].EnsureDecoded(types.Bytes, &rd.alloc); err != nil {
-		rd.MoveToDraining(err)
-		return nil, rd.DrainHelper()
-	}
-	datum := row[1].Datum
-	entryDatumBytes, ok := datum.(*tree.DBytes)
-	if !ok {
-		rd.MoveToDraining(errors.AssertionFailedf(`unexpected datum type %T: %+v`, datum, row))
-		return nil, rd.DrainHelper()
-	}
-
-	var entry execinfrapb.RestoreSpanEntry
-	if err := protoutil.Unmarshal([]byte(*entryDatumBytes), &entry); err != nil {
-		rd.MoveToDraining(errors.Wrap(err, "un-marshaling restore span entry"))
-		return nil, rd.DrainHelper()
-	}
-
-	newSpanKey, err := rewriteBackupSpanKey(rd.flowCtx.Codec(), rd.kr, entry.Span.Key)
-	if err != nil {
-		rd.MoveToDraining(errors.Wrap(err, "re-writing span key to import"))
-		return nil, rd.DrainHelper()
-	}
-
-	log.VEventf(rd.Ctx, 1 /* level */, "importing span %v", entry.Span)
-	summary, err := rd.processRestoreSpanEntry(entry, newSpanKey)
-	if err != nil {
-		rd.MoveToDraining(err)
-		return nil, rd.DrainHelper()
-	}
-
-	var prog execinfrapb.RemoteProducerMetadata_BulkProcessorProgress
-	progDetails := RestoreProgress{}
-	progDetails.Summary = countRows(summary, rd.spec.PKIDs)
-	progDetails.ProgressIdx = entry.ProgressIdx
-	progDetails.DataSpan = entry.Span
-	details, err := gogotypes.MarshalAny(&progDetails)
-	if err != nil {
-		rd.MoveToDraining(err)
-		return nil, rd.DrainHelper()
-	}
-	prog.ProgressDetails = *details
-	return nil, &execinfrapb.ProducerMetadata{BulkProcessorProgress: &prog}
+	rd.MoveToDraining(nil /* err */)
+	return nil, rd.DrainHelper()
 }
 
 // ConsumerClosed is part of the RowSource interface.
@@ -161,9 +150,71 @@ func (rd *restoreDataProcessor) ConsumerClosed() {
 	rd.InternalClose()
 }
 
-func init() {
-	rowexec.NewRestoreDataProcessor = newRestoreDataProcessor
+func (rd *restoreDataProcessor) runRestore() error {
+	mult := int(importLeadMultiplier.Get(&rd.EvalCtx.Settings.SV))
+	numWorkers := int(kvserver.ImportRequestsLimit.Get(&rd.EvalCtx.Settings.SV)) * mult
+	return ctxgroup.GroupWorkers(rd.Ctx, numWorkers, func(ctx context.Context, workerID int) error {
+		for {
+			// We read rows from the SplitAndScatter processor. We expect each row to
+			// contain 2 columns. The first is used to route the row to this processor,
+			// and the second contains the RestoreSpanEntry that we're interested in.
+			beforeNext := timeutil.Now()
+			row, meta := rd.input.Next()
+			rd.totalNext[workerID] += timeutil.Since(beforeNext)
+			if meta != nil {
+				if meta.Err != nil {
+					// We got an error.
+					return meta.Err
+				}
+
+				// TODO: This currently ignores all metadata.
+				// TODO: Should this be fwding metadata?
+			}
+			if row == nil {
+				// Done consuming rows.
+				return nil
+			}
+
+			if len(row) != 2 {
+				return errors.New("expected input rows to have exactly 2 columns")
+			}
+			if err := row[1].EnsureDecoded(types.Bytes, &rd.alloc); err != nil {
+				return err
+			}
+			datum := row[1].Datum
+			entryDatumBytes, ok := datum.(*tree.DBytes)
+			if !ok {
+				return errors.AssertionFailedf(`unexpected datum type %T: %+v`, datum, row)
+			}
+
+			var entry execinfrapb.RestoreSpanEntry
+			if err := protoutil.Unmarshal([]byte(*entryDatumBytes), &entry); err != nil {
+				return errors.Wrap(err, "un-marshaling restore span entry")
+			}
+
+			newSpanKey, err := rewriteBackupSpanKey(rd.flowCtx.Codec(), rd.kr, entry.Span.Key)
+			if err != nil {
+				return errors.Wrap(err, "re-writing span key to import")
+			}
+
+			beforeImport := timeutil.Now()
+			log.VEventf(rd.Ctx, 1 /* level */, "importing span %v", newSpanKey)
+			summary, err := rd.processRestoreSpanEntry(entry, entry.Span.Key)
+			if err != nil {
+				return err
+			}
+			rd.totalIngest[workerID] += timeutil.Since(beforeImport)
+
+			progDetails := &RestoreProgress{}
+			progDetails.Summary = countRows(summary, rd.spec.PKIDs)
+			progDetails.ProgressIdx = entry.ProgressIdx
+				progDetails.DataSpan = entry.Span
+
+			rd.progCh <- progDetails
+		}
+	})
 }
+
 
 func (rd *restoreDataProcessor) processRestoreSpanEntry(
 	entry execinfrapb.RestoreSpanEntry, newSpanKey roachpb.Key,
@@ -304,4 +355,8 @@ func (rd *restoreDataProcessor) processRestoreSpanEntry(
 	}
 
 	return batcher.GetSummary(), nil
+}
+
+func init() {
+	rowexec.NewRestoreDataProcessor = newRestoreDataProcessor
 }

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -121,8 +121,8 @@ var bulkIOWriteLimit = settings.RegisterByteSizeSetting(
 	1<<40,
 ).WithPublic()
 
-// importRequestsLimit limits concurrent import requests.
-var importRequestsLimit = settings.RegisterIntSetting(
+// ImportRequestsLimit limits concurrent import requests.
+var ImportRequestsLimit = settings.RegisterIntSetting(
 	"kv.bulk_io_write.concurrent_import_requests",
 	"number of import requests a store will handle concurrently before queuing",
 	1,
@@ -871,10 +871,10 @@ func NewStore(
 		s.limiters.BulkIOWriteRate.SetLimit(rate.Limit(bulkIOWriteLimit.Get(&cfg.Settings.SV)))
 	})
 	s.limiters.ConcurrentImportRequests = limit.MakeConcurrentRequestLimiter(
-		"importRequestLimiter", int(importRequestsLimit.Get(&cfg.Settings.SV)),
+		"importRequestLimiter", int(ImportRequestsLimit.Get(&cfg.Settings.SV)),
 	)
-	importRequestsLimit.SetOnChange(&cfg.Settings.SV, func() {
-		s.limiters.ConcurrentImportRequests.SetLimit(int(importRequestsLimit.Get(&cfg.Settings.SV)))
+	ImportRequestsLimit.SetOnChange(&cfg.Settings.SV, func() {
+		s.limiters.ConcurrentImportRequests.SetLimit(int(ImportRequestsLimit.Get(&cfg.Settings.SV)))
 	})
 	s.limiters.ConcurrentExportRequests = limit.MakeConcurrentRequestLimiter(
 		"exportRequestLimiter", int(ExportRequestsLimit.Get(&cfg.Settings.SV)),

--- a/pkg/server/status/runtime.go
+++ b/pkg/server/status/runtime.go
@@ -483,7 +483,7 @@ func (rsr *RuntimeStatSampler) SampleEnvironment(
 		rsr.HostDiskReadBytes.Update(diskCounters.readBytes)
 		rsr.HostDiskReadCount.Update(diskCounters.readCount)
 		rsr.HostDiskReadTime.Update(int64(diskCounters.readTime))
-		rsr.HostDiskWriteBytes.Update(diskCounters.writeBytes)
+		rsr.HostDiskWriteBytes.Update(diskCounters.writeBytes	)
 		rsr.HostDiskWriteCount.Update(diskCounters.writeCount)
 		rsr.HostDiskWriteTime.Update(int64(diskCounters.writeTime))
 		rsr.HostDiskIOTime.Update(int64(diskCounters.ioTime))


### PR DESCRIPTION
This commit is a WIP that aims to reintroduce parallelism
within the restore data processor. This was previously
configurable with a non-public cluster setting.

The goal for this commit is to document the usage of this
cluster setting and ensuring that appropriate backpressure
is maintained when the cluster setting is set too high.

Initial testing has shown potential improvements of up to 2x
faster restores on the restore2tb dataset.

Release note: None