### PR TITLE
sql/pgwire: support binary format for enums

### DIFF
--- a/pkg/sql/pgwire/pgwirebase/encoding.go
+++ b/pkg/sql/pgwire/pgwirebase/encoding.go
@@ -305,14 +305,6 @@ func DecodeDatum(
 	id := t.Oid()
 	switch code {
 	case FormatText:
-		switch t.Family() {
-		case types.EnumFamily:
-			if err := validateStringBytes(b); err != nil {
-				return nil, err
-			}
-			return tree.MakeDEnumFromLogicalRepresentation(t, string(b))
-		}
-
 		switch id {
 		case oid.T_bool:
 			t, err := strconv.ParseBool(string(b))
@@ -774,6 +766,13 @@ func DecodeDatum(
 	}
 
 	// Types with identical text/binary handling.
+	switch t.Family() {
+	case types.EnumFamily:
+		if err := validateStringBytes(b); err != nil {
+			return nil, err
+		}
+		return tree.MakeDEnumFromLogicalRepresentation(t, string(b))
+	}
 	switch id {
 	case oid.T_text, oid.T_varchar:
 		if err := validateStringBytes(b); err != nil {

--- a/pkg/sql/pgwire/testdata/pgtest/enum
+++ b/pkg/sql/pgwire/testdata/pgtest/enum
@@ -94,7 +94,25 @@ Query {"String": "SELECT * FROM tb"}
 ----
 
 until crdb_only
-DataRow
+ReadyForQuery
 ----
 {"Type":"RowDescription","Fields":[{"Name":"x","TableOID":54,"TableAttributeNumber":1,"DataTypeOID":100052,"DataTypeSize":-1,"TypeModifier":-1,"Format":0}]}
 {"Type":"DataRow","Values":[{"text":"hi"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# Prepare a query and use the binary format (ParameterFormatCodes = [1])
+send
+Parse {"Name": "s2", "Query": "INSERT INTO tb VALUES ($1)"}
+Bind {"DestinationPortal": "p2", "PreparedStatement": "s2", "ParameterFormatCodes": [1], "Parameters": [[104, 105]]}
+Execute {"Portal": "p2"}
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"CommandComplete","CommandTag":"INSERT 0 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}


### PR DESCRIPTION
fixes #57348

PostgreSQL treats this the same as the text format for enums.

Release note (bug fix): Prepared statements that include enums and use
the binary format will no longer result in an error.