### PR TITLE
release-20.2: sql/pgwire: support binary format for enums

### DIFF
--- a/pkg/sql/pgwire/pgwirebase/encoding.go
+++ b/pkg/sql/pgwire/pgwirebase/encoding.go
@@ -796,9 +796,6 @@ func DecodeOidDatum(
 		}
 		switch typ.Family() {
 		case types.EnumFamily:
-			if code != FormatText {
-				return nil, pgerror.Newf(pgcode.Syntax, "expected FormatText for ENUM value encoding")
-			}
 			if err := validateStringBytes(b); err != nil {
 				return nil, err
 			}

--- a/pkg/sql/pgwire/testdata/pgtest/enum
+++ b/pkg/sql/pgwire/testdata/pgtest/enum
@@ -94,7 +94,25 @@ Query {"String": "SELECT * FROM tb"}
 ----
 
 until crdb_only
-DataRow
+ReadyForQuery
 ----
 {"Type":"RowDescription","Fields":[{"Name":"x","TableOID":54,"TableAttributeNumber":1,"DataTypeOID":100052,"DataTypeSize":-1,"TypeModifier":-1,"Format":0}]}
 {"Type":"DataRow","Values":[{"text":"hi"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# Prepare a query and use the binary format (ParameterFormatCodes = [1])
+send
+Parse {"Name": "s2", "Query": "INSERT INTO tb VALUES ($1)"}
+Bind {"DestinationPortal": "p2", "PreparedStatement": "s2", "ParameterFormatCodes": [1], "Parameters": [[104, 105]]}
+Execute {"Portal": "p2"}
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"CommandComplete","CommandTag":"INSERT 0 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}


### PR DESCRIPTION
Backport 1/1 commits from #58043.

/cc @cockroachdb/release

---

fixes #57348

PostgreSQL treats this the same as the text format for enums.

Release note (bug fix): Prepared statements that include enums and use
the binary format will no longer result in an error.
