### PR TITLE
storageccl: make KeyRewriter lookup O(logn) and memoized

### DIFF
--- a/pkg/ccl/backupccl/restore_data_processor.go
+++ b/pkg/ccl/backupccl/restore_data_processor.go
@@ -173,13 +173,6 @@ func (rd *restoreDataProcessor) processRestoreSpanEntry(
 	ctx := rd.Ctx
 	evalCtx := rd.EvalCtx
 	var summary roachpb.BulkOpSummary
-	// rekeys could be using table descriptors from either the old or new
-	// foreign key representation on the table descriptor, but this is fine
-	// because foreign keys don't matter for the key rewriter.
-	kr, err := storageccl.MakeKeyRewriterFromRekeys(rd.spec.Rekeys)
-	if err != nil {
-		return summary, errors.Wrap(err, "make key rewriter")
-	}
 
 	// The sstables only contain MVCC data and no intents, so using an MVCC
 	// iterator is sufficient.
@@ -285,7 +278,7 @@ func (rd *restoreDataProcessor) processRestoreSpanEntry(
 		value := roachpb.Value{RawBytes: valueScratch}
 		iter.NextKey()
 
-		key.Key, ok, err = kr.RewriteKey(key.Key, false /* isFromSpan */)
+		key.Key, ok, err = rd.kr.RewriteKey(key.Key, false /* isFromSpan */)
 		if err != nil {
 			return summary, err
 		}

--- a/pkg/ccl/storageccl/import_test.go
+++ b/pkg/ccl/storageccl/import_test.go
@@ -297,10 +297,10 @@ func runTestImport(t *testing.T, init func(*cluster.Settings)) {
 	} {
 		t.Run(fmt.Sprintf("%d-%v", i, testCase), func(t *testing.T) {
 			newID := descpb.ID(100 + i)
-			kr := prefixRewriter{{
+			kr := prefixRewriter{rewrites: []prefixRewrite{{
 				OldPrefix: srcPrefix,
 				NewPrefix: makeKeyRewriterPrefixIgnoringInterleaved(newID, indexID),
-			}}
+			}}}
 			rekeys := []roachpb.ImportRequest_TableRekey{
 				{
 					OldID: oldID,

--- a/pkg/ccl/storageccl/key_rewriter_test.go
+++ b/pkg/ccl/storageccl/key_rewriter_test.go
@@ -27,7 +27,7 @@ import (
 func TestPrefixRewriter(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	kr := prefixRewriter{
+	kr := prefixRewriter{rewrites: []prefixRewrite{
 		{
 			OldPrefix: []byte{1, 2, 3},
 			NewPrefix: []byte{4, 5, 6},
@@ -36,8 +36,7 @@ func TestPrefixRewriter(t *testing.T) {
 			OldPrefix: []byte{7, 8, 9},
 			NewPrefix: []byte{10},
 		},
-	}
-
+	}}
 	t.Run("match", func(t *testing.T) {
 		key := []byte{1, 2, 3, 4}
 		newKey, ok := kr.rewriteKey(key)
@@ -159,7 +158,7 @@ func mustMarshalDesc(t *testing.T, tableDesc *descpb.TableDescriptor) []byte {
 }
 
 func BenchmarkPrefixRewriter(b *testing.B) {
-	kr := prefixRewriter{
+	kr := prefixRewriter{rewrites: []prefixRewrite{
 		{
 			OldPrefix: []byte{1, 2, 3},
 			NewPrefix: []byte{4, 5, 6},
@@ -168,7 +167,7 @@ func BenchmarkPrefixRewriter(b *testing.B) {
 			OldPrefix: []byte{7, 8, 9},
 			NewPrefix: []byte{10},
 		},
-	}
+	}}
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {


### PR DESCRIPTION
The previous code was O(n) in terms of number of tables, and could be very slow for very large numbers of tables.

The O(n) code on the two-prefix benchmark clocked in at about 10ns/op. Sorting the prefixes allows binary searching to find a matching one, but on this small benchmark, the binary search version alone actually takes closer to 30ns/op. 

Adding memoization should help considerably, both in the small benchmark, but also in real world usage too: as keys are passed to the rewriter in order and will almost always be matched by the same table prefix, memoization of just the last match likely has nearly 100% hit rate, and means that the log n lookup should only happen ~once per range.