### PR TITLE
server: improve logging for reset quorum

### DIFF
--- a/pkg/cli/debug_reset_quorum.go
+++ b/pkg/cli/debug_reset_quorum.go
@@ -16,6 +16,7 @@ import (
 	"strconv"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/spf13/cobra"
 )
 
@@ -50,6 +51,7 @@ func runDebugResetQuorum(cmd *cobra.Command, args []string) error {
 	// Set up GRPC Connection for running ResetQuorum.
 	cc, _, finish, err := getClientGRPCConn(ctx, serverCfg)
 	if err != nil {
+		log.Errorf(ctx, "connection to server failed: %v", err)
 		return err
 	}
 	defer finish()


### PR DESCRIPTION
Adds additional logging throughout reset quorum command and RPC.

Release note: None.