### PR TITLE
tracing: add StartSpanCtx

### DIFF
--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -513,7 +513,8 @@ func (r *Registry) CreateStartableJobWithTxn(
 	}
 	// Construct a context which contains a tracing span that follows from the
 	// span in the parent context. We don't directly use the parent span because
-	// we want independent lifetimes and cancellation.
+	// we want independent lifetimes and cancellation. For the same reason, we
+	// don't use the Context returned by ForkCtxSpan.
 	resumerCtx, cancel := r.makeCtx()
 	_, span := tracing.ForkCtxSpan(ctx, "job")
 	if span != nil {

--- a/pkg/kv/kvclient/kvcoord/transport.go
+++ b/pkg/kv/kvclient/kvcoord/transport.go
@@ -326,9 +326,6 @@ func (s *senderTransport) SendNext(
 	}
 	s.called = true
 
-	ctx, cleanup := tracing.EnsureContext(ctx, s.tracer, "node" /* name */)
-	defer cleanup()
-
 	ba.Replica = s.replica
 	log.Eventf(ctx, "%v", ba.String())
 	br, pErr := s.sender.Send(ctx, ba)

--- a/pkg/kv/kvserver/batcheval/BUILD.bazel
+++ b/pkg/kv/kvserver/batcheval/BUILD.bazel
@@ -72,7 +72,6 @@ go_library(
         "//pkg/util/hlc",
         "//pkg/util/limit",
         "//pkg/util/log",
-        "//pkg/util/tracing",
         "//pkg/util/uuid",
         "//vendor/github.com/cockroachdb/errors",
         "//vendor/github.com/kr/pretty",

--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
@@ -31,7 +31,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 )
 
@@ -810,9 +809,6 @@ func splitTrigger(
 	split *roachpb.SplitTrigger,
 	ts hlc.Timestamp,
 ) (enginepb.MVCCStats, result.Result, error) {
-	// TODO(andrei): should this span be a child of the ctx's (if any)?
-	sp := rec.ClusterSettings().Tracer.StartSpan("split", tracing.WithCtxLogTags(ctx))
-	defer sp.Finish()
 	desc := rec.Desc()
 	if !bytes.Equal(desc.StartKey, split.LeftDesc.StartKey) ||
 		!bytes.Equal(desc.EndKey, split.RightDesc.EndKey) {

--- a/pkg/kv/kvserver/replica_application_decoder.go
+++ b/pkg/kv/kvserver/replica_application_decoder.go
@@ -149,9 +149,14 @@ func (d *replicaDecoder) createTracingSpans(ctx context.Context) {
 			if err != nil {
 				log.Errorf(ctx, "unable to extract trace data from raft command: %s", err)
 			} else {
-				cmd.sp = d.r.AmbientContext.Tracer.StartSpan(
-					"raft application", tracing.WithParentAndManualCollection(spanCtx), tracing.WithFollowsFrom())
-				cmd.ctx = tracing.ContextWithSpan(ctx, cmd.sp)
+				cmd.ctx, cmd.sp = d.r.AmbientContext.Tracer.StartSpanCtx(
+					ctx,
+					"raft application",
+					// NB: we are lying here - we are not actually going to propagate
+					// the recording towards the root. That seems ok.
+					tracing.WithParentAndManualCollection(spanCtx),
+					tracing.WithFollowsFrom(),
+				)
 			}
 		} else {
 			cmd.ctx, cmd.sp = tracing.ForkCtxSpan(ctx, opName)

--- a/pkg/kv/kvserver/replica_send.go
+++ b/pkg/kv/kvserver/replica_send.go
@@ -57,8 +57,6 @@ func (r *Replica) sendWithRangeID(
 
 	// Add the range log tag.
 	ctx = r.AnnotateCtx(ctx)
-	ctx, cleanup := tracing.EnsureContext(ctx, r.AmbientContext.Tracer, "replica send")
-	defer cleanup()
 
 	// If the internal Raft group is not initialized, create it and wake the leader.
 	r.maybeInitializeRaftGroup(ctx)

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -12566,8 +12566,7 @@ func TestLaterReproposalsDoNotReuseContext(t *testing.T) {
 
 	// Hold the RaftLock to encourage the reproposals to occur in the same batch.
 	tc.repl.RaftLock()
-	sp := tracer.StartSpan("replica send", tracing.WithCtxLogTags(ctx), tracing.WithForceRealSpan())
-	tracedCtx := tracing.ContextWithSpan(ctx, sp)
+	tracedCtx, sp := tracer.StartSpanCtx(ctx, "replica send", tracing.WithForceRealSpan())
 	// Go out of our way to enable recording so that expensive logging is enabled
 	// for this context.
 	sp.SetVerbose(true)

--- a/pkg/sql/catalog/lease/BUILD.bazel
+++ b/pkg/sql/catalog/lease/BUILD.bazel
@@ -35,7 +35,6 @@ go_library(
         "//pkg/util/syncutil",
         "//pkg/util/syncutil/singleflight",
         "//pkg/util/timeutil",
-        "//pkg/util/tracing",
         "//vendor/github.com/cockroachdb/errors",
         "//vendor/github.com/cockroachdb/logtags",
         "//vendor/github.com/cockroachdb/redact",

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -49,7 +49,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil/singleflight"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
-	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
 	"github.com/cockroachdb/redact"
@@ -1036,9 +1035,6 @@ func (t *descriptorState) maybeQueueLeaseRenewal(
 	// Start the renewal. When it finishes, it will reset t.renewalInProgress.
 	return t.stopper.RunAsyncTask(context.Background(),
 		"lease renewal", func(ctx context.Context) {
-			var cleanup func()
-			ctx, cleanup = tracing.EnsureContext(ctx, m.ambientCtx.Tracer, "lease renewal")
-			defer cleanup()
 			t.startLeaseRenewal(ctx, m, id, name)
 		})
 }

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -1493,28 +1493,12 @@ func (ex *connExecutor) recordTransaction(ev txnEvent, implicit bool, txnStart t
 // parentCtx for an existing span and creates a root span if none is found, or a
 // child span if one is found. A context derived from parentCtx which
 // additionally contains the new span is also returned.
-// TODO(asubiotto): Use tracing.EnsureChildSpan once that is available.
 func createRootOrChildSpan(
-	parentCtx context.Context, opName string, tracer *tracing.Tracer,
+	parentCtx context.Context, opName string, tr *tracing.Tracer,
 ) (context.Context, *tracing.Span) {
 	// WithForceRealSpan is used to support the use of session tracing, which
 	// may start recording on this span.
-	var sp *tracing.Span
-	if parentSp := tracing.SpanFromContext(parentCtx); parentSp != nil {
-		// Create a child span for this operation.
-		sp = parentSp.Tracer().StartSpan(
-			opName,
-			tracing.WithParentAndAutoCollection(parentSp),
-			tracing.WithCtxLogTags(parentCtx),
-			tracing.WithForceRealSpan(),
-		)
-	} else {
-		// Create a root span for this operations.
-		sp = tracer.StartSpan(
-			opName, tracing.WithCtxLogTags(parentCtx), tracing.WithForceRealSpan(),
-		)
-	}
-	return tracing.ContextWithSpan(parentCtx, sp), sp
+	return tracing.EnsureChildSpan(parentCtx, tr, opName, tracing.WithForceRealSpan())
 }
 
 // logTraceAboveThreshold logs a span's recording if the duration is above a

--- a/pkg/util/log/ambient_context.go
+++ b/pkg/util/log/ambient_context.go
@@ -58,16 +58,16 @@ type AmbientContext struct {
 	// log or an open span (if not nil).
 	eventLog *ctxEventLog
 
+	// The buffer.
+	//
+	// NB: this should not be returned to the caller, to avoid other mutations
+	// leaking in. If we return this to the caller, it should be in immutable
+	// form.
 	tags *logtags.Buffer
 
 	// Cached annotated version of context.{TODO,Background}, to avoid annotating
 	// these contexts repeatedly.
 	backgroundCtx context.Context
-}
-
-// LogTags returns the tags in the ambient context.
-func (ac *AmbientContext) LogTags() *logtags.Buffer {
-	return ac.tags
 }
 
 // AddLogTag adds a tag to the ambient context.

--- a/pkg/util/tracing/tags.go
+++ b/pkg/util/tracing/tags.go
@@ -10,11 +10,7 @@
 
 package tracing
 
-import (
-	"context"
-
-	"github.com/cockroachdb/logtags"
-)
+import "github.com/cockroachdb/logtags"
 
 // LogTagsOption is a StartSpanOption that uses log tags to populate the Span tags.
 type logTagsOption logtags.Buffer
@@ -29,13 +25,13 @@ func (lt *logTagsOption) apply(opts spanOptions) spanOptions {
 // WithLogTags returns a SpanOption that sets the Span tags to the given log
 // tags. When applied, the returned option will apply any logtag name->Span tag
 // name remapping that has been registered via RegisterTagRemapping.
+//
+// Note that there is no need to use this option with StartSpanCtx, as that will
+// already propagate the log tags from the Context supplied to it to the Span.
+// However, if a WithLogTags option is supplied, it will be used and replaces
+// the Context-derived tags.
 func WithLogTags(tags *logtags.Buffer) SpanOption {
 	return (*logTagsOption)(tags)
-}
-
-// WithCtxLogTags returns WithLogTags(logtags.FromContext(ctx)).
-func WithCtxLogTags(ctx context.Context) SpanOption {
-	return WithLogTags(logtags.FromContext(ctx))
 }
 
 // tagRemap is a map that records desired conversions

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -620,24 +620,10 @@ func childSpan(ctx context.Context, opName string, remote bool) (context.Context
 	return ContextWithSpan(ctx, newSpan), newSpan
 }
 
-// EnsureContext checks whether the given context.Context contains a Span. If
-// not, it creates one using the provided Tracer and wraps it in the returned
-// Span. The returned closure must be called after the request has been fully
-// processed.
-//
-// Note that, if there's already a Span in the context, this method does nothing
-// even if the current context's log tags are different from that Span's tags.
-func EnsureContext(ctx context.Context, tracer *Tracer, opName string) (context.Context, func()) {
-	if SpanFromContext(ctx) == nil {
-		sp := tracer.StartSpan(opName, WithCtxLogTags(ctx))
-		return ContextWithSpan(ctx, sp), sp.Finish
-	}
-	return ctx, func() {}
-}
-
-// EnsureChildSpan is the same as EnsureContext, except it creates a child
-// Span for the input context if the input context already has an active
-// trace.
+// EnsureChildSpan looks at the supplied Context. If it contains a Span, returns
+// a child span via the WithParentAndAutoCollection option; otherwise starts a
+// new Span. In both cases, a context wrapping the Span is returned along with
+// the newly created Span.
 //
 // The caller is responsible for closing the Span (via Span.Finish).
 func EnsureChildSpan(ctx context.Context, tracer *Tracer, name string) (context.Context, *Span) {

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -16,6 +16,7 @@ import (
 	"math/rand"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 	"unsafe"
@@ -203,8 +204,28 @@ func (t *Tracer) getShadowTracer() *shadowTracer {
 	return (*shadowTracer)(atomic.LoadPointer(&t.shadowTracer))
 }
 
+// noCtx is a singleton that we use internally to unify code paths that only
+// optionally take a Context. The specific construction here does not matter,
+// the only thing we need is that no outside caller could ever pass this
+// context in (i.e. we can't use context.Background() and the like), and that
+// we can compare it directly.
+var noCtx context.Context = &struct{ context.Context }{context.Background()}
+
 // StartSpan starts a Span. See SpanOption for details.
 func (t *Tracer) StartSpan(operationName string, os ...SpanOption) *Span {
+	_, sp := t.StartSpanCtx(noCtx, operationName, os...)
+	return sp
+}
+
+// StartSpanCtx starts a Span and returns it alongside a wrapping Context
+// derived from the supplied Context. Any log tags found in the supplied
+// Context are propagated into the Span; this behavior can be modified by
+// passing WithLogTags explicitly.
+//
+// See SpanOption for other options that can be passed.
+func (t *Tracer) StartSpanCtx(
+	ctx context.Context, operationName string, os ...SpanOption,
+) (context.Context, *Span) {
 	// NB: apply takes and returns a value to avoid forcing
 	// `opts` on the heap here.
 	var opts spanOptions
@@ -212,7 +233,7 @@ func (t *Tracer) StartSpan(operationName string, os ...SpanOption) *Span {
 		opts = o.apply(opts)
 	}
 
-	return t.startSpanGeneric(operationName, opts)
+	return t.startSpanGeneric(ctx, operationName, opts)
 }
 
 func (t *Tracer) mode() mode {
@@ -226,8 +247,38 @@ func (t *Tracer) AlwaysTrace() bool {
 	return t.useNetTrace() || shadowTracer != nil
 }
 
-// startSpanGeneric is the implementation of StartSpan.
-func (t *Tracer) startSpanGeneric(opName string, opts spanOptions) *Span {
+// maybeWrapCtx returns a Context wrapping the Span, with two exceptions:
+// 1. if ctx==noCtx, it's a noop
+// 2. if ctx contains the noop Span, and sp is also the noop Span, elide
+//    allocating a new Context.
+func maybeWrapCtx(ctx context.Context, sp *Span) (context.Context, *Span) {
+	if ctx == noCtx {
+		return noCtx, sp
+	}
+	// NB: we check sp != nil explicitly because some callers want to remove a
+	// Span from a Context, and thus pass nil.
+	if sp != nil && sp.isNoop() {
+		// If the context originally had the noop span, and we would now be wrapping
+		// the noop span in it again, we don't have to wrap at all and can save an
+		// allocation.
+		//
+		// Note that applying this optimization for a nontrivial ctxSp would
+		// constitute a bug: A real, non-recording span might later start recording.
+		// Besides, the caller expects to get their own span, and will .Finish() it,
+		// leading to an extra, premature call to Finish().
+		if ctxSp := SpanFromContext(ctx); ctxSp != nil && ctxSp.isNoop() {
+			return ctx, sp
+		}
+	}
+	return context.WithValue(ctx, activeSpanKey{}, sp), sp
+}
+
+// startSpanGeneric is the implementation of StartSpanCtx and StartSpan. In
+// the latter case, ctx == noCtx and the returned Context is the supplied one;
+// otherwise the returned Context reflects the returned Span.
+func (t *Tracer) startSpanGeneric(
+	ctx context.Context, opName string, opts spanOptions,
+) (context.Context, *Span) {
 	if opts.RefType != opentracing.ChildOfRef && opts.RefType != opentracing.FollowsFromRef {
 		panic(fmt.Sprintf("unexpected RefType %v", opts.RefType))
 	}
@@ -241,6 +292,9 @@ func (t *Tracer) startSpanGeneric(opName string, opts spanOptions) *Span {
 	if t.mode() == modeBackground {
 		opts.ForceRealSpan = true
 	}
+	if opts.LogTags == nil {
+		opts.LogTags = logtags.FromContext(ctx)
+	}
 
 	// Avoid creating a real span when possible. If tracing is globally
 	// enabled, we always need to create spans. If the incoming
@@ -251,7 +305,7 @@ func (t *Tracer) startSpanGeneric(opName string, opts spanOptions) *Span {
 	if !t.AlwaysTrace() &&
 		opts.recordingType() == RecordingOff &&
 		!opts.ForceRealSpan {
-		return t.noopSpan
+		return maybeWrapCtx(ctx, t.noopSpan)
 	}
 
 	if opts.LogTags == nil && opts.Parent != nil && !opts.Parent.isNoop() {
@@ -388,7 +442,7 @@ func (t *Tracer) startSpanGeneric(opName string, opts spanOptions) *Span {
 		}
 	}
 
-	return s
+	return maybeWrapCtx(ctx, s)
 }
 
 type textMapWriterFn func(key, val string)
@@ -564,16 +618,13 @@ func (t *Tracer) Extract(format interface{}, carrier interface{}) (*SpanMeta, er
 //
 // See also ChildSpan() for a "parent-child relationship".
 func ForkCtxSpan(ctx context.Context, opName string) (context.Context, *Span) {
-	if sp := SpanFromContext(ctx); sp != nil {
-		if sp.isNoop() {
-			// Optimization: avoid ContextWithSpan call if tracing is disabled.
-			return ctx, sp
-		}
-		tr := sp.Tracer()
-		newSpan := tr.StartSpan(opName, WithParentAndAutoCollection(sp), WithCtxLogTags(ctx))
-		return ContextWithSpan(ctx, newSpan), newSpan
+	sp := SpanFromContext(ctx)
+	if sp == nil {
+		return ctx, nil
 	}
-	return ctx, nil
+	return sp.Tracer().StartSpanCtx(
+		ctx, opName, WithParentAndAutoCollection(sp), WithFollowsFrom(),
+	)
 }
 
 // ChildSpan opens a Span as a child of the current Span in the context (if
@@ -583,41 +634,22 @@ func ForkCtxSpan(ctx context.Context, opName string) (context.Context, *Span) {
 // Returns the new context and the new Span (if any). If a non-nil Span is
 // returned, it is the caller's duty to eventually call Finish() on it.
 func ChildSpan(ctx context.Context, opName string) (context.Context, *Span) {
-	return childSpan(ctx, opName, false /* remote */)
+	sp := SpanFromContext(ctx)
+	if sp == nil {
+		return ctx, nil
+	}
+	return sp.Tracer().StartSpanCtx(ctx, opName, WithParentAndAutoCollection(sp))
 }
 
 // ChildSpanRemote is like ChildSpan but the new Span is created using WithParentAndManualCollection
 // instead of WithParentAndAutoCollection. When this is used, it's the caller's duty to collect this span's
 // recording and return it to the root span of the trace.
 func ChildSpanRemote(ctx context.Context, opName string) (context.Context, *Span) {
-	return childSpan(ctx, opName, true /* remote */)
-}
-
-func childSpan(ctx context.Context, opName string, remote bool) (context.Context, *Span) {
 	sp := SpanFromContext(ctx)
 	if sp == nil {
 		return ctx, nil
 	}
-	tr := sp.Tracer()
-	var opts spanOptions
-	opts.LogTags = logtags.FromContext(ctx)
-	// NB: this code is correct when sp == nil.
-	if !remote {
-		opts.Parent = sp
-	} else {
-		opts.RemoteParent = sp.Meta()
-	}
-	newSpan := tr.startSpanGeneric(opName, opts)
-	if sp.isNoop() && newSpan.isNoop() {
-		// Optimization: if we started and end up with a noop, we can return
-		// the original context to save on the ContextWithSpan alloc. Note
-		// that it is important that the incoming span was the noop span. If
-		// it was a real, non-recording span, it might later start recording.
-		// Besides, the caller expects to get their own span, and will
-		// .Finish() it, leading to an extra, premature call to Finish().
-		return ctx, sp
-	}
-	return ContextWithSpan(ctx, newSpan), newSpan
+	return sp.Tracer().StartSpanCtx(ctx, opName, WithParentAndManualCollection(sp.Meta()))
 }
 
 // EnsureChildSpan looks at the supplied Context. If it contains a Span, returns
@@ -626,12 +658,30 @@ func childSpan(ctx context.Context, opName string, remote bool) (context.Context
 // the newly created Span.
 //
 // The caller is responsible for closing the Span (via Span.Finish).
-func EnsureChildSpan(ctx context.Context, tracer *Tracer, name string) (context.Context, *Span) {
-	if SpanFromContext(ctx) == nil {
-		sp := tracer.StartSpan(name, WithCtxLogTags(ctx))
-		return ContextWithSpan(ctx, sp), sp
+func EnsureChildSpan(
+	ctx context.Context, tr *Tracer, name string, os ...SpanOption,
+) (context.Context, *Span) {
+	slp := optsPool.Get().(*[]SpanOption)
+	*slp = append(*slp, WithParentAndAutoCollection(SpanFromContext(ctx)))
+	*slp = append(*slp, os...)
+	ctx, sp := tr.StartSpanCtx(ctx, name, *slp...)
+	// Clear and zero-length the slice. Note that we have to clear
+	// explicitly or the options will continue to be referenced by
+	// the slice.
+	for i := range *slp {
+		(*slp)[i] = nil
 	}
-	return ChildSpan(ctx, name)
+	*slp = (*slp)[0:0:cap(*slp)]
+	optsPool.Put(slp)
+	return ctx, sp
+}
+
+var optsPool = sync.Pool{
+	New: func() interface{} {
+		// It is unusual to pass more than 5 SpanOptions.
+		sl := make([]SpanOption, 0, 5)
+		return &sl
+	},
 }
 
 type activeSpanKey struct{}
@@ -647,27 +697,19 @@ func SpanFromContext(ctx context.Context) *Span {
 
 // ContextWithSpan returns a Context wrapping the supplied Span.
 func ContextWithSpan(ctx context.Context, sp *Span) context.Context {
-	return context.WithValue(ctx, activeSpanKey{}, sp)
+	ctx, _ = maybeWrapCtx(ctx, sp)
+	return ctx
 }
 
 // StartVerboseTrace takes in a context and returns a derived one with a
 // Span in it that is recording verbosely. The caller takes ownership of
 // this Span from the returned context and is in charge of Finish()ing it.
 //
-// TODO(andrei): remove this method once EXPLAIN(TRACE) is gone.
-func StartVerboseTrace(
-	ctx context.Context, tracer *Tracer, opName string,
-) (context.Context, *Span) {
-	var span *Span
-	if sp := SpanFromContext(ctx); sp != nil {
-		span = sp.Tracer().StartSpan(
-			opName, WithParentAndAutoCollection(sp), WithForceRealSpan(), WithCtxLogTags(ctx),
-		)
-	} else {
-		span = tracer.StartSpan(opName, WithForceRealSpan(), WithCtxLogTags(ctx))
-	}
-	span.SetVerbose(true)
-	return ContextWithSpan(ctx, span), span
+// TODO(tbg): remove this method. It adds very little over EnsureChildSpan.
+func StartVerboseTrace(ctx context.Context, tr *Tracer, opName string) (context.Context, *Span) {
+	ctx, sp := EnsureChildSpan(ctx, tr, opName, WithForceRealSpan())
+	sp.SetVerbose(true)
+	return ctx, sp
 }
 
 // ContextWithRecordingSpan returns a context with an embedded trace Span which
@@ -679,12 +721,11 @@ func StartVerboseTrace(
 // Recording.String(). Tests can also use FindMsgInRecording().
 func ContextWithRecordingSpan(
 	ctx context.Context, opName string,
-) (retCtx context.Context, getRecording func() Recording, cancel func()) {
+) (_ context.Context, getRecording func() Recording, cancel func()) {
 	tr := NewTracer()
-	sp := tr.StartSpan(opName, WithForceRealSpan(), WithCtxLogTags(ctx))
+	ctx, sp := tr.StartSpanCtx(ctx, opName, WithForceRealSpan())
 	sp.SetVerbose(true)
 	ctx, cancelCtx := context.WithCancel(ctx)
-	ctx = ContextWithSpan(ctx, sp)
 
 	cancel = func() {
 		cancelCtx()


### PR DESCRIPTION
Prior to this commit, the Tracer dealt only with Spans directly and any
kind of context wrapping had to be done out-of-band via a number of
helper methods.
This isn't ideal from a performance point of view. Context wrapping
figures prominently in the allocation overhead of tracing, so we ought
to be able to optimize it.

To this end, Tracer gets a StartSpanCtx method that internalizes the
context handling and will make it more straightforward to optimize.
StartSpanCtx also automates the propagation of log tags from the
incoming Context to the created Spans, reducing the number of options
passed in the common case. In particular, the WithCtxLogTags option was
removed.

The StartSpanCtx method was applied to the codebase where it was
straightforward. As far as I can tell, this includes all Spans created
in the critical path, so we should expect to see a measurable decrease
in allocation overhead related to ContextWithSpan once we add an
optimization to (the impl of) StartSpanCtx that allocates the wrapping
Context together with the Span.

A quick check via

```
go test -benchtime 1000x -benchmem -bench 'BenchmarkScan/MultinodeCockroach/count=1$/limit=1$' -memprofilerate 1 -memprofile branch.prof ./pkg/bench/
```

shows that we are saving a few allocations already as a result of this change (down from ~811/op on master to ~807/op here).

Release note: None
