### PR TITLE
roachtest,roachprod: Use new --log flag, fix parameterRE in expander

### DIFF
--- a/pkg/cmd/roachprod/install/expander.go
+++ b/pkg/cmd/roachprod/install/expander.go
@@ -18,7 +18,7 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-var parameterRe = regexp.MustCompile(`{[^}]*}`)
+var parameterRe = regexp.MustCompile(`{[^{}]*}`)
 var pgURLRe = regexp.MustCompile(`{pgurl(:[-,0-9]+)?}`)
 var pgHostRe = regexp.MustCompile(`{pghost(:[-,0-9]+)?}`)
 var pgPortRe = regexp.MustCompile(`{pgport(:[-,0-9]+)?}`)

--- a/pkg/cmd/roachtest/disk_stall.go
+++ b/pkg/cmd/roachtest/disk_stall.go
@@ -104,7 +104,7 @@ func runDiskStalledDetection(
 		t.WorkerStatus("running server")
 		out, err := c.RunWithBuffer(ctx, l, n,
 			fmt.Sprintf("timeout --signal 9 %ds env COCKROACH_ENGINE_MAX_SYNC_DURATION_DEFAULT=%s COCKROACH_LOG_MAX_SYNC_DURATION=%s "+
-				"./cockroach start-single-node --insecure --logtostderr=INFO --store {store-dir}/%s --log-dir {store-dir}/%s",
+				"./cockroach start-single-node --insecure --store {store-dir}/%s --log '{sinks: {stderr: {filter: INFO}}, file-defaults: {dir: \"{store-dir}/%s\"}}'",
 				int(dur.Seconds()), maxDataSync, maxLogSync, dataDir, logDir,
 			),
 		)


### PR DESCRIPTION
Now that logging configuration is specified using --log, and
not using that flag adds excess output, it's more desirable
to move the disk-stalled roachtest to that flag.

Also fixes a bug in the regular expression expander
in roachprod, as that was conflicting with parts
of YAML arguments that it shouldn't be touching.

Fixes #58021.

Release note: None.