### PR TITLE
workload/schemachange: update sequence number initialization and getTableColumns  error handling

### DIFF
--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -1629,6 +1629,9 @@ func (og *operationGenerator) getTableColumns(
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
+	if len(ret) == 0 {
+		return nil, pgx.ErrNoRows
+	}
 	for i := range ret {
 		c := &ret[i]
 		c.typ, err = og.typeFromTypeName(tx, typNames[i])

--- a/pkg/workload/schemachange/schemachange.go
+++ b/pkg/workload/schemachange/schemachange.go
@@ -173,9 +173,20 @@ func (s *schemaChange) initSeqNum(pool *workload.MultiConnPool) (*int64, error) 
 	seqNum := new(int64)
 
 	const q = `
-SELECT max(regexp_extract(name, '[0-9]+$')::int)
-  FROM ((SELECT table_name FROM [SHOW TABLES]) UNION (SELECT sequence_name FROM [SHOW SEQUENCES])) AS obj(name)
- WHERE name ~ '^(table|view|seq)[0-9]+$';
+SELECT max(regexp_extract(name, '[0-9]+$')::INT8)
+  FROM (
+    SELECT name
+      FROM (
+	           (SELECT table_name FROM [SHOW TABLES]) UNION
+						 (SELECT sequence_name FROM [SHOW SEQUENCES]) UNION
+						 (SELECT name FROM [SHOW ENUMS]) UNION
+	           (SELECT schema_name FROM [SHOW SCHEMAS]) UNION
+						 (SELECT column_name FROM information_schema.columns) UNION
+						 (SELECT index_name FROM information_schema.statistics)
+           ) AS obj (name)
+       )
+ WHERE name ~ '^(table|view|seq|enum|schema)[0-9]+$'
+    OR name ~ '^(col|index)[0-9]+_[0-9]+$';
 `
 	var max gosql.NullInt64
 	if err := pool.Get().QueryRow(q).Scan(&max); err != nil {


### PR DESCRIPTION
### workload/schemachange: update sequence number initialization

Previously, it was possible for the seqNum of operationGeneratorParams
to be initialized to an incorrect value. When the workload would start,
it would check all table names, view names, and sequence names to
determine the starting value of the sequence number. This change
updates this behavior to ensure that enum names, index names,
schema names, and column names are checked as well. This ensures
that the sequence number starts at an appropriate value each
time the workload starts. This value is important for uniqueness
assumptions when generating names throughout the workload.

Previously, failing to check the names of enums, indexes, schemas,
and columns to initialize the global sequence number would cause
seg faults as outlined in the issue below.

Closes: #58076

Release note: None

### workload/schemachange: return error when a table has no columns

Previously, unexpected syntax errors would occur if the workload
attempted to create an index on a table with no columns.
For example, the workload would generate a statements such as
`CREATE INDEX index2 ON table1 ()`, which are syntactically
invalid. This change updates the function `getTableColumns` to
return an error if a table has no columns to use when creating
an index. The workload will try to generate another operation
when it sees this error.

Release note: None
