### PR TITLE
sql: use "char" type for char columns in pg_catalog

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -465,40 +465,40 @@ JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
 WHERE n.nspname = 'public'
 ----
 relname       attname   atttypmod  attbyval  attstorage  attalign  attnotnull  atthasdef  attidentity  attgenerated
-t1            p         -1         NULL      NULL        NULL      true        false
-t1            a         -1         NULL      NULL        NULL      false       false
-t1            b         -1         NULL      NULL        NULL      false       false
-t1            c         -1         NULL      NULL        NULL      false       true
-t1            d         9          NULL      NULL        NULL      false       false
-t1            e         5          NULL      NULL        NULL      false       false
-t1            f         655371     NULL      NULL        NULL      false       false
-t1            g         -1         NULL      NULL        NULL      false       false                   s
-t1            h         16         NULL      NULL        NULL      false       false
-t1            i         24         NULL      NULL        NULL      false       false
-t1            j         -1         NULL      NULL        NULL      false       false
-t1            k         14         NULL      NULL        NULL      false       false
-primary       p         -1         NULL      NULL        NULL      true        false
-t1_a_key      a         -1         NULL      NULL        NULL      false       false
-index_key     b         -1         NULL      NULL        NULL      false       false
-index_key     c         -1         NULL      NULL        NULL      false       true
-t2            t1_id     -1         NULL      NULL        NULL      false       false
-t2            rowid     -1         NULL      NULL        NULL      true        true
-primary       rowid     -1         NULL      NULL        NULL      true        true
-t2_t1_id_idx  t1_id     -1         NULL      NULL        NULL      false       false
-t3            a         -1         NULL      NULL        NULL      false       false
-t3            b         -1         NULL      NULL        NULL      false       false
-t3            c         -1         NULL      NULL        NULL      false       true
-t3            rowid     -1         NULL      NULL        NULL      true        true
-primary       rowid     -1         NULL      NULL        NULL      true        true
-t3_a_b_idx    a         -1         NULL      NULL        NULL      false       false
-t3_a_b_idx    b         -1         NULL      NULL        NULL      false       false
-v1            p         -1         NULL      NULL        NULL      false       false
-v1            a         -1         NULL      NULL        NULL      false       false
-v1            b         -1         NULL      NULL        NULL      false       false
-v1            c         -1         NULL      NULL        NULL      false       false
-mv1           ?column?  -1         NULL      NULL        NULL      false       false
-mv1           rowid     -1         NULL      NULL        NULL      true        true
-primary       rowid     -1         NULL      NULL        NULL      true        true
+t1            p         -1         NULL      NULL        NULL      true        false      ·            ·
+t1            a         -1         NULL      NULL        NULL      false       false      ·            ·
+t1            b         -1         NULL      NULL        NULL      false       false      ·            ·
+t1            c         -1         NULL      NULL        NULL      false       true       ·            ·
+t1            d         9          NULL      NULL        NULL      false       false      ·            ·
+t1            e         5          NULL      NULL        NULL      false       false      ·            ·
+t1            f         655371     NULL      NULL        NULL      false       false      ·            ·
+t1            g         -1         NULL      NULL        NULL      false       false      ·            s
+t1            h         16         NULL      NULL        NULL      false       false      ·            ·
+t1            i         24         NULL      NULL        NULL      false       false      ·            ·
+t1            j         -1         NULL      NULL        NULL      false       false      ·            ·
+t1            k         14         NULL      NULL        NULL      false       false      ·            ·
+primary       p         -1         NULL      NULL        NULL      true        false      ·            ·
+t1_a_key      a         -1         NULL      NULL        NULL      false       false      ·            ·
+index_key     b         -1         NULL      NULL        NULL      false       false      ·            ·
+index_key     c         -1         NULL      NULL        NULL      false       true       ·            ·
+t2            t1_id     -1         NULL      NULL        NULL      false       false      ·            ·
+t2            rowid     -1         NULL      NULL        NULL      true        true       ·            ·
+primary       rowid     -1         NULL      NULL        NULL      true        true       ·            ·
+t2_t1_id_idx  t1_id     -1         NULL      NULL        NULL      false       false      ·            ·
+t3            a         -1         NULL      NULL        NULL      false       false      ·            ·
+t3            b         -1         NULL      NULL        NULL      false       false      ·            ·
+t3            c         -1         NULL      NULL        NULL      false       true       ·            ·
+t3            rowid     -1         NULL      NULL        NULL      true        true       ·            ·
+primary       rowid     -1         NULL      NULL        NULL      true        true       ·            ·
+t3_a_b_idx    a         -1         NULL      NULL        NULL      false       false      ·            ·
+t3_a_b_idx    b         -1         NULL      NULL        NULL      false       false      ·            ·
+v1            p         -1         NULL      NULL        NULL      false       false      ·            ·
+v1            a         -1         NULL      NULL        NULL      false       false      ·            ·
+v1            b         -1         NULL      NULL        NULL      false       false      ·            ·
+v1            c         -1         NULL      NULL        NULL      false       false      ·            ·
+mv1           ?column?  -1         NULL      NULL        NULL      false       false      ·            ·
+mv1           rowid     -1         NULL      NULL        NULL      true        true       ·            ·
+primary       rowid     -1         NULL      NULL        NULL      true        true       ·            ·
 
 query TTBBITTT colnames
 SELECT c.relname, attname, attisdropped, attislocal, attinhcount, attacl, attoptions, attfdwoptions
@@ -2902,3 +2902,16 @@ query TT
 SELECT pg_typeof(confkey), pg_typeof(conkey) FROM pg_constraint WHERE conname = 'fk_b_to_a'
 ----
 smallint[]  smallint[]
+
+# Postgres always uses "char" (oid=18) and not CHAR (oid=1042) for character
+# columns in pg_catalog. (Nor does it use CHAR[] (oid=1014).) See #57301.
+
+query I
+SELECT count(*)
+FROM pg_class c
+JOIN pg_attribute a ON a.attrelid = c.oid
+JOIN pg_type t ON t.oid = a.atttypid
+JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE n.nspname = 'pg_catalog' AND (t.oid = 1042 OR t.oid = 1014)
+----
+0

--- a/pkg/sql/vtable/pg_catalog.go
+++ b/pkg/sql/vtable/pg_catalog.go
@@ -50,7 +50,7 @@ CREATE TABLE pg_catalog.pg_am (
 	amcostestimate OID,
 	amoptions OID,
 	amhandler OID,
-	amtype CHAR
+	amtype "char"
 )`
 
 // PGCatalogAttrDef describes the schema of the pg_catalog.pg_attrdef table.
@@ -79,12 +79,12 @@ CREATE TABLE pg_catalog.pg_attribute (
 	attcacheoff INT4,
 	atttypmod INT4,
 	attbyval BOOL,
-	attstorage CHAR,
-	attalign CHAR,
+	attstorage "char",
+	attalign "char",
 	attnotnull BOOL,
 	atthasdef BOOL,
-	attidentity CHAR, 
-	attgenerated CHAR,
+	attidentity "char", 
+	attgenerated "char",
 	attisdropped BOOL,
 	attislocal BOOL,
 	attinhcount INT4,
@@ -103,8 +103,8 @@ CREATE TABLE pg_catalog.pg_cast (
 	castsource OID,
 	casttarget OID,
 	castfunc OID,
-	castcontext CHAR,
-	castmethod CHAR
+	castcontext "char",
+	castmethod "char"
 )`
 
 // PGCatalogAuthID describes the schema of the pg_catalog.pg_authid table.
@@ -166,9 +166,9 @@ CREATE TABLE pg_catalog.pg_class (
 	reltoastrelid OID,
 	relhasindex BOOL,
 	relisshared BOOL,
-	relpersistence CHAR,
+	relpersistence "char",
 	relistemp BOOL,
-	relkind CHAR,
+	relkind "char",
 	relnatts INT2,
 	relchecks INT2,
 	relhasoids BOOL,
@@ -274,7 +274,7 @@ CREATE TABLE pg_catalog.pg_default_acl (
 	oid OID,
 	defaclrole OID,
 	defaclnamespace OID,
-	defaclobjtype CHAR,
+	defaclobjtype "char",
 	defaclacl STRING[]
 )`
 
@@ -288,7 +288,7 @@ CREATE TABLE pg_catalog.pg_depend (
   refclassid OID,
   refobjid OID,
   refobjsubid INT4,
-  deptype CHAR
+  deptype "char"
 )`
 
 // PGCatalogDescription describes the schema of the pg_catalog.pg_description
@@ -331,7 +331,7 @@ CREATE TABLE pg_catalog.pg_event_trigger (
 	evtevent NAME,
 	evtowner OID,
 	evtfoid OID,
-	evtenabled CHAR,
+	evtenabled "char",
 	evttags TEXT[]
 )`
 
@@ -578,8 +578,8 @@ CREATE TABLE pg_catalog.pg_proc (
 	proleakproof BOOL,
 	proisstrict BOOL,
 	proretset BOOL,
-	provolatile CHAR,
-	proparallel CHAR,
+	provolatile "char",
+	proparallel "char",
 	pronargs INT2,
 	pronargdefaults INT2,
 	prorettype OID,
@@ -702,7 +702,7 @@ CREATE TABLE pg_catalog.pg_shdepend (
   objsubid INT4,
 	refclassid OID,
 	refobjid OID,
-	deptype CHAR
+	deptype "char"
 )`
 
 // PGCatalogTables describes the schema of the pg_catalog.pg_tables table.
@@ -766,11 +766,11 @@ CREATE TABLE pg_catalog.pg_type (
 	typowner OID,
 	typlen INT2,
 	typbyval BOOL,
-	typtype CHAR,
-	typcategory CHAR,
+	typtype "char",
+	typcategory "char",
 	typispreferred BOOL,
 	typisdefined BOOL,
-	typdelim CHAR,
+	typdelim "char",
 	typrelid OID,
 	typelem OID,
 	typarray OID,
@@ -781,8 +781,8 @@ CREATE TABLE pg_catalog.pg_type (
 	typmodin REGPROC,
 	typmodout REGPROC,
 	typanalyze REGPROC,
-	typalign CHAR,
-	typstorage CHAR,
+	typalign "char",
+	typstorage "char",
 	typnotnull BOOL,
 	typbasetype OID,
 	typtypmod INT4,
@@ -884,7 +884,7 @@ CREATE TABLE pg_catalog.pg_views (
 const PGCatalogAggregate = `
 CREATE TABLE pg_catalog.pg_aggregate (
 	aggfnoid REGPROC,
-	aggkind  CHAR,
+	aggkind  "char",
 	aggnumdirectargs INT2,
 	aggtransfn REGPROC,
 	aggfinalfn REGPROC,


### PR DESCRIPTION
fixes #57301 

Release note (bug fix, backward-incompatible change): The pg_catalog
metadata tables were using the CHAR data type for single-byte character
columns. Now they use the "char" data type, to match Postgres. This
resolves errors that would occur when using some drivers (like
tokio-postgres for Rust) to access pg_catalog tables in the binary query
format.