### PR TITLE
release-20.2: sql: fix SHOW GRANTS for DB-level privileges

### DIFF
--- a/pkg/ccl/backupccl/testdata/backup-restore/restore-grants
+++ b/pkg/ccl/backupccl/testdata/backup-restore/restore-grants
@@ -47,12 +47,18 @@ CREATE TABLE testdb.testtable_greeting_owner (a testdb.greeting_owner);
 
 # Check that the expected grants were given to user1.
 query-sql
-SELECT
-  database_name, schema_name, grantee, privilege_type
-FROM [SHOW GRANTS ON DATABASE testdb FOR user1]
-WHERE schema_name='public' OR schema_name='sc';
+SHOW GRANTS ON DATABASE testdb FOR user1;
 ----
 testdb public user1 ALL
+
+query-sql
+SHOW GRANTS ON SCHEMA public FOR user1;
+----
+testdb public user1 ALL
+
+query-sql
+SHOW GRANTS ON SCHEMA sc FOR user1;
+----
 testdb sc user1 USAGE
 
 query-sql
@@ -66,12 +72,18 @@ SHOW GRANTS ON TABLE testdb.testtable_simple FOR user1;
 
 # Check that the expected grants were given to testuser.
 query-sql
-SELECT
-  database_name, schema_name, grantee, privilege_type
-FROM [SHOW GRANTS ON DATABASE testdb FOR testuser]
-WHERE schema_name='public' OR schema_name='sc';
+SHOW GRANTS ON DATABASE testdb FOR testuser;
 ----
 testdb public testuser ALL
+
+query-sql
+SHOW GRANTS ON SCHEMA public FOR testuser;
+----
+testdb public testuser ALL
+
+query-sql
+SHOW GRANTS ON SCHEMA sc FOR testuser;
+----
 
 query-sql
 SHOW GRANTS ON TABLE testdb.testtable_greeting_usage FOR testuser;
@@ -139,17 +151,26 @@ RESTORE testdb.sc.othertable, testdb.testtable_greeting_usage FROM 'nodelocal://
 
 # Check that user1 doesn't have any privs, but testuser should be the owner.
 query-sql
-SELECT
-  database_name, schema_name, grantee, privilege_type
-FROM [SHOW GRANTS ON DATABASE testuser_db]
-WHERE schema_name='public' OR schema_name='sc';
+SHOW GRANTS ON DATABASE testuser_db;
 ----
 testuser_db public admin ALL
 testuser_db public root ALL
 testuser_db public testuser CREATE
-testuser_db sc admin ALL
-testuser_db sc root ALL
-testuser_db sc testuser CREATE
+
+query-sql
+SHOW GRANTS ON SCHEMA public;
+----
+testdb public admin ALL
+testdb public root ALL
+testdb public testuser ALL
+testdb public user1 ALL
+
+query-sql
+SHOW GRANTS ON SCHEMA sc;
+----
+testdb sc admin ALL
+testdb sc root ALL
+testdb sc user1 USAGE
 
 query-sql
 SHOW GRANTS ON testuser_db.sc.othertable
@@ -268,14 +289,27 @@ SHOW GRANTS ON testdb.sc.othertable FOR testuser;
 
 # Check that admin still has all the privs.
 query-sql
-SELECT
-  database_name, schema_name, grantee, privilege_type
-FROM [SHOW GRANTS ON DATABASE testdb FOR admin]
-WHERE schema_name='public' OR schema_name='sc';
+SHOW GRANTS ON DATABASE testdb FOR admin;
 ----
 testdb public admin ALL
+
+exec-sql
+USE testdb;
+----
+
+query-sql
+SHOW GRANTS ON SCHEMA public FOR admin;
+----
+testdb public admin ALL
+
+query-sql
+SHOW GRANTS ON SCHEMA sc FOR admin;
+----
 testdb sc admin ALL
 
+exec-sql
+USE defaultdb;
+----
 
 query-sql
 SHOW GRANTS ON TABLE testdb.testtable_simple FOR admin;
@@ -354,13 +388,27 @@ SHOW GRANTS ON testdb.sc.othertable FOR testuser;
 
 # Admin should still have all privs.
 query-sql
-SELECT
-  database_name, schema_name, grantee, privilege_type
-FROM [SHOW GRANTS ON DATABASE testdb FOR admin]
-WHERE schema_name='public' OR schema_name='sc';
+SHOW GRANTS ON DATABASE testdb FOR admin;
 ----
 testdb public admin ALL
+
+exec-sql
+USE testdb;
+----
+
+query-sql
+SHOW GRANTS ON SCHEMA public FOR admin;
+----
+testdb public admin ALL
+
+query-sql
+SHOW GRANTS ON SCHEMA sc FOR admin;
+----
 testdb sc admin ALL
+
+exec-sql
+USE defaultdb;
+----
 
 query-sql
 SHOW GRANTS ON TABLE testdb.testtable_simple FOR admin;
@@ -394,13 +442,27 @@ RESTORE FROM 'nodelocal://0/test/';
 
 # Check userr1.
 query-sql
-SELECT
-  database_name, schema_name, grantee, privilege_type
-FROM [SHOW GRANTS ON DATABASE testdb FOR user1]
-WHERE schema_name='public' OR schema_name='sc';
+SHOW GRANTS ON DATABASE testdb FOR user1;
 ----
 testdb public user1 ALL
+
+exec-sql
+USE testdb;
+----
+
+query-sql
+SHOW GRANTS ON SCHEMA public FOR user1;
+----
+testdb public user1 ALL
+
+query-sql
+SHOW GRANTS ON SCHEMA sc FOR user1;
+----
 testdb sc user1 USAGE
+
+exec-sql
+USE defaultdb;
+----
 
 query-sql
 SHOW GRANTS ON TABLE testdb.sc.othertable FOR user1;
@@ -413,12 +475,26 @@ SHOW GRANTS ON TABLE testdb.testtable_simple FOR user1;
 
 # Check testuser.
 query-sql
-SELECT
-  database_name, schema_name, grantee, privilege_type
-FROM [SHOW GRANTS ON DATABASE testdb FOR testuser]
-WHERE schema_name='public' OR schema_name='sc';
+SHOW GRANTS ON DATABASE testdb FOR testuser;
 ----
 testdb public testuser ALL
+
+exec-sql
+USE testdb;
+----
+
+query-sql
+SHOW GRANTS ON SCHEMA public FOR testuser;
+----
+testdb public testuser ALL
+
+query-sql
+SHOW GRANTS ON SCHEMA sc FOR testuser;
+----
+
+exec-sql
+USE defaultdb;
+----
 
 query-sql
 SHOW GRANTS ON TABLE testdb.testtable_greeting_usage FOR testuser;
@@ -445,13 +521,27 @@ ALTER TYPE testdb.greeting_owner ADD VALUE 'new' BEFORE 'howdy';
 
 # Check admin.
 query-sql
-SELECT
-  database_name, schema_name, grantee, privilege_type
-FROM [SHOW GRANTS ON DATABASE testdb FOR admin]
-WHERE schema_name='public' OR schema_name='sc';
+SHOW GRANTS ON DATABASE testdb FOR admin;
 ----
 testdb public admin ALL
+
+exec-sql
+USE testdb;
+----
+
+query-sql
+SHOW GRANTS ON SCHEMA public FOR admin;
+----
+testdb public admin ALL
+
+query-sql
+SHOW GRANTS ON SCHEMA sc FOR admin;
+----
 testdb sc admin ALL
+
+exec-sql
+USE defaultdb;
+----
 
 query-sql
 SHOW GRANTS ON TABLE testdb.testtable_simple FOR admin;

--- a/pkg/cli/testdata/zip/partial1
+++ b/pkg/cli/testdata/zip/partial1
@@ -10,6 +10,7 @@ requesting data for debug/events... writing: debug/events.json
 requesting data for debug/rangelog... writing: debug/rangelog.json
 requesting data for debug/settings... writing: debug/settings.json
 requesting data for debug/reports/problemranges... writing: debug/reports/problemranges.json
+retrieving SQL data for crdb_internal.cluster_database_privileges... writing: debug/crdb_internal.cluster_database_privileges.txt
 retrieving SQL data for crdb_internal.cluster_queries... writing: debug/crdb_internal.cluster_queries.txt
 retrieving SQL data for crdb_internal.cluster_sessions... writing: debug/crdb_internal.cluster_sessions.txt
 retrieving SQL data for crdb_internal.cluster_settings... writing: debug/crdb_internal.cluster_settings.txt

--- a/pkg/cli/testdata/zip/partial1_excluded
+++ b/pkg/cli/testdata/zip/partial1_excluded
@@ -10,6 +10,7 @@ requesting data for debug/events... writing: debug/events.json
 requesting data for debug/rangelog... writing: debug/rangelog.json
 requesting data for debug/settings... writing: debug/settings.json
 requesting data for debug/reports/problemranges... writing: debug/reports/problemranges.json
+retrieving SQL data for crdb_internal.cluster_database_privileges... writing: debug/crdb_internal.cluster_database_privileges.txt
 retrieving SQL data for crdb_internal.cluster_queries... writing: debug/crdb_internal.cluster_queries.txt
 retrieving SQL data for crdb_internal.cluster_sessions... writing: debug/crdb_internal.cluster_sessions.txt
 retrieving SQL data for crdb_internal.cluster_settings... writing: debug/crdb_internal.cluster_settings.txt

--- a/pkg/cli/testdata/zip/partial2
+++ b/pkg/cli/testdata/zip/partial2
@@ -10,6 +10,7 @@ requesting data for debug/events... writing: debug/events.json
 requesting data for debug/rangelog... writing: debug/rangelog.json
 requesting data for debug/settings... writing: debug/settings.json
 requesting data for debug/reports/problemranges... writing: debug/reports/problemranges.json
+retrieving SQL data for crdb_internal.cluster_database_privileges... writing: debug/crdb_internal.cluster_database_privileges.txt
 retrieving SQL data for crdb_internal.cluster_queries... writing: debug/crdb_internal.cluster_queries.txt
 retrieving SQL data for crdb_internal.cluster_sessions... writing: debug/crdb_internal.cluster_sessions.txt
 retrieving SQL data for crdb_internal.cluster_settings... writing: debug/crdb_internal.cluster_settings.txt

--- a/pkg/cli/testdata/zip/specialnames
+++ b/pkg/cli/testdata/zip/specialnames
@@ -1,5 +1,6 @@
 zip
 ----
+retrieving SQL data for crdb_internal.cluster_database_privileges... writing: debug/crdb_internal.cluster_database_privileges.txt
 requesting list of SQL databases... 8 found
 requesting database details for ../system... writing: debug/schema/___system@details.json
 0 tables found

--- a/pkg/cli/testdata/zip/testzip
+++ b/pkg/cli/testdata/zip/testzip
@@ -10,6 +10,7 @@ requesting data for debug/events... writing: debug/events.json
 requesting data for debug/rangelog... writing: debug/rangelog.json
 requesting data for debug/settings... writing: debug/settings.json
 requesting data for debug/reports/problemranges... writing: debug/reports/problemranges.json
+retrieving SQL data for crdb_internal.cluster_database_privileges... writing: debug/crdb_internal.cluster_database_privileges.txt
 retrieving SQL data for crdb_internal.cluster_queries... writing: debug/crdb_internal.cluster_queries.txt
 retrieving SQL data for crdb_internal.cluster_sessions... writing: debug/crdb_internal.cluster_sessions.txt
 retrieving SQL data for crdb_internal.cluster_settings... writing: debug/crdb_internal.cluster_settings.txt

--- a/pkg/cli/zip.go
+++ b/pkg/cli/zip.go
@@ -60,6 +60,7 @@ requires the cluster to be live.
 
 // Tables containing cluster-wide info that are collected in a debug zip.
 var debugZipTablesPerCluster = []string{
+	"crdb_internal.cluster_database_privileges",
 	"crdb_internal.cluster_queries",
 	"crdb_internal.cluster_sessions",
 	"crdb_internal.cluster_settings",

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -381,7 +381,7 @@ func TestAdminAPIDatabases(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if a, e := len(details.Grants), 2; a != e {
+			if a, e := len(details.Grants), 4; a != e {
 				t.Fatalf("# of grants %d != expected %d", a, e)
 			}
 

--- a/pkg/sql/catalog/catconstants/constants.go
+++ b/pkg/sql/catalog/catconstants/constants.go
@@ -74,6 +74,7 @@ const (
 	CrdbInternalTransactionStatsTableID
 	CrdbInternalTxnStatsTableID
 	CrdbInternalZonesTableID
+	CrdbInternalClusterDatabasePrivilegesTableID
 	InformationSchemaID
 	InformationSchemaAdministrableRoleAuthorizationsID
 	InformationSchemaApplicableRolesID

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -48,6 +48,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/roleoption"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemaexpr"
@@ -81,47 +82,48 @@ const CrdbInternalName = sessiondata.CRDBInternalSchemaName
 var crdbInternal = virtualSchema{
 	name: CrdbInternalName,
 	tableDefs: map[descpb.ID]virtualSchemaDef{
-		catconstants.CrdbInternalBackwardDependenciesTableID: crdbInternalBackwardDependenciesTable,
-		catconstants.CrdbInternalBuildInfoTableID:            crdbInternalBuildInfoTable,
-		catconstants.CrdbInternalBuiltinFunctionsTableID:     crdbInternalBuiltinFunctionsTable,
-		catconstants.CrdbInternalClusterQueriesTableID:       crdbInternalClusterQueriesTable,
-		catconstants.CrdbInternalClusterTransactionsTableID:  crdbInternalClusterTxnsTable,
-		catconstants.CrdbInternalClusterSessionsTableID:      crdbInternalClusterSessionsTable,
-		catconstants.CrdbInternalClusterSettingsTableID:      crdbInternalClusterSettingsTable,
-		catconstants.CrdbInternalCreateStmtsTableID:          crdbInternalCreateStmtsTable,
-		catconstants.CrdbInternalCreateTypeStmtsTableID:      crdbInternalCreateTypeStmtsTable,
-		catconstants.CrdbInternalDatabasesTableID:            crdbInternalDatabasesTable,
-		catconstants.CrdbInternalFeatureUsageID:              crdbInternalFeatureUsage,
-		catconstants.CrdbInternalForwardDependenciesTableID:  crdbInternalForwardDependenciesTable,
-		catconstants.CrdbInternalGossipNodesTableID:          crdbInternalGossipNodesTable,
-		catconstants.CrdbInternalGossipAlertsTableID:         crdbInternalGossipAlertsTable,
-		catconstants.CrdbInternalGossipLivenessTableID:       crdbInternalGossipLivenessTable,
-		catconstants.CrdbInternalGossipNetworkTableID:        crdbInternalGossipNetworkTable,
-		catconstants.CrdbInternalIndexColumnsTableID:         crdbInternalIndexColumnsTable,
-		catconstants.CrdbInternalJobsTableID:                 crdbInternalJobsTable,
-		catconstants.CrdbInternalKVNodeStatusTableID:         crdbInternalKVNodeStatusTable,
-		catconstants.CrdbInternalKVStoreStatusTableID:        crdbInternalKVStoreStatusTable,
-		catconstants.CrdbInternalLeasesTableID:               crdbInternalLeasesTable,
-		catconstants.CrdbInternalLocalQueriesTableID:         crdbInternalLocalQueriesTable,
-		catconstants.CrdbInternalLocalTransactionsTableID:    crdbInternalLocalTxnsTable,
-		catconstants.CrdbInternalLocalSessionsTableID:        crdbInternalLocalSessionsTable,
-		catconstants.CrdbInternalLocalMetricsTableID:         crdbInternalLocalMetricsTable,
-		catconstants.CrdbInternalPartitionsTableID:           crdbInternalPartitionsTable,
-		catconstants.CrdbInternalPredefinedCommentsTableID:   crdbInternalPredefinedCommentsTable,
-		catconstants.CrdbInternalRangesNoLeasesTableID:       crdbInternalRangesNoLeasesTable,
-		catconstants.CrdbInternalRangesViewID:                crdbInternalRangesView,
-		catconstants.CrdbInternalRuntimeInfoTableID:          crdbInternalRuntimeInfoTable,
-		catconstants.CrdbInternalSchemaChangesTableID:        crdbInternalSchemaChangesTable,
-		catconstants.CrdbInternalSessionTraceTableID:         crdbInternalSessionTraceTable,
-		catconstants.CrdbInternalSessionVariablesTableID:     crdbInternalSessionVariablesTable,
-		catconstants.CrdbInternalStmtStatsTableID:            crdbInternalStmtStatsTable,
-		catconstants.CrdbInternalTableColumnsTableID:         crdbInternalTableColumnsTable,
-		catconstants.CrdbInternalTableIndexesTableID:         crdbInternalTableIndexesTable,
-		catconstants.CrdbInternalTablesTableLastStatsID:      crdbInternalTablesTableLastStats,
-		catconstants.CrdbInternalTablesTableID:               crdbInternalTablesTable,
-		catconstants.CrdbInternalTransactionStatsTableID:     crdbInternalTransactionStatisticsTable,
-		catconstants.CrdbInternalTxnStatsTableID:             crdbInternalTxnStatsTable,
-		catconstants.CrdbInternalZonesTableID:                crdbInternalZonesTable,
+		catconstants.CrdbInternalBackwardDependenciesTableID:      crdbInternalBackwardDependenciesTable,
+		catconstants.CrdbInternalBuildInfoTableID:                 crdbInternalBuildInfoTable,
+		catconstants.CrdbInternalBuiltinFunctionsTableID:          crdbInternalBuiltinFunctionsTable,
+		catconstants.CrdbInternalClusterQueriesTableID:            crdbInternalClusterQueriesTable,
+		catconstants.CrdbInternalClusterTransactionsTableID:       crdbInternalClusterTxnsTable,
+		catconstants.CrdbInternalClusterSessionsTableID:           crdbInternalClusterSessionsTable,
+		catconstants.CrdbInternalClusterSettingsTableID:           crdbInternalClusterSettingsTable,
+		catconstants.CrdbInternalCreateStmtsTableID:               crdbInternalCreateStmtsTable,
+		catconstants.CrdbInternalCreateTypeStmtsTableID:           crdbInternalCreateTypeStmtsTable,
+		catconstants.CrdbInternalDatabasesTableID:                 crdbInternalDatabasesTable,
+		catconstants.CrdbInternalFeatureUsageID:                   crdbInternalFeatureUsage,
+		catconstants.CrdbInternalForwardDependenciesTableID:       crdbInternalForwardDependenciesTable,
+		catconstants.CrdbInternalGossipNodesTableID:               crdbInternalGossipNodesTable,
+		catconstants.CrdbInternalGossipAlertsTableID:              crdbInternalGossipAlertsTable,
+		catconstants.CrdbInternalGossipLivenessTableID:            crdbInternalGossipLivenessTable,
+		catconstants.CrdbInternalGossipNetworkTableID:             crdbInternalGossipNetworkTable,
+		catconstants.CrdbInternalIndexColumnsTableID:              crdbInternalIndexColumnsTable,
+		catconstants.CrdbInternalJobsTableID:                      crdbInternalJobsTable,
+		catconstants.CrdbInternalKVNodeStatusTableID:              crdbInternalKVNodeStatusTable,
+		catconstants.CrdbInternalKVStoreStatusTableID:             crdbInternalKVStoreStatusTable,
+		catconstants.CrdbInternalLeasesTableID:                    crdbInternalLeasesTable,
+		catconstants.CrdbInternalLocalQueriesTableID:              crdbInternalLocalQueriesTable,
+		catconstants.CrdbInternalLocalTransactionsTableID:         crdbInternalLocalTxnsTable,
+		catconstants.CrdbInternalLocalSessionsTableID:             crdbInternalLocalSessionsTable,
+		catconstants.CrdbInternalLocalMetricsTableID:              crdbInternalLocalMetricsTable,
+		catconstants.CrdbInternalPartitionsTableID:                crdbInternalPartitionsTable,
+		catconstants.CrdbInternalPredefinedCommentsTableID:        crdbInternalPredefinedCommentsTable,
+		catconstants.CrdbInternalRangesNoLeasesTableID:            crdbInternalRangesNoLeasesTable,
+		catconstants.CrdbInternalRangesViewID:                     crdbInternalRangesView,
+		catconstants.CrdbInternalRuntimeInfoTableID:               crdbInternalRuntimeInfoTable,
+		catconstants.CrdbInternalSchemaChangesTableID:             crdbInternalSchemaChangesTable,
+		catconstants.CrdbInternalSessionTraceTableID:              crdbInternalSessionTraceTable,
+		catconstants.CrdbInternalSessionVariablesTableID:          crdbInternalSessionVariablesTable,
+		catconstants.CrdbInternalStmtStatsTableID:                 crdbInternalStmtStatsTable,
+		catconstants.CrdbInternalTableColumnsTableID:              crdbInternalTableColumnsTable,
+		catconstants.CrdbInternalTableIndexesTableID:              crdbInternalTableIndexesTable,
+		catconstants.CrdbInternalTablesTableLastStatsID:           crdbInternalTablesTableLastStats,
+		catconstants.CrdbInternalTablesTableID:                    crdbInternalTablesTable,
+		catconstants.CrdbInternalTransactionStatsTableID:          crdbInternalTransactionStatisticsTable,
+		catconstants.CrdbInternalTxnStatsTableID:                  crdbInternalTxnStatsTable,
+		catconstants.CrdbInternalZonesTableID:                     crdbInternalZonesTable,
+		catconstants.CrdbInternalClusterDatabasePrivilegesTableID: crdbInternalClusterDatabasePrivilegesTable,
 	},
 	validWithNoDatabaseContext: true,
 }
@@ -3660,5 +3662,37 @@ CREATE TABLE crdb_internal.predefined_comments (
 		}
 
 		return nil
+	},
+}
+
+var crdbInternalClusterDatabasePrivilegesTable = virtualSchemaTable{
+	comment: `virtual table with database privileges`,
+	schema: `
+CREATE TABLE crdb_internal.cluster_database_privileges (
+	database_name   STRING NOT NULL,
+	grantee         STRING NOT NULL,
+	privilege_type  STRING NOT NULL
+)`,
+	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
+		return forEachDatabaseDesc(ctx, p, dbContext, true, /* requiresPrivileges */
+			func(db *dbdesc.Immutable) error {
+				privs := db.Privileges.Show(privilege.Database)
+				dbNameStr := tree.NewDString(db.GetName())
+				// TODO(knz): This should filter for the current user, see
+				// https://github.com/cockroachdb/cockroach/issues/35572
+				for _, u := range privs {
+					userNameStr := tree.NewDString(u.User)
+					for _, priv := range u.Privileges {
+						if err := addRow(
+							dbNameStr,             // database_name
+							userNameStr,           // grantee
+							tree.NewDString(priv), // privilege_type
+						); err != nil {
+							return err
+						}
+					}
+				}
+				return nil
+			})
 	},
 }

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -1125,7 +1125,7 @@ CREATE TABLE information_schema.schema_privileges (
 						privs = sc.Desc.GetPrivileges().Show(privilege.Schema)
 					} else {
 						// Other schemas inherit from the parent database.
-						privs = db.Privileges.Show(privilege.Schema)
+						privs = db.Privileges.Show(privilege.Database)
 					}
 					dbNameStr := tree.NewDString(db.GetName())
 					scNameStr := tree.NewDString(sc.Name)
@@ -1134,6 +1134,18 @@ CREATE TABLE information_schema.schema_privileges (
 					for _, u := range privs {
 						userNameStr := tree.NewDString(u.User)
 						for _, priv := range u.Privileges {
+							privKind := privilege.ByName[priv]
+							// Non-user defined schemas inherit privileges from the database,
+							// but the USAGE privilege is conferred by having SELECT privilege
+							// on the database. (There is no SELECT privilege on schemas.)
+							if sc.Kind != catalog.SchemaUserDefined {
+								if privKind == privilege.SELECT {
+									priv = privilege.USAGE.String()
+								} else if !privilege.SchemaPrivileges.Contains(privKind) {
+									continue
+								}
+							}
+
 							if err := addRow(
 								userNameStr,           // grantee
 								dbNameStr,             // table_catalog

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -1402,7 +1402,6 @@ ALTER TABLE t_cannot_rename_constraint_over_index RENAME CONSTRAINT v_unique TO 
 statement error relation idx_v already exists
 ALTER TABLE t_cannot_rename_constraint_over_index RENAME CONSTRAINT "primary" TO idx_v;
 
-# Regression for #54629.
 statement ok
 CREATE TABLE t54629 (c INT NOT NULL, UNIQUE INDEX (c));
 ALTER TABLE t54629 ADD CONSTRAINT pk PRIMARY KEY (c);

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -16,6 +16,7 @@ SHOW TABLES FROM crdb_internal
 ----
 crdb_internal  backward_dependencies        table  NULL  NULL
 crdb_internal  builtin_functions            table  NULL  NULL
+crdb_internal  cluster_database_privileges  table  NULL  NULL
 crdb_internal  cluster_queries              table  NULL  NULL
 crdb_internal  cluster_sessions             table  NULL  NULL
 crdb_internal  cluster_settings             table  NULL  NULL
@@ -690,3 +691,32 @@ node_id  application_name     key                   statement_ids               
 1        test_txn_statistics  7134109142904971730   {14727561584397653517}                                            1
 1        test_txn_statistics  7134109142904971742   {14727561584397653505}                                            1
 1        test_txn_statistics  10166963080898232577  {2484845987516053214}                                             1
+
+## crdb_internal.cluster_database_privileges
+subtest cluster_database_privileges
+
+statement ok
+CREATE DATABASE other_db; SET DATABASE = other_db
+
+query TTT colnames
+SELECT * FROM crdb_internal.cluster_database_privileges
+----
+database_name  grantee  privilege_type
+other_db       admin    ALL
+other_db       root     ALL
+
+statement ok
+GRANT SELECT ON DATABASE other_db TO testuser;
+GRANT DROP ON DATABASE other_db TO testuser
+
+query TTT colnames
+SELECT * FROM crdb_internal.cluster_database_privileges
+----
+database_name  grantee   privilege_type
+other_db       admin     ALL
+other_db       root      ALL
+other_db       testuser  DROP
+other_db       testuser  SELECT
+
+statement ok
+SET DATABASE = test

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal_tenant
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal_tenant
@@ -25,6 +25,7 @@ SHOW TABLES FROM crdb_internal
 ----
 crdb_internal  backward_dependencies        table  NULL  NULL
 crdb_internal  builtin_functions            table  NULL  NULL
+crdb_internal  cluster_database_privileges  table  NULL  NULL
 crdb_internal  cluster_queries              table  NULL  NULL
 crdb_internal  cluster_sessions             table  NULL  NULL
 crdb_internal  cluster_settings             table  NULL  NULL
@@ -64,7 +65,6 @@ crdb_internal  table_indexes                table  NULL  NULL
 crdb_internal  table_row_statistics         table  NULL  NULL
 crdb_internal  tables                       table  NULL  NULL
 crdb_internal  zones                        table  NULL  NULL
-
 
 statement ok
 CREATE DATABASE testdb; CREATE TABLE testdb.foo(x INT)

--- a/pkg/sql/logictest/testdata/logic_test/grant_database
+++ b/pkg/sql/logictest/testdata/logic_test/grant_database
@@ -8,17 +8,9 @@ CREATE DATABASE a
 query TTTT colnames
 SHOW GRANTS ON DATABASE a
 ----
-database_name  schema_name         grantee  privilege_type
-a              crdb_internal       admin    ALL
-a              crdb_internal       root     ALL
-a              information_schema  admin    ALL
-a              information_schema  root     ALL
-a              pg_catalog          admin    ALL
-a              pg_catalog          root     ALL
-a              pg_extension        admin    ALL
-a              pg_extension        root     ALL
-a              public              admin    ALL
-a              public              root     ALL
+database_name  schema_name  grantee  privilege_type
+a              public       admin    ALL
+a              public       root     ALL
 
 statement error user root must have exactly ALL privileges on system database with ID=.*
 REVOKE SELECT ON DATABASE a FROM root
@@ -47,26 +39,10 @@ REVOKE SELECT,ALL ON DATABASE a FROM readwrite
 query TTTT
 SHOW GRANTS ON DATABASE a
 ----
-a  crdb_internal       admin      ALL
-a  crdb_internal       readwrite  ALL
-a  crdb_internal       root       ALL
-a  crdb_internal       test-user  ALL
-a  information_schema  admin      ALL
-a  information_schema  readwrite  ALL
-a  information_schema  root       ALL
-a  information_schema  test-user  ALL
-a  pg_catalog          admin      ALL
-a  pg_catalog          readwrite  ALL
-a  pg_catalog          root       ALL
-a  pg_catalog          test-user  ALL
-a  pg_extension        admin      ALL
-a  pg_extension        readwrite  ALL
-a  pg_extension        root       ALL
-a  pg_extension        test-user  ALL
-a  public              admin      ALL
-a  public              readwrite  ALL
-a  public              root       ALL
-a  public              test-user  ALL
+a  public  admin      ALL
+a  public  readwrite  ALL
+a  public  root       ALL
+a  public  test-user  ALL
 
 # Create table to inherit DB permissions.
 statement ok
@@ -84,16 +60,8 @@ a              public       t           test-user  ALL
 query TTTT
 SHOW GRANTS ON DATABASE a FOR readwrite, "test-user"
 ----
-a  crdb_internal       readwrite  ALL
-a  crdb_internal       test-user  ALL
-a  information_schema  readwrite  ALL
-a  information_schema  test-user  ALL
-a  pg_catalog          readwrite  ALL
-a  pg_catalog          test-user  ALL
-a  pg_extension        readwrite  ALL
-a  pg_extension        test-user  ALL
-a  public              readwrite  ALL
-a  public              test-user  ALL
+a  public  readwrite  ALL
+a  public  test-user  ALL
 
 statement ok
 REVOKE INSERT,UPDATE ON DATABASE a FROM "test-user",readwrite
@@ -101,60 +69,36 @@ REVOKE INSERT,UPDATE ON DATABASE a FROM "test-user",readwrite
 query TTTT
 SHOW GRANTS ON DATABASE a
 ----
-a  crdb_internal       admin      ALL
-a  crdb_internal       readwrite  CREATE
-a  crdb_internal       readwrite  GRANT
-a  crdb_internal       root       ALL
-a  crdb_internal       test-user  CREATE
-a  crdb_internal       test-user  GRANT
-a  information_schema  admin      ALL
-a  information_schema  readwrite  CREATE
-a  information_schema  readwrite  GRANT
-a  information_schema  root       ALL
-a  information_schema  test-user  CREATE
-a  information_schema  test-user  GRANT
-a  pg_catalog          admin      ALL
-a  pg_catalog          readwrite  CREATE
-a  pg_catalog          readwrite  GRANT
-a  pg_catalog          root       ALL
-a  pg_catalog          test-user  CREATE
-a  pg_catalog          test-user  GRANT
-a  pg_extension        admin      ALL
-a  pg_extension        readwrite  CREATE
-a  pg_extension        readwrite  GRANT
-a  pg_extension        root       ALL
-a  pg_extension        test-user  CREATE
-a  pg_extension        test-user  GRANT
-a  public              admin      ALL
-a  public              readwrite  CREATE
-a  public              readwrite  GRANT
-a  public              root       ALL
-a  public              test-user  CREATE
-a  public              test-user  GRANT
+a  public  admin      ALL
+a  public  readwrite  CREATE
+a  public  readwrite  DELETE
+a  public  readwrite  DROP
+a  public  readwrite  GRANT
+a  public  readwrite  SELECT
+a  public  readwrite  ZONECONFIG
+a  public  root       ALL
+a  public  test-user  CREATE
+a  public  test-user  DELETE
+a  public  test-user  DROP
+a  public  test-user  GRANT
+a  public  test-user  SELECT
+a  public  test-user  ZONECONFIG
 
 query TTTT
 SHOW GRANTS ON DATABASE a FOR readwrite, "test-user"
 ----
-a  crdb_internal       readwrite  CREATE
-a  crdb_internal       readwrite  GRANT
-a  crdb_internal       test-user  CREATE
-a  crdb_internal       test-user  GRANT
-a  information_schema  readwrite  CREATE
-a  information_schema  readwrite  GRANT
-a  information_schema  test-user  CREATE
-a  information_schema  test-user  GRANT
-a  pg_catalog          readwrite  CREATE
-a  pg_catalog          readwrite  GRANT
-a  pg_catalog          test-user  CREATE
-a  pg_catalog          test-user  GRANT
-a  pg_extension        readwrite  CREATE
-a  pg_extension        readwrite  GRANT
-a  pg_extension        test-user  CREATE
-a  pg_extension        test-user  GRANT
-a  public              readwrite  CREATE
-a  public              readwrite  GRANT
-a  public              test-user  CREATE
-a  public              test-user  GRANT
+a  public  readwrite  CREATE
+a  public  readwrite  DELETE
+a  public  readwrite  DROP
+a  public  readwrite  GRANT
+a  public  readwrite  SELECT
+a  public  readwrite  ZONECONFIG
+a  public  test-user  CREATE
+a  public  test-user  DELETE
+a  public  test-user  DROP
+a  public  test-user  GRANT
+a  public  test-user  SELECT
+a  public  test-user  ZONECONFIG
 
 statement ok
 REVOKE SELECT ON DATABASE a FROM "test-user"
@@ -162,36 +106,19 @@ REVOKE SELECT ON DATABASE a FROM "test-user"
 query TTTT
 SHOW GRANTS ON DATABASE a
 ----
-a  crdb_internal       admin      ALL
-a  crdb_internal       readwrite  CREATE
-a  crdb_internal       readwrite  GRANT
-a  crdb_internal       root       ALL
-a  crdb_internal       test-user  CREATE
-a  crdb_internal       test-user  GRANT
-a  information_schema  admin      ALL
-a  information_schema  readwrite  CREATE
-a  information_schema  readwrite  GRANT
-a  information_schema  root       ALL
-a  information_schema  test-user  CREATE
-a  information_schema  test-user  GRANT
-a  pg_catalog          admin      ALL
-a  pg_catalog          readwrite  CREATE
-a  pg_catalog          readwrite  GRANT
-a  pg_catalog          root       ALL
-a  pg_catalog          test-user  CREATE
-a  pg_catalog          test-user  GRANT
-a  pg_extension        admin      ALL
-a  pg_extension        readwrite  CREATE
-a  pg_extension        readwrite  GRANT
-a  pg_extension        root       ALL
-a  pg_extension        test-user  CREATE
-a  pg_extension        test-user  GRANT
-a  public              admin      ALL
-a  public              readwrite  CREATE
-a  public              readwrite  GRANT
-a  public              root       ALL
-a  public              test-user  CREATE
-a  public              test-user  GRANT
+a  public  admin      ALL
+a  public  readwrite  CREATE
+a  public  readwrite  DELETE
+a  public  readwrite  DROP
+a  public  readwrite  GRANT
+a  public  readwrite  SELECT
+a  public  readwrite  ZONECONFIG
+a  public  root       ALL
+a  public  test-user  CREATE
+a  public  test-user  DELETE
+a  public  test-user  DROP
+a  public  test-user  GRANT
+a  public  test-user  ZONECONFIG
 
 statement ok
 REVOKE ALL ON DATABASE a FROM "test-user"
@@ -199,16 +126,12 @@ REVOKE ALL ON DATABASE a FROM "test-user"
 query TTTT
 SHOW GRANTS ON DATABASE a FOR readwrite, "test-user"
 ----
-a  crdb_internal       readwrite  CREATE
-a  crdb_internal       readwrite  GRANT
-a  information_schema  readwrite  CREATE
-a  information_schema  readwrite  GRANT
-a  pg_catalog          readwrite  CREATE
-a  pg_catalog          readwrite  GRANT
-a  pg_extension        readwrite  CREATE
-a  pg_extension        readwrite  GRANT
-a  public              readwrite  CREATE
-a  public              readwrite  GRANT
+a  public  readwrite  CREATE
+a  public  readwrite  DELETE
+a  public  readwrite  DROP
+a  public  readwrite  GRANT
+a  public  readwrite  SELECT
+a  public  readwrite  ZONECONFIG
 
 statement ok
 REVOKE ALL ON DATABASE a FROM readwrite,"test-user"
@@ -216,16 +139,8 @@ REVOKE ALL ON DATABASE a FROM readwrite,"test-user"
 query TTTT
 SHOW GRANTS ON DATABASE a
 ----
-a  crdb_internal       admin  ALL
-a  crdb_internal       root   ALL
-a  information_schema  admin  ALL
-a  information_schema  root   ALL
-a  pg_catalog          admin  ALL
-a  pg_catalog          root   ALL
-a  pg_extension        admin  ALL
-a  pg_extension        root   ALL
-a  public              admin  ALL
-a  public              root   ALL
+a  public  admin  ALL
+a  public  root   ALL
 
 query TTTT
 SHOW GRANTS ON DATABASE a FOR readwrite, "test-user"

--- a/pkg/sql/logictest/testdata/logic_test/grant_table
+++ b/pkg/sql/logictest/testdata/logic_test/grant_table
@@ -12,32 +12,23 @@ GRANT ALL ON DATABASE a TO readwrite
 query TTTT colnames
 SHOW GRANTS ON DATABASE a
 ----
-database_name  schema_name         grantee    privilege_type
-a              crdb_internal       admin      ALL
-a              crdb_internal       readwrite  ALL
-a              crdb_internal       root       ALL
-a              information_schema  admin      ALL
-a              information_schema  readwrite  ALL
-a              information_schema  root       ALL
-a              pg_catalog          admin      ALL
-a              pg_catalog          readwrite  ALL
-a              pg_catalog          root       ALL
-a              pg_extension        admin      ALL
-a              pg_extension        readwrite  ALL
-a              pg_extension        root       ALL
-a              public              admin      ALL
-a              public              readwrite  ALL
-a              public              root       ALL
+database_name  schema_name  grantee    privilege_type
+a              public       admin      ALL
+a              public       readwrite  ALL
+a              public       root       ALL
 
 # Show that by default GRANT is restricted to the current database
 query TTTTT colnames
 SHOW GRANTS
 ----
 database_name  schema_name         relation_name                      grantee  privilege_type
+test           NULL                NULL                               admin    ALL
+test           NULL                NULL                               root     ALL
 test           crdb_internal       NULL                               admin    ALL
 test           crdb_internal       NULL                               root     ALL
 test           crdb_internal       backward_dependencies              public   SELECT
 test           crdb_internal       builtin_functions                  public   SELECT
+test           crdb_internal       cluster_database_privileges        public   SELECT
 test           crdb_internal       cluster_queries                    public   SELECT
 test           crdb_internal       cluster_sessions                   public   SELECT
 test           crdb_internal       cluster_settings                   public   SELECT
@@ -392,6 +383,7 @@ query TTTTT colnames
 SHOW GRANTS FOR root
 ----
 database_name  schema_name         relation_name   grantee  privilege_type
+test           NULL                NULL            root     ALL
 test           crdb_internal       NULL            root     ALL
 test           information_schema  NULL            root     ALL
 test           pg_catalog          NULL            root     ALL
@@ -489,285 +481,289 @@ a              pg_extension  NULL                             root       ALL
 a              pg_extension  geography_columns                public     SELECT
 a              pg_extension  geometry_columns                 public     SELECT
 a              pg_extension  spatial_ref_sys                  public     SELECT
+a              public        NULL                             readwrite  ALL
 a              public        NULL                             admin      ALL
 a              public        NULL                             root       ALL
-a              public        NULL                             readwrite  ALL
 defaultdb      pg_extension  NULL                             admin      ALL
 defaultdb      pg_extension  NULL                             root       ALL
 defaultdb      pg_extension  geography_columns                public     SELECT
 defaultdb      pg_extension  geometry_columns                 public     SELECT
 defaultdb      pg_extension  spatial_ref_sys                  public     SELECT
-defaultdb      public        NULL                             root       ALL
 defaultdb      public        NULL                             admin      ALL
-postgres       pg_extension  NULL                             admin      ALL
+defaultdb      public        NULL                             root       ALL
 postgres       pg_extension  NULL                             root       ALL
+postgres       pg_extension  NULL                             admin      ALL
 postgres       pg_extension  geography_columns                public     SELECT
 postgres       pg_extension  geometry_columns                 public     SELECT
 postgres       pg_extension  spatial_ref_sys                  public     SELECT
-postgres       public        NULL                             admin      ALL
 postgres       public        NULL                             root       ALL
+postgres       public        NULL                             admin      ALL
 system         pg_extension  NULL                             admin      GRANT
+system         pg_extension  NULL                             root       USAGE
 system         pg_extension  NULL                             root       GRANT
+system         pg_extension  NULL                             admin      USAGE
 system         pg_extension  geography_columns                public     SELECT
 system         pg_extension  geometry_columns                 public     SELECT
 system         pg_extension  spatial_ref_sys                  public     SELECT
-system         public        NULL                             root       GRANT
 system         public        NULL                             admin      GRANT
-system         public        comments                         admin      DELETE
-system         public        comments                         root       SELECT
+system         public        NULL                             admin      USAGE
+system         public        NULL                             root       USAGE
+system         public        NULL                             root       GRANT
 system         public        comments                         root       UPDATE
-system         public        comments                         root       INSERT
-system         public        comments                         root       GRANT
-system         public        comments                         root       DELETE
-system         public        comments                         public     SELECT
-system         public        comments                         admin      UPDATE
-system         public        comments                         admin      SELECT
 system         public        comments                         admin      GRANT
+system         public        comments                         root       SELECT
+system         public        comments                         root       DELETE
+system         public        comments                         admin      UPDATE
 system         public        comments                         admin      INSERT
+system         public        comments                         admin      DELETE
+system         public        comments                         root       INSERT
+system         public        comments                         admin      SELECT
+system         public        comments                         public     SELECT
+system         public        comments                         root       GRANT
 system         public        descriptor                       admin      GRANT
-system         public        descriptor                       admin      SELECT
-system         public        descriptor                       root       GRANT
 system         public        descriptor                       root       SELECT
+system         public        descriptor                       root       GRANT
+system         public        descriptor                       admin      SELECT
 system         public        eventlog                         admin      GRANT
-system         public        eventlog                         admin      UPDATE
-system         public        eventlog                         admin      SELECT
 system         public        eventlog                         root       UPDATE
-system         public        eventlog                         root       INSERT
-system         public        eventlog                         root       DELETE
-system         public        eventlog                         root       SELECT
-system         public        eventlog                         admin      INSERT
 system         public        eventlog                         root       GRANT
 system         public        eventlog                         admin      DELETE
+system         public        eventlog                         admin      UPDATE
+system         public        eventlog                         root       DELETE
+system         public        eventlog                         admin      SELECT
+system         public        eventlog                         admin      INSERT
+system         public        eventlog                         root       SELECT
+system         public        eventlog                         root       INSERT
+system         public        jobs                             admin      INSERT
+system         public        jobs                             admin      UPDATE
+system         public        jobs                             root       SELECT
+system         public        jobs                             root       INSERT
+system         public        jobs                             root       GRANT
+system         public        jobs                             admin      SELECT
 system         public        jobs                             root       DELETE
 system         public        jobs                             admin      DELETE
-system         public        jobs                             root       GRANT
 system         public        jobs                             admin      GRANT
-system         public        jobs                             root       INSERT
-system         public        jobs                             admin      SELECT
-system         public        jobs                             admin      UPDATE
 system         public        jobs                             root       UPDATE
-system         public        jobs                             root       SELECT
-system         public        jobs                             admin      INSERT
-system         public        lease                            admin      SELECT
-system         public        lease                            root       UPDATE
-system         public        lease                            root       INSERT
-system         public        lease                            root       GRANT
-system         public        lease                            root       SELECT
-system         public        lease                            admin      UPDATE
 system         public        lease                            admin      INSERT
 system         public        lease                            admin      GRANT
-system         public        lease                            admin      DELETE
+system         public        lease                            root       UPDATE
+system         public        lease                            root       SELECT
+system         public        lease                            root       GRANT
 system         public        lease                            root       DELETE
-system         public        locations                        root       INSERT
-system         public        locations                        admin      DELETE
-system         public        locations                        admin      GRANT
-system         public        locations                        admin      INSERT
-system         public        locations                        admin      SELECT
-system         public        locations                        admin      UPDATE
-system         public        locations                        root       DELETE
-system         public        locations                        root       GRANT
-system         public        locations                        root       SELECT
+system         public        lease                            admin      UPDATE
+system         public        lease                            admin      SELECT
+system         public        lease                            admin      DELETE
+system         public        lease                            root       INSERT
 system         public        locations                        root       UPDATE
-system         public        namespace                        admin      GRANT
-system         public        namespace                        root       GRANT
-system         public        namespace                        root       SELECT
+system         public        locations                        root       SELECT
+system         public        locations                        root       INSERT
+system         public        locations                        root       GRANT
+system         public        locations                        root       DELETE
+system         public        locations                        admin      UPDATE
+system         public        locations                        admin      SELECT
+system         public        locations                        admin      INSERT
+system         public        locations                        admin      GRANT
+system         public        locations                        admin      DELETE
 system         public        namespace                        admin      SELECT
-system         public        namespace2                       admin      SELECT
+system         public        namespace                        root       GRANT
+system         public        namespace                        admin      GRANT
+system         public        namespace                        root       SELECT
 system         public        namespace2                       root       SELECT
 system         public        namespace2                       root       GRANT
 system         public        namespace2                       admin      GRANT
-system         public        protected_ts_meta                root       SELECT
+system         public        namespace2                       admin      SELECT
 system         public        protected_ts_meta                admin      GRANT
 system         public        protected_ts_meta                admin      SELECT
+system         public        protected_ts_meta                root       SELECT
 system         public        protected_ts_meta                root       GRANT
-system         public        protected_ts_records             root       SELECT
-system         public        protected_ts_records             admin      SELECT
-system         public        protected_ts_records             admin      GRANT
 system         public        protected_ts_records             root       GRANT
-system         public        rangelog                         root       SELECT
-system         public        rangelog                         admin      INSERT
+system         public        protected_ts_records             admin      GRANT
+system         public        protected_ts_records             admin      SELECT
+system         public        protected_ts_records             root       SELECT
 system         public        rangelog                         admin      UPDATE
+system         public        rangelog                         admin      SELECT
 system         public        rangelog                         admin      GRANT
 system         public        rangelog                         root       DELETE
-system         public        rangelog                         root       UPDATE
-system         public        rangelog                         admin      DELETE
-system         public        rangelog                         admin      SELECT
 system         public        rangelog                         root       GRANT
 system         public        rangelog                         root       INSERT
-system         public        replication_constraint_stats     root       UPDATE
-system         public        replication_constraint_stats     admin      INSERT
-system         public        replication_constraint_stats     admin      SELECT
-system         public        replication_constraint_stats     admin      GRANT
-system         public        replication_constraint_stats     root       DELETE
-system         public        replication_constraint_stats     root       GRANT
-system         public        replication_constraint_stats     root       INSERT
+system         public        rangelog                         root       SELECT
+system         public        rangelog                         admin      DELETE
+system         public        rangelog                         admin      INSERT
+system         public        rangelog                         root       UPDATE
 system         public        replication_constraint_stats     root       SELECT
-system         public        replication_constraint_stats     admin      DELETE
+system         public        replication_constraint_stats     root       INSERT
+system         public        replication_constraint_stats     root       GRANT
+system         public        replication_constraint_stats     root       DELETE
 system         public        replication_constraint_stats     admin      UPDATE
-system         public        replication_critical_localities  admin      UPDATE
+system         public        replication_constraint_stats     admin      SELECT
+system         public        replication_constraint_stats     admin      INSERT
+system         public        replication_constraint_stats     root       UPDATE
+system         public        replication_constraint_stats     admin      DELETE
+system         public        replication_constraint_stats     admin      GRANT
+system         public        replication_critical_localities  root       GRANT
+system         public        replication_critical_localities  admin      DELETE
+system         public        replication_critical_localities  root       INSERT
+system         public        replication_critical_localities  root       SELECT
+system         public        replication_critical_localities  admin      GRANT
+system         public        replication_critical_localities  root       UPDATE
 system         public        replication_critical_localities  admin      INSERT
 system         public        replication_critical_localities  admin      SELECT
-system         public        replication_critical_localities  admin      DELETE
+system         public        replication_critical_localities  admin      UPDATE
 system         public        replication_critical_localities  root       DELETE
-system         public        replication_critical_localities  root       UPDATE
-system         public        replication_critical_localities  root       SELECT
-system         public        replication_critical_localities  root       INSERT
-system         public        replication_critical_localities  admin      GRANT
-system         public        replication_critical_localities  root       GRANT
-system         public        replication_stats                root       DELETE
-system         public        replication_stats                admin      INSERT
-system         public        replication_stats                root       UPDATE
-system         public        replication_stats                admin      UPDATE
-system         public        replication_stats                admin      GRANT
 system         public        replication_stats                admin      SELECT
-system         public        replication_stats                root       INSERT
-system         public        replication_stats                admin      DELETE
 system         public        replication_stats                root       SELECT
+system         public        replication_stats                admin      DELETE
+system         public        replication_stats                admin      GRANT
+system         public        replication_stats                root       DELETE
+system         public        replication_stats                admin      UPDATE
 system         public        replication_stats                root       GRANT
+system         public        replication_stats                root       UPDATE
+system         public        replication_stats                admin      INSERT
+system         public        replication_stats                root       INSERT
+system         public        reports_meta                     admin      DELETE
 system         public        reports_meta                     root       INSERT
 system         public        reports_meta                     root       SELECT
-system         public        reports_meta                     root       UPDATE
 system         public        reports_meta                     admin      UPDATE
 system         public        reports_meta                     admin      SELECT
-system         public        reports_meta                     root       GRANT
+system         public        reports_meta                     root       UPDATE
 system         public        reports_meta                     admin      INSERT
-system         public        reports_meta                     admin      DELETE
 system         public        reports_meta                     admin      GRANT
 system         public        reports_meta                     root       DELETE
-system         public        role_members                     root       INSERT
-system         public        role_members                     root       GRANT
-system         public        role_members                     root       DELETE
-system         public        role_members                     admin      UPDATE
-system         public        role_members                     admin      SELECT
-system         public        role_members                     admin      GRANT
+system         public        reports_meta                     root       GRANT
 system         public        role_members                     admin      DELETE
+system         public        role_members                     admin      GRANT
 system         public        role_members                     admin      INSERT
-system         public        role_members                     root       SELECT
+system         public        role_members                     admin      SELECT
+system         public        role_members                     root       DELETE
+system         public        role_members                     root       GRANT
+system         public        role_members                     root       INSERT
 system         public        role_members                     root       UPDATE
+system         public        role_members                     root       SELECT
+system         public        role_members                     admin      UPDATE
+system         public        role_options                     admin      UPDATE
+system         public        role_options                     root       GRANT
+system         public        role_options                     root       DELETE
+system         public        role_options                     admin      DELETE
+system         public        role_options                     admin      GRANT
+system         public        role_options                     admin      INSERT
+system         public        role_options                     root       INSERT
 system         public        role_options                     root       SELECT
 system         public        role_options                     root       UPDATE
-system         public        role_options                     admin      INSERT
 system         public        role_options                     admin      SELECT
-system         public        role_options                     admin      UPDATE
-system         public        role_options                     admin      GRANT
-system         public        role_options                     admin      DELETE
-system         public        role_options                     root       DELETE
-system         public        role_options                     root       GRANT
-system         public        role_options                     root       INSERT
-system         public        scheduled_jobs                   admin      GRANT
+system         public        scheduled_jobs                   admin      INSERT
 system         public        scheduled_jobs                   root       UPDATE
 system         public        scheduled_jobs                   admin      DELETE
+system         public        scheduled_jobs                   root       SELECT
+system         public        scheduled_jobs                   admin      GRANT
 system         public        scheduled_jobs                   root       INSERT
 system         public        scheduled_jobs                   root       GRANT
 system         public        scheduled_jobs                   root       DELETE
-system         public        scheduled_jobs                   admin      UPDATE
 system         public        scheduled_jobs                   admin      SELECT
-system         public        scheduled_jobs                   admin      INSERT
-system         public        scheduled_jobs                   root       SELECT
-system         public        settings                         admin      SELECT
-system         public        settings                         root       SELECT
-system         public        settings                         root       UPDATE
-system         public        settings                         admin      INSERT
+system         public        scheduled_jobs                   admin      UPDATE
 system         public        settings                         root       DELETE
+system         public        settings                         root       INSERT
+system         public        settings                         root       SELECT
 system         public        settings                         admin      DELETE
 system         public        settings                         admin      GRANT
+system         public        settings                         admin      INSERT
+system         public        settings                         admin      SELECT
+system         public        settings                         root       UPDATE
 system         public        settings                         admin      UPDATE
 system         public        settings                         root       GRANT
-system         public        settings                         root       INSERT
+system         public        sqlliveness                      admin      SELECT
+system         public        sqlliveness                      admin      UPDATE
+system         public        sqlliveness                      admin      GRANT
+system         public        sqlliveness                      root       DELETE
 system         public        sqlliveness                      root       GRANT
 system         public        sqlliveness                      admin      DELETE
-system         public        sqlliveness                      admin      INSERT
-system         public        sqlliveness                      admin      SELECT
-system         public        sqlliveness                      root       INSERT
 system         public        sqlliveness                      root       SELECT
 system         public        sqlliveness                      root       UPDATE
-system         public        sqlliveness                      admin      GRANT
-system         public        sqlliveness                      admin      UPDATE
-system         public        sqlliveness                      root       DELETE
-system         public        statement_bundle_chunks          admin      DELETE
-system         public        statement_bundle_chunks          admin      GRANT
-system         public        statement_bundle_chunks          admin      INSERT
-system         public        statement_bundle_chunks          admin      UPDATE
-system         public        statement_bundle_chunks          root       DELETE
-system         public        statement_bundle_chunks          root       INSERT
+system         public        sqlliveness                      root       INSERT
+system         public        sqlliveness                      admin      INSERT
 system         public        statement_bundle_chunks          root       SELECT
-system         public        statement_bundle_chunks          root       UPDATE
+system         public        statement_bundle_chunks          root       INSERT
+system         public        statement_bundle_chunks          root       DELETE
+system         public        statement_bundle_chunks          admin      UPDATE
 system         public        statement_bundle_chunks          admin      SELECT
 system         public        statement_bundle_chunks          root       GRANT
-system         public        statement_diagnostics            admin      GRANT
-system         public        statement_diagnostics            root       UPDATE
+system         public        statement_bundle_chunks          admin      INSERT
+system         public        statement_bundle_chunks          root       UPDATE
+system         public        statement_bundle_chunks          admin      DELETE
+system         public        statement_bundle_chunks          admin      GRANT
 system         public        statement_diagnostics            root       SELECT
-system         public        statement_diagnostics            root       INSERT
 system         public        statement_diagnostics            root       GRANT
-system         public        statement_diagnostics            admin      DELETE
 system         public        statement_diagnostics            root       DELETE
 system         public        statement_diagnostics            admin      UPDATE
-system         public        statement_diagnostics            admin      INSERT
 system         public        statement_diagnostics            admin      SELECT
-system         public        statement_diagnostics_requests   admin      GRANT
+system         public        statement_diagnostics            admin      INSERT
+system         public        statement_diagnostics            admin      GRANT
+system         public        statement_diagnostics            admin      DELETE
+system         public        statement_diagnostics            root       UPDATE
+system         public        statement_diagnostics            root       INSERT
+system         public        statement_diagnostics_requests   admin      SELECT
 system         public        statement_diagnostics_requests   root       UPDATE
 system         public        statement_diagnostics_requests   root       SELECT
+system         public        statement_diagnostics_requests   root       INSERT
 system         public        statement_diagnostics_requests   root       GRANT
-system         public        statement_diagnostics_requests   root       DELETE
+system         public        statement_diagnostics_requests   admin      DELETE
 system         public        statement_diagnostics_requests   admin      UPDATE
 system         public        statement_diagnostics_requests   admin      INSERT
-system         public        statement_diagnostics_requests   admin      SELECT
-system         public        statement_diagnostics_requests   admin      DELETE
-system         public        statement_diagnostics_requests   root       INSERT
-system         public        table_statistics                 admin      UPDATE
-system         public        table_statistics                 admin      SELECT
-system         public        table_statistics                 admin      GRANT
+system         public        statement_diagnostics_requests   root       DELETE
+system         public        statement_diagnostics_requests   admin      GRANT
 system         public        table_statistics                 root       SELECT
+system         public        table_statistics                 admin      UPDATE
+system         public        table_statistics                 admin      DELETE
+system         public        table_statistics                 admin      INSERT
+system         public        table_statistics                 admin      SELECT
 system         public        table_statistics                 root       INSERT
 system         public        table_statistics                 root       GRANT
-system         public        table_statistics                 admin      DELETE
-system         public        table_statistics                 root       DELETE
-system         public        table_statistics                 admin      INSERT
 system         public        table_statistics                 root       UPDATE
+system         public        table_statistics                 admin      GRANT
+system         public        table_statistics                 root       DELETE
 system         public        tenants                          root       SELECT
 system         public        tenants                          root       GRANT
-system         public        tenants                          admin      GRANT
 system         public        tenants                          admin      SELECT
-system         public        ui                               admin      SELECT
-system         public        ui                               root       GRANT
-system         public        ui                               admin      INSERT
-system         public        ui                               root       DELETE
+system         public        tenants                          admin      GRANT
 system         public        ui                               admin      GRANT
 system         public        ui                               root       SELECT
 system         public        ui                               root       UPDATE
-system         public        ui                               root       INSERT
-system         public        ui                               admin      UPDATE
 system         public        ui                               admin      DELETE
-system         public        users                            admin      DELETE
-system         public        users                            root       INSERT
-system         public        users                            root       GRANT
-system         public        users                            root       DELETE
-system         public        users                            root       UPDATE
-system         public        users                            admin      UPDATE
-system         public        users                            admin      INSERT
-system         public        users                            admin      GRANT
-system         public        users                            root       SELECT
+system         public        ui                               admin      UPDATE
+system         public        ui                               admin      SELECT
+system         public        ui                               root       INSERT
+system         public        ui                               root       DELETE
+system         public        ui                               root       GRANT
+system         public        ui                               admin      INSERT
 system         public        users                            admin      SELECT
-system         public        web_sessions                     admin      DELETE
+system         public        users                            admin      GRANT
+system         public        users                            admin      DELETE
+system         public        users                            admin      UPDATE
+system         public        users                            root       DELETE
+system         public        users                            root       GRANT
+system         public        users                            root       INSERT
+system         public        users                            admin      INSERT
+system         public        users                            root       UPDATE
+system         public        users                            root       SELECT
 system         public        web_sessions                     admin      SELECT
-system         public        web_sessions                     admin      GRANT
-system         public        web_sessions                     admin      INSERT
+system         public        web_sessions                     root       UPDATE
 system         public        web_sessions                     root       SELECT
-system         public        web_sessions                     root       INSERT
+system         public        web_sessions                     admin      INSERT
 system         public        web_sessions                     root       GRANT
 system         public        web_sessions                     root       DELETE
-system         public        web_sessions                     root       UPDATE
+system         public        web_sessions                     admin      GRANT
+system         public        web_sessions                     admin      DELETE
+system         public        web_sessions                     root       INSERT
 system         public        web_sessions                     admin      UPDATE
-system         public        zones                            admin      SELECT
-system         public        zones                            admin      DELETE
-system         public        zones                            admin      INSERT
-system         public        zones                            admin      UPDATE
-system         public        zones                            root       DELETE
 system         public        zones                            root       UPDATE
-system         public        zones                            root       INSERT
+system         public        zones                            admin      UPDATE
+system         public        zones                            admin      INSERT
+system         public        zones                            admin      SELECT
+system         public        zones                            root       DELETE
 system         public        zones                            root       GRANT
-system         public        zones                            root       SELECT
 system         public        zones                            admin      GRANT
+system         public        zones                            root       SELECT
+system         public        zones                            admin      DELETE
+system         public        zones                            root       INSERT
 test           pg_extension  NULL                             admin      ALL
 test           pg_extension  NULL                             root       ALL
 test           pg_extension  geography_columns                public     SELECT
@@ -780,6 +776,7 @@ query TTTTT colnames
 SHOW GRANTS FOR root
 ----
 database_name  schema_name         relation_name                    grantee  privilege_type
+a              NULL                NULL                             root     ALL
 a              crdb_internal       NULL                             root     ALL
 a              information_schema  NULL                             root     ALL
 a              pg_catalog          NULL                             root     ALL
@@ -860,6 +857,7 @@ a              pg_catalog          varchar                          root     ALL
 a              pg_catalog          varchar[]                        root     ALL
 a              pg_extension        NULL                             root     ALL
 a              public              NULL                             root     ALL
+defaultdb      NULL                NULL                             root     ALL
 defaultdb      crdb_internal       NULL                             root     ALL
 defaultdb      information_schema  NULL                             root     ALL
 defaultdb      pg_catalog          NULL                             root     ALL
@@ -940,6 +938,7 @@ defaultdb      pg_catalog          varchar                          root     ALL
 defaultdb      pg_catalog          varchar[]                        root     ALL
 defaultdb      pg_extension        NULL                             root     ALL
 defaultdb      public              NULL                             root     ALL
+postgres       NULL                NULL                             root     ALL
 postgres       crdb_internal       NULL                             root     ALL
 postgres       information_schema  NULL                             root     ALL
 postgres       pg_catalog          NULL                             root     ALL
@@ -1020,9 +1019,14 @@ postgres       pg_catalog          varchar                          root     ALL
 postgres       pg_catalog          varchar[]                        root     ALL
 postgres       pg_extension        NULL                             root     ALL
 postgres       public              NULL                             root     ALL
+system         NULL                NULL                             root     GRANT
+system         NULL                NULL                             root     SELECT
 system         crdb_internal       NULL                             root     GRANT
+system         crdb_internal       NULL                             root     USAGE
 system         information_schema  NULL                             root     GRANT
+system         information_schema  NULL                             root     USAGE
 system         pg_catalog          NULL                             root     GRANT
+system         pg_catalog          NULL                             root     USAGE
 system         pg_catalog          ·                                root     ALL
 system         pg_catalog          "char"                           root     ALL
 system         pg_catalog          "char"[]                         root     ALL
@@ -1099,7 +1103,9 @@ system         pg_catalog          varbit[]                         root     ALL
 system         pg_catalog          varchar                          root     ALL
 system         pg_catalog          varchar[]                        root     ALL
 system         pg_extension        NULL                             root     GRANT
+system         pg_extension        NULL                             root     USAGE
 system         public              NULL                             root     GRANT
+system         public              NULL                             root     USAGE
 system         public              comments                         root     DELETE
 system         public              comments                         root     GRANT
 system         public              comments                         root     INSERT
@@ -1227,6 +1233,7 @@ system         public              zones                            root     GRA
 system         public              zones                            root     INSERT
 system         public              zones                            root     SELECT
 system         public              zones                            root     UPDATE
+test           NULL                NULL                             root     ALL
 test           crdb_internal       NULL                             root     ALL
 test           information_schema  NULL                             root     ALL
 test           pg_catalog          NULL                             root     ALL
@@ -1560,6 +1567,7 @@ a  public  v  test-user  ZONECONFIG
 query TTTTT
 SHOW GRANTS FOR readwrite, "test-user"
 ----
+a  NULL                NULL  readwrite  ALL
 a  crdb_internal       NULL  readwrite  ALL
 a  information_schema  NULL  readwrite  ALL
 a  pg_catalog          NULL  readwrite  ALL
@@ -1593,6 +1601,7 @@ SHOW GRANTS ON v FOR readwrite, "test-user"
 query TTTTT
 SHOW GRANTS FOR readwrite, "test-user"
 ----
+a  NULL                NULL  readwrite  ALL
 a  crdb_internal       NULL  readwrite  ALL
 a  information_schema  NULL  readwrite  ALL
 a  pg_catalog          NULL  readwrite  ALL
@@ -1603,22 +1612,10 @@ a  public              NULL  readwrite  ALL
 query TTTT colnames
 SHOW GRANTS ON DATABASE a
 ----
-database_name  schema_name         grantee    privilege_type
-a              crdb_internal       admin      ALL
-a              crdb_internal       readwrite  ALL
-a              crdb_internal       root       ALL
-a              information_schema  admin      ALL
-a              information_schema  readwrite  ALL
-a              information_schema  root       ALL
-a              pg_catalog          admin      ALL
-a              pg_catalog          readwrite  ALL
-a              pg_catalog          root       ALL
-a              pg_extension        admin      ALL
-a              pg_extension        readwrite  ALL
-a              pg_extension        root       ALL
-a              public              admin      ALL
-a              public              readwrite  ALL
-a              public              root       ALL
+database_name  schema_name  grantee    privilege_type
+a              public       admin      ALL
+a              public       readwrite  ALL
+a              public       root       ALL
 
 
 # Errors due to invalid targets.

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -223,6 +223,7 @@ select table_schema, table_name FROM information_schema.tables
 ----
 crdb_internal       backward_dependencies
 crdb_internal       builtin_functions
+crdb_internal       cluster_database_privileges
 crdb_internal       cluster_queries
 crdb_internal       cluster_sessions
 crdb_internal       cluster_settings
@@ -376,6 +377,7 @@ SELECT table_name FROM "".information_schema.tables WHERE table_catalog = 'other
 ----
 backward_dependencies
 builtin_functions
+cluster_database_privileges
 cluster_queries
 cluster_sessions
 cluster_settings
@@ -548,6 +550,7 @@ SELECT * FROM system.information_schema.tables
 table_catalog  table_schema        table_name                         table_type   is_insertable_into  version
 system         crdb_internal       backward_dependencies              SYSTEM VIEW  NO                  1
 system         crdb_internal       builtin_functions                  SYSTEM VIEW  NO                  1
+system         crdb_internal       cluster_database_privileges        SYSTEM VIEW  NO                  1
 system         crdb_internal       cluster_queries                    SYSTEM VIEW  NO                  1
 system         crdb_internal       cluster_sessions                   SYSTEM VIEW  NO                  1
 system         crdb_internal       cluster_settings                   SYSTEM VIEW  NO                  1
@@ -1614,6 +1617,9 @@ DROP DATABASE constraint_column CASCADE
 statement ok
 CREATE DATABASE other_db; SET DATABASE = other_db
 
+statement ok
+CREATE SCHEMA other_schema
+
 query TTTTT colnames
 SELECT * FROM information_schema.schema_privileges
 ----
@@ -1622,6 +1628,8 @@ admin    other_db       crdb_internal       ALL             NULL
 root     other_db       crdb_internal       ALL             NULL
 admin    other_db       information_schema  ALL             NULL
 root     other_db       information_schema  ALL             NULL
+admin    other_db       other_schema        ALL             NULL
+root     other_db       other_schema        ALL             NULL
 admin    other_db       pg_catalog          ALL             NULL
 root     other_db       pg_catalog          ALL             NULL
 admin    other_db       pg_extension        ALL             NULL
@@ -1638,14 +1646,47 @@ SELECT * FROM information_schema.schema_privileges
 grantee   table_catalog  table_schema        privilege_type  is_grantable
 admin     other_db       crdb_internal       ALL             NULL
 root      other_db       crdb_internal       ALL             NULL
+testuser  other_db       crdb_internal       USAGE           NULL
 admin     other_db       information_schema  ALL             NULL
 root      other_db       information_schema  ALL             NULL
+testuser  other_db       information_schema  USAGE           NULL
+admin     other_db       other_schema        ALL             NULL
+root      other_db       other_schema        ALL             NULL
 admin     other_db       pg_catalog          ALL             NULL
 root      other_db       pg_catalog          ALL             NULL
+testuser  other_db       pg_catalog          USAGE           NULL
 admin     other_db       pg_extension        ALL             NULL
 root      other_db       pg_extension        ALL             NULL
+testuser  other_db       pg_extension        USAGE           NULL
 admin     other_db       public              ALL             NULL
 root      other_db       public              ALL             NULL
+testuser  other_db       public              USAGE           NULL
+
+statement ok
+GRANT CREATE ON SCHEMA other_schema TO testuser
+
+query TTTTT colnames
+SELECT * FROM information_schema.schema_privileges
+----
+grantee   table_catalog  table_schema        privilege_type  is_grantable
+admin     other_db       crdb_internal       ALL             NULL
+root      other_db       crdb_internal       ALL             NULL
+testuser  other_db       crdb_internal       USAGE           NULL
+admin     other_db       information_schema  ALL             NULL
+root      other_db       information_schema  ALL             NULL
+testuser  other_db       information_schema  USAGE           NULL
+admin     other_db       other_schema        ALL             NULL
+root      other_db       other_schema        ALL             NULL
+testuser  other_db       other_schema        CREATE          NULL
+admin     other_db       pg_catalog          ALL             NULL
+root      other_db       pg_catalog          ALL             NULL
+testuser  other_db       pg_catalog          USAGE           NULL
+admin     other_db       pg_extension        ALL             NULL
+root      other_db       pg_extension        ALL             NULL
+testuser  other_db       pg_extension        USAGE           NULL
+admin     other_db       public              ALL             NULL
+root      other_db       public              ALL             NULL
+testuser  other_db       public              USAGE           NULL
 
 ## information_schema.table_privileges and information_schema.role_table_grants
 
@@ -1656,6 +1697,7 @@ SELECT * FROM system.information_schema.table_privileges ORDER BY table_schema, 
 grantor  grantee  table_catalog  table_schema        table_name                         privilege_type  is_grantable  with_hierarchy
 NULL     public   system         crdb_internal       backward_dependencies              SELECT          NULL          YES
 NULL     public   system         crdb_internal       builtin_functions                  SELECT          NULL          YES
+NULL     public   system         crdb_internal       cluster_database_privileges        SELECT          NULL          YES
 NULL     public   system         crdb_internal       cluster_queries                    SELECT          NULL          YES
 NULL     public   system         crdb_internal       cluster_sessions                   SELECT          NULL          YES
 NULL     public   system         crdb_internal       cluster_settings                   SELECT          NULL          YES
@@ -2034,6 +2076,7 @@ SELECT * FROM system.information_schema.role_table_grants
 grantor  grantee  table_catalog  table_schema        table_name                         privilege_type  is_grantable  with_hierarchy
 NULL     public   system         crdb_internal       backward_dependencies              SELECT          NULL          YES
 NULL     public   system         crdb_internal       builtin_functions                  SELECT          NULL          YES
+NULL     public   system         crdb_internal       cluster_database_privileges        SELECT          NULL          YES
 NULL     public   system         crdb_internal       cluster_queries                    SELECT          NULL          YES
 NULL     public   system         crdb_internal       cluster_sessions                   SELECT          NULL          YES
 NULL     public   system         crdb_internal       cluster_settings                   SELECT          NULL          YES

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -950,8 +950,8 @@ FROM pg_catalog.pg_depend
 ORDER BY objid
 ----
 classid     objid       objsubid  refclassid  refobjid   refobjsubid  deptype
-4294967218  2143281868  0         4294967220  450499961  0            n
-4294967218  4089604113  0         4294967220  450499960  0            n
+4294967217  2143281868  0         4294967219  450499961  0            n
+4294967217  4089604113  0         4294967219  450499960  0            n
 
 # All entries in pg_depend are dependency links from the pg_constraint system
 # table to the pg_class system table.
@@ -963,7 +963,7 @@ JOIN pg_class cla ON classid=cla.oid
 JOIN pg_class refcla ON refclassid=refcla.oid
 ----
 classid     refclassid  tablename      reftablename
-4294967218  4294967220  pg_constraint  pg_class
+4294967217  4294967219  pg_constraint  pg_class
 
 # All entries in pg_depend are foreign key constraints that reference an index
 # in pg_class.
@@ -1633,123 +1633,124 @@ SELECT objoid, classoid, objsubid, regexp_replace(description, e'\n.*', '') AS d
   FROM pg_catalog.pg_description
 ----
 objoid      classoid    objsubid  description
-4294967294  4294967220  0         backward inter-descriptor dependencies starting from tables accessible by current user in current database (KV scan)
-4294967292  4294967220  0         built-in functions (RAM/static)
-4294967291  4294967220  0         running queries visible by current user (cluster RPC; expensive!)
-4294967289  4294967220  0         running sessions visible to current user (cluster RPC; expensive!)
-4294967288  4294967220  0         cluster settings (RAM)
-4294967290  4294967220  0         running user transactions visible by the current user (cluster RPC; expensive!)
-4294967287  4294967220  0         CREATE and ALTER statements for all tables accessible by current user in current database (KV scan)
-4294967286  4294967220  0         CREATE statements for all user defined types accessible by the current user in current database (KV scan)
-4294967285  4294967220  0         databases accessible by the current user (KV scan)
-4294967284  4294967220  0         telemetry counters (RAM; local node only)
-4294967283  4294967220  0         forward inter-descriptor dependencies starting from tables accessible by current user in current database (KV scan)
-4294967281  4294967220  0         locally known gossiped health alerts (RAM; local node only)
-4294967280  4294967220  0         locally known gossiped node liveness (RAM; local node only)
-4294967279  4294967220  0         locally known edges in the gossip network (RAM; local node only)
-4294967282  4294967220  0         locally known gossiped node details (RAM; local node only)
-4294967278  4294967220  0         index columns for all indexes accessible by current user in current database (KV scan)
-4294967277  4294967220  0         decoded job metadata from system.jobs (KV scan)
-4294967276  4294967220  0         node details across the entire cluster (cluster RPC; expensive!)
-4294967275  4294967220  0         store details and status (cluster RPC; expensive!)
-4294967274  4294967220  0         acquired table leases (RAM; local node only)
-4294967293  4294967220  0         detailed identification strings (RAM, local node only)
-4294967270  4294967220  0         current values for metrics (RAM; local node only)
-4294967273  4294967220  0         running queries visible by current user (RAM; local node only)
-4294967265  4294967220  0         server parameters, useful to construct connection URLs (RAM, local node only)
-4294967271  4294967220  0         running sessions visible by current user (RAM; local node only)
-4294967261  4294967220  0         statement statistics (in-memory, not durable; local node only). This table is wiped periodically (by default, at least every two hours)
-4294967256  4294967220  0         finer-grained transaction statistics (in-memory, not durable; local node only). This table is wiped periodically (by default, at least every two hours)
-4294967272  4294967220  0         running user transactions visible by the current user (RAM; local node only)
-4294967255  4294967220  0         per-application transaction statistics (in-memory, not durable; local node only). This table is wiped periodically (by default, at least every two hours)
-4294967269  4294967220  0         defined partitions for all tables/indexes accessible by the current user in the current database (KV scan)
-4294967268  4294967220  0         comments for predefined virtual tables (RAM/static)
-4294967267  4294967220  0         range metadata without leaseholder details (KV join; expensive!)
-4294967264  4294967220  0         ongoing schema changes, across all descriptors accessible by current user (KV scan; expensive!)
-4294967263  4294967220  0         session trace accumulated so far (RAM)
-4294967262  4294967220  0         session variables (RAM)
-4294967260  4294967220  0         details for all columns accessible by current user in current database (KV scan)
-4294967259  4294967220  0         indexes accessible by current user in current database (KV scan)
-4294967257  4294967220  0         the latest stats for all tables accessible by current user in current database (KV scan)
-4294967258  4294967220  0         table descriptors accessible by current user, including non-public and virtual (KV scan; expensive!)
-4294967254  4294967220  0         decoded zone configurations from system.zones (KV scan)
-4294967252  4294967220  0         roles for which the current user has admin option
-4294967251  4294967220  0         roles available to the current user
-4294967250  4294967220  0         check constraints
-4294967249  4294967220  0         column privilege grants (incomplete)
-4294967247  4294967220  0         columns with user defined types
-4294967248  4294967220  0         table and view columns (incomplete)
-4294967246  4294967220  0         columns usage by constraints
-4294967245  4294967220  0         roles for the current user
-4294967244  4294967220  0         column usage by indexes and key constraints
-4294967243  4294967220  0         built-in function parameters (empty - introspection not yet supported)
-4294967242  4294967220  0         foreign key constraints
-4294967241  4294967220  0         privileges granted on table or views (incomplete; see also information_schema.table_privileges; may contain excess users or roles)
-4294967240  4294967220  0         built-in functions (empty - introspection not yet supported)
-4294967238  4294967220  0         schema privileges (incomplete; may contain excess users or roles)
-4294967239  4294967220  0         database schemas (may contain schemata without permission)
-4294967237  4294967220  0         sequences
-4294967236  4294967220  0         index metadata and statistics (incomplete)
-4294967235  4294967220  0         table constraints
-4294967234  4294967220  0         privileges granted on table or views (incomplete; may contain excess users or roles)
-4294967233  4294967220  0         tables and views
-4294967232  4294967220  0         type privileges (incomplete; may contain excess users or roles)
-4294967230  4294967220  0         grantable privileges (incomplete)
-4294967231  4294967220  0         views (incomplete)
-4294967228  4294967220  0         aggregated built-in functions (incomplete)
-4294967227  4294967220  0         index access methods (incomplete)
-4294967226  4294967220  0         column default values
-4294967225  4294967220  0         table columns (incomplete - see also information_schema.columns)
-4294967223  4294967220  0         role membership
-4294967224  4294967220  0         authorization identifiers - differs from postgres as we do not display passwords,
-4294967222  4294967220  0         available extensions
-4294967221  4294967220  0         casts (empty - needs filling out)
-4294967220  4294967220  0         tables and relation-like objects (incomplete - see also information_schema.tables/sequences/views)
-4294967219  4294967220  0         available collations (incomplete)
-4294967218  4294967220  0         table constraints (incomplete - see also information_schema.table_constraints)
-4294967217  4294967220  0         encoding conversions (empty - unimplemented)
-4294967216  4294967220  0         available databases (incomplete)
-4294967215  4294967220  0         default ACLs (empty - unimplemented)
-4294967214  4294967220  0         dependency relationships (incomplete)
-4294967213  4294967220  0         object comments
-4294967211  4294967220  0         enum types and labels (empty - feature does not exist)
-4294967210  4294967220  0         event triggers (empty - feature does not exist)
-4294967209  4294967220  0         installed extensions (empty - feature does not exist)
-4294967208  4294967220  0         foreign data wrappers (empty - feature does not exist)
-4294967207  4294967220  0         foreign servers (empty - feature does not exist)
-4294967206  4294967220  0         foreign tables (empty  - feature does not exist)
-4294967205  4294967220  0         indexes (incomplete)
-4294967204  4294967220  0         index creation statements
-4294967203  4294967220  0         table inheritance hierarchy (empty - feature does not exist)
-4294967202  4294967220  0         available languages (empty - feature does not exist)
-4294967201  4294967220  0         locks held by active processes (empty - feature does not exist)
-4294967200  4294967220  0         available materialized views (empty - feature does not exist)
-4294967199  4294967220  0         available namespaces (incomplete; namespaces and databases are congruent in CockroachDB)
-4294967198  4294967220  0         operators (incomplete)
-4294967197  4294967220  0         prepared statements
-4294967196  4294967220  0         prepared transactions (empty - feature does not exist)
-4294967195  4294967220  0         built-in functions (incomplete)
-4294967194  4294967220  0         range types (empty - feature does not exist)
-4294967193  4294967220  0         rewrite rules (empty - feature does not exist)
-4294967192  4294967220  0         database roles
-4294967179  4294967220  0         security labels (empty - feature does not exist)
-4294967191  4294967220  0         security labels (empty)
-4294967190  4294967220  0         sequences (see also information_schema.sequences)
-4294967189  4294967220  0         session variables (incomplete)
-4294967188  4294967220  0         shared dependencies (empty - not implemented)
-4294967212  4294967220  0         shared object comments
-4294967178  4294967220  0         shared security labels (empty - feature not supported)
-4294967180  4294967220  0         backend access statistics (empty - monitoring works differently in CockroachDB)
-4294967185  4294967220  0         tables summary (see also information_schema.tables, pg_catalog.pg_class)
-4294967184  4294967220  0         available tablespaces (incomplete; concept inapplicable to CockroachDB)
-4294967183  4294967220  0         triggers (empty - feature does not exist)
-4294967182  4294967220  0         scalar types (incomplete)
-4294967187  4294967220  0         database users
-4294967186  4294967220  0         local to remote user mapping (empty - feature does not exist)
-4294967181  4294967220  0         view definitions (incomplete - see also information_schema.views)
-4294967176  4294967220  0         Shows all defined geography columns. Matches PostGIS' geography_columns functionality.
-4294967175  4294967220  0         Shows all defined geometry columns. Matches PostGIS' geometry_columns functionality.
-4294967174  4294967220  0         Shows all defined Spatial Reference Identifiers (SRIDs). Matches PostGIS' spatial_ref_sys table.
+4294967294  4294967219  0         backward inter-descriptor dependencies starting from tables accessible by current user in current database (KV scan)
+4294967292  4294967219  0         built-in functions (RAM/static)
+4294967253  4294967219  0         virtual table with database privileges
+4294967291  4294967219  0         running queries visible by current user (cluster RPC; expensive!)
+4294967289  4294967219  0         running sessions visible to current user (cluster RPC; expensive!)
+4294967288  4294967219  0         cluster settings (RAM)
+4294967290  4294967219  0         running user transactions visible by the current user (cluster RPC; expensive!)
+4294967287  4294967219  0         CREATE and ALTER statements for all tables accessible by current user in current database (KV scan)
+4294967286  4294967219  0         CREATE statements for all user defined types accessible by the current user in current database (KV scan)
+4294967285  4294967219  0         databases accessible by the current user (KV scan)
+4294967284  4294967219  0         telemetry counters (RAM; local node only)
+4294967283  4294967219  0         forward inter-descriptor dependencies starting from tables accessible by current user in current database (KV scan)
+4294967281  4294967219  0         locally known gossiped health alerts (RAM; local node only)
+4294967280  4294967219  0         locally known gossiped node liveness (RAM; local node only)
+4294967279  4294967219  0         locally known edges in the gossip network (RAM; local node only)
+4294967282  4294967219  0         locally known gossiped node details (RAM; local node only)
+4294967278  4294967219  0         index columns for all indexes accessible by current user in current database (KV scan)
+4294967277  4294967219  0         decoded job metadata from system.jobs (KV scan)
+4294967276  4294967219  0         node details across the entire cluster (cluster RPC; expensive!)
+4294967275  4294967219  0         store details and status (cluster RPC; expensive!)
+4294967274  4294967219  0         acquired table leases (RAM; local node only)
+4294967293  4294967219  0         detailed identification strings (RAM, local node only)
+4294967270  4294967219  0         current values for metrics (RAM; local node only)
+4294967273  4294967219  0         running queries visible by current user (RAM; local node only)
+4294967265  4294967219  0         server parameters, useful to construct connection URLs (RAM, local node only)
+4294967271  4294967219  0         running sessions visible by current user (RAM; local node only)
+4294967261  4294967219  0         statement statistics (in-memory, not durable; local node only). This table is wiped periodically (by default, at least every two hours)
+4294967256  4294967219  0         finer-grained transaction statistics (in-memory, not durable; local node only). This table is wiped periodically (by default, at least every two hours)
+4294967272  4294967219  0         running user transactions visible by the current user (RAM; local node only)
+4294967255  4294967219  0         per-application transaction statistics (in-memory, not durable; local node only). This table is wiped periodically (by default, at least every two hours)
+4294967269  4294967219  0         defined partitions for all tables/indexes accessible by the current user in the current database (KV scan)
+4294967268  4294967219  0         comments for predefined virtual tables (RAM/static)
+4294967267  4294967219  0         range metadata without leaseholder details (KV join; expensive!)
+4294967264  4294967219  0         ongoing schema changes, across all descriptors accessible by current user (KV scan; expensive!)
+4294967263  4294967219  0         session trace accumulated so far (RAM)
+4294967262  4294967219  0         session variables (RAM)
+4294967260  4294967219  0         details for all columns accessible by current user in current database (KV scan)
+4294967259  4294967219  0         indexes accessible by current user in current database (KV scan)
+4294967257  4294967219  0         the latest stats for all tables accessible by current user in current database (KV scan)
+4294967258  4294967219  0         table descriptors accessible by current user, including non-public and virtual (KV scan; expensive!)
+4294967254  4294967219  0         decoded zone configurations from system.zones (KV scan)
+4294967251  4294967219  0         roles for which the current user has admin option
+4294967250  4294967219  0         roles available to the current user
+4294967249  4294967219  0         check constraints
+4294967248  4294967219  0         column privilege grants (incomplete)
+4294967246  4294967219  0         columns with user defined types
+4294967247  4294967219  0         table and view columns (incomplete)
+4294967245  4294967219  0         columns usage by constraints
+4294967244  4294967219  0         roles for the current user
+4294967243  4294967219  0         column usage by indexes and key constraints
+4294967242  4294967219  0         built-in function parameters (empty - introspection not yet supported)
+4294967241  4294967219  0         foreign key constraints
+4294967240  4294967219  0         privileges granted on table or views (incomplete; see also information_schema.table_privileges; may contain excess users or roles)
+4294967239  4294967219  0         built-in functions (empty - introspection not yet supported)
+4294967237  4294967219  0         schema privileges (incomplete; may contain excess users or roles)
+4294967238  4294967219  0         database schemas (may contain schemata without permission)
+4294967236  4294967219  0         sequences
+4294967235  4294967219  0         index metadata and statistics (incomplete)
+4294967234  4294967219  0         table constraints
+4294967233  4294967219  0         privileges granted on table or views (incomplete; may contain excess users or roles)
+4294967232  4294967219  0         tables and views
+4294967231  4294967219  0         type privileges (incomplete; may contain excess users or roles)
+4294967229  4294967219  0         grantable privileges (incomplete)
+4294967230  4294967219  0         views (incomplete)
+4294967227  4294967219  0         aggregated built-in functions (incomplete)
+4294967226  4294967219  0         index access methods (incomplete)
+4294967225  4294967219  0         column default values
+4294967224  4294967219  0         table columns (incomplete - see also information_schema.columns)
+4294967222  4294967219  0         role membership
+4294967223  4294967219  0         authorization identifiers - differs from postgres as we do not display passwords,
+4294967221  4294967219  0         available extensions
+4294967220  4294967219  0         casts (empty - needs filling out)
+4294967219  4294967219  0         tables and relation-like objects (incomplete - see also information_schema.tables/sequences/views)
+4294967218  4294967219  0         available collations (incomplete)
+4294967217  4294967219  0         table constraints (incomplete - see also information_schema.table_constraints)
+4294967216  4294967219  0         encoding conversions (empty - unimplemented)
+4294967215  4294967219  0         available databases (incomplete)
+4294967214  4294967219  0         default ACLs (empty - unimplemented)
+4294967213  4294967219  0         dependency relationships (incomplete)
+4294967212  4294967219  0         object comments
+4294967210  4294967219  0         enum types and labels (empty - feature does not exist)
+4294967209  4294967219  0         event triggers (empty - feature does not exist)
+4294967208  4294967219  0         installed extensions (empty - feature does not exist)
+4294967207  4294967219  0         foreign data wrappers (empty - feature does not exist)
+4294967206  4294967219  0         foreign servers (empty - feature does not exist)
+4294967205  4294967219  0         foreign tables (empty  - feature does not exist)
+4294967204  4294967219  0         indexes (incomplete)
+4294967203  4294967219  0         index creation statements
+4294967202  4294967219  0         table inheritance hierarchy (empty - feature does not exist)
+4294967201  4294967219  0         available languages (empty - feature does not exist)
+4294967200  4294967219  0         locks held by active processes (empty - feature does not exist)
+4294967199  4294967219  0         available materialized views (empty - feature does not exist)
+4294967198  4294967219  0         available namespaces (incomplete; namespaces and databases are congruent in CockroachDB)
+4294967197  4294967219  0         operators (incomplete)
+4294967196  4294967219  0         prepared statements
+4294967195  4294967219  0         prepared transactions (empty - feature does not exist)
+4294967194  4294967219  0         built-in functions (incomplete)
+4294967193  4294967219  0         range types (empty - feature does not exist)
+4294967192  4294967219  0         rewrite rules (empty - feature does not exist)
+4294967191  4294967219  0         database roles
+4294967178  4294967219  0         security labels (empty - feature does not exist)
+4294967190  4294967219  0         security labels (empty)
+4294967189  4294967219  0         sequences (see also information_schema.sequences)
+4294967188  4294967219  0         session variables (incomplete)
+4294967187  4294967219  0         shared dependencies (empty - not implemented)
+4294967211  4294967219  0         shared object comments
+4294967177  4294967219  0         shared security labels (empty - feature not supported)
+4294967179  4294967219  0         backend access statistics (empty - monitoring works differently in CockroachDB)
+4294967184  4294967219  0         tables summary (see also information_schema.tables, pg_catalog.pg_class)
+4294967183  4294967219  0         available tablespaces (incomplete; concept inapplicable to CockroachDB)
+4294967182  4294967219  0         triggers (empty - feature does not exist)
+4294967181  4294967219  0         scalar types (incomplete)
+4294967186  4294967219  0         database users
+4294967185  4294967219  0         local to remote user mapping (empty - feature does not exist)
+4294967180  4294967219  0         view definitions (incomplete - see also information_schema.views)
+4294967175  4294967219  0         Shows all defined geography columns. Matches PostGIS' geography_columns functionality.
+4294967174  4294967219  0         Shows all defined geometry columns. Matches PostGIS' geometry_columns functionality.
+4294967173  4294967219  0         Shows all defined Spatial Reference Identifiers (SRIDs). Matches PostGIS' spatial_ref_sys table.
 
 ## pg_catalog.pg_shdescription
 

--- a/pkg/sql/logictest/testdata/logic_test/privilege_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/privilege_builtins
@@ -1,8 +1,29 @@
 statement ok
-CREATE USER bar
+CREATE USER bar; CREATE USER all_user_db; CREATE USER all_user_schema
+
+statement ok
+CREATE SCHEMA test_schema
 
 statement ok
 GRANT CREATE ON DATABASE test TO bar
+
+statement ok
+GRANT SELECT ON DATABASE test to testuser
+
+statement ok
+GRANT CREATE ON SCHEMA test_schema TO bar
+
+statement ok
+GRANT CREATE ON SCHEMA test_schema TO testuser
+
+statement ok
+GRANT USAGE ON SCHEMA test_schema TO testuser
+
+statement ok
+GRANT ALL ON DATABASE test to all_user_db;
+
+statement ok
+GRANT ALL ON SCHEMA test_schema to all_user_schema;
 
 statement ok
 CREATE TABLE t (a INT, b INT);
@@ -595,6 +616,55 @@ SELECT has_schema_privilege('bar', 'public', 'CREATE WITH GRANT OPTION'),
        has_schema_privilege('bar', 'public', 'CREATE WITH GRANT OPTION, USAGE WITH GRANT OPTION')
 ----
 false  false  false
+
+query BBB
+SELECT has_schema_privilege('testuser', 'public', 'CREATE'),
+       has_schema_privilege('testuser', 'public', 'USAGE'),
+       has_schema_privilege('testuser', 'public', 'CREATE, USAGE')
+----
+false  true  false
+
+query BBB
+SELECT has_schema_privilege('bar', 'test_schema', 'CREATE'),
+       has_schema_privilege('bar', 'test_schema', 'USAGE'),
+       has_schema_privilege('bar', 'test_schema', 'CREATE, USAGE')
+----
+true  false  false
+
+query BBB
+SELECT has_schema_privilege('testuser', 'test_schema', 'CREATE'),
+       has_schema_privilege('testuser', 'test_schema', 'USAGE'),
+       has_schema_privilege('testuser', 'test_schema', 'CREATE, USAGE')
+----
+true  true  true
+
+query BBB
+SELECT has_schema_privilege('all_user_db', 'public', 'CREATE'),
+       has_schema_privilege('all_user_db', 'public', 'USAGE'),
+       has_schema_privilege('all_user_db', 'public', 'CREATE, USAGE')
+----
+true  true  true
+
+query BBB
+SELECT has_schema_privilege('all_user_db', 'test_schema', 'CREATE'),
+       has_schema_privilege('all_user_db', 'test_schema', 'USAGE'),
+       has_schema_privilege('all_user_db', 'test_schema', 'CREATE, USAGE')
+----
+false  false  false
+
+query BBB
+SELECT has_schema_privilege('all_user_schema', 'public', 'CREATE'),
+       has_schema_privilege('all_user_schema', 'public', 'USAGE'),
+       has_schema_privilege('all_user_schema', 'public', 'CREATE, USAGE')
+----
+false  false  false
+
+query BBB
+SELECT has_schema_privilege('all_user_schema', 'test_schema', 'CREATE'),
+       has_schema_privilege('all_user_schema', 'test_schema', 'USAGE'),
+       has_schema_privilege('all_user_schema', 'test_schema', 'CREATE, USAGE')
+----
+true  true  true
 
 
 ## has_sequence_privilege

--- a/pkg/sql/logictest/testdata/logic_test/rename_database
+++ b/pkg/sql/logictest/testdata/logic_test/rename_database
@@ -12,16 +12,8 @@ test       root
 query TTTT
 SHOW GRANTS ON DATABASE test
 ----
-test  crdb_internal       admin  ALL
-test  crdb_internal       root   ALL
-test  information_schema  admin  ALL
-test  information_schema  root   ALL
-test  pg_catalog          admin  ALL
-test  pg_catalog          root   ALL
-test  pg_extension        admin  ALL
-test  pg_extension        root   ALL
-test  public              admin  ALL
-test  public              root   ALL
+test  public  admin  ALL
+test  public  root   ALL
 
 statement ok
 CREATE TABLE kv (
@@ -68,16 +60,8 @@ u          root
 query TTTT
 SHOW GRANTS ON DATABASE u
 ----
-u  crdb_internal       admin  ALL
-u  crdb_internal       root   ALL
-u  information_schema  admin  ALL
-u  information_schema  root   ALL
-u  pg_catalog          admin  ALL
-u  pg_catalog          root   ALL
-u  pg_extension        admin  ALL
-u  pg_extension        root   ALL
-u  public              admin  ALL
-u  public              root   ALL
+u  public  admin  ALL
+u  public  root   ALL
 
 statement ok
 SET DATABASE = u

--- a/pkg/sql/logictest/testdata/logic_test/rename_database-mixed-20.1-20.2
+++ b/pkg/sql/logictest/testdata/logic_test/rename_database-mixed-20.1-20.2
@@ -14,16 +14,8 @@ test       root
 query TTTT
 SHOW GRANTS ON DATABASE test
 ----
-test  crdb_internal       admin  ALL
-test  crdb_internal       root   ALL
-test  information_schema  admin  ALL
-test  information_schema  root   ALL
-test  pg_catalog          admin  ALL
-test  pg_catalog          root   ALL
-test  pg_extension        admin  ALL
-test  pg_extension        root   ALL
-test  public              admin  ALL
-test  public              root   ALL
+test  public  admin  ALL
+test  public  root   ALL
 
 statement ok
 CREATE TABLE kv (
@@ -70,16 +62,8 @@ u          root
 query TTTT
 SHOW GRANTS ON DATABASE u
 ----
-u  crdb_internal       admin  ALL
-u  crdb_internal       root   ALL
-u  information_schema  admin  ALL
-u  information_schema  root   ALL
-u  pg_catalog          admin  ALL
-u  pg_catalog          root   ALL
-u  pg_extension        admin  ALL
-u  pg_extension        root   ALL
-u  public              admin  ALL
-u  public              root   ALL
+u  public  admin  ALL
+u  public  root   ALL
 
 statement ok
 SET DATABASE = u

--- a/pkg/sql/logictest/testdata/logic_test/role
+++ b/pkg/sql/logictest/testdata/logic_test/role
@@ -667,22 +667,10 @@ user testuser
 query TTTT colnames
 SHOW GRANTS ON DATABASE db2
 ----
-database_name  schema_name         grantee   privilege_type
-db2            crdb_internal       admin     ALL
-db2            crdb_internal       newgroup  ALL
-db2            crdb_internal       root      ALL
-db2            information_schema  admin     ALL
-db2            information_schema  newgroup  ALL
-db2            information_schema  root      ALL
-db2            pg_catalog          admin     ALL
-db2            pg_catalog          newgroup  ALL
-db2            pg_catalog          root      ALL
-db2            pg_extension        admin     ALL
-db2            pg_extension        newgroup  ALL
-db2            pg_extension        root      ALL
-db2            public              admin     ALL
-db2            public              newgroup  ALL
-db2            public              root      ALL
+database_name  schema_name  grantee   privilege_type
+db2            public       admin     ALL
+db2            public       newgroup  ALL
+db2            public       root      ALL
 
 statement ok
 CREATE TABLE db2.foo (k int);

--- a/pkg/sql/logictest/testdata/logic_test/system
+++ b/pkg/sql/logictest/testdata/logic_test/system
@@ -172,16 +172,10 @@ isAdmin  BOOL    false  NULL  ·  {}                                            
 query TTTT
 SHOW GRANTS ON DATABASE system
 ----
-system  crdb_internal       admin  GRANT
-system  crdb_internal       root   GRANT
-system  information_schema  admin  GRANT
-system  information_schema  root   GRANT
-system  pg_catalog          admin  GRANT
-system  pg_catalog          root   GRANT
-system  pg_extension        admin  GRANT
-system  pg_extension        root   GRANT
-system  public              admin  GRANT
-system  public              root   GRANT
+system  public  admin  GRANT
+system  public  admin  SELECT
+system  public  root   GRANT
+system  public  root   SELECT
 
 query TTTTT
 SHOW GRANTS ON system.*

--- a/pkg/sql/logictest/testdata/logic_test/table
+++ b/pkg/sql/logictest/testdata/logic_test/table
@@ -534,6 +534,7 @@ select table_name, estimated_row_count from crdb_internal.table_row_statistics;
 ----
 backward_dependencies              NULL
 builtin_functions                  NULL
+cluster_database_privileges        NULL
 cluster_queries                    NULL
 cluster_sessions                   NULL
 cluster_settings                   NULL

--- a/pkg/sql/privilege/privilege.go
+++ b/pkg/sql/privilege/privilege.go
@@ -160,6 +160,16 @@ func (pl List) ToBitField() uint32 {
 	return ret
 }
 
+// Contains returns true iff the list contains the given privilege kind.
+func (pl List) Contains(k Kind) bool {
+	for _, p := range pl {
+		if p == k {
+			return true
+		}
+	}
+	return false
+}
+
 // ListFromBitField takes a bitfield of privileges and a ObjectType
 // returns a List. It is ordered in increasing value of privilege.Kind.
 func ListFromBitField(m uint32, objectType ObjectType) List {


### PR DESCRIPTION
Backport 1/1 commits from #56866.

/cc @cockroachdb/release

---

The addition of user-defined schemas broke the ability to view
fine-grained privileges on a database. The only sensible way of
fixing this bug that I saw was to make a new crdb_internal table
that has these privileges.

This also revealed another bug, that information_schema.schema_privileges
was not including any information from non-user-defined schemas. In the
process of fixing this bug, the has_schema_privilege builtin had to be
updated to correctly check for the USAGE grant, which also
coincidentally fixed a bug where this builtin would not work correctly
with user-defined schemas.

Release note (bug fix): SHOW GRANTS ON DATABASE did
not include privileges that were granted on a database. Now it does. The
output includes database_name, schema_name, grantee, and privilege_type.
The schema_name is always "public" since these grants are not
per-schema.

Release note (bug fix): The
information_schema.schema_privileges table now includes the correct
schema-level privileges for non-user-defined schemas. Previously, all
of these schemas were ommitted from the table.

Release note (bug fix): The has_schema_privilege builtin function now
works on user-defined schemas when checking for the USAGE privilege.

fixes #56666 
