### PR TITLE
opt: add OptionalColList type

### DIFF
--- a/pkg/sql/opt/colset.go
+++ b/pkg/sql/opt/colset.go
@@ -99,6 +99,15 @@ func (s ColSet) SingleColumn() ColumnID {
 	return col
 }
 
+// ToList converts the set to a ColList, in column ID order.
+func (s ColSet) ToList() ColList {
+	res := make(ColList, 0, s.Len())
+	s.ForEach(func(x ColumnID) {
+		res = append(res, x)
+	})
+	return res
+}
+
 // TranslateColSet is used to translate a ColSet from one set of column IDs
 // to an equivalent set. This is relevant for set operations such as UNION,
 // INTERSECT and EXCEPT, and can be used to map a ColSet defined on the left

--- a/pkg/sql/opt/column_meta.go
+++ b/pkg/sql/opt/column_meta.go
@@ -87,15 +87,6 @@ func (cl ColList) Equals(other ColList) bool {
 	return true
 }
 
-// ColSetToList converts a column id set to a list, in column id order.
-func ColSetToList(set ColSet) ColList {
-	res := make(ColList, 0, set.Len())
-	set.ForEach(func(x ColumnID) {
-		res = append(res, x)
-	})
-	return res
-}
-
 // ColMap provides a 1:1 mapping from one column id to another. It is used by
 // operators that need to match columns from its inputs.
 type ColMap = util.FastIntMap

--- a/pkg/sql/opt/column_meta.go
+++ b/pkg/sql/opt/column_meta.go
@@ -26,32 +26,11 @@ func (c ColumnID) index() int {
 	return int(c - 1)
 }
 
-// ColList is a list of column ids.
+// ColList is a list of column IDs.
 //
 // TODO(radu): perhaps implement a FastIntList with the same "small"
 // representation as FastIntMap but with a slice for large cases.
 type ColList []ColumnID
-
-// ColumnMeta stores information about one of the columns stored in the
-// metadata.
-type ColumnMeta struct {
-	// MetaID is the identifier for this column that is unique within the query
-	// metadata.
-	MetaID ColumnID
-
-	// Alias is the best-effort name of this column. Since the same column in a
-	// query can have multiple names (using aliasing), one of those is chosen to
-	// be used for pretty-printing and debugging. This might be different than
-	// what is stored in the physical properties and is presented to end users.
-	Alias string
-
-	// Type is the scalar SQL type of this column.
-	Type *types.T
-
-	// Table is the base table to which this column belongs.
-	// If the column was synthesized (i.e. no base table), then it is 0.
-	Table TableID
-}
 
 // ToSet converts a column id list to a column id set.
 func (cl ColList) ToSet() ColSet {
@@ -85,6 +64,70 @@ func (cl ColList) Equals(other ColList) bool {
 		}
 	}
 	return true
+}
+
+// OptionalColList is a list of column IDs where some of the IDs can be unset.
+// It is used when the columns map 1-to-1 to a known list of objects (e.g. table
+// columns).
+type OptionalColList []ColumnID
+
+// IsEmpty returns true if all columns in the list are unset.
+func (ocl OptionalColList) IsEmpty() bool {
+	for i := range ocl {
+		if ocl[i] != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// Equals returns true if this column list is identical to another list.
+func (ocl OptionalColList) Equals(other OptionalColList) bool {
+	if len(ocl) != len(other) {
+		return false
+	}
+	for i := range ocl {
+		if ocl[i] != other[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// Find searches for a column in the list and returns its index in the list (if
+// successful).
+func (ocl OptionalColList) Find(col ColumnID) (idx int, ok bool) {
+	if col == 0 {
+		// An OptionalColList cannot contain zero column IDs.
+		return -1, false
+	}
+	for i := range ocl {
+		if ocl[i] == col {
+			return i, true
+		}
+	}
+	return -1, false
+}
+
+// ColumnMeta stores information about one of the columns stored in the
+// metadata.
+type ColumnMeta struct {
+	// MetaID is the identifier for this column that is unique within the query
+	// metadata.
+	MetaID ColumnID
+
+	// Alias is the best-effort name of this column. Since the same column in a
+	// query can have multiple names (using aliasing), one of those is chosen to
+	// be used for pretty-printing and debugging. This might be different than
+	// what is stored in the physical properties and is presented to end users.
+	Alias string
+
+	// Type is the scalar SQL type of this column.
+	Type *types.T
+
+	// Table is the base table to which this column belongs.
+	// If the column was synthesized (i.e. no base table), then it is 0.
+	Table TableID
 }
 
 // ColMap provides a 1:1 mapping from one column id to another. It is used by

--- a/pkg/sql/opt/exec/execbuilder/mutation.go
+++ b/pkg/sql/opt/exec/execbuilder/mutation.go
@@ -185,7 +185,7 @@ func (b *Builder) tryBuildFastPathInsert(ins *memo.InsertExpr) (_ execPlan, ok b
 
 		out := &fkChecks[i]
 		out.InsertCols = make([]exec.TableColumnOrdinal, len(lookupJoin.KeyCols))
-		findCol := func(cols opt.ColList, col opt.ColumnID) int {
+		findCol := func(cols opt.OptionalColList, col opt.ColumnID) int {
 			res, ok := cols.Find(col)
 			if !ok {
 				panic(errors.AssertionFailedf("cannot find column %d", col))
@@ -195,7 +195,7 @@ func (b *Builder) tryBuildFastPathInsert(ins *memo.InsertExpr) (_ execPlan, ok b
 		for i, keyCol := range lookupJoin.KeyCols {
 			// The keyCol comes from the WithScan operator. We must find the matching
 			// column in the mutation input.
-			withColOrd := findCol(withScan.OutCols, keyCol)
+			withColOrd := findCol(opt.OptionalColList(withScan.OutCols), keyCol)
 			inputCol := withScan.InCols[withColOrd]
 			out.InsertCols[i] = exec.TableColumnOrdinal(findCol(ins.InsertCols, inputCol))
 		}
@@ -294,7 +294,7 @@ func (b *Builder) buildUpdate(upd *memo.UpdateExpr) (execPlan, error) {
 	// to passthrough those columns so the projection above can use
 	// them.
 	if upd.NeedResults() {
-		colList = appendColsWhenPresent(colList, upd.PassthroughCols)
+		colList = append(colList, upd.PassthroughCols...)
 	}
 	colList = appendColsWhenPresent(colList, upd.CheckCols)
 	colList = appendColsWhenPresent(colList, upd.PartialIndexPutCols)
@@ -712,7 +712,7 @@ func (b *Builder) buildDeleteRange(
 
 // appendColsWhenPresent appends non-zero column IDs from the src list into the
 // dst list, and returns the possibly grown list.
-func appendColsWhenPresent(dst, src opt.ColList) opt.ColList {
+func appendColsWhenPresent(dst opt.ColList, src opt.OptionalColList) opt.ColList {
 	for _, col := range src {
 		if col != 0 {
 			dst = append(dst, col)
@@ -725,11 +725,8 @@ func appendColsWhenPresent(dst, src opt.ColList) opt.ColList {
 // column ID in the given list. This is used with mutation operators, which
 // maintain lists that correspond to the target table, with zero column IDs
 // indicating columns that are not involved in the mutation.
-func ordinalSetFromColList(colList opt.ColList) util.FastIntSet {
+func ordinalSetFromColList(colList opt.OptionalColList) util.FastIntSet {
 	var res util.FastIntSet
-	if colList == nil {
-		return res
-	}
 	for i, col := range colList {
 		if col != 0 {
 			res.Add(i)

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -1197,7 +1197,7 @@ func (b *Builder) buildDistinct(distinct memo.RelExpr) (execPlan, error) {
 	if input.outputCols.Len() == outCols.Len() {
 		return ep, nil
 	}
-	return b.ensureColumns(ep, opt.ColSetToList(outCols), distinct.ProvidedPhysical().Ordering)
+	return b.ensureColumns(ep, outCols.ToList(), distinct.ProvidedPhysical().Ordering)
 }
 
 func (b *Builder) buildGroupByInput(groupBy memo.RelExpr) (execPlan, error) {

--- a/pkg/sql/opt/memo/check_expr.go
+++ b/pkg/sql/opt/memo/check_expr.go
@@ -285,7 +285,7 @@ func (m *Memo) CheckExpr(e opt.Expr) {
 	}
 }
 
-func (m *Memo) checkColListLen(colList opt.ColList, expectedLen int, listName string) {
+func (m *Memo) checkColListLen(colList opt.OptionalColList, expectedLen int, listName string) {
 	if len(colList) != expectedLen {
 		panic(errors.AssertionFailedf("column list %s expected length = %d, actual length = %d",
 			listName, log.Safe(expectedLen), len(colList)))

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -282,7 +282,7 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 
 	default:
 		// Fall back to writing output columns in column id order.
-		colList = opt.ColSetToList(e.Relational().OutputCols)
+		colList = e.Relational().OutputCols.ToList()
 	}
 
 	f.formatColumns(e, tp, colList, required.Presentation)
@@ -294,7 +294,7 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 		*UpsertDistinctOnExpr, *EnsureUpsertDistinctOnExpr:
 		private := e.Private().(*GroupingPrivate)
 		if !f.HasFlags(ExprFmtHideColumns) && !private.GroupingCols.Empty() {
-			f.formatColList(e, tp, "grouping columns:", opt.ColSetToList(private.GroupingCols))
+			f.formatColList(e, tp, "grouping columns:", private.GroupingCols.ToList())
 		}
 		if !f.HasFlags(ExprFmtHidePhysProps) && !private.Ordering.Any() {
 			tp.Childf("internal-ordering: %s", private.Ordering)

--- a/pkg/sql/opt/memo/interner.go
+++ b/pkg/sql/opt/memo/interner.go
@@ -437,6 +437,15 @@ func (h *hasher) HashColList(val opt.ColList) {
 	h.hash = hash
 }
 
+func (h *hasher) HashOptionalColList(val opt.OptionalColList) {
+	hash := h.hash
+	for _, id := range val {
+		hash ^= internHash(id)
+		hash *= prime64
+	}
+	h.hash = hash
+}
+
 func (h *hasher) HashOrdering(val opt.Ordering) {
 	hash := h.hash
 	for _, id := range val {
@@ -833,6 +842,10 @@ func (h *hasher) IsColSetEqual(l, r opt.ColSet) bool {
 }
 
 func (h *hasher) IsColListEqual(l, r opt.ColList) bool {
+	return l.Equals(r)
+}
+
+func (h *hasher) IsOptionalColListEqual(l, r opt.OptionalColList) bool {
 	return l.Equals(r)
 }
 

--- a/pkg/sql/opt/ops/mutation.opt
+++ b/pkg/sql/opt/ops/mutation.opt
@@ -44,7 +44,7 @@ define MutationPrivate {
     #
     # If there is a delete-only mutation column "c", then InsertCols would contain
     # [a_colid, b_colid, 0].
-    InsertCols ColList
+    InsertCols OptionalColList
 
     # FetchCols are columns from the Input expression that will be fetched from
     # the target table. They must be a subset of the Input expression's output
@@ -69,7 +69,7 @@ define MutationPrivate {
     # updated value, and the "d" column is needed because it's in the same family
     # as "c". Taking all this into account, FetchCols would contain this list:
     # [a_colid, 0, c_colid, d_colid, 0].
-    FetchCols ColList
+    FetchCols OptionalColList
 
     # UpdateCols are columns from the Input expression that contain updated values
     # for columns of the target table. They must be a subset of the Input
@@ -85,7 +85,7 @@ define MutationPrivate {
     #
     # Since column "b" is updated, and "c" is a computed column dependent on "b",
     # then UpdateCols would contain [0, b_colid, c_colid].
-    UpdateCols ColList
+    UpdateCols OptionalColList
 
     # CheckCols are columns from the Input expression containing the results of
     # evaluating the check constraints from the target table. Evaluating a check
@@ -103,7 +103,7 @@ define MutationPrivate {
     # Since the check constraint for column "a" can be statically proven to be
     # true, CheckCols would contain [0, b_colid].
     # TODO(radu): we don't actually implement this optimization currently.
-    CheckCols ColList
+    CheckCols OptionalColList
 
     # PartialIndexPutCols are columns from the Input expression containing the
     # results of evaluating each partial index predicate from the target table
@@ -125,13 +125,13 @@ define MutationPrivate {
     # evaluating the predicate of the index on c. The index on b is not a
     # partial index, because it has no predicate, so it is not included in
     # PartialIndexPutCols.
-    PartialIndexPutCols ColList
+    PartialIndexPutCols OptionalColList
 
     # PartialIndexDelCols is similar to PartialIndexPutCols, but instead
     # indicates when the previous version of a row must be deleted from a
     # partial index during updates or deletes in order to maintain the state of
     # the index.
-    PartialIndexDelCols ColList
+    PartialIndexDelCols OptionalColList
 
     # CanaryCol is used only with the Upsert operator. It identifies the column
     # that the execution engine uses to decide whether to insert or to update.
@@ -153,7 +153,7 @@ define MutationPrivate {
     # including any columns that are undergoing mutation (being added or dropped
     # as part of online schema change). If no RETURNING clause was specified,
     # then ReturnCols is nil.
-    ReturnCols ColList
+    ReturnCols OptionalColList
 
     # PassthroughCols are columns that the mutation needs to passthrough from
     # its input. It's similar to the passthrough columns in projections. This

--- a/pkg/sql/opt/optgen/cmd/optgen/metadata.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/metadata.go
@@ -192,6 +192,7 @@ func newMetadata(compiled *lang.CompiledExpr, pkg string) *metadata {
 		"ColumnID":          {fullName: "opt.ColumnID", passByVal: true},
 		"ColSet":            {fullName: "opt.ColSet", passByVal: true},
 		"ColList":           {fullName: "opt.ColList", passByVal: true},
+		"OptionalColList":   {fullName: "opt.OptionalColList", passByVal: true},
 		"TableID":           {fullName: "opt.TableID", passByVal: true},
 		"SchemaID":          {fullName: "opt.SchemaID", passByVal: true},
 		"SequenceID":        {fullName: "opt.SequenceID", passByVal: true},

--- a/pkg/sql/opt/xform/limit_funcs.go
+++ b/pkg/sql/opt/xform/limit_funcs.go
@@ -231,13 +231,13 @@ func (c *CustomFuncs) SplitScanIntoUnionScans(
 
 	// Construct a new ScanExpr for each span and union them all together. We
 	// output the old ColumnIDs from each union.
-	oldColList := opt.ColSetToList(scan.Relational().OutputCols)
+	oldColList := scan.Relational().OutputCols.ToList()
 	last := c.makeNewScan(sp, cons.Columns, newHardLimit, newSpans.Get(0))
 	for i, cnt := 1, newSpans.Count(); i < cnt; i++ {
 		newScan := c.makeNewScan(sp, cons.Columns, newHardLimit, newSpans.Get(i))
 		last = c.e.f.ConstructUnion(last, newScan, &memo.SetPrivate{
-			LeftCols:  opt.ColSetToList(last.Relational().OutputCols),
-			RightCols: opt.ColSetToList(newScan.Relational().OutputCols),
+			LeftCols:  last.Relational().OutputCols.ToList(),
+			RightCols: newScan.Relational().OutputCols.ToList(),
 			OutCols:   oldColList,
 		})
 	}

--- a/pkg/sql/opt/xform/select_funcs.go
+++ b/pkg/sql/opt/xform/select_funcs.go
@@ -1729,10 +1729,10 @@ func (c *CustomFuncs) mapFilterCols(
 func (c *CustomFuncs) MakeSetPrivateForSplitDisjunction(
 	left, right *memo.ScanPrivate,
 ) *memo.SetPrivate {
-	leftAndOutCols := opt.ColSetToList(left.Cols)
+	leftAndOutCols := left.Cols.ToList()
 	return &memo.SetPrivate{
 		LeftCols:  leftAndOutCols,
-		RightCols: opt.ColSetToList(right.Cols),
+		RightCols: right.Cols.ToList(),
 		OutCols:   leftAndOutCols,
 	}
 }


### PR DESCRIPTION
I am open to better suggestions for the name.

#### opt: change ColSetToList() func to a ToList() method

Release note: None

#### opt: add OptionalColList type

For mutations, we use ColLists that map 1-to-1 to table columns, and
where some of the entries in the list can be 0. This is really meant
to represent a mapping of columns and it is an abuse of the ColList
type (which is supposed to be a simple list of columns).

We add a separate OptionalColList type which has the desired
semantics. This helps clarify things a bit (in particular it is now
obvious which of the lists are "real" lists and which are "mappings").
It will also allow a different ToSet() method which makes sense for
this structure (i.e. doesn't put 0 in the set).

Release note: None