### PR TITLE
physicalplan,colbuilder: evaluate placeholders during physical planning

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/prepare
+++ b/pkg/sql/logictest/testdata/logic_test/prepare
@@ -1368,3 +1368,16 @@ query TI
 EXECUTE enum_query
 ----
 howdy 2
+
+# Regression test for the vectorized engine not handling placeholders in
+# postqueries correctly (#58028).
+statement ok
+CREATE TABLE t58028 (a INT8 PRIMARY KEY, b INT8);
+CREATE TABLE tref58028 (
+  a INT8 PRIMARY KEY,
+  t_a INT8 NOT NULL REFERENCES t58028 (a) ON DELETE CASCADE
+);
+INSERT INTO t58028 VALUES (1, 2);
+INSERT INTO tref58028 VALUES (1, 1);
+PREPARE del AS DELETE FROM t58028 WHERE a = $1;
+EXECUTE del (1);


### PR DESCRIPTION
Previously, the vectorized engine would hit an internal error during the
flow setup when it encountered a placeholder in some cases. This
happened because `tree.Placeholder` is the only type that implements
`tree.Datum` interface, yet it cannot be cast (e.g. to `DInt`) without
being evaluated. In most cases the optimizer is able to pre-evaluate the
placeholders so they don't reach the physical planning, but in some
cases they happen to go through.

This commit extends an expression visitor to always evaluate the
placeholders in `makeExpression` during the physical planning
(previously, it would only evaluate the subqueries). This will make sure
that the placeholders don't trip up the execution.

Additionally, in the spirit of defensive programming, this commit adds
a separate `Eval` calls on the datums when we expect them to be
constant.

Fixes: #58028.

Release note: None (no release with the bug)