### PR TITLE
sql/rowexec: don't allocate buf per row in sketchInfo.addRow

### DIFF
--- a/pkg/sql/rowexec/sampler.go
+++ b/pkg/sql/rowexec/sampler.go
@@ -500,12 +500,17 @@ func (s *sketchInfo) addRow(
 	}
 
 	if useFastPath {
-		var intbuf [8]byte
 		// Fast path for integers.
 		// TODO(radu): make this more general.
 		val, err := row[col].GetInt()
 		if err != nil {
 			return err
+		}
+
+		if cap(*buf) < 8 {
+			*buf = make([]byte, 8)
+		} else {
+			*buf = (*buf)[:8]
 		}
 
 		// Note: this encoding is not identical with the one in the general path
@@ -518,8 +523,8 @@ func (s *sketchInfo) addRow(
 		// it must be a very good hash function (HLL expects the hash values to
 		// be uniformly distributed in the 2^64 range). Experiments (on tpcc
 		// order_line) with simplistic functions yielded bad results.
-		binary.LittleEndian.PutUint64(intbuf[:], uint64(val))
-		s.sketch.Insert(intbuf[:])
+		binary.LittleEndian.PutUint64(*buf, uint64(val))
+		s.sketch.Insert(*buf)
 		return nil
 	}
 	isNull := true


### PR DESCRIPTION
The `intbuf` array was meant to stay on the stack, but was escaping to the heap because the call through the `hash` function variable was opaque to escape analysis.

At the end of a 4 hour, 2.2 TB IMPORT of TPC-E, this was responsible for **76.70%** of all heap allocations (by object).

<img width="1684" alt="Screen Shot 2020-12-20 at 9 58 04 PM" src="https://user-images.githubusercontent.com/5438456/102735277-fb065a00-430f-11eb-837a-7ad1c903cf55.png">