### PR TITLE
roachtest/tpce: create a larger TPC-E test with 2 SSDs per node

### DIFF
--- a/pkg/cmd/roachprod/install/cassandra.go
+++ b/pkg/cmd/roachprod/install/cassandra.go
@@ -91,11 +91,14 @@ func (Cassandra) Start(c *SyncedCluster, extraArgs []string) {
 }
 
 // NodeDir implements the ClusterImpl.NodeDir interface.
-func (Cassandra) NodeDir(c *SyncedCluster, index int) string {
+func (Cassandra) NodeDir(c *SyncedCluster, index, storeIndex int) string {
 	if c.IsLocal() {
 		// TODO(peter): This will require a bit of work to adjust paths in
 		// cassandra.yaml.
 		panic("Cassandra.NodeDir unimplemented")
+	}
+	if storeIndex != 1 {
+		panic("Cassandra.NodeDir only supports one store")
 	}
 	return "/mnt/data1/cassandra"
 }

--- a/pkg/cmd/roachprod/install/cluster_synced.go
+++ b/pkg/cmd/roachprod/install/cluster_synced.go
@@ -46,7 +46,7 @@ import (
 type ClusterImpl interface {
 	Start(c *SyncedCluster, extraArgs []string)
 	CertsDir(c *SyncedCluster, index int) string
-	NodeDir(c *SyncedCluster, index int) string
+	NodeDir(c *SyncedCluster, index, storeIndex int) string
 	LogDir(c *SyncedCluster, index int) string
 	NodeURL(c *SyncedCluster, host string, port int) string
 	NodePort(c *SyncedCluster, index int) int
@@ -345,7 +345,7 @@ func (c *SyncedCluster) Monitor(ignoreEmptyNodes bool, oneShot bool) chan NodeMo
 			}{
 				OneShot:     oneShot,
 				IgnoreEmpty: ignoreEmptyNodes,
-				Store:       Cockroach{}.NodeDir(c, nodes[i]),
+				Store:       Cockroach{}.NodeDir(c, nodes[i], 1 /* storeIndex */),
 				Port:        Cockroach{}.NodePort(c, nodes[i]),
 			}
 

--- a/pkg/cmd/roachprod/install/expander.go
+++ b/pkg/cmd/roachprod/install/expander.go
@@ -176,7 +176,7 @@ func (e *expander) maybeExpandStoreDir(c *SyncedCluster, s string) (string, bool
 	if !storeDirRe.MatchString(s) {
 		return s, false, nil
 	}
-	return c.Impl.NodeDir(c, e.node), true, nil
+	return c.Impl.NodeDir(c, e.node, 1 /* storeIndex */), true, nil
 }
 
 // maybeExpandLogDir is an expanderFunc for "{log-dir}"

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -1796,6 +1796,8 @@ func main() {
 				&install.StartOpts.Encrypt, "encrypt", encrypt, "start nodes with encryption at rest turned on")
 			cmd.Flags().BoolVar(
 				&install.StartOpts.SkipInit, "skip-init", skipInit, "skip initializing the cluster")
+			cmd.Flags().IntVar(
+				&install.StartOpts.StoreCount, "store-count", 1, "number of stores to start each node with")
 			fallthrough
 		case sqlCmd:
 			cmd.Flags().StringVarP(

--- a/pkg/cmd/roachprod/vm/gce/utils.go
+++ b/pkg/cmd/roachprod/vm/gce/utils.go
@@ -61,7 +61,8 @@ for d in $(ls /dev/disk/by-id/google-local-* /dev/disk/by-id/google-persistent-d
     sudo mkdir -p "${mountpoint}"
     sudo mkfs.ext4 -F ${d}
     sudo mount -o ${mount_opts} ${d} ${mountpoint}
-    echo "${d} ${mountpoint} ext4 ${mount_opts} 1 1" | sudo tee -a /etc/fstab
+	echo "${d} ${mountpoint} ext4 ${mount_opts} 1 1" | sudo tee -a /etc/fstab
+	sudo chmod 777 ${mountpoint}
   else
     echo "Disk ${disknum}: ${d} already mounted, skipping..."
   fi
@@ -69,9 +70,9 @@ done
 if [ "${disknum}" -eq "0" ]; then
   echo "No disks mounted, creating /mnt/data1"
   sudo mkdir -p /mnt/data1
+  sudo chmod 777 /mnt/data1
 fi
 
-sudo chmod 777 /mnt/data1
 # sshguard can prevent frequent ssh connections to the same host. Disable it.
 sudo service sshguard stop
 # increase the number of concurrent unauthenticated connections to the sshd

--- a/pkg/cmd/roachtest/tpce.go
+++ b/pkg/cmd/roachtest/tpce.go
@@ -43,9 +43,7 @@ func registerTPCE(r *testRegistry) {
 
 			m := newMonitor(ctx, c, roachNodes)
 			m.Go(func(ctx context.Context) error {
-				// TODO(nvanbenschoten): switch this to `cockroachdb/tpce` once
-				// I get permissions to push the docker image there.
-				const dockerRun = `sudo docker run nvanbenschoten/tpce:latest`
+				const dockerRun = `sudo docker run cockroachdb/tpc-e:latest`
 
 				roachNodeIPs := c.InternalIP(ctx, roachNodes)
 				roachNodeIPFlags := make([]string, len(roachNodeIPs))

--- a/pkg/cmd/roachtest/tpce.go
+++ b/pkg/cmd/roachtest/tpce.go
@@ -20,56 +20,98 @@ import (
 )
 
 func registerTPCE(r *testRegistry) {
-	const customers = 5000
-	const nodes = 3
-	const duration = 1 * time.Hour
-	r.Add(testSpec{
-		Name:    fmt.Sprintf("tpce/c=%d/nodes=%d", customers, nodes),
-		Owner:   OwnerKV,
-		Cluster: makeClusterSpec(nodes+1, cpu(4)),
-		Run: func(ctx context.Context, t *test, c *cluster) {
-			roachNodes := c.Range(1, nodes)
-			loadNode := c.Node(nodes + 1)
-			racks := nodes
+	type tpceOptions struct {
+		customers int
+		nodes     int
+		cpus      int
+		ssds      int
 
-			t.Status("installing cockroach")
-			c.Put(ctx, cockroach, "./cockroach", roachNodes)
-			c.Start(ctx, t, roachNodes, startArgs(fmt.Sprintf("--racks=%d", racks)))
+		tags    []string
+		timeout time.Duration
+	}
 
-			t.Status("installing docker")
-			if err := c.Install(ctx, t.l, loadNode, "docker"); err != nil {
+	runTPCE := func(ctx context.Context, t *test, c *cluster, opts tpceOptions) {
+		roachNodes := c.Range(1, opts.nodes)
+		loadNode := c.Node(opts.nodes + 1)
+		racks := opts.nodes
+
+		t.Status("installing cockroach")
+		c.Put(ctx, cockroach, "./cockroach", roachNodes)
+		c.Start(ctx, t, roachNodes, startArgs(
+			fmt.Sprintf("--racks=%d", racks),
+			fmt.Sprintf("--store-count=%d", opts.ssds),
+		))
+
+		t.Status("installing docker")
+		if err := c.Install(ctx, t.l, loadNode, "docker"); err != nil {
+			t.Fatal(err)
+		}
+
+		// Configure to increase the speed of the import.
+		func() {
+			db := c.Conn(ctx, 1)
+			defer db.Close()
+			if _, err := db.ExecContext(
+				ctx, "SET CLUSTER SETTING kv.bulk_io_write.concurrent_addsstable_requests = $1", 4*opts.ssds,
+			); err != nil {
 				t.Fatal(err)
 			}
+			if _, err := db.ExecContext(
+				ctx, "SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false",
+			); err != nil {
+				t.Fatal(err)
+			}
+		}()
 
-			m := newMonitor(ctx, c, roachNodes)
-			m.Go(func(ctx context.Context) error {
-				const dockerRun = `sudo docker run cockroachdb/tpc-e:latest`
+		m := newMonitor(ctx, c, roachNodes)
+		m.Go(func(ctx context.Context) error {
+			const dockerRun = `sudo docker run cockroachdb/tpc-e:latest`
 
-				roachNodeIPs := c.InternalIP(ctx, roachNodes)
-				roachNodeIPFlags := make([]string, len(roachNodeIPs))
-				for i, ip := range roachNodeIPs {
-					roachNodeIPFlags[i] = fmt.Sprintf("--hosts=%s", ip)
-				}
+			roachNodeIPs := c.InternalIP(ctx, roachNodes)
+			roachNodeIPFlags := make([]string, len(roachNodeIPs))
+			for i, ip := range roachNodeIPs {
+				roachNodeIPFlags[i] = fmt.Sprintf("--hosts=%s", ip)
+			}
 
-				t.Status("preparing workload")
-				c.Run(ctx, loadNode, fmt.Sprintf("%s --customers=%d --racks=%d --init %s",
-					dockerRun, customers, racks, roachNodeIPFlags[0]))
+			t.Status("preparing workload")
+			c.Run(ctx, loadNode, fmt.Sprintf("%s --customers=%d --racks=%d --init %s",
+				dockerRun, opts.customers, racks, roachNodeIPFlags[0]))
 
-				t.Status("running workload")
-				out, err := c.RunWithBuffer(ctx, t.l, loadNode,
-					fmt.Sprintf("%s --customers=%d --racks=%d --duration=%s %s",
-						dockerRun, customers, racks, duration, strings.Join(roachNodeIPFlags, " ")))
-				if err != nil {
-					t.Fatalf("%v\n%s", err, out)
-				}
-				outStr := string(out)
-				t.l.Printf("workload output:\n%s\n", outStr)
-				if strings.Contains(outStr, "Reported tpsE :    --   (not between 80% and 100%)") {
-					return errors.New("invalid tpsE fraction")
-				}
-				return nil
-			})
-			m.Wait()
-		},
-	})
+			t.Status("running workload")
+			duration := 2 * time.Hour
+			threads := opts.nodes * opts.cpus
+			out, err := c.RunWithBuffer(ctx, t.l, loadNode,
+				fmt.Sprintf("%s --customers=%d --racks=%d --duration=%s --threads=%d %s",
+					dockerRun, opts.customers, racks, duration, threads, strings.Join(roachNodeIPFlags, " ")))
+			if err != nil {
+				t.Fatalf("%v\n%s", err, out)
+			}
+			outStr := string(out)
+			t.l.Printf("workload output:\n%s\n", outStr)
+			if strings.Contains(outStr, "Reported tpsE :    --   (not between 80% and 100%)") {
+				return errors.New("invalid tpsE fraction")
+			}
+			return nil
+		})
+		m.Wait()
+	}
+
+	for _, opts := range []tpceOptions{
+		// Nightly, small scale configurations.
+		{customers: 5_000, nodes: 3, cpus: 4, ssds: 1},
+		// Weekly, large scale configurations.
+		{customers: 100_000, nodes: 5, cpus: 32, ssds: 2, tags: []string{"weekly"}, timeout: 36 * time.Hour},
+	} {
+		opts := opts
+		r.Add(testSpec{
+			Name:    fmt.Sprintf("tpce/c=%d/nodes=%d", opts.customers, opts.nodes),
+			Owner:   OwnerKV,
+			Tags:    opts.tags,
+			Timeout: opts.timeout,
+			Cluster: makeClusterSpec(opts.nodes+1, cpu(opts.cpus), ssd(opts.ssds)),
+			Run: func(ctx context.Context, t *test, c *cluster) {
+				runTPCE(ctx, t, c, opts)
+			},
+		})
+	}
 }


### PR DESCRIPTION
This change introduces a new `tpce/c=100000/nodes=5` roachtest which uses a 4 node cluster of n1-standard-32 instances with 2 local SSDs each.

Thanks @lunevalex for making this possible with #51567.