### PR TITLE
storage: avoid heap allocation per value in pebbleIterator.FindSplitKey

### DIFF
--- a/pkg/storage/pebble_iterator.go
+++ b/pkg/storage/pebble_iterator.go
@@ -495,7 +495,7 @@ func findSplitKeyUsingIterator(
 			bestSplitKey.Key = append(bestSplitKey.Key[:0], prevKey.Key...)
 		}
 
-		sizeSoFar += int64(len(iter.Value()))
+		sizeSoFar += int64(len(iter.UnsafeValue()))
 		if mvccKey.IsValue() && bytes.Equal(prevKey.Key, mvccKey.Key) {
 			// We only advanced timestamps, but not new mvcc keys.
 			sizeSoFar += timestampLen


### PR DESCRIPTION
This was fallout from 95b836d. `pebble.Iterator.Value` is unsafe (no copy) but `pebbleIterator.Value` is safe (alloc + copy).

```
name                                     old time/op    new time/op    delta
MVCCFindSplitKey_Pebble/valueSize=32-16    97.0ms ± 5%    76.5ms ±15%   -21.08%  (p=0.000 n=9+10)

name                                     old speed      new speed      delta
MVCCFindSplitKey_Pebble/valueSize=32-16   693MB/s ± 5%   881MB/s ±13%   +27.19%  (p=0.000 n=9+10)

name                                     old alloc/op   new alloc/op   delta
MVCCFindSplitKey_Pebble/valueSize=32-16    27.8MB ± 0%     0.0MB ±27%   -99.99%  (p=0.000 n=10+10)

name                                     old allocs/op  new allocs/op  delta
MVCCFindSplitKey_Pebble/valueSize=32-16      580k ± 0%        0k ± 0%  -100.00%  (p=0.000 n=10+9)
```

At the end of a 4 hour, 2.2 TB IMPORT of TPC-E, this was responsible for 15.96% of all heap allocations (by object).

<img width="1680" alt="Screen Shot 2020-12-20 at 10 13 35 PM" src="https://user-images.githubusercontent.com/5438456/102735999-d6ab7d00-4311-11eb-81fb-a1bd6d807323.png">
