### PR TITLE
kvprober: introduce a package for probing the KV layer that does reads only

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -83,6 +83,7 @@ ALL_TESTS = [
     "//pkg/kv/kvclient/rangecache:rangecache_test",
     "//pkg/kv/kvclient/rangefeed:rangefeed_test",
     "//pkg/kv/kvnemesis:kvnemesis_test",
+    "//pkg/kv/kvprober:kvprober_test",
     "//pkg/kv/kvserver/abortspan:abortspan_test",
     "//pkg/kv/kvserver/apply:apply_test",
     "//pkg/kv/kvserver/batcheval/result:result_test",

--- a/pkg/kv/kvprober/BUILD.bazel
+++ b/pkg/kv/kvprober/BUILD.bazel
@@ -1,0 +1,59 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "kvprober",
+    srcs = [
+        "kvprober.go",
+        "planner.go",
+        "settings.go",
+    ],
+    importpath = "github.com/cockroachdb/cockroach/pkg/kv/kvprober",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/keys",
+        "//pkg/kv",
+        "//pkg/roachpb",
+        "//pkg/settings",
+        "//pkg/settings/cluster",
+        "//pkg/util/contextutil",
+        "//pkg/util/log",
+        "//pkg/util/log/logcrash",
+        "//pkg/util/metric",
+        "//pkg/util/stop",
+        "//pkg/util/timeutil",
+        "@com_github_cockroachdb_errors//:errors",
+    ],
+)
+
+go_test(
+    name = "kvprober_test",
+    srcs = [
+        "helpers_test.go",
+        "kvprober_integration_test.go",
+        "kvprober_test.go",
+        "main_test.go",
+    ],
+    embed = [":kvprober"],
+    deps = [
+        "//pkg/base",
+        "//pkg/keys",
+        "//pkg/kv",
+        "//pkg/kv/kvserver",
+        "//pkg/roachpb",
+        "//pkg/security",
+        "//pkg/security/securitytest",
+        "//pkg/server",
+        "//pkg/settings/cluster",
+        "//pkg/testutils",
+        "//pkg/testutils/serverutils",
+        "//pkg/testutils/skip",
+        "//pkg/testutils/testcluster",
+        "//pkg/util/leaktest",
+        "//pkg/util/log",
+        "//pkg/util/randutil",
+        "//pkg/util/syncutil",
+        "//pkg/util/tracing",
+        "@com_github_cockroachdb_errors//:errors",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/pkg/kv/kvprober/helpers_test.go
+++ b/pkg/kv/kvprober/helpers_test.go
@@ -1,0 +1,29 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package kvprober
+
+import "context"
+
+// Below are exported to enable testing from kvprober_test.
+
+var (
+	ReadEnabled          = readEnabled
+	ReadInterval         = readInterval
+	NumStepsToPlanAtOnce = numStepsToPlanAtOnce
+)
+
+func (p *Prober) Probe(ctx context.Context, db dbGet) {
+	p.probe(ctx, db)
+}
+
+func (p *Prober) PlannerNext(ctx context.Context) (Step, error) {
+	return p.planner.next(ctx)
+}

--- a/pkg/kv/kvprober/kvprober.go
+++ b/pkg/kv/kvprober/kvprober.go
@@ -1,0 +1,222 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Package kvprober sends queries to KV in a loop, with configurable sleep
+// times, in order to generate data about the healthiness or unhealthiness of
+// kvclient & below.
+//
+// Prober increments metrics that SRE & other operators can use as alerting
+// signals. It also writes to logs to help narrow down the problem (e.g. which
+// range(s) are acting up).
+package kvprober
+
+import (
+	"context"
+	"math/rand"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/log/logcrash"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+// Prober sends queries to KV in a loop. See package docstring for more.
+type Prober struct {
+	ambientCtx log.AmbientContext
+	db         *kv.DB
+	settings   *cluster.Settings
+	// planner is an interface for selecting a range to probe.
+	planner planner
+
+	// Metrics wraps up the set of prometheus metrics that the prober sets. The
+	// goal of the prober IS to populate these metrics.
+	Metrics Metrics
+}
+
+// Opts provides knobs to control kvprober.Prober.
+type Opts struct {
+	AmbientCtx log.AmbientContext
+	DB         *kv.DB
+	Settings   *cluster.Settings
+	// The windowed portion of the latency histogram retains values for
+	// approximately histogramWindow. See metrics library for more.
+	HistogramWindowInterval time.Duration
+}
+
+var (
+	metaReadProbeAttempts = metric.Metadata{
+		Name:        "kv.prober.read.attempts",
+		Help:        "Number of attempts made to probe KV, regardless of outcome",
+		Measurement: "Queries",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaReadProbeFailures = metric.Metadata{
+		Name: "kv.prober.read.failures",
+		Help: "Number of attempts made to probe KV that failed, " +
+			"whether due to error or timeout",
+		Measurement: "Queries",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaReadProbeLatency = metric.Metadata{
+		Name:        "kv.prober.read.latency",
+		Help:        "Latency of successful KV read probes",
+		Measurement: "Latency",
+		Unit:        metric.Unit_NANOSECONDS,
+	}
+	metaProbePlanAttempts = metric.Metadata{
+		Name: "kv.prober.planning_attempts",
+		Help: "Number of attempts at planning out probes made; " +
+			"in order to probe KV we need to plan out which ranges to probe;",
+		Measurement: "Runs",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaProbePlanFailures = metric.Metadata{
+		Name: "kv.prober.planning_failures",
+		Help: "Number of attempts at planning out probes that failed; " +
+			"in order to probe KV we need to plan out which ranges to probe; " +
+			"if planning fails, then kvprober is not able to send probes to " +
+			"all ranges; consider alerting on this metric as a result",
+		Measurement: "Runs",
+		Unit:        metric.Unit_COUNT,
+	}
+	// TODO(josh): Add a histogram that captures where in the "rangespace" errors
+	// are occurring. This will allow operators to see at a glance what percentage
+	// of ranges are affected.
+)
+
+// Metrics groups together the metrics that kvprober exports.
+type Metrics struct {
+	ReadProbeAttempts *metric.Counter
+	ReadProbeFailures *metric.Counter
+	ReadProbeLatency  *metric.Histogram
+	ProbePlanAttempts *metric.Counter
+	ProbePlanFailures *metric.Counter
+}
+
+// NewProber creates a Prober from Opts.
+func NewProber(opts Opts) *Prober {
+	return &Prober{
+		ambientCtx: opts.AmbientCtx,
+		db:         opts.DB,
+		settings:   opts.Settings,
+
+		planner: newMeta2Planner(opts.DB, opts.Settings),
+		Metrics: Metrics{
+			ReadProbeAttempts: metric.NewCounter(metaReadProbeAttempts),
+			ReadProbeFailures: metric.NewCounter(metaReadProbeFailures),
+			ReadProbeLatency:  metric.NewLatency(metaReadProbeLatency, opts.HistogramWindowInterval),
+			ProbePlanAttempts: metric.NewCounter(metaProbePlanAttempts),
+			ProbePlanFailures: metric.NewCounter(metaProbePlanFailures),
+		},
+	}
+}
+
+// Start causes kvprober to start probing KV. Start returns immediately. Start
+// returns an error only if stopper.RunAsyncTask returns an error.
+func (p *Prober) Start(ctx context.Context, stopper *stop.Stopper) error {
+	return stopper.RunAsyncTask(ctx, "probe loop", func(ctx context.Context) {
+		ambient := p.ambientCtx
+		ambient.AddLogTag("kvprober", nil)
+
+		ctx, sp := ambient.AnnotateCtxWithSpan(ctx, "probe loop")
+		defer sp.Finish()
+
+		ctx, cancel := stopper.WithCancelOnQuiesce(ctx)
+		defer cancel()
+
+		ticker := time.NewTicker(withJitter(readInterval.Get(&p.settings.SV), rand.Int63n))
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ticker.C:
+			case <-stopper.ShouldQuiesce():
+				return
+			}
+
+			// Jitter added to de-synchronize different nodes' probe loops.
+			ticker.Reset(withJitter(readInterval.Get(&p.settings.SV), rand.Int63n))
+
+			p.probe(ctx, p.db)
+		}
+	})
+}
+
+type dbGet interface {
+	Get(ctx context.Context, key interface{}) (kv.KeyValue, error)
+}
+
+// Doesn't return an error. Instead increments error type specific metrics.
+func (p *Prober) probe(ctx context.Context, db dbGet) {
+	defer logcrash.RecoverAndReportNonfatalPanic(ctx, &p.settings.SV)
+
+	if !readEnabled.Get(&p.settings.SV) {
+		return
+	}
+
+	p.Metrics.ProbePlanAttempts.Inc(1)
+
+	step, err := p.planner.next(ctx)
+	if err != nil {
+		log.Health.Errorf(ctx, "can't make a plan: %v", err)
+		p.Metrics.ProbePlanFailures.Inc(1)
+		return
+	}
+
+	// If errors above the KV scan, then this counter won't be incremented.
+	// This means that ReadProbeErrors / ReadProbeAttempts captures the KV
+	// error rate only as desired. It also means that operators can alert on
+	// an unexpectedly low rate of ReadProbeAttempts or else a high rate of
+	// ProbePlanFailures. This would probably be a ticket alerting as
+	// the impact is more low visibility into possible failures than a high
+	// impact production issue.
+	p.Metrics.ReadProbeAttempts.Inc(1)
+
+	start := timeutil.Now()
+
+	// Slow enough response times are not different than errors from the
+	// perspective of the user.
+	timeout := readTimeout.Get(&p.settings.SV)
+	err = contextutil.RunWithTimeout(ctx, "db.Get", timeout, func(ctx context.Context) error {
+		// We read the start key for the range. There may be no data at the key,
+		// but that is okay. Even if there is no data at the key, the prober still
+		// executes a basic read operation on the range.
+		// TODO(josh): Trace the probes.
+		_, err = db.Get(ctx, step.StartKey)
+		return err
+	})
+	if err != nil {
+		// TODO(josh): Write structured events with log.Structured.
+		log.Health.Errorf(ctx, "kv.Get(%s), r=%v failed with: %v", step.StartKey, step.RangeID, err)
+		p.Metrics.ReadProbeFailures.Inc(1)
+		return
+	}
+
+	d := timeutil.Since(start)
+	log.Health.Infof(ctx, "kv.Get(%s), r=%v returned success in %v", step.StartKey, step.RangeID, d)
+
+	// Latency of failures is not recorded. They are counted as failures tho.
+	p.Metrics.ReadProbeLatency.RecordValue(d.Nanoseconds())
+}
+
+// Returns a random duration pulled from the uniform distribution given below:
+// [d - 0.2*d, d + 0.2*d]
+func withJitter(d time.Duration, intn func(n int64) int64) time.Duration {
+	jitter := time.Duration(intn(d.Milliseconds()/5)) * time.Millisecond
+	if intn(2) == 1 {
+		return d + jitter
+	}
+	return d - jitter
+}

--- a/pkg/kv/kvprober/kvprober_integration_test.go
+++ b/pkg/kv/kvprober/kvprober_integration_test.go
@@ -1,0 +1,228 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package kvprober_test
+
+import (
+	"bytes"
+	"context"
+	gosql "database/sql"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvprober"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProberDoesReads(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	skip.UnderShort(t)
+
+	ctx := context.Background()
+
+	t.Run("disabled by default", func(t *testing.T) {
+		s, _, p, cleanup := initTestProber(t, base.TestingKnobs{})
+		defer cleanup()
+
+		kvprober.ReadInterval.Override(&s.ClusterSettings().SV, 5*time.Millisecond)
+
+		require.NoError(t, p.Start(ctx, s.Stopper()))
+
+		time.Sleep(100 * time.Millisecond)
+
+		require.Zero(t, p.Metrics.ProbePlanAttempts.Count())
+		require.Zero(t, p.Metrics.ReadProbeAttempts.Count())
+	})
+
+	t.Run("happy path", func(t *testing.T) {
+		s, _, p, cleanup := initTestProber(t, base.TestingKnobs{})
+		defer cleanup()
+
+		kvprober.ReadEnabled.Override(&s.ClusterSettings().SV, true)
+		kvprober.ReadInterval.Override(&s.ClusterSettings().SV, 5*time.Millisecond)
+
+		require.NoError(t, p.Start(ctx, s.Stopper()))
+
+		testutils.SucceedsSoon(t, func() error {
+			if p.Metrics.ReadProbeAttempts.Count() < int64(50) {
+				return errors.Newf("probe count too low: %v", p.Metrics.ReadProbeAttempts.Count())
+			}
+			return nil
+		})
+		require.Zero(t, p.Metrics.ReadProbeFailures.Count())
+		require.Zero(t, p.Metrics.ProbePlanFailures.Count())
+	})
+
+	t.Run("a single range is unavailable", func(t *testing.T) {
+		s, _, p, cleanup := initTestProber(t, base.TestingKnobs{
+			Store: &kvserver.StoreTestingKnobs{
+				TestingRequestFilter: func(i context.Context, ba roachpb.BatchRequest) *roachpb.Error {
+					for _, ru := range ba.Requests {
+						key := ru.GetInner().Header().Key
+						if bytes.HasPrefix(key, keys.TimeseriesPrefix) {
+							return roachpb.NewError(fmt.Errorf("boom"))
+						}
+					}
+					return nil
+				},
+			},
+		})
+		defer cleanup()
+
+		kvprober.ReadEnabled.Override(&s.ClusterSettings().SV, true)
+		kvprober.ReadInterval.Override(&s.ClusterSettings().SV, 5*time.Millisecond)
+
+		require.NoError(t, p.Start(ctx, s.Stopper()))
+
+		// Expect >=2 failures eventually due to unavailable time-series range.
+		// TODO(josh): Once structured logging is in, can check that failures
+		// involved only the time-series range.
+		testutils.SucceedsSoon(t, func() error {
+			if p.Metrics.ReadProbeFailures.Count() < int64(2) {
+				return errors.Newf("error count too low: %v", p.Metrics.ReadProbeFailures.Count())
+			}
+			return nil
+		})
+		require.Zero(t, p.Metrics.ProbePlanFailures.Count())
+	})
+
+	t.Run("all ranges are unavailable for Gets", func(t *testing.T) {
+		mu := syncutil.Mutex{}
+		dbIsAvailable := true
+
+		s, _, p, cleanup := initTestProber(t, base.TestingKnobs{
+			Store: &kvserver.StoreTestingKnobs{
+				TestingRequestFilter: func(i context.Context, ba roachpb.BatchRequest) *roachpb.Error {
+					mu.Lock()
+					defer mu.Unlock()
+					if !dbIsAvailable {
+						for _, ru := range ba.Requests {
+							// Planning depends on Scan so only returning an error on Get
+							// keeps planning working.
+							if ru.GetGet() != nil {
+								return roachpb.NewError(fmt.Errorf("boom"))
+							}
+						}
+						return nil
+					}
+					return nil
+				},
+			},
+		})
+		defer cleanup()
+
+		// Want server to startup successfully then become unavailable.
+		mu.Lock()
+		dbIsAvailable = false
+		mu.Unlock()
+
+		kvprober.ReadEnabled.Override(&s.ClusterSettings().SV, true)
+		kvprober.ReadInterval.Override(&s.ClusterSettings().SV, 5*time.Millisecond)
+
+		// Probe exactly ten times so we can make assertions below.
+		for i := 0; i < 10; i++ {
+			p.Probe(ctx, s.DB())
+		}
+
+		// Expect all probes to fail but planning to succeed.
+		require.Equal(t, int64(10), p.Metrics.ReadProbeAttempts.Count())
+		require.Equal(t, int64(10), p.Metrics.ReadProbeFailures.Count())
+		require.Zero(t, p.Metrics.ProbePlanFailures.Count())
+	})
+}
+
+func TestPlannerMakesPlansCoveringAllRanges(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	skip.UnderShort(t)
+
+	ctx := context.Background()
+	_, sqlDB, p, cleanup := initTestProber(t, base.TestingKnobs{})
+	defer cleanup()
+
+	rangeIDToTimesWouldBeProbed := make(map[int64]int)
+
+	test := func(n int) {
+		var numRanges int64
+		if err := sqlDB.QueryRow(
+			"SELECT count(*) FROM crdb_internal.ranges").Scan(&numRanges); err != nil {
+			require.True(t, false)
+		}
+		log.Infof(ctx, "want numRanges %v", numRanges)
+
+		require.Eventually(t, func() bool {
+			step, err := p.PlannerNext(ctx)
+			require.NoError(t, err)
+
+			rangeIDToTimesWouldBeProbed[int64(step.RangeID)]++
+
+			log.Infof(ctx, "current rangeID to times would be probed map: %v", rangeIDToTimesWouldBeProbed)
+
+			for i := int64(1); i <= numRanges; i++ {
+				// Expect all ranges to eventually be returned by Next n or n+1 times.
+				// Can't expect all ranges to be returned by Next exactly n times,
+				// as the order in which the lowest ordinal ranges are returned by
+				// Next the nth+1 time and the highest ordinal ranges are returned by
+				// Next the nth time is NOT specified. The reason for this is
+				// that we make plans in batches of a constant size and then randomize
+				// the order of the batch. See plan.go for more.
+				if rangeIDToTimesWouldBeProbed[i] != n && rangeIDToTimesWouldBeProbed[i] != n+1 {
+					return false
+				}
+			}
+			return true
+		}, time.Second, time.Millisecond)
+	}
+	for i := 0; i < 20; i++ {
+		test(i)
+	}
+}
+
+func initTestProber(
+	t *testing.T, knobs base.TestingKnobs,
+) (serverutils.TestServerInterface, *gosql.DB, *kvprober.Prober, func()) {
+
+	s, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{
+		Settings: cluster.MakeClusterSettings(),
+		Knobs:    knobs,
+	})
+	p := kvprober.NewProber(kvprober.Opts{
+		AmbientCtx: log.AmbientContext{
+			Tracer: tracing.NewTracer(),
+		},
+		DB:                      kvDB,
+		HistogramWindowInterval: time.Minute, // actual value not important to test
+		Settings:                s.ClusterSettings(),
+	})
+
+	// Given small test cluster, this better exercises the planning logic.
+	kvprober.NumStepsToPlanAtOnce.Override(&s.ClusterSettings().SV, 10)
+
+	return s, sqlDB, p, func() {
+		s.Stopper().Stop(context.Background())
+	}
+}

--- a/pkg/kv/kvprober/kvprober_test.go
+++ b/pkg/kv/kvprober/kvprober_test.go
@@ -1,0 +1,173 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package kvprober
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/stretchr/testify/require"
+)
+
+// TODO(josh): If I have some extra time, would folks want me to look into
+// setting up gomock? We use it a lot in CC; it is quite nice; I think it makes
+// for more readable tests than ones that use a custom mock. I see this issue:
+// https://github.com/cockroachdb/cockroach/issues/6933
+func TestProbe(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("disabled by default", func(t *testing.T) {
+		m := &mock{
+			t:      t,
+			noPlan: true,
+			noGet:  true,
+		}
+		p := initTestProber(m)
+
+		p.probe(ctx, m)
+
+		require.Zero(t, p.Metrics.ProbePlanAttempts.Count())
+		require.Zero(t, p.Metrics.ReadProbeAttempts.Count())
+		require.Zero(t, p.Metrics.ProbePlanFailures.Count())
+		require.Zero(t, p.Metrics.ReadProbeFailures.Count())
+	})
+
+	t.Run("happy path", func(t *testing.T) {
+		m := &mock{t: t}
+		p := initTestProber(m)
+		readEnabled.Override(&p.settings.SV, true)
+
+		p.probe(ctx, m)
+
+		require.Equal(t, int64(1), p.Metrics.ProbePlanAttempts.Count())
+		require.Equal(t, int64(1), p.Metrics.ReadProbeAttempts.Count())
+		require.Zero(t, p.Metrics.ProbePlanFailures.Count())
+		require.Zero(t, p.Metrics.ReadProbeFailures.Count())
+	})
+
+	t.Run("planning fails", func(t *testing.T) {
+		m := &mock{
+			t:       t,
+			planErr: fmt.Errorf("inject plan failure"),
+			noGet:   true,
+		}
+		p := initTestProber(m)
+		readEnabled.Override(&p.settings.SV, true)
+
+		p.probe(ctx, m)
+
+		require.Equal(t, int64(1), p.Metrics.ProbePlanAttempts.Count())
+		require.Zero(t, p.Metrics.ReadProbeAttempts.Count())
+		require.Equal(t, int64(1), p.Metrics.ProbePlanFailures.Count())
+		require.Zero(t, p.Metrics.ReadProbeFailures.Count())
+	})
+
+	t.Run("get fails", func(t *testing.T) {
+		m := &mock{
+			t:      t,
+			getErr: fmt.Errorf("inject get failure"),
+		}
+		p := initTestProber(m)
+		readEnabled.Override(&p.settings.SV, true)
+
+		p.probe(ctx, m)
+
+		require.Equal(t, int64(1), p.Metrics.ProbePlanAttempts.Count())
+		require.Equal(t, int64(1), p.Metrics.ReadProbeAttempts.Count())
+		require.Zero(t, p.Metrics.ProbePlanFailures.Count())
+		require.Equal(t, int64(1), p.Metrics.ReadProbeFailures.Count())
+	})
+}
+
+func initTestProber(m *mock) *Prober {
+	p := NewProber(Opts{
+		AmbientCtx: log.AmbientContext{
+			Tracer: tracing.NewTracer(),
+		},
+		HistogramWindowInterval: time.Minute, // actual value not important to test
+		Settings:                cluster.MakeTestingClusterSettings(),
+	})
+	p.planner = m
+	return p
+}
+
+type mock struct {
+	t *testing.T
+
+	noPlan  bool
+	planErr error
+
+	noGet  bool
+	getErr error
+}
+
+func (m *mock) next(ctx context.Context) (Step, error) {
+	if m.noPlan {
+		m.t.Errorf("plan call made but not expected")
+	}
+	return Step{}, m.planErr
+}
+
+func (m *mock) Get(ctx context.Context, key interface{}) (kv.KeyValue, error) {
+	if m.noGet {
+		m.t.Errorf("get call made but not expected")
+	}
+	return kv.KeyValue{}, m.getErr
+}
+
+func TestWithJitter(t *testing.T) {
+	cases := []struct {
+		desc string
+		in   time.Duration
+		intn func(n int64) int64
+		want time.Duration
+	}{
+		{
+			"no jitter added",
+			time.Minute,
+			func(n int64) int64 {
+				return 0
+			},
+			time.Minute,
+		},
+		{
+			"max jitter added",
+			time.Minute,
+			func(n int64) int64 {
+				return n - 1
+			},
+			72 * time.Second,
+		},
+		{
+			"max jitter subtracted",
+			time.Minute,
+			func(n int64) int64 {
+				if n == 2 {
+					return 0
+				}
+				return n - 1
+			},
+			48 * time.Second,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			got := withJitter(tc.in, tc.intn)
+			require.InEpsilon(t, tc.want, got, 0.01)
+		})
+	}
+}

--- a/pkg/kv/kvprober/main_test.go
+++ b/pkg/kv/kvprober/main_test.go
@@ -1,0 +1,31 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package kvprober_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+func TestMain(m *testing.M) {
+	security.SetAssetLoader(securitytest.EmbeddedAssets)
+	randutil.SeedForTests()
+	serverutils.InitTestServerFactory(server.TestServerFactory)
+	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
+	os.Exit(m.Run())
+}

--- a/pkg/kv/kvprober/planner.go
+++ b/pkg/kv/kvprober/planner.go
@@ -1,0 +1,198 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package kvprober
+
+import (
+	"context"
+	"math/rand"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
+	"github.com/cockroachdb/errors"
+)
+
+// Step is a decision on what range to probe next, including info needed by
+// kvprober to execute on the plan, such as the range's start key.
+//
+// Public to test from kvprober_test.go.
+type Step struct {
+	RangeID  roachpb.RangeID
+	StartKey roachpb.RKey
+}
+
+// planner abstracts deciding on ranges to probe. It is public to integration
+// test from kvprober_test.
+type planner interface {
+	// Next returns a Step for the prober to execute on. A Step is a decision on
+	// on what range to probe next. Executing on a series of Steps returned by
+	// repeated calls to Next should lead to an even distribution of probes over
+	// ranges, at least in the limit.
+	//
+	// Errors may be temporary or persistent; retrying is an acceptable response;
+	// callers should take care to backoff when retrying as always.
+	next(ctx context.Context) (Step, error)
+}
+
+// meta2Planner is a planner that scans meta2 to make plans. A plan is a slice
+// of steps. A Step is a decision on what range to probe next.
+type meta2Planner struct {
+	db       *kv.DB
+	settings *cluster.Settings
+	// cursor points to a key in meta2 at which scanning should resume when new
+	// plans are needed.
+	cursor roachpb.Key
+	// meta2Planner makes plans of size NumPrefetchedPlan as per below.
+	plan []Step
+}
+
+func newMeta2Planner(db *kv.DB, settings *cluster.Settings) *meta2Planner {
+	return &meta2Planner{
+		db:       db,
+		settings: settings,
+		cursor:   keys.Meta2Prefix,
+	}
+}
+
+// next returns a Step for the prober to execute on.
+//
+// Beyond even distribution of probes over the "rangespace", we have
+// two design goals for our approach to probabilistically selecting a place in
+// the keyspace to probe:
+//
+// 1. That the approach is efficient enough. Resource requirements shouldn't
+//    scale with the number of ranges in the cluster, for example.
+// 2. That the approach is available enough in times of outage that the
+//    prober is able to generate useful signal when we need it most.
+//
+// How do we do it? The first option we considered was to probe
+// crdb_internal.ranges_no_leases. We reject that approach in favor of making a
+// plan by scanning meta2 via *kv.DB. This approach shouldn't have the
+// performance issues that querying crdb_internal.ranges_no_leases does, e.g.
+// at plan time only a portion of meta2 is scanned. It also depends on just
+// meta2, unlike querying crdb_internal.ranges_no_leases (which pulls table
+// descriptors so as to list table names).
+//
+// Note that though we scan meta2 here, we also randomize the order of
+// ranges in the plan. This is avoid all nodes probing the same ranges at
+// the same time. Jitter is also added to the sleep between probe time
+// to de-synchronize different nodes' probe loops.
+//
+// What about resource usage?
+//
+// The first thing to note is that due to the
+// kv.prober.planner.n_probes_at_a_time cluster setting, the resource usage
+// should not scale up as the number of ranges in the cluster grows.
+//
+// Memory:
+// - The meta2Planner struct's mem usage scales with
+//   size(the Plan struct) * the kv.prober.planner.n_probes_at_a_time cluster
+//   setting.
+// - The Plan function's mem usage scales with
+//   size(KV pairs holding range descriptors) * the
+//   kv.prober.planner.n_probes_at_a_time cluster setting.
+//
+// CPU:
+// - Again scales with the the kv.prober.planner.n_probes_at_a_time cluster
+//   setting. Note the proto unmarshalling. We also shuffle a slice of size
+//   kv.prober.planner.n_probes_at_a_time. If the setting is set to a high
+//   number, we pay a higher CPU cost less often; if it's set to a low number,
+//   we pay a smaller CPU cost more often.
+func (p *meta2Planner) next(ctx context.Context) (Step, error) {
+	if len(p.plan) == 0 {
+		timeout := scanMeta2Timeout.Get(&p.settings.SV)
+		kvs, cursor, err := getNMeta2KVs(
+			ctx, p.db, numStepsToPlanAtOnce.Get(&p.settings.SV), p.cursor, timeout)
+		if err != nil {
+			return Step{}, errors.Wrapf(err, "failed to get meta2 rows")
+		}
+		p.cursor = cursor
+
+		plan, err := meta2KVsToPlan(kvs)
+		if err != nil {
+			return Step{}, errors.Wrapf(err, "failed to make plan from meta2 rows")
+		}
+
+		// This plus jitter added to the sleep time means probes on all nodes
+		// shouldn't hit same ranges at the same time.
+		rand.Shuffle(len(plan), func(i, j int) {
+			plan[i], plan[j] = plan[j], plan[i]
+		})
+
+		p.plan = plan
+	}
+
+	step := p.plan[0]
+	p.plan = p.plan[1:]
+	return step, nil
+}
+
+type dbScan interface {
+	Scan(ctx context.Context, begin, end interface{}, maxRows int64) ([]kv.KeyValue, error)
+}
+
+func getNMeta2KVs(
+	ctx context.Context, db dbScan, n int64, cursor roachpb.Key, timeout time.Duration,
+) ([]kv.KeyValue, roachpb.Key, error) {
+	var kvs []kv.KeyValue
+
+	for n > 0 {
+		var newkvs []kv.KeyValue
+		if err := contextutil.RunWithTimeout(ctx, "db.Scan", timeout, func(ctx context.Context) error {
+			// NB: keys.Meta2KeyMax stores a descriptor, so we want to include it.
+			var err error
+			newkvs, err = db.Scan(ctx, cursor, keys.Meta2KeyMax.Next(), n /*maxRows*/)
+			return err
+		}); err != nil {
+			return nil, nil, err
+		}
+
+		// This shouldn't happen but if it does we don't want an infinite loop.
+		if len(newkvs) == 0 {
+			return nil, nil, errors.New("scanning meta2 returned no KV pairs")
+		}
+
+		n = n - int64(len(newkvs))
+		kvs = append(kvs, newkvs...)
+		cursor = kvs[len(kvs)-1].Key.Next()
+		// If at end of meta2, wrap around to the beginning.
+		if cursor.Equal(keys.Meta2KeyMax.Next()) {
+			cursor = keys.Meta2Prefix
+		}
+	}
+
+	return kvs, cursor, nil
+}
+
+func meta2KVsToPlan(kvs []kv.KeyValue) ([]Step, error) {
+	plans := make([]Step, len(kvs))
+
+	var rangeDesc roachpb.RangeDescriptor
+	for i, kv := range kvs {
+		if err := kv.ValueProto(&rangeDesc); err != nil {
+			return nil, err
+		}
+		plans[i] = Step{
+			RangeID:  rangeDesc.RangeID,
+			StartKey: rangeDesc.StartKey,
+		}
+		// It appears r1's start key (/Min) can't be queried. The prober gets
+		// back this error if it's attempted: "attempted access to empty key"
+		if rangeDesc.RangeID == 1 {
+			plans[i].StartKey = plans[i].StartKey.Next()
+		}
+	}
+
+	return plans, nil
+}

--- a/pkg/kv/kvprober/settings.go
+++ b/pkg/kv/kvprober/settings.go
@@ -1,0 +1,76 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package kvprober
+
+import (
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/errors"
+)
+
+var readEnabled = settings.RegisterBoolSetting(
+	"kv.prober.read.enabled",
+	"whether the KV read prober is enabled",
+	false)
+
+// TODO(josh): Another option is for the cluster setting to be a QPS target
+// for the cluster as a whole.
+var readInterval = settings.RegisterDurationSetting(
+	"kv.prober.read.interval",
+	"how often each node sends a read probe to the KV layer on average (jitter is added); "+
+		"note that a very slow read can block kvprober from sending additional probes; "+
+		"kv.prober.read.timeout controls the max time kvprober can be blocked",
+	1*time.Minute, func(duration time.Duration) error {
+		if duration <= 0 {
+			return errors.New("param must be >0")
+		}
+		return nil
+	})
+
+var readTimeout = settings.RegisterDurationSetting(
+	"kv.prober.read.timeout",
+	// Slow enough response times are not different than errors from the
+	// perspective of the user.
+	"if this much time elapses without success, a KV read probe will be treated as an error; "+
+		"note that a very slow read can block kvprober from sending additional probes"+
+		"this setting controls the max time kvprober can be blocked",
+	2*time.Second, func(duration time.Duration) error {
+		if duration <= 0 {
+			return errors.New("param must be >0")
+		}
+		return nil
+	})
+
+var scanMeta2Timeout = settings.RegisterDurationSetting(
+	"kv.prober.planner.scan_meta2.timeout",
+	"timeout on scanning meta2 via db.Scan with max rows set to "+
+		"kv.prober.planner.num_steps_to_plan_at_once",
+	2*time.Second, func(duration time.Duration) error {
+		if duration <= 0 {
+			return errors.New("param must be >0")
+		}
+		return nil
+	})
+
+var numStepsToPlanAtOnce = settings.RegisterIntSetting(
+	"kv.prober.planner.num_steps_to_plan_at_once",
+	"the number of Steps to plan at once, where a Step is a decision on "+
+		"what range to probe; the order of the Steps is randomized within "+
+		"each planning run, so setting this to a small number will lead to "+
+		"close-to-lexical probing; already made plans are held in memory, so "+
+		"large values are advised against",
+	100, func(i int64) error {
+		if i <= 0 {
+			return errors.New("param must be >0")
+		}
+		return nil
+	})

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -67,6 +67,7 @@ go_library(
         "//pkg/kv/kvclient/kvcoord",
         "//pkg/kv/kvclient/kvtenant",
         "//pkg/kv/kvclient/rangefeed",
+        "//pkg/kv/kvprober",
         "//pkg/kv/kvserver",
         "//pkg/kv/kvserver/closedts/container",
         "//pkg/kv/kvserver/kvserverbase",

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -40,6 +40,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangefeed"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvprober"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts/container"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness"
@@ -155,7 +156,8 @@ type Server struct {
 	raftTransport   *kvserver.RaftTransport
 	stopper         *stop.Stopper
 
-	debug *debug.Server
+	debug    *debug.Server
+	kvProber *kvprober.Prober
 
 	replicationReporter   *reports.Reporter
 	protectedtsProvider   protectedts.Provider
@@ -638,6 +640,13 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		}
 	}
 
+	kvProber := kvprober.NewProber(kvprober.Opts{
+		AmbientCtx:              cfg.AmbientCtx,
+		DB:                      db,
+		Settings:                st,
+		HistogramWindowInterval: cfg.HistogramWindowInterval(),
+	})
+
 	sqlServer, err := newSQLServer(ctx, sqlServerArgs{
 		sqlServerOptionalKVArgs: sqlServerOptionalKVArgs{
 			nodesStatusServer:      serverpb.MakeOptionalNodesStatusServer(sStatus),
@@ -706,6 +715,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		raftTransport:          raftTransport,
 		stopper:                stopper,
 		debug:                  debugServer,
+		kvProber:               kvProber,
 		replicationReporter:    replicationReporter,
 		protectedtsProvider:    protectedtsProvider,
 		protectedtsReconciler:  protectedtsReconciler,
@@ -1814,6 +1824,10 @@ func (s *Server) PreStart(ctx context.Context) error {
 	// started. At this point we know that all sqlmigrations have successfully
 	// been run so it is safe to upgrade to the binary's current version.
 	s.startAttemptUpgrade(ctx)
+
+	if err := s.kvProber.Start(ctx, s.stopper); err != nil {
+		return errors.Wrapf(err, "failed to start KV prober")
+	}
 
 	log.Event(ctx, "server initialized")
 	return nil


### PR DESCRIPTION
https://docs.google.com/document/d/1NqsIgizseyMxUBimpE10m6sSnbebQ25VyJRUwxdmJyM/edit

**kv: introduce a package for probing the KV layer**
    
This commmit introduces a package for probing the KV layer. The goal
of sending such probes is greater obserability into the reliability of
the KV layer & below. In particular probes may make for a good SLI
metric. The control we have over the prober workload will generate data
with a high signal to noise ratio. This lets us alert operators with
confidence.

How does the prober work? Right now, it just does reads. In a
loop, it randomly selects a range to probe by scanning meta2.
It then does a single row read of the start key of that range via
*kv.DB.

Note that the prober is disabled by default. This commit introduces a
private cluster setting that defaults to off.

Release justification: auxiliary system that is off by default

Release note: None.