### PR TITLE
geo/geomfn: implement ST_LineSubstring({geometry,float8,float8})

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -1883,6 +1883,10 @@ calculated, the result is transformed back into a Geography with SRID 4326.</p>
 </span></td></tr>
 <tr><td><a name="st_linestringfromwkb"></a><code>st_linestringfromwkb(wkb: <a href="bytes.html">bytes</a>, srid: <a href="int.html">int</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the Geometry from a WKB (or EWKB) representation with an SRID. If the shape underneath is not LineString, NULL is returned.</p>
 </span></td></tr>
+<tr><td><a name="st_linesubstring"></a><code>st_linesubstring(linestring: geometry, start_fraction: <a href="decimal.html">decimal</a>, end_fraction: <a href="decimal.html">decimal</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Return a linestring being a substring of the input one starting and ending at the given fractions of total 2D length. Second and third arguments are float8 values between 0 and 1.</p>
+</span></td></tr>
+<tr><td><a name="st_linesubstring"></a><code>st_linesubstring(linestring: geometry, start_fraction: <a href="float.html">float</a>, end_fraction: <a href="float.html">float</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Return a linestring being a substring of the input one starting and ending at the given fractions of total 2D length. Second and third arguments are float8 values between 0 and 1.</p>
+</span></td></tr>
 <tr><td><a name="st_longestline"></a><code>st_longestline(geometry_a: geometry, geometry_b: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the LineString corresponds to the max distance across every pair of points comprising the given geometries.</p>
 <p>Note if geometries are the same, it will return the LineString with the maximum distance between the geometry’s vertexes. The function will return the longest line that was discovered first when comparing maximum distances if more than one is found.</p>
 </span></td></tr>

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -5678,3 +5678,31 @@ query T
 SELECT ST_AsText(ST_OrientedEnvelope(ST_GeomFromText('MULTIPOINT ((0 0), (-1 -1), (3 2))')));
 ----
 POLYGON ((3 2, 2.88 2.16, -1.12 -0.84, -1 -1, 3 2))
+
+
+statement error pq: st_linesubstring\(\): end must be greater or equal to the start
+select st_astext(st_linesubstring('LINESTRING(0 0, 0 5, 5 5,10 3)'::geometry,0.5,0.4))
+
+statement error pq: st_linesubstring\(\): start and and must be within 0 and 1
+select st_astext(st_linesubstring('LINESTRING(0 0, 0 5, 5 5,10 3)'::geometry,0,1.4));
+
+statement error pq: st_linesubstring\(\): end must be greater or equal to the start
+select st_astext(st_linesubstring('POINT(0 0)'::geometry,0.5,0.4));
+
+query T
+select st_astext(st_linesubstring(g,star,"end"))from (VALUES
+       ('LINESTRING(0 0, 0 5, 4 5, 4 2)'::geometry, 0.0, 0.3),
+       ('LINESTRING(-25 -50, 100 125, 150 190, 40 60)'::geometry, 0.8, 0.9),
+       ('LINESTRING(70 10, 10 125.6, 15.40 1.9, 4 6)'::geometry, 0.1, 0.8),
+       ('LINESTRING(70 10, 10 125)'::geometry, 0.1, 0.8),
+       ('LINESTRING(70 10, 10 125)'::geometry, 0.8, 0.8),
+       ('LINESTRING(0 0, 0 0)'::geometry, 0.8, 0.8)
+    ) t(g,star, "end");
+----
+LINESTRING (0 0, 0 3.6)
+LINESTRING (100.377266789273136 131.354951660050062, 70.188633394636568 95.677475830025031)
+LINESTRING (57.73791181125825 33.624956576975762, 10 125.599999999999994, 13.606639646773948 42.981236239641234)
+LINESTRING (64 21.5, 22 102)
+POINT (22 102)
+POINT (0 0)
+

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -5855,6 +5855,59 @@ May return a Point or LineString in the case of degenerate inputs.`,
 			Volatility: tree.VolatilityImmutable,
 		},
 	),
+	"st_linesubstring": makeBuiltin(defProps(),
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"linestring", types.Geometry},
+				{"start_fraction", types.Float},
+				{"end_fraction", types.Float},
+			},
+			ReturnType: tree.FixedReturnType(types.Geometry),
+			Volatility: tree.VolatilityImmutable,
+			Info: infoBuilder{
+				info: "Return a linestring being a substring of the input one starting and ending at the given fractions of total 2D length. Second and third arguments are float8 values between 0 and 1.",
+			}.String(),
+			Fn: func(_ *tree.EvalContext, datums tree.Datums) (tree.Datum, error) {
+				g := tree.MustBeDGeometry(datums[0])
+				startFraction := float64(tree.MustBeDFloat(datums[1]))
+				endFraction := float64(tree.MustBeDFloat(datums[2]))
+				geometry, err := geomfn.LineSubstring(g.Geometry, startFraction, endFraction)
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDGeometry(geometry), nil
+			},
+		},
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"linestring", types.Geometry},
+				{"start_fraction", types.Decimal},
+				{"end_fraction", types.Decimal},
+			},
+			ReturnType: tree.FixedReturnType(types.Geometry),
+			Volatility: tree.VolatilityImmutable,
+			Info: infoBuilder{
+				info: "Return a linestring being a substring of the input one starting and ending at the given fractions of total 2D length. Second and third arguments are float8 values between 0 and 1.",
+			}.String(),
+			Fn: func(_ *tree.EvalContext, datums tree.Datums) (tree.Datum, error) {
+				g := tree.MustBeDGeometry(datums[0])
+				startFraction := tree.MustBeDDecimal(datums[1])
+				startFractionFloat, err := startFraction.Float64()
+				if err != nil {
+					return nil, err
+				}
+				endFraction := tree.MustBeDDecimal(datums[2])
+				endFractionFloat, err := endFraction.Float64()
+				if err != nil {
+					return nil, err
+				}
+				geometry, err := geomfn.LineSubstring(g.Geometry, startFractionFloat, endFractionFloat)
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDGeometry(geometry), nil
+			},
+		}),
 
 	//
 	// Unimplemented.
@@ -5884,7 +5937,6 @@ May return a Point or LineString in the case of degenerate inputs.`,
 	"st_length2dspheroid":      makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 48967}),
 	"st_lengthspheroid":        makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 48968}),
 	"st_linecrossingdirection": makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 48969}),
-	"st_linesubstring":         makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 48975}),
 	"st_polygonize":            makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 49011}),
 	"st_quantizecoordinates":   makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 49012}),
 	"st_seteffectivearea":      makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 49030}),


### PR DESCRIPTION
Implement ST_LineSubString in CRDB

Fixes #48975.
Release note (sql change): Implemented the geometry-based builtins
ST_LineSubstring({geometry,float8,float8})