### PR TITLE
release-20.2: protoreflect,types,cli,builtins: fix json for types, plumb emitDefaults

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -796,6 +796,8 @@ has no relationship with the commit order of concurrent transactions.</p>
 </span></td></tr>
 <tr><td><a name="crdb_internal.pb_to_json"></a><code>crdb_internal.pb_to_json(pbname: <a href="string.html">string</a>, data: <a href="bytes.html">bytes</a>) &rarr; jsonb</code></td><td><span class="funcdesc"><p>Converts protocol message to its JSONB representation.</p>
 </span></td></tr>
+<tr><td><a name="crdb_internal.pb_to_json"></a><code>crdb_internal.pb_to_json(pbname: <a href="string.html">string</a>, data: <a href="bytes.html">bytes</a>, emit_defaults: <a href="bool.html">bool</a>) &rarr; jsonb</code></td><td><span class="funcdesc"><p>Converts protocol message to its JSONB representation.</p>
+</span></td></tr>
 <tr><td><a name="json_array_length"></a><code>json_array_length(json: jsonb) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Returns the number of elements in the outermost JSON or JSONB array.</p>
 </span></td></tr>
 <tr><td><a name="json_build_array"></a><code>json_build_array(anyelement...) &rarr; jsonb</code></td><td><span class="funcdesc"><p>Builds a possibly-heterogeneously-typed JSON or JSONB array out of a variadic argument list.</p>

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -488,6 +488,7 @@ Decode and print a hexadecimal-encoded key-value pair.
 }
 
 var debugDecodeProtoName string
+var debugDecodeProtoEmitDefaults bool
 var debugDecodeProtoCmd = &cobra.Command{
 	Use:   "decode-proto",
 	Short: "decode-proto <proto> --name=<fully qualified proto name>",
@@ -1342,4 +1343,6 @@ func init() {
 	f = debugDecodeProtoCmd.Flags()
 	f.StringVar(&debugDecodeProtoName, "schema", "cockroach.sql.sqlbase.Descriptor",
 		"fully qualified name of the proto to decode")
+	f.BoolVar(&debugDecodeProtoEmitDefaults, "emit-defaults", true,
+		"encode default values for every field")
 }

--- a/pkg/cli/decode_test.go
+++ b/pkg/cli/decode_test.go
@@ -119,7 +119,7 @@ func TestTryDecodeValue(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotOk, gotVal, err := tryDecodeValue(tt.s, protoName)
+			gotOk, gotVal, err := tryDecodeValue(tt.s, protoName, true /* emitDefaults */)
 			require.Equal(t, tt.wantOK, gotOk)
 			require.NoError(t, err)
 			require.Equal(t, gotVal, tt.wantVal)

--- a/pkg/sql/protoreflect/utils_test.go
+++ b/pkg/sql/protoreflect/utils_test.go
@@ -8,15 +8,18 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-package protoreflect
+package protoreflect_test
 
 import (
+	"encoding/hex"
 	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/geo/geoindex"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/protoreflect"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
@@ -52,6 +55,7 @@ func TestMessageToJSONBRoundTrip(t *testing.T) {
 				Name:            "column",
 				ID:              123,
 				OwnsSequenceIds: []descpb.ID{3, 2, 1},
+				Type:            types.MakeTuple([]*types.T{types.Date, types.IntArray}),
 			},
 		},
 		{ // Message with an array and other embedded descriptors
@@ -87,6 +91,18 @@ func TestMessageToJSONBRoundTrip(t *testing.T) {
 			pbname:  "cockroach.sql.sqlbase.TableDescriptor.SequenceOpts.SequenceOwner",
 			message: &descpb.TableDescriptor_SequenceOpts_SequenceOwner{OwnerColumnID: 123},
 		},
+		{
+			pbname: "cockroach.sql.sqlbase.Descriptor",
+			message: func() protoutil.Message {
+				// This is a real descriptor pulled from a demo cluster for system.jobs
+				// in a 21.1 alpha.
+				encoded, err := hex.DecodeString(`0aa8080a046a6f6273180f200128013a0042310a02696410011a0c08011040180030005014600020002a0e756e697175655f726f7769642829300068007000780080010042250a0673746174757310021a0c08071000180030005019600020003000680070007800800100423a0a076372656174656410031a0d080510001800300050da08600020002a116e6f7728293a3a3a54494d455354414d50300068007000780080010042260a077061796c6f616410041a0c0808100018003000501160002000300068007000780080010042270a0870726f677265737310051a0c08081000180030005011600020013000680070007800800100422e0a0f637265617465645f62795f7479706510061a0c08071000180030005019600020013000680070007800800100422c0a0d637265617465645f62795f696410071a0c08011040180030005014600020013000680070007800800100422f0a10636c61696d5f73657373696f6e5f696410081a0c0808100018003000501160002001300068007000780080010042300a11636c61696d5f696e7374616e63655f696410091a0c08011040180030005014600020013000680070007800800100480a524b0a077072696d6172791001180122026964300140004a10080010001a00200028003000380040005a007a020800800100880100900102980100a20106080012001800a80100b20100ba01005a6e0a176a6f62735f7374617475735f637265617465645f696478100218002206737461747573220763726561746564300230033801400040004a10080010001a00200028003000380040005a007a020800800100880100900102980100a20106080012001800a80100b20100ba01005a96010a266a6f62735f637265617465645f62795f747970655f637265617465645f62795f69645f69647810031800220f637265617465645f62795f74797065220d637265617465645f62795f69642a06737461747573300630073801400040004a10080010001a00200028003000380040005a0070027a020800800100880100900102980100a20106080012001800a80100b20100ba010060046a1f0a0a0a0561646d696e10f0030a090a04726f6f7410f00312046e6f64651801800101880103980100b2016f0a1f66616d5f305f69645f7374617475735f637265617465645f7061796c6f616410001a0269641a067374617475731a07637265617465641a077061796c6f61641a0f637265617465645f62795f747970651a0d637265617465645f62795f69642001200220032004200620072800b2011a0a0870726f677265737310011a0870726f677265737320052805b201340a05636c61696d10021a10636c61696d5f73657373696f6e5f69641a11636c61696d5f696e7374616e63655f6964200820092800b80103c20100e80100f2010408001200f801008002009202009a0200b20200b80200c0021dc80200`)
+				require.NoError(t, err)
+				var desc descpb.Descriptor
+				require.NoError(t, protoutil.Unmarshal(encoded, &desc))
+				return &desc
+			}(),
+		},
 	}
 
 	t.Run("pb-to-json-round-trip", func(t *testing.T) {
@@ -96,12 +112,12 @@ func TestMessageToJSONBRoundTrip(t *testing.T) {
 				require.NoError(t, err)
 
 				// Decode proto bytes to message and compare.
-				decoded, err := DecodeMessage(tc.pbname, protoData)
+				decoded, err := protoreflect.DecodeMessage(tc.pbname, protoData)
 				require.NoError(t, err)
 				require.Equal(t, tc.message, decoded)
 
 				// Encode message as json
-				jsonb, err := MessageToJSON(decoded, false /* emitDefaults */)
+				jsonb, err := protoreflect.MessageToJSON(decoded, false /* emitDefaults */)
 				require.NoError(t, err)
 
 				// Recreate message from json
@@ -118,13 +134,13 @@ func TestMessageToJSONBRoundTrip(t *testing.T) {
 	t.Run("identity-round-trip", func(t *testing.T) {
 		for _, tc := range testCases {
 			t.Run(tc.pbname, func(t *testing.T) {
-				jsonb, err := MessageToJSON(tc.message, false /* emitDefaults */)
+				jsonb, err := protoreflect.MessageToJSON(tc.message, false /* emitDefaults */)
 				require.NoError(t, err)
 
-				fromJSON, err := NewMessage(tc.pbname)
+				fromJSON, err := protoreflect.NewMessage(tc.pbname)
 				require.NoError(t, err)
 
-				fromJSONBytes, err := JSONBMarshalToMessage(jsonb, fromJSON)
+				fromJSONBytes, err := protoreflect.JSONBMarshalToMessage(jsonb, fromJSON)
 				require.NoError(t, err)
 
 				expectedBytes, err := protoutil.Marshal(tc.message)
@@ -143,13 +159,13 @@ func TestInvalidConversions(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	t.Run("no such messagge", func(t *testing.T) {
-		_, err := DecodeMessage("no.such.message", nil)
+		_, err := protoreflect.DecodeMessage("no.such.message", nil)
 		require.Error(t, err)
 	})
 
 	t.Run("must be message type", func(t *testing.T) {
 		// Valid proto enum, but we require types.
-		_, err := DecodeMessage("cockroach.sql.sqlbase.SystemColumnKind", nil)
+		_, err := protoreflect.DecodeMessage("cockroach.sql.sqlbase.SystemColumnKind", nil)
 		require.Error(t, err)
 	})
 }

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -3003,29 +3003,58 @@ may increase either contention or retry errors, or both.`,
 
 	"crdb_internal.pb_to_json": makeBuiltin(
 		jsonProps(),
-		tree.Overload{
-			Types: tree.ArgTypes{
-				{"pbname", types.String},
-				{"data", types.Bytes},
-			},
-			ReturnType: tree.FixedReturnType(types.Jsonb),
-			Fn: func(evalCtx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
-				msg, err := protoreflect.DecodeMessage(
-					string(tree.MustBeDString(args[0])),
-					[]byte(tree.MustBeDBytes(args[1])),
-				)
+		func() []tree.Overload {
+			pbToJSON := func(typ string, data []byte, emitDefaults bool) (tree.Datum, error) {
+				msg, err := protoreflect.DecodeMessage(typ, data)
 				if err != nil {
 					return nil, err
 				}
-				j, err := protoreflect.MessageToJSON(msg, true /* emitDefaults */)
+				j, err := protoreflect.MessageToJSON(msg, emitDefaults)
 				if err != nil {
 					return nil, err
 				}
 				return tree.NewDJSON(j), nil
-			},
-			Info:       "Converts protocol message to its JSONB representation.",
-			Volatility: tree.VolatilityImmutable,
-		}),
+			}
+			returnType := tree.FixedReturnType(types.Jsonb)
+			const info = "Converts protocol message to its JSONB representation."
+			volatility := tree.VolatilityImmutable
+			return []tree.Overload{
+				{
+					Info:       info,
+					Volatility: volatility,
+					Types: tree.ArgTypes{
+						{"pbname", types.String},
+						{"data", types.Bytes},
+					},
+					ReturnType: returnType,
+					Fn: func(context *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+						const emitDefaults = true
+						return pbToJSON(
+							string(tree.MustBeDString(args[0])),
+							[]byte(tree.MustBeDBytes(args[1])),
+							emitDefaults,
+						)
+					},
+				},
+				{
+					Info:       info,
+					Volatility: volatility,
+					Types: tree.ArgTypes{
+						{"pbname", types.String},
+						{"data", types.Bytes},
+						{"emit_defaults", types.Bool},
+					},
+					ReturnType: returnType,
+					Fn: func(context *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+						return pbToJSON(
+							string(tree.MustBeDString(args[0])),
+							[]byte(tree.MustBeDBytes(args[1])),
+							bool(tree.MustBeDBool(args[2])),
+						)
+					},
+				},
+			}
+		}()...),
 
 	"crdb_internal.json_to_pb": makeBuiltin(
 		jsonProps(),

--- a/pkg/sql/types/types_jsonpb.go
+++ b/pkg/sql/types/types_jsonpb.go
@@ -1,0 +1,44 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package types
+
+import (
+	"bytes"
+
+	"github.com/gogo/protobuf/jsonpb"
+)
+
+// This file contains logic to allow the *types.T to properly marshal to json.
+// It is a separate file to make it straightforward to defeat the linter that
+// refuses to allow one to call a method Marshal unless it's protoutil.Marshal.
+
+// MarshalJSONPB marshals the T to json. This is necessary as otherwise
+// this field will be lost to the crdb_internal.pb_to_json and the likes.
+func (t *T) MarshalJSONPB(marshaler *jsonpb.Marshaler) ([]byte, error) {
+	temp := *t
+	if err := temp.downgradeType(); err != nil {
+		return nil, err
+	}
+	var buf bytes.Buffer
+	if err := marshaler.Marshal(&buf, &temp.InternalType); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// UnmarshalJSONPB unmarshals the T to json. This is necessary as otherwise
+// this field will be lost to the crdb_internal.json_to_pb and the likes.
+func (t *T) UnmarshalJSONPB(unmarshaler *jsonpb.Unmarshaler, data []byte) error {
+	if err := unmarshaler.Unmarshal(bytes.NewReader(data), &t.InternalType); err != nil {
+		return err
+	}
+	return t.upgradeType()
+}

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -944,6 +944,7 @@ func TestLint(t *testing.T) {
 			":!util/protoutil/marshal.go",
 			":!util/protoutil/marshaler.go",
 			":!settings/settings_test.go",
+			":!sql/types/types_jsonpb.go",
 		)
 		if err != nil {
 			t.Fatal(err)
@@ -983,6 +984,7 @@ func TestLint(t *testing.T) {
 			":!util/protoutil/marshal.go",
 			":!util/protoutil/marshaler.go",
 			":!util/encoding/encoding.go",
+			":!sql/types/types_jsonpb.go",
 		)
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
Backport 1/1 commits from #58087.

/cc @cockroachdb/release

---

This commit fixes the behavior of marshaling for types.T to json. Prior to
this, the type details were being totally omitted. It also enables suppressing
default values which impede the ability to round-trip sql descriptors (and also
are quite noisy). This change does not affect the default behavior of either
the builtin (`crdb_internal.pb_to_json` or the cli command
`cockroach debug decode-proto`) but it does plump through the option.

This commit adds a few different testing approaches. Firstly, it ensures that
a repaired descriptor is usable. Secondly, it augments the protoreflect tests
to round-trip a `*types.T`. Thirdly, it uses a query at the end of every
logictest to ensure that all constructed descriptors round-trip. While that
last one isn't perfect, it should get reasonable coverage as dropped table
descriptors should still exist at the end of a logic test.

Release note (bug fix): Fixed a bug which caused type information to be
omitted when decoding descriptors using either `crdb_internal.pb_to_json` or
`cockroach debug decode-proto`.

Release note (sql change): Added an overload to `crdb_internal.pb_to_json` to
suppress populating default values in fields.

Release note (cli change): Added a flag to `cockroach debug decode-proto` to
suppress populating default values in fields.
