### PR TITLE
util/log: report the server identifiers in JSON payloads 

### DIFF
--- a/docs/generated/logformats.md
+++ b/docs/generated/logformats.md
@@ -184,6 +184,10 @@ Additionally, the following fields are conditionally present:
 
 | Field               | Description |
 |---------------------|-------------|
+| `node_id` | The node ID where the event was generated, once known. Only reported for single-tenant or KV servers. |
+| `cluster_id` | The cluster ID where the event was generated, once known. Only reported for single-tenant of KV servers. |
+| `instance_id` | The SQL instance ID where the event was generated, once known. Only reported for multi-tenant SQL servers. |
+| `tenant_id` | The SQL tenant ID where the event was generated, once known. Only reported for multi-tenant SQL servers. |
 | `tags`    | The logging context tags for the entry, if there were context tags. |
 | `message` | For unstructured events, the flat text payload. |
 | `event`   | The logging event, if structured (see below for details). |
@@ -230,6 +234,10 @@ Additionally, the following fields are conditionally present:
 
 | Field               | Description |
 |---------------------|-------------|
+| `N` | The node ID where the event was generated, once known. Only reported for single-tenant or KV servers. |
+| `x` | The cluster ID where the event was generated, once known. Only reported for single-tenant of KV servers. |
+| `q` | The SQL instance ID where the event was generated, once known. Only reported for multi-tenant SQL servers. |
+| `T` | The SQL tenant ID where the event was generated, once known. Only reported for multi-tenant SQL servers. |
 | `tags`    | The logging context tags for the entry, if there were context tags. |
 | `message` | For unstructured events, the flat text payload. |
 | `event`   | The logging event, if structured (see below for details). |
@@ -277,6 +285,10 @@ Additionally, the following fields are conditionally present:
 
 | Field               | Description |
 |---------------------|-------------|
+| `node_id` | The node ID where the event was generated, once known. Only reported for single-tenant or KV servers. |
+| `cluster_id` | The cluster ID where the event was generated, once known. Only reported for single-tenant of KV servers. |
+| `instance_id` | The SQL instance ID where the event was generated, once known. Only reported for multi-tenant SQL servers. |
+| `tenant_id` | The SQL tenant ID where the event was generated, once known. Only reported for multi-tenant SQL servers. |
 | `tags`    | The logging context tags for the entry, if there were context tags. |
 | `message` | For unstructured events, the flat text payload. |
 | `event`   | The logging event, if structured (see below for details). |
@@ -324,6 +336,10 @@ Additionally, the following fields are conditionally present:
 
 | Field               | Description |
 |---------------------|-------------|
+| `N` | The node ID where the event was generated, once known. Only reported for single-tenant or KV servers. |
+| `x` | The cluster ID where the event was generated, once known. Only reported for single-tenant of KV servers. |
+| `q` | The SQL instance ID where the event was generated, once known. Only reported for multi-tenant SQL servers. |
+| `T` | The SQL tenant ID where the event was generated, once known. Only reported for multi-tenant SQL servers. |
 | `tags`    | The logging context tags for the entry, if there were context tags. |
 | `message` | For unstructured events, the flat text payload. |
 | `event`   | The logging event, if structured (see below for details). |

--- a/pkg/util/log/format_json_test.go
+++ b/pkg/util/log/format_json_test.go
@@ -37,6 +37,8 @@ func TestJSONFormats(t *testing.T) {
 
 	testCases := []logEntry{
 		{},
+		{idPayload: idPayload{clusterID: "abc", nodeID: 123}},
+		{idPayload: idPayload{tenantID: "abc", sqlInstanceID: 123}},
 		makeStructuredEntry(ctx, severity.INFO, channel.DEV, 0, &eventpb.RenameDatabase{
 			CommonEventDetails: eventpb.CommonEventDetails{
 				Timestamp: 123,

--- a/pkg/util/log/log_entry.go
+++ b/pkg/util/log/log_entry.go
@@ -36,6 +36,8 @@ import (
 // formatters. logpb.Entry, in comparison, was tailored specifically
 // to the legacy crdb-v1 formatter, and is a lossy representation.
 type logEntry struct {
+	idPayload
+
 	// The entry timestamp.
 	ts int64
 	// The severity of the event.
@@ -90,12 +92,17 @@ func makeUnsafePayload(m string) entryPayload {
 
 // makeEntry creates a logEntry.
 func makeEntry(ctx context.Context, s Severity, c Channel, depth int) (res logEntry) {
+	logging.idMu.RLock()
+	ids := logging.idMu.idPayload
+	logging.idMu.RUnlock()
+
 	res = logEntry{
-		ts:   timeutil.Now().UnixNano(),
-		sev:  s,
-		ch:   c,
-		gid:  goid.Get(),
-		tags: logtags.FromContext(ctx),
+		idPayload: ids,
+		ts:        timeutil.Now().UnixNano(),
+		sev:       s,
+		ch:        c,
+		gid:       goid.Get(),
+		tags:      logtags.FromContext(ctx),
 	}
 
 	// Populate file/lineno.

--- a/pkg/util/log/log_entry.go
+++ b/pkg/util/log/log_entry.go
@@ -179,20 +179,20 @@ func (l *sinkInfo) getStartLines(now time.Time) []*buffer {
 		makeStartLine(f, "arguments: %s", os.Args),
 	)
 
-	logging.mu.Lock()
-	if logging.mu.clusterID != "" {
-		messages = append(messages, makeStartLine(f, "clusterID: %s", logging.mu.clusterID))
+	logging.idMu.RLock()
+	if logging.idMu.clusterID != "" {
+		messages = append(messages, makeStartLine(f, "clusterID: %s", logging.idMu.clusterID))
 	}
-	if logging.mu.nodeID != 0 {
-		messages = append(messages, makeStartLine(f, "nodeID: n%d", logging.mu.nodeID))
+	if logging.idMu.nodeID != 0 {
+		messages = append(messages, makeStartLine(f, "nodeID: n%d", logging.idMu.nodeID))
 	}
-	if logging.mu.tenantID != "" {
-		messages = append(messages, makeStartLine(f, "tenantID: %s", logging.mu.tenantID))
+	if logging.idMu.tenantID != "" {
+		messages = append(messages, makeStartLine(f, "tenantID: %s", logging.idMu.tenantID))
 	}
-	if logging.mu.sqlInstanceID != 0 {
-		messages = append(messages, makeStartLine(f, "instanceID: %d", logging.mu.sqlInstanceID))
+	if logging.idMu.sqlInstanceID != 0 {
+		messages = append(messages, makeStartLine(f, "instanceID: %d", logging.idMu.sqlInstanceID))
 	}
-	logging.mu.Unlock()
+	logging.idMu.RUnlock()
 
 	// Including a non-ascii character in the first 1024 bytes of the log helps
 	// viewers that attempt to guess the character encoding.

--- a/pkg/util/log/testdata/json
+++ b/pkg/util/log/testdata/json
@@ -6,6 +6,16 @@ json-fluent-compact: {"tag":"log_test.dev","c":0,"t":"1136214245.654321000","s":
        json-compact: {"c":0,"t":"1136214245.654321000","s":0,"g":11,"f":"","l":123,"n":0,"r":0,"message":""}
                json: {"channel_numeric":0,"channel":"DEV","timestamp":"1136214245.654321000","severity_numeric":0,"severity":"UNKNOWN","goroutine":11,"file":"","line":123,"entry_counter":0,"redactable":0,"message":""}
 #
+json-fluent-compact: {"tag":"log_test.dev","c":0,"t":"1136214245.654321000","x":"abc","N":123,"s":0,"g":11,"f":"","l":123,"n":0,"r":0,"message":""}
+        json-fluent: {"tag":"log_test.dev","channel_numeric":0,"channel":"DEV","timestamp":"1136214245.654321000","cluster_id":"abc","node_id":123,"severity_numeric":0,"severity":"UNKNOWN","goroutine":11,"file":"","line":123,"entry_counter":0,"redactable":0,"message":""}
+       json-compact: {"c":0,"t":"1136214245.654321000","x":"abc","N":123,"s":0,"g":11,"f":"","l":123,"n":0,"r":0,"message":""}
+               json: {"channel_numeric":0,"channel":"DEV","timestamp":"1136214245.654321000","cluster_id":"abc","node_id":123,"severity_numeric":0,"severity":"UNKNOWN","goroutine":11,"file":"","line":123,"entry_counter":0,"redactable":0,"message":""}
+#
+json-fluent-compact: {"tag":"log_test.dev","c":0,"t":"1136214245.654321000","T":"abc","q":123,"s":0,"g":11,"f":"","l":123,"n":0,"r":0,"message":""}
+        json-fluent: {"tag":"log_test.dev","channel_numeric":0,"channel":"DEV","timestamp":"1136214245.654321000","tenant_id":"abc","instance_id":123,"severity_numeric":0,"severity":"UNKNOWN","goroutine":11,"file":"","line":123,"entry_counter":0,"redactable":0,"message":""}
+       json-compact: {"c":0,"t":"1136214245.654321000","T":"abc","q":123,"s":0,"g":11,"f":"","l":123,"n":0,"r":0,"message":""}
+               json: {"channel_numeric":0,"channel":"DEV","timestamp":"1136214245.654321000","tenant_id":"abc","instance_id":123,"severity_numeric":0,"severity":"UNKNOWN","goroutine":11,"file":"","line":123,"entry_counter":0,"redactable":0,"message":""}
+#
 json-fluent-compact: {"tag":"log_test.dev","c":0,"t":"1136214245.654321000","s":1,"sev":"I","g":11,"f":"util/log/format_json_test.go","l":123,"n":0,"r":1,"tags":{"noval":"","s":"‹1›","long":"‹2›"},"event":{"Timestamp":123,"EventType":"rename_database","DatabaseName":"‹hello›","NewDatabaseName":"‹world›"}}
         json-fluent: {"tag":"log_test.dev","channel_numeric":0,"channel":"DEV","timestamp":"1136214245.654321000","severity_numeric":1,"severity":"INFO","goroutine":11,"file":"util/log/format_json_test.go","line":123,"entry_counter":0,"redactable":1,"tags":{"noval":"","s":"‹1›","long":"‹2›"},"event":{"Timestamp":123,"EventType":"rename_database","DatabaseName":"‹hello›","NewDatabaseName":"‹world›"}}
        json-compact: {"c":0,"t":"1136214245.654321000","s":1,"sev":"I","g":11,"f":"util/log/format_json_test.go","l":123,"n":0,"r":1,"tags":{"noval":"","s":"‹1›","long":"‹2›"},"event":{"Timestamp":123,"EventType":"rename_database","DatabaseName":"‹hello›","NewDatabaseName":"‹world›"}}


### PR DESCRIPTION
Fixes #57957. 

Release note (cli change): When using the JSON output formats for log
entries, the server identifiers are now reported as part of each
payload once known (either cluster ID + node ID in single-tenant or
KV servers, or tenant ID + SQL instance ID in multi-tenant SQL servers).