### PR TITLE
util: add crdb_test_off build tag to disable metamorphization

### DIFF
--- a/pkg/util/crdb_test_off.go
+++ b/pkg/util/crdb_test_off.go
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-// +build !crdb_test
+// +build !crdb_test crdb_test_off
 
 package util
 

--- a/pkg/util/crdb_test_on.go
+++ b/pkg/util/crdb_test_on.go
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-// +build crdb_test
+// +build crdb_test,!crdb_test_off
 
 package util
 


### PR DESCRIPTION
We are now metamorphizing most of the test builds. However, there are
cases where that behavior is undesirable (for example, when using
`-rewrite` test flag with logic tests) - in such scenarios we want the
"production" build to occur. In order to have such functionality this
commit makes `crdb_test` build be dependent on the absence of
`crdb_test_off` build tag. An example usage of `-rewrite` option would
be `make testoptlogic TESTFLAGS='-rewrite' TAGS=crdb_test_off`.

Release note: None