### PR TITLE
roachtest: fix panic injection in sqlsmith

### DIFF
--- a/pkg/cmd/roachtest/sqlsmith.go
+++ b/pkg/cmd/roachtest/sqlsmith.go
@@ -98,22 +98,6 @@ func registerSQLSmith(r *testRegistry) {
 		setup := setupFunc(rng)
 		setting := settingFunc(rng)
 
-		versionString, err := fetchCockroachVersion(ctx, c, c.Node(1)[0])
-		if err != nil {
-			t.Fatal(err)
-		}
-		crdbVersion, err := toCRDBVersion(versionString)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if crdbVersion >= crdbVersion21_1 {
-			// We will enable panic injection on this connection in the
-			// vectorized engine (and will ignore the injected errors) in order
-			// to test that the panic-catching mechanism of error propagation
-			// works as expected.
-			setup += "SET testing_vectorize_inject_panics=true;"
-		}
-
 		conn := c.Conn(ctx, 1)
 		t.Status("executing setup")
 		c.l.Printf("setup:\n%s", setup)
@@ -131,6 +115,27 @@ func registerSQLSmith(r *testRegistry) {
 			t.Fatal(err)
 		}
 		logStmt(setStmtTimeout)
+
+		versionString, err := fetchCockroachVersion(ctx, c, c.Node(1)[0])
+		if err != nil {
+			t.Fatal(err)
+		}
+		crdbVersion, err := toCRDBVersion(versionString)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if crdbVersion >= crdbVersion21_1 {
+			// We will enable panic injection on this connection in the
+			// vectorized engine (and will ignore the injected errors) in order
+			// to test that the panic-catching mechanism of error propagation
+			// works as expected.
+			// Note: it is important to enable this testing knob only after all
+			// other setup queries have already completed (otherwise, the setup
+			// might fail because of the injected panics).
+			if _, err := conn.Exec("SET testing_vectorize_inject_panics=true;"); err != nil {
+				t.Fatal(err)
+			}
+		}
 
 		smither, err := sqlsmith.NewSmither(conn, rng, setting.Options...)
 		if err != nil {


### PR DESCRIPTION
We recently enabled the injection of vectorized panics in the sqlsmith
roachtest, but it was done a bit too soon - we need to delay the
enablement of the panic injection till the very end of the setup of the
test.

Fixes: #58091

Release note: None