### PR TITLE
changefeedccl: detect and report primary key changes

### DIFF
--- a/pkg/ccl/changefeedccl/schemafeed/schematestutils/schema_test_utils.go
+++ b/pkg/ccl/changefeedccl/schemafeed/schematestutils/schema_test_utils.go
@@ -52,8 +52,9 @@ func MakeColumnDesc(id descpb.ColumnID) *descpb.ColumnDescriptor {
 // Yes, this does modify an Immutable.
 func AddColumnDropBackfillMutation(desc *tabledesc.Immutable) *tabledesc.Immutable {
 	desc.Mutations = append(desc.Mutations, descpb.DescriptorMutation{
-		State:     descpb.DescriptorMutation_DELETE_AND_WRITE_ONLY,
-		Direction: descpb.DescriptorMutation_DROP,
+		State:       descpb.DescriptorMutation_DELETE_AND_WRITE_ONLY,
+		Direction:   descpb.DescriptorMutation_DROP,
+		Descriptor_: &descpb.DescriptorMutation_Column{Column: MakeColumnDesc(desc.NextColumnID - 1)},
 	})
 	return desc
 }


### PR DESCRIPTION
This change, intended for backport, detects primary key changes and returns an
error. Prior to this change, primary key changes would go completely ignored.
Sometimes this would lead to an error if there is a row emitted at the right
time:

```
E201221 18:55:14.023926 1665 sql/sqltelemetry/report.go:57  [n1,client=‹127.0.0.1:46050›,hostssl,user=root] encountered internal error:
decoding unset EncDatum
(1)
Wraps: (2) assertion failure
Wraps: (3) attached stack trace
  -- stack trace:
  | github.com/cockroachdb/cockroach/pkg/sql/rowenc.(*EncDatum).EnsureDecoded
  | 	/home/ajwerner/src/github.com/cockroachdb/cockroach/pkg/sql/rowenc/encoded_datum.go:228
  | github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl.(*jsonEncoder).EncodeValue
  | 	/home/ajwerner/src/github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/encoder.go:178
  | github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl.emitEntries.func1
  | 	/home/ajwerner/src/github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeed.go:263
  | github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl.emitEntries.func2
  | 	/home/ajwerner/src/github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeed.go:308
  | github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl.(*changeAggregator).tick
  | 	/home/ajwerner/src/github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeed_processors.go:375
  | github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl.(*changeAggregator).Next
  | 	/home/ajwerner/src/github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeed_processors.go:357
  | github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl.(*changeFrontier).Next
  | 	/home/ajwerner/src/github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeed_processors.go:670
  | github.com/cockroachdb/cockroach/pkg/sql/execinfra.Run
  | 	/home/ajwerner/src/github.com/cockroachdb/cockroach/pkg/sql/execinfra/base.go:171
  | github.com/cockroachdb/cockroach/pkg/sql/execinfra.(*ProcessorBase).Run
  | 	/home/ajwerner/src/github.com/cockroachdb/cockroach/pkg/sql/execinfra/processorsbase.go:765
  | github.com/cockroachdb/cockroach/pkg/sql/flowinfra.(*FlowBase).Run
  | 	/home/ajwerner/src/github.com/cockroachdb/cockroach/pkg/sql/flowinfra/flow.go:380
  | github.com/cockroachdb/cockroach/pkg/sql.(*DistSQLPlanner).Run
  | 	/home/ajwerner/src/github.com/cockroachdb/cockroach/pkg/sql/distsql_running.go:366
  | github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl.distChangefeedFlow
  | 	/home/ajwerner/src/github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeed_dist.go:198
  | github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl.changefeedPlanHook.func2
  | 	/home/ajwerner/src/github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeed_stmt.go:275
  | github.com/cockroachdb/cockroach/pkg/sql.(*hookFnNode).startExec.func1
  | 	/home/ajwerner/src/github.com/cockroachdb/cockroach/pkg/sql/planhook.go:150
  | runtime.goexit
  | 	/usr/local/go/src/runtime/asm_amd64.s:1374
Wraps: (4) decoding unset EncDatum
```

Usually, the changefeed would just stop emitting rows, at least until the GC ttl
for the old primary index expired.

Fixes #57721. 

Release note (bug fix): Fixed a bug whereby primary key changes on tables being
watched by CHANGEFEEDs would be silently ignored.