### PR TITLE
logictest: fix upsert test

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -372,7 +372,7 @@ flow                                  Put /Table/57/1/2/0 -> /TUPLE/2:2:Int/2
 flow                                  Del /Table/57/2/3/0
 flow                                  CPut /Table/57/2/2/0 -> /BYTES/0x8a (expecting does not exist)
 kv.DistSender: sending partial batch  r35: sending batch 1 Put, 1 EndTxn to (n1,s1):1
-exec stmt                             execution failed after 0 rows: duplicate key value violates unique constraint "woo"\nDETAIL: Key (v)=(2) already exists\.
+exec stmt                             execution failed after 0 rows: duplicate key value violates unique constraint "woo"
 
 
 subtest regression_32473


### PR DESCRIPTION
The trace message appears to contain only a single line if an error
occurs (all lines apart from the first one are not shown), so this
commit adjusts `upsert` opt logic test accordingly.

Fixes: #58158.

Release note: None