### PR TITLE
opt,sql: add tests to demonstrate use of indexes for uniqueness checks

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/unique
+++ b/pkg/sql/logictest/testdata/logic_test/unique
@@ -55,6 +55,23 @@ CREATE TABLE uniq_fk_child (
 )
 
 statement ok
+CREATE TYPE region AS ENUM ('us-east', 'us-west', 'eu-west')
+
+# TODO(rytaft): When more of the multi-region syntax is supported,
+# add it here.
+statement ok
+CREATE TABLE uniq_enum (
+  r region DEFAULT 'us-east',
+  s STRING,
+  i INT,
+  j INT DEFAULT NULL,
+  PRIMARY KEY (r, i),
+  UNIQUE INDEX (r, s, j),
+  UNIQUE WITHOUT INDEX (i),
+  UNIQUE WITHOUT INDEX (s, j)
+)
+
+statement ok
 CREATE TABLE other (k INT, v INT, w INT NOT NULL, x INT, y INT)
 
 # Insert some data into the other table.
@@ -179,6 +196,24 @@ a  b  c
 1  1  1
 2  2  2
 
+# Insert into a table in which the unique constraints are the suffix of an
+# index, and the prefix of the index is an enum.
+statement ok
+INSERT INTO uniq_enum VALUES ('us-west', 'foo', 1, 1), ('eu-west', 'bar', 2, 2)
+
+# Insert into a table in which the unique constraints are the suffix of an
+# index, and the prefix of the index is an enum. This case uses the default
+# value for columns r and j.
+statement error pgcode 23505 pq: duplicate key value violates unique constraint "unique_i"\nDETAIL: Key \(i\)=\(1\) already exists\.
+INSERT INTO uniq_enum (s, i) VALUES ('foo', 1), ('bar', 2)
+
+query TTII colnames,rowsort
+SELECT * FROM uniq_enum
+----
+r        s    i  j
+us-west  foo  1  1
+eu-west  bar  2  2
+
 
 # -- Tests with UPDATE --
 subtest Update
@@ -266,3 +301,15 @@ SELECT * FROM uniq_fk_child
 a  b  c
 1  1  1
 2  2  2
+
+# Update a table in which the unique constraints are the suffix of an
+# index, and the prefix of the index is an enum.
+statement error pgcode 23505 pq: duplicate key value violates unique constraint "unique_s_j"\nDETAIL: Key \(s, j\)=\('foo', 1\) already exists\.
+UPDATE uniq_enum SET r = DEFAULT, s = 'foo', j = 1 WHERE r = 'eu-west'
+
+query TTII colnames,rowsort
+SELECT * FROM uniq_enum
+----
+r        s    i  j
+eu-west  bar  2  2
+us-west  foo  1  1

--- a/pkg/sql/opt/exec/execbuilder/testdata/unique
+++ b/pkg/sql/opt/exec/execbuilder/testdata/unique
@@ -58,6 +58,23 @@ CREATE TABLE uniq_fk_child (
 )
 
 statement ok
+CREATE TYPE region AS ENUM ('us-east', 'us-west', 'eu-west')
+
+# TODO(rytaft): When more of the multi-region syntax is supported,
+# add it here.
+statement ok
+CREATE TABLE uniq_enum (
+  r region DEFAULT CASE (random()*3)::int WHEN 0 THEN 'us-east' WHEN 1 THEN 'us-west' ELSE 'eu-west' END,
+  s STRING,
+  i INT,
+  j INT DEFAULT NULL,
+  PRIMARY KEY (r, i),
+  UNIQUE INDEX (r, s, j),
+  UNIQUE WITHOUT INDEX (i),
+  UNIQUE WITHOUT INDEX (s, j)
+)
+
+statement ok
 CREATE TABLE other (k INT, v INT, w INT NOT NULL, x INT, y INT)
 
 # -- Tests with INSERT --
@@ -413,6 +430,197 @@ vectorized: true
             │
             └── • scan buffer
                   label: buffer 1
+
+# Test that we use the index when available for the insert checks.
+query T
+EXPLAIN (VERBOSE) INSERT INTO uniq_enum VALUES ('us-west', 'foo', 1, 1), ('us-east', 'bar', 2, 2)
+----
+distribution: local
+vectorized: true
+·
+• root
+│ columns: ()
+│
+├── • insert
+│   │ columns: ()
+│   │ estimated row count: 0 (missing stats)
+│   │ into: uniq_enum(r, s, i, j)
+│   │
+│   └── • buffer
+│       │ columns: (column1, column2, column3, column4, check1)
+│       │ label: buffer 1
+│       │
+│       └── • render
+│           │ columns: (column1, column2, column3, column4, check1)
+│           │ estimated row count: 2
+│           │ render 0: column1 IN ('us-east', 'us-west', 'eu-west')
+│           │ render 1: column1
+│           │ render 2: column2
+│           │ render 3: column3
+│           │ render 4: column4
+│           │
+│           └── • values
+│                 columns: (column1, column2, column3, column4)
+│                 size: 4 columns, 2 rows
+│                 row 0, expr 0: 'us-west'
+│                 row 0, expr 1: 'foo'
+│                 row 0, expr 2: 1
+│                 row 0, expr 3: 1
+│                 row 1, expr 0: 'us-east'
+│                 row 1, expr 1: 'bar'
+│                 row 1, expr 2: 2
+│                 row 1, expr 3: 2
+│
+├── • constraint-check
+│   │
+│   └── • error if rows
+│       │ columns: ()
+│       │
+│       └── • project
+│           │ columns: (column3, column1)
+│           │ estimated row count: 1 (missing stats)
+│           │
+│           └── • lookup join (semi)
+│               │ columns: ("lookup_join_const_col_@14", column3, column1)
+│               │ table: uniq_enum@primary
+│               │ equality: (lookup_join_const_col_@14, column3) = (r,i)
+│               │ equality cols are key
+│               │ pred: column1 != r
+│               │
+│               └── • cross join (inner)
+│                   │ columns: ("lookup_join_const_col_@14", column3, column1)
+│                   │ estimated row count: 6
+│                   │
+│                   ├── • values
+│                   │     columns: ("lookup_join_const_col_@14")
+│                   │     size: 1 column, 3 rows
+│                   │     row 0, expr 0: 'us-east'
+│                   │     row 1, expr 0: 'us-west'
+│                   │     row 2, expr 0: 'eu-west'
+│                   │
+│                   └── • project
+│                       │ columns: (column3, column1)
+│                       │ estimated row count: 2
+│                       │
+│                       └── • scan buffer
+│                             columns: (column1, column2, column3, column4, check1)
+│                             label: buffer 1
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │ columns: ()
+        │
+        └── • project
+            │ columns: (column2, column4, column1, column3)
+            │ estimated row count: 1 (missing stats)
+            │
+            └── • lookup join (semi)
+                │ columns: ("lookup_join_const_col_@24", column2, column4, column1, column3)
+                │ table: uniq_enum@uniq_enum_r_s_j_key
+                │ equality: (lookup_join_const_col_@24, column2, column4) = (r,s,j)
+                │ equality cols are key
+                │ pred: (column1 != r) OR (column3 != i)
+                │
+                └── • cross join (inner)
+                    │ columns: ("lookup_join_const_col_@24", column2, column4, column1, column3)
+                    │ estimated row count: 6
+                    │
+                    ├── • values
+                    │     columns: ("lookup_join_const_col_@24")
+                    │     size: 1 column, 3 rows
+                    │     row 0, expr 0: 'us-east'
+                    │     row 1, expr 0: 'us-west'
+                    │     row 2, expr 0: 'eu-west'
+                    │
+                    └── • project
+                        │ columns: (column2, column4, column1, column3)
+                        │ estimated row count: 2
+                        │
+                        └── • scan buffer
+                              columns: (column1, column2, column3, column4, check1)
+                              label: buffer 1
+
+# Test that we use the index when available for the insert checks. This uses
+# the default value for columns r and j.
+query T
+EXPLAIN (VERBOSE) INSERT INTO uniq_enum (s, i) VALUES ('foo', 1), ('bar', 2)
+----
+distribution: local
+vectorized: true
+·
+• root
+│ columns: ()
+│
+├── • insert
+│   │ columns: ()
+│   │ estimated row count: 0 (missing stats)
+│   │ into: uniq_enum(r, s, i, j)
+│   │
+│   └── • buffer
+│       │ columns: (column9, column1, column2, column10, check1)
+│       │ label: buffer 1
+│       │
+│       └── • render
+│           │ columns: (column9, column1, column2, column10, check1)
+│           │ estimated row count: 2
+│           │ render 0: column9 IN ('us-east', 'us-west', 'eu-west')
+│           │ render 1: column1
+│           │ render 2: column2
+│           │ render 3: column9
+│           │ render 4: column10
+│           │
+│           └── • render
+│               │ columns: (column9, column10, column1, column2)
+│               │ estimated row count: 2
+│               │ render 0: CASE (random() * 3.0)::INT8 WHEN 0 THEN 'us-east' WHEN 1 THEN 'us-west' ELSE 'eu-west' END
+│               │ render 1: CAST(NULL AS INT8)
+│               │ render 2: column1
+│               │ render 3: column2
+│               │
+│               └── • values
+│                     columns: (column1, column2)
+│                     size: 2 columns, 2 rows
+│                     row 0, expr 0: 'foo'
+│                     row 0, expr 1: 1
+│                     row 1, expr 0: 'bar'
+│                     row 1, expr 1: 2
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │ columns: ()
+        │
+        └── • project
+            │ columns: (column2, column9)
+            │ estimated row count: 1 (missing stats)
+            │
+            └── • lookup join (semi)
+                │ columns: ("lookup_join_const_col_@14", column2, column9)
+                │ table: uniq_enum@primary
+                │ equality: (lookup_join_const_col_@14, column2) = (r,i)
+                │ equality cols are key
+                │ pred: column9 != r
+                │
+                └── • cross join (inner)
+                    │ columns: ("lookup_join_const_col_@14", column2, column9)
+                    │ estimated row count: 6
+                    │
+                    ├── • values
+                    │     columns: ("lookup_join_const_col_@14")
+                    │     size: 1 column, 3 rows
+                    │     row 0, expr 0: 'us-east'
+                    │     row 1, expr 0: 'us-west'
+                    │     row 2, expr 0: 'eu-west'
+                    │
+                    └── • project
+                        │ columns: (column2, column9)
+                        │ estimated row count: 2
+                        │
+                        └── • scan buffer
+                              columns: (column9, column1, column2, column10, check1)
+                              label: buffer 1
+
 
 # -- Tests with UPDATE --
 subtest Update
@@ -807,3 +1015,122 @@ vectorized: true
                   missing stats
                   table: uniq_fk_parent@uniq_fk_parent_b_c_key
                   spans: FULL SCAN
+
+# Test that we use the index when available for the update checks.
+query T
+EXPLAIN (VERBOSE) UPDATE uniq_enum SET r = DEFAULT, s = 'baz', i = 3 WHERE r = 'eu-west'
+----
+distribution: local
+vectorized: true
+·
+• root
+│ columns: ()
+│
+├── • update
+│   │ columns: ()
+│   │ estimated row count: 0 (missing stats)
+│   │ table: uniq_enum
+│   │ set: r, s, i
+│   │
+│   └── • buffer
+│       │ columns: (r, s, i, j, r_new, s_new, i_new, check1)
+│       │ label: buffer 1
+│       │
+│       └── • render
+│           │ columns: (r, s, i, j, r_new, s_new, i_new, check1)
+│           │ estimated row count: 10 (missing stats)
+│           │ render 0: r_new IN ('us-east', 'us-west', 'eu-west')
+│           │ render 1: r
+│           │ render 2: s
+│           │ render 3: i
+│           │ render 4: j
+│           │ render 5: r_new
+│           │ render 6: s_new
+│           │ render 7: i_new
+│           │
+│           └── • render
+│               │ columns: (r_new, s_new, i_new, r, s, i, j)
+│               │ estimated row count: 10 (missing stats)
+│               │ render 0: CASE (random() * 3.0)::INT8 WHEN 0 THEN 'us-east' WHEN 1 THEN 'us-west' ELSE 'eu-west' END
+│               │ render 1: 'baz'
+│               │ render 2: 3
+│               │ render 3: r
+│               │ render 4: s
+│               │ render 5: i
+│               │ render 6: j
+│               │
+│               └── • scan
+│                     columns: (r, s, i, j)
+│                     estimated row count: 10 (missing stats)
+│                     table: uniq_enum@primary
+│                     spans: /"\xc0"-/"\xc0"/PrefixEnd
+│
+├── • constraint-check
+│   │
+│   └── • error if rows
+│       │ columns: ()
+│       │
+│       └── • project
+│           │ columns: (i_new, r_new)
+│           │ estimated row count: 3 (missing stats)
+│           │
+│           └── • lookup join (semi)
+│               │ columns: (i_new, r_new, "lookup_join_const_col_@19")
+│               │ table: uniq_enum@primary
+│               │ equality: (lookup_join_const_col_@19, i_new) = (r,i)
+│               │ equality cols are key
+│               │ pred: r_new != r
+│               │
+│               └── • cross join (inner)
+│                   │ columns: (i_new, r_new, "lookup_join_const_col_@19")
+│                   │ estimated row count: 30 (missing stats)
+│                   │
+│                   ├── • project
+│                   │   │ columns: (i_new, r_new)
+│                   │   │ estimated row count: 10 (missing stats)
+│                   │   │
+│                   │   └── • scan buffer
+│                   │         columns: (r, s, i, j, r_new, s_new, i_new, check1)
+│                   │         label: buffer 1
+│                   │
+│                   └── • values
+│                         columns: ("lookup_join_const_col_@19")
+│                         size: 1 column, 3 rows
+│                         row 0, expr 0: 'us-east'
+│                         row 1, expr 0: 'us-west'
+│                         row 2, expr 0: 'eu-west'
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │ columns: ()
+        │
+        └── • project
+            │ columns: (s_new, j, r_new, i_new)
+            │ estimated row count: 3 (missing stats)
+            │
+            └── • lookup join (semi)
+                │ columns: (s_new, j, r_new, i_new, "lookup_join_const_col_@29")
+                │ table: uniq_enum@uniq_enum_r_s_j_key
+                │ equality: (lookup_join_const_col_@29, s_new, j) = (r,s,j)
+                │ equality cols are key
+                │ pred: (r_new != r) OR (i_new != i)
+                │
+                └── • cross join (inner)
+                    │ columns: (s_new, j, r_new, i_new, "lookup_join_const_col_@29")
+                    │ estimated row count: 30 (missing stats)
+                    │
+                    ├── • project
+                    │   │ columns: (s_new, j, r_new, i_new)
+                    │   │ estimated row count: 10 (missing stats)
+                    │   │
+                    │   └── • scan buffer
+                    │         columns: (r, s, i, j, r_new, s_new, i_new, check1)
+                    │         label: buffer 1
+                    │
+                    └── • values
+                          columns: ("lookup_join_const_col_@29")
+                          size: 1 column, 3 rows
+                          row 0, expr 0: 'us-east'
+                          row 1, expr 0: 'us-west'
+                          row 2, expr 0: 'eu-west'


### PR DESCRIPTION
This commit adds tests to validate that we are using the correct indexes
when planning uniqueness checks. In particular, we should be doing lookup
joins using an index when the unique columns are the suffix of the index,
and the prefix of the index is an enum type. This will be important for
supporting performant uniqueness checks in multi-region tables.

Release note: None