### PR TITLE
server: skip reset quorum testing

### DIFF
--- a/pkg/cmd/roachtest/reset_quorum.go
+++ b/pkg/cmd/roachtest/reset_quorum.go
@@ -16,10 +16,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/stretchr/testify/require"
 )
 
 func runResetQuorum(ctx context.Context, t *test, c *cluster) {
+	skip.WithIssue(t, 58165)
 	args := func(attr string) option {
 		return startArgs(
 			"-a=--attrs="+attr,

--- a/pkg/kv/kvserver/reset_quorum_test.go
+++ b/pkg/kv/kvserver/reset_quorum_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/errors"
@@ -48,6 +49,7 @@ import (
 // 5. A meta range (error expected).
 func TestResetQuorum(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 58165)
 	ctx := context.Background()
 
 	livenessDuration := 3000 * time.Millisecond


### PR DESCRIPTION
Temporarily skips TestResetQuorum and acceptance/reset-quorum.

Release note: None.