### PR TITLE
release-20.1: sql: fix bug in temp object cleaner

### DIFF
--- a/pkg/sql/temporary_schema.go
+++ b/pkg/sql/temporary_schema.go
@@ -164,6 +164,11 @@ func cleanupSessionTempObjects(
 ) error {
 	tempSchemaName := temporarySchemaName(sessionID)
 	return db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+		// Explicitly set the system config trigger, since we may write to the
+		// namespace table first.
+		if err := txn.SetSystemConfigTrigger(); err != nil {
+			return err
+		}
 		// We are going to read all database descriptor IDs, then for each database
 		// we will drop all the objects under the temporary schema.
 		dbIDs, err := GetAllDatabaseDescriptorIDs(ctx, txn)

--- a/pkg/sql/temporary_schema_test.go
+++ b/pkg/sql/temporary_schema_test.go
@@ -213,6 +213,14 @@ func TestTemporaryObjectCleaner(t *testing.T) {
 	)
 	defer tc.Stopper().Stop(context.TODO())
 
+	{
+		// Create another empty database to ensure that cleanup still works in the
+		// presence of databases without temp objects. Regression test for #55086.
+		db := tc.ServerConn(0)
+		sqlDB := sqlutils.MakeSQLRunner(db)
+		sqlDB.Exec(t, `CREATE DATABASE d`)
+	}
+
 	// Start and close two temporary schemas.
 	for _, dbID := range []int{0, 1} {
 		db := tc.ServerConn(dbID)


### PR DESCRIPTION
Backport 1/1 commits from #57922.

/cc @cockroachdb/release

---

The temp object cleaner used to fail in some cases in the presence of
databases with no temp objects, because we would update the namespace
table in the transaction prior to deleting the descriptors without
setting the system config trigger. This PR fixes the bug by setting the
system config trigger explicitly.

Release note (bug fix): Fixed a bug that caused temp tables to not be
cleaned up after the associated session was closed.