### PR TITLE
sql: add regression test for bug in temp object cleaner

### DIFF
--- a/pkg/sql/temporary_schema_test.go
+++ b/pkg/sql/temporary_schema_test.go
@@ -246,6 +246,14 @@ func TestTemporaryObjectCleaner(t *testing.T) {
 	)
 	defer tc.Stopper().Stop(context.Background())
 
+	{
+		// Create another empty database to ensure that cleanup still works in the
+		// presence of databases without temp objects. Regression test for #55086.
+		db := tc.ServerConn(0)
+		sqlDB := sqlutils.MakeSQLRunner(db)
+		sqlDB.Exec(t, `CREATE DATABASE d`)
+	}
+
 	// Start and close two temporary schemas.
 	for _, dbID := range []int{0, 1} {
 		db := tc.ServerConn(dbID)


### PR DESCRIPTION
The temp object cleaner used to fail in some cases in the presence of
databases with no temp objects, because we would update the namespace
table in the transaction prior to deleting the descriptors without
setting the system config trigger. This was (unintentionally) fixed
earlier in 21.1 due to the adoption of `descs.Txn()`, and fixed through
explicitly setting the system config trigger on other branches. This
commit adds a regression test for the bug.

Related to #55086.

Release note: None