### PR TITLE
enum: add IF NOT EXISTS option

### DIFF
--- a/docs/generated/sql/bnf/create_type.bnf
+++ b/docs/generated/sql/bnf/create_type.bnf
@@ -1,2 +1,3 @@
 create_type_stmt ::=
 	'CREATE' 'TYPE' type_name 'AS' 'ENUM' '(' opt_enum_val_list ')'
+	| 'CREATE' 'TYPE' type_name 'IF' 'NOT' 'EXISTS' 'AS' 'ENUM' '(' opt_enum_val_list ')'

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -1324,6 +1324,7 @@ create_table_as_stmt ::=
 
 create_type_stmt ::=
 	'CREATE' 'TYPE' type_name 'AS' 'ENUM' '(' opt_enum_val_list ')'
+	| 'CREATE' 'TYPE' type_name 'IF' 'NOT' 'EXISTS' 'AS' 'ENUM' '(' opt_enum_val_list ')'
 
 create_view_stmt ::=
 	'CREATE' opt_temp 'VIEW' view_name opt_column_list 'AS' select_stmt

--- a/pkg/sql/create_type.go
+++ b/pkg/sql/create_type.go
@@ -263,9 +263,17 @@ func (p *planner) createUserDefinedEnum(params runParams, n *createTypeNode) err
 	if err != nil {
 		return err
 	}
-	return params.p.createEnumWithID(
+	err = params.p.createEnumWithID(
 		params, id, n.n.EnumLabels, n.dbDesc, n.typeName, enumTypeUserDefined,
 	)
+	if err != nil {
+		if sqlerrors.IsTypeAlreadyExistsError(err) && n.n.IfNotExists {
+			return nil
+		}
+		return err
+	}
+	return nil
+
 }
 
 func (p *planner) createEnumWithID(

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -415,6 +415,10 @@ func TestParse(t *testing.T) {
 		{`CREATE TYPE a AS ENUM ('a', 'b', 'c')`},
 		{`CREATE TYPE a.b AS ENUM ('a', 'b', 'c')`},
 		{`CREATE TYPE a.b.c AS ENUM ('a', 'b', 'c')`},
+		{`CREATE TYPE a IF NOT EXISTS AS ENUM ('a')`},
+		{`CREATE TYPE a IF NOT EXISTS AS ENUM ('a', 'b', 'c')`},
+		{`CREATE TYPE a.b IF NOT EXISTS AS ENUM ('a', 'b', 'c')`},
+		{`CREATE TYPE a.b.c IF NOT EXISTS AS ENUM ('a', 'b', 'c')`},
 
 		{`DROP SCHEMA a`},
 		{`DROP SCHEMA a, b`},

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -6837,7 +6837,7 @@ opt_view_recursive:
 
 // %Help: CREATE TYPE -- create a type
 // %Category: DDL
-// %Text: CREATE TYPE <type_name> AS ENUM (...)
+// %Text: CREATE TYPE <type_name> [IF NOT EXISTS] AS ENUM (...)
 create_type_stmt:
   // Enum types.
   CREATE TYPE type_name AS ENUM '(' opt_enum_val_list ')'
@@ -6848,6 +6848,15 @@ create_type_stmt:
       EnumLabels: $7.enumValueList(),
     }
   }
+  | CREATE TYPE type_name IF NOT EXISTS AS ENUM '(' opt_enum_val_list ')'
+     {
+       $$.val = &tree.CreateType{
+         TypeName: $3.unresolvedObjectName(),
+         Variety: tree.Enum,
+         EnumLabels: $10.enumValueList(),
+         IfNotExists: true,
+       }
+     }
 | CREATE TYPE error // SHOW HELP: CREATE TYPE
   // Record/Composite types.
 | CREATE TYPE type_name AS '(' error      { return unimplementedWithIssue(sqllex, 27792) }

--- a/pkg/sql/sem/tree/create.go
+++ b/pkg/sql/sem/tree/create.go
@@ -308,7 +308,8 @@ type CreateType struct {
 	TypeName *UnresolvedObjectName
 	Variety  CreateTypeVariety
 	// EnumLabels is set when this represents a CREATE TYPE ... AS ENUM statement.
-	EnumLabels EnumValueList
+	EnumLabels  EnumValueList
+	IfNotExists bool
 }
 
 var _ Statement = &CreateType{}

--- a/pkg/sql/sqlerrors/errors.go
+++ b/pkg/sql/sqlerrors/errors.go
@@ -172,6 +172,11 @@ func IsRelationAlreadyExistsError(err error) bool {
 	return errHasCode(err, pgcode.DuplicateRelation)
 }
 
+//IsTypeAlreadyExistsError checks whether this is an error for preexisting type
+func IsTypeAlreadyExistsError(err error) bool {
+	return errHasCode(err, pgcode.DuplicateObject)
+}
+
 // NewWrongObjectTypeError creates a wrong object type error.
 func NewWrongObjectTypeError(name tree.NodeFormatter, desiredObjType string) error {
 	return pgerror.Newf(pgcode.WrongObjectType, "%q is not a %s",


### PR DESCRIPTION
Fixes #56651.

This commit adds the missing IF NOT EXISTS grammar rule for
enum creation.

Release note: None