### PR TITLE
sql: add support for the `CREATE TYPE IF NOT EXISTS` command

### DIFF
--- a/docs/generated/sql/bnf/create_type.bnf
+++ b/docs/generated/sql/bnf/create_type.bnf
@@ -1,2 +1,3 @@
 create_type_stmt ::=
 	'CREATE' 'TYPE' type_name 'AS' 'ENUM' '(' opt_enum_val_list ')'
+	| 'CREATE' 'TYPE' 'IF' 'NOT' 'EXISTS' type_name 'AS' 'ENUM' '(' opt_enum_val_list ')'

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -1324,6 +1324,7 @@ create_table_as_stmt ::=
 
 create_type_stmt ::=
 	'CREATE' 'TYPE' type_name 'AS' 'ENUM' '(' opt_enum_val_list ')'
+	| 'CREATE' 'TYPE' 'IF' 'NOT' 'EXISTS' type_name 'AS' 'ENUM' '(' opt_enum_val_list ')'
 
 create_view_stmt ::=
 	'CREATE' opt_temp 'VIEW' view_name opt_column_list 'AS' select_stmt

--- a/pkg/sql/create_type.go
+++ b/pkg/sql/create_type.go
@@ -75,6 +75,26 @@ func (p *planner) CreateType(ctx context.Context, n *tree.CreateType) (planNode,
 }
 
 func (n *createTypeNode) startExec(params runParams) error {
+	// Check if a type with the same name exists already.
+	flags := tree.ObjectLookupFlags{CommonLookupFlags: tree.CommonLookupFlags{
+		Required:    false,
+		AvoidCached: true,
+	}}
+	existing, err := params.p.Descriptors().GetTypeByName(params.ctx, params.p.Txn(), n.typeName, flags)
+	if err != nil {
+		return err
+	}
+	// If we found a descriptor and have IfNotExists = true, then exit without
+	// doing anything. Ideally, we would do this below by inspecting the type
+	// of error returned by getCreateTypeParams, but it doesn't return enough
+	// information for us to do so. For comparison, we handle this case in
+	// CREATE TABLE IF NOT EXISTS by checking the return code
+	// (pgcode.DuplicateRelation) of getCreateTableParams. However, there isn't
+	// a pgcode for duplicate types, only the more general pgcode.DuplicateObject.
+	if existing != nil && n.n.IfNotExists {
+		return nil
+	}
+
 	switch n.n.Variety {
 	case tree.Enum:
 		return params.p.createUserDefinedEnum(params, n)

--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -1283,3 +1283,21 @@ SHOW ENUMS FROM sc
 ----
 schema  name      values   owner
 sc      greeting  {hello}  root
+
+# Check that creating a type with IF NOT EXISTS succeeds.
+subtest if_not_exists
+
+statement ok
+CREATE TYPE ifne AS ENUM ('hi')
+
+statement error pq: type "ifne" already exists
+CREATE TYPE ifne AS ENUM ('hi')
+
+statement ok
+CREATE TYPE IF NOT EXISTS ifne AS ENUM ('hi')
+
+statement ok
+CREATE TABLE table_ifne (x INT)
+
+statement error pq: relation "table_ifne" already exists
+CREATE TYPE IF NOT EXISTS table_ifne AS ENUM ('hi')

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -411,6 +411,7 @@ func TestParse(t *testing.T) {
 		{`ANALYZE db.sc.t`},
 
 		{`CREATE TYPE a AS ENUM ()`},
+		{`CREATE TYPE IF NOT EXISTS a AS ENUM ()`},
 		{`CREATE TYPE a AS ENUM ('a')`},
 		{`CREATE TYPE a AS ENUM ('a', 'b', 'c')`},
 		{`CREATE TYPE a.b AS ENUM ('a', 'b', 'c')`},

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -6837,7 +6837,7 @@ opt_view_recursive:
 
 // %Help: CREATE TYPE -- create a type
 // %Category: DDL
-// %Text: CREATE TYPE <type_name> AS ENUM (...)
+// %Text: CREATE TYPE [IF NOT EXISTS] <type_name> AS ENUM (...)
 create_type_stmt:
   // Enum types.
   CREATE TYPE type_name AS ENUM '(' opt_enum_val_list ')'
@@ -6846,6 +6846,15 @@ create_type_stmt:
       TypeName: $3.unresolvedObjectName(),
       Variety: tree.Enum,
       EnumLabels: $7.enumValueList(),
+    }
+  }
+| CREATE TYPE IF NOT EXISTS type_name AS ENUM '(' opt_enum_val_list ')'
+  {
+    $$.val = &tree.CreateType{
+      TypeName: $6.unresolvedObjectName(),
+      Variety: tree.Enum,
+      EnumLabels: $10.enumValueList(),
+      IfNotExists: true,
     }
   }
 | CREATE TYPE error // SHOW HELP: CREATE TYPE

--- a/pkg/sql/sem/tree/create.go
+++ b/pkg/sql/sem/tree/create.go
@@ -309,6 +309,8 @@ type CreateType struct {
 	Variety  CreateTypeVariety
 	// EnumLabels is set when this represents a CREATE TYPE ... AS ENUM statement.
 	EnumLabels EnumValueList
+	// IfNotExists is true if IF NOT EXISTS was requested.
+	IfNotExists bool
 }
 
 var _ Statement = &CreateType{}
@@ -316,6 +318,9 @@ var _ Statement = &CreateType{}
 // Format implements the NodeFormatter interface.
 func (node *CreateType) Format(ctx *FmtCtx) {
 	ctx.WriteString("CREATE TYPE ")
+	if node.IfNotExists {
+		ctx.WriteString("IF NOT EXISTS ")
+	}
 	ctx.FormatNode(node.TypeName)
 	ctx.WriteString(" ")
 	switch node.Variety {


### PR DESCRIPTION
Fixes #56651.

Release note (sql change): Add support for the `IF NOT EXISTS` prefix to
`CREATE TYPE` statements.