### PR TITLE
storageccl: add chunked-stream encrypted file support

### DIFF
--- a/pkg/ccl/storageccl/encryption.go
+++ b/pkg/ccl/storageccl/encryption.go
@@ -14,6 +14,9 @@ import (
 	"crypto/cipher"
 	crypto_rand "crypto/rand"
 	"crypto/sha256"
+	"encoding/binary"
+	"io"
+	"io/ioutil"
 
 	"github.com/cockroachdb/errors"
 	"golang.org/x/crypto/pbkdf2"
@@ -33,7 +36,23 @@ import (
 var encryptionPreamble = []byte("encrypt")
 
 const encryptionSaltSize = 16
+
+// v1 is just the IV and then one sealed GCM message.
 const encryptionVersionIVPrefix = 1
+
+// v2 is an IV followed by 1 or more sealed GCM messages representing chunks of
+// the original input. The last chunk is always less than full size (and may be
+// empty) prior to being sealed, which is verified by the reader to
+// authticate against truncation at a chunk boundary.
+const encryptionVersionChunk = 2
+
+// encryptionChunkSizeV2 is the chunk-size used by v2, i.e. 64kb, which should
+// minimize overhead while still while still limiting the size of buffers and
+// allowing seeks to mid-file.
+var encryptionChunkSizeV2 = 64 << 10 // 64kb
+const nonceSize = 12                 // GCM standard nonce
+const headerSize = 7 + 1 + nonceSize // preamble + version + iv
+const tagSize = 16                   // GCM standard tag
 
 // GenerateSalt generates a 16 byte random salt.
 func GenerateSalt() ([]byte, error) {
@@ -56,14 +75,18 @@ func AppearsEncrypted(text []byte) bool {
 }
 
 // EncryptFile encrypts a file with the supplied key and a randomly chosen IV
-// which is prepended in a header on the returned ciphertext. It is intended for
-// use on collections of separate data files that are all encrypted/decrypted
-// with the same key, such as BACKUP data files, and notably does _not_ include
-// information for key derivation as that is _not_ done for individual files in
-// such cases. See EncryptFileStoringSalt for a function that produces a
-// ciphertext that also includes the salt and thus supports decrypting with only
-// the passphrase (at the cost in including key derivation).
+// which is prepended in a header on the returned ciphertext.
 func EncryptFile(plaintext, key []byte) ([]byte, error) {
+	return encryptFile(plaintext, key, false)
+}
+
+// EncryptFileChunked is like EncryptFile but chunks the file into fixed-size
+// messages encrypted individually, allowing streaming (by-chunk) decryption.
+func EncryptFileChunked(plaintext, key []byte) ([]byte, error) {
+	return encryptFile(plaintext, key, true)
+}
+
+func encryptFile(plaintext, key []byte, chunked bool) ([]byte, error) {
 	gcm, err := aesgcm(key)
 	if err != nil {
 		return nil, err
@@ -71,56 +94,176 @@ func EncryptFile(plaintext, key []byte) ([]byte, error) {
 
 	// Allocate our output buffer: preamble + 1B version + iv, plus additional
 	// pre-allocated capacity for the ciphertext.
-	headerSize := len(encryptionPreamble) + 1 + gcm.NonceSize()
-	ciphertext := make([]byte, headerSize, headerSize+len(plaintext)+gcm.Overhead())
+
+	numChunks := 1
+	var version byte
+	if chunked {
+		version = encryptionVersionChunk
+		numChunks = (len(plaintext) / encryptionChunkSizeV2) + 1
+	} else {
+		version = encryptionVersionIVPrefix
+	}
+
+	ciphertext := make([]byte, headerSize, headerSize+len(plaintext)+numChunks*gcm.Overhead())
 
 	// Write our header (preamble+version+IV) to the ciphertext buffer.
 	copy(ciphertext, encryptionPreamble)
-	ciphertext[len(encryptionPreamble)] = encryptionVersionIVPrefix
+	ciphertext[len(encryptionPreamble)] = version
+
 	// Pick a unique IV for this file and write it in the header.
-	iv := ciphertext[len(encryptionPreamble)+1:]
-	if _, err := crypto_rand.Read(iv); err != nil {
+	ivStart := len(encryptionPreamble) + 1
+	if _, err := crypto_rand.Read(ciphertext[ivStart : ivStart+nonceSize]); err != nil {
 		return nil, err
 	}
+	// Make a copy of the IV to increment for each chunk.
+	iv := append([]byte{}, ciphertext[ivStart:ivStart+nonceSize]...)
 
-	// Generate and write the actual ciphertext.
-	return gcm.Seal(ciphertext, iv, plaintext, nil), nil
+	if !chunked {
+		return gcm.Seal(ciphertext, iv, plaintext, nil), nil
+	}
+
+	for {
+		chunk := plaintext
+		if len(chunk) > encryptionChunkSizeV2 {
+			chunk = plaintext[:encryptionChunkSizeV2]
+		}
+		plaintext = plaintext[len(chunk):]
+		ciphertext = gcm.Seal(ciphertext, iv, chunk, nil)
+
+		// Unless we sealed less than a full chunk, continue to seal another chunk.
+		// Note: there may not be any plaintext left to seal if the chunk we just
+		// finished was the end of it, but sealing the (empty) remainder in a final
+		// chunk maintains the invariant that a chunked file always ends in a sealed
+		// chunk of less than chunk size, thus making tuncation, even along a chunk
+		// boundary, detectable.
+		if len(chunk) < encryptionChunkSizeV2 {
+			break
+		}
+		binary.BigEndian.PutUint64(iv[4:], binary.BigEndian.Uint64(iv[4:])+1)
+	}
+	return ciphertext, nil
 }
 
 // DecryptFile decrypts a file encrypted by EncryptFile, using the supplied key
 // and reading the IV from a prefix of the file. See comments on EncryptFile
 // for intended usage, and see DecryptFile
 func DecryptFile(ciphertext, key []byte) ([]byte, error) {
-	if !AppearsEncrypted(ciphertext) {
-		return nil, errors.New("file does not appear to be encrypted")
+	r, err := DecryptingReader(bytes.NewReader(ciphertext), key)
+	if err != nil {
+		return nil, err
 	}
-	ciphertext = ciphertext[len(encryptionPreamble):]
+	return ioutil.ReadAll(r)
+}
 
-	if len(ciphertext) < 1 {
-		return nil, errors.New("invalid encryption header")
-	}
-	version := ciphertext[0]
-	ciphertext = ciphertext[1:]
+type decryptReader struct {
+	ciphertext io.Reader
+	g          cipher.AEAD
+	fileIV     []byte
 
-	if version != encryptionVersionIVPrefix {
-		return nil, errors.Errorf("unexpected encryption scheme/config version %d", version)
-	}
+	eof       bool
+	ivScratch []byte
+	buf       []byte
+	pos       int
+	chunk     int64
+}
+
+// DecryptingReader returns a reader that decrypts on the fly with the given
+// key.
+func DecryptingReader(ciphertext io.Reader, key []byte) (io.Reader, error) {
 	gcm, err := aesgcm(key)
 	if err != nil {
 		return nil, err
 	}
 
-	ivSize := gcm.NonceSize()
-	if len(ciphertext) < ivSize {
-		return nil, errors.New("invalid encryption header: missing IV")
+	header := make([]byte, headerSize)
+	_, readHeaderErr := io.ReadFull(ciphertext, header)
+
+	// Verify that the read data does indeed look like an encrypted file and has
+	// a encoding version we can decode.
+	if !AppearsEncrypted(header) {
+		return nil, errors.New("file does not appear to be encrypted")
 	}
-	iv := ciphertext[:ivSize]
-	ciphertext = ciphertext[ivSize:]
-	plaintext, err := gcm.Open(ciphertext[:0], iv, ciphertext, nil)
-	if err != nil {
-		err = errors.Wrap(err, "failed to decrypt — maybe incorrect key")
+	if readHeaderErr != nil {
+		return nil, errors.Wrap(readHeaderErr, "invalid encryption header")
 	}
-	return plaintext, err
+
+	version := header[len(encryptionPreamble)]
+	if version < encryptionVersionIVPrefix || version > encryptionVersionChunk {
+		return nil, errors.Errorf("unexpected encryption scheme/config version %d", version)
+	}
+	iv := header[len(encryptionPreamble)+1:]
+
+	// If this version is not chunked, the entire file is one GCM message so we
+	// need to read all of it to open it, and can then just return a simple bytes
+	// reader on the decrypted body.
+	if version == encryptionVersionIVPrefix {
+		buf, err := ioutil.ReadAll(ciphertext)
+		if err != nil {
+			return nil, err
+		}
+		buf, err = gcm.Open(buf[:0], iv, buf, nil)
+		return bytes.NewReader(buf), errors.Wrap(err, "failed to decrypt — maybe incorrect key")
+	}
+	buf := make([]byte, nonceSize, encryptionChunkSizeV2+tagSize+nonceSize)
+	ivScratch := buf[:nonceSize]
+	buf = buf[nonceSize:]
+	r := &decryptReader{g: gcm, fileIV: iv, ivScratch: ivScratch, ciphertext: ciphertext, buf: buf, chunk: -1}
+	return r, err
+}
+
+func (r *decryptReader) fill() error {
+	if r.eof {
+		return io.EOF
+	}
+	r.pos = 0
+	r.buf = r.buf[:cap(r.buf)]
+	r.chunk++
+	var read int
+	for read < len(r.buf) {
+		n, err := r.ciphertext.Read(r.buf[read:])
+		read += n
+
+		// If we've reached end of the ciphertext, we still need to need to unseal
+		// the current chunk (even if it was empty, to detect truncations).
+		if err == io.EOF {
+			r.eof = true
+			break
+		}
+		if err != nil {
+			return err
+		}
+	}
+	var err error
+	r.buf, err = r.g.Open(r.buf[:0], r.chunkIV(r.chunk), r.buf[:read], nil)
+	if r.eof && len(r.buf) >= encryptionChunkSizeV2 {
+		return errors.Wrap(io.ErrUnexpectedEOF, "encrypted file appears truncated")
+	}
+	return errors.Wrap(err, "failed to decrypt — maybe incorrect key")
+}
+
+func (r *decryptReader) chunkIV(num int64) []byte {
+	r.ivScratch = append(r.ivScratch[:0], r.fileIV...)
+	binary.BigEndian.PutUint64(r.ivScratch[4:], binary.BigEndian.Uint64(r.ivScratch[4:])+uint64(num))
+	return r.ivScratch
+}
+
+func (r *decryptReader) Read(p []byte) (int, error) {
+	if r.pos >= len(r.buf) {
+		if err := r.fill(); err != nil {
+			r.chunk = -1
+			return 0, err
+		}
+	}
+	read := copy(p, r.buf[r.pos:])
+	r.pos += read
+	return read, nil
+}
+
+func (r *decryptReader) Close() error {
+	if closer, ok := r.ciphertext.(io.Closer); ok {
+		return closer.Close()
+	}
+	return nil
 }
 
 func aesgcm(key []byte) (cipher.AEAD, error) {

--- a/pkg/ccl/storageccl/encryption_test.go
+++ b/pkg/ccl/storageccl/encryption_test.go
@@ -10,17 +10,20 @@ package storageccl
 
 import (
 	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/stretchr/testify/require"
 )
 
 func TestEncryptDecrypt(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	plaintext := bytes.Repeat([]byte("hello world\n"), 3)
 	passphrase := []byte("this is a a key")
 	salt, err := GenerateSalt()
 	if err != nil {
@@ -29,103 +32,133 @@ func TestEncryptDecrypt(t *testing.T) {
 	key := GenerateKey(passphrase, salt)
 
 	t.Run("EncryptFile+DecryptFile", func(t *testing.T) {
-		ciphertext, err := EncryptFile(plaintext, key)
-		require.NoError(t, err)
-		require.True(t, AppearsEncrypted(ciphertext), "cipher text should appear encrypted")
+		for _, textCopies := range []int{0, 1, 3, 10, 100, 10000} {
+			plaintext := bytes.Repeat([]byte("hello world\n"), textCopies)
+			t.Run(fmt.Sprintf("copies=%d", textCopies), func(t *testing.T) {
+				for _, chunkSize := range []int{0, 1, 7, 64, 1 << 10, 1 << 20} {
+					encryptionChunkSizeV2 = chunkSize
 
-		decrypted, err := DecryptFile(ciphertext, key)
-		require.NoError(t, err)
-		require.Equal(t, plaintext, decrypted)
+					t.Run("chunk="+humanizeutil.IBytes(int64(chunkSize)), func(t *testing.T) {
+						ciphertext, err := encryptFile(plaintext, key, chunkSize > 0)
+						require.NoError(t, err)
+						require.True(t, AppearsEncrypted(ciphertext), "cipher text should appear encrypted")
+
+						decrypted, err := DecryptFile(ciphertext, key)
+						require.NoError(t, err)
+						require.Equal(t, plaintext, decrypted)
+					})
+				}
+			})
+		}
 	})
 
 	t.Run("helpful error on bad input", func(t *testing.T) {
-
 		_, err := DecryptFile([]byte("a"), key)
 		require.EqualError(t, err, "file does not appear to be encrypted")
 	})
+
+	t.Run("Random", func(t *testing.T) {
+		rng, _ := randutil.NewTestPseudoRand()
+		t.Run("DecryptFile", func(t *testing.T) {
+			for _, chunked := range []bool{false, true} {
+				t.Run(fmt.Sprintf("chunked=%v", chunked), func(t *testing.T) {
+					// For some number of randomly chosen chunk-sizes, generate a number
+					// of random length plaintexts of random bytes and ensure they each
+					// round-trip.
+					for i := 0; i < 10; i++ {
+						encryptionChunkSizeV2 = rng.Intn(1024*24) + 1
+						for j := 0; j < 100; j++ {
+							plaintext := randutil.RandBytes(rng, rng.Intn(1024*32))
+							ciphertext, err := encryptFile(plaintext, key, chunked)
+							require.NoError(t, err)
+							decrypted, err := DecryptFile(ciphertext, key)
+							require.NoError(t, err)
+							if len(plaintext) == 0 {
+								require.Equal(t, len(plaintext), len(decrypted))
+							} else {
+								require.Equal(t, plaintext, decrypted)
+							}
+						}
+					}
+				})
+			}
+		})
+	})
+	_ = EncryptFileChunked // suppress unused warning.
 }
 
 func BenchmarkEncryption(b *testing.B) {
 	plaintext1KB := bytes.Repeat([]byte("0123456789abcdef"), 64)
 	plaintext100KB := bytes.Repeat(plaintext1KB, 100)
 	plaintext1MB := bytes.Repeat(plaintext1KB, 1024)
+	plaintext64MB := bytes.Repeat(plaintext1MB, 64)
 
 	passphrase := []byte("this is a a key")
 	salt, err := GenerateSalt()
 	require.NoError(b, err)
 	key := GenerateKey(passphrase, salt)
-
-	ciphertext1KB, err := EncryptFile(plaintext1KB, key)
-	require.NoError(b, err)
-	ciphertext100KB, err := EncryptFile(plaintext100KB, key)
-	require.NoError(b, err)
-	ciphertext1MB, err := EncryptFile(plaintext1MB, key)
-	require.NoError(b, err)
-
+	chunkSizes := []int{0, 100, 4096, 512 << 10, 1 << 20}
+	ciphertext1KB := make([][]byte, len(chunkSizes))
+	ciphertext100KB := make([][]byte, len(chunkSizes))
+	ciphertext1MB := make([][]byte, len(chunkSizes))
+	ciphertext64MB := make([][]byte, len(chunkSizes))
 	b.ResetTimer()
 
 	b.Run("EncryptFile", func(b *testing.B) {
-		for _, plaintext := range [][]byte{plaintext1KB, plaintext100KB, plaintext1MB} {
+		for _, plaintext := range [][]byte{plaintext1KB, plaintext100KB, plaintext1MB, plaintext64MB} {
 			b.Run(humanizeutil.IBytes(int64(len(plaintext))), func(b *testing.B) {
-				for i := 0; i < b.N; i++ {
-					_, err := EncryptFile(plaintext, key)
-					if err != nil {
-						b.Fatal(err)
-					}
+				for _, chunkSize := range chunkSizes {
+					encryptionChunkSizeV2 = chunkSize
+					b.Run("chunk="+humanizeutil.IBytes(int64(chunkSize)), func(b *testing.B) {
+						for i := 0; i < b.N; i++ {
+							_, err := encryptFile(plaintext, key, chunkSize > 0)
+							if err != nil {
+								b.Fatal(err)
+							}
+						}
+						b.SetBytes(int64(len(plaintext)))
+					})
 				}
-				b.SetBytes(int64(len(plaintext)))
 			})
 		}
 	})
+
+	for i, chunkSize := range chunkSizes {
+		encryptionChunkSizeV2 = chunkSize
+		ciphertext1KB[i], err = encryptFile(plaintext1KB, key, chunkSize > 0)
+		require.NoError(b, err)
+		ciphertext100KB[i], err = encryptFile(plaintext100KB, key, chunkSize > 0)
+		require.NoError(b, err)
+		ciphertext1MB[i], err = encryptFile(plaintext1MB, key, chunkSize > 0)
+		require.NoError(b, err)
+		ciphertext64MB[i], err = encryptFile(plaintext64MB, key, chunkSize > 0)
+		require.NoError(b, err)
+	}
+	b.ResetTimer()
 
 	b.Run("DecryptFile", func(b *testing.B) {
-		for _, ciphertextOriginal := range [][]byte{ciphertext1KB, ciphertext100KB, ciphertext1MB} {
+		for _, ciphertextOriginal := range [][][]byte{ciphertext1KB, ciphertext100KB, ciphertext1MB, ciphertext64MB} {
 			// Decrypt reuses/clobbers the original ciphertext slice.
-			ciphertext := make([]byte, len(ciphertextOriginal))
-			b.Run(humanizeutil.IBytes(int64(len(ciphertext))), func(b *testing.B) {
-				for i := 0; i < b.N; i++ {
-					copy(ciphertext, ciphertextOriginal)
-					_, err := DecryptFile(ciphertext, key)
-					if err != nil {
-						b.Fatal(err)
-					}
-				}
-				b.SetBytes(int64(len(ciphertext)))
-			})
-		}
-	})
+			b.Run(humanizeutil.IBytes(int64(len(ciphertextOriginal[0]))), func(b *testing.B) {
+				for chunkSizeNum, chunkSize := range chunkSizes {
+					encryptionChunkSizeV2 = chunkSize
 
-	// If each file written or read also requires key derivation it is much more
-	// expensive.
-	b.Run("DeriveAndEncrypt", func(b *testing.B) {
-		for _, plaintext := range [][]byte{plaintext1KB, plaintext100KB, plaintext1MB} {
-			b.Run(humanizeutil.IBytes(int64(len(plaintext))), func(b *testing.B) {
-				for i := 0; i < b.N; i++ {
-					derived := GenerateKey(passphrase, salt)
-					_, err := EncryptFile(plaintext, derived)
-					if err != nil {
-						b.Fatal(err)
-					}
+					b.Run("chunk="+humanizeutil.IBytes(int64(chunkSize)), func(b *testing.B) {
+						ciphertext := bytes.NewReader(ciphertextOriginal[chunkSizeNum])
+						for i := 0; i < b.N; i++ {
+							ciphertext.Reset(ciphertextOriginal[chunkSizeNum])
+							r, err := DecryptingReader(ciphertext, key)
+							if err != nil {
+								b.Fatal(err)
+							}
+							_, err = io.Copy(ioutil.Discard, r)
+							if err != nil {
+								b.Fatal(err)
+							}
+						}
+						b.SetBytes(int64(len(ciphertextOriginal[chunkSizeNum])))
+					})
 				}
-				b.SetBytes(int64(len(plaintext)))
-			})
-		}
-	})
-
-	b.Run("DeriveAndDecrypt", func(b *testing.B) {
-		for _, ciphertextOriginal := range [][]byte{ciphertext1KB, ciphertext100KB, ciphertext1MB} {
-			// Decrypt reuses/clobbers the original ciphertext slice.
-			ciphertext := make([]byte, len(ciphertextOriginal))
-			b.Run(humanizeutil.IBytes(int64(len(ciphertext))), func(b *testing.B) {
-				for i := 0; i < b.N; i++ {
-					copy(ciphertext, ciphertextOriginal)
-					derived := GenerateKey(passphrase, salt)
-					_, err := DecryptFile(ciphertext, derived)
-					if err != nil {
-						b.Fatal(err)
-					}
-				}
-				b.SetBytes(int64(len(ciphertext)))
 			})
 		}
 	})

--- a/pkg/util/randutil/rand.go
+++ b/pkg/util/randutil/rand.go
@@ -40,6 +40,13 @@ func NewPseudoRand() (*rand.Rand, int64) {
 	return rand.New(rand.NewSource(seed)), seed
 }
 
+// NewTestPseudoRand wraps NewPseudoRand logging the seed for recovery later.
+func NewTestPseudoRand() (*rand.Rand, int64) {
+	rng, seed := NewPseudoRand()
+	log.Printf("random seed: %v", seed)
+	return rng, seed
+}
+
 // RandIntInRange returns a value in [min, max)
 func RandIntInRange(r *rand.Rand, min, max int) int {
 	return min + r.Intn(max-min)


### PR DESCRIPTION
This adds a support for reading and writing encrypted files that
rather than being a single message sealed with GCM, are chunked
into a sequence of fixed-size messages which are each individually
sealed.

This is done to allow a reader to decrypt and process chunks in a
streaming fashion rather than needing to read the entire file before
decrypting it. Chunks are fixed size to allow for seeking to an offset
in the clear-text, as its chunk can be computed deterministically.

A chunk size of 1MB should add minimal overhead, such as the GCM tag
that is appended to each chunk, while also providing a reasonable
bound on the size of the buffer that a reader has to hold before it
can decrypt and process.

This patch only introduces support for the new encoding and extends the
tests to cover it -- it does not change any existing callers to use it.

Also while the approach was chosen with the intent to allow a seek
within the reader, this initial patch does not yet implement the
seek logic.

Release note: none.