### PR TITLE
sql: fix DDL after write error message

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -157,7 +157,7 @@ func (b *Builder) buildRelational(e memo.RelExpr) (execPlan, error) {
 		if err := b.evalCtx.Txn.SetSystemConfigTrigger(b.evalCtx.Codec.ForSystemTenant()); err != nil {
 			return execPlan{}, errors.WithSecondaryError(
 				unimplemented.NewWithIssuef(26508,
-					"schema change statement cannot follow a statement that has written in the same transaction"),
+					"the first schema change statement in a transaction must precede any writes"),
 				err)
 		}
 	}

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -3579,7 +3579,7 @@ INSERT INTO t.kv VALUES ('a', 'b');
 			name:        `insert-create`,
 			firstStmt:   `INSERT INTO t.kv VALUES ('e', 'f')`,
 			secondStmt:  `CREATE INDEX foo2 ON t.kv (v)`,
-			expectedErr: `schema change statement cannot follow a statement that has written in the same transaction`,
+			expectedErr: `the first schema change statement in a transaction must precede any writes`,
 		},
 		// schema change at the end of a read only transaction.
 		{


### PR DESCRIPTION
Previously, the error message said "schema change statement
cannot follow a statement that has written in the same
transaction". This message is incorrect because DDLs after
writes are allowed if the first schema change in a txn occurs
before the first write. This change updates the error message
to reflect the latter.

Release note: None