### PR TITLE
backupccl: make progress updates non-blocking

### DIFF
--- a/pkg/ccl/backupccl/backup_processor_planning.go
+++ b/pkg/ccl/backupccl/backup_processor_planning.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/storage/cloud"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
 )


### PR DESCRIPTION
Previously, backup and restore were sensitive to inaccuracies in the
number of expected progress updates. If the estimation was wrong, the
job could be blocked.

This change makes this behavior more defensive and changes the progress
updates to be non-blocking sends. We prioritize not blocking backups and
restores over having an accurate progress metric.

Release note: None