### PR TITLE
sql: add Index interface and TableDescriptor methods in catalog

### DIFF
--- a/pkg/sql/catalog/BUILD.bazel
+++ b/pkg/sql/catalog/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/catalog",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/geo/geoindex",
         "//pkg/keys",
         "//pkg/kv",
         "//pkg/roachpb",

--- a/pkg/sql/catalog/tabledesc/BUILD.bazel
+++ b/pkg/sql/catalog/tabledesc/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "tabledesc",
     srcs = [
+        "index.go",
         "safe_format.go",
         "structured.go",
         "table.go",
@@ -11,6 +12,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/geo/geoindex",
         "//pkg/keys",
         "//pkg/roachpb",
         "//pkg/settings/cluster",

--- a/pkg/sql/catalog/tabledesc/index.go
+++ b/pkg/sql/catalog/tabledesc/index.go
@@ -1,0 +1,468 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tabledesc
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/geo/geoindex"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+)
+
+var _ catalog.Index = (*index)(nil)
+
+// index implements the catalog.Index interface by wrapping the protobuf index
+// descriptor along with some metadata from its parent table descriptor.
+type index struct {
+	desc              *descpb.IndexDescriptor
+	ordinal           int
+	mutationID        descpb.MutationID
+	mutationDirection descpb.DescriptorMutation_Direction
+	mutationState     descpb.DescriptorMutation_State
+}
+
+// IndexDesc returns the underlying protobuf descriptor.
+// Ideally, this method should be called as rarely as possible.
+func (w index) IndexDesc() *descpb.IndexDescriptor {
+	return w.desc
+}
+
+// IndexDescDeepCopy returns a deep copy of the underlying protobuf descriptor.
+func (w index) IndexDescDeepCopy() descpb.IndexDescriptor {
+	return *protoutil.Clone(w.desc).(*descpb.IndexDescriptor)
+}
+
+// Ordinal returns the ordinal of the index within the table descriptor.
+func (w index) Ordinal() int {
+	return w.ordinal
+}
+
+// Primary returns true iff the index is the primary index for the table
+// descriptor.
+func (w index) Primary() bool {
+	return w.ordinal == 0
+}
+
+// Public returns true iff the index is active, i.e. readable.
+func (w index) Public() bool {
+	return w.mutationState == descpb.DescriptorMutation_UNKNOWN
+}
+
+// Adding returns true iff the index is an add mutation in the table descriptor.
+func (w index) Adding() bool {
+	return w.mutationDirection == descpb.DescriptorMutation_ADD
+}
+
+// Adding returns true iff the index is a drop mutation in the table descriptor.
+func (w index) Dropped() bool {
+	return w.mutationDirection == descpb.DescriptorMutation_DROP
+}
+
+// WriteAndDeleteOnly returns true iff the index is a mutation in the
+// delete-and-write-only state.
+func (w index) WriteAndDeleteOnly() bool {
+	return w.mutationState == descpb.DescriptorMutation_DELETE_AND_WRITE_ONLY
+}
+
+// DeleteOnly returns true iff the index is a mutation in the delete-only state.
+func (w index) DeleteOnly() bool {
+	return w.mutationState == descpb.DescriptorMutation_DELETE_ONLY
+}
+
+// GetID returns the index ID.
+func (w index) GetID() descpb.IndexID {
+	return w.desc.ID
+}
+
+// GetName returns the index name.
+func (w index) GetName() string {
+	return w.desc.Name
+}
+
+// IsInterleaved returns true iff the index is interleaved.
+func (w index) IsInterleaved() bool {
+	return w.desc.IsInterleaved()
+}
+
+// IsPartial returns true iff the index is a partial index.
+func (w index) IsPartial() bool {
+	return w.desc.IsPartial()
+}
+
+// IsUnique returns true iff the index is a unique index.
+func (w index) IsUnique() bool {
+	return w.desc.Unique
+}
+
+// IsDisabled returns true iff the index is disabled.
+func (w index) IsDisabled() bool {
+	return w.desc.Disabled
+}
+
+// IsSharded returns true iff the index is hash sharded.
+func (w index) IsSharded() bool {
+	return w.desc.IsSharded()
+}
+
+// IsCreatedExplicitly returns true iff this index was created explicitly, i.e.
+// via 'CREATE INDEX' statement.
+func (w index) IsCreatedExplicitly() bool {
+	return w.desc.CreatedExplicitly
+}
+
+// GetPredicate returns the empty string when the index is not partial,
+// otherwise it returns the corresponding expression of the partial index.
+// Columns are referred to in the expression by their name.
+func (w index) GetPredicate() string {
+	return w.desc.Predicate
+}
+
+// GetType returns the type of index, inverted or forward.
+func (w index) GetType() descpb.IndexDescriptor_Type {
+	return w.desc.Type
+}
+
+// GetPartitioning returns the partitioning descriptor of the index.
+func (w index) GetPartitioning() descpb.PartitioningDescriptor {
+	return w.desc.Partitioning
+}
+
+// FindPartitionByName searches the index's partitioning descriptor for a
+// partition whose name is the input and returns it, or nil if no match is found.
+func (w index) FindPartitionByName(name string) descpb.PartitioningDescriptor {
+	return *w.desc.Partitioning.FindPartitionByName(name)
+}
+
+// PartitionNames returns a slice containing the name of every partition and
+// subpartition in an arbitrary order.
+func (w index) PartitionNames() []string {
+	return w.desc.Partitioning.PartitionNames()
+}
+
+// IsValidOriginIndex returns whether the index can serve as an origin index for
+// a foreign key constraint with the provided set of originColIDs.
+func (w index) IsValidOriginIndex(originColIDs descpb.ColumnIDs) bool {
+	return w.desc.IsValidOriginIndex(originColIDs)
+}
+
+// IsValidReferencedIndex returns whether the index can serve as a referenced
+// index for a foreign  key constraint with the provided set of
+// referencedColumnIDs.
+func (w index) IsValidReferencedIndex(referencedColIDs descpb.ColumnIDs) bool {
+	return w.desc.IsValidReferencedIndex(referencedColIDs)
+}
+
+// HasOldStoredColumns returns whether the index has stored columns in the old
+// format (data encoded the same way as if they were in an implicit column).
+func (w index) HasOldStoredColumns() bool {
+	return w.desc.HasOldStoredColumns()
+}
+
+// InvertedColumnID returns the ColumnID of the inverted column of the inverted
+// index. This is always the last column in ColumnIDs. Panics if the index is
+// not inverted.
+func (w index) InvertedColumnID() descpb.ColumnID {
+	return w.desc.InvertedColumnID()
+}
+
+// InvertedColumnName returns the name of the inverted column of the inverted
+// index. This is always the last column in ColumnNames. Panics if the index is
+// not inverted.
+func (w index) InvertedColumnName() string {
+	return w.desc.InvertedColumnName()
+}
+
+// ContainsColumnID returns true if the index descriptor contains the specified
+// column ID either in its explicit column IDs, the extra column IDs, or the
+// stored column IDs.
+func (w index) ContainsColumnID(colID descpb.ColumnID) bool {
+	return w.desc.ContainsColumnID(colID)
+}
+
+// GetGeoConfig returns the geo config in the index descriptor.
+func (w index) GetGeoConfig() geoindex.Config {
+	return w.desc.GeoConfig
+}
+
+// GetSharded returns the ShardedDescriptor in the index descriptor
+func (w index) GetSharded() descpb.ShardedDescriptor {
+	return w.desc.Sharded
+}
+
+// GetShardColumnName returns the name of the shard column if the index is hash
+// sharded, empty string otherwise.
+func (w index) GetShardColumnName() string {
+	return w.desc.Sharded.Name
+}
+
+// GetVersion returns the version of the index descriptor.
+func (w index) GetVersion() descpb.IndexDescriptorVersion {
+	return w.desc.Version
+}
+
+// GetEncodingType returns the encoding type of this index. For backward
+// compatibility reasons, this might not match what is stored in
+// w.desc.EncodingType.
+func (w index) GetEncodingType() descpb.IndexDescriptorEncodingType {
+	if w.Primary() {
+		// Primary indexes always use the PrimaryIndexEncoding, regardless of what
+		// desc.EncodingType indicates.
+		return descpb.PrimaryIndexEncoding
+	}
+	return w.desc.EncodingType
+}
+
+// NumInterleaveAncestors returns the number of interleave ancestors as per the
+// index descriptor.
+func (w index) NumInterleaveAncestors() int {
+	return len(w.desc.Interleave.Ancestors)
+}
+
+// GetInterleaveAncestor returns the ancestorOrdinal-th interleave ancestor.
+func (w index) GetInterleaveAncestor(ancestorOrdinal int) descpb.InterleaveDescriptor_Ancestor {
+	return w.desc.Interleave.Ancestors[ancestorOrdinal]
+}
+
+// NumInterleavedBy returns the number of tables/indexes that are interleaved
+// into this index.
+func (w index) NumInterleavedBy() int {
+	return len(w.desc.InterleavedBy)
+}
+
+// GetInterleavedBy returns the interleavedByOrdinal-th table/index that is
+// interleaved into this index.
+func (w index) GetInterleavedBy(interleavedByOrdinal int) descpb.ForeignKeyReference {
+	return w.desc.InterleavedBy[interleavedByOrdinal]
+}
+
+// NumColumns returns the number of columns as per the index descriptor.
+func (w index) NumColumns() int {
+	return len(w.desc.ColumnIDs)
+}
+
+// GetColumnID returns the ID of the columnOrdinal-th column.
+func (w index) GetColumnID(columnOrdinal int) descpb.ColumnID {
+	return w.desc.ColumnIDs[columnOrdinal]
+}
+
+// GetColumnName returns the name of the columnOrdinal-th column.
+func (w index) GetColumnName(columnOrdinal int) string {
+	return w.desc.ColumnNames[columnOrdinal]
+}
+
+// GetColumnDirection returns the direction of the columnOrdinal-th column.
+func (w index) GetColumnDirection(columnOrdinal int) descpb.IndexDescriptor_Direction {
+	return w.desc.ColumnDirections[columnOrdinal]
+}
+
+// ForEachColumnID applies its argument fn to each of the column IDs in the
+// index descriptor. If there is an error, that error is returned immediately.
+func (w index) ForEachColumnID(fn func(colID descpb.ColumnID) error) error {
+	return w.desc.RunOverAllColumns(fn)
+}
+
+// NumStoredColumns returns the number of columns which the index stores in
+// addition to the columns which are explicitly part of the index (STORING
+// clause). Only used for secondary indexes.
+func (w index) NumStoredColumns() int {
+	return len(w.desc.StoreColumnIDs)
+}
+
+// GetStoredColumnID returns the ID of the storeColumnOrdinal-th store column.
+func (w index) GetStoredColumnID(storedColumnOrdinal int) descpb.ColumnID {
+	return w.desc.StoreColumnIDs[storedColumnOrdinal]
+}
+
+// GetStoredColumnName returns the name of the storeColumnOrdinal-th store column.
+func (w index) GetStoredColumnName(storedColumnOrdinal int) string {
+	return w.desc.StoreColumnNames[storedColumnOrdinal]
+}
+
+// NumExtraColumns returns the number of additional columns referenced by the
+// index descriptor.
+func (w index) NumExtraColumns() int {
+	return len(w.desc.ExtraColumnIDs)
+}
+
+// GetExtraColumnID returns the ID of the extraColumnOrdinal-th extra column.
+func (w index) GetExtraColumnID(extraColumnOrdinal int) descpb.ColumnID {
+	return w.desc.ExtraColumnIDs[extraColumnOrdinal]
+}
+
+// NumCompositeColumns returns the number of composite columns referenced by the
+// index descriptor.
+func (w index) NumCompositeColumns() int {
+	return len(w.desc.CompositeColumnIDs)
+}
+
+// GetCompositeColumnID returns the ID of the compositeColumnOrdinal-th
+// composite column.
+func (w index) GetCompositeColumnID(compositeColumnOrdinal int) descpb.ColumnID {
+	return w.desc.CompositeColumnIDs[compositeColumnOrdinal]
+}
+
+// indexCache contains lazily precomputed slices of catalog.Index interfaces.
+// A field value of nil indicates that the slice hasn't been precomputed yet.
+type indexCache struct {
+	all                  []catalog.Index
+	active               []catalog.Index
+	nonDrop              []catalog.Index
+	publicNonPrimary     []catalog.Index
+	writableNonPrimary   []catalog.Index
+	deletableNonPrimary  []catalog.Index
+	deleteOnlyNonPrimary []catalog.Index
+	partial              []catalog.Index
+}
+
+// cachedIndexes returns an already-build slice of catalog.Index interfaces if
+// it exists, if not it builds it using the provided factory function and args.
+// Notice that, as a result, empty slices need to be handled carefully.
+func (c *indexCache) cachedIndexes(
+	cached *[]catalog.Index,
+	factory func(c *indexCache, desc *wrapper) []catalog.Index,
+	desc *wrapper,
+) []catalog.Index {
+	if *cached == nil {
+		*cached = factory(c, desc)
+		if *cached == nil {
+			*cached = []catalog.Index{}
+		}
+	}
+	if len(*cached) == 0 {
+		return nil
+	}
+	return *cached
+}
+
+// buildPublicNonPrimary builds a fresh return value for
+// desc.PublicNonPrimaryIndexes().
+func buildPublicNonPrimary(_ *indexCache, desc *wrapper) []catalog.Index {
+	s := make([]catalog.Index, len(desc.Indexes))
+	for i := range s {
+		s[i] = index{desc: &desc.Indexes[i], ordinal: i + 1}
+	}
+	return s
+}
+
+func (c *indexCache) publicNonPrimaryIndexes(desc *wrapper) []catalog.Index {
+	return c.cachedIndexes(&c.publicNonPrimary, buildPublicNonPrimary, desc)
+}
+
+// buildActive builds fresh return value for desc.ActiveIndexes().
+func buildActive(c *indexCache, desc *wrapper) []catalog.Index {
+	publicNonPrimary := c.publicNonPrimaryIndexes(desc)
+	s := make([]catalog.Index, 1, 1+len(publicNonPrimary))
+	s[0] = index{desc: &desc.PrimaryIndex}
+	return append(s, publicNonPrimary...)
+}
+
+func (c *indexCache) activeIndexes(desc *wrapper) []catalog.Index {
+	return c.cachedIndexes(&c.active, buildActive, desc)
+}
+
+// buildAll builds fresh return value for desc.AllIndexes().
+func buildAll(c *indexCache, desc *wrapper) []catalog.Index {
+	s := make([]catalog.Index, 0, 1+len(desc.Indexes)+len(desc.Mutations))
+	s = append(s, c.activeIndexes(desc)...)
+	for _, m := range desc.Mutations {
+		if idxDesc := m.GetIndex(); idxDesc != nil {
+			idx := index{
+				desc:              idxDesc,
+				ordinal:           len(s),
+				mutationID:        m.MutationID,
+				mutationState:     m.State,
+				mutationDirection: m.Direction,
+			}
+			s = append(s, idx)
+		}
+	}
+	return s
+}
+
+func (c *indexCache) allIndexes(desc *wrapper) []catalog.Index {
+	return c.cachedIndexes(&c.all, buildAll, desc)
+}
+
+// buildDeletableNonPrimary builds fresh return value for
+// desc.DeletableNonPrimaryIndexes().
+func buildDeletableNonPrimary(c *indexCache, desc *wrapper) []catalog.Index {
+	return c.allIndexes(desc)[1:]
+}
+
+func (c *indexCache) deletableNonPrimaryIndexes(desc *wrapper) []catalog.Index {
+	return c.cachedIndexes(&c.deletableNonPrimary, buildDeletableNonPrimary, desc)
+}
+
+// buildWritableNonPrimary builds fresh return value for
+// desc.WritableNonPrimaryIndexes().
+func buildWritableNonPrimary(c *indexCache, desc *wrapper) []catalog.Index {
+	deletableNonPrimary := c.deletableNonPrimaryIndexes(desc)
+	s := make([]catalog.Index, 0, len(deletableNonPrimary))
+	for _, idx := range deletableNonPrimary {
+		if idx.Public() || idx.WriteAndDeleteOnly() {
+			s = append(s, idx)
+		}
+	}
+	return s
+}
+
+func (c *indexCache) writableNonPrimaryIndexes(desc *wrapper) []catalog.Index {
+	return c.cachedIndexes(&c.writableNonPrimary, buildWritableNonPrimary, desc)
+}
+
+// buildDeleteOnlyNonPrimary builds fresh return value for
+// desc.DeleteOnlyNonPrimaryIndexes().
+func buildDeleteOnlyNonPrimary(c *indexCache, desc *wrapper) []catalog.Index {
+	deletableNonPublic := c.deletableNonPrimaryIndexes(desc)[len(desc.Indexes):]
+	s := make([]catalog.Index, 0, len(deletableNonPublic))
+	for _, idx := range deletableNonPublic {
+		if idx.DeleteOnly() {
+			s = append(s, idx)
+		}
+	}
+	return s
+}
+
+func (c *indexCache) deleteOnlyNonPrimaryIndexes(desc *wrapper) []catalog.Index {
+	return c.cachedIndexes(&c.deleteOnlyNonPrimary, buildDeleteOnlyNonPrimary, desc)
+}
+
+// buildNonDrop builds fresh return value for desc.NonDropIndexes().
+func buildNonDrop(c *indexCache, desc *wrapper) []catalog.Index {
+	all := c.allIndexes(desc)
+	s := make([]catalog.Index, 0, len(all))
+	for _, idx := range all {
+		if !idx.Dropped() && (!idx.Primary() || desc.IsPhysicalTable()) {
+			s = append(s, idx)
+		}
+	}
+	return s
+}
+
+func (c *indexCache) nonDropIndexes(desc *wrapper) []catalog.Index {
+	return c.cachedIndexes(&c.nonDrop, buildNonDrop, desc)
+}
+
+// buildPartial builds fresh return value for desc.PartialIndexes().
+func buildPartial(c *indexCache, desc *wrapper) []catalog.Index {
+	deletableNonPrimary := c.deletableNonPrimaryIndexes(desc)
+	s := make([]catalog.Index, 0, len(deletableNonPrimary))
+	for _, idx := range deletableNonPrimary {
+		if idx.IsPartial() {
+			s = append(s, idx)
+		}
+	}
+	return s
+}
+
+func (c *indexCache) partialIndexes(desc *wrapper) []catalog.Index {
+	return c.cachedIndexes(&c.partial, buildPartial, desc)
+}

--- a/pkg/sql/catalog/tabledesc/safe_format.go
+++ b/pkg/sql/catalog/tabledesc/safe_format.go
@@ -110,11 +110,13 @@ func formatSafeTableIndexes(w *redact.StringBuilder, desc catalog.TableDescripto
 	w.Printf(", PrimaryIndex: %d", desc.GetPrimaryIndexID())
 	w.Printf(", NextIndexID: %d", desc.TableDesc().NextIndexID)
 	w.Printf(", Indexes: [")
-	formatSafeIndex(w, desc.GetPrimaryIndex(), nil)
-	for i := range desc.GetPublicNonPrimaryIndexes() {
-		w.Printf(", ")
-		formatSafeIndex(w, &desc.GetPublicNonPrimaryIndexes()[i], nil)
-	}
+	_ = desc.ForEachActiveIndex(func(idx catalog.Index) error {
+		if !idx.Primary() {
+			w.Printf(", ")
+		}
+		formatSafeIndex(w, idx.IndexDesc(), nil)
+		return nil
+	})
 	w.Printf("]")
 }
 

--- a/pkg/sql/catalog/tabledesc/structured.go
+++ b/pkg/sql/catalog/tabledesc/structured.go
@@ -98,31 +98,27 @@ func NewFilledInExistingMutable(
 	skipFKsWithMissingTable bool,
 	tbl *descpb.TableDescriptor,
 ) (*Mutable, error) {
-	desc, err := makeFilledInImmutable(ctx, dg, tbl, skipFKsWithMissingTable)
+	changes, err := maybeFillInDescriptor(ctx, dg, tbl, skipFKsWithMissingTable)
 	if err != nil {
 		return nil, err
 	}
-	m := &Mutable{wrapper: desc.wrapper}
-	m.ClusterVersion = *tbl
-	return m, nil
+	w := wrapper{TableDescriptor: *tbl, postDeserializationChanges: changes}
+	return &Mutable{wrapper: w, ClusterVersion: *tbl}, nil
 }
 
 // MakeImmutable returns an Immutable from the given TableDescriptor.
 func MakeImmutable(tbl descpb.TableDescriptor) Immutable {
 	publicAndNonPublicCols := tbl.Columns
-	publicAndNonPublicIndexes := tbl.Indexes
 
 	readableCols := tbl.Columns
 
-	desc := Immutable{wrapper: wrapper{TableDescriptor: tbl}}
+	desc := Immutable{wrapper: wrapper{TableDescriptor: tbl, indexCache: &indexCache{}}}
 
 	if len(tbl.Mutations) > 0 {
 		publicAndNonPublicCols = make([]descpb.ColumnDescriptor, 0, len(tbl.Columns)+len(tbl.Mutations))
-		publicAndNonPublicIndexes = make([]descpb.IndexDescriptor, 0, len(tbl.Indexes)+len(tbl.Mutations))
 		readableCols = make([]descpb.ColumnDescriptor, 0, len(tbl.Columns)+len(tbl.Mutations))
 
 		publicAndNonPublicCols = append(publicAndNonPublicCols, tbl.Columns...)
-		publicAndNonPublicIndexes = append(publicAndNonPublicIndexes, tbl.Indexes...)
 		readableCols = append(readableCols, tbl.Columns...)
 
 		// Fill up mutations into the column/index lists by placing the writable columns/indexes
@@ -130,10 +126,7 @@ func MakeImmutable(tbl descpb.TableDescriptor) Immutable {
 		for _, m := range tbl.Mutations {
 			switch m.State {
 			case descpb.DescriptorMutation_DELETE_AND_WRITE_ONLY:
-				if idx := m.GetIndex(); idx != nil {
-					publicAndNonPublicIndexes = append(publicAndNonPublicIndexes, *idx)
-					desc.writeOnlyIndexCount++
-				} else if col := m.GetColumn(); col != nil {
+				if col := m.GetColumn(); col != nil {
 					publicAndNonPublicCols = append(publicAndNonPublicCols, *col)
 					desc.writeOnlyColCount++
 				}
@@ -143,9 +136,7 @@ func MakeImmutable(tbl descpb.TableDescriptor) Immutable {
 		for _, m := range tbl.Mutations {
 			switch m.State {
 			case descpb.DescriptorMutation_DELETE_ONLY:
-				if idx := m.GetIndex(); idx != nil {
-					publicAndNonPublicIndexes = append(publicAndNonPublicIndexes, *idx)
-				} else if col := m.GetColumn(); col != nil {
+				if col := m.GetColumn(); col != nil {
 					publicAndNonPublicCols = append(publicAndNonPublicCols, *col)
 				}
 			}
@@ -162,18 +153,10 @@ func MakeImmutable(tbl descpb.TableDescriptor) Immutable {
 
 	desc.readableColumns = readableCols
 	desc.publicAndNonPublicCols = publicAndNonPublicCols
-	desc.publicAndNonPublicIndexes = publicAndNonPublicIndexes
 
 	desc.allChecks = make([]descpb.TableDescriptor_CheckConstraint, len(tbl.Checks))
 	for i, c := range tbl.Checks {
 		desc.allChecks[i] = *c
-	}
-
-	// Track partial index ordinals.
-	for i := range publicAndNonPublicIndexes {
-		if publicAndNonPublicIndexes[i].IsPartial() {
-			desc.partialIndexOrds.Add(i)
-		}
 	}
 
 	// Remember what columns have user defined types.
@@ -211,10 +194,12 @@ func NewImmutableWithIsUncommittedVersion(
 func NewFilledInImmutable(
 	ctx context.Context, dg catalog.DescGetter, tbl *descpb.TableDescriptor,
 ) (*Immutable, error) {
-	desc, err := makeFilledInImmutable(ctx, dg, tbl, false /* skipFKsWithMissingTable */)
+	changes, err := maybeFillInDescriptor(ctx, dg, tbl, false /* skipFKsWithNoMatchingTable */)
 	if err != nil {
 		return nil, err
 	}
+	desc := MakeImmutable(*tbl)
+	desc.postDeserializationChanges = changes
 	return &desc, nil
 }
 
@@ -234,21 +219,6 @@ type PostDeserializationTableDescriptorChanges struct {
 	// UpgradedForeignKeyRepresentation indicates that the foreign key
 	// representation was upgraded.
 	UpgradedForeignKeyRepresentation bool
-}
-
-func makeFilledInImmutable(
-	ctx context.Context,
-	dg catalog.DescGetter,
-	tbl *descpb.TableDescriptor,
-	skipFKsWithMissingTable bool,
-) (Immutable, error) {
-	changes, err := maybeFillInDescriptor(ctx, dg, tbl, skipFKsWithMissingTable)
-	if err != nil {
-		return Immutable{}, err
-	}
-	desc := MakeImmutable(*tbl)
-	desc.postDeserializationChanges = changes
-	return desc, nil
 }
 
 // FindIndexPartitionByName searches this index descriptor for a partition whose name
@@ -271,6 +241,7 @@ func (desc *Mutable) SetName(name string) {
 
 // GetPrimaryIndex returns a pointer to the primary index of the table
 // descriptor.
+// This method is deprecated, use PrimaryIndexInterface instead.
 func (desc *wrapper) GetPrimaryIndex() *descpb.IndexDescriptor {
 	return &desc.PrimaryIndex
 }
@@ -300,27 +271,13 @@ func (desc *wrapper) IsPhysicalTable() bool {
 // FindIndexByID finds an index (active or inactive) with the specified ID.
 // Must return a pointer to the IndexDescriptor in the TableDescriptor, so that
 // callers can use returned values to modify the TableDesc.
+// This method is deprecated, use FindIndexWithID instead.
 func (desc *wrapper) FindIndexByID(id descpb.IndexID) (*descpb.IndexDescriptor, error) {
-	if desc.PrimaryIndex.ID == id {
-		return &desc.PrimaryIndex, nil
+	idx, err := desc.FindIndexWithID(id)
+	if err != nil {
+		return nil, err
 	}
-	for i := range desc.Indexes {
-		idx := &desc.Indexes[i]
-		if idx.ID == id {
-			return idx, nil
-		}
-	}
-	for _, m := range desc.Mutations {
-		if idx := m.GetIndex(); idx != nil && idx.ID == id {
-			return idx, nil
-		}
-	}
-	for _, m := range desc.GCMutations {
-		if m.IndexID == id {
-			return nil, ErrIndexGCMutationsList
-		}
-	}
-	return nil, fmt.Errorf("index-id \"%d\" does not exist", id)
+	return idx.IndexDesc(), nil
 }
 
 // KeysPerRow returns the maximum number of keys used to encode a row for the
@@ -356,10 +313,11 @@ func (desc *wrapper) AllNonDropColumns() []descpb.ColumnDescriptor {
 	return cols
 }
 
-// allocateName sets desc.Name to a value that is not EqualName to any
+// buildIndexName sets desc.Name to a value that is not EqualName to any
 // of tableDesc's indexes. allocateName roughly follows PostgreSQL's
 // convention for automatically-named indexes.
-func allocateIndexName(tableDesc *Mutable, idx *descpb.IndexDescriptor) {
+func buildIndexName(tableDesc *Mutable, index catalog.Index) string {
+	idx := index.IndexDesc()
 	segments := make([]string, 0, len(idx.ColumnNames)+2)
 	segments = append(segments, tableDesc.Name)
 	segments = append(segments, idx.ColumnNames...)
@@ -371,34 +329,25 @@ func allocateIndexName(tableDesc *Mutable, idx *descpb.IndexDescriptor) {
 
 	baseName := strings.Join(segments, "_")
 	name := baseName
-
-	exists := func(name string) bool {
-		_, _, err := tableDesc.FindIndexByName(name)
-		return err == nil
-	}
-	for i := 1; exists(name); i++ {
+	for i := 1; ; i++ {
+		foundIndex, _ := tableDesc.FindIndexWithName(name)
+		if foundIndex == nil {
+			break
+		}
 		name = fmt.Sprintf("%s%d", baseName, i)
 	}
 
-	idx.Name = name
+	return name
 }
 
 // AllNonDropIndexes returns all the indexes, including those being added
 // in the mutations.
+// This method is deprecated, use NonDropIndexes instead.
 func (desc *wrapper) AllNonDropIndexes() []*descpb.IndexDescriptor {
-	indexes := make([]*descpb.IndexDescriptor, 0, 1+len(desc.Indexes)+len(desc.Mutations))
-	if desc.IsPhysicalTable() {
-		indexes = append(indexes, &desc.PrimaryIndex)
-	}
-	for i := range desc.Indexes {
-		indexes = append(indexes, &desc.Indexes[i])
-	}
-	for _, m := range desc.Mutations {
-		if idx := m.GetIndex(); idx != nil {
-			if m.Direction == descpb.DescriptorMutation_ADD {
-				indexes = append(indexes, idx)
-			}
-		}
+	nonDropIndexes := desc.NonDropIndexes()
+	indexes := make([]*descpb.IndexDescriptor, len(nonDropIndexes))
+	for i, idx := range nonDropIndexes {
+		indexes[i] = idx.IndexDesc()
 	}
 	return indexes
 }
@@ -529,44 +478,21 @@ func (desc *wrapper) ForeachNonDropColumn(f func(column *descpb.ColumnDescriptor
 
 // ForeachNonDropIndex runs a function on all indexes, including those being
 // added in the mutations.
+// This method is deprecated, use ForEachNonDropIndex instead.
 func (desc *wrapper) ForeachNonDropIndex(f func(*descpb.IndexDescriptor) error) error {
-	if err := desc.ForeachIndex(catalog.IndexOpts{AddMutations: true}, func(idxDesc *descpb.IndexDescriptor, isPrimary bool) error {
-		return f(idxDesc)
-	}); err != nil {
-		return err
-	}
-	return nil
+	return desc.ForEachNonDropIndex(func(idx catalog.Index) error {
+		return f(idx.IndexDesc())
+	})
 }
 
 // ForeachIndex runs a function on the set of indexes as specified by opts.
+// This method is deprecated, use ForEachIndex instead.
 func (desc *wrapper) ForeachIndex(
 	opts catalog.IndexOpts, f func(idxDesc *descpb.IndexDescriptor, isPrimary bool) error,
 ) error {
-	if desc.IsPhysicalTable() || opts.NonPhysicalPrimaryIndex {
-		if err := f(&desc.PrimaryIndex, true /* isPrimary */); err != nil {
-			return err
-		}
-	}
-	for i := range desc.Indexes {
-		if err := f(&desc.Indexes[i], false /* isPrimary */); err != nil {
-			return err
-		}
-	}
-	if !opts.AddMutations && !opts.DropMutations {
-		return nil
-	}
-	for _, m := range desc.Mutations {
-		idx := m.GetIndex()
-		if idx == nil ||
-			(m.Direction == descpb.DescriptorMutation_ADD && !opts.AddMutations) ||
-			(m.Direction == descpb.DescriptorMutation_DROP && !opts.DropMutations) {
-			continue
-		}
-		if err := f(idx, false /* isPrimary */); err != nil {
-			return err
-		}
-	}
-	return nil
+	return desc.ForEachIndex(opts, func(idx catalog.Index) error {
+		return f(idx.IndexDesc(), idx.Primary())
+	})
 }
 
 // ForeachDependedOnBy runs a function on all indexes, including those being
@@ -952,9 +878,9 @@ func ForEachExprStringInTableDesc(descI catalog.TableDescriptor, f func(expr *st
 		}
 		return nil
 	}
-	doIndex := func(i *descpb.IndexDescriptor) error {
+	doIndex := func(i catalog.Index) error {
 		if i.IsPartial() {
-			return f(&i.Predicate)
+			return f(&i.IndexDesc().Predicate)
 		}
 		return nil
 	}
@@ -969,14 +895,13 @@ func ForEachExprStringInTableDesc(descI catalog.TableDescriptor, f func(expr *st
 		}
 	}
 
-	// Process indexes.
-	if err := doIndex(&desc.PrimaryIndex); err != nil {
+	// Process all indexes.
+	if err := descI.ForEachIndex(catalog.IndexOpts{
+		NonPhysicalPrimaryIndex: true,
+		DropMutations:           true,
+		AddMutations:            true,
+	}, doIndex); err != nil {
 		return err
-	}
-	for i := range desc.Indexes {
-		if err := doIndex(&desc.Indexes[i]); err != nil {
-			return err
-		}
 	}
 
 	// Process checks.
@@ -986,15 +911,10 @@ func ForEachExprStringInTableDesc(descI catalog.TableDescriptor, f func(expr *st
 		}
 	}
 
-	// Process all mutations.
+	// Process all non-index mutations.
 	for _, mut := range desc.GetMutations() {
 		if c := mut.GetColumn(); c != nil {
 			if err := doCol(c); err != nil {
-				return err
-			}
-		}
-		if i := mut.GetIndex(); i != nil {
-			if err := doIndex(i); err != nil {
 				return err
 			}
 		}
@@ -1176,30 +1096,13 @@ func (desc *Mutable) allocateIndexIDs(columnNames map[string]descpb.ColumnID) er
 		desc.NextIndexID = 1
 	}
 
-	// Keep track of unnamed indexes.
-	anonymousIndexes := make([]*descpb.IndexDescriptor, 0, len(desc.Indexes)+len(desc.Mutations))
-
-	// Create a slice of modifiable index descriptors.
-	indexes := make([]*descpb.IndexDescriptor, 0, 1+len(desc.Indexes)+len(desc.Mutations))
-	indexes = append(indexes, &desc.PrimaryIndex)
-	collectIndexes := func(index *descpb.IndexDescriptor) {
-		if len(index.Name) == 0 {
-			anonymousIndexes = append(anonymousIndexes, index)
+	// Assign names to unnamed indexes.
+	_ = desc.ForEachDeletableNonPrimaryIndex(func(idx catalog.Index) error {
+		if len(idx.GetName()) == 0 {
+			idx.IndexDesc().Name = buildIndexName(desc, idx)
 		}
-		indexes = append(indexes, index)
-	}
-	for i := range desc.Indexes {
-		collectIndexes(&desc.Indexes[i])
-	}
-	for _, m := range desc.Mutations {
-		if index := m.GetIndex(); index != nil {
-			collectIndexes(index)
-		}
-	}
-
-	for _, index := range anonymousIndexes {
-		allocateIndexName(desc, index)
-	}
+		return nil
+	})
 
 	var compositeColIDs catalog.TableColSet
 	for i := range desc.Columns {
@@ -1210,11 +1113,12 @@ func (desc *Mutable) allocateIndexIDs(columnNames map[string]descpb.ColumnID) er
 	}
 
 	// Populate IDs.
-	for _, index := range indexes {
-		if index.ID != 0 {
+	for _, idx := range desc.AllIndexes() {
+		if idx.GetID() != 0 {
 			// This index has already been populated. Nothing to do.
 			continue
 		}
+		index := idx.IndexDesc()
 		index.ID = desc.NextIndexID
 		desc.NextIndexID++
 
@@ -1227,7 +1131,7 @@ func (desc *Mutable) allocateIndexIDs(columnNames map[string]descpb.ColumnID) er
 			}
 		}
 
-		if index != &desc.PrimaryIndex && index.EncodingType == descpb.SecondaryIndexEncoding {
+		if !idx.Primary() && index.EncodingType == descpb.SecondaryIndexEncoding {
 			indexHasOldStoredColumns := index.HasOldStoredColumns()
 			// Need to clear ExtraColumnIDs and StoreColumnIDs because they are used
 			// by ContainsColumnID.
@@ -2635,18 +2539,6 @@ func (ps partitionInterval) Range() interval.Range {
 	return interval.Range{Start: []byte(ps.start), End: []byte(ps.end)}
 }
 
-// FindIndexesWithPartition returns all IndexDescriptors (potentially including
-// the primary index) which have a partition with the given name.
-func (desc *wrapper) FindIndexesWithPartition(name string) []*descpb.IndexDescriptor {
-	var indexes []*descpb.IndexDescriptor
-	for _, idx := range desc.AllNonDropIndexes() {
-		if FindIndexPartitionByName(idx, name) != nil {
-			indexes = append(indexes, idx)
-		}
-	}
-	return indexes
-}
-
 // validatePartitioning validates that any PartitioningDescriptors contained in
 // table indexes are well-formed. See validatePartitioningDesc for details.
 func (desc *wrapper) validatePartitioning() error {
@@ -2842,25 +2734,17 @@ func (desc *Mutable) RenameColumnDescriptor(column *descpb.ColumnDescriptor, new
 		}
 	}
 
-	renameColumnInIndex := func(idx *descpb.IndexDescriptor) {
-		for i, id := range idx.ColumnIDs {
+	for _, idx := range desc.AllIndexes() {
+		idxDesc := idx.IndexDesc()
+		for i, id := range idxDesc.ColumnIDs {
 			if id == colID {
-				idx.ColumnNames[i] = newColName
+				idxDesc.ColumnNames[i] = newColName
 			}
 		}
-		for i, id := range idx.StoreColumnIDs {
+		for i, id := range idxDesc.StoreColumnIDs {
 			if id == colID {
-				idx.StoreColumnNames[i] = newColName
+				idxDesc.StoreColumnNames[i] = newColName
 			}
-		}
-	}
-	renameColumnInIndex(&desc.PrimaryIndex)
-	for i := range desc.Indexes {
-		renameColumnInIndex(&desc.Indexes[i])
-	}
-	for _, m := range desc.Mutations {
-		if idx := m.GetIndex(); idx != nil {
-			renameColumnInIndex(idx)
 		}
 	}
 }
@@ -3021,6 +2905,14 @@ func (desc *wrapper) ContainsUserDefinedTypes() bool {
 	return len(desc.GetColumnOrdinalsWithUserDefinedTypes()) > 0
 }
 
+// ContainsUserDefinedTypes returns whether or not this table descriptor has
+// any columns of user defined types.
+// This method is re-implemented for Immutable only for the purpose of calling
+// the correct GetColumnOrdinalsWithUserDefinedTypes() method on desc.
+func (desc *Immutable) ContainsUserDefinedTypes() bool {
+	return len(desc.GetColumnOrdinalsWithUserDefinedTypes()) > 0
+}
+
 // GetColumnOrdinalsWithUserDefinedTypes returns a slice of column ordinals
 // of columns that contain user defined types.
 func (desc *Immutable) GetColumnOrdinalsWithUserDefinedTypes() []int {
@@ -3032,6 +2924,25 @@ func (desc *Immutable) GetColumnOrdinalsWithUserDefinedTypes() []int {
 // other descriptor. Note that this function is only valid on two descriptors
 // representing the same table at the same version.
 func (desc *wrapper) UserDefinedTypeColsHaveSameVersion(otherDesc catalog.TableDescriptor) bool {
+	thisCols := desc.DeletableColumns()
+	otherCols := otherDesc.DeletableColumns()
+	for _, idx := range desc.GetColumnOrdinalsWithUserDefinedTypes() {
+		this, other := thisCols[idx].Type, otherCols[idx].Type
+		if this.TypeMeta.Version != other.TypeMeta.Version {
+			return false
+		}
+	}
+	return true
+}
+
+// UserDefinedTypeColsHaveSameVersion returns whether this descriptor's columns
+// with user defined type metadata have the same versions of metadata as in the
+// other descriptor. Note that this function is only valid on two descriptors
+// representing the same table at the same version.
+// This method is re-implemented for Immutable only for the purpose of calling
+// the correct DeletableColumns() and GetColumnOrdinalsWithUserDefinedTypes()
+// methods on desc.
+func (desc *Immutable) UserDefinedTypeColsHaveSameVersion(otherDesc catalog.TableDescriptor) bool {
 	thisCols := desc.DeletableColumns()
 	otherCols := otherDesc.DeletableColumns()
 	for _, idx := range desc.GetColumnOrdinalsWithUserDefinedTypes() {
@@ -3071,26 +2982,15 @@ func (desc *wrapper) FindFamilyByID(id descpb.FamilyID) (*descpb.ColumnFamilyDes
 
 // FindIndexByName finds the index with the specified name in the active
 // list or the mutations list. It returns true if the index is being dropped.
+// This method is deprecated, use FindIndexWithName instead.
 func (desc *wrapper) FindIndexByName(
 	name string,
 ) (_ *descpb.IndexDescriptor, dropped bool, _ error) {
-	if desc.IsPhysicalTable() && desc.PrimaryIndex.Name == name {
-		return &desc.PrimaryIndex, false, nil
+	idx, err := desc.FindIndexWithName(name)
+	if err != nil {
+		return nil, false, err
 	}
-	for i := range desc.Indexes {
-		idx := &desc.Indexes[i]
-		if idx.Name == name {
-			return idx, false, nil
-		}
-	}
-	for _, m := range desc.Mutations {
-		if idx := m.GetIndex(); idx != nil {
-			if idx.Name == name {
-				return idx, m.Direction == descpb.DescriptorMutation_DROP, nil
-			}
-		}
-	}
-	return nil, false, fmt.Errorf("index %q does not exist", name)
+	return idx.IndexDesc(), idx.Dropped(), nil
 }
 
 // NamesForColumnIDs returns the names for the given column ids, or an error
@@ -3337,21 +3237,6 @@ func (desc *Mutable) RenameConstraint(
 		return unimplemented.Newf(fmt.Sprintf("rename-constraint-%s", detail.Kind),
 			"constraint %q has unsupported type", tree.ErrNameString(oldName))
 	}
-}
-
-// FindActiveIndexByID returns the index with the specified ID, or nil if it
-// does not exist. It only searches active indexes.
-func (desc *wrapper) FindActiveIndexByID(id descpb.IndexID) *descpb.IndexDescriptor {
-	if desc.PrimaryIndex.ID == id {
-		return &desc.PrimaryIndex
-	}
-	for i := range desc.Indexes {
-		idx := &desc.Indexes[i]
-		if idx.ID == id {
-			return idx
-		}
-	}
-	return nil
 }
 
 // FindIndexByIndexIdx returns an active index with the specified
@@ -4235,27 +4120,6 @@ func (desc *Immutable) DeletableColumns() []descpb.ColumnDescriptor {
 // MutationColumns returns a list of mutation columns.
 func (desc *Immutable) MutationColumns() []descpb.ColumnDescriptor {
 	return desc.publicAndNonPublicCols[len(desc.Columns):]
-}
-
-// WritableIndexes returns a list of public and write-only mutation indexes.
-func (desc *Immutable) WritableIndexes() []descpb.IndexDescriptor {
-	return desc.publicAndNonPublicIndexes[:len(desc.Indexes)+desc.writeOnlyIndexCount]
-}
-
-// DeletableIndexes returns a list of public and non-public indexes.
-func (desc *Immutable) DeletableIndexes() []descpb.IndexDescriptor {
-	return desc.publicAndNonPublicIndexes
-}
-
-// DeleteOnlyIndexes returns a list of delete-only mutation indexes.
-func (desc *Immutable) DeleteOnlyIndexes() []descpb.IndexDescriptor {
-	return desc.publicAndNonPublicIndexes[len(desc.Indexes)+desc.writeOnlyIndexCount:]
-}
-
-// PartialIndexOrds returns a set containing the ordinal of each partial index
-// defined on the table.
-func (desc *Immutable) PartialIndexOrds() util.FastIntSet {
-	return desc.partialIndexOrds
 }
 
 // IsShardColumn returns true if col corresponds to a non-dropped hash sharded

--- a/pkg/sql/catalog/tabledesc/table.go
+++ b/pkg/sql/catalog/tabledesc/table.go
@@ -344,11 +344,9 @@ func FindFKReferencedIndex(
 		return primaryIndex, nil
 	}
 	// If the PK doesn't match, find the index corresponding to the referenced column.
-	indexes := referencedTable.GetPublicNonPrimaryIndexes()
-	for i := range indexes {
-		idx := &indexes[i]
+	for _, idx := range referencedTable.PublicNonPrimaryIndexes() {
 		if idx.IsValidReferencedIndex(referencedColIDs) {
-			return idx, nil
+			return idx.IndexDesc(), nil
 		}
 	}
 	return nil, pgerror.Newf(
@@ -369,11 +367,9 @@ func FindFKOriginIndex(
 		return primaryIndex, nil
 	}
 	// If the PK doesn't match, find the index corresponding to the origin column.
-	indexes := originTable.GetPublicNonPrimaryIndexes()
-	for i := range indexes {
-		idx := &indexes[i]
+	for _, idx := range originTable.PublicNonPrimaryIndexes() {
 		if idx.IsValidOriginIndex(originColIDs) {
-			return idx, nil
+			return idx.IndexDesc(), nil
 		}
 	}
 	return nil, pgerror.Newf(

--- a/pkg/sql/catalog/tabledesc/table_desc.go
+++ b/pkg/sql/catalog/tabledesc/table_desc.go
@@ -14,8 +14,8 @@ package tabledesc
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
-	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/errors"
 )
 
 var _ catalog.TableDescriptor = (*Immutable)(nil)
@@ -27,6 +27,12 @@ var _ catalog.TableDescriptor = (*wrapper)(nil)
 // interface, which is overloaded by Immutable and Mutable.
 type wrapper struct {
 	descpb.TableDescriptor
+
+	// indexCache, when not nil, points to a struct containing precomputed
+	// catalog.Index slices. This can therefore only be set when creating an
+	// Immutable.
+	indexCache *indexCache
+
 	postDeserializationChanges PostDeserializationTableDescriptorChanges
 }
 
@@ -42,18 +48,6 @@ func (*wrapper) IsUncommittedVersion() bool {
 // this descriptor post deserialization.
 func (desc *wrapper) GetPostDeserializationChanges() PostDeserializationTableDescriptorChanges {
 	return desc.postDeserializationChanges
-}
-
-// PartialIndexOrds returns a set containing the ordinal of each partial index
-// defined on the table.
-func (desc *wrapper) PartialIndexOrds() util.FastIntSet {
-	var partialIndexOrds util.FastIntSet
-	for i, idx := range desc.DeletableIndexes() {
-		if idx.IsPartial() {
-			partialIndexOrds.Add(i)
-		}
-	}
-	return partialIndexOrds
 }
 
 // mutationIndexes returns all non-public indexes in the specified state.
@@ -76,11 +70,13 @@ func (desc *wrapper) mutationIndexes(
 }
 
 // DeleteOnlyIndexes returns a list of delete-only mutation indexes.
+// This method is deprecated, use DeleteOnlyNonPrimaryIndexes instead.
 func (desc *wrapper) DeleteOnlyIndexes() []descpb.IndexDescriptor {
 	return desc.mutationIndexes(descpb.DescriptorMutation_DELETE_ONLY)
 }
 
 // WritableIndexes returns a list of public and write-only mutation indexes.
+// This method is deprecated, use WritableNonPrimaryIndexes instead.
 func (desc *wrapper) WritableIndexes() []descpb.IndexDescriptor {
 	if len(desc.Mutations) == 0 {
 		return desc.Indexes
@@ -93,7 +89,8 @@ func (desc *wrapper) WritableIndexes() []descpb.IndexDescriptor {
 	return indexes
 }
 
-// DeletableIndexes implements the catalog.Descriptor interface.
+// DeletableIndexes returns a list of deletable indexes.
+// This method is deprecated, use DeletableNonPrimaryIndexes instead.
 func (desc *wrapper) DeletableIndexes() []descpb.IndexDescriptor {
 	if len(desc.Mutations) == 0 {
 		return desc.Indexes
@@ -106,7 +103,8 @@ func (desc *wrapper) DeletableIndexes() []descpb.IndexDescriptor {
 	return indexes
 }
 
-// mutationColumns returns all non-public writable columns in the specified state.
+// mutationColumns returns all non-public writable columns in the specified
+// state.
 func (desc *wrapper) mutationColumns(
 	mutationState descpb.DescriptorMutation_State,
 ) []descpb.ColumnDescriptor {
@@ -197,17 +195,9 @@ type Immutable struct {
 	// It is partitioned by the state of the column: public, write-only, delete-only
 	publicAndNonPublicCols []descpb.ColumnDescriptor
 
-	// publicAndNonPublicCols is a list of public and non-public indexes.
-	// It is partitioned by the state of the index: public, write-only, delete-only
-	publicAndNonPublicIndexes []descpb.IndexDescriptor
-
-	writeOnlyColCount   int
-	writeOnlyIndexCount int
+	writeOnlyColCount int
 
 	allChecks []descpb.TableDescriptor_CheckConstraint
-
-	// partialIndexOrds contains the ordinal of each partial index.
-	partialIndexOrds util.FastIntSet
 
 	// readableColumns is a list of columns (including those undergoing a schema change)
 	// which can be scanned. Columns in the process of a schema change
@@ -245,7 +235,9 @@ func (desc *wrapper) GetPrimaryIndexID() descpb.IndexID {
 	return desc.PrimaryIndex.ID
 }
 
-// GetPublicNonPrimaryIndexes returns the public non-primary indexes of the descriptor.
+// GetPublicNonPrimaryIndexes returns the public non-primary indexes of the
+// descriptor.
+// This method is deprecated, use PublicNonPrimaryIndexes instead.
 func (desc *wrapper) GetPublicNonPrimaryIndexes() []descpb.IndexDescriptor {
 	return desc.Indexes
 }
@@ -265,7 +257,8 @@ func (desc *wrapper) GetColumnAtIdx(idx int) *descpb.ColumnDescriptor {
 	return &desc.Columns[idx]
 }
 
-// ReadableColumns implements the catalog.TableDescriptor interface
+// ReadableColumns returns a list of columns (including those undergoing a
+// schema change) which can be scanned.
 func (desc *Immutable) ReadableColumns() []descpb.ColumnDescriptor {
 	return desc.readableColumns
 }
@@ -317,4 +310,243 @@ func (desc *Mutable) SetPrimaryIndex(index descpb.IndexDescriptor) {
 // index.
 func (desc *Mutable) SetPublicNonPrimaryIndex(indexOrdinal int, index descpb.IndexDescriptor) {
 	desc.Indexes[indexOrdinal-1] = index
+}
+
+// PrimaryIndexInterface returns the primary index in the form of a
+// catalog.Index interface.
+func (desc *wrapper) PrimaryIndexInterface() catalog.Index {
+	return index{desc: &desc.PrimaryIndex}
+}
+
+// getExistingOrNewIndexCache should be the only place where the indexCache
+// field in wrapper is ever read.
+func (desc *wrapper) getExistingOrNewIndexCache() *indexCache {
+	if desc.indexCache == nil {
+		return &indexCache{}
+	}
+	return desc.indexCache
+}
+
+// AllIndexes returns a slice containing all indexes represented in the table
+// descriptor, including mutations.
+func (desc *wrapper) AllIndexes() []catalog.Index {
+	return desc.getExistingOrNewIndexCache().allIndexes(desc)
+}
+
+// ActiveIndexes returns a slice of all active (aka public) indexes.
+func (desc *wrapper) ActiveIndexes() []catalog.Index {
+	return desc.getExistingOrNewIndexCache().activeIndexes(desc)
+}
+
+// NonDropIndexes returns a slice of all indexes (including mutations) which are
+// not being dropped.
+func (desc *wrapper) NonDropIndexes() []catalog.Index {
+	return desc.getExistingOrNewIndexCache().nonDropIndexes(desc)
+}
+
+// PartialIndexes returns a slice of all partial indexes in the table
+// descriptor, including mutations.
+func (desc *wrapper) PartialIndexes() []catalog.Index {
+	return desc.getExistingOrNewIndexCache().partialIndexes(desc)
+}
+
+// PublicNonPrimaryIndexes returns a slice of all active secondary indexes.
+func (desc *wrapper) PublicNonPrimaryIndexes() []catalog.Index {
+	return desc.getExistingOrNewIndexCache().publicNonPrimaryIndexes(desc)
+}
+
+// WritableNonPrimaryIndexes returns a slice of all secondary indexes which
+// allow being written to: active + delete-and-write-only.
+func (desc *wrapper) WritableNonPrimaryIndexes() []catalog.Index {
+	return desc.getExistingOrNewIndexCache().writableNonPrimaryIndexes(desc)
+}
+
+// DeletableNonPrimaryIndexes returns a slice of all secondary indexes which
+// allow being deleted from: active + delete-and-write-only + delete-only.
+func (desc *wrapper) DeletableNonPrimaryIndexes() []catalog.Index {
+	return desc.getExistingOrNewIndexCache().deletableNonPrimaryIndexes(desc)
+}
+
+// DeletableNonPrimaryIndexes returns a slice of all secondary indexes which
+// only allow being deleted from.
+func (desc *wrapper) DeleteOnlyNonPrimaryIndexes() []catalog.Index {
+	return desc.getExistingOrNewIndexCache().deleteOnlyNonPrimaryIndexes(desc)
+}
+
+// ForEachIndex runs f over each index in the table descriptor according to
+// filter parameters in opts.
+func (desc *wrapper) ForEachIndex(opts catalog.IndexOpts, f func(idx catalog.Index) error) error {
+	for _, idx := range desc.AllIndexes() {
+		if !opts.NonPhysicalPrimaryIndex && idx.Primary() && !desc.IsPhysicalTable() {
+			continue
+		}
+		if !opts.AddMutations && idx.Adding() {
+			continue
+		}
+		if !opts.DropMutations && idx.Dropped() {
+			continue
+		}
+		if err := f(idx); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func forEachIndex(slice []catalog.Index, f func(idx catalog.Index) error) error {
+	for _, idx := range slice {
+		if err := f(idx); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ForEachActiveIndex is like ForEachIndex over ActiveIndexes().
+func (desc *wrapper) ForEachActiveIndex(f func(idx catalog.Index) error) error {
+	return forEachIndex(desc.ActiveIndexes(), f)
+}
+
+// ForEachNonDropIndex is like ForEachIndex over NonDropIndexes().
+func (desc *wrapper) ForEachNonDropIndex(f func(idx catalog.Index) error) error {
+	return forEachIndex(desc.NonDropIndexes(), f)
+}
+
+// ForEachPartialIndex is like ForEachIndex over PartialIndexes().
+func (desc *wrapper) ForEachPartialIndex(f func(idx catalog.Index) error) error {
+	return forEachIndex(desc.PartialIndexes(), f)
+}
+
+// ForEachPublicNonPrimaryIndex is like ForEachIndex over
+// PublicNonPrimaryIndexes().
+func (desc *wrapper) ForEachPublicNonPrimaryIndex(f func(idx catalog.Index) error) error {
+	return forEachIndex(desc.PublicNonPrimaryIndexes(), f)
+}
+
+// ForEachWritableNonPrimaryIndex is like ForEachIndex over
+// WritableNonPrimaryIndexes().
+func (desc *wrapper) ForEachWritableNonPrimaryIndex(f func(idx catalog.Index) error) error {
+	return forEachIndex(desc.WritableNonPrimaryIndexes(), f)
+}
+
+// ForEachDeletableNonPrimaryIndex is like ForEachIndex over
+// DeletableNonPrimaryIndexes().
+func (desc *wrapper) ForEachDeletableNonPrimaryIndex(f func(idx catalog.Index) error) error {
+	return forEachIndex(desc.DeletableNonPrimaryIndexes(), f)
+}
+
+// ForEachDeleteOnlyNonPrimaryIndex is like ForEachIndex over
+// DeleteOnlyNonPrimaryIndexes().
+func (desc *wrapper) ForEachDeleteOnlyNonPrimaryIndex(f func(idx catalog.Index) error) error {
+	return forEachIndex(desc.DeleteOnlyNonPrimaryIndexes(), f)
+}
+
+// FindIndex returns the first index for which test returns true, nil otherwise,
+// according to the parameters in opts just like ForEachIndex.
+func (desc *wrapper) FindIndex(
+	opts catalog.IndexOpts, test func(idx catalog.Index) bool,
+) catalog.Index {
+	for _, idx := range desc.AllIndexes() {
+		if !opts.NonPhysicalPrimaryIndex && idx.Primary() && !desc.IsPhysicalTable() {
+			continue
+		}
+		if !opts.AddMutations && idx.Adding() {
+			continue
+		}
+		if !opts.DropMutations && idx.Dropped() {
+			continue
+		}
+		if test(idx) {
+			return idx
+		}
+	}
+	return nil
+}
+
+func findIndex(slice []catalog.Index, test func(idx catalog.Index) bool) catalog.Index {
+	for _, idx := range slice {
+		if test(idx) {
+			return idx
+		}
+	}
+	return nil
+}
+
+// FindActiveIndex returns the first index in ActiveIndex() for which test
+// returns true.
+func (desc *wrapper) FindActiveIndex(test func(idx catalog.Index) bool) catalog.Index {
+	return findIndex(desc.ActiveIndexes(), test)
+}
+
+// FindNonDropIndex returns the first index in NonDropIndex() for which test
+// returns true.
+func (desc *wrapper) FindNonDropIndex(test func(idx catalog.Index) bool) catalog.Index {
+	return findIndex(desc.NonDropIndexes(), test)
+}
+
+// FindPartialIndex returns the first index in PartialIndex() for which test
+// returns true.
+func (desc *wrapper) FindPartialIndex(test func(idx catalog.Index) bool) catalog.Index {
+	return findIndex(desc.PartialIndexes(), test)
+}
+
+// FindPublicNonPrimaryIndex returns the first index in PublicNonPrimaryIndex()
+// for which test returns true.
+func (desc *wrapper) FindPublicNonPrimaryIndex(test func(idx catalog.Index) bool) catalog.Index {
+	return findIndex(desc.PublicNonPrimaryIndexes(), test)
+}
+
+// FindWritableNonPrimaryIndex returns the first index in
+// WritableNonPrimaryIndex() for which test returns true.
+func (desc *wrapper) FindWritableNonPrimaryIndex(test func(idx catalog.Index) bool) catalog.Index {
+	return findIndex(desc.WritableNonPrimaryIndexes(), test)
+}
+
+// FindDeletableNonPrimaryIndex returns the first index in
+// DeletableNonPrimaryIndex() for which test returns true.
+func (desc *wrapper) FindDeletableNonPrimaryIndex(test func(idx catalog.Index) bool) catalog.Index {
+	return findIndex(desc.DeletableNonPrimaryIndexes(), test)
+}
+
+// FindDeleteOnlyNonPrimaryIndex returns the first index in
+// DeleteOnlyNonPrimaryIndex() for which test returns true.
+func (desc *wrapper) FindDeleteOnlyNonPrimaryIndex(
+	test func(idx catalog.Index) bool,
+) catalog.Index {
+	return findIndex(desc.DeleteOnlyNonPrimaryIndexes(), test)
+}
+
+// FindIndexWithID returns the first catalog.Index that matches the id
+// in the set of all indexes.
+func (desc *wrapper) FindIndexWithID(id descpb.IndexID) (catalog.Index, error) {
+	if idx := desc.FindIndex(catalog.IndexOpts{
+		NonPhysicalPrimaryIndex: true,
+		DropMutations:           true,
+		AddMutations:            true,
+	}, func(idx catalog.Index) bool {
+		return idx.GetID() == id
+	}); idx != nil {
+		return idx, nil
+	}
+	for _, m := range desc.GCMutations {
+		if m.IndexID == id {
+			return nil, ErrIndexGCMutationsList
+		}
+	}
+	return nil, errors.Errorf("index-id \"%d\" does not exist", id)
+}
+
+// FindIndexWithName returns the first catalog.Index that matches the name in
+// the set of all indexes, excluding the primary index of non-physical tables.
+func (desc *wrapper) FindIndexWithName(name string) (catalog.Index, error) {
+	if idx := desc.FindIndex(catalog.IndexOpts{
+		NonPhysicalPrimaryIndex: false,
+		DropMutations:           true,
+		AddMutations:            true,
+	}, func(idx catalog.Index) bool {
+		return idx.GetName() == name
+	}); idx != nil {
+		return idx, nil
+	}
+	return nil, errors.Errorf("index %q does not exist", name)
 }

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -2830,7 +2830,9 @@ CREATE TABLE crdb_internal.zones (
 				}
 
 				for i, s := range subzones {
-					index := table.FindActiveIndexByID(descpb.IndexID(s.IndexID))
+					index := table.FindActiveIndex(func(idx catalog.Index) bool {
+						return idx.GetID() == descpb.IndexID(s.IndexID)
+					})
 					if index == nil {
 						// If we can't find an active index that corresponds to this index
 						// ID then continue, as the index is being dropped, or is already
@@ -2839,7 +2841,7 @@ CREATE TABLE crdb_internal.zones (
 					}
 					if zoneSpecifier != nil {
 						zs := zs
-						zs.TableOrIndex.Index = tree.UnrestrictedName(index.Name)
+						zs.TableOrIndex.Index = tree.UnrestrictedName(index.GetName())
 						zs.Partition = tree.Name(s.PartitionName)
 						zoneSpecifier = &zs
 					}
@@ -2855,7 +2857,7 @@ CREATE TABLE crdb_internal.zones (
 					} else {
 						// We have a partition. Get the parent index partition from the zone and
 						// have it inherit constraints.
-						if indexSubzone := fullZone.GetSubzone(uint32(index.ID), ""); indexSubzone != nil {
+						if indexSubzone := fullZone.GetSubzone(uint32(index.GetID()), ""); indexSubzone != nil {
 							subZoneConfig.InheritFromParent(&indexSubzone.Config)
 						}
 						// Inherit remaining fields from the full parent zone.

--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -158,8 +158,7 @@ func (d *deleteNode) processSourceRow(params runParams, sourceVals tree.Datums) 
 	// satisfy the predicate and therefore do not exist in the partial index.
 	// This set is passed as a argument to tableDeleter.row below.
 	var pm row.PartialIndexUpdateHelper
-	partialIndexOrds := d.run.td.tableDesc().PartialIndexOrds()
-	if !partialIndexOrds.Empty() {
+	if len(d.run.td.tableDesc().PartialIndexes()) > 0 {
 		partialIndexDelVals := sourceVals[d.run.partialIndexDelValsOffset:]
 
 		err := pm.Init(tree.Datums{}, partialIndexDelVals, d.run.td.tableDesc())

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -130,8 +130,7 @@ func (r *insertRun) processSourceRow(params runParams, rowVals tree.Datums) erro
 	// written to when they are partial indexes and the row does not satisfy the
 	// predicate. This set is passed as a parameter to tableInserter.row below.
 	var pm row.PartialIndexUpdateHelper
-	partialIndexOrds := r.ti.tableDesc().PartialIndexOrds()
-	if !partialIndexOrds.Empty() {
+	if len(r.ti.tableDesc().PartialIndexes()) > 0 {
 		partialIndexPutVals := rowVals[len(r.insertCols)+r.checkOrds.Len():]
 
 		err := pm.Init(partialIndexPutVals, tree.Datums{}, r.ti.tableDesc())

--- a/pkg/sql/row/partial_index.go
+++ b/pkg/sql/row/partial_index.go
@@ -44,43 +44,38 @@ func (pm *PartialIndexUpdateHelper) Init(
 	partialIndexPutVals tree.Datums, partialIndexDelVals tree.Datums, tabDesc catalog.TableDescriptor,
 ) error {
 	colIdx := 0
-	partialIndexOrds := tabDesc.PartialIndexOrds()
-	indexes := tabDesc.DeletableIndexes()
 
-	for i, ok := partialIndexOrds.Next(0); ok; i, ok = partialIndexOrds.Next(i + 1) {
-		index := &indexes[i]
-		if index.IsPartial() {
+	for _, idx := range tabDesc.PartialIndexes() {
 
-			// Check the boolean partial index put column, if it exists.
-			if colIdx < len(partialIndexPutVals) {
-				val, err := tree.GetBool(partialIndexPutVals[colIdx])
-				if err != nil {
-					return err
-				}
-				if !val {
-					// If the value of the column for the index predicate
-					// expression is false, the row should not be added to the
-					// partial index.
-					pm.IgnoreForPut.Add(int(index.ID))
-				}
+		// Check the boolean partial index put column, if it exists.
+		if colIdx < len(partialIndexPutVals) {
+			val, err := tree.GetBool(partialIndexPutVals[colIdx])
+			if err != nil {
+				return err
 			}
-
-			// Check the boolean partial index del column, if it exists.
-			if colIdx < len(partialIndexDelVals) {
-				val, err := tree.GetBool(partialIndexDelVals[colIdx])
-				if err != nil {
-					return err
-				}
-				if !val {
-					// If the value of the column for the index predicate
-					// expression is false, the row should not be removed from
-					// the partial index.
-					pm.IgnoreForDel.Add(int(index.ID))
-				}
+			if !val {
+				// If the value of the column for the index predicate
+				// expression is false, the row should not be added to the
+				// partial index.
+				pm.IgnoreForPut.Add(int(idx.GetID()))
 			}
-
-			colIdx++
 		}
+
+		// Check the boolean partial index del column, if it exists.
+		if colIdx < len(partialIndexDelVals) {
+			val, err := tree.GetBool(partialIndexDelVals[colIdx])
+			if err != nil {
+				return err
+			}
+			if !val {
+				// If the value of the column for the index predicate
+				// expression is false, the row should not be removed from
+				// the partial index.
+				pm.IgnoreForDel.Add(int(idx.GetID()))
+			}
+		}
+
+		colIdx++
 	}
 
 	return nil

--- a/pkg/sql/set_zone_config.go
+++ b/pkg/sql/set_zone_config.go
@@ -332,12 +332,19 @@ func (n *setZoneConfigNode) startExec(params runParams) error {
 		// Backward compatibility for ALTER PARTITION ... OF TABLE. Determine which
 		// index has the specified partition.
 		partitionName := string(n.zoneSpecifier.Partition)
-		indexes := table.FindIndexesWithPartition(partitionName)
+
+		var indexes []catalog.Index
+		for _, idx := range table.NonDropIndexes() {
+			if tabledesc.FindIndexPartitionByName(idx.IndexDesc(), partitionName) != nil {
+				indexes = append(indexes, idx)
+			}
+		}
+
 		switch len(indexes) {
 		case 0:
 			return fmt.Errorf("partition %q does not exist on table %q", partitionName, table.GetName())
 		case 1:
-			n.zoneSpecifier.TableOrIndex.Index = tree.UnrestrictedName(indexes[0].Name)
+			n.zoneSpecifier.TableOrIndex.Index = tree.UnrestrictedName(indexes[0].GetName())
 		default:
 			err := fmt.Errorf(
 				"partition %q exists on multiple indexes of table %q", partitionName, table.GetName())

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -299,12 +299,11 @@ func (u *updateNode) processSourceRow(params runParams, sourceVals tree.Datums) 
 	// Create a set of partial index IDs to not add entries or remove entries
 	// from.
 	var pm row.PartialIndexUpdateHelper
-	partialIndexOrds := u.run.tu.tableDesc().PartialIndexOrds()
-	if !partialIndexOrds.Empty() {
+	if n := len(u.run.tu.tableDesc().PartialIndexes()); n > 0 {
 		partialIndexValOffset := len(u.run.tu.ru.FetchCols) + len(u.run.tu.ru.UpdateCols) + u.run.checkOrds.Len() + u.run.numPassthrough
 		partialIndexVals := sourceVals[partialIndexValOffset:]
-		partialIndexPutVals := partialIndexVals[:partialIndexOrds.Len()]
-		partialIndexDelVals := partialIndexVals[partialIndexOrds.Len() : partialIndexOrds.Len()*2]
+		partialIndexPutVals := partialIndexVals[:n]
+		partialIndexDelVals := partialIndexVals[n : n*2]
 
 		err := pm.Init(partialIndexPutVals, partialIndexDelVals, u.run.tu.tableDesc())
 		if err != nil {

--- a/pkg/sql/upsert.go
+++ b/pkg/sql/upsert.go
@@ -146,8 +146,7 @@ func (n *upsertNode) processSourceRow(params runParams, rowVals tree.Datums) err
 
 	// Create a set of partial index IDs to not add or remove entries from.
 	var pm row.PartialIndexUpdateHelper
-	partialIndexOrds := n.run.tw.tableDesc().PartialIndexOrds()
-	if !partialIndexOrds.Empty() {
+	if len(n.run.tw.tableDesc().PartialIndexes()) > 0 {
 		partialIndexValOffset := len(n.run.insertCols) + len(n.run.tw.fetchCols) + len(n.run.tw.updateCols) + n.run.checkOrds.Len()
 		if n.run.tw.canaryOrdinal != -1 {
 			partialIndexValOffset++


### PR DESCRIPTION
Previously, the catalog.TableDescriptor interface and its implementing
types would liberally return descpb.IndexDescriptor values, pointers and
slices. In an effort to stop manipulating such protos directly, this
patch introduces a catalog.Index interface to encapsulate it. In order
to enventually propagate this change throughout the code base, this
patch marks some existing catalog.TableDescriptor methods as deprecated
and introduces new ones to eventually replace them.

Partially addresses #57465

Release note: None