### PR TITLE
opt: don't update computed columns unnecessarily

### DIFF
--- a/pkg/sql/opt/column_meta.go
+++ b/pkg/sql/opt/column_meta.go
@@ -109,6 +109,17 @@ func (ocl OptionalColList) Find(col ColumnID) (idx int, ok bool) {
 	return -1, false
 }
 
+// ToSet returns the set of columns that are present in the list.
+func (ocl OptionalColList) ToSet() ColSet {
+	var r ColSet
+	for _, col := range ocl {
+		if col != 0 {
+			r.Add(col)
+		}
+	}
+	return r
+}
+
 // ColumnMeta stores information about one of the columns stored in the
 // metadata.
 type ColumnMeta struct {

--- a/pkg/sql/opt/exec/execbuilder/testdata/update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update
@@ -749,3 +749,36 @@ vectorized: true
 # Reset for rest of test.
 statement ok
 SET enable_implicit_select_for_update = true
+
+statement ok
+CREATE TABLE computed (
+  a INT PRIMARY KEY,
+  b INT,
+  c INT,
+  d INT AS (c+1) STORED,
+  INDEX (b),
+  FAMILY (a),
+  FAMILY (b),
+  FAMILY (c),
+  FAMILY (d)
+)
+
+# Verify that we don't do an index join to recalculate d (#42482).
+query T
+EXPLAIN UPDATE computed SET b=b*2 WHERE b BETWEEN 1 and 10
+----
+distribution: local
+vectorized: true
+·
+• update
+│ table: computed
+│ set: b
+│ auto commit
+│
+└── • render
+    │
+    └── • scan
+          missing stats
+          table: computed@computed_b_idx
+          spans: [/1 - /10]
+          locking strength: for update

--- a/pkg/sql/opt/memo/testdata/logprops/update
+++ b/pkg/sql/opt/memo/testdata/logprops/update
@@ -238,20 +238,19 @@ build
 UPDATE abcde SET a=1 WHERE b=c RETURNING *;
 ----
 project
- ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(int!null)
+ ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(int)
  ├── volatile, mutations
- ├── fd: ()-->(1), (2)==(3), (3)==(2), (2)-->(4)
+ ├── fd: ()-->(1), (2)==(3), (3)==(2)
  ├── prune: (1-4)
  └── update abcde
-      ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(int!null) rowid:5(int!null)
+      ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(int) rowid:5(int!null)
       ├── fetch columns: a:8(int) b:9(int) c:10(int) d:11(int) rowid:12(int) e:13(int)
       ├── update-mapping:
       │    ├── a_new:15 => a:1
-      │    ├── column17:17 => d:4
       │    └── column16:16 => e:6
       ├── volatile, mutations
       ├── key: (5)
-      ├── fd: ()-->(1), (2)==(3), (3)==(2), (5)-->(2-4), (2)-->(4)
+      ├── fd: ()-->(1), (2)==(3), (3)==(2), (5)-->(2-4)
       └── project
            ├── columns: column17:17(int!null) a:8(int!null) b:9(int!null) c:10(int!null) d:11(int) rowid:12(int!null) e:13(int) crdb_internal_mvcc_timestamp:14(decimal) a_new:15(int!null) column16:16(int!null)
            ├── immutable

--- a/pkg/sql/opt/memo/testdata/logprops/upsert
+++ b/pkg/sql/opt/memo/testdata/logprops/upsert
@@ -454,8 +454,7 @@ project
  │    │    ├── column9:9 => c:3
  │    │    └── column8:8 => rowid:4
  │    ├── update-mapping:
- │    │    ├── column1:6 => a:1
- │    │    └── upsert_c:17 => c:3
+ │    │    └── column1:6 => a:1
  │    ├── return-mapping:
  │    │    ├── column1:6 => a:1
  │    │    ├── upsert_b:16 => b:2
@@ -562,14 +561,14 @@ project
  │              │    │    │    └── null [type=unknown]
  │              │    │    └── variable: column7:7 [type=int]
  │              │    └── variable: b:11 [type=int]
- │              ├── case [as=upsert_c:17, type=int, outer=(9,13,15)]
+ │              ├── case [as=upsert_c:17, type=int, outer=(9,12,13)]
  │              │    ├── true [type=bool]
  │              │    ├── when [type=int]
  │              │    │    ├── is [type=bool]
  │              │    │    │    ├── variable: rowid:13 [type=int]
  │              │    │    │    └── null [type=unknown]
  │              │    │    └── variable: column9:9 [type=int]
- │              │    └── variable: column15:15 [type=int]
+ │              │    └── variable: c:12 [type=int]
  │              └── case [as=upsert_rowid:18, type=int, outer=(8,13)]
  │                   ├── true [type=bool]
  │                   ├── when [type=int]

--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -82,6 +82,20 @@ CREATE TABLE uniq (
 ----
 
 exec-ddl
+CREATE TABLE computed (
+    a INT PRIMARY KEY,
+    b INT,
+    c INT,
+    d INT AS (c+1) STORED,
+    "x:write-only" INT AS (c+10) STORED,
+    FAMILY (a),
+    FAMILY (b),
+    FAMILY (c),
+    FAMILY (d)
+)
+----
+
+exec-ddl
 CREATE TABLE virt (
   a INT PRIMARY KEY,
   b INT,
@@ -1965,6 +1979,84 @@ delete a
       ├── columns: k:6!null s:9
       ├── key: (6)
       └── fd: (6)-->(9)
+
+# We should not be producing a value for the computed column d, which is not
+# being changed. We should, however, produce a value for the write-only column
+# x even if the column it depends on hasn't changed.
+norm expect=PruneMutationInputCols
+UPDATE computed SET b = b*2 WHERE b = 1
+----
+update computed
+ ├── columns: <none>
+ ├── fetch columns: a:7 b:8 x:11
+ ├── update-mapping:
+ │    ├── b_new:13 => b:2
+ │    └── column15:15 => x:5
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ └── project
+      ├── columns: column15:15 b_new:13!null a:7!null b:8!null x:11
+      ├── immutable
+      ├── key: (7)
+      ├── fd: ()-->(8,13), (7)-->(11,15)
+      ├── select
+      │    ├── columns: a:7!null b:8!null c:9 x:11
+      │    ├── key: (7)
+      │    ├── fd: ()-->(8), (7)-->(9,11)
+      │    ├── scan computed
+      │    │    ├── columns: a:7!null b:8 c:9 x:11
+      │    │    ├── computed column expressions
+      │    │    │    └── d:10
+      │    │    │         └── c:9 + 1
+      │    │    ├── key: (7)
+      │    │    └── fd: (7)-->(8,9,11)
+      │    └── filters
+      │         └── b:8 = 1 [outer=(8), constraints=(/8: [/1 - /1]; tight), fd=()-->(8)]
+      └── projections
+           ├── c:9 + 10 [as=column15:15, outer=(9), immutable]
+           └── b:8 * 2 [as=b_new:13, outer=(8), immutable]
+
+# We should produce a value for the computed column d.
+norm expect=PruneMutationInputCols
+UPDATE computed SET c = c*2 WHERE b = 1
+----
+update computed
+ ├── columns: <none>
+ ├── fetch columns: a:7 c:9 d:10 x:11
+ ├── update-mapping:
+ │    ├── c_new:13 => c:3
+ │    ├── column14:14 => d:4
+ │    └── column15:15 => x:5
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ └── project
+      ├── columns: column14:14 column15:15 a:7!null c:9 d:10 x:11 c_new:13
+      ├── immutable
+      ├── key: (7)
+      ├── fd: (7)-->(9-11), (9)-->(13), (13)-->(14,15)
+      ├── project
+      │    ├── columns: c_new:13 a:7!null c:9 d:10 x:11
+      │    ├── immutable
+      │    ├── key: (7)
+      │    ├── fd: (7)-->(9-11), (9)-->(13)
+      │    ├── select
+      │    │    ├── columns: a:7!null b:8!null c:9 d:10 x:11
+      │    │    ├── key: (7)
+      │    │    ├── fd: ()-->(8), (7)-->(9-11)
+      │    │    ├── scan computed
+      │    │    │    ├── columns: a:7!null b:8 c:9 d:10 x:11
+      │    │    │    ├── computed column expressions
+      │    │    │    │    └── d:10
+      │    │    │    │         └── c:9 + 1
+      │    │    │    ├── key: (7)
+      │    │    │    └── fd: (7)-->(8-11)
+      │    │    └── filters
+      │    │         └── b:8 = 1 [outer=(8), constraints=(/8: [/1 - /1]; tight), fd=()-->(8)]
+      │    └── projections
+      │         └── c:9 * 2 [as=c_new:13, outer=(9), immutable]
+      └── projections
+           ├── c_new:13 + 1 [as=column14:14, outer=(13), immutable]
+           └── c_new:13 + 10 [as=column15:15, outer=(13), immutable]
 
 # Do not prune columns that are required for evaluating partial index
 # predicates.

--- a/pkg/sql/opt/optbuilder/groupby.go
+++ b/pkg/sql/opt/optbuilder/groupby.go
@@ -634,7 +634,7 @@ func (b *Builder) buildGrouping(
 		// Save a representation of the GROUP BY expression for validation of the
 		// SELECT and HAVING expressions. This enables queries such as:
 		//   SELECT x+y FROM t GROUP BY x+y
-		col := b.addColumn(aggInScope, alias, e)
+		col := aggInScope.addColumn(alias, e)
 		b.buildScalar(e, fromScope, aggInScope, col, nil)
 		fromScope.groupby.groupStrs[exprStr] = col
 	}
@@ -648,7 +648,7 @@ func (b *Builder) buildAggArg(
 ) opt.ScalarExpr {
 	// This synthesizes a new tempScope column, unless the argument is a
 	// simple VariableOp.
-	col := b.addColumn(tempScope, "" /* alias */, e)
+	col := tempScope.addColumn("" /* alias */, e)
 	b.buildScalar(e, fromScope, tempScope, col, &info.colRefs)
 	if col.scalar != nil {
 		return col.scalar

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -1352,7 +1352,7 @@ func (mb *mutationBuilder) projectPartialIndexDistinctColumn(
 	texpr := insertScope.resolveAndRequireType(expr, types.Bool)
 
 	alias := fmt.Sprintf("upsert_partial_index_distinct%d", idx)
-	scopeCol := mb.b.addColumn(projectionScope, alias, texpr)
+	scopeCol := projectionScope.addColumn(alias, texpr)
 	mb.b.buildScalar(texpr, mb.outScope, projectionScope, scopeCol, nil)
 
 	mb.b.constructProjectForScope(mb.outScope, projectionScope)

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -615,20 +615,14 @@ func (mb *mutationBuilder) addSynthesizedColsForInsert() {
 	// Start by adding non-computed columns that have not already been explicitly
 	// specified in the query. Do this before adding computed columns, since those
 	// may depend on non-computed columns.
-	mb.addSynthesizedCols(
-		mb.insertColIDs,
-		func(col *cat.Column) bool { return !col.IsComputed() },
-	)
+	mb.addSynthesizedDefaultCols(mb.insertColIDs, false /* onlyWriteOnly */)
 
 	// Possibly round DECIMAL-related columns containing insertion values (whether
 	// synthesized or not).
 	mb.roundDecimalValues(mb.insertColIDs, false /* roundComputedCols */)
 
 	// Now add all computed columns.
-	mb.addSynthesizedCols(
-		mb.insertColIDs,
-		func(col *cat.Column) bool { return col.IsComputed() },
-	)
+	mb.addSynthesizedComputedCols(mb.insertColIDs)
 
 	// Possibly round DECIMAL-related computed columns.
 	mb.roundDecimalValues(mb.insertColIDs, true /* roundComputedCols */)

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -615,14 +615,14 @@ func (mb *mutationBuilder) addSynthesizedColsForInsert() {
 	// Start by adding non-computed columns that have not already been explicitly
 	// specified in the query. Do this before adding computed columns, since those
 	// may depend on non-computed columns.
-	mb.addSynthesizedDefaultCols(mb.insertColIDs, false /* onlyWriteOnly */)
+	mb.addSynthesizedDefaultCols(mb.insertColIDs, true /* includeOrdinary */)
 
 	// Possibly round DECIMAL-related columns containing insertion values (whether
 	// synthesized or not).
 	mb.roundDecimalValues(mb.insertColIDs, false /* roundComputedCols */)
 
 	// Now add all computed columns.
-	mb.addSynthesizedComputedCols(mb.insertColIDs)
+	mb.addSynthesizedComputedCols(mb.insertColIDs, false /* restrict */)
 
 	// Possibly round DECIMAL-related computed columns.
 	mb.roundDecimalValues(mb.insertColIDs, true /* roundComputedCols */)

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -539,25 +539,26 @@ func (mb *mutationBuilder) replaceDefaultExprs(inRows *tree.Select) (outRows *tr
 	return inRows
 }
 
-// addSynthesizedCols is a helper method for addSynthesizedColsForInsert
-// and addSynthesizedColsForUpdate that scans the list of table columns, looking
-// for any that do not yet have values provided by the input expression. New
-// columns are synthesized for any missing columns, as long as the addCol
-// callback function returns true for that column.
+// addSynthesizedDefaultCols is a helper method for addSynthesizedColsForInsert
+// and addSynthesizedColsForUpdate that scans the list of Ordinary and WriteOnly
+// table columns, looking for any that are not computed and do not yet have
+// values provided by the input expression. New columns are synthesized for any
+// missing columns.
 //
 // Values are synthesized for columns based on checking these rules, in order:
-//   1. If column is computed, evaluate that expression as its value.
-//   2. If column has a default value specified for it, use that as its value.
-//   3. If column is nullable, use NULL as its value.
-//   4. If column is currently being added or dropped (i.e. a mutation column),
+//   1. If column has a default value specified for it, use that as its value.
+//   2. If column is nullable, use NULL as its value.
+//   3. If column is currently being added or dropped (i.e. a mutation column),
 //      use a default value (0 for INT column, "" for STRING column, etc). Note
 //      that the existing "fetched" value returned by the scan cannot be used,
 //      since it may not have been initialized yet by the backfiller.
 //
+// If onlyWriteOnly is true, then only WriteOnly columns are considered.
+//
 // NOTE: colIDs is updated with the column IDs of any synthesized columns which
-// are added to outScope.
-func (mb *mutationBuilder) addSynthesizedCols(
-	colIDs opt.OptionalColList, addCol func(col *cat.Column) bool,
+// are added to mb.outScope.
+func (mb *mutationBuilder) addSynthesizedDefaultCols(
+	colIDs opt.OptionalColList, onlyWriteOnly bool,
 ) {
 	// We will construct a new Project operator that will contain the newly
 	// synthesized column(s).
@@ -565,14 +566,11 @@ func (mb *mutationBuilder) addSynthesizedCols(
 
 	for i, n := 0, mb.tab.ColumnCount(); i < n; i++ {
 		tabCol := mb.tab.Column(i)
-		kind := tabCol.Kind()
-		// Skip delete-only mutation columns, since they are ignored by all
-		// mutation operators that synthesize columns.
-		if kind == cat.DeleteOnly {
+		if kind := tabCol.Kind(); !(kind == cat.WriteOnly || (!onlyWriteOnly && kind == cat.Ordinary)) {
+			// Wrong kind.
 			continue
 		}
-		// Skip system and virtual inverted columns.
-		if kind == cat.System || kind == cat.VirtualInverted {
+		if tabCol.IsComputed() {
 			continue
 		}
 		// Skip columns that are already specified.
@@ -580,8 +578,50 @@ func (mb *mutationBuilder) addSynthesizedCols(
 			continue
 		}
 
-		// Invoke addCol to determine whether column should be added.
-		if !addCol(tabCol) {
+		tabColID := mb.tabID.ColumnID(i)
+		expr := mb.parseDefaultOrComputedExpr(tabColID)
+
+		// Add synthesized column. It is important to use the real column name in
+		// when this is a default column, which may latter be referred by a computed
+		// column.
+		newCol := pb.Add(tabCol.ColName(), expr, tabCol.DatumType())
+
+		// Remember id of newly synthesized column.
+		colIDs[i] = newCol
+
+		// Add corresponding target column.
+		mb.targetColList = append(mb.targetColList, tabColID)
+		mb.targetColSet.Add(tabColID)
+	}
+
+	mb.outScope = pb.Finish()
+}
+
+// addSynthesizedComputedCols is a helper method for addSynthesizedColsForInsert
+// and addSynthesizedColsForUpdate that scans the list of table columns, looking
+// for any that are computed and do not yet have values provided by the input
+// expression. New columns are synthesized for any missing columns using the
+// computed column expression.
+//
+// NOTE: colIDs is updated with the column IDs of any synthesized columns which
+// are added to mb.outScope.
+func (mb *mutationBuilder) addSynthesizedComputedCols(colIDs opt.OptionalColList) {
+	// We will construct a new Project operator that will contain the newly
+	// synthesized column(s).
+	pb := makeProjectionBuilder(mb.b, mb.outScope)
+
+	for i, n := 0, mb.tab.ColumnCount(); i < n; i++ {
+		tabCol := mb.tab.Column(i)
+		if kind := tabCol.Kind(); kind != cat.Ordinary && kind != cat.WriteOnly {
+			// Wrong kind
+			continue
+		}
+		if !tabCol.IsComputed() {
+			continue
+		}
+
+		// Skip columns that are already specified (this is possible for upserts).
+		if colIDs[i] != 0 {
 			continue
 		}
 

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -592,7 +592,7 @@ func (mb *mutationBuilder) addSynthesizedCols(
 		tabColID := mb.tabID.ColumnID(i)
 		expr := mb.parseDefaultOrComputedExpr(tabColID)
 		texpr := mb.outScope.resolveAndRequireType(expr, tabCol.DatumType())
-		scopeCol := mb.b.addColumn(projectionsScope, "" /* alias */, texpr)
+		scopeCol := projectionsScope.addColumn("" /* alias */, texpr)
 		mb.b.buildScalar(texpr, mb.outScope, projectionsScope, scopeCol, nil)
 
 		// Assign name to synthesized column. Computed columns may refer to default
@@ -758,7 +758,7 @@ func (mb *mutationBuilder) addCheckConstraintCols() {
 
 			alias := fmt.Sprintf("check%d", i+1)
 			texpr := mb.outScope.resolveAndRequireType(expr, types.Bool)
-			scopeCol := mb.b.addColumn(projectionsScope, alias, texpr)
+			scopeCol := projectionsScope.addColumn(alias, texpr)
 
 			// TODO(ridwanmsharif): Maybe we can avoid building constraints here
 			// and instead use the constraints stored in the table metadata.
@@ -868,7 +868,7 @@ func (mb *mutationBuilder) projectPartialIndexColsImpl(putScope, delScope *scope
 			if putScope != nil {
 				texpr := putScope.resolveAndRequireType(expr, types.Bool)
 				alias := fmt.Sprintf("partial_index_put%d", ord+1)
-				scopeCol := mb.b.addColumn(projectionScope, alias, texpr)
+				scopeCol := projectionScope.addColumn(alias, texpr)
 
 				mb.b.buildScalar(texpr, putScope, projectionScope, scopeCol, nil)
 				mb.partialIndexPutColIDs[ord] = scopeCol.id
@@ -878,7 +878,7 @@ func (mb *mutationBuilder) projectPartialIndexColsImpl(putScope, delScope *scope
 			if delScope != nil {
 				texpr := delScope.resolveAndRequireType(expr, types.Bool)
 				alias := fmt.Sprintf("partial_index_del%d", ord+1)
-				scopeCol := mb.b.addColumn(projectionScope, alias, texpr)
+				scopeCol := projectionScope.addColumn(alias, texpr)
 
 				mb.b.buildScalar(texpr, delScope, projectionScope, scopeCol, nil)
 				mb.partialIndexDelColIDs[ord] = scopeCol.id

--- a/pkg/sql/opt/optbuilder/orderby.go
+++ b/pkg/sql/opt/optbuilder/orderby.go
@@ -146,7 +146,7 @@ func (b *Builder) analyzeOrderByIndex(
 
 		colItem := tree.NewColumnItem(&tn, col.ColName())
 		expr := inScope.resolveType(colItem, types.Any)
-		outCol := b.addColumn(orderByScope, "" /* alias */, expr)
+		outCol := orderByScope.addColumn("" /* alias */, expr)
 		outCol.descending = desc
 	}
 }
@@ -252,7 +252,7 @@ func (b *Builder) analyzeExtraArgument(
 	for _, e := range exprs {
 		// Ensure we can order on the given column(s).
 		ensureColumnOrderable(e)
-		b.addColumn(extraColsScope, "" /* alias */, e)
+		extraColsScope.addColumn("" /* alias */, e)
 	}
 }
 

--- a/pkg/sql/opt/optbuilder/project.go
+++ b/pkg/sql/opt/optbuilder/project.go
@@ -140,7 +140,7 @@ func (b *Builder) analyzeSelectList(
 						outScope.cols = make([]scopeColumn, 0, len(selects)+len(exprs)-1)
 					}
 					for j, e := range exprs {
-						b.addColumn(outScope, aliases[j], e)
+						outScope.addColumn(aliases[j], e)
 					}
 					continue
 				}
@@ -161,7 +161,7 @@ func (b *Builder) analyzeSelectList(
 			outScope.cols = make([]scopeColumn, 0, len(selects))
 		}
 		alias := b.getColName(e)
-		b.addColumn(outScope, alias, texpr)
+		outScope.addColumn(alias, texpr)
 	}
 }
 

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -91,7 +91,7 @@ func (b *Builder) buildScalar(
 			// Note that normalization rules will trim down the list of grouping
 			// columns based on FDs, so this is only for the purposes of building a
 			// valid operator.
-			aggInCol := b.addColumn(g.aggInScope, "" /* alias */, t)
+			aggInCol := g.aggInScope.addColumn("" /* alias */, t)
 			b.finishBuildScalarRef(t, inScope, g.aggInScope, aggInCol, nil)
 			g.groupStrs[symbolicExprStr(t)] = aggInCol
 

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -1046,7 +1046,7 @@ func (b *Builder) buildSelectStmtWithoutParens(
 		projectionsScope.cols = make([]scopeColumn, 0, len(outScope.cols))
 		for i := range outScope.cols {
 			expr := &outScope.cols[i]
-			col := b.addColumn(projectionsScope, "" /* alias */, expr)
+			col := projectionsScope.addColumn("" /* alias */, expr)
 			b.buildScalar(expr, outScope, projectionsScope, col, nil)
 		}
 		orderByScope := b.analyzeOrderBy(orderBy, outScope, projectionsScope, tree.RejectGenerators|tree.RejectAggregates|tree.RejectWindowApplications)

--- a/pkg/sql/opt/optbuilder/srfs.go
+++ b/pkg/sql/opt/optbuilder/srfs.go
@@ -113,7 +113,7 @@ func (b *Builder) buildZip(exprs tree.Exprs, inScope *scope) (outScope *scope) {
 				// when used in a from clause.
 				alias = def.ReturnLabels[0]
 			}
-			outCol = b.addColumn(outScope, alias, texpr)
+			outCol = outScope.addColumn(alias, texpr)
 		}
 
 		scalar := b.buildScalar(texpr, inScope, outScope, outCol, nil)

--- a/pkg/sql/opt/optbuilder/testdata/update
+++ b/pkg/sql/opt/optbuilder/testdata/update
@@ -66,7 +66,6 @@ update abcde
  ├── fetch columns: a:8 b:9 c:10 d:11 e:12 rowid:13
  ├── update-mapping:
  │    ├── a_new:15 => a:1
- │    ├── column16:16 => d:4
  │    └── a_new:15 => e:5
  └── project
       ├── columns: column16:16 a:8!null b:9 c:10 d:11 e:12 rowid:13!null crdb_internal_mvcc_timestamp:14 a_new:15!null
@@ -250,8 +249,7 @@ update abcde
  ├── fetch columns: a:8 b:9 c:10 d:11 e:12 rowid:13
  ├── update-mapping:
  │    ├── b_new:15 => b:2
- │    ├── column16:16 => d:4
- │    └── a:8 => e:5
+ │    └── column16:16 => d:4
  └── project
       ├── columns: column16:16 a:8!null b:9 c:10 d:11 e:12 rowid:13!null crdb_internal_mvcc_timestamp:14 b_new:15!null
       ├── project
@@ -574,7 +572,6 @@ project
       ├── fetch columns: a:8 b:9 c:10 d:11 e:12 rowid:13
       ├── update-mapping:
       │    ├── a_new:15 => a:1
-      │    ├── column16:16 => d:4
       │    └── a_new:15 => e:5
       └── project
            ├── columns: column16:16 a:8!null b:9 c:10 d:11 e:12 rowid:13!null crdb_internal_mvcc_timestamp:14 a_new:15!null
@@ -607,7 +604,6 @@ project
  │    ├── fetch columns: a:8 b:9 c:10 d:11 e:12 rowid:13
  │    ├── update-mapping:
  │    │    ├── a_new:15 => a:1
- │    │    ├── column16:16 => d:4
  │    │    └── a_new:15 => e:5
  │    └── project
  │         ├── columns: column16:16 a:8!null b:9 c:10 d:11 e:12 rowid:13!null crdb_internal_mvcc_timestamp:14 a_new:15!null
@@ -645,7 +641,6 @@ with &1
  │         ├── fetch columns: abcde.a:8 abcde.b:9 abcde.c:10 abcde.d:11 abcde.e:12 rowid:13
  │         ├── update-mapping:
  │         │    ├── a_new:15 => abcde.a:1
- │         │    ├── column16:16 => abcde.d:4
  │         │    └── a_new:15 => abcde.e:5
  │         └── project
  │              ├── columns: column16:16 abcde.a:8!null abcde.b:9 abcde.c:10 abcde.d:11 abcde.e:12 rowid:13!null crdb_internal_mvcc_timestamp:14 a_new:15!null
@@ -692,11 +687,9 @@ UPDATE abcde SET rowid=rowid+1 RETURNING rowid
 project
  ├── columns: rowid:6!null
  └── update abcde
-      ├── columns: a:1!null b:2 c:3 d:4 e:5!null rowid:6!null
+      ├── columns: a:1!null b:2 c:3 d:4 e:5 rowid:6!null
       ├── fetch columns: a:8 b:9 c:10 d:11 e:12 rowid:13
       ├── update-mapping:
-      │    ├── column16:16 => d:4
-      │    ├── a:8 => e:5
       │    └── rowid_new:15 => rowid:6
       └── project
            ├── columns: column16:16 a:8!null b:9 c:10 d:11 e:12 rowid:13!null crdb_internal_mvcc_timestamp:14 rowid_new:15!null
@@ -740,8 +733,7 @@ update abcde
  ├── update-mapping:
  │    ├── b_new:15 => b:2
  │    ├── c_new:16 => c:3
- │    ├── column17:17 => d:4
- │    └── a:8 => e:5
+ │    └── column17:17 => d:4
  └── project
       ├── columns: column17:17 a:8!null b:9 c:10 d:11 e:12 rowid:13!null crdb_internal_mvcc_timestamp:14 b_new:15 c_new:16!null
       ├── project
@@ -769,7 +761,6 @@ update abcde
  ├── fetch columns: a:8 b:9 c:10 d:11 e:12 rowid:13
  ├── update-mapping:
  │    ├── a_new:15 => a:1
- │    ├── column16:16 => d:4
  │    └── a_new:15 => e:5
  └── project
       ├── columns: column16:16 a:8!null b:9 c:10 d:11 e:12 rowid:13!null crdb_internal_mvcc_timestamp:14 a_new:15
@@ -866,8 +857,7 @@ update abcde
  ├── update-mapping:
  │    ├── b_new:15 => b:2
  │    ├── c_new:16 => c:3
- │    ├── column17:17 => d:4
- │    └── a:8 => e:5
+ │    └── column17:17 => d:4
  └── project
       ├── columns: column17:17 a:8!null b:9 c:10 d:11 e:12 rowid:13!null crdb_internal_mvcc_timestamp:14 b_new:15 c_new:16!null
       ├── project
@@ -946,7 +936,6 @@ update abcde
  ├── fetch columns: a:8 b:9 c:10 d:11 e:12 rowid:13
  ├── update-mapping:
  │    ├── one:15 => a:1
- │    ├── column16:16 => d:4
  │    └── one:15 => e:5
  └── project
       ├── columns: column16:16 a:8!null b:9 c:10 d:11 e:12 rowid:13!null crdb_internal_mvcc_timestamp:14 one:15
@@ -1178,14 +1167,13 @@ build
 UPDATE abcde AS abcde1 SET b=(SELECT b FROM abcde AS abcde2 WHERE abcde2.rowid=abcde1.a) RETURNING *
 ----
 project
- ├── columns: a:1!null b:2 c:3 d:4 e:5!null
+ ├── columns: a:1!null b:2 c:3 d:4 e:5
  └── update abcde [as=abcde1]
-      ├── columns: abcde1.a:1!null abcde1.b:2 abcde1.c:3 abcde1.d:4 abcde1.e:5!null abcde1.rowid:6!null
+      ├── columns: abcde1.a:1!null abcde1.b:2 abcde1.c:3 abcde1.d:4 abcde1.e:5 abcde1.rowid:6!null
       ├── fetch columns: abcde1.a:8 abcde1.b:9 abcde1.c:10 abcde1.d:11 abcde1.e:12 abcde1.rowid:13
       ├── update-mapping:
       │    ├── b_new:22 => abcde1.b:2
-      │    ├── column23:23 => abcde1.d:4
-      │    └── abcde1.a:8 => abcde1.e:5
+      │    └── column23:23 => abcde1.d:4
       └── project
            ├── columns: column23:23 abcde1.a:8!null abcde1.b:9 abcde1.c:10 abcde1.d:11 abcde1.e:12 abcde1.rowid:13!null abcde1.crdb_internal_mvcc_timestamp:14 b_new:22
            ├── project
@@ -1514,9 +1502,8 @@ update checks
  ├── columns: <none>
  ├── fetch columns: a:6 b:7 c:8 d:9
  ├── update-mapping:
- │    ├── a_new:11 => a:1
- │    └── column12:12 => d:4
- ├── check columns: check1:13 check2:14
+ │    └── a_new:11 => a:1
+ ├── check columns: check2:14
  └── project
       ├── columns: check1:13 check2:14!null a:6!null b:7 c:8 d:9 crdb_internal_mvcc_timestamp:10 a_new:11!null column12:12
       ├── project
@@ -1535,7 +1522,7 @@ update checks
       │    └── projections
       │         └── c:8 + 1 [as=column12:12]
       └── projections
-           ├── b:7 < column12:12 [as=check1:13]
+           ├── b:7 < d:9 [as=check1:13]
            └── a_new:11 > 0 [as=check2:14]
 
 # Update one column in constraint, but not the other.
@@ -1546,8 +1533,7 @@ update checks
  ├── columns: <none>
  ├── fetch columns: a:6 b:7 c:8 d:9
  ├── update-mapping:
- │    ├── b_new:11 => b:2
- │    └── column12:12 => d:4
+ │    └── b_new:11 => b:2
  ├── check columns: check1:13
  └── project
       ├── columns: check1:13 check2:14!null a:6!null b:7 c:8 d:9 crdb_internal_mvcc_timestamp:10 b_new:11!null column12:12
@@ -1567,7 +1553,7 @@ update checks
       │    └── projections
       │         └── c:8 + 1 [as=column12:12]
       └── projections
-           ├── b_new:11 < column12:12 [as=check1:13]
+           ├── b_new:11 < d:9 [as=check1:13]
            └── a:6 > 0 [as=check2:14]
 
 # Update using tuple and subquery.
@@ -1579,8 +1565,7 @@ update checks
  ├── fetch columns: checks.a:6 checks.b:7 checks.c:8 checks.d:9
  ├── update-mapping:
  │    ├── abcde.a:11 => checks.a:1
- │    ├── abcde.b:12 => checks.b:2
- │    └── column18:18 => checks.d:4
+ │    └── abcde.b:12 => checks.b:2
  ├── check columns: check1:19 check2:20
  └── project
       ├── columns: check1:19 check2:20 checks.a:6!null checks.b:7 checks.c:8 checks.d:9 checks.crdb_internal_mvcc_timestamp:10 abcde.a:11 abcde.b:12 column18:18
@@ -1614,7 +1599,7 @@ update checks
       │    └── projections
       │         └── checks.c:8 + 1 [as=column18:18]
       └── projections
-           ├── abcde.b:12 < column18:18 [as=check1:19]
+           ├── abcde.b:12 < checks.d:9 [as=check1:19]
            └── abcde.a:11 > 0 [as=check2:20]
 
 # ------------------------------------------------------------------------------

--- a/pkg/sql/opt/optbuilder/testdata/upsert
+++ b/pkg/sql/opt/optbuilder/testdata/upsert
@@ -87,8 +87,7 @@ upsert abc
  │    ├── column11:11 => c:3
  │    └── column10:10 => rowid:4
  ├── update-mapping:
- │    ├── upsert_a:19 => a:1
- │    └── upsert_c:21 => c:3
+ │    └── upsert_a:19 => a:1
  └── project
       ├── columns: upsert_a:19!null upsert_b:20 upsert_c:21 upsert_rowid:22 x:6!null y:7 column10:10 column11:11 a:12 b:13 c:14 rowid:15 abc.crdb_internal_mvcc_timestamp:16 a_new:17!null column18:18
       ├── project
@@ -133,7 +132,7 @@ upsert abc
       └── projections
            ├── CASE WHEN a:12 IS NULL THEN x:6 ELSE a_new:17 END [as=upsert_a:19]
            ├── CASE WHEN a:12 IS NULL THEN y:7 ELSE b:13 END [as=upsert_b:20]
-           ├── CASE WHEN a:12 IS NULL THEN column11:11 ELSE column18:18 END [as=upsert_c:21]
+           ├── CASE WHEN a:12 IS NULL THEN column11:11 ELSE c:14 END [as=upsert_c:21]
            └── CASE WHEN a:12 IS NULL THEN column10:10 ELSE rowid:15 END [as=upsert_rowid:22]
 
 # Set all columns, multi-column conflict.
@@ -384,8 +383,7 @@ upsert abc [as=tab]
  │    ├── column9:9 => c:3
  │    └── column8:8 => rowid:4
  ├── update-mapping:
- │    ├── upsert_a:17 => a:1
- │    └── upsert_c:19 => c:3
+ │    └── upsert_a:17 => a:1
  └── project
       ├── columns: upsert_a:17 upsert_b:18 upsert_c:19 upsert_rowid:20 column1:6!null column2:7!null column8:8 column9:9!null a:10 b:11 c:12 rowid:13 crdb_internal_mvcc_timestamp:14 a_new:15 column16:16
       ├── project
@@ -429,7 +427,7 @@ upsert abc [as=tab]
       └── projections
            ├── CASE WHEN a:10 IS NULL THEN column1:6 ELSE a_new:15 END [as=upsert_a:17]
            ├── CASE WHEN a:10 IS NULL THEN column2:7 ELSE b:11 END [as=upsert_b:18]
-           ├── CASE WHEN a:10 IS NULL THEN column9:9 ELSE column16:16 END [as=upsert_c:19]
+           ├── CASE WHEN a:10 IS NULL THEN column9:9 ELSE c:12 END [as=upsert_c:19]
            └── CASE WHEN a:10 IS NULL THEN column8:8 ELSE rowid:13 END [as=upsert_rowid:20]
 
 # Conflict columns are in different order than index key columns.
@@ -450,8 +448,7 @@ upsert abc
  │    ├── column9:9 => c:3
  │    └── column8:8 => rowid:4
  ├── update-mapping:
- │    ├── upsert_a:17 => a:1
- │    └── upsert_c:19 => c:3
+ │    └── upsert_a:17 => a:1
  └── project
       ├── columns: upsert_a:17!null upsert_b:18 upsert_c:19 upsert_rowid:20 column1:6!null column2:7!null column8:8 column9:9!null a:10 b:11 c:12 rowid:13 crdb_internal_mvcc_timestamp:14 a_new:15!null column16:16
       ├── project
@@ -494,7 +491,7 @@ upsert abc
       └── projections
            ├── CASE WHEN rowid:13 IS NULL THEN column1:6 ELSE a_new:15 END [as=upsert_a:17]
            ├── CASE WHEN rowid:13 IS NULL THEN column2:7 ELSE b:11 END [as=upsert_b:18]
-           ├── CASE WHEN rowid:13 IS NULL THEN column9:9 ELSE column16:16 END [as=upsert_c:19]
+           ├── CASE WHEN rowid:13 IS NULL THEN column9:9 ELSE c:12 END [as=upsert_c:19]
            └── CASE WHEN rowid:13 IS NULL THEN column8:8 ELSE rowid:13 END [as=upsert_rowid:20]
 
 # Conflict columns don't match unique index (too few columns).
@@ -1460,8 +1457,7 @@ upsert checks
  │    ├── column8:8 => c:3
  │    └── column9:9 => d:4
  ├── update-mapping:
- │    ├── column2:7 => b:2
- │    └── upsert_d:18 => d:4
+ │    └── column2:7 => b:2
  ├── check columns: check1:19 check2:20
  └── project
       ├── columns: check1:19 check2:20 column1:6!null column2:7!null column8:8 column9:9 a:10 b:11 c:12 d:13 crdb_internal_mvcc_timestamp:14 column15:15 upsert_a:16 upsert_c:17 upsert_d:18
@@ -1506,7 +1502,7 @@ upsert checks
       │    └── projections
       │         ├── CASE WHEN a:10 IS NULL THEN column1:6 ELSE a:10 END [as=upsert_a:16]
       │         ├── CASE WHEN a:10 IS NULL THEN column8:8 ELSE c:12 END [as=upsert_c:17]
-      │         └── CASE WHEN a:10 IS NULL THEN column9:9 ELSE column15:15 END [as=upsert_d:18]
+      │         └── CASE WHEN a:10 IS NULL THEN column9:9 ELSE d:13 END [as=upsert_d:18]
       └── projections
            ├── column2:7 < upsert_d:18 [as=check1:19]
            └── upsert_a:16 > 0 [as=check2:20]
@@ -1529,8 +1525,7 @@ upsert checks
  │    └── column12:12 => d:4
  ├── update-mapping:
  │    ├── abc.a:6 => checks.a:1
- │    ├── upsert_b:24 => checks.b:2
- │    └── upsert_d:26 => d:4
+ │    └── upsert_b:24 => checks.b:2
  ├── check columns: check1:27 check2:28
  └── project
       ├── columns: check1:27 check2:28!null abc.a:6!null abc.b:7 column11:11 column12:12 checks.a:13 checks.b:14 checks.c:15 d:16 checks.crdb_internal_mvcc_timestamp:17 b_new:22 column23:23 upsert_b:24 upsert_c:25 upsert_d:26
@@ -1593,7 +1588,7 @@ upsert checks
       │    └── projections
       │         ├── CASE WHEN checks.a:13 IS NULL THEN abc.b:7 ELSE b_new:22 END [as=upsert_b:24]
       │         ├── CASE WHEN checks.a:13 IS NULL THEN column11:11 ELSE checks.c:15 END [as=upsert_c:25]
-      │         └── CASE WHEN checks.a:13 IS NULL THEN column12:12 ELSE column23:23 END [as=upsert_d:26]
+      │         └── CASE WHEN checks.a:13 IS NULL THEN column12:12 ELSE d:16 END [as=upsert_d:26]
       └── projections
            ├── upsert_b:24 < upsert_d:26 [as=check1:27]
            └── abc.a:6 > 0 [as=check2:28]
@@ -1665,68 +1660,63 @@ upsert decimals
  │    ├── c:11 => decimals.c:3
  │    └── d:13 => decimals.d:4
  ├── update-mapping:
- │    ├── b:10 => decimals.b:2
- │    └── upsert_d:23 => decimals.d:4
- ├── check columns: check1:24 check2:25
+ │    └── b:10 => decimals.b:2
+ ├── check columns: check1:23 check2:24
  └── project
-      ├── columns: check1:24 check2:25 a:9 b:10 c:11 d:13 decimals.a:14 decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18 d:20 upsert_a:21 upsert_c:22 upsert_d:23
+      ├── columns: check1:23 check2:24 a:9 b:10 c:11 d:13 decimals.a:14 decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18 column19:19 upsert_a:20 upsert_c:21 upsert_d:22
       ├── project
-      │    ├── columns: upsert_a:21 upsert_c:22 upsert_d:23 a:9 b:10 c:11 d:13 decimals.a:14 decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18 d:20
+      │    ├── columns: upsert_a:20 upsert_c:21 upsert_d:22 a:9 b:10 c:11 d:13 decimals.a:14 decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18 column19:19
       │    ├── project
-      │    │    ├── columns: d:20 a:9 b:10 c:11 d:13 decimals.a:14 decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18
-      │    │    ├── project
-      │    │    │    ├── columns: column19:19 a:9 b:10 c:11 d:13 decimals.a:14 decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18
-      │    │    │    ├── left-join (hash)
-      │    │    │    │    ├── columns: a:9 b:10 c:11 d:13 decimals.a:14 decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18
-      │    │    │    │    ├── ensure-upsert-distinct-on
-      │    │    │    │    │    ├── columns: a:9 b:10 c:11 d:13
-      │    │    │    │    │    ├── grouping columns: a:9
+      │    │    ├── columns: column19:19 a:9 b:10 c:11 d:13 decimals.a:14 decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18
+      │    │    ├── left-join (hash)
+      │    │    │    ├── columns: a:9 b:10 c:11 d:13 decimals.a:14 decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18
+      │    │    │    ├── ensure-upsert-distinct-on
+      │    │    │    │    ├── columns: a:9 b:10 c:11 d:13
+      │    │    │    │    ├── grouping columns: a:9
+      │    │    │    │    ├── project
+      │    │    │    │    │    ├── columns: d:13 a:9 b:10 c:11
       │    │    │    │    │    ├── project
-      │    │    │    │    │    │    ├── columns: d:13 a:9 b:10 c:11
+      │    │    │    │    │    │    ├── columns: column12:12 a:9 b:10 c:11
       │    │    │    │    │    │    ├── project
-      │    │    │    │    │    │    │    ├── columns: column12:12 a:9 b:10 c:11
+      │    │    │    │    │    │    │    ├── columns: a:9 b:10 c:11
       │    │    │    │    │    │    │    ├── project
-      │    │    │    │    │    │    │    │    ├── columns: a:9 b:10 c:11
-      │    │    │    │    │    │    │    │    ├── project
-      │    │    │    │    │    │    │    │    │    ├── columns: column8:8!null column1:6!null column2:7
-      │    │    │    │    │    │    │    │    │    ├── values
-      │    │    │    │    │    │    │    │    │    │    ├── columns: column1:6!null column2:7
-      │    │    │    │    │    │    │    │    │    │    └── (1.1, ARRAY[0.95])
-      │    │    │    │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │    │    │    │         └── 1.23 [as=column8:8]
+      │    │    │    │    │    │    │    │    ├── columns: column8:8!null column1:6!null column2:7
+      │    │    │    │    │    │    │    │    ├── values
+      │    │    │    │    │    │    │    │    │    ├── columns: column1:6!null column2:7
+      │    │    │    │    │    │    │    │    │    └── (1.1, ARRAY[0.95])
       │    │    │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │    │    │         ├── crdb_internal.round_decimal_values(column1:6, 0) [as=a:9]
-      │    │    │    │    │    │    │    │         ├── crdb_internal.round_decimal_values(column2:7, 1) [as=b:10]
-      │    │    │    │    │    │    │    │         └── crdb_internal.round_decimal_values(column8:8, 1) [as=c:11]
+      │    │    │    │    │    │    │    │         └── 1.23 [as=column8:8]
       │    │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │    │         └── a:9 + c:11 [as=column12:12]
+      │    │    │    │    │    │    │         ├── crdb_internal.round_decimal_values(column1:6, 0) [as=a:9]
+      │    │    │    │    │    │    │         ├── crdb_internal.round_decimal_values(column2:7, 1) [as=b:10]
+      │    │    │    │    │    │    │         └── crdb_internal.round_decimal_values(column8:8, 1) [as=c:11]
       │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │         └── crdb_internal.round_decimal_values(column12:12, 1) [as=d:13]
-      │    │    │    │    │    └── aggregations
-      │    │    │    │    │         ├── first-agg [as=b:10]
-      │    │    │    │    │         │    └── b:10
-      │    │    │    │    │         ├── first-agg [as=c:11]
-      │    │    │    │    │         │    └── c:11
-      │    │    │    │    │         └── first-agg [as=d:13]
-      │    │    │    │    │              └── d:13
-      │    │    │    │    ├── scan decimals
-      │    │    │    │    │    ├── columns: decimals.a:14!null decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18
-      │    │    │    │    │    └── computed column expressions
-      │    │    │    │    │         └── decimals.d:17
-      │    │    │    │    │              └── decimals.a:14::DECIMAL + decimals.c:16::DECIMAL
-      │    │    │    │    └── filters
-      │    │    │    │         └── a:9 = decimals.a:14
-      │    │    │    └── projections
-      │    │    │         └── decimals.a:14::DECIMAL + decimals.c:16::DECIMAL [as=column19:19]
+      │    │    │    │    │    │         └── a:9 + c:11 [as=column12:12]
+      │    │    │    │    │    └── projections
+      │    │    │    │    │         └── crdb_internal.round_decimal_values(column12:12, 1) [as=d:13]
+      │    │    │    │    └── aggregations
+      │    │    │    │         ├── first-agg [as=b:10]
+      │    │    │    │         │    └── b:10
+      │    │    │    │         ├── first-agg [as=c:11]
+      │    │    │    │         │    └── c:11
+      │    │    │    │         └── first-agg [as=d:13]
+      │    │    │    │              └── d:13
+      │    │    │    ├── scan decimals
+      │    │    │    │    ├── columns: decimals.a:14!null decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18
+      │    │    │    │    └── computed column expressions
+      │    │    │    │         └── decimals.d:17
+      │    │    │    │              └── decimals.a:14::DECIMAL + decimals.c:16::DECIMAL
+      │    │    │    └── filters
+      │    │    │         └── a:9 = decimals.a:14
       │    │    └── projections
-      │    │         └── crdb_internal.round_decimal_values(column19:19, 1) [as=d:20]
+      │    │         └── decimals.a:14::DECIMAL + decimals.c:16::DECIMAL [as=column19:19]
       │    └── projections
-      │         ├── CASE WHEN decimals.a:14 IS NULL THEN a:9 ELSE decimals.a:14 END [as=upsert_a:21]
-      │         ├── CASE WHEN decimals.a:14 IS NULL THEN c:11 ELSE decimals.c:16 END [as=upsert_c:22]
-      │         └── CASE WHEN decimals.a:14 IS NULL THEN d:13 ELSE d:20 END [as=upsert_d:23]
+      │         ├── CASE WHEN decimals.a:14 IS NULL THEN a:9 ELSE decimals.a:14 END [as=upsert_a:20]
+      │         ├── CASE WHEN decimals.a:14 IS NULL THEN c:11 ELSE decimals.c:16 END [as=upsert_c:21]
+      │         └── CASE WHEN decimals.a:14 IS NULL THEN d:13 ELSE decimals.d:17 END [as=upsert_d:22]
       └── projections
-           ├── round(upsert_a:21) = upsert_a:21 [as=check1:24]
-           └── b:10[0] > 1 [as=check2:25]
+           ├── round(upsert_a:20) = upsert_a:20 [as=check1:23]
+           └── b:10[0] > 1 [as=check2:24]
 
 # Regular UPSERT case.
 build
@@ -1742,70 +1732,64 @@ upsert decimals
  │    ├── b:10 => decimals.b:2
  │    ├── c:11 => decimals.c:3
  │    └── d:13 => decimals.d:4
- ├── update-mapping:
- │    └── upsert_d:24 => decimals.d:4
- ├── check columns: check1:25 check2:26
+ ├── check columns: check1:24 check2:25
  └── project
-      ├── columns: check1:25 check2:26 a:9 b:10 c:11 d:13 decimals.a:14 decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18 d:20 upsert_a:21 upsert_b:22 upsert_c:23 upsert_d:24
+      ├── columns: check1:24 check2:25 a:9 b:10 c:11 d:13 decimals.a:14 decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18 column19:19 upsert_a:20 upsert_b:21 upsert_c:22 upsert_d:23
       ├── project
-      │    ├── columns: upsert_a:21 upsert_b:22 upsert_c:23 upsert_d:24 a:9 b:10 c:11 d:13 decimals.a:14 decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18 d:20
+      │    ├── columns: upsert_a:20 upsert_b:21 upsert_c:22 upsert_d:23 a:9 b:10 c:11 d:13 decimals.a:14 decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18 column19:19
       │    ├── project
-      │    │    ├── columns: d:20 a:9 b:10 c:11 d:13 decimals.a:14 decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18
-      │    │    ├── project
-      │    │    │    ├── columns: column19:19 a:9 b:10 c:11 d:13 decimals.a:14 decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18
-      │    │    │    ├── left-join (hash)
-      │    │    │    │    ├── columns: a:9 b:10 c:11 d:13 decimals.a:14 decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18
-      │    │    │    │    ├── ensure-upsert-distinct-on
-      │    │    │    │    │    ├── columns: a:9 b:10 c:11 d:13
-      │    │    │    │    │    ├── grouping columns: a:9
+      │    │    ├── columns: column19:19 a:9 b:10 c:11 d:13 decimals.a:14 decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18
+      │    │    ├── left-join (hash)
+      │    │    │    ├── columns: a:9 b:10 c:11 d:13 decimals.a:14 decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18
+      │    │    │    ├── ensure-upsert-distinct-on
+      │    │    │    │    ├── columns: a:9 b:10 c:11 d:13
+      │    │    │    │    ├── grouping columns: a:9
+      │    │    │    │    ├── project
+      │    │    │    │    │    ├── columns: d:13 a:9 b:10 c:11
       │    │    │    │    │    ├── project
-      │    │    │    │    │    │    ├── columns: d:13 a:9 b:10 c:11
+      │    │    │    │    │    │    ├── columns: column12:12 a:9 b:10 c:11
       │    │    │    │    │    │    ├── project
-      │    │    │    │    │    │    │    ├── columns: column12:12 a:9 b:10 c:11
+      │    │    │    │    │    │    │    ├── columns: a:9 b:10 c:11
       │    │    │    │    │    │    │    ├── project
-      │    │    │    │    │    │    │    │    ├── columns: a:9 b:10 c:11
-      │    │    │    │    │    │    │    │    ├── project
-      │    │    │    │    │    │    │    │    │    ├── columns: column7:7 column8:8!null column1:6!null
-      │    │    │    │    │    │    │    │    │    ├── values
-      │    │    │    │    │    │    │    │    │    │    ├── columns: column1:6!null
-      │    │    │    │    │    │    │    │    │    │    └── (1.1,)
-      │    │    │    │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │    │    │    │         ├── NULL::DECIMAL(5,1)[] [as=column7:7]
-      │    │    │    │    │    │    │    │    │         └── 1.23 [as=column8:8]
+      │    │    │    │    │    │    │    │    ├── columns: column7:7 column8:8!null column1:6!null
+      │    │    │    │    │    │    │    │    ├── values
+      │    │    │    │    │    │    │    │    │    ├── columns: column1:6!null
+      │    │    │    │    │    │    │    │    │    └── (1.1,)
       │    │    │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │    │    │         ├── crdb_internal.round_decimal_values(column1:6, 0) [as=a:9]
-      │    │    │    │    │    │    │    │         ├── crdb_internal.round_decimal_values(column7:7, 1) [as=b:10]
-      │    │    │    │    │    │    │    │         └── crdb_internal.round_decimal_values(column8:8, 1) [as=c:11]
+      │    │    │    │    │    │    │    │         ├── NULL::DECIMAL(5,1)[] [as=column7:7]
+      │    │    │    │    │    │    │    │         └── 1.23 [as=column8:8]
       │    │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │    │         └── a:9 + c:11 [as=column12:12]
+      │    │    │    │    │    │    │         ├── crdb_internal.round_decimal_values(column1:6, 0) [as=a:9]
+      │    │    │    │    │    │    │         ├── crdb_internal.round_decimal_values(column7:7, 1) [as=b:10]
+      │    │    │    │    │    │    │         └── crdb_internal.round_decimal_values(column8:8, 1) [as=c:11]
       │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │         └── crdb_internal.round_decimal_values(column12:12, 1) [as=d:13]
-      │    │    │    │    │    └── aggregations
-      │    │    │    │    │         ├── first-agg [as=b:10]
-      │    │    │    │    │         │    └── b:10
-      │    │    │    │    │         ├── first-agg [as=c:11]
-      │    │    │    │    │         │    └── c:11
-      │    │    │    │    │         └── first-agg [as=d:13]
-      │    │    │    │    │              └── d:13
-      │    │    │    │    ├── scan decimals
-      │    │    │    │    │    ├── columns: decimals.a:14!null decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18
-      │    │    │    │    │    └── computed column expressions
-      │    │    │    │    │         └── decimals.d:17
-      │    │    │    │    │              └── decimals.a:14::DECIMAL + decimals.c:16::DECIMAL
-      │    │    │    │    └── filters
-      │    │    │    │         └── a:9 = decimals.a:14
-      │    │    │    └── projections
-      │    │    │         └── decimals.a:14::DECIMAL + decimals.c:16::DECIMAL [as=column19:19]
+      │    │    │    │    │    │         └── a:9 + c:11 [as=column12:12]
+      │    │    │    │    │    └── projections
+      │    │    │    │    │         └── crdb_internal.round_decimal_values(column12:12, 1) [as=d:13]
+      │    │    │    │    └── aggregations
+      │    │    │    │         ├── first-agg [as=b:10]
+      │    │    │    │         │    └── b:10
+      │    │    │    │         ├── first-agg [as=c:11]
+      │    │    │    │         │    └── c:11
+      │    │    │    │         └── first-agg [as=d:13]
+      │    │    │    │              └── d:13
+      │    │    │    ├── scan decimals
+      │    │    │    │    ├── columns: decimals.a:14!null decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18
+      │    │    │    │    └── computed column expressions
+      │    │    │    │         └── decimals.d:17
+      │    │    │    │              └── decimals.a:14::DECIMAL + decimals.c:16::DECIMAL
+      │    │    │    └── filters
+      │    │    │         └── a:9 = decimals.a:14
       │    │    └── projections
-      │    │         └── crdb_internal.round_decimal_values(column19:19, 1) [as=d:20]
+      │    │         └── decimals.a:14::DECIMAL + decimals.c:16::DECIMAL [as=column19:19]
       │    └── projections
-      │         ├── CASE WHEN decimals.a:14 IS NULL THEN a:9 ELSE decimals.a:14 END [as=upsert_a:21]
-      │         ├── CASE WHEN decimals.a:14 IS NULL THEN b:10 ELSE decimals.b:15 END [as=upsert_b:22]
-      │         ├── CASE WHEN decimals.a:14 IS NULL THEN c:11 ELSE decimals.c:16 END [as=upsert_c:23]
-      │         └── CASE WHEN decimals.a:14 IS NULL THEN d:13 ELSE d:20 END [as=upsert_d:24]
+      │         ├── CASE WHEN decimals.a:14 IS NULL THEN a:9 ELSE decimals.a:14 END [as=upsert_a:20]
+      │         ├── CASE WHEN decimals.a:14 IS NULL THEN b:10 ELSE decimals.b:15 END [as=upsert_b:21]
+      │         ├── CASE WHEN decimals.a:14 IS NULL THEN c:11 ELSE decimals.c:16 END [as=upsert_c:22]
+      │         └── CASE WHEN decimals.a:14 IS NULL THEN d:13 ELSE decimals.d:17 END [as=upsert_d:23]
       └── projections
-           ├── round(upsert_a:21) = upsert_a:21 [as=check1:25]
-           └── upsert_b:22[0] > 1 [as=check2:26]
+           ├── round(upsert_a:20) = upsert_a:20 [as=check1:24]
+           └── upsert_b:21[0] > 1 [as=check2:25]
 
 # INSERT...ON CONFLICT case.
 build
@@ -1824,77 +1808,72 @@ upsert decimals
  │    ├── c:11 => decimals.c:3
  │    └── d:13 => decimals.d:4
  ├── update-mapping:
- │    ├── upsert_b:24 => decimals.b:2
- │    └── upsert_d:26 => decimals.d:4
- ├── check columns: check1:27 check2:28
+ │    └── upsert_b:23 => decimals.b:2
+ ├── check columns: check1:26 check2:27
  └── project
-      ├── columns: check1:27 check2:28 a:9 b:10 c:11 d:13 decimals.a:14 decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18 b:20 d:22 upsert_a:23 upsert_b:24 upsert_c:25 upsert_d:26
+      ├── columns: check1:26 check2:27 a:9 b:10 c:11 d:13 decimals.a:14 decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18 b:20 column21:21 upsert_a:22 upsert_b:23 upsert_c:24 upsert_d:25
       ├── project
-      │    ├── columns: upsert_a:23 upsert_b:24 upsert_c:25 upsert_d:26 a:9 b:10 c:11 d:13 decimals.a:14 decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18 b:20 d:22
+      │    ├── columns: upsert_a:22 upsert_b:23 upsert_c:24 upsert_d:25 a:9 b:10 c:11 d:13 decimals.a:14 decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18 b:20 column21:21
       │    ├── project
-      │    │    ├── columns: d:22 a:9 b:10 c:11 d:13 decimals.a:14 decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18 b:20
+      │    │    ├── columns: column21:21 a:9 b:10 c:11 d:13 decimals.a:14 decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18 b:20
       │    │    ├── project
-      │    │    │    ├── columns: column21:21 a:9 b:10 c:11 d:13 decimals.a:14 decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18 b:20
+      │    │    │    ├── columns: b:20 a:9 b:10 c:11 d:13 decimals.a:14 decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18
       │    │    │    ├── project
-      │    │    │    │    ├── columns: b:20 a:9 b:10 c:11 d:13 decimals.a:14 decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18
-      │    │    │    │    ├── project
-      │    │    │    │    │    ├── columns: b_new:19!null a:9 b:10 c:11 d:13 decimals.a:14 decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18
-      │    │    │    │    │    ├── left-join (hash)
-      │    │    │    │    │    │    ├── columns: a:9 b:10 c:11 d:13 decimals.a:14 decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18
-      │    │    │    │    │    │    ├── ensure-upsert-distinct-on
-      │    │    │    │    │    │    │    ├── columns: a:9 b:10 c:11 d:13
-      │    │    │    │    │    │    │    ├── grouping columns: a:9
+      │    │    │    │    ├── columns: b_new:19!null a:9 b:10 c:11 d:13 decimals.a:14 decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18
+      │    │    │    │    ├── left-join (hash)
+      │    │    │    │    │    ├── columns: a:9 b:10 c:11 d:13 decimals.a:14 decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18
+      │    │    │    │    │    ├── ensure-upsert-distinct-on
+      │    │    │    │    │    │    ├── columns: a:9 b:10 c:11 d:13
+      │    │    │    │    │    │    ├── grouping columns: a:9
+      │    │    │    │    │    │    ├── project
+      │    │    │    │    │    │    │    ├── columns: d:13 a:9 b:10 c:11
       │    │    │    │    │    │    │    ├── project
-      │    │    │    │    │    │    │    │    ├── columns: d:13 a:9 b:10 c:11
+      │    │    │    │    │    │    │    │    ├── columns: column12:12 a:9 b:10 c:11
       │    │    │    │    │    │    │    │    ├── project
-      │    │    │    │    │    │    │    │    │    ├── columns: column12:12 a:9 b:10 c:11
+      │    │    │    │    │    │    │    │    │    ├── columns: a:9 b:10 c:11
       │    │    │    │    │    │    │    │    │    ├── project
-      │    │    │    │    │    │    │    │    │    │    ├── columns: a:9 b:10 c:11
-      │    │    │    │    │    │    │    │    │    │    ├── project
-      │    │    │    │    │    │    │    │    │    │    │    ├── columns: column8:8!null column1:6!null column2:7
-      │    │    │    │    │    │    │    │    │    │    │    ├── values
-      │    │    │    │    │    │    │    │    │    │    │    │    ├── columns: column1:6!null column2:7
-      │    │    │    │    │    │    │    │    │    │    │    │    └── (1.1, ARRAY[0.95])
-      │    │    │    │    │    │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │    │    │    │    │    │         └── 1.23 [as=column8:8]
+      │    │    │    │    │    │    │    │    │    │    ├── columns: column8:8!null column1:6!null column2:7
+      │    │    │    │    │    │    │    │    │    │    ├── values
+      │    │    │    │    │    │    │    │    │    │    │    ├── columns: column1:6!null column2:7
+      │    │    │    │    │    │    │    │    │    │    │    └── (1.1, ARRAY[0.95])
       │    │    │    │    │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │    │    │    │    │         ├── crdb_internal.round_decimal_values(column1:6, 0) [as=a:9]
-      │    │    │    │    │    │    │    │    │    │         ├── crdb_internal.round_decimal_values(column2:7, 1) [as=b:10]
-      │    │    │    │    │    │    │    │    │    │         └── crdb_internal.round_decimal_values(column8:8, 1) [as=c:11]
+      │    │    │    │    │    │    │    │    │    │         └── 1.23 [as=column8:8]
       │    │    │    │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │    │    │    │         └── a:9 + c:11 [as=column12:12]
+      │    │    │    │    │    │    │    │    │         ├── crdb_internal.round_decimal_values(column1:6, 0) [as=a:9]
+      │    │    │    │    │    │    │    │    │         ├── crdb_internal.round_decimal_values(column2:7, 1) [as=b:10]
+      │    │    │    │    │    │    │    │    │         └── crdb_internal.round_decimal_values(column8:8, 1) [as=c:11]
       │    │    │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │    │    │         └── crdb_internal.round_decimal_values(column12:12, 1) [as=d:13]
-      │    │    │    │    │    │    │    └── aggregations
-      │    │    │    │    │    │    │         ├── first-agg [as=b:10]
-      │    │    │    │    │    │    │         │    └── b:10
-      │    │    │    │    │    │    │         ├── first-agg [as=c:11]
-      │    │    │    │    │    │    │         │    └── c:11
-      │    │    │    │    │    │    │         └── first-agg [as=d:13]
-      │    │    │    │    │    │    │              └── d:13
-      │    │    │    │    │    │    ├── scan decimals
-      │    │    │    │    │    │    │    ├── columns: decimals.a:14!null decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18
-      │    │    │    │    │    │    │    └── computed column expressions
-      │    │    │    │    │    │    │         └── decimals.d:17
-      │    │    │    │    │    │    │              └── decimals.a:14::DECIMAL + decimals.c:16::DECIMAL
-      │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │         └── a:9 = decimals.a:14
-      │    │    │    │    │    └── projections
-      │    │    │    │    │         └── ARRAY[0.99] [as=b_new:19]
+      │    │    │    │    │    │    │    │         └── a:9 + c:11 [as=column12:12]
+      │    │    │    │    │    │    │    └── projections
+      │    │    │    │    │    │    │         └── crdb_internal.round_decimal_values(column12:12, 1) [as=d:13]
+      │    │    │    │    │    │    └── aggregations
+      │    │    │    │    │    │         ├── first-agg [as=b:10]
+      │    │    │    │    │    │         │    └── b:10
+      │    │    │    │    │    │         ├── first-agg [as=c:11]
+      │    │    │    │    │    │         │    └── c:11
+      │    │    │    │    │    │         └── first-agg [as=d:13]
+      │    │    │    │    │    │              └── d:13
+      │    │    │    │    │    ├── scan decimals
+      │    │    │    │    │    │    ├── columns: decimals.a:14!null decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18
+      │    │    │    │    │    │    └── computed column expressions
+      │    │    │    │    │    │         └── decimals.d:17
+      │    │    │    │    │    │              └── decimals.a:14::DECIMAL + decimals.c:16::DECIMAL
+      │    │    │    │    │    └── filters
+      │    │    │    │    │         └── a:9 = decimals.a:14
       │    │    │    │    └── projections
-      │    │    │    │         └── crdb_internal.round_decimal_values(b_new:19, 1) [as=b:20]
+      │    │    │    │         └── ARRAY[0.99] [as=b_new:19]
       │    │    │    └── projections
-      │    │    │         └── decimals.a:14::DECIMAL + decimals.c:16::DECIMAL [as=column21:21]
+      │    │    │         └── crdb_internal.round_decimal_values(b_new:19, 1) [as=b:20]
       │    │    └── projections
-      │    │         └── crdb_internal.round_decimal_values(column21:21, 1) [as=d:22]
+      │    │         └── decimals.a:14::DECIMAL + decimals.c:16::DECIMAL [as=column21:21]
       │    └── projections
-      │         ├── CASE WHEN decimals.a:14 IS NULL THEN a:9 ELSE decimals.a:14 END [as=upsert_a:23]
-      │         ├── CASE WHEN decimals.a:14 IS NULL THEN b:10 ELSE b:20 END [as=upsert_b:24]
-      │         ├── CASE WHEN decimals.a:14 IS NULL THEN c:11 ELSE decimals.c:16 END [as=upsert_c:25]
-      │         └── CASE WHEN decimals.a:14 IS NULL THEN d:13 ELSE d:22 END [as=upsert_d:26]
+      │         ├── CASE WHEN decimals.a:14 IS NULL THEN a:9 ELSE decimals.a:14 END [as=upsert_a:22]
+      │         ├── CASE WHEN decimals.a:14 IS NULL THEN b:10 ELSE b:20 END [as=upsert_b:23]
+      │         ├── CASE WHEN decimals.a:14 IS NULL THEN c:11 ELSE decimals.c:16 END [as=upsert_c:24]
+      │         └── CASE WHEN decimals.a:14 IS NULL THEN d:13 ELSE decimals.d:17 END [as=upsert_d:25]
       └── projections
-           ├── round(upsert_a:23) = upsert_a:23 [as=check1:27]
-           └── upsert_b:24[0] > 1 [as=check2:28]
+           ├── round(upsert_a:22) = upsert_a:22 [as=check1:26]
+           └── upsert_b:23[0] > 1 [as=check2:27]
 
 # ------------------------------------------------------------------------------
 # Test partial index column values.

--- a/pkg/sql/opt/optbuilder/update.go
+++ b/pkg/sql/opt/optbuilder/update.go
@@ -304,7 +304,7 @@ func (mb *mutationBuilder) addSynthesizedColsForUpdate() {
 	// table. These are not visible to queries, and will always be updated to
 	// their default values. This is necessary because they may not yet have been
 	// set by the backfiller.
-	mb.addSynthesizedDefaultCols(mb.updateColIDs, true /* onlyWriteOnly */)
+	mb.addSynthesizedDefaultCols(mb.updateColIDs, false /* includeOrdinary */)
 
 	// Possibly round DECIMAL-related columns containing update values. Do
 	// this before evaluating computed expressions, since those may depend on
@@ -316,7 +316,7 @@ func (mb *mutationBuilder) addSynthesizedColsForUpdate() {
 	mb.disambiguateColumns()
 
 	// Add all computed columns in case their values have changed.
-	mb.addSynthesizedComputedCols(mb.updateColIDs)
+	mb.addSynthesizedComputedCols(mb.updateColIDs, true /* restrict */)
 
 	// Possibly round DECIMAL-related computed columns.
 	mb.roundDecimalValues(mb.updateColIDs, true /* roundComputedCols */)

--- a/pkg/sql/opt/optbuilder/update.go
+++ b/pkg/sql/opt/optbuilder/update.go
@@ -14,7 +14,6 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -305,12 +304,7 @@ func (mb *mutationBuilder) addSynthesizedColsForUpdate() {
 	// table. These are not visible to queries, and will always be updated to
 	// their default values. This is necessary because they may not yet have been
 	// set by the backfiller.
-	mb.addSynthesizedCols(
-		mb.updateColIDs,
-		func(col *cat.Column) bool {
-			return !col.IsComputed() && col.IsMutation()
-		},
-	)
+	mb.addSynthesizedDefaultCols(mb.updateColIDs, true /* onlyWriteOnly */)
 
 	// Possibly round DECIMAL-related columns containing update values. Do
 	// this before evaluating computed expressions, since those may depend on
@@ -322,10 +316,7 @@ func (mb *mutationBuilder) addSynthesizedColsForUpdate() {
 	mb.disambiguateColumns()
 
 	// Add all computed columns in case their values have changed.
-	mb.addSynthesizedCols(
-		mb.updateColIDs,
-		func(col *cat.Column) bool { return col.IsComputed() },
-	)
+	mb.addSynthesizedComputedCols(mb.updateColIDs)
 
 	// Possibly round DECIMAL-related computed columns.
 	mb.roundDecimalValues(mb.updateColIDs, true /* roundComputedCols */)

--- a/pkg/sql/opt/optbuilder/update.go
+++ b/pkg/sql/opt/optbuilder/update.go
@@ -228,7 +228,7 @@ func (mb *mutationBuilder) addUpdateCols(exprs tree.UpdateExprs) {
 		targetColMeta := mb.md.ColumnMeta(targetColID)
 		desiredType := targetColMeta.Type
 		texpr := inScope.resolveType(expr, desiredType)
-		scopeCol := mb.b.addColumn(projectionsScope, targetColMeta.Alias+"_new", texpr)
+		scopeCol := projectionsScope.addColumn(targetColMeta.Alias+"_new", texpr)
 		mb.b.buildScalar(texpr, inScope, projectionsScope, scopeCol, nil)
 
 		checkCol(scopeCol, targetColID)

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -244,19 +244,6 @@ func (b *Builder) shouldCreateDefaultColumn(texpr tree.TypedExpr) bool {
 	return len(texpr.ResolvedType().TupleLabels()) == 0
 }
 
-// addColumn adds a column to scope with the given alias, type, and
-// expression. It returns a pointer to the new column. The column ID and group
-// are left empty so they can be filled in later.
-func (b *Builder) addColumn(scope *scope, alias string, expr tree.TypedExpr) *scopeColumn {
-	name := tree.Name(alias)
-	scope.cols = append(scope.cols, scopeColumn{
-		name: name,
-		typ:  expr.ResolvedType(),
-		expr: expr,
-	})
-	return &scope.cols[len(scope.cols)-1]
-}
-
 func (b *Builder) synthesizeResultColumns(scope *scope, cols colinfo.ResultColumns) {
 	for i := range cols {
 		c := b.synthesizeColumn(scope, cols[i].Name, cols[i].Typ, nil /* expr */, nil /* scalar */)


### PR DESCRIPTION
#### optbuilder: make addColumn a method on scope

Release note: None

#### optbuilder: projectionBuilder helper

Separating a small helper to make the `addSynthesizedCols` code more
readable.

Release note: None

#### optbuilder: split addSynthesizedCols

This code is always used to either build only non-computed columns, or
only computed columns. These two cases are logically different steps
in the process.

This commit splits it into two versions for the two purposes. This
removes the callbacks and will allow adding improvements that are
specific to a single step.

Release note: None

#### opt: don't update computed columns unnecessarily

We currently project the new value for all computed columns, even when
we are doing an UPDATE that doesn't affect a computed column. This can
lead to unnecessary index joins in some cases.

This change fixes this by checking whether any of the referenced
columns are being updated. If not, we do not update the target
columns (which lets existing normalization rules prune the
unnecessary projection).

Fixes #42482.

Release note (performance improvement): potentially improved
performance for UPDATE statements where the table has computed columns
that don't depend on updated columns.