### PR TITLE
row: fix import default expr sequence logic

### DIFF
--- a/pkg/sql/row/row_converter.go
+++ b/pkg/sql/row/row_converter.go
@@ -357,19 +357,25 @@ func NewDatumRowConverter(
 	c.Datums = make([]tree.Datum, len(targetColDescriptors), len(cols))
 	c.defaultCache = make([]tree.TypedExpr, len(cols))
 
+	annot := make(tree.Annotations, 1)
+	var cellInfoAnnot CellInfoAnnotation
+	// Currently, this is only true for an IMPORT INTO CSV.
+	if seqChunkProvider != nil {
+		seqNameToMetadata, err := c.getSequenceAnnotation(evalCtx, c.cols)
+		if err != nil {
+			return nil, err
+		}
+		cellInfoAnnot.seqNameToMetadata = seqNameToMetadata
+		cellInfoAnnot.seqChunkProvider = seqChunkProvider
+	}
+	cellInfoAnnot.uniqueRowIDInstance = 0
+	annot.Set(cellInfoAddr, &cellInfoAnnot)
+	c.EvalCtx.Annotations = &annot
+
 	// Check for a hidden column. This should be the unique_rowid PK if present.
 	// In addition, check for non-targeted columns with non-null DEFAULT expressions.
 	// If the DEFAULT expression is immutable, we can store it in the cache so that it
 	// doesn't have to be reevaluated for every row.
-	annot := make(tree.Annotations, 1)
-	var seqNameToMetadata map[string]*SequenceMetadata
-	seqNameToMetadata, err = c.getSequenceAnnotation(evalCtx, c.cols)
-	if err != nil {
-		return nil, err
-	}
-	annot.Set(cellInfoAddr, &CellInfoAnnotation{uniqueRowIDInstance: 0,
-		seqNameToMetadata: seqNameToMetadata, seqChunkProvider: seqChunkProvider})
-	c.EvalCtx.Annotations = &annot
 	for i := range cols {
 		col := &cols[i]
 		if col.DefaultExpr != nil {


### PR DESCRIPTION
Previously, we would attempt to create a sequence annotation when
creating a NewDatumConverter. This code path is shared by various
formats of IMPORT, and we only really want to create this annotation
when coming from a subset of them (CSV only as of today). The annotation
involves resolving sequence descs, and depending on whether we are
coming from an IMPORT PGDUMP or an IMPORT CSV we use different
resolvers to do this. Therefore, calling this method with the wrong
resolver can result in a "descriptor not found" error.

Informs: #58147

Release note: None