### PR TITLE
ccl/sqlproxyccl: developer provided proxy handler

### DIFF
--- a/pkg/ccl/cliccl/BUILD.bazel
+++ b/pkg/ccl/cliccl/BUILD.bazel
@@ -40,7 +40,6 @@ go_library(
         "@com_github_cockroachdb_cmux//:cmux",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_errors//oserror",
-        "@com_github_jackc_pgproto3_v2//:pgproto3",
         "@com_github_spf13_cobra//:cobra",
         "@org_golang_x_sync//errgroup",
     ],

--- a/pkg/ccl/sqlproxyccl/authentication.go
+++ b/pkg/ccl/sqlproxyccl/authentication.go
@@ -14,7 +14,7 @@ import (
 	"github.com/jackc/pgproto3/v2"
 )
 
-func authenticate(clientConn, crdbConn net.Conn) error {
+func Authenticate(clientConn, crdbConn net.Conn) error {
 	fe := pgproto3.NewBackend(pgproto3.NewChunkReader(clientConn), clientConn)
 	be := pgproto3.NewFrontend(pgproto3.NewChunkReader(crdbConn), crdbConn)
 

--- a/pkg/ccl/sqlproxyccl/authentication_test.go
+++ b/pkg/ccl/sqlproxyccl/authentication_test.go
@@ -33,7 +33,7 @@ func TestAuthenticateOK(t *testing.T) {
 		require.Equal(t, beMsg, &pgproto3.ReadyForQuery{})
 	}()
 
-	require.NoError(t, authenticate(srv, cli))
+	require.NoError(t, Authenticate(srv, cli))
 }
 
 func TestAuthenticateClearText(t *testing.T) {
@@ -75,7 +75,7 @@ func TestAuthenticateClearText(t *testing.T) {
 		require.Equal(t, beMsg, &pgproto3.ReadyForQuery{})
 	}()
 
-	require.NoError(t, authenticate(srv, cli))
+	require.NoError(t, Authenticate(srv, cli))
 }
 
 func TestAuthenticateError(t *testing.T) {
@@ -93,11 +93,11 @@ func TestAuthenticateError(t *testing.T) {
 		require.Equal(t, beMsg, &pgproto3.ErrorResponse{Severity: "FATAL", Code: "foo"})
 	}()
 
-	err := authenticate(srv, cli)
+	err := Authenticate(srv, cli)
 	require.Error(t, err)
 	codeErr := (*CodeError)(nil)
 	require.True(t, errors.As(err, &codeErr))
-	require.Equal(t, CodeAuthFailed, codeErr.code)
+	require.Equal(t, CodeAuthFailed, codeErr.Code)
 }
 
 func TestAuthenticateUnexpectedMessage(t *testing.T) {
@@ -115,9 +115,9 @@ func TestAuthenticateUnexpectedMessage(t *testing.T) {
 		require.Equal(t, beMsg, &pgproto3.BindComplete{})
 	}()
 
-	err := authenticate(srv, cli)
+	err := Authenticate(srv, cli)
 	require.Error(t, err)
 	codeErr := (*CodeError)(nil)
 	require.True(t, errors.As(err, &codeErr))
-	require.Equal(t, CodeBackendDisconnected, codeErr.code)
+	require.Equal(t, CodeBackendDisconnected, codeErr.Code)
 }

--- a/pkg/ccl/sqlproxyccl/error.go
+++ b/pkg/ccl/sqlproxyccl/error.go
@@ -85,18 +85,18 @@ const (
 // CodeError is combines an error with one of the above codes to ease
 // the processing of the errors.
 type CodeError struct {
-	code ErrorCode
+	Code ErrorCode
 	err  error
 }
 
 func (e *CodeError) Error() string {
-	return fmt.Sprintf("%s: %s", e.code, e.err)
+	return fmt.Sprintf("%s: %s", e.Code, e.err)
 }
 
 // NewErrorf returns a new CodeError out of the supplied args.
 func NewErrorf(code ErrorCode, format string, args ...interface{}) error {
 	return &CodeError{
-		code: code,
+		Code: code,
 		err:  errors.Errorf(format, args...),
 	}
 }

--- a/pkg/ccl/sqlproxyccl/frontend_admitter.go
+++ b/pkg/ccl/sqlproxyccl/frontend_admitter.go
@@ -36,12 +36,12 @@ func FrontendAdmit(
 		case *pgproto3.SSLRequest:
 		case *pgproto3.CancelRequest:
 			// Ignore CancelRequest explicitly. We don't need to do this but it makes
-			// testing easier by avoiding a call to sendErrToClient on this path
+			// testing easier by avoiding a call to SendErrToClient on this path
 			// (which would confuse assertCtx).
 			return nil, nil, nil
 		default:
 			code := CodeUnexpectedInsecureStartupMessage
-			return nil, nil, NewErrorf(code, "unsupported startup message: %T", m)
+			return conn, nil, NewErrorf(code, "unsupported startup message: %T", m)
 		}
 
 		_, err = conn.Write([]byte{pgAcceptSSLRequest})

--- a/pkg/ccl/sqlproxyccl/proxy.go
+++ b/pkg/ccl/sqlproxyccl/proxy.go
@@ -9,8 +9,6 @@
 package sqlproxyccl
 
 import (
-	"context"
-	"crypto/tls"
 	"io"
 	"net"
 	"os"
@@ -24,76 +22,66 @@ const pgAcceptSSLRequest = 'S'
 // See https://www.postgresql.org/docs/9.1/protocol-message-formats.html.
 var pgSSLRequest = []int32{8, 80877103}
 
-// BackendConfig contains the configuration of a backend connection that is
-// being proxied.
-// To be removed once all clients are migrated to use backend dialer.
-type BackendConfig struct {
-	// The address to which the connection is forwarded.
-	OutgoingAddress string
-	// TLS settings to use when connecting to OutgoingAddress.
-	TLSConf *tls.Config
-	// Called after successfully connecting to OutgoingAddr.
-	OnConnectionSuccess func()
-	// KeepAliveLoop if provided controls the lifetime of the proxy connection.
-	// It will be run in its own goroutine when the connection is successfully
-	// opened. Returning from `KeepAliveLoop` will close the proxy connection.
-	// Note that non-nil error return values will be forwarded to the user and
-	// hence should explain the reason for terminating the connection.
-	// Most common use of KeepAliveLoop will be as an infinite loop that
-	// periodically checks if the connection should still be kept alive. Hence it
-	// may block indefinitely so it's prudent to use the provided context and
-	// return on context cancellation.
-	// See `TestProxyKeepAlive` for example usage.
-	KeepAliveLoop func(context.Context) error
+// UpdateMetricsForError updates the metrics relevant for the type of the
+// error message.
+func UpdateMetricsForError(metrics *Metrics, err error) {
+	if err == nil {
+		return
+	}
+	codeErr := (*CodeError)(nil)
+	if errors.As(err, &codeErr) {
+		switch codeErr.Code {
+		case CodeExpiredClientConnection:
+			metrics.ExpiredClientConnCount.Inc(1)
+		case CodeBackendDisconnected:
+			metrics.BackendDisconnectCount.Inc(1)
+		case CodeClientDisconnected:
+			metrics.ClientDisconnectCount.Inc(1)
+		case CodeIdleDisconnect:
+			metrics.IdleDisconnectCount.Inc(1)
+		case CodeProxyRefusedConnection:
+			metrics.RefusedConnCount.Inc(1)
+			metrics.BackendDownCount.Inc(1)
+		case CodeParamsRoutingFailed:
+			metrics.RoutingErrCount.Inc(1)
+			metrics.BackendDownCount.Inc(1)
+		case CodeBackendDown:
+			metrics.BackendDownCount.Inc(1)
+		case CodeAuthFailed:
+			metrics.AuthFailedCount.Inc(1)
+		}
+	}
 }
 
-// Options are the options to the Proxy method.
-type Options struct {
-	// Deprecated: construct FrontendAdmitter, passing this information in case
-	// that SSL is desired.
-	IncomingTLSConfig *tls.Config // config used for client -> proxy connection
-
-	// BackendFromParams returns the config to use for the proxy -> backend
-	// connection. The TLS config is in it and it must have an appropriate
-	// ServerName for the remote backend.
-	// Deprecated: processing of the params now happens in the BackendDialer.
-	// This is only here to support OnSuccess and KeepAlive.
-	BackendConfigFromParams func(
-		params map[string]string, incomingConn *Conn,
-	) (config *BackendConfig, clientErr error)
-
-	// If set, consulted to modify the parameters set by the frontend before
-	// forwarding them to the backend during startup.
-	// Deprecated: include the code that modifies the request params
-	// in the backend dialer.
-	ModifyRequestParams func(map[string]string)
-
-	// If set, consulted to decorate an error message to be sent to the client.
-	// The error passed to this method will contain no internal information.
-	OnSendErrToClient func(code ErrorCode, msg string) string
-
-	// If set, will be called immediately after a new incoming connection
-	// is accepted. It can optionally negotiate SSL, provide admittance control or
-	// other types of frontend connection filtering.
-	FrontendAdmitter func(incoming net.Conn) (net.Conn, *pgproto3.StartupMessage, error)
-
-	// If set, will be used to establish and return connection to the backend.
-	// If not set, the old logic will be used.
-	// The argument is the startup message received from the frontend. It
-	// contains the protocol version and params sent by the client.
-	BackendDialer func(msg *pgproto3.StartupMessage) (net.Conn, error)
-}
-
-// Proxy takes an incoming client connection and relays it to a backend SQL
-// server.
-func (s *Server) Proxy(proxyConn *Conn) error {
-	sendErrToClient := func(conn net.Conn, code ErrorCode, msg string) {
-		if s.opts.OnSendErrToClient != nil {
-			msg = s.opts.OnSendErrToClient(code, msg)
+// SendErrToClient will encode and pass back to the SQL client an error message.
+// It can be called by the implementors of ProxyHandler to give more
+// information to the end user in case of a problem.
+func SendErrToClient(conn net.Conn, err error) {
+	if err == nil || conn == nil {
+		return
+	}
+	codeErr := (*CodeError)(nil)
+	if errors.As(err, &codeErr) {
+		var msg string
+		switch codeErr.Code {
+		// These are send as is.
+		case CodeExpiredClientConnection,
+			CodeBackendDown,
+			CodeParamsRoutingFailed,
+			CodeClientDisconnected,
+			CodeBackendDisconnected,
+			CodeAuthFailed,
+			CodeProxyRefusedConnection:
+			msg = codeErr.Error()
+		// The rest - the message send back is sanitized.
+		case CodeIdleDisconnect:
+			msg = "terminating connection due to idle timeout"
+		case CodeUnexpectedInsecureStartupMessage:
+			msg = "server requires encryption"
 		}
 
 		var pgCode string
-		if code == CodeIdleDisconnect {
+		if codeErr.Code == CodeIdleDisconnect {
 			pgCode = "57P01" // admin shutdown
 		} else {
 			pgCode = "08004" // rejected connection
@@ -104,135 +92,13 @@ func (s *Server) Proxy(proxyConn *Conn) error {
 			Message:  msg,
 		}).Encode(nil))
 	}
+}
 
-	frontendAdmitter := s.opts.FrontendAdmitter
-	if frontendAdmitter == nil {
-		// Keep this until all clients are switched to provide FrontendAdmitter
-		// at what point we can also drop IncomingTLSConfig
-		frontendAdmitter = func(incoming net.Conn) (net.Conn, *pgproto3.StartupMessage, error) {
-			return FrontendAdmit(incoming, s.opts.IncomingTLSConfig)
-		}
-	}
-
-	conn, msg, err := frontendAdmitter(proxyConn)
-	if err != nil {
-		var codeErr *CodeError
-		if ok := errors.As(err, &codeErr); ok && codeErr.code == CodeUnexpectedInsecureStartupMessage {
-			sendErrToClient(
-				proxyConn, // Do this on the TCP connection as it means denying SSL
-				CodeUnexpectedInsecureStartupMessage,
-				"server requires encryption",
-			)
-		} else if ok {
-			sendErrToClient(proxyConn, codeErr.code, codeErr.Error())
-		} else {
-			sendErrToClient(proxyConn, CodeClientDisconnected, err.Error())
-		}
-		return err
-	}
-
-	// This currently only happens for CancelRequest type of startup messages
-	// that we don't support
-	if conn == nil {
-		return nil
-
-	}
-	defer func() { _ = conn.Close() }()
-
-	backendDialer := s.opts.BackendDialer
-	var backendConfig *BackendConfig
-	if s.opts.BackendConfigFromParams != nil {
-		var clientErr error
-		backendConfig, clientErr = s.opts.BackendConfigFromParams(msg.Parameters, proxyConn)
-		if clientErr != nil {
-			var codeErr *CodeError
-			if !errors.As(clientErr, &codeErr) {
-				codeErr = &CodeError{
-					code: CodeParamsRoutingFailed,
-					err:  errors.Errorf("rejected by BackendConfigFromParams: %v", clientErr),
-				}
-			}
-			sendErrToClient(conn, codeErr.code, codeErr.Error())
-			return codeErr
-		}
-	}
-	if backendDialer == nil {
-		// This we need to keep until all the clients are switched to provide BackendDialer.
-		// It constructs a backend dialer from the information provided via
-		// BackendConfigFromParams function.
-		backendDialer = func(msg *pgproto3.StartupMessage) (net.Conn, error) {
-			// We should be able to remove this when the all clients switch to
-			// backend dialer.
-			if s.opts.ModifyRequestParams != nil {
-				s.opts.ModifyRequestParams(msg.Parameters)
-			}
-
-			crdbConn, err := BackendDial(msg, backendConfig.OutgoingAddress, backendConfig.TLSConf)
-			if err != nil {
-				if codeErr := (*CodeError)(nil); errors.As(err, &codeErr) {
-					sendErrToClient(conn, codeErr.code, codeErr.Error())
-				} else {
-					sendErrToClient(conn, CodeBackendDisconnected, err.Error())
-				}
-				return nil, err
-			}
-
-			return crdbConn, nil
-		}
-	}
-
-	crdbConn, err := backendDialer(msg)
-	if err != nil {
-		s.metrics.BackendDownCount.Inc(1)
-		var codeErr *CodeError
-		if !errors.As(err, &codeErr) {
-			codeErr = &CodeError{
-				code: CodeBackendDown,
-				err:  errors.Errorf("unable to reach backend SQL server: %v", err),
-			}
-		}
-		if codeErr.code == CodeProxyRefusedConnection {
-			s.metrics.RefusedConnCount.Inc(1)
-		} else if codeErr.code == CodeParamsRoutingFailed {
-			s.metrics.RoutingErrCount.Inc(1)
-		}
-		sendErrToClient(conn, codeErr.code, codeErr.Error())
-		return codeErr
-	}
-	defer func() { _ = crdbConn.Close() }()
-
-	if err := authenticate(conn, crdbConn); err != nil {
-		s.metrics.AuthFailedCount.Inc(1)
-		var codeErr *CodeError
-		if !errors.As(err, &codeErr) {
-			codeErr = &CodeError{
-				code: CodeParamsRoutingFailed,
-				err:  errors.Errorf("unrecognized auth failure"),
-			}
-		}
-		sendErrToClient(conn, codeErr.code, codeErr.Error())
-		return codeErr
-	}
-
-	s.metrics.SuccessfulConnCount.Inc(1)
-
-	// These channels are buffered because we'll only consume one of them.
+// ConnectionCopy does a bi-directional copy between the backend and frontend
+// connections. It terminates when one of connections terminate.
+func ConnectionCopy(crdbConn, conn net.Conn) error {
 	errOutgoing := make(chan error, 1)
 	errIncoming := make(chan error, 1)
-	errExpired := make(chan error, 1)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	if backendConfig != nil {
-		if backendConfig.OnConnectionSuccess != nil {
-			backendConfig.OnConnectionSuccess()
-		}
-		if backendConfig.KeepAliveLoop != nil {
-			go func() {
-				errExpired <- backendConfig.KeepAliveLoop(ctx)
-			}()
-		}
-	}
 
 	go func() {
 		_, err := io.Copy(crdbConn, conn)
@@ -254,33 +120,17 @@ func (s *Server) Proxy(proxyConn *Conn) error {
 		if err == nil {
 			return nil
 		} else if codeErr := (*CodeError)(nil); errors.As(err, &codeErr) &&
-			codeErr.code == CodeExpiredClientConnection {
-			s.metrics.ExpiredClientConnCount.Inc(1)
-			sendErrToClient(conn, codeErr.code, codeErr.Error())
+			codeErr.Code == CodeExpiredClientConnection {
 			return codeErr
 		} else if errors.Is(err, os.ErrDeadlineExceeded) {
-			s.metrics.IdleDisconnectCount.Inc(1)
-			sendErrToClient(conn, CodeIdleDisconnect, "terminating connection due to idle timeout")
 			return NewErrorf(CodeIdleDisconnect, "terminating connection due to idle timeout: %v", err)
 		} else {
-			s.metrics.BackendDisconnectCount.Inc(1)
-			sendErrToClient(conn, CodeBackendDisconnected, "copying from target server to client")
 			return NewErrorf(CodeBackendDisconnected, "copying from target server to client: %s", err)
 		}
 	case err := <-errOutgoing:
 		// The incoming connection got closed.
 		if err != nil {
-			s.metrics.ClientDisconnectCount.Inc(1)
 			return NewErrorf(CodeClientDisconnected, "copying from target server to client: %v", err)
-		}
-		return nil
-	case err := <-errExpired:
-		if err != nil {
-			// The client connection expired.
-			s.metrics.ExpiredClientConnCount.Inc(1)
-			code := CodeExpiredClientConnection
-			sendErrToClient(conn, code, err.Error())
-			return NewErrorf(code, "expired client conn: %v", err)
 		}
 		return nil
 	}

--- a/pkg/ccl/sqlproxyccl/server_test.go
+++ b/pkg/ccl/sqlproxyccl/server_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestHandleHealth(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	proxyServer := NewServer(Options{})
+	proxyServer := NewServer(testProxyHandler(&testHandlerOptions{}))
 
 	rw := httptest.NewRecorder()
 	r := httptest.NewRequest("GET", "/_status/healthz/", nil)
@@ -36,7 +36,7 @@ func TestHandleHealth(t *testing.T) {
 
 func TestHandleVars(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	proxyServer := NewServer(Options{})
+	proxyServer := NewServer(testProxyHandler(&testHandlerOptions{}))
 
 	rw := httptest.NewRecorder()
 	r := httptest.NewRequest("GET", "/_status/vars/", nil)


### PR DESCRIPTION
This PR changes the sqlproxyccl's Proxy implementation. Previously, it
was expected that the developer will populate an options struct that
will customize how the provided proxy will operate. With this PR, it is
expected that the developer will provide a proxy handler instead that
will do everything needed to proxy an SQL connection from a frontend to
a backend. To help with the implementation, the code has been split into
number of helper methods that can be combined and that make easy bulding
a custom proxy. The existing implementation is now moved into the test
file and is just one example of how a complicated proxy can be
constructed.

Release note: none