### PR TITLE
opt: use join filters to imply IS NOT NULL partial index predicates

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/fk
+++ b/pkg/sql/opt/exec/execbuilder/testdata/fk
@@ -1520,3 +1520,91 @@ vectorized: true
                   estimated row count: 10
                   table: small_parent@primary
                   spans: FULL SCAN
+
+# Test that partial indexes with IS NOT NULL predicates are used for performing
+# FK checks.
+subtest partial_index
+
+statement ok
+CREATE TABLE partial_parent (
+  id INT PRIMARY KEY
+)
+
+statement ok
+CREATE TABLE partial_child (
+  id INT PRIMARY KEY,
+  parent_id INT,
+  CONSTRAINT fk FOREIGN KEY (parent_id) REFERENCES partial_parent(id),
+  INDEX partial_idx (parent_id) WHERE parent_id IS NOT NULL
+)
+
+query T
+EXPLAIN DELETE FROM partial_parent WHERE id = 1
+----
+distribution: local
+vectorized: true
+·
+• root
+│
+├── • delete
+│   │ from: partial_parent
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • scan
+│             missing stats
+│             table: partial_parent@primary
+│             spans: [/1 - /1]
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │
+        └── • lookup join (semi)
+            │ table: partial_child@partial_idx (partial index)
+            │ equality: (id) = (parent_id)
+            │
+            └── • scan buffer
+                  label: buffer 1
+
+query T
+EXPLAIN UPDATE partial_parent SET id = 2 WHERE id = 1
+----
+distribution: local
+vectorized: true
+·
+• root
+│
+├── • update
+│   │ table: partial_parent
+│   │ set: id
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • render
+│           │
+│           └── • scan
+│                 missing stats
+│                 table: partial_parent@primary
+│                 spans: [/1 - /1]
+│                 locking strength: for update
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │
+        └── • lookup join (semi)
+            │ table: partial_child@partial_idx (partial index)
+            │ equality: (id) = (parent_id)
+            │
+            └── • except
+                │
+                ├── • scan buffer
+                │     label: buffer 1
+                │
+                └── • scan buffer
+                      label: buffer 1
+
+subtest end

--- a/pkg/sql/opt/exec/execbuilder/testdata/partial_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/partial_index
@@ -1,5 +1,81 @@
 # LogicTest: local
 
+statement ok
+CREATE TABLE t (
+    a INT PRIMARY KEY,
+    b INT,
+    c STRING,
+    FAMILY (a, b, c),
+    INDEX b_partial (b) WHERE b > 10
+)
+
+statement ok
+CREATE TABLE inv (
+    a INT PRIMARY KEY,
+    b JSON,
+    c STRING,
+    INVERTED INDEX i (b) WHERE c IN ('foo', 'bar'),
+    FAMILY (a, b, c)
+)
+
+# ---------------------------------------------------------
+# EXPLAIN
+# ---------------------------------------------------------
+
+# EXPLAIN output shows the partial index label on scans over partial indexes.
+query T
+EXPLAIN SELECT b FROM t WHERE b > 10
+----
+distribution: local
+vectorized: true
+·
+• scan
+  missing stats
+  table: t@b_partial (partial index)
+  spans: FULL SCAN
+
+query T
+EXPLAIN SELECT a FROM inv@i WHERE b @> '{"x": "y"}' AND c IN ('foo', 'bar')
+----
+distribution: local
+vectorized: true
+·
+• scan
+  missing stats
+  table: inv@i (partial index)
+  spans: 1 span
+
+query T
+EXPLAIN SELECT a FROM inv@i WHERE b @> '{"x": "y"}' AND c = 'foo'
+----
+distribution: local
+vectorized: true
+·
+• filter
+│ filter: c = 'foo'
+│
+└── • index join
+    │ table: inv@primary
+    │
+    └── • scan
+          missing stats
+          table: inv@i (partial index)
+          spans: 1 span
+
+query T
+EXPLAIN SELECT * FROM inv@i WHERE b @> '{"x": "y"}' AND c IN ('foo', 'bar')
+----
+distribution: local
+vectorized: true
+·
+• index join
+│ table: inv@primary
+│
+└── • scan
+      missing stats
+      table: inv@i (partial index)
+      spans: 1 span
+
 # ---------------------------------------------------------
 # JOIN
 # ---------------------------------------------------------

--- a/pkg/sql/opt/exec/execbuilder/testdata/partial_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/partial_index
@@ -22,7 +22,8 @@ CREATE TABLE inv (
 # EXPLAIN
 # ---------------------------------------------------------
 
-# EXPLAIN output shows the partial index label on scans over partial indexes.
+# EXPLAIN output shows the partial index label on scans and joins on partial
+# indexes.
 query T
 EXPLAIN SELECT b FROM t WHERE b > 10
 ----
@@ -33,6 +34,21 @@ vectorized: true
   missing stats
   table: t@b_partial (partial index)
   spans: FULL SCAN
+
+query T
+EXPLAIN SELECT t1.a FROM t t1 INNER LOOKUP JOIN t t2 ON t1.a = t2.b AND t2.b > 10
+----
+distribution: local
+vectorized: true
+·
+• lookup join
+│ table: t@b_partial (partial index)
+│ equality: (a) = (b)
+│
+└── • scan
+      missing stats
+      table: t@primary
+      spans: [/11 - ]
 
 query T
 EXPLAIN SELECT a FROM inv@i WHERE b @> '{"x": "y"}' AND c IN ('foo', 'bar')

--- a/pkg/sql/opt/exec/execbuilder/testdata/partial_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/partial_index
@@ -1,0 +1,33 @@
+# LogicTest: local
+
+# ---------------------------------------------------------
+# JOIN
+# ---------------------------------------------------------
+
+statement ok
+CREATE TABLE a (a INT PRIMARY KEY);
+
+statement ok
+CREATE TABLE b (b INT, INDEX (b) WHERE b IS NOT NULL)
+
+# The partial index can be used because the ON condition implicitly implies the
+# partial index predicate, b IS NOT NULL.
+query T
+EXPLAIN SELECT * FROM a JOIN b ON a = b
+----
+distribution: local
+vectorized: true
+·
+• merge join
+│ equality: (a) = (b)
+│ left cols are key
+│
+├── • scan
+│     missing stats
+│     table: a@primary
+│     spans: FULL SCAN
+│
+└── • scan
+      missing stats
+      table: b@b_b_idx (partial index)
+      spans: FULL SCAN

--- a/pkg/sql/opt/exec/execbuilder/testdata/partial_index_nonmetamorphic
+++ b/pkg/sql/opt/exec/execbuilder/testdata/partial_index_nonmetamorphic
@@ -882,64 +882,6 @@ UPSERT INTO inv VALUES (6, '{"x": "y", "num": 8}', 'baz')
 Scan /Table/55/1/6{-/#}
 CPut /Table/55/1/6/0 -> /TUPLE/
 
-# ---------------------------------------------------------
-# EXPLAIN
-# ---------------------------------------------------------
-
-# EXPLAIN output shows the partial index label on scans over partial indexes.
-query T
-EXPLAIN SELECT b FROM t WHERE b > 10
-----
-distribution: local
-vectorized: true
-·
-• scan
-  missing stats
-  table: t@b_partial (partial index)
-  spans: FULL SCAN
-
-query T
-EXPLAIN SELECT a FROM inv@i WHERE b @> '{"x": "y"}' AND c IN ('foo', 'bar')
-----
-distribution: local
-vectorized: true
-·
-• scan
-  missing stats
-  table: inv@i (partial index)
-  spans: 1 span
-
-query T
-EXPLAIN SELECT a FROM inv@i WHERE b @> '{"x": "y"}' AND c = 'foo'
-----
-distribution: local
-vectorized: true
-·
-• filter
-│ filter: c = 'foo'
-│
-└── • index join
-    │ table: inv@primary
-    │
-    └── • scan
-          missing stats
-          table: inv@i (partial index)
-          spans: 1 span
-
-query T
-EXPLAIN SELECT * FROM inv@i WHERE b @> '{"x": "y"}' AND c IN ('foo', 'bar')
-----
-distribution: local
-vectorized: true
-·
-• index join
-│ table: inv@primary
-│
-└── • scan
-      missing stats
-      table: inv@i (partial index)
-      spans: 1 span
-
 # Regression test for #57085. Cascading DELETEs should not issue DEL operations
 # for partial indexes of a child table when the deleted row was not in the
 # partial index.

--- a/pkg/sql/opt/norm/reject_nulls_funcs.go
+++ b/pkg/sql/opt/norm/reject_nulls_funcs.go
@@ -162,6 +162,9 @@ func DeriveRejectNullCols(in memo.RelExpr) opt.ColSet {
 
 	case opt.ProjectOp:
 		relProps.Rule.RejectNullCols.UnionWith(deriveProjectRejectNullCols(in))
+
+	case opt.ScanOp:
+		relProps.Rule.RejectNullCols.UnionWith(deriveScanRejectNullCols(in))
 	}
 
 	return relProps.Rule.RejectNullCols
@@ -316,4 +319,44 @@ func deriveProjectRejectNullCols(in memo.RelExpr) opt.ColSet {
 		}
 	}
 	return (rejectNullCols.Union(projectionsRejectCols)).Intersection(in.Relational().OutputCols)
+}
+
+// deriveScanRejectNullCols returns the set of Scan columns which are eligible
+// for null rejection. Scan columns can be null-rejected only when there are
+// partial indexes that have explicit "column IS NOT NULL" expressions. Creating
+// null-rejecting filters is useful in this case because the filters may imply a
+// partial index predicate expression, allowing a scan over the index.
+func deriveScanRejectNullCols(in memo.RelExpr) opt.ColSet {
+	md := in.Memo().Metadata()
+	scan := in.(*memo.ScanExpr)
+
+	var rejectNullCols opt.ColSet
+	for _, pred := range md.TableMeta(scan.Table).PartialIndexPredicates {
+		predFilters := *pred.(*memo.FiltersExpr)
+		rejectNullCols.UnionWith(isNotNullCols(predFilters))
+	}
+
+	return rejectNullCols
+}
+
+// isNotNullCols returns the set of columns with explicit, top-level IS NOT NULL
+// filter conditions in the given filters. Note that And and Or expressions are
+// not traversed.
+func isNotNullCols(filters memo.FiltersExpr) opt.ColSet {
+	var notNullCols opt.ColSet
+	for i := range filters {
+		c := filters[i].Condition
+		isNot, ok := c.(*memo.IsNotExpr)
+		if !ok {
+			continue
+		}
+		col, ok := isNot.Left.(*memo.VariableExpr)
+		if !ok {
+			continue
+		}
+		if isNot.Right == memo.NullSingleton {
+			notNullCols.Add(col.Col)
+		}
+	}
+	return notNullCols
 }

--- a/pkg/sql/opt/norm/rules/reject_nulls.opt
+++ b/pkg/sql/opt/norm/rules/reject_nulls.opt
@@ -179,7 +179,8 @@
 
 # RejectNullsUnderJoinRight mirrors RejectNullsUnderJoinLeft.
 [RejectNullsUnderJoinRight, Normalize, LowPriority]
-(InnerJoin | InnerJoinApply | LeftJoin | LeftJoinApply
+(InnerJoin | InnerJoinApply | LeftJoin | LeftJoinApply | SemiJoin
+        | AntiJoin
     $left:*
     $right:* &
         ^(ColsAreEmpty $rejectCols:(RejectNullCols $right))

--- a/pkg/sql/opt/norm/testdata/rules/reject_nulls
+++ b/pkg/sql/opt/norm/testdata/rules/reject_nulls
@@ -1166,6 +1166,120 @@ left-join-apply
  └── filters
       └── u:1 = y:6 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
 
+exec-ddl
+CREATE TABLE ab (
+  a INT,
+  b INT,
+  c INT,
+  INDEX b_idx (b) WHERE b IS NOT NULL,
+  INDEX c_idx (c) WHERE c > 0
+)
+----
+
+# Reject nulls for a scan with an IS NOT NULL partial index predicate expression
+# on the right side of a semi-join.
+norm expect=RejectNullsUnderJoinRight
+SELECT * FROM ab t1 WHERE EXISTS (SELECT * FROM ab t2 WHERE t1.a = t2.b)
+----
+semi-join (hash)
+ ├── columns: a:1 b:2 c:3
+ ├── scan ab [as=t1]
+ │    ├── columns: t1.a:1 t1.b:2 t1.c:3
+ │    └── partial index predicates
+ │         ├── b_idx: filters
+ │         │    └── t1.b:2 IS NOT NULL [outer=(2), constraints=(/2: (/NULL - ]; tight)]
+ │         └── c_idx: filters
+ │              └── t1.c:3 > 0 [outer=(3), constraints=(/3: [/1 - ]; tight)]
+ ├── select
+ │    ├── columns: t2.b:7!null
+ │    ├── scan ab [as=t2]
+ │    │    ├── columns: t2.b:7
+ │    │    └── partial index predicates
+ │    │         ├── b_idx: filters
+ │    │         │    └── t2.b:7 IS NOT NULL [outer=(7), constraints=(/7: (/NULL - ]; tight)]
+ │    │         └── c_idx: filters
+ │    │              └── t2.c:8 > 0 [outer=(8), constraints=(/8: [/1 - ]; tight)]
+ │    └── filters
+ │         └── t2.b:7 IS NOT NULL [outer=(7), constraints=(/7: (/NULL - ]; tight)]
+ └── filters
+      └── t1.a:1 = t2.b:7 [outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
+
+# Fully optimizing the query shows that a partial index scan is generated
+# because the null-reject filters imply the partial index predicate.
+opt expect=(RejectNullsUnderJoinRight,GeneratePartialIndexScans)
+SELECT * FROM ab t1 WHERE EXISTS (SELECT * FROM ab t2 WHERE t1.a = t2.b)
+----
+project
+ ├── columns: a:1 b:2 c:3
+ └── inner-join (hash)
+      ├── columns: t1.a:1!null t1.b:2 t1.c:3 t2.b:7!null
+      ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+      ├── fd: (1)==(7), (7)==(1)
+      ├── scan ab [as=t1]
+      │    ├── columns: t1.a:1 t1.b:2 t1.c:3
+      │    └── partial index predicates
+      │         ├── b_idx: filters
+      │         │    └── t1.b:2 IS NOT NULL [outer=(2), constraints=(/2: (/NULL - ]; tight)]
+      │         └── c_idx: filters
+      │              └── t1.c:3 > 0 [outer=(3), constraints=(/3: [/1 - ]; tight)]
+      ├── distinct-on
+      │    ├── columns: t2.b:7!null
+      │    ├── grouping columns: t2.b:7!null
+      │    ├── internal-ordering: +7
+      │    ├── key: (7)
+      │    └── scan ab@b_idx,partial [as=t2]
+      │         ├── columns: t2.b:7!null
+      │         └── ordering: +7
+      └── filters
+           └── t1.a:1 = t2.b:7 [outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
+
+# Reject nulls for a scan with an IS NOT NULL partial index predicate expression
+# on the right side of a anti-join.
+norm expect=RejectNullsUnderJoinRight
+SELECT * FROM ab t1 WHERE NOT EXISTS (SELECT * FROM ab t2 WHERE t1.a = t2.b)
+----
+anti-join (hash)
+ ├── columns: a:1 b:2 c:3
+ ├── scan ab [as=t1]
+ │    ├── columns: t1.a:1 t1.b:2 t1.c:3
+ │    └── partial index predicates
+ │         ├── b_idx: filters
+ │         │    └── t1.b:2 IS NOT NULL [outer=(2), constraints=(/2: (/NULL - ]; tight)]
+ │         └── c_idx: filters
+ │              └── t1.c:3 > 0 [outer=(3), constraints=(/3: [/1 - ]; tight)]
+ ├── select
+ │    ├── columns: t2.b:7!null
+ │    ├── scan ab [as=t2]
+ │    │    ├── columns: t2.b:7
+ │    │    └── partial index predicates
+ │    │         ├── b_idx: filters
+ │    │         │    └── t2.b:7 IS NOT NULL [outer=(7), constraints=(/7: (/NULL - ]; tight)]
+ │    │         └── c_idx: filters
+ │    │              └── t2.c:8 > 0 [outer=(8), constraints=(/8: [/1 - ]; tight)]
+ │    └── filters
+ │         └── t2.b:7 IS NOT NULL [outer=(7), constraints=(/7: (/NULL - ]; tight)]
+ └── filters
+      └── t1.a:1 = t2.b:7 [outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
+
+# Fully optimizing the query shows that a partial index scan is generated
+# because the null-reject filters imply the partial index predicate.
+opt expect=(RejectNullsUnderJoinRight,GeneratePartialIndexScans)
+SELECT * FROM ab t1 WHERE NOT EXISTS (SELECT * FROM ab t2 WHERE t1.a = t2.b)
+----
+anti-join (hash)
+ ├── columns: a:1 b:2 c:3
+ ├── scan ab [as=t1]
+ │    ├── columns: t1.a:1 t1.b:2 t1.c:3
+ │    └── partial index predicates
+ │         ├── b_idx: filters
+ │         │    └── t1.b:2 IS NOT NULL [outer=(2), constraints=(/2: (/NULL - ]; tight)]
+ │         └── c_idx: filters
+ │              └── t1.c:3 > 0 [outer=(3), constraints=(/3: [/1 - ]; tight)]
+ ├── scan ab@b_idx,partial [as=t2]
+ │    └── columns: t2.b:7!null
+ └── filters
+      └── t1.a:1 = t2.b:7 [outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
+
 # ----------------------------------------------------------
 # RejectNullsProject
 # ----------------------------------------------------------


### PR DESCRIPTION
#### opt: use join filters to imply IS NOT NULL partial index predicates

This commit updates the reject null normalization rules so that:

1. `RejectNullsUnderJoinRight` matches `SemiJoin` and `AntiJoin`.
2. A `Scan` with a `col IS NOT NULL` predicate requests null rejection
   of `col`.

In combination, these two changes allow partial indexes with
`IS NOT NULL` predicates to be used in more cases.

As an example, they can be used in JOINs where the ON condition
implicitly implies the predicate:

    CREATE TABLE a (a INT PRIMARY KEY)
    CREATE TABLE b (b INT, INDEX (b) WHERE b IS NOT NULL)

    SELECT * FROM a JOIN b ON a = b

As a another example, partial indexes with `IS NOT NULL` predicates can
be used to satisfy foreign key checks.

    CREATE TABLE parent (id INT PRIMARY KEY)

    CREATE TABLE child (
      id INT PRIMARY KEY,
      p_id INT,
      CONSTRAINT fk FOREIGN KEY (p_id) REFERENCES parent(id),
      INDEX (p_id) WHERE p_id IS NOT NULL
    )

    DELETE FROM p WHERE id = 1

The `DELETE` requires a foreign key check to ensure that no existing
rows in `child` have a matching `p_id`. Prior to this commit, the check
performed a full table scan rather than using the partial index because
its predicate was not implied. By pushing down the null-rejecting filter
derived from the check's `child.p_id = parent.id` filter, the partial
index can be used.

Fixes #57841

Release justification: This improves performance for joins and foreign
key checks on tables with partial indexes. Partial indexes are a new
feature introduced in 20.2.

Release note (performance improvement): Partial indexes with IS NOT NULL
predicates can be used in cases where JOIN filters implicitly imply the
predicate. This results in more efficient query plans for JOINs and
foreign checks.
