### PR TITLE
coldata: generate vec.eg.go within the bazel sandbox

### DIFF
--- a/pkg/col/coldata/BUILD.bazel
+++ b/pkg/col/coldata/BUILD.bazel
@@ -2,8 +2,6 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "coldata",
-    # TODO(irfansharif): The dependency tree for vec.eg.go need fleshing out.
-    # It's generated using execgen+templates, from another package.
     srcs = [
         "batch.go",
         "bytes.go",
@@ -11,8 +9,8 @@ go_library(
         "native_types.go",
         "nulls.go",
         "testutils.go",
-        "vec.eg.go",  # keep
         "vec.go",
+        ":gen-vec",  # keep
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/col/coldata",
     visibility = ["//visibility:public"],
@@ -47,5 +45,20 @@ go_test(
         "//vendor/github.com/cockroachdb/errors",
         "//vendor/github.com/stretchr/testify/assert",
         "//vendor/github.com/stretchr/testify/require",
+    ],
+)
+
+genrule(
+    name = "gen-vec",
+    srcs = ["vec_tmpl.go"],
+    outs = ["vec.eg.go"],
+    cmd = """
+      $(location //pkg/sql/colexec/execgen/cmd/execgen) \
+        -fmt=false pkg/col/coldata/$@ > $@
+      $(location //vendor/github.com/cockroachdb/gostdlib/x/tools/cmd/goimports) -w $@
+    """,
+    tools = [
+        "//pkg/sql/colexec/execgen/cmd/execgen",
+        "//vendor/github.com/cockroachdb/gostdlib/x/tools/cmd/goimports",
     ],
 )

--- a/pkg/col/coldata/vec.eg.go
+++ b/pkg/col/coldata/vec.eg.go
@@ -19,6 +19,14 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
 )
 
+// Workaround for bazel auto-generated code. goimports does not automatically
+// pick up the right packages when run within the bazel sandbox.
+var (
+	_ = typeconv.DatumVecCanonicalTypeFamily
+	_ apd.Context
+	_ duration.Duration
+)
+
 func (m *memColumn) Append(args SliceArgs) {
 	switch m.CanonicalTypeFamily() {
 	case types.BoolFamily:

--- a/pkg/col/coldata/vec_tmpl.go
+++ b/pkg/col/coldata/vec_tmpl.go
@@ -22,8 +22,19 @@ package coldata
 import (
 	"fmt"
 
+	"github.com/cockroachdb/apd/v2"
+	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/duration"
+)
+
+// Workaround for bazel auto-generated code. goimports does not automatically
+// pick up the right packages when run within the bazel sandbox.
+var (
+	_ = typeconv.DatumVecCanonicalTypeFamily
+	_ apd.Context
+	_ duration.Duration
 )
 
 // {{/*


### PR DESCRIPTION
Fixes #57801. We apply the same treatment as 52c5f51.

Release note: None

Co-authored-by: irfan sharif <irfanmahmoudsharif@gmail.com>