### PR TITLE
sql: fix crash when explaining a constrained virtual table scan

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -1431,3 +1431,29 @@ vectorized: true
                       missing stats
                       table: u@primary
                       spans: [/1 - /1]
+
+# Make sure EXPLAIN (VERBOSE) works when there is a constrained scan of a
+# virtual table (#58193).
+statement ok
+CREATE TABLE ab (a INT, b INT)
+
+query T
+EXPLAIN (VERBOSE) SELECT attnum FROM pg_attribute WHERE attrelid = 'ab'::regclass AND attname = 'b';
+----
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (attnum)
+│ estimated row count: 1 (missing stats)
+│
+└── • filter
+    │ columns: (attrelid, attname, attnum)
+    │ estimated row count: 1 (missing stats)
+    │ filter: attname = 'b'
+    │
+    └── • virtual table
+          columns: (attrelid, attname, attnum)
+          estimated row count: 10 (missing stats)
+          table: pg_attribute@pg_attribute_attrelid_idx
+          spans: [/ab - /ab]

--- a/pkg/sql/opt/exec/execbuilder/testdata/scalar
+++ b/pkg/sql/opt/exec/execbuilder/testdata/scalar
@@ -1061,7 +1061,7 @@ vectorized: true
   columns: (attrelid, attname, atttypid, attstattarget, attlen, attnum, attndims, attcacheoff, atttypmod, attbyval, attstorage, attalign, attnotnull, atthasdef, attidentity, attgenerated, attisdropped, attislocal, attinhcount, attcollation, attacl, attoptions, attfdwoptions)
   estimated row count: 10 (missing stats)
   table: pg_attribute@pg_attribute_attrelid_idx
-  spans: /53-/54
+  spans: [/t - /t]
 
 query T
 EXPLAIN (VERBOSE) SELECT CASE WHEN current_database() = 'test' THEN 42 ELSE 1/3 END

--- a/pkg/sql/opt/exec/explain/emit.go
+++ b/pkg/sql/opt/exec/explain/emit.go
@@ -116,8 +116,9 @@ func Emit(plan *Plan, ob *OutputBuilder, spanFormatFn SpanFormatFn) error {
 	return nil
 }
 
-// SpanFormatFn is a function used to format spans for EXPLAIN. Only called when
-// there is an index constraint or an inverted constraint.
+// SpanFormatFn is a function used to format spans for EXPLAIN. Only called on
+// non-virtual tables, when there is an index constraint or an inverted
+// constraint.
 type SpanFormatFn func(table cat.Table, index cat.Index, scanParams exec.ScanParams) string
 
 // omitTrivialProjections returns the given node and its result columns and
@@ -723,8 +724,8 @@ func (e *emitter) spansStr(table cat.Table, index cat.Index, scanParams exec.Sca
 		return "FULL SCAN"
 	}
 
-	// In verbose mode show the physical spans.
-	if e.ob.flags.Verbose {
+	// In verbose mode show the physical spans, unless the table is virtual.
+	if e.ob.flags.Verbose && !table.IsVirtualTable() {
 		return e.spanFormatFn(table, index, scanParams)
 	}
 

--- a/pkg/sql/rowenc/index_encoding.go
+++ b/pkg/sql/rowenc/index_encoding.go
@@ -358,7 +358,7 @@ func NeededColumnFamilyIDs(
 		return nil
 	})
 	if family0 == nil {
-		panic("column family 0 not found")
+		panic(errors.AssertionFailedf("column family 0 not found"))
 	}
 
 	// If all the needed families are nullable, we also need family 0 as a
@@ -1367,11 +1367,11 @@ func EncodeSecondaryIndexes(
 	indexBoundAccount mon.BoundAccount,
 ) ([]IndexEntry, error) {
 	if len(secondaryIndexEntries) > 0 {
-		panic("Length of secondaryIndexEntries was non-zero")
+		panic(errors.AssertionFailedf("length of secondaryIndexEntries was non-zero"))
 	}
 
 	if indexBoundAccount.Monitor() == nil {
-		panic("Memory monitor passed to EncodeSecondaryIndexes was nil")
+		panic(errors.AssertionFailedf("memory monitor passed to EncodeSecondaryIndexes was nil"))
 	}
 	const sizeOfIndexEntry = int64(unsafe.Sizeof(IndexEntry{}))
 


### PR DESCRIPTION
When emitting `EXPLAIN (VERBOSE)` output, we use a callback to
generate and format the physical spans; this callback currently
crashes for virtual tables.

Note that this code path is used when collecting statement
diagnostics, which can lead to a severe situation.

The fix is to always show the logical spans and use the callback only
for physical tables.

In addition, we add logic to catch panics inside emitExplain;
unfortunately, it would not have helped here because the panic object
was a bare string (and not an assertion error).

Fixes #58193.

Release note (bug fix): fixed a "column family 0 not found" crash
caused by explaining or gathering statement diagnostics on certain
queries involving virtual tables.