### PR TITLE
release-20.2: sql: safeguard against nil fetcher in GetBytesRead

### DIFF
--- a/pkg/sql/row/kv_fetcher.go
+++ b/pkg/sql/row/kv_fetcher.go
@@ -61,6 +61,9 @@ func newKVFetcher(batchFetcher kvBatchFetcher) *KVFetcher {
 
 // GetBytesRead returns the number of bytes read by this fetcher.
 func (f *KVFetcher) GetBytesRead() int64 {
+	if f == nil {
+		return 0
+	}
 	return f.bytesRead
 }
 


### PR DESCRIPTION
This crash can happen if a scan is finished early; I ran into it while
running logic tests with statement diagnostics enabled on all queries.

Note that this safeguard already exists on master.

Release note (bug fix): fixed a potential "nil pointer dereference"
panic when collecting diagnostics on certain queries.

/cc @cockroachdb/release