### PR TITLE
release-20.1: sql: make information_schema.statistics deterministic

### DIFF
--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -1165,13 +1165,23 @@ CREATE TABLE information_schema.statistics (
 						sequence++
 						delete(implicitCols, col)
 					}
-					for col := range implicitCols {
-						// We add a row for each implicit column of index.
-						if err := appendRow(index, col, sequence,
-							indexDirectionAsc, false, true); err != nil {
-							return err
+					if len(implicitCols) > 0 {
+						// In order to have the implicit columns reported in a
+						// deterministic order, we will add all of them in the
+						// same order as they are mentioned in the primary key.
+						//
+						// Note that simply iterating over implicitCols map
+						// produces non-deterministic output.
+						for _, col := range table.GetPrimaryIndex().ColumnNames {
+							if _, isImplicit := implicitCols[col]; isImplicit {
+								// We add a row for each implicit column of index.
+								if err := appendRow(index, col, sequence,
+									indexDirectionAsc, false, true); err != nil {
+									return err
+								}
+								sequence++
+							}
 						}
-						sequence++
 					}
 					return nil
 				})

--- a/pkg/sql/logictest/testdata/logic_test/show_indexes
+++ b/pkg/sql/logictest/testdata/logic_test/show_indexes
@@ -1,0 +1,62 @@
+statement ok
+CREATE TABLE t1 (
+  a INT,
+  b INT,
+  c INT,
+  d INT,
+  PRIMARY KEY (a, b),
+  INDEX c_idx (c ASC),
+  UNIQUE INDEX d_b_idx (d ASC, b ASC)
+)
+
+query TTBITTBB rowsort,colnames
+SHOW INDEXES from t1
+----
+table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit
+t1          c_idx       true        1             c            ASC        false    false
+t1          c_idx       true        2             a            ASC        false    true
+t1          c_idx       true        3             b            ASC        false    true
+t1          d_b_idx     false       1             d            ASC        false    false
+t1          d_b_idx     false       2             b            ASC        false    false
+t1          d_b_idx     false       3             a            ASC        false    true
+t1          primary     false       1             a            ASC        false    false
+t1          primary     false       2             b            ASC        false    false
+
+statement ok
+CREATE TABLE t2 (
+  a INT,
+  b INT,
+  c INT,
+  d INT,
+  e INT,
+  PRIMARY KEY (c, b, a),
+  INDEX a_e_c_idx (a ASC, e ASC, c ASC),
+  UNIQUE INDEX b_d_idx (b ASC, d ASC),
+  UNIQUE INDEX c_e_d_a_idx (c ASC, e ASC, d ASC, a ASC),
+  INDEX d_idx (d ASC)
+)
+
+query TTBITTBB rowsort,colnames
+SHOW INDEXES from t2
+----
+table_name  index_name   non_unique  seq_in_index  column_name  direction  storing  implicit
+t2          a_e_c_idx    true        1             a            ASC        false    false
+t2          a_e_c_idx    true        2             e            ASC        false    false
+t2          a_e_c_idx    true        3             c            ASC        false    false
+t2          a_e_c_idx    true        4             b            ASC        false    true
+t2          b_d_idx      false       1             b            ASC        false    false
+t2          b_d_idx      false       2             d            ASC        false    false
+t2          b_d_idx      false       3             c            ASC        false    true
+t2          b_d_idx      false       4             a            ASC        false    true
+t2          c_e_d_a_idx  false       1             c            ASC        false    false
+t2          c_e_d_a_idx  false       2             e            ASC        false    false
+t2          c_e_d_a_idx  false       3             d            ASC        false    false
+t2          c_e_d_a_idx  false       4             a            ASC        false    false
+t2          c_e_d_a_idx  false       5             b            ASC        false    true
+t2          d_idx        true        1             d            ASC        false    false
+t2          d_idx        true        2             c            ASC        false    true
+t2          d_idx        true        3             b            ASC        false    true
+t2          d_idx        true        4             a            ASC        false    true
+t2          primary      false       1             c            ASC        false    false
+t2          primary      false       2             b            ASC        false    false
+t2          primary      false       3             a            ASC        false    false


### PR DESCRIPTION
Backport 1/1 commits from #58191.

/cc @cockroachdb/release

---

Previously, "implicit" columns could be added to the
`information_schema.statistics` virtual table in an arbitray order since
we were iterating over a map when adding them. This is unfortunate since
some schema inspection tools might rely on the output being
deterministic.

Release note (bug fix): Previously, CockroachDB could return
non-deterministic output when querying `information_schema.statistics`
virtual table (internally used by `SHOW INDEXES` command) - namely, the
implicit columns of the secondary indexes could be in arbitrary order.
This is now fixed, and the columns will be in the same order as they are
in the primary index.
