### PR TITLE
sql: check for nil memo expression when generating bundle plans

### DIFF
--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -465,14 +465,6 @@ func (p *planTop) savePlanInfo(ctx context.Context) {
 	p.instrumentation.RecordPlanInfo(distribution, vectorized)
 }
 
-// formatOptPlan returns a visual representation of the optimizer plan that was
-// used.
-func (p *planTop) formatOptPlan(flags memo.ExprFmtFlags) string {
-	f := memo.MakeExprFmtCtx(flags, p.mem, p.catalog)
-	f.FormatExpr(p.mem.RootExpr())
-	return f.Buffer.String()
-}
-
 // startExec calls startExec() on each planNode using a depth-first, post-order
 // traversal.  The subqueries, if any, are also started.
 //


### PR DESCRIPTION
I encountered a rare error case where we have a memo but the root
expression is not set, which led to a crash if statements diagnostics
were active.

I ran into it with some changes related to statement diagnostics; the
statement was 'PREPARE fail AS SELECT array_length($1, 1)`. I was not
able to reproduce on a clean tree (I tried a few things, including a
statement diagnostics test where the exact fingerprint was inserted in
the diagnostics table).

Release note: None