### PR TITLE
release-20.2: sql: check for nil memo expression when generating bundle plans

### DIFF
--- a/pkg/sql/explain_bundle.go
+++ b/pkg/sql/explain_bundle.go
@@ -241,16 +241,22 @@ func (b *stmtBundleBuilder) addStatement() {
 // addOptPlans adds the EXPLAIN (OPT) variants as files opt.txt, opt-v.txt,
 // opt-vv.txt.
 func (b *stmtBundleBuilder) addOptPlans() {
-	if b.plan.mem == nil {
+	if b.plan.mem == nil || b.plan.mem.RootExpr() == nil {
 		// No optimizer plans; an error must have occurred during planning.
 		return
 	}
 
-	b.z.AddFile("opt.txt", b.plan.formatOptPlan(memo.ExprFmtHideAll))
-	b.z.AddFile("opt-v.txt", b.plan.formatOptPlan(
+	formatOptPlan := func(flags memo.ExprFmtFlags) string {
+		f := memo.MakeExprFmtCtx(flags, b.plan.mem, b.plan.catalog)
+		f.FormatExpr(b.plan.mem.RootExpr())
+		return f.Buffer.String()
+	}
+
+	b.z.AddFile("opt.txt", formatOptPlan(memo.ExprFmtHideAll))
+	b.z.AddFile("opt-v.txt", formatOptPlan(
 		memo.ExprFmtHideQualifications|memo.ExprFmtHideScalars|memo.ExprFmtHideTypes,
 	))
-	b.z.AddFile("opt-vv.txt", b.plan.formatOptPlan(memo.ExprFmtHideQualifications))
+	b.z.AddFile("opt-vv.txt", formatOptPlan(memo.ExprFmtHideQualifications))
 }
 
 // addExecPlan adds the EXPLAIN (VERBOSE) plan as file plan.txt.

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -475,14 +475,6 @@ func (p *planTop) savePlanInfo(ctx context.Context) {
 	}
 }
 
-// formatOptPlan returns a visual representation of the optimizer plan that was
-// used.
-func (p *planTop) formatOptPlan(flags memo.ExprFmtFlags) string {
-	f := memo.MakeExprFmtCtx(flags, p.mem, p.catalog)
-	f.FormatExpr(p.mem.RootExpr())
-	return f.Buffer.String()
-}
-
 // startExec calls startExec() on each planNode using a depth-first, post-order
 // traversal.  The subqueries, if any, are also started.
 //


### PR DESCRIPTION
Backport 1/1 commits from #58225.

/cc @cockroachdb/release

---

I encountered a rare error case where we have a memo but the root
expression is not set, which led to a crash if statements diagnostics
were active.

I ran into it with some changes related to statement diagnostics; the
statement was 'PREPARE fail AS SELECT array_length($1, 1)`. I was not
able to reproduce on a clean tree (I tried a few things, including a
statement diagnostics test where the exact fingerprint was inserted in
the diagnostics table).

Release note: None
