### PR TITLE
importccl: Fixed COPY FROM STDIN compatibility for IMPORT pgdump array data

### DIFF
--- a/pkg/sql/sem/tree/parse_string.go
+++ b/pkg/sql/sem/tree/parse_string.go
@@ -16,7 +16,7 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-// ParseAndRequireString parses s as type t for simple types. Arrays and collated
+// ParseAndRequireString parses s as type t for simple types. Collated
 // strings are not handled.
 //
 // The dependsOnContext return value indicates if we had to consult the


### PR DESCRIPTION
Previously, when users imported pgdumps that contained
populated tables with array (ex. text[]) column types,
a parsing error would occur when data was populated with
COPY FROM STDIN.

We currently support INSERTing array data using the ARRAY
function or casting it from a string when the
data is enclosed in single quotes (ex. '{3,4}').

Now, we can IMPORT pgdump a file that COPY FROM STDIN
array data (Note that the PGdumped array will
be formatted with curly braces without quotes ({3,4}).

Release note: bug fix
Parsing errors are no longer thrown when importing a pgdump file
with array data.

Fixes: #29043 , #56593