### PR TITLE
roachtest: improve sqlsmith

### DIFF
--- a/pkg/cmd/roachtest/sqlsmith.go
+++ b/pkg/cmd/roachtest/sqlsmith.go
@@ -191,7 +191,9 @@ func registerSQLSmith(r *testRegistry) {
 			}()
 			if err != nil {
 				es := err.Error()
-				if strings.Contains(es, "internal error") {
+				// TODO(yuzefovich): we temporarily ignore internal errors that
+				// are because of #39433.
+				if strings.Contains(es, "internal error") && !strings.Contains(es, "internal error: invalid index") {
 					logStmt(stmt)
 					t.Fatalf("error: %s\nstmt:\n%s;", err, stmt)
 				} else if strings.Contains(es, "communication error") {


### PR DESCRIPTION
**roachtest: delay panic injection in sqlsmith**

We need to delay the panic injection until after the smither is created
because some queries are run during its instantiation.

Fixes: #58235.

Release note: None

**roachtest: ignore a known issue in sqlsmith**

This commit temporarily skips failing `sqlsmith` roachtest on `internal
error: invalid index` errors which are due to issues with subqueries
(#39433) in order to reduce the noise.

Release note: None