### PR TITLE
backupccl: cleanup extraneous error check

### DIFF
--- a/pkg/ccl/backupccl/manifest_handling.go
+++ b/pkg/ccl/backupccl/manifest_handling.go
@@ -670,9 +670,6 @@ func resolveBackupManifests(
 				}
 			}
 		}
-		if err != nil {
-			return nil, nil, nil, err
-		}
 	} else {
 		// Since incremental layers were *not* explicitly specified, search for any
 		// automatically created incremental layers inside the base layer.


### PR DESCRIPTION
This error check would always return false, so it wasn't needed

Release note: None