### PR TITLE
sql: fix a panic when showing statistics on a table with enums

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -1007,3 +1007,45 @@ FROM [SHOW STATISTICS USING JSON FOR TABLE all_null]
 
 statement ok
 SELECT * FROM all_null WHERE c IS NOT NULL
+
+# Regression for 58220.
+statement ok
+CREATE TYPE greeting AS ENUM ('hello', 'howdy', 'hi');
+CREATE TABLE greeting_stats (x greeting PRIMARY KEY);
+INSERT INTO greeting_stats VALUES ('hi');
+CREATE STATISTICS s FROM greeting_stats
+
+query T
+SELECT jsonb_pretty(COALESCE(json_agg(stat), '[]'))
+  FROM (
+SELECT json_array_elements(statistics) - 'created_at' AS stat
+FROM [SHOW STATISTICS USING JSON FOR TABLE greeting_stats]
+)
+----
+[
+    {
+        "columns": [
+            "x"
+        ],
+        "distinct_count": 1,
+        "histo_buckets": [
+            {
+                "distinct_range": 0,
+                "num_eq": 1,
+                "num_range": 0,
+                "upper_bound": "hi"
+            }
+        ],
+        "histo_col_type": "public.greeting",
+        "name": "s",
+        "null_count": 0,
+        "row_count": 1
+    }
+]
+
+# Check that we can inject the statistics back into the table as well.
+let $stats
+SHOW STATISTICS USING JSON FOR TABLE greeting_stats
+
+statement ok
+ALTER TABLE greeting_stats INJECT STATISTICS '$stats'

--- a/pkg/sql/show_stats.go
+++ b/pkg/sql/show_stats.go
@@ -112,7 +112,7 @@ func (p *planner) ShowTableStats(ctx context.Context, n *tree.ShowTableStats) (p
 					for j, d := range colIDs {
 						result[i].Columns[j] = statColumnString(desc, d)
 					}
-					if err := result[i].DecodeAndSetHistogram(r[histogramIdx]); err != nil {
+					if err := result[i].DecodeAndSetHistogram(ctx, &p.semaCtx, r[histogramIdx]); err != nil {
 						v.Close(ctx)
 						return nil, err
 					}

--- a/pkg/sql/stats/json.go
+++ b/pkg/sql/stats/json.go
@@ -11,6 +11,7 @@
 package stats
 
 import (
+	"context"
 	fmt "fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
@@ -19,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/errors"
 )
 
 // JSONStatistic is a struct used for JSON marshaling and unmarshaling statistics.
@@ -80,7 +82,9 @@ func (js *JSONStatistic) SetHistogram(h *HistogramData) error {
 
 // DecodeAndSetHistogram decodes a histogram marshaled as a Bytes datum and
 // fills in the HistogramColumnType and HistogramBuckets fields.
-func (js *JSONStatistic) DecodeAndSetHistogram(datum tree.Datum) error {
+func (js *JSONStatistic) DecodeAndSetHistogram(
+	ctx context.Context, semaCtx *tree.SemaContext, datum tree.Datum,
+) error {
 	if datum == tree.DNull {
 		return nil
 	}
@@ -94,6 +98,19 @@ func (js *JSONStatistic) DecodeAndSetHistogram(datum tree.Datum) error {
 	h := &HistogramData{}
 	if err := protoutil.Unmarshal([]byte(*datum.(*tree.DBytes)), h); err != nil {
 		return err
+	}
+	// If the serialized column type is user defined, then it needs to be
+	// hydrated before use.
+	if h.ColumnType.UserDefined() {
+		resolver := semaCtx.GetTypeResolver()
+		if resolver == nil {
+			return errors.AssertionFailedf("attempt to resolve user defined type with nil TypeResolver")
+		}
+		typ, err := resolver.ResolveTypeByOID(ctx, h.ColumnType.Oid())
+		if err != nil {
+			return err
+		}
+		h.ColumnType = typ
 	}
 	return js.SetHistogram(h)
 }


### PR DESCRIPTION
Fixes #58220.

The panic was caused by using a user defined type without hydration of
type metadata.

Release note (bug fix): Fix a internal panic when using the `SHOW
STATISTICS USING JSON` statement on a table containing ENUM types.