### PR TITLE
sql: Fix privilege checks to consider direct/indirect roles

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1057,6 +1057,14 @@ func golangFillQueryArguments(args ...interface{}) (tree.Datums, error) {
 				switch {
 				case val.IsNil():
 					d = tree.DNull
+				case val.Type().Elem().Kind() == reflect.String:
+					a := tree.NewDArray(types.String)
+					for v := 0; v < val.Len(); v++ {
+						if err := a.Append(tree.NewDString(val.Index(v).String())); err != nil {
+							return nil, err
+						}
+					}
+					d = a
 				case val.Type().Elem().Kind() == reflect.Uint8:
 					d = tree.NewDBytes(tree.DBytes(val.Bytes()))
 				}

--- a/pkg/sql/faketreeeval/BUILD.bazel
+++ b/pkg/sql/faketreeeval/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/faketreeeval",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/security",
         "//pkg/sql/parser",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -14,6 +14,7 @@ package faketreeeval
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -120,6 +121,13 @@ func (ep *DummyEvalPlanner) CompactEngineSpan(
 	ctx context.Context, nodeID int32, storeID int32, startKey []byte, endKey []byte,
 ) error {
 	return errors.WithStack(errEvalPlanner)
+}
+
+// MemberOfWithAdminOption is part of the EvalPlanner interface.
+func (ep *DummyEvalPlanner) MemberOfWithAdminOption(
+	ctx context.Context, member security.SQLUsername,
+) (map[security.SQLUsername]bool, error) {
+	return nil, errors.WithStack(errEvalPlanner)
 }
 
 var _ tree.EvalPlanner = &DummyEvalPlanner{}

--- a/pkg/sql/logictest/testdata/logic_test/privilege_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/privilege_builtins
@@ -1056,3 +1056,76 @@ query B
 SELECT has_column_privilege('hcp_test'::REGCLASS, 4, 'SELECT')
 ----
 true
+
+# Regression test for #58254. Tests privilege inheritance for roles (direct and indirect).
+
+user root
+
+statement ok
+DROP DATABASE IF EXISTS my_db;
+CREATE DATABASE my_db;
+
+statement ok
+CREATE ROLE my_role;
+
+statement ok
+GRANT CREATE ON DATABASE my_db TO my_role;
+GRANT my_role TO testuser;
+
+user testuser
+
+statement ok
+use my_db
+
+statement ok
+CREATE SCHEMA s;
+CREATE TABLE s.t()
+
+# Privilege check on direct member of role with CREATE privilege granted.
+query B
+SELECT has_schema_privilege('testuser', 's', 'create')
+----
+true
+
+# Privilege check on direct member of role without USAGE privilege granted.
+query B
+SELECT has_schema_privilege('testuser', 's', 'usage')
+----
+false
+
+# Confirm privilege checks on all objects.
+query BBB
+SELECT has_database_privilege('testuser', 'my_db', 'create'),
+       has_schema_privilege('testuser', 'public', 'usage'),
+       has_table_privilege('testuser', 's.t', 'select')
+----
+true false false
+
+user root
+
+statement ok
+CREATE USER testuser2;
+GRANT testuser TO testuser2;
+GRANT ALL ON SCHEMA my_db.s TO testuser2
+
+user testuser2
+
+statement ok
+use my_db
+
+# Make sure testuser only has CREATE privilege on schema s but testuser2 has both CREATE and USAGE.
+query BBBB
+SELECT has_schema_privilege('testuser', 's', 'create'),
+       has_schema_privilege('testuser', 's', 'usage'),
+       has_schema_privilege('testuser2', 's', 'create'),
+       has_schema_privilege('testuser2', 's', 'usage')
+----
+true false true true
+
+# Confirm privilege checks on all objects with testuser2, should match testuser.
+query BBB
+SELECT has_database_privilege('testuser2', 'my_db', 'create'),
+       has_schema_privilege('testuser2', 'public', 'usage'),
+       has_table_privilege('testuser2', 's.t', 'select')
+----
+true false false

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -531,13 +531,25 @@ func evalPrivilegeCheck(
 	if withGrantOpt {
 		privChecks = append(privChecks, privilege.GRANT)
 	}
+
+	allRoleMemberships, err := ctx.Planner.MemberOfWithAdminOption(ctx.Context, user)
+	if err != nil {
+		return nil, err
+	}
+
+	// Slice containing all roles user is a direct and indirect member of.
+	allRoles := []string{security.PublicRole, user.Normalized()}
+	for role := range allRoleMemberships {
+		allRoles = append(allRoles, role.Normalized())
+	}
+
 	for _, p := range privChecks {
 		query := fmt.Sprintf(`
 			SELECT bool_or(privilege_type IN ('%s', '%s')) IS TRUE
-			FROM information_schema.%s WHERE grantee IN ($1, $2) AND %s`,
+			FROM information_schema.%s WHERE grantee = ANY ($1) AND %s`,
 			privilege.ALL, p, infoTable, pred)
 		r, err := ctx.InternalExecutor.QueryRow(
-			ctx.Ctx(), "eval-privilege-check", ctx.Txn, query, security.PublicRole, user.Normalized(),
+			ctx.Ctx(), "eval-privilege-check", ctx.Txn, query, allRoles,
 		)
 		if err != nil {
 			return nil, err

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -3072,6 +3073,14 @@ type EvalPlanner interface {
 	CompactEngineSpan(
 		ctx context.Context, nodeID int32, storeID int32, startKey []byte, endKey []byte,
 	) error
+
+	// MemberOfWithAdminOption is used to collect a list of roles (direct and
+	// indirect) that the member is part of. See the comment on the planner
+	// implementation in authorization.go
+	MemberOfWithAdminOption(
+		ctx context.Context,
+		member security.SQLUsername,
+	) (map[security.SQLUsername]bool, error)
 }
 
 // EvalSessionAccessor is a limited interface to access session variables.


### PR DESCRIPTION
Resolves #57621 

Previously, privilege inquiry functions  only looked for whether
the user passed in in the first argument or current user had
privileges on schemas, databases, tables, etc. with the built-ins
such as `has_schema_privileges`, which was incorrect. This change
makes sure that all roles the user is a direct or indirect member
of are checked for privileges as well.

Release note (bug fix): The has_${OBJECT}_privilege built-in methods
such as `has_schema_privilege` now additionally checks whether roles
the user is a direct or indirect member of also have privileges on
the object. Previously only one user was checked which was incorrect.
This bug has been present since version 2.0 but became more
prominent as of v20.2 when role-based access control was included in
CockroachDB Core.