### PR TITLE
sql: ensure event log entries for ALTER/DROP TYPE are fully qualified

### DIFF
--- a/pkg/sql/alter_type.go
+++ b/pkg/sql/alter_type.go
@@ -85,6 +85,7 @@ func (p *planner) AlterType(ctx context.Context, n *tree.AlterType) (planNode, e
 func (n *alterTypeNode) startExec(params runParams) error {
 	telemetry.Inc(n.n.Cmd.TelemetryCounter())
 
+	typeName := tree.AsStringWithFQNames(n.n.Type, params.p.Ann())
 	eventLogDone := false
 	var err error
 	switch t := n.n.Cmd.(type) {
@@ -97,9 +98,7 @@ func (n *alterTypeNode) startExec(params runParams) error {
 			return err
 		}
 		err = params.p.logEvent(params.ctx, n.desc.ID, &eventpb.RenameType{
-			// TODO(knz): This name is insufficiently qualified.
-			// See: https://github.com/cockroachdb/cockroach/issues/57734
-			TypeName:    n.desc.Name,
+			TypeName:    typeName,
 			NewTypeName: string(t.NewName),
 		})
 		eventLogDone = true
@@ -130,7 +129,7 @@ func (n *alterTypeNode) startExec(params runParams) error {
 		if err := params.p.logEvent(params.ctx,
 			n.desc.ID,
 			&eventpb.AlterType{
-				TypeName: n.desc.Name,
+				TypeName: typeName,
 			}); err != nil {
 			return err
 		}

--- a/pkg/sql/logictest/testdata/logic_test/event_log
+++ b/pkg/sql/logictest/testdata/logic_test/event_log
@@ -854,3 +854,58 @@ statement ok
 DROP DATABASE atest CASCADE;
  DROP USER v;
  DROP USER u
+
+# Regression for #57734. Ensure that type names are fully qualified in the
+# event log.
+subtest regression_57734
+
+statement ok
+CREATE TYPE eventlog AS ENUM ('event', 'log')
+
+query ITT
+SELECT "reportingID", "eventType", info::JSONB - 'Timestamp' - 'DescriptorID'
+  FROM system.eventlog
+ WHERE "eventType" = 'create_type' AND info::JSONB->>'TypeName' LIKE '%eventlog'
+ORDER BY "timestamp", info
+----
+1  create_type  {"EventType": "create_type", "Statement": "CREATE TYPE defaultdb.public.eventlog AS ENUM ('event', 'log')", "TypeName": "defaultdb.public.eventlog", "User": "root"}
+
+statement ok
+ALTER TYPE eventlog ADD VALUE 'test'
+
+statement ok
+ALTER TYPE eventlog RENAME VALUE 'test' TO 'testing'
+
+statement ok
+CREATE SCHEMA testing
+
+statement ok
+ALTER TYPE eventlog SET SCHEMA testing;
+ALTER TYPE testing.eventlog SET SCHEMA public
+
+statement ok
+ALTER TYPE eventlog RENAME TO eventlog_renamed
+
+query ITT
+SELECT "reportingID", "eventType", info::JSONB - 'Timestamp' - 'DescriptorID'
+  FROM system.eventlog
+ WHERE ("eventType" = 'alter_type' OR "eventType" = 'rename_type') AND info::JSONB->>'TypeName' LIKE '%eventlog%'
+ORDER BY "timestamp", info
+----
+1  alter_type   {"EventType": "alter_type", "Statement": "ALTER TYPE defaultdb.public.eventlog ADD VALUE 'test'", "TypeName": "defaultdb.public.eventlog", "User": "root"}
+1  alter_type   {"EventType": "alter_type", "Statement": "ALTER TYPE defaultdb.public.eventlog RENAME VALUE 'test' TO 'testing'", "TypeName": "defaultdb.public.eventlog", "User": "root"}
+1  alter_type   {"EventType": "alter_type", "Statement": "ALTER TYPE defaultdb.public.eventlog SET SCHEMA testing", "TypeName": "defaultdb.public.eventlog", "User": "root"}
+1  alter_type   {"EventType": "alter_type", "Statement": "ALTER TYPE defaultdb.testing.eventlog SET SCHEMA public", "TypeName": "defaultdb.testing.eventlog", "User": "root"}
+1  rename_type  {"EventType": "rename_type", "NewTypeName": "eventlog_renamed", "Statement": "ALTER TYPE defaultdb.public.eventlog RENAME TO eventlog_renamed", "TypeName": "defaultdb.public.eventlog", "User": "root"}
+
+statement ok
+DROP TYPE eventlog_renamed
+
+query ITT
+SELECT "reportingID", "eventType", info::JSONB - 'Timestamp' - 'DescriptorID'
+  FROM system.eventlog
+ WHERE "eventType" = 'drop_type' AND info::JSONB->>'TypeName' LIKE '%eventlog%'
+ORDER BY "timestamp", info
+----
+1  drop_type  {"EventType": "drop_type", "Statement": "DROP TYPE defaultdb.public.eventlog_renamed", "TypeName": "defaultdb.public.eventlog_renamed", "User": "root"}
+1  drop_type  {"EventType": "drop_type", "Statement": "DROP TYPE defaultdb.public.eventlog_renamed", "TypeName": "defaultdb.public._eventlog_renamed", "User": "root"}


### PR DESCRIPTION
Fixes #57734.

Release note (bug fix): Fully qualified names in the `TypeName` field of
the event log for `ALTER TYPE` and `DROP TYPE` statements.