### PR TITLE
release-20.2: storageccl: tolerate rewriting span keys ending in interleaved sentinel

### DIFF
--- a/pkg/ccl/storageccl/key_rewriter.go
+++ b/pkg/ccl/storageccl/key_rewriter.go
@@ -223,6 +223,11 @@ func (kr *KeyRewriter) RewriteKey(key []byte, isFromSpan bool) ([]byte, bool, er
 	if !ok {
 		return key, true, nil
 	}
+	if len(k) == 0 {
+		// We have seen some span keys end in an interleaved sentinel.
+		// Check if we ran out of key before getting to an interleave child?
+		return key, true, nil
+	}
 	prefix := key[:len(key)-len(k)]
 	k, ok, err = kr.RewriteKey(k, isFromSpan)
 	if err != nil {


### PR DESCRIPTION
Backport 1/1 commits from #58219.

/cc @cockroachdb/release

---

Some index span keys have been observed to end with the interleaved
sentinel value. It is not yet clear how these types of keys are created
but from the perspective of the key-rewriter it has rewritten the key.

Fixes https://github.com/cockroachdb/cockroach/issues/58080.

Release note (sql change): Fix a bug in RESTORE where some unusual range
boundaries in interleaved tables caused an error.
