### PR TITLE
sql: fix substring(byte[]) to treat input as raw bytes without escaping

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -333,6 +333,21 @@ SELECT
 ----
 ff0001  ff  ff0001  0001  ·
 
+query TTTTTTTTTT
+SELECT
+  encode(substring(decode('5c0001', 'hex'), 1), 'hex'),
+  encode(substring(decode('aa5c0001', 'hex'), 1), 'hex'),
+  encode(substring(decode('aa5c0001', 'hex'), 2), 'hex'),
+  encode(substring(decode('aa5c1a1a1a1a0001', 'hex'), 2), 'hex'),
+  encode(substring(decode('5c0001', 'hex'), 1, 1), 'hex'),
+  encode(substring(decode('aa5c0001', 'hex'), 1, 2), 'hex'),
+  encode(substring(decode('aa5c0001', 'hex'), 2, 2), 'hex'),
+  encode(substring(decode('aa5c1a1a1a1a0001', 'hex'), 2, 2), 'hex'),
+  encode(substring(decode('5c0001', 'hex'), 1), 'escape'),
+  encode(substring(decode('aa5c0001', 'hex'), 2, 1), 'escape')
+----
+5c0001  aa5c0001  5c0001  5c1a1a1a1a0001  5c  aa5c  5c00  5c1a  \\\000\001  \\
+
 query error unknown signature: concat_ws\(\)
 SELECT concat_ws()
 

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -323,6 +323,16 @@ abc abc abc
 query error substring\(\): negative byte subarray length -1 not allowed
 SELECT substring('11100011'::bytea, 4, -1)
 
+query TTTTT
+SELECT
+  encode(substring(decode('ff0001', 'hex'), 1), 'hex'),
+  encode(substring(decode('ff0001', 'hex'), 1, 1), 'hex'),
+  encode(substring(decode('ff0001', 'hex'), 1, 7), 'hex'),
+  encode(substring(decode('ff0001', 'hex'), 2), 'hex'),
+  encode(substring(decode('ff0001', 'hex'), 4), 'hex')
+----
+ff0001  ff  ff0001  0001  ·
+
 query error unknown signature: concat_ws\(\)
 SELECT concat_ws()
 

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -4825,7 +4825,7 @@ var substringImpls = makeBuiltin(tree.FunctionProperties{Category: categoryStrin
 		Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
 			byteString := string(*args[0].(*tree.DBytes))
 			start := int(tree.MustBeDInt(args[1]))
-			substring := getSubstringFromIndex(byteString, start)
+			substring := getSubstringFromIndexBytes(byteString, start)
 			return tree.ParseDByte(substring)
 		},
 		Info:       "Returns a byte subarray of `input` starting at `start_pos` (count starts at 1).",
@@ -4843,7 +4843,7 @@ var substringImpls = makeBuiltin(tree.FunctionProperties{Category: categoryStrin
 			start := int(tree.MustBeDInt(args[1]))
 			length := int(tree.MustBeDInt(args[2]))
 
-			substring, err := getSubstringFromIndexOfLength(byteString, "byte subarray", start, length)
+			substring, err := getSubstringFromIndexOfLengthBytes(byteString, "byte subarray", start, length)
 			if err != nil {
 				return nil, err
 			}
@@ -4870,7 +4870,7 @@ func getSubstringFromIndex(str string, start int) string {
 }
 
 // Returns a substring of given string starting at given position and
-// include upto certain length.
+// include up to a certain length.
 func getSubstringFromIndexOfLength(str, errMsg string, start, length int) (string, error) {
 	runes := []rune(str)
 	// SQL strings are 1-indexed.
@@ -4897,6 +4897,51 @@ func getSubstringFromIndexOfLength(str, errMsg string, start, length int) (strin
 		start = len(runes)
 	}
 	return string(runes[start:end]), nil
+}
+
+// Returns a substring of given string starting at given position by
+// interpreting the string as raw bytes.
+func getSubstringFromIndexBytes(str string, start int) string {
+	bytes := []byte(str)
+	// SQL strings are 1-indexed.
+	start--
+
+	if start < 0 {
+		start = 0
+	} else if start > len(bytes) {
+		start = len(bytes)
+	}
+	return string(bytes[start:])
+}
+
+// Returns a substring of given string starting at given position and include up
+// to a certain length by interpreting the string as raw bytes.
+func getSubstringFromIndexOfLengthBytes(str, errMsg string, start, length int) (string, error) {
+	bytes := []byte(str)
+	// SQL strings are 1-indexed.
+	start--
+
+	if length < 0 {
+		return "", pgerror.Newf(
+			pgcode.InvalidParameterValue, "negative %s length %d not allowed", errMsg, length)
+	}
+
+	end := start + length
+	// Check for integer overflow.
+	if end < start {
+		end = len(bytes)
+	} else if end < 0 {
+		end = 0
+	} else if end > len(bytes) {
+		end = len(bytes)
+	}
+
+	if start < 0 {
+		start = 0
+	} else if start > len(bytes) {
+		start = len(bytes)
+	}
+	return string(bytes[start:end]), nil
 }
 
 var generateRandomUUIDImpl = makeBuiltin(

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -4826,7 +4826,7 @@ var substringImpls = makeBuiltin(tree.FunctionProperties{Category: categoryStrin
 			byteString := string(*args[0].(*tree.DBytes))
 			start := int(tree.MustBeDInt(args[1]))
 			substring := getSubstringFromIndexBytes(byteString, start)
-			return tree.ParseDByte(substring)
+			return tree.NewDBytes(tree.DBytes(substring)), nil
 		},
 		Info:       "Returns a byte subarray of `input` starting at `start_pos` (count starts at 1).",
 		Volatility: tree.VolatilityImmutable,
@@ -4847,7 +4847,7 @@ var substringImpls = makeBuiltin(tree.FunctionProperties{Category: categoryStrin
 			if err != nil {
 				return nil, err
 			}
-			return tree.ParseDByte(substring)
+			return tree.NewDBytes(tree.DBytes(substring)), nil
 		},
 		Info: "Returns a byte subarray of `input` starting at `start_pos` (count starts at 1) and " +
 			"including up to `length` characters.",


### PR DESCRIPTION
fixes #57367 

Release note (bug fix): The substring function on byte arrays would
treat its input as unicode code points, which would cause the wrong
bytes to be returned. Now it only operates on the raw bytes.

Release note (bug fix): The substring(byte[]) functions were not able to
interpret bytes that had the `\` character since it was treating it as
the beginning of an escape sequence. This is now fixed.