### PR TITLE
release-20.2: opt: use join filters to imply IS NOT NULL partial index predicates

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/fk
+++ b/pkg/sql/opt/exec/execbuilder/testdata/fk
@@ -1130,3 +1130,72 @@ root                               ·                    ·
 
 statement ok
 SET prefer_lookup_joins_for_fks = false
+
+# Test that partial indexes with IS NOT NULL predicates are used for performing
+# FK checks.
+subtest partial_index
+
+statement ok
+CREATE TABLE partial_parent (
+  id INT PRIMARY KEY
+)
+
+statement ok
+CREATE TABLE partial_child (
+  id INT PRIMARY KEY,
+  parent_id INT,
+  CONSTRAINT fk FOREIGN KEY (parent_id) REFERENCES partial_parent(id),
+  INDEX partial_idx (parent_id) WHERE parent_id IS NOT NULL
+)
+
+query TTT
+EXPLAIN DELETE FROM partial_parent WHERE id = 1
+----
+·                                  distribution   local
+·                                  vectorized     false
+root                               ·              ·
+ ├── delete                        ·              ·
+ │    │                            from           partial_parent
+ │    └── buffer                   ·              ·
+ │         │                       label          buffer 1
+ │         └── scan                ·              ·
+ │                                 missing stats  ·
+ │                                 table          partial_parent@primary
+ │                                 spans          [/1 - /1]
+ └── fk-check                      ·              ·
+      └── error if rows            ·              ·
+           └── lookup join (semi)  ·              ·
+                │                  table          partial_child@partial_idx (partial index)
+                │                  equality       (id) = (parent_id)
+                └── scan buffer    ·              ·
+·                                  label          buffer 1
+
+query TTT
+EXPLAIN UPDATE partial_parent SET id = 2 WHERE id = 1
+----
+·                                     distribution      local
+·                                     vectorized        false
+root                                  ·                 ·
+ ├── update                           ·                 ·
+ │    │                               table             partial_parent
+ │    │                               set               id
+ │    └── buffer                      ·                 ·
+ │         │                          label             buffer 1
+ │         └── render                 ·                 ·
+ │              └── scan              ·                 ·
+ │                                    missing stats     ·
+ │                                    table             partial_parent@primary
+ │                                    spans             [/1 - /1]
+ │                                    locking strength  for update
+ └── fk-check                         ·                 ·
+      └── error if rows               ·                 ·
+           └── lookup join (semi)     ·                 ·
+                │                     table             partial_child@partial_idx (partial index)
+                │                     equality          (id) = (parent_id)
+                └── except            ·                 ·
+                     ├── scan buffer  ·                 ·
+                     │                label             buffer 1
+                     └── scan buffer  ·                 ·
+·                                     label             buffer 1
+
+subtest end

--- a/pkg/sql/opt/exec/execbuilder/testdata/partial_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/partial_index
@@ -714,3 +714,32 @@ Scan /Table/56/{1-2}
 Del /Table/56/2/1/10/0
 Del /Table/56/1/10/0
 Del /Table/56/1/20/0
+
+# ---------------------------------------------------------
+# JOIN
+# ---------------------------------------------------------
+
+statement ok
+CREATE TABLE a (a INT PRIMARY KEY);
+
+statement ok
+CREATE TABLE b (b INT, INDEX (b) WHERE b IS NOT NULL)
+
+# The partial index can be used because the ON condition implicitly implies the
+# partial index predicate, b IS NOT NULL.
+query TTT
+EXPLAIN SELECT * FROM a JOIN b ON a = b
+----
+·           distribution       local
+·           vectorized         true
+merge join  ·                  ·
+ │          equality           (a) = (b)
+ │          left cols are key  ·
+ ├── scan   ·                  ·
+ │          missing stats      ·
+ │          table              a@primary
+ │          spans              FULL SCAN
+ └── scan   ·                  ·
+·           missing stats      ·
+·           table              b@b_b_idx (partial index)
+·           spans              FULL SCAN

--- a/pkg/sql/opt/norm/reject_nulls_funcs.go
+++ b/pkg/sql/opt/norm/reject_nulls_funcs.go
@@ -162,6 +162,9 @@ func DeriveRejectNullCols(in memo.RelExpr) opt.ColSet {
 
 	case opt.ProjectOp:
 		relProps.Rule.RejectNullCols.UnionWith(deriveProjectRejectNullCols(in))
+
+	case opt.ScanOp:
+		relProps.Rule.RejectNullCols.UnionWith(deriveScanRejectNullCols(in))
 	}
 
 	return relProps.Rule.RejectNullCols
@@ -316,4 +319,44 @@ func deriveProjectRejectNullCols(in memo.RelExpr) opt.ColSet {
 		}
 	}
 	return (rejectNullCols.Union(projectionsRejectCols)).Intersection(in.Relational().OutputCols)
+}
+
+// deriveScanRejectNullCols returns the set of Scan columns which are eligible
+// for null rejection. Scan columns can be null-rejected only when there are
+// partial indexes that have explicit "column IS NOT NULL" expressions. Creating
+// null-rejecting filters is useful in this case because the filters may imply a
+// partial index predicate expression, allowing a scan over the index.
+func deriveScanRejectNullCols(in memo.RelExpr) opt.ColSet {
+	md := in.Memo().Metadata()
+	scan := in.(*memo.ScanExpr)
+
+	var rejectNullCols opt.ColSet
+	for _, pred := range md.TableMeta(scan.Table).PartialIndexPredicates {
+		predFilters := *pred.(*memo.FiltersExpr)
+		rejectNullCols.UnionWith(isNotNullCols(predFilters))
+	}
+
+	return rejectNullCols
+}
+
+// isNotNullCols returns the set of columns with explicit, top-level IS NOT NULL
+// filter conditions in the given filters. Note that And and Or expressions are
+// not traversed.
+func isNotNullCols(filters memo.FiltersExpr) opt.ColSet {
+	var notNullCols opt.ColSet
+	for i := range filters {
+		c := filters[i].Condition
+		isNot, ok := c.(*memo.IsNotExpr)
+		if !ok {
+			continue
+		}
+		col, ok := isNot.Left.(*memo.VariableExpr)
+		if !ok {
+			continue
+		}
+		if isNot.Right == memo.NullSingleton {
+			notNullCols.Add(col.Col)
+		}
+	}
+	return notNullCols
 }

--- a/pkg/sql/opt/norm/rules/reject_nulls.opt
+++ b/pkg/sql/opt/norm/rules/reject_nulls.opt
@@ -179,7 +179,8 @@
 
 # RejectNullsUnderJoinRight mirrors RejectNullsUnderJoinLeft.
 [RejectNullsUnderJoinRight, Normalize, LowPriority]
-(InnerJoin | InnerJoinApply | LeftJoin | LeftJoinApply
+(InnerJoin | InnerJoinApply | LeftJoin | LeftJoinApply | SemiJoin
+        | AntiJoin
     $left:*
     $right:* &
         ^(ColsAreEmpty $rejectCols:(RejectNullCols $right))

--- a/pkg/sql/opt/norm/testdata/rules/reject_nulls
+++ b/pkg/sql/opt/norm/testdata/rules/reject_nulls
@@ -1166,6 +1166,120 @@ left-join-apply
  └── filters
       └── u:1 = y:6 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
 
+exec-ddl
+CREATE TABLE ab (
+  a INT,
+  b INT,
+  c INT,
+  INDEX b_idx (b) WHERE b IS NOT NULL,
+  INDEX c_idx (c) WHERE c > 0
+)
+----
+
+# Reject nulls for a scan with an IS NOT NULL partial index predicate expression
+# on the right side of a semi-join.
+norm expect=RejectNullsUnderJoinRight
+SELECT * FROM ab t1 WHERE EXISTS (SELECT * FROM ab t2 WHERE t1.a = t2.b)
+----
+semi-join (hash)
+ ├── columns: a:1 b:2 c:3
+ ├── scan t1
+ │    ├── columns: t1.a:1 t1.b:2 t1.c:3
+ │    └── partial index predicates
+ │         ├── b_idx: filters
+ │         │    └── t1.b:2 IS NOT NULL [outer=(2), constraints=(/2: (/NULL - ]; tight)]
+ │         └── c_idx: filters
+ │              └── t1.c:3 > 0 [outer=(3), constraints=(/3: [/1 - ]; tight)]
+ ├── select
+ │    ├── columns: t2.b:7!null
+ │    ├── scan t2
+ │    │    ├── columns: t2.b:7
+ │    │    └── partial index predicates
+ │    │         ├── b_idx: filters
+ │    │         │    └── t2.b:7 IS NOT NULL [outer=(7), constraints=(/7: (/NULL - ]; tight)]
+ │    │         └── c_idx: filters
+ │    │              └── t2.c:8 > 0 [outer=(8), constraints=(/8: [/1 - ]; tight)]
+ │    └── filters
+ │         └── t2.b:7 IS NOT NULL [outer=(7), constraints=(/7: (/NULL - ]; tight)]
+ └── filters
+      └── t1.a:1 = t2.b:7 [outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
+
+# Fully optimizing the query shows that a partial index scan is generated
+# because the null-reject filters imply the partial index predicate.
+opt expect=(RejectNullsUnderJoinRight,GeneratePartialIndexScans)
+SELECT * FROM ab t1 WHERE EXISTS (SELECT * FROM ab t2 WHERE t1.a = t2.b)
+----
+project
+ ├── columns: a:1 b:2 c:3
+ └── inner-join (hash)
+      ├── columns: t1.a:1!null t1.b:2 t1.c:3 t2.b:7!null
+      ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+      ├── fd: (1)==(7), (7)==(1)
+      ├── scan t1
+      │    ├── columns: t1.a:1 t1.b:2 t1.c:3
+      │    └── partial index predicates
+      │         ├── b_idx: filters
+      │         │    └── t1.b:2 IS NOT NULL [outer=(2), constraints=(/2: (/NULL - ]; tight)]
+      │         └── c_idx: filters
+      │              └── t1.c:3 > 0 [outer=(3), constraints=(/3: [/1 - ]; tight)]
+      ├── distinct-on
+      │    ├── columns: t2.b:7!null
+      │    ├── grouping columns: t2.b:7!null
+      │    ├── internal-ordering: +7
+      │    ├── key: (7)
+      │    └── scan t2@b_idx,partial
+      │         ├── columns: t2.b:7!null
+      │         └── ordering: +7
+      └── filters
+           └── t1.a:1 = t2.b:7 [outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
+
+# Reject nulls for a scan with an IS NOT NULL partial index predicate expression
+# on the right side of a anti-join.
+norm expect=RejectNullsUnderJoinRight
+SELECT * FROM ab t1 WHERE NOT EXISTS (SELECT * FROM ab t2 WHERE t1.a = t2.b)
+----
+anti-join (hash)
+ ├── columns: a:1 b:2 c:3
+ ├── scan t1
+ │    ├── columns: t1.a:1 t1.b:2 t1.c:3
+ │    └── partial index predicates
+ │         ├── b_idx: filters
+ │         │    └── t1.b:2 IS NOT NULL [outer=(2), constraints=(/2: (/NULL - ]; tight)]
+ │         └── c_idx: filters
+ │              └── t1.c:3 > 0 [outer=(3), constraints=(/3: [/1 - ]; tight)]
+ ├── select
+ │    ├── columns: t2.b:7!null
+ │    ├── scan t2
+ │    │    ├── columns: t2.b:7
+ │    │    └── partial index predicates
+ │    │         ├── b_idx: filters
+ │    │         │    └── t2.b:7 IS NOT NULL [outer=(7), constraints=(/7: (/NULL - ]; tight)]
+ │    │         └── c_idx: filters
+ │    │              └── t2.c:8 > 0 [outer=(8), constraints=(/8: [/1 - ]; tight)]
+ │    └── filters
+ │         └── t2.b:7 IS NOT NULL [outer=(7), constraints=(/7: (/NULL - ]; tight)]
+ └── filters
+      └── t1.a:1 = t2.b:7 [outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
+
+# Fully optimizing the query shows that a partial index scan is generated
+# because the null-reject filters imply the partial index predicate.
+opt expect=(RejectNullsUnderJoinRight,GeneratePartialIndexScans)
+SELECT * FROM ab t1 WHERE NOT EXISTS (SELECT * FROM ab t2 WHERE t1.a = t2.b)
+----
+anti-join (hash)
+ ├── columns: a:1 b:2 c:3
+ ├── scan t1
+ │    ├── columns: t1.a:1 t1.b:2 t1.c:3
+ │    └── partial index predicates
+ │         ├── b_idx: filters
+ │         │    └── t1.b:2 IS NOT NULL [outer=(2), constraints=(/2: (/NULL - ]; tight)]
+ │         └── c_idx: filters
+ │              └── t1.c:3 > 0 [outer=(3), constraints=(/3: [/1 - ]; tight)]
+ ├── scan t2@b_idx,partial
+ │    └── columns: t2.b:7!null
+ └── filters
+      └── t1.a:1 = t2.b:7 [outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
+
 # ----------------------------------------------------------
 # RejectNullsProject
 # ----------------------------------------------------------


### PR DESCRIPTION
Backport 1/3 commits from #58204.

/cc @cockroachdb/release

---

#### opt: use join filters to imply IS NOT NULL partial index predicates

This commit updates the reject null normalization rules so that:

1. `RejectNullsUnderJoinRight` matches `SemiJoin` and `AntiJoin`.
2. A `Scan` with a `col IS NOT NULL` predicate requests null rejection
   of `col`.

In combination, these two changes allow partial indexes with
`IS NOT NULL` predicates to be used in more cases.

As an example, they can be used in JOINs where the ON condition
implicitly implies the predicate:

    CREATE TABLE a (a INT PRIMARY KEY)
    CREATE TABLE b (b INT, INDEX (b) WHERE b IS NOT NULL)

    SELECT * FROM a JOIN b ON a = b

As a another example, partial indexes with `IS NOT NULL` predicates can
be used to satisfy foreign key checks.

    CREATE TABLE parent (id INT PRIMARY KEY)

    CREATE TABLE child (
      id INT PRIMARY KEY,
      p_id INT,
      CONSTRAINT fk FOREIGN KEY (p_id) REFERENCES parent(id),
      INDEX (p_id) WHERE p_id IS NOT NULL
    )

    DELETE FROM p WHERE id = 1

The `DELETE` requires a foreign key check to ensure that no existing
rows in `child` have a matching `p_id`. Prior to this commit, the check
performed a full table scan rather than using the partial index because
its predicate was not implied. By pushing down the null-rejecting filter
derived from the check's `child.p_id = parent.id` filter, the partial
index can be used.

Fixes #57841

Release justification: This improves performance for joins and foreign
key checks on tables with partial indexes. Partial indexes are a new
feature introduced in 20.2.

Release note (performance improvement): Partial indexes with IS NOT NULL
predicates can be used in cases where JOIN filters implicitly imply the
predicate. This results in more efficient query plans for JOINs and
foreign checks.

