### PR TITLE
release-20.2: opt: build all partial index predicate expressions in TableMeta

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -547,7 +547,7 @@ func (b *Builder) buildScan(scan *memo.ScanExpr) (execPlan, error) {
 	md := b.mem.Metadata()
 	tab := md.Table(scan.Table)
 
-	if !b.disableTelemetry && scan.UsesPartialIndex(md) {
+	if !b.disableTelemetry && scan.PartialIndexPredicate(md) != nil {
 		telemetry.Inc(sqltelemetry.PartialIndexScanUseCounter)
 	}
 

--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -622,7 +622,7 @@ func (s *ScanPrivate) IsUnfiltered(md *opt.Metadata) bool {
 	return (s.Constraint == nil || s.Constraint.IsUnconstrained()) &&
 		s.InvertedConstraint == nil &&
 		s.HardLimit == 0 &&
-		!s.UsesPartialIndex(md)
+		s.PartialIndexPredicate(md) == nil
 }
 
 // IsLocking returns true if the ScanPrivate is configured to use a row-level
@@ -633,23 +633,15 @@ func (s *ScanPrivate) IsLocking() bool {
 	return s.Locking != nil
 }
 
-// UsesPartialIndex returns true if the ScanPrivate indicates a scan over a
-// partial index.
-func (s *ScanPrivate) UsesPartialIndex(md *opt.Metadata) bool {
-	_, isPartialIndex := md.Table(s.Table).Index(s.Index).Predicate()
-	return isPartialIndex
-}
-
 // PartialIndexPredicate returns the FiltersExpr representing the predicate of
 // the partial index that the scan uses. If the scan does not use a partial
-// index or if a partial index predicate was not built for this index, this
-// function panics. UsesPartialIndex should be called first to determine if the
-// scan operates over a partial index.
+// index, nil is returned.
 func (s *ScanPrivate) PartialIndexPredicate(md *opt.Metadata) FiltersExpr {
 	tabMeta := md.TableMeta(s.Table)
 	pred, ok := PartialIndexPredicate(tabMeta, s.Index)
 	if !ok {
-		panic(errors.AssertionFailedf("partial index predicate not found for %s", tabMeta.Table.Index(s.Index).Name()))
+		// The index is not a partial index.
+		return nil
 	}
 	return pred
 }

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -1252,7 +1252,7 @@ func FormatPrivate(f *ExprFmtCtx, private interface{}, physProps *physical.Requi
 		if ScanIsReverseFn(f.Memo.Metadata(), t, &physProps.Ordering) {
 			f.Buffer.WriteString(",rev")
 		}
-		if t.UsesPartialIndex(f.Memo.Metadata()) {
+		if t.PartialIndexPredicate(f.Memo.Metadata()) != nil {
 			f.Buffer.WriteString(",partial")
 		}
 

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -622,11 +622,7 @@ func (sb *statisticsBuilder) buildScan(scan *ScanExpr, relProps *props.Relationa
 
 	inputStats := sb.makeTableStatistics(scan.Table)
 	s.RowCount = inputStats.RowCount
-
-	var pred FiltersExpr
-	if scan.UsesPartialIndex(sb.md) {
-		pred = scan.PartialIndexPredicate(sb.md)
-	}
+	pred := scan.PartialIndexPredicate(sb.md)
 
 	// If the constraints and pred are nil, then this scan is an unconstrained
 	// scan on a non-partial index. The stats of the scan are the same as the

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -1205,6 +1205,7 @@ func (mb *mutationBuilder) arbiterIndexes(
 	tabMeta := mb.md.TableMeta(mb.tabID)
 	var tableScope *scope
 	var im *partialidx.Implicator
+	var arbiterFilters memo.FiltersExpr
 	for idx, idxCount := 0, mb.tab.IndexCount(); idx < idxCount; idx++ {
 		index := mb.tab.Index(idx)
 
@@ -1271,16 +1272,20 @@ func (mb *mutationBuilder) arbiterIndexes(
 				im.Init(mb.b.factory, mb.md, mb.b.evalCtx)
 			}
 
-			arbiterFilter, err := mb.b.buildPartialIndexPredicate(
-				tableScope, arbiterPredicate, "arbiter predicate",
-			)
-			if err != nil {
-				// The error is due to a non-immutable operator in the arbiter
-				// predicate. Continue on to see if a matching non-partial or
-				// pseudo-partial index exists.
-				continue
+			// Build the arbiter filters once.
+			if arbiterFilters == nil {
+				arbiterFilters, err = mb.b.buildPartialIndexPredicate(
+					tableScope, arbiterPredicate, "arbiter predicate",
+				)
+				if err != nil {
+					// The error is due to a non-immutable operator in the arbiter
+					// predicate. Continue on to see if a matching non-partial or
+					// pseudo-partial index exists.
+					continue
+				}
 			}
-			if _, ok := im.FiltersImplyPredicate(arbiterFilter, predFilter); ok {
+
+			if _, ok := im.FiltersImplyPredicate(arbiterFilters, predFilter); ok {
 				arbiters.Add(idx)
 			}
 		}

--- a/pkg/sql/opt/optbuilder/partial_index.go
+++ b/pkg/sql/opt/optbuilder/partial_index.go
@@ -23,14 +23,14 @@ import (
 // Returns an error if any non-immutable operators are found.
 //
 // Note: This function should only be used to build partial index or arbiter
-// predicate expressions that have only a table's columns in scope and that are
-// not part of the relational expression tree. For example, this is used to
-// populate the TableMeta.PartialIndexPredicates cache and for determining
-// arbiter indexes in UPSERT and INSERT ON CONFLICT mutations. But it is not
-// used for building synthesized mutation columns that determine whether or not
-// to PUT or DEL a partial index entry for a row; these synthesized columns are
-// projected as part of the opt expression tree and they reference columns
-// beyond a table's base scope.
+// predicate expressions that have only a table's ordinary columns in scope and
+// that are not part of the relational expression tree. For example, this is
+// used to populate the TableMeta.PartialIndexPredicates cache and for
+// determining arbiter indexes in UPSERT and INSERT ON CONFLICT mutations. But
+// it is not used for building synthesized mutation columns that determine
+// whether to issue PUT or DEL operations on a partial index for a mutated row;
+// these synthesized columns are projected as part of the opt expression tree
+// and they can reference columns not part of a table's ordinary columns.
 func (b *Builder) buildPartialIndexPredicate(
 	tableScope *scope, expr tree.Expr, context string,
 ) (memo.FiltersExpr, error) {

--- a/pkg/sql/opt/xform/join_order_builder_test.go
+++ b/pkg/sql/opt/xform/join_order_builder_test.go
@@ -453,7 +453,7 @@ func parseVertexSet(sesStr string) vertexSet {
 func printVertexSet(set vertexSet) string {
 	buf := bytes.Buffer{}
 	for idx, ok := set.next(0); ok; idx, ok = set.next(idx + 1) {
-		buf.WriteString(string('A' + idx))
+		buf.WriteString(string(rune('A' + idx)))
 	}
 	return buf.String()
 }

--- a/pkg/sql/opt/xform/limit_funcs.go
+++ b/pkg/sql/opt/xform/limit_funcs.go
@@ -54,7 +54,8 @@ func (c *CustomFuncs) CanLimitFilteredScan(
 		return false
 	}
 
-	if scanPrivate.Constraint == nil && !scanPrivate.UsesPartialIndex(c.e.mem.Metadata()) {
+	md := c.e.mem.Metadata()
+	if scanPrivate.Constraint == nil && scanPrivate.PartialIndexPredicate(md) == nil {
 		// This is not a constrained scan nor a partial index scan, so skip it.
 		// The GenerateLimitedScans rule is responsible for limited
 		// unconstrained scans on non-partial indexes.


### PR DESCRIPTION
Backport 2/2 commits from #57707. The backport #58272 relies on these changes.

/cc @cockroachdb/release

---

#### opt: build all partial index predicate expressions in TableMeta

Previously, partial index predicates were only built and added to
`TableMeta.PartialIndexPredicates` if the scope of the scan in
`Builder.buildScan` included all ordinary table columns. This behavior
prevented errors when building partial index predicate expressions for
foriegn key check scans. These scans do not include all columns, so when
building a predicate expression that referenced a table column not
included, optbuilder would err with "column does not exist".

This commit changes this behavior so that partial index predicates are
always built and added to `TableMeta.PartialIndexPredicates`. In order
to do this, `Builder.addPartialIndexPredicatesForTable` creates its own
table scope. It also constructs a new scan rather than relying on the
already-built scan. Constructing a scan is required for considering
logical properties while normalizing partial index predicates.

See discussion at https://github.com/cockroachdb/cockroach/pull/57622
for more context on this change.

Release note: None

#### optbuilder: reduce redundant building of arbiter filter expressions

Previously, the arbiter predicate provided in the `WHERE` clause of an
`INSERT ... ON CONFLICT` statement was rebuilt as a `memo.FiltersExpr`
repetitively while the optbuilder determined arbiter indexes. Now, the
expression is built only once, reducing work.

Release note: None
