### PR TITLE
Add testing to the aggregate functions in operator.go [DO NOT MERGE]

### DIFF
--- a/pkg/sql/opt/operator_test.go
+++ b/pkg/sql/opt/operator_test.go
@@ -57,12 +57,12 @@ func TestAggregateProperties(t *testing.T) {
 	}
 }
 
-func TestAggregateIgnoresNulls(t *testing.T){
-	test := func(expected, actual bool){
-		if expected != actual {
-			t. Errorf("expected %v, got %v", expected, actual)
-		}
-	}
+// func TestAggregateIgnoresNulls(t *testing.T){
+// 	test := func(expected, actual bool){
+// 		if expected != actual {
+// 			t. Errorf("expected %v, got %v", expected, actual)
+// 		}
+// 	}
 
-	test(true, AggregateIgnoresNulls())
-}
+// 	test(true, AggregateIgnoresNulls())
+// }

--- a/pkg/sql/opt/operator_test.go
+++ b/pkg/sql/opt/operator_test.go
@@ -56,3 +56,13 @@ func TestAggregateProperties(t *testing.T) {
 		}
 	}
 }
+
+func TestAggregateIgnoresNulls(t *testing.T){
+	test := func(expected, actual bool){
+		if expected != actual {
+			t. Errorf("expected %v, got %v", expected, actual)
+		}
+	}
+
+	test(true, AggregateIgnoresNulls())
+}


### PR DESCRIPTION
This is in regards to issue #55851. The idea being to implement various tests to see if the aggregate functions in [operator.go](https://github.com/cockroachdb/cockroach/blob/master/pkg/sql/opt/operator.go) are actually returning the values that are expected.

> This is currently drafted since my local environment is not working, I will try with GitHub's CI env, for now until I can solve the issue

