### PR TITLE
backupccl: use path.Join for collection subdir concatenation

### DIFF
--- a/pkg/ccl/backupccl/backup_destination_test.go
+++ b/pkg/ccl/backupccl/backup_destination_test.go
@@ -282,7 +282,7 @@ func TestBackupRestoreResolveDestination(t *testing.T) {
 			// - BACKUP INTO LATEST IN collection
 			// - BACKUP INTO full1 IN collection
 			t.Run("collection", func(t *testing.T) {
-				collectionLoc := fmt.Sprintf("nodelocal://1/%s?AUTH=implicit", t.Name())
+				collectionLoc := fmt.Sprintf("nodelocal://1/%s/?AUTH=implicit", t.Name())
 				collectionTo := localizeURI(t, collectionLoc, localities)
 				fullTime := time.Date(2020, 12, 25, 6, 0, 0, 0, time.UTC)
 				inc1Time := fullTime.Add(time.Minute * 30)

--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -14,6 +14,7 @@ import (
 	cryptorand "crypto/rand"
 	"fmt"
 	"net/url"
+	"path"
 	"sort"
 	"strconv"
 
@@ -382,7 +383,7 @@ func getLocalityAndBaseURI(uri, appendPath string) (string, string, error) {
 	q.Del(localityURLParam)
 	parsedURI.RawQuery = q.Encode()
 	if appendPath != "" {
-		parsedURI.Path = parsedURI.Path + appendPath
+		parsedURI.Path = path.Join(parsedURI.Path, appendPath)
 	}
 	baseURI := parsedURI.String()
 	return localityKV, baseURI, nil


### PR DESCRIPTION
Previously when resolving the path to a specific backup within a collection,
the collection path and the subpath of that backup within the collection were
simply concatenated (subpaths always have a slash prefix).

However if a user supplied a collection path that included a trailing slash,
this simple concatenation would result in a repeated slash in the path to the
specific backup, e.g. path/to/collecton//2020-12-0…. While many file systems
treat slashes specially (as directory separators) and ignore repeated slashes,
many cloud storage APIs just treat them as part of the path and thus a path
with 2 slashes is distinct from a path with just one. This would mean that
attempts to list files within the (incorrectly double-slashed) sub-path would fail.

Instead, this changes that path concatenation to use 'path.Join' which correctly
handles repeated separators.

Release note (bug fix): fixed a bug which could cause incremental backups to a backup in a collection (i.e. BACKUP INTO … IN …) on some cloud storage providers to ignore existing incremental backups previously appended to that destination and instead backup incrementally from the base backup in that destination.