### PR TITLE
cli/demo: make the generated password shorter and simpler to say

### DIFF
--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -598,7 +598,7 @@ If problems persist, please see %s.`
 			// Run SQL for new clusters.
 			// TODO(knz): If/when we want auto-creation of an initial admin user,
 			// this can be achieved here.
-			if _, err := runInitialSQL(ctx, s, startSingleNode, "" /* adminUser */); err != nil {
+			if err := runInitialSQL(ctx, s, startSingleNode, "" /* adminUser */, "" /* adminPassword */); err != nil {
 				return err
 			}
 

--- a/pkg/security/password.go
+++ b/pkg/security/password.go
@@ -11,12 +11,9 @@
 package security
 
 import (
-	"crypto/rand"
 	"crypto/sha256"
 	"fmt"
-	"math/big"
 	"os"
-	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/errors"
@@ -91,28 +88,3 @@ var MinPasswordLength = settings.RegisterIntSetting(
 	1,
 	settings.NonNegativeInt,
 )
-
-// GenerateRandomPassword generates a somewhat secure password
-// composed of alphanumeric characters.
-func GenerateRandomPassword() (string, error) {
-	// Length 43 and 62 symbols gives us at least 256 bits of entropy.
-	// If 256 random bits are good enough for AES, it's good enough for us.
-	const length = 43
-	const symbols = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
-	var result strings.Builder
-	max := big.NewInt(int64(len(symbols)))
-	for i := 0; i < length; i++ {
-		// The following code is really equivalent to
-		// 	   r := rand.Intn(len(symbols))
-		// with the math/rand package. However we want to use the crypto
-		// package for better randomness.
-		br, err := rand.Int(rand.Reader, max)
-		if err != nil {
-			return "", err
-		}
-		r := int(br.Int64())
-
-		result.WriteByte(symbols[r])
-	}
-	return result.String(), nil
-}


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/642886/103229057-9613bb00-4932-11eb-8a1a-53bae93fb057.png)

After:

![image](https://user-images.githubusercontent.com/642886/103229074-9d3ac900-4932-11eb-901c-815cdd80ce2e.png)

(This is separate and complementary to the change proposed in #56740) 


Release note (security update): The entropy of the auto-generated user
account password for `cockroach demo` shell has been lowered, to
ensure that the passwords are short and easy to copy over. This makes
the password easy to bruteforce and thus removes any remaining
protection there may have been to the confidentiality of `demo`
sessions. (The reason why a password remains, as opposed to no
password whatsoever, is to prevent accidental misuse of the HTTP
service by other applications running on the same machine.) Since the
required shortness erases any pretense of security, the algorithm has
been simplified to remove usage of a crypto PRNG altogether.

Release note (cli change): The URLs generated when `cockroach demo`
starts have been made shorter and easier to copy/paste by shortening
the generated password.