### PR TITLE
release-20.2: opt: reset Implicator constraint cache in Init

### DIFF
--- a/pkg/sql/opt/partialidx/implicator.go
+++ b/pkg/sql/opt/partialidx/implicator.go
@@ -140,11 +140,12 @@ type constraintCacheItem struct {
 }
 
 // Init initializes an Implicator with the given factory, metadata, and eval
-// context.
+// context. It also resets the constraint cache.
 func (im *Implicator) Init(f *norm.Factory, md *opt.Metadata, evalCtx *tree.EvalContext) {
 	im.f = f
 	im.md = md
 	im.evalCtx = evalCtx
+	im.constraintCache = nil
 }
 
 // FiltersImplyPredicate attempts to prove that a partial index predicate is


### PR DESCRIPTION
Backport 1/1 commits from #58306.

/cc @cockroachdb/release

---

The Implicator's constraint cache is now cleared when `Init` is called.
This prevents the constraint cache from growing indefinitely.

Release justification: This is a simple fix that prevents memory leaks
in the optimizer when planning queries on tables with partial indexes.

Release note (bug fix): A memory leak in the optimizer has been fixed.
The leak could have caused unbounded growth of memory usage for a
session when planning queries on tables with partial indexes.
