### PR TITLE
opt: fix invariant violations in FDs

### DIFF
--- a/pkg/sql/opt/props/func_dep.go
+++ b/pkg/sql/opt/props/func_dep.go
@@ -959,6 +959,8 @@ func (f *FuncDepSet) ProjectCols(cols opt.ColSet) {
 			// Equivalence dependencies already maintain closure, so skip them.
 			if !fd.equiv {
 				fd.to = f.ComputeClosure(fd.to)
+				// Maintain the invariant that from and to columns don't overlap.
+				fd.to.DifferenceWith(fd.from)
 			}
 		}
 


### PR DESCRIPTION
Fix a bug in `ProjectCols` which led to a column being in both sides
of a FD relation. This was causing test-only assertion violations.

Fixes #56358.

Release note: None