### PR TITLE
release-20.2: sql: make sure to capture ctx when setting up flows

### DIFF
--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -171,9 +171,7 @@ func (dsp *DistSQLPlanner) setupFlows(
 			flowCtx := dsp.distSQLSrv.NewFlowContext(ctx, execinfrapb.FlowID{}, &evalCtx.EvalContext, setupReq.TraceKV, localState)
 			// This flowCtx is only used during the vectorize check, so we need to
 			// clean up any accessed descriptors after checking.
-			defer func() {
-				flowCtx.TypeResolverFactory.CleanupFunc(ctx)
-			}()
+			defer flowCtx.TypeResolverFactory.CleanupFunc(ctx)
 
 			for scheduledOnNodeID, spec := range flows {
 				scheduledOnRemoteNode := scheduledOnNodeID != thisNodeID


### PR DESCRIPTION
This commit changes the flow setup code slightly to capture `ctx`
object. I'm not sure whether it changes anything execution-wise, but the
change does look nicer anyway.

Informs: #58303.

Release note: None