### PR TITLE
cloudimpl: fix SHOW BACKUP when AUTH="" for s3

### DIFF
--- a/pkg/storage/cloudimpl/external_storage.go
+++ b/pkg/storage/cloudimpl/external_storage.go
@@ -376,7 +376,7 @@ func AccessIsWithExplicitAuth(path string) (bool, string, error) {
 	switch uri.Scheme {
 	case "s3":
 		auth := uri.Query().Get(AuthParam)
-		hasExplicitAuth = auth == AuthParamSpecified
+		hasExplicitAuth = auth == AuthParamSpecified || auth == ""
 
 		// If a custom endpoint has been specified in the S3 URI then this is no
 		// longer an explicit AUTH.


### PR DESCRIPTION
When the AUTH param for an s3 URI is left unset, it defaults to
specified. This case was missed when checking if an operation such as
show backup required a user with admin role.

It is important to note that when AUTH is left empty for GS URIs it
defaults to reading from the cluster settings or env variables and so we
consider it implicit authentication.

Fixes: #58190

Release note: None