### PR TITLE
opt: fetch only required columns for partial index mutations

### DIFF
--- a/pkg/sql/backfill/backfill.go
+++ b/pkg/sql/backfill/backfill.go
@@ -253,9 +253,10 @@ func (cb *ColumnBackfiller) RunColumnBackfillChunk(
 ) (roachpb.Key, error) {
 	// TODO(dan): Tighten up the bound on the requestedCols parameter to
 	// makeRowUpdater.
-	requestedCols := make([]descpb.ColumnDescriptor, 0, len(tableDesc.Columns)+len(cb.added))
+	requestedCols := make([]descpb.ColumnDescriptor, 0, len(tableDesc.Columns)+len(cb.added)+len(cb.dropped))
 	requestedCols = append(requestedCols, tableDesc.Columns...)
 	requestedCols = append(requestedCols, cb.added...)
+	requestedCols = append(requestedCols, cb.dropped...)
 	ru, err := row.MakeUpdater(
 		ctx,
 		txn,

--- a/pkg/sql/logictest/testdata/logic_test/partial_index
+++ b/pkg/sql/logictest/testdata/logic_test/partial_index
@@ -1281,6 +1281,44 @@ SELECT * FROM inv_c@i WHERE j @> '{"x": "y"}' AND s IN ('foo', 'bar') ORDER BY k
 1  {"num": 1, "x": "y"}  foo
 3  {"num": 3, "x": "y"}  bar
 
+# Updates and Upserts with fetch columns pruned.
+
+statement ok
+CREATE TABLE prune (
+    a INT PRIMARY KEY,
+    b INT,
+    c INT,
+    d INT,
+    INDEX idx (b) WHERE c > 0,
+    FAMILY (a),
+    FAMILY (b),
+    FAMILY (c),
+    FAMILY (d)
+)
+
+statement ok
+INSERT INTO prune (a, b, c, d) VALUES (1, 2, 3, 4)
+
+# Test that an update is successful when fetch columns b and c are pruned
+# because an update to idx is not required.
+statement ok
+UPDATE prune SET d = d + 1 WHERE a = 1
+
+query IIII rowsort
+SELECT * FROM prune@idx WHERE c > 0
+----
+1  2  3  5
+
+# Test that an upsert is successful when fetch columns b and c are pruned
+# because an update to idx is not required.
+statement ok
+UPSERT INTO prune (a, d) VALUES (1, 6)
+
+query IIII rowsort
+SELECT * FROM prune@idx WHERE c > 0
+----
+1  2  3  6
+
 # Regression tests for #52318. Mutations on partial indexes in the
 # DELETE_AND_WRITE_ONLY state should update the indexes correctly.
 subtest regression_52318

--- a/pkg/sql/opt/cat/index.go
+++ b/pkg/sql/opt/cat/index.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util"
 )
 
 // IndexOrdinal identifies an index (in the context of a Table).
@@ -22,6 +23,9 @@ type IndexOrdinal = int
 
 // IndexOrdinals identifies a list of indexes (in the context of a Table).
 type IndexOrdinals = []IndexOrdinal
+
+// IndexOrdinalSet identifies a set of indexes (in the context of a Table).
+type IndexOrdinalSet = util.FastIntSet
 
 // PrimaryIndex selects the primary index of a table when calling the
 // Table.Index method. Every table is guaranteed to have a unique primary

--- a/pkg/sql/opt/memo/testdata/logprops/delete
+++ b/pkg/sql/opt/memo/testdata/logprops/delete
@@ -64,7 +64,6 @@ project
       ├── volatile, mutations
       ├── key: (5)
       ├── fd: ()-->(1), (5)-->(2-4)
-      ├── prune: (1-4)
       └── select
            ├── columns: a:8(int!null) b:9(int) c:10(int!null) d:11(int) rowid:12(int!null) e:13(int) crdb_internal_mvcc_timestamp:14(decimal)
            ├── key: (12)
@@ -107,7 +106,6 @@ project
       ├── volatile, mutations
       ├── key: ()
       ├── fd: ()-->(1-5)
-      ├── prune: (1-4)
       └── select
            ├── columns: a:8(int!null) b:9(int) c:10(int!null) d:11(int) rowid:12(int!null) e:13(int) crdb_internal_mvcc_timestamp:14(decimal)
            ├── cardinality: [0 - 1]
@@ -148,7 +146,6 @@ project
       ├── volatile, mutations
       ├── key: (5)
       ├── fd: (2)==(3), (3)==(2), (5)-->(1-4)
-      ├── prune: (1-4)
       └── select
            ├── columns: a:8(int!null) b:9(int!null) c:10(int!null) d:11(int) rowid:12(int!null) e:13(int) crdb_internal_mvcc_timestamp:14(decimal)
            ├── key: (12)

--- a/pkg/sql/opt/norm/prune_cols_funcs.go
+++ b/pkg/sql/opt/norm/prune_cols_funcs.go
@@ -12,7 +12,6 @@ package norm
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
@@ -92,26 +91,8 @@ func (c *CustomFuncs) NeededMutationFetchCols(
 	var cols opt.ColSet
 	tabMeta := c.mem.Metadata().TableMeta(private.Table)
 
-	// familyCols returns the columns in the given family.
-	familyCols := func(fam cat.Family) opt.ColSet {
-		var colSet opt.ColSet
-		for i, n := 0, fam.ColumnCount(); i < n; i++ {
-			id := tabMeta.MetaID.ColumnID(fam.Column(i).Ordinal)
-			colSet.Add(id)
-		}
-		return colSet
-	}
-
-	// addFamilyCols adds all columns in each family containing at least one
-	// column that is being updated.
-	addFamilyCols := func(updateCols opt.ColSet) {
-		for i, n := 0, tabMeta.Table.FamilyCount(); i < n; i++ {
-			famCols := familyCols(tabMeta.Table.Family(i))
-			if famCols.Intersects(updateCols) {
-				cols.UnionWith(famCols)
-			}
-		}
-	}
+	// Retain any FetchCols that are needed for updating indexes.
+	cols.UnionWith(private.IndexFetchCols)
 
 	// Retain any FetchCols that are needed for ReturnCols. If a RETURN column
 	// is needed, then:
@@ -129,77 +110,6 @@ func (c *CustomFuncs) NeededMutationFetchCols(
 			if op == opt.DeleteOp || len(private.UpdateCols) == 0 || private.UpdateCols[ord] == 0 {
 				cols.Add(tabMeta.MetaID.ColumnID(ord))
 			}
-		}
-	}
-
-	switch op {
-	case opt.UpdateOp, opt.UpsertOp:
-		// Determine set of target table columns that need to be updated.
-		var updateCols opt.ColSet
-		for ord, col := range private.UpdateCols {
-			if col != 0 {
-				updateCols.Add(tabMeta.MetaID.ColumnID(ord))
-			}
-		}
-
-		// Make sure to consider indexes that are being added or dropped.
-		for i, n := 0, tabMeta.Table.DeletableIndexCount(); i < n; i++ {
-			// If the columns being updated are not part of the index and the
-			// index is not a partial index, then the update does not require
-			// changes to the index. Partial indexes may be updated (even when a
-			// column in the index is not changing) when rows that were not
-			// previously in the index must be added to the index because they
-			// now satisfy the partial index predicate.
-			//
-			// Note that we use the set of index columns where the virtual
-			// columns have been mapped to their source columns. Virtual columns
-			// are never part of the updated columns. Updates to source columns
-			// trigger index changes.
-			//
-			// TODO(mgartner): Index columns are not necessary when neither the
-			// index columns nor the columns referenced in the partial index
-			// predicate are being updated. We should prune mutation fetch
-			// columns when this is the case, rather than always marking index
-			// columns of partial indexes as "needed".
-			indexCols := tabMeta.IndexColumnsMapVirtual(i)
-			_, isPartialIndex := tabMeta.Table.Index(i).Predicate()
-			if !indexCols.Intersects(updateCols) && !isPartialIndex {
-				continue
-			}
-
-			// Always add index strict key columns, since these are needed to fetch
-			// existing rows from the store.
-			keyCols := tabMeta.IndexKeyColumnsMapVirtual(i)
-			cols.UnionWith(keyCols)
-
-			// Add all columns in any family that includes an update column.
-			// It is possible to update a subset of families only for the primary
-			// index, and only when key columns are not being updated. Otherwise,
-			// all columns in the index must be fetched.
-			// TODO(andyk): It should be possible to not include columns that are
-			// being updated, since the existing value is not used. However, this
-			// would require execution support.
-			if i == cat.PrimaryIndex && !keyCols.Intersects(updateCols) {
-				addFamilyCols(updateCols)
-			} else {
-				// Add all of the index columns into cols.
-				indexCols.ForEach(func(col opt.ColumnID) {
-					ord := tabMeta.MetaID.ColumnOrdinal(col)
-					// We don't want to include system columns.
-					if tabMeta.Table.Column(ord).Kind() != cat.System {
-						cols.Add(col)
-					}
-				})
-			}
-		}
-
-	case opt.DeleteOp:
-		// Add in all strict key columns from all indexes, since these are needed
-		// to compose the keys of rows to delete. Include mutation indexes, since
-		// it is necessary to delete rows even from indexes that are being added
-		// or dropped.
-		for i, n := 0, tabMeta.Table.DeletableIndexCount(); i < n; i++ {
-			cols.UnionWith(tabMeta.IndexKeyColumnsMapVirtual(i))
 		}
 	}
 

--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -2076,27 +2076,27 @@ update partial_indexes
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── project
-      ├── columns: partial_index_put1:12 d_new:11 a:6!null d:9
+      ├── columns: partial_index_put1:12!null d_new:11 a:6!null d:9
       ├── cardinality: [0 - 1]
       ├── immutable
       ├── key: ()
       ├── fd: ()-->(6,9,11,12)
       ├── select
-      │    ├── columns: a:6!null b:7 d:9
+      │    ├── columns: a:6!null d:9
       │    ├── cardinality: [0 - 1]
       │    ├── key: ()
-      │    ├── fd: ()-->(6,7,9)
+      │    ├── fd: ()-->(6,9)
       │    ├── scan partial_indexes
-      │    │    ├── columns: a:6!null b:7 d:9
+      │    │    ├── columns: a:6!null d:9
       │    │    ├── partial index predicates
       │    │    │    └── secondary: filters
       │    │    │         └── b:7 > 1 [outer=(7), constraints=(/7: [/2 - ]; tight)]
       │    │    ├── key: (6)
-      │    │    └── fd: (6)-->(7,9)
+      │    │    └── fd: (6)-->(9)
       │    └── filters
       │         └── a:6 = 1 [outer=(6), constraints=(/6: [/1 - /1]; tight), fd=()-->(6)]
       └── projections
-           ├── b:7 > 1 [as=partial_index_put1:12, outer=(7)]
+           ├── false [as=partial_index_put1:12]
            └── d:9 + 1 [as=d_new:11, outer=(9), immutable]
 
 # Prune UPSERT fetch columns when the partial index indexes the column but
@@ -2118,20 +2118,20 @@ upsert partial_indexes
  ├── update-mapping:
  │    └── column2:7 => d:4
  ├── partial index put columns: partial_index_put1:18
- ├── partial index del columns: partial_index_del1:19
+ ├── partial index del columns: partial_index_put1:18
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── project
-      ├── columns: partial_index_put1:18 partial_index_del1:19 column1:6!null column2:7!null column8:8 column9:9 a:10 d:13
+      ├── columns: partial_index_put1:18!null column1:6!null column2:7!null column8:8 column9:9 a:10 d:13
       ├── cardinality: [1 - 1]
       ├── key: ()
-      ├── fd: ()-->(6-10,13,18,19)
+      ├── fd: ()-->(6-10,13,18)
       ├── left-join (cross)
-      │    ├── columns: column1:6!null column2:7!null column8:8 column9:9 a:10 b:11 d:13
+      │    ├── columns: column1:6!null column2:7!null column8:8 column9:9 a:10 d:13
       │    ├── cardinality: [1 - 1]
       │    ├── multiplicity: left-rows(exactly-one), right-rows(exactly-one)
       │    ├── key: ()
-      │    ├── fd: ()-->(6-11,13)
+      │    ├── fd: ()-->(6-10,13)
       │    ├── values
       │    │    ├── columns: column1:6!null column2:7!null column8:8 column9:9
       │    │    ├── cardinality: [1 - 1]
@@ -2139,23 +2139,22 @@ upsert partial_indexes
       │    │    ├── fd: ()-->(6-9)
       │    │    └── (1, 2, NULL, NULL)
       │    ├── select
-      │    │    ├── columns: a:10!null b:11 d:13
+      │    │    ├── columns: a:10!null d:13
       │    │    ├── cardinality: [0 - 1]
       │    │    ├── key: ()
-      │    │    ├── fd: ()-->(10,11,13)
+      │    │    ├── fd: ()-->(10,13)
       │    │    ├── scan partial_indexes
-      │    │    │    ├── columns: a:10!null b:11 d:13
+      │    │    │    ├── columns: a:10!null d:13
       │    │    │    ├── partial index predicates
       │    │    │    │    └── secondary: filters
       │    │    │    │         └── b:11 > 1 [outer=(11), constraints=(/11: [/2 - ]; tight)]
       │    │    │    ├── key: (10)
-      │    │    │    └── fd: (10)-->(11,13)
+      │    │    │    └── fd: (10)-->(13)
       │    │    └── filters
       │    │         └── a:10 = 1 [outer=(10), constraints=(/10: [/1 - /1]; tight), fd=()-->(10)]
       │    └── filters (true)
       └── projections
-           ├── CASE WHEN a:10 IS NULL THEN column8:8 ELSE b:11 END > 1 [as=partial_index_put1:18, outer=(8,10,11)]
-           └── b:11 > 1 [as=partial_index_del1:19, outer=(11)]
+           └── false [as=partial_index_put1:18]
 
 # Do not prune DELETE fetch columns when the a partial index indexes the column
 # and neither the column nor the columns referenced in the partial index

--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -48,9 +48,11 @@ CREATE TABLE partial_indexes (
     a INT PRIMARY KEY,
     b INT,
     c STRING,
+    d INT,
     FAMILY (a),
     FAMILY (b),
     FAMILY (c),
+    FAMILY (d),
     INDEX (c) WHERE b > 1
 )
 ----
@@ -2058,51 +2060,183 @@ update computed
            ├── c_new:13 + 1 [as=column14:14, outer=(13), immutable]
            └── c_new:13 + 10 [as=column15:15, outer=(13), immutable]
 
-# Do not prune columns that are required for evaluating partial index
-# predicates.
-norm expect-not=PruneMutationFetchCols
-UPDATE partial_indexes SET b = b + 1 WHERE a = 1
+# Prune UPDATE fetch columns when the partial index indexes the column but
+# neither the column nor the columns referenced in the partial index predicate
+# are mutating.
+norm expect=(PruneMutationFetchCols,PruneMutationInputCols)
+UPDATE partial_indexes SET d = d + 1 WHERE a = 1
 ----
 update partial_indexes
  ├── columns: <none>
- ├── fetch columns: a:5 b:6 c:7
+ ├── fetch columns: a:6 d:9
  ├── update-mapping:
- │    └── b_new:9 => b:2
- ├── partial index put columns: partial_index_put1:10
+ │    └── d_new:11 => d:4
+ ├── partial index put columns: partial_index_put1:12
+ ├── partial index del columns: partial_index_put1:12
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ └── project
+      ├── columns: partial_index_put1:12 d_new:11 a:6!null d:9
+      ├── cardinality: [0 - 1]
+      ├── immutable
+      ├── key: ()
+      ├── fd: ()-->(6,9,11,12)
+      ├── select
+      │    ├── columns: a:6!null b:7 d:9
+      │    ├── cardinality: [0 - 1]
+      │    ├── key: ()
+      │    ├── fd: ()-->(6,7,9)
+      │    ├── scan partial_indexes
+      │    │    ├── columns: a:6!null b:7 d:9
+      │    │    ├── partial index predicates
+      │    │    │    └── secondary: filters
+      │    │    │         └── b:7 > 1 [outer=(7), constraints=(/7: [/2 - ]; tight)]
+      │    │    ├── key: (6)
+      │    │    └── fd: (6)-->(7,9)
+      │    └── filters
+      │         └── a:6 = 1 [outer=(6), constraints=(/6: [/1 - /1]; tight), fd=()-->(6)]
+      └── projections
+           ├── b:7 > 1 [as=partial_index_put1:12, outer=(7)]
+           └── d:9 + 1 [as=d_new:11, outer=(9), immutable]
+
+# Prune UPSERT fetch columns when the partial index indexes the column but
+# neither the column nor the columns referenced in the partial index predicate
+# are mutating.
+norm expect=(PruneMutationFetchCols,PruneMutationInputCols)
+UPSERT INTO partial_indexes (a, d) VALUES (1, 2)
+----
+upsert partial_indexes
+ ├── columns: <none>
+ ├── arbiter indexes: primary
+ ├── canary column: a:10
+ ├── fetch columns: a:10 d:13
+ ├── insert-mapping:
+ │    ├── column1:6 => a:1
+ │    ├── column8:8 => b:2
+ │    ├── column9:9 => c:3
+ │    └── column2:7 => d:4
+ ├── update-mapping:
+ │    └── column2:7 => d:4
+ ├── partial index put columns: partial_index_put1:18
+ ├── partial index del columns: partial_index_del1:19
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ └── project
+      ├── columns: partial_index_put1:18 partial_index_del1:19 column1:6!null column2:7!null column8:8 column9:9 a:10 d:13
+      ├── cardinality: [1 - 1]
+      ├── key: ()
+      ├── fd: ()-->(6-10,13,18,19)
+      ├── left-join (cross)
+      │    ├── columns: column1:6!null column2:7!null column8:8 column9:9 a:10 b:11 d:13
+      │    ├── cardinality: [1 - 1]
+      │    ├── multiplicity: left-rows(exactly-one), right-rows(exactly-one)
+      │    ├── key: ()
+      │    ├── fd: ()-->(6-11,13)
+      │    ├── values
+      │    │    ├── columns: column1:6!null column2:7!null column8:8 column9:9
+      │    │    ├── cardinality: [1 - 1]
+      │    │    ├── key: ()
+      │    │    ├── fd: ()-->(6-9)
+      │    │    └── (1, 2, NULL, NULL)
+      │    ├── select
+      │    │    ├── columns: a:10!null b:11 d:13
+      │    │    ├── cardinality: [0 - 1]
+      │    │    ├── key: ()
+      │    │    ├── fd: ()-->(10,11,13)
+      │    │    ├── scan partial_indexes
+      │    │    │    ├── columns: a:10!null b:11 d:13
+      │    │    │    ├── partial index predicates
+      │    │    │    │    └── secondary: filters
+      │    │    │    │         └── b:11 > 1 [outer=(11), constraints=(/11: [/2 - ]; tight)]
+      │    │    │    ├── key: (10)
+      │    │    │    └── fd: (10)-->(11,13)
+      │    │    └── filters
+      │    │         └── a:10 = 1 [outer=(10), constraints=(/10: [/1 - /1]; tight), fd=()-->(10)]
+      │    └── filters (true)
+      └── projections
+           ├── CASE WHEN a:10 IS NULL THEN column8:8 ELSE b:11 END > 1 [as=partial_index_put1:18, outer=(8,10,11)]
+           └── b:11 > 1 [as=partial_index_del1:19, outer=(11)]
+
+# Do not prune DELETE fetch columns when the a partial index indexes the column
+# and neither the column nor the columns referenced in the partial index
+# predicate are mutating. It is required to fetch all index key columns in order
+# to delete all index entries.
+norm
+DELETE FROM partial_indexes WHERE a = 1
+----
+delete partial_indexes
+ ├── columns: <none>
+ ├── fetch columns: a:6 c:8
  ├── partial index del columns: partial_index_del1:11
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── project
-      ├── columns: partial_index_put1:10 partial_index_del1:11 a:5!null b:6 c:7 b_new:9
+      ├── columns: partial_index_del1:11 a:6!null c:8
+      ├── cardinality: [0 - 1]
+      ├── key: ()
+      ├── fd: ()-->(6,8,11)
+      ├── select
+      │    ├── columns: a:6!null b:7 c:8
+      │    ├── cardinality: [0 - 1]
+      │    ├── key: ()
+      │    ├── fd: ()-->(6-8)
+      │    ├── scan partial_indexes
+      │    │    ├── columns: a:6!null b:7 c:8
+      │    │    ├── partial index predicates
+      │    │    │    └── secondary: filters
+      │    │    │         └── b:7 > 1 [outer=(7), constraints=(/7: [/2 - ]; tight)]
+      │    │    ├── key: (6)
+      │    │    └── fd: (6)-->(7,8)
+      │    └── filters
+      │         └── a:6 = 1 [outer=(6), constraints=(/6: [/1 - /1]; tight), fd=()-->(6)]
+      └── projections
+           └── b:7 > 1 [as=partial_index_del1:11, outer=(7)]
+
+# Do not prune columns that are required for evaluating partial index
+# predicates.
+norm
+UPDATE partial_indexes SET b = b + 1 WHERE a = 1
+----
+update partial_indexes
+ ├── columns: <none>
+ ├── fetch columns: a:6 b:7 c:8
+ ├── update-mapping:
+ │    └── b_new:11 => b:2
+ ├── partial index put columns: partial_index_put1:12
+ ├── partial index del columns: partial_index_del1:13
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ └── project
+      ├── columns: partial_index_put1:12 partial_index_del1:13 a:6!null b:7 c:8 b_new:11
       ├── cardinality: [0 - 1]
       ├── immutable
       ├── key: ()
-      ├── fd: ()-->(5-7,9-11)
+      ├── fd: ()-->(6-8,11-13)
       ├── project
-      │    ├── columns: b_new:9 a:5!null b:6 c:7
+      │    ├── columns: b_new:11 a:6!null b:7 c:8
       │    ├── cardinality: [0 - 1]
       │    ├── immutable
       │    ├── key: ()
-      │    ├── fd: ()-->(5-7,9)
+      │    ├── fd: ()-->(6-8,11)
       │    ├── select
-      │    │    ├── columns: a:5!null b:6 c:7
+      │    │    ├── columns: a:6!null b:7 c:8
       │    │    ├── cardinality: [0 - 1]
       │    │    ├── key: ()
-      │    │    ├── fd: ()-->(5-7)
+      │    │    ├── fd: ()-->(6-8)
       │    │    ├── scan partial_indexes
-      │    │    │    ├── columns: a:5!null b:6 c:7
+      │    │    │    ├── columns: a:6!null b:7 c:8
       │    │    │    ├── partial index predicates
       │    │    │    │    └── secondary: filters
-      │    │    │    │         └── b:6 > 1 [outer=(6), constraints=(/6: [/2 - ]; tight)]
-      │    │    │    ├── key: (5)
-      │    │    │    └── fd: (5)-->(6,7)
+      │    │    │    │         └── b:7 > 1 [outer=(7), constraints=(/7: [/2 - ]; tight)]
+      │    │    │    ├── key: (6)
+      │    │    │    └── fd: (6)-->(7,8)
       │    │    └── filters
-      │    │         └── a:5 = 1 [outer=(5), constraints=(/5: [/1 - /1]; tight), fd=()-->(5)]
+      │    │         └── a:6 = 1 [outer=(6), constraints=(/6: [/1 - /1]; tight), fd=()-->(6)]
       │    └── projections
-      │         └── b:6 + 1 [as=b_new:9, outer=(6), immutable]
+      │         └── b:7 + 1 [as=b_new:11, outer=(7), immutable]
       └── projections
-           ├── b_new:9 > 1 [as=partial_index_put1:10, outer=(9)]
-           └── b:6 > 1 [as=partial_index_del1:11, outer=(6)]
+           ├── b_new:11 > 1 [as=partial_index_put1:12, outer=(11)]
+           └── b:7 > 1 [as=partial_index_del1:13, outer=(7)]
 
 # Prune secondary family column not needed for the update.
 norm expect=(PruneMutationFetchCols,PruneMutationInputCols)

--- a/pkg/sql/opt/ops/mutation.opt
+++ b/pkg/sql/opt/ops/mutation.opt
@@ -133,6 +133,10 @@ define MutationPrivate {
     # the index.
     PartialIndexDelCols OptionalColList
 
+    # IndexFetchCols is the set of column IDs that are required to fetch in
+    # order to update indexes for UPDATE, UPSERT, and DELETE operations.
+    IndexFetchCols ColSet
+
     # CanaryCol is used only with the Upsert operator. It identifies the column
     # that the execution engine uses to decide whether to insert or to update.
     # If the canary column value is null for a particular input row, then a new
@@ -159,7 +163,8 @@ define MutationPrivate {
     # its input. It's similar to the passthrough columns in projections. This
     # is useful for `UPDATE .. FROM` mutations where the `RETURNING` clause
     # references columns from tables in the `FROM` clause. When this happens
-    # the update will need to pass through those refenced columns from its input.
+    # the update will need to pass through those referenced columns from its
+    # input.
     PassthroughCols ColList
 
     # Mutation operators can act similarly to a With operator: they buffer their

--- a/pkg/sql/opt/optbuilder/delete.go
+++ b/pkg/sql/opt/optbuilder/delete.go
@@ -76,9 +76,8 @@ func (b *Builder) buildDelete(del *tree.Delete, inScope *scope) (outScope *scope
 func (mb *mutationBuilder) buildDelete(returning tree.ReturningExprs) {
 	mb.buildFKChecksAndCascadesForDelete()
 
-	// Set the index fetch columns. Don't attempt to reduce the columns, because
-	// a delete always requires all key columns of all indexes.
-	mb.setIndexFetchCols(false /* reduce */)
+	// Set the index fetch columns and mutating partial index.
+	mb.setIndexFetchColsAndMutatingPartialIndexes()
 
 	// Project partial index DEL boolean columns.
 	mb.projectPartialIndexDelCols(mb.fetchScope)

--- a/pkg/sql/opt/optbuilder/delete.go
+++ b/pkg/sql/opt/optbuilder/delete.go
@@ -76,6 +76,10 @@ func (b *Builder) buildDelete(del *tree.Delete, inScope *scope) (outScope *scope
 func (mb *mutationBuilder) buildDelete(returning tree.ReturningExprs) {
 	mb.buildFKChecksAndCascadesForDelete()
 
+	// Set the index fetch columns. Don't attempt to reduce the columns, because
+	// a delete always requires all key columns of all indexes.
+	mb.setIndexFetchCols(false /* reduce */)
+
 	// Project partial index DEL boolean columns.
 	mb.projectPartialIndexDelCols(mb.fetchScope)
 

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -643,6 +643,9 @@ func (mb *mutationBuilder) buildInsert(returning tree.ReturningExprs) {
 	// Add any check constraint boolean columns to the input.
 	mb.addCheckConstraintCols()
 
+	// Set the index fetch columns and mutating partial index.
+	mb.setIndexFetchColsAndMutatingPartialIndexes()
+
 	// Project partial index PUT boolean columns.
 	mb.projectPartialIndexPutCols(preCheckScope)
 
@@ -1061,9 +1064,8 @@ func (mb *mutationBuilder) buildUpsert(returning tree.ReturningExprs) {
 	// Add any check constraint boolean columns to the input.
 	mb.addCheckConstraintCols()
 
-	// Set the index fetch columns. Attempt to reduce the columns, because an
-	// upsert may not need all columns in order to update the indexes.
-	mb.setIndexFetchCols(true /* reduce */)
+	// Set the index fetch columns and mutating partial index.
+	mb.setIndexFetchColsAndMutatingPartialIndexes()
 
 	// Project partial index PUT and DEL boolean columns.
 	//

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -1061,6 +1061,10 @@ func (mb *mutationBuilder) buildUpsert(returning tree.ReturningExprs) {
 	// Add any check constraint boolean columns to the input.
 	mb.addCheckConstraintCols()
 
+	// Set the index fetch columns. Attempt to reduce the columns, because an
+	// upsert may not need all columns in order to update the indexes.
+	mb.setIndexFetchCols(true /* reduce */)
+
 	// Project partial index PUT and DEL boolean columns.
 	//
 	// In some cases existing rows may not be fetched for an UPSERT (see

--- a/pkg/sql/opt/optbuilder/testdata/update
+++ b/pkg/sql/opt/optbuilder/testdata/update
@@ -1723,6 +1723,46 @@ update partial_indexes
            ├── c:7 = 'delete-only' [as=partial_index_put3:13]
            └── c:7 = 'write-only' [as=partial_index_put4:14]
 
+# Project false PUT and DEL columns when the index is guaranteed to not require
+# an update.
+exec-ddl
+CREATE TABLE partial_index_project_false (
+    a INT PRIMARY KEY,
+    b INT,
+    c INT,
+    d INT,
+    INDEX (b) WHERE c > 0
+)
+----
+
+build
+UPDATE partial_index_project_false SET d = d + 1 WHERE a = 1
+----
+update partial_index_project_false
+ ├── columns: <none>
+ ├── fetch columns: a:6 b:7 c:8 d:9
+ ├── update-mapping:
+ │    └── d_new:11 => d:4
+ ├── partial index put columns: partial_index_put1:12
+ ├── partial index del columns: partial_index_put1:12
+ └── project
+      ├── columns: partial_index_put1:12!null a:6!null b:7 c:8 d:9 crdb_internal_mvcc_timestamp:10 d_new:11
+      ├── project
+      │    ├── columns: d_new:11 a:6!null b:7 c:8 d:9 crdb_internal_mvcc_timestamp:10
+      │    ├── select
+      │    │    ├── columns: a:6!null b:7 c:8 d:9 crdb_internal_mvcc_timestamp:10
+      │    │    ├── scan partial_index_project_false
+      │    │    │    ├── columns: a:6!null b:7 c:8 d:9 crdb_internal_mvcc_timestamp:10
+      │    │    │    └── partial index predicates
+      │    │    │         └── secondary: filters
+      │    │    │              └── c:8 > 0
+      │    │    └── filters
+      │    │         └── a:6 = 1
+      │    └── projections
+      │         └── d:9 + 1 [as=d_new:11]
+      └── projections
+           └── false [as=partial_index_put1:12]
+
 # Do not error with "column reference is ambiguous" when table column names
 # match synthesized column names.
 exec-ddl

--- a/pkg/sql/opt/optbuilder/testdata/upsert
+++ b/pkg/sql/opt/optbuilder/testdata/upsert
@@ -2080,6 +2080,175 @@ upsert partial_indexes
            ├── column3:7 = 'write-only' [as=partial_index_put4:19]
            └── c:10 = 'write-only' [as=partial_index_del4:20]
 
+# Project false PUT and DEL columns when the index is guaranteed to not require
+# an update.
+exec-ddl
+CREATE TABLE partial_index_project_false (
+    a INT PRIMARY KEY,
+    b INT,
+    c INT,
+    d INT,
+    INDEX (b) WHERE c > 0
+)
+----
+
+build
+UPSERT INTO partial_index_project_false (a, d) VALUES (1, 2)
+----
+upsert partial_index_project_false
+ ├── columns: <none>
+ ├── arbiter indexes: primary
+ ├── canary column: a:9
+ ├── fetch columns: a:9 b:10 c:11 d:12
+ ├── insert-mapping:
+ │    ├── column1:6 => a:1
+ │    ├── column8:8 => b:2
+ │    ├── column8:8 => c:3
+ │    └── column2:7 => d:4
+ ├── update-mapping:
+ │    └── column2:7 => d:4
+ ├── partial index put columns: partial_index_put1:17
+ ├── partial index del columns: partial_index_put1:17
+ └── project
+      ├── columns: partial_index_put1:17!null column1:6!null column2:7!null column8:8 a:9 b:10 c:11 d:12 crdb_internal_mvcc_timestamp:13 upsert_a:14 upsert_b:15 upsert_c:16
+      ├── project
+      │    ├── columns: upsert_a:14 upsert_b:15 upsert_c:16 column1:6!null column2:7!null column8:8 a:9 b:10 c:11 d:12 crdb_internal_mvcc_timestamp:13
+      │    ├── left-join (hash)
+      │    │    ├── columns: column1:6!null column2:7!null column8:8 a:9 b:10 c:11 d:12 crdb_internal_mvcc_timestamp:13
+      │    │    ├── ensure-upsert-distinct-on
+      │    │    │    ├── columns: column1:6!null column2:7!null column8:8
+      │    │    │    ├── grouping columns: column1:6!null
+      │    │    │    ├── project
+      │    │    │    │    ├── columns: column8:8 column1:6!null column2:7!null
+      │    │    │    │    ├── values
+      │    │    │    │    │    ├── columns: column1:6!null column2:7!null
+      │    │    │    │    │    └── (1, 2)
+      │    │    │    │    └── projections
+      │    │    │    │         └── NULL::INT8 [as=column8:8]
+      │    │    │    └── aggregations
+      │    │    │         ├── first-agg [as=column2:7]
+      │    │    │         │    └── column2:7
+      │    │    │         └── first-agg [as=column8:8]
+      │    │    │              └── column8:8
+      │    │    ├── scan partial_index_project_false
+      │    │    │    ├── columns: a:9!null b:10 c:11 d:12 crdb_internal_mvcc_timestamp:13
+      │    │    │    └── partial index predicates
+      │    │    │         └── secondary: filters
+      │    │    │              └── c:11 > 0
+      │    │    └── filters
+      │    │         └── column1:6 = a:9
+      │    └── projections
+      │         ├── CASE WHEN a:9 IS NULL THEN column1:6 ELSE a:9 END [as=upsert_a:14]
+      │         ├── CASE WHEN a:9 IS NULL THEN column8:8 ELSE b:10 END [as=upsert_b:15]
+      │         └── CASE WHEN a:9 IS NULL THEN column8:8 ELSE c:11 END [as=upsert_c:16]
+      └── projections
+           └── false [as=partial_index_put1:17]
+
+build
+INSERT INTO partial_index_project_false (a, d) VALUES (1, 2) ON CONFLICT (a) DO UPDATE SET d = 3
+----
+upsert partial_index_project_false
+ ├── columns: <none>
+ ├── arbiter indexes: primary
+ ├── canary column: a:9
+ ├── fetch columns: a:9 b:10 c:11 d:12
+ ├── insert-mapping:
+ │    ├── column1:6 => a:1
+ │    ├── column8:8 => b:2
+ │    ├── column8:8 => c:3
+ │    └── column2:7 => d:4
+ ├── update-mapping:
+ │    └── upsert_d:18 => d:4
+ ├── partial index put columns: partial_index_put1:19
+ ├── partial index del columns: partial_index_put1:19
+ └── project
+      ├── columns: partial_index_put1:19!null column1:6!null column2:7!null column8:8 a:9 b:10 c:11 d:12 crdb_internal_mvcc_timestamp:13 d_new:14!null upsert_a:15 upsert_b:16 upsert_c:17 upsert_d:18!null
+      ├── project
+      │    ├── columns: upsert_a:15 upsert_b:16 upsert_c:17 upsert_d:18!null column1:6!null column2:7!null column8:8 a:9 b:10 c:11 d:12 crdb_internal_mvcc_timestamp:13 d_new:14!null
+      │    ├── project
+      │    │    ├── columns: d_new:14!null column1:6!null column2:7!null column8:8 a:9 b:10 c:11 d:12 crdb_internal_mvcc_timestamp:13
+      │    │    ├── left-join (hash)
+      │    │    │    ├── columns: column1:6!null column2:7!null column8:8 a:9 b:10 c:11 d:12 crdb_internal_mvcc_timestamp:13
+      │    │    │    ├── ensure-upsert-distinct-on
+      │    │    │    │    ├── columns: column1:6!null column2:7!null column8:8
+      │    │    │    │    ├── grouping columns: column1:6!null
+      │    │    │    │    ├── project
+      │    │    │    │    │    ├── columns: column8:8 column1:6!null column2:7!null
+      │    │    │    │    │    ├── values
+      │    │    │    │    │    │    ├── columns: column1:6!null column2:7!null
+      │    │    │    │    │    │    └── (1, 2)
+      │    │    │    │    │    └── projections
+      │    │    │    │    │         └── NULL::INT8 [as=column8:8]
+      │    │    │    │    └── aggregations
+      │    │    │    │         ├── first-agg [as=column2:7]
+      │    │    │    │         │    └── column2:7
+      │    │    │    │         └── first-agg [as=column8:8]
+      │    │    │    │              └── column8:8
+      │    │    │    ├── scan partial_index_project_false
+      │    │    │    │    ├── columns: a:9!null b:10 c:11 d:12 crdb_internal_mvcc_timestamp:13
+      │    │    │    │    └── partial index predicates
+      │    │    │    │         └── secondary: filters
+      │    │    │    │              └── c:11 > 0
+      │    │    │    └── filters
+      │    │    │         └── column1:6 = a:9
+      │    │    └── projections
+      │    │         └── 3 [as=d_new:14]
+      │    └── projections
+      │         ├── CASE WHEN a:9 IS NULL THEN column1:6 ELSE a:9 END [as=upsert_a:15]
+      │         ├── CASE WHEN a:9 IS NULL THEN column8:8 ELSE b:10 END [as=upsert_b:16]
+      │         ├── CASE WHEN a:9 IS NULL THEN column8:8 ELSE c:11 END [as=upsert_c:17]
+      │         └── CASE WHEN a:9 IS NULL THEN column2:7 ELSE d_new:14 END [as=upsert_d:18]
+      └── projections
+           └── false [as=partial_index_put1:19]
+
+# Do not project false PUT and DEL columns for an INSERT ON CONFLICT DO NOTHING.
+build
+INSERT INTO partial_index_project_false (a, d) VALUES (1, 2) ON CONFLICT DO NOTHING
+----
+insert partial_index_project_false
+ ├── columns: <none>
+ ├── arbiter indexes: primary
+ ├── insert-mapping:
+ │    ├── column1:6 => a:1
+ │    ├── column8:8 => b:2
+ │    ├── column8:8 => c:3
+ │    └── column2:7 => d:4
+ ├── partial index put columns: partial_index_put1:14
+ └── project
+      ├── columns: partial_index_put1:14 column1:6!null column2:7!null column8:8
+      ├── upsert-distinct-on
+      │    ├── columns: column1:6!null column2:7!null column8:8
+      │    ├── grouping columns: column1:6!null
+      │    ├── project
+      │    │    ├── columns: column1:6!null column2:7!null column8:8
+      │    │    └── select
+      │    │         ├── columns: column1:6!null column2:7!null column8:8 a:9 b:10 c:11 d:12
+      │    │         ├── left-join (hash)
+      │    │         │    ├── columns: column1:6!null column2:7!null column8:8 a:9 b:10 c:11 d:12
+      │    │         │    ├── project
+      │    │         │    │    ├── columns: column8:8 column1:6!null column2:7!null
+      │    │         │    │    ├── values
+      │    │         │    │    │    ├── columns: column1:6!null column2:7!null
+      │    │         │    │    │    └── (1, 2)
+      │    │         │    │    └── projections
+      │    │         │    │         └── NULL::INT8 [as=column8:8]
+      │    │         │    ├── scan partial_index_project_false
+      │    │         │    │    ├── columns: a:9!null b:10 c:11 d:12
+      │    │         │    │    └── partial index predicates
+      │    │         │    │         └── secondary: filters
+      │    │         │    │              └── c:11 > 0
+      │    │         │    └── filters
+      │    │         │         └── column1:6 = a:9
+      │    │         └── filters
+      │    │              └── a:9 IS NULL
+      │    └── aggregations
+      │         ├── first-agg [as=column2:7]
+      │         │    └── column2:7
+      │         └── first-agg [as=column8:8]
+      │              └── column8:8
+      └── projections
+           └── column8:8 > 0 [as=partial_index_put1:14]
+
 # Columns referenced in the SET expression are ambiguous without a table name.
 # Is it the value of the column being inserted or the value of the column
 # currently in the table?

--- a/pkg/sql/opt/optbuilder/update.go
+++ b/pkg/sql/opt/optbuilder/update.go
@@ -337,9 +337,8 @@ func (mb *mutationBuilder) buildUpdate(returning tree.ReturningExprs) {
 	// Add any check constraint boolean columns to the input.
 	mb.addCheckConstraintCols()
 
-	// Set the index fetch columns. Attempt to reduce the columns, because an
-	// update may not need all columns in order to update the indexes.
-	mb.setIndexFetchCols(true /* reduce */)
+	// Set the index fetch columns and mutating partial index.
+	mb.setIndexFetchColsAndMutatingPartialIndexes()
 
 	// Project partial index PUT and DEL boolean columns.
 	mb.projectPartialIndexPutAndDelCols(preCheckScope, mb.fetchScope)

--- a/pkg/sql/opt/optbuilder/update.go
+++ b/pkg/sql/opt/optbuilder/update.go
@@ -334,7 +334,12 @@ func (mb *mutationBuilder) buildUpdate(returning tree.ReturningExprs) {
 	// columns because the check columns are not in-scope for those expressions.
 	preCheckScope := mb.outScope
 
+	// Add any check constraint boolean columns to the input.
 	mb.addCheckConstraintCols()
+
+	// Set the index fetch columns. Attempt to reduce the columns, because an
+	// update may not need all columns in order to update the indexes.
+	mb.setIndexFetchCols(true /* reduce */)
 
 	// Project partial index PUT and DEL boolean columns.
 	mb.projectPartialIndexPutAndDelCols(preCheckScope, mb.fetchScope)

--- a/pkg/sql/row/updater.go
+++ b/pkg/sql/row/updater.go
@@ -122,14 +122,14 @@ func MakeUpdater(
 		if primaryKeyColChange {
 			return true
 		}
-		// If the index is a partial index, an update may be required even if
-		// the indexed columns aren't changing. For example, an index entry must
-		// be added when an update to a non-indexed column causes a row to
-		// satisfy the partial index predicate when it did not before.
-		// TODO(mgartner): needsUpdate does not need to return true for every
-		// partial index. A partial index will never require updating if neither
-		// its indexed columns nor the columns referenced in its predicate
-		// expression are changing.
+		// Partial indexes may require updates even if the indexed columns
+		// aren't changing. For example, an index entry must be added when an
+		// update to a non-indexed column causes a row to satisfy the partial
+		// index predicate when it did not before. Each row must be assessed
+		// individually to determine if an update is needed. Therefore, we
+		// always return true here and rely on two columns synthesized for each
+		// partial index that indicate whether PUT and DEL operations should be
+		// performed for each row.
 		if index.IsPartial() {
 			return true
 		}


### PR DESCRIPTION
Fixes #51623

#### opt: do not derive prune columns for Upsert, Update, Delete

We no longer derive output prune columns for Upsert, Update, and Delete
ops in `DerivePruneCols`. There are no PruneCols rules for these
operators, so deriving their prune columns was only performing
unnecessary work. There are other rules that prune the fetch and return
columns for these operators. These rules do not rely on
`DerivePruneCols`.

Release note: None

#### opt: move needed mutation fetch columns logic to optbuilder

Previously, logic within prune columns normalization rules calculated
the fetch columns required for updating indexes during a mutation. This
logic has been moved to the optbuilder.

This will make it easier to reduce this set of columns in the future
when we can prove that a column is not needed to maintain the state of a
partial index because the partial index is guaranteed not to change.

In addition, this change reduces repetitive computation to calculate
these fetch columns every time the `PruneMutationFetchCols` rule
attempted to match an expression. For a simple `UPDATE` mutation, this
can occur ~3 times.

Release note: None

#### sql: remove logic to determine fetch cols in row updater

Previously, the `row.MakeUpdater` function had logic to determine the
fetch columns required for an update operation. This is not necessary
because the cost based optimizer already determines the necessary fetch
columns and plumbs them to `MakeUpdater` as the `requestedCols`
argument.

Release note: None

#### opt: prune update/upsert fetch columns not needed for partial indexes

Indexed columns of partial indexes are now only fetched for UPDATE and
UPSERT operations when needed. They are pruned in cases where it is
guaranteed that they are not needed to build old or new index entries.
For example, consider the table and UPDATE:

    CREATE TABLE t (
      a INT PRIMARY KEY,
      b INT,
      c INT,
      d INT,
      INDEX (b) WHERE c > 0,
      FAMILY (a), FAMILY (b), FAMILY (c), FAMILY (d)
    )

    UPDATE t SET d = d + 1 WHERE a = 1

The partial index is guaranteed not to change with this UPDATE because
neither its indexed columns not the columns referenced in its predicate
are mutating. Therefore, the existing values of b do not need to be
fetched to maintain the state of the partial index. Furthermore, the
primary index does require the existing values of b because no columns
in b's family are mutating. So, b can be pruned from the UPDATE's fetch
columns.

Release note (performance improvement): Previously, indexed columns of
partial indexes were always fetched for UPDATEs and UPSERTs. Now they
are only fetched if they are required for maintaining the state of the
index. If an UPDATE or UPSERT mutates columns that are neither indexed by a
partial index nor referenced in a partial index predicate, they will no
longer be fetched (assuming that they are not needed to maintain the
state of other indexes, including the primary index).

#### opt: project false for partial index PUT and DEL columns when possible

The optimizer now projects false expressions for partial index PUT and
DEL columns, rather than predicate expressions, in cases where it is
guaranteed that a UPDATE or UPSERT will not alter the entries of a
partial index.

Release note (performance improvement): UPDATE and UPSERT operations on
tables with partial indexes no longer evaluate partial index predicate
expressions when it is guaranteed that the operation will not alter the
state of the partial index. In some cases, this can eliminate fetching
the existing value of columns that are referenced in partial index
predicates.
