### PR TITLE
build: fix bazel build error of `vec.eg.go`

### DIFF
--- a/pkg/col/coldata/BUILD.bazel
+++ b/pkg/col/coldata/BUILD.bazel
@@ -56,10 +56,10 @@ genrule(
     cmd = """
       $(location //pkg/sql/colexec/execgen/cmd/execgen) \
         -fmt=false pkg/col/coldata/$@ > $@
-      $(location //vendor/github.com/cockroachdb/gostdlib/x/tools/cmd/goimports) -w $@
+      $(location @com_github_cockroachdb_gostdlib//x/tools/cmd/goimports) -w $@
     """,
     tools = [
+        "@com_github_cockroachdb_gostdlib//x/tools/cmd/goimports",
         "//pkg/sql/colexec/execgen/cmd/execgen",
-        "//vendor/github.com/cockroachdb/gostdlib/x/tools/cmd/goimports",
     ],
 )


### PR DESCRIPTION
This conflicts with `129c7ce83ce37d4b6b845e6cec019c41414d79ac` which
removed all the `BUILD.bazel` files from `vendor`. Update the rule here
to be consistent with that change.

Release note: none