### PR TITLE
physicalplan: add local stage for sum_int aggregate function

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/distsql_agg
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_agg
@@ -36,28 +36,38 @@ NULL       /1       {1}       1
 /8         /9       {4}       4
 /9         NULL     {5}       5
 
-query R
-SELECT sum(a) FROM data
+query RI
+SELECT sum(a), sum_int(a) FROM data
 ----
-55000
+55000 55000
 
 query R
 SELECT sum((a-1)*1000 + (b-1)*100 + (c::INT-1)*10 + (d-1)) FROM data
 ----
 49995000
 
-query RII
-SELECT sum(a), count(a), max(a) FROM data
+query I
+SELECT sum_int((a-1)*1000 + (b-1)*100 + (c::INT-1)*10 + (d::INT-1)) FROM data
 ----
-55000 10000 10
+49995000
 
-query RII
-SELECT sum(a+b), count(a+b), max(a+b) FROM data
+query RIII
+SELECT sum(a), sum_int(a), count(a), max(a) FROM data
 ----
-110000 10000 20
+55000 55000 10000 10
+
+query RIII
+SELECT sum(a+b), sum_int(a+b), count(a+b), max(a+b) FROM data
+----
+110000 110000 10000 20
 
 query R
 SELECT sum((a-1)*1000) + sum((b-1)*100) + sum((c::INT-1)*10) + sum(d-1) FROM data
+----
+49995000
+
+query I
+SELECT sum_int((a-1)*1000) + sum_int((b-1)*100) + sum_int((c::INT-1)*10) + sum_int(d::INT-1) FROM data
 ----
 49995000
 
@@ -91,10 +101,10 @@ SELECT variance(a+b+c::INT+d) FROM data
 ----
 33.0033003300330033
 
-query RRRRRRR
-SELECT sum(a), avg(b), sum(c), avg(d), stddev(a), variance(b), sum(a+b+c::INT+d) FROM data
+query RIRRRRRR
+SELECT sum(a), sum_int(a), avg(b), sum(c), avg(d), stddev(a), variance(b), sum(a+b+c::INT+d) FROM data
 ----
-55000 5.5 55000 5.5 2.8724249481071304094 8.2508250825082508251 220000
+55000 55000 5.5 55000 5.5 2.8724249481071304094 8.2508250825082508251 220000
 
 query RIRIRRR
 SELECT sum(a), min(b), max(c), count(d), avg(a+b+c::INT+d), stddev(a+b), variance(c::INT+d) FROM data
@@ -121,10 +131,10 @@ SELECT sum(a), avg(b), sum(a), sum(a), avg(b) FROM data
 ----
 55000 5.5 55000 55000 5.5
 
-query RRRR
-SELECT avg(c), sum(c), avg(d), sum(d) FROM data
+query RRIRR
+SELECT avg(c), sum(c), sum_int(c::INT), avg(d), sum(d) FROM data
 ----
-5.5 55000 5.5 55000
+5.5 55000 55000 5.5 55000
 
 query II
 SELECT max(a), min(b) FROM data HAVING min(b) > 2
@@ -145,15 +155,15 @@ SELECT DISTINCT (a) FROM data
 9
 10
 
-query R
-SELECT SUM (DISTINCT A) FROM data
-----
-55
-
-query RR
-SELECT SUM (DISTINCT A), SUM (DISTINCT B) from data
+query RI
+SELECT sum(DISTINCT a), sum_int(DISTINCT a) FROM data
 ----
 55 55
+
+query RIRI
+SELECT sum(DISTINCT a), sum_int(DISTINCT a), sum(DISTINCT b), sum_int(DISTINCT b) from data
+----
+55 55 55 55
 
 query II
 SELECT DISTINCT a, b FROM data WHERE (a + b + c::INT) = 27 ORDER BY a,b
@@ -183,109 +193,109 @@ SELECT DISTINCT a, b FROM data WHERE (a + b + c::INT) = 27 ORDER BY b,a
 9  10
 10 10
 
-query RRR
-SELECT c, d, sum(a+c::INT) + avg(b+d) FROM data GROUP BY c, d ORDER BY c, d
+query RRRI
+SELECT c, d, sum(a+c::INT) + avg(b+d), sum_int(a+c::INT) + avg(b+d)::INT FROM data GROUP BY c, d ORDER BY c, d
 ----
-1   1   656.5
-1   2   657.5
-1   3   658.5
-1   4   659.5
-1   5   660.5
-1   6   661.5
-1   7   662.5
-1   8   663.5
-1   9   664.5
-1   10  665.5
-2   1   756.5
-2   2   757.5
-2   3   758.5
-2   4   759.5
-2   5   760.5
-2   6   761.5
-2   7   762.5
-2   8   763.5
-2   9   764.5
-2   10  765.5
-3   1   856.5
-3   2   857.5
-3   3   858.5
-3   4   859.5
-3   5   860.5
-3   6   861.5
-3   7   862.5
-3   8   863.5
-3   9   864.5
-3   10  865.5
-4   1   956.5
-4   2   957.5
-4   3   958.5
-4   4   959.5
-4   5   960.5
-4   6   961.5
-4   7   962.5
-4   8   963.5
-4   9   964.5
-4   10  965.5
-5   1   1056.5
-5   2   1057.5
-5   3   1058.5
-5   4   1059.5
-5   5   1060.5
-5   6   1061.5
-5   7   1062.5
-5   8   1063.5
-5   9   1064.5
-5   10  1065.5
-6   1   1156.5
-6   2   1157.5
-6   3   1158.5
-6   4   1159.5
-6   5   1160.5
-6   6   1161.5
-6   7   1162.5
-6   8   1163.5
-6   9   1164.5
-6   10  1165.5
-7   1   1256.5
-7   2   1257.5
-7   3   1258.5
-7   4   1259.5
-7   5   1260.5
-7   6   1261.5
-7   7   1262.5
-7   8   1263.5
-7   9   1264.5
-7   10  1265.5
-8   1   1356.5
-8   2   1357.5
-8   3   1358.5
-8   4   1359.5
-8   5   1360.5
-8   6   1361.5
-8   7   1362.5
-8   8   1363.5
-8   9   1364.5
-8   10  1365.5
-9   1   1456.5
-9   2   1457.5
-9   3   1458.5
-9   4   1459.5
-9   5   1460.5
-9   6   1461.5
-9   7   1462.5
-9   8   1463.5
-9   9   1464.5
-9   10  1465.5
-10  1   1556.5
-10  2   1557.5
-10  3   1558.5
-10  4   1559.5
-10  5   1560.5
-10  6   1561.5
-10  7   1562.5
-10  8   1563.5
-10  9   1564.5
-10  10  1565.5
+1   1   656.5   657
+1   2   657.5   658
+1   3   658.5   659
+1   4   659.5   660
+1   5   660.5   661
+1   6   661.5   662
+1   7   662.5   663
+1   8   663.5   664
+1   9   664.5   665
+1   10  665.5   666
+2   1   756.5   757
+2   2   757.5   758
+2   3   758.5   759
+2   4   759.5   760
+2   5   760.5   761
+2   6   761.5   762
+2   7   762.5   763
+2   8   763.5   764
+2   9   764.5   765
+2   10  765.5   766
+3   1   856.5   857
+3   2   857.5   858
+3   3   858.5   859
+3   4   859.5   860
+3   5   860.5   861
+3   6   861.5   862
+3   7   862.5   863
+3   8   863.5   864
+3   9   864.5   865
+3   10  865.5   866
+4   1   956.5   957
+4   2   957.5   958
+4   3   958.5   959
+4   4   959.5   960
+4   5   960.5   961
+4   6   961.5   962
+4   7   962.5   963
+4   8   963.5   964
+4   9   964.5   965
+4   10  965.5   966
+5   1   1056.5  1057
+5   2   1057.5  1058
+5   3   1058.5  1059
+5   4   1059.5  1060
+5   5   1060.5  1061
+5   6   1061.5  1062
+5   7   1062.5  1063
+5   8   1063.5  1064
+5   9   1064.5  1065
+5   10  1065.5  1066
+6   1   1156.5  1157
+6   2   1157.5  1158
+6   3   1158.5  1159
+6   4   1159.5  1160
+6   5   1160.5  1161
+6   6   1161.5  1162
+6   7   1162.5  1163
+6   8   1163.5  1164
+6   9   1164.5  1165
+6   10  1165.5  1166
+7   1   1256.5  1257
+7   2   1257.5  1258
+7   3   1258.5  1259
+7   4   1259.5  1260
+7   5   1260.5  1261
+7   6   1261.5  1262
+7   7   1262.5  1263
+7   8   1263.5  1264
+7   9   1264.5  1265
+7   10  1265.5  1266
+8   1   1356.5  1357
+8   2   1357.5  1358
+8   3   1358.5  1359
+8   4   1359.5  1360
+8   5   1360.5  1361
+8   6   1361.5  1362
+8   7   1362.5  1363
+8   8   1363.5  1364
+8   9   1364.5  1365
+8   10  1365.5  1366
+9   1   1456.5  1457
+9   2   1457.5  1458
+9   3   1458.5  1459
+9   4   1459.5  1460
+9   5   1460.5  1461
+9   6   1461.5  1462
+9   7   1462.5  1463
+9   8   1463.5  1464
+9   9   1464.5  1465
+9   10  1465.5  1466
+10  1   1556.5  1557
+10  2   1557.5  1558
+10  3   1558.5  1559
+10  4   1559.5  1560
+10  5   1560.5  1561
+10  6   1561.5  1562
+10  7   1562.5  1563
+10  8   1563.5  1564
+10  9   1564.5  1565
+10  10  1565.5  1566
 
 # Test plans with empty streams.
 statement ok
@@ -362,34 +372,34 @@ SELECT avg(a+b), c FROM data GROUP BY c, d HAVING c = d
 11  9
 11  10
 
-query RRR rowsort
-SELECT sum(a+b), sum(a+b) FILTER (WHERE a < d), sum(a+b) FILTER (WHERE a = c) FROM data GROUP BY d
+query RRIR rowsort
+SELECT sum(a+b), sum(a+b) FILTER (WHERE a < d), sum_int(a+b) FILTER (WHERE a < d), sum(a+b) FILTER (WHERE a = c) FROM data GROUP BY d
 ----
-11000  NULL  1100
-11000  650   1100
-11000  1400  1100
-11000  3200  1100
-11000  2250  1100
-11000  4250  1100
-11000  5400  1100
-11000  6650  1100
-11000  8000  1100
-11000  9450  1100
+11000  NULL  NULL 1100
+11000  650   650  1100
+11000  1400  1400 1100
+11000  3200  3200 1100
+11000  2250  2250 1100
+11000  4250  4250 1100
+11000  5400  5400 1100
+11000  6650  6650 1100
+11000  8000  8000 1100
+11000  9450  9450 1100
 
 # Same query but restricted to a single range; no local aggregation stage.
-query RRR rowsort
-SELECT sum(a+b), sum(a+b) FILTER (WHERE a < d), sum(a+b) FILTER (WHERE a = c) FROM data WHERE a = 1 GROUP BY d
+query RRIR rowsort
+SELECT sum(a+b), sum(a+b) FILTER (WHERE a < d), sum_int(a+b) FILTER (WHERE a < d), sum(a+b) FILTER (WHERE a = c) FROM data WHERE a = 1 GROUP BY d
 ----
-650  NULL  65
-650  650   65
-650  650   65
-650  650   65
-650  650   65
-650  650   65
-650  650   65
-650  650   65
-650  650   65
-650  650   65
+650  NULL  NULL 65
+650  650   650  65
+650  650   650  65
+650  650   650  65
+650  650   650  65
+650  650   650  65
+650  650   650  65
+650  650   650  65
+650  650   650  65
+650  650   650  65
 
 query IIRT
 VALUES (1, 2, 1.0, 'string1'), (4, 3, 2.3, 'string2')

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_agg
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_agg
@@ -1,7 +1,7 @@
 # LogicTest: 5node
 
 statement ok
-CREATE TABLE data (a INT, b INT, c FLOAT, d DECIMAL, PRIMARY KEY (a, b, c, d))
+CREATE TABLE data (a INT, b INT, c FLOAT, d DECIMAL, _bool BOOL, _bytes BYTES, _bit BIT, PRIMARY KEY (a, b, c, d))
 
 # Split into ten parts.
 statement ok
@@ -27,6 +27,45 @@ NULL       /1       {1}       1
 /7         /8       {3}       3
 /8         /9       {4}       4
 /9         NULL     {5}       5
+
+# Verify that all aggregate functions that we expect to have multi-stage
+# execution do, in fact, get planned with 2 stages.
+query T
+EXPLAIN (DISTSQL) SELECT
+  b, -- any_not_null
+  avg(a),
+  bool_and(_bool),
+  bool_or(_bool),
+  count(a),
+  max(a),
+  min(a),
+  stddev(a),
+  sum(a),
+  sum_int(a),
+  variance(a),
+  xor_agg(_bytes),
+  count(*), -- count_rows
+  bit_and(_bit),
+  bit_or(_bit)
+FROM data GROUP BY b
+----
+distribution: full
+vectorized: true
+·
+• group
+│ group by: b
+│
+└── • scan
+      missing stats
+      table: data@primary
+      spans: FULL SCAN
+·
+Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJzsV11v4jgUfd9fYfkprIyC88HXk5lCq0iQdALMdrRCkSEWjURjNglVq6r_fZVAgVDGzsh0nnghvsk9vtfn-FyJN5j-t4JdOHi4H_YcF2h9ZzwZfx_WwHgwHNxMwBwB-rzUaA2BOeergMahFuSrjxc82ccLvomzIvWJvmyfUVw80ywM2fN2uXn6eAbRLv2ZJhGNF6wIXngS0OVSC-avGUv32_6dF4yyXQNRtguL8lFWA7e-NwIhzSi4873pPfj2E8whgjEPmUufWAq7_0IMETQggiZE0III2nCG4DrhC5amPMlT3gqAE77AbgPBKF5vsvz1DMEFTxjsvsEsylYMduGEzlfMZzRkid6ACIYso9GqKJN3QdZJ9ESTV4jgeE3jtAvqOgY0DgEGPHtkCUTQ22RdQDAiBiI2Ik1EWnD2jiDfZIe6aUaXDHbxO6reW2-5TNiSZjzR7XJrJD9-z_0ZuN4kcKfDoUaMWt7jdKQRnK9uvKk72a2_ed4w6Ll9jZj70PN3UZEY-N4_Yy0PR72HHWrkuLvV-Lvfd25vP6LpKHD2ez94ftC7u9OIVWztTLaF7I8or2PXTvg4HHH-Ch5p-nhyOgxn7wfOjF9ydthnE_MkZAkLSzsVuwhYxY1PhU9pxXtajdLhzTKxVolYu5Ta3PPa2vPazle3jtsbBuNJvz_4oZFOcYHMMsWNQ96Pnu_03JtBKXNPP8Yl_rFxLAAucn0Whywprioghk5MBIiFALERIE0ESAsB0kaAdPLPCBDcyH_yZGzsUnCOwdYvr7d5WalcXudrHdsnmedrW6XauLrtcRXb67iuGxczvqS7oyvavBr_DGfKxsdX43-h8Y3q5jMqmc-o6-bFzCfp7uiatK7mO8OZsvmMq_m-0HxmdfOZlcxn1nXrYuaTdHd0TdpX853hTNl85tV8X2g-q7r5rErms-q6fTHzSbo7uiadq_nOcKZsPutqvj_0f_OMED5L1zxOWaV_k41cShYu2Vb3lG-SBbtP-KIosw29Ale8CFmabb_ibeDE2095g8dgfArGx2CjBMa_B26qgDsqYKzUN7bFaEPItykGm2KxmmK1LCHaFoNtFanFYInUYrBEajFYJrUELZG6qSJ1Swhui8Vqq4glBkvEEoMlYonBMrEkaIlYHRWxsGSKysao2hxVG6Rqk1RxlKrNUqw0TLFkmloS0T6N098STYyWiSZGy0QTo6WiSeAy0T4NVaFos_e__g8AAP__dlZT8w==
+
+statement ok
+ALTER TABLE data DROP COLUMN _bool;
+ALTER TABLE data DROP COLUMN _bytes;
+ALTER TABLE data DROP COLUMN _bit;
 
 query T
 EXPLAIN (DISTSQL) SELECT sum(a) FROM data

--- a/pkg/sql/physicalplan/aggregator_funcs.go
+++ b/pkg/sql/physicalplan/aggregator_funcs.go
@@ -185,6 +185,16 @@ var DistAggregationTable = map[execinfrapb.AggregatorSpec_Func]DistAggregationIn
 		},
 	},
 
+	execinfrapb.AggregatorSpec_SUM_INT: {
+		LocalStage: []execinfrapb.AggregatorSpec_Func{execinfrapb.AggregatorSpec_SUM_INT},
+		FinalStage: []FinalStageInfo{
+			{
+				Fn:        execinfrapb.AggregatorSpec_SUM_INT,
+				LocalIdxs: passThroughLocalIdxs,
+			},
+		},
+	},
+
 	execinfrapb.AggregatorSpec_XOR_AGG: {
 		LocalStage: []execinfrapb.AggregatorSpec_Func{execinfrapb.AggregatorSpec_XOR_AGG},
 		FinalStage: []FinalStageInfo{

--- a/pkg/sql/physicalplan/aggregator_funcs.go
+++ b/pkg/sql/physicalplan/aggregator_funcs.go
@@ -95,118 +95,8 @@ var DistAggregationTable = map[execinfrapb.AggregatorSpec_Func]DistAggregationIn
 		},
 	},
 
-	execinfrapb.AggregatorSpec_BIT_AND: {
-		LocalStage: []execinfrapb.AggregatorSpec_Func{execinfrapb.AggregatorSpec_BIT_AND},
-		FinalStage: []FinalStageInfo{
-			{
-				Fn:        execinfrapb.AggregatorSpec_BIT_AND,
-				LocalIdxs: passThroughLocalIdxs,
-			},
-		},
-	},
-
-	execinfrapb.AggregatorSpec_BIT_OR: {
-		LocalStage: []execinfrapb.AggregatorSpec_Func{execinfrapb.AggregatorSpec_BIT_OR},
-		FinalStage: []FinalStageInfo{
-			{
-				Fn:        execinfrapb.AggregatorSpec_BIT_OR,
-				LocalIdxs: passThroughLocalIdxs,
-			},
-		},
-	},
-
-	execinfrapb.AggregatorSpec_BOOL_AND: {
-		LocalStage: []execinfrapb.AggregatorSpec_Func{execinfrapb.AggregatorSpec_BOOL_AND},
-		FinalStage: []FinalStageInfo{
-			{
-				Fn:        execinfrapb.AggregatorSpec_BOOL_AND,
-				LocalIdxs: passThroughLocalIdxs,
-			},
-		},
-	},
-
-	execinfrapb.AggregatorSpec_BOOL_OR: {
-		LocalStage: []execinfrapb.AggregatorSpec_Func{execinfrapb.AggregatorSpec_BOOL_OR},
-		FinalStage: []FinalStageInfo{
-			{
-				Fn:        execinfrapb.AggregatorSpec_BOOL_OR,
-				LocalIdxs: passThroughLocalIdxs,
-			},
-		},
-	},
-
-	execinfrapb.AggregatorSpec_COUNT: {
-		LocalStage: []execinfrapb.AggregatorSpec_Func{execinfrapb.AggregatorSpec_COUNT},
-		FinalStage: []FinalStageInfo{
-			{
-				Fn:        execinfrapb.AggregatorSpec_SUM_INT,
-				LocalIdxs: passThroughLocalIdxs,
-			},
-		},
-	},
-
-	execinfrapb.AggregatorSpec_COUNT_ROWS: {
-		LocalStage: []execinfrapb.AggregatorSpec_Func{execinfrapb.AggregatorSpec_COUNT_ROWS},
-		FinalStage: []FinalStageInfo{
-			{
-				Fn:        execinfrapb.AggregatorSpec_SUM_INT,
-				LocalIdxs: passThroughLocalIdxs,
-			},
-		},
-	},
-
-	execinfrapb.AggregatorSpec_MAX: {
-		LocalStage: []execinfrapb.AggregatorSpec_Func{execinfrapb.AggregatorSpec_MAX},
-		FinalStage: []FinalStageInfo{
-			{
-				Fn:        execinfrapb.AggregatorSpec_MAX,
-				LocalIdxs: passThroughLocalIdxs,
-			},
-		},
-	},
-
-	execinfrapb.AggregatorSpec_MIN: {
-		LocalStage: []execinfrapb.AggregatorSpec_Func{execinfrapb.AggregatorSpec_MIN},
-		FinalStage: []FinalStageInfo{
-			{
-				Fn:        execinfrapb.AggregatorSpec_MIN,
-				LocalIdxs: passThroughLocalIdxs,
-			},
-		},
-	},
-
-	execinfrapb.AggregatorSpec_SUM: {
-		LocalStage: []execinfrapb.AggregatorSpec_Func{execinfrapb.AggregatorSpec_SUM},
-		FinalStage: []FinalStageInfo{
-			{
-				Fn:        execinfrapb.AggregatorSpec_SUM,
-				LocalIdxs: passThroughLocalIdxs,
-			},
-		},
-	},
-
-	execinfrapb.AggregatorSpec_SUM_INT: {
-		LocalStage: []execinfrapb.AggregatorSpec_Func{execinfrapb.AggregatorSpec_SUM_INT},
-		FinalStage: []FinalStageInfo{
-			{
-				Fn:        execinfrapb.AggregatorSpec_SUM_INT,
-				LocalIdxs: passThroughLocalIdxs,
-			},
-		},
-	},
-
-	execinfrapb.AggregatorSpec_XOR_AGG: {
-		LocalStage: []execinfrapb.AggregatorSpec_Func{execinfrapb.AggregatorSpec_XOR_AGG},
-		FinalStage: []FinalStageInfo{
-			{
-				Fn:        execinfrapb.AggregatorSpec_XOR_AGG,
-				LocalIdxs: passThroughLocalIdxs,
-			},
-		},
-	},
-
-	// AVG is more tricky than the ones above; we need two intermediate values in
-	// the local and final stages:
+	// AVG is more tricky than others; we need two intermediate values in the
+	// local and final stages:
 	//  - the local stage accumulates the SUM and the COUNT;
 	//  - the final stage sums these partial results (SUM and SUM_INT);
 	//  - a final rendering then divides the two results.
@@ -255,6 +145,90 @@ var DistAggregationTable = map[execinfrapb.AggregatorSpec_Func]DistAggregationIn
 		},
 	},
 
+	execinfrapb.AggregatorSpec_BOOL_AND: {
+		LocalStage: []execinfrapb.AggregatorSpec_Func{execinfrapb.AggregatorSpec_BOOL_AND},
+		FinalStage: []FinalStageInfo{
+			{
+				Fn:        execinfrapb.AggregatorSpec_BOOL_AND,
+				LocalIdxs: passThroughLocalIdxs,
+			},
+		},
+	},
+
+	execinfrapb.AggregatorSpec_BOOL_OR: {
+		LocalStage: []execinfrapb.AggregatorSpec_Func{execinfrapb.AggregatorSpec_BOOL_OR},
+		FinalStage: []FinalStageInfo{
+			{
+				Fn:        execinfrapb.AggregatorSpec_BOOL_OR,
+				LocalIdxs: passThroughLocalIdxs,
+			},
+		},
+	},
+
+	execinfrapb.AggregatorSpec_COUNT: {
+		LocalStage: []execinfrapb.AggregatorSpec_Func{execinfrapb.AggregatorSpec_COUNT},
+		FinalStage: []FinalStageInfo{
+			{
+				Fn:        execinfrapb.AggregatorSpec_SUM_INT,
+				LocalIdxs: passThroughLocalIdxs,
+			},
+		},
+	},
+
+	execinfrapb.AggregatorSpec_MAX: {
+		LocalStage: []execinfrapb.AggregatorSpec_Func{execinfrapb.AggregatorSpec_MAX},
+		FinalStage: []FinalStageInfo{
+			{
+				Fn:        execinfrapb.AggregatorSpec_MAX,
+				LocalIdxs: passThroughLocalIdxs,
+			},
+		},
+	},
+
+	execinfrapb.AggregatorSpec_MIN: {
+		LocalStage: []execinfrapb.AggregatorSpec_Func{execinfrapb.AggregatorSpec_MIN},
+		FinalStage: []FinalStageInfo{
+			{
+				Fn:        execinfrapb.AggregatorSpec_MIN,
+				LocalIdxs: passThroughLocalIdxs,
+			},
+		},
+	},
+
+	execinfrapb.AggregatorSpec_STDDEV: {
+		LocalStage: []execinfrapb.AggregatorSpec_Func{
+			execinfrapb.AggregatorSpec_SQRDIFF,
+			execinfrapb.AggregatorSpec_SUM,
+			execinfrapb.AggregatorSpec_COUNT,
+		},
+		FinalStage: []FinalStageInfo{
+			{
+				Fn:        execinfrapb.AggregatorSpec_FINAL_STDDEV,
+				LocalIdxs: []uint32{0, 1, 2},
+			},
+		},
+	},
+
+	execinfrapb.AggregatorSpec_SUM: {
+		LocalStage: []execinfrapb.AggregatorSpec_Func{execinfrapb.AggregatorSpec_SUM},
+		FinalStage: []FinalStageInfo{
+			{
+				Fn:        execinfrapb.AggregatorSpec_SUM,
+				LocalIdxs: passThroughLocalIdxs,
+			},
+		},
+	},
+
+	execinfrapb.AggregatorSpec_SUM_INT: {
+		LocalStage: []execinfrapb.AggregatorSpec_Func{execinfrapb.AggregatorSpec_SUM_INT},
+		FinalStage: []FinalStageInfo{
+			{
+				Fn:        execinfrapb.AggregatorSpec_SUM_INT,
+				LocalIdxs: passThroughLocalIdxs,
+			},
+		},
+	},
+
 	// For VARIANCE/STDDEV the local stage consists of three aggregations,
 	// and the final stage aggregation uses all three values.
 	// respectively:
@@ -287,16 +261,42 @@ var DistAggregationTable = map[execinfrapb.AggregatorSpec_Func]DistAggregationIn
 		},
 	},
 
-	execinfrapb.AggregatorSpec_STDDEV: {
-		LocalStage: []execinfrapb.AggregatorSpec_Func{
-			execinfrapb.AggregatorSpec_SQRDIFF,
-			execinfrapb.AggregatorSpec_SUM,
-			execinfrapb.AggregatorSpec_COUNT,
-		},
+	execinfrapb.AggregatorSpec_XOR_AGG: {
+		LocalStage: []execinfrapb.AggregatorSpec_Func{execinfrapb.AggregatorSpec_XOR_AGG},
 		FinalStage: []FinalStageInfo{
 			{
-				Fn:        execinfrapb.AggregatorSpec_FINAL_STDDEV,
-				LocalIdxs: []uint32{0, 1, 2},
+				Fn:        execinfrapb.AggregatorSpec_XOR_AGG,
+				LocalIdxs: passThroughLocalIdxs,
+			},
+		},
+	},
+
+	execinfrapb.AggregatorSpec_COUNT_ROWS: {
+		LocalStage: []execinfrapb.AggregatorSpec_Func{execinfrapb.AggregatorSpec_COUNT_ROWS},
+		FinalStage: []FinalStageInfo{
+			{
+				Fn:        execinfrapb.AggregatorSpec_SUM_INT,
+				LocalIdxs: passThroughLocalIdxs,
+			},
+		},
+	},
+
+	execinfrapb.AggregatorSpec_BIT_AND: {
+		LocalStage: []execinfrapb.AggregatorSpec_Func{execinfrapb.AggregatorSpec_BIT_AND},
+		FinalStage: []FinalStageInfo{
+			{
+				Fn:        execinfrapb.AggregatorSpec_BIT_AND,
+				LocalIdxs: passThroughLocalIdxs,
+			},
+		},
+	},
+
+	execinfrapb.AggregatorSpec_BIT_OR: {
+		LocalStage: []execinfrapb.AggregatorSpec_Func{execinfrapb.AggregatorSpec_BIT_OR},
+		FinalStage: []FinalStageInfo{
+			{
+				Fn:        execinfrapb.AggregatorSpec_BIT_OR,
+				LocalIdxs: passThroughLocalIdxs,
 			},
 		},
 	},


### PR DESCRIPTION
**physicalplan: add local stage for sum_int aggregate function**

I'm not sure why we didn't have it before given that `sum` function does
have a local stage.

Release note (performance improvement): `sum_int` aggregate function is
now evaluated more efficiently in a distributed setting.

**physicalplan: reorder aggregate funcs according to their proto ordinals**

Release note: None