### PR TITLE
cdc: Always use statement time name to build Kafka topic

### DIFF
--- a/pkg/ccl/changefeedccl/sink_test.go
+++ b/pkg/ccl/changefeedccl/sink_test.go
@@ -66,8 +66,10 @@ func TestKafkaSink(t *testing.T) {
 	}
 	sink := &kafkaSink{
 		producer: p,
-		topics:   map[string]struct{}{`t`: {}},
 	}
+	targets := make(jobspb.ChangefeedTargets, 1)
+	targets[0] = jobspb.ChangefeedTarget{StatementTimeName: `t`}
+	sink.setTargets(targets)
 	sink.start()
 	defer func() {
 		if err := sink.Close(); err != nil {
@@ -156,8 +158,10 @@ func TestKafkaSinkEscaping(t *testing.T) {
 	}
 	sink := &kafkaSink{
 		producer: p,
-		topics:   map[string]struct{}{SQLNameToKafkaName(`☃`): {}},
 	}
+	targets := make(jobspb.ChangefeedTargets, 1)
+	targets[0] = jobspb.ChangefeedTarget{StatementTimeName: `☃`}
+	sink.setTargets(targets)
 	sink.start()
 	defer func() { require.NoError(t, sink.Close()) }()
 	if err := sink.EmitRow(ctx, table(`☃`), []byte(`k☃`), []byte(`v☃`), zeroTS); err != nil {


### PR DESCRIPTION
This is meant to be a trivial step on the way to adding the fully-qualified-name flag, but I haven't been able to completely persuade myself this is doing what I think it's doing, so while I test it locally I'm making the PR just in case some is online to whom it's obvious. The idea is that since we save and serialize the statement time name of a table when creating a changefeed on it, we should use that when interpolating it into the Kafka topic. The main reason I'm confused is that I'm not sure that the table id referenced in the changefeed job isn't the descriptor id that gets incremented on a schema change, which would break this (and I would think existing behavior) anyway.

Hopefully I'll have figured this out myself but I wanted to make sure I at least had something pushed for this week, trivial though it is.

Release note (bug fix): Previously, behavior was inconsistent if a table name
used in a Kafka topic changed. Now the Kafka topic written to will
be unaffected by table name changes.