### PR TITLE
sql: remove wrappedPlanHooks

### DIFF
--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -523,14 +523,6 @@ func (p *planner) maybePlanHook(ctx context.Context, stmt tree.Statement) (planN
 			return &hookFnNode{f: fn, header: header, subplans: subplans}, nil
 		}
 	}
-	for _, planHook := range wrappedPlanHooks {
-		if node, err := planHook(ctx, stmt, p); err != nil {
-			return nil, err
-		} else if node != nil {
-			return node, err
-		}
-	}
-
 	return nil, nil
 }
 

--- a/pkg/sql/planhook.go
+++ b/pkg/sql/planhook.go
@@ -51,14 +51,6 @@ type PlanHookRowFn func(context.Context, []planNode, chan<- tree.Datums) error
 
 var planHooks []planHookFn
 
-// wrappedPlanHookFn is similar to planHookFn but returns an existing plan type.
-// Additionally, it takes a context.
-type wrappedPlanHookFn func(
-	context.Context, tree.Statement, PlanHookState,
-) (planNode, error)
-
-var wrappedPlanHooks []wrappedPlanHookFn
-
 func (p *planner) RunParams(ctx context.Context) runParams {
 	return runParams{ctx, p.ExtendedEvalContext(), p}
 }


### PR DESCRIPTION
wrappedPlanHooks were introduced for RBAC (bf766d6) and have not seen use since RBAC was moved into the BSL license (ae65915).