### PR TITLE
sqlproxyccl: always close the client connection

### DIFF
--- a/pkg/ccl/sqlproxyccl/server.go
+++ b/pkg/ccl/sqlproxyccl/server.go
@@ -145,6 +145,7 @@ func (s *Server) Serve(ln net.Listener) error {
 		}
 
 		go func() {
+			defer func() { _ = conn.Close() }()
 			s.metrics.CurConnCount.Inc(1)
 			defer s.metrics.CurConnCount.Dec(1)
 			tBegin := timeutil.Now()


### PR DESCRIPTION
Previously, the sqlproxy failed to close the incoming TCP connection if
an error occurred in the frontend admitter. This leaked the connection
server-side and left the client connection hanging.

This adds back the deferred close of the incoming TCP connection
(removed in #57306). The custom Conn type allows callers to call Close
multiple times.

Release note: none