### PR TITLE
build: check for stale BUILD files in CI

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,3 @@
+# TODO(irfansharif): We should fold this into `dev` instead (#56965).
+
+build --ui_event_filters=-DEBUG

--- a/build/teamcity-check.sh
+++ b/build/teamcity-check.sh
@@ -43,6 +43,9 @@ check_clean "Run \`make generate\` to automatically regenerate these."
 run build/builder.sh make buildshort &> artifacts/buildshort.log || (cat artifacts/buildshort.log && false)
 rm artifacts/buildshort.log
 check_clean "Run \`make buildshort\` to automatically regenerate these."
+run build/builder.sh make bazel-generate &> artifacts/buildshort.log || (cat artifacts/buildshort.log && false)
+rm artifacts/buildshort.log
+check_clean "Run \`make bazel-generate\` to automatically regenerate these."
 tc_end_block "Ensure generated code is up-to-date"
 
 # generated code can generate new dependencies; check dependencies after generated code.
@@ -54,7 +57,6 @@ run build/builder.sh make -k vendor_rebuild
 cd vendor
 check_clean "Run \`make -k vendor_rebuild\` to automatically regenerate these."
 cd ..
-check_clean "Run \`make -k vendor_rebuild\` to automatically regenerate these. If it is only BUILD.bazel files that are affected, run \`bazel run //:gazelle\` to automatically regenerate these."
 tc_end_block "Ensure dependencies are up-to-date"
 
 tc_start_block "Lint"

--- a/pkg/col/coldata/BUILD.bazel
+++ b/pkg/col/coldata/BUILD.bazel
@@ -58,7 +58,7 @@ genrule(
       $(location @com_github_cockroachdb_gostdlib//x/tools/cmd/goimports) -w $@
     """,
     tools = [
-        "@com_github_cockroachdb_gostdlib//x/tools/cmd/goimports",
         "//pkg/sql/colexec/execgen/cmd/execgen",
+        "@com_github_cockroachdb_gostdlib//x/tools/cmd/goimports",
     ],
 )


### PR DESCRIPTION
We'll want to do this explicitly now that we've decoupled bazel from
vendor (#58229). Previously this staleness check was happening when
checking to see that `vendor` was up-to-date.

---

*: elide DEBUG logging for `bazel build` 

Things have gotten a lot more verbose since #58256 and #58229. This
should help control some of that.

Release note: None.