### PR TITLE
sql: support extracting from scalar JSON values with indexes

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/json
+++ b/pkg/sql/logictest/testdata/logic_test/json
@@ -168,10 +168,9 @@ SELECT bar FROM foo WHERE bar ?| ARRAY['a', null]
 ----
 {"a": "b"}
 
-# TODO(justin): #29355
-# query T
-# SELECT bar FROM foo WHERE bar ?| ARRAY[null, null]::STRING[]
-# ----
+query T
+SELECT bar FROM foo WHERE bar ?| ARRAY[null, null]::STRING[]
+----
 
 query T
 SELECT bar FROM foo WHERE bar ?& ARRAY['a', null]
@@ -362,6 +361,56 @@ query T
 SELECT '[1, 2, 3]'::JSONB->>3
 ----
 NULL
+
+query TTTT
+SELECT 'null'::jsonb->-2, 'null'::jsonb->-1, 'null'::jsonb->0, 'null'::jsonb->1
+----
+NULL  null  null  NULL
+
+query TTTT
+SELECT 'true'::jsonb->-2, 'true'::jsonb->-1, 'true'::jsonb->0, 'true'::jsonb->1
+----
+NULL  true  true  NULL
+
+query TTTT
+SELECT 'false'::jsonb->-2, 'false'::jsonb->-1, 'false'::jsonb->0, 'false'::jsonb->1
+----
+NULL  false  false  NULL
+
+query TTTT
+SELECT '"foo"'::jsonb->-2, '"foo"'::jsonb->-1, '"foo"'::jsonb->0, '"foo"'::jsonb->1
+----
+NULL  "foo"  "foo"  NULL
+
+query TTTT
+SELECT '123'::jsonb->-2, '123'::jsonb->-1, '123'::jsonb->0, '123'::jsonb->1
+----
+NULL  123  123  NULL
+
+query TTTT
+SELECT 'null'::jsonb->>-2, 'null'::jsonb->>-1, 'null'::jsonb->>0, 'null'::jsonb->>1
+----
+NULL  NULL  NULL  NULL
+
+query TTTT
+SELECT 'true'::jsonb->>-2, 'true'::jsonb->>-1, 'true'::jsonb->>0, 'true'::jsonb->>1
+----
+NULL  true  true  NULL
+
+query TTTT
+SELECT 'false'::jsonb->>-2, 'false'::jsonb->>-1, 'false'::jsonb->>0, 'false'::jsonb->>1
+----
+NULL  false  false  NULL
+
+query TTTT
+SELECT '"foo"'::jsonb->>-2, '"foo"'::jsonb->>-1, '"foo"'::jsonb->>0, '"foo"'::jsonb->>1
+----
+NULL  foo  foo  NULL
+
+query TTTT
+SELECT '123'::jsonb->>-2, '123'::jsonb->>-1, '123'::jsonb->>0, '123'::jsonb->>1
+----
+NULL  123  123  NULL
 
 query T
 SELECT '{"a": 1}'::JSONB#>'{a}'::STRING[]

--- a/pkg/util/json/encoded.go
+++ b/pkg/util/json/encoded.go
@@ -387,7 +387,10 @@ func (j *jsonEncoded) FetchValIdx(idx int) (JSON, error) {
 		return dec.FetchValIdx(idx)
 	}
 
-	if j.Type() == ArrayJSONType {
+	switch j.typ {
+	case NumberJSONType, StringJSONType, TrueJSONType, FalseJSONType, NullJSONType:
+		return fetchValIdxForScalar(j, idx), nil
+	case ArrayJSONType:
 		if idx < 0 {
 			idx = j.containerLen + idx
 		}
@@ -404,8 +407,11 @@ func (j *jsonEncoded) FetchValIdx(idx int) (JSON, error) {
 		}
 
 		return newEncoded(entry, j.arrayGetDataRange(begin, end))
+	case ObjectJSONType:
+		return nil, nil
+	default:
+		return nil, errors.AssertionFailedf("unknown json type: %v", errors.Safe(j.typ))
 	}
-	return nil, nil
 }
 
 func (j *jsonEncoded) FetchValKey(key string) (JSON, error) {

--- a/pkg/util/json/json.go
+++ b/pkg/util/json/json.go
@@ -1429,6 +1429,22 @@ func (jsonString) FetchValKey(string) (JSON, error) { return nil, nil }
 func (jsonNumber) FetchValKey(string) (JSON, error) { return nil, nil }
 func (jsonArray) FetchValKey(string) (JSON, error)  { return nil, nil }
 
+func fetchValIdxForScalar(j JSON, idx int) JSON {
+	// The 0'th element (and -1'st element with negative indexing) of a scalar
+	// JSON value is the scalar itself. This effectively treats scalar values as
+	// single element arrays.
+	if idx == 0 || idx == -1 {
+		return j
+	}
+	return nil
+}
+
+func (j jsonNull) FetchValIdx(idx int) (JSON, error)   { return fetchValIdxForScalar(j, idx), nil }
+func (j jsonTrue) FetchValIdx(idx int) (JSON, error)   { return fetchValIdxForScalar(j, idx), nil }
+func (j jsonFalse) FetchValIdx(idx int) (JSON, error)  { return fetchValIdxForScalar(j, idx), nil }
+func (j jsonString) FetchValIdx(idx int) (JSON, error) { return fetchValIdxForScalar(j, idx), nil }
+func (j jsonNumber) FetchValIdx(idx int) (JSON, error) { return fetchValIdxForScalar(j, idx), nil }
+
 func (j jsonArray) FetchValIdx(idx int) (JSON, error) {
 	if idx < 0 {
 		idx = len(j) + idx
@@ -1439,11 +1455,6 @@ func (j jsonArray) FetchValIdx(idx int) (JSON, error) {
 	return nil, nil
 }
 
-func (jsonNull) FetchValIdx(int) (JSON, error)   { return nil, nil }
-func (jsonTrue) FetchValIdx(int) (JSON, error)   { return nil, nil }
-func (jsonFalse) FetchValIdx(int) (JSON, error)  { return nil, nil }
-func (jsonString) FetchValIdx(int) (JSON, error) { return nil, nil }
-func (jsonNumber) FetchValIdx(int) (JSON, error) { return nil, nil }
 func (jsonObject) FetchValIdx(int) (JSON, error) { return nil, nil }
 
 // FetchPath implements the #> operator.
@@ -1736,8 +1747,12 @@ func (j jsonObject) RemoveString(s string) (JSON, bool, error) {
 	return jsonObject(newVal), true, nil
 }
 
-func (jsonNull) RemoveString(string) (JSON, bool, error) { return nil, false, errCannotDeleteFromScalar }
-func (jsonTrue) RemoveString(string) (JSON, bool, error) { return nil, false, errCannotDeleteFromScalar }
+func (jsonNull) RemoveString(string) (JSON, bool, error) {
+	return nil, false, errCannotDeleteFromScalar
+}
+func (jsonTrue) RemoveString(string) (JSON, bool, error) {
+	return nil, false, errCannotDeleteFromScalar
+}
 func (jsonFalse) RemoveString(string) (JSON, bool, error) {
 	return nil, false, errCannotDeleteFromScalar
 }

--- a/pkg/util/json/json_test.go
+++ b/pkg/util/json/json_test.go
@@ -695,6 +695,12 @@ func TestJSONFetchIdx(t *testing.T) {
 			{10, json(`10`)},
 			{35, json(`35`)},
 		},
+		// Scalar values can be indexed.
+		`null`:  {{-2, nil}, {-1, json(`null`)}, {0, json(`null`)}, {1, nil}},
+		`true`:  {{-2, nil}, {-1, json(`true`)}, {0, json(`true`)}, {1, nil}},
+		`false`: {{-2, nil}, {-1, json(`false`)}, {0, json(`false`)}, {1, nil}},
+		`"foo"`: {{-2, nil}, {-1, json(`"foo"`)}, {0, json(`"foo"`)}, {1, nil}},
+		`123`:   {{-2, nil}, {-1, json(`123`)}, {0, json(`123`)}, {1, nil}},
 	}
 
 	for k, tests := range cases {


### PR DESCRIPTION
This commit adds support for extracting from scalar JSON values with an index using the `->` and `->>` operators. In 
Postgres, the 0'th element (and -1'st element with negative indexing) of a scalar JSON value is the scalar itself. This effectively treats scalar values as single-element arrays.

I stumbled upon this fun idiosyncrasy while reading through https://scattered-thoughts.net/writing/select-wat-from-sql/. Little did I know while reading that the author of this JSON code, the man himself, @justinj, was also a contributor to that post.

Release note (sql change): Indexing into scalar JSON values using an integer index is now properly supported.