### PR TITLE
sql, json, opt: make zigzag join use type Bytes for virtual inverted columns

### DIFF
--- a/pkg/sql/opt/idxconstraint/index_constraints.go
+++ b/pkg/sql/opt/idxconstraint/index_constraints.go
@@ -1368,14 +1368,6 @@ func (ic *Instance) UnconsolidatedConstraint() *constraint.Constraint {
 	return &ic.constraint
 }
 
-// AllInvertedIndexConstraints returns all constraints that can be created on
-// the specified inverted index. Only works for inverted indexes.
-func (ic *Instance) AllInvertedIndexConstraints() ([]*constraint.Constraint, error) {
-	_, allConstraints := ic.makeInvertedIndexSpansForExpr(&ic.allFilters, nil /* constraints */, true /* allPaths */)
-
-	return allConstraints, nil
-}
-
 // RemainingFilters calculates a simplified FiltersExpr that needs to be applied
 // within the returned Spans.
 func (ic *Instance) RemainingFilters() memo.FiltersExpr {

--- a/pkg/sql/opt/invertedexpr/expression.go
+++ b/pkg/sql/opt/invertedexpr/expression.go
@@ -172,8 +172,8 @@ func MakeSingleInvertedValSpan(val EncInvertedVal) InvertedSpan {
 	return InvertedSpan{Start: val, End: end}
 }
 
-// isSingleVal returns true iff the span is equivalent to [val, val].
-func (s InvertedSpan) isSingleVal() bool {
+// IsSingleVal returns true iff the span is equivalent to [val, val].
+func (s InvertedSpan) IsSingleVal() bool {
 	return bytes.Equal(roachpb.Key(s.Start).PrefixEnd(), s.End)
 }
 
@@ -222,7 +222,7 @@ func (is InvertedSpans) Format(tp treeprinter.Node, label string) {
 func formatSpan(span InvertedSpan) string {
 	end := span.End
 	spanEndOpenOrClosed := ')'
-	if span.isSingleVal() {
+	if span.IsSingleVal() {
 		end = span.Start
 		spanEndOpenOrClosed = ']'
 	}

--- a/pkg/sql/opt/invertedexpr/expression.go
+++ b/pkg/sql/opt/invertedexpr/expression.go
@@ -362,8 +362,9 @@ type SpanExpression struct {
 
 	// Unique is true if the spans are guaranteed not to produce duplicate
 	// primary keys. Otherwise, Unique is false. Unique may be true for certain
-	// JSON or Array SpanExpressions, but it does not hold when these
-	// SpanExpressions are combined with And or Or.
+	// JSON or Array SpanExpressions, and it holds when SpanExpressions are
+	// combined with And. It does not hold when these SpanExpressions are
+	// combined with Or.
 	Unique bool
 
 	// SpansToRead are the spans to read from the inverted index
@@ -672,6 +673,7 @@ func intersectSpanExpressions(left, right *SpanExpression) *SpanExpression {
 	// TODO(sumeer): tighten the SpansToRead for this case.
 	expr := &SpanExpression{
 		Tight:              left.Tight && right.Tight,
+		Unique:             left.Unique && right.Unique,
 		SpansToRead:        unionSpans(left.SpansToRead, right.SpansToRead),
 		FactoredUnionSpans: intersectSpans(left.FactoredUnionSpans, right.FactoredUnionSpans),
 		Operator:           SetIntersection,

--- a/pkg/sql/opt/invertedexpr/json_array_expression.go
+++ b/pkg/sql/opt/invertedexpr/json_array_expression.go
@@ -26,7 +26,7 @@ func JSONOrArrayToContainingSpanExpr(
 ) (*SpanExpression, error) {
 	var b []byte
 	spansSlice, tight, unique, err := rowenc.EncodeContainingInvertedIndexSpans(
-		evalCtx, d, b, descpb.EmptyArraysInInvertedIndexesVersion,
+		evalCtx, d, b, descpb.EmptyArraysInInvertedIndexesVersion, false, /* uniqueOnly */
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/sql/opt/invertedexpr/json_array_expression.go
+++ b/pkg/sql/opt/invertedexpr/json_array_expression.go
@@ -30,14 +30,14 @@ func JSONOrArrayToContainingInvertedExpr(
 	evalCtx *tree.EvalContext, d tree.Datum, uniqueOnly bool,
 ) (InvertedExpression, error) {
 	var b []byte
-	spansSlice, tight, unique, err := rowenc.EncodeContainingInvertedIndexSpans(
+	spansSlice, tight, unique, ok, err := rowenc.EncodeContainingInvertedIndexSpans(
 		evalCtx, d, b, descpb.EmptyArraysInInvertedIndexesVersion, uniqueOnly,
 	)
 	if err != nil {
 		return nil, err
 	}
-	if uniqueOnly && !unique {
-		// It was not possible to find unique spans.
+	if !ok {
+		// It was not possible to find spans with the given requirements.
 		return NonInvertedColExpression{}, nil
 	}
 	if len(spansSlice) == 0 {

--- a/pkg/sql/opt/invertedexpr/testdata/expression
+++ b/pkg/sql/opt/invertedexpr/testdata/expression
@@ -195,7 +195,7 @@ span expression
 and result=b-and-b left=b right=b
 ----
 span expression
- ├── tight: true, unique: false
+ ├── tight: true, unique: true
  ├── to read: ["b", "b"]
  └── union spans: ["b", "b"]
 
@@ -241,7 +241,7 @@ span expression
 and result=_ left=b right=ac
 ----
 span expression
- ├── tight: true, unique: false
+ ├── tight: true, unique: true
  ├── to read: ["a", "c")
  └── union spans: ["b", "b"]
 
@@ -264,7 +264,7 @@ span expression
 and result=_ left=b right=bj
 ----
 span expression
- ├── tight: true, unique: false
+ ├── tight: true, unique: true
  ├── to read: ["b", "j")
  └── union spans: ["b", "b"]
 
@@ -280,7 +280,7 @@ span expression
 and result=bj-and-ac left=bj right=ac
 ----
 span expression
- ├── tight: true, unique: false
+ ├── tight: true, unique: true
  ├── to read: ["a", "j")
  ├── union spans: ["b", "b"]
  └── INTERSECTION
@@ -308,7 +308,7 @@ span expression
       │         ├── ["a", "a"]
       │         └── ["c", "j")
       └── span expression
-           ├── tight: true, unique: false
+           ├── tight: true, unique: true
            ├── to read: ["a", "j")
            ├── union spans: empty
            └── INTERSECTION
@@ -330,7 +330,7 @@ span expression
  ├── union spans: ["b", "b"]
  └── INTERSECTION
       ├── span expression
-      │    ├── tight: true, unique: false
+      │    ├── tight: true, unique: true
       │    ├── to read: ["a", "j")
       │    ├── union spans: empty
       │    └── INTERSECTION
@@ -383,7 +383,7 @@ span expression
       │    ├── union spans: empty
       │    └── INTERSECTION
       │         ├── span expression
-      │         │    ├── tight: true, unique: false
+      │         │    ├── tight: true, unique: true
       │         │    ├── to read: ["a", "j")
       │         │    ├── union spans: empty
       │         │    └── INTERSECTION
@@ -430,7 +430,7 @@ span expression
       │    ├── union spans: empty
       │    └── INTERSECTION
       │         ├── span expression
-      │         │    ├── tight: true, unique: false
+      │         │    ├── tight: true, unique: true
       │         │    ├── to read: ["a", "j")
       │         │    ├── union spans: empty
       │         │    └── INTERSECTION

--- a/pkg/sql/opt/invertedidx/geo_test.go
+++ b/pkg/sql/opt/invertedidx/geo_test.go
@@ -492,6 +492,7 @@ func TestTryFilterGeoIndex(t *testing.T) {
 		// the index when we expect to.
 		spanExpr, _, remainingFilters, pfState, ok := invertedidx.TryFilterInvertedIndex(
 			evalCtx, &f, filters, nil /* optionalFilters */, tab, md.Table(tab).Index(tc.indexOrd),
+			false, /* forZigZag */
 		)
 		if tc.ok != ok {
 			t.Fatalf("expected %v, got %v", tc.ok, ok)

--- a/pkg/sql/opt/invertedidx/json_array_test.go
+++ b/pkg/sql/opt/invertedidx/json_array_test.go
@@ -307,20 +307,22 @@ func TestTryFilterJsonOrArrayIndex(t *testing.T) {
 			remainingFilters: "j @> '1'",
 		},
 		{
-			// We cannot guarantee unique primary keys when there are multiple paths.
+			// We can guarantee unique primary keys when there are multiple paths
+			// that are each unique.
 			filters:  "j @> '[1, 2]'",
 			indexOrd: jsonOrd,
 			ok:       true,
 			tight:    true,
-			unique:   false,
+			unique:   true,
 		},
 		{
-			// We cannot guarantee unique primary keys when there are multiple paths.
+			// We can guarantee unique primary keys when there are multiple paths
+			// that are each unique.
 			filters:  "a @> '{1, 2}'",
 			indexOrd: arrayOrd,
 			ok:       true,
 			tight:    true,
-			unique:   false,
+			unique:   true,
 		},
 		{
 			// We cannot guarantee that the span expression is tight when there is a
@@ -330,7 +332,7 @@ func TestTryFilterJsonOrArrayIndex(t *testing.T) {
 			indexOrd:         jsonOrd,
 			ok:               true,
 			tight:            false,
-			unique:           false,
+			unique:           true,
 			remainingFilters: "j @> '[[1, 2]]'",
 		},
 		{
@@ -378,7 +380,7 @@ func TestTryFilterJsonOrArrayIndex(t *testing.T) {
 			indexOrd:         jsonOrd,
 			ok:               true,
 			tight:            false,
-			unique:           false,
+			unique:           true,
 			remainingFilters: "j @> '{\"a\": [1, 2]}' AND j @> '[[3, 4]]'",
 		},
 		{
@@ -388,7 +390,7 @@ func TestTryFilterJsonOrArrayIndex(t *testing.T) {
 			indexOrd:         jsonOrd,
 			ok:               true,
 			tight:            false,
-			unique:           false,
+			unique:           true,
 			remainingFilters: "j @> '[[1, 2]]'",
 		},
 	}

--- a/pkg/sql/opt/invertedidx/json_array_test.go
+++ b/pkg/sql/opt/invertedidx/json_array_test.go
@@ -405,6 +405,7 @@ func TestTryFilterJsonOrArrayIndex(t *testing.T) {
 		// unique, and remainingFilters.
 		spanExpr, _, remainingFilters, _, ok := invertedidx.TryFilterInvertedIndex(
 			evalCtx, &f, filters, nil /* optionalFilters */, tab, md.Table(tab).Index(tc.indexOrd),
+			false, /* forZigZag */
 		)
 		if tc.ok != ok {
 			t.Fatalf("expected %v, got %v", tc.ok, ok)

--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -881,8 +881,8 @@ inner-join (lookup t_json_arr)
  ├── inner-join (zigzag t_json_arr@b_idx t_json_arr@b_idx)
  │    ├── columns: a:1(int!null)
  │    ├── eq columns: [1] = [1]
- │    ├── left fixed columns: [2] = ['{"a": "b"}']
- │    ├── right fixed columns: [2] = ['{"c": "d"}']
+ │    ├── left fixed columns: [6] = ['\x3761000112620001']
+ │    ├── right fixed columns: [6] = ['\x3763000112640001']
  │    ├── stats: [rows=61.7283951, distinct(1)=61.7283951, null(1)=0]
  │    └── filters (true)
  └── filters

--- a/pkg/sql/opt/xform/select_funcs.go
+++ b/pkg/sql/opt/xform/select_funcs.go
@@ -740,7 +740,7 @@ func (c *CustomFuncs) GenerateInvertedIndexScans(
 		// Check whether the filter can constrain the index.
 		// TODO(rytaft): Unify these two cases so both return a spanExpr.
 		spanExpr, constraint, remainingFilters, pfState, filterOk := invertedidx.TryFilterInvertedIndex(
-			c.e.evalCtx, c.e.f, filters, optionalFilters, scanPrivate.Table, index,
+			c.e.evalCtx, c.e.f, filters, optionalFilters, scanPrivate.Table, index, false, /* forZigZag */
 		)
 		if filterOk {
 			spansToRead = spanExpr.SpansToRead
@@ -849,28 +849,6 @@ func (c *CustomFuncs) tryConstrainIndex(
 	// Make copy of constraint so that idxconstraint instance is not referenced.
 	copy := *constraint
 	return &copy, remaining, true
-}
-
-// allInvIndexConstraints tries to derive all constraints for the specified inverted
-// index that can be derived. If no constraint is derived, then it returns ok = false,
-// similar to tryConstrainIndex.
-func (c *CustomFuncs) allInvIndexConstraints(
-	filters memo.FiltersExpr, tabID opt.TableID, indexOrd int,
-) (constraints []*constraint.Constraint, ok bool) {
-	ic := c.initIdxConstraintForIndex(filters, nil /* optionalFilters */, tabID, indexOrd, true /* isInverted */)
-	constraints, err := ic.AllInvertedIndexConstraints()
-	if err != nil {
-		return nil, false
-	}
-	// As long as there was no error, AllInvertedIndexConstraints is guaranteed
-	// to add at least one constraint to the slice. It will be set to
-	// unconstrained if no constraints could be derived for this index.
-	constraint := constraints[0]
-	if constraint.IsUnconstrained() {
-		return constraints, false
-	}
-
-	return constraints, true
 }
 
 // canMaybeConstrainNonInvertedIndex returns true if we should try to constrain
@@ -1302,36 +1280,55 @@ func (c *CustomFuncs) GenerateInvertedIndexZigzagJoins(
 	var iter scanIndexIter
 	iter.Init(c.e.mem, &c.im, scanPrivate, filters, rejectNonInvertedIndexes)
 	iter.ForEach(func(index cat.Index, filters memo.FiltersExpr, indexCols opt.ColSet, _ bool) {
-		// See if there are two or more constraints that can be satisfied
-		// by this inverted index. This is possible with inverted indexes as
-		// opposed to secondary indexes, because one row in the primary index
-		// can often correspond to multiple rows in an inverted index. This
-		// function generates all constraints it can derive for this index;
-		// not all of which might get used in this function.
-		constraints, ok := c.allInvIndexConstraints(
-			filters, scanPrivate.Table, index.Ordinal(),
+		if index.NonInvertedPrefixColumnCount() > 0 {
+			// TODO(mgartner): We don't yet support using multi-column inverted
+			//  indexes with zigzag joins.
+			return
+		}
+
+		// Check whether the filter can constrain the index with spans that
+		// are guaranteed not to produce duplicate primary keys.
+		spanExpr, _, _, _, ok := invertedidx.TryFilterInvertedIndex(
+			c.e.evalCtx, c.e.f, filters, nil /* optionalFilters */, scanPrivate.Table, index,
+			true, /* forZigZag */
 		)
-		if !ok || len(constraints) < 2 {
+		if !ok {
 			return
 		}
-		// In theory, we could explore zigzag joins on all constraint pairs.
-		// However, in the absence of stats on inverted indexes, we will not
-		// be able to distinguish more selective constraints from less
-		// selective ones anyway, so just pick the first two constraints.
-		//
-		// TODO(itsbilal): Use the remaining constraints to build a remaining
-		// filters expression, instead of just reusing filters from the scan.
-		constraint := constraints[0]
-		constraint2 := constraints[1]
 
-		minPrefix := constraint.ExactPrefix(c.e.evalCtx)
-		if otherPrefix := constraint2.ExactPrefix(c.e.evalCtx); otherPrefix < minPrefix {
-			minPrefix = otherPrefix
+		// Recursively traverse the span expression to find single-value spans.
+		var vals []invertedexpr.EncInvertedVal
+		var getVals func(invertedExpr invertedexpr.InvertedExpression)
+		getVals = func(invertedExpr invertedexpr.InvertedExpression) {
+			if len(vals) >= 2 {
+				// We only need two constraints to plan a zigzag join, so don't bother
+				// exploring further.
+				// TODO(rytaft): use stats here to choose the two most selective
+				//  constraints instead of the first two.
+				return
+			}
+			spanExprLocal, ok := invertedExpr.(*invertedexpr.SpanExpression)
+			if !ok {
+				return
+			}
+			if spanExprLocal.Operator == invertedexpr.SetIntersection {
+				getVals(spanExprLocal.Left)
+				getVals(spanExprLocal.Right)
+				return
+			}
+
+			if len(spanExprLocal.SpansToRead) == 1 && spanExprLocal.SpansToRead[0].IsSingleVal() {
+				vals = append(vals, spanExprLocal.SpansToRead[0].Start)
+			}
 		}
-
-		if minPrefix == 0 {
+		getVals(spanExpr)
+		if len(vals) < 2 {
 			return
 		}
+
+		// We treat the fixed values for JSON and Array as DBytes.
+		leftVal := tree.DBytes(vals[0])
+		rightVal := tree.DBytes(vals[1])
 
 		zigzagJoin := memo.ZigzagJoinExpr{
 			On: filters,
@@ -1343,26 +1340,31 @@ func (c *CustomFuncs) GenerateInvertedIndexZigzagJoins(
 			},
 		}
 
-		// Get constant values from each constraint. Add them to FixedVals as
-		// tuples, with associated Column IDs in both {Left,Right}FixedCols.
-		leftVals := make(memo.ScalarListExpr, minPrefix)
-		leftTypes := make([]*types.T, minPrefix)
-		rightVals := make(memo.ScalarListExpr, minPrefix)
-		rightTypes := make([]*types.T, minPrefix)
+		// The fixed columns include all the prefix columns and the inverted column.
+		fixedColsCount := index.NonInvertedPrefixColumnCount() + 1
 
-		zigzagJoin.LeftFixedCols = make(opt.ColList, minPrefix)
-		zigzagJoin.RightFixedCols = make(opt.ColList, minPrefix)
-		for i := 0; i < minPrefix; i++ {
-			leftVal := constraint.Spans.Get(0).StartKey().Value(i)
-			rightVal := constraint2.Spans.Get(0).StartKey().Value(i)
+		// Get constant values and add them to FixedVals as tuples, with associated
+		// Column IDs in both {Left,Right}FixedCols.
+		leftVals := make(memo.ScalarListExpr, fixedColsCount)
+		leftTypes := make([]*types.T, fixedColsCount)
+		rightVals := make(memo.ScalarListExpr, fixedColsCount)
+		rightTypes := make([]*types.T, fixedColsCount)
+		zigzagJoin.LeftFixedCols = make(opt.ColList, fixedColsCount)
+		zigzagJoin.RightFixedCols = make(opt.ColList, fixedColsCount)
 
-			leftVals[i] = c.e.f.ConstructConstVal(leftVal, leftVal.ResolvedType())
-			leftTypes[i] = leftVal.ResolvedType()
-			rightVals[i] = c.e.f.ConstructConstVal(rightVal, rightVal.ResolvedType())
-			rightTypes[i] = rightVal.ResolvedType()
-			zigzagJoin.LeftFixedCols[i] = constraint.Columns.Get(i).ID()
-			zigzagJoin.RightFixedCols[i] = constraint.Columns.Get(i).ID()
-		}
+		// TODO(rytaft): set types, values, and fixed columns for the prefix
+		//  columns here.
+
+		// invertedColIdx is the position of the inverted column in the inverted
+		// index.
+		invertedColIdx := index.NonInvertedPrefixColumnCount()
+		leftVals[invertedColIdx] = c.e.f.ConstructConstVal(&leftVal, leftVal.ResolvedType())
+		leftTypes[invertedColIdx] = leftVal.ResolvedType()
+		rightVals[invertedColIdx] = c.e.f.ConstructConstVal(&rightVal, rightVal.ResolvedType())
+		rightTypes[invertedColIdx] = rightVal.ResolvedType()
+		invertedCol := scanPrivate.Table.ColumnID(index.VirtualInvertedColumn().Ordinal())
+		zigzagJoin.LeftFixedCols[invertedColIdx] = invertedCol
+		zigzagJoin.RightFixedCols[invertedColIdx] = invertedCol
 
 		leftTupleTyp := types.MakeTuple(leftTypes)
 		rightTupleTyp := types.MakeTuple(rightTypes)
@@ -1373,13 +1375,13 @@ func (c *CustomFuncs) GenerateInvertedIndexZigzagJoins(
 
 		// Set equality columns - all remaining columns after the fixed prefix
 		// need to be equal.
-		eqColLen := index.ColumnCount() - minPrefix
+		eqColLen := index.ColumnCount() - fixedColsCount
 		zigzagJoin.LeftEqCols = make(opt.ColList, eqColLen)
 		zigzagJoin.RightEqCols = make(opt.ColList, eqColLen)
-		for i := minPrefix; i < index.ColumnCount(); i++ {
+		for i := fixedColsCount; i < index.ColumnCount(); i++ {
 			colID := scanPrivate.Table.IndexColumnID(index, i)
-			zigzagJoin.LeftEqCols[i-minPrefix] = colID
-			zigzagJoin.RightEqCols[i-minPrefix] = colID
+			zigzagJoin.LeftEqCols[i-fixedColsCount] = colID
+			zigzagJoin.RightEqCols[i-fixedColsCount] = colID
 		}
 		zigzagJoin.On = filters
 

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -4615,8 +4615,8 @@ project
       ├── inner-join (zigzag b@j_inv_idx b@j_inv_idx)
       │    ├── columns: k:1!null
       │    ├── eq columns: [1] = [1]
-      │    ├── left fixed columns: [4] = ['{"a": "b"}']
-      │    ├── right fixed columns: [4] = ['{"c": "d"}']
+      │    ├── left fixed columns: [8] = ['\x3761000112620001']
+      │    ├── right fixed columns: [8] = ['\x3763000112640001']
       │    └── filters (true)
       └── filters
            └── j:4 @> '{"a": "b", "c": "d"}' [outer=(4), immutable, constraints=(/4: (/NULL - ])]
@@ -4636,8 +4636,8 @@ inner-join (lookup b)
  ├── inner-join (zigzag b@j_inv_idx b@j_inv_idx)
  │    ├── columns: k:1!null
  │    ├── eq columns: [1] = [1]
- │    ├── left fixed columns: [4] = ['{"a": "b"}']
- │    ├── right fixed columns: [4] = ['{"c": "d"}']
+ │    ├── left fixed columns: [8] = ['\x3761000112620001']
+ │    ├── right fixed columns: [8] = ['\x3763000112640001']
  │    └── filters (true)
  └── filters
       └── j:4 @> '{"a": "b", "c": "d"}' [outer=(4), immutable, constraints=(/4: (/NULL - ])]
@@ -4655,8 +4655,8 @@ inner-join (lookup b)
  ├── inner-join (zigzag b@j_inv_idx b@j_inv_idx)
  │    ├── columns: k:1!null
  │    ├── eq columns: [1] = [1]
- │    ├── left fixed columns: [4] = ['{"a": {"b": "c"}}']
- │    ├── right fixed columns: [4] = ['{"a": {"d": "e"}}']
+ │    ├── left fixed columns: [8] = ['\x3761000262000112630001']
+ │    ├── right fixed columns: [8] = ['\x3761000264000112650001']
  │    └── filters (true)
  └── filters
       └── j:4 @> '{"a": {"b": "c", "d": "e"}, "f": "g"}' [outer=(4), immutable, constraints=(/4: (/NULL - ])]
@@ -4675,8 +4675,8 @@ inner-join (lookup b)
  ├── inner-join (zigzag b@j_inv_idx b@j_inv_idx)
  │    ├── columns: k:1!null
  │    ├── eq columns: [1] = [1]
- │    ├── left fixed columns: [4] = ['{"a": [{"b": "c"}]}']
- │    ├── right fixed columns: [4] = ['{"a": [{"d": 3}]}']
+ │    ├── left fixed columns: [8] = ['\x37610002000300012a0a00']
+ │    ├── right fixed columns: [8] = ['\x37610002000362000112630001']
  │    └── filters (true)
  └── filters
       └── j:4 @> '{"a": [{"b": "c", "d": 3}, 5]}' [outer=(4), immutable, constraints=(/4: (/NULL - ])]
@@ -4698,8 +4698,8 @@ project
       ├── inner-join (zigzag c@a_inv_idx c@a_inv_idx)
       │    ├── columns: k:1!null
       │    ├── eq columns: [1] = [1]
-      │    ├── left fixed columns: [2] = [ARRAY[1]]
-      │    ├── right fixed columns: [2] = [ARRAY[3]]
+      │    ├── left fixed columns: [7] = ['\x89']
+      │    ├── right fixed columns: [7] = ['\x8b']
       │    └── filters (true)
       └── filters
            └── a:2 @> ARRAY[1,3,1,5] [outer=(2), immutable, constraints=(/2: (/NULL - ])]
@@ -4800,8 +4800,8 @@ project
       ├── inner-join (zigzag inv_zz_partial@zz_idx,partial inv_zz_partial@zz_idx,partial)
       │    ├── columns: k:1!null
       │    ├── eq columns: [1] = [1]
-      │    ├── left fixed columns: [2] = ['{"a": 1}']
-      │    ├── right fixed columns: [2] = ['{"b": 2}']
+      │    ├── left fixed columns: [6] = ['\x376100012a0200']
+      │    ├── right fixed columns: [6] = ['\x376200012a0400']
       │    └── filters (true)
       └── filters
            ├── j:2 @> '{"a": 1, "b": 2}' [outer=(2), immutable, constraints=(/2: (/NULL - ])]

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -1867,7 +1867,7 @@ select
  │         │    ├── union spans: empty
  │         │    └── UNION
  │         │         ├── span expression
- │         │         │    ├── tight: false, unique: false
+ │         │         │    ├── tight: false, unique: true
  │         │         │    ├── union spans: empty
  │         │         │    └── INTERSECTION
  │         │         │         ├── span expression
@@ -1877,7 +1877,7 @@ select
  │         │         │              ├── tight: false, unique: false
  │         │         │              └── union spans: ["7\x00\x03\x00\x03\x00\x01*\x04\x00", "7\x00\x03\x00\x03\x00\x01*\x04\x00"]
  │         │         └── span expression
- │         │              ├── tight: false, unique: false
+ │         │              ├── tight: false, unique: true
  │         │              ├── union spans: empty
  │         │              └── INTERSECTION
  │         │                   ├── span expression
@@ -3114,7 +3114,7 @@ select
  │    └── inverted-filter
  │         ├── columns: k:1!null
  │         ├── inverted expression: /8
- │         │    ├── tight: false, unique: false
+ │         │    ├── tight: false, unique: true
  │         │    ├── union spans: empty
  │         │    └── INTERSECTION
  │         │         ├── span expression
@@ -4717,7 +4717,7 @@ index-join b
  └── inverted-filter
       ├── columns: k:1!null
       ├── inverted expression: /8
-      │    ├── tight: true, unique: false
+      │    ├── tight: true, unique: true
       │    ├── union spans: empty
       │    └── INTERSECTION
       │         ├── span expression
@@ -4763,7 +4763,7 @@ project
  └── inverted-filter
       ├── columns: k:1!null
       ├── inverted expression: /6
-      │    ├── tight: true, unique: false
+      │    ├── tight: true, unique: true
       │    ├── union spans: empty
       │    └── INTERSECTION
       │         ├── span expression

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -835,12 +835,7 @@ func (ef *execFactory) ConstructZigzagJoin(
 		for i := range cols {
 			col := index.Column(i)
 			cols[i].Name = string(col.ColName())
-			// TODO(rytaft): Remove this once the optimizer encodes the fixed values.
-			if col.Kind() == cat.VirtualInverted {
-				cols[i].Typ = index.Table().Column(col.InvertedSourceColumnOrdinal()).DatumType()
-			} else {
-				cols[i].Typ = col.DatumType()
-			}
+			cols[i].Typ = col.DatumType()
 		}
 		return &valuesNode{
 			columns:          cols,

--- a/pkg/sql/rowenc/index_encoding.go
+++ b/pkg/sql/rowenc/index_encoding.go
@@ -755,6 +755,28 @@ func (a byID) Less(i, j int) bool { return a[i].id < a[j].id }
 func EncodeInvertedIndexKeys(
 	index *descpb.IndexDescriptor, colMap catalog.TableColMap, values []tree.Datum, keyPrefix []byte,
 ) (key [][]byte, err error) {
+	keyPrefix, err = EncodeInvertedIndexPrefixKeys(index, colMap, values, keyPrefix)
+	if err != nil {
+		return nil, err
+	}
+
+	var val tree.Datum
+	if i, ok := colMap.Get(index.InvertedColumnID()); ok {
+		val = values[i]
+	} else {
+		val = tree.DNull
+	}
+	if !geoindex.IsEmptyConfig(&index.GeoConfig) {
+		return EncodeGeoInvertedIndexTableKeys(val, keyPrefix, index)
+	}
+	return EncodeInvertedIndexTableKeys(val, keyPrefix, index.Version)
+}
+
+// EncodeInvertedIndexPrefixKeys encodes the non-inverted prefix columns if
+// the given index is a multi-column inverted index.
+func EncodeInvertedIndexPrefixKeys(
+	index *descpb.IndexDescriptor, colMap catalog.TableColMap, values []tree.Datum, keyPrefix []byte,
+) (_ []byte, err error) {
 	numColumns := len(index.ColumnIDs)
 
 	// If the index is a multi-column inverted index, we encode the non-inverted
@@ -774,17 +796,7 @@ func EncodeInvertedIndexKeys(
 			return nil, err
 		}
 	}
-
-	var val tree.Datum
-	if i, ok := colMap.Get(index.ColumnIDs[numColumns-1]); ok {
-		val = values[i]
-	} else {
-		val = tree.DNull
-	}
-	if !geoindex.IsEmptyConfig(&index.GeoConfig) {
-		return EncodeGeoInvertedIndexTableKeys(val, keyPrefix, index)
-	}
-	return EncodeInvertedIndexTableKeys(val, keyPrefix, index.Version)
+	return keyPrefix, nil
 }
 
 // EncodeInvertedIndexTableKeys produces one inverted index key per element in

--- a/pkg/sql/rowenc/index_encoding_test.go
+++ b/pkg/sql/rowenc/index_encoding_test.go
@@ -422,13 +422,13 @@ func TestEncodeContainingArrayInvertedIndexSpans(t *testing.T) {
 		{`{}`, `{1}`, false, true},
 		{`{1}`, `{}`, true, false},
 		{`{1}`, `{1}`, true, true},
-		{`{1}`, `{1, 2}`, false, false},
+		{`{1}`, `{1, 2}`, false, true},
 		{`{1, 2}`, `{1}`, true, true},
 		{`{1, 2}`, `{2}`, true, true},
-		{`{1, 2}`, `{1, 2}`, true, false},
-		{`{1, 2}`, `{1, 2, 1}`, true, false},
+		{`{1, 2}`, `{1, 2}`, true, true},
+		{`{1, 2}`, `{1, 2, 1}`, true, true},
 		{`{1, 2}`, `{1, 1}`, true, true},
-		{`{1, 2, 3}`, `{1, 2, 4}`, false, false},
+		{`{1, 2, 3}`, `{1, 2, 4}`, false, true},
 		{`{1, 2, 3}`, `{}`, true, false},
 		{`{}`, `{NULL}`, false, true},
 		{`{NULL}`, `{}`, true, false},
@@ -454,7 +454,9 @@ func TestEncodeContainingArrayInvertedIndexSpans(t *testing.T) {
 		keys, err := EncodeInvertedIndexTableKeys(left, nil, version)
 		require.NoError(t, err)
 
-		spansSlice, tight, unique, err := EncodeContainingInvertedIndexSpans(&evalCtx, right, nil, version)
+		spansSlice, tight, unique, err := EncodeContainingInvertedIndexSpans(
+			&evalCtx, right, nil, version, false, /* uniqueOnly */
+		)
 		require.NoError(t, err)
 
 		// Array spans are always tight.
@@ -528,16 +530,10 @@ func TestEncodeContainingArrayInvertedIndexSpans(t *testing.T) {
 		res, err := tree.ArrayContains(&evalCtx, left.(*tree.DArray), right.(*tree.DArray))
 		require.NoError(t, err)
 
-		// The spans should not have duplicate values if there is exactly one
-		// element after de-duplication.
+		// The spans should not have duplicate values if there is at least one
+		// element.
 		arr := right.(*tree.DArray).Array
 		expectUnique := len(arr) > 0
-		for i := range arr {
-			if i > 0 && arr[i].Compare(&evalCtx, arr[0]) != 0 {
-				expectUnique = false
-				break
-			}
-		}
 
 		// Now check that we get the same result with the inverted index spans.
 		runTest(left, right, bool(*res), expectUnique)

--- a/pkg/sql/rowenc/index_encoding_test.go
+++ b/pkg/sql/rowenc/index_encoding_test.go
@@ -454,10 +454,13 @@ func TestEncodeContainingArrayInvertedIndexSpans(t *testing.T) {
 		keys, err := EncodeInvertedIndexTableKeys(left, nil, version)
 		require.NoError(t, err)
 
-		spansSlice, tight, unique, err := EncodeContainingInvertedIndexSpans(
+		spansSlice, tight, unique, ok, err := EncodeContainingInvertedIndexSpans(
 			&evalCtx, right, nil, version, false, /* uniqueOnly */
 		)
 		require.NoError(t, err)
+		if !ok {
+			t.Fatalf("ok should never be false if uniqueOnly is false and there is no error")
+		}
 
 		// Array spans are always tight.
 		if tight != true {

--- a/pkg/sql/rowexec/zigzagjoiner.go
+++ b/pkg/sql/rowexec/zigzagjoiner.go
@@ -427,7 +427,13 @@ func (z *zigzagJoiner) setupInfo(
 	columnTypes := info.table.ColumnTypes()
 	colIdxMap := info.table.ColumnIdxMap()
 	for i, columnID := range columnIDs {
-		info.indexTypes[i] = columnTypes[colIdxMap.GetDefault(columnID)]
+		if info.index.Type == descpb.IndexDescriptor_INVERTED &&
+			columnID == info.index.InvertedColumnID() {
+			// Inverted key columns have type Bytes.
+			info.indexTypes[i] = types.Bytes
+		} else {
+			info.indexTypes[i] = columnTypes[colIdxMap.GetDefault(columnID)]
+		}
 	}
 
 	// Add the outputted columns.
@@ -578,7 +584,8 @@ func (z *zigzagJoiner) produceInvertedIndexKey(
 		}
 	}
 
-	keys, err := rowenc.EncodeInvertedIndexKeys(
+	// First encode datums for any non-inverted prefix columns.
+	keyPrefix, err := rowenc.EncodeInvertedIndexPrefixKeys(
 		info.index,
 		colMap,
 		decodedDatums,
@@ -587,8 +594,16 @@ func (z *zigzagJoiner) produceInvertedIndexKey(
 	if err != nil {
 		return roachpb.Span{}, err
 	}
-	if len(keys) != 1 {
-		return roachpb.Span{}, errors.Errorf("%d fixed values passed in for inverted index", len(keys))
+
+	// Add the inverted key, which is already encoded as a DBytes.
+	if i, ok := colMap.Get(info.index.InvertedColumnID()); ok {
+		invertedKey, ok := decodedDatums[i].(*tree.DBytes)
+		if !ok {
+			return roachpb.Span{}, errors.AssertionFailedf("inverted key must be type DBytes")
+		}
+		keyPrefix = append(keyPrefix, []byte(*invertedKey)...)
+	} else {
+		return roachpb.Span{}, errors.AssertionFailedf("inverted column not found in colMap")
 	}
 
 	// Append remaining (non-JSON) datums to the key.
@@ -597,7 +612,7 @@ func (z *zigzagJoiner) produceInvertedIndexKey(
 		info.indexDirs[1:],
 		colMap,
 		decodedDatums,
-		keys[0],
+		keyPrefix,
 	)
 	key := roachpb.Key(keyBytes)
 	return roachpb.Span{Key: key, EndKey: key.PrefixEnd()}, err

--- a/pkg/util/json/encoded.go
+++ b/pkg/util/json/encoded.go
@@ -722,13 +722,13 @@ func (j *jsonEncoded) encodeInvertedIndexKeys(b []byte) ([][]byte, error) {
 }
 
 func (j *jsonEncoded) encodeContainingInvertedIndexSpans(
-	b []byte, isRoot, isObjectValue bool,
+	b []byte, isRoot, isObjectValue, uniqueOnly bool,
 ) ([]roachpb.Spans, bool, bool, error) {
 	decoded, err := j.decode()
 	if err != nil {
 		return nil, false, false, err
 	}
-	return decoded.encodeContainingInvertedIndexSpans(b, isRoot, isObjectValue)
+	return decoded.encodeContainingInvertedIndexSpans(b, isRoot, isObjectValue, uniqueOnly)
 }
 
 // numInvertedIndexEntries implements the JSON interface.


### PR DESCRIPTION
**sql,json: add uniqueOnly parameter to EncodeContainingInvertedIndexSpans**

This commit adds a new parameter `uniqueOnly` to the function
`EncodeContainingInvertedIndexSpans`. If `uniqueOnly` is false, the function
has the old behavior and produces spans for all paths through the given JSON
or Array. If `unqiueOnly` is true, however, `EncodeContainingInvertedIndexSpans`
only produces spans that are guaranteed not to produce duplicate primary
keys. For JSON, this equates to removing all JSON paths that end in a
container leaf (i.e., empty object or array). For Array, no change is
required as a non-empty array will produce all unique spans. If there are
no paths through the JSON or Array that satisfy the uniqueness requirement,
`EncodeContainingInvertedIndexSpans` returns `unique=false`.

This commit also subtly changes the meaning of the `unique` return parameter for
`EncodeContainingInvertedIndexSpans`. Previously, `unique` was always false if more
than one span slice was returned (indicating an `INTERSECTION` was required). Now
`unique` is true if every span slice returned is itself unique.

To match this behavior, when `SpanExpression`s are intersected (combined with
`And`), the resulting `SpanExpression` is unique if both its children are unique.
The union of `SpanExpressions` (combined with `Or`) is still not guaranteed to be
unique, however, even if its children are.

These changes are necessary in order to be able to use this infrastructure for
planning zigzag joins in a future commit.

**sql,opt: make zigzag join use type Bytes for virtual inverted columns**

This commit updates `GenerateInvertedIndexZigzagJoins` in the optimizer to
make use of the new code that is already being used for planning inverted
constrained scans in `GenerateInvertedIndexScans`. This will be necessary to
support multi-column inverted indexes and brings us closer to being able
to remove inverted indexes from the `idxconstraint` library.

This commit also updates the way the zigzag joiner handles inverted indexes.
the processor now expects the fixed values for the inverted key column
to have type bytes instead of JSON or Array. Instead of attempting to
encode the inverted index key, it now assumes the key has already
been encoded and is stored as a `DBytes`.