### PR TITLE
opt: use safer struct initialization pattern

### DIFF
--- a/pkg/sql/opt/cat/column.go
+++ b/pkg/sql/opt/cat/column.go
@@ -185,24 +185,24 @@ func (c *Column) InitNonVirtual(
 	if kind == VirtualInverted {
 		panic(errors.AssertionFailedf("incorrect init method"))
 	}
-	c.ordinal = ordinal
-	c.stableID = stableID
-	c.name = name
-	c.kind = kind
-	c.datumType = datumType
-	c.nullable = nullable
-	c.hidden = hidden
+	// This initialization pattern ensures that fields are not unwittingly
+	// reused. Field reuse must be explicit.
+	*c = Column{
+		ordinal:                     ordinal,
+		stableID:                    stableID,
+		name:                        name,
+		kind:                        kind,
+		datumType:                   datumType,
+		nullable:                    nullable,
+		hidden:                      hidden,
+		invertedSourceColumnOrdinal: -1,
+	}
 	if defaultExpr != nil {
 		c.defaultExpr = *defaultExpr
-	} else {
-		c.defaultExpr = ""
 	}
 	if computedExpr != nil {
 		c.computedExpr = *computedExpr
-	} else {
-		c.computedExpr = ""
 	}
-	c.invertedSourceColumnOrdinal = -1
 }
 
 // InitVirtualInverted is used by catalog implementations to populate a
@@ -210,16 +210,18 @@ func (c *Column) InitNonVirtual(
 func (c *Column) InitVirtualInverted(
 	ordinal int, name tree.Name, datumType *types.T, nullable bool, invertedSourceColumnOrdinal int,
 ) {
-	c.ordinal = ordinal
-	c.stableID = 0
-	c.name = name
-	c.kind = VirtualInverted
-	c.datumType = datumType
-	c.nullable = nullable
-	c.hidden = true
-	c.defaultExpr = ""
-	c.computedExpr = ""
-	c.invertedSourceColumnOrdinal = invertedSourceColumnOrdinal
+	// This initialization pattern ensures that fields are not unwittingly
+	// reused. Field reuse must be explicit.
+	*c = Column{
+		ordinal:                     ordinal,
+		stableID:                    0,
+		name:                        name,
+		kind:                        VirtualInverted,
+		datumType:                   datumType,
+		nullable:                    nullable,
+		hidden:                      true,
+		invertedSourceColumnOrdinal: invertedSourceColumnOrdinal,
+	}
 }
 
 // InitVirtualComputed is used by catalog implementations to populate a
@@ -233,15 +235,18 @@ func (c *Column) InitVirtualComputed(
 	hidden bool,
 	computedExpr string,
 ) {
-	c.ordinal = ordinal
-	c.stableID = stableID
-	c.name = name
-	c.kind = Ordinary
-	c.datumType = datumType
-	c.nullable = nullable
-	c.hidden = hidden
-	c.defaultExpr = ""
-	c.computedExpr = computedExpr
-	c.virtualComputed = true
-	c.invertedSourceColumnOrdinal = -1
+	// This initialization pattern ensures that fields are not unwittingly
+	// reused. Field reuse must be explicit.
+	*c = Column{
+		ordinal:                     ordinal,
+		stableID:                    stableID,
+		name:                        name,
+		kind:                        Ordinary,
+		datumType:                   datumType,
+		nullable:                    nullable,
+		hidden:                      hidden,
+		computedExpr:                computedExpr,
+		virtualComputed:             true,
+		invertedSourceColumnOrdinal: -1,
+	}
 }

--- a/pkg/sql/opt/constraint/columns.go
+++ b/pkg/sql/opt/constraint/columns.go
@@ -33,15 +33,20 @@ type Columns struct {
 
 // Init initializes a Columns structure.
 func (c *Columns) Init(cols []opt.OrderingColumn) {
-	c.firstCol = cols[0]
-	c.otherCols = cols[1:]
+	// This initialization pattern ensures that fields are not unwittingly
+	// reused. Field reuse must be explicit.
+	*c = Columns{
+		firstCol:  cols[0],
+		otherCols: cols[1:],
+	}
 }
 
 // InitSingle is a more efficient version of Init for the common case of a
 // single column.
 func (c *Columns) InitSingle(col opt.OrderingColumn) {
-	c.firstCol = col
-	c.otherCols = nil
+	// This initialization pattern ensures that fields are not unwittingly
+	// reused. Field reuse must be explicit.
+	*c = Columns{firstCol: col}
 }
 
 var _ = (*Columns).InitSingle

--- a/pkg/sql/opt/constraint/constraint.go
+++ b/pkg/sql/opt/constraint/constraint.go
@@ -52,15 +52,23 @@ func (c *Constraint) Init(keyCtx *KeyContext, spans *Spans) {
 			panic(errors.AssertionFailedf("spans must be ordered and non-overlapping"))
 		}
 	}
-	c.Columns = keyCtx.Columns
-	c.Spans = *spans
+	// This initialization pattern ensures that fields are not unwittingly
+	// reused. Field reuse must be explicit.
+	*c = Constraint{
+		Columns: keyCtx.Columns,
+		Spans:   *spans,
+	}
 	c.Spans.makeImmutable()
 }
 
 // InitSingleSpan initializes the constraint to the columns in the key context
 // and with one span.
 func (c *Constraint) InitSingleSpan(keyCtx *KeyContext, span *Span) {
-	c.Columns = keyCtx.Columns
+	// This initialization pattern ensures that fields are not unwittingly
+	// reused. Field reuse must be explicit.
+	*c = Constraint{
+		Columns: keyCtx.Columns,
+	}
 	c.Spans.InitSingleSpan(span)
 }
 

--- a/pkg/sql/opt/constraint/span.go
+++ b/pkg/sql/opt/constraint/span.go
@@ -122,10 +122,14 @@ func (sp *Span) Init(start Key, startBoundary SpanBoundary, end Key, endBoundary
 		panic(errors.AssertionFailedf("an empty end boundary must be inclusive"))
 	}
 
-	sp.start = start
-	sp.startBoundary = startBoundary
-	sp.end = end
-	sp.endBoundary = endBoundary
+	// This initialization pattern ensures that fields are not unwittingly
+	// reused. Field reuse must be explicit.
+	*sp = Span{
+		start:         start,
+		startBoundary: startBoundary,
+		end:           end,
+		endBoundary:   endBoundary,
+	}
 }
 
 // Compare returns an integer indicating the ordering of the two spans. The

--- a/pkg/sql/opt/constraint/spans.go
+++ b/pkg/sql/opt/constraint/spans.go
@@ -43,10 +43,12 @@ func (s *Spans) Alloc(capacity int) {
 
 // InitSingleSpan initializes the structure with a single span.
 func (s *Spans) InitSingleSpan(sp *Span) {
-	s.firstSpan = *sp
-	s.otherSpans = nil
-	s.numSpans = 1
-	s.immutable = false
+	// This initialization pattern ensures that fields are not unwittingly
+	// reused. Field reuse must be explicit.
+	*s = Spans{
+		firstSpan: *sp,
+		numSpans:  1,
+	}
 }
 
 // Count returns the number of spans.

--- a/pkg/sql/opt/idxconstraint/index_constraints.go
+++ b/pkg/sql/opt/idxconstraint/index_constraints.go
@@ -1295,7 +1295,11 @@ func (ic *Instance) Init(
 	evalCtx *tree.EvalContext,
 	factory *norm.Factory,
 ) {
-	ic.requiredFilters = requiredFilters
+	// This initialization pattern ensures that fields are not unwittingly
+	// reused. Field reuse must be explicit.
+	*ic = Instance{
+		requiredFilters: requiredFilters,
+	}
 	if len(optionalFilters) == 0 {
 		ic.allFilters = requiredFilters
 	} else {
@@ -1428,15 +1432,18 @@ func (c *indexConstraintCtx) init(
 	evalCtx *tree.EvalContext,
 	factory *norm.Factory,
 ) {
-	c.md = factory.Metadata()
-	c.columns = columns
-	c.notNullCols = notNullCols
-	c.computedCols = computedCols
-	c.isInverted = isInverted
-	c.evalCtx = evalCtx
-	c.factory = factory
-
-	c.keyCtx = make([]constraint.KeyContext, len(columns))
+	// This initialization pattern ensures that fields are not unwittingly
+	// reused. Field reuse must be explicit.
+	*c = indexConstraintCtx{
+		md:           factory.Metadata(),
+		columns:      columns,
+		notNullCols:  notNullCols,
+		computedCols: computedCols,
+		isInverted:   isInverted,
+		evalCtx:      evalCtx,
+		factory:      factory,
+		keyCtx:       make([]constraint.KeyContext, len(columns)),
+	}
 	for i := range columns {
 		c.keyCtx[i].EvalCtx = evalCtx
 		c.keyCtx[i].Columns.Init(columns[i:])

--- a/pkg/sql/opt/memo/filters_expr_mutate_checker.go
+++ b/pkg/sql/opt/memo/filters_expr_mutate_checker.go
@@ -24,6 +24,9 @@ type FiltersExprMutateChecker struct {
 
 // Init initializes a FiltersExprMutateChecker with the original filters.
 func (fmc *FiltersExprMutateChecker) Init(filters FiltersExpr) {
+	// This initialization pattern ensures that fields are not unwittingly
+	// reused. Field reuse must be explicit.
+	*fmc = FiltersExprMutateChecker{}
 	fmc.hasher.Init()
 	fmc.hasher.HashFiltersExpr(filters)
 	fmc.hash = fmc.hasher.hash

--- a/pkg/sql/opt/memo/interner.go
+++ b/pkg/sql/opt/memo/interner.go
@@ -277,7 +277,13 @@ type hasher struct {
 }
 
 func (h *hasher) Init() {
-	h.hash = offset64
+	// This initialization pattern ensures that fields are not unwittingly
+	// reused. Field reuse must be explicit.
+	*h = hasher{
+		bytes:  h.bytes,
+		bytes2: h.bytes2,
+		hash:   offset64,
+	}
 }
 
 // ----------------------------------------------------------------------

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -49,8 +49,12 @@ type logicalPropsBuilder struct {
 }
 
 func (b *logicalPropsBuilder) init(evalCtx *tree.EvalContext, mem *Memo) {
-	b.evalCtx = evalCtx
-	b.mem = mem
+	// This initialization pattern ensures that fields are not unwittingly
+	// reused. Field reuse must be explicit.
+	*b = logicalPropsBuilder{
+		evalCtx: evalCtx,
+		mem:     mem,
+	}
 	b.sb.init(evalCtx, mem.Metadata())
 }
 
@@ -1948,7 +1952,9 @@ type joinPropsHelper struct {
 }
 
 func (h *joinPropsHelper) init(b *logicalPropsBuilder, joinExpr RelExpr) {
-	h.join = joinExpr
+	// This initialization pattern ensures that fields are not unwittingly
+	// reused. Field reuse must be explicit.
+	*h = joinPropsHelper{join: joinExpr}
 
 	switch join := joinExpr.(type) {
 	case *LookupJoinExpr:

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -167,8 +167,12 @@ type statisticsBuilder struct {
 }
 
 func (sb *statisticsBuilder) init(evalCtx *tree.EvalContext, md *opt.Metadata) {
-	sb.evalCtx = evalCtx
-	sb.md = md
+	// This initialization pattern ensures that fields are not unwittingly
+	// reused. Field reuse must be explicit.
+	*sb = statisticsBuilder{
+		evalCtx: evalCtx,
+		md:      md,
+	}
 }
 
 func (sb *statisticsBuilder) clear() {

--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -118,7 +118,8 @@ type Metadata struct {
 	// mutation operators, used to determine the logical properties of WithScan.
 	withBindings map[WithID]Expr
 
-	// NOTE! When adding fields here, update Init, CopyFrom and TestMetadata.
+	// NOTE! When adding fields here, update Init (if reusing allocated
+	// data structures is desired), CopyFrom and TestMetadata.
 }
 
 type mdDep struct {
@@ -150,41 +151,42 @@ func (n *MDDepName) equals(other *MDDepName) bool {
 func (md *Metadata) Init() {
 	// Clear the metadata objects to release memory (this clearing pattern is
 	// optimized by Go).
+	// TODO(mgartner): determine if the new clearing pattern is still optimized
+	// by Go. Look at original commit message and assembly.
 	for i := range md.schemas {
 		md.schemas[i] = nil
 	}
-	md.schemas = md.schemas[:0]
 
 	for i := range md.cols {
 		md.cols[i] = ColumnMeta{}
 	}
-	md.cols = md.cols[:0]
 
 	for i := range md.tables {
 		md.tables[i] = TableMeta{}
 	}
-	md.tables = md.tables[:0]
 
 	for i := range md.sequences {
 		md.sequences[i] = nil
 	}
-	md.sequences = md.sequences[:0]
 
 	for i := range md.deps {
 		md.deps[i] = mdDep{}
 	}
-	md.deps = md.deps[:0]
 
 	for i := range md.views {
 		md.views[i] = nil
 	}
-	md.views = md.views[:0]
 
-	md.currUniqueID = 0
-
-	md.withBindings = nil
-	md.userDefinedTypes = nil
-	md.userDefinedTypesSlice = nil
+	// This initialization pattern ensures that fields are not unwittingly
+	// reused. Field reuse must be explicit.
+	*md = Metadata{
+		schemas:   md.schemas[:0],
+		cols:      md.cols[:0],
+		tables:    md.tables[:0],
+		sequences: md.sequences[:0],
+		deps:      md.deps[:0],
+		views:     md.views[:0],
+	}
 }
 
 // CopyFrom initializes the metadata with a copy of the provided metadata.

--- a/pkg/sql/opt/norm/decorrelate_funcs.go
+++ b/pkg/sql/opt/norm/decorrelate_funcs.go
@@ -735,10 +735,14 @@ type subqueryHoister struct {
 }
 
 func (r *subqueryHoister) init(c *CustomFuncs, input memo.RelExpr) {
-	r.c = c
-	r.f = c.f
-	r.mem = c.mem
-	r.hoisted = input
+	// This initialization pattern ensures that fields are not unwittingly
+	// reused. Field reuse must be explicit.
+	*r = subqueryHoister{
+		c:       c,
+		f:       c.f,
+		mem:     c.mem,
+		hoisted: input,
+	}
 }
 
 // input returns a single expression tree that contains the input expression

--- a/pkg/sql/opt/norm/factory.go
+++ b/pkg/sql/opt/norm/factory.go
@@ -95,16 +95,21 @@ type Factory struct {
 // changed using FoldingControl().AllowStableFolds().
 func (f *Factory) Init(evalCtx *tree.EvalContext, catalog cat.Catalog) {
 	// Initialize (or reinitialize) the memo.
-	if f.mem == nil {
-		f.mem = &memo.Memo{}
+	mem := f.mem
+	if mem == nil {
+		mem = &memo.Memo{}
 	}
-	f.mem.Init(evalCtx)
+	mem.Init(evalCtx)
 
-	f.evalCtx = evalCtx
-	f.catalog = catalog
+	// This initialization pattern ensures that fields are not unwittingly
+	// reused. Field reuse must be explicit.
+	*f = Factory{
+		mem:     mem,
+		evalCtx: evalCtx,
+		catalog: catalog,
+	}
+
 	f.funcs.Init(f)
-	f.matchedRule = nil
-	f.appliedRule = nil
 	f.foldingControl.DisallowStableFolds()
 }
 

--- a/pkg/sql/opt/norm/general_funcs.go
+++ b/pkg/sql/opt/norm/general_funcs.go
@@ -33,8 +33,12 @@ type CustomFuncs struct {
 
 // Init initializes a new CustomFuncs with the given factory.
 func (c *CustomFuncs) Init(f *Factory) {
-	c.f = f
-	c.mem = f.Memo()
+	// This initialization pattern ensures that fields are not unwittingly
+	// reused. Field reuse must be explicit.
+	*c = CustomFuncs{
+		f:   f,
+		mem: f.Memo(),
+	}
 }
 
 // Succeeded returns true if a result expression is not nil.

--- a/pkg/sql/opt/norm/project_builder.go
+++ b/pkg/sql/opt/norm/project_builder.go
@@ -32,7 +32,9 @@ type projectBuilder struct {
 }
 
 func (pb *projectBuilder) init(f *Factory) {
-	pb.f = f
+	// This initialization pattern ensures that fields are not unwittingly
+	// reused. Field reuse must be explicit.
+	*pb = projectBuilder{f: f}
 }
 
 // empty returns true if there are no synthesized columns (and hence a

--- a/pkg/sql/opt/optbuilder/join.go
+++ b/pkg/sql/opt/optbuilder/join.go
@@ -322,14 +322,18 @@ func (jb *usingJoinBuilder) init(
 	flags memo.JoinFlags,
 	leftScope, rightScope, outScope *scope,
 ) {
-	jb.b = b
-	jb.joinType = joinType
-	jb.joinFlags = flags
-	jb.leftScope = leftScope
-	jb.rightScope = rightScope
-	jb.outScope = outScope
-	jb.hideCols = make(map[*scopeColumn]struct{})
-	jb.showCols = make(map[*scopeColumn]struct{})
+	// This initialization pattern ensures that fields are not unwittingly
+	// reused. Field reuse must be explicit.
+	*jb = usingJoinBuilder{
+		b:          b,
+		joinType:   joinType,
+		joinFlags:  flags,
+		leftScope:  leftScope,
+		rightScope: rightScope,
+		outScope:   outScope,
+		hideCols:   make(map[*scopeColumn]struct{}),
+		showCols:   make(map[*scopeColumn]struct{}),
+	}
 }
 
 // buildUsingJoin constructs a Join operator with join columns matching the

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -180,11 +180,15 @@ type mutationBuilder struct {
 }
 
 func (mb *mutationBuilder) init(b *Builder, opName string, tab cat.Table, alias tree.TableName) {
-	mb.b = b
-	mb.md = b.factory.Metadata()
-	mb.opName = opName
-	mb.tab = tab
-	mb.alias = alias
+	// This initialization pattern ensures that fields are not unwittingly
+	// reused. Field reuse must be explicit.
+	*mb = mutationBuilder{
+		b:      b,
+		md:     b.factory.Metadata(),
+		opName: opName,
+		tab:    tab,
+		alias:  alias,
+	}
 
 	n := tab.ColumnCount()
 	mb.targetColList = make(opt.ColList, 0, n)

--- a/pkg/sql/opt/optbuilder/mutation_builder_fk.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder_fk.go
@@ -522,6 +522,8 @@ type fkCheckHelper struct {
 // Returns false if the FK relation should be ignored (e.g. because the new
 // values for the FK columns are known to be always NULL).
 func (h *fkCheckHelper) initWithOutboundFK(mb *mutationBuilder, fkOrdinal int) bool {
+	// This initialization pattern ensures that fields are not unwittingly
+	// reused. Field reuse must be explicit.
 	*h = fkCheckHelper{
 		mb:         mb,
 		fk:         mb.tab.OutboundForeignKey(fkOrdinal),
@@ -572,6 +574,8 @@ func (h *fkCheckHelper) initWithOutboundFK(mb *mutationBuilder, fkOrdinal int) b
 // Returns false if the FK relation should be ignored (because the other table
 // is in the process of being created).
 func (h *fkCheckHelper) initWithInboundFK(mb *mutationBuilder, fkOrdinal int) (ok bool) {
+	// This initialization pattern ensures that fields are not unwittingly
+	// reused. Field reuse must be explicit.
 	*h = fkCheckHelper{
 		mb:         mb,
 		fk:         mb.tab.InboundForeignKey(fkOrdinal),

--- a/pkg/sql/opt/optbuilder/mutation_builder_unique.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder_unique.go
@@ -142,6 +142,8 @@ type uniqueCheckHelper struct {
 // Returns false if the constraint should be ignored (e.g. because the new
 // values for the unique columns are known to be always NULL).
 func (h *uniqueCheckHelper) init(mb *mutationBuilder, uniqueOrdinal int) bool {
+	// This initialization pattern ensures that fields are not unwittingly
+	// reused. Field reuse must be explicit.
 	*h = uniqueCheckHelper{
 		mb:            mb,
 		unique:        mb.tab.Unique(uniqueOrdinal),

--- a/pkg/sql/opt/optgen/cmd/optgen/rule_gen.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/rule_gen.go
@@ -104,9 +104,13 @@ type newRuleGen struct {
 }
 
 func (g *newRuleGen) init(compiled *lang.CompiledExpr, md *metadata, w *matchWriter) {
-	g.compiled = compiled
-	g.md = md
-	g.w = w
+	// This initialization pattern ensures that fields are not unwittingly
+	// reused. Field reuse must be explicit.
+	*g = newRuleGen{
+		compiled: compiled,
+		md:       md,
+		w:        w,
+	}
 }
 
 // genRule generates match and replace code for one rule within the scope of

--- a/pkg/sql/opt/optgen/cmd/optgen/uniquifier.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/uniquifier.go
@@ -20,7 +20,11 @@ type uniquifier struct {
 }
 
 func (u *uniquifier) init() {
-	u.seen = make(map[string]struct{})
+	// This initialization pattern ensures that fields are not unwittingly
+	// reused. Field reuse must be explicit.
+	*u = uniquifier{
+		seen: make(map[string]struct{}),
+	}
 }
 
 func (u *uniquifier) makeUnique(s string) string {

--- a/pkg/sql/opt/partialidx/implicator.go
+++ b/pkg/sql/opt/partialidx/implicator.go
@@ -142,10 +142,13 @@ type constraintCacheItem struct {
 // Init initializes an Implicator with the given factory, metadata, and eval
 // context. It also resets the constraint cache.
 func (im *Implicator) Init(f *norm.Factory, md *opt.Metadata, evalCtx *tree.EvalContext) {
-	im.f = f
-	im.md = md
-	im.evalCtx = evalCtx
-	im.constraintCache = nil
+	// This initialization pattern ensures that fields are not unwittingly
+	// reused. Field reuse must be explicit.
+	*im = Implicator{
+		f:       f,
+		md:      md,
+		evalCtx: evalCtx,
+	}
 }
 
 // ClearCache empties the Implicator's constraint cache.

--- a/pkg/sql/opt/props/histogram.go
+++ b/pkg/sql/opt/props/histogram.go
@@ -48,9 +48,13 @@ func (h *Histogram) String() string {
 func (h *Histogram) Init(
 	evalCtx *tree.EvalContext, col opt.ColumnID, buckets []cat.HistogramBucket,
 ) {
-	h.evalCtx = evalCtx
-	h.col = col
-	h.buckets = buckets
+	// This initialization pattern ensures that fields are not unwittingly
+	// reused. Field reuse must be explicit.
+	*h = Histogram{
+		evalCtx: evalCtx,
+		col:     col,
+		buckets: buckets,
+	}
 }
 
 // copy returns a deep copy of the histogram.
@@ -466,12 +470,16 @@ type histogramIter struct {
 // histogram. If desc is true, the iterator starts from the end of the
 // histogram and moves backwards.
 func (hi *histogramIter) init(h *Histogram, desc bool) {
-	hi.idx = -1
+	// This initialization pattern ensures that fields are not unwittingly
+	// reused. Field reuse must be explicit.
+	*hi = histogramIter{
+		idx:  -1,
+		h:    h,
+		desc: desc,
+	}
 	if desc {
 		hi.idx = h.BucketCount()
 	}
-	hi.h = h
-	hi.desc = desc
 	hi.next()
 }
 
@@ -767,11 +775,15 @@ const (
 )
 
 func (w *histogramWriter) init(buckets []cat.HistogramBucket) {
-	w.cells = [][]string{
-		make([]string, len(buckets)*2),
-		make([]string, len(buckets)*2),
+	// This initialization pattern ensures that fields are not unwittingly
+	// reused. Field reuse must be explicit.
+	*w = histogramWriter{
+		cells: [][]string{
+			make([]string, len(buckets)*2),
+			make([]string, len(buckets)*2),
+		},
+		colWidths: make([]int, len(buckets)*2),
 	}
-	w.colWidths = make([]int, len(buckets)*2)
 
 	for i, b := range buckets {
 		w.cells[counts][i*2] = fmt.Sprintf(" %.5g ", b.NumRange)

--- a/pkg/sql/opt/props/statistics.go
+++ b/pkg/sql/opt/props/statistics.go
@@ -68,6 +68,9 @@ type Statistics struct {
 
 // Init initializes the data members of Statistics.
 func (s *Statistics) Init(relProps *Relational) (zeroCardinality bool) {
+	// This initialization pattern ensures that fields are not unwittingly
+	// reused. Reusing fields must be done explicitly.
+	*s = Statistics{}
 	if relProps.Cardinality.IsZero() {
 		s.RowCount = 0
 		s.Selectivity = 0

--- a/pkg/sql/opt/testutils/opttester/forcing_opt.go
+++ b/pkg/sql/opt/testutils/opttester/forcing_opt.go
@@ -141,9 +141,13 @@ type forcingCoster struct {
 }
 
 func (fc *forcingCoster) Init(o *xform.Optimizer, groups *memoGroups) {
-	fc.o = o
-	fc.groups = groups
-	fc.inner = o.Coster()
+	// This initialization pattern ensures that fields are not unwittingly
+	// reused. Field reuse must be explicit.
+	*fc = forcingCoster{
+		o:      o,
+		groups: groups,
+		inner:  o.Coster(),
+	}
 }
 
 // RestrictGroupToMember forces the expression in the given location to be the

--- a/pkg/sql/opt/testutils/scalar_vars.go
+++ b/pkg/sql/opt/testutils/scalar_vars.go
@@ -37,6 +37,9 @@ type ScalarVars struct {
 // The not-null columns can be retrieved via NotNullCols().
 //
 func (sv *ScalarVars) Init(md *opt.Metadata, vars []string) error {
+	// This initialization pattern ensures that fields are not unwittingly
+	// reused. Field reuse must be explicit.
+	*sv = ScalarVars{}
 	// We use the same syntax that is used with CREATE TABLE, so reuse the parsing
 	// logic.
 	varDef := strings.Join(vars, ", ")

--- a/pkg/sql/opt/xform/coster.go
+++ b/pkg/sql/opt/xform/coster.go
@@ -407,9 +407,13 @@ var fnCost = map[string]memo.Cost{
 
 // Init initializes a new coster structure with the given memo.
 func (c *coster) Init(evalCtx *tree.EvalContext, mem *memo.Memo, perturbation float64) {
-	c.mem = mem
-	c.locality = evalCtx.Locality
-	c.perturbation = perturbation
+	// This initialization pattern ensures that fields are not unwittingly
+	// reused. Field reuse must be explicit.
+	*c = coster{
+		mem:          mem,
+		locality:     evalCtx.Locality,
+		perturbation: perturbation,
+	}
 }
 
 // ComputeCost calculates the estimated cost of the top-level operator in a

--- a/pkg/sql/opt/xform/explorer.go
+++ b/pkg/sql/opt/xform/explorer.go
@@ -94,10 +94,14 @@ type explorer struct {
 
 // init initializes the explorer for use (or reuse).
 func (e *explorer) init(o *Optimizer) {
-	e.evalCtx = o.evalCtx
-	e.o = o
-	e.f = o.Factory()
-	e.mem = o.mem
+	// This initialization pattern ensures that fields are not unwittingly
+	// reused. Field reuse must be explicit.
+	*e = explorer{
+		evalCtx: o.evalCtx,
+		o:       o,
+		f:       o.Factory(),
+		mem:     o.mem,
+	}
 	e.funcs.Init(e)
 }
 

--- a/pkg/sql/opt/xform/general_funcs.go
+++ b/pkg/sql/opt/xform/general_funcs.go
@@ -30,8 +30,12 @@ type CustomFuncs struct {
 
 // Init initializes a new CustomFuncs with the given explorer.
 func (c *CustomFuncs) Init(e *explorer) {
+	// This initialization pattern ensures that fields are not unwittingly
+	// reused. Field reuse must be explicit.
+	*c = CustomFuncs{
+		e: e,
+	}
 	c.CustomFuncs.Init(e.f)
-	c.e = e
 	c.im.Init(e.f, e.mem.Metadata(), e.evalCtx)
 }
 

--- a/pkg/sql/opt/xform/index_scan_builder.go
+++ b/pkg/sql/opt/xform/index_scan_builder.go
@@ -51,10 +51,14 @@ type indexScanBuilder struct {
 }
 
 func (b *indexScanBuilder) init(c *CustomFuncs, tabID opt.TableID) {
-	b.c = c
-	b.f = c.e.f
-	b.mem = c.e.mem
-	b.tabID = tabID
+	// This initialization pattern ensures that fields are not unwittingly
+	// reused. Field reuse must be explicit.
+	*b = indexScanBuilder{
+		c:     c,
+		f:     c.e.f,
+		mem:   c.e.mem,
+		tabID: tabID,
+	}
 }
 
 // primaryKeyCols returns the columns from the scanned table's primary index.

--- a/pkg/sql/opt/xform/join_order_builder.go
+++ b/pkg/sql/opt/xform/join_order_builder.go
@@ -298,15 +298,15 @@ type JoinOrderBuilder struct {
 // graph is reset, so a JoinOrderBuilder can be reused. Callback functions are
 // not reset.
 func (jb *JoinOrderBuilder) Init(f *norm.Factory, evalCtx *tree.EvalContext) {
-	jb.f = f
-	jb.evalCtx = evalCtx
-
-	jb.vertexes = []memo.RelExpr{}
-	jb.edges = []edge{}
-	jb.nonInnerEdges = edgeSet{}
-	jb.innerEdges = edgeSet{}
-	jb.plans = map[vertexSet]memo.RelExpr{}
-	jb.joinCount = 0
+	// This initialization pattern ensures that fields are not unwittingly
+	// reused. Field reuse must be explicit.
+	*jb = JoinOrderBuilder{
+		f:             f,
+		evalCtx:       evalCtx,
+		plans:         make(map[vertexSet]memo.RelExpr),
+		onReorderFunc: jb.onReorderFunc,
+		onAddJoinFunc: jb.onAddJoinFunc,
+	}
 }
 
 // Reorder adds all valid orderings of the given join to the memo.

--- a/pkg/sql/opt/xform/scan_index_iter.go
+++ b/pkg/sql/opt/xform/scan_index_iter.go
@@ -88,12 +88,16 @@ func (it *scanIndexIter) Init(
 	filters memo.FiltersExpr,
 	rejectFlags indexRejectFlags,
 ) {
-	it.mem = mem
-	it.im = im
-	it.tabMeta = mem.Metadata().TableMeta(scanPrivate.Table)
-	it.scanPrivate = scanPrivate
-	it.filters = filters
-	it.rejectFlags = rejectFlags
+	// This initialization pattern ensures that fields are not unwittingly
+	// reused. Field reuse must be explicit.
+	*it = scanIndexIter{
+		mem:         mem,
+		im:          im,
+		tabMeta:     mem.Metadata().TableMeta(scanPrivate.Table),
+		scanPrivate: scanPrivate,
+		filters:     filters,
+		rejectFlags: rejectFlags,
+	}
 	it.filtersMutateChecker.Init(it.filters)
 }
 


### PR DESCRIPTION
We commonly use a pattern of declaring structs and then initializing
them via an `Init` method. This allows internal data structures to be
reused, reducing allocations. However, the common initialization
implementation is dangerous because fields are implicitly reused. This
can lead to inconspicuous bugs (see #58306).

This commit introduces a new pattern for initialization functions that
requires reused fields to be explicitly listed. This should reduce the
risk of these types of bugs.

Release note: None