### PR TITLE
opt: fold stacked DistinctOns and aggregations on grouping columns

### DIFF
--- a/pkg/sql/opt/norm/groupby_funcs.go
+++ b/pkg/sql/opt/norm/groupby_funcs.go
@@ -273,9 +273,14 @@ func (c *CustomFuncs) areRowsDistinct(
 	return true
 }
 
-// CanMergeAggs returns true if the given inner and outer AggregationsExprs can
-// be replaced with a single equivalent AggregationsExpr.
-func (c *CustomFuncs) CanMergeAggs(innerAggs, outerAggs memo.AggregationsExpr) bool {
+// CanMergeAggs returns true if one of the following applies to each of the
+// given outer aggregation expressions:
+//   1. The aggregation can be merged with a single inner aggregation.
+//   2. The aggregation takes an inner grouping column as input and ignores
+//      duplicates.
+func (c *CustomFuncs) CanMergeAggs(
+	innerAggs, outerAggs memo.AggregationsExpr, innerGroupingCols opt.ColSet,
+) bool {
 	// Create a mapping from the output ColumnID of each inner aggregate to its
 	// operator type.
 	innerColsToAggOps := map[opt.ColumnID]opt.Operator{}
@@ -304,9 +309,15 @@ func (c *CustomFuncs) CanMergeAggs(innerAggs, outerAggs memo.AggregationsExpr) b
 			// The outer aggregate does not directly aggregate on a column.
 			return false
 		}
+		if innerGroupingCols.Contains(input.Col) && opt.AggregateIgnoresDuplicates(outerAgg.Op()) {
+			// The outer aggregate ignores duplicates and references an inner grouping
+			// column.
+			continue
+		}
 		innerOp, ok := innerColsToAggOps[input.Col]
 		if !ok {
-			// This outer aggregate does not reference an inner aggregate.
+			// This outer aggregate does not reference an inner aggregate or an inner
+			// grouping column.
 			return false
 		}
 		if !opt.AggregatesCanMerge(innerOp, outerAgg.Op()) {
@@ -319,7 +330,9 @@ func (c *CustomFuncs) CanMergeAggs(innerAggs, outerAggs memo.AggregationsExpr) b
 
 // MergeAggs returns an AggregationsExpr that is equivalent to the two given
 // AggregationsExprs. MergeAggs will panic if CanMergeAggs is false.
-func (c *CustomFuncs) MergeAggs(innerAggs, outerAggs memo.AggregationsExpr) memo.AggregationsExpr {
+func (c *CustomFuncs) MergeAggs(
+	innerAggs, outerAggs memo.AggregationsExpr, innerGroupingCols opt.ColSet,
+) memo.AggregationsExpr {
 	// Create a mapping from the output ColumnIDs of the inner aggregates to their
 	// indices in innerAggs.
 	innerColsToAggs := map[opt.ColumnID]int{}
@@ -337,9 +350,17 @@ func (c *CustomFuncs) MergeAggs(innerAggs, outerAggs memo.AggregationsExpr) memo
 		// same, but in the count and count-rows cases the inner aggregate must
 		// be used (see opt.AggregatesCanMerge for details). The column from the
 		// outer aggregate has to be used to preserve logical equivalency.
+		//
+		// In the case when the outer aggregate takes an inner grouping column as
+		// input, simply reuse the outer aggregate. This works because CanMergeAggs
+		// has already ensured that the aggregate ignores duplicate values.
 		inputCol := outerAggs[i].Agg.Child(0).(*memo.VariableExpr).Col
-		innerAgg := innerAggs[innerColsToAggs[inputCol]].Agg
-		newAggs[i] = c.f.ConstructAggregationsItem(innerAgg, outerAggs[i].Col)
+		if innerGroupingCols.Contains(inputCol) {
+			newAggs[i] = outerAggs[i]
+		} else {
+			innerAgg := innerAggs[innerColsToAggs[inputCol]].Agg
+			newAggs[i] = c.f.ConstructAggregationsItem(innerAgg, outerAggs[i].Col)
+		}
 	}
 	return newAggs
 }

--- a/pkg/sql/opt/norm/rules/groupby.opt
+++ b/pkg/sql/opt/norm/rules/groupby.opt
@@ -435,24 +435,35 @@
 # operator. As an example, the following pairs of queries are equivalent:
 #
 #   SELECT sum(t) FROM (SELECT sum(b) FROM ab GROUP BY a) AS g(t);
+#   =>
 #   SELECT sum(b) FROM ab;
 #
 #   SELECT max(t) FROM (SELECT max(b) FROM ab GROUP BY a) AS g(t);
+#   =>
 #   SELECT max(b) FROM ab;
 #
 #   SELECT sum_int(t) FROM (SELECT count(b) FROM ab GROUP BY a) AS g(t);
+#   =>
 #   SELECT count(b) FROM ab;
+#
+#   SELECT DISTINCT ON (x), x, y
+#   FROM (SELECT DISTINCT ON (a, b) a, b FROM ab) AS f(x y)
+#   =>
+#   SELECT DISTINCT ON (a) a, b FROM ab;
 #
 # This transformation is possible when the following conditions are met:
 #
-# 1. All of the outer aggregates are aggregating on the output columns of the
-#    inner aggregates.
+# 1. All of the outer aggregates either aggregate on:
+#      A. the output columns of the inner aggregates
+#      B. a grouping column of the inner grouping operator.
 # 2. All of the inner-outer aggregate pairs can be replaced with an equivalent
 #    single aggregate. (See the AggregatesCanMerge comment in operator.go).
-# 3. The grouping columns of the inner operator functionally determine the
+# 3. All of the outer aggregates that aggregate on inner grouping columns ignore
+#    duplicate values (See AggregateIgnoresDuplicates comment in operator.go).
+# 4. The grouping columns of the inner operator functionally determine the
 #    grouping columns of the outer operator according to the functional
 #    dependencies of the input of the inner operator.
-# 4. Both grouping operators are unordered.
+# 5. Both grouping operators are unordered.
 #
 # Why is it sufficient for the inner grouping columns to functionally determine
 # the outer grouping columns?
@@ -465,7 +476,7 @@
 #   values.
 # * Therefore, grouping on the dependent produces the same final groups as
 #   grouping on the dependent after grouping on the determinant.
-# * Conditions #2 and #4 guarantee that the aggregates produce the same result
+# * The conditions guarantee that the aggregates produce the same result
 #   regardless of how the grouping is accomplished, as long as the same groups
 #   result in the end.
 #
@@ -496,8 +507,8 @@
 # This situation is rare in direct SQL queries, but can arise when composing
 # views and queries.
 [FoldGroupingOperators, Normalize]
-(GroupBy | ScalarGroupBy
-    (GroupBy
+(GroupBy | ScalarGroupBy | DistinctOn
+    (GroupBy | DistinctOn
         $innerInput:*
         $innerAggs:*
         $innerGrouping:* & (IsUnorderedGrouping $innerGrouping)
@@ -507,14 +518,14 @@
         (IsUnorderedGrouping $outerGrouping) &
         (ColsAreDeterminedBy
             $outerGroupingCols:(GroupingCols $outerGrouping)
-            (GroupingCols $innerGrouping)
+            $innerGroupingCols:(GroupingCols $innerGrouping)
             $innerInput
         ) &
-        (CanMergeAggs $innerAggs $outerAggs)
+        (CanMergeAggs $innerAggs $outerAggs $innerGroupingCols)
 )
 =>
 ((OpName)
     $innerInput
-    (MergeAggs $innerAggs $outerAggs)
+    (MergeAggs $innerAggs $outerAggs $innerGroupingCols)
     (MakeGrouping $outerGroupingCols (EmptyOrdering))
 )

--- a/pkg/sql/opt/norm/testdata/rules/groupby
+++ b/pkg/sql/opt/norm/testdata/rules/groupby
@@ -3722,6 +3722,22 @@ scalar-group-by
       │    └── b:2
       └── count-rows [as=sum_int:10]
 
+# Case with aggregation on a grouping column.
+norm expect=FoldGroupingOperators
+SELECT max(x)
+FROM (SELECT DISTINCT ON (a) a FROM abc) AS f(x)
+----
+scalar-group-by
+ ├── columns: max:5
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(5)
+ ├── scan abc
+ │    └── columns: a:1!null
+ └── aggregations
+      └── max [as=max:5, outer=(1)]
+           └── a:1
+
 # GroupBy on GroupBy case where the inner grouping columns determine the outer
 # grouping columns, but they do not intersect.
 norm expect=FoldGroupingOperators
@@ -3758,6 +3774,37 @@ project
       └── aggregations
            └── sum [as=sum:6, outer=(3)]
                 └── c:3
+
+# DistinctOn on a DistinctOn case.
+norm expect=FoldGroupingOperators
+SELECT DISTINCT ON (x) x, y, z
+FROM (SELECT DISTINCT ON (a, b) a, b, c FROM abc) AS f(x, y, z)
+----
+distinct-on
+ ├── columns: x:1!null y:2!null z:3!null
+ ├── grouping columns: a:1!null
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── scan abc
+ │    ├── columns: a:1!null b:2!null c:3!null
+ │    └── key: (1-3)
+ └── aggregations
+      ├── first-agg [as=b:2, outer=(2)]
+      │    └── b:2
+      └── first-agg [as=c:3, outer=(3)]
+           └── c:3
+
+# DistinctOn on a DistinctOn case with no aggregates.
+norm expect=FoldGroupingOperators
+SELECT DISTINCT ON (x) x
+FROM (SELECT DISTINCT ON (a, b) a FROM abc) AS f(x)
+----
+distinct-on
+ ├── columns: x:1!null
+ ├── grouping columns: a:1!null
+ ├── key: (1)
+ └── scan abc
+      └── columns: a:1!null
 
 # No-op case with an AvgOp. Note: this query actually could be folded if the
 # groups were known to be of the same size.
@@ -3873,3 +3920,23 @@ scalar-group-by
  └── aggregations
       └── sum [as=sum:9, outer=(7)]
            └── sum:7
+
+# No-op case because sum does not ignore duplicates.
+norm expect-not=FoldGroupingOperators
+SELECT sum(x)
+FROM (SELECT DISTINCT ON (a) a FROM abc) AS f(x)
+----
+scalar-group-by
+ ├── columns: sum:5
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(5)
+ ├── distinct-on
+ │    ├── columns: a:1!null
+ │    ├── grouping columns: a:1!null
+ │    ├── key: (1)
+ │    └── scan abc
+ │         └── columns: a:1!null
+ └── aggregations
+      └── sum [as=sum:5, outer=(1)]
+           └── a:1

--- a/pkg/sql/opt/operator.go
+++ b/pkg/sql/opt/operator.go
@@ -400,9 +400,9 @@ func AggregateIsNeverNull(op Operator) bool {
 
 // AggregatesCanMerge returns true if the given inner and outer operators can be
 // replaced with a single equivalent operator, assuming the outer operator is
-// aggregating on the inner. In other words, the inner-outer aggregate pair
-// forms a valid "decomposition" of a single aggregate. For example, the
-// following pairs of queries are equivalent:
+// aggregating on the inner and that both operators are unordered. In other
+// words, the inner-outer aggregate pair forms a valid "decomposition" of a
+// single aggregate. For example, the following pairs of queries are equivalent:
 //
 //   SELECT sum(s) FROM (SELECT sum(y) FROM xy GROUP BY x) AS f(s);
 //   SELECT sum(y) FROM xy;


### PR DESCRIPTION
This patch extends the `FoldGroupingOperators` match pattern to include
`DistinctOn` operators. This allows two `DistinctOn` operators to be
folded into one when the inner grouping columns functionally determine
the outer grouping columns.

In addition, `FoldGroupingOperators` can now handle the case when an
outer aggregate function ignores duplicate values and takes an inner
grouping column as input. Ex:
```
SELECT max(x)
FROM (SELECT DISTINCT ON (a) FROM ab) AS f(x);
=>
SELECT max(a) FROM ab AS t(x);
```
Note that in the rewrite of this query, the `max` will 'see' duplicate
values that it didn't see before because its input was previously  a
grouping column of the inner `DistinctOn` (which removes duplicates
in its grouping columns). However, this does not affect the output,
because `max` ignores duplicates.

Fixes #58382

Release note: None