### PR TITLE
release-20.2: sql: fix a panic when showing statistics on a table with enums

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -994,3 +994,45 @@ FROM [SHOW STATISTICS USING JSON FOR TABLE all_null]
 
 statement ok
 SELECT * FROM all_null WHERE c IS NOT NULL
+
+# Regression for 58220.
+statement ok
+CREATE TYPE greeting AS ENUM ('hello', 'howdy', 'hi');
+CREATE TABLE greeting_stats (x greeting PRIMARY KEY);
+INSERT INTO greeting_stats VALUES ('hi');
+CREATE STATISTICS s FROM greeting_stats
+
+query T
+SELECT jsonb_pretty(COALESCE(json_agg(stat), '[]'))
+  FROM (
+SELECT json_array_elements(statistics) - 'created_at' AS stat
+FROM [SHOW STATISTICS USING JSON FOR TABLE greeting_stats]
+)
+----
+[
+    {
+        "columns": [
+            "x"
+        ],
+        "distinct_count": 1,
+        "histo_buckets": [
+            {
+                "distinct_range": 0,
+                "num_eq": 1,
+                "num_range": 0,
+                "upper_bound": "hi"
+            }
+        ],
+        "histo_col_type": "public.greeting",
+        "name": "s",
+        "null_count": 0,
+        "row_count": 1
+    }
+]
+
+# Check that we can inject the statistics back into the table as well.
+let $stats
+SHOW STATISTICS USING JSON FOR TABLE greeting_stats
+
+statement ok
+ALTER TABLE greeting_stats INJECT STATISTICS '$stats'

--- a/pkg/sql/show_stats.go
+++ b/pkg/sql/show_stats.go
@@ -130,7 +130,7 @@ func (p *planner) ShowTableStats(ctx context.Context, n *tree.ShowTableStats) (p
 					for j, d := range colIDs {
 						result[i].Columns[j] = statColumnString(desc, d)
 					}
-					if err := result[i].DecodeAndSetHistogram(r[histogramIdx]); err != nil {
+					if err := result[i].DecodeAndSetHistogram(ctx, &p.semaCtx, r[histogramIdx]); err != nil {
 						v.Close(ctx)
 						return nil, err
 					}


### PR DESCRIPTION
Backport 1/1 commits from #58251.

/cc @cockroachdb/release

---

Fixes #58220.

The panic was caused by using a user defined type without hydration of
type metadata.

Release note (bug fix): Fix a internal panic when using the `SHOW
STATISTICS USING JSON` statement on a table containing ENUM types.
