### PR TITLE
pg_catalog: properly handle zero when joining against pg_type on oid

### DIFF
--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -285,6 +285,7 @@ go_library(
         "//pkg/sql/gcjob/gcjobnotifier",
         "//pkg/sql/lex",
         "//pkg/sql/mutations",
+        "//pkg/sql/oidext",
         "//pkg/sql/opt",
         "//pkg/sql/opt/cat",
         "//pkg/sql/opt/constraint",

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -16,7 +16,6 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
-	"runtime/debug"
 	"sort"
 	"strings"
 	"sync"
@@ -1642,11 +1641,6 @@ func (m *Manager) findDescriptorState(id descpb.ID, create bool) *descriptorStat
 	t := m.mu.descriptors[id]
 	if t == nil && create {
 		t = &descriptorState{id: id, stopper: m.stopper}
-		if id >= 4294867200 {
-			stack := debug.Stack()
-			log.Warningf(context.TODO(), "adding questionable descriptor %d to lease manager: %v %s",
-				id, t, string(stack))
-		}
 		m.mu.descriptors[id] = t
 	}
 	return t

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemaexpr"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/oidext"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -2399,6 +2400,15 @@ https://www.postgresql.org/docs/9.5/catalog-pg-type.html`,
 						return false, err
 					}
 					return true, nil
+				}
+
+				// This oid is not a user-defined type and we didn't find it in the
+				// map of predefined types, return false. Note that in common usage we
+				// only really expect the value 0 here (which cockroach uses internally
+				// in the typelem field amongst others). Users, however, may join on
+				// this index with any value.
+				if ooid <= oidext.CockroachPredefinedOIDMax {
+					return false, nil
 				}
 
 				// Check if it is a user defined type.


### PR DESCRIPTION
Zero is used in the `typelem` field of `pg_type` when not referring to
anything. We currently end up treating `0` like a bogus user-defined type
(see #58414). This commit detects zero and avoids this bad behavior.

I want to backport this change but I don't really know how to describe
its impact beyond eliminating an alarming log message.

Fixes #57868.
Fixes #55290.

Release note: None