### PR TITLE
builtins: implement gateway_region

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -862,6 +862,16 @@ has no relationship with the commit order of concurrent transactions.</p>
 </span></td></tr></tbody>
 </table>
 
+### Multi-region functions
+
+<table>
+<thead><tr><th>Function &rarr; Returns</th><th>Description</th></tr></thead>
+<tbody>
+<tr><td><a name="gateway_region"></a><code>gateway_region() &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the region of the connection’s current node as defined by
+the locality flag on node startup. Returns an error if no region is set.</p>
+</span></td></tr></tbody>
+</table>
+
 ### Multi-tenancy functions
 
 <table>

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -598,6 +598,28 @@ var logicTestConfigs = []testClusterConfig{
 		isCCLConfig:       true,
 	},
 	{
+		name:              "multiregion-invalid-locality",
+		numNodes:          3,
+		overrideAutoStats: "false",
+		localities: map[int]roachpb.Locality{
+			1: {
+				Tiers: []roachpb.Tier{
+					{Key: "invalid-region-setup", Value: "test1"},
+					{Key: "availability-zone", Value: "test1-az1"},
+				},
+			},
+			2: {
+				Tiers: []roachpb.Tier{},
+			},
+			3: {
+				Tiers: []roachpb.Tier{
+					{Key: "region", Value: "test1"},
+					{Key: "availability-zone", Value: "test1-az3"},
+				},
+			},
+		},
+	},
+	{
 		name:              "multiregion-9node-3region-3azs",
 		numNodes:          9,
 		overrideAutoStats: "false",
@@ -1022,6 +1044,9 @@ type logicQuery struct {
 	kvOpTypes        []string
 	keyPrefixFilters []string
 
+	// nodeIdx determines which node on the cluster to execute a query on for the given query.
+	nodeIdx int
+
 	// noticetrace indicates we're comparing the output of a notice trace.
 	noticetrace bool
 
@@ -1224,7 +1249,23 @@ func (t *logicTest) setUser(user string) func() {
 	}
 	pgURL, cleanupFunc := sqlutils.PGUrl(t.rootT, addr, "TestLogic", url.User(user))
 	pgURL.Path = "test"
+	db := t.openDB(pgURL)
 
+	// The default value for extra_float_digits assumed by tests is
+	// 0. However, lib/pq by default configures this to 2 during
+	// connection initialization, so we need to set it back to 0 before
+	// we run anything.
+	if _, err := db.Exec("SET extra_float_digits = 0"); err != nil {
+		t.Fatal(err)
+	}
+	t.clients[user] = db
+	t.db = db
+	t.user = user
+
+	return cleanupFunc
+}
+
+func (t *logicTest) openDB(pgURL url.URL) *gosql.DB {
 	base, err := pq.NewConnector(pgURL.String())
 	if err != nil {
 		t.Fatal(err)
@@ -1239,20 +1280,8 @@ func (t *logicTest) setUser(user string) func() {
 			t.noticeBuffer = append(t.noticeBuffer, "HINT: "+notice.Hint)
 		}
 	})
-	db := gosql.OpenDB(connector)
 
-	// The default value for extra_float_digits assumed by tests is
-	// 0. However, lib/pq by default configures this to 2 during
-	// connection initialization, so we need to set it back to 0 before
-	// we run anything.
-	if _, err := db.Exec("SET extra_float_digits = 0"); err != nil {
-		t.Fatal(err)
-	}
-	t.clients[user] = db
-	t.db = db
-	t.user = user
-
-	return cleanupFunc
+	return gosql.OpenDB(connector)
 }
 
 func (t *logicTest) setup(cfg testClusterConfig, serverArgs TestServerArgs) {
@@ -2012,6 +2041,15 @@ func (t *logicTest) processSubtest(
 							query.noticetrace = true
 
 						default:
+							if strings.HasPrefix(opt, "nodeidx=") {
+								idx, err := strconv.ParseInt(strings.SplitN(opt, "=", 2)[1], 10, 64)
+								if err != nil {
+									return errors.Wrapf(err, "error parsing nodeidx")
+								}
+								query.nodeIdx = int(idx)
+								break
+							}
+
 							return errors.Errorf("%s: unknown sort mode: %s", query.pos, opt)
 						}
 					}
@@ -2492,7 +2530,21 @@ func (t *logicTest) execQuery(query logicQuery) error {
 
 	t.noticeBuffer = nil
 
-	rows, err := t.db.Query(query.sql)
+	db := t.db
+	if query.nodeIdx != 0 {
+		addr := t.cluster.Server(query.nodeIdx).ServingSQLAddr()
+		pgURL, cleanupFunc := sqlutils.PGUrl(t.rootT, addr, "TestLogic", url.User(t.user))
+		defer cleanupFunc()
+		pgURL.Path = "test"
+
+		db = t.openDB(pgURL)
+		defer func() {
+			if err := db.Close(); err != nil {
+				t.Fatal(err)
+			}
+		}()
+	}
+	rows, err := db.Query(query.sql)
 	if err == nil {
 		sqlutils.VerifyStatementPrettyRoundtrip(t.t(), query.sql)
 

--- a/pkg/sql/logictest/testdata/logic_test/multiregion
+++ b/pkg/sql/logictest/testdata/logic_test/multiregion
@@ -17,6 +17,20 @@ CREATE DATABASE multi_region_test_db PRIMARY REGION "test2" REGIONS "test1", "te
 statement ok
 CREATE DATABASE multi_region_test_explicit_primary_region_db PRIMARY REGION "test1" REGIONS "test1", "test2", "test3" SURVIVE REGION FAILURE
 
+query T
+SELECT gateway_region()
+----
+test1
+
+query T nodeidx=3
+SELECT gateway_region()
+----
+test2
+
+query T nodeidx=6
+SELECT gateway_region()
+----
+test3
 
 # Ensure that the region types were created for all the MR databases above.
 query IITI colnames

--- a/pkg/sql/logictest/testdata/logic_test/multiregion-invalid-locality
+++ b/pkg/sql/logictest/testdata/logic_test/multiregion-invalid-locality
@@ -1,0 +1,15 @@
+# LogicTest: multiregion-invalid-locality
+
+query TT colnames
+SHOW REGIONS FROM CLUSTER
+----
+region  zones
+test1   {test1-az3}
+
+query error no region set on the locality flag on this node
+SELECT gateway_region()
+
+query T nodeidx=2
+SELECT gateway_region()
+----
+test1

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -105,6 +105,7 @@ const (
 	categoryFuzzyStringMatching = "Fuzzy String Matching"
 	categoryIDGeneration        = "ID generation"
 	categoryJSON                = "JSONB"
+	categoryMultiRegion         = "Multi-region"
 	categoryMultiTenancy        = "Multi-tenancy"
 	categorySequences           = "Sequence"
 	categorySpatial             = "Spatial"
@@ -4711,6 +4712,27 @@ may increase either contention or retry errors, or both.`,
 			},
 			Info:       "Returns the number of nonnull arguments.",
 			Volatility: tree.VolatilityImmutable,
+		},
+	),
+
+	"gateway_region": makeBuiltin(
+		tree.FunctionProperties{Category: categoryMultiRegion},
+		tree.Overload{
+			Types:      tree.ArgTypes{},
+			ReturnType: tree.FixedReturnType(types.String),
+			Fn: func(evalCtx *tree.EvalContext, arg tree.Datums) (tree.Datum, error) {
+				region, found := evalCtx.Locality.Find("region")
+				if !found {
+					return nil, pgerror.Newf(
+						pgcode.ConfigFile,
+						"no region set on the locality flag on this node",
+					)
+				}
+				return tree.NewDString(region), nil
+			},
+			Info: `Returns the region of the connection's current node as defined by
+the locality flag on node startup. Returns an error if no region is set.`,
+			Volatility: tree.VolatilityStable,
 		},
 	),
 }


### PR DESCRIPTION
Implement the `gateway_region` builtin, which returns the region of the
current node.

Refs #57672

Release note (sql change): Implement the `gateway_region`, which returns
the region of the current node the connection is on.