### PR TITLE
release-20.2: pg_catalog: properly handle zero when joining against pg_type on oid

### DIFF
--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemadesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/oidext"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -2326,6 +2327,15 @@ https://www.postgresql.org/docs/9.5/catalog-pg-type.html`,
 						return false, err
 					}
 					return true, nil
+				}
+
+				// This oid is not a user-defined type and we didn't find it in the
+				// map of predefined types, return false. Note that in common usage we
+				// only really expect the value 0 here (which cockroach uses internally
+				// in the typelem field amongst others). Users, however, may join on
+				// this index with any value.
+				if ooid <= oidext.CockroachPredefinedOIDMax {
+					return false, nil
 				}
 
 				// Check if it is a user defined type.


### PR DESCRIPTION
Backport 1/1 commits from #58416.

/cc @cockroachdb/release

---

Zero is used in the `typelem` field of `pg_type` when not referring to
anything. We currently end up treating `0` like a bogus user-defined type
(see #58414). This commit detects zero and avoids this bad behavior.

I want to backport this change but I don't really know how to describe
its impact beyond eliminating an alarming log message.

Fixes #57868.
Fixes #55290.

Release note: None
