### PR TITLE
backupccl: avoid NPE when closing backup ExternalStorage

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -406,7 +406,11 @@ func backupPlanHook(
 		// the var, instead of defering the Close() method directly on this specifc
 		// instance.
 		defer func() {
-			defaultStore.Close()
+			// `defaultStore` could be nil if we fail to create an ExternalStorage
+			// instance and assign to the variable, somewhere below.
+			if defaultStore != nil {
+				defaultStore.Close()
+			}
 		}()
 
 		var encryption *roachpb.FileEncryptionOptions


### PR DESCRIPTION
If the external storage object is nil, the call to Close() will lead to
an NPE. The object could be nil if the method returning the value
assigned to it, errors out.

Informs: cockroachlabs/support/issues/744

Release note: None