### PR TITLE
opt: assign placeholders for cascade queries

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/cascade
+++ b/pkg/sql/logictest/testdata/logic_test/cascade
@@ -4322,3 +4322,33 @@ NULL  3
 
 statement ok
 DROP TABLE child, parent
+
+subtest AssignPlaceholders
+
+# Regression test for #58028. Make sure that placeholders get assigned for
+# cascade queries.
+
+statement ok
+CREATE TABLE parent (a INT PRIMARY KEY, b INT);
+CREATE TABLE child (a INT PRIMARY KEY, p_a INT NOT NULL REFERENCES parent(a) ON DELETE CASCADE);
+INSERT INTO parent VALUES (1, 2), (3, 4);
+INSERT INTO child VALUES (1, 1), (3, 3);
+
+statement ok
+PREPARE del AS DELETE FROM parent WHERE a = $1
+
+statement ok
+EXECUTE del (1)
+
+query II rowsort
+SELECT * FROM parent
+----
+3  4
+
+query II rowsort
+SELECT * FROM child
+----
+3  3
+
+statement ok
+DROP TABLE child, parent


### PR DESCRIPTION
Prior to this commit, it was possible that placeholders could
appear in cascade queries without getting replaced, causing an error
at execution time. This commit fixes the problem by ensuring that
placeholders are replaced before the cascade query is executed.

Fixes #58028

Release note (bug fix): Fixed an internal error that could occur when
executing prepared statements with placeholders that delete data from
columns referenced by a foreign key with ON DELETE CASCADE.