### PR TITLE
release-20.2: kvtenant: fetch ID of cluster during tenant startup

### DIFF
--- a/pkg/ccl/kvccl/kvtenantccl/connector.go
+++ b/pkg/ccl/kvccl/kvtenantccl/connector.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil/singleflight"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -89,6 +90,7 @@ var _ kvcoord.RangeDescriptorDB = (*Connector)(nil)
 var _ config.SystemConfigProvider = (*Connector)(nil)
 
 // NewConnector creates a new Connector.
+// NOTE: Calling Start will set cfg.RPCContext.ClusterID.
 func NewConnector(cfg kvtenant.ConnectorConfig, addrs []string) *Connector {
 	cfg.AmbientCtx.AddLogTag("tenant-connector", nil)
 	return &Connector{
@@ -110,8 +112,9 @@ func (connectorFactory) NewConnector(
 	return NewConnector(cfg, addrs), nil
 }
 
-// Start launches the connector's worker thread and waits for it to receive an
-// initial GossipSubscription event.
+// Start launches the connector's worker thread and waits for it to successfully
+// connect to a KV node. Start returns once the connector has determined the
+// cluster's ID and set Connector.rpcContext.ClusterID.
 func (c *Connector) Start(ctx context.Context) error {
 	startupC := c.startupC
 	c.rpcContext.Stopper.RunWorker(context.Background(), func(ctx context.Context) {
@@ -165,7 +168,10 @@ func (c *Connector) runGossipSubscription(ctx context.Context) {
 				continue
 			}
 			handler(c, ctx, e.Key, e.Content)
-			if c.startupC != nil {
+
+			// Signal that startup is complete once the ClusterID gossip key has
+			// been handled.
+			if c.startupC != nil && e.PatternMatched == gossip.KeyClusterID {
 				close(c.startupC)
 				c.startupC = nil
 			}
@@ -174,6 +180,8 @@ func (c *Connector) runGossipSubscription(ctx context.Context) {
 }
 
 var gossipSubsHandlers = map[string]func(*Connector, context.Context, string, roachpb.Value){
+	// Subscribe to the ClusterID update.
+	gossip.KeyClusterID: (*Connector).updateClusterID,
 	// Subscribe to all *NodeDescriptor updates.
 	gossip.MakePrefixPattern(gossip.KeyNodeIDPrefix): (*Connector).updateNodeAddress,
 	// Subscribe to a filtered view of *SystemConfig updates.
@@ -188,6 +196,22 @@ var gossipSubsPatterns = func() []string {
 	sort.Strings(patterns)
 	return patterns
 }()
+
+// updateClusterID handles updates to the "ClusterID" gossip key, and sets the
+// rpcContext so that it's available to other code running in the tenant.
+func (c *Connector) updateClusterID(ctx context.Context, key string, content roachpb.Value) {
+	bytes, err := content.GetBytes()
+	if err != nil {
+		log.Errorf(ctx, "invalid ClusterID value: %v", content.RawBytes)
+		return
+	}
+	clusterID, err := uuid.FromBytes(bytes)
+	if err != nil {
+		log.Errorf(ctx, "invalid ClusterID value: %v", content.RawBytes)
+		return
+	}
+	c.rpcContext.ClusterID.Set(ctx, clusterID)
+}
 
 // updateNodeAddress handles updates to "node" gossip keys, performing the
 // corresponding update to the Connector's cached NodeDescriptor set.

--- a/pkg/ccl/kvccl/kvtenantccl/connector_test.go
+++ b/pkg/ccl/kvccl/kvtenantccl/connector_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -70,6 +71,14 @@ func (m *mockServer) Join(
 	context.Context, *roachpb.JoinNodeRequest,
 ) (*roachpb.JoinNodeResponse, error) {
 	panic("unimplemented")
+}
+
+func gossipEventForClusterID(clusterID uuid.UUID) *roachpb.GossipSubscriptionEvent {
+	return &roachpb.GossipSubscriptionEvent{
+		Key:            gossip.KeyClusterID,
+		Content:        roachpb.MakeValueFromBytesAndTimestamp(clusterID.GetBytes(), hlc.Timestamp{}),
+		PatternMatched: gossip.KeyClusterID,
+	}
 }
 
 func gossipEventForNodeDesc(desc *roachpb.NodeDescriptor) *roachpb.GossipSubscriptionEvent {
@@ -116,12 +125,18 @@ func TestConnectorGossipSubscription(t *testing.T) {
 	rpcContext := rpc.NewInsecureTestingContext(clock, stopper)
 	s := rpc.NewServer(rpcContext)
 
+	// Test setting the cluster ID by setting it to nil then ensuring it's later
+	// set to the original ID value.
+	clusterID := rpcContext.ClusterID.Get()
+	rpcContext.ClusterID.Reset(uuid.Nil)
+
 	gossipSubC := make(chan *roachpb.GossipSubscriptionEvent)
 	defer close(gossipSubC)
 	gossipSubFn := func(req *roachpb.GossipSubscriptionRequest, stream roachpb.Internal_GossipSubscriptionServer) error {
-		assert.Len(t, req.Patterns, 2)
-		assert.Equal(t, "node:.*", req.Patterns[0])
-		assert.Equal(t, "system-db", req.Patterns[1])
+		assert.Len(t, req.Patterns, 3)
+		assert.Equal(t, "cluster-id", req.Patterns[0])
+		assert.Equal(t, "node:.*", req.Patterns[1])
+		assert.Equal(t, "system-db", req.Patterns[2])
 		for gossipSub := range gossipSubC {
 			if err := stream.Send(gossipSub); err != nil {
 				return err
@@ -157,7 +172,11 @@ func TestConnectorGossipSubscription(t *testing.T) {
 	node2 := &roachpb.NodeDescriptor{NodeID: 2, Address: util.MakeUnresolvedAddr("tcp", "2.2.2.2")}
 	gossipSubC <- gossipEventForNodeDesc(node1)
 	gossipSubC <- gossipEventForNodeDesc(node2)
+	gossipSubC <- gossipEventForClusterID(clusterID)
 	require.NoError(t, <-startedC)
+
+	// Ensure that ClusterID was updated.
+	require.Equal(t, clusterID, rpcContext.ClusterID.Get())
 
 	// Test kvcoord.NodeDescStore impl. Wait for full update first.
 	waitForNodeDesc(t, c, 2)
@@ -325,13 +344,15 @@ func TestConnectorRetriesUnreachable(t *testing.T) {
 	node1 := &roachpb.NodeDescriptor{NodeID: 1, Address: util.MakeUnresolvedAddr("tcp", "1.1.1.1")}
 	node2 := &roachpb.NodeDescriptor{NodeID: 2, Address: util.MakeUnresolvedAddr("tcp", "2.2.2.2")}
 	gossipSubEvents := []*roachpb.GossipSubscriptionEvent{
+		gossipEventForClusterID(rpcContext.ClusterID.Get()),
 		gossipEventForNodeDesc(node1),
 		gossipEventForNodeDesc(node2),
 	}
 	gossipSubFn := func(req *roachpb.GossipSubscriptionRequest, stream roachpb.Internal_GossipSubscriptionServer) error {
-		assert.Len(t, req.Patterns, 2)
-		assert.Equal(t, "node:.*", req.Patterns[0])
-		assert.Equal(t, "system-db", req.Patterns[1])
+		assert.Len(t, req.Patterns, 3)
+		assert.Equal(t, "cluster-id", req.Patterns[0])
+		assert.Equal(t, "node:.*", req.Patterns[1])
+		assert.Equal(t, "system-db", req.Patterns[2])
 		for _, event := range gossipSubEvents {
 			if err := stream.Send(event); err != nil {
 				return err

--- a/pkg/rpc/auth_tenant.go
+++ b/pkg/rpc/auth_tenant.go
@@ -160,6 +160,7 @@ func (a tenantAuthorizer) authGossipSubscription(
 // keyspace that GossipSubscription RPC invocations are allowed to touch.
 // WIP: can't import gossip directly.
 var gossipSubscriptionPatternAllowlist = []string{
+	"cluster-id",
 	"node:.*",
 	"system-db",
 }

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -659,7 +659,9 @@ func (s *sqlServer) start(
 	orphanedLeasesTimeThresholdNanos int64,
 ) error {
 	// If necessary, start the tenant proxy first, to ensure all other
-	// components can properly route to KV nodes.
+	// components can properly route to KV nodes. The Start method will block
+	// until a connection is established to the cluster and its ID has been
+	// determined.
 	if s.tenantConnect != nil {
 		if err := s.tenantConnect.Start(ctx); err != nil {
 			return err

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal_tenant
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal_tenant
@@ -334,11 +334,11 @@ CREATE TABLE foo (a INT PRIMARY KEY, INDEX idx(a)); INSERT INTO foo VALUES(1)
 statement error unsupported in multi-tenancy mode
 ALTER TABLE foo SPLIT AT VALUES(2)
 
-# Cluster ID is unset for tenants.
+# Make sure that the cluster id isn't unset.
 query B
 select crdb_internal.cluster_id() != '00000000-0000-0000-0000-000000000000' FROM foo
 ----
-false
+true
 
 # Check that privileged builtins are only allowed for 'root'
 user testuser


### PR DESCRIPTION
Previously, the ClusterID was not available to SQL tenants. Calling the
crdb_internal.cluster_id method returned a Nil UUID. However, the ClusterID
is needed for logging and metrics for SQL tenants. This commit fetchs the
ClusterID during tenant startup by subscribing to the "cluster-id" gossip
value. That value is then stored in the rpc.Context.ClusterID field, which
is used throughout the code when the ClusterID is needed.

Release note (sql change): The crdb_internal.cluster_id method now returns
the ID of the underlying KV cluster in multi-tenant scenarios rather than
the Nil UUID.