### PR TITLE
release-20.2: sql: fix assertion failure for CREATE TABLE with duplicate index names

### DIFF
--- a/pkg/sql/catalog/tabledesc/structured.go
+++ b/pkg/sql/catalog/tabledesc/structured.go
@@ -2041,7 +2041,7 @@ func (desc *Immutable) validateTableIndexes(columnNames map[string]descpb.Column
 		if _, indexNameExists := indexNames[index.Name]; indexNameExists {
 			for i := range desc.Indexes {
 				if desc.Indexes[i].Name == index.Name {
-					// This error should be caught in MakeIndexDescriptor.
+					// This error should be caught in MakeIndexDescriptor or NewTableDesc.
 					return errors.HandleAsAssertionFailure(fmt.Errorf("duplicate index name: %q", index.Name))
 				}
 			}

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1416,6 +1416,11 @@ func NewTableDesc(
 			// pass, handled above.
 
 		case *tree.IndexTableDef:
+			// If the index is named, ensure that the name is unique.
+			// Unnamed indexes will be given a unique auto-generated name later on.
+			if d.Name != "" && desc.ValidateIndexNameIsUnique(d.Name.String()) != nil {
+				return nil, pgerror.Newf(pgcode.DuplicateRelation, "duplicate index name: %q", d.Name)
+			}
 			idx := descpb.IndexDescriptor{
 				Name:             string(d.Name),
 				StoreColumnNames: d.Storing.ToStrings(),

--- a/pkg/sql/logictest/testdata/logic_test/create_table
+++ b/pkg/sql/logictest/testdata/logic_test/create_table
@@ -316,3 +316,9 @@ CREATE TABLE error (LIKE like_hash_base INCLUDING STATISTICS)
 
 statement error unimplemented
 CREATE TABLE error (LIKE like_hash_base INCLUDING STORAGE)
+
+subtest regression_57630
+
+statement error pgcode 42P07 duplicate index name: \"idx\"
+CREATE TABLE error (a INT, b INT, INDEX idx (a), INDEX idx (b))
+


### PR DESCRIPTION
Backport 1/1 commits from #58433.

/cc @cockroachdb/release

---

Previously, since version 20.2, executing a statement such as
```
CREATE TABLE t (a INT, b INT, INDEX idx (a), INDEX idx (b))
```
yields an assertion failure during the validation of the table descriptor.
This is a regression from version 20.1 which yields a proper error:
```
ERROR: duplicate index name: "idx"
```
This patch fixes this regression and restores the original behaviour.

Fixes #57630.

Release note (bug fix): A CREATE TABLE statement with indexes with
duplicate names will no longer result in an assertion failure. This bug
was present since version 20.2.
