### PR TITLE
[wip] sql: add support for experimental DROP ALL command

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -15,6 +15,7 @@
 <tr><td><code>external.graphite.interval</code></td><td>duration</td><td><code>10s</code></td><td>the interval at which metrics are pushed to Graphite (if enabled)</td></tr>
 <tr><td><code>feature.backup.enabled</code></td><td>boolean</td><td><code>true</code></td><td>set to true to enable backups, false to disable; default is true</td></tr>
 <tr><td><code>feature.changefeed.enabled</code></td><td>boolean</td><td><code>true</code></td><td>set to true to enable changefeeds, false to disable; default is true</td></tr>
+<tr><td><code>feature.experimental_drop_all_tables.enabled</code></td><td>boolean</td><td><code>false</code></td><td>set to true to enable the experimental DROP ALL feature that deletes all tables</td></tr>
 <tr><td><code>feature.export.enabled</code></td><td>boolean</td><td><code>true</code></td><td>set to true to enable exports, false to disable; default is true</td></tr>
 <tr><td><code>feature.import.enabled</code></td><td>boolean</td><td><code>true</code></td><td>set to true to enable imports, false to disable; default is true</td></tr>
 <tr><td><code>feature.restore.enabled</code></td><td>boolean</td><td><code>true</code></td><td>set to true to enable restore, false to disable; default is true</td></tr>

--- a/docs/generated/sql/bnf/drop_stmt.bnf
+++ b/docs/generated/sql/bnf/drop_stmt.bnf
@@ -6,5 +6,6 @@ drop_stmt ::=
 	| drop_sequence_stmt
 	| drop_schema_stmt
 	| drop_type_stmt
+	| drop_all_stmt
 	| drop_role_stmt
 	| drop_schedule_stmt

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -475,6 +475,7 @@ drop_ddl_stmt ::=
 	| drop_sequence_stmt
 	| drop_schema_stmt
 	| drop_type_stmt
+	| drop_all_stmt
 
 drop_role_stmt ::=
 	'DROP' role_or_group_or_user string_or_placeholder_list
@@ -1416,6 +1417,9 @@ drop_schema_stmt ::=
 drop_type_stmt ::=
 	'DROP' 'TYPE' type_name_list opt_drop_behavior
 	| 'DROP' 'TYPE' 'IF' 'EXISTS' type_name_list opt_drop_behavior
+
+drop_all_stmt ::=
+	'DROP' 'ALL'
 
 explain_option_name ::=
 	non_reserved_word

--- a/pkg/sql/catalog/accessors/logical_schema_accessors.go
+++ b/pkg/sql/catalog/accessors/logical_schema_accessors.go
@@ -12,7 +12,6 @@ package accessors
 
 import (
 	"context"
-
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"

--- a/pkg/sql/drop_all.go
+++ b/pkg/sql/drop_all.go
@@ -1,0 +1,165 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"context"
+	"github.com/cockroachdb/cockroach/pkg/build"
+	"github.com/cockroachdb/cockroach/pkg/config"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkeys"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/errors"
+)
+
+// featureBackupEnabled is used to enable and disable the BACKUP feature.
+var featureExperimentalDropAllTablesEnabled = settings.RegisterBoolSetting(
+	"feature.experimental_drop_all_tables.enabled",
+	"set to true to enable the experimental DROP ALL feature that deletes all tables",
+	false,
+).WithPublic()
+
+type dropAllNode struct {
+	n  *tree.DropAll
+}
+
+var _ planNode = &dropAllNode{n: nil}
+
+func (p *planner) DropAll(ctx context.Context, n *tree.DropAll) (planNode, error) {
+	node := &dropAllNode{
+		n:  n,
+	}
+	return node, nil
+}
+
+func (n *dropAllNode) startExec(params runParams) error {
+	if err := params.p.dropAllImpl(params.ctx); err != nil {
+		return err
+	}
+
+	// Log an event.
+
+	return nil
+}
+
+// dropTypeImpl does the work of dropping a type and everything that depends on it.
+func (p *planner) dropAllImpl(ctx context.Context) error {
+	// TODO: Make this a session var informed by a cluster setting.
+	if !featureExperimentalDropAllTablesEnabled.Get(&p.execCfg.Settings.SV) {
+		return errors.WithHint(
+			errors.WithIssueLink(
+				errors.Newf("drop all tables is only supported experimentally"),
+				errors.IssueLink{IssueURL: build.MakeIssueURL(46260)},
+			),
+			"You can enable DROP ALL by running `SET CLUSTER SETTING feature.experimental_drop_all_tables.enabled = 'on'`.",
+		)
+	}
+
+	// First clear all user data.
+	{
+		startKey := keys.TODOSQLCodec.TablePrefix(keys.MinUserDescID)
+		sp := roachpb.Span{Key: startKey, EndKey: keys.MaxKey}
+		b := &kv.Batch{}
+		b.AddRawRequest(&roachpb.ClearRangeRequest{
+			RequestHeader: roachpb.RequestHeader{
+				Key:    sp.Key,
+				EndKey: sp.EndKey,
+			},
+		})
+		if err := p.txn.DB().Run(ctx, b); err != nil {
+			return errors.Wrap(err, "dropping all the data")
+		}
+	}
+
+	codec := p.ExecCfg().Codec
+	if err := p.txn.SetSystemConfigTrigger(codec.ForSystemTenant()); err != nil {
+		return err
+	}
+
+	execCfg := p.execCfg
+
+	// TODO: Users can still query the dropped tables (although they will not
+	// appear in queries such as SHOW TABLES). The cache holding these objects
+	// need to be cleared
+	return descs.Txn(ctx, execCfg.Settings, execCfg.LeaseManager, execCfg.InternalExecutor,
+		execCfg.DB, func(ctx context.Context, txn *kv.Txn, descsCol *descs.Collection) error {
+			b := &kv.Batch{}
+
+			allDescs, err := descsCol.GetAllDescriptors(ctx, txn)
+			if err != nil {
+				return err
+			}
+
+			for _, desc := range allDescs {
+				if desc.GetID() == keys.SystemDatabaseID || desc.GetParentID() == keys.SystemDatabaseID {
+					continue
+				}
+
+				var mutTable *tabledesc.Mutable
+				if tableDesc, ok := desc.(catalog.TableDescriptor); ok {
+					if immutableTable := tableDesc.TableDesc(); immutableTable != nil {
+						mutTable = tabledesc.NewExistingMutable(*immutableTable)
+					} else {
+						return errors.New("expected a table")
+					}
+				} else {
+					// We only want to delete tables.
+					continue
+				}
+
+				// Remove any associated comments.
+				if err := p.removeTableComments(ctx, desc.GetID()); err != nil {
+					return err
+				}
+
+				// Delete the zone config entry.
+				if codec.ForSystemTenant() {
+					zoneKeyPrefix := config.MakeZoneKeyPrefix(config.SystemTenantObjectID(desc.GetID()))
+					b.DelRange(zoneKeyPrefix, zoneKeyPrefix.PrefixEnd(), false /* returnKeys */)
+				}
+
+				mutTable.Version = mutTable.GetVersion() + 1
+				if err := descsCol.WriteDescToBatch(
+					ctx, false /* kvTrace */, mutTable, b,
+				); err != nil {
+					return err
+				}
+
+				// Delete the descriptor.
+				b.Del(catalogkeys.MakeDescMetadataKey(codec, desc.GetID()))
+
+				// Remove from namespace.
+				catalogkv.WriteObjectNamespaceEntryRemovalToBatch(
+					ctx,
+					b,
+					keys.SystemSQLCodec,
+					desc.GetParentID(),
+					desc.GetParentSchemaID(),
+					desc.GetName(),
+					false, /* kvTrace */
+				)
+			}
+
+			return p.txn.Run(ctx, b)
+		})
+}
+
+func (n *dropAllNode) Next(params runParams) (bool, error) { return false, nil }
+func (n *dropAllNode) Values() tree.Datums                 { return tree.Datums{} }
+func (n *dropAllNode) Close(ctx context.Context)           {}
+func (n *dropAllNode) ReadingOwnWrites()                   {}

--- a/pkg/sql/drop_table.go
+++ b/pkg/sql/drop_table.go
@@ -350,7 +350,7 @@ func (p *planner) dropTableImpl(
 		droppedViews = append(droppedViews, viewDesc.Name)
 	}
 
-	err := p.removeTableComments(ctx, tableDesc)
+	err := p.removeTableComments(ctx, tableDesc.ID)
 	if err != nil {
 		return droppedViews, err
 	}
@@ -682,14 +682,14 @@ func removeMatchingReferences(
 	return updatedRefs
 }
 
-func (p *planner) removeTableComments(ctx context.Context, tableDesc *tabledesc.Mutable) error {
+func (p *planner) removeTableComments(ctx context.Context, tableID descpb.ID) error {
 	_, err := p.ExtendedEvalContext().ExecCfg.InternalExecutor.ExecEx(
 		ctx,
 		"delete-table-comments",
 		p.txn,
 		sessiondata.InternalExecutorOverride{User: security.RootUserName()},
 		"DELETE FROM system.comments WHERE object_id=$1",
-		tableDesc.ID)
+		tableID)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/opaque.go
+++ b/pkg/sql/opaque.go
@@ -117,6 +117,8 @@ func buildOpaque(
 		plan, err = p.DropTable(ctx, n)
 	case *tree.DropType:
 		plan, err = p.DropType(ctx, n)
+	case *tree.DropAll:
+		plan, err = p.DropAll(ctx, n)
 	case *tree.DropView:
 		plan, err = p.DropView(ctx, n)
 	case *tree.Grant:
@@ -230,6 +232,7 @@ func init() {
 		&tree.DropSequence{},
 		&tree.DropTable{},
 		&tree.DropType{},
+		&tree.DropAll{},
 		&tree.DropView{},
 		&tree.Grant{},
 		&tree.GrantRole{},

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -831,6 +831,7 @@ func (u *sqlSymUnion) objectNamePrefixList() tree.ObjectNamePrefixList {
 %type <tree.Statement> drop_schema_stmt
 %type <tree.Statement> drop_table_stmt
 %type <tree.Statement> drop_type_stmt
+%type <tree.Statement> drop_all_stmt
 %type <tree.Statement> drop_view_stmt
 %type <tree.Statement> drop_sequence_stmt
 
@@ -3362,6 +3363,7 @@ drop_ddl_stmt:
 | drop_sequence_stmt // EXTEND WITH HELP: DROP SEQUENCE
 | drop_schema_stmt   // EXTEND WITH HELP: DROP SCHEMA
 | drop_type_stmt     // EXTEND WITH HELP: DROP TYPE
+| drop_all_stmt      // EXTEND WITH HELP: DROP ALL
 
 // %Help: DROP VIEW - remove a view
 // %Category: DDL
@@ -3495,6 +3497,16 @@ drop_type_stmt:
     }
   }
 | DROP TYPE error // SHOW HELP: DROP TYPE
+
+// %Help: DROP ALL - remove everything
+// %Category: DDL
+// %Text: DROP ALL
+drop_all_stmt:
+  DROP ALL
+  {
+    $$.val = &tree.DropAll{ }
+  }
+| DROP ALL error // SHOW HELP: DROP ALL
 
 target_types:
   type_name_list

--- a/pkg/sql/sem/tree/drop.go
+++ b/pkg/sql/sem/tree/drop.go
@@ -196,6 +196,16 @@ func (node *DropType) Format(ctx *FmtCtx) {
 	}
 }
 
+// DropAll represents a DROP ALL command.
+type DropAll struct{}
+
+var _ Statement = &DropAll{}
+
+// Format implements the NodeFormatter interface.
+func (node *DropAll) Format(ctx *FmtCtx) {
+	ctx.WriteString("DROP ALL")
+}
+
 // DropSchema represents a DROP SCHEMA command.
 type DropSchema struct {
 	Names        ObjectNamePrefixList

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -525,6 +525,12 @@ func (*DropType) StatementType() StatementType { return DDL }
 func (*DropType) StatementTag() string { return "DROP TYPE" }
 
 // StatementType implements the Statement interface.
+func (*DropAll) StatementType() StatementType { return DDL }
+
+// StatementTag returns a short string identifying the type of statement.
+func (*DropAll) StatementTag() string { return "DROP ALL" }
+
+// StatementType implements the Statement interface.
 func (*DropSchema) StatementType() StatementType { return DDL }
 
 // StatementTag implements the Statement interface.
@@ -1109,6 +1115,7 @@ func (n *DropSchema) String() string                     { return AsString(n) }
 func (n *DropSequence) String() string                   { return AsString(n) }
 func (n *DropTable) String() string                      { return AsString(n) }
 func (n *DropType) String() string                       { return AsString(n) }
+func (n *DropAll) String() string                        { return AsString(n) }
 func (n *DropView) String() string                       { return AsString(n) }
 func (n *DropRole) String() string                       { return AsString(n) }
 func (n *Execute) String() string                        { return AsString(n) }

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -362,6 +362,7 @@ var planNodeNames = map[reflect.Type]string{
 	reflect.TypeOf(&dropSchemaNode{}):              "drop schema",
 	reflect.TypeOf(&dropTableNode{}):               "drop table",
 	reflect.TypeOf(&dropTypeNode{}):                "drop type",
+	reflect.TypeOf(&dropAllNode{}):                 "drop all",
 	reflect.TypeOf(&DropRoleNode{}):                "drop user/role",
 	reflect.TypeOf(&dropViewNode{}):                "drop view",
 	reflect.TypeOf(&errorIfRowsNode{}):             "error if rows",


### PR DESCRIPTION
This commit adds support for an experimental command DROP ALL which
drops all tables, as well as all user table data. This is intended to be
used before a cluster restore.

Still a WIP, TODO:
- [ ] Handle checking for running jobs and deleting those jobs
- [ ] Ensure that the names are invalidated from caches for deleted descriptors
- [ ] Delete database metadata
- [ ] Consider time travel queries
- [ ] Testing

Addresses https://github.com/cockroachdb/cockroach/issues/54505.

Release note (sql change): Add an experimental DROP ALL command that
deletes all tables and table data.