### PR TITLE
build: set default git branch name for teamcity builds

### DIFF
--- a/build/packer/teamcity-agent.sh
+++ b/build/packer/teamcity-agent.sh
@@ -54,6 +54,11 @@ usermod -a -G docker agent
 su - agent <<'EOF'
 set -euxo pipefail
 
+# Set the default branch name for git. (Out of an abundance of caution because
+# I don't know how well TC handles having a different default branch name, stick
+# with "master".)
+git config --global init.defaultBranch master
+
 echo 'export GOPATH="$HOME"/work/.go' >> .profile && source .profile
 
 wget https://teamcity.cockroachdb.com/update/buildAgent.zip


### PR DESCRIPTION
We've apparently picked up a new version of Git that [picks up the
changes to how default branch naming
works](https://github.blog/2020-07-27-highlights-from-git-2-28/). This
is fine, except that TeamCity freaks out if `git init` prints anything
to stderr, which does happen now; specifically, this error message is
printed:

    hint: Using 'master' as the name for the initial branch. This default branch name
    hint: is subject to change. To configure the initial branch name to use in all
    hint: of your new repositories, which will suppress this warning, call:
    hint:
    hint: 	git config --global init.defaultBranch <name>

So we just follow that advice in the Packer script to quash the error.

Release note: None