### PR TITLE
changefeedccl: Freeze table name to the (optionally fully qualified) statement time name

### DIFF
--- a/pkg/ccl/changefeedccl/avro.go
+++ b/pkg/ccl/changefeedccl/avro.go
@@ -389,11 +389,11 @@ func columnDescToAvroSchema(colDesc *descpb.ColumnDescriptor) (*avroSchemaField,
 // indexToAvroSchema converts a column descriptor into its corresponding avro
 // record schema. The fields are kept in the same order as columns in the index.
 func indexToAvroSchema(
-	tableDesc catalog.TableDescriptor, indexDesc *descpb.IndexDescriptor,
+	tableDesc catalog.TableDescriptor, indexDesc *descpb.IndexDescriptor, name string,
 ) (*avroDataRecord, error) {
 	schema := &avroDataRecord{
 		avroRecord: avroRecord{
-			Name:       SQLNameToAvroName(tableDesc.GetName()),
+			Name:       SQLNameToAvroName(name),
 			SchemaType: `record`,
 		},
 		fieldIdxByName:   make(map[string]int),

--- a/pkg/ccl/changefeedccl/avro_test.go
+++ b/pkg/ccl/changefeedccl/avro_test.go
@@ -285,7 +285,7 @@ func TestAvroSchema(t *testing.T) {
 				`{"type":["null","long"],"name":"_u0001f366_","default":null,`+
 				`"__crdb__":"🍦 INT8 NOT NULL"}]}`,
 			tableSchema.codec.Schema())
-		indexSchema, err := indexToAvroSchema(tableDesc, tableDesc.GetPrimaryIndex().IndexDesc())
+		indexSchema, err := indexToAvroSchema(tableDesc, tableDesc.GetPrimaryIndex(), tableDesc.GetName())
 		require.NoError(t, err)
 		require.Equal(t,
 			`{"type":"record","name":"_u2603_","fields":[`+

--- a/pkg/ccl/changefeedccl/changefeedbase/options.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options.go
@@ -30,6 +30,7 @@ const (
 	OptCursor                   = `cursor`
 	OptEnvelope                 = `envelope`
 	OptFormat                   = `format`
+	OptFullTableName            = `full_table_name`
 	OptKeyInValue               = `key_in_value`
 	OptResolvedTimestamps       = `resolved`
 	OptUpdatedTimestamps        = `updated`
@@ -100,6 +101,7 @@ var ChangefeedOptionExpectValues = map[string]sql.KVStringOptValidate{
 	OptCursor:                   sql.KVStringOptRequireValue,
 	OptEnvelope:                 sql.KVStringOptRequireValue,
 	OptFormat:                   sql.KVStringOptRequireValue,
+	OptFullTableName:            sql.KVStringOptRequireNoValue,
 	OptKeyInValue:               sql.KVStringOptRequireNoValue,
 	OptResolvedTimestamps:       sql.KVStringOptAny,
 	OptUpdatedTimestamps:        sql.KVStringOptRequireNoValue,

--- a/pkg/ccl/changefeedccl/changefeedbase/validate.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/validate.go
@@ -49,9 +49,6 @@ func ValidateTable(targets jobspb.ChangefeedTargets, tableDesc *tabledesc.Immuta
 	if tableDesc.State == descpb.DescriptorState_DROP {
 		return errors.Errorf(`"%s" was dropped or truncated`, t.StatementTimeName)
 	}
-	if tableDesc.Name != t.StatementTimeName {
-		return errors.Errorf(`"%s" was renamed to "%s"`, t.StatementTimeName, tableDesc.Name)
-	}
 
 	// TODO(mrtracy): re-enable this when allow-backfill option is added.
 	// if tableDesc.HasColumnBackfillMutation() {

--- a/pkg/ccl/changefeedccl/encoder.go
+++ b/pkg/ccl/changefeedccl/encoder.go
@@ -273,8 +273,8 @@ func (e *jsonEncoder) EncodeResolvedTimestamp(
 // JSON format. Keys are the primary key columns in a record. Values are all
 // columns in a record.
 type confluentAvroEncoder struct {
-	registryURL                        string
-	updatedField, beforeField, keyOnly bool
+	registryURL                                       string
+	updatedField, beforeField, keyOnly, fullTableName bool
 
 	keyCache      map[tableIDAndVersion]confluentRegisteredKeySchema
 	valueCache    map[tableIDAndVersionPair]confluentRegisteredEnvelopeSchema
@@ -326,12 +326,12 @@ func newConfluentAvroEncoder(opts map[string]string) (*confluentAvroEncoder, err
 		return nil, errors.Errorf(`%s is not supported with %s=%s`,
 			changefeedbase.OptKeyInValue, changefeedbase.OptFormat, changefeedbase.OptFormatAvro)
 	}
+	_, e.fullTableName = opts[changefeedbase.OptFullTableName]
 
 	if len(e.registryURL) == 0 {
 		return nil, errors.Errorf(`WITH option %s is required for %s=%s`,
 			changefeedbase.OptConfluentSchemaRegistry, changefeedbase.OptFormat, changefeedbase.OptFormatAvro)
 	}
-
 	e.keyCache = make(map[tableIDAndVersion]confluentRegisteredKeySchema)
 	e.valueCache = make(map[tableIDAndVersionPair]confluentRegisteredEnvelopeSchema)
 	e.resolvedCache = make(map[string]confluentRegisteredEnvelopeSchema)
@@ -341,10 +341,11 @@ func newConfluentAvroEncoder(opts map[string]string) (*confluentAvroEncoder, err
 // EncodeKey implements the Encoder interface.
 func (e *confluentAvroEncoder) EncodeKey(ctx context.Context, row encodeRow) ([]byte, error) {
 	cacheKey := makeTableIDAndVersion(row.tableDesc.GetID(), row.tableDesc.GetVersion())
+
 	registered, ok := e.keyCache[cacheKey]
 	if !ok {
 		var err error
-		registered.schema, err = indexToAvroSchema(row.tableDesc, row.tableDesc.GetPrimaryIndex().IndexDesc())
+		registered.schema, err = indexToAvroSchema(row.tableDesc, row.tableDesc.GetPrimaryIndex(), row.tableDesc.GetName())
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/ccl/changefeedccl/sink_test.go
+++ b/pkg/ccl/changefeedccl/sink_test.go
@@ -66,8 +66,10 @@ func TestKafkaSink(t *testing.T) {
 	}
 	sink := &kafkaSink{
 		producer: p,
-		topics:   map[string]struct{}{`t`: {}},
 	}
+	targets := make(jobspb.ChangefeedTargets, 1)
+	targets[0] = jobspb.ChangefeedTarget{StatementTimeName: `t`}
+	sink.setTargets(targets)
 	sink.start()
 	defer func() {
 		if err := sink.Close(); err != nil {
@@ -156,8 +158,10 @@ func TestKafkaSinkEscaping(t *testing.T) {
 	}
 	sink := &kafkaSink{
 		producer: p,
-		topics:   map[string]struct{}{SQLNameToKafkaName(`☃`): {}},
 	}
+	targets := make(jobspb.ChangefeedTargets, 1)
+	targets[0] = jobspb.ChangefeedTarget{StatementTimeName: `☃`}
+	sink.setTargets(targets)
 	sink.start()
 	defer func() { require.NoError(t, sink.Close()) }()
 	if err := sink.EmitRow(ctx, table(`☃`), []byte(`k☃`), []byte(`v☃`), zeroTS); err != nil {
@@ -184,7 +188,8 @@ func TestSQLSink(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	table := func(name string) *tabledesc.Immutable {
-		return tabledesc.NewImmutable(descpb.TableDescriptor{Name: name})
+		id, _ := strconv.ParseUint(name, 36, 64)
+		return tabledesc.NewImmutable(descpb.TableDescriptor{Name: name, ID: descpb.ID(id)})
 	}
 
 	ctx := context.Background()
@@ -198,8 +203,8 @@ func TestSQLSink(t *testing.T) {
 	sinkURL.Path = `d`
 
 	targets := jobspb.ChangefeedTargets{
-		0: jobspb.ChangefeedTarget{StatementTimeName: `foo`},
-		1: jobspb.ChangefeedTarget{StatementTimeName: `bar`},
+		table(`foo`).GetID(): jobspb.ChangefeedTarget{StatementTimeName: `foo`},
+		table(`bar`).GetID(): jobspb.ChangefeedTarget{StatementTimeName: `bar`},
 	}
 	sink, err := makeSQLSink(sinkURL.String(), `sink`, targets)
 	require.NoError(t, err)
@@ -210,7 +215,7 @@ func TestSQLSink(t *testing.T) {
 
 	// Undeclared topic
 	require.EqualError(t,
-		sink.EmitRow(ctx, table(`nope`), nil, nil, zeroTS), `cannot emit to undeclared topic: nope`)
+		sink.EmitRow(ctx, table(`nope`), nil, nil, zeroTS), `cannot emit to undeclared topic: `)
 
 	// With one row, nothing flushes until Flush is called.
 	require.NoError(t, sink.EmitRow(ctx, table(`foo`), []byte(`k1`), []byte(`v0`), zeroTS))


### PR DESCRIPTION
Previously, Kafka topics and top-level keys were always derived from the
table name in changefeeds.  If the table name changed, the feed
eventually failed, and if the table name was non-unique across
databases, collisions were unavoidable. This PR adds a WITH
full_table_name option to changefeeds, and honors it by serializing
movr.public.drivers as the statement time name and relying on that.

There are probably more things that need to change downstream.

Release note (sql change): Added "WITH full_table_name" option to create
a changefeed on "movr.public.drivers" instead of
"drivers".