### PR TITLE
opt: prevent columns reuse in Union and UnionAll

### DIFF
--- a/pkg/sql/opt/norm/general_funcs.go
+++ b/pkg/sql/opt/norm/general_funcs.go
@@ -290,6 +290,26 @@ func (c *CustomFuncs) RedundantCols(input memo.RelExpr, cols opt.ColSet) opt.Col
 	return cols.Difference(reducedCols)
 }
 
+// DuplicateColumnIDs duplicates a table and set of columns IDs in the metadata.
+// It returns the new table's ID and the new set of columns IDs.
+func (c *CustomFuncs) DuplicateColumnIDs(
+	table opt.TableID, cols opt.ColSet,
+) (opt.TableID, opt.ColSet) {
+	md := c.mem.Metadata()
+	tabMeta := md.TableMeta(table)
+	newTableID := md.DuplicateTable(table, c.RemapCols)
+
+	// Build a new set of column IDs from the new TableMeta.
+	var newColIDs opt.ColSet
+	for col, ok := cols.Next(0); ok; col, ok = cols.Next(col + 1) {
+		ord := tabMeta.MetaID.ColumnOrdinal(col)
+		newColID := newTableID.ColumnID(ord)
+		newColIDs.Add(newColID)
+	}
+
+	return newTableID, newColIDs
+}
+
 // RemapCols remaps columns IDs in the input ScalarExpr by replacing occurrences
 // of the keys of colMap with the corresponding values. If column IDs are
 // encountered in the input ScalarExpr that are not keys in colMap, they are not
@@ -1054,23 +1074,11 @@ func (c *CustomFuncs) DatumsEqual(first, second tree.Datum) bool {
 // ScanPrivate, so the new ScanPrivate will not have constraints even if the old
 // one did.
 func (c *CustomFuncs) DuplicateScanPrivate(sp *memo.ScanPrivate) *memo.ScanPrivate {
-	md := c.mem.Metadata()
-	tabMeta := md.TableMeta(sp.Table)
-	newTableID := md.DuplicateTable(sp.Table, c.RemapCols)
-
-	// Build a new set of column IDs from the new TableMeta.
-	var newColIDs opt.ColSet
-	cols := sp.Cols
-	for col, ok := cols.Next(0); ok; col, ok = cols.Next(col + 1) {
-		ord := tabMeta.MetaID.ColumnOrdinal(col)
-		newColID := newTableID.ColumnID(ord)
-		newColIDs.Add(newColID)
-	}
-
+	table, cols := c.DuplicateColumnIDs(sp.Table, sp.Cols)
 	return &memo.ScanPrivate{
-		Table:   newTableID,
+		Table:   table,
 		Index:   sp.Index,
-		Cols:    newColIDs,
+		Cols:    cols,
 		Flags:   sp.Flags,
 		Locking: sp.Locking,
 	}

--- a/pkg/sql/opt/xform/limit_funcs.go
+++ b/pkg/sql/opt/xform/limit_funcs.go
@@ -249,12 +249,11 @@ func (c *CustomFuncs) SplitScanIntoUnionScans(
 
 	// makeNewUnion extends the Union tree rooted at 'last' to include 'newScan'.
 	// The ColumnIDs of the original Scan are used by the resulting expression.
-	oldColList := scan.Relational().OutputCols.ToList()
-	makeNewUnion := func(last, newScan memo.RelExpr) memo.RelExpr {
+	makeNewUnion := func(last, newScan memo.RelExpr, outCols opt.ColList) memo.RelExpr {
 		return c.e.f.ConstructUnion(last, newScan, &memo.SetPrivate{
 			LeftCols:  last.Relational().OutputCols.ToList(),
 			RightCols: newScan.Relational().OutputCols.ToList(),
-			OutCols:   oldColList,
+			OutCols:   outCols,
 		})
 	}
 
@@ -263,7 +262,7 @@ func (c *CustomFuncs) SplitScanIntoUnionScans(
 	// construct a single unlimited Scan, which will also be added to the Unions.
 	var noLimitSpans constraint.Spans
 	var last memo.RelExpr
-	for i := 0; i < spans.Count(); i++ {
+	for i, n := 0, spans.Count(); i < n; i++ {
 		if i >= budgetExceededIndex {
 			// The Scan budget has been reached; no additional Scans can be created.
 			noLimitSpans.Append(spans.Get(i))
@@ -276,15 +275,27 @@ func (c *CustomFuncs) SplitScanIntoUnionScans(
 			noLimitSpans.Append(spans.Get(i))
 			continue
 		}
-		for j := 0; j < singleKeySpans.Count(); j++ {
+		for j, m := 0, singleKeySpans.Count(); j < m; j++ {
 			if last == nil {
 				// This is the first limited Scan, so no Union necessary.
 				last = c.makeNewScan(sp, cons.Columns, newHardLimit, singleKeySpans.Get(j))
 				continue
 			}
-			// Construct a new Scan for each span and add it to the Union tree.
+			// Construct a new Scan for each span.
 			newScan := c.makeNewScan(sp, cons.Columns, newHardLimit, singleKeySpans.Get(j))
-			last = makeNewUnion(last, newScan)
+
+			// Add the scan to the union tree. If it is the final union in the
+			// tree, use the original scan's columns as the union's out columns.
+			// Otherwise, create new output column IDs for the union.
+			var outCols opt.ColList
+			finalUnion := i == n-1 && j == m-1 && noLimitSpans.Count() == 0
+			if finalUnion {
+				outCols = sp.Cols.ToList()
+			} else {
+				_, cols := c.DuplicateColumnIDs(sp.Table, sp.Cols)
+				outCols = cols.ToList()
+			}
+			last = makeNewUnion(last, newScan, outCols)
 		}
 	}
 	if noLimitSpans.Count() == spans.Count() {
@@ -306,7 +317,7 @@ func (c *CustomFuncs) SplitScanIntoUnionScans(
 		Spans:   noLimitSpans,
 	}
 	newScan := c.e.f.ConstructScan(newScanPrivate)
-	return makeNewUnion(last, newScan)
+	return makeNewUnion(last, newScan, sp.Cols.ToList())
 }
 
 // indexHasOrderingSequence returns whether the Scan can provide a given

--- a/pkg/sql/opt/xform/limit_funcs.go
+++ b/pkg/sql/opt/xform/limit_funcs.go
@@ -302,7 +302,7 @@ func (c *CustomFuncs) SplitScanIntoUnionScans(
 	// construct an unlimited Scan and add it to the Union tree.
 	newScanPrivate := c.DuplicateScanPrivate(sp)
 	newScanPrivate.Constraint = &constraint.Constraint{
-		Columns: sp.Constraint.Columns,
+		Columns: sp.Constraint.Columns.RemapColumns(sp.Table, newScanPrivate.Table),
 		Spans:   noLimitSpans,
 	}
 	newScan := c.e.f.ConstructScan(newScanPrivate)

--- a/pkg/sql/opt/xform/testdata/external/trading
+++ b/pkg/sql/opt/xform/testdata/external/trading
@@ -612,25 +612,25 @@ project
  │    │    │    ├── limit hint: 1.00
  │    │    │    └── union
  │    │    │         ├── columns: dealerid:8!null version:16!null
- │    │    │         ├── left columns: dealerid:8!null version:16!null
- │    │    │         ├── right columns: dealerid:65 version:73
+ │    │    │         ├── left columns: dealerid:75 version:83
+ │    │    │         ├── right columns: dealerid:85 version:93
  │    │    │         ├── cardinality: [0 - 4]
  │    │    │         ├── stats: [rows=4, distinct(8,16)=4, null(8,16)=0]
  │    │    │         ├── key: (8,16)
  │    │    │         ├── union
- │    │    │         │    ├── columns: dealerid:8!null version:16!null
- │    │    │         │    ├── left columns: dealerid:8!null version:16!null
- │    │    │         │    ├── right columns: dealerid:55 version:63
+ │    │    │         │    ├── columns: dealerid:75!null version:83!null
+ │    │    │         │    ├── left columns: dealerid:55 version:63
+ │    │    │         │    ├── right columns: dealerid:65 version:73
  │    │    │         │    ├── cardinality: [0 - 3]
- │    │    │         │    ├── stats: [rows=3, distinct(8,16)=3, null(8,16)=0]
- │    │    │         │    ├── key: (8,16)
+ │    │    │         │    ├── stats: [rows=3, distinct(75,83)=3, null(75,83)=0]
+ │    │    │         │    ├── key: (75,83)
  │    │    │         │    ├── union
- │    │    │         │    │    ├── columns: dealerid:8!null version:16!null
+ │    │    │         │    │    ├── columns: dealerid:55!null version:63!null
  │    │    │         │    │    ├── left columns: dealerid:35 version:43
  │    │    │         │    │    ├── right columns: dealerid:45 version:53
  │    │    │         │    │    ├── cardinality: [0 - 2]
- │    │    │         │    │    ├── stats: [rows=2, distinct(8,16)=2, null(8,16)=0]
- │    │    │         │    │    ├── key: (8,16)
+ │    │    │         │    │    ├── stats: [rows=2, distinct(55,63)=2, null(55,63)=0]
+ │    │    │         │    │    ├── key: (55,63)
  │    │    │         │    │    ├── scan cardsinfo@cardsinfoversionindex,rev
  │    │    │         │    │    │    ├── columns: dealerid:35!null version:43!null
  │    │    │         │    │    │    ├── constraint: /35/43: [/1 - /1]
@@ -646,19 +646,19 @@ project
  │    │    │         │    │         ├── key: ()
  │    │    │         │    │         └── fd: ()-->(45,53)
  │    │    │         │    └── scan cardsinfo@cardsinfoversionindex,rev
- │    │    │         │         ├── columns: dealerid:55!null version:63!null
- │    │    │         │         ├── constraint: /55/63: [/3 - /3]
+ │    │    │         │         ├── columns: dealerid:65!null version:73!null
+ │    │    │         │         ├── constraint: /65/73: [/3 - /3]
  │    │    │         │         ├── limit: 1(rev)
- │    │    │         │         ├── stats: [rows=1, distinct(55)=1, null(55)=0, distinct(55,63)=1, null(55,63)=0]
+ │    │    │         │         ├── stats: [rows=1, distinct(65)=1, null(65)=0, distinct(65,73)=1, null(65,73)=0]
  │    │    │         │         ├── key: ()
- │    │    │         │         └── fd: ()-->(55,63)
+ │    │    │         │         └── fd: ()-->(65,73)
  │    │    │         └── scan cardsinfo@cardsinfoversionindex,rev
- │    │    │              ├── columns: dealerid:65!null version:73!null
- │    │    │              ├── constraint: /65/73: [/4 - /4]
+ │    │    │              ├── columns: dealerid:85!null version:93!null
+ │    │    │              ├── constraint: /85/93: [/4 - /4]
  │    │    │              ├── limit: 1(rev)
- │    │    │              ├── stats: [rows=1, distinct(65)=1, null(65)=0, distinct(65,73)=1, null(65,73)=0]
+ │    │    │              ├── stats: [rows=1, distinct(85)=1, null(85)=0, distinct(85,93)=1, null(85,93)=0]
  │    │    │              ├── key: ()
- │    │    │              └── fd: ()-->(65,73)
+ │    │    │              └── fd: ()-->(85,93)
  │    │    └── 1
  │    └── aggregations
  │         └── const-agg [as=max:33, outer=(16)]

--- a/pkg/sql/opt/xform/testdata/external/trading-mutation
+++ b/pkg/sql/opt/xform/testdata/external/trading-mutation
@@ -618,25 +618,25 @@ project
  │    │    │    ├── limit hint: 1.00
  │    │    │    └── union
  │    │    │         ├── columns: dealerid:8!null version:16!null
- │    │    │         ├── left columns: dealerid:8!null version:16!null
- │    │    │         ├── right columns: dealerid:81 version:89
+ │    │    │         ├── left columns: dealerid:95 version:103
+ │    │    │         ├── right columns: dealerid:109 version:117
  │    │    │         ├── cardinality: [0 - 4]
  │    │    │         ├── stats: [rows=4, distinct(8,16)=4, null(8,16)=0]
  │    │    │         ├── key: (8,16)
  │    │    │         ├── union
- │    │    │         │    ├── columns: dealerid:8!null version:16!null
- │    │    │         │    ├── left columns: dealerid:8!null version:16!null
- │    │    │         │    ├── right columns: dealerid:67 version:75
+ │    │    │         │    ├── columns: dealerid:95!null version:103!null
+ │    │    │         │    ├── left columns: dealerid:67 version:75
+ │    │    │         │    ├── right columns: dealerid:81 version:89
  │    │    │         │    ├── cardinality: [0 - 3]
- │    │    │         │    ├── stats: [rows=3, distinct(8,16)=3, null(8,16)=0]
- │    │    │         │    ├── key: (8,16)
+ │    │    │         │    ├── stats: [rows=3, distinct(95,103)=3, null(95,103)=0]
+ │    │    │         │    ├── key: (95,103)
  │    │    │         │    ├── union
- │    │    │         │    │    ├── columns: dealerid:8!null version:16!null
+ │    │    │         │    │    ├── columns: dealerid:67!null version:75!null
  │    │    │         │    │    ├── left columns: dealerid:39 version:47
  │    │    │         │    │    ├── right columns: dealerid:53 version:61
  │    │    │         │    │    ├── cardinality: [0 - 2]
- │    │    │         │    │    ├── stats: [rows=2, distinct(8,16)=2, null(8,16)=0]
- │    │    │         │    │    ├── key: (8,16)
+ │    │    │         │    │    ├── stats: [rows=2, distinct(67,75)=2, null(67,75)=0]
+ │    │    │         │    │    ├── key: (67,75)
  │    │    │         │    │    ├── scan cardsinfo@cardsinfoversionindex,rev
  │    │    │         │    │    │    ├── columns: dealerid:39!null version:47!null
  │    │    │         │    │    │    ├── constraint: /39/47: [/1 - /1]
@@ -652,19 +652,19 @@ project
  │    │    │         │    │         ├── key: ()
  │    │    │         │    │         └── fd: ()-->(53,61)
  │    │    │         │    └── scan cardsinfo@cardsinfoversionindex,rev
- │    │    │         │         ├── columns: dealerid:67!null version:75!null
- │    │    │         │         ├── constraint: /67/75: [/3 - /3]
+ │    │    │         │         ├── columns: dealerid:81!null version:89!null
+ │    │    │         │         ├── constraint: /81/89: [/3 - /3]
  │    │    │         │         ├── limit: 1(rev)
- │    │    │         │         ├── stats: [rows=1, distinct(67)=1, null(67)=0, distinct(67,75)=1, null(67,75)=0]
+ │    │    │         │         ├── stats: [rows=1, distinct(81)=1, null(81)=0, distinct(81,89)=1, null(81,89)=0]
  │    │    │         │         ├── key: ()
- │    │    │         │         └── fd: ()-->(67,75)
+ │    │    │         │         └── fd: ()-->(81,89)
  │    │    │         └── scan cardsinfo@cardsinfoversionindex,rev
- │    │    │              ├── columns: dealerid:81!null version:89!null
- │    │    │              ├── constraint: /81/89: [/4 - /4]
+ │    │    │              ├── columns: dealerid:109!null version:117!null
+ │    │    │              ├── constraint: /109/117: [/4 - /4]
  │    │    │              ├── limit: 1(rev)
- │    │    │              ├── stats: [rows=1, distinct(81)=1, null(81)=0, distinct(81,89)=1, null(81,89)=0]
+ │    │    │              ├── stats: [rows=1, distinct(109)=1, null(109)=0, distinct(109,117)=1, null(109,117)=0]
  │    │    │              ├── key: ()
- │    │    │              └── fd: ()-->(81,89)
+ │    │    │              └── fd: ()-->(109,117)
  │    │    └── 1
  │    └── aggregations
  │         └── const-agg [as=max:37, outer=(16)]

--- a/pkg/sql/opt/xform/testdata/rules/limit
+++ b/pkg/sql/opt/xform/testdata/rules/limit
@@ -842,16 +842,16 @@ limit
  │    ├── limit hint: 10.00
  │    └── union
  │         ├── columns: val:2!null data1:6!null
- │         ├── left columns: val:2!null data1:6!null
- │         ├── right columns: val:32 data1:36
+ │         ├── left columns: val:32 data1:36
+ │         ├── right columns: val:42 data1:46
  │         ├── cardinality: [0 - 30]
  │         ├── key: (2,6)
  │         ├── union
- │         │    ├── columns: val:2!null data1:6!null
+ │         │    ├── columns: val:32!null data1:36!null
  │         │    ├── left columns: val:12 data1:16
  │         │    ├── right columns: val:22 data1:26
  │         │    ├── cardinality: [0 - 20]
- │         │    ├── key: (2,6)
+ │         │    ├── key: (32,36)
  │         │    ├── scan index_tab@b
  │         │    │    ├── columns: val:12!null data1:16!null
  │         │    │    ├── constraint: /12/16/17/11: [/1 - /1]
@@ -863,10 +863,10 @@ limit
  │         │         ├── limit: 10
  │         │         └── fd: ()-->(22)
  │         └── scan index_tab@b
- │              ├── columns: val:32!null data1:36!null
- │              ├── constraint: /32/36/37/31: [/3 - /3]
+ │              ├── columns: val:42!null data1:46!null
+ │              ├── constraint: /42/46/47/41: [/3 - /3]
  │              ├── limit: 10
- │              └── fd: ()-->(32)
+ │              └── fd: ()-->(42)
  └── 10
 
 # Case with single-key spans.
@@ -982,16 +982,16 @@ scalar-group-by
  │    │    ├── limit hint: 1.00
  │    │    └── union
  │    │         ├── columns: val:2!null data1:6!null
- │    │         ├── left columns: val:2!null data1:6!null
- │    │         ├── right columns: val:33 data1:37
+ │    │         ├── left columns: val:33 data1:37
+ │    │         ├── right columns: val:43 data1:47
  │    │         ├── cardinality: [0 - 3]
  │    │         ├── key: (2,6)
  │    │         ├── union
- │    │         │    ├── columns: val:2!null data1:6!null
+ │    │         │    ├── columns: val:33!null data1:37!null
  │    │         │    ├── left columns: val:13 data1:17
  │    │         │    ├── right columns: val:23 data1:27
  │    │         │    ├── cardinality: [0 - 2]
- │    │         │    ├── key: (2,6)
+ │    │         │    ├── key: (33,37)
  │    │         │    ├── scan index_tab@b,rev
  │    │         │    │    ├── columns: val:13!null data1:17!null
  │    │         │    │    ├── constraint: /13/17/18/12: [/1 - /1]
@@ -1005,11 +1005,11 @@ scalar-group-by
  │    │         │         ├── key: ()
  │    │         │         └── fd: ()-->(23,27)
  │    │         └── scan index_tab@b,rev
- │    │              ├── columns: val:33!null data1:37!null
- │    │              ├── constraint: /33/37/38/32: [/3 - /3]
+ │    │              ├── columns: val:43!null data1:47!null
+ │    │              ├── constraint: /43/47/48/42: [/3 - /3]
  │    │              ├── limit: 1(rev)
  │    │              ├── key: ()
- │    │              └── fd: ()-->(33,37)
+ │    │              └── fd: ()-->(43,47)
  │    └── 1
  └── aggregations
       └── const-agg [as=max:11, outer=(6)]
@@ -1190,21 +1190,21 @@ limit
  │    ├── limit hint: 10.00
  │    └── union
  │         ├── columns: latitude:4!null longitude:5 data1:6!null data2:7!null
- │         ├── left columns: latitude:4!null longitude:5 data1:6!null data2:7!null
- │         ├── right columns: latitude:64 longitude:65 data1:66 data2:67
+ │         ├── left columns: latitude:74 longitude:75 data1:76 data2:77
+ │         ├── right columns: latitude:84 longitude:85 data1:86 data2:87
  │         ├── key: (4-7)
  │         ├── union
- │         │    ├── columns: latitude:4!null longitude:5!null data1:6!null data2:7!null
- │         │    ├── left columns: latitude:4!null longitude:5!null data1:6!null data2:7!null
- │         │    ├── right columns: latitude:54 longitude:55 data1:56 data2:57
+ │         │    ├── columns: latitude:74!null longitude:75!null data1:76!null data2:77!null
+ │         │    ├── left columns: latitude:54 longitude:55 data1:56 data2:57
+ │         │    ├── right columns: latitude:64 longitude:65 data1:66 data2:67
  │         │    ├── cardinality: [0 - 30]
- │         │    ├── key: (4-7)
+ │         │    ├── key: (74-77)
  │         │    ├── union
- │         │    │    ├── columns: latitude:4!null longitude:5!null data1:6!null data2:7!null
+ │         │    │    ├── columns: latitude:54!null longitude:55!null data1:56!null data2:57!null
  │         │    │    ├── left columns: latitude:34 longitude:35 data1:36 data2:37
  │         │    │    ├── right columns: latitude:44 longitude:45 data1:46 data2:47
  │         │    │    ├── cardinality: [0 - 20]
- │         │    │    ├── key: (4-7)
+ │         │    │    ├── key: (54-57)
  │         │    │    ├── scan index_tab@d
  │         │    │    │    ├── columns: latitude:34!null longitude:35!null data1:36!null data2:37!null
  │         │    │    │    ├── constraint: /34/35/36/37/31: [/10/11 - /10/11]
@@ -1216,13 +1216,13 @@ limit
  │         │    │         ├── limit: 10
  │         │    │         └── fd: ()-->(44,45)
  │         │    └── scan index_tab@d
- │         │         ├── columns: latitude:54!null longitude:55!null data1:56!null data2:57!null
- │         │         ├── constraint: /54/55/56/57/51: [/10/13 - /10/13]
+ │         │         ├── columns: latitude:64!null longitude:65!null data1:66!null data2:67!null
+ │         │         ├── constraint: /64/65/66/67/61: [/10/13 - /10/13]
  │         │         ├── limit: 10
- │         │         └── fd: ()-->(54,55)
+ │         │         └── fd: ()-->(64,65)
  │         └── scan index_tab@d
- │              ├── columns: latitude:64!null longitude:65 data1:66!null data2:67!null
- │              └── constraint: /64/65/66/67/61
+ │              ├── columns: latitude:84!null longitude:85 data1:86!null data2:87!null
+ │              └── constraint: /84/85/86/87/81
  │                   ├── [/-5 - /-5]
  │                   └── [/0 - /0]
  └── 10
@@ -1291,16 +1291,16 @@ limit
  │    ├── limit hint: 5.00
  │    └── union
  │         ├── columns: p:1!null q:2!null r:3!null s:4!null
- │         ├── left columns: p:1!null q:2!null r:3!null s:4!null
- │         ├── right columns: p:16 q:17 r:18 s:19
+ │         ├── left columns: p:16 q:17 r:18 s:19
+ │         ├── right columns: p:21 q:22 r:23 s:24
  │         ├── cardinality: [0 - 15]
  │         ├── key: (1-4)
  │         ├── union
- │         │    ├── columns: p:1!null q:2!null r:3!null s:4!null
+ │         │    ├── columns: p:16!null q:17!null r:18!null s:19!null
  │         │    ├── left columns: p:6 q:7 r:8 s:9
  │         │    ├── right columns: p:11 q:12 r:13 s:14
  │         │    ├── cardinality: [0 - 10]
- │         │    ├── key: (1-4)
+ │         │    ├── key: (16-19)
  │         │    ├── scan pqrs
  │         │    │    ├── columns: p:6!null q:7!null r:8!null s:9!null
  │         │    │    ├── constraint: /6/7: [/1 - /1]
@@ -1314,11 +1314,11 @@ limit
  │         │         ├── key: (12)
  │         │         └── fd: ()-->(11), (12)-->(13,14)
  │         └── scan pqrs
- │              ├── columns: p:16!null q:17!null r:18!null s:19!null
- │              ├── constraint: /16/17: [/10 - /10]
+ │              ├── columns: p:21!null q:22!null r:23!null s:24!null
+ │              ├── constraint: /21/22: [/10 - /10]
  │              ├── limit: 5
- │              ├── key: (17)
- │              └── fd: ()-->(16), (17)-->(18,19)
+ │              ├── key: (22)
+ │              └── fd: ()-->(21), (22)-->(23,24)
  └── 5
 
 # Case where multiple check constraints are combined into one constraint

--- a/pkg/sql/opt/xform/testdata/rules/limit
+++ b/pkg/sql/opt/xform/testdata/rules/limit
@@ -65,6 +65,9 @@ CREATE TABLE partial_index_tab
 )
 ----
 
+# Insert statistics for index_tab. Histogram buckets are included for the
+# latitude column in order to make the optimizer choose specific plans for
+# SplitScanIntoUnionScans tests.
 exec-ddl
 ALTER TABLE index_tab INJECT STATISTICS '[
   {
@@ -83,7 +86,14 @@ ALTER TABLE index_tab INJECT STATISTICS '[
     "columns": ["latitude"],
     "created_at": "2018-01-01 2:00:00.00000+00:00",
     "row_count": 1000000,
-    "distinct_count": 100
+    "distinct_count": 100,
+    "null_count": 0,
+    "histo_col_type": "int",
+    "histo_buckets": [
+      {"num_eq": 1000, "num_range": 0, "distinct_range": 0, "upper_bound": "-5"},
+      {"num_eq": 1000, "num_range": 0, "distinct_range": 0, "upper_bound": "0"},
+      {"num_eq": 0, "num_range": 998000, "distinct_range": 98, "upper_bound": "2000"}
+    ]
   },
   {
     "columns": ["longitude"],
@@ -1174,13 +1184,13 @@ limit
  ├── cardinality: [0 - 10]
  ├── ordering: +6,+7
  ├── sort
- │    ├── columns: latitude:4 longitude:5 data1:6!null data2:7!null
+ │    ├── columns: latitude:4!null longitude:5 data1:6!null data2:7!null
  │    ├── key: (4-7)
  │    ├── ordering: +6,+7
  │    ├── limit hint: 10.00
  │    └── union
- │         ├── columns: latitude:4 longitude:5 data1:6!null data2:7!null
- │         ├── left columns: latitude:4 longitude:5 data1:6!null data2:7!null
+ │         ├── columns: latitude:4!null longitude:5 data1:6!null data2:7!null
+ │         ├── left columns: latitude:4!null longitude:5 data1:6!null data2:7!null
  │         ├── right columns: latitude:64 longitude:65 data1:66 data2:67
  │         ├── key: (4-7)
  │         ├── union
@@ -1211,8 +1221,8 @@ limit
  │         │         ├── limit: 10
  │         │         └── fd: ()-->(54,55)
  │         └── scan index_tab@d
- │              ├── columns: latitude:64 longitude:65 data1:66!null data2:67!null
- │              └── constraint: /4/5/6/7/1
+ │              ├── columns: latitude:64!null longitude:65 data1:66!null data2:67!null
+ │              └── constraint: /64/65/66/67/61
  │                   ├── [/-5 - /-5]
  │                   └── [/0 - /0]
  └── 10


### PR DESCRIPTION
#### opt: fix columns in SplitScanIntoUnionScans constraint

This commit fixes a minor bug in `SplitScanIntoUnionScans` that resulted
in a scan's constraint containing columns not associated with the scan.
This did not affect the correctness of results. However it appears that
it did cause inaccurate stats calculations; I had to add histogram
buckets to the tests to coerce the optimizer into choosing the same
plan for the corresponding test.

Release note: None

#### opt: do not reuse columns for Unions in SplitScanIntoUnionScans

Unions generated in SplitScanIntoUnionScans no longer reuse column IDs
from their left children as output column IDs. Reusing column IDs in
this way has shown to be dangerous (see #58434).

Release note: None

#### opt: add Union column ID check to CheckExpr

A check has been added to `CheckExpr` that asserts that the output
columns of `Union`s and `UnionAll`s are not reused from the left or
right inputs of the union. Reusing columns in this way is dangerous
(see #58434).

Release note: None
