### PR TITLE
bazel: generate colexecagg .eg.go files within the sandbox 

### DIFF
--- a/pkg/sql/colexec/colexecagg/BUILD.bazel
+++ b/pkg/sql/colexec/colexecagg/BUILD.bazel
@@ -1,33 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
-
-# TODO(irfansharif): The dependency tree for the *.eg.go needs sorting out. It
-# depends on execgen+templates from a parent package. Look towards colexec for
-# how this should be done. For now we just lazily depend on the already
-# generated+checked in file.
+load(":COLEXECAGG.bzl", "eg_go_filegroup", "gen_eg_go_rules")
 
 go_library(
     name = "colexecagg",
     srcs = [
         "aggregate_funcs.go",
         "aggregators_util.go",
-        "hash_any_not_null_agg.eg.go",  # keep
-        "hash_avg_agg.eg.go",  # keep
-        "hash_bool_and_or_agg.eg.go",  # keep
-        "hash_concat_agg.eg.go",  # keep
-        "hash_count_agg.eg.go",  # keep
-        "hash_default_agg.eg.go",  # keep
-        "hash_min_max_agg.eg.go",  # keep
-        "hash_sum_agg.eg.go",  # keep
-        "hash_sum_int_agg.eg.go",  # keep
-        "ordered_any_not_null_agg.eg.go",  # keep
-        "ordered_avg_agg.eg.go",  # keep
-        "ordered_bool_and_or_agg.eg.go",  # keep
-        "ordered_concat_agg.eg.go",  # keep
-        "ordered_count_agg.eg.go",  # keep
-        "ordered_default_agg.eg.go",  # keep
-        "ordered_min_max_agg.eg.go",  # keep
-        "ordered_sum_agg.eg.go",  # keep
-        "ordered_sum_int_agg.eg.go",  # keep
+        ":gen-exec",  # keep
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecagg",
     visibility = ["//visibility:public"],
@@ -50,3 +29,9 @@ go_library(
         "@com_github_cockroachdb_errors//:errors",
     ],
 )
+
+# Define a file group for all the .eg.go targets.
+eg_go_filegroup(name = "gen-exec")
+
+# Define gen rules for individual eg.go files.
+gen_eg_go_rules()

--- a/pkg/sql/colexec/colexecagg/COLEXECAGG.bzl
+++ b/pkg/sql/colexec/colexecagg/COLEXECAGG.bzl
@@ -1,0 +1,73 @@
+# NB: The helpers here were grafted from pkg/sql/colexec/COLEXEC.bzl.
+# Future changes here may apply there.
+
+# Map between target name and relevant template.
+targets = [
+    ('hash_any_not_null_agg.eg.go', 'any_not_null_agg_tmpl.go'),
+    ('hash_avg_agg.eg.go', 'avg_agg_tmpl.go'),
+    ('hash_bool_and_or_agg.eg.go', 'bool_and_or_agg_tmpl.go'),
+    ('hash_concat_agg.eg.go', 'concat_agg_tmpl.go'),
+    ('hash_count_agg.eg.go', 'count_agg_tmpl.go'),
+    ('hash_default_agg.eg.go', 'default_agg_tmpl.go'),
+    ('hash_min_max_agg.eg.go', 'min_max_agg_tmpl.go'),
+    ('hash_sum_agg.eg.go', 'sum_agg_tmpl.go'),
+    ('hash_sum_int_agg.eg.go', 'sum_agg_tmpl.go'),
+    ('ordered_any_not_null_agg.eg.go', 'any_not_null_agg_tmpl.go'),
+    ('ordered_avg_agg.eg.go', 'avg_agg_tmpl.go'),
+    ('ordered_bool_and_or_agg.eg.go', 'bool_and_or_agg_tmpl.go'),
+    ('ordered_concat_agg.eg.go', 'concat_agg_tmpl.go'),
+    ('ordered_count_agg.eg.go', 'count_agg_tmpl.go'),
+    ('ordered_default_agg.eg.go', 'default_agg_tmpl.go'),
+    ('ordered_min_max_agg.eg.go', 'min_max_agg_tmpl.go'),
+    ('ordered_sum_agg.eg.go', 'sum_agg_tmpl.go'),
+    ('ordered_sum_int_agg.eg.go', 'sum_agg_tmpl.go'),
+]
+
+def rule_name_for(target):
+    # e.g. 'vec_comparators.eg.go' -> 'gen-vec-comparators'
+    return 'gen-{}'.format(target.replace('.eg.go', '').replace('_', '-'))
+
+# Define a file group for all the .eg.go targets.
+def eg_go_filegroup(name):
+    native.filegroup(
+        name = name,
+        srcs = [':{}'.format(rule_name_for(target)) for target, _ in targets],
+    )
+
+# Define gen rules for individual eg.go files.
+def gen_eg_go_rules():
+    # Define some aliases for ease of use.
+    native.alias(
+        name = "execgen",
+        actual = "//pkg/sql/colexec/execgen/cmd/execgen",
+    )
+    native.alias(
+        name = "goimports",
+        actual = "@com_github_cockroachdb_gostdlib//x/tools/cmd/goimports",
+    )
+
+    for target, template in targets:
+        name = rule_name_for(target)
+
+        native.genrule(
+            name = name,
+            srcs = [template],
+            outs = [target],
+            # `$@` lets us substitute in the output path[1]. The symlink below
+            # is frowned upon for genrules[2]. That said, when testing
+            # pkg/sql/colexec through bazel it expects to find the template
+            # files in a path other than what SRCS would suggest. We haven't
+            # really investigated why. For now lets just symlink the relevant
+            # files into the "right" path within the bazel sandbox[3].
+            #
+            # [1]: https://docs.bazel.build/versions/3.7.0/be/general.html#genrule_args
+            # [2]: https://docs.bazel.build/versions/3.7.0/be/general.html#general-advice
+            # [3]: https://github.com/cockroachdb/cockroach/pull/57027
+            cmd = """
+              ln -s external/cockroach/pkg pkg
+              $(location :execgen) -template $(SRCS) \
+                  -fmt=false pkg/sql/colexec/$@ > $@
+              $(location :goimports) -w $@
+              """,
+            tools = [":execgen", ":goimports"],
+        )

--- a/pkg/sql/colexec/colexecagg/any_not_null_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/any_not_null_agg_tmpl.go
@@ -22,13 +22,23 @@ package colexecagg
 import (
 	"unsafe"
 
+	"github.com/cockroachdb/apd/v2"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coldataext"
 	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
-	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/cockroachdb/errors"
+)
+
+// Workaround for bazel auto-generated code. goimports does not automatically
+// pick up the right packages when run within the bazel sandbox.
+var (
+	_ tree.AggType
+	_ apd.Context
+	_ duration.Duration
 )
 
 // {{/*

--- a/pkg/sql/colexec/colexecagg/avg_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/avg_agg_tmpl.go
@@ -22,12 +22,23 @@ package colexecagg
 import (
 	"unsafe"
 
+	"github.com/cockroachdb/apd/v2"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/cockroachdb/errors"
+)
+
+// Workaround for bazel auto-generated code. goimports does not automatically
+// pick up the right packages when run within the bazel sandbox.
+var (
+	_ tree.AggType
+	_ apd.Context
+	_ duration.Duration
 )
 
 // {{/*

--- a/pkg/sql/colexec/colexecagg/hash_any_not_null_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_any_not_null_agg.eg.go
@@ -24,6 +24,14 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
+// Workaround for bazel auto-generated code. goimports does not automatically
+// pick up the right packages when run within the bazel sandbox.
+var (
+	_ tree.AggType
+	_ apd.Context
+	_ duration.Duration
+)
+
 func newAnyNotNullHashAggAlloc(
 	allocator *colmem.Allocator, t *types.T, allocSize int64,
 ) (aggregateFuncAlloc, error) {

--- a/pkg/sql/colexec/colexecagg/hash_avg_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_avg_agg.eg.go
@@ -23,6 +23,14 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
+// Workaround for bazel auto-generated code. goimports does not automatically
+// pick up the right packages when run within the bazel sandbox.
+var (
+	_ tree.AggType
+	_ apd.Context
+	_ duration.Duration
+)
+
 func newAvgHashAggAlloc(
 	allocator *colmem.Allocator, t *types.T, allocSize int64,
 ) (aggregateFuncAlloc, error) {

--- a/pkg/sql/colexec/colexecagg/hash_min_max_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_min_max_agg.eg.go
@@ -26,6 +26,14 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
 )
 
+// Workaround for bazel auto-generated code. goimports does not automatically
+// pick up the right packages when run within the bazel sandbox.
+var (
+	_ tree.AggType
+	_ apd.Context
+	_ duration.Duration
+)
+
 // Remove unused warning.
 var _ = colexecerror.InternalError
 

--- a/pkg/sql/colexec/colexecagg/hash_sum_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_sum_agg.eg.go
@@ -24,6 +24,14 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
+// Workaround for bazel auto-generated code. goimports does not automatically
+// pick up the right packages when run within the bazel sandbox.
+var (
+	_ tree.AggType
+	_ apd.Context
+	_ duration.Duration
+)
+
 func newSumHashAggAlloc(
 	allocator *colmem.Allocator, t *types.T, allocSize int64,
 ) (aggregateFuncAlloc, error) {

--- a/pkg/sql/colexec/colexecagg/hash_sum_int_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_sum_int_agg.eg.go
@@ -13,12 +13,22 @@ import (
 	"strings"
 	"unsafe"
 
+	"github.com/cockroachdb/apd/v2"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/cockroachdb/errors"
+)
+
+// Workaround for bazel auto-generated code. goimports does not automatically
+// pick up the right packages when run within the bazel sandbox.
+var (
+	_ tree.AggType
+	_ apd.Context
+	_ duration.Duration
 )
 
 func newSumIntHashAggAlloc(

--- a/pkg/sql/colexec/colexecagg/min_max_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/min_max_agg_tmpl.go
@@ -22,14 +22,23 @@ package colexecagg
 import (
 	"unsafe"
 
+	"github.com/cockroachdb/apd/v2"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coldataext"
 	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
-	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
-	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/cockroach/pkg/util/duration"
+)
+
+// Workaround for bazel auto-generated code. goimports does not automatically
+// pick up the right packages when run within the bazel sandbox.
+var (
+	_ tree.AggType
+	_ apd.Context
+	_ duration.Duration
 )
 
 // Remove unused warning.

--- a/pkg/sql/colexec/colexecagg/ordered_any_not_null_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_any_not_null_agg.eg.go
@@ -24,6 +24,14 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
+// Workaround for bazel auto-generated code. goimports does not automatically
+// pick up the right packages when run within the bazel sandbox.
+var (
+	_ tree.AggType
+	_ apd.Context
+	_ duration.Duration
+)
+
 func newAnyNotNullOrderedAggAlloc(
 	allocator *colmem.Allocator, t *types.T, allocSize int64,
 ) (aggregateFuncAlloc, error) {

--- a/pkg/sql/colexec/colexecagg/ordered_avg_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_avg_agg.eg.go
@@ -23,6 +23,14 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
+// Workaround for bazel auto-generated code. goimports does not automatically
+// pick up the right packages when run within the bazel sandbox.
+var (
+	_ tree.AggType
+	_ apd.Context
+	_ duration.Duration
+)
+
 func newAvgOrderedAggAlloc(
 	allocator *colmem.Allocator, t *types.T, allocSize int64,
 ) (aggregateFuncAlloc, error) {

--- a/pkg/sql/colexec/colexecagg/ordered_min_max_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_min_max_agg.eg.go
@@ -26,6 +26,14 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
 )
 
+// Workaround for bazel auto-generated code. goimports does not automatically
+// pick up the right packages when run within the bazel sandbox.
+var (
+	_ tree.AggType
+	_ apd.Context
+	_ duration.Duration
+)
+
 // Remove unused warning.
 var _ = colexecerror.InternalError
 

--- a/pkg/sql/colexec/colexecagg/ordered_sum_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_sum_agg.eg.go
@@ -24,6 +24,14 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
+// Workaround for bazel auto-generated code. goimports does not automatically
+// pick up the right packages when run within the bazel sandbox.
+var (
+	_ tree.AggType
+	_ apd.Context
+	_ duration.Duration
+)
+
 func newSumOrderedAggAlloc(
 	allocator *colmem.Allocator, t *types.T, allocSize int64,
 ) (aggregateFuncAlloc, error) {

--- a/pkg/sql/colexec/colexecagg/ordered_sum_int_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_sum_int_agg.eg.go
@@ -13,12 +13,22 @@ import (
 	"strings"
 	"unsafe"
 
+	"github.com/cockroachdb/apd/v2"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/cockroachdb/errors"
+)
+
+// Workaround for bazel auto-generated code. goimports does not automatically
+// pick up the right packages when run within the bazel sandbox.
+var (
+	_ tree.AggType
+	_ apd.Context
+	_ duration.Duration
 )
 
 func newSumIntOrderedAggAlloc(

--- a/pkg/sql/colexec/colexecagg/sum_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/sum_agg_tmpl.go
@@ -23,12 +23,23 @@ import (
 	"strings"
 	"unsafe"
 
+	"github.com/cockroachdb/apd/v2"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/cockroachdb/errors"
+)
+
+// Workaround for bazel auto-generated code. goimports does not automatically
+// pick up the right packages when run within the bazel sandbox.
+var (
+	_ tree.AggType
+	_ apd.Context
+	_ duration.Duration
 )
 
 // {{/*


### PR DESCRIPTION
Fixes #58421. For the go dependency changes, we've applied the same
treatment as 52c5f51.

Release note: None