### PR TITLE
roachtest: add expected failure for activerecord for 21.1

### DIFF
--- a/pkg/cmd/roachtest/activerecord_blocklist.go
+++ b/pkg/cmd/roachtest/activerecord_blocklist.go
@@ -27,7 +27,9 @@ var activeRecordBlocklists = blocklistsForVersion{
 // Please keep these lists alphabetized for easy diffing.
 // After a failed run, an updated version of this blocklist should be available
 // in the test log.
-var activeRecordBlockList21_1 = blocklist{}
+var activeRecordBlockList21_1 = blocklist{
+	"ActiveRecord::CockroachDB::UnloggedTablesTest#test_gracefully_handles_temporary_tables": "modified to pass on 20.2",
+}
 
 var activeRecordBlockList20_2 = blocklist{}
 


### PR DESCRIPTION
This test was overriden to pass on 20.2, but the override is no longer
needed for 21.1. Until the override is removed in the activerecord
adapter, this test is expected to fail on 21.1

Release note: none