### PR TITLE
release-20.2: roachtest: test rails 6 in activerecord test

### DIFF
--- a/pkg/cmd/roachtest/activerecord.go
+++ b/pkg/cmd/roachtest/activerecord.go
@@ -20,7 +20,8 @@ import (
 
 var activerecordResultRegex = regexp.MustCompile(`^(?P<test>[^\s]+#[^\s]+) = (?P<timing>\d+\.\d+ s) = (?P<result>.)$`)
 var railsReleaseTagRegex = regexp.MustCompile(`^v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<point>\d+)\.?(?P<subpoint>\d*)$`)
-var supportedRailsVersion = "5.2.4.3"
+var supportedRailsVersion = "6.0.3.4"
+var adapterVersion = "v6.0.0beta2"
 
 // This test runs pgjdbc's full test suite against a single cockroach node.
 
@@ -77,6 +78,7 @@ func registerActiveRecord(r *testRegistry) {
 		}
 		c.l.Printf("Latest rails release is %s.", latestTag)
 		c.l.Printf("Supported rails release is %s.", supportedRailsVersion)
+		c.l.Printf("Supported adapter version is %s.", adapterVersion)
 
 		if err := repeatRunE(
 			ctx, c, node, "update apt-get", `sudo apt-get -qq update`,
@@ -120,7 +122,7 @@ func registerActiveRecord(r *testRegistry) {
 			c,
 			"https://github.com/cockroachdb/activerecord-cockroachdb-adapter.git",
 			"/mnt/data1/activerecord-cockroachdb-adapter",
-			"master",
+			adapterVersion,
 			node,
 		); err != nil {
 			t.Fatal(err)

--- a/pkg/cmd/roachtest/activerecord_blocklist.go
+++ b/pkg/cmd/roachtest/activerecord_blocklist.go
@@ -28,7 +28,19 @@ var activeRecordBlocklists = blocklistsForVersion{
 // in the test log.
 var activeRecordBlockList20_2 = blocklist{}
 
-var activeRecordBlockList20_1 = blocklist{}
+var activeRecordBlockList20_1 = blocklist{
+	"ActiveRecord::ConnectionAdapters::PostgreSQLAdapterTest#test_partial_index":          "9683",
+	"ActiveRecord::Migration::CompatibilityTest#test_migration_does_remove_unnamed_index": "9683",
+	"PostgresqlActiveSchemaTest#test_add_index":                                           "9683",
+	"PostgresqlEnumTest#test_assigning_enum_to_nil":                                       "24873",
+	"PostgresqlEnumTest#test_column":                                                      "24873",
+	"PostgresqlEnumTest#test_enum_defaults":                                               "24873",
+	"PostgresqlEnumTest#test_enum_mapping":                                                "24873",
+	"PostgresqlEnumTest#test_enum_type_cast":                                              "24873",
+	"PostgresqlEnumTest#test_invalid_enum_update":                                         "24873",
+	"PostgresqlEnumTest#test_no_oid_warning":                                              "24873",
+	"PostgresqlUUIDTest#test_add_column_with_default_array":                               "55320",
+}
 
 var activeRecordIgnoreList20_2 = blocklist{
 	"FixturesTest#test_create_fixtures": "flaky - FK constraint violated sometimes when loading all fixture data",


### PR DESCRIPTION
Backport 1/1 commits from #58206.

/cc @cockroachdb/release

---

This is the new version of the ActiveRecord adapter. It enables some
tests that are not expected to pass on 20.1

Release note: None
