### PR TITLE
backupccl: skip collecting/verifying full-file SHA512 checksums

### DIFF
--- a/pkg/ccl/backupccl/backup_processor.go
+++ b/pkg/ccl/backupccl/backup_processor.go
@@ -224,6 +224,7 @@ func runBackupProcessor(
 					Encryption:                          spec.Encryption,
 					TargetFileSize:                      targetFileSize,
 					ReturnSST:                           writeSSTsInProcessor,
+					OmitChecksum:                        true,
 				}
 
 				// If we're doing re-attempts but are not yet in the priority regime,

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -3959,12 +3959,11 @@ func TestBackupRestoreChecksum(t *testing.T) {
 		t.Fatalf("%+v", err)
 	}
 	defer f.Close()
-	// The last eight bytes of an SST file store a nonzero magic number. We can
-	// blindly null out those bytes and guarantee that the checksum will change.
-	if _, err := f.Seek(-8, io.SeekEnd); err != nil {
+	// mess with some bytes.
+	if _, err := f.Seek(-65, io.SeekEnd); err != nil {
 		t.Fatalf("%+v", err)
 	}
-	if _, err := f.Write(make([]byte, 8)); err != nil {
+	if _, err := f.Write([]byte{'1', '2', '3'}); err != nil {
 		t.Fatalf("%+v", err)
 	}
 	if err := f.Sync(); err != nil {

--- a/pkg/ccl/backupccl/restore_data_processor.go
+++ b/pkg/ccl/backupccl/restore_data_processor.go
@@ -9,7 +9,6 @@
 package backupccl
 
 import (
-	"bytes"
 	"context"
 	"io/ioutil"
 
@@ -210,16 +209,6 @@ func (rd *restoreDataProcessor) processRestoreSpanEntry(
 			fileContents, err = storageccl.DecryptFile(fileContents, rd.spec.Encryption.Key)
 			if err != nil {
 				return summary, err
-			}
-		}
-
-		if len(file.Sha512) > 0 {
-			checksum, err := storageccl.SHA512ChecksumData(fileContents)
-			if err != nil {
-				return summary, err
-			}
-			if !bytes.Equal(checksum, file.Sha512) {
-				return summary, errors.Errorf("checksum mismatch for %s", file.Path)
 			}
 		}
 


### PR DESCRIPTION
BACKUP uses SSTables to store its data. SSTables maintain block-level checksums internally, which
allow verifying the integrity of data _as it is read_. BACKUP previously also checksummed the
entire file, using SHA512. However these full-file checksums, by nature, require reading the whole
file to verify them. RESTORE would prefer to be able to open and read only the subsets of the
files it actually needs, or to only read and process files incrementally.

Release note (sql change): BACKUP and RESTORE now uses the block-level checksums embedded in its data files instead of collecting / verifying more expensive file-level SHA512 checksums.