### PR TITLE
tracing: add registry of unfinished local root Spans

### DIFF
--- a/pkg/util/tracing/alloc_test.go
+++ b/pkg/util/tracing/alloc_test.go
@@ -60,7 +60,7 @@ func BenchmarkTracer_StartSpanCtx(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				newCtx, sp := tr.StartSpanCtx(ctx, "benching", tc.opts...)
 				_ = newCtx
-				_ = sp
+				sp.Finish() // clean up
 			}
 		})
 	}

--- a/pkg/util/tracing/span.go
+++ b/pkg/util/tracing/span.go
@@ -436,6 +436,9 @@ func (s *Span) Finish() {
 	if s.netTr != nil {
 		s.netTr.Finish()
 	}
+	s.tracer.activeSpans.Lock()
+	delete(s.tracer.activeSpans.m, s)
+	s.tracer.activeSpans.Unlock()
 }
 
 // Meta returns the information which needs to be propagated across


### PR DESCRIPTION
A local root span is a Span which was created without the
`WithParentAndAutoCollection` option, meaning that either
it is the root of the trace, or it is a child whose parent
will not include the child in its recording.

A new method `Tracer.VisitSpans` is added which allows
iterating through these Spans.

Touches #55592.

Release note: None
