### PR TITLE
ui: changed metric label CPUs to vCPUs

### DIFF
--- a/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
@@ -285,7 +285,7 @@ export class NodeList extends React.Component<LiveNodeListProps> {
     },
     {
       key: "numCpus",
-      title: <CPUsTooltip>CPUs</CPUsTooltip>,
+      title: <CPUsTooltip>vCPUs</CPUsTooltip>,
       dataIndex: "numCpus",
       sorter: true,
       className: "column--align-right",

--- a/pkg/ui/src/views/cluster/containers/nodesOverview/nodesOverview.spec.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodesOverview/nodesOverview.spec.tsx
@@ -254,7 +254,7 @@ describe("Nodes Overview page", () => {
         "replicas",
         "capacity usage",
         "memory use",
-        "cpus",
+        "vcpus",
         "version",
         "status",
         "", // logs column doesn't have header text
@@ -277,7 +277,7 @@ describe("Nodes Overview page", () => {
         "replicas",
         "capacity usage",
         "memory use",
-        "cpus",
+        "vcpus",
         "version",
         "status",
         "", // logs column doesn't have header text


### PR DESCRIPTION
Release note (ui change): CPUs metric column renamed to vCPUs in node
overview in cluster overview page.