### PR TITLE
Revert "kvserver: don't allow raft forwarding of lease requests"

### DIFF
--- a/pkg/kv/kvserver/client_raft_helpers_test.go
+++ b/pkg/kv/kvserver/client_raft_helpers_test.go
@@ -12,7 +12,6 @@ package kvserver_test
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -23,9 +22,7 @@ import (
 )
 
 type unreliableRaftHandlerFuncs struct {
-	// If non-nil, can return false to avoid dropping the msg to
-	// unreliableRaftHandler.rangeID. If nil, all messages pertaining to the
-	// respective range are dropped.
+	// If non-nil, can return false to avoid dropping a msg to rangeID.
 	dropReq  func(*kvserver.RaftMessageRequest) bool
 	dropHB   func(*kvserver.RaftHeartbeat) bool
 	dropResp func(*kvserver.RaftMessageResponse) bool
@@ -50,7 +47,6 @@ func noopRaftHandlerFuncs() unreliableRaftHandlerFuncs {
 // unreliableRaftHandler drops all Raft messages that are addressed to the
 // specified rangeID, but lets all other messages through.
 type unreliableRaftHandler struct {
-	name    string
 	rangeID roachpb.RangeID
 	kvserver.RaftMessageHandler
 	unreliableRaftHandlerFuncs
@@ -72,14 +68,9 @@ func (h *unreliableRaftHandler) HandleRaftRequest(
 		}
 	} else if req.RangeID == h.rangeID {
 		if h.dropReq == nil || h.dropReq(req) {
-			var prefix string
-			if h.name != "" {
-				prefix = fmt.Sprintf("[%s] ", h.name)
-			}
 			log.Infof(
 				ctx,
-				"%sdropping r%d Raft message %s",
-				prefix,
+				"dropping r%d Raft message %s",
 				req.RangeID,
 				raft.DescribeMessage(req.Message, func([]byte) string {
 					return "<omitted>"

--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -35,7 +35,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
-	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
@@ -904,7 +903,6 @@ func TestSnapshotAfterTruncationWithUncommittedTail(t *testing.T) {
 	//        x      x
 	//      [1]<---->[2]
 	//
-	log.Infof(ctx, "test: installing unreliable Raft transports")
 	for _, s := range []int{0, 1, 2} {
 		h := &unreliableRaftHandler{rangeID: 1, RaftMessageHandler: mtc.stores[s]}
 		if s != partStore {
@@ -924,7 +922,6 @@ func TestSnapshotAfterTruncationWithUncommittedTail(t *testing.T) {
 	// not succeed before their context is canceled, but they will be appended
 	// to the partitioned replica's Raft log because it is currently the Raft
 	// leader.
-	log.Infof(ctx, "test: sending writes to partitioned replica")
 	g := ctxgroup.WithContext(ctx)
 	for i := 0; i < 32; i++ {
 		otherKey := roachpb.Key(fmt.Sprintf("other-%d", i))
@@ -945,45 +942,26 @@ func TestSnapshotAfterTruncationWithUncommittedTail(t *testing.T) {
 	}
 
 	// Transfer the lease to one of the followers and perform a write. The
-	// partition ensures that this will require a Raft leadership change. It's
-	// unpredictable which one of the followers will become leader. Only the
-	// leader will be allowed to acquire the lease (see
-	// TestSnapshotAfterTruncationWithUncommittedTail), so it's also unpredictable
-	// who will get the lease. We try repeatedly sending requests to both
-	// candidates until one of them succeeds.
-	var nonPartitionedSenders [2]kv.Sender
-	nonPartitionedSenders[0] = mtc.stores[1].TestSender()
-	nonPartitionedSenders[1] = mtc.stores[2].TestSender()
+	// partition ensures that this will require a Raft leadership change.
+	const newLeaderStore = partStore + 1
+	newLeaderRepl, err := mtc.stores[newLeaderStore].GetReplica(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	newLeaderReplSender := mtc.stores[newLeaderStore].TestSender()
 
-	log.Infof(ctx, "test: sending write to transfer lease")
 	incArgs = incrementArgs(key, incB)
-	var i int
-	var newLeaderRepl *kvserver.Replica
-	var newLeaderReplSender kv.Sender
 	testutils.SucceedsSoon(t, func() error {
 		mtc.advanceClock(ctx)
-		i++
-		sender := nonPartitionedSenders[i%2]
-		_, pErr := kv.SendWrapped(ctx, sender, incArgs)
+		_, pErr := kv.SendWrapped(ctx, newLeaderReplSender, incArgs)
 		if _, ok := pErr.GetDetail().(*roachpb.NotLeaseHolderError); ok {
 			return pErr.GoError()
 		} else if pErr != nil {
 			t.Fatal(pErr)
 		}
-
-		// A request succeeded, proving that there is a new leader and leaseholder.
-		// Remember who that is.
-		newLeaderStoreIdx := 1 + (i % 2)
-		newLeaderRepl, err = mtc.stores[newLeaderStoreIdx].GetReplica(1)
-		if err != nil {
-			t.Fatal(err)
-		}
-		newLeaderReplSender = mtc.stores[newLeaderStoreIdx].TestSender()
 		return nil
 	})
-	log.Infof(ctx, "test: waiting for values...")
 	mtc.waitForValues(key, []int64{incA, incAB, incAB})
-	log.Infof(ctx, "test: waiting for values... done")
 
 	index, err := newLeaderRepl.GetLastIndex()
 	if err != nil {
@@ -992,7 +970,6 @@ func TestSnapshotAfterTruncationWithUncommittedTail(t *testing.T) {
 
 	// Truncate the log at index+1 (log entries < N are removed, so this
 	// includes the increment).
-	log.Infof(ctx, "test: truncating log")
 	truncArgs := truncateLogArgs(index+1, 1)
 	testutils.SucceedsSoon(t, func() error {
 		mtc.advanceClock(ctx)
@@ -1009,7 +986,6 @@ func TestSnapshotAfterTruncationWithUncommittedTail(t *testing.T) {
 	snapsBefore := snapsMetric.Count()
 
 	// Remove the partition. Snapshot should follow.
-	log.Infof(ctx, "test: removing the partition")
 	for _, s := range []int{0, 1, 2} {
 		mtc.transport.Listen(mtc.stores[s].Ident.StoreID, &unreliableRaftHandler{
 			rangeID:            1,
@@ -1046,235 +1022,6 @@ func TestSnapshotAfterTruncationWithUncommittedTail(t *testing.T) {
 		t.Fatal(pErr)
 	}
 	mtc.waitForValues(key, []int64{incABC, incABC, incABC})
-}
-
-// TestRequestsOnLaggingReplica tests that requests sent to a replica that's
-// behind in log application don't block. The test indirectly verifies that a
-// replica that's not the leader does not attempt to acquire a lease and, thus,
-// does not block until it figures out that it cannot, in fact, take the lease.
-//
-// This test relies on follower replicas refusing to forward lease acquisition
-// requests to the leader, thereby refusing to acquire a lease. The point of
-// this behavior is to prevent replicas that are behind from trying to acquire
-// the lease and then blocking traffic for a long time until they find out
-// whether they successfully took the lease or not.
-func TestRequestsOnLaggingReplica(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-	ctx := context.Background()
-
-	clusterArgs := base.TestClusterArgs{
-		ReplicationMode: base.ReplicationManual,
-		ServerArgs: base.TestServerArgs{
-			// Reduce the election timeout some to speed up the test.
-			RaftConfig: base.RaftConfig{RaftElectionTimeoutTicks: 10},
-			Knobs: base.TestingKnobs{
-				NodeLiveness: kvserver.NodeLivenessTestingKnobs{
-					// This test waits for an epoch-based lease to expire, so we're
-					// setting the liveness duration as low as possible while still
-					// keeping the test stable.
-					LivenessDuration: 3000 * time.Millisecond,
-					RenewalDuration:  1500 * time.Millisecond,
-				},
-				Store: &kvserver.StoreTestingKnobs{
-					// We eliminate clock offsets in order to eliminate the stasis period
-					// of leases, in order to speed up the test.
-					MaxOffset: time.Nanosecond,
-				},
-			},
-		},
-	}
-
-	tc := testcluster.StartTestCluster(t, 3, clusterArgs)
-	defer tc.Stopper().Stop(ctx)
-
-	rngDesc, err := tc.Servers[0].ScratchRangeEx()
-	require.NoError(t, err)
-	key := rngDesc.StartKey.AsRawKey()
-	// Add replicas on all the stores.
-	tc.AddReplicasOrFatal(t, rngDesc.StartKey.AsRawKey(), tc.Target(1), tc.Target(2))
-
-	{
-		// Write a value so that the respective key is present in all stores and we
-		// can increment it again later.
-		_, err := tc.Server(0).DB().Inc(ctx, key, 1)
-		require.NoError(t, err)
-		log.Infof(ctx, "test: waiting for initial values...")
-		tc.WaitForValues(t, key, []int64{1, 1, 1})
-		log.Infof(ctx, "test: waiting for initial values... done")
-	}
-
-	// Partition the original leader from its followers. We do this by installing
-	// unreliableRaftHandler listeners on all three Stores. The handler on the
-	// partitioned store filters out all messages while the handler on the other
-	// two stores only filters out messages from the partitioned store. The
-	// configuration looks like:
-	//
-	//           [0]
-	//          x  x
-	//         /    \
-	//        x      x
-	//      [1]<---->[2]
-	//
-	log.Infof(ctx, "test: partitioning node")
-	const partitionNodeIdx = 0
-	partitionStore := tc.GetFirstStoreFromServer(t, partitionNodeIdx)
-	partRepl, err := partitionStore.GetReplica(rngDesc.RangeID)
-	require.NoError(t, err)
-	partReplDesc, err := partRepl.GetReplicaDescriptor()
-	require.NoError(t, err)
-	partitionedStoreSender := partitionStore.TestSender()
-	const otherStoreIdx = 1
-	otherStore := tc.GetFirstStoreFromServer(t, otherStoreIdx)
-	otherRepl, err := otherStore.GetReplica(rngDesc.RangeID)
-	require.NoError(t, err)
-
-	for _, i := range []int{0, 1, 2} {
-		store := tc.GetFirstStoreFromServer(t, i)
-		h := &unreliableRaftHandler{
-			name:               fmt.Sprintf("store %d", i),
-			rangeID:            rngDesc.RangeID,
-			RaftMessageHandler: store,
-		}
-		if i != partitionNodeIdx {
-			// Only filter messages from the partitioned store on the other two
-			// stores.
-			h.dropReq = func(req *kvserver.RaftMessageRequest) bool {
-				return req.FromReplica.StoreID == partRepl.StoreID()
-			}
-			h.dropHB = func(hb *kvserver.RaftHeartbeat) bool {
-				return hb.FromReplicaID == partReplDesc.ReplicaID
-			}
-		}
-		store.Transport().Listen(store.Ident.StoreID, h)
-	}
-
-	// Stop the heartbeats so that n1's lease can expire.
-	log.Infof(ctx, "test: suspending heartbeats for n1")
-	resumeN1Heartbeats := partitionStore.NodeLiveness().PauseAllHeartbeatsForTest()
-
-	// Wait until another replica campaigns and becomes leader, replacing the
-	// partitioned one.
-	log.Infof(ctx, "test: waiting for leadership transfer")
-	testutils.SucceedsSoon(t, func() error {
-		// Make sure this replica has not inadvertently quiesced. We need the
-		// replica ticking so that it campaigns.
-		if otherRepl.IsQuiescent() {
-			otherRepl.UnquiesceAndWakeLeader()
-		}
-		lead := otherRepl.RaftStatus().Lead
-		if lead == raft.None {
-			return errors.New("no leader yet")
-		}
-		if roachpb.ReplicaID(lead) == partReplDesc.ReplicaID {
-			return errors.New("partitioned replica is still leader")
-		}
-		return nil
-	})
-
-	leaderReplicaID := roachpb.ReplicaID(otherRepl.RaftStatus().Lead)
-	log.Infof(ctx, "test: the leader is replica ID %d", leaderReplicaID)
-	if leaderReplicaID != 2 && leaderReplicaID != 3 {
-		t.Fatalf("expected leader to be 1 or 2, was: %d", leaderReplicaID)
-	}
-	leaderNodeIdx := int(leaderReplicaID - 1)
-	leaderNode := tc.Server(leaderNodeIdx).(*server.TestServer)
-	leaderStore, err := leaderNode.GetStores().(*kvserver.Stores).GetStore(leaderNode.GetFirstStoreID())
-	require.NoError(t, err)
-
-	// Wait until the lease expires.
-	log.Infof(ctx, "test: waiting for lease expiration")
-	partitionedReplica, err := partitionStore.GetReplica(rngDesc.RangeID)
-	require.NoError(t, err)
-	testutils.SucceedsSoon(t, func() error {
-		status := partitionedReplica.CurrentLeaseStatus(ctx)
-		require.True(t,
-			status.Lease.OwnedBy(partitionStore.StoreID()), "someone else got the lease: %s", status)
-		if status.State == kvserverpb.LeaseState_VALID {
-			return errors.New("lease still valid")
-		}
-		// We need to wait for the stasis state to pass too; during stasis other
-		// replicas can't take the lease.
-		if status.State == kvserverpb.LeaseState_STASIS {
-			return errors.New("lease still in stasis")
-		}
-		return nil
-	})
-	log.Infof(ctx, "test: lease expired")
-
-	{
-		// Write something to generate some Raft log entries and then truncate the log.
-		log.Infof(ctx, "test: incrementing")
-		incArgs := incrementArgs(key, 1)
-		sender := leaderStore.TestSender()
-		_, pErr := kv.SendWrapped(ctx, sender, incArgs)
-		require.Nil(t, pErr)
-	}
-
-	tc.WaitForValues(t, key, []int64{1, 2, 2})
-	index, err := otherRepl.GetLastIndex()
-	require.NoError(t, err)
-
-	// Truncate the log at index+1 (log entries < N are removed, so this includes
-	// the increment). This means that the partitioned replica will need a
-	// snapshot to catch up.
-	log.Infof(ctx, "test: truncating log...")
-	truncArgs := &roachpb.TruncateLogRequest{
-		RequestHeader: roachpb.RequestHeader{
-			Key: key,
-		},
-		Index:   index,
-		RangeID: rngDesc.RangeID,
-	}
-	{
-		_, pErr := kv.SendWrapped(ctx, leaderStore.TestSender(), truncArgs)
-		require.NoError(t, pErr.GoError())
-	}
-
-	// Resume n1's heartbeats and wait for it to become live again. This is to
-	// ensure that the rest of the test does not somehow fool itself because n1 is
-	// not live.
-	log.Infof(ctx, "test: resuming n1 heartbeats")
-	resumeN1Heartbeats()
-
-	// Resolve the partition, but continue blocking snapshots destined for the
-	// previously-partitioned replica. The point of blocking the snapshots is to
-	// prevent the respective replica from catching up and becoming eligible to
-	// become the leader/leaseholder. The point of resolving the partition is to
-	// allow the replica in question to figure out that it's not the leader any
-	// more. As long as it is completely partitioned, the replica continues
-	// believing that it is the leader, and lease acquisition requests block.
-	log.Infof(ctx, "test: removing partition")
-	slowSnapHandler := &slowSnapRaftHandler{
-		rangeID:            rngDesc.RangeID,
-		waitCh:             make(chan struct{}),
-		RaftMessageHandler: partitionStore,
-	}
-	defer slowSnapHandler.unblock()
-	partitionStore.Transport().Listen(partitionStore.Ident.StoreID, slowSnapHandler)
-	// Remove the unreliable transport from the other stores, so that messages
-	// sent by the partitioned store can reach them.
-	for _, i := range []int{0, 1, 2} {
-		if i == partitionNodeIdx {
-			// We've handled the partitioned store above.
-			continue
-		}
-		store := tc.GetFirstStoreFromServer(t, i)
-		store.Transport().Listen(store.Ident.StoreID, store)
-	}
-
-	// Now we're going to send a request to the behind replica, and we expect it
-	// to not block; we expect a redirection to the leader.
-	log.Infof(ctx, "test: sending request")
-	timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-	getRequest := getArgs(key)
-	_, pErr := kv.SendWrapped(timeoutCtx, partitionedStoreSender, getRequest)
-	require.NotNil(t, pErr, "unexpected success")
-	nlhe := pErr.GetDetail().(*roachpb.NotLeaseHolderError)
-	require.NotNil(t, nlhe, "expected NotLeaseholderError, got: %s", pErr)
-	require.NotNil(t, nlhe.LeaseHolder, "expected NotLeaseholderError with a known leaseholder, got: %s", pErr)
-	require.Equal(t, leaderReplicaID, nlhe.LeaseHolder.ReplicaID)
 }
 
 type fakeSnapshotStream struct {
@@ -3815,12 +3562,10 @@ func TestRemovedReplicaError(t *testing.T) {
 	})
 }
 
-// Test that the Raft leadership is transferred to follow the lease.
 func TestTransferRaftLeadership(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	ctx := context.Background()
 	const numStores = 3
 	sc := kvserver.TestStoreConfig(nil)
 	sc.TestingKnobs.DisableMergeQueue = true
@@ -3889,14 +3634,25 @@ func TestTransferRaftLeadership(t *testing.T) {
 		t.Fatalf("raft leader should be %d, but got status %+v", rd0.ReplicaID, status)
 	}
 
+	// Force a read on Store 2 to request a new lease. Other moving parts in
+	// the system could have requested another lease as well, so we
+	// expire-request in a loop until we get our foot in the door.
 	origCount0 := store0.Metrics().RangeRaftLeaderTransfers.Count()
-	// Transfer the lease. We'll then check that the leadership follows
-	// automatically.
-	transferLeaseArgs := adminTransferLeaseArgs(key, store1.StoreID())
-	_, pErr := kv.SendWrappedWith(ctx, store0, roachpb.Header{RangeID: repl0.RangeID}, transferLeaseArgs)
-	require.NoError(t, pErr.GoError())
-
-	// Verify leadership is transferred.
+	for {
+		mtc.advanceClock(context.Background())
+		if _, pErr := kv.SendWrappedWith(
+			context.Background(), store1, roachpb.Header{RangeID: repl0.RangeID}, getArgs,
+		); pErr == nil {
+			break
+		} else {
+			switch pErr.GetDetail().(type) {
+			case *roachpb.NotLeaseHolderError, *roachpb.RangeNotFoundError:
+			default:
+				t.Fatal(pErr)
+			}
+		}
+	}
+	// Verify lease is transferred.
 	testutils.SucceedsSoon(t, func() error {
 		if a, e := repl0.RaftStatus().Lead, uint64(rd1.ReplicaID); a != e {
 			return errors.Errorf("expected raft leader be %d; got %d", e, a)

--- a/pkg/kv/kvserver/client_test.go
+++ b/pkg/kv/kvserver/client_test.go
@@ -904,8 +904,6 @@ func (m *multiTestContext) addStore(idx int) {
 	nodeID := roachpb.NodeID(idx + 1)
 	cfg := m.makeStoreConfig(idx)
 	ambient := log.AmbientContext{Tracer: cfg.Settings.Tracer}
-	ambient.AddLogTag("n", nodeID)
-
 	m.populateDB(idx, cfg.Settings, stopper)
 	nlActive, nlRenewal := cfg.NodeLivenessDurations()
 	m.nodeLivenesses[idx] = kvserver.NewNodeLiveness(
@@ -1237,8 +1235,7 @@ func (m *multiTestContext) changeReplicas(
 	return desc.NextReplicaID, nil
 }
 
-// replicateRange replicates the given range onto the given destination stores. The destinations
-// are indicated by indexes within m.stores.
+// replicateRange replicates the given range onto the given stores.
 func (m *multiTestContext) replicateRange(rangeID roachpb.RangeID, dests ...int) {
 	m.t.Helper()
 	if err := m.replicateRangeNonFatal(rangeID, dests...); err != nil {
@@ -1363,9 +1360,9 @@ func (m *multiTestContext) waitForValuesT(t testing.TB, key roachpb.Key, expecte
 	})
 }
 
-// waitForValues waits for the integer values at the given key to match the
-// expected slice (across all engines). Fails the test if they do not match
-// after the SucceedsSoon period.
+// waitForValues waits up to the given duration for the integer values
+// at the given key to match the expected slice (across all engines).
+// Fails the test if they do not match.
 func (m *multiTestContext) waitForValues(key roachpb.Key, expected []int64) {
 	m.t.Helper()
 	m.waitForValuesT(m.t, key, expected)

--- a/pkg/kv/kvserver/closed_timestamp_test.go
+++ b/pkg/kv/kvserver/closed_timestamp_test.go
@@ -549,12 +549,6 @@ func TestClosedTimestampInactiveAfterSubsumption(t *testing.T) {
 							return nil
 						},
 						DisableMergeQueue: true,
-						// A subtest wants to force a lease change by stopping the liveness
-						// heartbeats on the old leaseholder and sending a request to
-						// another replica. If we didn't use this knob, we'd have to
-						// architect a Raft leadership change too in order to let the
-						// replica get the lease.
-						AllowLeaseRequestProposalsWhenNotLeader: true,
 					},
 				},
 			},
@@ -705,7 +699,7 @@ func forceLeaseTransferOnSubsumedRange(
 	})
 	restartHeartbeats := oldLeaseholderStore.NodeLiveness().PauseAllHeartbeatsForTest()
 	defer restartHeartbeats()
-	log.Infof(ctx, "test: paused RHS rightLeaseholder's liveness heartbeats")
+	log.Infof(ctx, "paused RHS rightLeaseholder's liveness heartbeats")
 	time.Sleep(oldLeaseholderStore.NodeLiveness().GetLivenessThreshold())
 
 	// Send a read request from one of the followers of RHS so that it notices
@@ -716,8 +710,7 @@ func forceLeaseTransferOnSubsumedRange(
 		log.Infof(ctx,
 			"sending a read request from a follower of RHS (store %d) in order to trigger lease acquisition",
 			newRightLeaseholder.StoreID())
-		_, pErr := newRightLeaseholder.Send(ctx, leaseAcquisitionRequest)
-		log.Infof(ctx, "test: RHS read returned err: %v", pErr)
+		newRightLeaseholder.Send(ctx, leaseAcquisitionRequest)
 		// After the merge commits, the RHS will cease to exist and this read
 		// request will return a RangeNotFoundError. But we cannot guarantee that
 		// the merge will always successfully commit on its first attempt

--- a/pkg/kv/kvserver/replica_init.go
+++ b/pkg/kv/kvserver/replica_init.go
@@ -95,7 +95,6 @@ func newUnloadedReplica(
 	r.mu.proposals = map[kvserverbase.CmdIDKey]*ProposalData{}
 	r.mu.checksums = map[uuid.UUID]ReplicaChecksum{}
 	r.mu.proposalBuf.Init((*replicaProposer)(r))
-	r.mu.proposalBuf.testing.allowLeaseProposalWhenNotLeader = store.cfg.TestingKnobs.AllowLeaseRequestProposalsWhenNotLeader
 
 	if leaseHistoryMaxEntries > 0 {
 		r.leaseHistory = newLeaseHistory()

--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -584,9 +584,9 @@ func (r *Replica) leaseStatus(
 	return status
 }
 
-// CurrentLeaseStatus returns the status of the current lease for a current
+// currentLeaseStatus returns the status of the current lease for a current
 // timestamp.
-func (r *Replica) CurrentLeaseStatus(ctx context.Context) kvserverpb.LeaseStatus {
+func (r *Replica) currentLeaseStatus(ctx context.Context) kvserverpb.LeaseStatus {
 	timestamp := r.store.Clock().Now()
 	r.mu.RLock()
 	defer r.mu.RUnlock()

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -1467,7 +1467,7 @@ func TestReplicaDrainLease(t *testing.T) {
 	rd := tc.LookupRangeOrFatal(t, rngKey)
 	r1, err := store1.GetReplica(rd.RangeID)
 	require.NoError(t, err)
-	status := r1.CurrentLeaseStatus(ctx)
+	status := r1.currentLeaseStatus(ctx)
 	require.True(t, status.Lease.OwnedBy(store1.StoreID()), "someone else got the lease: %s", status)
 	// We expect the lease to be valid, but don't check that because, under race, it might have
 	// expired already.
@@ -1480,7 +1480,7 @@ func TestReplicaDrainLease(t *testing.T) {
 
 	require.NoError(t, err)
 	testutils.SucceedsSoon(t, func() error {
-		status := r1.CurrentLeaseStatus(ctx)
+		status := r1.currentLeaseStatus(ctx)
 		require.True(t, status.Lease.OwnedBy(store1.StoreID()), "someone else got the lease: %s", status)
 		if status.State == kvserverpb.LeaseState_VALID {
 			return errors.New("lease still valid")

--- a/pkg/kv/kvserver/testing_knobs.go
+++ b/pkg/kv/kvserver/testing_knobs.go
@@ -247,14 +247,6 @@ type StoreTestingKnobs struct {
 	// RangeFeedPushTxnsAge overrides the default value for
 	// rangefeed.Config.PushTxnsAge.
 	RangeFeedPushTxnsAge time.Duration
-	// AllowLeaseProposalWhenNotLeader, if set, makes the proposal buffer allow
-	// lease request proposals even when the replica inserting that proposal is
-	// not the Raft leader. This can be used in tests to allow a replica to
-	// acquire a lease without first moving the Raft leadership to it (e.g. it
-	// allows tests to expire leases by stopping the old leaseholder's liveness
-	// heartbeats and then expect other replicas to take the lease without
-	// worrying about Raft).
-	AllowLeaseRequestProposalsWhenNotLeader bool
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -1228,28 +1228,18 @@ func (ts *TestServer) ForceTableGC(
 	return pErr.GoError()
 }
 
-// ScratchRangeEx splits off a range suitable to be used as KV scratch space.
-// (it doesn't overlap system spans or SQL tables).
+// ScratchRange splits off a range suitable to be used as KV scratch space. (it
+// doesn't overlap system spans or SQL tables).
 //
 // Calling this multiple times is undefined (but see TestCluster.ScratchRange()
 // which is idempotent).
-func (ts *TestServer) ScratchRangeEx() (roachpb.RangeDescriptor, error) {
-	scratchKey := keys.TableDataMax
-	_, rngDesc, err := ts.SplitRange(scratchKey)
-	if err != nil {
-		return roachpb.RangeDescriptor{}, err
-	}
-	return rngDesc, nil
-}
-
-// ScratchRange is like ScratchRangeEx, but only returns the start key of the
-// new range instead of the range descriptor.
 func (ts *TestServer) ScratchRange() (roachpb.Key, error) {
-	desc, err := ts.ScratchRangeEx()
+	scratchKey := keys.TableDataMax
+	_, _, err := ts.SplitRange(scratchKey)
 	if err != nil {
 		return nil, err
 	}
-	return desc.StartKey.AsRawKey(), nil
+	return scratchKey, nil
 }
 
 type testServerFactoryImpl struct{}


### PR DESCRIPTION
This reverts commit 8f98ade581db44f2b7ce92286a3ec8c656111d85.

This is a revert of the main commit in #57789 (which was a backport of #55148).
It turns out that the commit in question introduced a deadlock: if
replicas that are not the leader refuse to take the lease (because their
not the leader) and the leader is a VOTER_INCOMING, VOTER_DEMOTING or
VOTER_OUTGOING replica which also refuses to take the lease because it's
not a VOTER_FULL [0] => deadlock.
This deadlock was found in #57798.

The patch will return with some massaging.

This revert is original work on the 20.2 branch; I'm not reverting it on
master in the hope of just fixing the issue.

Touches #37906

Release note: This voids the previous release note reading "A bug
causing queries sent to a freshly-restarted node to sometimes hang for a
long time while the node catches up with replication has been fixed."