### PR TITLE
release-20.2: roachtest: ignore flaky pgjdbc tests

### DIFF
--- a/pkg/cmd/roachtest/pgjdbc_blocklist.go
+++ b/pkg/cmd/roachtest/pgjdbc_blocklist.go
@@ -3521,4 +3521,7 @@ var pgjdbcIgnoreList19_2 = blocklist{
 	"org.postgresql.test.jdbc2.BatchedInsertReWriteEnabledTest.testBatchWithReWrittenSpaceAfterValues[3: autoCommit=NO, binary=FORCE]":              "54477",
 	"org.postgresql.test.jdbc2.BatchedInsertReWriteEnabledTest.testReWriteDisabledForPlainBatch[2: autoCommit=NO, binary=REGULAR]":                  "54477",
 	"org.postgresql.test.jdbc2.BatchedInsertReWriteEnabledTest.testReWriteDisabledForPlainBatch[3: autoCommit=NO, binary=FORCE]":                    "54477",
+	"org.postgresql.test.jdbc2.DatabaseEncodingTest.testBadUTF8Decode":                                                                              "54477",
+	"org.postgresql.test.jdbc2.DatabaseEncodingTest.testTruncatedUTF8Decode":                                                                        "54477",
+	"org.postgresql.test.jdbc2.DatabaseEncodingTest.testUTF8Decode":                                                                                 "54477",
 }


### PR DESCRIPTION
Backport 1/1 commits from #58485.

/cc @cockroachdb/release

---

Release note: none

fixes https://github.com/cockroachdb/cockroach/issues/57603
fixes https://github.com/cockroachdb/cockroach/issues/57368
