### PR TITLE
opt: constrain inverted join prefix columns with optional filters

### DIFF
--- a/pkg/sql/opt/xform/join_funcs.go
+++ b/pkg/sql/opt/xform/join_funcs.go
@@ -470,23 +470,44 @@ func (c *CustomFuncs) GenerateInvertedJoins(
 	inputCols := input.Relational().OutputCols
 	var pkCols opt.ColList
 
-	eqColsCalculated := false
+	eqColsAndOptionalFiltersCalculated := false
 	var leftEqCols opt.ColList
 	var rightEqCols opt.ColList
 	var rightSideCols opt.ColList
+	var optionalFilters memo.FiltersExpr
 
 	var iter scanIndexIter
 	iter.Init(c.e.mem, &c.im, scanPrivate, on, rejectNonInvertedIndexes)
-	iter.ForEach(func(index cat.Index, on memo.FiltersExpr, indexCols opt.ColSet, isCovering bool) {
+	iter.ForEach(func(index cat.Index, onFilters memo.FiltersExpr, indexCols opt.ColSet, isCovering bool) {
 		invertedJoin := memo.InvertedJoinExpr{Input: input}
 		numPrefixCols := index.NonInvertedPrefixColumnCount()
 
-		// Only calculate the left and right equality columns if there is a
-		// multi-column inverted index.
-		if numPrefixCols > 0 && !eqColsCalculated {
-			inputProps := input.Relational()
-			leftEqCols, rightEqCols = memo.ExtractJoinEqualityColumns(inputProps.OutputCols, scanPrivate.Cols, on)
-			eqColsCalculated = true
+		var allFilters memo.FiltersExpr
+		if numPrefixCols > 0 {
+			// Only calculate the left and right equality columns and optional
+			// filters if there is a multi-column inverted index.
+			if !eqColsAndOptionalFiltersCalculated {
+				inputProps := input.Relational()
+				leftEqCols, rightEqCols = memo.ExtractJoinEqualityColumns(inputProps.OutputCols, scanPrivate.Cols, onFilters)
+
+				// Generate implicit filters from CHECK constraints and computed
+				// columns as optional filters. We build the computed column
+				// optional filters from the original on filters, not the
+				// filters within the context of the iter.ForEach callback. The
+				// latter may be reduced during partial index implication and
+				// using them here would result in a reduced set of optional
+				// filters.
+				optionalFilters = c.checkConstraintFilters(scanPrivate.Table)
+				computedColFilters := c.computedColFilters(scanPrivate.Table, on, optionalFilters)
+				optionalFilters = append(optionalFilters, computedColFilters...)
+
+				eqColsAndOptionalFiltersCalculated = true
+			}
+
+			// Combine the ON filters and optional filters together. This set of
+			// filters will be used to attempt to constrain non-inverted prefix
+			// columns of the multi-column inverted index.
+			allFilters = append(onFilters, optionalFilters...)
 		}
 
 		// The non-inverted prefix columns of a multi-column inverted index must
@@ -494,8 +515,6 @@ func (c *CustomFuncs) GenerateInvertedJoins(
 		// constrain each prefix column to non-ranging constant values. These
 		// values are joined with the input to create key columns for the
 		// InvertedJoin, similar to GenerateLookupJoins.
-		// TODO(mgartner): Try to constrain prefix columns with CHECK
-		// constraints and computed column expressions.
 		var constFilters memo.FiltersExpr
 		for i := 0; i < numPrefixCols; i++ {
 			prefixCol := scanPrivate.Table.IndexColumnID(index, i)
@@ -508,7 +527,7 @@ func (c *CustomFuncs) GenerateInvertedJoins(
 			}
 
 			// Try to constrain prefixCol to constant, non-ranging values.
-			foundVals, onIdx, ok := c.findJoinFilterConstants(on, prefixCol)
+			foundVals, allIdx, ok := c.findJoinFilterConstants(allFilters, prefixCol)
 			if !ok {
 				// Cannot constrain prefix column and therefore cannot generate
 				// an inverted join.
@@ -532,20 +551,20 @@ func (c *CustomFuncs) GenerateInvertedJoins(
 
 			invertedJoin.Input = join
 			invertedJoin.PrefixKeyCols = append(invertedJoin.PrefixKeyCols, constColID)
-			constFilters = append(constFilters, on[onIdx])
+			constFilters = append(constFilters, allFilters[allIdx])
 		}
 
 		// Remove the redundant filters and update the ON condition if there are
 		// non-inverted prefix columns that have been constrained.
 		if len(rightSideCols) > 0 || len(constFilters) > 0 {
-			on = memo.ExtractRemainingJoinFilters(on, invertedJoin.PrefixKeyCols, rightSideCols)
-			on.RemoveCommonFilters(constFilters)
+			onFilters = memo.ExtractRemainingJoinFilters(onFilters, invertedJoin.PrefixKeyCols, rightSideCols)
+			onFilters.RemoveCommonFilters(constFilters)
 			invertedJoin.ConstFilters = constFilters
 		}
 
 		// Check whether the filter can constrain the inverted column.
 		invertedExpr := invertedidx.TryJoinInvertedIndex(
-			c.e.evalCtx.Context, c.e.f, on, scanPrivate.Table, index, inputCols,
+			c.e.evalCtx.Context, c.e.f, onFilters, scanPrivate.Table, index, inputCols,
 		)
 		if invertedExpr == nil {
 			return
@@ -608,8 +627,8 @@ func (c *CustomFuncs) GenerateInvertedJoins(
 		// ON may have some conditions that are bound by the columns in the index
 		// and some conditions that refer to other columns. We can put the former
 		// in the InvertedJoin and the latter in the index join.
-		invertedJoin.On = c.ExtractBoundConditions(on, invertedJoin.Cols)
-		indexJoin.On = c.ExtractUnboundConditions(on, invertedJoin.Cols)
+		invertedJoin.On = c.ExtractBoundConditions(onFilters, invertedJoin.Cols)
+		indexJoin.On = c.ExtractUnboundConditions(onFilters, invertedJoin.Cols)
 
 		indexJoin.Input = c.e.f.ConstructInvertedJoin(
 			invertedJoin.Input,

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -4663,6 +4663,26 @@ CREATE TABLE json_arr2 (
 ----
 
 exec-ddl
+CREATE TABLE json_check (
+  k INT PRIMARY KEY,
+  i INT NOT NULL,
+  j JSONB,
+  CHECK (i IN (1, 2, 3)),
+  INVERTED INDEX (i, j)
+)
+----
+
+exec-ddl
+CREATE TABLE json_comp (
+  k INT PRIMARY KEY,
+  a INT,
+  b INT AS (a % 4) STORED,
+  j JSONB,
+  INVERTED INDEX bj_idx (b, j)
+)
+----
+
+exec-ddl
 ALTER TABLE json_arr1 INJECT STATISTICS '[
   {
     "columns": ["j"],
@@ -5250,6 +5270,124 @@ project
       │    └── filters (true)
       └── filters
            └── t1.j:8 @> t2.j:3 [outer=(3,8), immutable]
+
+# Constrain a prefix column with a CHECK constraint.
+opt expect=GenerateInvertedJoins
+SELECT t1.k
+FROM json_arr2 AS t2
+INNER INVERTED JOIN json_check AS t1
+ON t1.j @> t2.j
+----
+project
+ ├── columns: k:6!null
+ ├── immutable
+ └── inner-join (lookup json_check [as=t1])
+      ├── columns: t2.j:3 t1.k:6!null t1.j:8
+      ├── key columns: [6] = [6]
+      ├── lookup columns are key
+      ├── immutable
+      ├── fd: (6)-->(8)
+      ├── inner-join (inverted json_check@secondary [as=t1])
+      │    ├── columns: t2.j:3 t1.k:6!null i:7!null "inverted_join_const_col_@7":11!null
+      │    ├── flags: force inverted join (into right side)
+      │    ├── prefix key columns: [11] = [7]
+      │    ├── inverted-expr
+      │    │    └── t1.j:8 @> t2.j:3
+      │    ├── fd: (6)-->(7), (7)==(11), (11)==(7)
+      │    ├── inner-join (cross)
+      │    │    ├── columns: t2.j:3 "inverted_join_const_col_@7":11!null
+      │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
+      │    │    ├── scan json_arr2 [as=t2]
+      │    │    │    └── columns: t2.j:3
+      │    │    ├── values
+      │    │    │    ├── columns: "inverted_join_const_col_@7":11!null
+      │    │    │    ├── cardinality: [3 - 3]
+      │    │    │    ├── (1,)
+      │    │    │    ├── (2,)
+      │    │    │    └── (3,)
+      │    │    └── filters (true)
+      │    └── filters (true)
+      └── filters
+           └── t1.j:8 @> t2.j:3 [outer=(3,8), immutable]
+
+# Constrain a prefix column with a computed column expression.
+opt expect=GenerateInvertedJoinsFromSelect
+SELECT t1.k
+FROM json_arr2 AS t2
+INNER INVERTED JOIN json_comp AS t1
+ON t1.j @> t2.j AND t1.a = 5
+----
+project
+ ├── columns: k:6!null
+ ├── immutable
+ └── inner-join (lookup json_comp [as=t1])
+      ├── columns: t2.j:3 t1.k:6!null t1.a:7!null t1.j:9
+      ├── key columns: [6] = [6]
+      ├── lookup columns are key
+      ├── immutable
+      ├── fd: ()-->(7), (6)-->(9)
+      ├── inner-join (inverted json_comp@bj_idx [as=t1])
+      │    ├── columns: t2.j:3 t1.k:6!null b:8!null "inverted_join_const_col_@8":12!null
+      │    ├── flags: force inverted join (into right side)
+      │    ├── prefix key columns: [12] = [8]
+      │    ├── inverted-expr
+      │    │    └── t1.j:9 @> t2.j:3
+      │    ├── fd: ()-->(8,12), (8)==(12), (12)==(8)
+      │    ├── project
+      │    │    ├── columns: "inverted_join_const_col_@8":12!null t2.j:3
+      │    │    ├── fd: ()-->(12)
+      │    │    ├── scan json_arr2 [as=t2]
+      │    │    │    └── columns: t2.j:3
+      │    │    └── projections
+      │    │         └── 1 [as="inverted_join_const_col_@8":12]
+      │    └── filters (true)
+      └── filters
+           ├── t1.j:9 @> t2.j:3 [outer=(3,9), immutable]
+           └── t1.a:7 = 5 [outer=(7), constraints=(/7: [/5 - /5]; tight), fd=()-->(7)]
+
+exec-ddl
+DROP INDEX bj_idx
+----
+
+exec-ddl
+CREATE INVERTED INDEX bj_partial_idx ON json_comp (b, j) WHERE a = 5
+----
+
+# Use the original filters, not the filters reduced during partial index
+# implication, to generate computed column filters that can constrain a prefix
+# column.
+opt expect=GenerateInvertedJoinsFromSelect
+SELECT t1.k
+FROM json_arr2 AS t2
+INNER INVERTED JOIN json_comp AS t1
+ON t1.j @> t2.j AND t1.a = 5
+----
+project
+ ├── columns: k:6!null
+ ├── immutable
+ └── inner-join (lookup json_comp [as=t1])
+      ├── columns: t2.j:3 t1.k:6!null t1.a:7!null t1.j:9
+      ├── key columns: [6] = [6]
+      ├── lookup columns are key
+      ├── immutable
+      ├── fd: ()-->(7), (6)-->(9)
+      ├── inner-join (inverted json_comp@bj_partial_idx,partial [as=t1])
+      │    ├── columns: t2.j:3 t1.k:6!null b:8!null "inverted_join_const_col_@8":13!null
+      │    ├── flags: force inverted join (into right side)
+      │    ├── prefix key columns: [13] = [8]
+      │    ├── inverted-expr
+      │    │    └── t1.j:9 @> t2.j:3
+      │    ├── fd: ()-->(8,13), (8)==(13), (13)==(8)
+      │    ├── project
+      │    │    ├── columns: "inverted_join_const_col_@8":13!null t2.j:3
+      │    │    ├── fd: ()-->(13)
+      │    │    ├── scan json_arr2 [as=t2]
+      │    │    │    └── columns: t2.j:3
+      │    │    └── projections
+      │    │         └── 1 [as="inverted_join_const_col_@8":13]
+      │    └── filters (true)
+      └── filters
+           └── t1.j:9 @> t2.j:3 [outer=(3,9), immutable]
 
 # Do not generate an inverted join when the prefix column is not constrained.
 opt expect-not=GenerateInvertedJoinsFromSelect format=hide-all


### PR DESCRIPTION
The `GenerateInvertedJoins` rule can now constrain the non-inverted
prefix columns of inverted indexes with optional filters from CHECK
constraints and computed column expressions. This allows inverted joins
to be planned on multi-column inverted indexes in more cases. This is
particularly important for multi-region schemas where the region column
of a table will be a non-inverted prefix column of any inverted index on
the table, and will have a corresponding CHECK constraint.

Release note: None