### PR TITLE
tracing: refactor "logging" components of the API

### DIFF
--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -720,6 +720,7 @@ func TestLint(t *testing.T) {
 			":!util/timeutil/time.go",
 			":!util/timeutil/zoneinfo.go",
 			":!util/tracing/span.go",
+			":!util/tracing/crdbspan.go",
 			":!util/tracing/tracer.go",
 		)
 		if err != nil {

--- a/pkg/testutils/lint/passes/fmtsafe/functions.go
+++ b/pkg/testutils/lint/passes/fmtsafe/functions.go
@@ -85,6 +85,8 @@ var requireConstFmt = map[string]bool{
 
 	"github.com/cockroachdb/cockroach/pkg/util/log/logcrash.ReportOrPanic": true,
 
+	"(*github.com/cockroachdb/cockroach/pkg/util/tracing.Span).Recordf": true,
+
 	"(github.com/cockroachdb/cockroach/pkg/rpc.breakerLogger).Debugf": true,
 	"(github.com/cockroachdb/cockroach/pkg/rpc.breakerLogger).Infof":  true,
 

--- a/pkg/util/log/BUILD.bazel
+++ b/pkg/util/log/BUILD.bazel
@@ -60,13 +60,11 @@ go_library(
         "//pkg/util/sysutil",
         "//pkg/util/timeutil",
         "//pkg/util/tracing",
-        "//pkg/util/tracing/tracingpb",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_errors//oserror",
         "@com_github_cockroachdb_logtags//:logtags",
         "@com_github_cockroachdb_redact//:redact",
         "@com_github_cockroachdb_ttycolor//:ttycolor",
-        "@com_github_opentracing_opentracing_go//log",
         "@com_github_petermattis_goid//:goid",
         "@org_golang_x_net//trace",
     ] + select({

--- a/pkg/util/log/trace.go
+++ b/pkg/util/log/trace.go
@@ -20,10 +20,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log/severity"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
-	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
 	"github.com/cockroachdb/logtags"
 	"github.com/cockroachdb/redact"
-	otlog "github.com/opentracing/opentracing-go/log"
 	"golang.org/x/net/trace"
 )
 
@@ -147,9 +145,7 @@ func eventInternal(sp *tracing.Span, el *ctxEventLog, isErr bool, entry logpb.En
 	}
 
 	if sp != nil {
-		// TODO(radu): pass tags directly to sp.LogKV when LightStep supports
-		// that.
-		sp.LogFields(otlog.String(tracingpb.LogMessageField, msg))
+		sp.Record(msg)
 		// if isErr {
 		// 	// TODO(radu): figure out a way to signal that this is an error. We
 		// 	// could use a different "error" key (provided it shows up in

--- a/pkg/util/tracing/BUILD.bazel
+++ b/pkg/util/tracing/BUILD.bazel
@@ -54,7 +54,6 @@ go_test(
     embed = [":tracing"],
     deps = [
         "//pkg/settings",
-        "//pkg/util/tracing/tracingpb",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_logtags//:logtags",
         "@com_github_gogo_protobuf//types",

--- a/pkg/util/tracing/BUILD.bazel
+++ b/pkg/util/tracing/BUILD.bazel
@@ -4,7 +4,9 @@ go_library(
     name = "tracing",
     srcs = [
         "context.go",
+        "crdbspan.go",
         "grpc_interceptor.go",
+        "otspan.go",
         "recording.go",
         "shadow.go",
         "span.go",

--- a/pkg/util/tracing/crdbspan.go
+++ b/pkg/util/tracing/crdbspan.go
@@ -1,0 +1,358 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tracing
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
+	"github.com/cockroachdb/logtags"
+	"github.com/gogo/protobuf/types"
+	"github.com/opentracing/opentracing-go"
+	otlog "github.com/opentracing/opentracing-go/log"
+)
+
+// crdbSpan is a span for internal crdb usage. This is used to power SQL session
+// tracing.
+type crdbSpan struct {
+	traceID      uint64 // probabilistically unique.
+	spanID       uint64 // probabilistically unique.
+	parentSpanID uint64
+
+	operation string
+	startTime time.Time
+
+	// logTags are set to the log tags that were available when this Span was
+	// created, so that there's no need to eagerly copy all of those log tags
+	// into this Span's tags. If the Span's tags are actually requested, these
+	// logTags will be copied out at that point.
+	//
+	// Note that these tags have not gone through the log tag -> Span tag
+	// remapping procedure; tagName() needs to be called before exposing each
+	// tag's key to a user.
+	logTags *logtags.Buffer
+
+	mu crdbSpanMu
+}
+
+type crdbSpanMu struct {
+	syncutil.Mutex
+	// duration is initialized to -1 and set on Finish().
+	duration time.Duration
+
+	// recording maintains state once StartRecording() is called.
+	recording struct {
+		// recordingType is the recording type of the ongoing recording, if any.
+		// Its 'load' method may be called without holding the surrounding mutex,
+		// but its 'swap' method requires the mutex.
+		recordingType atomicRecordingType
+		recordedLogs  []opentracing.LogRecord
+		// children contains the list of child spans started after this Span
+		// started recording.
+		children []*crdbSpan
+		// remoteSpan contains the list of remote child spans manually imported.
+		remoteSpans []tracingpb.RecordedSpan
+	}
+
+	// tags are only set when recording. These are tags that have been added to
+	// this Span, and will be appended to the tags in logTags when someone
+	// needs to actually observe the total set of tags that is a part of this
+	// Span.
+	// TODO(radu): perhaps we want a recording to capture all the tags (even
+	// those that were set before recording started)?
+	tags opentracing.Tags
+
+	stats      SpanStats
+	structured []Structured
+
+	// The Span's associated baggage.
+	Baggage map[string]string
+}
+
+func (s *crdbSpan) recordingType() RecordingType {
+	if s == nil {
+		return RecordingOff
+	}
+	return s.mu.recording.recordingType.load()
+}
+
+// enableRecording start recording on the Span. From now on, log events and
+// child spans will be stored.
+//
+// If parent != nil, the Span will be registered as a child of the respective
+// parent.
+// If separate recording is specified, the child is not registered with the
+// parent. Thus, the parent's recording will not include this child.
+func (s *crdbSpan) enableRecording(parent *crdbSpan, recType RecordingType) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.mu.recording.recordingType.swap(recType)
+	if parent != nil {
+		parent.addChild(s)
+	}
+	if recType == RecordingVerbose {
+		s.setBaggageItemLocked(verboseTracingBaggageKey, "1")
+	}
+	// Clear any previously recorded info. This is needed by SQL SessionTracing,
+	// who likes to start and stop recording repeatedly on the same Span, and
+	// collect the (separate) recordings every time.
+	s.mu.recording.recordedLogs = nil
+	s.mu.recording.children = nil
+	s.mu.recording.remoteSpans = nil
+}
+
+func (s *crdbSpan) disableRecording() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	oldRecType := s.mu.recording.recordingType.swap(RecordingOff)
+	// We test the duration as a way to check if the Span has been finished. If it
+	// has, we don't want to do the call below as it might crash (at least if
+	// there's a netTr).
+	if (s.mu.duration == -1) && (oldRecType == RecordingVerbose) {
+		// Clear the verboseTracingBaggageKey baggage item, assuming that it was set by
+		// enableRecording().
+		s.setBaggageItemLocked(verboseTracingBaggageKey, "")
+	}
+}
+
+func (s *crdbSpan) getRecording(m mode) Recording {
+	if s == nil {
+		return nil
+	}
+	if m == modeLegacy && s.recordingType() == RecordingOff {
+		// In legacy tracing (pre always-on), we avoid allocations when the
+		// Span is not actively recording.
+		//
+		// TODO(tbg): we could consider doing the same when background tracing
+		// is on but the current span contains "nothing of interest".
+		return nil
+	}
+	s.mu.Lock()
+	// The capacity here is approximate since we don't know how many grandchildren
+	// there are.
+	result := make(Recording, 0, 1+len(s.mu.recording.children)+len(s.mu.recording.remoteSpans))
+	// Shallow-copy the children so we can process them without the lock.
+	children := s.mu.recording.children
+	result = append(result, s.getRecordingLocked(m))
+	result = append(result, s.mu.recording.remoteSpans...)
+	s.mu.Unlock()
+
+	for _, child := range children {
+		result = append(result, child.getRecording(m)...)
+	}
+
+	// Sort the spans by StartTime, except the first Span (the root of this
+	// recording) which stays in place.
+	toSort := sortPool.Get().(*Recording) // avoids allocations in sort.Sort
+	*toSort = result[1:]
+	sort.Sort(toSort)
+	*toSort = nil
+	sortPool.Put(toSort)
+	return result
+}
+
+func (s *crdbSpan) importRemoteSpans(remoteSpans []tracingpb.RecordedSpan) error {
+	// Change the root of the remote recording to be a child of this Span. This is
+	// usually already the case, except with DistSQL traces where remote
+	// processors run in spans that FollowFrom an RPC Span that we don't collect.
+	remoteSpans[0].ParentSpanID = s.spanID
+
+	s.mu.Lock()
+	s.mu.recording.remoteSpans = append(s.mu.recording.remoteSpans, remoteSpans...)
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *crdbSpan) setTagLocked(key string, value interface{}) {
+	if s.mu.tags == nil {
+		s.mu.tags = make(opentracing.Tags)
+	}
+	s.mu.tags[key] = value
+}
+
+func (s *crdbSpan) record(msg string) {
+	if s.recordingType() != RecordingVerbose {
+		return
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.mu.recording.recordedLogs) < maxLogsPerSpan {
+		s.mu.recording.recordedLogs = append(s.mu.recording.recordedLogs, opentracing.LogRecord{
+			Timestamp: time.Now(),
+			Fields: []otlog.Field{
+				otlog.String(tracingpb.LogMessageField, msg),
+			},
+		})
+	}
+}
+
+func (s *crdbSpan) logStructured(item Structured) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.mu.structured = append(s.mu.structured, item)
+}
+
+func (s *crdbSpan) setBaggageItemAndTag(restrictedKey, value string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.setBaggageItemLocked(restrictedKey, value)
+	// Don't set the tag if this is the special cased baggage item indicating
+	// span verbosity, as it is named nondescriptly and the recording knows
+	// how to display its verbosity independently.
+	if restrictedKey != verboseTracingBaggageKey {
+		s.setTagLocked(restrictedKey, value)
+	}
+}
+
+func (s *crdbSpan) setBaggageItemLocked(restrictedKey, value string) {
+	if oldVal, ok := s.mu.Baggage[restrictedKey]; ok && oldVal == value {
+		// No-op.
+		return
+	}
+	if s.mu.Baggage == nil {
+		s.mu.Baggage = make(map[string]string)
+	}
+	s.mu.Baggage[restrictedKey] = value
+}
+
+// getRecordingLocked returns the Span's recording. This does not include
+// children.
+func (s *crdbSpan) getRecordingLocked(m mode) tracingpb.RecordedSpan {
+	rs := tracingpb.RecordedSpan{
+		TraceID:      s.traceID,
+		SpanID:       s.spanID,
+		ParentSpanID: s.parentSpanID,
+		Operation:    s.operation,
+		StartTime:    s.startTime,
+		Duration:     s.mu.duration,
+	}
+
+	addTag := func(k, v string) {
+		if rs.Tags == nil {
+			rs.Tags = make(map[string]string)
+		}
+		rs.Tags[k] = v
+	}
+
+	// When nobody is configured to see our spans, skip some allocations
+	// related to Span UX improvements.
+	onlyBackgroundTracing := m == modeBackground && s.recordingType() == RecordingOff
+	if !onlyBackgroundTracing {
+		if rs.Duration == -1 {
+			// -1 indicates an unfinished Span. For a recording it's better to put some
+			// duration in it, otherwise tools get confused. For example, we export
+			// recordings to Jaeger, and spans with a zero duration don't look nice.
+			rs.Duration = timeutil.Now().Sub(rs.StartTime)
+			addTag("_unfinished", "1")
+		}
+		if s.mu.recording.recordingType.load() == RecordingVerbose {
+			addTag("_verbose", "1")
+		}
+	}
+
+	if s.mu.stats != nil {
+		stats, err := types.MarshalAny(s.mu.stats)
+		if err != nil {
+			panic(err)
+		}
+		rs.DeprecatedStats = stats
+	}
+
+	if s.mu.structured != nil {
+		rs.InternalStructured = make([]*types.Any, 0, len(s.mu.structured))
+		for i := range s.mu.structured {
+			item, err := types.MarshalAny(s.mu.structured[i])
+			if err != nil {
+				// An error here is an error from Marshal; these
+				// are unlikely to happen.
+				continue
+			}
+			rs.InternalStructured = append(rs.InternalStructured, item)
+		}
+	}
+
+	if len(s.mu.Baggage) > 0 {
+		rs.Baggage = make(map[string]string)
+		for k, v := range s.mu.Baggage {
+			rs.Baggage[k] = v
+		}
+	}
+	if !onlyBackgroundTracing && s.logTags != nil {
+		setLogTags(s.logTags.Get(), func(remappedKey string, tag *logtags.Tag) {
+			addTag(remappedKey, tag.ValueStr())
+		})
+	}
+	if len(s.mu.tags) > 0 {
+		for k, v := range s.mu.tags {
+			// We encode the tag values as strings.
+			addTag(k, fmt.Sprint(v))
+		}
+	}
+	rs.Logs = make([]tracingpb.LogRecord, len(s.mu.recording.recordedLogs))
+	for i, r := range s.mu.recording.recordedLogs {
+		rs.Logs[i].Time = r.Timestamp
+		rs.Logs[i].Fields = make([]tracingpb.LogRecord_Field, len(r.Fields))
+		for j, f := range r.Fields {
+			rs.Logs[i].Fields[j] = tracingpb.LogRecord_Field{
+				Key:   f.Key(),
+				Value: fmt.Sprint(f.Value()),
+			}
+		}
+	}
+
+	return rs
+}
+
+func (s *crdbSpan) addChild(child *crdbSpan) {
+	s.mu.Lock()
+	s.mu.recording.children = append(s.mu.recording.children, child)
+	s.mu.Unlock()
+}
+
+var sortPool = sync.Pool{
+	New: func() interface{} {
+		return &Recording{}
+	},
+}
+
+// Less implements sort.Interface.
+func (r Recording) Less(i, j int) bool {
+	return r[i].StartTime.Before(r[j].StartTime)
+}
+
+// Swap implements sort.Interface.
+func (r Recording) Swap(i, j int) {
+	r[i], r[j] = r[j], r[i]
+}
+
+// Len implements sort.Interface.
+func (r Recording) Len() int {
+	return len(r)
+}
+
+type atomicRecordingType RecordingType
+
+// load returns the recording type.
+func (art *atomicRecordingType) load() RecordingType {
+	return RecordingType(atomic.LoadInt32((*int32)(art)))
+}
+
+// swap stores the new recording type and returns the old one.
+func (art *atomicRecordingType) swap(recType RecordingType) RecordingType {
+	return RecordingType(atomic.SwapInt32((*int32)(art), int32(recType)))
+}

--- a/pkg/util/tracing/otspan.go
+++ b/pkg/util/tracing/otspan.go
@@ -1,0 +1,26 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tracing
+
+import "github.com/opentracing/opentracing-go"
+
+// otSpan is a span for an external opentracing compatible tracer such as
+// lightstep, zipkin, jaeger, etc.
+type otSpan struct {
+	// shadowTr is the shadowTracer this span was created from. We need
+	// to hold on to it separately because shadowSpan.Tracer() returns
+	// the wrapper tracer and we lose the ability to find out
+	// what tracer it is. This is important when deriving children from
+	// this span, as we want to avoid mixing different tracers, which
+	// would otherwise be the result of cluster settings changed.
+	shadowTr   *shadowTracer
+	shadowSpan opentracing.Span
+}

--- a/pkg/util/tracing/span.go
+++ b/pkg/util/tracing/span.go
@@ -11,23 +11,55 @@
 package tracing
 
 import (
-	"fmt"
-	"sort"
-	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
-	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
-	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
 	"github.com/cockroachdb/errors"
-	"github.com/cockroachdb/logtags"
-	"github.com/gogo/protobuf/types"
 	opentracing "github.com/opentracing/opentracing-go"
 	otlog "github.com/opentracing/opentracing-go/log"
 	"golang.org/x/net/trace"
 )
+
+const (
+	// TagPrefix is prefixed to all tags that should be output in SHOW TRACE.
+	TagPrefix = "cockroach."
+)
+
+// Span is the tracing Span that we use in CockroachDB. Depending on the tracing
+// configuration, it can hold anywhere between zero and three destinations for
+// trace information:
+//
+// 1. external OpenTracing-compatible trace collector (Jaeger, Zipkin, Lightstep),
+// 2. /debug/requests endpoint (net/trace package); mostly useful for local debugging
+// 3. CRDB-internal trace span (powers SQL session tracing).
+//
+// When there is no need to allocate either of these three destinations,
+// a "noop span", i.e. an immutable *Span wrapping the *Tracer, may be
+// returned, to allow starting additional nontrivial Spans from the return
+// value later, when direct access to the tracer may no longer be available.
+//
+// The CockroachDB-internal Span (crdbSpan) is more complex because
+// rather than reporting to some external sink, the caller's "owner"
+// must propagate the trace data back across process boundaries towards
+// the root of the trace span tree; see WithParentAndAutoCollection
+// and WithParentAndManualCollection, respectively.
+//
+// Additionally, the internal span type also supports turning on, stopping,
+// and restarting its data collection (see Span.StartRecording), and this is
+// used extensively in SQL session tracing.
+type Span struct {
+	tracer *Tracer // never nil
+
+	// Internal trace Span; nil if not tracing to crdb.
+	// When not-nil, allocated together with the surrounding Span for
+	// performance.
+	crdb *crdbSpan
+	// x/net/trace.Trace instance; nil if not tracing to x/net/trace.
+	netTr trace.Trace
+	// Shadow tracer and Span; zero if not using a shadow tracer.
+	ot otSpan
+}
 
 // SpanMeta is information about a Span that is not local to this
 // process. Typically, SpanMeta is populated from information
@@ -63,181 +95,8 @@ type SpanMeta struct {
 	Baggage map[string]string
 }
 
-const (
-	// TagPrefix is prefixed to all tags that should be output in SHOW TRACE.
-	TagPrefix = "cockroach."
-)
-
-// SpanStats are stats that can be added to a Span.
-type SpanStats interface {
-	protoutil.Message
-	// StatsTags returns the stats that the object represents as a map of
-	// key/value tags that will be added to the Span tags. The tag keys should
-	// start with TagPrefix.
-	StatsTags() map[string]string
-}
-
-// Structured is an opaque protobuf that can be attached to a trace via
-// `Span.LogStructured`. This is the only kind of data a Span carries when
-// `trace.mode = background`.
-type Structured interface {
-	protoutil.Message
-}
-
-type atomicRecordingType RecordingType
-
-// load returns the recording type.
-func (art *atomicRecordingType) load() RecordingType {
-	return RecordingType(atomic.LoadInt32((*int32)(art)))
-}
-
-// swap stores the new recording type and returns the old one.
-func (art *atomicRecordingType) swap(recType RecordingType) RecordingType {
-	return RecordingType(atomic.SwapInt32((*int32)(art), int32(recType)))
-}
-
-type crdbSpanMu struct {
-	syncutil.Mutex
-	// duration is initialized to -1 and set on Finish().
-	duration time.Duration
-
-	// recording maintains state once StartRecording() is called.
-	recording struct {
-		// recordingType is the recording type of the ongoing recording, if any.
-		// Its 'load' method may be called without holding the surrounding mutex,
-		// but its 'swap' method requires the mutex.
-		recordingType atomicRecordingType
-		recordedLogs  []opentracing.LogRecord
-		// children contains the list of child spans started after this Span
-		// started recording.
-		children []*crdbSpan
-		// remoteSpan contains the list of remote child spans manually imported.
-		remoteSpans []tracingpb.RecordedSpan
-	}
-
-	// tags are only set when recording. These are tags that have been added to
-	// this Span, and will be appended to the tags in logTags when someone
-	// needs to actually observe the total set of tags that is a part of this
-	// Span.
-	// TODO(radu): perhaps we want a recording to capture all the tags (even
-	// those that were set before recording started)?
-	tags opentracing.Tags
-
-	stats      SpanStats
-	structured []Structured
-
-	// The Span's associated baggage.
-	Baggage map[string]string
-}
-
-type crdbSpan struct {
-	// The traceID, probabilistically unique.
-	traceID uint64
-	// The spanID, probabilistically unique.
-	spanID uint64
-
-	parentSpanID uint64
-
-	operation string
-	startTime time.Time
-
-	// logTags are set to the log tags that were available when this Span was
-	// created, so that there's no need to eagerly copy all of those log tags into
-	// this Span's tags. If the Span's tags are actually requested, these logTags
-	// will be copied out at that point.
-	// Note that these tags have not gone through the log tag -> Span tag
-	// remapping procedure; tagName() needs to be called before exposing each
-	// tag's key to a user.
-	logTags *logtags.Buffer
-
-	mu crdbSpanMu
-}
-
-func (s *crdbSpan) recordingType() RecordingType {
-	if s == nil {
-		return RecordingOff
-	}
-	return s.mu.recording.recordingType.load()
-}
-
-// otSpan is a span for an external opentracing compatible tracer
-// such as lightstep, zipkin, jaeger, etc.
-type otSpan struct {
-	// shadowTr is the shadowTracer this span was created from. We need
-	// to hold on to it separately because shadowSpan.Tracer() returns
-	// the wrapper tracer and we lose the ability to find out
-	// what tracer it is. This is important when deriving children from
-	// this span, as we want to avoid mixing different tracers, which
-	// would otherwise be the result of cluster settings changed.
-	shadowTr   *shadowTracer
-	shadowSpan opentracing.Span
-}
-
-// Span is the tracing Span that we use in CockroachDB. Depending on the tracing configuration,
-// it can hold anywhere between zero and three destinations for trace information:
-//
-// 1. external OpenTracing-compatible trace collector (Jaeger, Zipkin, Lightstep),
-// 2. /debug/requests endpoint (net/trace package); mostly useful for local debugging
-// 3. CRDB-internal trace span (powers SQL session tracing).
-//
-// When there is no need to allocate either of these three destinations,
-// a "noop span", i.e. an immutable *Span wrapping the *Tracer, may be
-// returned, to allow starting additional nontrivial Spans from the return
-// value later, when direct access to the tracer may no longer be available.
-//
-// The CockroachDB-internal Span (crdbSpan) is more complex because
-// rather than reporting to some external sink, the caller's "owner"
-// must propagate the trace data back across process boundaries towards
-// the root of the trace span tree; see WithParentAndAutoCollection
-// and WithParentAndManualCollection, respectively.
-//
-// Additionally, the internal span type also supports turning on, stopping,
-// and restarting its data collection (see Span.StartRecording), and this is
-// used extensively in SQL session tracing.
-type Span struct {
-	tracer *Tracer // never nil
-
-	// Internal trace Span; nil if not tracing to crdb.
-	// When not-nil, allocated together with the surrounding Span for
-	// performance.
-	crdb *crdbSpan
-	// x/net/trace.Trace instance; nil if not tracing to x/net/trace.
-	netTr trace.Trace
-	// Shadow tracer and Span; zero if not using a shadow tracer.
-	ot otSpan
-}
-
-func (s *Span) isBlackHole() bool {
-	return s.crdb.recordingType() == RecordingOff && s.netTr == nil && s.ot == (otSpan{})
-}
-
 func (s *Span) isNoop() bool {
 	return s.crdb == nil && s.netTr == nil && s.ot == (otSpan{})
-}
-
-// enableRecording start recording on the Span. From now on, log events and child spans
-// will be stored.
-//
-// If parent != nil, the Span will be registered as a child of the respective
-// parent.
-// If separate recording is specified, the child is not registered with the
-// parent. Thus, the parent's recording will not include this child.
-func (s *crdbSpan) enableRecording(parent *crdbSpan, recType RecordingType) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.mu.recording.recordingType.swap(recType)
-	if parent != nil {
-		parent.addChild(s)
-	}
-	if recType == RecordingVerbose {
-		s.setBaggageItemLocked(verboseTracingBaggageKey, "1")
-	}
-	// Clear any previously recorded info. This is needed by SQL SessionTracing,
-	// who likes to start and stop recording repeatedly on the same Span, and
-	// collect the (separate) recordings every time.
-	s.mu.recording.recordedLogs = nil
-	s.mu.recording.children = nil
-	s.mu.recording.remoteSpans = nil
 }
 
 // IsVerbose returns true if the Span is verbose. See SetVerbose for details.
@@ -279,82 +138,11 @@ func (s *Span) SetVerbose(to bool) {
 	}
 }
 
-func (s *crdbSpan) disableRecording() {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	oldRecType := s.mu.recording.recordingType.swap(RecordingOff)
-	// We test the duration as a way to check if the Span has been finished. If it
-	// has, we don't want to do the call below as it might crash (at least if
-	// there's a netTr).
-	if (s.mu.duration == -1) && (oldRecType == RecordingVerbose) {
-		// Clear the verboseTracingBaggageKey baggage item, assuming that it was set by
-		// enableRecording().
-		s.setBaggageItemLocked(verboseTracingBaggageKey, "")
-	}
-}
-
 // GetRecording retrieves the current recording, if the Span has recording
 // enabled. This can be called while spans that are part of the recording are
 // still open; it can run concurrently with operations on those spans.
 func (s *Span) GetRecording() Recording {
 	return s.crdb.getRecording(s.tracer.mode())
-}
-
-func (s *crdbSpan) getRecording(m mode) Recording {
-	if s == nil {
-		return nil
-	}
-	if m == modeLegacy && s.recordingType() == RecordingOff {
-		// In legacy tracing (pre always-on), we avoid allocations when the
-		// Span is not actively recording.
-		//
-		// TODO(tbg): we could consider doing the same when background tracing
-		// is on but the current span contains "nothing of interest".
-		return nil
-	}
-	s.mu.Lock()
-	// The capacity here is approximate since we don't know how many grandchildren
-	// there are.
-	result := make(Recording, 0, 1+len(s.mu.recording.children)+len(s.mu.recording.remoteSpans))
-	// Shallow-copy the children so we can process them without the lock.
-	children := s.mu.recording.children
-	result = append(result, s.getRecordingLocked(m))
-	result = append(result, s.mu.recording.remoteSpans...)
-	s.mu.Unlock()
-
-	for _, child := range children {
-		result = append(result, child.getRecording(m)...)
-	}
-
-	// Sort the spans by StartTime, except the first Span (the root of this
-	// recording) which stays in place.
-	toSort := sortPool.Get().(*Recording) // avoids allocations in sort.Sort
-	*toSort = result[1:]
-	sort.Sort(toSort)
-	*toSort = nil
-	sortPool.Put(toSort)
-	return result
-}
-
-var sortPool = sync.Pool{
-	New: func() interface{} {
-		return &Recording{}
-	},
-}
-
-// Less implements sort.Interface.
-func (r Recording) Less(i, j int) bool {
-	return r[i].StartTime.Before(r[j].StartTime)
-}
-
-// Swap implements sort.Interface.
-func (r Recording) Swap(i, j int) {
-	r[i], r[j] = r[j], r[i]
-}
-
-// Len implements sort.Interface.
-func (r Recording) Len() int {
-	return len(r)
 }
 
 // ImportRemoteSpans adds RecordedSpan data to the recording of the given Span;
@@ -364,19 +152,7 @@ func (s *Span) ImportRemoteSpans(remoteSpans []tracingpb.RecordedSpan) error {
 	if s.tracer.mode() == modeLegacy && s.crdb.recordingType() == RecordingOff {
 		return nil
 	}
-	return s.crdb.ImportRemoteSpans(remoteSpans)
-}
-
-func (s *crdbSpan) ImportRemoteSpans(remoteSpans []tracingpb.RecordedSpan) error {
-	// Change the root of the remote recording to be a child of this Span. This is
-	// usually already the case, except with DistSQL traces where remote
-	// processors run in spans that FollowFrom an RPC Span that we don't collect.
-	remoteSpans[0].ParentSpanID = s.spanID
-
-	s.mu.Lock()
-	s.mu.recording.remoteSpans = append(s.mu.recording.remoteSpans, remoteSpans...)
-	s.mu.Unlock()
-	return nil
+	return s.crdb.importRemoteSpans(remoteSpans)
 }
 
 // IsBlackHole returns true if events for this Span are just dropped. This
@@ -388,7 +164,7 @@ func (s *crdbSpan) ImportRemoteSpans(remoteSpans []tracingpb.RecordedSpan) error
 // only minimal overhead. It is therefore not worth it to call this method to avoid
 // starting spans.
 func (s *Span) IsBlackHole() bool {
-	return s.isBlackHole()
+	return s.crdb.recordingType() == RecordingOff && s.netTr == nil && s.ot == (otSpan{})
 }
 
 // isNilOrNoop returns true if the Span context is either nil
@@ -396,6 +172,15 @@ func (s *Span) IsBlackHole() bool {
 // derived from this context will be a "black hole Span".
 func (sc *SpanMeta) isNilOrNoop() bool {
 	return sc == nil || (sc.recordingType == RecordingOff && sc.shadowTracerType == "")
+}
+
+// SpanStats are stats that can be added to a Span.
+type SpanStats interface {
+	protoutil.Message
+	// StatsTags returns the stats that the object represents as a map of
+	// key/value tags that will be added to the Span tags. The tag keys should
+	// start with TagPrefix.
+	StatsTags() map[string]string
 }
 
 // SetSpanStats sets the stats on a Span. stats.Stats() will also be added to
@@ -440,10 +225,10 @@ func (s *Span) Finish() {
 	s.tracer.activeSpans.Unlock()
 }
 
-// Meta returns the information which needs to be propagated across
-// process boundaries in order to derive child spans from this Span.
-// This may return nil, which is a valid input to `WithParentAndManualCollection`,
-// if the Span has been optimized out.
+// Meta returns the information which needs to be propagated across process
+// boundaries in order to derive child spans from this Span. This may return
+// nil, which is a valid input to `WithParentAndManualCollection`, if the Span
+// has been optimized out.
 func (s *Span) Meta() *SpanMeta {
 	var traceID uint64
 	var spanID uint64
@@ -490,7 +275,7 @@ func (s *Span) Meta() *SpanMeta {
 	}
 }
 
-// SetOperationName is part of the opentracing.Span interface.
+// SetOperationName sets the name of the operation.
 func (s *Span) SetOperationName(operationName string) *Span {
 	if s.isNoop() {
 		return s
@@ -502,19 +287,13 @@ func (s *Span) SetOperationName(operationName string) *Span {
 	return s
 }
 
-// SetTag is part of the opentracing.Span interface.
+// SetTag adds a tag to the span. If there is a pre-existing tag set for the
+// key, it is overwritten.
 func (s *Span) SetTag(key string, value interface{}) *Span {
 	if s.isNoop() {
 		return s
 	}
 	return s.setTagInner(key, value, false /* locked */)
-}
-
-func (s *crdbSpan) setTagLocked(key string, value interface{}) {
-	if s.mu.tags == nil {
-		s.mu.tags = make(opentracing.Tags)
-	}
-	s.mu.tags[key] = value
 }
 
 func (s *Span) setTagInner(key string, value interface{}, locked bool) *Span {
@@ -533,31 +312,11 @@ func (s *Span) setTagInner(key string, value interface{}, locked bool) *Span {
 	return s
 }
 
-func (s *crdbSpan) record(msg string) {
-	if s.recordingType() != RecordingVerbose {
-		return
-	}
-
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if len(s.mu.recording.recordedLogs) < maxLogsPerSpan {
-		s.mu.recording.recordedLogs = append(s.mu.recording.recordedLogs, opentracing.LogRecord{
-			Timestamp: time.Now(),
-			Fields: []otlog.Field{
-				otlog.String(tracingpb.LogMessageField, msg),
-			},
-		})
-	}
-}
-
-// hasVerboseSink returns false if there is no
-// reason to even evaluate LogKV and LogData calls
-// because the result wouldn't be used for anything.
-func (s *Span) hasVerboseSink() bool {
-	if s.netTr == nil && s.ot == (otSpan{}) && s.crdb.recordingType() != RecordingVerbose {
-		return false
-	}
-	return true
+// Structured is an opaque protobuf that can be attached to a trace via
+// `Span.LogStructured`. This is the only kind of data a Span carries when
+// `trace.mode = background`.
+type Structured interface {
+	protoutil.Message
 }
 
 // LogStructured adds a Structured payload to the Span. It will be added to the
@@ -569,7 +328,7 @@ func (s *Span) LogStructured(item Structured) {
 	if s.isNoop() {
 		return
 	}
-	s.crdb.LogStructured(item)
+	s.crdb.logStructured(item)
 }
 
 // Record provides a way to put free-form text into verbose spans.
@@ -586,12 +345,24 @@ func (s *Span) Record(msg string) {
 	s.crdb.record(msg)
 }
 
-// SetBaggageItem is part of the opentracing.Span interface.
+// hasVerboseSink returns false if there is no reason to even evaluate Record
+// because the result wouldn't be used for anything.
+func (s *Span) hasVerboseSink() bool {
+	if s.netTr == nil && s.ot == (otSpan{}) && !s.IsVerbose() {
+		return false
+	}
+	return true
+}
+
+// SetBaggageItem attaches "baggage" to this span, a key:value pair that's
+// propagated to all future descendants of this Span. Any attached baggage
+// crosses RPC boundaries, and is copied transitively for every remote
+// descendant.
 func (s *Span) SetBaggageItem(restrictedKey, value string) *Span {
 	if s.isNoop() {
 		return s
 	}
-	s.crdb.SetBaggageItemAndTag(restrictedKey, value)
+	s.crdb.setBaggageItemAndTag(restrictedKey, value)
 	if s.ot.shadowSpan != nil {
 		s.ot.shadowSpan.SetBaggageItem(restrictedKey, value)
 		s.ot.shadowSpan.SetTag(restrictedKey, value)
@@ -601,124 +372,7 @@ func (s *Span) SetBaggageItem(restrictedKey, value string) *Span {
 	return s
 }
 
-func (s *crdbSpan) SetBaggageItemAndTag(restrictedKey, value string) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.setBaggageItemLocked(restrictedKey, value)
-	// Don't set the tag if this is the special cased baggage item indicating
-	// span verbosity, as it is named nondescriptly and the recording knows
-	// how to display its verbosity independently.
-	if restrictedKey != verboseTracingBaggageKey {
-		s.setTagLocked(restrictedKey, value)
-	}
-}
-
-func (s *crdbSpan) setBaggageItemLocked(restrictedKey, value string) {
-	if oldVal, ok := s.mu.Baggage[restrictedKey]; ok && oldVal == value {
-		// No-op.
-		return
-	}
-	if s.mu.Baggage == nil {
-		s.mu.Baggage = make(map[string]string)
-	}
-	s.mu.Baggage[restrictedKey] = value
-}
-
-// Tracer is part of the opentracing.Span interface.
+// Tracer exports the tracer this span was created using.
 func (s *Span) Tracer() *Tracer {
 	return s.tracer
-}
-
-// getRecordingLocked returns the Span's recording. This does not include
-// children.
-func (s *crdbSpan) getRecordingLocked(m mode) tracingpb.RecordedSpan {
-	rs := tracingpb.RecordedSpan{
-		TraceID:      s.traceID,
-		SpanID:       s.spanID,
-		ParentSpanID: s.parentSpanID,
-		Operation:    s.operation,
-		StartTime:    s.startTime,
-		Duration:     s.mu.duration,
-	}
-
-	addTag := func(k, v string) {
-		if rs.Tags == nil {
-			rs.Tags = make(map[string]string)
-		}
-		rs.Tags[k] = v
-	}
-
-	// When nobody is configured to see our spans, skip some allocations
-	// related to Span UX improvements.
-	onlyBackgroundTracing := m == modeBackground && s.recordingType() == RecordingOff
-	if !onlyBackgroundTracing {
-		if rs.Duration == -1 {
-			// -1 indicates an unfinished Span. For a recording it's better to put some
-			// duration in it, otherwise tools get confused. For example, we export
-			// recordings to Jaeger, and spans with a zero duration don't look nice.
-			rs.Duration = timeutil.Now().Sub(rs.StartTime)
-			addTag("_unfinished", "1")
-		}
-		if s.mu.recording.recordingType.load() == RecordingVerbose {
-			addTag("_verbose", "1")
-		}
-	}
-
-	if s.mu.stats != nil {
-		stats, err := types.MarshalAny(s.mu.stats)
-		if err != nil {
-			panic(err)
-		}
-		rs.DeprecatedStats = stats
-	}
-
-	if s.mu.structured != nil {
-		rs.InternalStructured = make([]*types.Any, 0, len(s.mu.structured))
-		for i := range s.mu.structured {
-			item, err := types.MarshalAny(s.mu.structured[i])
-			if err != nil {
-				// An error here is an error from Marshal; these
-				// are unlikely to happen.
-				continue
-			}
-			rs.InternalStructured = append(rs.InternalStructured, item)
-		}
-	}
-
-	if len(s.mu.Baggage) > 0 {
-		rs.Baggage = make(map[string]string)
-		for k, v := range s.mu.Baggage {
-			rs.Baggage[k] = v
-		}
-	}
-	if !onlyBackgroundTracing && s.logTags != nil {
-		setLogTags(s.logTags.Get(), func(remappedKey string, tag *logtags.Tag) {
-			addTag(remappedKey, tag.ValueStr())
-		})
-	}
-	if len(s.mu.tags) > 0 {
-		for k, v := range s.mu.tags {
-			// We encode the tag values as strings.
-			addTag(k, fmt.Sprint(v))
-		}
-	}
-	rs.Logs = make([]tracingpb.LogRecord, len(s.mu.recording.recordedLogs))
-	for i, r := range s.mu.recording.recordedLogs {
-		rs.Logs[i].Time = r.Timestamp
-		rs.Logs[i].Fields = make([]tracingpb.LogRecord_Field, len(r.Fields))
-		for j, f := range r.Fields {
-			rs.Logs[i].Fields[j] = tracingpb.LogRecord_Field{
-				Key:   f.Key(),
-				Value: fmt.Sprint(f.Value()),
-			}
-		}
-	}
-
-	return rs
-}
-
-func (s *crdbSpan) addChild(child *crdbSpan) {
-	s.mu.Lock()
-	s.mu.recording.children = append(s.mu.recording.children, child)
-	s.mu.Unlock()
 }

--- a/pkg/util/tracing/span.go
+++ b/pkg/util/tracing/span.go
@@ -11,7 +11,6 @@
 package tracing
 
 import (
-	"bytes"
 	"fmt"
 	"sort"
 	"sync"
@@ -246,20 +245,20 @@ func (s *Span) IsVerbose() bool {
 	return s.crdb.recordingType() == RecordingVerbose
 }
 
-// SetVerbose toggles verbose recording on the Span, which must not be a noop span
-// (see the WithForceRealSpan option).
+// SetVerbose toggles verbose recording on the Span, which must not be a noop
+// span (see the WithForceRealSpan option).
 //
-// With 'true', future calls to LogFields and LogKV are recorded, and any future
-// descendants of this Span will do so automatically as well. This does not apply
-// to past derived Spans, which may in fact be noop spans.
+// With 'true', future calls to Record are actually recorded, and any future
+// descendants of this Span will do so automatically as well. This does not
+// apply to past derived Spans, which may in fact be noop spans.
 //
 // As a side effect, calls to `SetVerbose(true)` on a span that was not already
 // verbose will reset any past recording stored on this Span.
 //
-// When passed 'false', LogFields and LogKV will cede to add data to the recording
-// (though they may still be collected, should the Span have been set up with an
-// auxiliary trace sink). This does not apply to Spans derived from this one when
-// it was verbose.
+// When set to 'false', Record will cede to add data to the recording (though
+// they may still be collected, should the Span have been set up with an
+// auxiliary trace sink). This does not apply to Spans derived from this one
+// when it was verbose.
 func (s *Span) SetVerbose(to bool) {
 	// TODO(tbg): when always-on tracing is firmly established, we can remove the ugly
 	// caveat that SetVerbose(true) is a panic on a noop span because there will be no
@@ -534,45 +533,19 @@ func (s *Span) setTagInner(key string, value interface{}, locked bool) *Span {
 	return s
 }
 
-// LogFields is part of the opentracing.Span interface.
-func (s *Span) LogFields(fields ...otlog.Field) {
-	if !s.hasVerboseSink() {
-		return
-	}
-	if s.ot.shadowSpan != nil {
-		s.ot.shadowSpan.LogFields(fields...)
-	}
-	if s.netTr != nil {
-		// TODO(radu): when LightStep supports arbitrary fields, we should make
-		// the formatting of the message consistent with that. Until then we treat
-		// legacy events that just have an "event" key specially.
-		if len(fields) == 1 && fields[0].Key() == tracingpb.LogMessageField {
-			s.netTr.LazyPrintf("%s", fields[0].Value())
-		} else {
-			var buf bytes.Buffer
-			for i, f := range fields {
-				if i > 0 {
-					buf.WriteByte(' ')
-				}
-				fmt.Fprintf(&buf, "%s:%v", f.Key(), f.Value())
-			}
-
-			s.netTr.LazyPrintf("%s", buf.String())
-		}
-	}
-	s.crdb.LogFields(fields...)
-}
-
-func (s *crdbSpan) LogFields(fields ...otlog.Field) {
+func (s *crdbSpan) record(msg string) {
 	if s.recordingType() != RecordingVerbose {
 		return
 	}
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if len(s.mu.recording.recordedLogs) < maxLogsPerSpan {
 		s.mu.recording.recordedLogs = append(s.mu.recording.recordedLogs, opentracing.LogRecord{
 			Timestamp: time.Now(),
-			Fields:    fields,
+			Fields: []otlog.Field{
+				otlog.String(tracingpb.LogMessageField, msg),
+			},
 		})
 	}
 }
@@ -587,19 +560,6 @@ func (s *Span) hasVerboseSink() bool {
 	return true
 }
 
-// LogKV is part of the opentracing.Span interface.
-func (s *Span) LogKV(alternatingKeyValues ...interface{}) {
-	if !s.hasVerboseSink() {
-		return
-	}
-	fields, err := otlog.InterleavedKVToFields(alternatingKeyValues...)
-	if err != nil {
-		s.LogFields(otlog.Error(err), otlog.String("function", "LogKV"))
-		return
-	}
-	s.LogFields(fields...)
-}
-
 // LogStructured adds a Structured payload to the Span. It will be added to the
 // recording even if the Span is not verbose; however it will be discarded if
 // the underlying Span has been optimized out (i.e. is a noop span).
@@ -612,10 +572,18 @@ func (s *Span) LogStructured(item Structured) {
 	s.crdb.LogStructured(item)
 }
 
-func (s *crdbSpan) LogStructured(item Structured) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.mu.structured = append(s.mu.structured, item)
+// Record provides a way to put free-form text into verbose spans.
+func (s *Span) Record(msg string) {
+	if !s.hasVerboseSink() {
+		return
+	}
+	if s.ot.shadowSpan != nil {
+		s.ot.shadowSpan.LogFields(otlog.String(tracingpb.LogMessageField, msg))
+	}
+	if s.netTr != nil {
+		s.netTr.LazyPrintf("%s", msg)
+	}
+	s.crdb.record(msg)
 }
 
 // SetBaggageItem is part of the opentracing.Span interface.

--- a/pkg/util/tracing/tracer_test.go
+++ b/pkg/util/tracing/tracer_test.go
@@ -11,7 +11,6 @@
 package tracing
 
 import (
-	"fmt"
 	"sort"
 	"testing"
 
@@ -68,14 +67,14 @@ func TestTracerRecording(t *testing.T) {
 	}
 	noop3.Finish()
 
-	s1.Record(fmt.Sprintf("x=%d", 1))
+	s1.Recordf("x=%d", 1)
 	s1.SetVerbose(true)
-	s1.Record(fmt.Sprintf("x=%d", 2))
+	s1.Recordf("x=%d", 2)
 	s2 := tr.StartSpan("b", WithParentAndAutoCollection(s1))
 	if s2.IsBlackHole() {
 		t.Error("recording Span should not be black hole")
 	}
-	s2.Record(fmt.Sprintf("x=%d", 3))
+	s2.Recordf("x=%d", 3)
 
 	if err := TestingCheckRecordedSpans(s1.GetRecording(), `
 		Span a:
@@ -97,7 +96,7 @@ func TestTracerRecording(t *testing.T) {
 	}
 
 	s3 := tr.StartSpan("c", WithParentAndAutoCollection(s2))
-	s3.Record(fmt.Sprintf("x=%d", 4))
+	s3.Recordf("x=%d", 4)
 	s3.SetTag("tag", "val")
 
 	s2.Finish()
@@ -130,13 +129,13 @@ func TestTracerRecording(t *testing.T) {
 		t.Fatal(err)
 	}
 	s1.SetVerbose(false)
-	s1.Record(fmt.Sprintf("x=%d", 100))
+	s1.Recordf("x=%d", 100)
 	if err := TestingCheckRecordedSpans(s1.GetRecording(), ``); err != nil {
 		t.Fatal(err)
 	}
 
 	// The child Span is still recording.
-	s3.Record(fmt.Sprintf("x=%d", 5))
+	s3.Recordf("x=%d", 5)
 	if err := TestingCheckRecordedSpans(s3.GetRecording(), `
 		Span c:
 			tags: _verbose=1 tag=val
@@ -256,7 +255,7 @@ func TestTracerInjectExtract(t *testing.T) {
 	if trace1 != trace2 {
 		t.Errorf("traceID doesn't match: parent %d child %d", trace1, trace2)
 	}
-	s2.Record(fmt.Sprintf("x=%d", 1))
+	s2.Recordf("x=%d", 1)
 	s2.Finish()
 
 	// Verify that recording was started automatically.

--- a/pkg/util/tracing/tracer_test.go
+++ b/pkg/util/tracing/tracer_test.go
@@ -11,6 +11,7 @@
 package tracing
 
 import (
+	"fmt"
 	"sort"
 	"testing"
 
@@ -43,7 +44,7 @@ func TestTracerRecording(t *testing.T) {
 	if !noop1.isNoop() {
 		t.Error("expected noop Span")
 	}
-	noop1.LogKV("hello", "void")
+	noop1.Record("hello")
 
 	noop2 := tr.StartSpan("noop2", WithParentAndManualCollection(noop1.Meta()))
 	if !noop2.isNoop() {
@@ -67,22 +68,22 @@ func TestTracerRecording(t *testing.T) {
 	}
 	noop3.Finish()
 
-	s1.LogKV("x", 1)
+	s1.Record(fmt.Sprintf("x=%d", 1))
 	s1.SetVerbose(true)
-	s1.LogKV("x", 2)
+	s1.Record(fmt.Sprintf("x=%d", 2))
 	s2 := tr.StartSpan("b", WithParentAndAutoCollection(s1))
 	if s2.IsBlackHole() {
 		t.Error("recording Span should not be black hole")
 	}
-	s2.LogKV("x", 3)
+	s2.Record(fmt.Sprintf("x=%d", 3))
 
 	if err := TestingCheckRecordedSpans(s1.GetRecording(), `
 		Span a:
 			tags: _unfinished=1 _verbose=1
-			x: 2
+			event: x=2
 		Span b:
 			tags: _unfinished=1 _verbose=1
-			x: 3
+			event: x=3
 	`); err != nil {
 		t.Fatal(err)
 	}
@@ -90,13 +91,13 @@ func TestTracerRecording(t *testing.T) {
 	if err := TestingCheckRecordedSpans(s2.GetRecording(), `
 		Span b:
 			tags: _unfinished=1 _verbose=1
-			x: 3
+			event: x=3
 	`); err != nil {
 		t.Fatal(err)
 	}
 
 	s3 := tr.StartSpan("c", WithParentAndAutoCollection(s2))
-	s3.LogKV("x", 4)
+	s3.Record(fmt.Sprintf("x=%d", 4))
 	s3.SetTag("tag", "val")
 
 	s2.Finish()
@@ -104,13 +105,13 @@ func TestTracerRecording(t *testing.T) {
 	if err := TestingCheckRecordedSpans(s1.GetRecording(), `
 		Span a:
 			tags: _unfinished=1 _verbose=1
-			x: 2
+			event: x=2
 		Span b:
 			tags: _verbose=1
-			x: 3
+			event: x=3
 		Span c:
 			tags: _unfinished=1 _verbose=1 tag=val
-			x: 4
+			event: x=4
 	`); err != nil {
 		t.Fatal(err)
 	}
@@ -118,29 +119,29 @@ func TestTracerRecording(t *testing.T) {
 	if err := TestingCheckRecordedSpans(s1.GetRecording(), `
 		Span a:
       tags: _unfinished=1 _verbose=1
-			x: 2
+			event: x=2
 		Span b:
       tags: _verbose=1
-			x: 3
+			event: x=3
 		Span c:
 			tags: _verbose=1 tag=val
-			x: 4
+			event: x=4
 	`); err != nil {
 		t.Fatal(err)
 	}
 	s1.SetVerbose(false)
-	s1.LogKV("x", 100)
+	s1.Record(fmt.Sprintf("x=%d", 100))
 	if err := TestingCheckRecordedSpans(s1.GetRecording(), ``); err != nil {
 		t.Fatal(err)
 	}
 
 	// The child Span is still recording.
-	s3.LogKV("x", 5)
+	s3.Record(fmt.Sprintf("x=%d", 5))
 	if err := TestingCheckRecordedSpans(s3.GetRecording(), `
 		Span c:
 			tags: _verbose=1 tag=val
-			x: 4
-			x: 5
+			event: x=4
+			event: x=5
 	`); err != nil {
 		t.Fatal(err)
 	}
@@ -255,7 +256,7 @@ func TestTracerInjectExtract(t *testing.T) {
 	if trace1 != trace2 {
 		t.Errorf("traceID doesn't match: parent %d child %d", trace1, trace2)
 	}
-	s2.LogKV("x", 1)
+	s2.Record(fmt.Sprintf("x=%d", 1))
 	s2.Finish()
 
 	// Verify that recording was started automatically.
@@ -263,7 +264,7 @@ func TestTracerInjectExtract(t *testing.T) {
 	if err := TestingCheckRecordedSpans(rec, `
 		Span remote op:
 			tags: _verbose=1
-			x: 1
+			event: x=1
 	`); err != nil {
 		t.Fatal(err)
 	}
@@ -285,7 +286,7 @@ func TestTracerInjectExtract(t *testing.T) {
 			tags: _verbose=1
 		Span remote op:
 			tags: _verbose=1
-			x: 1
+			event: x=1
 	`); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
..to use the "recording" terminology instead, and simplify it to avoid
exposing opentracing symbols from this package. 

While here, we also pull out span types into their own files. There's too much
inter-mingling happening here which makes it a bit tedious to pull out the
various span types into their own packages. But separate files makes it a bit
easier to navigate, and can make do for now.

Release note: None
