### PR TITLE
release-20.2: sql: Fix privilege checks to consider direct/indirect roles

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1072,6 +1072,14 @@ func golangFillQueryArguments(args ...interface{}) (tree.Datums, error) {
 				switch {
 				case val.IsNil():
 					d = tree.DNull
+				case val.Type().Elem().Kind() == reflect.String:
+					a := tree.NewDArray(types.String)
+					for v := 0; v < val.Len(); v++ {
+						if err := a.Append(tree.NewDString(val.Index(v).String())); err != nil {
+							return nil, err
+						}
+					}
+					d = a
 				case val.Type().Elem().Kind() == reflect.Uint8:
 					d = tree.NewDBytes(tree.DBytes(val.Bytes()))
 				}

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -114,6 +114,13 @@ func (ep *DummyEvalPlanner) UnsafeDeleteNamespaceEntry(
 	return errors.WithStack(errEvalPlanner)
 }
 
+// MemberOfWithAdminOption is part of the EvalPlanner interface.
+func (ep *DummyEvalPlanner) MemberOfWithAdminOption(
+	ctx context.Context, member string,
+) (map[string]bool, error) {
+	return nil, errors.WithStack(errEvalPlanner)
+}
+
 var _ tree.EvalPlanner = &DummyEvalPlanner{}
 
 var errEvalPlanner = pgerror.New(pgcode.ScalarOperationCannotRunWithoutFullSessionContext,

--- a/pkg/sql/logictest/testdata/logic_test/privilege_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/privilege_builtins
@@ -1054,3 +1054,77 @@ query B
 SELECT has_column_privilege('hcp_test'::REGCLASS, 4, 'SELECT')
 ----
 true
+
+# Regression test for #58254. Tests privilege inheritance for roles (direct and indirect).
+
+user root
+
+statement ok
+DROP DATABASE IF EXISTS my_db;
+CREATE DATABASE my_db;
+
+statement ok
+CREATE ROLE my_role;
+
+statement ok
+GRANT CREATE ON DATABASE my_db TO my_role;
+GRANT my_role TO testuser;
+
+user testuser
+
+statement ok
+use my_db
+
+statement ok
+CREATE SCHEMA s;
+CREATE TABLE s.t()
+
+# Privilege check on direct member of role with CREATE privilege granted.
+query B
+SELECT has_schema_privilege('testuser', 's', 'create')
+----
+true
+
+# Privilege check on direct member of role without USAGE privilege granted.
+query B
+SELECT has_schema_privilege('testuser', 's', 'usage')
+----
+false
+
+# Confirm privilege checks on all objects.
+query BBB
+SELECT has_database_privilege('testuser', 'my_db', 'create'),
+       has_schema_privilege('testuser', 'public', 'usage'),
+       has_table_privilege('testuser', 's.t', 'select')
+----
+true false false
+
+user root
+
+statement ok
+use my_db;
+CREATE USER testuser2;
+GRANT testuser TO testuser2;
+GRANT ALL ON SCHEMA s TO testuser2
+
+user testuser2
+
+statement ok
+use my_db
+
+# Make sure testuser only has CREATE privilege on schema s but testuser2 has both CREATE and USAGE.
+query BBBB
+SELECT has_schema_privilege('testuser', 's', 'create'),
+       has_schema_privilege('testuser', 's', 'usage'),
+       has_schema_privilege('testuser2', 's', 'create'),
+       has_schema_privilege('testuser2', 's', 'usage')
+----
+true false true true
+
+# Confirm privilege checks on all objects with testuser2, should match testuser.
+query BBB
+SELECT has_database_privilege('testuser2', 'my_db', 'create'),
+       has_schema_privilege('testuser2', 'public', 'usage'),
+       has_table_privilege('testuser2', 's.t', 'select')
+----
+true false false

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3017,6 +3017,14 @@ type EvalPlanner interface {
 		descID int64,
 		force bool,
 	) error
+
+	// MemberOfWithAdminOption is used to collect a list of roles (direct and
+	// indirect) that the member is part of. See the comment on the planner
+	// implementation in authorization.go
+	MemberOfWithAdminOption(
+		ctx context.Context,
+		member string,
+	) (map[string]bool, error)
 }
 
 // EvalSessionAccessor is a limited interface to access session variables.


### PR DESCRIPTION
Backport 1/1 commits from #58254.

/cc @cockroachdb/release

---

Resolves #57621 

Previously, privilege inquiry functions  only looked for whether
the user passed in in the first argument or current user had
privileges on schemas, databases, tables, etc. with the built-ins
such as `has_schema_privileges`, which was incorrect. This change
makes sure that all roles the user is a direct or indirect member
of are checked for privileges as well.

Release note (bug fix): The has_${OBJECT}_privilege built-in methods
such as `has_schema_privilege` now additionally checks whether roles
the user is a direct or indirect member of also have privileges on
the object. Previously only one user was checked which was incorrect.
This bug has been present since version 2.0 but became more
prominent as of v20.2 when role-based access control was included in
CockroachDB Core.
