### PR TITLE
storage: use consistent iterators when needed, and when possible

### DIFF
--- a/pkg/kv/kvserver/replica_read.go
+++ b/pkg/kv/kvserver/replica_read.go
@@ -50,6 +50,11 @@ func (r *Replica) executeReadOnlyBatch(
 	// we're stuck with a ReadWriter because of the way evaluateBatch is
 	// designed.
 	rw := r.store.Engine().NewReadOnly()
+	if !rw.ConsistentIterators() {
+		// This is not currently needed for correctness, but future optimizations
+		// may start relying on this, so we assert here.
+		panic("expected consistent iterators")
+	}
 	if util.RaceEnabled {
 		rw = spanset.NewReadWriterAt(rw, spans, ba.Timestamp)
 	}

--- a/pkg/kv/kvserver/replica_write.go
+++ b/pkg/kv/kvserver/replica_write.go
@@ -669,6 +669,11 @@ func (r *Replica) evaluateWriteBatchWrapper(
 // Its recording should be attached to the Result of request evaluation.
 func (r *Replica) newBatchedEngine(spans *spanset.SpanSet) (storage.Batch, *storage.OpLoggerBatch) {
 	batch := r.store.Engine().NewBatch()
+	if !batch.ConsistentIterators() {
+		// This is not currently needed for correctness, but future optimizations
+		// may start relying on this, so we assert here.
+		panic("expected consistent iterators")
+	}
 	var opLogger *storage.OpLoggerBatch
 	if r.isSystemRange() || RangefeedEnabled.Get(&r.store.cfg.Settings.SV) {
 		// TODO(nvanbenschoten): once we get rid of the RangefeedEnabled

--- a/pkg/kv/kvserver/spanset/BUILD.bazel
+++ b/pkg/kv/kvserver/spanset/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//pkg/util/protoutil",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_pebble//:pebble",
     ],
 )
 

--- a/pkg/kv/kvserver/spanset/batch.go
+++ b/pkg/kv/kvserver/spanset/batch.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"github.com/cockroachdb/pebble"
 )
 
 // MVCCIterator wraps an storage.MVCCIterator and ensures that it can
@@ -322,6 +323,11 @@ func (i *EngineIterator) SetUpperBound(key roachpb.Key) {
 	i.i.SetUpperBound(key)
 }
 
+// GetRawIter is part of the storage.EngineIterator interface.
+func (i *EngineIterator) GetRawIter() *pebble.Iterator {
+	return i.i.GetRawIter()
+}
+
 type spanSetReader struct {
 	r     storage.Reader
 	spans *SpanSet
@@ -414,6 +420,10 @@ func (s spanSetReader) NewEngineIterator(opts storage.IterOptions) storage.Engin
 		i:     s.r.NewEngineIterator(opts),
 		spans: s.spans,
 	}
+}
+
+func (s spanSetReader) ConsistentIterators() bool {
+	return s.r.ConsistentIterators()
 }
 
 // GetDBEngine recursively searches for the underlying rocksDB engine.


### PR DESCRIPTION
For pebbleBatch and pebbleReadOnly, all iterators without timestamp
hints see the same underlying engine state, with no interface
change for the caller. This is done by cloning the first created
pebble.Iterator.

intentInterleavingIter explicitly requests a clone, when it creates
two iterators, which ensures the consistency guarantee applies to
all Reader implementations.

Informs #55461
Informs #41720

Release note: None