### PR TITLE
docs: fix link to community slack

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ regarding:
 as well as many other practical topics. 
 
 ## Don’t Forget to Join our Community
-Join our [Community Slack](https://cockroa.ch/slack) (there's a dedicated #contributors channel!) to ask questions, discuss your ideas, or connect with other contributors.
+Join our [Community Slack](https://go.crdb.dev/p/slack) (there's a dedicated #contributors channel!) to ask questions, discuss your ideas, or connect with other contributors.
 
 Please follow the guidelines outlined in our [Code of Conduct](https://docs.google.com/document/d/1_BB3IrsAVglDNPy37Z6KQlii_c3fYETFlWMMBUpbY1M/edit#) to help us make the CockroachDB community a welcoming and helpful place for everyone.
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ CockroachDB supports the PostgreSQL wire protocol, so you can use any available 
 
 ## Need Help?
 
-- [CockroachDB Community Slack](https://cockroa.ch/slack) - Join our slack to
+- [CockroachDB Community Slack](https://go.crdb.dev/p/slack) - Join our slack to
   connect with our engineers and other users running CockroachDB.
 - [CockroachDB Forum](https://forum.cockroachlabs.com/) and
   [Stack Overflow](https://stackoverflow.com/questions/tagged/cockroachdb) - Ask questions,
@@ -92,7 +92,7 @@ for more details.
 
 Engineering discussion takes place on our public mailing list,
 [cockroach-db@googlegroups.com](https://groups.google.com/forum/#!forum/cockroach-db),
-and feel free to join our [Community Slack](https://cockroa.ch/slack) (there's
+and feel free to join our [Community Slack](https://go.crdb.dev/p/slack) (there's
 a dedicated #contributors channel!) to ask questions, discuss your ideas, or
 connect with other contributors.
 


### PR DESCRIPTION
Move from a bit.ly link that can't be changed to an internal link
shortener that we actually control.

The new link is here: https://go.crdb.dev/p/slack

Release note: None