### PR TITLE
sql: set running status for GC jobs

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -78,8 +78,8 @@ WHERE job_type = 'SCHEMA CHANGE' OR job_type = 'SCHEMA CHANGE GC'
 ORDER BY created DESC
 LIMIT 2
 ----
-SCHEMA CHANGE GC  GC for ROLLBACK of ALTER TABLE test.public.t ADD CONSTRAINT bar UNIQUE (c)  root  running   NULL  0.00
-SCHEMA CHANGE     ALTER TABLE test.public.t ADD CONSTRAINT bar UNIQUE (c)                     root  failed    NULL  0.00
+SCHEMA CHANGE GC  GC for ROLLBACK of ALTER TABLE test.public.t ADD CONSTRAINT bar UNIQUE (c)  root  running  waiting for GC TTL  0.00
+SCHEMA CHANGE     ALTER TABLE test.public.t ADD CONSTRAINT bar UNIQUE (c)                     root  failed   NULL                0.00
 
 query IIII colnames,rowsort
 SELECT * FROM t
@@ -199,8 +199,8 @@ WHERE job_type = 'SCHEMA CHANGE' OR job_type = 'SCHEMA CHANGE GC'
 ORDER BY created DESC
 LIMIT 2
 ----
-SCHEMA CHANGE GC  GC for DROP INDEX test.public.t@foo CASCADE  root  running    NULL  0  ·
-SCHEMA CHANGE     DROP INDEX test.public.t@foo CASCADE         root  succeeded  NULL  1  ·
+SCHEMA CHANGE GC  GC for DROP INDEX test.public.t@foo CASCADE  root  running    waiting for GC TTL  0  ·
+SCHEMA CHANGE     DROP INDEX test.public.t@foo CASCADE         root  succeeded  NULL                1  ·
 
 query TTBITTBB colnames
 SHOW INDEXES FROM t
@@ -281,8 +281,8 @@ WHERE job_type = 'SCHEMA CHANGE' OR job_type = 'SCHEMA CHANGE GC'
 ORDER BY created DESC
 LIMIT 2
 ----
-SCHEMA CHANGE GC  GC for DROP INDEX test.public.t@t_f_idx   root  running    NULL  0  ·
-SCHEMA CHANGE     DROP INDEX test.public.t@t_f_idx          root  succeeded  NULL  1  ·
+SCHEMA CHANGE GC  GC for DROP INDEX test.public.t@t_f_idx  root  running    waiting for GC TTL  0  ·
+SCHEMA CHANGE     DROP INDEX test.public.t@t_f_idx         root  succeeded  NULL                1  ·
 
 statement ok
 ALTER TABLE t DROP COLUMN f

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -1854,6 +1854,7 @@ func CreateGCJobRecord(
 		DescriptorIDs: descriptorIDs,
 		Details:       details,
 		Progress:      jobspb.SchemaChangeGCProgress{},
+		RunningStatus: RunningStatusWaitingGC,
 		NonCancelable: true,
 	}
 }


### PR DESCRIPTION
Previously GC jobs didn't populate their RunningStatus leaving users no
way to tell whether a job is waiting on the timer or actually doing
garbage collection. This change addresses this.

Fixes #57826.

Release note (sql change): GC jobs now populate the running_status
column for SHOW JOBS.