### PR TITLE
ui: sessions page copy changes

### DIFF
--- a/pkg/ui/src/views/sessions/sessionsTableContent.tsx
+++ b/pkg/ui/src/views/sessions/sessionsTableContent.tsx
@@ -64,12 +64,12 @@ export const SessionTableTitle = {
       title={
         <div className={cx("tooltip__table--title")}>
           <p>
-            {"The age of the session."}
+            {"The duration of the session."}
           </p>
         </div>
       }
     >
-      Session Age
+      Session Duration
     </Tooltip>
   ),
   txnAge: (
@@ -78,12 +78,12 @@ export const SessionTableTitle = {
       title={
         <div className={cx("tooltip__table--title")}>
           <p>
-            {"The age of the open transaction, if there is one."}
+            {"The duration of the open transaction, if there is one."}
           </p>
         </div>
       }
     >
-      Txn Age
+      Transaction Duration
     </Tooltip>
   ),
   statementAge: (
@@ -92,12 +92,12 @@ export const SessionTableTitle = {
       title={
         <div className={cx("tooltip__table--title")}>
           <p>
-            {"The age of the active statement, if there is one."}
+            {"The duration of the active statement, if there is one."}
           </p>
         </div>
       }
     >
-      Statement Age
+      Statement Duration
     </Tooltip>
   ),
   memUsage: (


### PR DESCRIPTION
This change updates the sessions page to use
'duration' instead of 'age' and 'transaction'
instead of 'txn'. This aims to make the meaning
of these fields less ambiguous.

Release note (ui change): On the sessions page in db console, any 'age'
label has been replaced with 'duration' and 'txn' has been replaced with
'transaction'. This was only a label change, with the actual metrics
remaining unchanged.

Relates to https://github.com/cockroachdb/cockroach/issues/57047.