### PR TITLE
sql: add qualification prefix for user-defined schema names

### DIFF
--- a/pkg/sql/create_schema.go
+++ b/pkg/sql/create_schema.go
@@ -167,12 +167,16 @@ func (p *planner) createUserDefinedSchema(params runParams, n *tree.CreateSchema
 	); err != nil {
 		return err
 	}
+
+	qualifiedSchemaName, err := p.getQualifiedSchemaName(params.ctx, desc)
+	if err != nil {
+		return err
+	}
+
 	return params.p.logEvent(params.ctx,
 		desc.GetID(),
-		// TODO(knz): This is missing some details about the database.
-		// See: https://github.com/cockroachdb/cockroach/issues/57738
 		&eventpb.CreateSchema{
-			SchemaName: schemaName,
+			SchemaName: qualifiedSchemaName.String(),
 			Owner:      privs.Owner().Normalized(),
 		})
 }

--- a/pkg/sql/drop_schema.go
+++ b/pkg/sql/drop_schema.go
@@ -169,11 +169,16 @@ func (n *dropSchemaNode) startExec(params runParams) error {
 	// in the same transaction as table descriptor update.
 	for _, schemaToDelete := range n.d.schemasToDelete {
 		sc := schemaToDelete.schema
+		qualifiedSchemaName, err := p.getQualifiedSchemaName(params.ctx, sc.Desc)
+		if err != nil {
+			return err
+		}
+
 		if err := params.p.logEvent(params.ctx,
 			sc.ID,
-			// TODO(knz): This is missing some details about the database.
-			// See: https://github.com/cockroachdb/cockroach/issues/57738
-			&eventpb.DropSchema{SchemaName: sc.Name}); err != nil {
+			&eventpb.DropSchema{
+				SchemaName: qualifiedSchemaName.String(),
+			}); err != nil {
 			return err
 		}
 	}

--- a/pkg/sql/logictest/testdata/logic_test/event_log
+++ b/pkg/sql/logictest/testdata/logic_test/event_log
@@ -657,9 +657,9 @@ FROM system.eventlog
 WHERE "eventType" = 'create_schema'
 ORDER BY "timestamp", info
 ----
-1  {"EventType": "create_schema", "Owner": "root", "SchemaName": "sc", "Statement": "CREATE SCHEMA \"\".sc", "User": "root"}
-1  {"EventType": "create_schema", "Owner": "root", "SchemaName": "s", "Statement": "CREATE SCHEMA \"\".s", "User": "root"}
-1  {"EventType": "create_schema", "Owner": "u", "SchemaName": "u", "Statement": "CREATE SCHEMA AUTHORIZATION u", "User": "root"}
+1  {"EventType": "create_schema", "Owner": "root", "SchemaName": "test.sc", "Statement": "CREATE SCHEMA \"\".sc", "User": "root"}
+1  {"EventType": "create_schema", "Owner": "root", "SchemaName": "test.s", "Statement": "CREATE SCHEMA \"\".s", "User": "root"}
+1  {"EventType": "create_schema", "Owner": "u", "SchemaName": "test.u", "Statement": "CREATE SCHEMA AUTHORIZATION u", "User": "root"}
 
 statement ok
 ALTER SCHEMA u RENAME TO t
@@ -669,7 +669,7 @@ SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
 FROM system.eventlog
 WHERE "eventType" = 'rename_schema'
 ----
-1  {"EventType": "rename_schema", "NewSchemaName": "t", "SchemaName": "u", "Statement": "ALTER SCHEMA \"\".u RENAME TO t", "User": "root"}
+1  {"EventType": "rename_schema", "NewSchemaName": "test.t", "SchemaName": "test.u", "Statement": "ALTER SCHEMA \"\".u RENAME TO t", "User": "root"}
 
 statement ok
 DROP SCHEMA s, t
@@ -683,10 +683,10 @@ FROM system.eventlog
 WHERE "eventType" = 'drop_schema'
 ORDER BY "timestamp", info
 ----
-1  {"EventType": "drop_schema", "SchemaName": "eventlogtonewname", "Statement": "DROP SCHEMA \"\".eventlogtonewname", "User": "root"}
-1  {"EventType": "drop_schema", "SchemaName": "sc", "Statement": "DROP SCHEMA \"\".sc", "User": "root"}
-1  {"EventType": "drop_schema", "SchemaName": "s", "Statement": "DROP SCHEMA \"\".s, \"\".t", "User": "root"}
-1  {"EventType": "drop_schema", "SchemaName": "t", "Statement": "DROP SCHEMA \"\".s, \"\".t", "User": "root"}
+1  {"EventType": "drop_schema", "SchemaName": "test.eventlogtonewname", "Statement": "DROP SCHEMA \"\".eventlogtonewname", "User": "root"}
+1  {"EventType": "drop_schema", "SchemaName": "test.sc", "Statement": "DROP SCHEMA \"\".sc", "User": "root"}
+1  {"EventType": "drop_schema", "SchemaName": "test.s", "Statement": "DROP SCHEMA \"\".s, \"\".t", "User": "root"}
+1  {"EventType": "drop_schema", "SchemaName": "test.t", "Statement": "DROP SCHEMA \"\".s, \"\".t", "User": "root"}
 
 
 subtest eventlog_setting_disable
@@ -801,7 +801,7 @@ SELECT "reportingID", "eventType", info::JSONB - 'Timestamp' - 'DescriptorID'
 ORDER BY "timestamp", info
 ----
 1  alter_database_owner  {"DatabaseName": "atest", "EventType": "alter_database_owner", "Owner": "u", "Statement": "ALTER DATABASE atest OWNER TO u", "User": "root"}
-1  alter_schema_owner    {"EventType": "alter_schema_owner", "Owner": "u", "SchemaName": "sc", "Statement": "ALTER SCHEMA atest.sc OWNER TO u", "User": "root"}
+1  alter_schema_owner    {"EventType": "alter_schema_owner", "Owner": "u", "SchemaName": "atest.sc", "Statement": "ALTER SCHEMA atest.sc OWNER TO u", "User": "root"}
 1  alter_table_owner     {"EventType": "alter_table_owner", "Owner": "u", "Statement": "ALTER TABLE atest.sc.t OWNER TO u", "TableName": "atest.sc.t", "User": "root"}
 1  alter_type_owner      {"EventType": "alter_type_owner", "Owner": "u", "Statement": "ALTER TYPE atest.sc.ty OWNER TO u", "TypeName": "ty", "User": "root"}
 1  alter_type_owner      {"EventType": "alter_type_owner", "Owner": "u", "Statement": "ALTER TYPE atest.sc.ty OWNER TO u", "TypeName": "_ty", "User": "root"}
@@ -840,7 +840,7 @@ SELECT "reportingID", "eventType", info::JSONB - 'Timestamp' - 'DescriptorID'
 ORDER BY "timestamp", info
 ----
 1  alter_database_owner  {"DatabaseName": "atest", "EventType": "alter_database_owner", "Owner": "v", "Statement": "REASSIGN OWNED BY testuser TO v", "User": "root"}
-1  alter_schema_owner    {"EventType": "alter_schema_owner", "Owner": "v", "SchemaName": "sc", "Statement": "REASSIGN OWNED BY testuser TO v", "User": "root"}
+1  alter_schema_owner    {"EventType": "alter_schema_owner", "Owner": "v", "SchemaName": "atest.sc", "Statement": "REASSIGN OWNED BY testuser TO v", "User": "root"}
 1  alter_table_owner     {"EventType": "alter_table_owner", "Owner": "v", "Statement": "REASSIGN OWNED BY testuser TO v", "TableName": "atest.sc.t", "User": "root"}
 1  alter_table_owner     {"EventType": "alter_table_owner", "Owner": "v", "Statement": "REASSIGN OWNED BY testuser TO v", "TableName": "atest.sc.v", "User": "root"}
 1  alter_table_owner     {"EventType": "alter_table_owner", "Owner": "v", "Statement": "REASSIGN OWNED BY testuser TO v", "TableName": "atest.sc.s", "User": "root"}

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -423,6 +423,25 @@ func (p *planner) getQualifiedTableName(
 	return &tbName, nil
 }
 
+// getQualifiedSchemaName returns the database-qualified name of the
+// schema represented by the provided descriptor.
+func (p *planner) getQualifiedSchemaName(
+	ctx context.Context, desc catalog.SchemaDescriptor,
+) (*tree.ObjectNamePrefix, error) {
+	dbDesc, err := p.Descriptors().GetImmutableDatabaseByID(ctx, p.txn, desc.GetParentID(), tree.DatabaseLookupFlags{
+		Required: true,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &tree.ObjectNamePrefix{
+		CatalogName:     tree.Name(dbDesc.GetName()),
+		SchemaName:      tree.Name(desc.GetName()),
+		ExplicitCatalog: true,
+		ExplicitSchema:  true,
+	}, nil
+}
+
 // findTableContainingIndex returns the descriptor of a table
 // containing the index of the given name.
 // This is used by expandMutableIndexName().


### PR DESCRIPTION
Fixes https://github.com/cockroachdb/cockroach/issues/57738.

Previously, event logs were not capturing the qualified schema names
for create_schema, drop_schema, rename_schema and alter_schema_owner events.
This PR changes the event logs to use the qualified schema names.
Tests were also updated to reflect these changes.

Release note (bug fix): add qualification prefix for user-defined schema names.