### PR TITLE
roachtest: Enable encryption-at-rest in many storage-heavy non-bench tests

### DIFF
--- a/pkg/cmd/roachtest/backup.go
+++ b/pkg/cmd/roachtest/backup.go
@@ -37,6 +37,8 @@ const (
 func registerBackup(r *testRegistry) {
 	importBankData := func(ctx context.Context, rows int, t *test, c *cluster) string {
 		dest := c.name
+		// Randomize starting with encryption-at-rest enabled.
+		c.encryptAtRandom = true
 
 		if local {
 			rows = 100
@@ -205,6 +207,8 @@ func registerBackup(r *testRegistry) {
 		Cluster: makeClusterSpec(3),
 		Timeout: 1 * time.Hour,
 		Run: func(ctx context.Context, t *test, c *cluster) {
+			// Randomize starting with encryption-at-rest enabled.
+			c.encryptAtRandom = true
 			c.Put(ctx, cockroach, "./cockroach")
 			c.Put(ctx, workload, "./workload")
 			c.Start(ctx, t)

--- a/pkg/cmd/roachtest/import.go
+++ b/pkg/cmd/roachtest/import.go
@@ -22,6 +22,8 @@ import (
 
 func registerImportTPCC(r *testRegistry) {
 	runImportTPCC := func(ctx context.Context, t *test, c *cluster, warehouses int) {
+		// Randomize starting with encryption-at-rest enabled.
+		c.encryptAtRandom = true
 		c.Put(ctx, cockroach, "./cockroach")
 		c.Put(ctx, workload, "./workload")
 		t.Status("starting csv servers")
@@ -95,6 +97,8 @@ func registerImportTPCH(r *testRegistry) {
 			Cluster: makeClusterSpec(item.nodes),
 			Timeout: item.timeout,
 			Run: func(ctx context.Context, t *test, c *cluster) {
+				// Randomize starting with encryption-at-rest enabled.
+				c.encryptAtRandom = true
 				c.Put(ctx, cockroach, "./cockroach")
 				c.Start(ctx, t)
 				conn := c.Conn(ctx, 1)

--- a/pkg/cmd/roachtest/many_splits.go
+++ b/pkg/cmd/roachtest/many_splits.go
@@ -18,6 +18,8 @@ import (
 // runManySplits attempts to create 2000 tiny ranges on a 4-node cluster using
 // left-to-right splits and check the cluster is still live afterwards.
 func runManySplits(ctx context.Context, t *test, c *cluster) {
+	// Randomize starting with encryption-at-rest enabled.
+	c.encryptAtRandom = true
 	args := startArgs("--env=COCKROACH_SCAN_MAX_IDLE_TIME=5ms")
 	c.Put(ctx, cockroach, "./cockroach")
 	c.Start(ctx, t, args)

--- a/pkg/cmd/roachtest/restore.go
+++ b/pkg/cmd/roachtest/restore.go
@@ -223,6 +223,8 @@ func registerRestore(r *testRegistry) {
 			Cluster: makeClusterSpec(item.nodes),
 			Timeout: item.timeout,
 			Run: func(ctx context.Context, t *test, c *cluster) {
+				// Randomize starting with encryption-at-rest enabled.
+				c.encryptAtRandom = true
 				c.Put(ctx, cockroach, "./cockroach")
 				c.Start(ctx, t)
 				m := newMonitor(ctx, c)

--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -77,6 +77,8 @@ func tpccImportCmd(warehouses int, extraArgs ...string) string {
 func setupTPCC(
 	ctx context.Context, t *test, c *cluster, opts tpccOptions,
 ) (crdbNodes, workloadNode nodeListOption) {
+	// Randomize starting with encryption-at-rest enabled.
+	c.encryptAtRandom = true
 	crdbNodes = c.Range(1, c.spec.NodeCount-1)
 	workloadNode = c.Node(c.spec.NodeCount)
 	if c.isLocal() {
@@ -110,7 +112,7 @@ func setupTPCC(
 	func() {
 		db := c.Conn(ctx, 1)
 		defer db.Close()
-		c.Start(ctx, t, crdbNodes, startArgsDontEncrypt)
+		c.Start(ctx, t, crdbNodes)
 		waitForFullReplication(t, c.Conn(ctx, crdbNodes[0]))
 		switch opts.SetupType {
 		case usingImport:


### PR DESCRIPTION

Currently, encryption-at-rest is only used in roachtests that either have
`enc=true`, `encryption` or `encrypted` in their name. In addition, the other
roachtest to use encryption-at-rest is `clearrange/*`, and only on some random
runs.

This change updates many more roachtests to use encryption-at-rest on about
half of all runs (chosen by a random var):
 * `backup/2TB/*`
 * `acceptance/many-splits`
 * `import/tpc{c,h}/*`
 * `tpcc/*, tpcc-nowait/*, schemachange/*tpcc*, scrub/*tpcc*` (NOT tpccbench/*)
 * `restore2TB/*`

Fixes #57997.

Release note: None