### PR TITLE
release-20.2: demo: fix --global option

### DIFF
--- a/pkg/cli/interactive_tests/test_demo_global.tcl
+++ b/pkg/cli/interactive_tests/test_demo_global.tcl
@@ -2,10 +2,13 @@
 
 source [file join [file dirname $argv0] common.tcl]
 
+# Set a larger timeout since we are going global.
+set timeout 90
+
 start_test "Check --global flag runs as expected"
 
 # Start a demo with --global set
-spawn $argv demo movr --global
+spawn $argv demo movr --nodes 9 --global
 
 # Ensure db is movr.
 eexpect "movr>"


### PR DESCRIPTION
Backport 1/2 commits from #58466.

/cc @cockroachdb/release

---

The --global option broke somewhere during the 20.2 cycle. This patch
revives it. --global simulates geo-latencies between nodes. Best used
with `--global --geo-partitioned-replicas`.

Release note (cli change): fix cockroach demo --global from crashing
with "didn't get expected magic bytes header".
