### PR TITLE
storageccl: implement on-the-fly decrypting remote sst reader

### DIFF
--- a/pkg/ccl/storageccl/BUILD.bazel
+++ b/pkg/ccl/storageccl/BUILD.bazel
@@ -40,6 +40,8 @@ go_library(
         "//pkg/util/retry",
         "//pkg/util/tracing",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_pebble//sstable",
+        "@com_github_cockroachdb_pebble//vfs",
         "@org_golang_x_crypto//pbkdf2",
     ],
 )

--- a/pkg/ccl/storageccl/export.go
+++ b/pkg/ccl/storageccl/export.go
@@ -179,6 +179,7 @@ func evalExport(
 		}
 
 		if args.Encryption != nil {
+			// TODO(dt): cluster version gate use EncryptFileChunked.
 			data, err = EncryptFile(data, args.Encryption.Key)
 			if err != nil {
 				return result.Result{}, err


### PR DESCRIPTION
The chunked encrypted encoding means we can jump to arbitrary chunks and
start decrypting. This allows implementing ReadAt and thus a pebble SST
reader can be created that decrypts on the fly, as it reads.

Release note: none.