### PR TITLE
cli: de-flake test_demo_global.tcl

### DIFF
--- a/pkg/cli/interactive_tests/test_demo_global.tcl
+++ b/pkg/cli/interactive_tests/test_demo_global.tcl
@@ -1,7 +1,9 @@
 #! /usr/bin/env expect -f
 
-# This testcase is disabled until #56264 is resolved
 source [file join [file dirname $argv0] common.tcl]
+
+# Set a larger timeout since we are going global.
+set timeout 90
 
 start_test "Check --global flag runs as expected"
 


### PR DESCRIPTION
Oops, this should be 90s not 30s. Seemed to miss this accidentally on a
rebase on b8ae0ee562eb434390e69ea7459ce2400e828d0a.

Resolves #58634 

Release note: None