### PR TITLE
ui: statements page with altered base path (for demo purposes only)

### DIFF
--- a/pkg/ui/src/app.tsx
+++ b/pkg/ui/src/app.tsx
@@ -64,6 +64,7 @@ import SessionDetails from "src/views/sessions/sessionDetails";
 import TransactionsPage from "src/views/transactions/transactionsPage";
 import StatementsDiagnosticsHistoryView from "src/views/reports/containers/statementDiagnosticsHistory";
 import "styl/app.styl";
+import { ConnectedStatementsPage, BasePathContext } from "@cockroachlabs/admin-ui-components";
 
 // NOTE: If you are adding a new path to the router, and that path contains any
 // components that are personally identifying information, you MUST update the
@@ -137,6 +138,19 @@ export const App: React.FC<AppProps> = (props: AppProps) => {
                   <Route exact path={ `/statements/:${appAttr}`} component={ StatementsPage } />
                   <Route exact path={ `/statements/:${appAttr}/:${statementAttr}` } component={ StatementDetails } />
                   <Route exact path={ `/statements/:${appAttr}/:${implicitTxnAttr}/:${statementAttr}` } component={ StatementDetails } />
+
+                  {/* statement statistics with altered base path */}
+                  {/* Routes below replicate the same logic as `/statements` rotes above, but with arbitrary paths */}
+                  <Route path="/some/nested/path">
+                    <Switch>
+                      <BasePathContext.Provider value="/some/nested/path">
+                        <Route exact path="/some/nested/path/statements" component={ ConnectedStatementsPage }/>
+                        <Route exact path={ `/some/nested/path/statements/:${appAttr}`} component={ ConnectedStatementsPage } />
+                        <Route exact path={ `/some/nested/path/statements/:${appAttr}/:${statementAttr}` } component={ ConnectedStatementsPage } />
+                        <Route exact path={ `/some/nested/path/statements/:${appAttr}/:${implicitTxnAttr}/:${statementAttr}` } component={ ConnectedStatementsPage } />
+                      </BasePathContext.Provider>
+                    </Switch>
+                  </Route>
 
                   <Route exact path="/statement" component={() => <Redirect to="/statements" />}/>
                   <Route exact path={`/statement/:${statementAttr}`} component={StatementDetails}/>

--- a/pkg/ui/src/redux/state.ts
+++ b/pkg/ui/src/redux/state.ts
@@ -24,6 +24,7 @@ import { timeWindowReducer, TimeWindowState } from "./timewindow";
 import { uiDataReducer, UIDataState } from "./uiData";
 import { loginReducer, LoginAPIState } from "./login";
 import rootSaga from "./sagas";
+import { rootReducer, AppState, sagas as adminUiSagas } from "@cockroachlabs/admin-ui-components";
 
 export interface AdminUIState {
   cachedData: APIReducersState;
@@ -35,6 +36,7 @@ export interface AdminUIState {
   timewindow: TimeWindowState;
   uiData: UIDataState;
   login: LoginAPIState;
+  adminUI: AppState["adminUI"];
 }
 
 const history = createHashHistory();
@@ -57,6 +59,7 @@ export function createAdminUIStore(historyInst: History<any>) {
       timewindow: timeWindowReducer,
       uiData: uiDataReducer,
       login: loginReducer,
+      adminUI: rootReducer,
     }),
     compose(
       applyMiddleware(thunk, sagaMiddleware, routerMiddleware(historyInst)),
@@ -78,6 +81,7 @@ export function createAdminUIStore(historyInst: History<any>) {
   );
 
   sagaMiddleware.run(rootSaga);
+  sagaMiddleware.run(adminUiSagas);
   return s;
 }
 


### PR DESCRIPTION
This is an example of usage connected pages with arbitrary base paths.
`BasePathContext` context should provide base path for children components -
that's all changes required from client application to make internal routes
work properly.
