### PR TITLE
build: filter out debug logging for `bazel query`

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,4 @@
 # TODO(irfansharif): We should fold this into `dev` instead (#56965).
 
 build --ui_event_filters=-DEBUG
+query --ui_event_filters=-DEBUG


### PR DESCRIPTION
We already made this change for builds; this also filters out irrelevant
logging for `bazel query`.

Release note: None