### PR TITLE
ccl/backupccl: skip TestBackupRestoreAppend

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -477,6 +477,7 @@ func TestBackupRestorePartitioned(t *testing.T) {
 
 func TestBackupRestoreAppend(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 54599, "flaky test")
 	skip.UnderRace(t, "flaky test. Issues #50984, #54599")
 	defer log.Scope(t).Close(t)
 


### PR DESCRIPTION
Refs: #54599

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes

Release note: None