### PR TITLE
kv/kvserver: skip TestReplicateQueueUpReplicate

### DIFF
--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -166,6 +166,7 @@ func testReplicateQueueRebalanceInner(t *testing.T, atomic bool) {
 // allow a subsequent up-replication to an odd number.
 func TestReplicateQueueUpReplicate(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 57144, "flaky test")
 	defer log.Scope(t).Close(t)
 	const replicaCount = 3
 


### PR DESCRIPTION
Refs: #57144

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes

Release note: None