### PR TITLE
sql: fix span generation for system tables

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/system
+++ b/pkg/sql/logictest/testdata/logic_test/system
@@ -77,6 +77,17 @@ SELECT id FROM system.descriptor
 51
 52
 
+# Verify we can read ID on its own (see #58614).
+query I
+SELECT id FROM system.descriptor WHERE id=1
+----
+1
+
+query I
+SELECT id FROM (VALUES(1)) AS v(a) INNER LOOKUP JOIN system.descriptor on id=a
+----
+1
+
 # Verify we can read "protobuf" columns.
 query I
 SELECT length(descriptor) * (id - 1) FROM system.descriptor WHERE id = 1

--- a/pkg/sql/span/BUILD.bazel
+++ b/pkg/sql/span/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "span",
@@ -20,5 +20,17 @@ go_library(
         "//pkg/util",
         "//pkg/util/encoding",
         "@com_github_cockroachdb_errors//:errors",
+    ],
+)
+
+go_test(
+    name = "span_test",
+    srcs = ["span_builder_test.go"],
+    embed = [":span"],
+    deps = [
+        "//pkg/keys",
+        "//pkg/settings/cluster",
+        "//pkg/sql/catalog/systemschema",
+        "//pkg/sql/sem/tree",
     ],
 )

--- a/pkg/sql/span/span_builder.go
+++ b/pkg/sql/span/span_builder.go
@@ -193,7 +193,11 @@ func (s *Builder) CanSplitSpanIntoSeparateFamilies(
 	//   and it cannot be an inverted index.
 	// * We have all of the lookup columns of the index.
 	// * We don't need all of the families.
-	return s.index.Unique && len(s.table.Families) > 1 &&
+	// * The table is not a special system table. (System tables claim to have
+	//   column families, but actually do not, since they're written to with
+	//   raw KV puts in a "legacy" way.)
+	isSystemTable := s.table.ID > 0 && s.table.ID < keys.MaxReservedDescID
+	return !isSystemTable && s.index.Unique && len(s.table.Families) > 1 &&
 		(s.index.ID == s.table.GetPrimaryIndexID() ||
 			// Secondary index specific checks.
 			(s.index.Version >= descpb.SecondaryIndexFamilyFormatVersion &&

--- a/pkg/sql/span/span_builder_test.go
+++ b/pkg/sql/span/span_builder_test.go
@@ -1,0 +1,32 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package span
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+)
+
+func TestSpanBuilderDoesNotSplitSystemTableFamilySpans(t *testing.T) {
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
+	builder := MakeBuilder(&evalCtx, keys.SystemSQLCodec, systemschema.DescriptorTable,
+		&systemschema.DescriptorTable.PrimaryIndex)
+
+	if res := builder.CanSplitSpanIntoSeparateFamilies(
+		1, 1, false); res {
+		t.Errorf("expected the system table to not be splittable")
+	}
+}


### PR DESCRIPTION
Previously, queries that requested just the key columns of system tables
would perplexingly return incorrect results. This also manifests for
existence and anti-existence lookup joins against system tables.

Closes #58614.

This was because we were generating incorrect spans for these tables,
which have incorrect column family specifications for historical
reasons.

Now, this behavior is corrected.

Release note (bug fix): queries that attempt to retrieve just key
columns of a single system table row will no longer erroneously return 0
values.