### PR TITLE
release-20.2: backupccl: fix progress updating test

### DIFF
--- a/pkg/ccl/backupccl/backup_processor.go
+++ b/pkg/ccl/backupccl/backup_processor.go
@@ -18,13 +18,14 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowexec"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/storage/cloudimpl"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
-	hlc "github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
@@ -235,6 +236,13 @@ func runBackupProcessor(
 					return errors.Wrapf(pErr.GoError(), "exporting %s", span.span)
 				}
 				res := rawRes.(*roachpb.ExportResponse)
+
+				if backupKnobs, ok := flowCtx.TestingKnobs().BackupRestoreTestingKnobs.(*sql.BackupRestoreTestingKnobs); ok {
+					if backupKnobs.RunAfterExportingSpanEntry != nil {
+						backupKnobs.RunAfterExportingSpanEntry(ctx)
+					}
+				}
+
 				files := make([]BackupManifest_File, 0)
 				var prog execinfrapb.RemoteProducerMetadata_BulkProcessorProgress
 				progDetails := BackupManifest_Progress{}

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -1291,27 +1291,18 @@ func (ip inProgressState) latestJobID() (int64, error) {
 func checkInProgressBackupRestore(
 	t testing.TB, checkBackup inProgressChecker, checkRestore inProgressChecker,
 ) {
-	// To test incremental progress updates, we install a store response filter,
-	// which runs immediately before a KV command returns its response, in our
-	// test cluster. Whenever we see an Export or Import response, we do a
-	// blocking read on the allowResponse channel to give the test a chance to
-	// assert the progress of the job.
 	var allowResponse chan struct{}
 	params := base.TestClusterArgs{}
-	params.ServerArgs.Knobs.Store = &kvserver.StoreTestingKnobs{
-		TestingResponseFilter: func(ctx context.Context, ba roachpb.BatchRequest, br *roachpb.BatchResponse) *roachpb.Error {
-			for _, ru := range br.Responses {
-				switch ru.GetInner().(type) {
-				case *roachpb.ExportResponse, *roachpb.ImportResponse:
-					<-allowResponse
-				}
-			}
-			return nil
+	params.ServerArgs.Knobs.BackupRestore = &sql.BackupRestoreTestingKnobs{
+		RunAfterExportingSpanEntry: func(_ context.Context) {
+			<-allowResponse
+		},
+		RunAfterProcessingRestoreSpanEntry: func(_ context.Context) {
+			<-allowResponse
 		},
 	}
 
 	const numAccounts = 1000
-	const totalExpectedResponses = backupRestoreDefaultRanges
 
 	ctx, _, sqlDB, dir, cleanup := backupRestoreTestSetupWithParams(t, MultiNode, numAccounts, InitNone, params)
 	conn := sqlDB.DB.(*gosql.DB)
@@ -1319,9 +1310,55 @@ func checkInProgressBackupRestore(
 
 	sqlDB.Exec(t, `CREATE DATABASE restoredb`)
 
+	var totalExpectedBackupRequests int
+	// mergedRangeQuery calculates the number of spans we expect PartitionSpans to
+	// produce. It merges contiguous ranges on the same node.
+	// It sorts ranges by start_key and counts the number of times the
+	// lease_holder changes by comparing against the previous row's lease_holder.
+	mergedRangeQuery := `
+WITH
+	ranges
+		AS (
+			SELECT
+				start_key,
+				lag(lease_holder) OVER (ORDER BY start_key)
+					AS prev_lease_holder,
+				lease_holder
+			FROM
+				[SHOW RANGES FROM TABLE data.bank]
+		)
+SELECT
+	count(*)
+FROM
+	ranges
+WHERE
+	lease_holder != prev_lease_holder
+	OR prev_lease_holder IS NULL;
+`
+
+	sqlDB.QueryRow(t, mergedRangeQuery).Scan(&totalExpectedBackupRequests)
+
 	backupTableID := sqlutils.QueryTableID(t, conn, "data", "public", "bank")
 
 	do := func(query string, check inProgressChecker) {
+		t.Logf("checking query %q", query)
+
+		var totalExpectedResponses int
+		if strings.Contains(query, "BACKUP") {
+			// totalExpectedBackupRequests takes into account the merging that backup
+			// does of co-located ranges. It is the expected number of ExportRequests
+			// backup issues. DistSender will still split those requests to different
+			// ranges on the same node. Each range will write a file, so the number of
+			// SST files this backup will write is `backupRestoreDefaultRanges` .
+			totalExpectedResponses = totalExpectedBackupRequests
+		} else if strings.Contains(query, "RESTORE") {
+			// We expect restore to process each file in the backup individually.
+			// SST files are written per-range in the backup. So we expect the
+			// restore to process #(ranges) that made up the original table.
+			totalExpectedResponses = backupRestoreDefaultRanges
+		} else {
+			t.Fatal("expected query to be either a backup or restore")
+		}
 		jobDone := make(chan error)
 		allowResponse = make(chan struct{}, totalExpectedResponses)
 
@@ -1335,7 +1372,7 @@ func checkInProgressBackupRestore(
 			allowResponse <- struct{}{}
 		}
 
-		err := retry.ForDuration(testutils.DefaultSucceedsSoonDuration, func() error {
+		testutils.SucceedsSoon(t, func() error {
 			return check(ctx, inProgressState{
 				DB:            conn,
 				backupTableID: backupTableID,
@@ -1352,10 +1389,6 @@ func checkInProgressBackupRestore(
 		if err := <-jobDone; err != nil {
 			t.Fatalf("%q: %+v", query, err)
 		}
-
-		if err != nil {
-			t.Fatal(err)
-		}
 	}
 
 	do(`BACKUP DATABASE data TO $1`, checkBackup)
@@ -1366,8 +1399,6 @@ func TestBackupRestoreSystemJobsProgress(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	defer jobs.TestingSetProgressThresholds()()
-
-	skip.WithIssue(t, 58427, "flaky test")
 
 	checkFraction := func(ctx context.Context, ip inProgressState) error {
 		jobID, err := ip.latestJobID()

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -403,6 +403,9 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 	if cfg.TestingKnobs.JobsTestingKnobs != nil {
 		distSQLCfg.TestingKnobs.JobsTestingKnobs = cfg.TestingKnobs.JobsTestingKnobs
 	}
+	if cfg.TestingKnobs.BackupRestore != nil {
+		distSQLCfg.TestingKnobs.BackupRestoreTestingKnobs = cfg.TestingKnobs.BackupRestore
+	}
 	distSQLServer := distsql.NewServer(ctx, distSQLCfg)
 	execinfrapb.RegisterDistSQLServer(cfg.grpcServer, distSQLServer)
 

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -892,6 +892,14 @@ type BackupRestoreTestingKnobs struct {
 	// AllowImplicitAccess allows implicit access to data sources for non-admin
 	// users. This enables using nodelocal for testing BACKUP/RESTORE permissions.
 	AllowImplicitAccess bool
+
+	// RunAfterProcessingRestoreSpanEntry allows blocking the RESTORE job after a
+	// single RestoreSpanEntry has been processed and added to the SSTBatcher.
+	RunAfterProcessingRestoreSpanEntry func(ctx context.Context)
+
+	// RunAfterExportingSpanEntry allows blocking the BACKUP job after a single
+	// span has been exported.
+	RunAfterExportingSpanEntry func(ctx context.Context)
 }
 
 var _ base.ModuleTestingKnobs = &BackupRestoreTestingKnobs{}

--- a/pkg/sql/execinfra/server_config.go
+++ b/pkg/sql/execinfra/server_config.go
@@ -217,6 +217,9 @@ type TestingKnobs struct {
 
 	// JobsTestingKnobs is jobs infra specific testing knobs.
 	JobsTestingKnobs base.ModuleTestingKnobs
+
+	// BackupRestoreTestingKnobs are backup and restore specific testing knobs.
+	BackupRestoreTestingKnobs base.ModuleTestingKnobs
 }
 
 // MetadataTestLevel represents the types of queries where metadata test


### PR DESCRIPTION
Backport 1/1 commits from #58015.

/cc @cockroachdb/release

---

This test was previously flaky since it was assuming that backup would
issue the same number of requests as spans issued. This assumption was
incorrect, and fixing the progress accounting for backup revealed that
this test was faulty.

While planning the work distribution for backup worker nodes,
PartitionSpans automatically merges spans that are co-located on the
same node, therefore reducing the number of ExportRequests issued.
Before this commit, we used to block on the ExportRequest responses.
The blocking was triggered on a per-range-request level. However,
progress is only updated when the processor-level batch request is
returned. This meant that the test might block a batch request and
therefore the progress of the job would be less than what the test
expected.

This is now fixed by adjusting the blocking mechanism and range counting
to all be at the level of the merged ranges with which the backup
processor operates.

Fixes https://github.com/cockroachdb/cockroach/issues/58427.


Release note: none
