### PR TITLE
 cli: support `cockroach --version`, `cockroach version --build-tag`

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -11,6 +11,7 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"math/rand"
@@ -162,22 +163,34 @@ Output build version information.
 `,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		info := build.GetInfo()
-		tw := tabwriter.NewWriter(os.Stdout, 2, 1, 2, ' ', 0)
-		fmt.Fprintf(tw, "Build Tag:        %s\n", info.Tag)
-		fmt.Fprintf(tw, "Build Time:       %s\n", info.Time)
-		fmt.Fprintf(tw, "Distribution:     %s\n", info.Distribution)
-		fmt.Fprintf(tw, "Platform:         %s", info.Platform)
-		if info.CgoTargetTriple != "" {
-			fmt.Fprintf(tw, " (%s)", info.CgoTargetTriple)
+		if cliCtx.showVersionUsingOnlyBuildTag {
+			info := build.GetInfo()
+			fmt.Println(info.Tag)
+		} else {
+			fmt.Println(fullVersionString())
 		}
-		fmt.Fprintln(tw)
-		fmt.Fprintf(tw, "Go Version:       %s\n", info.GoVersion)
-		fmt.Fprintf(tw, "C Compiler:       %s\n", info.CgoCompiler)
-		fmt.Fprintf(tw, "Build Commit ID:  %s\n", info.Revision)
-		fmt.Fprintf(tw, "Build Type:       %s\n", info.Type)
-		return tw.Flush()
+		return nil
 	},
+}
+
+func fullVersionString() string {
+	info := build.GetInfo()
+	var buf bytes.Buffer
+	tw := tabwriter.NewWriter(&buf, 2, 1, 2, ' ', 0)
+	fmt.Fprintf(tw, "Build Tag:        %s\n", info.Tag)
+	fmt.Fprintf(tw, "Build Time:       %s\n", info.Time)
+	fmt.Fprintf(tw, "Distribution:     %s\n", info.Distribution)
+	fmt.Fprintf(tw, "Platform:         %s", info.Platform)
+	if info.CgoTargetTriple != "" {
+		fmt.Fprintf(tw, " (%s)", info.CgoTargetTriple)
+	}
+	fmt.Fprintln(tw)
+	fmt.Fprintf(tw, "Go Version:       %s\n", info.GoVersion)
+	fmt.Fprintf(tw, "C Compiler:       %s\n", info.CgoCompiler)
+	fmt.Fprintf(tw, "Build Commit ID:  %s\n", info.Revision)
+	fmt.Fprintf(tw, "Build Type:       %s", info.Type) // No final newline: cobra prints one for us.
+	_ = tw.Flush()
+	return buf.String()
 }
 
 var cockroachCmd = &cobra.Command{
@@ -196,6 +209,10 @@ var cockroachCmd = &cobra.Command{
 	// details and hints, which cobra does not do for us. Instead
 	// we do the printing in Main().
 	SilenceErrors: true,
+	// Version causes cobra to automatically support a --version flag
+	// that reports this string.
+	Version: "details:\n" + fullVersionString() +
+		"\n(use '" + os.Args[0] + " version --build-tag' to display only the build tag)",
 }
 
 var workloadCmd = workloadcli.WorkloadCmd(true /* userFacing */)

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -1432,10 +1432,14 @@ Flags:
       --log <string>         
                                      Logging configuration. See the documentation for details.
                                     
+      --version              version for cockroach
 
 Use "cockroach [command] --help" for more information about a command.
 `
-	helpExpected := fmt.Sprintf("CockroachDB command-line interface and server.\n\n%s", expUsage)
+	helpExpected := fmt.Sprintf("CockroachDB command-line interface and server.\n\n%s",
+		// Due to a bug in spf13/cobra, 'cockroach help' does not include the --version
+		// flag. Strangely, 'cockroach --help' does, as well as usage error messages.
+		strings.ReplaceAll(expUsage, "      --version              version for cockroach\n", ""))
 	badFlagExpected := fmt.Sprintf("%s\nError: unknown flag: --foo\n", expUsage)
 
 	testCases := []struct {

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -1308,4 +1308,12 @@ may need to be tweaked if the Postgres dump file has extremely long lines.
 If non-empty, create a SQL audit log in this directory.
 `,
 	}
+
+	BuildTag = FlagInfo{
+		Name: "build-tag",
+		Description: `
+When set, the command prints only the build tag for the executable,
+without any other details.
+`,
+	}
 )

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -180,6 +180,9 @@ type cliContext struct {
 	// that no log directory was specified and there were multiple
 	// on-disk stores.
 	ambiguousLogDir bool
+
+	// For `cockroach version --build-tag`.
+	showVersionUsingOnlyBuildTag bool
 }
 
 // cliCtx captures the command-line parameters common to most CLI utilities.
@@ -220,6 +223,7 @@ func setCliContextDefaults() {
 	cliCtx.ambiguousLogDir = false
 	// TODO(knz): Deprecated in v21.1. Remove this.
 	cliCtx.deprecatedLogOverrides.reset()
+	cliCtx.showVersionUsingOnlyBuildTag = false
 }
 
 // sqlCtx captures the configuration of the `sql` command.

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -783,6 +783,12 @@ func init() {
 		boolFlag(f, &sqlfmtCtx.align, cliflags.SQLFmtAlign)
 	}
 
+	// version command.
+	{
+		f := versionCmd.Flags()
+		boolFlag(f, &cliCtx.showVersionUsingOnlyBuildTag, cliflags.BuildTag)
+	}
+
 	// Debug commands.
 	{
 		f := debugKeysCmd.Flags()

--- a/pkg/cmd/roachprod/install/cockroach.go
+++ b/pkg/cmd/roachprod/install/cockroach.go
@@ -85,18 +85,35 @@ func getCockroachVersion(c *SyncedCluster, node int) (*version.Version, error) {
 	}
 	defer sess.Close()
 
+	var verString string
+
 	cmd := cockroachNodeBinary(c, node) + " version"
-	out, err := sess.CombinedOutput(cmd)
+	out, err := sess.CombinedOutput(cmd + " --build-tag")
 	if err != nil {
-		return nil, errors.Wrapf(err, "~ %s\n%s", cmd, out)
-	}
+		// The --build-tag may not be supported. Try without.
+		// Note: this way to extract the version number is brittle.
+		// It should be removed once 'roachprod' is not used
+		// to invoke pre-v20.2 binaries any more.
+		sess, err := c.newSession(node)
+		if err != nil {
+			return nil, err
+		}
+		defer sess.Close()
+		out, err = sess.CombinedOutput(cmd)
+		if err != nil {
+			return nil, errors.Wrapf(err, "~ %s\n%s", cmd, out)
+		}
 
-	matches := regexp.MustCompile(`(?m)^Build Tag:\s+(.*)$`).FindSubmatch(out)
-	if len(matches) != 2 {
-		return nil, fmt.Errorf("unable to parse cockroach version output:%s", out)
-	}
+		matches := regexp.MustCompile(`(?m)^Build Tag:\s+(.*)$`).FindSubmatch(out)
+		if len(matches) != 2 {
+			return nil, fmt.Errorf("unable to parse cockroach version output:%s", out)
+		}
 
-	return version.Parse(string(matches[1]))
+		verString = string(matches[1])
+	} else {
+		verString = strings.TrimSpace(string(out))
+	}
+	return version.Parse(verString)
 }
 
 // GetAdminUIPort returns the admin UI port for ths specified RPC port.

--- a/scripts/verify-release-binaries.sh
+++ b/scripts/verify-release-binaries.sh
@@ -40,6 +40,10 @@ function check_linux() {
   curl -s https://binaries.cockroachdb.com/cockroach-${BETA_TAG}${linux}.tgz | tar xz
   local tag=$($(dirname $0)/../build/builder.sh ./cockroach-${BETA_TAG}${linux}/cockroach version |
               grep 'Build Tag:' | awk '{print $NF}' | tr -d '\r')
+  if test -z "$tag"; then
+      # From v21.1 onwards.
+      tag=$($(dirname $0)/../build/builder.sh ./cockroach-${BETA_TAG}${linux}/cockroach version --build-tag | tr -d '\r')
+  fi
   rm -fr ./cockroach-${BETA_TAG}${linux}
   verify_tag "${tag}"
 
@@ -56,7 +60,11 @@ function check_darwin() {
 
   curl -s https://binaries.cockroachdb.com/cockroach-${BETA_TAG}${darwin}.tgz | tar xz
   local tag=$(./cockroach-${BETA_TAG}${darwin}/cockroach version |
-              grep 'Build Tag:' | awk '{print $NF}' | tr -d '\r')
+		  grep 'Build Tag:' | awk '{print $NF}' | tr -d '\r')
+  if test -z "$tag"; then
+      # From v21.1 onwards.
+      tag=$(./cockroach-${BETA_TAG}${darwin}/cockroach version | tr -d '\r')
+  fi
   rm -fr cockroach-${BETA_TAG}${darwin}
   verify_tag "${tag}"
 
@@ -69,6 +77,10 @@ function check_docker() {
   trap "rm -f docker.stderr" 0
   local tag=$(docker run --rm cockroachdb/cockroach:${BETA_TAG} version 2>docker.stderr |
               grep 'Build Tag:' | awk '{print $NF}' | tr -d '\r')
+  if test -z "$tag"; then
+      # From v21.1 onwards.
+      tag=$(docker run --rm cockroachdb/cockroach:${BETA_TAG} version --build-tag 2>docker.stderr | tr -d '\r')
+  fi
   if [ -z "${tag}" ]; then
       echo
       cat docker.stderr


### PR DESCRIPTION
Requested by the CC SRE team: we want a guaranteed machine-readable
way to extract the version of a crdb executable. `cockroach version`
did not provide this.

Release note (cli change): The `cockroach` command now
supports the command-line parameter `--version` which reports its
version parameters. This makes `cockroach --version` equivalent to
`cockroach version`.

Release note (ops change); The `cockroach version` command now
supports a new parameter `--build-tag`; when specified, it displays
the technical build tag, which makes it possible to integrate
with automated deployment tools.

