### PR TITLE
roachtest: skip bank/cluster-recovery

### DIFF
--- a/pkg/cmd/roachtest/acceptance.go
+++ b/pkg/cmd/roachtest/acceptance.go
@@ -25,7 +25,10 @@ func registerAcceptance(r *testRegistry) {
 		timeout    time.Duration
 	}{
 		// Sorted. Please keep it that way.
-		{name: "bank/cluster-recovery", fn: runBankClusterRecovery},
+		{
+			name: "bank/cluster-recovery", fn: runBankClusterRecovery,
+			skip: "https://github.com/cockroachdb/cockroach/issues/57342",
+		},
 		{name: "bank/node-restart", fn: runBankNodeRestart},
 		{
 			name: "bank/zerosum-splits", fn: runBankNodeZeroSum,


### PR DESCRIPTION
Skips bank/cluster-recovery due to flakes.
See https://github.com/cockroachdb/cockroach/issues/57342.

Release note: none