### PR TITLE
vendor: Bump pebble to 48f55301c5c4197021b030979007fe2fecf17380

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -448,8 +448,8 @@ def go_deps():
         name = "com_github_cockroachdb_pebble",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/cockroachdb/pebble",
-        sum = "h1:7E8+895ZA2tkVvTTMbCNf2ejF47pFmo6wj0LSsvuGxM=",
-        version = "v0.0.0-20210105203824-97dabc1c2dca",
+        sum = "h1:B1/hB6T+hU0IbvuaHWqEwraZbUx1xwgsOXngIRf4lQs=",
+        version = "v0.0.0-20210108212919-48f55301c5c4",
     )
     go_repository(
         name = "com_github_cockroachdb_redact",
@@ -2988,8 +2988,8 @@ def go_deps():
         name = "org_golang_x_sys",
         build_file_proto_mode = "disable_global",
         importpath = "golang.org/x/sys",
-        sum = "h1:/dSxr6gT0FNI1MO5WLJo8mTmItROeOKTkDn+7OwWBos=",
-        version = "v0.0.0-20210105210732-16f7687f5001",
+        sum = "h1:wHn06sgWHMO1VsQ8F+KzDJx/JzqfsNLnc+oEi07qD7s=",
+        version = "v0.0.0-20210108172913-0df2131ae363",
     )
     go_repository(
         name = "org_golang_x_text",

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/cockroachdb/go-test-teamcity v0.0.0-20191211140407-cff980ad0a55
 	github.com/cockroachdb/gostdlib v1.13.0
 	github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f
-	github.com/cockroachdb/pebble v0.0.0-20210105203824-97dabc1c2dca
+	github.com/cockroachdb/pebble v0.0.0-20210108212919-48f55301c5c4
 	github.com/cockroachdb/redact v1.0.9
 	github.com/cockroachdb/returncheck v0.0.0-20200612231554-92cdbca611dd
 	github.com/cockroachdb/sentry-go v0.6.1-cockroachdb.2
@@ -153,7 +153,7 @@ require (
 	golang.org/x/oauth2 v0.0.0-20190115181402-5dab4167f31c
 	golang.org/x/perf v0.0.0-20180704124530-6e6d33e29852
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
-	golang.org/x/sys v0.0.0-20210105210732-16f7687f5001
+	golang.org/x/sys v0.0.0-20210108172913-0df2131ae363
 	golang.org/x/text v0.3.3
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
 	golang.org/x/tools v0.0.0-20210104081019-d8d6ddbec6ee

--- a/go.sum
+++ b/go.sum
@@ -163,8 +163,8 @@ github.com/cockroachdb/grpc-gateway v1.14.6-0.20200519165156-52697fc4a249 h1:pZu
 github.com/cockroachdb/grpc-gateway v1.14.6-0.20200519165156-52697fc4a249/go.mod h1:UJ0EZAp832vCd54Wev9N1BMKEyvcZ5+IM0AwDrnlkEc=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f h1:o/kfcElHqOiXqcou5a3rIlMc7oJbMQkeLk0VQJ7zgqY=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
-github.com/cockroachdb/pebble v0.0.0-20210105203824-97dabc1c2dca h1:7E8+895ZA2tkVvTTMbCNf2ejF47pFmo6wj0LSsvuGxM=
-github.com/cockroachdb/pebble v0.0.0-20210105203824-97dabc1c2dca/go.mod h1:9RB/z2OoNt2vP08nc73FlTVOUhwvgA2/nPSQfgSxq4g=
+github.com/cockroachdb/pebble v0.0.0-20210108212919-48f55301c5c4 h1:B1/hB6T+hU0IbvuaHWqEwraZbUx1xwgsOXngIRf4lQs=
+github.com/cockroachdb/pebble v0.0.0-20210108212919-48f55301c5c4/go.mod h1:9RB/z2OoNt2vP08nc73FlTVOUhwvgA2/nPSQfgSxq4g=
 github.com/cockroachdb/redact v1.0.8 h1:8QG/764wK+vmEYoOlfobpe12EQcS81ukx/a4hdVMxNw=
 github.com/cockroachdb/redact v1.0.8/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/redact v1.0.9 h1:sjlUvGorKMIVQfo+w2RqDi5eewCHn453C/vdIXMzjzI=
@@ -855,8 +855,8 @@ golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200519105757-fe76b779f299/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201009025420-dfb3f7c4e634/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210105210732-16f7687f5001 h1:/dSxr6gT0FNI1MO5WLJo8mTmItROeOKTkDn+7OwWBos=
-golang.org/x/sys v0.0.0-20210105210732-16f7687f5001/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210108172913-0df2131ae363 h1:wHn06sgWHMO1VsQ8F+KzDJx/JzqfsNLnc+oEi07qD7s=
+golang.org/x/sys v0.0.0-20210108172913-0df2131ae363/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=


### PR DESCRIPTION
Changes pulled in:

```
48f55301c5c4197021b030979007fe2fecf17380 db: Fix possible deadlock between Close and delete goroutines
9d5aeb08af3b2de412c2fba183d0a59a42ba0f8a *: Wait for deletion goroutines to finish in db.Close
06cbd4dddcb4ef63f204f7065907e8ad6e09cc0b metamorphic: reposition all batch iterators after mutation
d1f165776a26b5e2257ada44a7f3eaacb514a721 vfs: Add comment on vfs.File.Write about modifying input in-place
acc0391aab7877213fcbc51dded3336cfe804c15 sstable: sanity check read blockhandles are within file
```

Fixes #57759.

Release note: None.