### PR TITLE
server/debug: add LSM debug endpoint

### DIFF
--- a/pkg/server/debug/server.go
+++ b/pkg/server/debug/server.go
@@ -235,8 +235,14 @@ func (ds *Server) RegisterEngines(specs []base.StoreSpec, engines []storage.Engi
 			return err
 		}
 
-		dir := specs[i].Path
+		eng := engines[i]
 		ds.mux.HandleFunc(fmt.Sprintf("/debug/lsm/%d", id.StoreID),
+			func(w http.ResponseWriter, req *http.Request) {
+				_, _ = io.WriteString(w, eng.GetCompactionStats())
+			})
+
+		dir := specs[i].Path
+		ds.mux.HandleFunc(fmt.Sprintf("/debug/lsm-viz/%d", id.StoreID),
 			func(w http.ResponseWriter, req *http.Request) {
 				if err := analyzeLSM(dir, w); err != nil {
 					fmt.Fprintf(w, "error analyzing LSM at %s: %v", dir, err)

--- a/pkg/ui/src/views/reports/containers/debug/index.tsx
+++ b/pkg/ui/src/views/reports/containers/debug/index.tsx
@@ -159,6 +159,11 @@ export default function Debug() {
             url="#/reports/stores/1"
             note="#/reports/stores/[node_id]"
           />
+          <DebugTableLink
+            name="Store LSM details on this node"
+            url="/debug/lsm/1"
+            note="/debug/lsm/[store_id]"
+          />
         </DebugTableRow>
         <DebugTableRow title="Security">
           <DebugTableLink name="Certificates on this node" url="#/reports/certificates/local" />


### PR DESCRIPTION
There was an existing `/debug/lsm/<storeID>` endpoint that served a
LSM visualization of the most recent MANIFEST. That endpoint is a little
less general purpose and is undocumented, so I moved it to
`/debug/lsm-viz/<storeID>`. Open to alternative /debug paths or names.

Close #58658.

Release note: None