### PR TITLE
sql: avoid looking up empty-string object names

### DIFF
--- a/pkg/bench/ddl_analysis/system_bench_test.go
+++ b/pkg/bench/ddl_analysis/system_bench_test.go
@@ -14,26 +14,25 @@ import "testing"
 
 func BenchmarkSystemDatabaseQueries(b *testing.B) {
 	tests := []RoundTripBenchTestCase{
+		// This query performs 2 lookups: getting the descriptor ID by name, then
+		// fetching the system table descriptor.
+		{
+			name: "select system.users with schema name",
+			stmt: `SELECT username, "hashedPassword" FROM system.public.users WHERE username = 'root'`,
+		},
 		// This query performs 1 extra lookup since the executor first tries to
 		// lookup the name `current_db.system.users`.
 		{
 			name: "select system.users without schema name",
 			stmt: `SELECT username, "hashedPassword" FROM system.users WHERE username = 'root'`,
 		},
-		// This query performs 4 extra lookup since the executor tries to
-		// lookup the name `"".system.users`. Since the "" database doesn't exist,
-		// it also falls back to looking up that database name in the deprecated
-		// namespace table.
+		// This query performs 0 extra lookup since the name resolution logic does
+		// not try to resolve `"".system.users` and instead resolves
+		//`system.public.users` right away.
 		{
 			name:  "select system.users with empty database name",
 			setup: `SET sql_safe_updates = false; USE "";`,
 			stmt:  `SELECT username, "hashedPassword"  FROM system.users WHERE username = 'root'`,
-		},
-		// This query performs 2 lookups: getting the descriptor ID by name, then
-		// fetching the system table descriptor.
-		{
-			name: "select system.users with schema name",
-			stmt: `SELECT username, "hashedPassword" FROM system.public.users WHERE username = 'root'`,
 		},
 	}
 

--- a/pkg/bench/ddl_analysis/testdata/benchmark_expectations
+++ b/pkg/bench/ddl_analysis/testdata/benchmark_expectations
@@ -66,5 +66,5 @@ min	max	benchmark
 8	8	VirtualTableQueries/select_crdb_internal.invalid_objects_with_1_fk
 1	1	VirtualTableQueries/select_crdb_internal.tables_with_1_fk
 3	3	SystemDatabaseQueries/select_system.users_without_schema_name
-6	6	SystemDatabaseQueries/select_system.users_with_empty_database_name
+2	2	SystemDatabaseQueries/select_system.users_with_empty_database_name
 2	2	SystemDatabaseQueries/select_system.users_with_schema_name

--- a/pkg/sql/catalog/catalogkv/namespace.go
+++ b/pkg/sql/catalog/catalogkv/namespace.go
@@ -168,6 +168,11 @@ func LookupObjectID(
 	parentSchemaID descpb.ID,
 	name string,
 ) (bool, descpb.ID, error) {
+	// Avoid a network round-trip if we accidentally ended up here without a
+	// name to look up.
+	if name == "" {
+		return false, descpb.InvalidID, nil
+	}
 	var key catalogkeys.DescriptorKey
 	if parentID == keys.RootNamespaceID {
 		key = catalogkeys.NewDatabaseKey(name)

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -752,3 +752,55 @@ other_db       testuser  SELECT
 
 statement ok
 SET DATABASE = test
+
+# crdb_internal can be used with the anonymous database.
+# It should show information across all databases.
+subtest anonymous_database
+
+query TTT colnames
+SELECT * FROM "".crdb_internal.cluster_database_privileges ORDER BY 1,2,3
+----
+database_name  grantee   privilege_type
+defaultdb      admin     ALL
+defaultdb      root      ALL
+other_db       admin     ALL
+other_db       root      ALL
+other_db       testuser  DROP
+other_db       testuser  SELECT
+postgres       admin     ALL
+postgres       root      ALL
+system         admin     GRANT
+system         admin     SELECT
+system         root      GRANT
+system         root      SELECT
+test           admin     ALL
+test           root      ALL
+testdb         admin     ALL
+testdb         root      ALL
+
+statement ok
+SET DATABASE = "";
+
+query TTT colnames
+SELECT * FROM crdb_internal.cluster_database_privileges ORDER BY 1,2,3
+----
+database_name  grantee   privilege_type
+defaultdb      admin     ALL
+defaultdb      root      ALL
+other_db       admin     ALL
+other_db       root      ALL
+other_db       testuser  DROP
+other_db       testuser  SELECT
+postgres       admin     ALL
+postgres       root      ALL
+system         admin     GRANT
+system         admin     SELECT
+system         root      GRANT
+system         root      SELECT
+test           admin     ALL
+test           root      ALL
+testdb         admin     ALL
+testdb         root      ALL
+
+statement ok
+SET DATABASE = test

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -3373,3 +3373,47 @@ transaction_priority                                  normal
 transaction_read_only                                 off
 transaction_status                                    NoTxn
 vectorize_row_count_threshold                         0
+
+# information_schema can be used with the anonymous database.
+# It should show information across all databases.
+subtest anonymous_database
+
+statement ok
+CREATE TABLE t1(a INT PRIMARY KEY, b BOOLEAN);
+CREATE DATABASE other_db;
+SET DATABASE = other_db;
+CREATE TABLE t2(c STRING PRIMARY KEY, d DECIMAL);
+
+query TTTTI colnames
+SELECT table_catalog, table_schema, table_name, column_name, ordinal_position
+FROM "".information_schema.columns
+WHERE (table_catalog = 'test' OR table_catalog = 'other_db')
+AND table_schema = 'public'
+AND (table_name = 't1' OR table_name = 't2')
+ORDER BY 3,4
+----
+table_catalog  table_schema  table_name  column_name  ordinal_position
+test           public        t1          a            1
+test           public        t1          b            2
+other_db       public        t2          c            1
+other_db       public        t2          d            2
+
+statement ok
+SET DATABASE = "";
+
+query TTTTI colnames
+SELECT table_catalog, table_schema, table_name, column_name, ordinal_position
+FROM "".information_schema.columns
+WHERE (table_catalog = 'test' OR table_catalog = 'other_db')
+AND table_schema = 'public'
+AND (table_name = 't1' OR table_name = 't2')
+ORDER BY 3,4
+----
+table_catalog  table_schema  table_name  column_name  ordinal_position
+test           public        t1          a            1
+test           public        t1          b            2
+other_db       public        t2          c            1
+other_db       public        t2          d            2
+
+statement ok
+SET DATABASE = test

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2916,3 +2916,16 @@ JOIN pg_namespace n ON n.oid = c.relnamespace
 WHERE n.nspname = 'pg_catalog' AND (t.oid = 1042 OR t.oid = 1014)
 ----
 0
+
+# pg_catalog is explicitly disallowed for use with the anonymous database.
+query error cannot access virtual schema in anonymous database
+SELECT tablename FROM "".pg_catalog.pg_tables
+
+statement ok
+SET DATABASE = "";
+
+query error cannot access virtual schema in anonymous database
+SELECT tablename FROM pg_catalog.pg_tables
+
+statement ok
+SET DATABASE = test;

--- a/pkg/sql/logictest/testdata/logic_test/pg_extension
+++ b/pkg/sql/logictest/testdata/logic_test/pg_extension
@@ -41,3 +41,16 @@ SELECT * FROM spatial_ref_sys WHERE srid IN (3857, 4326) ORDER BY srid ASC
 ----
 3857  EPSG  3857  PROJCS["WGS 84 / Pseudo-Mercator",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],PROJECTION["Mercator_1SP"],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["X",EAST],AXIS["Y",NORTH],EXTENSION["PROJ4","+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs"],AUTHORITY["EPSG","3857"]]  +proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs
 4326  EPSG  4326  GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]]                                                                                                                                                                                                                                                                                                                                                                                                                                      +proj=longlat +datum=WGS84 +no_defs
+
+# pg_extension is explicitly disallowed for use with the anonymous database.
+query error cannot access virtual schema in anonymous database
+SELECT f_table_name FROM "".pg_extension.geometry_columns
+
+statement ok
+SET DATABASE = "";
+
+query error cannot access virtual schema in anonymous database
+SELECT f_table_name FROM pg_extension.geometry_columns
+
+statement ok
+SET DATABASE = test;

--- a/pkg/sql/logictest/testdata/logic_test/system
+++ b/pkg/sql/logictest/testdata/logic_test/system
@@ -600,3 +600,18 @@ query TTB
 SELECT * from system.role_members
 ----
 admin  root  true
+
+statement ok
+SET DATABASE = "";
+
+query T
+SELECT username FROM system.users WHERE username = 'root'
+----
+root
+
+statement ok
+SET DATABASE = test
+
+# system is a database, not a schema.
+query error relation ".system.users" does not exist
+SELECT username FROM "".system.users WHERE username = 'root'

--- a/pkg/sql/sem/tree/name_resolution.go
+++ b/pkg/sql/sem/tree/name_resolution.go
@@ -308,19 +308,22 @@ func ResolveExisting(
 		// Two parts: D.T.
 		// Try to use the current database, and be satisfied if it's sufficient to find the object.
 		//
-		// Note: we test this even if curDb == "", because CockroachDB
-		// supports querying virtual schemas even when the current
-		// database is not set. For example, `select * from
-		// pg_catalog.pg_tables` is meant to show all tables across all
-		// databases when there is no current database set.
+		// Note: CockroachDB supports querying virtual schemas even when the current
+		// database is not set. For example, `select * from pg_catalog.pg_tables` is
+		// meant to show all tables across all databases when there is no current
+		// database set. Therefore, we test this even if curDb == "", as long as the
+		// schema name is for a virtual schema.
 
-		if found, objMeta, err := r.LookupObject(ctx, lookupFlags, curDb, scName, u.Object()); found || err != nil {
-			if err == nil {
-				namePrefix.CatalogName = Name(curDb)
-				namePrefix.SchemaName = Name(scName)
+		if _, isVirtualSchema := sessiondata.VirtualSchemaNames[scName]; isVirtualSchema || curDb != "" {
+			if found, objMeta, err := r.LookupObject(ctx, lookupFlags, curDb, scName, u.Object()); found || err != nil {
+				if err == nil {
+					namePrefix.CatalogName = Name(curDb)
+					namePrefix.SchemaName = Name(scName)
+				}
+				return found, namePrefix, objMeta, err
 			}
-			return found, namePrefix, objMeta, err
 		}
+
 		// No luck so far. Compatibility with CockroachDB v1.1: try D.public.T instead.
 		if found, objMeta, err := r.LookupObject(ctx, lookupFlags, u.Schema(), PublicSchema, u.Object()); found || err != nil {
 			if err == nil {

--- a/pkg/sql/sem/tree/name_resolution_test.go
+++ b/pkg/sql/sem/tree/name_resolution_test.go
@@ -529,6 +529,7 @@ func newFakeMetadata() *fakeMetadata {
 				{"public", []tree.Name{"foo", "bar"}},
 				{"pg_temp_123", []tree.Name{"foo", "baz"}},
 			}},
+			{"system", []knownSchema{{"public", []tree.Name{"users"}}}},
 		},
 	}
 }
@@ -624,6 +625,9 @@ func TestResolveTablePatternOrName(t *testing.T) {
 		{`kv`, ``, mpath("public", "pg_catalog"), true, ``, ``, ``, `prefix or object not found`},
 		{`pg_tables`, ``, mpath("public", "pg_catalog"), true, `pg_tables`, `"".pg_catalog.pg_tables`, `.pg_catalog[0]`, ``},
 		{`pg_tables`, ``, mpath(), true, `pg_tables`, `"".pg_catalog.pg_tables`, `.pg_catalog[0]`, ``},
+		{`system.users`, ``, mpath(), true, `system.public.users`, `system.public.users`, `system.public[0]`, ``},
+		{`"".system.users`, ``, mpath(), true, ``, ``, ``, `prefix or object not found`},
+		{`"".system.users`, ``, mpath(), false, ``, ``, ``, `prefix or object not found`},
 
 		{`blix`, ``, mpath("public"), false, ``, ``, ``, `prefix or object not found`},
 		{`blix`, ``, mpath("public", "pg_catalog"), false, `blix`, `"".pg_catalog.blix`, `.pg_catalog`, ``},

--- a/pkg/sql/sessiondata/search_path.go
+++ b/pkg/sql/sessiondata/search_path.go
@@ -44,6 +44,14 @@ const PgTempSchemaName = "pg_temp"
 // when installing an extension, but must be stored as a separate schema in CRDB.
 const PgExtensionSchemaName = "pg_extension"
 
+// VirtualSchemaNames is a set of all virtual schema names.
+var VirtualSchemaNames = map[string]struct{}{
+	PgCatalogName:          {},
+	InformationSchemaName:  {},
+	CRDBInternalSchemaName: {},
+	PgExtensionSchemaName:  {},
+}
+
 // DefaultSearchPath is the search path used by virgin sessions.
 var DefaultSearchPath = MakeSearchPath(
 	[]string{UserSchemaName, PublicSchemaName},


### PR DESCRIPTION
### sql: fix name resolution to avoid empty-name db lookups

The internal executor has a current DB of "", and it also executes
against queries against system tables using names like `system.users`.
The name resolution logic turned this into a lookup of "".system.users,
which was not desired.

Now we explicitly only allow the "" DB name if the schema name
corresponds to a virtual schema.

Release note: None

### sql/catalog: avoid KV lookup for "" name

Sometimes the current DB is "". Normally we wouldn't try to resolve this
name, but if there's a mistake in name resolution logic, this check is a
simple way to avoid a KV lookup when we don't need it.

Release note: None