### PR TITLE
cli: deflake test_demo_global.tcl (attempt #2)

### DIFF
--- a/pkg/cli/interactive_tests/test_demo_global.tcl
+++ b/pkg/cli/interactive_tests/test_demo_global.tcl
@@ -2,21 +2,16 @@
 
 source [file join [file dirname $argv0] common.tcl]
 
-# Set a larger timeout since we are going global.
+# Set a larger timeout since we are talking to every node with a delay.
 set timeout 90
 
 start_test "Check --global flag runs as expected"
 
 # Start a demo with --global set
-spawn $argv demo movr --nodes 9 --global
+spawn $argv demo --empty --nodes 9 --global
 
-# Ensure db is movr.
-eexpect "movr>"
-
-# Expect queries to work.
-send "SELECT count(*) FROM movr.rides;\r"
-eexpect "500"
-eexpect "movr>"
+# Ensure db is defaultdb.
+eexpect "defaultdb>"
 
 interrupt
 eexpect eof


### PR DESCRIPTION
Looks like the movr series can take a while to initialize on
TestDockerCLI, so starting an empty database instead. This would still
have caught the original regression.

Release note: None