### PR TITLE
acceptance: skip TestDockerCSharp

### DIFF
--- a/pkg/acceptance/adapter_test.go
+++ b/pkg/acceptance/adapter_test.go
@@ -39,6 +39,7 @@ func TestDockerC(t *testing.T) {
 }
 
 func TestDockerCSharp(t *testing.T) {
+	skip.WithIssue(t, 58218, "flaky test")
 	s := log.Scope(t)
 	defer s.Close(t)
 


### PR DESCRIPTION
Refs: #58218

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes

Release note: None