### PR TITLE
sql: add event logs for SET SCHEMA statements

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/event_log
+++ b/pkg/sql/logictest/testdata/logic_test/event_log
@@ -949,3 +949,35 @@ FROM system.eventlog
 WHERE "eventType" = 'comment_on_table'
 ----
 1  {"Comment": "This is a table.", "EventType": "comment_on_table", "Statement": "COMMENT ON TABLE defaultdb.public.a IS 'This is a table.'", "TableName": "defaultdb.public.a", "User": "root"}
+
+subtest set_schema
+
+statement ok
+ALTER TABLE a SET SCHEMA testing
+
+statement ok
+CREATE SEQUENCE s
+
+statement ok
+CREATE SCHEMA test_sc
+
+statement ok
+ALTER SEQUENCE s SET SCHEMA testing
+
+statement ok
+CREATE VIEW v AS SELECT 1
+
+statement ok
+ALTER VIEW v SET SCHEMA test_sc
+
+query IT
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
+FROM system.eventlog
+WHERE "eventType" = 'set_schema'
+ORDER BY "timestamp", info
+----
+1  {"DescriptorType": "type", "EventType": "set_schema", "NewSchemaName": "defaultdb.testing", "OldSchemaName": "public", "Statement": "ALTER TYPE defaultdb.public.eventlog SET SCHEMA testing", "User": "root"}
+1  {"DescriptorType": "type", "EventType": "set_schema", "NewSchemaName": "public", "OldSchemaName": "defaultdb.testing", "Statement": "ALTER TYPE defaultdb.testing.eventlog SET SCHEMA public", "User": "root"}
+1  {"DescriptorType": "table", "EventType": "set_schema", "NewSchemaName": "defaultdb.testing", "OldSchemaName": "public", "Statement": "ALTER TABLE a SET SCHEMA testing", "User": "root"}
+1  {"DescriptorType": "sequence", "EventType": "set_schema", "NewSchemaName": "defaultdb.testing", "OldSchemaName": "public", "Statement": "ALTER SEQUENCE s SET SCHEMA testing", "User": "root"}
+1  {"DescriptorType": "view", "EventType": "set_schema", "NewSchemaName": "defaultdb.test_sc", "OldSchemaName": "public", "Statement": "ALTER VIEW v SET SCHEMA test_sc", "User": "root"}

--- a/pkg/sql/set_schema.go
+++ b/pkg/sql/set_schema.go
@@ -16,12 +16,18 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
+	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
+)
+
+const (
+	tableKind    = "table"
+	viewKind     = "view"
+	sequenceKind = "sequence"
+	typeKind     = "type"
 )
 
 // prepareSetSchema verifies that a table/type can be set to the desired
@@ -30,8 +36,12 @@ func (p *planner) prepareSetSchema(
 	ctx context.Context, desc catalog.MutableDescriptor, schema string,
 ) (descpb.ID, error) {
 
+	var kind string
 	switch t := desc.(type) {
-	case *tabledesc.Mutable, *typedesc.Mutable:
+	case catalog.TableDescriptor:
+		kind = getKind(t)
+	case catalog.TypeDescriptor:
+		kind = typeKind
 	default:
 		return 0, pgerror.Newf(
 			pgcode.InvalidParameterValue,
@@ -43,6 +53,18 @@ func (p *planner) prepareSetSchema(
 
 	// Lookup the schema we want to set to.
 	_, res, err := p.ResolveUncachedSchemaDescriptor(ctx, databaseID, schema, true /* required */)
+	if err != nil {
+		return 0, err
+	}
+	newSchemaQualified, err := p.getQualifiedSchemaName(ctx, res)
+	if err != nil {
+		return 0, err
+	}
+	oldSchema, err := p.Descriptors().ResolveSchemaByID(ctx, p.Txn(), schemaID)
+	if err != nil {
+		return 0, err
+	}
+	oldSchemaQualified, err := p.getQualifiedSchemaName(ctx, oldSchema)
 	if err != nil {
 		return 0, err
 	}
@@ -85,5 +107,25 @@ func (p *planner) prepareSetSchema(
 		return 0, sqlerrors.MakeObjectAlreadyExistsError(collidingDesc.DescriptorProto(), desc.GetName())
 	}
 
-	return desiredSchemaID, nil
+	return desiredSchemaID, p.logEvent(ctx,
+		desiredSchemaID,
+		&eventpb.SetSchema{
+			CommonEventDetails:    eventpb.CommonEventDetails{},
+			CommonSQLEventDetails: eventpb.CommonSQLEventDetails{},
+			OldSchemaName:         oldSchemaQualified.String(),
+			NewSchemaName:         newSchemaQualified.String(),
+			DescriptorType:        kind,
+		},
+	)
+}
+
+// getKind returns a string representation of the table descriptor.
+func getKind(td catalog.TableDescriptor) string {
+	if td.IsTable() {
+		return tableKind
+	} else if td.IsView() {
+		return viewKind
+	} else {
+		return sequenceKind
+	}
 }

--- a/pkg/util/log/eventpb/ddl_events.pb.go
+++ b/pkg/util/log/eventpb/ddl_events.pb.go
@@ -32,7 +32,7 @@ func (m *CreateDatabase) Reset()         { *m = CreateDatabase{} }
 func (m *CreateDatabase) String() string { return proto.CompactTextString(m) }
 func (*CreateDatabase) ProtoMessage()    {}
 func (*CreateDatabase) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_29e9024d78ea4c87, []int{0}
+	return fileDescriptor_ddl_events_35532f60564d6d3a, []int{0}
 }
 func (m *CreateDatabase) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -71,7 +71,7 @@ func (m *DropDatabase) Reset()         { *m = DropDatabase{} }
 func (m *DropDatabase) String() string { return proto.CompactTextString(m) }
 func (*DropDatabase) ProtoMessage()    {}
 func (*DropDatabase) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_29e9024d78ea4c87, []int{1}
+	return fileDescriptor_ddl_events_35532f60564d6d3a, []int{1}
 }
 func (m *DropDatabase) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -110,7 +110,7 @@ func (m *RenameDatabase) Reset()         { *m = RenameDatabase{} }
 func (m *RenameDatabase) String() string { return proto.CompactTextString(m) }
 func (*RenameDatabase) ProtoMessage()    {}
 func (*RenameDatabase) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_29e9024d78ea4c87, []int{2}
+	return fileDescriptor_ddl_events_35532f60564d6d3a, []int{2}
 }
 func (m *RenameDatabase) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -149,7 +149,7 @@ func (m *ConvertToSchema) Reset()         { *m = ConvertToSchema{} }
 func (m *ConvertToSchema) String() string { return proto.CompactTextString(m) }
 func (*ConvertToSchema) ProtoMessage()    {}
 func (*ConvertToSchema) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_29e9024d78ea4c87, []int{3}
+	return fileDescriptor_ddl_events_35532f60564d6d3a, []int{3}
 }
 func (m *ConvertToSchema) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -188,7 +188,7 @@ func (m *CreateSchema) Reset()         { *m = CreateSchema{} }
 func (m *CreateSchema) String() string { return proto.CompactTextString(m) }
 func (*CreateSchema) ProtoMessage()    {}
 func (*CreateSchema) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_29e9024d78ea4c87, []int{4}
+	return fileDescriptor_ddl_events_35532f60564d6d3a, []int{4}
 }
 func (m *CreateSchema) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -225,7 +225,7 @@ func (m *DropSchema) Reset()         { *m = DropSchema{} }
 func (m *DropSchema) String() string { return proto.CompactTextString(m) }
 func (*DropSchema) ProtoMessage()    {}
 func (*DropSchema) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_29e9024d78ea4c87, []int{5}
+	return fileDescriptor_ddl_events_35532f60564d6d3a, []int{5}
 }
 func (m *DropSchema) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -264,7 +264,7 @@ func (m *RenameSchema) Reset()         { *m = RenameSchema{} }
 func (m *RenameSchema) String() string { return proto.CompactTextString(m) }
 func (*RenameSchema) ProtoMessage()    {}
 func (*RenameSchema) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_29e9024d78ea4c87, []int{6}
+	return fileDescriptor_ddl_events_35532f60564d6d3a, []int{6}
 }
 func (m *RenameSchema) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -289,6 +289,47 @@ func (m *RenameSchema) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_RenameSchema proto.InternalMessageInfo
 
+// SetSchema is recorded when a table, view, sequence or type's schema is changed.
+type SetSchema struct {
+	CommonEventDetails    `protobuf:"bytes,1,opt,name=common,proto3,embedded=common" json:""`
+	CommonSQLEventDetails `protobuf:"bytes,2,opt,name=sql,proto3,embedded=sql" json:""`
+	// The old name of the affected schema.
+	OldSchemaName string `protobuf:"bytes,3,opt,name=old_schema_name,json=oldSchemaName,proto3" json:",omitempty"`
+	// The new name of the affected schema.
+	NewSchemaName string `protobuf:"bytes,4,opt,name=new_schema_name,json=newSchemaName,proto3" json:",omitempty"`
+	// The descriptor type being changed (table, view, sequence, type).
+	DescriptorType string `protobuf:"bytes,5,opt,name=descriptor_type,json=descriptorType,proto3" json:",omitempty"`
+}
+
+func (m *SetSchema) Reset()         { *m = SetSchema{} }
+func (m *SetSchema) String() string { return proto.CompactTextString(m) }
+func (*SetSchema) ProtoMessage()    {}
+func (*SetSchema) Descriptor() ([]byte, []int) {
+	return fileDescriptor_ddl_events_35532f60564d6d3a, []int{7}
+}
+func (m *SetSchema) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *SetSchema) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	b = b[:cap(b)]
+	n, err := m.MarshalTo(b)
+	if err != nil {
+		return nil, err
+	}
+	return b[:n], nil
+}
+func (dst *SetSchema) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SetSchema.Merge(dst, src)
+}
+func (m *SetSchema) XXX_Size() int {
+	return m.Size()
+}
+func (m *SetSchema) XXX_DiscardUnknown() {
+	xxx_messageInfo_SetSchema.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_SetSchema proto.InternalMessageInfo
+
 // CreateTable is recorded when a table is created.
 type CreateTable struct {
 	CommonEventDetails    `protobuf:"bytes,1,opt,name=common,proto3,embedded=common" json:""`
@@ -303,7 +344,7 @@ func (m *CreateTable) Reset()         { *m = CreateTable{} }
 func (m *CreateTable) String() string { return proto.CompactTextString(m) }
 func (*CreateTable) ProtoMessage()    {}
 func (*CreateTable) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_29e9024d78ea4c87, []int{7}
+	return fileDescriptor_ddl_events_35532f60564d6d3a, []int{8}
 }
 func (m *CreateTable) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -342,7 +383,7 @@ func (m *DropTable) Reset()         { *m = DropTable{} }
 func (m *DropTable) String() string { return proto.CompactTextString(m) }
 func (*DropTable) ProtoMessage()    {}
 func (*DropTable) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_29e9024d78ea4c87, []int{8}
+	return fileDescriptor_ddl_events_35532f60564d6d3a, []int{9}
 }
 func (m *DropTable) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -381,7 +422,7 @@ func (m *RenameTable) Reset()         { *m = RenameTable{} }
 func (m *RenameTable) String() string { return proto.CompactTextString(m) }
 func (*RenameTable) ProtoMessage()    {}
 func (*RenameTable) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_29e9024d78ea4c87, []int{9}
+	return fileDescriptor_ddl_events_35532f60564d6d3a, []int{10}
 }
 func (m *RenameTable) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -418,7 +459,7 @@ func (m *TruncateTable) Reset()         { *m = TruncateTable{} }
 func (m *TruncateTable) String() string { return proto.CompactTextString(m) }
 func (*TruncateTable) ProtoMessage()    {}
 func (*TruncateTable) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_29e9024d78ea4c87, []int{10}
+	return fileDescriptor_ddl_events_35532f60564d6d3a, []int{11}
 }
 func (m *TruncateTable) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -459,7 +500,7 @@ func (m *AlterTable) Reset()         { *m = AlterTable{} }
 func (m *AlterTable) String() string { return proto.CompactTextString(m) }
 func (*AlterTable) ProtoMessage()    {}
 func (*AlterTable) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_29e9024d78ea4c87, []int{11}
+	return fileDescriptor_ddl_events_35532f60564d6d3a, []int{12}
 }
 func (m *AlterTable) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -502,7 +543,7 @@ func (m *CommentOnColumn) Reset()         { *m = CommentOnColumn{} }
 func (m *CommentOnColumn) String() string { return proto.CompactTextString(m) }
 func (*CommentOnColumn) ProtoMessage()    {}
 func (*CommentOnColumn) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_29e9024d78ea4c87, []int{12}
+	return fileDescriptor_ddl_events_35532f60564d6d3a, []int{13}
 }
 func (m *CommentOnColumn) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -543,7 +584,7 @@ func (m *CommentOnDatabase) Reset()         { *m = CommentOnDatabase{} }
 func (m *CommentOnDatabase) String() string { return proto.CompactTextString(m) }
 func (*CommentOnDatabase) ProtoMessage()    {}
 func (*CommentOnDatabase) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_29e9024d78ea4c87, []int{13}
+	return fileDescriptor_ddl_events_35532f60564d6d3a, []int{14}
 }
 func (m *CommentOnDatabase) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -584,7 +625,7 @@ func (m *CommentOnTable) Reset()         { *m = CommentOnTable{} }
 func (m *CommentOnTable) String() string { return proto.CompactTextString(m) }
 func (*CommentOnTable) ProtoMessage()    {}
 func (*CommentOnTable) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_29e9024d78ea4c87, []int{14}
+	return fileDescriptor_ddl_events_35532f60564d6d3a, []int{15}
 }
 func (m *CommentOnTable) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -627,7 +668,7 @@ func (m *CommentOnIndex) Reset()         { *m = CommentOnIndex{} }
 func (m *CommentOnIndex) String() string { return proto.CompactTextString(m) }
 func (*CommentOnIndex) ProtoMessage()    {}
 func (*CommentOnIndex) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_29e9024d78ea4c87, []int{15}
+	return fileDescriptor_ddl_events_35532f60564d6d3a, []int{16}
 }
 func (m *CommentOnIndex) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -668,7 +709,7 @@ func (m *CreateIndex) Reset()         { *m = CreateIndex{} }
 func (m *CreateIndex) String() string { return proto.CompactTextString(m) }
 func (*CreateIndex) ProtoMessage()    {}
 func (*CreateIndex) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_29e9024d78ea4c87, []int{16}
+	return fileDescriptor_ddl_events_35532f60564d6d3a, []int{17}
 }
 func (m *CreateIndex) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -711,7 +752,7 @@ func (m *DropIndex) Reset()         { *m = DropIndex{} }
 func (m *DropIndex) String() string { return proto.CompactTextString(m) }
 func (*DropIndex) ProtoMessage()    {}
 func (*DropIndex) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_29e9024d78ea4c87, []int{17}
+	return fileDescriptor_ddl_events_35532f60564d6d3a, []int{18}
 }
 func (m *DropIndex) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -752,7 +793,7 @@ func (m *AlterIndex) Reset()         { *m = AlterIndex{} }
 func (m *AlterIndex) String() string { return proto.CompactTextString(m) }
 func (*AlterIndex) ProtoMessage()    {}
 func (*AlterIndex) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_29e9024d78ea4c87, []int{18}
+	return fileDescriptor_ddl_events_35532f60564d6d3a, []int{19}
 }
 func (m *AlterIndex) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -793,7 +834,7 @@ func (m *CreateView) Reset()         { *m = CreateView{} }
 func (m *CreateView) String() string { return proto.CompactTextString(m) }
 func (*CreateView) ProtoMessage()    {}
 func (*CreateView) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_29e9024d78ea4c87, []int{19}
+	return fileDescriptor_ddl_events_35532f60564d6d3a, []int{20}
 }
 func (m *CreateView) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -832,7 +873,7 @@ func (m *DropView) Reset()         { *m = DropView{} }
 func (m *DropView) String() string { return proto.CompactTextString(m) }
 func (*DropView) ProtoMessage()    {}
 func (*DropView) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_29e9024d78ea4c87, []int{20}
+	return fileDescriptor_ddl_events_35532f60564d6d3a, []int{21}
 }
 func (m *DropView) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -871,7 +912,7 @@ func (m *CreateSequence) Reset()         { *m = CreateSequence{} }
 func (m *CreateSequence) String() string { return proto.CompactTextString(m) }
 func (*CreateSequence) ProtoMessage()    {}
 func (*CreateSequence) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_29e9024d78ea4c87, []int{21}
+	return fileDescriptor_ddl_events_35532f60564d6d3a, []int{22}
 }
 func (m *CreateSequence) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -908,7 +949,7 @@ func (m *DropSequence) Reset()         { *m = DropSequence{} }
 func (m *DropSequence) String() string { return proto.CompactTextString(m) }
 func (*DropSequence) ProtoMessage()    {}
 func (*DropSequence) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_29e9024d78ea4c87, []int{22}
+	return fileDescriptor_ddl_events_35532f60564d6d3a, []int{23}
 }
 func (m *DropSequence) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -945,7 +986,7 @@ func (m *AlterSequence) Reset()         { *m = AlterSequence{} }
 func (m *AlterSequence) String() string { return proto.CompactTextString(m) }
 func (*AlterSequence) ProtoMessage()    {}
 func (*AlterSequence) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_29e9024d78ea4c87, []int{23}
+	return fileDescriptor_ddl_events_35532f60564d6d3a, []int{24}
 }
 func (m *AlterSequence) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -993,7 +1034,7 @@ func (m *CommonSchemaChangeEventDetails) Reset()         { *m = CommonSchemaChan
 func (m *CommonSchemaChangeEventDetails) String() string { return proto.CompactTextString(m) }
 func (*CommonSchemaChangeEventDetails) ProtoMessage()    {}
 func (*CommonSchemaChangeEventDetails) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_29e9024d78ea4c87, []int{24}
+	return fileDescriptor_ddl_events_35532f60564d6d3a, []int{25}
 }
 func (m *CommonSchemaChangeEventDetails) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1034,7 +1075,7 @@ func (m *ReverseSchemaChange) Reset()         { *m = ReverseSchemaChange{} }
 func (m *ReverseSchemaChange) String() string { return proto.CompactTextString(m) }
 func (*ReverseSchemaChange) ProtoMessage()    {}
 func (*ReverseSchemaChange) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_29e9024d78ea4c87, []int{25}
+	return fileDescriptor_ddl_events_35532f60564d6d3a, []int{26}
 }
 func (m *ReverseSchemaChange) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1070,7 +1111,7 @@ func (m *FinishSchemaChange) Reset()         { *m = FinishSchemaChange{} }
 func (m *FinishSchemaChange) String() string { return proto.CompactTextString(m) }
 func (*FinishSchemaChange) ProtoMessage()    {}
 func (*FinishSchemaChange) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_29e9024d78ea4c87, []int{26}
+	return fileDescriptor_ddl_events_35532f60564d6d3a, []int{27}
 }
 func (m *FinishSchemaChange) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1106,7 +1147,7 @@ func (m *FinishSchemaChangeRollback) Reset()         { *m = FinishSchemaChangeRo
 func (m *FinishSchemaChangeRollback) String() string { return proto.CompactTextString(m) }
 func (*FinishSchemaChangeRollback) ProtoMessage()    {}
 func (*FinishSchemaChangeRollback) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_29e9024d78ea4c87, []int{27}
+	return fileDescriptor_ddl_events_35532f60564d6d3a, []int{28}
 }
 func (m *FinishSchemaChangeRollback) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1145,7 +1186,7 @@ func (m *CreateType) Reset()         { *m = CreateType{} }
 func (m *CreateType) String() string { return proto.CompactTextString(m) }
 func (*CreateType) ProtoMessage()    {}
 func (*CreateType) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_29e9024d78ea4c87, []int{28}
+	return fileDescriptor_ddl_events_35532f60564d6d3a, []int{29}
 }
 func (m *CreateType) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1182,7 +1223,7 @@ func (m *DropType) Reset()         { *m = DropType{} }
 func (m *DropType) String() string { return proto.CompactTextString(m) }
 func (*DropType) ProtoMessage()    {}
 func (*DropType) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_29e9024d78ea4c87, []int{29}
+	return fileDescriptor_ddl_events_35532f60564d6d3a, []int{30}
 }
 func (m *DropType) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1219,7 +1260,7 @@ func (m *AlterType) Reset()         { *m = AlterType{} }
 func (m *AlterType) String() string { return proto.CompactTextString(m) }
 func (*AlterType) ProtoMessage()    {}
 func (*AlterType) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_29e9024d78ea4c87, []int{30}
+	return fileDescriptor_ddl_events_35532f60564d6d3a, []int{31}
 }
 func (m *AlterType) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1258,7 +1299,7 @@ func (m *RenameType) Reset()         { *m = RenameType{} }
 func (m *RenameType) String() string { return proto.CompactTextString(m) }
 func (*RenameType) ProtoMessage()    {}
 func (*RenameType) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_29e9024d78ea4c87, []int{31}
+	return fileDescriptor_ddl_events_35532f60564d6d3a, []int{32}
 }
 func (m *RenameType) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1299,7 +1340,7 @@ func (m *CreateStatistics) Reset()         { *m = CreateStatistics{} }
 func (m *CreateStatistics) String() string { return proto.CompactTextString(m) }
 func (*CreateStatistics) ProtoMessage()    {}
 func (*CreateStatistics) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_29e9024d78ea4c87, []int{32}
+	return fileDescriptor_ddl_events_35532f60564d6d3a, []int{33}
 }
 func (m *CreateStatistics) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1339,7 +1380,7 @@ func (m *UnsafeUpsertDescriptor) Reset()         { *m = UnsafeUpsertDescriptor{}
 func (m *UnsafeUpsertDescriptor) String() string { return proto.CompactTextString(m) }
 func (*UnsafeUpsertDescriptor) ProtoMessage()    {}
 func (*UnsafeUpsertDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_29e9024d78ea4c87, []int{33}
+	return fileDescriptor_ddl_events_35532f60564d6d3a, []int{34}
 }
 func (m *UnsafeUpsertDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1383,7 +1424,7 @@ func (m *UnsafeDeleteDescriptor) Reset()         { *m = UnsafeDeleteDescriptor{}
 func (m *UnsafeDeleteDescriptor) String() string { return proto.CompactTextString(m) }
 func (*UnsafeDeleteDescriptor) ProtoMessage()    {}
 func (*UnsafeDeleteDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_29e9024d78ea4c87, []int{34}
+	return fileDescriptor_ddl_events_35532f60564d6d3a, []int{35}
 }
 func (m *UnsafeDeleteDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1429,7 +1470,7 @@ func (m *UnsafeUpsertNamespaceEntry) Reset()         { *m = UnsafeUpsertNamespac
 func (m *UnsafeUpsertNamespaceEntry) String() string { return proto.CompactTextString(m) }
 func (*UnsafeUpsertNamespaceEntry) ProtoMessage()    {}
 func (*UnsafeUpsertNamespaceEntry) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_29e9024d78ea4c87, []int{35}
+	return fileDescriptor_ddl_events_35532f60564d6d3a, []int{36}
 }
 func (m *UnsafeUpsertNamespaceEntry) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1473,7 +1514,7 @@ func (m *UnsafeDeleteNamespaceEntry) Reset()         { *m = UnsafeDeleteNamespac
 func (m *UnsafeDeleteNamespaceEntry) String() string { return proto.CompactTextString(m) }
 func (*UnsafeDeleteNamespaceEntry) ProtoMessage()    {}
 func (*UnsafeDeleteNamespaceEntry) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_29e9024d78ea4c87, []int{36}
+	return fileDescriptor_ddl_events_35532f60564d6d3a, []int{37}
 }
 func (m *UnsafeDeleteNamespaceEntry) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1506,6 +1547,7 @@ func init() {
 	proto.RegisterType((*CreateSchema)(nil), "cockroach.util.log.eventpb.CreateSchema")
 	proto.RegisterType((*DropSchema)(nil), "cockroach.util.log.eventpb.DropSchema")
 	proto.RegisterType((*RenameSchema)(nil), "cockroach.util.log.eventpb.RenameSchema")
+	proto.RegisterType((*SetSchema)(nil), "cockroach.util.log.eventpb.SetSchema")
 	proto.RegisterType((*CreateTable)(nil), "cockroach.util.log.eventpb.CreateTable")
 	proto.RegisterType((*DropTable)(nil), "cockroach.util.log.eventpb.DropTable")
 	proto.RegisterType((*RenameTable)(nil), "cockroach.util.log.eventpb.RenameTable")
@@ -1856,7 +1898,7 @@ func (m *RenameSchema) MarshalTo(dAtA []byte) (int, error) {
 	return i, nil
 }
 
-func (m *CreateTable) Marshal() (dAtA []byte, err error) {
+func (m *SetSchema) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
 	n, err := m.MarshalTo(dAtA)
@@ -1866,7 +1908,7 @@ func (m *CreateTable) Marshal() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *CreateTable) MarshalTo(dAtA []byte) (int, error) {
+func (m *SetSchema) MarshalTo(dAtA []byte) (int, error) {
 	var i int
 	_ = i
 	var l int
@@ -1887,6 +1929,58 @@ func (m *CreateTable) MarshalTo(dAtA []byte) (int, error) {
 		return 0, err
 	}
 	i += n16
+	if len(m.OldSchemaName) > 0 {
+		dAtA[i] = 0x1a
+		i++
+		i = encodeVarintDdlEvents(dAtA, i, uint64(len(m.OldSchemaName)))
+		i += copy(dAtA[i:], m.OldSchemaName)
+	}
+	if len(m.NewSchemaName) > 0 {
+		dAtA[i] = 0x22
+		i++
+		i = encodeVarintDdlEvents(dAtA, i, uint64(len(m.NewSchemaName)))
+		i += copy(dAtA[i:], m.NewSchemaName)
+	}
+	if len(m.DescriptorType) > 0 {
+		dAtA[i] = 0x2a
+		i++
+		i = encodeVarintDdlEvents(dAtA, i, uint64(len(m.DescriptorType)))
+		i += copy(dAtA[i:], m.DescriptorType)
+	}
+	return i, nil
+}
+
+func (m *CreateTable) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *CreateTable) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	dAtA[i] = 0xa
+	i++
+	i = encodeVarintDdlEvents(dAtA, i, uint64(m.CommonEventDetails.Size()))
+	n17, err := m.CommonEventDetails.MarshalTo(dAtA[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n17
+	dAtA[i] = 0x12
+	i++
+	i = encodeVarintDdlEvents(dAtA, i, uint64(m.CommonSQLEventDetails.Size()))
+	n18, err := m.CommonSQLEventDetails.MarshalTo(dAtA[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n18
 	if len(m.TableName) > 0 {
 		dAtA[i] = 0x1a
 		i++
@@ -1920,19 +2014,19 @@ func (m *DropTable) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintDdlEvents(dAtA, i, uint64(m.CommonEventDetails.Size()))
-	n17, err := m.CommonEventDetails.MarshalTo(dAtA[i:])
+	n19, err := m.CommonEventDetails.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n17
+	i += n19
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintDdlEvents(dAtA, i, uint64(m.CommonSQLEventDetails.Size()))
-	n18, err := m.CommonSQLEventDetails.MarshalTo(dAtA[i:])
+	n20, err := m.CommonSQLEventDetails.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n18
+	i += n20
 	if len(m.TableName) > 0 {
 		dAtA[i] = 0x1a
 		i++
@@ -1975,19 +2069,19 @@ func (m *RenameTable) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintDdlEvents(dAtA, i, uint64(m.CommonEventDetails.Size()))
-	n19, err := m.CommonEventDetails.MarshalTo(dAtA[i:])
+	n21, err := m.CommonEventDetails.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n19
+	i += n21
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintDdlEvents(dAtA, i, uint64(m.CommonSQLEventDetails.Size()))
-	n20, err := m.CommonSQLEventDetails.MarshalTo(dAtA[i:])
+	n22, err := m.CommonSQLEventDetails.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n20
+	i += n22
 	if len(m.TableName) > 0 {
 		dAtA[i] = 0x1a
 		i++
@@ -2021,19 +2115,19 @@ func (m *TruncateTable) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintDdlEvents(dAtA, i, uint64(m.CommonEventDetails.Size()))
-	n21, err := m.CommonEventDetails.MarshalTo(dAtA[i:])
+	n23, err := m.CommonEventDetails.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n21
+	i += n23
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintDdlEvents(dAtA, i, uint64(m.CommonSQLEventDetails.Size()))
-	n22, err := m.CommonSQLEventDetails.MarshalTo(dAtA[i:])
+	n24, err := m.CommonSQLEventDetails.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n22
+	i += n24
 	if len(m.TableName) > 0 {
 		dAtA[i] = 0x1a
 		i++
@@ -2061,19 +2155,19 @@ func (m *AlterTable) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintDdlEvents(dAtA, i, uint64(m.CommonEventDetails.Size()))
-	n23, err := m.CommonEventDetails.MarshalTo(dAtA[i:])
+	n25, err := m.CommonEventDetails.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n23
+	i += n25
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintDdlEvents(dAtA, i, uint64(m.CommonSQLEventDetails.Size()))
-	n24, err := m.CommonSQLEventDetails.MarshalTo(dAtA[i:])
+	n26, err := m.CommonSQLEventDetails.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n24
+	i += n26
 	if len(m.TableName) > 0 {
 		dAtA[i] = 0x1a
 		i++
@@ -2121,19 +2215,19 @@ func (m *CommentOnColumn) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintDdlEvents(dAtA, i, uint64(m.CommonEventDetails.Size()))
-	n25, err := m.CommonEventDetails.MarshalTo(dAtA[i:])
+	n27, err := m.CommonEventDetails.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n25
+	i += n27
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintDdlEvents(dAtA, i, uint64(m.CommonSQLEventDetails.Size()))
-	n26, err := m.CommonSQLEventDetails.MarshalTo(dAtA[i:])
+	n28, err := m.CommonSQLEventDetails.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n26
+	i += n28
 	if len(m.TableName) > 0 {
 		dAtA[i] = 0x1a
 		i++
@@ -2183,19 +2277,19 @@ func (m *CommentOnDatabase) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintDdlEvents(dAtA, i, uint64(m.CommonEventDetails.Size()))
-	n27, err := m.CommonEventDetails.MarshalTo(dAtA[i:])
+	n29, err := m.CommonEventDetails.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n27
+	i += n29
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintDdlEvents(dAtA, i, uint64(m.CommonSQLEventDetails.Size()))
-	n28, err := m.CommonSQLEventDetails.MarshalTo(dAtA[i:])
+	n30, err := m.CommonSQLEventDetails.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n28
+	i += n30
 	if len(m.DatabaseName) > 0 {
 		dAtA[i] = 0x1a
 		i++
@@ -2239,19 +2333,19 @@ func (m *CommentOnTable) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintDdlEvents(dAtA, i, uint64(m.CommonEventDetails.Size()))
-	n29, err := m.CommonEventDetails.MarshalTo(dAtA[i:])
+	n31, err := m.CommonEventDetails.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n29
+	i += n31
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintDdlEvents(dAtA, i, uint64(m.CommonSQLEventDetails.Size()))
-	n30, err := m.CommonSQLEventDetails.MarshalTo(dAtA[i:])
+	n32, err := m.CommonSQLEventDetails.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n30
+	i += n32
 	if len(m.TableName) > 0 {
 		dAtA[i] = 0x1a
 		i++
@@ -2295,19 +2389,19 @@ func (m *CommentOnIndex) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintDdlEvents(dAtA, i, uint64(m.CommonEventDetails.Size()))
-	n31, err := m.CommonEventDetails.MarshalTo(dAtA[i:])
+	n33, err := m.CommonEventDetails.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n31
+	i += n33
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintDdlEvents(dAtA, i, uint64(m.CommonSQLEventDetails.Size()))
-	n32, err := m.CommonSQLEventDetails.MarshalTo(dAtA[i:])
+	n34, err := m.CommonSQLEventDetails.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n32
+	i += n34
 	if len(m.TableName) > 0 {
 		dAtA[i] = 0x1a
 		i++
@@ -2357,19 +2451,19 @@ func (m *CreateIndex) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintDdlEvents(dAtA, i, uint64(m.CommonEventDetails.Size()))
-	n33, err := m.CommonEventDetails.MarshalTo(dAtA[i:])
+	n35, err := m.CommonEventDetails.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n33
+	i += n35
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintDdlEvents(dAtA, i, uint64(m.CommonSQLEventDetails.Size()))
-	n34, err := m.CommonSQLEventDetails.MarshalTo(dAtA[i:])
+	n36, err := m.CommonSQLEventDetails.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n34
+	i += n36
 	if len(m.TableName) > 0 {
 		dAtA[i] = 0x1a
 		i++
@@ -2408,19 +2502,19 @@ func (m *DropIndex) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintDdlEvents(dAtA, i, uint64(m.CommonEventDetails.Size()))
-	n35, err := m.CommonEventDetails.MarshalTo(dAtA[i:])
+	n37, err := m.CommonEventDetails.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n35
+	i += n37
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintDdlEvents(dAtA, i, uint64(m.CommonSQLEventDetails.Size()))
-	n36, err := m.CommonSQLEventDetails.MarshalTo(dAtA[i:])
+	n38, err := m.CommonSQLEventDetails.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n36
+	i += n38
 	if len(m.TableName) > 0 {
 		dAtA[i] = 0x1a
 		i++
@@ -2474,19 +2568,19 @@ func (m *AlterIndex) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintDdlEvents(dAtA, i, uint64(m.CommonEventDetails.Size()))
-	n37, err := m.CommonEventDetails.MarshalTo(dAtA[i:])
+	n39, err := m.CommonEventDetails.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n37
+	i += n39
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintDdlEvents(dAtA, i, uint64(m.CommonSQLEventDetails.Size()))
-	n38, err := m.CommonSQLEventDetails.MarshalTo(dAtA[i:])
+	n40, err := m.CommonSQLEventDetails.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n38
+	i += n40
 	if len(m.TableName) > 0 {
 		dAtA[i] = 0x1a
 		i++
@@ -2525,19 +2619,19 @@ func (m *CreateView) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintDdlEvents(dAtA, i, uint64(m.CommonEventDetails.Size()))
-	n39, err := m.CommonEventDetails.MarshalTo(dAtA[i:])
+	n41, err := m.CommonEventDetails.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n39
+	i += n41
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintDdlEvents(dAtA, i, uint64(m.CommonSQLEventDetails.Size()))
-	n40, err := m.CommonSQLEventDetails.MarshalTo(dAtA[i:])
+	n42, err := m.CommonSQLEventDetails.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n40
+	i += n42
 	if len(m.ViewName) > 0 {
 		dAtA[i] = 0x1a
 		i++
@@ -2577,19 +2671,19 @@ func (m *DropView) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintDdlEvents(dAtA, i, uint64(m.CommonEventDetails.Size()))
-	n41, err := m.CommonEventDetails.MarshalTo(dAtA[i:])
+	n43, err := m.CommonEventDetails.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n41
+	i += n43
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintDdlEvents(dAtA, i, uint64(m.CommonSQLEventDetails.Size()))
-	n42, err := m.CommonSQLEventDetails.MarshalTo(dAtA[i:])
+	n44, err := m.CommonSQLEventDetails.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n42
+	i += n44
 	if len(m.ViewName) > 0 {
 		dAtA[i] = 0x1a
 		i++
@@ -2632,19 +2726,19 @@ func (m *CreateSequence) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintDdlEvents(dAtA, i, uint64(m.CommonEventDetails.Size()))
-	n43, err := m.CommonEventDetails.MarshalTo(dAtA[i:])
+	n45, err := m.CommonEventDetails.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n43
+	i += n45
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintDdlEvents(dAtA, i, uint64(m.CommonSQLEventDetails.Size()))
-	n44, err := m.CommonSQLEventDetails.MarshalTo(dAtA[i:])
+	n46, err := m.CommonSQLEventDetails.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n44
+	i += n46
 	if len(m.SequenceName) > 0 {
 		dAtA[i] = 0x1a
 		i++
@@ -2678,19 +2772,19 @@ func (m *DropSequence) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintDdlEvents(dAtA, i, uint64(m.CommonEventDetails.Size()))
-	n45, err := m.CommonEventDetails.MarshalTo(dAtA[i:])
+	n47, err := m.CommonEventDetails.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n45
+	i += n47
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintDdlEvents(dAtA, i, uint64(m.CommonSQLEventDetails.Size()))
-	n46, err := m.CommonSQLEventDetails.MarshalTo(dAtA[i:])
+	n48, err := m.CommonSQLEventDetails.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n46
+	i += n48
 	if len(m.SequenceName) > 0 {
 		dAtA[i] = 0x1a
 		i++
@@ -2718,19 +2812,19 @@ func (m *AlterSequence) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintDdlEvents(dAtA, i, uint64(m.CommonEventDetails.Size()))
-	n47, err := m.CommonEventDetails.MarshalTo(dAtA[i:])
+	n49, err := m.CommonEventDetails.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n47
+	i += n49
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintDdlEvents(dAtA, i, uint64(m.CommonSQLEventDetails.Size()))
-	n48, err := m.CommonSQLEventDetails.MarshalTo(dAtA[i:])
+	n50, err := m.CommonSQLEventDetails.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n48
+	i += n50
 	if len(m.SequenceName) > 0 {
 		dAtA[i] = 0x1a
 		i++
@@ -2791,19 +2885,19 @@ func (m *ReverseSchemaChange) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintDdlEvents(dAtA, i, uint64(m.CommonEventDetails.Size()))
-	n49, err := m.CommonEventDetails.MarshalTo(dAtA[i:])
+	n51, err := m.CommonEventDetails.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n49
+	i += n51
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintDdlEvents(dAtA, i, uint64(m.CommonSchemaChangeEventDetails.Size()))
-	n50, err := m.CommonSchemaChangeEventDetails.MarshalTo(dAtA[i:])
+	n52, err := m.CommonSchemaChangeEventDetails.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n50
+	i += n52
 	if len(m.Error) > 0 {
 		dAtA[i] = 0x22
 		i++
@@ -2837,19 +2931,19 @@ func (m *FinishSchemaChange) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintDdlEvents(dAtA, i, uint64(m.CommonEventDetails.Size()))
-	n51, err := m.CommonEventDetails.MarshalTo(dAtA[i:])
+	n53, err := m.CommonEventDetails.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n51
+	i += n53
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintDdlEvents(dAtA, i, uint64(m.CommonSchemaChangeEventDetails.Size()))
-	n52, err := m.CommonSchemaChangeEventDetails.MarshalTo(dAtA[i:])
+	n54, err := m.CommonSchemaChangeEventDetails.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n52
+	i += n54
 	return i, nil
 }
 
@@ -2871,19 +2965,19 @@ func (m *FinishSchemaChangeRollback) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintDdlEvents(dAtA, i, uint64(m.CommonEventDetails.Size()))
-	n53, err := m.CommonEventDetails.MarshalTo(dAtA[i:])
+	n55, err := m.CommonEventDetails.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n53
+	i += n55
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintDdlEvents(dAtA, i, uint64(m.CommonSchemaChangeEventDetails.Size()))
-	n54, err := m.CommonSchemaChangeEventDetails.MarshalTo(dAtA[i:])
+	n56, err := m.CommonSchemaChangeEventDetails.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n54
+	i += n56
 	return i, nil
 }
 
@@ -2905,19 +2999,19 @@ func (m *CreateType) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintDdlEvents(dAtA, i, uint64(m.CommonEventDetails.Size()))
-	n55, err := m.CommonEventDetails.MarshalTo(dAtA[i:])
+	n57, err := m.CommonEventDetails.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n55
+	i += n57
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintDdlEvents(dAtA, i, uint64(m.CommonSQLEventDetails.Size()))
-	n56, err := m.CommonSQLEventDetails.MarshalTo(dAtA[i:])
+	n58, err := m.CommonSQLEventDetails.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n56
+	i += n58
 	if len(m.TypeName) > 0 {
 		dAtA[i] = 0x22
 		i++
@@ -2951,19 +3045,19 @@ func (m *DropType) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintDdlEvents(dAtA, i, uint64(m.CommonEventDetails.Size()))
-	n57, err := m.CommonEventDetails.MarshalTo(dAtA[i:])
+	n59, err := m.CommonEventDetails.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n57
+	i += n59
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintDdlEvents(dAtA, i, uint64(m.CommonSQLEventDetails.Size()))
-	n58, err := m.CommonSQLEventDetails.MarshalTo(dAtA[i:])
+	n60, err := m.CommonSQLEventDetails.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n58
+	i += n60
 	if len(m.TypeName) > 0 {
 		dAtA[i] = 0x1a
 		i++
@@ -2991,19 +3085,19 @@ func (m *AlterType) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintDdlEvents(dAtA, i, uint64(m.CommonEventDetails.Size()))
-	n59, err := m.CommonEventDetails.MarshalTo(dAtA[i:])
+	n61, err := m.CommonEventDetails.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n59
+	i += n61
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintDdlEvents(dAtA, i, uint64(m.CommonSQLEventDetails.Size()))
-	n60, err := m.CommonSQLEventDetails.MarshalTo(dAtA[i:])
+	n62, err := m.CommonSQLEventDetails.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n60
+	i += n62
 	if len(m.TypeName) > 0 {
 		dAtA[i] = 0x1a
 		i++
@@ -3031,19 +3125,19 @@ func (m *RenameType) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintDdlEvents(dAtA, i, uint64(m.CommonEventDetails.Size()))
-	n61, err := m.CommonEventDetails.MarshalTo(dAtA[i:])
+	n63, err := m.CommonEventDetails.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n61
+	i += n63
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintDdlEvents(dAtA, i, uint64(m.CommonSQLEventDetails.Size()))
-	n62, err := m.CommonSQLEventDetails.MarshalTo(dAtA[i:])
+	n64, err := m.CommonSQLEventDetails.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n62
+	i += n64
 	if len(m.TypeName) > 0 {
 		dAtA[i] = 0x1a
 		i++
@@ -3077,19 +3171,19 @@ func (m *CreateStatistics) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintDdlEvents(dAtA, i, uint64(m.CommonEventDetails.Size()))
-	n63, err := m.CommonEventDetails.MarshalTo(dAtA[i:])
+	n65, err := m.CommonEventDetails.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n63
+	i += n65
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintDdlEvents(dAtA, i, uint64(m.CommonSQLEventDetails.Size()))
-	n64, err := m.CommonSQLEventDetails.MarshalTo(dAtA[i:])
+	n66, err := m.CommonSQLEventDetails.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n64
+	i += n66
 	if len(m.TableName) > 0 {
 		dAtA[i] = 0x1a
 		i++
@@ -3117,19 +3211,19 @@ func (m *UnsafeUpsertDescriptor) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintDdlEvents(dAtA, i, uint64(m.CommonEventDetails.Size()))
-	n65, err := m.CommonEventDetails.MarshalTo(dAtA[i:])
+	n67, err := m.CommonEventDetails.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n65
+	i += n67
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintDdlEvents(dAtA, i, uint64(m.CommonSQLEventDetails.Size()))
-	n66, err := m.CommonSQLEventDetails.MarshalTo(dAtA[i:])
+	n68, err := m.CommonSQLEventDetails.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n66
+	i += n68
 	if len(m.PreviousDescriptor) > 0 {
 		dAtA[i] = 0x1a
 		i++
@@ -3179,19 +3273,19 @@ func (m *UnsafeDeleteDescriptor) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintDdlEvents(dAtA, i, uint64(m.CommonEventDetails.Size()))
-	n67, err := m.CommonEventDetails.MarshalTo(dAtA[i:])
+	n69, err := m.CommonEventDetails.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n67
+	i += n69
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintDdlEvents(dAtA, i, uint64(m.CommonSQLEventDetails.Size()))
-	n68, err := m.CommonSQLEventDetails.MarshalTo(dAtA[i:])
+	n70, err := m.CommonSQLEventDetails.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n68
+	i += n70
 	if m.ParentID != 0 {
 		dAtA[i] = 0x18
 		i++
@@ -3245,19 +3339,19 @@ func (m *UnsafeUpsertNamespaceEntry) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintDdlEvents(dAtA, i, uint64(m.CommonEventDetails.Size()))
-	n69, err := m.CommonEventDetails.MarshalTo(dAtA[i:])
+	n71, err := m.CommonEventDetails.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n69
+	i += n71
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintDdlEvents(dAtA, i, uint64(m.CommonSQLEventDetails.Size()))
-	n70, err := m.CommonSQLEventDetails.MarshalTo(dAtA[i:])
+	n72, err := m.CommonSQLEventDetails.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n70
+	i += n72
 	if m.ParentID != 0 {
 		dAtA[i] = 0x18
 		i++
@@ -3326,19 +3420,19 @@ func (m *UnsafeDeleteNamespaceEntry) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintDdlEvents(dAtA, i, uint64(m.CommonEventDetails.Size()))
-	n71, err := m.CommonEventDetails.MarshalTo(dAtA[i:])
+	n73, err := m.CommonEventDetails.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n71
+	i += n73
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintDdlEvents(dAtA, i, uint64(m.CommonSQLEventDetails.Size()))
-	n72, err := m.CommonSQLEventDetails.MarshalTo(dAtA[i:])
+	n74, err := m.CommonSQLEventDetails.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n72
+	i += n74
 	if m.ParentID != 0 {
 		dAtA[i] = 0x18
 		i++
@@ -3518,6 +3612,31 @@ func (m *RenameSchema) Size() (n int) {
 		n += 1 + l + sovDdlEvents(uint64(l))
 	}
 	l = len(m.NewSchemaName)
+	if l > 0 {
+		n += 1 + l + sovDdlEvents(uint64(l))
+	}
+	return n
+}
+
+func (m *SetSchema) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = m.CommonEventDetails.Size()
+	n += 1 + l + sovDdlEvents(uint64(l))
+	l = m.CommonSQLEventDetails.Size()
+	n += 1 + l + sovDdlEvents(uint64(l))
+	l = len(m.OldSchemaName)
+	if l > 0 {
+		n += 1 + l + sovDdlEvents(uint64(l))
+	}
+	l = len(m.NewSchemaName)
+	if l > 0 {
+		n += 1 + l + sovDdlEvents(uint64(l))
+	}
+	l = len(m.DescriptorType)
 	if l > 0 {
 		n += 1 + l + sovDdlEvents(uint64(l))
 	}
@@ -5308,6 +5427,203 @@ func (m *RenameSchema) Unmarshal(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.NewSchemaName = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipDdlEvents(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthDdlEvents
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *SetSchema) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowDdlEvents
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: SetSchema: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: SetSchema: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CommonEventDetails", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowDdlEvents
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthDdlEvents
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.CommonEventDetails.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CommonSQLEventDetails", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowDdlEvents
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthDdlEvents
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.CommonSQLEventDetails.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field OldSchemaName", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowDdlEvents
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthDdlEvents
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.OldSchemaName = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field NewSchemaName", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowDdlEvents
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthDdlEvents
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.NewSchemaName = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DescriptorType", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowDdlEvents
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthDdlEvents
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.DescriptorType = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -10659,99 +10975,102 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("util/log/eventpb/ddl_events.proto", fileDescriptor_ddl_events_29e9024d78ea4c87)
+	proto.RegisterFile("util/log/eventpb/ddl_events.proto", fileDescriptor_ddl_events_35532f60564d6d3a)
 }
 
-var fileDescriptor_ddl_events_29e9024d78ea4c87 = []byte{
-	// 1431 bytes of a gzipped FileDescriptorProto
+var fileDescriptor_ddl_events_35532f60564d6d3a = []byte{
+	// 1478 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xec, 0x5a, 0xcd, 0x6f, 0x1b, 0x45,
-	0x14, 0xcf, 0xae, 0xe3, 0xc4, 0x7e, 0xfe, 0x68, 0xb2, 0x69, 0x2b, 0x2b, 0x02, 0x3b, 0xac, 0x7a,
-	0x08, 0x82, 0x3a, 0x6a, 0xcb, 0x87, 0x54, 0x54, 0x50, 0x13, 0x07, 0xc9, 0xa8, 0xb4, 0x4d, 0xe2,
-	0x56, 0x88, 0x8b, 0xb5, 0xd9, 0x9d, 0x26, 0x4b, 0xd7, 0x33, 0x9b, 0x9d, 0xb1, 0x4d, 0xfe, 0x00,
-	0x24, 0x24, 0x24, 0x84, 0x10, 0xe2, 0xc2, 0x85, 0x03, 0x12, 0x12, 0x17, 0x24, 0x2e, 0x5c, 0xb8,
-	0x01, 0xa2, 0x07, 0x40, 0x15, 0x5c, 0x7a, 0xb2, 0x5a, 0x47, 0xa2, 0x52, 0x05, 0x1c, 0x10, 0x12,
-	0x57, 0x34, 0x33, 0xbb, 0xf6, 0x26, 0xfe, 0x68, 0x23, 0x25, 0x07, 0x6f, 0x72, 0xb3, 0x3d, 0xbf,
-	0xf7, 0xd6, 0xef, 0xf7, 0x3e, 0x67, 0x66, 0xe1, 0x99, 0x3a, 0xb3, 0x9d, 0x05, 0x87, 0x6c, 0x2c,
-	0xa0, 0x06, 0xc2, 0xcc, 0x5d, 0x5f, 0xb0, 0x2c, 0xa7, 0x2a, 0x3e, 0xd3, 0xa2, 0xeb, 0x11, 0x46,
-	0xb4, 0x59, 0x93, 0x98, 0xb7, 0x3d, 0x62, 0x98, 0x9b, 0x45, 0x0e, 0x2e, 0x3a, 0x64, 0xa3, 0xe8,
-	0x83, 0x67, 0x4f, 0x6e, 0x90, 0x0d, 0x22, 0x60, 0x0b, 0xfc, 0x93, 0x94, 0x98, 0x7d, 0xba, 0x47,
-	0x69, 0x58, 0xa1, 0xfe, 0xb7, 0x02, 0xd9, 0x25, 0x0f, 0x19, 0x0c, 0x95, 0x0c, 0x66, 0xac, 0x1b,
-	0x14, 0x69, 0x15, 0x98, 0x30, 0x49, 0xad, 0x46, 0x70, 0x4e, 0x99, 0x53, 0xe6, 0x53, 0xe7, 0x8b,
-	0xc5, 0xc1, 0x0f, 0x2d, 0x2e, 0x09, 0xe4, 0x32, 0xff, 0x56, 0x42, 0xcc, 0xb0, 0x1d, 0xba, 0x98,
-	0xbe, 0xd3, 0x2a, 0x8c, 0xdd, 0x6d, 0x15, 0x94, 0x47, 0xad, 0xc2, 0xd8, 0xaa, 0xaf, 0x4b, 0x5b,
-	0x81, 0x18, 0xdd, 0x72, 0x72, 0xaa, 0x50, 0x79, 0xee, 0xf1, 0x2a, 0xd7, 0x56, 0xae, 0x0c, 0xd1,
-	0xca, 0x75, 0x69, 0x17, 0x20, 0x63, 0xf9, 0x7f, 0xba, 0x8a, 0x8d, 0x1a, 0xca, 0xc5, 0xe6, 0x94,
-	0xf9, 0xe4, 0x62, 0xf6, 0x51, 0xab, 0x00, 0xcf, 0x93, 0x9a, 0xcd, 0x50, 0xcd, 0x65, 0xdb, 0xab,
-	0xe9, 0x00, 0x74, 0xd5, 0xa8, 0x21, 0xfd, 0x1b, 0x15, 0xd2, 0x25, 0x8f, 0xb8, 0x47, 0xc3, 0x5c,
-	0xad, 0x04, 0xa7, 0x2d, 0x8f, 0xb8, 0x2e, 0xb2, 0xaa, 0xd4, 0xdc, 0x44, 0x35, 0xa3, 0x4a, 0xd6,
-	0xdf, 0x41, 0x26, 0xa3, 0xb9, 0xf1, 0xb9, 0x58, 0x1f, 0xe9, 0x93, 0x3e, 0x7a, 0x4d, 0x80, 0xaf,
-	0x49, 0xac, 0xfe, 0x95, 0x0a, 0xd9, 0x55, 0xc4, 0x1f, 0x7a, 0x44, 0x68, 0xbb, 0x08, 0xd3, 0x18,
-	0x35, 0xab, 0xbb, 0x05, 0xc7, 0xfb, 0x0a, 0x9e, 0xc0, 0xa8, 0x59, 0x0a, 0x47, 0xd8, 0xd7, 0x2a,
-	0x9c, 0x58, 0x22, 0xb8, 0x81, 0x3c, 0x56, 0x21, 0x92, 0xc7, 0x88, 0xb3, 0xf5, 0x2a, 0xcc, 0xec,
-	0x62, 0xcb, 0x35, 0x3c, 0x84, 0xd9, 0x00, 0xbe, 0xa6, 0x43, 0x7c, 0x5d, 0x17, 0x40, 0xfd, 0x43,
-	0x15, 0xd2, 0xb2, 0x08, 0x8d, 0x1a, 0x5d, 0x0b, 0x90, 0xf2, 0xd3, 0x6a, 0x08, 0x59, 0x20, 0x21,
-	0x82, 0xaa, 0x33, 0x10, 0x27, 0x4d, 0x8c, 0xbc, 0x01, 0xe4, 0xc8, 0x45, 0xfd, 0x0f, 0x05, 0x80,
-	0x17, 0xa9, 0xa8, 0xd3, 0xa1, 0x7f, 0xae, 0x42, 0x5a, 0x16, 0x96, 0xc8, 0x7b, 0xfe, 0x25, 0xe0,
-	0x95, 0xa2, 0x1a, 0x16, 0xea, 0x1f, 0x03, 0x19, 0x8c, 0x9a, 0x6b, 0x5d, 0x8a, 0x3e, 0x50, 0x21,
-	0x25, 0x93, 0xa3, 0x62, 0xac, 0x3b, 0x23, 0x54, 0x78, 0xcf, 0x02, 0x30, 0xfe, 0x8f, 0x87, 0x11,
-	0x94, 0x14, 0x88, 0x7d, 0x64, 0xc6, 0x97, 0x2a, 0x24, 0x79, 0x66, 0x44, 0x9b, 0x8b, 0x45, 0x38,
-	0x65, 0x1a, 0xd4, 0x34, 0x2c, 0x54, 0x0d, 0xba, 0x77, 0xc3, 0x46, 0xcd, 0x41, 0x4d, 0x7b, 0xc6,
-	0x07, 0x97, 0x24, 0xf6, 0x26, 0x87, 0xea, 0x9f, 0xa9, 0x90, 0x92, 0xa9, 0x15, 0x6d, 0xae, 0x5e,
-	0x80, 0x2c, 0xcf, 0xab, 0x90, 0x48, 0xff, 0x00, 0x4a, 0x63, 0xd4, 0xac, 0x04, 0x52, 0xfa, 0x43,
-	0x05, 0x32, 0x15, 0xaf, 0x8e, 0xcd, 0xa8, 0xe7, 0x95, 0xfe, 0x50, 0x05, 0xb8, 0xec, 0x30, 0xe4,
-	0x45, 0x3b, 0x0c, 0x2e, 0x41, 0xaa, 0x56, 0x67, 0x06, 0xb3, 0x09, 0xae, 0xda, 0x96, 0x88, 0x81,
-	0xcc, 0xe2, 0x53, 0xed, 0x56, 0x01, 0xde, 0xf4, 0x7f, 0x2e, 0x97, 0xf6, 0x56, 0xe7, 0x40, 0xa0,
-	0x6c, 0x0d, 0xce, 0xb8, 0xf8, 0x93, 0x67, 0xdc, 0x7f, 0x62, 0xf0, 0xab, 0xd5, 0x10, 0x66, 0xd7,
-	0xf0, 0x12, 0x71, 0xea, 0x35, 0x1c, 0x59, 0xba, 0x17, 0x20, 0x65, 0x0a, 0x0b, 0x87, 0xa5, 0x1c,
-	0x48, 0x88, 0x10, 0x98, 0x87, 0x49, 0x53, 0x72, 0x93, 0x8b, 0xf7, 0x05, 0x07, 0xcb, 0xda, 0x39,
-	0x48, 0xe3, 0xba, 0xe3, 0x54, 0x03, 0xf8, 0xc4, 0x9c, 0x32, 0x9f, 0xe8, 0x81, 0xa7, 0x38, 0xc6,
-	0x67, 0x5b, 0xff, 0x55, 0x85, 0xe9, 0x0e, 0xf3, 0x47, 0x64, 0x8b, 0x12, 0x22, 0x74, 0xfc, 0xc0,
-	0x09, 0xfd, 0x51, 0x85, 0x6c, 0x87, 0xd0, 0x68, 0x17, 0x8e, 0x43, 0xe5, 0xf1, 0xdf, 0x30, 0x8f,
-	0x65, 0x6c, 0xa1, 0x77, 0x23, 0xcb, 0xe3, 0x59, 0x00, 0x9b, 0x1b, 0x38, 0xac, 0x20, 0x24, 0x05,
-	0xe2, 0xf0, 0xeb, 0xc1, 0xef, 0x9d, 0x99, 0xf9, 0x98, 0xf3, 0x10, 0xe7, 0x7b, 0x7a, 0x64, 0x7c,
-	0x7f, 0x3d, 0x52, 0x7f, 0x2f, 0x26, 0x67, 0xef, 0x63, 0x4e, 0x0f, 0x8c, 0x53, 0xed, 0xfc, 0xa0,
-	0xb9, 0x63, 0x82, 0xcf, 0x1d, 0xfd, 0xe7, 0x8c, 0xdf, 0x82, 0x89, 0xee, 0xd8, 0x11, 0x07, 0x17,
-	0xdc, 0xdf, 0xaa, 0x00, 0xb2, 0x64, 0x70, 0x92, 0x47, 0x87, 0xd4, 0xe7, 0x20, 0xc9, 0x03, 0x66,
-	0x18, 0xa7, 0x09, 0x0e, 0x78, 0xf2, 0x3d, 0x36, 0x27, 0x5e, 0xa8, 0xdc, 0xaa, 0x23, 0x6f, 0x7b,
-	0x40, 0x75, 0x16, 0x0f, 0x5d, 0xe1, 0x00, 0xfd, 0x0b, 0x15, 0x12, 0x3c, 0x3e, 0x23, 0xcc, 0xdb,
-	0x41, 0xec, 0xc7, 0x3f, 0x51, 0x83, 0x9b, 0x96, 0x35, 0xb4, 0x55, 0x47, 0xd8, 0x1c, 0xad, 0x01,
-	0x95, 0xfa, 0x7f, 0x7a, 0xe8, 0x80, 0x1a, 0x80, 0xf6, 0x71, 0xa0, 0xf3, 0xa7, 0x22, 0xef, 0x63,
-	0x8e, 0x06, 0x29, 0xfa, 0x5f, 0x0a, 0x64, 0x44, 0xed, 0x3e, 0x22, 0xf6, 0xee, 0x28, 0x90, 0xf7,
-	0x9f, 0x20, 0x8e, 0x34, 0x97, 0x36, 0x0d, 0xbc, 0x81, 0xc2, 0x8f, 0xe2, 0x85, 0xdb, 0xc6, 0x94,
-	0x19, 0x5c, 0xaf, 0x6d, 0x09, 0x16, 0xe2, 0xb2, 0x70, 0x97, 0xfd, 0x9f, 0x7b, 0x0b, 0x77, 0x20,
-	0x50, 0xb6, 0xb4, 0x25, 0xc8, 0x58, 0x88, 0x9a, 0x9e, 0xed, 0x32, 0xe2, 0x71, 0x05, 0xaa, 0xa8,
-	0xfc, 0xf9, 0x76, 0xab, 0x90, 0x2e, 0x75, 0x16, 0x7a, 0x54, 0xa4, 0xbb, 0x42, 0x65, 0x6b, 0x6f,
-	0xf3, 0x88, 0xed, 0xb3, 0x79, 0x7c, 0xa7, 0xc2, 0xcc, 0x2a, 0x6a, 0x20, 0x8f, 0xa2, 0xb0, 0x99,
-	0x87, 0xe4, 0xdb, 0xb7, 0x40, 0xa5, 0xa6, 0xef, 0xda, 0x8b, 0x4f, 0xe0, 0xda, 0x01, 0xc4, 0xef,
-	0xd1, 0xae, 0x52, 0x93, 0xa7, 0x2c, 0xf2, 0x3c, 0x32, 0x30, 0x65, 0xc5, 0xa2, 0x76, 0x0d, 0x12,
-	0x74, 0xcb, 0xa1, 0xcc, 0x60, 0xc8, 0xef, 0x0e, 0x17, 0xda, 0xad, 0x42, 0x62, 0x6d, 0xe5, 0xca,
-	0x5a, 0xe5, 0x72, 0x65, 0x79, 0xb7, 0xd0, 0x3f, 0xad, 0xc2, 0x29, 0x0f, 0x59, 0x86, 0xc9, 0x2e,
-	0xea, 0x98, 0x60, 0x8a, 0x30, 0xb5, 0x99, 0xdd, 0x40, 0xfa, 0x6a, 0x47, 0x89, 0xfe, 0x83, 0x02,
-	0xda, 0xeb, 0x36, 0xb6, 0xe9, 0xe6, 0x28, 0xb3, 0xa7, 0xff, 0xac, 0xc0, 0x6c, 0xaf, 0x19, 0xab,
-	0xc4, 0x71, 0xd6, 0x0d, 0xf3, 0xf6, 0xc8, 0x99, 0xf3, 0x7e, 0x67, 0x22, 0xaa, 0x6c, 0xbb, 0x68,
-	0xa4, 0x3a, 0x3b, 0xdb, 0x76, 0x87, 0x9e, 0x05, 0x27, 0x38, 0x60, 0x77, 0x93, 0x8a, 0x0f, 0x6b,
-	0x52, 0xf7, 0x15, 0x39, 0xe2, 0x8c, 0x30, 0x11, 0xb1, 0xe1, 0x44, 0xe8, 0x0f, 0x14, 0x48, 0xca,
-	0x63, 0xe2, 0xe8, 0xda, 0xf8, 0xa9, 0x0a, 0xe0, 0x5f, 0x89, 0x44, 0xd6, 0x48, 0xed, 0x3c, 0x64,
-	0xc4, 0x7d, 0xc8, 0x63, 0x52, 0x20, 0x85, 0x51, 0xb3, 0x12, 0x10, 0xf3, 0x48, 0x81, 0x29, 0x7f,
-	0x36, 0xe5, 0x3d, 0x8d, 0x32, 0xdb, 0xa4, 0x91, 0xbd, 0x10, 0xf9, 0x38, 0x06, 0xa7, 0x6f, 0x60,
-	0x6a, 0xdc, 0x42, 0x37, 0x5c, 0x8a, 0x3c, 0xd6, 0x1d, 0x12, 0x46, 0xc7, 0xe4, 0xd7, 0x60, 0xc6,
-	0xf5, 0x50, 0xc3, 0x26, 0x75, 0x5a, 0xed, 0x0e, 0x32, 0x03, 0x6c, 0xd7, 0x02, 0x68, 0xc8, 0xd2,
-	0x17, 0xe5, 0xad, 0x59, 0x48, 0x76, 0xf0, 0x65, 0x74, 0x48, 0xec, 0x0c, 0xc4, 0x6f, 0x11, 0xcf,
-	0x94, 0x7d, 0xbf, 0xf7, 0x10, 0x4e, 0x2e, 0x6a, 0xe7, 0x20, 0x2d, 0x3e, 0x54, 0x31, 0x61, 0xb6,
-	0x89, 0xc4, 0x89, 0x5d, 0x9f, 0x08, 0x14, 0x98, 0xab, 0x02, 0xa2, 0x7f, 0xdf, 0x71, 0x4a, 0x09,
-	0x39, 0x88, 0xa1, 0x51, 0x74, 0xca, 0xcb, 0x90, 0x94, 0x6f, 0xbe, 0x74, 0x47, 0xc8, 0x59, 0x3e,
-	0x18, 0xc9, 0xb7, 0x5c, 0x7a, 0x06, 0xc8, 0x84, 0x04, 0x97, 0x2d, 0xed, 0x0d, 0x98, 0xf2, 0x05,
-	0xfd, 0xb7, 0x03, 0x3a, 0x17, 0x58, 0x73, 0xed, 0x56, 0x21, 0x2b, 0xe5, 0x65, 0xe7, 0xee, 0xd1,
-	0x92, 0x75, 0xc3, 0xab, 0x96, 0xa6, 0xc3, 0xb8, 0x48, 0x83, 0xfe, 0xfd, 0x4c, 0xac, 0x75, 0xbd,
-	0x38, 0xb1, 0x1f, 0x2f, 0x4e, 0x3e, 0xde, 0x8b, 0xbf, 0x8c, 0xc3, 0x6c, 0x38, 0xb5, 0x78, 0xbe,
-	0x51, 0xd7, 0x30, 0xd1, 0x32, 0x66, 0xde, 0xf6, 0xb1, 0x27, 0x0f, 0xdc, 0x93, 0x97, 0x20, 0xd5,
-	0xa9, 0x03, 0xb6, 0x25, 0xfc, 0xe9, 0xef, 0x5b, 0xae, 0xfb, 0x3f, 0xf7, 0xee, 0x5b, 0x02, 0x81,
-	0xb2, 0xd5, 0x0d, 0x84, 0xc9, 0x61, 0x81, 0xf0, 0x0a, 0x4c, 0xdf, 0x32, 0x6c, 0x07, 0x59, 0xd5,
-	0x86, 0xe1, 0xd8, 0x96, 0xd8, 0xf4, 0xe4, 0x12, 0x7d, 0x25, 0xa6, 0x24, 0xf0, 0x66, 0x07, 0xc7,
-	0x85, 0xbb, 0x52, 0x55, 0xb1, 0x81, 0xa0, 0xb9, 0x64, 0x5f, 0x93, 0xa6, 0xba, 0xc0, 0x65, 0x81,
-	0xd3, 0x7f, 0x8a, 0x05, 0xf1, 0x24, 0xab, 0xc2, 0x71, 0x3c, 0x8d, 0x68, 0x65, 0x58, 0x7c, 0xf6,
-	0xce, 0x83, 0xfc, 0xd8, 0x9d, 0x76, 0x5e, 0xb9, 0xdb, 0xce, 0x2b, 0xf7, 0xda, 0x79, 0xe5, 0x7e,
-	0x3b, 0xaf, 0x7c, 0xb4, 0x93, 0x1f, 0xbb, 0xbb, 0x93, 0x1f, 0xbb, 0xb7, 0x93, 0x1f, 0x7b, 0x7b,
-	0xd2, 0x67, 0x75, 0x7d, 0x42, 0xbc, 0x99, 0x7c, 0xe1, 0xff, 0x00, 0x00, 0x00, 0xff, 0xff, 0x52,
-	0x2c, 0xd3, 0x6c, 0x0f, 0x2d, 0x00, 0x00,
+	0x1b, 0xcf, 0xae, 0xf3, 0x61, 0x3f, 0xfe, 0x48, 0xb2, 0x69, 0x2b, 0x2b, 0x7a, 0x5f, 0x3b, 0xef,
+	0xaa, 0x87, 0xbc, 0x82, 0x3a, 0x6a, 0x0b, 0xad, 0x54, 0x54, 0x50, 0x13, 0x07, 0xc9, 0xa8, 0xb4,
+	0x4d, 0xec, 0x56, 0x88, 0xcb, 0x6a, 0xb3, 0x3b, 0x4d, 0x96, 0xae, 0x67, 0x36, 0xbb, 0x63, 0x1b,
+	0xff, 0x01, 0x48, 0x48, 0x48, 0x08, 0x21, 0xc4, 0x85, 0x0b, 0x07, 0x24, 0x24, 0x2e, 0x48, 0x5c,
+	0xb8, 0x70, 0x03, 0x44, 0x0f, 0x80, 0x2a, 0xb8, 0xf4, 0x82, 0xd5, 0x3a, 0x12, 0x95, 0x2a, 0xe0,
+	0x80, 0x90, 0xb8, 0xa2, 0x99, 0xd9, 0xb5, 0x37, 0xf1, 0x47, 0x1a, 0x91, 0x1e, 0xbc, 0xc9, 0xcd,
+	0xf6, 0xfc, 0x9e, 0x67, 0xfd, 0xfc, 0x9e, 0xcf, 0x99, 0x59, 0xf8, 0x5f, 0x8d, 0x5a, 0xf6, 0x92,
+	0x4d, 0x36, 0x97, 0x50, 0x1d, 0x61, 0xea, 0x6c, 0x2c, 0x99, 0xa6, 0xad, 0xf1, 0xcf, 0x5e, 0xc1,
+	0x71, 0x09, 0x25, 0xca, 0xbc, 0x41, 0x8c, 0x3b, 0x2e, 0xd1, 0x8d, 0xad, 0x02, 0x03, 0x17, 0x6c,
+	0xb2, 0x59, 0xf0, 0xc1, 0xf3, 0x27, 0x36, 0xc9, 0x26, 0xe1, 0xb0, 0x25, 0xf6, 0x49, 0x48, 0xcc,
+	0xff, 0xb7, 0x47, 0x69, 0x58, 0xa1, 0xfa, 0x87, 0x04, 0x99, 0x15, 0x17, 0xe9, 0x14, 0x15, 0x75,
+	0xaa, 0x6f, 0xe8, 0x1e, 0x52, 0x2a, 0x30, 0x69, 0x90, 0x6a, 0x95, 0xe0, 0xac, 0xb4, 0x20, 0x2d,
+	0x26, 0xcf, 0x15, 0x0a, 0x83, 0x1f, 0x5a, 0x58, 0xe1, 0xc8, 0x55, 0xf6, 0xad, 0x88, 0xa8, 0x6e,
+	0xd9, 0xde, 0x72, 0xea, 0x6e, 0x2b, 0x3f, 0x76, 0xaf, 0x95, 0x97, 0x1e, 0xb7, 0xf2, 0x63, 0xeb,
+	0xbe, 0x2e, 0x65, 0x0d, 0x62, 0xde, 0xb6, 0x9d, 0x95, 0xb9, 0xca, 0xb3, 0xfb, 0xab, 0x2c, 0xaf,
+	0x5d, 0x1d, 0xa2, 0x95, 0xe9, 0x52, 0xce, 0x43, 0xda, 0xf4, 0xff, 0xb4, 0x86, 0xf5, 0x2a, 0xca,
+	0xc6, 0x16, 0xa4, 0xc5, 0xc4, 0x72, 0xe6, 0x71, 0x2b, 0x0f, 0xcf, 0x92, 0xaa, 0x45, 0x51, 0xd5,
+	0xa1, 0xcd, 0xf5, 0x54, 0x00, 0xba, 0xa6, 0x57, 0x91, 0xfa, 0x85, 0x0c, 0xa9, 0xa2, 0x4b, 0x9c,
+	0xa3, 0x61, 0xae, 0x52, 0x84, 0x53, 0xa6, 0x4b, 0x1c, 0x07, 0x99, 0x9a, 0x67, 0x6c, 0xa1, 0xaa,
+	0xae, 0x91, 0x8d, 0x37, 0x90, 0x41, 0xbd, 0xec, 0xf8, 0x42, 0xac, 0x8f, 0xf4, 0x09, 0x1f, 0x5d,
+	0xe6, 0xe0, 0xeb, 0x02, 0xab, 0x7e, 0x26, 0x43, 0x66, 0x1d, 0xb1, 0x87, 0x1e, 0x11, 0xda, 0x2e,
+	0xc1, 0x2c, 0x46, 0x0d, 0x6d, 0xb7, 0xe0, 0x78, 0x5f, 0xc1, 0x69, 0x8c, 0x1a, 0xc5, 0x70, 0x84,
+	0x7d, 0x2e, 0xc3, 0xf4, 0x0a, 0xc1, 0x75, 0xe4, 0xd2, 0x0a, 0x11, 0x3c, 0x46, 0x9c, 0xad, 0x17,
+	0x61, 0x6e, 0x17, 0x5b, 0x8e, 0xee, 0x22, 0x4c, 0x07, 0xf0, 0x35, 0x1b, 0xe2, 0xeb, 0x06, 0x07,
+	0xaa, 0xef, 0xca, 0x90, 0x12, 0x45, 0x68, 0xd4, 0xe8, 0x5a, 0x82, 0xa4, 0x9f, 0x56, 0x43, 0xc8,
+	0x02, 0x01, 0xe1, 0x54, 0x9d, 0x86, 0x09, 0xd2, 0xc0, 0xc8, 0x1d, 0x40, 0x8e, 0x58, 0x54, 0x7f,
+	0x95, 0x00, 0x58, 0x91, 0x8a, 0x3a, 0x1d, 0xea, 0xc7, 0x32, 0xa4, 0x44, 0x61, 0x89, 0xbc, 0xe7,
+	0x2f, 0x00, 0xab, 0x14, 0x5a, 0x58, 0xa8, 0x7f, 0x0c, 0xa4, 0x31, 0x6a, 0x94, 0xbb, 0x14, 0xfd,
+	0x22, 0x43, 0xa2, 0x8c, 0xe8, 0xa8, 0xf1, 0x73, 0x01, 0xa6, 0x89, 0x6d, 0x6a, 0xfb, 0x73, 0x94,
+	0x26, 0xb6, 0x59, 0xfe, 0xd7, 0x34, 0x29, 0x17, 0x61, 0xda, 0x44, 0x9e, 0xe1, 0x5a, 0x0e, 0x25,
+	0xae, 0x46, 0x9b, 0x0e, 0xca, 0x4e, 0xf4, 0x95, 0xcb, 0x74, 0x61, 0x95, 0xa6, 0x83, 0xd4, 0x77,
+	0x64, 0x48, 0x8a, 0xe2, 0x53, 0xd1, 0x37, 0xec, 0x11, 0x6a, 0x6c, 0x67, 0x00, 0x28, 0xfb, 0xc7,
+	0xc3, 0xc8, 0x4d, 0x70, 0xc4, 0x01, 0x2a, 0xcf, 0xa7, 0x32, 0x24, 0x58, 0xe5, 0x89, 0x36, 0x17,
+	0xcb, 0x70, 0xd2, 0xd0, 0x3d, 0x43, 0x37, 0x91, 0x16, 0x4c, 0x47, 0x75, 0x0b, 0x35, 0x06, 0x0d,
+	0x45, 0x73, 0x3e, 0xb8, 0x28, 0xb0, 0xb7, 0x18, 0x54, 0xfd, 0x48, 0x86, 0xa4, 0x28, 0x5d, 0xd1,
+	0xe6, 0xea, 0x39, 0xc8, 0xb0, 0x84, 0x0c, 0x89, 0xf4, 0x0f, 0xa0, 0x14, 0x46, 0x8d, 0x4a, 0x20,
+	0xa5, 0x3e, 0x92, 0x20, 0x5d, 0x71, 0x6b, 0xd8, 0x88, 0x7a, 0x5e, 0xa9, 0x8f, 0x64, 0x80, 0x2b,
+	0x36, 0x45, 0x6e, 0xb4, 0xc3, 0xe0, 0x32, 0x24, 0xab, 0x35, 0xaa, 0x53, 0x8b, 0x60, 0xcd, 0x32,
+	0x79, 0x0c, 0xa4, 0x97, 0xff, 0xd3, 0x6e, 0xe5, 0xe1, 0x55, 0xff, 0xe7, 0x52, 0x71, 0x6f, 0xf7,
+	0x0b, 0x04, 0x4a, 0xe6, 0xe0, 0x8c, 0x9b, 0x78, 0xf2, 0x8c, 0xfb, 0x9b, 0x0f, 0xd6, 0xd5, 0x2a,
+	0xc2, 0xf4, 0x3a, 0x5e, 0x21, 0x76, 0xad, 0x8a, 0x23, 0x4b, 0xf7, 0x12, 0x24, 0x0d, 0x6e, 0xe1,
+	0xb0, 0x94, 0x03, 0x01, 0xe1, 0x02, 0x8b, 0x30, 0x65, 0x08, 0x6e, 0x06, 0xf4, 0xbd, 0x60, 0x59,
+	0x39, 0x0b, 0x29, 0x5c, 0xb3, 0x6d, 0x2d, 0x80, 0x4f, 0x2e, 0x48, 0x8b, 0xf1, 0x1e, 0x78, 0x92,
+	0x61, 0x7c, 0xb6, 0xd5, 0x1f, 0x65, 0x98, 0xed, 0x30, 0x7f, 0x44, 0xb6, 0x80, 0x21, 0x42, 0xc7,
+	0x0f, 0x9d, 0xd0, 0x6f, 0x65, 0xc8, 0x74, 0x08, 0x8d, 0x76, 0xe1, 0x78, 0xaa, 0x3c, 0xfe, 0x15,
+	0xe6, 0xb1, 0x84, 0x4d, 0xf4, 0x66, 0x64, 0x79, 0x3c, 0x03, 0x60, 0x31, 0x03, 0x87, 0x15, 0x84,
+	0x04, 0x47, 0x3c, 0xfd, 0x7a, 0xf0, 0x73, 0x67, 0x66, 0x3e, 0xe6, 0x3c, 0xc4, 0xf9, 0x9e, 0x1e,
+	0x39, 0x71, 0xb0, 0x1e, 0xa9, 0xbe, 0x15, 0x13, 0xb3, 0xf7, 0x31, 0xa7, 0x87, 0xc6, 0xa9, 0x72,
+	0x6e, 0xd0, 0xdc, 0x31, 0xc9, 0xe6, 0x8e, 0xfe, 0x73, 0xc6, 0x4f, 0xc1, 0x44, 0x77, 0xec, 0x88,
+	0xc3, 0x0b, 0xee, 0x2f, 0x65, 0x00, 0x51, 0x32, 0x18, 0xc9, 0xa3, 0x43, 0xea, 0x33, 0x90, 0x60,
+	0x01, 0x33, 0x8c, 0xd3, 0x38, 0x03, 0x3c, 0xf9, 0x1e, 0x9b, 0x11, 0xcf, 0x55, 0x6e, 0xd7, 0x90,
+	0xdb, 0x1c, 0x50, 0x9d, 0xf9, 0x43, 0xd7, 0x18, 0x40, 0xfd, 0x44, 0x86, 0x38, 0x8b, 0xcf, 0x08,
+	0xf3, 0x76, 0x18, 0xfb, 0xf1, 0x0f, 0xe4, 0xe0, 0x26, 0xab, 0x8c, 0xb6, 0x6b, 0x08, 0x1b, 0xa3,
+	0x35, 0xa0, 0x7a, 0xfe, 0x9f, 0x1e, 0x3a, 0xa0, 0x06, 0xa0, 0x03, 0x1c, 0xe8, 0xfc, 0x26, 0x89,
+	0xfb, 0xae, 0xa3, 0x41, 0x8a, 0xfa, 0xbb, 0x04, 0x69, 0x5e, 0xbb, 0x8f, 0x88, 0xbd, 0x3b, 0x12,
+	0xe4, 0xfc, 0x27, 0xf0, 0xb3, 0xd0, 0x95, 0x2d, 0x1d, 0x6f, 0xa2, 0xf0, 0xa3, 0x58, 0xe1, 0xb6,
+	0xb0, 0x47, 0x75, 0xa6, 0xd7, 0x32, 0x39, 0x0b, 0x13, 0xa2, 0x70, 0x97, 0xfc, 0x9f, 0x7b, 0x0b,
+	0x77, 0x20, 0x50, 0x32, 0x95, 0x15, 0x48, 0x87, 0x0e, 0x56, 0x2d, 0x93, 0xdb, 0x9c, 0x5e, 0xce,
+	0xb5, 0x5b, 0xf9, 0x54, 0xb1, 0xb3, 0xd0, 0xa3, 0x22, 0xd5, 0x15, 0x2a, 0x99, 0x7b, 0x9b, 0x47,
+	0xec, 0x80, 0xcd, 0xe3, 0x2b, 0x19, 0xe6, 0xd6, 0x51, 0x1d, 0xb9, 0x1e, 0x0a, 0x9b, 0xf9, 0x94,
+	0x7c, 0xfb, 0x1a, 0xc8, 0x9e, 0xe1, 0xbb, 0xf6, 0xd2, 0x13, 0xb8, 0x76, 0x00, 0xf1, 0x7b, 0xb4,
+	0xcb, 0x9e, 0xc1, 0x52, 0x16, 0xb9, 0x2e, 0x19, 0x98, 0xb2, 0x7c, 0x51, 0xb9, 0x0e, 0x71, 0x6f,
+	0xdb, 0xf6, 0xa8, 0x4e, 0x83, 0x33, 0xec, 0xf3, 0xed, 0x56, 0x3e, 0x5e, 0x5e, 0xbb, 0x5a, 0xae,
+	0x5c, 0xa9, 0xac, 0xee, 0x16, 0xfa, 0xb3, 0x95, 0x3f, 0xe9, 0x22, 0x53, 0x37, 0xe8, 0x25, 0x15,
+	0x13, 0xec, 0x21, 0xec, 0x59, 0xd4, 0xaa, 0x23, 0x75, 0xbd, 0xa3, 0x44, 0xfd, 0x46, 0x02, 0xe5,
+	0x65, 0x0b, 0x5b, 0xde, 0xd6, 0x28, 0xb3, 0xa7, 0x7e, 0x2f, 0xc1, 0x7c, 0xaf, 0x19, 0xeb, 0xc4,
+	0xb6, 0x37, 0x74, 0xe3, 0xce, 0xc8, 0x99, 0xf3, 0x76, 0x67, 0x22, 0xaa, 0x34, 0x1d, 0x34, 0x52,
+	0x9d, 0x9d, 0x36, 0x9d, 0xa1, 0x67, 0xc1, 0x71, 0x06, 0xd8, 0xdd, 0xa4, 0x26, 0x86, 0x35, 0xa9,
+	0x07, 0x92, 0x18, 0x71, 0x46, 0x98, 0x88, 0xd8, 0x70, 0x22, 0xd4, 0x87, 0x12, 0x24, 0xc4, 0x31,
+	0x71, 0x74, 0x6d, 0xfc, 0x50, 0x06, 0xf0, 0xaf, 0x44, 0x22, 0x6b, 0xa4, 0x72, 0x0e, 0xd2, 0xfc,
+	0x3e, 0x64, 0x9f, 0x14, 0x48, 0x62, 0xd4, 0xa8, 0x04, 0xc4, 0x3c, 0x96, 0x60, 0xc6, 0x9f, 0x4d,
+	0x59, 0x4f, 0xf3, 0xa8, 0x65, 0x78, 0x91, 0xbd, 0x10, 0x79, 0x3f, 0x06, 0xa7, 0x6e, 0x62, 0x4f,
+	0xbf, 0x8d, 0x6e, 0x3a, 0x1e, 0x72, 0x69, 0x77, 0x48, 0x18, 0x1d, 0x93, 0x5f, 0x82, 0x39, 0xc7,
+	0x45, 0x75, 0x8b, 0xd4, 0x3c, 0xad, 0x3b, 0xc8, 0x0c, 0xb0, 0x5d, 0x09, 0xa0, 0x21, 0x4b, 0x9f,
+	0x17, 0xb7, 0x66, 0x21, 0xd9, 0xc1, 0xb7, 0xd8, 0x21, 0xb1, 0xd3, 0x30, 0x71, 0x9b, 0xb8, 0x86,
+	0xe8, 0xfb, 0xbd, 0x87, 0x70, 0x62, 0x51, 0x39, 0x0b, 0x29, 0xfe, 0x41, 0xc3, 0x84, 0x5a, 0x06,
+	0xe2, 0x27, 0x76, 0x7d, 0x22, 0x90, 0x63, 0xae, 0x71, 0x88, 0xfa, 0x75, 0xc7, 0x29, 0x45, 0x64,
+	0x23, 0x8a, 0x46, 0xd1, 0x29, 0x17, 0x21, 0x21, 0xde, 0x2c, 0xea, 0x8e, 0x90, 0xf3, 0x6c, 0x30,
+	0x12, 0x6f, 0x11, 0xf5, 0x0c, 0x90, 0x71, 0x01, 0x2e, 0x99, 0xca, 0x2b, 0x30, 0xe3, 0x0b, 0xfa,
+	0xaf, 0x15, 0x74, 0x2e, 0xb0, 0x16, 0xda, 0xad, 0x7c, 0x46, 0xc8, 0x8b, 0xce, 0xdd, 0xa3, 0x25,
+	0xe3, 0x84, 0x57, 0x4d, 0x45, 0x85, 0x71, 0x9e, 0x06, 0xfd, 0xfb, 0x19, 0x5f, 0xeb, 0x7a, 0x71,
+	0xf2, 0x20, 0x5e, 0x9c, 0xda, 0xdf, 0x8b, 0x3f, 0x8c, 0xc3, 0x7c, 0x38, 0xb5, 0x58, 0xbe, 0x79,
+	0x8e, 0x6e, 0xa0, 0x55, 0x4c, 0xdd, 0xe6, 0xb1, 0x27, 0x0f, 0xdd, 0x93, 0x97, 0x21, 0xd9, 0xa9,
+	0x03, 0x96, 0xc9, 0xfd, 0xe9, 0xef, 0x5b, 0x6e, 0xf8, 0x3f, 0xf7, 0xee, 0x5b, 0x02, 0x81, 0x92,
+	0xd9, 0x0d, 0x84, 0xa9, 0x61, 0x81, 0xf0, 0x02, 0xcc, 0xde, 0xd6, 0x2d, 0x1b, 0x99, 0x5a, 0x5d,
+	0xb7, 0x2d, 0x93, 0x6f, 0x7a, 0xb2, 0xf1, 0xbe, 0x12, 0x33, 0x02, 0x78, 0xab, 0x83, 0x63, 0xc2,
+	0x5d, 0x29, 0x8d, 0x6f, 0x20, 0xbc, 0x6c, 0xa2, 0xaf, 0x49, 0x33, 0x5d, 0xe0, 0x2a, 0xc7, 0xa9,
+	0xdf, 0xc5, 0x82, 0x78, 0x12, 0x55, 0xe1, 0x38, 0x9e, 0x46, 0xb4, 0x32, 0x2c, 0xff, 0xff, 0xee,
+	0xc3, 0xdc, 0xd8, 0xdd, 0x76, 0x4e, 0xba, 0xd7, 0xce, 0x49, 0xf7, 0xdb, 0x39, 0xe9, 0x41, 0x3b,
+	0x27, 0xbd, 0xb7, 0x93, 0x1b, 0xbb, 0xb7, 0x93, 0x1b, 0xbb, 0xbf, 0x93, 0x1b, 0x7b, 0x7d, 0xca,
+	0x67, 0x75, 0x63, 0x92, 0xbf, 0xf9, 0x7d, 0xfe, 0x9f, 0x00, 0x00, 0x00, 0xff, 0xff, 0x31, 0x65,
+	0x49, 0x0f, 0x6f, 0x2e, 0x00, 0x00,
 }

--- a/pkg/util/log/eventpb/ddl_events.proto
+++ b/pkg/util/log/eventpb/ddl_events.proto
@@ -98,6 +98,18 @@ message RenameSchema {
   string new_schema_name = 4  [(gogoproto.jsontag) = ",omitempty"];
 }
 
+// SetSchema is recorded when a table, view, sequence or type's schema is changed.
+message SetSchema {
+  CommonEventDetails common = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];
+  CommonSQLEventDetails sql = 2 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];
+  // The old name of the affected schema.
+  string old_schema_name = 3 [(gogoproto.jsontag) = ",omitempty"];
+  // The new name of the affected schema.
+  string new_schema_name = 4 [(gogoproto.jsontag) = ",omitempty"];
+  // The descriptor type being changed (table, view, sequence, type).
+  string descriptor_type = 5 [(gogoproto.jsontag) = ",omitempty"];
+}
+
 // CreateTable is recorded when a table is created.
 message CreateTable {
   CommonEventDetails common = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];

--- a/pkg/util/log/eventpb/eventlog_channels_generated.go
+++ b/pkg/util/log/eventpb/eventlog_channels_generated.go
@@ -116,6 +116,9 @@ func (m *RenameType) LoggingChannel() logpb.Channel { return logpb.Channel_SQL_S
 func (m *ReverseSchemaChange) LoggingChannel() logpb.Channel { return logpb.Channel_SQL_SCHEMA }
 
 // LoggingChannel implements the EventPayload interface.
+func (m *SetSchema) LoggingChannel() logpb.Channel { return logpb.Channel_SQL_SCHEMA }
+
+// LoggingChannel implements the EventPayload interface.
 func (m *TruncateTable) LoggingChannel() logpb.Channel { return logpb.Channel_SQL_SCHEMA }
 
 // LoggingChannel implements the EventPayload interface.

--- a/pkg/util/log/eventpb/json_encode_generated.go
+++ b/pkg/util/log/eventpb/json_encode_generated.go
@@ -1757,6 +1757,52 @@ func (m *SetClusterSetting) AppendJSONFields(printComma bool, b redact.Redactabl
 }
 
 // AppendJSONFields implements the EventPayload interface.
+func (m *SetSchema) AppendJSONFields(printComma bool, b redact.RedactableBytes) (bool, redact.RedactableBytes) {
+
+	printComma, b = m.CommonEventDetails.AppendJSONFields(printComma, b)
+
+	printComma, b = m.CommonSQLEventDetails.AppendJSONFields(printComma, b)
+
+	if m.OldSchemaName != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"OldSchemaName\":\""...)
+		b = append(b, redact.StartMarker()...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.OldSchemaName)))))
+		b = append(b, redact.EndMarker()...)
+		b = append(b, '"')
+	}
+
+	if m.NewSchemaName != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"NewSchemaName\":\""...)
+		b = append(b, redact.StartMarker()...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.NewSchemaName)))))
+		b = append(b, redact.EndMarker()...)
+		b = append(b, '"')
+	}
+
+	if m.DescriptorType != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"DescriptorType\":\""...)
+		b = append(b, redact.StartMarker()...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.DescriptorType)))))
+		b = append(b, redact.EndMarker()...)
+		b = append(b, '"')
+	}
+
+	return printComma, b
+}
+
+// AppendJSONFields implements the EventPayload interface.
 func (m *SetZoneConfig) AppendJSONFields(printComma bool, b redact.RedactableBytes) (bool, redact.RedactableBytes) {
 
 	printComma, b = m.CommonEventDetails.AppendJSONFields(printComma, b)


### PR DESCRIPTION
Fixes https://github.com/cockroachdb/cockroach/issues/57741.

Previously, we had event log entries for table/views/sequence renames,
however no event log entry is generated for SET SCHEMA.
This is inconsistent, as SET SCHEMA changes the way that objects are named.
To address this, this patch adds event logs for SET SCHEMA statements.

Release note (bug fix): add event logs for SET SCHEMA statements