### PR TITLE
release-20.2: util/log: conditionally include the tenant+server IDs on every line

### DIFF
--- a/pkg/ccl/backupccl/create_scheduled_backup_test.go
+++ b/pkg/ccl/backupccl/create_scheduled_backup_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	pbtypes "github.com/gogo/protobuf/types"
 	"github.com/stretchr/testify/require"
@@ -172,6 +173,8 @@ func (t userType) String() string {
 // itself with the actual scheduling and the execution of those backups.
 func TestSerializesScheduledBackupExecutionArgs(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
 	th, cleanup := newTestHelper(t)
 	defer cleanup()
 
@@ -429,6 +432,8 @@ func TestSerializesScheduledBackupExecutionArgs(t *testing.T) {
 
 func TestScheduleBackup(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
 	th, cleanup := newTestHelper(t)
 	defer cleanup()
 
@@ -570,6 +575,8 @@ INSERT INTO t1 values (-1), (10), (-100);
 
 func TestCreateBackupScheduleRequiresAdminRole(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
 	th, cleanup := newTestHelper(t)
 	defer cleanup()
 
@@ -591,6 +598,8 @@ func TestCreateBackupScheduleRequiresAdminRole(t *testing.T) {
 
 func TestCreateBackupScheduleCollectionOverwrite(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
 	th, cleanup := newTestHelper(t)
 	defer cleanup()
 
@@ -611,6 +620,8 @@ func TestCreateBackupScheduleCollectionOverwrite(t *testing.T) {
 
 func TestCreateBackupScheduleInExplicitTxnRollback(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
 	th, cleanup := newTestHelper(t)
 	defer cleanup()
 

--- a/pkg/cli/interactive_tests/test_force_auth_log.tcl
+++ b/pkg/cli/interactive_tests/test_force_auth_log.tcl
@@ -1,0 +1,47 @@
+#! /usr/bin/env expect -f
+
+source [file join [file dirname $argv0] common.tcl]
+
+set ::env(COCKROACH_INSECURE) "false"
+set ::env(COCKROACH_HOST) "localhost"
+set certs_dir "/certs"
+
+set ::env(COCKROACH_ALWAYS_LOG_SERVER_IDS) 1
+set ::env(COCKROACH_ALWAYS_LOG_AUTHN_EVENTS) 1
+
+proc start_secure_server {argv certs_dir extra} {
+    report "BEGIN START SECURE SERVER"
+    system "$argv start-single-node --host=localhost --socket-dir=. --certs-dir=$certs_dir --pid-file=server_pid -s=path=logs/db --background $extra >>expect-cmd.log 2>&1;
+            $argv sql --certs-dir=$certs_dir -e 'select 1'"
+    report "END START SECURE SERVER"
+}
+
+proc stop_secure_server {argv certs_dir} {
+    report "BEGIN STOP SECURE SERVER"
+    system "$argv quit --certs-dir=$certs_dir"
+    report "END STOP SECURE SERVER"
+}
+
+
+start_secure_server $argv $certs_dir ""
+
+set logfile logs/db/logs/cockroach-auth.log
+
+# run a client command, so we have at least one authn event in the log.
+system "$argv sql -e 'create user someuser' --certs-dir=$certs_dir"
+system "$argv sql -e 'select 1' --user someuser --certs-dir=$certs_dir</dev/null || true"
+
+start_test "Check that the authentication events are reported"
+
+system "grep -q 'authentication succeeded' $logfile"
+system "grep -q 'authentication failed' $logfile"
+
+end_test
+
+start_test "Check that the auth events have both node ID and cluster ID"
+
+system "grep -q '\\\[n1,.*clusterID=........-....-....-....-............\\\] . authentication' $logfile"
+
+end_test
+
+stop_secure_server $argv $certs_dir

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -57,6 +57,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ts"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/netutil"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
@@ -649,6 +650,7 @@ func StartTenant(
 	if err != nil {
 		return nil, "", "", err
 	}
+
 	s, err := newSQLServer(ctx, args)
 	if err != nil {
 		return nil, "", "", err
@@ -745,6 +747,11 @@ func StartTenant(
 	); err != nil {
 		return nil, "", "", err
 	}
+
+	// Inform the logging package of the cluster identifiers.
+	clusterID := args.rpcContext.ClusterID.Get().String()
+	log.SetClusterID(clusterID)
+	log.SetTenantIDs(args.TenantID.String(), int32(s.SQLInstanceID()))
 
 	return s, pgLAddr, httpLAddr, nil
 }

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1335,6 +1335,10 @@ func (t *logicTest) setup(cfg testClusterConfig, serverArgs TestServerArgs) {
 			TenantID:                    roachpb.MakeTenantID(10),
 			AllowSettingClusterSettings: true,
 		}
+
+		// Prevent a logging assertion that the server ID is initialized multiple times.
+		log.TestingClearServerIdentifiers()
+
 		tenant, err := t.cluster.Server(t.nodeIdx).StartTenant(tenantArgs)
 		if err != nil {
 			t.rootT.Fatalf("%+v", err)
@@ -2877,9 +2881,14 @@ func RunLogicTestWithDefaultConfig(
 					//  - we're generating testfiles, or
 					//  - we are in race mode (where we can hit a limit on alive
 					//    goroutines).
-					if !*showSQL && !*rewriteResultsInTestfiles && !*rewriteSQL && !util.RaceEnabled {
+					if !*showSQL && !*rewriteResultsInTestfiles && !*rewriteSQL && !util.RaceEnabled && !cfg.useTenant {
 						// Skip parallelizing tests that use the kv-batch-size directive since
 						// the batch size is a global variable.
+						//
+						// We also cannot parallelise tests that use tenant servers
+						// because they change shared state in the logging configuration
+						// and there is an assertion against conflicting changes.
+						//
 						// TODO(jordan, radu): make sqlbase.kvBatchSize non-global to fix this.
 						if filepath.Base(path) != "select_index_span_ranges" {
 							t.Parallel() // SAFE FOR TESTING (this comments satisfies the linter)

--- a/pkg/sql/telemetry_test.go
+++ b/pkg/sql/telemetry_test.go
@@ -144,6 +144,9 @@ func (tt *telemetryTest) Start(t *testing.T) {
 	tt.server, tt.serverDB, _ = serverutils.StartServer(tt.t, params)
 	tt.prepareCluster(tt.serverDB)
 
+	// Prevent a logging assertion that the server ID is initialized multiple times.
+	log.TestingClearServerIdentifiers()
+
 	tt.tenant, tt.tenantDB = serverutils.StartTenant(tt.t, tt.server, base.TestTenantArgs{
 		TenantID:                    roachpb.MakeTenantID(security.EmbeddedTenantIDs()[0]),
 		AllowSettingClusterSettings: true,

--- a/pkg/util/log/flags.go
+++ b/pkg/util/log/flags.go
@@ -13,6 +13,7 @@ package log
 import (
 	"context"
 	"flag"
+	"sync/atomic"
 
 	"github.com/cockroachdb/cockroach/pkg/cli/cliflags"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logflags"
@@ -34,6 +35,15 @@ func init() {
 		logflags.LogToStderrName, "logs at or above this threshold go to stderr")
 	flag.Var(&mainLog.fileThreshold,
 		logflags.LogFileVerbosityThresholdName, "minimum verbosity of messages written to the log file")
+}
+
+// TestingClearServerIdentifiers clears the server identity from the
+// logging system. This is for use in tests that start multiple
+// servers with conflicting identities subsequently.
+func TestingClearServerIdentifiers() {
+	logging.clusterID.Set("")
+	logging.tenantID.Set("")
+	atomic.StoreInt32(&logging.sqlInstanceID, 0)
 }
 
 // IsActive returns true iff the main logger already has some events

--- a/pkg/util/log/sync_buffer.go
+++ b/pkg/util/log/sync_buffer.go
@@ -253,11 +253,9 @@ func (l *loggerT) initializeNewOutputFile(
 		l.makeStartLine("arguments: %s", os.Args),
 	)
 
-	logging.mu.Lock()
-	if logging.mu.clusterID != "" {
-		messages = append(messages, l.makeStartLine("clusterID: %s", logging.mu.clusterID))
+	if clusterID := logging.clusterID.Get(); len(clusterID) > 0 {
+		messages = append(messages, l.makeStartLine("clusterID: %s", clusterID))
 	}
-	logging.mu.Unlock()
 
 	// Including a non-ascii character in the first 1024 bytes of the log helps
 	// viewers that attempt to guess the character encoding.

--- a/pkg/util/log/test_log_scope.go
+++ b/pkg/util/log/test_log_scope.go
@@ -151,6 +151,10 @@ func ScopeWithoutShowLogs(t tShim) (sc *TestLogScope) {
 	// they only go to files.
 	mainLog.stderrThreshold.set(Severity_NONE)
 
+	// Clear the server identifiers to prevent double initialization
+	// panics.
+	TestingClearServerIdentifiers()
+
 	t.Logf("test logs captured to: %s", tempDir)
 	return sc
 }


### PR DESCRIPTION
Fixes #58705.
 
For CC security logging we want the ability to route the logging
events from the files where they are written into a centralized
logging collector.

However this routing is done line-by-line. To enable log aggregation
across multiple clusters, or multiple nodes, we need to disambiguate
which log entries come from which cluster and which node.

This patch accommodates this requirement by adding the cluster ID and,
for tenant servers, the tenant and SQL instance ID, on every output
line when the env var `COCKROACH_ALWAYS_LOG_SERVER_IDS` is set to a
true-ish value.

Note: this feature is unneeded in v21.1 because in that version JSON
logging is available and that already includes the server identity
bits.

Release note: None