### PR TITLE
tracing,sql: introduce BenchmarkTracing

### DIFF
--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -330,8 +330,8 @@ func runStart(cmd *cobra.Command, args []string, startSingleNode bool) (returnEr
 	// has completed.
 	// TODO(andrei): we don't close the span on the early returns below.
 	tracer := serverCfg.Settings.Tracer
-	sp := tracer.StartSpan("server start")
-	ctx = tracing.ContextWithSpan(ctx, sp)
+	startupSpan := tracer.StartSpan("server start")
+	ctx = tracing.ContextWithSpan(ctx, startupSpan)
 
 	// Set up the logging and profiling output.
 	//
@@ -543,7 +543,7 @@ If problems persist, please see %s.`
 		}()
 		// When the start up goroutine completes, so can the start up span
 		// defined above.
-		defer sp.Finish()
+		defer startupSpan.Finish()
 
 		// Any error beyond this point should be reported through the
 		// errChan defined above. However, in Go the code pattern "if err

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -959,7 +959,6 @@ func (n *Node) setupSpanForIncomingRPC(
 		if br == nil {
 			return
 		}
-		// TODO(irfansharif): How come this span is never Finish()-ed? #58721.
 		if grpcSpan != nil {
 			// If our local span descends from a parent on the other
 			// end of the RPC (i.e. the !isLocalRequest) case,

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -959,6 +959,7 @@ func (n *Node) setupSpanForIncomingRPC(
 		if br == nil {
 			return
 		}
+		// TODO(irfansharif): How come this span is never Finish()-ed? #58721.
 		if grpcSpan != nil {
 			// If our local span descends from a parent on the other
 			// end of the RPC (i.e. the !isLocalRequest) case,

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -947,6 +947,7 @@ func (s *vectorizedFlowCreator) setupOutput(
 						// Start a separate recording so that GetRecording will return
 						// the recordings for only the child spans containing stats.
 						ctx, span := tracing.ChildSpanRemote(ctx, "")
+						// TODO(irfansharif): How come this span is never Finish()-ed? #58721.
 						if atomic.AddInt32(&s.numOutboxesDrained, 1) == atomic.LoadInt32(&s.numOutboxes) {
 							// At the last outbox, we can accurately retrieve stats for the
 							// whole flow from parent monitors. These stats are added to a

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -947,7 +947,6 @@ func (s *vectorizedFlowCreator) setupOutput(
 						// Start a separate recording so that GetRecording will return
 						// the recordings for only the child spans containing stats.
 						ctx, span := tracing.ChildSpanRemote(ctx, "")
-						// TODO(irfansharif): How come this span is never Finish()-ed? #58721.
 						if atomic.AddInt32(&s.numOutboxesDrained, 1) == atomic.LoadInt32(&s.numOutboxes) {
 							// At the last outbox, we can accurately retrieve stats for the
 							// whole flow from parent monitors. These stats are added to a
@@ -965,6 +964,7 @@ func (s *vectorizedFlowCreator) setupOutput(
 							})
 						}
 						finishVectorizedStatsCollectors(ctx, vscs)
+						span.Finish()
 						return []execinfrapb.ProducerMetadata{{TraceData: span.GetRecording()}}
 					},
 				},

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -636,6 +636,7 @@ func (ex *connExecutor) execStmtInOpenState(
 	if !alreadyRecording && stmtTraceThreshold > 0 {
 		ctx, stmtThresholdSpan = createRootOrChildSpan(ctx, "trace-stmt-threshold", ex.transitionCtx.tracer)
 		stmtThresholdSpan.SetVerbose(true)
+		// TODO(irfansharif): How come this span is never Finish()-ed? #58721.
 	}
 
 	if err := ex.dispatchToExecutionEngine(ctx, p, res); err != nil {

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -636,14 +636,15 @@ func (ex *connExecutor) execStmtInOpenState(
 	if !alreadyRecording && stmtTraceThreshold > 0 {
 		ctx, stmtThresholdSpan = createRootOrChildSpan(ctx, "trace-stmt-threshold", ex.transitionCtx.tracer)
 		stmtThresholdSpan.SetVerbose(true)
-		// TODO(irfansharif): How come this span is never Finish()-ed? #58721.
 	}
 
 	if err := ex.dispatchToExecutionEngine(ctx, p, res); err != nil {
+		stmtThresholdSpan.Finish()
 		return nil, nil, err
 	}
 
 	if stmtThresholdSpan != nil {
+		stmtThresholdSpan.Finish()
 		logTraceAboveThreshold(
 			ctx,
 			stmtThresholdSpan.GetRecording(),

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1443,7 +1443,7 @@ type SessionTracing struct {
 	enabled bool
 
 	// kvTracingEnabled is set at times when KV tracing is active. When
-	// KV tracning is enabled, the SQL/KV interface logs individual K/V
+	// KV tracing is enabled, the SQL/KV interface logs individual K/V
 	// operators to the current context.
 	kvTracingEnabled bool
 

--- a/pkg/sql/flowinfra/outbox.go
+++ b/pkg/sql/flowinfra/outbox.go
@@ -217,9 +217,9 @@ func (m *Outbox) mainLoop(ctx context.Context) error {
 		span.SetTag(execinfrapb.FlowIDTagKey, m.flowCtx.ID.String())
 		span.SetTag(execinfrapb.StreamIDTagKey, m.streamID)
 	}
-	// spanFinished specifies whether we called tracing.FinishSpan on the span.
-	// Some code paths (e.g. stats collection) need to prematurely call
-	// FinishSpan to get trace data.
+	// spanFinished specifies whether we've Finish()-ed the span. Some code
+	// paths (e.g. stats collection) need to prematurely call it to get trace
+	// data.
 	spanFinished := false
 	defer func() {
 		if !spanFinished {

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -263,7 +263,7 @@ func (t *Tracer) AlwaysTrace() bool {
 
 // startSpanGeneric is the implementation of StartSpanCtx and StartSpan. In
 // the latter case, ctx == noCtx and the returned Context is the supplied one;
-// otherwise the returned Context reflects the returned Span.
+// otherwise the returned Context embeds the returned Span.
 func (t *Tracer) startSpanGeneric(
 	ctx context.Context, opName string, opts spanOptions,
 ) (context.Context, *Span) {


### PR DESCRIPTION
BenchmarkTracing measures the overhead of always-on tracing. It also
reports the memory utilization.

    make bench PKG=./pkg/bench \
      TESTFLAGS='-benchtime=5000x -count 20' \
      BENCHES='BenchmarkTracing' BENCHTIMEOUT=50m

Plumbing that into `benchstat` (old is without always-on tracing, new is
with):

    name                                            old time/op    new time/op    delta
    Tracing/Cockroach/tracing=x/Scan1-16               172µs ± 2%     164µs ± 4%   -4.87%  (p=0.000 n=17+19)
    Tracing/Cockroach/tracing=x/Insert-16              253µs ± 5%     249µs ± 5%   -1.68%  (p=0.028 n=19+20)
    Tracing/MultinodeCockroach/tracing=x/Scan1-16      413µs ± 5%     491µs ±30%  +18.89%  (p=0.000 n=19+20)
    Tracing/MultinodeCockroach/tracing=x/Insert-16     543µs ±12%     539µs ± 7%     ~     (p=0.925 n=20+20)

    name                                            old alloc/op   new alloc/op   delta
    Tracing/Cockroach/tracing=x/Scan1-16              23.0kB ± 0%    23.3kB ± 2%   +0.95%  (p=0.000 n=17+17)
    Tracing/Cockroach/tracing=x/Insert-16             38.7kB ±21%    38.1kB ± 7%     ~     (p=0.687 n=20+19)
    Tracing/MultinodeCockroach/tracing=x/Scan1-16     72.0kB ±15%    75.1kB ±10%   +4.28%  (p=0.000 n=19+20)
    Tracing/MultinodeCockroach/tracing=x/Insert-16     102kB ±19%     101kB ±11%     ~     (p=0.813 n=20+19)

    name                                            old allocs/op  new allocs/op  delta
    Tracing/Cockroach/tracing=x/Scan1-16                 247 ± 0%       248 ± 1%   +0.21%  (p=0.004 n=16+17)
    Tracing/Cockroach/tracing=x/Insert-16                309 ± 0%       310 ± 2%     ~     (p=0.059 n=17+20)
    Tracing/MultinodeCockroach/tracing=x/Scan1-16        762 ± 3%       766 ± 3%   +0.58%  (p=0.015 n=17+19)
    Tracing/MultinodeCockroach/tracing=x/Insert-16       734 ± 3%       733 ± 2%     ~     (p=0.402 n=19+19)

Release note: None
