### PR TITLE
opt: always add deletable index predicates to table metadata

### DIFF
--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -1064,7 +1064,7 @@ func (mb *mutationBuilder) buildUpsert(returning tree.ReturningExprs) {
 	// Add the partial index predicate expressions to the table metadata.
 	// These expressions are used to prune fetch columns during
 	// normalization.
-	mb.b.addPartialIndexPredicatesForTable(mb.md.TableMeta(mb.tabID), nil /* scan */, true /* includeDeletable */)
+	mb.b.addPartialIndexPredicatesForTable(mb.md.TableMeta(mb.tabID), nil /* scan */)
 
 	// Project partial index PUT and DEL boolean columns.
 	//

--- a/pkg/sql/opt/optbuilder/partial_index.go
+++ b/pkg/sql/opt/optbuilder/partial_index.go
@@ -31,16 +31,9 @@ import (
 // outputs all the ordinary columns in the table, we avoid constructing a new
 // scan. A scan and its logical properties are required in order to fully
 // normalize the partial index predicates.
-func (b *Builder) addPartialIndexPredicatesForTable(
-	tabMeta *opt.TableMeta, scan memo.RelExpr, includeDeletable bool,
-) {
+func (b *Builder) addPartialIndexPredicatesForTable(tabMeta *opt.TableMeta, scan memo.RelExpr) {
 	tab := tabMeta.Table
-	var numIndexes int
-	if includeDeletable {
-		numIndexes = tab.DeletableIndexCount()
-	} else {
-		numIndexes = tab.IndexCount()
-	}
+	numIndexes := tab.DeletableIndexCount()
 
 	// Find the first partial index.
 	indexOrd := 0

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -539,7 +539,7 @@ func (b *Builder) buildScan(
 	// logical properties of the scan to fully normalize the index predicates.
 	// We don't need to add deletable partial index predicates in the context of
 	// a scan.
-	b.addPartialIndexPredicatesForTable(tabMeta, outScope.expr, false /* includeDeletable */)
+	b.addPartialIndexPredicatesForTable(tabMeta, outScope.expr)
 
 	if !virtualColIDs.Empty() {
 		// Project the expressions for the virtual columns (and pass through all

--- a/pkg/sql/opt/optbuilder/testdata/delete
+++ b/pkg/sql/opt/optbuilder/testdata/delete
@@ -469,8 +469,12 @@ delete partial_indexes
       │    └── partial index predicates
       │         ├── secondary: filters
       │         │    └── c:7 = 'foo'
-      │         └── secondary: filters
-      │              └── (a:5 > b:6) AND (c:7 = 'bar')
+      │         ├── secondary: filters
+      │         │    └── (a:5 > b:6) AND (c:7 = 'bar')
+      │         ├── b: filters
+      │         │    └── c:7 = 'delete-only'
+      │         └── b: filters
+      │              └── c:7 = 'write-only'
       └── projections
            ├── c:7 = 'foo' [as=partial_index_del1:9]
            ├── (a:5 > b:6) AND (c:7 = 'bar') [as=partial_index_del2:10]

--- a/pkg/sql/opt/optbuilder/testdata/update
+++ b/pkg/sql/opt/optbuilder/testdata/update
@@ -1682,8 +1682,12 @@ update partial_indexes
       │    │    └── partial index predicates
       │    │         ├── secondary: filters
       │    │         │    └── c:7 = 'foo'
-      │    │         └── secondary: filters
-      │    │              └── (a:5 > b:6) AND (c:7 = 'bar')
+      │    │         ├── secondary: filters
+      │    │         │    └── (a:5 > b:6) AND (c:7 = 'bar')
+      │    │         ├── b: filters
+      │    │         │    └── c:7 = 'delete-only'
+      │    │         └── b: filters
+      │    │              └── c:7 = 'write-only'
       │    └── projections
       │         └── 1 [as=a_new:9]
       └── projections
@@ -1712,8 +1716,12 @@ update partial_indexes
       │    │    └── partial index predicates
       │    │         ├── secondary: filters
       │    │         │    └── c:7 = 'foo'
-      │    │         └── secondary: filters
-      │    │              └── (a:5 > b:6) AND (c:7 = 'bar')
+      │    │         ├── secondary: filters
+      │    │         │    └── (a:5 > b:6) AND (c:7 = 'bar')
+      │    │         ├── b: filters
+      │    │         │    └── c:7 = 'delete-only'
+      │    │         └── b: filters
+      │    │              └── c:7 = 'write-only'
       │    └── projections
       │         └── a:5 + 5 [as=a_new:9]
       └── projections

--- a/pkg/sql/opt/optbuilder/testdata/upsert
+++ b/pkg/sql/opt/optbuilder/testdata/upsert
@@ -1932,8 +1932,12 @@ insert partial_indexes
       │    │         │    │    │         │    │    └── partial index predicates
       │    │         │    │    │         │    │         ├── secondary: filters
       │    │         │    │    │         │    │         │    └── c:10 = 'foo'
-      │    │         │    │    │         │    │         └── secondary: filters
-      │    │         │    │    │         │    │              └── (a:8 > b:9) AND (c:10 = 'bar')
+      │    │         │    │    │         │    │         ├── secondary: filters
+      │    │         │    │    │         │    │         │    └── (a:8 > b:9) AND (c:10 = 'bar')
+      │    │         │    │    │         │    │         ├── b: filters
+      │    │         │    │    │         │    │         │    └── c:10 = 'delete-only'
+      │    │         │    │    │         │    │         └── b: filters
+      │    │         │    │    │         │    │              └── c:10 = 'write-only'
       │    │         │    │    │         │    └── filters
       │    │         │    │    │         │         └── column1:5 = a:8
       │    │         │    │    │         └── filters
@@ -1948,8 +1952,12 @@ insert partial_indexes
       │    │         │    │    └── partial index predicates
       │    │         │    │         ├── secondary: filters
       │    │         │    │         │    └── c:14 = 'foo'
-      │    │         │    │         └── secondary: filters
-      │    │         │    │              └── (a:12 > b:13) AND (c:14 = 'bar')
+      │    │         │    │         ├── secondary: filters
+      │    │         │    │         │    └── (a:12 > b:13) AND (c:14 = 'bar')
+      │    │         │    │         ├── b: filters
+      │    │         │    │         │    └── c:14 = 'delete-only'
+      │    │         │    │         └── b: filters
+      │    │         │    │              └── c:14 = 'write-only'
       │    │         │    └── filters
       │    │         │         ├── column2:6 = b:13
       │    │         │         └── column3:7 = c:14
@@ -2003,8 +2011,12 @@ upsert partial_indexes
       │    │    │    │    └── partial index predicates
       │    │    │    │         ├── secondary: filters
       │    │    │    │         │    └── c:10 = 'foo'
-      │    │    │    │         └── secondary: filters
-      │    │    │    │              └── (a:8 > b:9) AND (c:10 = 'bar')
+      │    │    │    │         ├── secondary: filters
+      │    │    │    │         │    └── (a:8 > b:9) AND (c:10 = 'bar')
+      │    │    │    │         ├── b: filters
+      │    │    │    │         │    └── c:10 = 'delete-only'
+      │    │    │    │         └── b: filters
+      │    │    │    │              └── c:10 = 'write-only'
       │    │    │    └── filters
       │    │    │         ├── column2:6 = b:9
       │    │    │         └── column3:7 = c:10
@@ -2064,8 +2076,12 @@ upsert partial_indexes
       │    │    │    └── partial index predicates
       │    │    │         ├── secondary: filters
       │    │    │         │    └── c:10 = 'foo'
-      │    │    │         └── secondary: filters
-      │    │    │              └── (a:8 > b:9) AND (c:10 = 'bar')
+      │    │    │         ├── secondary: filters
+      │    │    │         │    └── (a:8 > b:9) AND (c:10 = 'bar')
+      │    │    │         ├── b: filters
+      │    │    │         │    └── c:10 = 'delete-only'
+      │    │    │         └── b: filters
+      │    │    │              └── c:10 = 'write-only'
       │    │    └── filters
       │    │         └── column1:5 = a:8
       │    └── projections

--- a/pkg/sql/opt/optbuilder/update.go
+++ b/pkg/sql/opt/optbuilder/update.go
@@ -339,7 +339,7 @@ func (mb *mutationBuilder) buildUpdate(returning tree.ReturningExprs) {
 	// Add the partial index predicate expressions to the table metadata.
 	// These expressions are used to prune fetch columns during
 	// normalization.
-	mb.b.addPartialIndexPredicatesForTable(mb.md.TableMeta(mb.tabID), nil /* scan */, true /* includeDeletable */)
+	mb.b.addPartialIndexPredicatesForTable(mb.md.TableMeta(mb.tabID), nil /* scan */)
 
 	// Project partial index PUT and DEL boolean columns.
 	mb.projectPartialIndexPutAndDelCols(preCheckScope, mb.fetchScope)


### PR DESCRIPTION
There is no need to avoid adding deletable indexes to the table metadata
in the context of a Select. Exploration rules that require access to
partial index predicates must already discriminate between public and
write/delete-only indexes. For example, `scanIndexIter` only considers
public indexes. Therefore, the partial index predicates in the table
metadata do not need to be an indication of what indexes are available
for a Select query to use. This reduces the complexity of some
optbuilder code.

Release note: None