### PR TITLE
release-19.2: server: remove support for binary protobuf payloads in the HTTP endpoints

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1174,13 +1174,10 @@ func (s *Server) Start(ctx context.Context) error {
 		EmitDefaults: true,
 		Indent:       "  ",
 	}
-	protopb := new(protoutil.ProtoPb)
 	gwMux := gwruntime.NewServeMux(
 		gwruntime.WithMarshalerOption(gwruntime.MIMEWildcard, jsonpb),
 		gwruntime.WithMarshalerOption(httputil.JSONContentType, jsonpb),
 		gwruntime.WithMarshalerOption(httputil.AltJSONContentType, jsonpb),
-		gwruntime.WithMarshalerOption(httputil.ProtoContentType, protopb),
-		gwruntime.WithMarshalerOption(httputil.AltProtoContentType, protopb),
 		gwruntime.WithOutgoingHeaderMatcher(authenticationHeaderMatcher),
 		gwruntime.WithMetadata(forwardAuthenticationMetadata),
 	)

--- a/pkg/util/httputil/http.go
+++ b/pkg/util/httputil/http.go
@@ -34,10 +34,6 @@ const (
 	JSONContentType = "application/json"
 	// AltJSONContentType is the alternate JSON content type.
 	AltJSONContentType = "application/x-json"
-	// ProtoContentType is the protobuf content type.
-	ProtoContentType = "application/x-protobuf"
-	// AltProtoContentType is the alternate protobuf content type.
-	AltProtoContentType = "application/x-google-protobuf"
 	// PlaintextContentType is the plaintext content type.
 	PlaintextContentType = "text/plain"
 	// GzipEncoding is the gzip encoding.


### PR DESCRIPTION
Backport 1/1 commits from #58657.

/cc @cockroachdb/release

---
