### PR TITLE
opt: clean up sort costing

### DIFF
--- a/pkg/sql/opt/xform/coster.go
+++ b/pkg/sql/opt/xform/coster.go
@@ -525,34 +525,40 @@ func (c *coster) ComputeCost(candidate memo.RelExpr, required *physical.Required
 }
 
 func (c *coster) computeSortCost(sort *memo.SortExpr, required *physical.Required) memo.Cost {
-	// We calculate the cost of a segmented sort. We assume each segment
-	// is of the same size of (rowCount / numSegments). We also calculate the
-	// per-row cost. The cost of the sort is:
+	// We calculate the cost of a (potentially) segmented sort.
 	//
-	// perRowCost * (rowCount + (segmentSize * log2(segmentSize) * numOrderedSegments))
+	// In a non-segmented sort, we have a single segment to sort according to
+	// required.Ordering.Columns.
 	//
-	// The constant term is necessary for cases where the estimated row count is
-	// very small.
+	// In a segmented sort, rows are split into segments according to
+	// InputOrdering.Columns; each segment is sorted according to the remaining
+	// columns from required.Ordering.Columns.
+	//
 	// TODO(rytaft): This is the cost of a local, in-memory sort. When a
 	// certain amount of memory is used, distsql switches to a disk-based sort
 	// with a temp RocksDB store.
+	numKeyCols := len(required.Ordering.Columns)
+	numPreorderedCols := len(sort.InputOrdering.Columns)
 
+	stats := sort.Relational().Stats
 	numSegments := c.countSegments(sort)
 	cost := memo.Cost(0)
-	stats := sort.Relational().Stats
-	rowCount := stats.RowCount
-	perRowCost := c.rowSortCost(len(required.Ordering.Columns) - len(sort.InputOrdering.Columns))
 
 	if !sort.InputOrdering.Any() {
-		// Add the cost for finding the segments.
-		cost += memo.Cost(float64(len(sort.InputOrdering.Columns))*rowCount) * cpuCostFactor
+		// Add the cost for finding the segments: each row is compared to the
+		// previous row on the preordered columns. Most of these comparisons will
+		// yield equality, so we don't use rowCmpCost(): we expect to have to
+		// compare all preordered columns.
+		cost += cpuCostFactor * memo.Cost(numPreorderedCols) * memo.Cost(stats.RowCount)
 	}
 
-	segmentSize := rowCount / numSegments
-	if segmentSize > 1 {
-		cost += memo.Cost(segmentSize) * (memo.Cost(math.Log2(segmentSize)) * memo.Cost(numSegments))
+	// Add the cost to sort the segments. On average, each row is involved in
+	// O(log(segmentSize)) comparisons.
+	numCmpOpsPerRow := float64(1)
+	if segmentSize := stats.RowCount / numSegments; segmentSize > 1 {
+		numCmpOpsPerRow += math.Log2(segmentSize)
 	}
-	cost = perRowCost * (memo.Cost(rowCount) + cost)
+	cost += c.rowCmpCost(numKeyCols-numPreorderedCols) * memo.Cost(numCmpOpsPerRow*stats.RowCount)
 	return cost
 }
 
@@ -1058,9 +1064,9 @@ func (c *coster) countSegments(sort *memo.SortExpr) float64 {
 	return orderedStats.DistinctCount
 }
 
-// rowSortCost is the CPU cost to sort one row, which depends on the number of
-// columns in the sort key.
-func (c *coster) rowSortCost(numKeyCols int) memo.Cost {
+// rowCmpCost is the CPU cost to compare a pair of rows, which depends on the
+// number of columns in the sort key.
+func (c *coster) rowCmpCost(numKeyCols int) memo.Cost {
 	// Sorting involves comparisons on the key columns, but the cost isn't
 	// directly proportional: we only compare the second column if the rows are
 	// equal on the first column; and so on. We also account for a fixed

--- a/pkg/sql/opt/xform/testdata/coster/sort
+++ b/pkg/sql/opt/xform/testdata/coster/sort
@@ -67,7 +67,7 @@ SELECT * FROM abc ORDER BY a, b, c
 sort (segmented)
  ├── columns: a:1 b:2 c:3
  ├── stats: [rows=1000, distinct(1,2)=1000, null(1,2)=0.1]
- ├── cost: 1094.43
+ ├── cost: 1114.03
  ├── ordering: +1,+2,+3
  └── scan abc@ab
       ├── columns: a:1 b:2 c:3
@@ -82,7 +82,7 @@ SELECT * FROM abc ORDER BY c, b, a
 sort (segmented)
  ├── columns: a:1 b:2 c:3
  ├── stats: [rows=1000, distinct(2,3)=1000, null(2,3)=0.1]
- ├── cost: 1094.43
+ ├── cost: 1114.03
  ├── ordering: +3,+2,+1
  └── scan abc@cb
       ├── columns: a:1 b:2 c:3
@@ -97,7 +97,7 @@ SELECT * FROM abc ORDER BY c, a, b
 sort (segmented)
  ├── columns: a:1 b:2 c:3
  ├── stats: [rows=1000, distinct(3)=100, null(3)=10]
- ├── cost: 1165.00049
+ ├── cost: 1174.79049
  ├── ordering: +3,+1,+2
  └── scan abc@cb
       ├── columns: a:1 b:2 c:3
@@ -130,7 +130,7 @@ SELECT * FROM abc ORDER BY a, b, c
 sort (segmented)
  ├── columns: a:1 b:2 c:3
  ├── stats: [rows=10000, distinct(1,2)=10, null(1,2)=0]
- ├── cost: 12901.1869
+ ├── cost: 13097.1869
  ├── ordering: +1,+2,+3
  └── scan abc@ab
       ├── columns: a:1 b:2 c:3
@@ -145,7 +145,7 @@ SELECT * FROM abc  WHERE a = b ORDER BY b, a, c
 sort (segmented)
  ├── columns: a:1!null b:2!null c:3
  ├── stats: [rows=2000, distinct(1)=2, null(1)=0, distinct(2)=2, null(2)=0]
- ├── cost: 11243.0714
+ ├── cost: 11262.6714
  ├── fd: (1)==(2), (2)==(1)
  ├── ordering: +(1|2),+3 [actual: +1,+3]
  └── select

--- a/pkg/sql/opt/xform/testdata/rules/groupby
+++ b/pkg/sql/opt/xform/testdata/rules/groupby
@@ -1274,13 +1274,13 @@ memo (optimized, ~12KB, required=[presentation: array_agg:6])
  │    │    └── cost: 1084.02
  │    ├── [ordering: +2,+4]
  │    │    ├── best: (sort G6="[ordering: +2]")
- │    │    └── cost: 1170.67
+ │    │    └── cost: 1180.47
  │    ├── [ordering: +2]
  │    │    ├── best: (scan kuvw@uvw,cols=(1-4))
  │    │    └── cost: 1084.02
  │    ├── [ordering: +4,+2]
  │    │    ├── best: (sort G6="[ordering: +4]")
- │    │    └── cost: 1170.67
+ │    │    └── cost: 1180.47
  │    ├── [ordering: +4]
  │    │    ├── best: (scan kuvw@wvu,cols=(1-4))
  │    │    └── cost: 1084.02
@@ -1294,7 +1294,7 @@ memo (optimized, ~12KB, required=[presentation: array_agg:6])
  │    │    └── cost: 1073.21
  │    ├── [ordering: +2,+4]
  │    │    ├── best: (sort G8="[ordering: +2]")
- │    │    └── cost: 1158.71
+ │    │    └── cost: 1168.41
  │    ├── [ordering: +2]
  │    │    ├── best: (scan kuvw@uvw,cols=(1-4),constrained)
  │    │    └── cost: 1073.21
@@ -1547,7 +1547,7 @@ memo (optimized, ~4KB, required=[presentation: u:2,v:3,w:4] [ordering: +2])
  ├── G2: (scan kuvw,cols=(2-4)) (scan kuvw@uvw,cols=(2-4)) (scan kuvw@wvu,cols=(2-4)) (scan kuvw@vw,cols=(2-4)) (scan kuvw@w,cols=(2-4))
  │    ├── [ordering: +2,+4]
  │    │    ├── best: (sort G2="[ordering: +2]")
- │    │    └── cost: 1160.67
+ │    │    └── cost: 1170.47
  │    ├── [ordering: +2]
  │    │    ├── best: (scan kuvw@uvw,cols=(2-4))
  │    │    └── cost: 1074.02
@@ -1605,14 +1605,14 @@ memo (optimized, ~4KB, required=[presentation: u:2,v:3,w:4] [ordering: +4,+2])
  ├── G1: (distinct-on G2 G3 cols=(2,4),ordering=-3 opt(2,4))
  │    ├── [presentation: u:2,v:3,w:4] [ordering: +4,+2]
  │    │    ├── best: (distinct-on G2="[ordering: +4,+2,-3]" G3 cols=(2,4),ordering=-3 opt(2,4))
- │    │    └── cost: 1205.02
+ │    │    └── cost: 1214.81
  │    └── []
  │         ├── best: (distinct-on G2="[ordering: -3 opt(2,4)]" G3 cols=(2,4),ordering=-3 opt(2,4))
  │         └── cost: 1223.70
  ├── G2: (scan kuvw,cols=(2-4)) (scan kuvw@uvw,cols=(2-4)) (scan kuvw@wvu,cols=(2-4)) (scan kuvw@vw,cols=(2-4)) (scan kuvw@w,cols=(2-4))
  │    ├── [ordering: +4,+2,-3]
  │    │    ├── best: (sort G2="[ordering: +4]")
- │    │    └── cost: 1165.00
+ │    │    └── cost: 1174.79
  │    ├── [ordering: +4]
  │    │    ├── best: (scan kuvw@wvu,cols=(2-4))
  │    │    └── cost: 1074.02
@@ -1633,14 +1633,14 @@ memo (optimized, ~4KB, required=[presentation: u:2,v:3,w:4] [ordering: +4])
  ├── G1: (distinct-on G2 G3 cols=(4),ordering=-2,+3 opt(4))
  │    ├── [presentation: u:2,v:3,w:4] [ordering: +4]
  │    │    ├── best: (distinct-on G2="[ordering: +4,-2,+3]" G3 cols=(4),ordering=-2,+3 opt(4))
- │    │    └── cost: 1196.02
+ │    │    └── cost: 1205.81
  │    └── []
  │         ├── best: (distinct-on G2="[ordering: -2,+3 opt(4)]" G3 cols=(4),ordering=-2,+3 opt(4))
  │         └── cost: 1345.33
  ├── G2: (scan kuvw,cols=(2-4)) (scan kuvw@uvw,cols=(2-4)) (scan kuvw@wvu,cols=(2-4)) (scan kuvw@vw,cols=(2-4)) (scan kuvw@w,cols=(2-4))
  │    ├── [ordering: +4,-2,+3]
  │    │    ├── best: (sort G2="[ordering: +4]")
- │    │    └── cost: 1165.00
+ │    │    └── cost: 1174.79
  │    ├── [ordering: +4]
  │    │    ├── best: (scan kuvw@wvu,cols=(2-4))
  │    │    └── cost: 1074.02
@@ -1690,20 +1690,20 @@ memo (optimized, ~4KB, required=[presentation: u:2,v:3,w:4] [ordering: +4])
  ├── G1: (distinct-on G2 G3 cols=(4),ordering=+2,-3 opt(4))
  │    ├── [presentation: u:2,v:3,w:4] [ordering: +4]
  │    │    ├── best: (distinct-on G2="[ordering: +4,+2,-3]" G3 cols=(4),ordering=+2,-3 opt(4))
- │    │    └── cost: 1196.02
+ │    │    └── cost: 1205.81
  │    └── []
  │         ├── best: (distinct-on G2="[ordering: +2,-3 opt(4)]" G3 cols=(4),ordering=+2,-3 opt(4))
- │         └── cost: 1201.69
+ │         └── cost: 1211.49
  ├── G2: (scan kuvw,cols=(2-4)) (scan kuvw@uvw,cols=(2-4)) (scan kuvw@wvu,cols=(2-4)) (scan kuvw@vw,cols=(2-4)) (scan kuvw@w,cols=(2-4))
  │    ├── [ordering: +2,-3 opt(4)]
  │    │    ├── best: (sort G2="[ordering: +2]")
- │    │    └── cost: 1160.67
+ │    │    └── cost: 1170.47
  │    ├── [ordering: +2]
  │    │    ├── best: (scan kuvw@uvw,cols=(2-4))
  │    │    └── cost: 1074.02
  │    ├── [ordering: +4,+2,-3]
  │    │    ├── best: (sort G2="[ordering: +4]")
- │    │    └── cost: 1165.00
+ │    │    └── cost: 1174.79
  │    ├── [ordering: +4]
  │    │    ├── best: (scan kuvw@wvu,cols=(2-4))
  │    │    └── cost: 1074.02

--- a/pkg/sql/opt/xform/testdata/rules/scan
+++ b/pkg/sql/opt/xform/testdata/rules/scan
@@ -241,7 +241,7 @@ memo (optimized, ~2KB, required=[presentation: s:4,i:2,f:3] [ordering: -4,+2])
  └── G1: (scan a,cols=(2-4)) (scan a@s_idx,cols=(2-4))
       ├── [presentation: s:4,i:2,f:3] [ordering: -4,+2]
       │    ├── best: (sort G1="[ordering: -4]")
-      │    └── cost: 1260.33
+      │    └── cost: 1270.13
       ├── [ordering: -4]
       │    ├── best: (scan a@s_idx,rev,cols=(2-4))
       │    └── cost: 1173.68
@@ -361,7 +361,7 @@ memo (optimized, ~2KB, required=[presentation: i:2,k:1] [ordering: -4,+2,+1])
  └── G1: (scan a,cols=(1,2,4)) (scan a@s_idx,cols=(1,2,4)) (scan a@si_idx,cols=(1,2,4))
       ├── [presentation: i:2,k:1] [ordering: -4,+2,+1]
       │    ├── best: (sort G1="[ordering: -4]")
-      │    └── cost: 1165.00
+      │    └── cost: 1174.79
       ├── [ordering: -4]
       │    ├── best: (scan a@si_idx,cols=(1,2,4))
       │    └── cost: 1074.02


### PR DESCRIPTION
This change makes some corrections and cleanup to the sort costing.
The cost of an unsegmented sort is unchanged. For a segmented sort,
the cost to determine the segments was incorrectly scaled with the
per-row comparison cost.

Fixes #55650.

Release note: None