### PR TITLE
kvserver: don't refuse to fwd lease proposals in some edge cases

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_lease.go
+++ b/pkg/kv/kvserver/batcheval/cmd_lease.go
@@ -33,10 +33,24 @@ func newFailedLeaseTrigger(isTransfer bool) result.Result {
 	return trigger
 }
 
-func checkCanReceiveLease(newLease *roachpb.Lease, rec EvalContext) error {
-	repDesc, ok := rec.Desc().GetReplicaDescriptorByID(newLease.Replica.ReplicaID)
+// checkCanReceiveLease checks whether `wouldbeLeaseholder` can receive a lease.
+// Returns an error if the respective replica is not eligible.
+//
+// An error is also returned is the replica is not part of `rngDesc`.
+//
+// For now, don't allow replicas of type LEARNER to be leaseholders. There's
+// no reason this wouldn't work in principle, but it seems inadvisable. In
+// particular, learners can't become raft leaders, so we wouldn't be able to
+// co-locate the leaseholder + raft leader, which is going to affect tail
+// latencies. Additionally, as of the time of writing, learner replicas are
+// only used for a short time in replica addition, so it's not worth working
+// out the edge cases.
+func checkCanReceiveLease(
+	wouldbeLeaseholder roachpb.ReplicaDescriptor, rngDesc *roachpb.RangeDescriptor,
+) error {
+	repDesc, ok := rngDesc.GetReplicaDescriptorByID(wouldbeLeaseholder.ReplicaID)
 	if !ok {
-		return errors.Errorf(`replica %s not found in %s`, newLease.Replica, rec.Desc())
+		return errors.Errorf(`replica %s not found in %s`, wouldbeLeaseholder, rngDesc)
 	} else if t := repDesc.GetType(); t != roachpb.VOTER_FULL {
 		// NB: there's no harm in transferring the lease to a VOTER_INCOMING,
 		// but we disallow it anyway. On the other hand, transferring to

--- a/pkg/kv/kvserver/batcheval/cmd_lease.go
+++ b/pkg/kv/kvserver/batcheval/cmd_lease.go
@@ -36,10 +36,6 @@ func newFailedLeaseTrigger(isTransfer bool) result.Result {
 func checkCanReceiveLease(newLease *roachpb.Lease, rec EvalContext) error {
 	repDesc, ok := rec.Desc().GetReplicaDescriptorByID(newLease.Replica.ReplicaID)
 	if !ok {
-		if newLease.Replica.StoreID == rec.StoreID() {
-			return errors.AssertionFailedf(
-				`could not find replica for store %s in %s`, rec.StoreID(), rec.Desc())
-		}
 		return errors.Errorf(`replica %s not found in %s`, newLease.Replica, rec.Desc())
 	} else if t := repDesc.GetType(); t != roachpb.VOTER_FULL {
 		// NB: there's no harm in transferring the lease to a VOTER_INCOMING,

--- a/pkg/kv/kvserver/batcheval/cmd_lease.go
+++ b/pkg/kv/kvserver/batcheval/cmd_lease.go
@@ -33,7 +33,7 @@ func newFailedLeaseTrigger(isTransfer bool) result.Result {
 	return trigger
 }
 
-// checkCanReceiveLease checks whether `wouldbeLeaseholder` can receive a lease.
+// CheckCanReceiveLease checks whether `wouldbeLeaseholder` can receive a lease.
 // Returns an error if the respective replica is not eligible.
 //
 // An error is also returned is the replica is not part of `rngDesc`.
@@ -45,7 +45,7 @@ func newFailedLeaseTrigger(isTransfer bool) result.Result {
 // latencies. Additionally, as of the time of writing, learner replicas are
 // only used for a short time in replica addition, so it's not worth working
 // out the edge cases.
-func checkCanReceiveLease(
+func CheckCanReceiveLease(
 	wouldbeLeaseholder roachpb.ReplicaDescriptor, rngDesc *roachpb.RangeDescriptor,
 ) error {
 	repDesc, ok := rngDesc.GetReplicaDescriptorByID(wouldbeLeaseholder.ReplicaID)

--- a/pkg/kv/kvserver/batcheval/cmd_lease_request.go
+++ b/pkg/kv/kvserver/batcheval/cmd_lease_request.go
@@ -58,7 +58,7 @@ func RequestLease(
 
 	// If this check is removed at some point, the filtering of learners on the
 	// sending side would have to be removed as well.
-	if err := checkCanReceiveLease(args.Lease.Replica, cArgs.EvalCtx.Desc()); err != nil {
+	if err := CheckCanReceiveLease(args.Lease.Replica, cArgs.EvalCtx.Desc()); err != nil {
 		rErr.Message = err.Error()
 		return newFailedLeaseTrigger(false /* isTransfer */), rErr
 	}

--- a/pkg/kv/kvserver/batcheval/cmd_lease_request.go
+++ b/pkg/kv/kvserver/batcheval/cmd_lease_request.go
@@ -56,18 +56,9 @@ func RequestLease(
 		Requested: args.Lease,
 	}
 
-	// For now, don't allow replicas of type LEARNER to be leaseholders. There's
-	// no reason this wouldn't work in principle, but it seems inadvisable. In
-	// particular, learners can't become raft leaders, so we wouldn't be able to
-	// co-locate the leaseholder + raft leader, which is going to affect tail
-	// latencies. Additionally, as of the time of writing, learner replicas are
-	// only used for a short time in replica addition, so it's not worth working
-	// out the edge cases. If we decide to start using long-lived learners at some
-	// point, that math may change.
-	//
 	// If this check is removed at some point, the filtering of learners on the
 	// sending side would have to be removed as well.
-	if err := checkCanReceiveLease(&args.Lease, cArgs.EvalCtx); err != nil {
+	if err := checkCanReceiveLease(args.Lease.Replica, cArgs.EvalCtx.Desc()); err != nil {
 		rErr.Message = err.Error()
 		return newFailedLeaseTrigger(false /* isTransfer */), rErr
 	}

--- a/pkg/kv/kvserver/batcheval/cmd_lease_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_lease_test.go
@@ -156,3 +156,38 @@ func TestLeaseCommandLearnerReplica(t *testing.T) {
 		`replica (n2,s2):2LEARNER of type LEARNER cannot hold lease`
 	require.EqualError(t, err, expForLearner)
 }
+
+func TestCheckCanReceiveLease(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	for _, tc := range []struct {
+		leaseholderType roachpb.ReplicaType
+		eligible        bool
+	}{
+		{leaseholderType: roachpb.VOTER_FULL, eligible: true},
+		{leaseholderType: roachpb.VOTER_INCOMING, eligible: false},
+		{leaseholderType: roachpb.VOTER_OUTGOING, eligible: false},
+		{leaseholderType: roachpb.VOTER_DEMOTING, eligible: false},
+		{leaseholderType: roachpb.LEARNER, eligible: false},
+		{leaseholderType: roachpb.NON_VOTER, eligible: false},
+	} {
+		t.Run(tc.leaseholderType.String(), func(t *testing.T) {
+			repDesc := roachpb.ReplicaDescriptor{
+				ReplicaID: 1,
+				Type:      &tc.leaseholderType,
+			}
+			rngDesc := roachpb.RangeDescriptor{
+				InternalReplicas: []roachpb.ReplicaDescriptor{repDesc},
+			}
+			err := CheckCanReceiveLease(rngDesc.InternalReplicas[0], &rngDesc)
+			require.Equal(t, tc.eligible, err == nil, "err: %v", err)
+		})
+	}
+
+	t.Run("replica not in range desc", func(t *testing.T) {
+		repDesc := roachpb.ReplicaDescriptor{ReplicaID: 1}
+		rngDesc := roachpb.RangeDescriptor{}
+		require.Regexp(t, "replica.*not found", CheckCanReceiveLease(repDesc, &rngDesc))
+	})
+}

--- a/pkg/kv/kvserver/batcheval/cmd_lease_transfer.go
+++ b/pkg/kv/kvserver/batcheval/cmd_lease_transfer.go
@@ -51,7 +51,7 @@ func TransferLease(
 
 	// If this check is removed at some point, the filtering of learners on the
 	// sending side would have to be removed as well.
-	if err := checkCanReceiveLease(args.Lease.Replica, cArgs.EvalCtx.Desc()); err != nil {
+	if err := CheckCanReceiveLease(args.Lease.Replica, cArgs.EvalCtx.Desc()); err != nil {
 		return newFailedLeaseTrigger(true /* isTransfer */), err
 	}
 

--- a/pkg/kv/kvserver/batcheval/cmd_lease_transfer.go
+++ b/pkg/kv/kvserver/batcheval/cmd_lease_transfer.go
@@ -49,18 +49,9 @@ func TransferLease(
 	// a newFailedLeaseTrigger() to satisfy stats.
 	args := cArgs.Args.(*roachpb.TransferLeaseRequest)
 
-	// For now, don't allow replicas of type LEARNER to be leaseholders. There's
-	// no reason this wouldn't work in principle, but it seems inadvisable. In
-	// particular, learners can't become raft leaders, so we wouldn't be able to
-	// co-locate the leaseholder + raft leader, which is going to affect tail
-	// latencies. Additionally, as of the time of writing, learner replicas are
-	// only used for a short time in replica addition, so it's not worth working
-	// out the edge cases. If we decide to start using long-lived learners at some
-	// point, that math may change.
-	//
 	// If this check is removed at some point, the filtering of learners on the
 	// sending side would have to be removed as well.
-	if err := checkCanReceiveLease(&args.Lease, cArgs.EvalCtx); err != nil {
+	if err := checkCanReceiveLease(args.Lease.Replica, cArgs.EvalCtx.Desc()); err != nil {
 		return newFailedLeaseTrigger(true /* isTransfer */), err
 	}
 


### PR DESCRIPTION
This patch backpedals a little bit on the logic introduced in #55148.
That patch said that, if a leader is known, every other replica refuses
to propose a lease acquisition. Instead, the replica in question
redirects whomever was triggering the lease acquisition to the leader,
thinking that the leader should take the lease.
That patch introduced a deadlock: some replicas refuse to take the lease
because they are not VOTER_FULL (see CheckCanReceiveLease()). To fix the
deadlock, this patch incorporates that check in the proposal buffer's
decision about whether or not to reject a proposal: if the leader is
believed to refuse to take the lease, then we again forward our own
lease request.

An edge case to the edge case is when the leader is not even part of the
proposer's range descriptor. This can happen if the proposer is far
behind. In this case, we assume that the leader is eligible. If it
isn't, the deadlock will resolve once the proposer catches up.

A future patch will relax the conditions under which a replica agrees to
take the lease. VOTER_INCOMING replicas should take the lease.
VOTER_DEMOTING are more controversial.

Fixes #57798

Release note: None