### PR TITLE
colexec: fix decimal/interval overload error propagation

### DIFF
--- a/pkg/sql/colexec/execgen/cmd/execgen/overloads_bin.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/overloads_bin.go
@@ -714,7 +714,7 @@ func (c intervalDecimalCustomizer) getBinOpAssignFunc() assignFunc {
 			return fmt.Sprintf(`
 		  f, err := %[3]s.Float64()
 		  if err != nil {
-		    colexecerror.InternalError(err)
+		    colexecerror.ExpectedError(err)
 		  }
 		  %[1]s = %[2]s.MulFloat(f)`,
 				targetElem, leftElem, rightElem)
@@ -732,7 +732,7 @@ func (c decimalIntervalCustomizer) getBinOpAssignFunc() assignFunc {
 			return fmt.Sprintf(`
 		  f, err := %[2]s.Float64()
 		  if err != nil {
-		    colexecerror.InternalError(err)
+		    colexecerror.ExpectedError(err)
 		  }
 		  %[1]s = %[3]s.MulFloat(f)`,
 				targetElem, leftElem, rightElem)

--- a/pkg/sql/colexec/proj_const_left_ops.eg.go
+++ b/pkg/sql/colexec/proj_const_left_ops.eg.go
@@ -11673,7 +11673,7 @@ func (p projMultDecimalConstIntervalOp) Next(ctx context.Context) coldata.Batch 
 
 						f, err := p.constArg.Float64()
 						if err != nil {
-							colexecerror.InternalError(err)
+							colexecerror.ExpectedError(err)
 						}
 						projCol[i] = arg.MulFloat(f)
 					}
@@ -11689,7 +11689,7 @@ func (p projMultDecimalConstIntervalOp) Next(ctx context.Context) coldata.Batch 
 
 						f, err := p.constArg.Float64()
 						if err != nil {
-							colexecerror.InternalError(err)
+							colexecerror.ExpectedError(err)
 						}
 						projCol[i] = arg.MulFloat(f)
 					}
@@ -11709,7 +11709,7 @@ func (p projMultDecimalConstIntervalOp) Next(ctx context.Context) coldata.Batch 
 
 					f, err := p.constArg.Float64()
 					if err != nil {
-						colexecerror.InternalError(err)
+						colexecerror.ExpectedError(err)
 					}
 					projCol[i] = arg.MulFloat(f)
 				}
@@ -11722,7 +11722,7 @@ func (p projMultDecimalConstIntervalOp) Next(ctx context.Context) coldata.Batch 
 
 					f, err := p.constArg.Float64()
 					if err != nil {
-						colexecerror.InternalError(err)
+						colexecerror.ExpectedError(err)
 					}
 					projCol[i] = arg.MulFloat(f)
 				}
@@ -14565,7 +14565,7 @@ func (p projMultIntervalConstDecimalOp) Next(ctx context.Context) coldata.Batch 
 
 						f, err := arg.Float64()
 						if err != nil {
-							colexecerror.InternalError(err)
+							colexecerror.ExpectedError(err)
 						}
 						projCol[i] = p.constArg.MulFloat(f)
 					}
@@ -14581,7 +14581,7 @@ func (p projMultIntervalConstDecimalOp) Next(ctx context.Context) coldata.Batch 
 
 						f, err := arg.Float64()
 						if err != nil {
-							colexecerror.InternalError(err)
+							colexecerror.ExpectedError(err)
 						}
 						projCol[i] = p.constArg.MulFloat(f)
 					}
@@ -14601,7 +14601,7 @@ func (p projMultIntervalConstDecimalOp) Next(ctx context.Context) coldata.Batch 
 
 					f, err := arg.Float64()
 					if err != nil {
-						colexecerror.InternalError(err)
+						colexecerror.ExpectedError(err)
 					}
 					projCol[i] = p.constArg.MulFloat(f)
 				}
@@ -14614,7 +14614,7 @@ func (p projMultIntervalConstDecimalOp) Next(ctx context.Context) coldata.Batch 
 
 					f, err := arg.Float64()
 					if err != nil {
-						colexecerror.InternalError(err)
+						colexecerror.ExpectedError(err)
 					}
 					projCol[i] = p.constArg.MulFloat(f)
 				}

--- a/pkg/sql/colexec/proj_const_right_ops.eg.go
+++ b/pkg/sql/colexec/proj_const_right_ops.eg.go
@@ -11674,7 +11674,7 @@ func (p projMultDecimalIntervalConstOp) Next(ctx context.Context) coldata.Batch 
 
 						f, err := arg.Float64()
 						if err != nil {
-							colexecerror.InternalError(err)
+							colexecerror.ExpectedError(err)
 						}
 						projCol[i] = p.constArg.MulFloat(f)
 					}
@@ -11690,7 +11690,7 @@ func (p projMultDecimalIntervalConstOp) Next(ctx context.Context) coldata.Batch 
 
 						f, err := arg.Float64()
 						if err != nil {
-							colexecerror.InternalError(err)
+							colexecerror.ExpectedError(err)
 						}
 						projCol[i] = p.constArg.MulFloat(f)
 					}
@@ -11710,7 +11710,7 @@ func (p projMultDecimalIntervalConstOp) Next(ctx context.Context) coldata.Batch 
 
 					f, err := arg.Float64()
 					if err != nil {
-						colexecerror.InternalError(err)
+						colexecerror.ExpectedError(err)
 					}
 					projCol[i] = p.constArg.MulFloat(f)
 				}
@@ -11723,7 +11723,7 @@ func (p projMultDecimalIntervalConstOp) Next(ctx context.Context) coldata.Batch 
 
 					f, err := arg.Float64()
 					if err != nil {
-						colexecerror.InternalError(err)
+						colexecerror.ExpectedError(err)
 					}
 					projCol[i] = p.constArg.MulFloat(f)
 				}
@@ -14566,7 +14566,7 @@ func (p projMultIntervalDecimalConstOp) Next(ctx context.Context) coldata.Batch 
 
 						f, err := p.constArg.Float64()
 						if err != nil {
-							colexecerror.InternalError(err)
+							colexecerror.ExpectedError(err)
 						}
 						projCol[i] = arg.MulFloat(f)
 					}
@@ -14582,7 +14582,7 @@ func (p projMultIntervalDecimalConstOp) Next(ctx context.Context) coldata.Batch 
 
 						f, err := p.constArg.Float64()
 						if err != nil {
-							colexecerror.InternalError(err)
+							colexecerror.ExpectedError(err)
 						}
 						projCol[i] = arg.MulFloat(f)
 					}
@@ -14602,7 +14602,7 @@ func (p projMultIntervalDecimalConstOp) Next(ctx context.Context) coldata.Batch 
 
 					f, err := p.constArg.Float64()
 					if err != nil {
-						colexecerror.InternalError(err)
+						colexecerror.ExpectedError(err)
 					}
 					projCol[i] = arg.MulFloat(f)
 				}
@@ -14615,7 +14615,7 @@ func (p projMultIntervalDecimalConstOp) Next(ctx context.Context) coldata.Batch 
 
 					f, err := p.constArg.Float64()
 					if err != nil {
-						colexecerror.InternalError(err)
+						colexecerror.ExpectedError(err)
 					}
 					projCol[i] = arg.MulFloat(f)
 				}

--- a/pkg/sql/colexec/proj_non_const_ops.eg.go
+++ b/pkg/sql/colexec/proj_non_const_ops.eg.go
@@ -12405,7 +12405,7 @@ func (p projMultDecimalIntervalOp) Next(ctx context.Context) coldata.Batch {
 
 						f, err := arg1.Float64()
 						if err != nil {
-							colexecerror.InternalError(err)
+							colexecerror.ExpectedError(err)
 						}
 						projCol[i] = arg2.MulFloat(f)
 					}
@@ -12425,7 +12425,7 @@ func (p projMultDecimalIntervalOp) Next(ctx context.Context) coldata.Batch {
 
 						f, err := arg1.Float64()
 						if err != nil {
-							colexecerror.InternalError(err)
+							colexecerror.ExpectedError(err)
 						}
 						projCol[i] = arg2.MulFloat(f)
 					}
@@ -12446,7 +12446,7 @@ func (p projMultDecimalIntervalOp) Next(ctx context.Context) coldata.Batch {
 
 					f, err := arg1.Float64()
 					if err != nil {
-						colexecerror.InternalError(err)
+						colexecerror.ExpectedError(err)
 					}
 					projCol[i] = arg2.MulFloat(f)
 				}
@@ -12462,7 +12462,7 @@ func (p projMultDecimalIntervalOp) Next(ctx context.Context) coldata.Batch {
 
 					f, err := arg1.Float64()
 					if err != nil {
-						colexecerror.InternalError(err)
+						colexecerror.ExpectedError(err)
 					}
 					projCol[i] = arg2.MulFloat(f)
 				}
@@ -15473,7 +15473,7 @@ func (p projMultIntervalDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 						f, err := arg2.Float64()
 						if err != nil {
-							colexecerror.InternalError(err)
+							colexecerror.ExpectedError(err)
 						}
 						projCol[i] = arg1.MulFloat(f)
 					}
@@ -15493,7 +15493,7 @@ func (p projMultIntervalDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 						f, err := arg2.Float64()
 						if err != nil {
-							colexecerror.InternalError(err)
+							colexecerror.ExpectedError(err)
 						}
 						projCol[i] = arg1.MulFloat(f)
 					}
@@ -15514,7 +15514,7 @@ func (p projMultIntervalDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 					f, err := arg2.Float64()
 					if err != nil {
-						colexecerror.InternalError(err)
+						colexecerror.ExpectedError(err)
 					}
 					projCol[i] = arg1.MulFloat(f)
 				}
@@ -15530,7 +15530,7 @@ func (p projMultIntervalDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 					f, err := arg2.Float64()
 					if err != nil {
-						colexecerror.InternalError(err)
+						colexecerror.ExpectedError(err)
 					}
 					projCol[i] = arg1.MulFloat(f)
 				}

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_overloads
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_overloads
@@ -709,3 +709,7 @@ SELECT _int, _int2, _int // _int2 FROM many_types WHERE _int2 <> 0
 312  1  312
 789  4  197
 2    2  1
+
+# Regression test for incorrectly propagating an error as internal (#57773).
+statement error .* value out of range
+SELECT ((-1.234E+401)::DECIMAL * '-53 years -10 mons -377 days -08:33:40.519057'::INTERVAL::INTERVAL)::INTERVAL FROM many_types


### PR DESCRIPTION
Fixes: #57773.

Release note (bug fix): CockroachDB could previously return an internal
error when evaluating a binary expression between a Decimal and an
Interval that required a cast to a Float when the value is out of range,
and now a more user-friendly error is returned instead.