### PR TITLE
sql: implement index changes of PARTITION ALL BY on CREATE TABLE

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning
@@ -17,11 +17,6 @@ CREATE TABLE t (a INT, b INT, c INT) PARTITION BY LIST (a) (
     PARTITION p1 VALUES IN (0)
 )
 
-statement error PARTITION ALL BY not yet implemented
-CREATE TABLE t (a INT, b INT) PARTITION ALL BY LIST (b) (
-  PARTITION p1 VALUES IN (0)
-)
-
 statement error declared partition columns \(a, b, c\) exceed the number of columns in index being partitioned \(a, b\)
 CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a, b, c) (
     PARTITION p1 VALUES IN (0)

--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
@@ -1,5 +1,25 @@
 # LogicTest: local
 
+statement error  declared partition columns \(partition_by\) do not match first 1 columns in index being partitioned \(a\)
+CREATE TABLE t (
+  pk INT PRIMARY KEY,
+  partition_by int,
+  a INT,
+  INDEX (a) PARTITION BY LIST (partition_by) (
+    PARTITION one VALUES IN (1),
+    PARTITION two VALUES IN (2)
+  )
+)
+
+statement error PARTITION ALL BY LIST/RANGE is currently experimental
+CREATE TABLE public.t (
+  pk int PRIMARY KEY,
+  partition_by int
+) PARTITION ALL BY LIST (partition_by) (
+  PARTITION one VALUES IN (1),
+  PARTITION two VALUES IN (2)
+)
+
 statement ok
 SET experimental_enable_implicit_column_partitioning = true
 
@@ -113,11 +133,11 @@ WHERE indrelid = (SELECT oid FROM pg_class WHERE relname = 't')
 ORDER BY 1,2,3
 ----
 indexrelid  indrelid  indkey  indclass  indoption  indcollation
-450499960   55        3       0         2          0
-450499961   55        4       0         2          0
-450499963   55        1       0         2          0
-450499966   55        2 3 4   0 0 0     2 2 2      0 0 0
-450499967   55        5       0         2          0
+969972496   57        2 3 4   0 0 0     2 2 2      0 0 0
+969972497   57        5       0         2          0
+969972501   57        1       0         2          0
+969972502   57        3       0         2          0
+969972503   57        4       0         2          0
 
 query TTB colnames
 SELECT index_name, column_name, implicit FROM crdb_internal.index_columns
@@ -161,3 +181,80 @@ statement error cannot ALTER TABLE PARTITION BY on table which already has impli
 ALTER TABLE t PARTITION BY LIST (a) (
   PARTITION pk_implicit VALUES IN (1)
 )
+
+statement error PARTITION ALL BY not yet implemented
+ALTER TABLE t PARTITION ALL BY LIST (a) (
+  PARTITION pk_implicit VALUES IN (1)
+)
+
+statement ok
+DROP TABLE t
+
+statement error cannot define PARTITION BY on an index if the table has a PARTITION ALL BY definition
+CREATE TABLE public.t (
+  pk int PRIMARY KEY,
+  partition_by int,
+  a int,
+  INDEX(a) PARTITION BY LIST (partition_by) (
+    PARTITION one VALUES IN (1)
+  )
+) PARTITION ALL BY LIST (partition_by) (
+  PARTITION one VALUES IN (1),
+  PARTITION two VALUES IN (2)
+)
+
+statement error cannot define PARTITION BY on an unique constraint if the table has a PARTITION ALL BY definition
+CREATE TABLE public.t (
+  pk int PRIMARY KEY,
+  partition_by int,
+  a int,
+  UNIQUE(a) PARTITION BY LIST (partition_by) (
+    PARTITION one VALUES IN (1)
+  )
+) PARTITION ALL BY LIST (partition_by) (
+  PARTITION one VALUES IN (1),
+  PARTITION two VALUES IN (2)
+)
+
+statement ok
+CREATE TABLE public.t (
+  pk int PRIMARY KEY,
+  partition_by int,
+  a int,
+  b int,
+  c int,
+  d int,
+  INDEX (a),
+  UNIQUE (b),
+  FAMILY (pk, partition_by, a, b, c, d)
+) PARTITION ALL BY LIST (partition_by) (
+  PARTITION one VALUES IN (1),
+  PARTITION two VALUES IN (2)
+)
+
+# TODO(#58878): PARTITION BY should be hidden for index definitions.
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE t]
+----
+CREATE TABLE public.t (
+  pk INT8 NOT NULL,
+  partition_by INT8 NULL,
+  a INT8 NULL,
+  b INT8 NULL,
+  c INT8 NULL,
+  d INT8 NULL,
+  CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+  INDEX t_a_idx (a ASC) PARTITION BY LIST (partition_by) (
+    PARTITION one VALUES IN ((1)),
+    PARTITION two VALUES IN ((2))
+  ),
+  UNIQUE INDEX t_b_key (b ASC) PARTITION BY LIST (partition_by) (
+    PARTITION one VALUES IN ((1)),
+    PARTITION two VALUES IN ((2))
+  ),
+  FAMILY fam_0_pk_partition_by_a_b_c_d (pk, partition_by, a, b, c, d)
+) PARTITION BY LIST (partition_by) (
+  PARTITION one VALUES IN ((1)),
+  PARTITION two VALUES IN ((2))
+)
+-- Warning: Partitioned table with no zone configurations.


### PR DESCRIPTION
Resolves #58733 

Release note (sql change): Implemented PARTITION ALL BY syntax for CREATE
TABLE, which automatically partitions all indexes on the current table
with the same partitioning scheme.