### PR TITLE
sql: virtual table changes for implicit column definitions

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
@@ -119,6 +119,25 @@ indexrelid  indrelid  indkey  indclass  indoption  indcollation
 450499966   55        2 3 4   0 0 0     2 2 2      0 0 0
 450499967   55        5       0         2          0
 
+query TTB colnames
+SELECT index_name, column_name, implicit FROM crdb_internal.index_columns
+WHERE descriptor_name = 't' AND column_type = 'key'
+ORDER BY 1, 2
+----
+index_name     column_name  implicit
+new_idx        a            true
+new_idx        d            false
+primary        a            true
+primary        pk           false
+t_a_b_idx      a            true
+t_a_b_idx      b            false
+t_a_c_key      a            true
+t_a_c_key      c            false
+t_d_a_b_c_idx  a            false
+t_d_a_b_c_idx  b            false
+t_d_a_b_c_idx  c            false
+t_d_a_b_c_idx  d            true
+
 query TTT colnames
 SELECT
   tablename, indexname, indexdef

--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
@@ -39,6 +39,9 @@ CREATE TABLE t (
   UNIQUE INDEX (c) PARTITION BY LIST (a) (
     PARTITION c_implicit VALUES IN (3)
   ),
+  INDEX (a, b, c) PARTITION BY LIST (d) (
+    PARTITION a_b_c_implicit VALUES IN ((4))
+  ),
   FAMILY (pk, a, b, c, d)
 ) PARTITION BY LIST(a) (
   PARTITION pk_implicit VALUES IN (1)
@@ -59,6 +62,9 @@ CREATE TABLE public.t (
   ),
   UNIQUE INDEX t_a_c_key (c ASC) PARTITION BY LIST (a) (
     PARTITION c_implicit VALUES IN ((3))
+  ),
+  INDEX t_d_a_b_c_idx (a ASC, b ASC, c ASC) PARTITION BY LIST (d) (
+    PARTITION a_b_c_implicit VALUES IN ((4))
   ),
   FAMILY fam_0_pk_a_b_c_d (pk, a, b, c, d)
 ) PARTITION BY LIST (a) (
@@ -87,6 +93,9 @@ CREATE TABLE public.t (
   UNIQUE INDEX t_a_c_key (c ASC) PARTITION BY LIST (a) (
     PARTITION c_implicit VALUES IN ((3))
   ),
+  INDEX t_d_a_b_c_idx (a ASC, b ASC, c ASC) PARTITION BY LIST (d) (
+    PARTITION a_b_c_implicit VALUES IN ((4))
+  ),
   INDEX new_idx (d ASC) PARTITION BY LIST (a) (
     PARTITION d_implicit VALUES IN ((1))
   ),
@@ -95,6 +104,34 @@ CREATE TABLE public.t (
   PARTITION pk_implicit VALUES IN ((1))
 )
 -- Warning: Partitioned table with no zone configurations.
+
+query TTTTTT colnames
+SELECT
+  indexrelid, indrelid, indkey, indclass, indoption, indcollation
+FROM pg_index
+WHERE indrelid = (SELECT oid FROM pg_class WHERE relname = 't')
+ORDER BY 1,2,3
+----
+indexrelid  indrelid  indkey  indclass  indoption  indcollation
+450499960   55        3       0         2          0
+450499961   55        4       0         2          0
+450499963   55        1       0         2          0
+450499966   55        2 3 4   0 0 0     2 2 2      0 0 0
+450499967   55        5       0         2          0
+
+query TTT colnames
+SELECT
+  tablename, indexname, indexdef
+FROM pg_indexes
+WHERE tablename = 't'
+ORDER BY 1, 2, 3
+----
+tablename  indexname      indexdef
+t          new_idx        CREATE INDEX new_idx ON test.public.t USING btree (d ASC)
+t          primary        CREATE UNIQUE INDEX "primary" ON test.public.t USING btree (pk ASC)
+t          t_a_b_idx      CREATE INDEX t_a_b_idx ON test.public.t USING btree (b ASC)
+t          t_a_c_key      CREATE UNIQUE INDEX t_a_c_key ON test.public.t USING btree (c ASC)
+t          t_d_a_b_c_idx  CREATE INDEX t_d_a_b_c_idx ON test.public.t USING btree (a ASC, b ASC, c ASC)
 
 statement error cannot ALTER INDEX PARTITION BY on index which already has implicit column partitioning
 ALTER INDEX new_idx PARTITION BY LIST (a) (

--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
@@ -53,11 +53,11 @@ CREATE TABLE public.t (
   b INT8 NULL,
   c INT8 NULL,
   d INT8 NULL,
-  CONSTRAINT "primary" PRIMARY KEY (a ASC, pk ASC),
-  INDEX t_a_b_idx (a ASC, b ASC) PARTITION BY LIST (a) (
+  CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+  INDEX t_a_b_idx (b ASC) PARTITION BY LIST (a) (
     PARTITION b_implicit VALUES IN ((2))
   ),
-  UNIQUE INDEX t_a_c_key (a ASC, c ASC) PARTITION BY LIST (a) (
+  UNIQUE INDEX t_a_c_key (c ASC) PARTITION BY LIST (a) (
     PARTITION c_implicit VALUES IN ((3))
   ),
   FAMILY fam_0_pk_a_b_c_d (pk, a, b, c, d)
@@ -80,14 +80,14 @@ CREATE TABLE public.t (
   b INT8 NULL,
   c INT8 NULL,
   d INT8 NULL,
-  CONSTRAINT "primary" PRIMARY KEY (a ASC, pk ASC),
-  INDEX t_a_b_idx (a ASC, b ASC) PARTITION BY LIST (a) (
+  CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+  INDEX t_a_b_idx (b ASC) PARTITION BY LIST (a) (
     PARTITION b_implicit VALUES IN ((2))
   ),
-  UNIQUE INDEX t_a_c_key (a ASC, c ASC) PARTITION BY LIST (a) (
+  UNIQUE INDEX t_a_c_key (c ASC) PARTITION BY LIST (a) (
     PARTITION c_implicit VALUES IN ((3))
   ),
-  INDEX new_idx (a ASC, d ASC) PARTITION BY LIST (a) (
+  INDEX new_idx (d ASC) PARTITION BY LIST (a) (
     PARTITION d_implicit VALUES IN ((1))
   ),
   FAMILY fam_0_pk_a_b_c_d (pk, a, b, c, d)

--- a/pkg/sql/catalog/descpb/index.go
+++ b/pkg/sql/catalog/descpb/index.go
@@ -67,15 +67,23 @@ func (desc *IndexDescriptor) IsPartial() bool {
 	return desc.Predicate != ""
 }
 
-// ColNamesFormat writes a string describing the column names and directions
-// in this index to the given buffer.
-func (desc *IndexDescriptor) ColNamesFormat(ctx *tree.FmtCtx) {
-	start := 0
+// ExplicitColumnStartIdx returns the start index of any explicit columns.
+func (desc *IndexDescriptor) ExplicitColumnStartIdx() int {
+	start := int(desc.Partitioning.NumImplicitColumns)
+	// We do not currently handle implicit columns along with hash sharded indexes.
+	// Thus, safe to override this to 1.
 	if desc.IsSharded() {
 		start = 1
 	}
-	for i := start; i < len(desc.ColumnNames); i++ {
-		if i > start {
+	return start
+}
+
+// ColNamesFormat writes a string describing the column names and directions
+// in this index to the given buffer.
+func (desc *IndexDescriptor) ColNamesFormat(ctx *tree.FmtCtx) {
+	startIdx := desc.ExplicitColumnStartIdx()
+	for i := startIdx; i < len(desc.ColumnNames); i++ {
+		if i > startIdx {
 			ctx.WriteString(", ")
 		}
 		ctx.FormatNameP(&desc.ColumnNames[i])

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -228,10 +228,10 @@ SELECT * FROM crdb_internal.table_indexes WHERE descriptor_name = ''
 ----
 descriptor_id  descriptor_name  index_id  index_name  index_type  is_unique  is_inverted
 
-query ITITTITT colnames
+query ITITTITTB colnames
 SELECT * FROM crdb_internal.index_columns WHERE descriptor_name = ''
 ----
-descriptor_id  descriptor_name  index_id  index_name  column_type  column_id  column_name  column_direction
+descriptor_id  descriptor_name  index_id  index_name  column_type  column_id  column_name  column_direction  implicit
 
 query ITIIITITT colnames
 SELECT * FROM crdb_internal.backward_dependencies WHERE descriptor_name = ''

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal_tenant
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal_tenant
@@ -237,10 +237,10 @@ SELECT * FROM crdb_internal.table_indexes WHERE descriptor_name = ''
 ----
 descriptor_id  descriptor_name  index_id  index_name  index_type  is_unique  is_inverted
 
-query ITITTITT colnames
+query ITITTITTB colnames
 SELECT * FROM crdb_internal.index_columns WHERE descriptor_name = ''
 ----
-descriptor_id  descriptor_name  index_id  index_name  column_type  column_id  column_name  column_direction
+descriptor_id  descriptor_name  index_id  index_name  column_type  column_id  column_name  column_direction  implicit
 
 query ITIIITITT colnames
 SELECT * FROM crdb_internal.backward_dependencies WHERE descriptor_name = ''

--- a/pkg/sql/logictest/testdata/logic_test/dependencies
+++ b/pkg/sql/logictest/testdata/logic_test/dependencies
@@ -51,31 +51,31 @@ descriptor_id  descriptor_name  index_id  index_name       index_type  is_unique
 59             test_v1          0         ·                primary     false      false
 60             test_v2          0         ·                primary     false      false
 
-query ITITTITT colnames
+query ITITTITTB colnames
 SELECT * FROM crdb_internal.index_columns WHERE descriptor_name LIKE 'test_%' ORDER BY descriptor_id, index_id, column_type, column_id
 ----
-descriptor_id  descriptor_name  index_id  index_name       column_type  column_id  column_name  column_direction
-53             test_kv          1         primary          key          1          k            ASC
-53             test_kv          2         test_v_idx       extra        1          NULL         NULL
-53             test_kv          2         test_v_idx       key          2          v            ASC
-53             test_kv          3         test_v_idx2      extra        1          NULL         NULL
-53             test_kv          3         test_v_idx2      key          2          v            DESC
-53             test_kv          3         test_v_idx2      storing      3          NULL         NULL
-53             test_kv          4         test_v_idx3      composite    3          NULL         NULL
-53             test_kv          4         test_v_idx3      extra        1          NULL         NULL
-53             test_kv          4         test_v_idx3      key          3          w            ASC
-53             test_kv          4         test_v_idx3      storing      2          NULL         NULL
-54             test_kvr1        1         primary          key          1          k            ASC
-55             test_kvr2        1         primary          key          3          rowid        ASC
-55             test_kvr2        2         test_kvr2_v_key  extra        3          NULL         NULL
-55             test_kvr2        2         test_kvr2_v_key  key          2          v            ASC
-56             test_kvr3        1         primary          key          3          rowid        ASC
-56             test_kvr3        2         test_kvr3_v_key  extra        3          NULL         NULL
-56             test_kvr3        2         test_kvr3_v_key  key          2          v            ASC
-57             test_kvi1        1         primary          key          1          k            ASC
-58             test_kvi2        1         primary          key          1          k            ASC
-58             test_kvi2        2         test_kvi2_idx    extra        1          NULL         NULL
-58             test_kvi2        2         test_kvi2_idx    key          2          v            ASC
+descriptor_id  descriptor_name  index_id  index_name       column_type  column_id  column_name  column_direction  implicit
+53             test_kv          1         primary          key          1          k            ASC               false
+53             test_kv          2         test_v_idx       extra        1          NULL         NULL              false
+53             test_kv          2         test_v_idx       key          2          v            ASC               false
+53             test_kv          3         test_v_idx2      extra        1          NULL         NULL              false
+53             test_kv          3         test_v_idx2      key          2          v            DESC              false
+53             test_kv          3         test_v_idx2      storing      3          NULL         NULL              false
+53             test_kv          4         test_v_idx3      composite    3          NULL         NULL              false
+53             test_kv          4         test_v_idx3      extra        1          NULL         NULL              false
+53             test_kv          4         test_v_idx3      key          3          w            ASC               false
+53             test_kv          4         test_v_idx3      storing      2          NULL         NULL              false
+54             test_kvr1        1         primary          key          1          k            ASC               false
+55             test_kvr2        1         primary          key          3          rowid        ASC               false
+55             test_kvr2        2         test_kvr2_v_key  extra        3          NULL         NULL              false
+55             test_kvr2        2         test_kvr2_v_key  key          2          v            ASC               false
+56             test_kvr3        1         primary          key          3          rowid        ASC               false
+56             test_kvr3        2         test_kvr3_v_key  extra        3          NULL         NULL              false
+56             test_kvr3        2         test_kvr3_v_key  key          2          v            ASC               false
+57             test_kvi1        1         primary          key          1          k            ASC               false
+58             test_kvi2        1         primary          key          1          k            ASC               false
+58             test_kvi2        2         test_kvi2_idx    extra        1          NULL         NULL              false
+58             test_kvi2        2         test_kvi2_idx    key          2          v            ASC               false
 
 query ITIIITITT colnames
 SELECT * FROM crdb_internal.backward_dependencies WHERE descriptor_name LIKE 'test_%' ORDER BY descriptor_id, index_id, dependson_type, dependson_id, dependson_index_id

--- a/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
+++ b/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
@@ -46,6 +46,16 @@ sharded_primary  CREATE TABLE public.sharded_primary (
                  FAMILY "primary" (crdb_internal_a_shard_10, a)
 )
 
+query TTT colnames
+SELECT
+  tablename, indexname, indexdef
+FROM pg_indexes
+WHERE tablename = 'sharded_primary'
+ORDER BY 1, 2, 3
+----
+tablename        indexname  indexdef
+sharded_primary  primary    CREATE UNIQUE INDEX "primary" ON test.public.sharded_primary USING btree (a ASC)
+
 statement ok
 INSERT INTO sharded_primary values (1), (2), (3)
 

--- a/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
+++ b/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
@@ -56,6 +56,15 @@ ORDER BY 1, 2, 3
 tablename        indexname  indexdef
 sharded_primary  primary    CREATE UNIQUE INDEX "primary" ON test.public.sharded_primary USING btree (a ASC)
 
+query TTB colnames
+SELECT index_name, column_name, implicit FROM crdb_internal.index_columns
+WHERE descriptor_name = 'sharded_primary' AND column_type = 'key'
+ORDER BY 1, 2
+----
+index_name  column_name               implicit
+primary     a                         false
+primary     crdb_internal_a_shard_10  true
+
 statement ok
 INSERT INTO sharded_primary values (1), (2), (3)
 


### PR DESCRIPTION
resolves #58730 

# descpb: hide implicit partitioning columns from SHOW CREATE TABLE

The implicit partitioning columns are now hidden from SHOW CREATE TABLE
statements. This more accurately re-creates the same syntax used for
creating the implicit partitioning columns of each index.

Release note: None

# sql: hide sharded index and implicit columns from pg_index/pg_indexes

To mimic Postgres behavior to ORMs, we should hide any columns we
implicitly add, which in this case is the pg_index and pg_indexes column
names/ids.

Release note (sql change): Columns implicitly added from hash sharded
indexes will no longer display on pg_index and pg_indexes.

# sql: add implicit column for crdb_internal.index_columns

Release note (sql change): Add a new `implicit` column to
crdb_internal.index_columns, which signifies whether the column is
implicitly added onto the index.

