### PR TITLE
kvclient: allow DistSender to consider non-voters when routing requests

### DIFF
--- a/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads.go
+++ b/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads.go
@@ -103,6 +103,8 @@ func canUseFollowerRead(clusterID uuid.UUID, st *cluster.Settings, ts hlc.Timest
 
 // canSendToFollower implements the logic for checking whether a batch request
 // may be sent to a follower.
+// TODO(aayush): We should try to bind clusterID to the function here, rather
+// than having callers plumb it in every time.
 func canSendToFollower(clusterID uuid.UUID, st *cluster.Settings, ba roachpb.BatchRequest) bool {
 	return batchCanBeEvaluatedOnFollower(ba) &&
 		txnCanPerformFollowerRead(ba.Txn) &&

--- a/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed.go
@@ -229,7 +229,8 @@ func (ds *DistSender) singleRangeFeed(
 	if ds.rpcContext != nil {
 		latencyFn = ds.rpcContext.RemoteClocks.Latency
 	}
-	replicas, err := NewReplicaSlice(ctx, ds.nodeDescs, desc, nil /* leaseholder */)
+	// TODO(aayush): We should enable creating RangeFeeds on non-voting replicas.
+	replicas, err := NewReplicaSlice(ctx, ds.nodeDescs, desc, nil, OnlyPotentialLeaseholders)
 	if err != nil {
 		return args.Timestamp, err
 	}

--- a/pkg/kv/kvclient/kvcoord/replica_slice.go
+++ b/pkg/kv/kvclient/kvcoord/replica_slice.go
@@ -39,18 +39,32 @@ func (i ReplicaInfo) addr() string {
 // A ReplicaSlice is a slice of ReplicaInfo.
 type ReplicaSlice []ReplicaInfo
 
+// ReplicaSliceFilter controls which kinds of replicas are to be included in
+// the slice for routing BatchRequests to.
+type ReplicaSliceFilter int
+
+const (
+	// OnlyPotentialLeaseholders prescribes that the ReplicaSlice should include
+	// only replicas that are allowed to be leaseholders (i.e. replicas of type
+	// VOTER_FULL).
+	OnlyPotentialLeaseholders ReplicaSliceFilter = iota
+	// AllExtantReplicas prescribes that the ReplicaSlice should include all
+	// replicas that are not LEARNERs, VOTER_OUTGOING, or
+	// VOTER_DEMOTING_{LEARNER/NON_VOTER}.
+	AllExtantReplicas
+)
+
 // NewReplicaSlice creates a ReplicaSlice from the replicas listed in the range
 // descriptor and using gossip to lookup node descriptors. Replicas on nodes
 // that are not gossiped are omitted from the result.
 //
-// Generally, only voting replicas are returned. However, if a non-nil
-// leaseholder is passed in, it will be included in the result even if the
-// descriptor has it as a learner (we assert that the leaseholder is part of the
-// descriptor). The idea is that the descriptor might be stale and list the
-// leaseholder as a learner erroneously, and lease info is a strong signal in
-// that direction. Note that the returned ReplicaSlice might still not include
-// the leaseholder if info for the respective node is missing from the
-// NodeDescStore.
+// Generally, learners are not returned. However, if a non-nil leaseholder is
+// passed in, it will be included in the result even if the descriptor has it as
+// a learner (we assert that the leaseholder is part of the descriptor). The
+// idea is that the descriptor might be stale and list the leaseholder as a
+// learner erroneously, and lease info is a strong signal in that direction.
+// Note that the returned ReplicaSlice might still not include the leaseholder
+// if info for the respective node is missing from the NodeDescStore.
 //
 // If there's no info in gossip for any of the nodes in the descriptor, a
 // sendError is returned.
@@ -59,21 +73,36 @@ func NewReplicaSlice(
 	nodeDescs NodeDescStore,
 	desc *roachpb.RangeDescriptor,
 	leaseholder *roachpb.ReplicaDescriptor,
+	filter ReplicaSliceFilter,
 ) (ReplicaSlice, error) {
 	if leaseholder != nil {
 		if _, ok := desc.GetReplicaDescriptorByID(leaseholder.ReplicaID); !ok {
 			log.Fatalf(ctx, "leaseholder not in descriptor; leaseholder: %s, desc: %s", leaseholder, desc)
 		}
 	}
+	canReceiveLease := func(rDesc roachpb.ReplicaDescriptor) bool {
+		if err := roachpb.CheckCanReceiveLease(rDesc, desc); err != nil {
+			return false
+		}
+		return true
+	}
 
-	// Learner replicas won't serve reads/writes, so we'll send only to the
-	// `VoterDescriptors` replicas. This is just an optimization to save a network hop,
-	// everything would still work if we had `All` here.
-	voters := desc.Replicas().VoterDescriptors()
+	// Learner replicas won't serve reads/writes, so we'll send only to the voters
+	// and non-voting replicas. This is just an optimization to save a network
+	// hop, everything would still work if we had `All` here.
+	var replicas []roachpb.ReplicaDescriptor
+	switch filter {
+	case OnlyPotentialLeaseholders:
+		replicas = desc.Replicas().Filter(canReceiveLease).Descriptors()
+	case AllExtantReplicas:
+		replicas = desc.Replicas().VoterFullAndNonVoterDescriptors()
+	default:
+		log.Fatalf(ctx, "unknown ReplicaSliceFilter %s", filter)
+	}
 	// If we know a leaseholder, though, let's make sure we include it.
-	if leaseholder != nil && len(voters) < len(desc.Replicas().Descriptors()) {
+	if leaseholder != nil && len(replicas) < len(desc.Replicas().Descriptors()) {
 		found := false
-		for _, v := range voters {
+		for _, v := range replicas {
 			if v == *leaseholder {
 				found = true
 				break
@@ -81,11 +110,11 @@ func NewReplicaSlice(
 		}
 		if !found {
 			log.Eventf(ctx, "the descriptor has the leaseholder as a learner; including it anyway")
-			voters = append(voters, *leaseholder)
+			replicas = append(replicas, *leaseholder)
 		}
 	}
-	rs := make(ReplicaSlice, 0, len(voters))
-	for _, r := range voters {
+	rs := make(ReplicaSlice, 0, len(replicas))
+	for _, r := range replicas {
 		nd, err := nodeDescs.GetNodeDescriptor(r.NodeID)
 		if err != nil {
 			if log.V(1) {

--- a/pkg/kv/kvclient/kvcoord/replica_slice.go
+++ b/pkg/kv/kvclient/kvcoord/replica_slice.go
@@ -95,9 +95,9 @@ func NewReplicaSlice(
 	case OnlyPotentialLeaseholders:
 		replicas = desc.Replicas().Filter(canReceiveLease).Descriptors()
 	case AllExtantReplicas:
-		replicas = desc.Replicas().VoterFullAndNonVoterDescriptors()
+		replicas = desc.Replicas().VoterAndNonVoterDescriptors()
 	default:
-		log.Fatalf(ctx, "unknown ReplicaSliceFilter %s", filter)
+		log.Fatalf(ctx, "unknown ReplicaSliceFilter %v", filter)
 	}
 	// If we know a leaseholder, though, let's make sure we include it.
 	if leaseholder != nil && len(replicas) < len(desc.Replicas().Descriptors()) {

--- a/pkg/kv/kvclient/kvcoord/replica_slice_test.go
+++ b/pkg/kv/kvclient/kvcoord/replica_slice_test.go
@@ -68,21 +68,34 @@ func TestNewReplicaSlice(t *testing.T) {
 			},
 		},
 	}
-	rs, err := NewReplicaSlice(ctx, ns, rd, nil /* leaseholder */)
+	rs, err := NewReplicaSlice(ctx, ns, rd, nil, OnlyPotentialLeaseholders)
 	require.NoError(t, err)
 	require.Equal(t, 3, rs.Len())
 
 	// Check that learners are not included.
 	typLearner := roachpb.LEARNER
 	rd.InternalReplicas[2].Type = &typLearner
-	rs, err = NewReplicaSlice(ctx, ns, rd, nil /* leaseholder */)
+	rs, err = NewReplicaSlice(ctx, ns, rd, nil, OnlyPotentialLeaseholders)
+	require.NoError(t, err)
+	require.Equal(t, 2, rs.Len())
+	rs, err = NewReplicaSlice(ctx, ns, rd, nil, AllExtantReplicas)
 	require.NoError(t, err)
 	require.Equal(t, 2, rs.Len())
 
-	// Check that, if the leasehoder points to a learner, that learner is
+	// Check that non-voters are included iff we ask for them to be.
+	typNonVoter := roachpb.NON_VOTER
+	rd.InternalReplicas[2].Type = &typNonVoter
+	rs, err = NewReplicaSlice(ctx, ns, rd, nil, AllExtantReplicas)
+	require.NoError(t, err)
+	require.Equal(t, 3, rs.Len())
+	rs, err = NewReplicaSlice(ctx, ns, rd, nil, OnlyPotentialLeaseholders)
+	require.NoError(t, err)
+	require.Equal(t, 2, rs.Len())
+
+	// Check that, if the leaseholder points to a learner, that learner is
 	// included.
 	leaseholder := &roachpb.ReplicaDescriptor{NodeID: 3, StoreID: 3}
-	rs, err = NewReplicaSlice(ctx, ns, rd, leaseholder)
+	rs, err = NewReplicaSlice(ctx, ns, rd, leaseholder, OnlyPotentialLeaseholders)
 	require.NoError(t, err)
 	require.Equal(t, 3, rs.Len())
 }

--- a/pkg/kv/kvclient/kvcoord/replica_slice_test.go
+++ b/pkg/kv/kvclient/kvcoord/replica_slice_test.go
@@ -47,9 +47,9 @@ func TestNewReplicaSlice(t *testing.T) {
 	ctx := context.Background()
 	rd := &roachpb.RangeDescriptor{
 		InternalReplicas: []roachpb.ReplicaDescriptor{
-			{NodeID: 1, StoreID: 1},
-			{NodeID: 2, StoreID: 2},
-			{NodeID: 3, StoreID: 3},
+			{NodeID: 1, StoreID: 1, ReplicaID: 1},
+			{NodeID: 2, StoreID: 2, ReplicaID: 2},
+			{NodeID: 3, StoreID: 3, ReplicaID: 3},
 		},
 	}
 	ns := &mockNodeStore{
@@ -94,7 +94,7 @@ func TestNewReplicaSlice(t *testing.T) {
 
 	// Check that, if the leaseholder points to a learner, that learner is
 	// included.
-	leaseholder := &roachpb.ReplicaDescriptor{NodeID: 3, StoreID: 3}
+	leaseholder := &roachpb.ReplicaDescriptor{NodeID: 3, StoreID: 3, ReplicaID: 3}
 	rs, err = NewReplicaSlice(ctx, ns, rd, leaseholder, OnlyPotentialLeaseholders)
 	require.NoError(t, err)
 	require.Equal(t, 3, rs.Len())

--- a/pkg/kv/kvserver/batcheval/cmd_lease_request.go
+++ b/pkg/kv/kvserver/batcheval/cmd_lease_request.go
@@ -58,7 +58,7 @@ func RequestLease(
 
 	// If this check is removed at some point, the filtering of learners on the
 	// sending side would have to be removed as well.
-	if err := CheckCanReceiveLease(args.Lease.Replica, cArgs.EvalCtx.Desc()); err != nil {
+	if err := roachpb.CheckCanReceiveLease(args.Lease.Replica, cArgs.EvalCtx.Desc()); err != nil {
 		rErr.Message = err.Error()
 		return newFailedLeaseTrigger(false /* isTransfer */), rErr
 	}

--- a/pkg/kv/kvserver/batcheval/cmd_lease_transfer.go
+++ b/pkg/kv/kvserver/batcheval/cmd_lease_transfer.go
@@ -51,7 +51,7 @@ func TransferLease(
 
 	// If this check is removed at some point, the filtering of learners on the
 	// sending side would have to be removed as well.
-	if err := CheckCanReceiveLease(args.Lease.Replica, cArgs.EvalCtx.Desc()); err != nil {
+	if err := roachpb.CheckCanReceiveLease(args.Lease.Replica, cArgs.EvalCtx.Desc()); err != nil {
 		return newFailedLeaseTrigger(true /* isTransfer */), err
 	}
 

--- a/pkg/kv/kvserver/client_lease_test.go
+++ b/pkg/kv/kvserver/client_lease_test.go
@@ -341,7 +341,7 @@ func TestCannotTransferLeaseToVoterOutgoing(t *testing.T) {
 			require.Error(t, err)
 			require.Regexp(t,
 				// The error generated during evaluation.
-				"replica.*of type VOTER_DEMOTING cannot hold lease|"+
+				"replica cannot hold lease|"+
 					// If the lease transfer request has not yet made it to the latching
 					// phase by the time we close(ch) below, we can receive the following
 					// error due to the sanity checking which happens in

--- a/pkg/kv/kvserver/closed_timestamp_test.go
+++ b/pkg/kv/kvserver/closed_timestamp_test.go
@@ -65,53 +65,69 @@ func TestClosedTimestampCanServe(t *testing.T) {
 	// drives up the test duration.
 	skip.UnderRace(t)
 
-	ctx := context.Background()
-	tc, db0, desc := setupClusterForClosedTSTesting(ctx, t, testingTargetDuration, testingCloseFraction, aggressiveResolvedTimestampClusterArgs, "cttest", "kv")
-	defer tc.Stopper().Stop(ctx)
-	repls := replsForRange(ctx, t, tc, desc, numNodes)
+	testutils.RunTrueAndFalse(t, "withNonVoters", func(t *testing.T, withNonVoters bool) {
+		ctx := context.Background()
+		dbName, tableName := "cttest", "kv"
+		clusterArgs := aggressiveResolvedTimestampClusterArgs
+		// Disable the replicateQueue so that it doesn't interfere with replica
+		// membership ranges.
+		clusterArgs.ReplicationMode = base.ReplicationManual
+		tc, db0, desc := setupClusterForClosedTSTesting(ctx, t, testingTargetDuration,
+			testingCloseFraction, clusterArgs, dbName, tableName)
+		defer tc.Stopper().Stop(ctx)
 
-	if _, err := db0.Exec(`INSERT INTO cttest.kv VALUES(1, $1)`, "foo"); err != nil {
-		t.Fatal(err)
-	}
-
-	ts := hlc.Timestamp{WallTime: timeutil.Now().UnixNano()}
-	baRead := makeReadBatchRequestForDesc(desc, ts)
-	testutils.SucceedsSoon(t, func() error {
-		return verifyCanReadFromAllRepls(ctx, t, baRead, repls, expectRows(1))
-	})
-
-	// We just served a follower read. As a sanity check, make sure that we can't write at
-	// that same timestamp.
-	{
-		var baWrite roachpb.BatchRequest
-		r := &roachpb.DeleteRequest{}
-		r.Key = desc.StartKey.AsRawKey()
-		txn := roachpb.MakeTransaction("testwrite", r.Key, roachpb.NormalUserPriority, ts, 100)
-		baWrite.Txn = &txn
-		baWrite.Add(r)
-		baWrite.RangeID = repls[0].RangeID
-		if err := baWrite.SetActiveTimestamp(tc.Server(0).Clock().Now); err != nil {
+		if _, err := db0.Exec(`INSERT INTO cttest.kv VALUES(1, $1)`, "foo"); err != nil {
 			t.Fatal(err)
 		}
 
-		var found bool
-		for _, repl := range repls {
-			resp, pErr := repl.Send(ctx, baWrite)
-			if errors.HasType(pErr.GoError(), (*roachpb.NotLeaseHolderError)(nil)) {
-				continue
-			} else if pErr != nil {
-				t.Fatal(pErr)
-			}
-			found = true
-			if resp.Txn.WriteTimestamp.LessEq(ts) || resp.Txn.ReadTimestamp == resp.Txn.WriteTimestamp {
-				t.Fatal("timestamp did not get bumped")
-			}
-			break
+		if withNonVoters {
+			desc = tc.AddNonVotersOrFatal(t, desc.StartKey.AsRawKey(), tc.Target(1),
+				tc.Target(2))
+		} else {
+			desc = tc.AddVotersOrFatal(t, desc.StartKey.AsRawKey(), tc.Target(1),
+				tc.Target(2))
 		}
-		if !found {
-			t.Fatal("unable to send to any replica")
+
+		repls := replsForRange(ctx, t, tc, desc, numNodes)
+		ts := hlc.Timestamp{WallTime: timeutil.Now().UnixNano()}
+		baRead := makeReadBatchRequestForDesc(desc, ts)
+		testutils.SucceedsSoon(t, func() error {
+			return verifyCanReadFromAllRepls(ctx, t, baRead, repls, expectRows(1))
+		})
+
+		// We just served a follower read. As a sanity check, make sure that we can't write at
+		// that same timestamp.
+		{
+			var baWrite roachpb.BatchRequest
+			r := &roachpb.DeleteRequest{}
+			r.Key = desc.StartKey.AsRawKey()
+			txn := roachpb.MakeTransaction("testwrite", r.Key, roachpb.NormalUserPriority, ts, 100)
+			baWrite.Txn = &txn
+			baWrite.Add(r)
+			baWrite.RangeID = repls[0].RangeID
+			if err := baWrite.SetActiveTimestamp(tc.Server(0).Clock().Now); err != nil {
+				t.Fatal(err)
+			}
+
+			var found bool
+			for _, repl := range repls {
+				resp, pErr := repl.Send(ctx, baWrite)
+				if errors.HasType(pErr.GoError(), (*roachpb.NotLeaseHolderError)(nil)) {
+					continue
+				} else if pErr != nil {
+					t.Fatal(pErr)
+				}
+				found = true
+				if resp.Txn.WriteTimestamp.LessEq(ts) || resp.Txn.ReadTimestamp == resp.Txn.WriteTimestamp {
+					t.Fatal("timestamp did not get bumped")
+				}
+				break
+			}
+			if !found {
+				t.Fatal("unable to send to any replica")
+			}
 		}
-	}
+	})
 }
 
 // TestClosedTimestampCanServerThroughoutLeaseTransfer verifies that lease
@@ -892,6 +908,21 @@ func setupClusterForClosedTSTestingWithSplitRanges(
 	return tc, leftDesc, rightDesc
 }
 
+func getEncodedKeyForTable(
+	t *testing.T, db *gosql.DB, dbName, tableName string, val tree.Datum,
+) roachpb.Key {
+	tableID, err := getTableID(db, dbName, tableName)
+	if err != nil {
+		t.Fatalf("failed to lookup ids: %+v", err)
+	}
+	idxPrefix := keys.SystemSQLCodec.IndexPrefix(uint32(tableID), 1)
+	k, err := rowenc.EncodeTableKey(idxPrefix, val, encoding.Ascending)
+	if err != nil {
+		t.Fatalf("failed to encode split key: %+v", err)
+	}
+	return k
+}
+
 // splitDummyRangeInTestCluster is supposed to be used in conjunction with the
 // dummy table created in setupTestClusterWithDummyRange. It adds two rows to
 // the given table and performs splits on the table's range such that the 2
@@ -912,26 +943,14 @@ func splitDummyRangeInTestCluster(
 		t.Fatal(err)
 	}
 	// Manually split the table to have easier access to descriptors.
-	tableID, err := getTableID(db0, dbName, tableName)
-	if err != nil {
-		t.Fatalf("failed to lookup ids: %+v", err)
-	}
-
-	idxPrefix := keys.SystemSQLCodec.IndexPrefix(uint32(tableID), 1)
-	k, err := rowenc.EncodeTableKey(idxPrefix, tree.NewDInt(1), encoding.Ascending)
-	if err != nil {
-		t.Fatalf("failed to encode split key: %+v", err)
-	}
+	k := getEncodedKeyForTable(t, db0, dbName, tableName, tree.NewDInt(1))
 	tcImpl := tc.(*testcluster.TestCluster)
-	// Split at `k` so that the table has exactly two ranges: [1,2) and [2, Max).
-	// This split will never be merged by the merge queue so the expiration time
-	// doesn't matter here.
+	// Split at `1` and `2` so that the table has exactly two ranges: [1,2) and
+	// [2, Max). This first split will never be merged by the merge queue so the
+	// expiration time doesn't matter here.
 	tcImpl.SplitRangeOrFatal(t, k)
-	idxPrefix = keys.SystemSQLCodec.IndexPrefix(uint32(tableID), 1)
-	k, err = rowenc.EncodeTableKey(idxPrefix, tree.NewDInt(2), encoding.Ascending)
-	if err != nil {
-		t.Fatalf("failed to encode split key: %+v", err)
-	}
+
+	k = getEncodedKeyForTable(t, db0, dbName, tableName, tree.NewDInt(2))
 	leftDesc, rightDesc, err := tcImpl.SplitRangeWithExpiration(k, splitExpirationTime)
 	require.NoError(t, err)
 
@@ -1166,7 +1185,7 @@ SET CLUSTER SETTING kv.closed_timestamp.follower_reads_enabled = true;
 	return nil
 }
 
-// setupTestClusterWithDummyRange creates a TestCluster with an empty table and
+// setupTestClusterWithDummyRange creates a TestCluster with an empty table. It
 // returns a handle to the range descriptor corresponding to this table.
 func setupTestClusterWithDummyRange(
 	t *testing.T, clusterArgs base.TestClusterArgs, dbName, tableName string, numNodes int,
@@ -1180,36 +1199,37 @@ func setupTestClusterWithDummyRange(
 -- forever under high load (testrace under high concurrency).
 SET statement_timeout='30s';
 CREATE DATABASE %[1]s;
-CREATE TABLE %[1]s.%[2]s (id INT PRIMARY KEY, value STRING);
+CREATE TABLE %[1]s.%[2]s (id INT PRIMARY KEY CHECK (id >= 0), value STRING);
 -- Reset the timeout set above.
 RESET statement_timeout;
 `, dbName, tableName)); err != nil {
 		t.Fatal(err)
 	}
 
-	var rangeID roachpb.RangeID
-	var startKey roachpb.Key
 	var numReplicas int
+	var err error
+	var desc roachpb.RangeDescriptor
 	// If replicate queue is not disabled, wait until the table's range is fully
 	// replicated.
 	if clusterArgs.ReplicationMode != base.ReplicationManual {
 		testutils.SucceedsSoon(t, func() error {
 			if err := db0.QueryRow(
 				fmt.Sprintf(
-					`SELECT range_id, start_key, array_length(replicas, 1) FROM crdb_internal.ranges WHERE table_name = '%s' AND database_name = '%s'`,
-					tableName, dbName),
-			).Scan(&rangeID, &startKey, &numReplicas); err != nil {
+					`SELECT array_length(replicas, 1) FROM crdb_internal.ranges
+WHERE table_name = '%s' AND database_name = '%s'`, tableName, dbName),
+			).Scan(&numReplicas); err != nil {
 				return err
 			}
 			if numReplicas != numNodes {
 				return errors.New("not fully replicated yet")
 			}
+			require.Nil(t, err)
 			return nil
 		})
 	}
-
-	desc, err := tc.LookupRange(startKey)
-	require.Nil(t, err)
+	startKey := getEncodedKeyForTable(t, tc.ServerConn(0), dbName, tableName, tree.NewDInt(0))
+	_, desc, err = tc.Server(0).SplitRange(startKey)
+	require.NoError(t, err)
 	return tc, desc
 }
 

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -628,11 +628,11 @@ func (r *Replica) AdminMerge(
 		// queues should fix things up quickly).
 		lReplicas, rReplicas := origLeftDesc.Replicas(), rightDesc.Replicas()
 
-		if len(lReplicas.VoterAndNonVoterDescriptors()) != len(lReplicas.Descriptors()) {
+		if len(lReplicas.VoterFullAndNonVoterDescriptors()) != len(lReplicas.Descriptors()) {
 			return errors.Errorf("cannot merge ranges when lhs is in a joint state or has learners: %s",
 				lReplicas)
 		}
-		if len(rReplicas.VoterAndNonVoterDescriptors()) != len(rReplicas.Descriptors()) {
+		if len(rReplicas.VoterFullAndNonVoterDescriptors()) != len(rReplicas.Descriptors()) {
 			return errors.Errorf("cannot merge ranges when rhs is in a joint state or has learners: %s",
 				rReplicas)
 		}
@@ -2472,7 +2472,7 @@ func (s *Store) relocateOne(
 	desc *roachpb.RangeDescriptor,
 	voterTargets, nonVoterTargets []roachpb.ReplicationTarget,
 ) ([]roachpb.ReplicationChange, *roachpb.ReplicationTarget, error) {
-	if repls := desc.Replicas(); len(repls.VoterAndNonVoterDescriptors()) != len(repls.Descriptors()) {
+	if repls := desc.Replicas(); len(repls.VoterFullAndNonVoterDescriptors()) != len(repls.Descriptors()) {
 		// The caller removed all the learners and left the joint config, so there
 		// shouldn't be anything but voters and non_voters.
 		return nil, nil, errors.AssertionFailedf(

--- a/pkg/kv/kvserver/replica_follower_read.go
+++ b/pkg/kv/kvserver/replica_follower_read.go
@@ -61,7 +61,9 @@ func (r *Replica) canServeFollowerRead(
 	if err != nil {
 		return roachpb.NewError(err)
 	}
-	if typ := repDesc.GetType(); typ != roachpb.VOTER_FULL {
+
+	typ := repDesc.GetType()
+	if typ != roachpb.VOTER_FULL && typ != roachpb.NON_VOTER {
 		log.Eventf(ctx, "%s replicas cannot serve follower reads", typ)
 		return pErr
 	}

--- a/pkg/kv/kvserver/replica_follower_read.go
+++ b/pkg/kv/kvserver/replica_follower_read.go
@@ -52,18 +52,14 @@ func (r *Replica) canServeFollowerRead(
 		return pErr
 	}
 
-	// There's no known reason that a non-VOTER_FULL replica couldn't serve follower
-	// reads (or RangeFeed), but as of the time of writing, these are expected
-	// to be short-lived, so it's not worth working out the edge-cases. Revisit if
-	// we add long-lived learners or feel that incoming/outgoing voters also need
-	// to be able to serve follower reads.
 	repDesc, err := r.GetReplicaDescriptor()
 	if err != nil {
 		return roachpb.NewError(err)
 	}
 
-	typ := repDesc.GetType()
-	if typ != roachpb.VOTER_FULL && typ != roachpb.NON_VOTER {
+	switch typ := repDesc.GetType(); typ {
+	case roachpb.VOTER_FULL, roachpb.VOTER_INCOMING, roachpb.NON_VOTER:
+	default:
 		log.Eventf(ctx, "%s replicas cannot serve follower reads", typ)
 		return pErr
 	}

--- a/pkg/kv/kvserver/replica_proposal_buf.go
+++ b/pkg/kv/kvserver/replica_proposal_buf.go
@@ -15,7 +15,6 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
@@ -763,7 +762,7 @@ func (rp *replicaProposer) leaderStatusRLocked(raftGroup proposerRaft) rangeLead
 			// lease again, and by then hopefully we will have caught up.
 			leaderEligibleForLease = true
 		} else {
-			err := batcheval.CheckCanReceiveLease(leaderRep, rangeDesc)
+			err := roachpb.CheckCanReceiveLease(leaderRep, rangeDesc)
 			leaderEligibleForLease = err == nil
 		}
 	}

--- a/pkg/kv/kvserver/replica_proposal_buf_test.go
+++ b/pkg/kv/kvserver/replica_proposal_buf_test.go
@@ -17,7 +17,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -127,7 +126,7 @@ func (t *testProposer) leaderStatusRLocked(raftGroup proposerRaft) rangeLeaderIn
 			rngDesc := roachpb.RangeDescriptor{
 				InternalReplicas: []roachpb.ReplicaDescriptor{repDesc},
 			}
-			err := batcheval.CheckCanReceiveLease(repDesc, &rngDesc)
+			err := roachpb.CheckCanReceiveLease(repDesc, &rngDesc)
 			leaderEligibleForLease = err == nil
 		} else {
 			// This matches replicaProposed.leaderStatusRLocked().

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -1008,7 +1008,7 @@ func TestReplicaLease(t *testing.T) {
 				Args: &roachpb.RequestLeaseRequest{
 					Lease: lease,
 				},
-			}, &roachpb.RequestLeaseResponse{}); !testutils.IsError(err, "replica \\(n0,s0\\):\\? not found in r1") {
+			}, &roachpb.RequestLeaseResponse{}); !testutils.IsError(err, "replica not found") {
 			t.Fatalf("unexpected error: %+v", err)
 		}
 	}

--- a/pkg/roachpb/api.go
+++ b/pkg/roachpb/api.go
@@ -53,6 +53,8 @@ const (
 
 // RequiresReadLease returns whether the ReadConsistencyType requires
 // that a read-only request be performed on an active valid leaseholder.
+// TODO(aayush): Rename the method since we no longer require a replica to be a
+// leaseholder to serve a consistent read.
 func (rc ReadConsistencyType) RequiresReadLease() bool {
 	switch rc {
 	case CONSISTENT:

--- a/pkg/roachpb/metadata_replicas.go
+++ b/pkg/roachpb/metadata_replicas.go
@@ -273,6 +273,13 @@ func (d ReplicaSet) VoterFullAndNonVoterDescriptors() []ReplicaDescriptor {
 	return d.FilterToDescriptors(predVoterFullOrNonVoter)
 }
 
+// VoterAndNonVoterDescriptors returns the descriptors of VOTER_FULL,
+// VOTER_INCOMING and NON_VOTER replicas in the set. Notably, this is the set of
+// replicas the DistSender will consider routing follower read requests to.
+func (d ReplicaSet) VoterAndNonVoterDescriptors() []ReplicaDescriptor {
+	return d.FilterToDescriptors(predVoterOrNonVoter)
+}
+
 // Filter returns a ReplicaSet corresponding to the replicas for which the
 // supplied predicate returns true.
 func (d ReplicaSet) Filter(pred func(rDesc ReplicaDescriptor) bool) ReplicaSet {

--- a/pkg/roachpb/metadata_replicas.go
+++ b/pkg/roachpb/metadata_replicas.go
@@ -13,6 +13,7 @@ package roachpb
 import (
 	"fmt"
 
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
 	"go.etcd.io/etcd/raft/v3/raftpb"
 )
@@ -479,4 +480,44 @@ func (c ReplicaChangeType) IsRemoval() bool {
 	default:
 		panic(fmt.Sprintf("unexpected ReplicaChangeType %s", c))
 	}
+}
+
+// CheckCanReceiveLease checks whether `wouldbeLeaseholder` can receive a lease.
+// Returns an error if the respective replica is not eligible.
+//
+// An error is also returned is the replica is not part of `rngDesc`.
+//
+// For now, don't allow replicas of type LEARNER to be leaseholders. There's
+// no reason this wouldn't work in principle, but it seems inadvisable. In
+// particular, learners can't become raft leaders, so we wouldn't be able to
+// co-locate the leaseholder + raft leader, which is going to affect tail
+// latencies. Additionally, as of the time of writing, learner replicas are
+// only used for a short time in replica addition, so it's not worth working
+// out the edge cases.
+func CheckCanReceiveLease(wouldbeLeaseholder ReplicaDescriptor, rngDesc *RangeDescriptor) error {
+	repDesc, ok := rngDesc.GetReplicaDescriptorByID(wouldbeLeaseholder.ReplicaID)
+	if !ok {
+		return errors.Errorf(`replica %s not found in %s`, wouldbeLeaseholder, rngDesc)
+	} else if t := repDesc.GetType(); t != VOTER_FULL {
+		// NB: there's no harm in transferring the lease to a VOTER_INCOMING,
+		// but we disallow it anyway. On the other hand, transferring to
+		// VOTER_OUTGOING would be a pretty bad idea since those voters are
+		// dropped when transitioning out of the joint config, which then
+		// amounts to removing the leaseholder without any safety precautions.
+		// This would either wedge the range or allow illegal reads to be
+		// served.
+		//
+		// Since the leaseholder can't remove itself and is a VOTER_FULL, we
+		// also know that in any configuration there's at least one VOTER_FULL.
+		//
+		// TODO(tbg): if this code path is hit during a lease transfer (we check
+		// upstream of raft, but this check has false negatives) then we are in
+		// a situation where the leaseholder is a node that has set its
+		// minProposedTS and won't be using its lease any more. Either the setting
+		// of minProposedTS needs to be "reversible" (tricky) or we make the
+		// lease evaluation succeed, though with a lease that's "invalid" so that
+		// a new lease can be requested right after.
+		return errors.Errorf(`replica %s of type %s cannot hold lease`, repDesc, t)
+	}
+	return nil
 }


### PR DESCRIPTION
Before this patch, the DistSender would only route BatchRequests to
replicas of types `VOTER_FULL` and `VOTER_INCOMING`. This patch changes
that to let the DistSender route requests (for instance, follower read
requests) to `NON_VOTER` replicas as well.

Release note: None