### PR TITLE
release-20.1: Revert "server: remove support for binary protobuf payloads in the HTTP endpoints

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1344,10 +1344,13 @@ func (s *Server) Start(ctx context.Context) error {
 		EmitDefaults: true,
 		Indent:       "  ",
 	}
+	protopb := new(protoutil.ProtoPb)
 	gwMux := gwruntime.NewServeMux(
 		gwruntime.WithMarshalerOption(gwruntime.MIMEWildcard, jsonpb),
 		gwruntime.WithMarshalerOption(httputil.JSONContentType, jsonpb),
 		gwruntime.WithMarshalerOption(httputil.AltJSONContentType, jsonpb),
+		gwruntime.WithMarshalerOption(httputil.ProtoContentType, protopb),
+		gwruntime.WithMarshalerOption(httputil.AltProtoContentType, protopb),
 		gwruntime.WithOutgoingHeaderMatcher(authenticationHeaderMatcher),
 		gwruntime.WithMetadata(forwardAuthenticationMetadata),
 	)

--- a/pkg/util/httputil/http.go
+++ b/pkg/util/httputil/http.go
@@ -34,6 +34,10 @@ const (
 	JSONContentType = "application/json"
 	// AltJSONContentType is the alternate JSON content type.
 	AltJSONContentType = "application/x-json"
+	// ProtoContentType is the protobuf content type.
+	ProtoContentType = "application/x-protobuf"
+	// AltProtoContentType is the alternate protobuf content type.
+	AltProtoContentType = "application/x-google-protobuf"
 	// PlaintextContentType is the plaintext content type.
 	PlaintextContentType = "text/plain"
 	// GzipEncoding is the gzip encoding.


### PR DESCRIPTION


This reverts commit 7ee34ea8ad18993c62bef8cf44eeee3cb0620533.

cc @cockroachdb/release 