### PR TITLE
sql, opt: allow foreign keys to reference UNIQUE WITHOUT INDEX constraints

### DIFF
--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -537,7 +537,7 @@ func (sc *SchemaChanger) addConstraints(
 					// referenced table. It's possible for the unique index found during
 					// planning to have been dropped in the meantime, since only the
 					// presence of the backreference prevents it.
-					_, err = tabledesc.FindFKReferencedIndex(backrefTable, constraint.ForeignKey.ReferencedColumnIDs)
+					_, err = tabledesc.FindFKReferencedUniqueConstraint(backrefTable, constraint.ForeignKey.ReferencedColumnIDs)
 					if err != nil {
 						return err
 					}

--- a/pkg/sql/catalog/descpb/index.go
+++ b/pkg/sql/catalog/descpb/index.go
@@ -172,10 +172,16 @@ func (desc *IndexDescriptor) IsValidOriginIndex(originColIDs ColumnIDs) bool {
 	return !desc.IsPartial() && ColumnIDs(desc.ColumnIDs).HasPrefix(originColIDs)
 }
 
-// IsValidReferencedIndex returns whether the index can serve as a referenced index for a foreign
+// IsValidReferencedUniqueConstraint  is part of the UniqueConstraint interface.
+// It returns whether the index can serve as a referenced index for a foreign
 // key constraint with the provided set of referencedColumnIDs.
-func (desc *IndexDescriptor) IsValidReferencedIndex(referencedColIDs ColumnIDs) bool {
+func (desc *IndexDescriptor) IsValidReferencedUniqueConstraint(referencedColIDs ColumnIDs) bool {
 	return desc.Unique && !desc.IsPartial() && ColumnIDs(desc.ColumnIDs).Equals(referencedColIDs)
+}
+
+// GetName is part of the UniqueConstraint interface.
+func (desc *IndexDescriptor) GetName() string {
+	return desc.Name
 }
 
 // HasOldStoredColumns returns whether the index has stored columns in the old

--- a/pkg/sql/catalog/descpb/structured.go
+++ b/pkg/sql/catalog/descpb/structured.go
@@ -334,3 +334,31 @@ func (DescriptorState) SafeValue() {}
 
 // SafeValue implements the redact.SafeValue interface.
 func (ConstraintType) SafeValue() {}
+
+// UniqueConstraint is an interface for a unique constraint. It allows
+// both UNIQUE indexes and UNIQUE WITHOUT INDEX constraints to serve as
+// the referenced side of a foreign key constraint.
+type UniqueConstraint interface {
+	// IsValidReferencedUniqueConstraint returns whether the unique constraint can
+	// serve as a referenced unique constraint for a foreign key constraint with the
+	// provided set of referencedColumnIDs.
+	IsValidReferencedUniqueConstraint(referencedColIDs ColumnIDs) bool
+
+	// GetName returns the constraint name.
+	GetName() string
+}
+
+var _ UniqueConstraint = &UniqueWithoutIndexConstraint{}
+var _ UniqueConstraint = &IndexDescriptor{}
+
+// IsValidReferencedUniqueConstraint is part of the UniqueConstraint interface.
+func (u *UniqueWithoutIndexConstraint) IsValidReferencedUniqueConstraint(
+	referencedColIDs ColumnIDs,
+) bool {
+	return ColumnIDs(u.ColumnIDs).Equals(referencedColIDs)
+}
+
+// GetName is part of the UniqueConstraint interface.
+func (u *UniqueWithoutIndexConstraint) GetName() string {
+	return u.Name
+}

--- a/pkg/sql/catalog/descriptor.go
+++ b/pkg/sql/catalog/descriptor.go
@@ -240,6 +240,7 @@ type TableDescriptor interface {
 	GetChecks() []*descpb.TableDescriptor_CheckConstraint
 	AllActiveAndInactiveChecks() []*descpb.TableDescriptor_CheckConstraint
 	ActiveChecks() []descpb.TableDescriptor_CheckConstraint
+	GetUniqueWithoutIndexConstraints() []descpb.UniqueWithoutIndexConstraint
 	AllActiveAndInactiveUniqueWithoutIndexConstraints() []*descpb.UniqueWithoutIndexConstraint
 	ForeachInboundFK(f func(fk *descpb.ForeignKeyConstraint) error) error
 	FindActiveColumnByName(s string) (*descpb.ColumnDescriptor, error)
@@ -312,7 +313,7 @@ type Index interface {
 	GetShardColumnName() string
 
 	IsValidOriginIndex(originColIDs descpb.ColumnIDs) bool
-	IsValidReferencedIndex(referencedColIDs descpb.ColumnIDs) bool
+	IsValidReferencedUniqueConstraint(referencedColIDs descpb.ColumnIDs) bool
 
 	GetPartitioning() descpb.PartitioningDescriptor
 	FindPartitionByName(name string) descpb.PartitioningDescriptor

--- a/pkg/sql/catalog/tabledesc/index.go
+++ b/pkg/sql/catalog/tabledesc/index.go
@@ -157,11 +157,11 @@ func (w index) IsValidOriginIndex(originColIDs descpb.ColumnIDs) bool {
 	return w.desc.IsValidOriginIndex(originColIDs)
 }
 
-// IsValidReferencedIndex returns whether the index can serve as a referenced
-// index for a foreign  key constraint with the provided set of
+// IsValidReferencedUniqueConstraint returns whether the index can serve as a
+// referenced index for a foreign  key constraint with the provided set of
 // referencedColumnIDs.
-func (w index) IsValidReferencedIndex(referencedColIDs descpb.ColumnIDs) bool {
-	return w.desc.IsValidReferencedIndex(referencedColIDs)
+func (w index) IsValidReferencedUniqueConstraint(referencedColIDs descpb.ColumnIDs) bool {
+	return w.desc.IsValidReferencedUniqueConstraint(referencedColIDs)
 }
 
 // HasOldStoredColumns returns whether the index has stored columns in the old

--- a/pkg/sql/catalog/tabledesc/structured.go
+++ b/pkg/sql/catalog/tabledesc/structured.go
@@ -1440,7 +1440,7 @@ func (desc *wrapper) validateCrossReferences(ctx context.Context, dg catalog.Des
 			}
 			// Determine whether the index on the other table is a unique index that
 			// could support this FK constraint.
-			if !referencedIdx.IsValidReferencedIndex(fk.ReferencedColumnIDs) {
+			if !referencedIdx.IsValidReferencedUniqueConstraint(fk.ReferencedColumnIDs) {
 				return nil
 			}
 			// Now check the backreferences. Backreferences in ReferencedBy only had
@@ -1539,7 +1539,7 @@ func (desc *wrapper) validateCrossReferences(ctx context.Context, dg catalog.Des
 					fk.Index, desc.Name, backref.Name, originTable.GetName(),
 				)
 			}
-			if originalReferencedIndex.IsValidReferencedIndex(backref.ReferencedColumnIDs) {
+			if originalReferencedIndex.IsValidReferencedUniqueConstraint(backref.ReferencedColumnIDs) {
 				found = true
 			}
 			return nil

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -2249,9 +2249,13 @@ CREATE TABLE crdb_internal.backward_dependencies (
 				if err != nil {
 					return err
 				}
-				refIdx, err := tabledesc.FindFKReferencedIndex(refTbl, fk.ReferencedColumnIDs)
+				refConstraint, err := tabledesc.FindFKReferencedUniqueConstraint(refTbl, fk.ReferencedColumnIDs)
 				if err != nil {
 					return err
+				}
+				var refIdxID descpb.IndexID
+				if refIdx, ok := refConstraint.(*descpb.IndexDescriptor); ok {
+					refIdxID = refIdx.ID
 				}
 				return addRow(
 					tableID, tableName,
@@ -2259,7 +2263,7 @@ CREATE TABLE crdb_internal.backward_dependencies (
 					tree.DNull,
 					tree.NewDInt(tree.DInt(fk.ReferencedTableID)),
 					fkDep,
-					tree.NewDInt(tree.DInt(refIdx.ID)),
+					tree.NewDInt(tree.DInt(refIdxID)),
 					tree.NewDString(fk.Name),
 					tree.DNull,
 				)

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -907,8 +907,8 @@ func ResolveFK(
 		}
 	}
 
-	// Ensure that there is an index on the referenced side to use.
-	_, err = tabledesc.FindFKReferencedIndex(target, targetColIDs)
+	// Ensure that there is a unique constraint on the referenced side to use.
+	_, err = tabledesc.FindFKReferencedUniqueConstraint(target, targetColIDs)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -900,22 +900,24 @@ CREATE TABLE information_schema.referential_constraints (
 				if r, ok := matchOptionMap[fk.Match]; ok {
 					matchType = r
 				}
-				referencedIdx, err := tabledesc.FindFKReferencedIndex(refTable, fk.ReferencedColumnIDs)
+				refConstraint, err := tabledesc.FindFKReferencedUniqueConstraint(
+					refTable, fk.ReferencedColumnIDs,
+				)
 				if err != nil {
 					return err
 				}
 				return addRow(
-					dbNameStr,                           // constraint_catalog
-					scNameStr,                           // constraint_schema
-					tree.NewDString(fk.Name),            // constraint_name
-					dbNameStr,                           // unique_constraint_catalog
-					scNameStr,                           // unique_constraint_schema
-					tree.NewDString(referencedIdx.Name), // unique_constraint_name
-					matchType,                           // match_option
-					dStringForFKAction(fk.OnUpdate),     // update_rule
-					dStringForFKAction(fk.OnDelete),     // delete_rule
-					tbNameStr,                           // table_name
-					tree.NewDString(refTable.GetName()), // referenced_table_name
+					dbNameStr,                                // constraint_catalog
+					scNameStr,                                // constraint_schema
+					tree.NewDString(fk.Name),                 // constraint_name
+					dbNameStr,                                // unique_constraint_catalog
+					scNameStr,                                // unique_constraint_schema
+					tree.NewDString(refConstraint.GetName()), // unique_constraint_name
+					matchType,                                // match_option
+					dStringForFKAction(fk.OnUpdate),          // update_rule
+					dStringForFKAction(fk.OnDelete),          // delete_rule
+					tbNameStr,                                // table_name
+					tree.NewDString(refTable.GetName()),      // referenced_table_name
 				)
 			})
 		})

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -1418,9 +1418,19 @@ CREATE TABLE unique_without_index (
   a INT,
   b INT UNIQUE WITHOUT INDEX,
   c INT UNIQUE,
+  d INT UNIQUE WITHOUT INDEX,
+  e INT,
   UNIQUE WITHOUT INDEX (b),
   UNIQUE WITHOUT INDEX (a, b),
-  UNIQUE WITHOUT INDEX (c)
+  UNIQUE WITHOUT INDEX (c),
+  UNIQUE WITHOUT INDEX (d, e)
+)
+
+statement ok
+CREATE TABLE uwi_child (
+  d INT REFERENCES unique_without_index (d),
+  e INT,
+  CONSTRAINT fk_d_e FOREIGN KEY (d, e) REFERENCES unique_without_index (d, e)
 )
 
 # We don't yet support adding unique constraints without an index after a table
@@ -1444,6 +1454,8 @@ unique_without_index  unique_a_b                  UNIQUE  UNIQUE WITHOUT INDEX (
 unique_without_index  unique_b                    UNIQUE  UNIQUE WITHOUT INDEX (b)     true
 unique_without_index  unique_b_1                  UNIQUE  UNIQUE WITHOUT INDEX (b)     true
 unique_without_index  unique_c                    UNIQUE  UNIQUE WITHOUT INDEX (c)     true
+unique_without_index  unique_d                    UNIQUE  UNIQUE WITHOUT INDEX (d)     true
+unique_without_index  unique_d_e                  UNIQUE  UNIQUE WITHOUT INDEX (d, e)  true
 unique_without_index  unique_without_index_c_key  UNIQUE  UNIQUE (c ASC)               true
 
 statement ok
@@ -1465,6 +1477,8 @@ unique_without_index  unique_a_b                  UNIQUE  UNIQUE WITHOUT INDEX (
 unique_without_index  unique_b_1                  UNIQUE  UNIQUE WITHOUT INDEX (b)      true
 unique_without_index  unique_b_2                  UNIQUE  UNIQUE WITHOUT INDEX (b)      true
 unique_without_index  unique_c                    UNIQUE  UNIQUE WITHOUT INDEX (c)      true
+unique_without_index  unique_d                    UNIQUE  UNIQUE WITHOUT INDEX (d)      true
+unique_without_index  unique_d_e                  UNIQUE  UNIQUE WITHOUT INDEX (d, e)   true
 unique_without_index  unique_without_index_c_key  UNIQUE  UNIQUE (c ASC)                true
 
 statement error pgcode 0A000 cannot drop UNIQUE constraint \"unique_without_index_c_key\"
@@ -1483,8 +1497,34 @@ ALTER TABLE unique_without_index DROP COLUMN b
 query TTTTB
 SHOW CONSTRAINTS FROM unique_without_index
 ----
+unique_without_index  unique_c                    UNIQUE  UNIQUE WITHOUT INDEX (c)     true
+unique_without_index  unique_d                    UNIQUE  UNIQUE WITHOUT INDEX (d)     true
+unique_without_index  unique_d_e                  UNIQUE  UNIQUE WITHOUT INDEX (d, e)  true
+unique_without_index  unique_without_index_c_key  UNIQUE  UNIQUE (c ASC)               true
+
+query TTTTB
+SHOW CONSTRAINTS FROM uwi_child
+----
+uwi_child  fk_d_e                         FOREIGN KEY  FOREIGN KEY (d, e) REFERENCES unique_without_index(d, e)  true
+uwi_child  fk_d_ref_unique_without_index  FOREIGN KEY  FOREIGN KEY (d) REFERENCES unique_without_index(d)        true
+
+# Attempting to drop a column with a foreign key reference fails.
+statement error pq: "unique_d" is referenced by foreign key from table "uwi_child"
+ALTER TABLE unique_without_index DROP COLUMN d
+
+# It succeeds if we use CASCADE, and also drops the fk reference.
+statement ok
+ALTER TABLE unique_without_index DROP COLUMN d CASCADE
+
+query TTTTB
+SHOW CONSTRAINTS FROM unique_without_index
+----
 unique_without_index  unique_c                    UNIQUE  UNIQUE WITHOUT INDEX (c)  true
 unique_without_index  unique_without_index_c_key  UNIQUE  UNIQUE (c ASC)            true
+
+query TTTTB
+SHOW CONSTRAINTS FROM uwi_child
+----
 
 # TODO(rytaft): Add test cases for dropping both a valid and not-valid
 # unique constraint once supported.

--- a/pkg/sql/logictest/testdata/logic_test/dependencies
+++ b/pkg/sql/logictest/testdata/logic_test/dependencies
@@ -1,4 +1,7 @@
 statement ok
+SET experimental_enable_unique_without_index_constraints = true
+
+statement ok
 CREATE TABLE test_kv(k INT PRIMARY KEY, v INT, w DECIMAL);
   CREATE UNIQUE INDEX test_v_idx ON test_kv(v);
   CREATE INDEX test_v_idx2 ON test_kv(v DESC) STORING(w);
@@ -11,6 +14,8 @@ CREATE TABLE test_kv(k INT PRIMARY KEY, v INT, w DECIMAL);
   CREATE UNIQUE INDEX test_kvi2_idx ON test_kvi2(v) INTERLEAVE IN PARENT test_kv(v);
   CREATE VIEW test_v1 AS SELECT v FROM test_kv;
   CREATE VIEW test_v2 AS SELECT v FROM test_v1;
+  CREATE TABLE test_uwi_parent(a INT UNIQUE WITHOUT INDEX);
+  CREATE TABLE test_uwi_child(a INT REFERENCES test_uwi_parent(a));
 
 query ITITTBTB colnames
 SELECT * FROM crdb_internal.table_columns WHERE descriptor_name LIKE 'test_%' ORDER BY descriptor_id, column_id
@@ -31,6 +36,10 @@ descriptor_id  descriptor_name  column_id  column_name  column_type             
 58             test_kvi2        2          v            family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 time_precision_is_set:false        true      NULL            false
 59             test_v1          1          v            family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 time_precision_is_set:false        true      NULL            false
 60             test_v2          1          v            family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 time_precision_is_set:false        true      NULL            false
+61             test_uwi_parent  1          a            family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 time_precision_is_set:false        true      NULL            false
+61             test_uwi_parent  2          rowid        family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 time_precision_is_set:false        false     unique_rowid()  true
+62             test_uwi_child   1          a            family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 time_precision_is_set:false        true      NULL            false
+62             test_uwi_child   2          rowid        family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 time_precision_is_set:false        false     unique_rowid()  true
 
 query ITITTBB colnames
 SELECT * FROM crdb_internal.table_indexes WHERE descriptor_name LIKE 'test_%' ORDER BY descriptor_id, index_id
@@ -50,6 +59,8 @@ descriptor_id  descriptor_name  index_id  index_name       index_type  is_unique
 58             test_kvi2        2         test_kvi2_idx    secondary   true       false
 59             test_v1          0         ·                primary     false      false
 60             test_v2          0         ·                primary     false      false
+61             test_uwi_parent  1         primary          primary     true       false
+62             test_uwi_child   1         primary          primary     true       false
 
 query ITITTITTB colnames
 SELECT * FROM crdb_internal.index_columns WHERE descriptor_name LIKE 'test_%' ORDER BY descriptor_id, index_id, column_type, column_id
@@ -76,18 +87,21 @@ descriptor_id  descriptor_name  index_id  index_name       column_type  column_i
 58             test_kvi2        1         primary          key          1          k            ASC               false
 58             test_kvi2        2         test_kvi2_idx    extra        1          NULL         NULL              false
 58             test_kvi2        2         test_kvi2_idx    key          2          v            ASC               false
+61             test_uwi_parent  1         primary          key          2          rowid        ASC               false
+62             test_uwi_child   1         primary          key          2          rowid        ASC               false
 
 query ITIIITITT colnames
 SELECT * FROM crdb_internal.backward_dependencies WHERE descriptor_name LIKE 'test_%' ORDER BY descriptor_id, index_id, dependson_type, dependson_id, dependson_index_id
 ----
-descriptor_id  descriptor_name  index_id  column_id  dependson_id  dependson_type  dependson_index_id  dependson_name    dependson_details
-54             test_kvr1        NULL      NULL       53            fk              1                   fk_k_ref_test_kv  NULL
-55             test_kvr2        NULL      NULL       53            fk              1                   fk_v_ref_test_kv  NULL
-56             test_kvr3        NULL      NULL       53            fk              2                   fk_v_ref_test_kv  NULL
-57             test_kvi1        1         NULL       53            interleave      1                   NULL              SharedPrefixLen: 1
-58             test_kvi2        2         NULL       53            interleave      1                   NULL              SharedPrefixLen: 1
-59             test_v1          NULL      NULL       53            view            NULL                NULL              NULL
-60             test_v2          NULL      NULL       59            view            NULL                NULL              NULL
+descriptor_id  descriptor_name  index_id  column_id  dependson_id  dependson_type  dependson_index_id  dependson_name            dependson_details
+54             test_kvr1        NULL      NULL       53            fk              1                   fk_k_ref_test_kv          NULL
+55             test_kvr2        NULL      NULL       53            fk              1                   fk_v_ref_test_kv          NULL
+56             test_kvr3        NULL      NULL       53            fk              2                   fk_v_ref_test_kv          NULL
+57             test_kvi1        1         NULL       53            interleave      1                   NULL                      SharedPrefixLen: 1
+58             test_kvi2        2         NULL       53            interleave      1                   NULL                      SharedPrefixLen: 1
+59             test_v1          NULL      NULL       53            view            NULL                NULL                      NULL
+60             test_v2          NULL      NULL       59            view            NULL                NULL                      NULL
+62             test_uwi_child   NULL      NULL       61            fk              0                   fk_a_ref_test_uwi_parent  NULL
 
 query ITIITITT colnames
 SELECT * FROM crdb_internal.forward_dependencies WHERE descriptor_name LIKE 'test_%' ORDER BY descriptor_id, index_id, dependedonby_type, dependedonby_id, dependedonby_index_id
@@ -100,6 +114,7 @@ descriptor_id  descriptor_name  index_id  dependedonby_id  dependedonby_type  de
 53             test_kv          1         57               interleave         1                      NULL               SharedPrefixLen: 0
 53             test_kv          1         58               interleave         2                      NULL               SharedPrefixLen: 0
 59             test_v1          NULL      60               view               0                      NULL               Columns: [1]
+61             test_uwi_parent  NULL      62               fk                 NULL                   NULL               NULL
 
 # Checks view dependencies (#17306)
 statement ok
@@ -110,13 +125,13 @@ query ITIIITITT colnames
 SELECT * FROM crdb_internal.backward_dependencies WHERE descriptor_name LIKE 'moretest_%' ORDER BY descriptor_id, index_id, dependson_type, dependson_id, dependson_index_id
 ----
 descriptor_id  descriptor_name  index_id  column_id  dependson_id  dependson_type  dependson_index_id  dependson_name  dependson_details
-62             moretest_v       NULL      NULL       61            view            NULL                NULL            NULL
+64             moretest_v       NULL      NULL       63            view            NULL                NULL            NULL
 
 query ITIITITT colnames
 SELECT * FROM crdb_internal.forward_dependencies WHERE descriptor_name LIKE 'moretest_%' ORDER BY descriptor_id, index_id, dependedonby_type, dependedonby_id, dependedonby_index_id
 ----
 descriptor_id  descriptor_name  index_id  dependedonby_id  dependedonby_type  dependedonby_index_id  dependedonby_name  dependedonby_details
-61             moretest_t       NULL      62               view               0                      NULL               Columns: [2]
+63             moretest_t       NULL      64               view               0                      NULL               Columns: [2]
 
 # Check sequence dependencies.
 
@@ -130,10 +145,10 @@ query ITIIITITT colnames
 SELECT * FROM crdb_internal.backward_dependencies WHERE descriptor_name LIKE 'blog_posts'
 ----
 descriptor_id  descriptor_name  index_id  column_id  dependson_id  dependson_type  dependson_index_id  dependson_name  dependson_details
-64             blog_posts       NULL      1          63            sequence        NULL                NULL            NULL
+66             blog_posts       NULL      1          65            sequence        NULL                NULL            NULL
 
 query ITIITITT colnames
 SELECT * FROM crdb_internal.forward_dependencies WHERE descriptor_name LIKE 'blog_posts%'
 ----
 descriptor_id  descriptor_name    index_id  dependedonby_id  dependedonby_type  dependedonby_index_id  dependedonby_name  dependedonby_details
-63             blog_posts_id_seq  NULL      64               sequence           0                      NULL               Columns: [1]
+65             blog_posts_id_seq  NULL      66               sequence           0                      NULL               Columns: [1]

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -1674,6 +1674,25 @@ CREATE TABLE constraint_column.t3 (
 )
 
 statement ok
+SET experimental_enable_unique_without_index_constraints = true
+
+statement ok
+CREATE TABLE constraint_column.t4 (
+    a INT UNIQUE WITHOUT INDEX,
+    b FLOAT,
+    c STRING,
+    UNIQUE WITHOUT INDEX (b, c)
+)
+
+statement ok
+CREATE TABLE constraint_column.t5 (
+    a INT REFERENCES constraint_column.t4(a) ON DELETE CASCADE,
+    b FLOAT,
+    c STRING,
+    CONSTRAINT fk3 FOREIGN KEY (b, c) REFERENCES constraint_column.t4(b, c) MATCH FULL ON UPDATE RESTRICT
+)
+
+statement ok
 SET DATABASE = constraint_column
 
 query TTTTTTTII colnames
@@ -1688,6 +1707,12 @@ constraint_column   public             fk               constraint_column  publi
 constraint_column   public             primary          constraint_column  public        t2          t1_id        1                 NULL
 constraint_column   public             fk2              constraint_column  public        t3          a            1                 1
 constraint_column   public             fk2              constraint_column  public        t3          b            2                 2
+constraint_column   public             unique_a         constraint_column  public        t4          a            1                 NULL
+constraint_column   public             unique_b_c       constraint_column  public        t4          b            1                 NULL
+constraint_column   public             unique_b_c       constraint_column  public        t4          c            2                 NULL
+constraint_column   public             fk3              constraint_column  public        t5          b            1                 1
+constraint_column   public             fk3              constraint_column  public        t5          c            2                 2
+constraint_column   public             fk_a_ref_t4      constraint_column  public        t5          a            1                 1
 
 query TTTTTTTTTTT colnames
 SELECT * FROM information_schema.referential_constraints WHERE constraint_schema = 'public' ORDER BY TABLE_NAME, CONSTRAINT_NAME
@@ -1695,6 +1720,8 @@ SELECT * FROM information_schema.referential_constraints WHERE constraint_schema
 constraint_catalog  constraint_schema  constraint_name  unique_constraint_catalog  unique_constraint_schema  unique_constraint_name  match_option  update_rule  delete_rule  table_name  referenced_table_name
 constraint_column   public             fk               constraint_column          public                    t1_a_key                NONE          NO ACTION    RESTRICT     t2          t1
 constraint_column   public             fk2              constraint_column          public                    index_key               NONE          CASCADE      NO ACTION    t3          t1
+constraint_column   public             fk3              constraint_column          public                    unique_b_c              FULL          RESTRICT     NO ACTION    t5          t4
+constraint_column   public             fk_a_ref_t4      constraint_column          public                    unique_a                NONE          NO ACTION    CASCADE      t5          t4
 
 statement ok
 DROP DATABASE constraint_column CASCADE
@@ -3330,7 +3357,7 @@ experimental_enable_hash_sharded_indexes              off
 experimental_enable_implicit_column_partitioning      off
 experimental_enable_multi_column_inverted_indexes     off
 experimental_enable_temp_tables                       off
-experimental_enable_unique_without_index_constraints  off
+experimental_enable_unique_without_index_constraints  on
 experimental_enable_virtual_columns                   off
 extra_float_digits                                    0
 force_savepoint_restart                               off

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -226,6 +226,25 @@ CREATE TABLE constraint_db.t3 (
 statement ok
 CREATE VIEW constraint_db.v1 AS SELECT p,a,b,c FROM constraint_db.t1
 
+statement ok
+SET experimental_enable_unique_without_index_constraints = true
+
+statement ok
+CREATE TABLE constraint_db.t4 (
+    a INT UNIQUE WITHOUT INDEX,
+    b FLOAT,
+    c STRING,
+    CONSTRAINT uwi_b_c UNIQUE WITHOUT INDEX (b, c)
+)
+
+statement ok
+CREATE TABLE constraint_db.t5 (
+    a INT REFERENCES constraint_db.t4(a) ON DELETE CASCADE,
+    b FLOAT,
+    c STRING,
+    CONSTRAINT fk_b_c FOREIGN KEY (b, c) REFERENCES constraint_db.t4(b, c) MATCH FULL ON UPDATE RESTRICT
+)
+
 ## pg_catalog.pg_namespace
 
 query OTOT colnames
@@ -289,6 +308,8 @@ schemaname  tablename  tableowner  tablespace  hasindexes  hasrules  hastriggers
 public      t1         root        NULL        true        false     false        false
 public      t2         root        NULL        true        false     false        false
 public      t3         root        NULL        true        false     false        false
+public      t4         root        NULL        true        false     false        false
+public      t5         root        NULL        true        false     false        false
 
 query TB colnames
 SELECT tablename, hasindexes FROM pg_catalog.pg_tables WHERE schemaname = 'information_schema' AND tablename LIKE '%table%'
@@ -346,8 +367,12 @@ oid         relname       relnamespace  reltype  reloftype  relowner    relam   
 969972501   primary       2332901747    0        0          1546506610  2631952481  0            0
 969972502   t3_a_b_idx    2332901747    0        0          1546506610  2631952481  0            0
 58          v1            2332901747    0        0          1546506610  0           0            0
-59          mv1           2332901747    0        0          1546506610  0           0            0
+59          t4            2332901747    0        0          1546506610  2631952481  0            0
 3660126519  primary       2332901747    0        0          1546506610  2631952481  0            0
+60          t5            2332901747    0        0          1546506610  2631952481  0            0
+1229708768  primary       2332901747    0        0          1546506610  2631952481  0            0
+61          mv1           2332901747    0        0          1546506610  0           0            0
+4179599057  primary       2332901747    0        0          1546506610  2631952481  0            0
 
 query TIRIOBBT colnames
 SELECT relname, relpages, reltuples, relallvisible, reltoastrelid, relhasindex, relisshared, relpersistence
@@ -367,6 +392,10 @@ t3            NULL      NULL       0              0              true         fa
 primary       NULL      NULL       0              0              false        false        p
 t3_a_b_idx    NULL      NULL       0              0              false        false        p
 v1            NULL      NULL       0              0              false        false        p
+t4            NULL      NULL       0              0              true         false        p
+primary       NULL      NULL       0              0              false        false        p
+t5            NULL      NULL       0              0              true         false        p
+primary       NULL      NULL       0              0              false        false        p
 mv1           NULL      NULL       0              0              true         false        p
 primary       NULL      NULL       0              0              false        false        p
 
@@ -388,6 +417,10 @@ t3            false      r        4         2          false       true
 primary       false      i        1         0          false       false
 t3_a_b_idx    false      i        2         0          false       false
 v1            false      v        4         0          false       false
+t4            false      r        4         0          false       true
+primary       false      i        1         0          false       false
+t5            false      r        4         0          false       true
+primary       false      i        1         0          false       false
 mv1           false      m        2         0          false       true
 primary       false      i        1         0          false       false
 
@@ -409,6 +442,10 @@ t3            false        false           false           0             NULL   
 primary       false        false           false           0             NULL    NULL
 t3_a_b_idx    false        false           false           0             NULL    NULL
 v1            false        false           false           0             NULL    NULL
+t4            false        false           false           0             NULL    NULL
+primary       false        false           false           0             NULL    NULL
+t5            false        false           false           0             NULL    NULL
+primary       false        false           false           0             NULL    NULL
 mv1           false        false           false           0             NULL    NULL
 primary       false        false           false           0             NULL    NULL
 
@@ -453,9 +490,19 @@ attrelid    relname       attname   atttypid  attstattarget  attlen  attnum  att
 58          v1            a         20        0              8       2       0         -1
 58          v1            b         20        0              8       3       0         -1
 58          v1            c         20        0              8       4       0         -1
-59          mv1           ?column?  20        0              8       1       0         -1
-59          mv1           rowid     20        0              8       2       0         -1
-3660126519  primary       rowid     20        0              8       2       0         -1
+59          t4            a         20        0              8       1       0         -1
+59          t4            b         701       0              8       2       0         -1
+59          t4            c         25        0              -1      3       0         -1
+59          t4            rowid     20        0              8       4       0         -1
+3660126519  primary       rowid     20        0              8       4       0         -1
+60          t5            a         20        0              8       1       0         -1
+60          t5            b         701       0              8       2       0         -1
+60          t5            c         25        0              -1      3       0         -1
+60          t5            rowid     20        0              8       4       0         -1
+1229708768  primary       rowid     20        0              8       4       0         -1
+61          mv1           ?column?  20        0              8       1       0         -1
+61          mv1           rowid     20        0              8       2       0         -1
+4179599057  primary       rowid     20        0              8       2       0         -1
 
 query TTIBTTBBTT colnames
 SELECT c.relname, attname, atttypmod, attbyval, attstorage, attalign, attnotnull, atthasdef, attidentity, attgenerated
@@ -496,6 +543,16 @@ v1            p         -1         NULL      NULL        NULL      false       f
 v1            a         -1         NULL      NULL        NULL      false       false      ·            ·
 v1            b         -1         NULL      NULL        NULL      false       false      ·            ·
 v1            c         -1         NULL      NULL        NULL      false       false      ·            ·
+t4            a         -1         NULL      NULL        NULL      false       false      ·            ·
+t4            b         -1         NULL      NULL        NULL      false       false      ·            ·
+t4            c         -1         NULL      NULL        NULL      false       false      ·            ·
+t4            rowid     -1         NULL      NULL        NULL      true        true       ·            ·
+primary       rowid     -1         NULL      NULL        NULL      true        true       ·            ·
+t5            a         -1         NULL      NULL        NULL      false       false      ·            ·
+t5            b         -1         NULL      NULL        NULL      false       false      ·            ·
+t5            c         -1         NULL      NULL        NULL      false       false      ·            ·
+t5            rowid     -1         NULL      NULL        NULL      true        true       ·            ·
+primary       rowid     -1         NULL      NULL        NULL      true        true       ·            ·
 mv1           ?column?  -1         NULL      NULL        NULL      false       false      ·            ·
 mv1           rowid     -1         NULL      NULL        NULL      true        true       ·            ·
 primary       rowid     -1         NULL      NULL        NULL      true        true       ·            ·
@@ -539,6 +596,16 @@ v1            p         false         true        0            NULL    NULL     
 v1            a         false         true        0            NULL    NULL        NULL
 v1            b         false         true        0            NULL    NULL        NULL
 v1            c         false         true        0            NULL    NULL        NULL
+t4            a         false         true        0            NULL    NULL        NULL
+t4            b         false         true        0            NULL    NULL        NULL
+t4            c         false         true        0            NULL    NULL        NULL
+t4            rowid     false         true        0            NULL    NULL        NULL
+primary       rowid     false         true        0            NULL    NULL        NULL
+t5            a         false         true        0            NULL    NULL        NULL
+t5            b         false         true        0            NULL    NULL        NULL
+t5            c         false         true        0            NULL    NULL        NULL
+t5            rowid     false         true        0            NULL    NULL        NULL
+primary       rowid     false         true        0            NULL    NULL        NULL
 mv1           ?column?  false         true        0            NULL    NULL        NULL
 mv1           rowid     false         true        0            NULL    NULL        NULL
 primary       rowid     false         true        0            NULL    NULL        NULL
@@ -598,10 +665,12 @@ WHERE n.nspname = 'public'
 ----
 relname  attname  typname   attcollation  collname
 t1       d        varchar   3403232968    default
-t1       h        _bpchar   3403232968    default
-t1       i        _varchar  3403232968    default
-t1       j        char      3403232968    default
+t5       c        text      3403232968    default
+t4       c        text      3403232968    default
 t3       c        text      3403232968    default
+t1       j        char      3403232968    default
+t1       i        _varchar  3403232968    default
+t1       h        _bpchar   3403232968    default
 t1       k        varchar   999873346     sv
 
 
@@ -629,7 +698,9 @@ oid         relname  adrelid  adnum  adbin           adsrc           pg_get_expr
 841178406   t2       56       2      unique_rowid()  unique_rowid()  unique_rowid()
 2186255414  t3       57       3      'FOO'::STRING   'FOO'::STRING   'FOO'::STRING
 2186255409  t3       57       4      unique_rowid()  unique_rowid()  unique_rowid()
-581442133   mv1      59       2      unique_rowid()  unique_rowid()  unique_rowid()
+581442131   t4       59       4      unique_rowid()  unique_rowid()  unique_rowid()
+4050804964  t5       60       4      unique_rowid()  unique_rowid()  unique_rowid()
+1100914675  mv1      61       2      unique_rowid()  unique_rowid()  unique_rowid()
 
 ## pg_catalog.pg_indexes
 
@@ -646,7 +717,9 @@ crdb_oid    schemaname  tablename  indexname     tablespace
 2315049511  public      t2         t2_t1_id_idx  NULL
 969972501   public      t3         primary       NULL
 969972502   public      t3         t3_a_b_idx    NULL
-3660126519  public      mv1        primary       NULL
+3660126519  public      t4         primary       NULL
+1229708768  public      t5         primary       NULL
+4179599057  public      mv1        primary       NULL
 
 query OTTT colnames
 SELECT crdb_oid, tablename, indexname, indexdef
@@ -661,7 +734,9 @@ crdb_oid    tablename  indexname     indexdef
 2315049511  t2         t2_t1_id_idx  CREATE INDEX t2_t1_id_idx ON constraint_db.public.t2 USING btree (t1_id ASC)
 969972501   t3         primary       CREATE UNIQUE INDEX "primary" ON constraint_db.public.t3 USING btree (rowid ASC)
 969972502   t3         t3_a_b_idx    CREATE INDEX t3_a_b_idx ON constraint_db.public.t3 USING btree (a ASC, b DESC) STORING (c)
-3660126519  mv1        primary       CREATE UNIQUE INDEX "primary" ON constraint_db.public.mv1 USING btree (rowid ASC)
+3660126519  t4         primary       CREATE UNIQUE INDEX "primary" ON constraint_db.public.t4 USING btree (rowid ASC)
+1229708768  t5         primary       CREATE UNIQUE INDEX "primary" ON constraint_db.public.t5 USING btree (rowid ASC)
+4179599057  mv1        primary       CREATE UNIQUE INDEX "primary" ON constraint_db.public.mv1 USING btree (rowid ASC)
 
 ## pg_catalog.pg_index
 
@@ -845,14 +920,18 @@ JOIN pg_catalog.pg_namespace n ON con.connamespace = n.oid
 WHERE n.nspname = 'public'
 ORDER BY con.oid
 ----
-oid         conname    connamespace  contype  condef
-370295511   check_c    2332901747    c        CHECK ((c != ''::STRING))
-2143281868  fk         2332901747    f        FOREIGN KEY (a, b) REFERENCES t1(b, c)
-2792001267  check_b    2332901747    c        CHECK ((b > 11))
-3572320190  primary    2332901747    p        PRIMARY KEY (p ASC)
-4089604113  fk         2332901747    f        FOREIGN KEY (t1_id) REFERENCES t1(a)
-4243354484  t1_a_key   2332901747    u        UNIQUE (a ASC)
-4243354485  index_key  2332901747    u        UNIQUE (b ASC, c ASC)
+oid         conname      connamespace  contype  condef
+370295511   check_c      2332901747    c        CHECK ((c != ''::STRING))
+644272476   unique_a     2332901747    u        UNIQUE WITHOUT INDEX (a)
+2112301379  uwi_b_c      2332901747    u        UNIQUE WITHOUT INDEX (b, c)
+2143281868  fk           2332901747    f        FOREIGN KEY (a, b) REFERENCES t1(b, c)
+2355671820  fk_b_c       2332901747    f        FOREIGN KEY (b, c) REFERENCES t4(b, c) MATCH FULL ON UPDATE RESTRICT
+2792001267  check_b      2332901747    c        CHECK ((b > 11))
+3572320190  primary      2332901747    p        PRIMARY KEY (p ASC)
+3911002394  fk_a_ref_t4  2332901747    f        FOREIGN KEY (a) REFERENCES t4(a) ON DELETE CASCADE
+4089604113  fk           2332901747    f        FOREIGN KEY (t1_id) REFERENCES t1(a)
+4243354484  t1_a_key     2332901747    u        UNIQUE (a ASC)
+4243354485  index_key    2332901747    u        UNIQUE (b ASC, c ASC)
 
 query TTBBBOOO colnames
 SELECT conname, contype, condeferrable, condeferred, convalidated, conrelid, contypid, conindid
@@ -861,14 +940,18 @@ JOIN pg_catalog.pg_namespace n ON con.connamespace = n.oid
 WHERE n.nspname = 'public'
 ORDER BY con.oid
 ----
-conname    contype  condeferrable  condeferred  convalidated  conrelid  contypid  conindid
-check_c    c        false          false        true          57        0         0
-fk         f        false          false        true          57        0         450499961
-check_b    c        false          false        true          57        0         0
-primary    p        false          false        true          55        0         450499963
-fk         f        false          false        true          56        0         450499960
-t1_a_key   u        false          false        true          55        0         450499960
-index_key  u        false          false        true          55        0         450499961
+conname      contype  condeferrable  condeferred  convalidated  conrelid  contypid  conindid
+check_c      c        false          false        true          57        0         0
+unique_a     u        false          false        true          59        0         0
+uwi_b_c      u        false          false        true          59        0         0
+fk           f        false          false        true          57        0         450499961
+fk_b_c       f        false          false        true          60        0         0
+check_b      c        false          false        true          57        0         0
+primary      p        false          false        true          55        0         450499963
+fk_a_ref_t4  f        false          false        true          60        0         0
+fk           f        false          false        true          56        0         450499960
+t1_a_key     u        false          false        true          55        0         450499960
+index_key    u        false          false        true          55        0         450499961
 
 query T
 SELECT conname
@@ -887,6 +970,8 @@ ORDER BY con.oid
 ----
 conname    confrelid  confupdtype  confdeltype  confmatchtype
 check_c    0          NULL         NULL         NULL
+unique_a   0          NULL         NULL         NULL
+uwi_b_c    0          NULL         NULL         NULL
 check_b    0          NULL         NULL         NULL
 primary    0          NULL         NULL         NULL
 t1_a_key   0          NULL         NULL         NULL
@@ -899,9 +984,11 @@ JOIN pg_catalog.pg_namespace n ON con.connamespace = n.oid
 WHERE n.nspname = 'public' AND contype = 'f'
 ORDER BY con.oid
 ----
-conname  confrelid  confupdtype  confdeltype  confmatchtype
-fk       55         a            a            s
-fk       55         a            a            s
+conname      confrelid  confupdtype  confdeltype  confmatchtype
+fk           55         a            a            s
+fk_b_c       59         r            a            f
+fk_a_ref_t4  59         a            c            s
+fk           55         a            a            s
 
 query TBIBT colnames
 SELECT conname, conislocal, coninhcount, connoinherit, conkey
@@ -910,14 +997,18 @@ JOIN pg_catalog.pg_namespace n ON con.connamespace = n.oid
 WHERE n.nspname = 'public'
 ORDER BY con.oid
 ----
-conname    conislocal  coninhcount  connoinherit  conkey
-check_c    true        0            true          {3}
-fk         true        0            true          {1,2}
-check_b    true        0            true          {2}
-primary    true        0            true          {1}
-fk         true        0            true          {1}
-t1_a_key   true        0            true          {2}
-index_key  true        0            true          {3,4}
+conname      conislocal  coninhcount  connoinherit  conkey
+check_c      true        0            true          {3}
+unique_a     true        0            true          NULL
+uwi_b_c      true        0            true          NULL
+fk           true        0            true          {1,2}
+fk_b_c       true        0            true          {2,3}
+check_b      true        0            true          {2}
+primary      true        0            true          {1}
+fk_a_ref_t4  true        0            true          {1}
+fk           true        0            true          {1}
+t1_a_key     true        0            true          {2}
+index_key    true        0            true          {3,4}
 
 query TTTTTTTTT colnames
 SELECT conname, confkey, conpfeqop, conppeqop, conffeqop, conexclop, conbin, consrc, pg_get_constraintdef(con.oid) as condef
@@ -928,6 +1019,8 @@ ORDER BY con.oid
 ----
 conname    confkey  conpfeqop  conppeqop  conffeqop  conexclop  conbin             consrc             condef
 check_c    NULL     NULL       NULL       NULL       NULL       (c != ''::STRING)  (c != ''::STRING)  CHECK ((c != ''::STRING))
+unique_a   NULL     NULL       NULL       NULL       NULL       NULL               NULL               UNIQUE WITHOUT INDEX (a)
+uwi_b_c    NULL     NULL       NULL       NULL       NULL       NULL               NULL               UNIQUE WITHOUT INDEX (b, c)
 check_b    NULL     NULL       NULL       NULL       NULL       (b > 11)           (b > 11)           CHECK ((b > 11))
 primary    NULL     NULL       NULL       NULL       NULL       NULL               NULL               PRIMARY KEY (p ASC)
 t1_a_key   NULL     NULL       NULL       NULL       NULL       NULL               NULL               UNIQUE (a ASC)
@@ -940,9 +1033,11 @@ JOIN pg_catalog.pg_namespace n ON con.connamespace = n.oid
 WHERE n.nspname = 'public' AND contype = 'f'
 ORDER BY con.oid
 ----
-conname  confkey  conpfeqop  conppeqop  conffeqop  conexclop  conbin  consrc
-fk       {3,4}    NULL       NULL       NULL       NULL       NULL    NULL
-fk       {2}      NULL       NULL       NULL       NULL       NULL    NULL
+conname      confkey  conpfeqop  conppeqop  conffeqop  conexclop  conbin  consrc
+fk           {3,4}    NULL       NULL       NULL       NULL       NULL    NULL
+fk_b_c       {2,3}    NULL       NULL       NULL       NULL       NULL    NULL
+fk_a_ref_t4  {1}      NULL       NULL       NULL       NULL       NULL    NULL
+fk           {2}      NULL       NULL       NULL       NULL       NULL    NULL
 
 ## pg_catalog.pg_depend
 
@@ -957,6 +1052,8 @@ classid     objid       objsubid  refclassid  refobjid   refobjsubid  deptype
 4294967214  58          0         4294967214  55         3            n
 4294967214  58          0         4294967214  55         4            n
 4294967212  2143281868  0         4294967214  450499961  0            n
+4294967212  2355671820  0         4294967214  0          0            n
+4294967212  3911002394  0         4294967214  0          0            n
 4294967212  4089604113  0         4294967214  450499960  0            n
 
 # Some entries in pg_depend are dependency links from the pg_constraint system
@@ -1045,10 +1142,10 @@ query OORT colnames
 SELECT * FROM pg_enum
 ----
 oid         enumtypid  enumsortorder  enumlabel
-1932239604  100068     0              v1
-1932239412  100068     1              v2
-1965794714  100070     0              v3
-1965794650  100070     1              v4
+1965794714  100070     0              v1
+1965794650  100070     1              v2
+1730908048  100072     0              v3
+1730907984  100072     1              v4
 
 ## pg_catalog.pg_type
 
@@ -1133,10 +1230,10 @@ oid     typname        typnamespace  typowner    typlen  typbyval  typtype
 90003   _geography     1307062959    NULL        -1      false     b
 90004   box2d          1307062959    NULL        32      true      b
 90005   _box2d         1307062959    NULL        -1      false     b
-100068  newtype1       2332901747    1546506610  -1      false     e
-100069  _newtype1      2332901747    1546506610  -1      false     b
-100070  newtype2       2332901747    1546506610  -1      false     e
-100071  _newtype2      2332901747    1546506610  -1      false     b
+100070  newtype1       2332901747    1546506610  -1      false     e
+100071  _newtype1      2332901747    1546506610  -1      false     b
+100072  newtype2       2332901747    1546506610  -1      false     e
+100073  _newtype2      2332901747    1546506610  -1      false     b
 
 query OTTBBTOOO colnames
 SELECT oid, typname, typcategory, typispreferred, typisdefined, typdelim, typrelid, typelem, typarray
@@ -1219,10 +1316,10 @@ oid     typname        typcategory  typispreferred  typisdefined  typdelim  typr
 90003   _geography     A            false           true          ,         0         90002    0
 90004   box2d          U            false           true          ,         0         0        90005
 90005   _box2d         A            false           true          ,         0         90004    0
-100068  newtype1       E            false           true          ,         0         0        100069
-100069  _newtype1      A            false           true          ,         0         100068   0
-100070  newtype2       E            false           true          ,         0         0        100071
-100071  _newtype2      A            false           true          ,         0         100070   0
+100070  newtype1       E            false           true          ,         0         0        100071
+100071  _newtype1      A            false           true          ,         0         100070   0
+100072  newtype2       E            false           true          ,         0         0        100073
+100073  _newtype2      A            false           true          ,         0         100072   0
 
 query OTOOOOOOO colnames
 SELECT oid, typname, typinput, typoutput, typreceive, typsend, typmodin, typmodout, typanalyze
@@ -1305,10 +1402,10 @@ oid     typname        typinput        typoutput        typreceive        typsen
 90003   _geography     array_in        array_out        array_recv        array_send        0         0          0
 90004   box2d          box2d_in        box2d_out        box2d_recv        box2d_send        0         0          0
 90005   _box2d         array_in        array_out        array_recv        array_send        0         0          0
-100068  newtype1       enum_in         enum_out         enum_recv         enum_send         0         0          0
-100069  _newtype1      array_in        array_out        array_recv        array_send        0         0          0
-100070  newtype2       enum_in         enum_out         enum_recv         enum_send         0         0          0
-100071  _newtype2      array_in        array_out        array_recv        array_send        0         0          0
+100070  newtype1       enum_in         enum_out         enum_recv         enum_send         0         0          0
+100071  _newtype1      array_in        array_out        array_recv        array_send        0         0          0
+100072  newtype2       enum_in         enum_out         enum_recv         enum_send         0         0          0
+100073  _newtype2      array_in        array_out        array_recv        array_send        0         0          0
 
 query OTTTBOI colnames
 SELECT oid, typname, typalign, typstorage, typnotnull, typbasetype, typtypmod
@@ -1391,10 +1488,10 @@ oid     typname        typalign  typstorage  typnotnull  typbasetype  typtypmod
 90003   _geography     NULL      NULL        false       0            -1
 90004   box2d          NULL      NULL        false       0            -1
 90005   _box2d         NULL      NULL        false       0            -1
-100068  newtype1       NULL      NULL        false       0            -1
-100069  _newtype1      NULL      NULL        false       0            -1
-100070  newtype2       NULL      NULL        false       0            -1
-100071  _newtype2      NULL      NULL        false       0            -1
+100070  newtype1       NULL      NULL        false       0            -1
+100071  _newtype1      NULL      NULL        false       0            -1
+100072  newtype2       NULL      NULL        false       0            -1
+100073  _newtype2      NULL      NULL        false       0            -1
 
 query OTIOTTT colnames
 SELECT oid, typname, typndims, typcollation, typdefaultbin, typdefault, typacl
@@ -1477,10 +1574,10 @@ oid     typname        typndims  typcollation  typdefaultbin  typdefault  typacl
 90003   _geography     0         0             NULL           NULL        NULL
 90004   box2d          0         0             NULL           NULL        NULL
 90005   _box2d         0         0             NULL           NULL        NULL
-100068  newtype1       0         0             NULL           NULL        NULL
-100069  _newtype1      0         0             NULL           NULL        NULL
-100070  newtype2       0         0             NULL           NULL        NULL
-100071  _newtype2      0         0             NULL           NULL        NULL
+100070  newtype1       0         0             NULL           NULL        NULL
+100071  _newtype1      0         0             NULL           NULL        NULL
+100072  newtype2       0         0             NULL           NULL        NULL
+100073  _newtype2      0         0             NULL           NULL        NULL
 
 user testuser
 
@@ -1509,7 +1606,7 @@ FROM pg_catalog.pg_type
 WHERE typname = 'newtype1'
 ----
 oid     typname   typnamespace  typowner    typlen  typbyval  typtype
-100068  newtype1  2332901747    1546506610  -1      false     e
+100070  newtype1  2332901747    1546506610  -1      false     e
 
 query OTOOIBT colnames
 SELECT oid, typname, typnamespace, typowner, typlen, typbyval, typtype
@@ -1897,7 +1994,7 @@ experimental_enable_hash_sharded_indexes              off                 NULL  
 experimental_enable_implicit_column_partitioning      off                 NULL      NULL        NULL        string
 experimental_enable_multi_column_inverted_indexes     off                 NULL      NULL        NULL        string
 experimental_enable_temp_tables                       off                 NULL      NULL        NULL        string
-experimental_enable_unique_without_index_constraints  off                 NULL      NULL        NULL        string
+experimental_enable_unique_without_index_constraints  on                  NULL      NULL        NULL        string
 experimental_enable_virtual_columns                   off                 NULL      NULL        NULL        string
 extra_float_digits                                    0                   NULL      NULL        NULL        string
 force_savepoint_restart                               off                 NULL      NULL        NULL        string
@@ -1973,7 +2070,7 @@ experimental_enable_hash_sharded_indexes              off                 NULL  
 experimental_enable_implicit_column_partitioning      off                 NULL  user     NULL      off                 off
 experimental_enable_multi_column_inverted_indexes     off                 NULL  user     NULL      off                 off
 experimental_enable_temp_tables                       off                 NULL  user     NULL      off                 off
-experimental_enable_unique_without_index_constraints  off                 NULL  user     NULL      off                 off
+experimental_enable_unique_without_index_constraints  on                  NULL  user     NULL      off                 off
 experimental_enable_virtual_columns                   off                 NULL  user     NULL      off                 off
 extra_float_digits                                    0                   NULL  user     NULL      0                   2
 force_savepoint_restart                               off                 NULL  user     NULL      off                 off
@@ -2108,8 +2205,8 @@ query OOIIIIIB colnames
 SELECT * FROM pg_catalog.pg_sequence
 ----
 seqrelid  seqtypid  seqstart  seqincrement  seqmax               seqmin  seqcache  seqcycle
-73        20        1         1             9223372036854775807  1       1         false
-74        20        6         2             10                   5       1         false
+75        20        1         1             9223372036854775807  1       1         false
+76        20        6         2             10                   5       1         false
 
 statement ok
 DROP DATABASE seq
@@ -2156,7 +2253,9 @@ WHERE n.nspname = 'public'
 841178406   t2   unique_rowid()
 2186255414  t3   'FOO'::STRING
 2186255409  t3   unique_rowid()
-581442133   mv1  unique_rowid()
+581442131   t4   unique_rowid()
+4050804964  t5   unique_rowid()
+1100914675  mv1  unique_rowid()
 
 # Verify that a set database shows tables from that database for a non-root
 # user, when that user has permissions.
@@ -2172,7 +2271,7 @@ SET DATABASE = 'constraint_db'
 query I
 SELECT count(*) FROM pg_catalog.pg_tables WHERE schemaname='public'
 ----
-4
+6
 
 user root
 
@@ -2565,7 +2664,7 @@ CREATE INDEX regression_46450_idx ON regression_46450 USING gin(json)
 query TTTTTT
 select * from pg_indexes where indexname = 'regression_46450_idx'
 ----
-617444901  public  regression_46450  regression_46450_idx  NULL  CREATE INDEX regression_46450_idx ON test.public.regression_46450 USING gin (json ASC)
+1136917443  public  regression_46450  regression_46450_idx  NULL  CREATE INDEX regression_46450_idx ON test.public.regression_46450 USING gin (json ASC)
 
 # Make sure that selecting from vtables with indexes in other dbs properly
 # hides descriptors that should be hidden.
@@ -2678,13 +2777,13 @@ CREATE TABLE jt (a INT PRIMARY KEY); INSERT INTO jt VALUES(1); INSERT INTO jt VA
 query ITT
 SELECT a, oid, relname FROM jt INNER LOOKUP JOIN pg_class ON a::oid=oid
 ----
-98  98  jt
+100  100  jt
 
 query ITT
 SELECT a, oid, relname FROM jt LEFT OUTER LOOKUP JOIN pg_class ON a::oid=oid
 ----
-1   NULL  NULL
-98  98    jt
+1    NULL  NULL
+100  100   jt
 
 subtest regression_49207
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/unique
+++ b/pkg/sql/logictest/testdata/logic_test/unique
@@ -35,21 +35,23 @@ CREATE TABLE uniq_hidden_pk (
   UNIQUE WITHOUT INDEX (a)
 )
 
-# TODO(rytaft): make this table use UNIQUE WITHOUT INDEX constraints once
-# we allow foreign keys to reference them (see #57977).
 statement ok
 CREATE TABLE uniq_fk_parent (
   a INT UNIQUE,
   b INT,
   c INT,
-  UNIQUE (b, c)
+  d INT UNIQUE WITHOUT INDEX,
+  e INT UNIQUE WITHOUT INDEX,
+  UNIQUE WITHOUT INDEX (b, c)
 )
 
 statement ok
 CREATE TABLE uniq_fk_child (
-  a INT REFERENCES uniq_fk_parent (a),
+  a INT,
   b INT,
   c INT,
+  d INT REFERENCES uniq_fk_parent (d),
+  e INT REFERENCES uniq_fk_parent (e) ON DELETE SET NULL,
   FOREIGN KEY (b, c) REFERENCES uniq_fk_parent (b, c) ON UPDATE CASCADE,
   UNIQUE WITHOUT INDEX (c)
 )
@@ -181,8 +183,8 @@ a  b  c  d
 
 # Combine unique checks with foreign keys.
 statement ok
-INSERT INTO uniq_fk_parent VALUES (1, 1, 1), (2, 2, 2);
-INSERT INTO uniq_fk_child VALUES (1, 1, 1), (2, 2, 2)
+INSERT INTO uniq_fk_parent VALUES (1, 1, 1, 1, 1), (2, 2, 2, 2, 2);
+INSERT INTO uniq_fk_child VALUES (1, 1, 1, 1, 1), (2, 2, 2, 2, 2)
 
 # This passes the foreign key checks but fails the uniqueness checks.
 statement error pgcode 23505 pq: duplicate key value violates unique constraint "unique_c"\nDETAIL: Key \(c\)=\(1\) already exists\.
@@ -196,12 +198,12 @@ INSERT INTO uniq_fk_child VALUES (3, 3, 3), (4, 4, 4)
 statement error pgcode 23505 pq: duplicate key value violates unique constraint "unique_c"\nDETAIL: Key \(c\)=\(2\) already exists\.
 INSERT INTO uniq_fk_child VALUES (1, 1, 2), (4, 2, 2)
 
-query III colnames,rowsort
+query IIIII colnames,rowsort
 SELECT * FROM uniq_fk_child
 ----
-a  b  c
-1  1  1
-2  2  2
+a  b  c  d  e
+1  1  1  1  1
+2  2  2  2  2
 
 
 # Insert into a table in which the unique constraints are the suffix of an
@@ -298,17 +300,21 @@ a  b  c  d
 statement error pgcode 23505 pq: duplicate key value violates unique constraint "unique_c"\nDETAIL: Key \(c\)=\(1\) already exists\.
 UPDATE uniq_fk_parent SET c = 1
 
+# Inbound foreign key check should fail.
+statement error pgcode 23503 pq: update on table "uniq_fk_parent" violates foreign key constraint "fk_d_ref_uniq_fk_parent" on table "uniq_fk_child"\nDETAIL: Key \(d\)=\(2\) is still referenced from table "uniq_fk_child"\.
+UPDATE uniq_fk_parent SET d = 3 WHERE a = 2
+
 # Combine unique checks with foreign keys.
 # This passes the foreign key checks but fails the uniqueness check.
 statement error pgcode 23505 pq: duplicate key value violates unique constraint "unique_c"\nDETAIL: Key \(c\)=\(2\) already exists\.
 UPDATE uniq_fk_child SET b = 2, c = 2
 
-query III colnames,rowsort
+query IIIII colnames,rowsort
 SELECT * FROM uniq_fk_child
 ----
-a  b  c
-1  1  1
-2  2  2
+a  b  c  d  e
+1  1  1  1  1
+2  2  2  2  2
 
 
 # Update a table in which the unique constraints are the suffix of an
@@ -466,12 +472,12 @@ INSERT INTO uniq_fk_parent VALUES (2, 1) ON CONFLICT (a) DO UPDATE SET c = 1
 statement error pgcode 23505 pq: duplicate key value violates unique constraint "unique_c"\nDETAIL: Key \(c\)=\(1\) already exists\.
 UPSERT INTO uniq_fk_child VALUES (2, 1, 1)
 
-query III colnames,rowsort
+query IIIII colnames,rowsort
 SELECT * FROM uniq_fk_child
 ----
-a  b  c
-1  1  1
-2  2  2
+a  b  c  d  e
+1  1  1  1  1
+2  2  2  2  2
 
 
 # Upsert  into a table in which the unique constraints are the suffix of an
@@ -486,3 +492,34 @@ SELECT * FROM uniq_enum
 r        s    i  j
 us-west  foo  1  1
 eu-west  bar  2  2
+
+# -- Tests with DELETE --
+subtest Delete
+
+# We don't need unique checks with DELETE, but make sure that foreign key
+# checks still work.
+
+# Inbound foreign key check should fail.
+statement error pgcode 23503 pq: delete on table "uniq_fk_parent" violates foreign key constraint "fk_b_ref_uniq_fk_parent" on table "uniq_fk_child"\nDETAIL: Key \(b, c\)=\(2, 2\) is still referenced from table "uniq_fk_child"\.
+DELETE FROM uniq_fk_parent WHERE a = 2
+
+statement ok
+UPDATE uniq_fk_child SET b = NULL WHERE a = 2
+
+# Inbound foreign key check should still fail.
+statement error pgcode 23503 pq: delete on table "uniq_fk_parent" violates foreign key constraint "fk_d_ref_uniq_fk_parent" on table "uniq_fk_child"\nDETAIL: Key \(d\)=\(2\) is still referenced from table "uniq_fk_child"\.
+DELETE FROM uniq_fk_parent WHERE a = 2
+
+statement ok
+UPDATE uniq_fk_child SET d = NULL WHERE a = 2
+
+# Now this should succeed and set e to NULL due to ON DELETE SET NULL.
+statement ok
+DELETE FROM uniq_fk_parent WHERE a = 2
+
+query IIIII colnames,rowsort
+SELECT * FROM uniq_fk_child
+----
+a  b     c  d     e
+1  1     1  1     1
+2  NULL  2  NULL  NULL

--- a/pkg/sql/old_foreign_key_desc_test.go
+++ b/pkg/sql/old_foreign_key_desc_test.go
@@ -72,14 +72,14 @@ CREATE INDEX ON t.t1 (x);
 			if err != nil {
 				t.Fatal(err)
 			}
-			refIdx, err := tabledesc.FindFKReferencedIndex(referencedTbl, fk.ReferencedColumnIDs)
+			refIdx, err := tabledesc.FindFKReferencedUniqueConstraint(referencedTbl, fk.ReferencedColumnIDs)
 			if err != nil {
 				t.Fatal(err)
 			}
 			idx.ForeignKey = descpb.ForeignKeyReference{
 				Name:            fk.Name,
 				Table:           fk.ReferencedTableID,
-				Index:           refIdx.ID,
+				Index:           refIdx.(*descpb.IndexDescriptor).ID,
 				Validity:        fk.Validity,
 				SharedPrefixLen: int32(len(fk.OriginColumnIDs)),
 				OnDelete:        fk.OnDelete,
@@ -91,7 +91,7 @@ CREATE INDEX ON t.t1 (x);
 		// Downgrade the inbound foreign keys.
 		for i := range tbl.InboundFKs {
 			fk := &tbl.InboundFKs[i]
-			idx, err := tabledesc.FindFKReferencedIndex(desc, fk.ReferencedColumnIDs)
+			refIdx, err := tabledesc.FindFKReferencedUniqueConstraint(desc, fk.ReferencedColumnIDs)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -111,6 +111,7 @@ CREATE INDEX ON t.t1 (x);
 				Table: fk.OriginTableID,
 				Index: originIdx.ID,
 			}
+			idx := refIdx.(*descpb.IndexDescriptor)
 			idx.ReferencedBy = append(idx.ReferencedBy, fkRef)
 		}
 		tbl.InboundFKs = nil

--- a/pkg/sql/opt/exec/execbuilder/testdata/unique
+++ b/pkg/sql/opt/exec/execbuilder/testdata/unique
@@ -37,14 +37,12 @@ CREATE TABLE uniq_hidden_pk (
   UNIQUE WITHOUT INDEX (a)
 )
 
-# TODO(rytaft): make this table use UNIQUE WITHOUT INDEX constraints once
-# we allow foreign keys to reference them (see #57977).
 statement ok
 CREATE TABLE uniq_fk_parent (
-  a INT UNIQUE,
+  a INT UNIQUE WITHOUT INDEX,
   b INT,
   c INT,
-  UNIQUE (b, c),
+  UNIQUE WITHOUT INDEX (b, c),
   FAMILY (rowid, a, b, c)
 )
 
@@ -352,23 +350,56 @@ vectorized: true
                   spans: FULL SCAN
 
 # Combine unique checks with foreign keys.
-# TODO(rytaft): This currently isn't testing anything, since uniq_fk_parent
-# doesn't have any UNIQUE WITHOUT INDEX constraints. See comment above where
-# uniq_fk_parent is created.
 query T
 EXPLAIN INSERT INTO uniq_fk_parent VALUES (1, 1, 1), (2, 2, 2)
 ----
 distribution: local
 vectorized: true
 ·
-• insert
-│ into: uniq_fk_parent(a, b, c, rowid)
-│ auto commit
+• root
 │
-└── • render
+├── • insert
+│   │ into: uniq_fk_parent(a, b, c, rowid)
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • render
+│           │
+│           └── • values
+│                 size: 3 columns, 2 rows
+│
+├── • constraint-check
+│   │
+│   └── • error if rows
+│       │
+│       └── • hash join (right semi)
+│           │ equality: (a) = (column1)
+│           │ pred: column10 != rowid
+│           │
+│           ├── • scan
+│           │     missing stats
+│           │     table: uniq_fk_parent@primary
+│           │     spans: FULL SCAN
+│           │
+│           └── • scan buffer
+│                 label: buffer 1
+│
+└── • constraint-check
     │
-    └── • values
-          size: 3 columns, 2 rows
+    └── • error if rows
+        │
+        └── • hash join (right semi)
+            │ equality: (b, c) = (column2, column3)
+            │ pred: column10 != rowid
+            │
+            ├── • scan
+            │     missing stats
+            │     table: uniq_fk_parent@primary
+            │     spans: FULL SCAN
+            │
+            └── • scan buffer
+                  label: buffer 1
 
 # Combine unique checks with foreign keys. There should be two foreign key
 # checks and one uniqueness check.
@@ -411,10 +442,13 @@ vectorized: true
 │   │
 │   └── • error if rows
 │       │
-│       └── • lookup join (anti)
-│           │ table: uniq_fk_parent@uniq_fk_parent_b_c_key
-│           │ equality: (column2, column3) = (b,c)
-│           │ equality cols are key
+│       └── • hash join (right anti)
+│           │ equality: (b, c) = (column2, column3)
+│           │
+│           ├── • scan
+│           │     missing stats
+│           │     table: uniq_fk_parent@primary
+│           │     spans: FULL SCAN
 │           │
 │           └── • scan buffer
 │                 label: buffer 1
@@ -423,10 +457,13 @@ vectorized: true
     │
     └── • error if rows
         │
-        └── • lookup join (anti)
-            │ table: uniq_fk_parent@uniq_fk_parent_a_key
-            │ equality: (column1) = (a)
-            │ equality cols are key
+        └── • hash join (right anti)
+            │ equality: (a) = (column1)
+            │
+            ├── • scan
+            │     missing stats
+            │     table: uniq_fk_parent@primary
+            │     spans: FULL SCAN
             │
             └── • scan buffer
                   label: buffer 1
@@ -898,9 +935,25 @@ vectorized: true
 │                 spans: FULL SCAN
 │                 locking strength: for update
 │
-└── • fk-cascade
-      fk: fk_b_ref_uniq_fk_parent
-      input: buffer 1
+├── • fk-cascade
+│     fk: fk_b_ref_uniq_fk_parent
+│     input: buffer 1
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │
+        └── • hash join (semi)
+            │ equality: (b, c_new) = (b, c)
+            │ pred: rowid != rowid
+            │
+            ├── • scan buffer
+            │     label: buffer 1
+            │
+            └── • scan
+                  missing stats
+                  table: uniq_fk_parent@primary
+                  spans: FULL SCAN
 
 # Combine unique checks with foreign keys.
 # There is no uniquness check since column c is not updated.
@@ -936,7 +989,7 @@ vectorized: true
 │           │
 │           ├── • scan
 │           │     missing stats
-│           │     table: uniq_fk_parent@uniq_fk_parent_b_c_key
+│           │     table: uniq_fk_parent@primary
 │           │     spans: FULL SCAN
 │           │
 │           └── • filter
@@ -957,7 +1010,7 @@ vectorized: true
             │
             └── • scan
                   missing stats
-                  table: uniq_fk_parent@uniq_fk_parent_a_key
+                  table: uniq_fk_parent@primary
                   spans: FULL SCAN
 
 # Combine unique checks with foreign keys.
@@ -1013,7 +1066,7 @@ vectorized: true
             │
             └── • scan
                   missing stats
-                  table: uniq_fk_parent@uniq_fk_parent_b_c_key
+                  table: uniq_fk_parent@primary
                   spans: FULL SCAN
 
 # Test that we use the index when available for the update checks.
@@ -1607,24 +1660,58 @@ vectorized: true
 │   └── • buffer
 │       │ label: buffer 1
 │       │
-│       └── • lookup join (left outer)
-│           │ table: uniq_fk_parent@primary
-│           │ equality: (column10) = (rowid)
-│           │ equality cols are key
+│       └── • render
 │           │
-│           └── • distinct
-│               │ distinct on: column10
-│               │ nulls are distinct
-│               │ error on duplicate
+│           └── • lookup join (left outer)
+│               │ table: uniq_fk_parent@primary
+│               │ equality: (column10) = (rowid)
+│               │ equality cols are key
 │               │
-│               └── • render
+│               └── • distinct
+│                   │ distinct on: column10
+│                   │ nulls are distinct
+│                   │ error on duplicate
 │                   │
-│                   └── • values
-│                         size: 3 columns, 2 rows
+│                   └── • render
+│                       │
+│                       └── • values
+│                             size: 3 columns, 2 rows
 │
 ├── • fk-cascade
 │     fk: fk_b_ref_uniq_fk_parent
 │     input: buffer 1
+│
+├── • constraint-check
+│   │
+│   └── • error if rows
+│       │
+│       └── • hash join (right semi)
+│           │ equality: (a) = (column1)
+│           │ pred: upsert_rowid != rowid
+│           │
+│           ├── • scan
+│           │     missing stats
+│           │     table: uniq_fk_parent@primary
+│           │     spans: FULL SCAN
+│           │
+│           └── • scan buffer
+│                 label: buffer 1
+│
+├── • constraint-check
+│   │
+│   └── • error if rows
+│       │
+│       └── • hash join (right semi)
+│           │ equality: (b, c) = (column2, column3)
+│           │ pred: upsert_rowid != rowid
+│           │
+│           ├── • scan
+│           │     missing stats
+│           │     table: uniq_fk_parent@primary
+│           │     spans: FULL SCAN
+│           │
+│           └── • scan buffer
+│                 label: buffer 1
 │
 └── • constraint-check
     │
@@ -1687,10 +1774,13 @@ vectorized: true
 │   │
 │   └── • error if rows
 │       │
-│       └── • lookup join (anti)
-│           │ table: uniq_fk_parent@uniq_fk_parent_b_c_key
-│           │ equality: (column2, column3) = (b,c)
-│           │ equality cols are key
+│       └── • hash join (right anti)
+│           │ equality: (b, c) = (column2, column3)
+│           │
+│           ├── • scan
+│           │     missing stats
+│           │     table: uniq_fk_parent@primary
+│           │     spans: FULL SCAN
 │           │
 │           └── • scan buffer
 │                 label: buffer 1
@@ -1699,10 +1789,13 @@ vectorized: true
     │
     └── • error if rows
         │
-        └── • lookup join (anti)
-            │ table: uniq_fk_parent@uniq_fk_parent_a_key
-            │ equality: (column1) = (a)
-            │ equality cols are key
+        └── • hash join (right anti)
+            │ equality: (a) = (column1)
+            │
+            ├── • scan
+            │     missing stats
+            │     table: uniq_fk_parent@primary
+            │     spans: FULL SCAN
             │
             └── • scan buffer
                   label: buffer 1

--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -79,7 +79,43 @@ CREATE TABLE uniq (
   x INT,
   y INT,
   z INT UNIQUE,
-  UNIQUE WITHOUT INDEX (x, y)
+  UNIQUE WITHOUT INDEX (x, y),
+  FAMILY (k),
+  FAMILY (v),
+  FAMILY (w),
+  FAMILY (x),
+  FAMILY (y),
+  FAMILY (z)
+)
+----
+
+exec-ddl
+CREATE TABLE uniq_fk_parent (
+  k INT PRIMARY KEY,
+  a INT UNIQUE WITHOUT INDEX,
+  b INT,
+  c INT,
+  d INT,
+  UNIQUE WITHOUT INDEX (b, c),
+  FAMILY (a),
+  FAMILY (b),
+  FAMILY (c),
+  FAMILY (d)
+)
+----
+
+exec-ddl
+CREATE TABLE uniq_fk_child (
+  a INT REFERENCES uniq_fk_parent (a),
+  b INT,
+  c INT,
+  d INT,
+  FOREIGN KEY (b, c) REFERENCES uniq_fk_parent (b, c) ON UPDATE CASCADE,
+  UNIQUE WITHOUT INDEX (c),
+  FAMILY (a),
+  FAMILY (b),
+  FAMILY (c),
+  FAMILY (d)
 )
 ----
 
@@ -3067,7 +3103,7 @@ UPDATE uniq SET w = 1, x = 2 WHERE k = 3
 ----
 update uniq
  ├── columns: <none>
- ├── fetch columns: uniq.k:8 v:9 w:10 x:11 uniq.y:12 z:13
+ ├── fetch columns: uniq.k:8 w:10 x:11
  ├── update-mapping:
  │    ├── w_new:15 => w:3
  │    └── x_new:16 => x:4
@@ -3075,19 +3111,19 @@ update uniq
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── project
- │    ├── columns: w_new:15!null x_new:16!null uniq.k:8!null v:9 w:10 x:11 uniq.y:12 z:13
+ │    ├── columns: w_new:15!null x_new:16!null uniq.k:8!null w:10 x:11 uniq.y:12
  │    ├── cardinality: [0 - 1]
  │    ├── key: ()
- │    ├── fd: ()-->(8-13,15,16)
+ │    ├── fd: ()-->(8,10-12,15,16)
  │    ├── select
- │    │    ├── columns: uniq.k:8!null v:9 w:10 x:11 uniq.y:12 z:13
+ │    │    ├── columns: uniq.k:8!null w:10 x:11 uniq.y:12
  │    │    ├── cardinality: [0 - 1]
  │    │    ├── key: ()
- │    │    ├── fd: ()-->(8-13)
+ │    │    ├── fd: ()-->(8,10-12)
  │    │    ├── scan uniq
- │    │    │    ├── columns: uniq.k:8!null v:9 w:10 x:11 uniq.y:12 z:13
+ │    │    │    ├── columns: uniq.k:8!null w:10 x:11 uniq.y:12
  │    │    │    ├── key: (8)
- │    │    │    └── fd: (8)-->(9-13), (13)~~>(8-12)
+ │    │    │    └── fd: (8)-->(10-12)
  │    │    └── filters
  │    │         └── uniq.k:8 = 3 [outer=(8), constraints=(/8: [/3 - /3]; tight), fd=()-->(8)]
  │    └── projections
@@ -3138,6 +3174,268 @@ update uniq
                      ├── x_new:26 = x:32 [outer=(26,32), constraints=(/26: (/NULL - ]; /32: (/NULL - ]), fd=(26)==(32), (32)==(26)]
                      ├── y:27 = uniq.y:33 [outer=(27,33), constraints=(/27: (/NULL - ]; /33: (/NULL - ]), fd=(27)==(33), (33)==(27)]
                      └── k:28 != uniq.k:29 [outer=(28,29), constraints=(/28: (/NULL - ]; /29: (/NULL - ])]
+
+# Do not prune columns that are needed for foreign key checks or cascades.
+norm expect=PruneMutationInputCols
+INSERT INTO uniq_fk_parent VALUES (2, 1) ON CONFLICT (k) DO UPDATE SET c = 1
+----
+upsert uniq_fk_parent
+ ├── columns: <none>
+ ├── arbiter indexes: primary
+ ├── canary column: k:10
+ ├── fetch columns: k:10 b:12 c:13
+ ├── insert-mapping:
+ │    ├── column1:7 => k:1
+ │    ├── column2:8 => a:2
+ │    ├── column9:9 => b:3
+ │    ├── column9:9 => c:4
+ │    └── column9:9 => d:5
+ ├── update-mapping:
+ │    └── upsert_c:20 => c:4
+ ├── input binding: &1
+ ├── cascades
+ │    └── fk_b_ref_uniq_fk_parent
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ ├── project
+ │    ├── columns: upsert_k:17 upsert_a:18 upsert_b:19 upsert_c:20 column1:7!null column2:8!null column9:9 k:10 b:12 c:13
+ │    ├── cardinality: [1 - 1]
+ │    ├── key: ()
+ │    ├── fd: ()-->(7-10,12,13,17-20)
+ │    ├── left-join (cross)
+ │    │    ├── columns: column1:7!null column2:8!null column9:9 k:10 a:11 b:12 c:13
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── multiplicity: left-rows(exactly-one), right-rows(exactly-one)
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(7-13)
+ │    │    ├── values
+ │    │    │    ├── columns: column1:7!null column2:8!null column9:9
+ │    │    │    ├── cardinality: [1 - 1]
+ │    │    │    ├── key: ()
+ │    │    │    ├── fd: ()-->(7-9)
+ │    │    │    └── (2, 1, NULL)
+ │    │    ├── select
+ │    │    │    ├── columns: k:10!null a:11 b:12 c:13
+ │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    ├── key: ()
+ │    │    │    ├── fd: ()-->(10-13)
+ │    │    │    ├── scan uniq_fk_parent
+ │    │    │    │    ├── columns: k:10!null a:11 b:12 c:13
+ │    │    │    │    ├── key: (10)
+ │    │    │    │    └── fd: (10)-->(11-13)
+ │    │    │    └── filters
+ │    │    │         └── k:10 = 2 [outer=(10), constraints=(/10: [/2 - /2]; tight), fd=()-->(10)]
+ │    │    └── filters (true)
+ │    └── projections
+ │         ├── CASE WHEN k:10 IS NULL THEN column1:7 ELSE k:10 END [as=upsert_k:17, outer=(7,10)]
+ │         ├── CASE WHEN k:10 IS NULL THEN column2:8 ELSE a:11 END [as=upsert_a:18, outer=(8,10,11)]
+ │         ├── CASE WHEN k:10 IS NULL THEN column9:9 ELSE b:12 END [as=upsert_b:19, outer=(9,10,12)]
+ │         └── CASE WHEN k:10 IS NULL THEN column9:9 ELSE 1 END [as=upsert_c:20, outer=(9,10)]
+ └── unique-checks
+      ├── unique-checks-item: uniq_fk_parent(a)
+      │    └── semi-join (hash)
+      │         ├── columns: upsert_a:22 upsert_k:23
+      │         ├── cardinality: [0 - 1]
+      │         ├── key: ()
+      │         ├── fd: ()-->(22,23)
+      │         ├── with-scan &1
+      │         │    ├── columns: upsert_a:22 upsert_k:23
+      │         │    ├── mapping:
+      │         │    │    ├──  upsert_a:18 => upsert_a:22
+      │         │    │    └──  upsert_k:17 => upsert_k:23
+      │         │    ├── cardinality: [1 - 1]
+      │         │    ├── key: ()
+      │         │    └── fd: ()-->(22,23)
+      │         ├── scan uniq_fk_parent
+      │         │    ├── columns: k:24!null a:25
+      │         │    ├── key: (24)
+      │         │    └── fd: (24)-->(25)
+      │         └── filters
+      │              ├── upsert_a:22 = a:25 [outer=(22,25), constraints=(/22: (/NULL - ]; /25: (/NULL - ]), fd=(22)==(25), (25)==(22)]
+      │              └── upsert_k:23 != k:24 [outer=(23,24), constraints=(/23: (/NULL - ]; /24: (/NULL - ])]
+      └── unique-checks-item: uniq_fk_parent(b,c)
+           └── semi-join (hash)
+                ├── columns: upsert_b:30 upsert_c:31 upsert_k:32
+                ├── cardinality: [0 - 1]
+                ├── key: ()
+                ├── fd: ()-->(30-32)
+                ├── with-scan &1
+                │    ├── columns: upsert_b:30 upsert_c:31 upsert_k:32
+                │    ├── mapping:
+                │    │    ├──  upsert_b:19 => upsert_b:30
+                │    │    ├──  upsert_c:20 => upsert_c:31
+                │    │    └──  upsert_k:17 => upsert_k:32
+                │    ├── cardinality: [1 - 1]
+                │    ├── key: ()
+                │    └── fd: ()-->(30-32)
+                ├── scan uniq_fk_parent
+                │    ├── columns: k:33!null b:35 c:36
+                │    ├── key: (33)
+                │    └── fd: (33)-->(35,36)
+                └── filters
+                     ├── upsert_b:30 = b:35 [outer=(30,35), constraints=(/30: (/NULL - ]; /35: (/NULL - ]), fd=(30)==(35), (35)==(30)]
+                     ├── upsert_c:31 = c:36 [outer=(31,36), constraints=(/31: (/NULL - ]; /36: (/NULL - ]), fd=(31)==(36), (36)==(31)]
+                     └── upsert_k:32 != k:33 [outer=(32,33), constraints=(/32: (/NULL - ]; /33: (/NULL - ])]
+
+# Prune inbound foreign key columns when they are not updated.
+norm expect=PruneMutationInputCols
+INSERT INTO uniq_fk_parent VALUES (1) ON CONFLICT (k) DO UPDATE SET d = 1
+----
+upsert uniq_fk_parent
+ ├── columns: <none>
+ ├── arbiter indexes: primary
+ ├── canary column: k:9
+ ├── fetch columns: k:9 d:13
+ ├── insert-mapping:
+ │    ├── column1:7 => k:1
+ │    ├── column8:8 => a:2
+ │    ├── column8:8 => b:3
+ │    ├── column8:8 => c:4
+ │    └── column8:8 => d:5
+ ├── update-mapping:
+ │    └── upsert_d:20 => d:5
+ ├── input binding: &1
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ ├── project
+ │    ├── columns: upsert_k:16 upsert_a:17 upsert_b:18 upsert_c:19 upsert_d:20 column1:7!null column8:8 k:9 d:13
+ │    ├── cardinality: [1 - 1]
+ │    ├── key: ()
+ │    ├── fd: ()-->(7-9,13,16-20)
+ │    ├── left-join (cross)
+ │    │    ├── columns: column1:7!null column8:8 k:9 a:10 b:11 c:12 d:13
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── multiplicity: left-rows(exactly-one), right-rows(exactly-one)
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(7-13)
+ │    │    ├── values
+ │    │    │    ├── columns: column1:7!null column8:8
+ │    │    │    ├── cardinality: [1 - 1]
+ │    │    │    ├── key: ()
+ │    │    │    ├── fd: ()-->(7,8)
+ │    │    │    └── (1, NULL)
+ │    │    ├── select
+ │    │    │    ├── columns: k:9!null a:10 b:11 c:12 d:13
+ │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    ├── key: ()
+ │    │    │    ├── fd: ()-->(9-13)
+ │    │    │    ├── scan uniq_fk_parent
+ │    │    │    │    ├── columns: k:9!null a:10 b:11 c:12 d:13
+ │    │    │    │    ├── key: (9)
+ │    │    │    │    └── fd: (9)-->(10-13)
+ │    │    │    └── filters
+ │    │    │         └── k:9 = 1 [outer=(9), constraints=(/9: [/1 - /1]; tight), fd=()-->(9)]
+ │    │    └── filters (true)
+ │    └── projections
+ │         ├── CASE WHEN k:9 IS NULL THEN column1:7 ELSE k:9 END [as=upsert_k:16, outer=(7,9)]
+ │         ├── CASE WHEN k:9 IS NULL THEN column8:8 ELSE a:10 END [as=upsert_a:17, outer=(8-10)]
+ │         ├── CASE WHEN k:9 IS NULL THEN column8:8 ELSE b:11 END [as=upsert_b:18, outer=(8,9,11)]
+ │         ├── CASE WHEN k:9 IS NULL THEN column8:8 ELSE c:12 END [as=upsert_c:19, outer=(8,9,12)]
+ │         └── CASE WHEN k:9 IS NULL THEN column8:8 ELSE 1 END [as=upsert_d:20, outer=(8,9)]
+ └── unique-checks
+      ├── unique-checks-item: uniq_fk_parent(a)
+      │    └── semi-join (hash)
+      │         ├── columns: upsert_a:21 upsert_k:22
+      │         ├── cardinality: [0 - 1]
+      │         ├── key: ()
+      │         ├── fd: ()-->(21,22)
+      │         ├── with-scan &1
+      │         │    ├── columns: upsert_a:21 upsert_k:22
+      │         │    ├── mapping:
+      │         │    │    ├──  upsert_a:17 => upsert_a:21
+      │         │    │    └──  upsert_k:16 => upsert_k:22
+      │         │    ├── cardinality: [1 - 1]
+      │         │    ├── key: ()
+      │         │    └── fd: ()-->(21,22)
+      │         ├── scan uniq_fk_parent
+      │         │    ├── columns: k:23!null a:24
+      │         │    ├── key: (23)
+      │         │    └── fd: (23)-->(24)
+      │         └── filters
+      │              ├── upsert_a:21 = a:24 [outer=(21,24), constraints=(/21: (/NULL - ]; /24: (/NULL - ]), fd=(21)==(24), (24)==(21)]
+      │              └── upsert_k:22 != k:23 [outer=(22,23), constraints=(/22: (/NULL - ]; /23: (/NULL - ])]
+      └── unique-checks-item: uniq_fk_parent(b,c)
+           └── semi-join (hash)
+                ├── columns: upsert_b:29 upsert_c:30 upsert_k:31
+                ├── cardinality: [0 - 1]
+                ├── key: ()
+                ├── fd: ()-->(29-31)
+                ├── with-scan &1
+                │    ├── columns: upsert_b:29 upsert_c:30 upsert_k:31
+                │    ├── mapping:
+                │    │    ├──  upsert_b:18 => upsert_b:29
+                │    │    ├──  upsert_c:19 => upsert_c:30
+                │    │    └──  upsert_k:16 => upsert_k:31
+                │    ├── cardinality: [1 - 1]
+                │    ├── key: ()
+                │    └── fd: ()-->(29-31)
+                ├── scan uniq_fk_parent
+                │    ├── columns: k:32!null b:34 c:35
+                │    ├── key: (32)
+                │    └── fd: (32)-->(34,35)
+                └── filters
+                     ├── upsert_b:29 = b:34 [outer=(29,34), constraints=(/29: (/NULL - ]; /34: (/NULL - ]), fd=(29)==(34), (34)==(29)]
+                     ├── upsert_c:30 = c:35 [outer=(30,35), constraints=(/30: (/NULL - ]; /35: (/NULL - ]), fd=(30)==(35), (35)==(30)]
+                     └── upsert_k:31 != k:32 [outer=(31,32), constraints=(/31: (/NULL - ]; /32: (/NULL - ])]
+
+# Do not prune columns that are needed for foreign key checks or cascades.
+norm expect=PruneMutationInputCols
+DELETE FROM uniq_fk_parent WHERE k = 1
+----
+delete uniq_fk_parent
+ ├── columns: <none>
+ ├── fetch columns: k:7 uniq_fk_parent.a:8 uniq_fk_parent.b:9 uniq_fk_parent.c:10
+ ├── input binding: &1
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ ├── select
+ │    ├── columns: k:7!null uniq_fk_parent.a:8 uniq_fk_parent.b:9 uniq_fk_parent.c:10
+ │    ├── cardinality: [0 - 1]
+ │    ├── key: ()
+ │    ├── fd: ()-->(7-10)
+ │    ├── scan uniq_fk_parent
+ │    │    ├── columns: k:7!null uniq_fk_parent.a:8 uniq_fk_parent.b:9 uniq_fk_parent.c:10
+ │    │    ├── key: (7)
+ │    │    └── fd: (7)-->(8-10)
+ │    └── filters
+ │         └── k:7 = 1 [outer=(7), constraints=(/7: [/1 - /1]; tight), fd=()-->(7)]
+ └── f-k-checks
+      ├── f-k-checks-item: uniq_fk_child(b,c) -> uniq_fk_parent(b,c)
+      │    └── semi-join (hash)
+      │         ├── columns: b:13 c:14
+      │         ├── cardinality: [0 - 1]
+      │         ├── key: ()
+      │         ├── fd: ()-->(13,14)
+      │         ├── with-scan &1
+      │         │    ├── columns: b:13 c:14
+      │         │    ├── mapping:
+      │         │    │    ├──  uniq_fk_parent.b:9 => b:13
+      │         │    │    └──  uniq_fk_parent.c:10 => c:14
+      │         │    ├── cardinality: [0 - 1]
+      │         │    ├── key: ()
+      │         │    └── fd: ()-->(13,14)
+      │         ├── scan uniq_fk_child
+      │         │    └── columns: uniq_fk_child.b:16 uniq_fk_child.c:17
+      │         └── filters
+      │              ├── b:13 = uniq_fk_child.b:16 [outer=(13,16), constraints=(/13: (/NULL - ]; /16: (/NULL - ]), fd=(13)==(16), (16)==(13)]
+      │              └── c:14 = uniq_fk_child.c:17 [outer=(14,17), constraints=(/14: (/NULL - ]; /17: (/NULL - ]), fd=(14)==(17), (17)==(14)]
+      └── f-k-checks-item: uniq_fk_child(a) -> uniq_fk_parent(a)
+           └── semi-join (hash)
+                ├── columns: a:21
+                ├── cardinality: [0 - 1]
+                ├── key: ()
+                ├── fd: ()-->(21)
+                ├── with-scan &1
+                │    ├── columns: a:21
+                │    ├── mapping:
+                │    │    └──  uniq_fk_parent.a:8 => a:21
+                │    ├── cardinality: [0 - 1]
+                │    ├── key: ()
+                │    └── fd: ()-->(21)
+                ├── scan uniq_fk_child
+                │    └── columns: uniq_fk_child.a:22
+                └── filters
+                     └── a:21 = uniq_fk_child.a:22 [outer=(21,22), constraints=(/21: (/NULL - ]; /22: (/NULL - ]), fd=(21)==(22), (22)==(21)]
 
 # We should be pruning the virtual column.
 norm expect=(PruneMutationFetchCols,PruneMutationInputCols)

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -1287,7 +1287,7 @@ func (mb *mutationBuilder) makeCheckInputScan(
 			inputCols[i] = mb.fetchColIDs[tabOrd]
 		}
 		if inputCols[i] == 0 {
-			panic(errors.AssertionFailedf("no value for FK column (tabOrd=%d)", tabOrd))
+			panic(errors.AssertionFailedf("no value for check input column (tabOrd=%d)", tabOrd))
 		}
 
 		// Synthesize new column.

--- a/pkg/sql/opt/optbuilder/testdata/unique-checks-upsert
+++ b/pkg/sql/opt/optbuilder/testdata/unique-checks-upsert
@@ -872,3 +872,122 @@ build
 INSERT INTO uniq_hidden_pk VALUES (1, 2, 3, 4) ON CONFLICT (a, b, d) DO UPDATE SET a = 10
 ----
 error (42P10): there is no unique or exclusion constraint matching the ON CONFLICT specification
+
+exec-ddl
+CREATE TABLE uniq_fk_parent (
+  a INT UNIQUE WITHOUT INDEX
+)
+----
+
+exec-ddl
+CREATE TABLE uniq_fk_child (
+  k INT PRIMARY KEY,
+  a INT REFERENCES uniq_fk_parent (a)
+)
+----
+
+exec-ddl
+CREATE TABLE uniq_fk_grandchild (
+  k INT REFERENCES uniq_fk_child (k)
+)
+----
+
+# We need existing rows since we are updating an inbound foreign key column.
+build
+UPSERT INTO uniq_fk_parent (a) VALUES (1)
+----
+upsert uniq_fk_parent
+ ├── columns: <none>
+ ├── arbiter indexes: primary
+ ├── canary column: rowid:7
+ ├── fetch columns: uniq_fk_parent.a:6 rowid:7
+ ├── insert-mapping:
+ │    ├── column1:4 => uniq_fk_parent.a:1
+ │    └── column5:5 => rowid:2
+ ├── update-mapping:
+ │    └── column1:4 => uniq_fk_parent.a:1
+ ├── input binding: &1
+ ├── project
+ │    ├── columns: upsert_rowid:9 column1:4!null column5:5 uniq_fk_parent.a:6 rowid:7 uniq_fk_parent.crdb_internal_mvcc_timestamp:8
+ │    ├── left-join (hash)
+ │    │    ├── columns: column1:4!null column5:5 uniq_fk_parent.a:6 rowid:7 uniq_fk_parent.crdb_internal_mvcc_timestamp:8
+ │    │    ├── ensure-upsert-distinct-on
+ │    │    │    ├── columns: column1:4!null column5:5
+ │    │    │    ├── grouping columns: column5:5
+ │    │    │    ├── project
+ │    │    │    │    ├── columns: column5:5 column1:4!null
+ │    │    │    │    ├── values
+ │    │    │    │    │    ├── columns: column1:4!null
+ │    │    │    │    │    └── (1,)
+ │    │    │    │    └── projections
+ │    │    │    │         └── unique_rowid() [as=column5:5]
+ │    │    │    └── aggregations
+ │    │    │         └── first-agg [as=column1:4]
+ │    │    │              └── column1:4
+ │    │    ├── scan uniq_fk_parent
+ │    │    │    └── columns: uniq_fk_parent.a:6 rowid:7!null uniq_fk_parent.crdb_internal_mvcc_timestamp:8
+ │    │    └── filters
+ │    │         └── column5:5 = rowid:7
+ │    └── projections
+ │         └── CASE WHEN rowid:7 IS NULL THEN column5:5 ELSE rowid:7 END [as=upsert_rowid:9]
+ ├── unique-checks
+ │    └── unique-checks-item: uniq_fk_parent(a)
+ │         └── semi-join (hash)
+ │              ├── columns: column1:10!null upsert_rowid:11
+ │              ├── with-scan &1
+ │              │    ├── columns: column1:10!null upsert_rowid:11
+ │              │    └── mapping:
+ │              │         ├──  column1:4 => column1:10
+ │              │         └──  upsert_rowid:9 => upsert_rowid:11
+ │              ├── scan uniq_fk_parent
+ │              │    └── columns: uniq_fk_parent.a:12 rowid:13!null
+ │              └── filters
+ │                   ├── column1:10 = uniq_fk_parent.a:12
+ │                   └── upsert_rowid:11 != rowid:13
+ └── f-k-checks
+      └── f-k-checks-item: uniq_fk_child(a) -> uniq_fk_parent(a)
+           └── semi-join (hash)
+                ├── columns: a:15
+                ├── except
+                │    ├── columns: a:15
+                │    ├── left columns: a:15
+                │    ├── right columns: column1:16
+                │    ├── with-scan &1
+                │    │    ├── columns: a:15
+                │    │    └── mapping:
+                │    │         └──  uniq_fk_parent.a:6 => a:15
+                │    └── with-scan &1
+                │         ├── columns: column1:16!null
+                │         └── mapping:
+                │              └──  column1:4 => column1:16
+                ├── scan uniq_fk_child
+                │    └── columns: uniq_fk_child.a:18
+                └── filters
+                     └── a:15 = uniq_fk_child.a:18
+
+# We do not need existing rows since we are not updating an inbound foreign key
+# column (k is the UPSERT key column so it's not updated).
+build
+UPSERT INTO uniq_fk_child (k, a) VALUES (1, 2)
+----
+upsert uniq_fk_child
+ ├── columns: <none>
+ ├── upsert-mapping:
+ │    ├── column1:4 => k:1
+ │    └── column2:5 => uniq_fk_child.a:2
+ ├── input binding: &1
+ ├── values
+ │    ├── columns: column1:4!null column2:5!null
+ │    └── (1, 2)
+ └── f-k-checks
+      └── f-k-checks-item: uniq_fk_child(a) -> uniq_fk_parent(a)
+           └── anti-join (hash)
+                ├── columns: column2:6!null
+                ├── with-scan &1
+                │    ├── columns: column2:6!null
+                │    └── mapping:
+                │         └──  column2:5 => column2:6
+                ├── scan uniq_fk_parent
+                │    └── columns: uniq_fk_parent.a:7
+                └── filters
+                     └── column2:6 = uniq_fk_parent.a:7

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -788,10 +788,13 @@ func populateTableConstraints(
 			if err != nil {
 				return err
 			}
-			if idx, err := tabledesc.FindFKReferencedIndex(referencedTable, con.FK.ReferencedColumnIDs); err != nil {
-				// We couldn't find an index that matched. This shouldn't happen.
+			if refConstraint, err := tabledesc.FindFKReferencedUniqueConstraint(
+				referencedTable, con.FK.ReferencedColumnIDs,
+			); err != nil {
+				// We couldn't find a unique constraint that matched. This shouldn't
+				// happen.
 				log.Warningf(ctx, "broken fk reference: %v", err)
-			} else {
+			} else if idx, ok := refConstraint.(*descpb.IndexDescriptor); ok {
 				conindid = h.IndexOid(con.ReferencedTable.ID, idx.ID)
 			}
 			confrelid = tableOid(con.ReferencedTable.ID)
@@ -1218,10 +1221,13 @@ https://www.postgresql.org/docs/9.5/catalog-pg-depend.html`,
 					return err
 				}
 				refObjID := oidZero
-				if idx, err := tabledesc.FindFKReferencedIndex(referencedTable, con.FK.ReferencedColumnIDs); err != nil {
-					// We couldn't find an index that matched. This shouldn't happen.
+				if refConstraint, err := tabledesc.FindFKReferencedUniqueConstraint(
+					referencedTable, con.FK.ReferencedColumnIDs,
+				); err != nil {
+					// We couldn't find a unique constraint that matched. This shouldn't
+					// happen.
 					log.Warningf(ctx, "broken fk reference: %v", err)
-				} else {
+				} else if idx, ok := refConstraint.(*descpb.IndexDescriptor); ok {
 					refObjID = h.IndexOid(con.ReferencedTable.ID, idx.ID)
 				}
 				constraintOid := h.ForeignKeyConstraintOid(db.GetID(), scName, table.GetID(), con.FK)

--- a/pkg/sql/pgwire/testdata/pgtest/notice
+++ b/pkg/sql/pgwire/testdata/pgtest/notice
@@ -55,7 +55,7 @@ Query {"String": "DROP INDEX t_x_idx"}
 until crdb_only
 CommandComplete
 ----
-{"Severity":"NOTICE","Code":"00000","Message":"the data for dropped indexes is reclaimed asynchronously","Detail":"","Hint":"The reclamation delay can be customized in the zone configuration for the table.","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"drop_index.go","Line":528,"Routine":"dropIndexByName","UnknownFields":null}
+{"Severity":"NOTICE","Code":"00000","Message":"the data for dropped indexes is reclaimed asynchronously","Detail":"","Hint":"The reclamation delay can be customized in the zone configuration for the table.","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"drop_index.go","Line":515,"Routine":"dropIndexByName","UnknownFields":null}
 {"Type":"CommandComplete","CommandTag":"DROP INDEX"}
 
 until noncrdb_only


### PR DESCRIPTION
**sql: allow foreign keys to reference `UNIQUE WITHOUT INDEX` constraints**

Prior to this commit, it was not possible to create a foreign key with no
unique index on the referenced columns. This commit updates the `sql` package
to support creating foreign keys on columns that have a `UNIQUE WITHOUT INDEX`
constraint, thus removing the requirement that the referenced columns have a
unique index. This commit also ensures that if a user tries to drop a column
in the `UNIQUE WITHOUT INDEX` constraint without using `CASCADE`, it will fail due
to a foreign key dependency.

There is no release note since `UNIQUE WITHOUT INDEX` constraints are still
gated behind the `experimental_enable_unique_without_index_constraints` session
variable.

Release note: None

**opt: support foreign key checks referencing `UNIQUE WITHOUT INDEX` constraints**

Prior to this commit, the optimizer did not correctly support checks and
cascades for foreign keys referencing `UNIQUE WITHOUT INDEX` constraints. This
commit updates the logic to determine whether existing values are needed from
certain columns when performing mutations, so that these checks and cascades
can function correctly.

There is no release note since `UNIQUE WITHOUT INDEX` constraints are still
gated behind the `experimental_enable_unique_without_index_constraints` session
variable.

Fixes #57977

Release note: None