### PR TITLE
release-20.2: colexec: fix decimal/interval overload error propagation

### DIFF
--- a/pkg/sql/colexec/execgen/cmd/execgen/overloads_bin.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/overloads_bin.go
@@ -710,7 +710,7 @@ func (c intervalDecimalCustomizer) getBinOpAssignFunc() assignFunc {
 			return fmt.Sprintf(`
 		  f, err := %[3]s.Float64()
 		  if err != nil {
-		    colexecerror.InternalError(err)
+		    colexecerror.ExpectedError(err)
 		  }
 		  %[1]s = %[2]s.MulFloat(f)`,
 				targetElem, leftElem, rightElem)
@@ -728,7 +728,7 @@ func (c decimalIntervalCustomizer) getBinOpAssignFunc() assignFunc {
 			return fmt.Sprintf(`
 		  f, err := %[2]s.Float64()
 		  if err != nil {
-		    colexecerror.InternalError(err)
+		    colexecerror.ExpectedError(err)
 		  }
 		  %[1]s = %[3]s.MulFloat(f)`,
 				targetElem, leftElem, rightElem)

--- a/pkg/sql/colexec/proj_const_left_ops.eg.go
+++ b/pkg/sql/colexec/proj_const_left_ops.eg.go
@@ -11229,7 +11229,7 @@ func (p projMultDecimalConstIntervalOp) Next(ctx context.Context) coldata.Batch 
 
 						f, err := p.constArg.Float64()
 						if err != nil {
-							colexecerror.InternalError(err)
+							colexecerror.ExpectedError(err)
 						}
 						projCol[i] = arg.MulFloat(f)
 					}
@@ -11244,7 +11244,7 @@ func (p projMultDecimalConstIntervalOp) Next(ctx context.Context) coldata.Batch 
 
 						f, err := p.constArg.Float64()
 						if err != nil {
-							colexecerror.InternalError(err)
+							colexecerror.ExpectedError(err)
 						}
 						projCol[i] = arg.MulFloat(f)
 					}
@@ -11264,7 +11264,7 @@ func (p projMultDecimalConstIntervalOp) Next(ctx context.Context) coldata.Batch 
 
 					f, err := p.constArg.Float64()
 					if err != nil {
-						colexecerror.InternalError(err)
+						colexecerror.ExpectedError(err)
 					}
 					projCol[i] = arg.MulFloat(f)
 				}
@@ -11276,7 +11276,7 @@ func (p projMultDecimalConstIntervalOp) Next(ctx context.Context) coldata.Batch 
 
 					f, err := p.constArg.Float64()
 					if err != nil {
-						colexecerror.InternalError(err)
+						colexecerror.ExpectedError(err)
 					}
 					projCol[i] = arg.MulFloat(f)
 				}
@@ -14011,7 +14011,7 @@ func (p projMultIntervalConstDecimalOp) Next(ctx context.Context) coldata.Batch 
 
 						f, err := arg.Float64()
 						if err != nil {
-							colexecerror.InternalError(err)
+							colexecerror.ExpectedError(err)
 						}
 						projCol[i] = p.constArg.MulFloat(f)
 					}
@@ -14026,7 +14026,7 @@ func (p projMultIntervalConstDecimalOp) Next(ctx context.Context) coldata.Batch 
 
 						f, err := arg.Float64()
 						if err != nil {
-							colexecerror.InternalError(err)
+							colexecerror.ExpectedError(err)
 						}
 						projCol[i] = p.constArg.MulFloat(f)
 					}
@@ -14046,7 +14046,7 @@ func (p projMultIntervalConstDecimalOp) Next(ctx context.Context) coldata.Batch 
 
 					f, err := arg.Float64()
 					if err != nil {
-						colexecerror.InternalError(err)
+						colexecerror.ExpectedError(err)
 					}
 					projCol[i] = p.constArg.MulFloat(f)
 				}
@@ -14058,7 +14058,7 @@ func (p projMultIntervalConstDecimalOp) Next(ctx context.Context) coldata.Batch 
 
 					f, err := arg.Float64()
 					if err != nil {
-						colexecerror.InternalError(err)
+						colexecerror.ExpectedError(err)
 					}
 					projCol[i] = p.constArg.MulFloat(f)
 				}

--- a/pkg/sql/colexec/proj_const_right_ops.eg.go
+++ b/pkg/sql/colexec/proj_const_right_ops.eg.go
@@ -11227,7 +11227,7 @@ func (p projMultDecimalIntervalConstOp) Next(ctx context.Context) coldata.Batch 
 
 						f, err := arg.Float64()
 						if err != nil {
-							colexecerror.InternalError(err)
+							colexecerror.ExpectedError(err)
 						}
 						projCol[i] = p.constArg.MulFloat(f)
 					}
@@ -11242,7 +11242,7 @@ func (p projMultDecimalIntervalConstOp) Next(ctx context.Context) coldata.Batch 
 
 						f, err := arg.Float64()
 						if err != nil {
-							colexecerror.InternalError(err)
+							colexecerror.ExpectedError(err)
 						}
 						projCol[i] = p.constArg.MulFloat(f)
 					}
@@ -11262,7 +11262,7 @@ func (p projMultDecimalIntervalConstOp) Next(ctx context.Context) coldata.Batch 
 
 					f, err := arg.Float64()
 					if err != nil {
-						colexecerror.InternalError(err)
+						colexecerror.ExpectedError(err)
 					}
 					projCol[i] = p.constArg.MulFloat(f)
 				}
@@ -11274,7 +11274,7 @@ func (p projMultDecimalIntervalConstOp) Next(ctx context.Context) coldata.Batch 
 
 					f, err := arg.Float64()
 					if err != nil {
-						colexecerror.InternalError(err)
+						colexecerror.ExpectedError(err)
 					}
 					projCol[i] = p.constArg.MulFloat(f)
 				}
@@ -14009,7 +14009,7 @@ func (p projMultIntervalDecimalConstOp) Next(ctx context.Context) coldata.Batch 
 
 						f, err := p.constArg.Float64()
 						if err != nil {
-							colexecerror.InternalError(err)
+							colexecerror.ExpectedError(err)
 						}
 						projCol[i] = arg.MulFloat(f)
 					}
@@ -14024,7 +14024,7 @@ func (p projMultIntervalDecimalConstOp) Next(ctx context.Context) coldata.Batch 
 
 						f, err := p.constArg.Float64()
 						if err != nil {
-							colexecerror.InternalError(err)
+							colexecerror.ExpectedError(err)
 						}
 						projCol[i] = arg.MulFloat(f)
 					}
@@ -14044,7 +14044,7 @@ func (p projMultIntervalDecimalConstOp) Next(ctx context.Context) coldata.Batch 
 
 					f, err := p.constArg.Float64()
 					if err != nil {
-						colexecerror.InternalError(err)
+						colexecerror.ExpectedError(err)
 					}
 					projCol[i] = arg.MulFloat(f)
 				}
@@ -14056,7 +14056,7 @@ func (p projMultIntervalDecimalConstOp) Next(ctx context.Context) coldata.Batch 
 
 					f, err := p.constArg.Float64()
 					if err != nil {
-						colexecerror.InternalError(err)
+						colexecerror.ExpectedError(err)
 					}
 					projCol[i] = arg.MulFloat(f)
 				}

--- a/pkg/sql/colexec/proj_non_const_ops.eg.go
+++ b/pkg/sql/colexec/proj_non_const_ops.eg.go
@@ -12355,7 +12355,7 @@ func (p projMultDecimalIntervalOp) Next(ctx context.Context) coldata.Batch {
 
 						f, err := arg1.Float64()
 						if err != nil {
-							colexecerror.InternalError(err)
+							colexecerror.ExpectedError(err)
 						}
 						projCol[i] = arg2.MulFloat(f)
 					}
@@ -12374,7 +12374,7 @@ func (p projMultDecimalIntervalOp) Next(ctx context.Context) coldata.Batch {
 
 						f, err := arg1.Float64()
 						if err != nil {
-							colexecerror.InternalError(err)
+							colexecerror.ExpectedError(err)
 						}
 						projCol[i] = arg2.MulFloat(f)
 					}
@@ -12395,7 +12395,7 @@ func (p projMultDecimalIntervalOp) Next(ctx context.Context) coldata.Batch {
 
 					f, err := arg1.Float64()
 					if err != nil {
-						colexecerror.InternalError(err)
+						colexecerror.ExpectedError(err)
 					}
 					projCol[i] = arg2.MulFloat(f)
 				}
@@ -12410,7 +12410,7 @@ func (p projMultDecimalIntervalOp) Next(ctx context.Context) coldata.Batch {
 
 					f, err := arg1.Float64()
 					if err != nil {
-						colexecerror.InternalError(err)
+						colexecerror.ExpectedError(err)
 					}
 					projCol[i] = arg2.MulFloat(f)
 				}
@@ -15401,7 +15401,7 @@ func (p projMultIntervalDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 						f, err := arg2.Float64()
 						if err != nil {
-							colexecerror.InternalError(err)
+							colexecerror.ExpectedError(err)
 						}
 						projCol[i] = arg1.MulFloat(f)
 					}
@@ -15420,7 +15420,7 @@ func (p projMultIntervalDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 						f, err := arg2.Float64()
 						if err != nil {
-							colexecerror.InternalError(err)
+							colexecerror.ExpectedError(err)
 						}
 						projCol[i] = arg1.MulFloat(f)
 					}
@@ -15441,7 +15441,7 @@ func (p projMultIntervalDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 					f, err := arg2.Float64()
 					if err != nil {
-						colexecerror.InternalError(err)
+						colexecerror.ExpectedError(err)
 					}
 					projCol[i] = arg1.MulFloat(f)
 				}
@@ -15456,7 +15456,7 @@ func (p projMultIntervalDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 					f, err := arg2.Float64()
 					if err != nil {
-						colexecerror.InternalError(err)
+						colexecerror.ExpectedError(err)
 					}
 					projCol[i] = arg1.MulFloat(f)
 				}

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_overloads
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_overloads
@@ -660,3 +660,7 @@ SELECT _int, _int2, _int // _int2 FROM many_types WHERE _int2 <> 0
 312  1  312
 789  4  197
 2    2  1
+
+# Regression test for incorrectly propagating an error as internal (#57773).
+statement error .* value out of range
+SELECT ((-1.234E+401)::DECIMAL * '-53 years -10 mons -377 days -08:33:40.519057'::INTERVAL::INTERVAL)::INTERVAL FROM many_types


### PR DESCRIPTION
Backport 1/1 commits from #58743.

/cc @cockroachdb/release

---

Fixes: #57773.

Release note (bug fix): CockroachDB could previously return an internal
error when evaluating a binary expression between a Decimal and an
Interval that required a cast to a Float when the value is out of range,
and now a more user-friendly error is returned instead.
