### PR TITLE
build: remove `com_github_cockroachdb_tools` from bazel workspace

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -3003,13 +3003,6 @@ def go_deps():
         version = "v0.0.0-20190308202827-9d24e82272b4",
     )
     go_repository(
-        name = "org_golang_x_tools",
-        build_file_proto_mode = "disable_global",
-        importpath = "golang.org/x/tools",
-        sum = "h1:5xKxdl/RhlelmSPaxyVeq5PYSmJ4H14yeQT58qP1F6o=",
-        version = "v0.0.0-20210104081019-d8d6ddbec6ee",
-    )
-    go_repository(
         name = "org_golang_x_xerrors",
         build_file_proto_mode = "disable_global",
         importpath = "golang.org/x/xerrors",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -35,6 +35,14 @@ git_repository(
 load("@bazel_gazelle//:deps.bzl", "go_repository")
 
 go_repository(
+    name = "org_golang_x_tools",
+    build_file_proto_mode = "disable_global",
+    importpath = "golang.org/x/tools",
+    sum = "h1:5xKxdl/RhlelmSPaxyVeq5PYSmJ4H14yeQT58qP1F6o=",
+    version = "v0.0.0-20210104081019-d8d6ddbec6ee",
+)
+
+go_repository(
     name = "com_github_gogo_protobuf",
     build_file_proto_mode = "disable_global",
     importpath = "github.com/gogo/protobuf",
@@ -123,25 +131,3 @@ git_repository(
 load("@rules_foreign_cc//:workspace_definitions.bzl", "rules_foreign_cc_dependencies")
 
 rules_foreign_cc_dependencies()
-
-# Gazelle silently ignores go_repository re-declarations. See
-# https://github.com/bazelbuild/bazel-gazelle/issues/561. What that means for
-# us, given we want to run a custom version of goyacc
-# (https://github.com/cockroachdb/cockroach/pull/57384, sitting under
-# @org_golang_x_tools by default), is that bazel doesn't actually pick it up.
-#
-# TODO(irfansharif): This is a wart that we can remove once
-# https://github.com/golang/tools/pull/259/files is merged upstream. We could
-# also generate a .patch file and apply it directly:
-# https://github.com/bazelbuild/rules_go/blob/0.19.0/go/workspace.rst#overriding-dependencies
-# It is a bit unfortunate though that depending on what the default modules we
-# load above end up loading, we're no longer able to override it with our own
-# fork. We'll need a longer term solution here.
-go_repository(
-    name = "com_github_cockroachdb_tools",
-    build_file_proto_mode = "disable_global",
-    importpath = "golang.org/x/tools",
-    replace = "github.com/cockroachdb/tools",
-    sum = "h1:TZHlzTz/OL/BaGcWzajnqbmf6Tn+399ylrK/at75zXM=",
-    version = "v0.0.0-20201202174556-f18ddc082e74",
-)

--- a/pkg/sql/parser/BUILD.bazel
+++ b/pkg/sql/parser/BUILD.bazel
@@ -81,13 +81,13 @@ genrule(
     outs = ["sql.go"],
     cmd = """
       $(location :sql-gen) $(location sql.y) $(location replace_help_rules.awk) \
-          $(location sql.go) $(location @com_github_cockroachdb_tools//cmd/goyacc) \
+          $(location sql.go) $(location @org_golang_x_tools//cmd/goyacc) \
           $(location @com_github_cockroachdb_gostdlib//x/tools/cmd/goimports)
     """,
     tools = [
         ":sql-gen",
         "@com_github_cockroachdb_gostdlib//x/tools/cmd/goimports",
-        "@com_github_cockroachdb_tools//cmd/goyacc",
+        "@org_golang_x_tools//cmd/goyacc",
     ],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
The inclusion of this repo was a hack because the version of
`golang.org/x/tools` didn't have a necessary patch. As of Jan 4 2021
that PR was merged upstream, and `007c90ed8` vendored it. Now we can
delete the reference to the fork. Also, move the `go_repository()`
declaration up closer to the top of `WORKSPACE` so we properly
override the version that `rules_go` sees.

Release note: None