### PR TITLE
sql, jobs: stop queuing schema change jobs for in-txn schema changes

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -1535,3 +1535,23 @@ CREATE TABLE t54629 (c INT NOT NULL, UNIQUE INDEX (c));
 ALTER TABLE t54629 ADD CONSTRAINT pk PRIMARY KEY (c);
 INSERT INTO t54629 VALUES (1);
 DELETE FROM t54629 WHERE c = 1;
+
+subtest regression_45985
+
+statement ok
+BEGIN;
+CREATE TABLE t45985 (a INT);
+ALTER TABLE t45985 ADD COLUMN b INT;
+COMMIT;
+
+query I
+SELECT count(descriptor_id)
+  FROM (
+        SELECT json_array_elements_text(
+                crdb_internal.pb_to_json('cockroach.sql.jobs.jobspb.Payload', payload)->'descriptorIds'
+               )::INT8 AS descriptor_id
+          FROM system.jobs
+       )
+ WHERE descriptor_id = ('test.public.t45985'::REGCLASS)::INT8;
+----
+0

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -223,8 +223,10 @@ func (p *planner) writeSchemaChange(
 		return errors.Errorf("no schema changes allowed on table %q as it is being dropped",
 			tableDesc.Name)
 	}
-	if err := p.createOrUpdateSchemaChangeJob(ctx, tableDesc, jobDesc, mutationID); err != nil {
-		return err
+	if !tableDesc.IsNew() {
+		if err := p.createOrUpdateSchemaChangeJob(ctx, tableDesc, jobDesc, mutationID); err != nil {
+			return err
+		}
 	}
 	return p.writeTableDesc(ctx, tableDesc)
 }


### PR DESCRIPTION
Creating a table and changing its schema within a transaction would
cause a schema change job to be queued. Such jobs are not necessary and
don't do anything. This patch prevents them from being queued in the
first place.

Fixes #45985.

Release note (sql change): Creating a table and changing its schema
within a transaction no longer schedules a schema change job.