### PR TITLE
changefeedccl: backfill changefeeds when a column is renamed

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -518,21 +518,6 @@ func TestChangefeedSchemaChangeNoBackfill(t *testing.T) {
 			})
 		})
 
-		t.Run(`rename column`, func(t *testing.T) {
-			sqlDB.Exec(t, `CREATE TABLE rename_column (a INT PRIMARY KEY, b STRING)`)
-			sqlDB.Exec(t, `INSERT INTO rename_column VALUES (1, '1')`)
-			renameColumn := feed(t, f, `CREATE CHANGEFEED FOR rename_column`)
-			defer closeFeed(t, renameColumn)
-			assertPayloads(t, renameColumn, []string{
-				`rename_column: [1]->{"after": {"a": 1, "b": "1"}}`,
-			})
-			sqlDB.Exec(t, `ALTER TABLE rename_column RENAME COLUMN b TO c`)
-			sqlDB.Exec(t, `INSERT INTO rename_column VALUES (2, '2')`)
-			assertPayloads(t, renameColumn, []string{
-				`rename_column: [2]->{"after": {"a": 2, "c": "2"}}`,
-			})
-		})
-
 		t.Run(`add default`, func(t *testing.T) {
 			sqlDB.Exec(t, `CREATE TABLE add_default (a INT PRIMARY KEY, b STRING)`)
 			sqlDB.Exec(t, `INSERT INTO add_default (a, b) VALUES (1, '1')`)
@@ -711,6 +696,23 @@ func TestChangefeedSchemaChangeAllowBackfill(t *testing.T) {
 					ts.AsOfSystemTime()),
 				fmt.Sprintf(`add_column_def: [2]->{"after": {"a": 2, "b": "d"}, "updated": "%s"}`,
 					ts.AsOfSystemTime()),
+			})
+		})
+
+		t.Run(`rename column`, func(t *testing.T) {
+			sqlDB.Exec(t, `CREATE TABLE rename_column (a INT PRIMARY KEY, b STRING)`)
+			sqlDB.Exec(t, `INSERT INTO rename_column VALUES (1, '1')`)
+			renameColumn := feed(t, f, `CREATE CHANGEFEED FOR rename_column`)
+			defer closeFeed(t, renameColumn)
+			assertPayloads(t, renameColumn, []string{
+				`rename_column: [1]->{"after": {"a": 1, "b": "1"}}`,
+			})
+			sqlDB.Exec(t, `ALTER TABLE rename_column RENAME COLUMN b TO c`)
+			sqlDB.Exec(t, `INSERT INTO rename_column VALUES (2, '2')`)
+
+			assertPayloadsStripTs(t, renameColumn, []string{
+				`rename_column: [1]->{"after": {"a": 1, "c": "1"}}`,
+				`rename_column: [2]->{"after": {"a": 2, "c": "2"}}`,
 			})
 		})
 

--- a/pkg/ccl/changefeedccl/schemafeed/table_event_filter.go
+++ b/pkg/ccl/changefeedccl/schemafeed/table_event_filter.go
@@ -26,12 +26,14 @@ const (
 	tableEventTypeDropColumn
 	tableEventTruncate
 	tableEventPrimaryKeyChange
+	tableEventTypeRenameColumn
 )
 
 var (
 	defaultTableEventFilter = tableEventFilter{
 		tableEventTypeDropColumn:            false,
 		tableEventTypeAddColumnWithBackfill: false,
+		tableEventTypeRenameColumn:          false,
 		tableEventTypeAddColumnNoBackfill:   true,
 		tableEventTypeUnknown:               true,
 	}
@@ -40,6 +42,7 @@ var (
 		tableEventTypeDropColumn:            false,
 		tableEventTypeAddColumnWithBackfill: false,
 		tableEventTypeAddColumnNoBackfill:   false,
+		tableEventTypeRenameColumn:          false,
 		tableEventTypeUnknown:               true,
 	}
 
@@ -61,6 +64,8 @@ func classifyTableEvent(e TableEvent) tableEventType {
 		return tableEventTruncate
 	case primaryKeyChanged(e):
 		return tableEventPrimaryKeyChange
+	case renameColumn(e):
+		return tableEventTypeRenameColumn
 	default:
 		return tableEventTypeUnknown
 	}
@@ -99,6 +104,18 @@ func dropColumnMutationExists(desc *tabledesc.Immutable) bool {
 		}
 		if m.Direction == descpb.DescriptorMutation_DROP &&
 			m.State == descpb.DescriptorMutation_DELETE_AND_WRITE_ONLY {
+			return true
+		}
+	}
+	return false
+}
+
+func renameColumn(e TableEvent) (res bool) {
+	if len(e.Before.Columns) != len(e.After.Columns) {
+		return false
+	}
+	for i, c := range e.Before.Columns {
+		if c.ColName() != e.After.Columns[i].ColName() {
 			return true
 		}
 	}


### PR DESCRIPTION
Renaming a column in a populated table in effect creates a logical
backfill, but this didn't show up in a changefeed. This PR aligns the
behavior with that of adding a column.

Release note (bug fix): Renaming a column in a changefeed target now
triggers a backfill

Closes #58518