### PR TITLE
*: upgrade vendored protobuf to v3.9.2

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -93,8 +93,8 @@ gazelle_dependencies()
 #      https://github.com/bazelbuild/bazel-gazelle/issues/591
 git_repository(
     name = "com_google_protobuf",
-    commit = "09745575a923640154bcf307fba8aedff47f240a",
-    remote = "https://github.com/protocolbuffers/protobuf",
+    commit = "9b23a34c7275aa0ceb2fc69ed1ae6737b34656a3",
+    remote = "https://github.com/cockroachdb/protobuf",
 )
 
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")

--- a/pkg/acceptance/cluster/testconfig.pb.go
+++ b/pkg/acceptance/cluster/testconfig.pb.go
@@ -61,7 +61,7 @@ func (x *InitMode) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (InitMode) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_testconfig_a82c0aa336d029cb, []int{0}
+	return fileDescriptor_testconfig_1105934915520239, []int{0}
 }
 
 // StoreConfig holds the configuration of a collection of similar stores.
@@ -73,7 +73,7 @@ func (m *StoreConfig) Reset()         { *m = StoreConfig{} }
 func (m *StoreConfig) String() string { return proto.CompactTextString(m) }
 func (*StoreConfig) ProtoMessage()    {}
 func (*StoreConfig) Descriptor() ([]byte, []int) {
-	return fileDescriptor_testconfig_a82c0aa336d029cb, []int{0}
+	return fileDescriptor_testconfig_1105934915520239, []int{0}
 }
 func (m *StoreConfig) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -108,7 +108,7 @@ func (m *NodeConfig) Reset()         { *m = NodeConfig{} }
 func (m *NodeConfig) String() string { return proto.CompactTextString(m) }
 func (*NodeConfig) ProtoMessage()    {}
 func (*NodeConfig) Descriptor() ([]byte, []int) {
-	return fileDescriptor_testconfig_a82c0aa336d029cb, []int{1}
+	return fileDescriptor_testconfig_1105934915520239, []int{1}
 }
 func (m *NodeConfig) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -149,7 +149,7 @@ func (m *TestConfig) Reset()         { *m = TestConfig{} }
 func (m *TestConfig) String() string { return proto.CompactTextString(m) }
 func (*TestConfig) ProtoMessage()    {}
 func (*TestConfig) Descriptor() ([]byte, []int) {
-	return fileDescriptor_testconfig_a82c0aa336d029cb, []int{2}
+	return fileDescriptor_testconfig_1105934915520239, []int{2}
 }
 func (m *TestConfig) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -805,10 +805,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("acceptance/cluster/testconfig.proto", fileDescriptor_testconfig_a82c0aa336d029cb)
+	proto.RegisterFile("acceptance/cluster/testconfig.proto", fileDescriptor_testconfig_1105934915520239)
 }
 
-var fileDescriptor_testconfig_a82c0aa336d029cb = []byte{
+var fileDescriptor_testconfig_1105934915520239 = []byte{
 	// 405 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x7c, 0x90, 0xc1, 0x6e, 0xd3, 0x40,
 	0x14, 0x45, 0x3d, 0x89, 0x43, 0xec, 0x57, 0x8a, 0xac, 0x11, 0x48, 0x56, 0x05, 0x53, 0xcb, 0x95,

--- a/pkg/blobs/blobspb/blobs.pb.go
+++ b/pkg/blobs/blobspb/blobs.pb.go
@@ -38,7 +38,7 @@ func (m *GetRequest) Reset()         { *m = GetRequest{} }
 func (m *GetRequest) String() string { return proto.CompactTextString(m) }
 func (*GetRequest) ProtoMessage()    {}
 func (*GetRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_blobs_5a88788af93dff11, []int{0}
+	return fileDescriptor_blobs_1ec98e9f736ff3b2, []int{0}
 }
 func (m *GetRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -72,7 +72,7 @@ func (m *GetResponse) Reset()         { *m = GetResponse{} }
 func (m *GetResponse) String() string { return proto.CompactTextString(m) }
 func (*GetResponse) ProtoMessage()    {}
 func (*GetResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_blobs_5a88788af93dff11, []int{1}
+	return fileDescriptor_blobs_1ec98e9f736ff3b2, []int{1}
 }
 func (m *GetResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -108,7 +108,7 @@ func (m *PutRequest) Reset()         { *m = PutRequest{} }
 func (m *PutRequest) String() string { return proto.CompactTextString(m) }
 func (*PutRequest) ProtoMessage()    {}
 func (*PutRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_blobs_5a88788af93dff11, []int{2}
+	return fileDescriptor_blobs_1ec98e9f736ff3b2, []int{2}
 }
 func (m *PutRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -141,7 +141,7 @@ func (m *PutResponse) Reset()         { *m = PutResponse{} }
 func (m *PutResponse) String() string { return proto.CompactTextString(m) }
 func (*PutResponse) ProtoMessage()    {}
 func (*PutResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_blobs_5a88788af93dff11, []int{3}
+	return fileDescriptor_blobs_1ec98e9f736ff3b2, []int{3}
 }
 func (m *PutResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -175,7 +175,7 @@ func (m *GlobRequest) Reset()         { *m = GlobRequest{} }
 func (m *GlobRequest) String() string { return proto.CompactTextString(m) }
 func (*GlobRequest) ProtoMessage()    {}
 func (*GlobRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_blobs_5a88788af93dff11, []int{4}
+	return fileDescriptor_blobs_1ec98e9f736ff3b2, []int{4}
 }
 func (m *GlobRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -209,7 +209,7 @@ func (m *GlobResponse) Reset()         { *m = GlobResponse{} }
 func (m *GlobResponse) String() string { return proto.CompactTextString(m) }
 func (*GlobResponse) ProtoMessage()    {}
 func (*GlobResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_blobs_5a88788af93dff11, []int{5}
+	return fileDescriptor_blobs_1ec98e9f736ff3b2, []int{5}
 }
 func (m *GlobResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -244,7 +244,7 @@ func (m *DeleteRequest) Reset()         { *m = DeleteRequest{} }
 func (m *DeleteRequest) String() string { return proto.CompactTextString(m) }
 func (*DeleteRequest) ProtoMessage()    {}
 func (*DeleteRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_blobs_5a88788af93dff11, []int{6}
+	return fileDescriptor_blobs_1ec98e9f736ff3b2, []int{6}
 }
 func (m *DeleteRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -277,7 +277,7 @@ func (m *DeleteResponse) Reset()         { *m = DeleteResponse{} }
 func (m *DeleteResponse) String() string { return proto.CompactTextString(m) }
 func (*DeleteResponse) ProtoMessage()    {}
 func (*DeleteResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_blobs_5a88788af93dff11, []int{7}
+	return fileDescriptor_blobs_1ec98e9f736ff3b2, []int{7}
 }
 func (m *DeleteResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -312,7 +312,7 @@ func (m *StatRequest) Reset()         { *m = StatRequest{} }
 func (m *StatRequest) String() string { return proto.CompactTextString(m) }
 func (*StatRequest) ProtoMessage()    {}
 func (*StatRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_blobs_5a88788af93dff11, []int{8}
+	return fileDescriptor_blobs_1ec98e9f736ff3b2, []int{8}
 }
 func (m *StatRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -346,7 +346,7 @@ func (m *BlobStat) Reset()         { *m = BlobStat{} }
 func (m *BlobStat) String() string { return proto.CompactTextString(m) }
 func (*BlobStat) ProtoMessage()    {}
 func (*BlobStat) Descriptor() ([]byte, []int) {
-	return fileDescriptor_blobs_5a88788af93dff11, []int{9}
+	return fileDescriptor_blobs_1ec98e9f736ff3b2, []int{9}
 }
 func (m *BlobStat) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -380,7 +380,7 @@ func (m *StreamChunk) Reset()         { *m = StreamChunk{} }
 func (m *StreamChunk) String() string { return proto.CompactTextString(m) }
 func (*StreamChunk) ProtoMessage()    {}
 func (*StreamChunk) Descriptor() ([]byte, []int) {
-	return fileDescriptor_blobs_5a88788af93dff11, []int{10}
+	return fileDescriptor_blobs_1ec98e9f736ff3b2, []int{10}
 }
 func (m *StreamChunk) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -413,7 +413,7 @@ func (m *StreamResponse) Reset()         { *m = StreamResponse{} }
 func (m *StreamResponse) String() string { return proto.CompactTextString(m) }
 func (*StreamResponse) ProtoMessage()    {}
 func (*StreamResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_blobs_5a88788af93dff11, []int{11}
+	return fileDescriptor_blobs_1ec98e9f736ff3b2, []int{11}
 }
 func (m *StreamResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2192,9 +2192,9 @@ var (
 	ErrIntOverflowBlobs   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("blobs/blobspb/blobs.proto", fileDescriptor_blobs_5a88788af93dff11) }
+func init() { proto.RegisterFile("blobs/blobspb/blobs.proto", fileDescriptor_blobs_1ec98e9f736ff3b2) }
 
-var fileDescriptor_blobs_5a88788af93dff11 = []byte{
+var fileDescriptor_blobs_1ec98e9f736ff3b2 = []byte{
 	// 433 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x53, 0xcf, 0x6e, 0xd3, 0x30,
 	0x18, 0xb7, 0xdb, 0xd2, 0x2d, 0x5f, 0xb7, 0x31, 0x59, 0x13, 0xca, 0x02, 0x98, 0xca, 0x42, 0x90,

--- a/pkg/build/info.pb.go
+++ b/pkg/build/info.pb.go
@@ -58,7 +58,7 @@ func (m *Info) Reset()         { *m = Info{} }
 func (m *Info) String() string { return proto.CompactTextString(m) }
 func (*Info) ProtoMessage()    {}
 func (*Info) Descriptor() ([]byte, []int) {
-	return fileDescriptor_info_6120d08447ce7654, []int{0}
+	return fileDescriptor_info_4e97a9e72e768597, []int{0}
 }
 func (m *Info) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -719,9 +719,9 @@ var (
 	ErrIntOverflowInfo   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("build/info.proto", fileDescriptor_info_6120d08447ce7654) }
+func init() { proto.RegisterFile("build/info.proto", fileDescriptor_info_4e97a9e72e768597) }
 
-var fileDescriptor_info_6120d08447ce7654 = []byte{
+var fileDescriptor_info_4e97a9e72e768597 = []byte{
 	// 339 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x54, 0x91, 0x41, 0x8e, 0xda, 0x30,
 	0x14, 0x86, 0x93, 0x12, 0x0a, 0x18, 0x24, 0x5a, 0xab, 0xaa, 0xac, 0x2e, 0x5c, 0x54, 0x54, 0xc1,

--- a/pkg/ccl/backupccl/backup.pb.go
+++ b/pkg/ccl/backupccl/backup.pb.go
@@ -52,7 +52,7 @@ func (x MVCCFilter) String() string {
 	return proto.EnumName(MVCCFilter_name, int32(x))
 }
 func (MVCCFilter) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_backup_58760e41a5796fb8, []int{0}
+	return fileDescriptor_backup_6c7bca054e22c1ca, []int{0}
 }
 
 type ScheduledBackupExecutionArgs_BackupType int32
@@ -75,7 +75,7 @@ func (x ScheduledBackupExecutionArgs_BackupType) String() string {
 	return proto.EnumName(ScheduledBackupExecutionArgs_BackupType_name, int32(x))
 }
 func (ScheduledBackupExecutionArgs_BackupType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_backup_58760e41a5796fb8, []int{4, 0}
+	return fileDescriptor_backup_6c7bca054e22c1ca, []int{4, 0}
 }
 
 // RowCount tracks the size and row/index entry counts.
@@ -89,7 +89,7 @@ func (m *RowCount) Reset()         { *m = RowCount{} }
 func (m *RowCount) String() string { return proto.CompactTextString(m) }
 func (*RowCount) ProtoMessage()    {}
 func (*RowCount) Descriptor() ([]byte, []int) {
-	return fileDescriptor_backup_58760e41a5796fb8, []int{0}
+	return fileDescriptor_backup_6c7bca054e22c1ca, []int{0}
 }
 func (m *RowCount) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -167,7 +167,7 @@ func (m *BackupManifest) Reset()         { *m = BackupManifest{} }
 func (m *BackupManifest) String() string { return proto.CompactTextString(m) }
 func (*BackupManifest) ProtoMessage()    {}
 func (*BackupManifest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_backup_58760e41a5796fb8, []int{1}
+	return fileDescriptor_backup_6c7bca054e22c1ca, []int{1}
 }
 func (m *BackupManifest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -210,7 +210,7 @@ func (m *BackupManifest_File) Reset()         { *m = BackupManifest_File{} }
 func (m *BackupManifest_File) String() string { return proto.CompactTextString(m) }
 func (*BackupManifest_File) ProtoMessage()    {}
 func (*BackupManifest_File) Descriptor() ([]byte, []int) {
-	return fileDescriptor_backup_58760e41a5796fb8, []int{1, 0}
+	return fileDescriptor_backup_6c7bca054e22c1ca, []int{1, 0}
 }
 func (m *BackupManifest_File) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -245,7 +245,7 @@ func (m *BackupManifest_DescriptorRevision) Reset()         { *m = BackupManifes
 func (m *BackupManifest_DescriptorRevision) String() string { return proto.CompactTextString(m) }
 func (*BackupManifest_DescriptorRevision) ProtoMessage()    {}
 func (*BackupManifest_DescriptorRevision) Descriptor() ([]byte, []int) {
-	return fileDescriptor_backup_58760e41a5796fb8, []int{1, 1}
+	return fileDescriptor_backup_6c7bca054e22c1ca, []int{1, 1}
 }
 func (m *BackupManifest_DescriptorRevision) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -279,7 +279,7 @@ func (m *BackupManifest_Progress) Reset()         { *m = BackupManifest_Progress
 func (m *BackupManifest_Progress) String() string { return proto.CompactTextString(m) }
 func (*BackupManifest_Progress) ProtoMessage()    {}
 func (*BackupManifest_Progress) Descriptor() ([]byte, []int) {
-	return fileDescriptor_backup_58760e41a5796fb8, []int{1, 2}
+	return fileDescriptor_backup_6c7bca054e22c1ca, []int{1, 2}
 }
 func (m *BackupManifest_Progress) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -314,7 +314,7 @@ func (m *BackupPartitionDescriptor) Reset()         { *m = BackupPartitionDescri
 func (m *BackupPartitionDescriptor) String() string { return proto.CompactTextString(m) }
 func (*BackupPartitionDescriptor) ProtoMessage()    {}
 func (*BackupPartitionDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_backup_58760e41a5796fb8, []int{2}
+	return fileDescriptor_backup_6c7bca054e22c1ca, []int{2}
 }
 func (m *BackupPartitionDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -350,7 +350,7 @@ func (m *StatsTable) Reset()         { *m = StatsTable{} }
 func (m *StatsTable) String() string { return proto.CompactTextString(m) }
 func (*StatsTable) ProtoMessage()    {}
 func (*StatsTable) Descriptor() ([]byte, []int) {
-	return fileDescriptor_backup_58760e41a5796fb8, []int{3}
+	return fileDescriptor_backup_6c7bca054e22c1ca, []int{3}
 }
 func (m *StatsTable) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -387,7 +387,7 @@ func (m *ScheduledBackupExecutionArgs) Reset()         { *m = ScheduledBackupExe
 func (m *ScheduledBackupExecutionArgs) String() string { return proto.CompactTextString(m) }
 func (*ScheduledBackupExecutionArgs) ProtoMessage()    {}
 func (*ScheduledBackupExecutionArgs) Descriptor() ([]byte, []int) {
-	return fileDescriptor_backup_58760e41a5796fb8, []int{4}
+	return fileDescriptor_backup_6c7bca054e22c1ca, []int{4}
 }
 func (m *ScheduledBackupExecutionArgs) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -424,7 +424,7 @@ func (m *RestoreProgress) Reset()         { *m = RestoreProgress{} }
 func (m *RestoreProgress) String() string { return proto.CompactTextString(m) }
 func (*RestoreProgress) ProtoMessage()    {}
 func (*RestoreProgress) Descriptor() ([]byte, []int) {
-	return fileDescriptor_backup_58760e41a5796fb8, []int{5}
+	return fileDescriptor_backup_6c7bca054e22c1ca, []int{5}
 }
 func (m *RestoreProgress) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3378,9 +3378,9 @@ var (
 	ErrIntOverflowBackup   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("ccl/backupccl/backup.proto", fileDescriptor_backup_58760e41a5796fb8) }
+func init() { proto.RegisterFile("ccl/backupccl/backup.proto", fileDescriptor_backup_6c7bca054e22c1ca) }
 
-var fileDescriptor_backup_58760e41a5796fb8 = []byte{
+var fileDescriptor_backup_6c7bca054e22c1ca = []byte{
 	// 1549 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xa4, 0x57, 0xcd, 0x6e, 0xdb, 0xc0,
 	0x11, 0x36, 0x25, 0x59, 0x3f, 0x23, 0xff, 0xc8, 0x6b, 0x3b, 0x66, 0xd5, 0x54, 0x52, 0x14, 0x14,

--- a/pkg/ccl/baseccl/encryption_options.pb.go
+++ b/pkg/ccl/baseccl/encryption_options.pb.go
@@ -38,7 +38,7 @@ func (x EncryptionKeySource) String() string {
 	return proto.EnumName(EncryptionKeySource_name, int32(x))
 }
 func (EncryptionKeySource) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_encryption_options_46022063d9b927cf, []int{0}
+	return fileDescriptor_encryption_options_80b9a505141c04a1, []int{0}
 }
 
 // EncryptionKeyFiles is used when plain key files are passed.
@@ -51,7 +51,7 @@ func (m *EncryptionKeyFiles) Reset()         { *m = EncryptionKeyFiles{} }
 func (m *EncryptionKeyFiles) String() string { return proto.CompactTextString(m) }
 func (*EncryptionKeyFiles) ProtoMessage()    {}
 func (*EncryptionKeyFiles) Descriptor() ([]byte, []int) {
-	return fileDescriptor_encryption_options_46022063d9b927cf, []int{0}
+	return fileDescriptor_encryption_options_80b9a505141c04a1, []int{0}
 }
 func (m *EncryptionKeyFiles) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -90,7 +90,7 @@ func (m *EncryptionOptions) Reset()         { *m = EncryptionOptions{} }
 func (m *EncryptionOptions) String() string { return proto.CompactTextString(m) }
 func (*EncryptionOptions) ProtoMessage()    {}
 func (*EncryptionOptions) Descriptor() ([]byte, []int) {
-	return fileDescriptor_encryption_options_46022063d9b927cf, []int{1}
+	return fileDescriptor_encryption_options_80b9a505141c04a1, []int{1}
 }
 func (m *EncryptionOptions) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -581,10 +581,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("ccl/baseccl/encryption_options.proto", fileDescriptor_encryption_options_46022063d9b927cf)
+	proto.RegisterFile("ccl/baseccl/encryption_options.proto", fileDescriptor_encryption_options_80b9a505141c04a1)
 }
 
-var fileDescriptor_encryption_options_46022063d9b927cf = []byte{
+var fileDescriptor_encryption_options_80b9a505141c04a1 = []byte{
 	// 317 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x91, 0x4f, 0x4f, 0xf2, 0x40,
 	0x10, 0xc6, 0xbb, 0x2f, 0x09, 0x7f, 0x86, 0x37, 0x46, 0x57, 0x89, 0xc4, 0xc3, 0x4a, 0xd0, 0x03,

--- a/pkg/ccl/storageccl/engineccl/enginepbccl/key_registry.pb.go
+++ b/pkg/ccl/storageccl/engineccl/enginepbccl/key_registry.pb.go
@@ -50,7 +50,7 @@ func (x EncryptionType) String() string {
 	return proto.EnumName(EncryptionType_name, int32(x))
 }
 func (EncryptionType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_key_registry_cc37749f10f852e8, []int{0}
+	return fileDescriptor_key_registry_160983c0db19b441, []int{0}
 }
 
 // DataKeysRegistry contains all data keys (including the raw key) as well
@@ -70,7 +70,7 @@ func (m *DataKeysRegistry) Reset()         { *m = DataKeysRegistry{} }
 func (m *DataKeysRegistry) String() string { return proto.CompactTextString(m) }
 func (*DataKeysRegistry) ProtoMessage()    {}
 func (*DataKeysRegistry) Descriptor() ([]byte, []int) {
-	return fileDescriptor_key_registry_cc37749f10f852e8, []int{0}
+	return fileDescriptor_key_registry_160983c0db19b441, []int{0}
 }
 func (m *DataKeysRegistry) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -118,7 +118,7 @@ func (m *KeyInfo) Reset()         { *m = KeyInfo{} }
 func (m *KeyInfo) String() string { return proto.CompactTextString(m) }
 func (*KeyInfo) ProtoMessage()    {}
 func (*KeyInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_key_registry_cc37749f10f852e8, []int{1}
+	return fileDescriptor_key_registry_160983c0db19b441, []int{1}
 }
 func (m *KeyInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -156,7 +156,7 @@ func (m *SecretKey) Reset()         { *m = SecretKey{} }
 func (m *SecretKey) String() string { return proto.CompactTextString(m) }
 func (*SecretKey) ProtoMessage()    {}
 func (*SecretKey) Descriptor() ([]byte, []int) {
-	return fileDescriptor_key_registry_cc37749f10f852e8, []int{2}
+	return fileDescriptor_key_registry_160983c0db19b441, []int{2}
 }
 func (m *SecretKey) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -197,7 +197,7 @@ func (m *EncryptionSettings) Reset()         { *m = EncryptionSettings{} }
 func (m *EncryptionSettings) String() string { return proto.CompactTextString(m) }
 func (*EncryptionSettings) ProtoMessage()    {}
 func (*EncryptionSettings) Descriptor() ([]byte, []int) {
-	return fileDescriptor_key_registry_cc37749f10f852e8, []int{3}
+	return fileDescriptor_key_registry_160983c0db19b441, []int{3}
 }
 func (m *EncryptionSettings) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1509,10 +1509,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("ccl/storageccl/engineccl/enginepbccl/key_registry.proto", fileDescriptor_key_registry_cc37749f10f852e8)
+	proto.RegisterFile("ccl/storageccl/engineccl/enginepbccl/key_registry.proto", fileDescriptor_key_registry_160983c0db19b441)
 }
 
-var fileDescriptor_key_registry_cc37749f10f852e8 = []byte{
+var fileDescriptor_key_registry_160983c0db19b441 = []byte{
 	// 594 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xc4, 0x94, 0x4f, 0x6f, 0xd3, 0x4c,
 	0x10, 0xc6, 0xb3, 0x49, 0x93, 0x36, 0x93, 0x26, 0x8d, 0xf6, 0xed, 0x8b, 0xa2, 0x1e, 0x4c, 0x14,

--- a/pkg/ccl/storageccl/engineccl/enginepbccl/stats.pb.go
+++ b/pkg/ccl/storageccl/engineccl/enginepbccl/stats.pb.go
@@ -32,7 +32,7 @@ func (m *EncryptionStatus) Reset()         { *m = EncryptionStatus{} }
 func (m *EncryptionStatus) String() string { return proto.CompactTextString(m) }
 func (*EncryptionStatus) ProtoMessage()    {}
 func (*EncryptionStatus) Descriptor() ([]byte, []int) {
-	return fileDescriptor_stats_7873e8ad9241be3d, []int{0}
+	return fileDescriptor_stats_8a7eddef5c8c7733, []int{0}
 }
 func (m *EncryptionStatus) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -359,10 +359,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("ccl/storageccl/engineccl/enginepbccl/stats.proto", fileDescriptor_stats_7873e8ad9241be3d)
+	proto.RegisterFile("ccl/storageccl/engineccl/enginepbccl/stats.proto", fileDescriptor_stats_8a7eddef5c8c7733)
 }
 
-var fileDescriptor_stats_7873e8ad9241be3d = []byte{
+var fileDescriptor_stats_8a7eddef5c8c7733 = []byte{
 	// 252 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xa4, 0x90, 0xb1, 0x4e, 0xc3, 0x30,
 	0x10, 0x86, 0x63, 0x06, 0x86, 0x54, 0x40, 0x55, 0x31, 0xa0, 0x0e, 0x16, 0x62, 0x62, 0xc1, 0x45,

--- a/pkg/ccl/utilccl/licenseccl/license.pb.go
+++ b/pkg/ccl/utilccl/licenseccl/license.pb.go
@@ -45,7 +45,7 @@ func (x License_Type) String() string {
 	return proto.EnumName(License_Type_name, int32(x))
 }
 func (License_Type) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_license_9dc270caeb56da02, []int{0, 0}
+	return fileDescriptor_license_ab5207e359a48f57, []int{0, 0}
 }
 
 type License struct {
@@ -59,7 +59,7 @@ func (m *License) Reset()         { *m = License{} }
 func (m *License) String() string { return proto.CompactTextString(m) }
 func (*License) ProtoMessage()    {}
 func (*License) Descriptor() ([]byte, []int) {
-	return fileDescriptor_license_9dc270caeb56da02, []int{0}
+	return fileDescriptor_license_ab5207e359a48f57, []int{0}
 }
 func (m *License) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -436,10 +436,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("ccl/utilccl/licenseccl/license.proto", fileDescriptor_license_9dc270caeb56da02)
+	proto.RegisterFile("ccl/utilccl/licenseccl/license.proto", fileDescriptor_license_ab5207e359a48f57)
 }
 
-var fileDescriptor_license_9dc270caeb56da02 = []byte{
+var fileDescriptor_license_ab5207e359a48f57 = []byte{
 	// 362 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x84, 0x91, 0x31, 0x8f, 0xda, 0x30,
 	0x1c, 0xc5, 0x63, 0x40, 0xad, 0xb0, 0x5a, 0x14, 0x22, 0x86, 0xa8, 0x83, 0x89, 0x50, 0x87, 0x48,

--- a/pkg/cli/systembench/systembenchpb/ping.pb.go
+++ b/pkg/cli/systembench/systembenchpb/ping.pb.go
@@ -33,7 +33,7 @@ func (m *PingRequest) Reset()         { *m = PingRequest{} }
 func (m *PingRequest) String() string { return proto.CompactTextString(m) }
 func (*PingRequest) ProtoMessage()    {}
 func (*PingRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ping_72d92a0e7b9988d9, []int{0}
+	return fileDescriptor_ping_3cfa0224b0cfaca1, []int{0}
 }
 func (m *PingRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -66,7 +66,7 @@ func (m *PingResponse) Reset()         { *m = PingResponse{} }
 func (m *PingResponse) String() string { return proto.CompactTextString(m) }
 func (*PingResponse) ProtoMessage()    {}
 func (*PingResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ping_72d92a0e7b9988d9, []int{1}
+	return fileDescriptor_ping_3cfa0224b0cfaca1, []int{1}
 }
 func (m *PingResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -532,10 +532,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("cli/systembench/systembenchpb/ping.proto", fileDescriptor_ping_72d92a0e7b9988d9)
+	proto.RegisterFile("cli/systembench/systembenchpb/ping.proto", fileDescriptor_ping_3cfa0224b0cfaca1)
 }
 
-var fileDescriptor_ping_72d92a0e7b9988d9 = []byte{
+var fileDescriptor_ping_3cfa0224b0cfaca1 = []byte{
 	// 175 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0xd2, 0x48, 0xce, 0xc9, 0xd4,
 	0x2f, 0xae, 0x2c, 0x2e, 0x49, 0xcd, 0x4d, 0x4a, 0xcd, 0x4b, 0xce, 0x40, 0x66, 0x17, 0x24, 0xe9,

--- a/pkg/clusterversion/cluster_version.pb.go
+++ b/pkg/clusterversion/cluster_version.pb.go
@@ -33,7 +33,7 @@ type ClusterVersion struct {
 func (m *ClusterVersion) Reset()      { *m = ClusterVersion{} }
 func (*ClusterVersion) ProtoMessage() {}
 func (*ClusterVersion) Descriptor() ([]byte, []int) {
-	return fileDescriptor_cluster_version_d76e19b7fb1f16de, []int{0}
+	return fileDescriptor_cluster_version_d06e03f22342a30e, []int{0}
 }
 func (m *ClusterVersion) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -330,10 +330,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("clusterversion/cluster_version.proto", fileDescriptor_cluster_version_d76e19b7fb1f16de)
+	proto.RegisterFile("clusterversion/cluster_version.proto", fileDescriptor_cluster_version_d06e03f22342a30e)
 }
 
-var fileDescriptor_cluster_version_d76e19b7fb1f16de = []byte{
+var fileDescriptor_cluster_version_d06e03f22342a30e = []byte{
 	// 212 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x52, 0x49, 0xce, 0x29, 0x2d,
 	0x2e, 0x49, 0x2d, 0x2a, 0x4b, 0x2d, 0x2a, 0xce, 0xcc, 0xcf, 0xd3, 0x87, 0x72, 0xe3, 0xa1, 0x7c,

--- a/pkg/config/system.pb.go
+++ b/pkg/config/system.pb.go
@@ -29,7 +29,7 @@ func (m *SystemConfigEntries) Reset()         { *m = SystemConfigEntries{} }
 func (m *SystemConfigEntries) String() string { return proto.CompactTextString(m) }
 func (*SystemConfigEntries) ProtoMessage()    {}
 func (*SystemConfigEntries) Descriptor() ([]byte, []int) {
-	return fileDescriptor_system_5254723255d57bbf, []int{0}
+	return fileDescriptor_system_8d822484ad218767, []int{0}
 }
 func (m *SystemConfigEntries) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -310,9 +310,9 @@ var (
 	ErrIntOverflowSystem   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("config/system.proto", fileDescriptor_system_5254723255d57bbf) }
+func init() { proto.RegisterFile("config/system.proto", fileDescriptor_system_8d822484ad218767) }
 
-var fileDescriptor_system_5254723255d57bbf = []byte{
+var fileDescriptor_system_8d822484ad218767 = []byte{
 	// 181 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x12, 0x4e, 0xce, 0xcf, 0x4b,
 	0xcb, 0x4c, 0xd7, 0x2f, 0xae, 0x2c, 0x2e, 0x49, 0xcd, 0xd5, 0x2b, 0x28, 0xca, 0x2f, 0xc9, 0x17,

--- a/pkg/config/zonepb/zone.pb.go
+++ b/pkg/config/zonepb/zone.pb.go
@@ -64,7 +64,7 @@ func (x *Constraint_Type) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (Constraint_Type) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_zone_cd8e37a638b916ef, []int{1, 0}
+	return fileDescriptor_zone_e0f724a3b706ed21, []int{1, 0}
 }
 
 // GCPolicy defines garbage collection policies which apply to MVCC
@@ -84,7 +84,7 @@ func (m *GCPolicy) Reset()         { *m = GCPolicy{} }
 func (m *GCPolicy) String() string { return proto.CompactTextString(m) }
 func (*GCPolicy) ProtoMessage()    {}
 func (*GCPolicy) Descriptor() ([]byte, []int) {
-	return fileDescriptor_zone_cd8e37a638b916ef, []int{0}
+	return fileDescriptor_zone_e0f724a3b706ed21, []int{0}
 }
 func (m *GCPolicy) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -121,7 +121,7 @@ type Constraint struct {
 func (m *Constraint) Reset()      { *m = Constraint{} }
 func (*Constraint) ProtoMessage() {}
 func (*Constraint) Descriptor() ([]byte, []int) {
-	return fileDescriptor_zone_cd8e37a638b916ef, []int{1}
+	return fileDescriptor_zone_e0f724a3b706ed21, []int{1}
 }
 func (m *Constraint) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -163,7 +163,7 @@ type ConstraintsConjunction struct {
 func (m *ConstraintsConjunction) Reset()      { *m = ConstraintsConjunction{} }
 func (*ConstraintsConjunction) ProtoMessage() {}
 func (*ConstraintsConjunction) Descriptor() ([]byte, []int) {
-	return fileDescriptor_zone_cd8e37a638b916ef, []int{2}
+	return fileDescriptor_zone_e0f724a3b706ed21, []int{2}
 }
 func (m *ConstraintsConjunction) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -198,7 +198,7 @@ func (m *LeasePreference) Reset()         { *m = LeasePreference{} }
 func (m *LeasePreference) String() string { return proto.CompactTextString(m) }
 func (*LeasePreference) ProtoMessage()    {}
 func (*LeasePreference) Descriptor() ([]byte, []int) {
-	return fileDescriptor_zone_cd8e37a638b916ef, []int{3}
+	return fileDescriptor_zone_e0f724a3b706ed21, []int{3}
 }
 func (m *LeasePreference) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -276,7 +276,7 @@ func (m *ZoneConfig) Reset()         { *m = ZoneConfig{} }
 func (m *ZoneConfig) String() string { return proto.CompactTextString(m) }
 func (*ZoneConfig) ProtoMessage()    {}
 func (*ZoneConfig) Descriptor() ([]byte, []int) {
-	return fileDescriptor_zone_cd8e37a638b916ef, []int{4}
+	return fileDescriptor_zone_e0f724a3b706ed21, []int{4}
 }
 func (m *ZoneConfig) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -317,7 +317,7 @@ func (m *Subzone) Reset()         { *m = Subzone{} }
 func (m *Subzone) String() string { return proto.CompactTextString(m) }
 func (*Subzone) ProtoMessage()    {}
 func (*Subzone) Descriptor() ([]byte, []int) {
-	return fileDescriptor_zone_cd8e37a638b916ef, []int{5}
+	return fileDescriptor_zone_e0f724a3b706ed21, []int{5}
 }
 func (m *Subzone) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -363,7 +363,7 @@ func (m *SubzoneSpan) Reset()         { *m = SubzoneSpan{} }
 func (m *SubzoneSpan) String() string { return proto.CompactTextString(m) }
 func (*SubzoneSpan) ProtoMessage()    {}
 func (*SubzoneSpan) Descriptor() ([]byte, []int) {
-	return fileDescriptor_zone_cd8e37a638b916ef, []int{6}
+	return fileDescriptor_zone_e0f724a3b706ed21, []int{6}
 }
 func (m *SubzoneSpan) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2381,9 +2381,9 @@ var (
 	ErrIntOverflowZone   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("config/zonepb/zone.proto", fileDescriptor_zone_cd8e37a638b916ef) }
+func init() { proto.RegisterFile("config/zonepb/zone.proto", fileDescriptor_zone_e0f724a3b706ed21) }
 
-var fileDescriptor_zone_cd8e37a638b916ef = []byte{
+var fileDescriptor_zone_e0f724a3b706ed21 = []byte{
 	// 873 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x9c, 0x54, 0x3d, 0x73, 0xe3, 0x44,
 	0x18, 0xf6, 0xda, 0x8e, 0xad, 0x7b, 0xed, 0x24, 0x66, 0xef, 0x48, 0x44, 0x18, 0x2c, 0x23, 0x60,

--- a/pkg/geo/geoindex/config.pb.go
+++ b/pkg/geo/geoindex/config.pb.go
@@ -35,7 +35,7 @@ func (m *Config) Reset()         { *m = Config{} }
 func (m *Config) String() string { return proto.CompactTextString(m) }
 func (*Config) ProtoMessage()    {}
 func (*Config) Descriptor() ([]byte, []int) {
-	return fileDescriptor_config_4fdfa32e25381f1e, []int{0}
+	return fileDescriptor_config_91e5b6ac35c7431c, []int{0}
 }
 func (m *Config) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -85,7 +85,7 @@ func (m *S2Config) Reset()         { *m = S2Config{} }
 func (m *S2Config) String() string { return proto.CompactTextString(m) }
 func (*S2Config) ProtoMessage()    {}
 func (*S2Config) Descriptor() ([]byte, []int) {
-	return fileDescriptor_config_4fdfa32e25381f1e, []int{1}
+	return fileDescriptor_config_91e5b6ac35c7431c, []int{1}
 }
 func (m *S2Config) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -118,7 +118,7 @@ func (m *S2GeographyConfig) Reset()         { *m = S2GeographyConfig{} }
 func (m *S2GeographyConfig) String() string { return proto.CompactTextString(m) }
 func (*S2GeographyConfig) ProtoMessage()    {}
 func (*S2GeographyConfig) Descriptor() ([]byte, []int) {
-	return fileDescriptor_config_4fdfa32e25381f1e, []int{2}
+	return fileDescriptor_config_91e5b6ac35c7431c, []int{2}
 }
 func (m *S2GeographyConfig) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -157,7 +157,7 @@ func (m *S2GeometryConfig) Reset()         { *m = S2GeometryConfig{} }
 func (m *S2GeometryConfig) String() string { return proto.CompactTextString(m) }
 func (*S2GeometryConfig) ProtoMessage()    {}
 func (*S2GeometryConfig) Descriptor() ([]byte, []int) {
-	return fileDescriptor_config_4fdfa32e25381f1e, []int{3}
+	return fileDescriptor_config_91e5b6ac35c7431c, []int{3}
 }
 func (m *S2GeometryConfig) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1140,9 +1140,9 @@ var (
 	ErrIntOverflowConfig   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("geo/geoindex/config.proto", fileDescriptor_config_4fdfa32e25381f1e) }
+func init() { proto.RegisterFile("geo/geoindex/config.proto", fileDescriptor_config_91e5b6ac35c7431c) }
 
-var fileDescriptor_config_4fdfa32e25381f1e = []byte{
+var fileDescriptor_config_91e5b6ac35c7431c = []byte{
 	// 376 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x9c, 0x92, 0xbf, 0x6e, 0xea, 0x30,
 	0x18, 0xc5, 0x63, 0x2e, 0xa0, 0x60, 0xee, 0x70, 0x6f, 0xee, 0x55, 0x95, 0xb6, 0x92, 0x41, 0x4c,

--- a/pkg/geo/geopb/geopb.pb.go
+++ b/pkg/geo/geopb/geopb.pb.go
@@ -69,7 +69,7 @@ func (x ShapeType) String() string {
 	return proto.EnumName(ShapeType_name, int32(x))
 }
 func (ShapeType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_geopb_bd402adf6a465ece, []int{0}
+	return fileDescriptor_geopb_35d37c4d6e2361b0, []int{0}
 }
 
 // SpatialObjectType represents the type of the SpatialObject.
@@ -96,7 +96,7 @@ func (x SpatialObjectType) String() string {
 	return proto.EnumName(SpatialObjectType_name, int32(x))
 }
 func (SpatialObjectType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_geopb_bd402adf6a465ece, []int{1}
+	return fileDescriptor_geopb_35d37c4d6e2361b0, []int{1}
 }
 
 // SpatialObject represents a serialization of a Geospatial type.
@@ -117,7 +117,7 @@ func (m *SpatialObject) Reset()         { *m = SpatialObject{} }
 func (m *SpatialObject) String() string { return proto.CompactTextString(m) }
 func (*SpatialObject) ProtoMessage()    {}
 func (*SpatialObject) Descriptor() ([]byte, []int) {
-	return fileDescriptor_geopb_bd402adf6a465ece, []int{0}
+	return fileDescriptor_geopb_35d37c4d6e2361b0, []int{0}
 }
 func (m *SpatialObject) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -158,7 +158,7 @@ func (m *BoundingBox) Reset()         { *m = BoundingBox{} }
 func (m *BoundingBox) String() string { return proto.CompactTextString(m) }
 func (*BoundingBox) ProtoMessage()    {}
 func (*BoundingBox) Descriptor() ([]byte, []int) {
-	return fileDescriptor_geopb_bd402adf6a465ece, []int{1}
+	return fileDescriptor_geopb_35d37c4d6e2361b0, []int{1}
 }
 func (m *BoundingBox) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -719,9 +719,9 @@ var (
 	ErrIntOverflowGeopb   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("geo/geopb/geopb.proto", fileDescriptor_geopb_bd402adf6a465ece) }
+func init() { proto.RegisterFile("geo/geopb/geopb.proto", fileDescriptor_geopb_35d37c4d6e2361b0) }
 
-var fileDescriptor_geopb_bd402adf6a465ece = []byte{
+var fileDescriptor_geopb_35d37c4d6e2361b0 = []byte{
 	// 468 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x64, 0x92, 0xc1, 0x6e, 0xd3, 0x4c,
 	0x10, 0xc7, 0xbd, 0x89, 0xdd, 0x36, 0x93, 0xb4, 0xdd, 0xec, 0xf7, 0x81, 0xa2, 0x0a, 0x99, 0x28,

--- a/pkg/gossip/gossip.pb.go
+++ b/pkg/gossip/gossip.pb.go
@@ -46,7 +46,7 @@ func (m *BootstrapInfo) Reset()         { *m = BootstrapInfo{} }
 func (m *BootstrapInfo) String() string { return proto.CompactTextString(m) }
 func (*BootstrapInfo) ProtoMessage()    {}
 func (*BootstrapInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_gossip_af8c9a20540e5252, []int{0}
+	return fileDescriptor_gossip_a2029af5abd89691, []int{0}
 }
 func (m *BootstrapInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -90,7 +90,7 @@ func (m *Request) Reset()         { *m = Request{} }
 func (m *Request) String() string { return proto.CompactTextString(m) }
 func (*Request) ProtoMessage()    {}
 func (*Request) Descriptor() ([]byte, []int) {
-	return fileDescriptor_gossip_af8c9a20540e5252, []int{1}
+	return fileDescriptor_gossip_a2029af5abd89691, []int{1}
 }
 func (m *Request) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -138,7 +138,7 @@ func (m *Response) Reset()         { *m = Response{} }
 func (m *Response) String() string { return proto.CompactTextString(m) }
 func (*Response) ProtoMessage()    {}
 func (*Response) Descriptor() ([]byte, []int) {
-	return fileDescriptor_gossip_af8c9a20540e5252, []int{2}
+	return fileDescriptor_gossip_a2029af5abd89691, []int{2}
 }
 func (m *Response) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -172,7 +172,7 @@ type ConnStatus struct {
 func (m *ConnStatus) Reset()      { *m = ConnStatus{} }
 func (*ConnStatus) ProtoMessage() {}
 func (*ConnStatus) Descriptor() ([]byte, []int) {
-	return fileDescriptor_gossip_af8c9a20540e5252, []int{3}
+	return fileDescriptor_gossip_a2029af5abd89691, []int{3}
 }
 func (m *ConnStatus) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -208,7 +208,7 @@ type MetricSnap struct {
 func (m *MetricSnap) Reset()      { *m = MetricSnap{} }
 func (*MetricSnap) ProtoMessage() {}
 func (*MetricSnap) Descriptor() ([]byte, []int) {
-	return fileDescriptor_gossip_af8c9a20540e5252, []int{4}
+	return fileDescriptor_gossip_a2029af5abd89691, []int{4}
 }
 func (m *MetricSnap) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -241,7 +241,7 @@ type OutgoingConnStatus struct {
 func (m *OutgoingConnStatus) Reset()      { *m = OutgoingConnStatus{} }
 func (*OutgoingConnStatus) ProtoMessage() {}
 func (*OutgoingConnStatus) Descriptor() ([]byte, []int) {
-	return fileDescriptor_gossip_af8c9a20540e5252, []int{5}
+	return fileDescriptor_gossip_a2029af5abd89691, []int{5}
 }
 func (m *OutgoingConnStatus) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -274,7 +274,7 @@ type ClientStatus struct {
 func (m *ClientStatus) Reset()      { *m = ClientStatus{} }
 func (*ClientStatus) ProtoMessage() {}
 func (*ClientStatus) Descriptor() ([]byte, []int) {
-	return fileDescriptor_gossip_af8c9a20540e5252, []int{6}
+	return fileDescriptor_gossip_a2029af5abd89691, []int{6}
 }
 func (m *ClientStatus) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -308,7 +308,7 @@ type ServerStatus struct {
 func (m *ServerStatus) Reset()      { *m = ServerStatus{} }
 func (*ServerStatus) ProtoMessage() {}
 func (*ServerStatus) Descriptor() ([]byte, []int) {
-	return fileDescriptor_gossip_af8c9a20540e5252, []int{7}
+	return fileDescriptor_gossip_a2029af5abd89691, []int{7}
 }
 func (m *ServerStatus) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -341,7 +341,7 @@ type Connectivity struct {
 func (m *Connectivity) Reset()      { *m = Connectivity{} }
 func (*Connectivity) ProtoMessage() {}
 func (*Connectivity) Descriptor() ([]byte, []int) {
-	return fileDescriptor_gossip_af8c9a20540e5252, []int{8}
+	return fileDescriptor_gossip_a2029af5abd89691, []int{8}
 }
 func (m *Connectivity) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -375,7 +375,7 @@ func (m *Connectivity_Conn) Reset()         { *m = Connectivity_Conn{} }
 func (m *Connectivity_Conn) String() string { return proto.CompactTextString(m) }
 func (*Connectivity_Conn) ProtoMessage()    {}
 func (*Connectivity_Conn) Descriptor() ([]byte, []int) {
-	return fileDescriptor_gossip_af8c9a20540e5252, []int{8, 0}
+	return fileDescriptor_gossip_a2029af5abd89691, []int{8, 0}
 }
 func (m *Connectivity_Conn) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -412,7 +412,7 @@ func (m *InfoStatus) Reset()         { *m = InfoStatus{} }
 func (m *InfoStatus) String() string { return proto.CompactTextString(m) }
 func (*InfoStatus) ProtoMessage()    {}
 func (*InfoStatus) Descriptor() ([]byte, []int) {
-	return fileDescriptor_gossip_af8c9a20540e5252, []int{9}
+	return fileDescriptor_gossip_a2029af5abd89691, []int{9}
 }
 func (m *InfoStatus) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -457,7 +457,7 @@ func (m *Info) Reset()         { *m = Info{} }
 func (m *Info) String() string { return proto.CompactTextString(m) }
 func (*Info) ProtoMessage()    {}
 func (*Info) Descriptor() ([]byte, []int) {
-	return fileDescriptor_gossip_af8c9a20540e5252, []int{10}
+	return fileDescriptor_gossip_a2029af5abd89691, []int{10}
 }
 func (m *Info) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3668,9 +3668,9 @@ var (
 	ErrIntOverflowGossip   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("gossip/gossip.proto", fileDescriptor_gossip_af8c9a20540e5252) }
+func init() { proto.RegisterFile("gossip/gossip.proto", fileDescriptor_gossip_a2029af5abd89691) }
 
-var fileDescriptor_gossip_af8c9a20540e5252 = []byte{
+var fileDescriptor_gossip_a2029af5abd89691 = []byte{
 	// 1220 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xcc, 0x57, 0xcf, 0x6f, 0x1b, 0x45,
 	0x14, 0xf6, 0xc6, 0x3f, 0xe2, 0x7d, 0x76, 0xd2, 0x76, 0xa8, 0x90, 0x71, 0xa9, 0x1d, 0xb9, 0x54,

--- a/pkg/jobs/jobspb/jobs.pb.go
+++ b/pkg/jobs/jobspb/jobs.pb.go
@@ -56,7 +56,7 @@ func (x EncryptionMode) String() string {
 	return proto.EnumName(EncryptionMode_name, int32(x))
 }
 func (EncryptionMode) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_jobs_c17d603d73ac14a2, []int{0}
+	return fileDescriptor_jobs_400d82d31f2b1a36, []int{0}
 }
 
 type Status int32
@@ -85,7 +85,7 @@ func (x Status) String() string {
 	return proto.EnumName(Status_name, int32(x))
 }
 func (Status) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_jobs_c17d603d73ac14a2, []int{1}
+	return fileDescriptor_jobs_400d82d31f2b1a36, []int{1}
 }
 
 type Type int32
@@ -134,7 +134,7 @@ var Type_value = map[string]int32{
 }
 
 func (Type) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_jobs_c17d603d73ac14a2, []int{2}
+	return fileDescriptor_jobs_400d82d31f2b1a36, []int{2}
 }
 
 type EncryptionInfo_Scheme int32
@@ -154,7 +154,7 @@ func (x EncryptionInfo_Scheme) String() string {
 	return proto.EnumName(EncryptionInfo_Scheme_name, int32(x))
 }
 func (EncryptionInfo_Scheme) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_jobs_c17d603d73ac14a2, []int{2, 0}
+	return fileDescriptor_jobs_400d82d31f2b1a36, []int{2, 0}
 }
 
 type SchemaChangeGCProgress_Status int32
@@ -184,7 +184,7 @@ func (x SchemaChangeGCProgress_Status) String() string {
 	return proto.EnumName(SchemaChangeGCProgress_Status_name, int32(x))
 }
 func (SchemaChangeGCProgress_Status) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_jobs_c17d603d73ac14a2, []int{20, 0}
+	return fileDescriptor_jobs_400d82d31f2b1a36, []int{20, 0}
 }
 
 type Lease struct {
@@ -198,7 +198,7 @@ func (m *Lease) Reset()         { *m = Lease{} }
 func (m *Lease) String() string { return proto.CompactTextString(m) }
 func (*Lease) ProtoMessage()    {}
 func (*Lease) Descriptor() ([]byte, []int) {
-	return fileDescriptor_jobs_c17d603d73ac14a2, []int{0}
+	return fileDescriptor_jobs_400d82d31f2b1a36, []int{0}
 }
 func (m *Lease) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -239,7 +239,7 @@ func (m *BackupEncryptionOptions) Reset()         { *m = BackupEncryptionOptions
 func (m *BackupEncryptionOptions) String() string { return proto.CompactTextString(m) }
 func (*BackupEncryptionOptions) ProtoMessage()    {}
 func (*BackupEncryptionOptions) Descriptor() ([]byte, []int) {
-	return fileDescriptor_jobs_c17d603d73ac14a2, []int{1}
+	return fileDescriptor_jobs_400d82d31f2b1a36, []int{1}
 }
 func (m *BackupEncryptionOptions) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -273,7 +273,7 @@ func (m *BackupEncryptionOptions_KMSInfo) Reset()         { *m = BackupEncryptio
 func (m *BackupEncryptionOptions_KMSInfo) String() string { return proto.CompactTextString(m) }
 func (*BackupEncryptionOptions_KMSInfo) ProtoMessage()    {}
 func (*BackupEncryptionOptions_KMSInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_jobs_c17d603d73ac14a2, []int{1, 0}
+	return fileDescriptor_jobs_400d82d31f2b1a36, []int{1, 0}
 }
 func (m *BackupEncryptionOptions_KMSInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -313,7 +313,7 @@ func (m *EncryptionInfo) Reset()         { *m = EncryptionInfo{} }
 func (m *EncryptionInfo) String() string { return proto.CompactTextString(m) }
 func (*EncryptionInfo) ProtoMessage()    {}
 func (*EncryptionInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_jobs_c17d603d73ac14a2, []int{2}
+	return fileDescriptor_jobs_400d82d31f2b1a36, []int{2}
 }
 func (m *EncryptionInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -350,7 +350,7 @@ func (m *StreamIngestionDetails) Reset()         { *m = StreamIngestionDetails{}
 func (m *StreamIngestionDetails) String() string { return proto.CompactTextString(m) }
 func (*StreamIngestionDetails) ProtoMessage()    {}
 func (*StreamIngestionDetails) Descriptor() ([]byte, []int) {
-	return fileDescriptor_jobs_c17d603d73ac14a2, []int{3}
+	return fileDescriptor_jobs_400d82d31f2b1a36, []int{3}
 }
 func (m *StreamIngestionDetails) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -382,7 +382,7 @@ func (m *StreamIngestionProgress) Reset()         { *m = StreamIngestionProgress
 func (m *StreamIngestionProgress) String() string { return proto.CompactTextString(m) }
 func (*StreamIngestionProgress) ProtoMessage()    {}
 func (*StreamIngestionProgress) Descriptor() ([]byte, []int) {
-	return fileDescriptor_jobs_c17d603d73ac14a2, []int{4}
+	return fileDescriptor_jobs_400d82d31f2b1a36, []int{4}
 }
 func (m *StreamIngestionProgress) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -437,7 +437,7 @@ func (m *BackupDetails) Reset()         { *m = BackupDetails{} }
 func (m *BackupDetails) String() string { return proto.CompactTextString(m) }
 func (*BackupDetails) ProtoMessage()    {}
 func (*BackupDetails) Descriptor() ([]byte, []int) {
-	return fileDescriptor_jobs_c17d603d73ac14a2, []int{5}
+	return fileDescriptor_jobs_400d82d31f2b1a36, []int{5}
 }
 func (m *BackupDetails) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -469,7 +469,7 @@ func (m *BackupProgress) Reset()         { *m = BackupProgress{} }
 func (m *BackupProgress) String() string { return proto.CompactTextString(m) }
 func (*BackupProgress) ProtoMessage()    {}
 func (*BackupProgress) Descriptor() ([]byte, []int) {
-	return fileDescriptor_jobs_c17d603d73ac14a2, []int{6}
+	return fileDescriptor_jobs_400d82d31f2b1a36, []int{6}
 }
 func (m *BackupProgress) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -531,7 +531,7 @@ func (m *RestoreDetails) Reset()         { *m = RestoreDetails{} }
 func (m *RestoreDetails) String() string { return proto.CompactTextString(m) }
 func (*RestoreDetails) ProtoMessage()    {}
 func (*RestoreDetails) Descriptor() ([]byte, []int) {
-	return fileDescriptor_jobs_c17d603d73ac14a2, []int{7}
+	return fileDescriptor_jobs_400d82d31f2b1a36, []int{7}
 }
 func (m *RestoreDetails) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -568,7 +568,7 @@ func (m *RestoreDetails_DescriptorRewrite) Reset()         { *m = RestoreDetails
 func (m *RestoreDetails_DescriptorRewrite) String() string { return proto.CompactTextString(m) }
 func (*RestoreDetails_DescriptorRewrite) ProtoMessage()    {}
 func (*RestoreDetails_DescriptorRewrite) Descriptor() ([]byte, []int) {
-	return fileDescriptor_jobs_c17d603d73ac14a2, []int{7, 0}
+	return fileDescriptor_jobs_400d82d31f2b1a36, []int{7, 0}
 }
 func (m *RestoreDetails_DescriptorRewrite) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -601,7 +601,7 @@ func (m *RestoreDetails_BackupLocalityInfo) Reset()         { *m = RestoreDetail
 func (m *RestoreDetails_BackupLocalityInfo) String() string { return proto.CompactTextString(m) }
 func (*RestoreDetails_BackupLocalityInfo) ProtoMessage()    {}
 func (*RestoreDetails_BackupLocalityInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_jobs_c17d603d73ac14a2, []int{7, 1}
+	return fileDescriptor_jobs_400d82d31f2b1a36, []int{7, 1}
 }
 func (m *RestoreDetails_BackupLocalityInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -634,7 +634,7 @@ func (m *RestoreProgress) Reset()         { *m = RestoreProgress{} }
 func (m *RestoreProgress) String() string { return proto.CompactTextString(m) }
 func (*RestoreProgress) ProtoMessage()    {}
 func (*RestoreProgress) Descriptor() ([]byte, []int) {
-	return fileDescriptor_jobs_c17d603d73ac14a2, []int{8}
+	return fileDescriptor_jobs_400d82d31f2b1a36, []int{8}
 }
 func (m *RestoreProgress) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -695,7 +695,7 @@ func (m *ImportDetails) Reset()         { *m = ImportDetails{} }
 func (m *ImportDetails) String() string { return proto.CompactTextString(m) }
 func (*ImportDetails) ProtoMessage()    {}
 func (*ImportDetails) Descriptor() ([]byte, []int) {
-	return fileDescriptor_jobs_c17d603d73ac14a2, []int{9}
+	return fileDescriptor_jobs_400d82d31f2b1a36, []int{9}
 }
 func (m *ImportDetails) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -733,7 +733,7 @@ func (m *ImportDetails_Table) Reset()         { *m = ImportDetails_Table{} }
 func (m *ImportDetails_Table) String() string { return proto.CompactTextString(m) }
 func (*ImportDetails_Table) ProtoMessage()    {}
 func (*ImportDetails_Table) Descriptor() ([]byte, []int) {
-	return fileDescriptor_jobs_c17d603d73ac14a2, []int{9, 0}
+	return fileDescriptor_jobs_400d82d31f2b1a36, []int{9, 0}
 }
 func (m *ImportDetails_Table) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -775,7 +775,7 @@ func (m *SequenceValChunk) Reset()         { *m = SequenceValChunk{} }
 func (m *SequenceValChunk) String() string { return proto.CompactTextString(m) }
 func (*SequenceValChunk) ProtoMessage()    {}
 func (*SequenceValChunk) Descriptor() ([]byte, []int) {
-	return fileDescriptor_jobs_c17d603d73ac14a2, []int{10}
+	return fileDescriptor_jobs_400d82d31f2b1a36, []int{10}
 }
 func (m *SequenceValChunk) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -811,7 +811,7 @@ func (m *SequenceDetails) Reset()         { *m = SequenceDetails{} }
 func (m *SequenceDetails) String() string { return proto.CompactTextString(m) }
 func (*SequenceDetails) ProtoMessage()    {}
 func (*SequenceDetails) Descriptor() ([]byte, []int) {
-	return fileDescriptor_jobs_c17d603d73ac14a2, []int{11}
+	return fileDescriptor_jobs_400d82d31f2b1a36, []int{11}
 }
 func (m *SequenceDetails) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -846,7 +846,7 @@ func (m *SequenceDetails_SequenceChunks) Reset()         { *m = SequenceDetails_
 func (m *SequenceDetails_SequenceChunks) String() string { return proto.CompactTextString(m) }
 func (*SequenceDetails_SequenceChunks) ProtoMessage()    {}
 func (*SequenceDetails_SequenceChunks) Descriptor() ([]byte, []int) {
-	return fileDescriptor_jobs_c17d603d73ac14a2, []int{11, 0}
+	return fileDescriptor_jobs_400d82d31f2b1a36, []int{11, 0}
 }
 func (m *SequenceDetails_SequenceChunks) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -892,7 +892,7 @@ func (m *ImportProgress) Reset()         { *m = ImportProgress{} }
 func (m *ImportProgress) String() string { return proto.CompactTextString(m) }
 func (*ImportProgress) ProtoMessage()    {}
 func (*ImportProgress) Descriptor() ([]byte, []int) {
-	return fileDescriptor_jobs_c17d603d73ac14a2, []int{12}
+	return fileDescriptor_jobs_400d82d31f2b1a36, []int{12}
 }
 func (m *ImportProgress) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -926,7 +926,7 @@ func (m *TypeSchemaChangeDetails) Reset()         { *m = TypeSchemaChangeDetails
 func (m *TypeSchemaChangeDetails) String() string { return proto.CompactTextString(m) }
 func (*TypeSchemaChangeDetails) ProtoMessage()    {}
 func (*TypeSchemaChangeDetails) Descriptor() ([]byte, []int) {
-	return fileDescriptor_jobs_c17d603d73ac14a2, []int{13}
+	return fileDescriptor_jobs_400d82d31f2b1a36, []int{13}
 }
 func (m *TypeSchemaChangeDetails) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -959,7 +959,7 @@ func (m *TypeSchemaChangeProgress) Reset()         { *m = TypeSchemaChangeProgre
 func (m *TypeSchemaChangeProgress) String() string { return proto.CompactTextString(m) }
 func (*TypeSchemaChangeProgress) ProtoMessage()    {}
 func (*TypeSchemaChangeProgress) Descriptor() ([]byte, []int) {
-	return fileDescriptor_jobs_c17d603d73ac14a2, []int{14}
+	return fileDescriptor_jobs_400d82d31f2b1a36, []int{14}
 }
 func (m *TypeSchemaChangeProgress) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -992,7 +992,7 @@ func (m *ResumeSpanList) Reset()         { *m = ResumeSpanList{} }
 func (m *ResumeSpanList) String() string { return proto.CompactTextString(m) }
 func (*ResumeSpanList) ProtoMessage()    {}
 func (*ResumeSpanList) Descriptor() ([]byte, []int) {
-	return fileDescriptor_jobs_c17d603d73ac14a2, []int{15}
+	return fileDescriptor_jobs_400d82d31f2b1a36, []int{15}
 }
 func (m *ResumeSpanList) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1027,7 +1027,7 @@ func (m *DroppedTableDetails) Reset()         { *m = DroppedTableDetails{} }
 func (m *DroppedTableDetails) String() string { return proto.CompactTextString(m) }
 func (*DroppedTableDetails) ProtoMessage()    {}
 func (*DroppedTableDetails) Descriptor() ([]byte, []int) {
-	return fileDescriptor_jobs_c17d603d73ac14a2, []int{16}
+	return fileDescriptor_jobs_400d82d31f2b1a36, []int{16}
 }
 func (m *DroppedTableDetails) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1085,7 +1085,7 @@ func (m *SchemaChangeGCDetails) Reset()         { *m = SchemaChangeGCDetails{} }
 func (m *SchemaChangeGCDetails) String() string { return proto.CompactTextString(m) }
 func (*SchemaChangeGCDetails) ProtoMessage()    {}
 func (*SchemaChangeGCDetails) Descriptor() ([]byte, []int) {
-	return fileDescriptor_jobs_c17d603d73ac14a2, []int{17}
+	return fileDescriptor_jobs_400d82d31f2b1a36, []int{17}
 }
 func (m *SchemaChangeGCDetails) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1119,7 +1119,7 @@ func (m *SchemaChangeGCDetails_DroppedIndex) Reset()         { *m = SchemaChange
 func (m *SchemaChangeGCDetails_DroppedIndex) String() string { return proto.CompactTextString(m) }
 func (*SchemaChangeGCDetails_DroppedIndex) ProtoMessage()    {}
 func (*SchemaChangeGCDetails_DroppedIndex) Descriptor() ([]byte, []int) {
-	return fileDescriptor_jobs_c17d603d73ac14a2, []int{17, 0}
+	return fileDescriptor_jobs_400d82d31f2b1a36, []int{17, 0}
 }
 func (m *SchemaChangeGCDetails_DroppedIndex) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1153,7 +1153,7 @@ func (m *SchemaChangeGCDetails_DroppedID) Reset()         { *m = SchemaChangeGCD
 func (m *SchemaChangeGCDetails_DroppedID) String() string { return proto.CompactTextString(m) }
 func (*SchemaChangeGCDetails_DroppedID) ProtoMessage()    {}
 func (*SchemaChangeGCDetails_DroppedID) Descriptor() ([]byte, []int) {
-	return fileDescriptor_jobs_c17d603d73ac14a2, []int{17, 1}
+	return fileDescriptor_jobs_400d82d31f2b1a36, []int{17, 1}
 }
 func (m *SchemaChangeGCDetails_DroppedID) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1217,7 +1217,7 @@ func (m *SchemaChangeDetails) Reset()         { *m = SchemaChangeDetails{} }
 func (m *SchemaChangeDetails) String() string { return proto.CompactTextString(m) }
 func (*SchemaChangeDetails) ProtoMessage()    {}
 func (*SchemaChangeDetails) Descriptor() ([]byte, []int) {
-	return fileDescriptor_jobs_c17d603d73ac14a2, []int{18}
+	return fileDescriptor_jobs_400d82d31f2b1a36, []int{18}
 }
 func (m *SchemaChangeDetails) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1249,7 +1249,7 @@ func (m *SchemaChangeProgress) Reset()         { *m = SchemaChangeProgress{} }
 func (m *SchemaChangeProgress) String() string { return proto.CompactTextString(m) }
 func (*SchemaChangeProgress) ProtoMessage()    {}
 func (*SchemaChangeProgress) Descriptor() ([]byte, []int) {
-	return fileDescriptor_jobs_c17d603d73ac14a2, []int{19}
+	return fileDescriptor_jobs_400d82d31f2b1a36, []int{19}
 }
 func (m *SchemaChangeProgress) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1285,7 +1285,7 @@ func (m *SchemaChangeGCProgress) Reset()         { *m = SchemaChangeGCProgress{}
 func (m *SchemaChangeGCProgress) String() string { return proto.CompactTextString(m) }
 func (*SchemaChangeGCProgress) ProtoMessage()    {}
 func (*SchemaChangeGCProgress) Descriptor() ([]byte, []int) {
-	return fileDescriptor_jobs_c17d603d73ac14a2, []int{20}
+	return fileDescriptor_jobs_400d82d31f2b1a36, []int{20}
 }
 func (m *SchemaChangeGCProgress) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1319,7 +1319,7 @@ func (m *SchemaChangeGCProgress_IndexProgress) Reset()         { *m = SchemaChan
 func (m *SchemaChangeGCProgress_IndexProgress) String() string { return proto.CompactTextString(m) }
 func (*SchemaChangeGCProgress_IndexProgress) ProtoMessage()    {}
 func (*SchemaChangeGCProgress_IndexProgress) Descriptor() ([]byte, []int) {
-	return fileDescriptor_jobs_c17d603d73ac14a2, []int{20, 0}
+	return fileDescriptor_jobs_400d82d31f2b1a36, []int{20, 0}
 }
 func (m *SchemaChangeGCProgress_IndexProgress) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1353,7 +1353,7 @@ func (m *SchemaChangeGCProgress_TableProgress) Reset()         { *m = SchemaChan
 func (m *SchemaChangeGCProgress_TableProgress) String() string { return proto.CompactTextString(m) }
 func (*SchemaChangeGCProgress_TableProgress) ProtoMessage()    {}
 func (*SchemaChangeGCProgress_TableProgress) Descriptor() ([]byte, []int) {
-	return fileDescriptor_jobs_c17d603d73ac14a2, []int{20, 1}
+	return fileDescriptor_jobs_400d82d31f2b1a36, []int{20, 1}
 }
 func (m *SchemaChangeGCProgress_TableProgress) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1386,7 +1386,7 @@ func (m *ChangefeedTarget) Reset()         { *m = ChangefeedTarget{} }
 func (m *ChangefeedTarget) String() string { return proto.CompactTextString(m) }
 func (*ChangefeedTarget) ProtoMessage()    {}
 func (*ChangefeedTarget) Descriptor() ([]byte, []int) {
-	return fileDescriptor_jobs_c17d603d73ac14a2, []int{21}
+	return fileDescriptor_jobs_400d82d31f2b1a36, []int{21}
 }
 func (m *ChangefeedTarget) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1439,7 +1439,7 @@ func (m *ChangefeedDetails) Reset()         { *m = ChangefeedDetails{} }
 func (m *ChangefeedDetails) String() string { return proto.CompactTextString(m) }
 func (*ChangefeedDetails) ProtoMessage()    {}
 func (*ChangefeedDetails) Descriptor() ([]byte, []int) {
-	return fileDescriptor_jobs_c17d603d73ac14a2, []int{22}
+	return fileDescriptor_jobs_400d82d31f2b1a36, []int{22}
 }
 func (m *ChangefeedDetails) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1474,7 +1474,7 @@ func (m *ResolvedSpan) Reset()         { *m = ResolvedSpan{} }
 func (m *ResolvedSpan) String() string { return proto.CompactTextString(m) }
 func (*ResolvedSpan) ProtoMessage()    {}
 func (*ResolvedSpan) Descriptor() ([]byte, []int) {
-	return fileDescriptor_jobs_c17d603d73ac14a2, []int{23}
+	return fileDescriptor_jobs_400d82d31f2b1a36, []int{23}
 }
 func (m *ResolvedSpan) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1517,7 +1517,7 @@ func (m *ChangefeedProgress) Reset()         { *m = ChangefeedProgress{} }
 func (m *ChangefeedProgress) String() string { return proto.CompactTextString(m) }
 func (*ChangefeedProgress) ProtoMessage()    {}
 func (*ChangefeedProgress) Descriptor() ([]byte, []int) {
-	return fileDescriptor_jobs_c17d603d73ac14a2, []int{24}
+	return fileDescriptor_jobs_400d82d31f2b1a36, []int{24}
 }
 func (m *ChangefeedProgress) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1561,7 +1561,7 @@ func (m *CreateStatsDetails) Reset()         { *m = CreateStatsDetails{} }
 func (m *CreateStatsDetails) String() string { return proto.CompactTextString(m) }
 func (*CreateStatsDetails) ProtoMessage()    {}
 func (*CreateStatsDetails) Descriptor() ([]byte, []int) {
-	return fileDescriptor_jobs_c17d603d73ac14a2, []int{25}
+	return fileDescriptor_jobs_400d82d31f2b1a36, []int{25}
 }
 func (m *CreateStatsDetails) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1602,7 +1602,7 @@ func (m *CreateStatsDetails_ColStat) Reset()         { *m = CreateStatsDetails_C
 func (m *CreateStatsDetails_ColStat) String() string { return proto.CompactTextString(m) }
 func (*CreateStatsDetails_ColStat) ProtoMessage()    {}
 func (*CreateStatsDetails_ColStat) Descriptor() ([]byte, []int) {
-	return fileDescriptor_jobs_c17d603d73ac14a2, []int{25, 0}
+	return fileDescriptor_jobs_400d82d31f2b1a36, []int{25, 0}
 }
 func (m *CreateStatsDetails_ColStat) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1634,7 +1634,7 @@ func (m *CreateStatsProgress) Reset()         { *m = CreateStatsProgress{} }
 func (m *CreateStatsProgress) String() string { return proto.CompactTextString(m) }
 func (*CreateStatsProgress) ProtoMessage()    {}
 func (*CreateStatsProgress) Descriptor() ([]byte, []int) {
-	return fileDescriptor_jobs_c17d603d73ac14a2, []int{26}
+	return fileDescriptor_jobs_400d82d31f2b1a36, []int{26}
 }
 func (m *CreateStatsProgress) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1702,7 +1702,7 @@ func (m *Payload) Reset()         { *m = Payload{} }
 func (m *Payload) String() string { return proto.CompactTextString(m) }
 func (*Payload) ProtoMessage()    {}
 func (*Payload) Descriptor() ([]byte, []int) {
-	return fileDescriptor_jobs_c17d603d73ac14a2, []int{27}
+	return fileDescriptor_jobs_400d82d31f2b1a36, []int{27}
 }
 func (m *Payload) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2072,7 +2072,7 @@ func (m *Progress) Reset()         { *m = Progress{} }
 func (m *Progress) String() string { return proto.CompactTextString(m) }
 func (*Progress) ProtoMessage()    {}
 func (*Progress) Descriptor() ([]byte, []int) {
-	return fileDescriptor_jobs_c17d603d73ac14a2, []int{28}
+	return fileDescriptor_jobs_400d82d31f2b1a36, []int{28}
 }
 func (m *Progress) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2508,7 +2508,7 @@ func (m *Job) Reset()         { *m = Job{} }
 func (m *Job) String() string { return proto.CompactTextString(m) }
 func (*Job) ProtoMessage()    {}
 func (*Job) Descriptor() ([]byte, []int) {
-	return fileDescriptor_jobs_c17d603d73ac14a2, []int{29}
+	return fileDescriptor_jobs_400d82d31f2b1a36, []int{29}
 }
 func (m *Job) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -13596,9 +13596,9 @@ var (
 	ErrIntOverflowJobs   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("jobs/jobspb/jobs.proto", fileDescriptor_jobs_c17d603d73ac14a2) }
+func init() { proto.RegisterFile("jobs/jobspb/jobs.proto", fileDescriptor_jobs_400d82d31f2b1a36) }
 
-var fileDescriptor_jobs_c17d603d73ac14a2 = []byte{
+var fileDescriptor_jobs_400d82d31f2b1a36 = []byte{
 	// 4517 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xc4, 0x5b, 0x4b, 0x6c, 0x1b, 0x49,
 	0x7a, 0x16, 0x1f, 0x22, 0x9b, 0x3f, 0x45, 0xb2, 0x59, 0x92, 0x6d, 0x2e, 0x33, 0x23, 0x2a, 0x9c,

--- a/pkg/jobs/jobspb/schedule.pb.go
+++ b/pkg/jobs/jobspb/schedule.pb.go
@@ -51,7 +51,7 @@ func (x ScheduleDetails_WaitBehavior) String() string {
 	return proto.EnumName(ScheduleDetails_WaitBehavior_name, int32(x))
 }
 func (ScheduleDetails_WaitBehavior) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_schedule_f9148e808af91a6b, []int{0, 0}
+	return fileDescriptor_schedule_2c4135f09ebfe46a, []int{0, 0}
 }
 
 // ErrorHandlingBehavior describes how to handle failed job runs.
@@ -81,7 +81,7 @@ func (x ScheduleDetails_ErrorHandlingBehavior) String() string {
 	return proto.EnumName(ScheduleDetails_ErrorHandlingBehavior_name, int32(x))
 }
 func (ScheduleDetails_ErrorHandlingBehavior) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_schedule_f9148e808af91a6b, []int{0, 1}
+	return fileDescriptor_schedule_2c4135f09ebfe46a, []int{0, 1}
 }
 
 // ScheduleDetails describes how to schedule and execute the job.
@@ -96,7 +96,7 @@ func (m *ScheduleDetails) Reset()         { *m = ScheduleDetails{} }
 func (m *ScheduleDetails) String() string { return proto.CompactTextString(m) }
 func (*ScheduleDetails) ProtoMessage()    {}
 func (*ScheduleDetails) Descriptor() ([]byte, []int) {
-	return fileDescriptor_schedule_f9148e808af91a6b, []int{0}
+	return fileDescriptor_schedule_2c4135f09ebfe46a, []int{0}
 }
 func (m *ScheduleDetails) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -130,7 +130,7 @@ func (m *ExecutionArguments) Reset()         { *m = ExecutionArguments{} }
 func (m *ExecutionArguments) String() string { return proto.CompactTextString(m) }
 func (*ExecutionArguments) ProtoMessage()    {}
 func (*ExecutionArguments) Descriptor() ([]byte, []int) {
-	return fileDescriptor_schedule_f9148e808af91a6b, []int{1}
+	return fileDescriptor_schedule_2c4135f09ebfe46a, []int{1}
 }
 func (m *ExecutionArguments) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -164,7 +164,7 @@ func (m *SqlStatementExecutionArg) Reset()         { *m = SqlStatementExecutionA
 func (m *SqlStatementExecutionArg) String() string { return proto.CompactTextString(m) }
 func (*SqlStatementExecutionArg) ProtoMessage()    {}
 func (*SqlStatementExecutionArg) Descriptor() ([]byte, []int) {
-	return fileDescriptor_schedule_f9148e808af91a6b, []int{2}
+	return fileDescriptor_schedule_2c4135f09ebfe46a, []int{2}
 }
 func (m *SqlStatementExecutionArg) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -199,7 +199,7 @@ func (m *ScheduleState) Reset()         { *m = ScheduleState{} }
 func (m *ScheduleState) String() string { return proto.CompactTextString(m) }
 func (*ScheduleState) ProtoMessage()    {}
 func (*ScheduleState) Descriptor() ([]byte, []int) {
-	return fileDescriptor_schedule_f9148e808af91a6b, []int{3}
+	return fileDescriptor_schedule_2c4135f09ebfe46a, []int{3}
 }
 func (m *ScheduleState) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -847,10 +847,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("jobs/jobspb/schedule.proto", fileDescriptor_schedule_f9148e808af91a6b)
+	proto.RegisterFile("jobs/jobspb/schedule.proto", fileDescriptor_schedule_2c4135f09ebfe46a)
 }
 
-var fileDescriptor_schedule_f9148e808af91a6b = []byte{
+var fileDescriptor_schedule_2c4135f09ebfe46a = []byte{
 	// 404 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x90, 0x41, 0x6f, 0xd3, 0x30,
 	0x14, 0xc7, 0xe3, 0xa8, 0xea, 0xb6, 0x57, 0xd8, 0x22, 0x6b, 0x43, 0xa5, 0x42, 0x16, 0xca, 0x85,

--- a/pkg/kv/kvnemesis/operations.pb.go
+++ b/pkg/kv/kvnemesis/operations.pb.go
@@ -43,7 +43,7 @@ func (x ClosureTxnType) String() string {
 	return proto.EnumName(ClosureTxnType_name, int32(x))
 }
 func (ClosureTxnType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_operations_c04d3dad6d2c0ccd, []int{0}
+	return fileDescriptor_operations_928d467cbd1fe68c, []int{0}
 }
 
 type ResultType int32
@@ -75,7 +75,7 @@ func (x ResultType) String() string {
 	return proto.EnumName(ResultType_name, int32(x))
 }
 func (ResultType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_operations_c04d3dad6d2c0ccd, []int{1}
+	return fileDescriptor_operations_928d467cbd1fe68c, []int{1}
 }
 
 type BatchOperation struct {
@@ -87,7 +87,7 @@ func (m *BatchOperation) Reset()         { *m = BatchOperation{} }
 func (m *BatchOperation) String() string { return proto.CompactTextString(m) }
 func (*BatchOperation) ProtoMessage()    {}
 func (*BatchOperation) Descriptor() ([]byte, []int) {
-	return fileDescriptor_operations_c04d3dad6d2c0ccd, []int{0}
+	return fileDescriptor_operations_928d467cbd1fe68c, []int{0}
 }
 func (m *BatchOperation) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -125,7 +125,7 @@ func (m *ClosureTxnOperation) Reset()         { *m = ClosureTxnOperation{} }
 func (m *ClosureTxnOperation) String() string { return proto.CompactTextString(m) }
 func (*ClosureTxnOperation) ProtoMessage()    {}
 func (*ClosureTxnOperation) Descriptor() ([]byte, []int) {
-	return fileDescriptor_operations_c04d3dad6d2c0ccd, []int{1}
+	return fileDescriptor_operations_928d467cbd1fe68c, []int{1}
 }
 func (m *ClosureTxnOperation) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -159,7 +159,7 @@ func (m *GetOperation) Reset()         { *m = GetOperation{} }
 func (m *GetOperation) String() string { return proto.CompactTextString(m) }
 func (*GetOperation) ProtoMessage()    {}
 func (*GetOperation) Descriptor() ([]byte, []int) {
-	return fileDescriptor_operations_c04d3dad6d2c0ccd, []int{2}
+	return fileDescriptor_operations_928d467cbd1fe68c, []int{2}
 }
 func (m *GetOperation) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -195,7 +195,7 @@ func (m *ScanOperation) Reset()         { *m = ScanOperation{} }
 func (m *ScanOperation) String() string { return proto.CompactTextString(m) }
 func (*ScanOperation) ProtoMessage()    {}
 func (*ScanOperation) Descriptor() ([]byte, []int) {
-	return fileDescriptor_operations_c04d3dad6d2c0ccd, []int{3}
+	return fileDescriptor_operations_928d467cbd1fe68c, []int{3}
 }
 func (m *ScanOperation) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -230,7 +230,7 @@ func (m *PutOperation) Reset()         { *m = PutOperation{} }
 func (m *PutOperation) String() string { return proto.CompactTextString(m) }
 func (*PutOperation) ProtoMessage()    {}
 func (*PutOperation) Descriptor() ([]byte, []int) {
-	return fileDescriptor_operations_c04d3dad6d2c0ccd, []int{4}
+	return fileDescriptor_operations_928d467cbd1fe68c, []int{4}
 }
 func (m *PutOperation) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -264,7 +264,7 @@ func (m *SplitOperation) Reset()         { *m = SplitOperation{} }
 func (m *SplitOperation) String() string { return proto.CompactTextString(m) }
 func (*SplitOperation) ProtoMessage()    {}
 func (*SplitOperation) Descriptor() ([]byte, []int) {
-	return fileDescriptor_operations_c04d3dad6d2c0ccd, []int{5}
+	return fileDescriptor_operations_928d467cbd1fe68c, []int{5}
 }
 func (m *SplitOperation) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -298,7 +298,7 @@ func (m *MergeOperation) Reset()         { *m = MergeOperation{} }
 func (m *MergeOperation) String() string { return proto.CompactTextString(m) }
 func (*MergeOperation) ProtoMessage()    {}
 func (*MergeOperation) Descriptor() ([]byte, []int) {
-	return fileDescriptor_operations_c04d3dad6d2c0ccd, []int{6}
+	return fileDescriptor_operations_928d467cbd1fe68c, []int{6}
 }
 func (m *MergeOperation) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -333,7 +333,7 @@ func (m *ChangeReplicasOperation) Reset()         { *m = ChangeReplicasOperation
 func (m *ChangeReplicasOperation) String() string { return proto.CompactTextString(m) }
 func (*ChangeReplicasOperation) ProtoMessage()    {}
 func (*ChangeReplicasOperation) Descriptor() ([]byte, []int) {
-	return fileDescriptor_operations_c04d3dad6d2c0ccd, []int{7}
+	return fileDescriptor_operations_928d467cbd1fe68c, []int{7}
 }
 func (m *ChangeReplicasOperation) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -376,7 +376,7 @@ type Operation struct {
 func (m *Operation) Reset()      { *m = Operation{} }
 func (*Operation) ProtoMessage() {}
 func (*Operation) Descriptor() ([]byte, []int) {
-	return fileDescriptor_operations_c04d3dad6d2c0ccd, []int{8}
+	return fileDescriptor_operations_928d467cbd1fe68c, []int{8}
 }
 func (m *Operation) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -411,7 +411,7 @@ func (m *KeyValue) Reset()         { *m = KeyValue{} }
 func (m *KeyValue) String() string { return proto.CompactTextString(m) }
 func (*KeyValue) ProtoMessage()    {}
 func (*KeyValue) Descriptor() ([]byte, []int) {
-	return fileDescriptor_operations_c04d3dad6d2c0ccd, []int{9}
+	return fileDescriptor_operations_928d467cbd1fe68c, []int{9}
 }
 func (m *KeyValue) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -450,7 +450,7 @@ func (m *Result) Reset()         { *m = Result{} }
 func (m *Result) String() string { return proto.CompactTextString(m) }
 func (*Result) ProtoMessage()    {}
 func (*Result) Descriptor() ([]byte, []int) {
-	return fileDescriptor_operations_c04d3dad6d2c0ccd, []int{10}
+	return fileDescriptor_operations_928d467cbd1fe68c, []int{10}
 }
 func (m *Result) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -488,7 +488,7 @@ type Step struct {
 func (m *Step) Reset()      { *m = Step{} }
 func (*Step) ProtoMessage() {}
 func (*Step) Descriptor() ([]byte, []int) {
-	return fileDescriptor_operations_c04d3dad6d2c0ccd, []int{11}
+	return fileDescriptor_operations_928d467cbd1fe68c, []int{11}
 }
 func (m *Step) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3428,10 +3428,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("kv/kvnemesis/operations.proto", fileDescriptor_operations_c04d3dad6d2c0ccd)
+	proto.RegisterFile("kv/kvnemesis/operations.proto", fileDescriptor_operations_928d467cbd1fe68c)
 }
 
-var fileDescriptor_operations_c04d3dad6d2c0ccd = []byte{
+var fileDescriptor_operations_928d467cbd1fe68c = []byte{
 	// 957 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xb4, 0x56, 0x41, 0x6f, 0x1b, 0xc5,
 	0x17, 0xf7, 0x78, 0xd7, 0x8e, 0xfd, 0xec, 0xba, 0xfe, 0xcf, 0xbf, 0xd0, 0x55, 0xa5, 0xd8, 0xc6,

--- a/pkg/kv/kvserver/api.pb.go
+++ b/pkg/kv/kvserver/api.pb.go
@@ -35,7 +35,7 @@ func (m *StoreRequestHeader) Reset()         { *m = StoreRequestHeader{} }
 func (m *StoreRequestHeader) String() string { return proto.CompactTextString(m) }
 func (*StoreRequestHeader) ProtoMessage()    {}
 func (*StoreRequestHeader) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_4b6691848ee10d89, []int{0}
+	return fileDescriptor_api_327ea446f2b95cd5, []int{0}
 }
 func (m *StoreRequestHeader) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -74,7 +74,7 @@ func (m *CollectChecksumRequest) Reset()         { *m = CollectChecksumRequest{}
 func (m *CollectChecksumRequest) String() string { return proto.CompactTextString(m) }
 func (*CollectChecksumRequest) ProtoMessage()    {}
 func (*CollectChecksumRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_4b6691848ee10d89, []int{1}
+	return fileDescriptor_api_327ea446f2b95cd5, []int{1}
 }
 func (m *CollectChecksumRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -119,7 +119,7 @@ func (m *CollectChecksumResponse) Reset()         { *m = CollectChecksumResponse
 func (m *CollectChecksumResponse) String() string { return proto.CompactTextString(m) }
 func (*CollectChecksumResponse) ProtoMessage()    {}
 func (*CollectChecksumResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_4b6691848ee10d89, []int{2}
+	return fileDescriptor_api_327ea446f2b95cd5, []int{2}
 }
 func (m *CollectChecksumResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -156,7 +156,7 @@ func (m *WaitForApplicationRequest) Reset()         { *m = WaitForApplicationReq
 func (m *WaitForApplicationRequest) String() string { return proto.CompactTextString(m) }
 func (*WaitForApplicationRequest) ProtoMessage()    {}
 func (*WaitForApplicationRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_4b6691848ee10d89, []int{3}
+	return fileDescriptor_api_327ea446f2b95cd5, []int{3}
 }
 func (m *WaitForApplicationRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -188,7 +188,7 @@ func (m *WaitForApplicationResponse) Reset()         { *m = WaitForApplicationRe
 func (m *WaitForApplicationResponse) String() string { return proto.CompactTextString(m) }
 func (*WaitForApplicationResponse) ProtoMessage()    {}
 func (*WaitForApplicationResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_4b6691848ee10d89, []int{4}
+	return fileDescriptor_api_327ea446f2b95cd5, []int{4}
 }
 func (m *WaitForApplicationResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -222,7 +222,7 @@ func (m *WaitForReplicaInitRequest) Reset()         { *m = WaitForReplicaInitReq
 func (m *WaitForReplicaInitRequest) String() string { return proto.CompactTextString(m) }
 func (*WaitForReplicaInitRequest) ProtoMessage()    {}
 func (*WaitForReplicaInitRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_4b6691848ee10d89, []int{5}
+	return fileDescriptor_api_327ea446f2b95cd5, []int{5}
 }
 func (m *WaitForReplicaInitRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -254,7 +254,7 @@ func (m *WaitForReplicaInitResponse) Reset()         { *m = WaitForReplicaInitRe
 func (m *WaitForReplicaInitResponse) String() string { return proto.CompactTextString(m) }
 func (*WaitForReplicaInitResponse) ProtoMessage()    {}
 func (*WaitForReplicaInitResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_4b6691848ee10d89, []int{6}
+	return fileDescriptor_api_327ea446f2b95cd5, []int{6}
 }
 func (m *WaitForReplicaInitResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -290,7 +290,7 @@ func (m *CompactEngineSpanRequest) Reset()         { *m = CompactEngineSpanReque
 func (m *CompactEngineSpanRequest) String() string { return proto.CompactTextString(m) }
 func (*CompactEngineSpanRequest) ProtoMessage()    {}
 func (*CompactEngineSpanRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_4b6691848ee10d89, []int{7}
+	return fileDescriptor_api_327ea446f2b95cd5, []int{7}
 }
 func (m *CompactEngineSpanRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -322,7 +322,7 @@ func (m *CompactEngineSpanResponse) Reset()         { *m = CompactEngineSpanResp
 func (m *CompactEngineSpanResponse) String() string { return proto.CompactTextString(m) }
 func (*CompactEngineSpanResponse) ProtoMessage()    {}
 func (*CompactEngineSpanResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_4b6691848ee10d89, []int{8}
+	return fileDescriptor_api_327ea446f2b95cd5, []int{8}
 }
 func (m *CompactEngineSpanResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1789,9 +1789,9 @@ var (
 	ErrIntOverflowApi   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("kv/kvserver/api.proto", fileDescriptor_api_4b6691848ee10d89) }
+func init() { proto.RegisterFile("kv/kvserver/api.proto", fileDescriptor_api_327ea446f2b95cd5) }
 
-var fileDescriptor_api_4b6691848ee10d89 = []byte{
+var fileDescriptor_api_327ea446f2b95cd5 = []byte{
 	// 649 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xd4, 0x55, 0x31, 0x6f, 0xd3, 0x40,
 	0x14, 0x8e, 0xdb, 0x34, 0x09, 0x17, 0x26, 0x8b, 0xd2, 0x36, 0xad, 0xec, 0xca, 0x08, 0xa9, 0x74,

--- a/pkg/kv/kvserver/closedts/ctpb/entry.pb.go
+++ b/pkg/kv/kvserver/closedts/ctpb/entry.pb.go
@@ -55,7 +55,7 @@ type Entry struct {
 func (m *Entry) Reset()      { *m = Entry{} }
 func (*Entry) ProtoMessage() {}
 func (*Entry) Descriptor() ([]byte, []int) {
-	return fileDescriptor_entry_cedfda89c463dabb, []int{0}
+	return fileDescriptor_entry_d2113849c095b590, []int{0}
 }
 func (m *Entry) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -92,7 +92,7 @@ type Reaction struct {
 func (m *Reaction) Reset()      { *m = Reaction{} }
 func (*Reaction) ProtoMessage() {}
 func (*Reaction) Descriptor() ([]byte, []int) {
-	return fileDescriptor_entry_cedfda89c463dabb, []int{1}
+	return fileDescriptor_entry_d2113849c095b590, []int{1}
 }
 func (m *Reaction) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -726,10 +726,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("kv/kvserver/closedts/ctpb/entry.proto", fileDescriptor_entry_cedfda89c463dabb)
+	proto.RegisterFile("kv/kvserver/closedts/ctpb/entry.proto", fileDescriptor_entry_d2113849c095b590)
 }
 
-var fileDescriptor_entry_cedfda89c463dabb = []byte{
+var fileDescriptor_entry_d2113849c095b590 = []byte{
 	// 442 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x9c, 0x92, 0x3f, 0x6f, 0xd4, 0x30,
 	0x18, 0xc6, 0xe3, 0x4b, 0x82, 0x7a, 0xee, 0x40, 0x15, 0x75, 0x88, 0x4e, 0xe0, 0x44, 0x95, 0x40,

--- a/pkg/kv/kvserver/closedts/ctpb/service.pb.go
+++ b/pkg/kv/kvserver/closedts/ctpb/service.pb.go
@@ -128,10 +128,10 @@ var _ClosedTimestamp_serviceDesc = grpc.ServiceDesc{
 }
 
 func init() {
-	proto.RegisterFile("kv/kvserver/closedts/ctpb/service.proto", fileDescriptor_service_3759bf1dbe758d6d)
+	proto.RegisterFile("kv/kvserver/closedts/ctpb/service.proto", fileDescriptor_service_3096204571c3b264)
 }
 
-var fileDescriptor_service_3759bf1dbe758d6d = []byte{
+var fileDescriptor_service_3096204571c3b264 = []byte{
 	// 230 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x84, 0x8f, 0xb1, 0x4a, 0x04, 0x31,
 	0x10, 0x86, 0x13, 0x14, 0x8b, 0x6d, 0x84, 0xc5, 0x6a, 0x91, 0x29, 0x84, 0xd3, 0xab, 0x12, 0xd1,

--- a/pkg/kv/kvserver/concurrency/lock/locking.pb.go
+++ b/pkg/kv/kvserver/concurrency/lock/locking.pb.go
@@ -155,7 +155,7 @@ func (x Strength) String() string {
 	return proto.EnumName(Strength_name, int32(x))
 }
 func (Strength) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_locking_4b2d63c7788afc75, []int{0}
+	return fileDescriptor_locking_eecdbf5930525074, []int{0}
 }
 
 // Durability represents the different durability properties of a lock acquired
@@ -195,7 +195,7 @@ func (x Durability) String() string {
 	return proto.EnumName(Durability_name, int32(x))
 }
 func (Durability) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_locking_4b2d63c7788afc75, []int{1}
+	return fileDescriptor_locking_eecdbf5930525074, []int{1}
 }
 
 // WaitPolicy specifies the behavior of a request when it encounters conflicting
@@ -230,7 +230,7 @@ func (x WaitPolicy) String() string {
 	return proto.EnumName(WaitPolicy_name, int32(x))
 }
 func (WaitPolicy) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_locking_4b2d63c7788afc75, []int{2}
+	return fileDescriptor_locking_eecdbf5930525074, []int{2}
 }
 
 func init() {
@@ -240,10 +240,10 @@ func init() {
 }
 
 func init() {
-	proto.RegisterFile("kv/kvserver/concurrency/lock/locking.proto", fileDescriptor_locking_4b2d63c7788afc75)
+	proto.RegisterFile("kv/kvserver/concurrency/lock/locking.proto", fileDescriptor_locking_eecdbf5930525074)
 }
 
-var fileDescriptor_locking_4b2d63c7788afc75 = []byte{
+var fileDescriptor_locking_eecdbf5930525074 = []byte{
 	// 275 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x4c, 0xcf, 0xbd, 0x4e, 0xc3, 0x30,
 	0x10, 0xc0, 0x71, 0x1b, 0x42, 0x69, 0x8f, 0x0f, 0x59, 0x16, 0x53, 0x07, 0x0f, 0x0c, 0x1d, 0x32,

--- a/pkg/kv/kvserver/kvserverpb/lease_status.pb.go
+++ b/pkg/kv/kvserver/kvserverpb/lease_status.pb.go
@@ -85,7 +85,7 @@ func (x LeaseState) String() string {
 	return proto.EnumName(LeaseState_name, int32(x))
 }
 func (LeaseState) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_lease_status_019eb0d13224e9d6, []int{0}
+	return fileDescriptor_lease_status_d34a6264c23a8b82, []int{0}
 }
 
 // LeaseStatus holds the lease state, the timestamp at which the state
@@ -106,7 +106,7 @@ func (m *LeaseStatus) Reset()         { *m = LeaseStatus{} }
 func (m *LeaseStatus) String() string { return proto.CompactTextString(m) }
 func (*LeaseStatus) ProtoMessage()    {}
 func (*LeaseStatus) Descriptor() ([]byte, []int) {
-	return fileDescriptor_lease_status_019eb0d13224e9d6, []int{0}
+	return fileDescriptor_lease_status_d34a6264c23a8b82, []int{0}
 }
 func (m *LeaseStatus) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -487,10 +487,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("kv/kvserver/kvserverpb/lease_status.proto", fileDescriptor_lease_status_019eb0d13224e9d6)
+	proto.RegisterFile("kv/kvserver/kvserverpb/lease_status.proto", fileDescriptor_lease_status_d34a6264c23a8b82)
 }
 
-var fileDescriptor_lease_status_019eb0d13224e9d6 = []byte{
+var fileDescriptor_lease_status_d34a6264c23a8b82 = []byte{
 	// 379 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x84, 0x92, 0xcf, 0x6a, 0xea, 0x40,
 	0x18, 0xc5, 0x33, 0xfe, 0xbb, 0xd7, 0x11, 0x24, 0x0c, 0x77, 0x11, 0x84, 0x3b, 0xca, 0x5d, 0x79,

--- a/pkg/kv/kvserver/kvserverpb/log.pb.go
+++ b/pkg/kv/kvserver/kvserverpb/log.pb.go
@@ -67,7 +67,7 @@ func (x RangeLogEventType) String() string {
 	return proto.EnumName(RangeLogEventType_name, int32(x))
 }
 func (RangeLogEventType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_log_5c85c87c8c818051, []int{0}
+	return fileDescriptor_log_a9bcb61d63001828, []int{0}
 }
 
 type RangeLogEvent struct {
@@ -83,7 +83,7 @@ func (m *RangeLogEvent) Reset()         { *m = RangeLogEvent{} }
 func (m *RangeLogEvent) String() string { return proto.CompactTextString(m) }
 func (*RangeLogEvent) ProtoMessage()    {}
 func (*RangeLogEvent) Descriptor() ([]byte, []int) {
-	return fileDescriptor_log_5c85c87c8c818051, []int{0}
+	return fileDescriptor_log_a9bcb61d63001828, []int{0}
 }
 func (m *RangeLogEvent) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -122,7 +122,7 @@ func (m *RangeLogEvent_Info) Reset()         { *m = RangeLogEvent_Info{} }
 func (m *RangeLogEvent_Info) String() string { return proto.CompactTextString(m) }
 func (*RangeLogEvent_Info) ProtoMessage()    {}
 func (*RangeLogEvent_Info) Descriptor() ([]byte, []int) {
-	return fileDescriptor_log_5c85c87c8c818051, []int{0, 0}
+	return fileDescriptor_log_a9bcb61d63001828, []int{0, 0}
 }
 func (m *RangeLogEvent_Info) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -942,10 +942,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("kv/kvserver/kvserverpb/log.proto", fileDescriptor_log_5c85c87c8c818051)
+	proto.RegisterFile("kv/kvserver/kvserverpb/log.proto", fileDescriptor_log_a9bcb61d63001828)
 }
 
-var fileDescriptor_log_5c85c87c8c818051 = []byte{
+var fileDescriptor_log_a9bcb61d63001828 = []byte{
 	// 678 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xa4, 0x94, 0xc1, 0x4e, 0xdb, 0x4a,
 	0x14, 0x86, 0x63, 0x48, 0x08, 0x1e, 0x02, 0x37, 0xcc, 0x85, 0xab, 0xdc, 0xe8, 0xca, 0x8e, 0xd0,

--- a/pkg/kv/kvserver/kvserverpb/proposer_kv.pb.go
+++ b/pkg/kv/kvserver/kvserverpb/proposer_kv.pb.go
@@ -48,7 +48,7 @@ func (m *Split) Reset()         { *m = Split{} }
 func (m *Split) String() string { return proto.CompactTextString(m) }
 func (*Split) ProtoMessage()    {}
 func (*Split) Descriptor() ([]byte, []int) {
-	return fileDescriptor_proposer_kv_eb94ca29d884b99a, []int{0}
+	return fileDescriptor_proposer_kv_367b1f11f61ba339, []int{0}
 }
 func (m *Split) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -83,7 +83,7 @@ func (m *Merge) Reset()         { *m = Merge{} }
 func (m *Merge) String() string { return proto.CompactTextString(m) }
 func (*Merge) ProtoMessage()    {}
 func (*Merge) Descriptor() ([]byte, []int) {
-	return fileDescriptor_proposer_kv_eb94ca29d884b99a, []int{1}
+	return fileDescriptor_proposer_kv_367b1f11f61ba339, []int{1}
 }
 func (m *Merge) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -117,7 +117,7 @@ type ChangeReplicas struct {
 func (m *ChangeReplicas) Reset()      { *m = ChangeReplicas{} }
 func (*ChangeReplicas) ProtoMessage() {}
 func (*ChangeReplicas) Descriptor() ([]byte, []int) {
-	return fileDescriptor_proposer_kv_eb94ca29d884b99a, []int{2}
+	return fileDescriptor_proposer_kv_367b1f11f61ba339, []int{2}
 }
 func (m *ChangeReplicas) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -169,7 +169,7 @@ func (m *ComputeChecksum) Reset()         { *m = ComputeChecksum{} }
 func (m *ComputeChecksum) String() string { return proto.CompactTextString(m) }
 func (*ComputeChecksum) ProtoMessage()    {}
 func (*ComputeChecksum) Descriptor() ([]byte, []int) {
-	return fileDescriptor_proposer_kv_eb94ca29d884b99a, []int{3}
+	return fileDescriptor_proposer_kv_367b1f11f61ba339, []int{3}
 }
 func (m *ComputeChecksum) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -206,7 +206,7 @@ func (m *Compaction) Reset()         { *m = Compaction{} }
 func (m *Compaction) String() string { return proto.CompactTextString(m) }
 func (*Compaction) ProtoMessage()    {}
 func (*Compaction) Descriptor() ([]byte, []int) {
-	return fileDescriptor_proposer_kv_eb94ca29d884b99a, []int{4}
+	return fileDescriptor_proposer_kv_367b1f11f61ba339, []int{4}
 }
 func (m *Compaction) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -243,7 +243,7 @@ func (m *SuggestedCompaction) Reset()         { *m = SuggestedCompaction{} }
 func (m *SuggestedCompaction) String() string { return proto.CompactTextString(m) }
 func (*SuggestedCompaction) ProtoMessage()    {}
 func (*SuggestedCompaction) Descriptor() ([]byte, []int) {
-	return fileDescriptor_proposer_kv_eb94ca29d884b99a, []int{5}
+	return fileDescriptor_proposer_kv_367b1f11f61ba339, []int{5}
 }
 func (m *SuggestedCompaction) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -305,7 +305,7 @@ func (m *ReplicatedEvalResult) Reset()         { *m = ReplicatedEvalResult{} }
 func (m *ReplicatedEvalResult) String() string { return proto.CompactTextString(m) }
 func (*ReplicatedEvalResult) ProtoMessage()    {}
 func (*ReplicatedEvalResult) Descriptor() ([]byte, []int) {
-	return fileDescriptor_proposer_kv_eb94ca29d884b99a, []int{6}
+	return fileDescriptor_proposer_kv_367b1f11f61ba339, []int{6}
 }
 func (m *ReplicatedEvalResult) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -349,7 +349,7 @@ func (m *ReplicatedEvalResult_AddSSTable) Reset()         { *m = ReplicatedEvalR
 func (m *ReplicatedEvalResult_AddSSTable) String() string { return proto.CompactTextString(m) }
 func (*ReplicatedEvalResult_AddSSTable) ProtoMessage()    {}
 func (*ReplicatedEvalResult_AddSSTable) Descriptor() ([]byte, []int) {
-	return fileDescriptor_proposer_kv_eb94ca29d884b99a, []int{6, 0}
+	return fileDescriptor_proposer_kv_367b1f11f61ba339, []int{6, 0}
 }
 func (m *ReplicatedEvalResult_AddSSTable) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -386,7 +386,7 @@ func (m *WriteBatch) Reset()         { *m = WriteBatch{} }
 func (m *WriteBatch) String() string { return proto.CompactTextString(m) }
 func (*WriteBatch) ProtoMessage()    {}
 func (*WriteBatch) Descriptor() ([]byte, []int) {
-	return fileDescriptor_proposer_kv_eb94ca29d884b99a, []int{7}
+	return fileDescriptor_proposer_kv_367b1f11f61ba339, []int{7}
 }
 func (m *WriteBatch) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -423,7 +423,7 @@ func (m *LogicalOpLog) Reset()         { *m = LogicalOpLog{} }
 func (m *LogicalOpLog) String() string { return proto.CompactTextString(m) }
 func (*LogicalOpLog) ProtoMessage()    {}
 func (*LogicalOpLog) Descriptor() ([]byte, []int) {
-	return fileDescriptor_proposer_kv_eb94ca29d884b99a, []int{8}
+	return fileDescriptor_proposer_kv_367b1f11f61ba339, []int{8}
 }
 func (m *LogicalOpLog) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -528,7 +528,7 @@ func (m *RaftCommand) Reset()         { *m = RaftCommand{} }
 func (m *RaftCommand) String() string { return proto.CompactTextString(m) }
 func (*RaftCommand) ProtoMessage()    {}
 func (*RaftCommand) Descriptor() ([]byte, []int) {
-	return fileDescriptor_proposer_kv_eb94ca29d884b99a, []int{9}
+	return fileDescriptor_proposer_kv_367b1f11f61ba339, []int{9}
 }
 func (m *RaftCommand) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -567,7 +567,7 @@ func (m *RaftCommandFooter) Reset()         { *m = RaftCommandFooter{} }
 func (m *RaftCommandFooter) String() string { return proto.CompactTextString(m) }
 func (*RaftCommandFooter) ProtoMessage()    {}
 func (*RaftCommandFooter) Descriptor() ([]byte, []int) {
-	return fileDescriptor_proposer_kv_eb94ca29d884b99a, []int{10}
+	return fileDescriptor_proposer_kv_367b1f11f61ba339, []int{10}
 }
 func (m *RaftCommandFooter) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3477,10 +3477,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("kv/kvserver/kvserverpb/proposer_kv.proto", fileDescriptor_proposer_kv_eb94ca29d884b99a)
+	proto.RegisterFile("kv/kvserver/kvserverpb/proposer_kv.proto", fileDescriptor_proposer_kv_367b1f11f61ba339)
 }
 
-var fileDescriptor_proposer_kv_eb94ca29d884b99a = []byte{
+var fileDescriptor_proposer_kv_367b1f11f61ba339 = []byte{
 	// 1424 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xa4, 0x57, 0x4f, 0x6f, 0xdb, 0x46,
 	0x16, 0xb7, 0x2c, 0xc9, 0xa6, 0x9e, 0x6c, 0x89, 0x9e, 0x38, 0x09, 0xd7, 0xbb, 0x2b, 0x19, 0xda,

--- a/pkg/kv/kvserver/kvserverpb/state.pb.go
+++ b/pkg/kv/kvserver/kvserverpb/state.pb.go
@@ -108,7 +108,7 @@ func (m *ReplicaState) Reset()         { *m = ReplicaState{} }
 func (m *ReplicaState) String() string { return proto.CompactTextString(m) }
 func (*ReplicaState) ProtoMessage()    {}
 func (*ReplicaState) Descriptor() ([]byte, []int) {
-	return fileDescriptor_state_50e6a6403c7eff35, []int{0}
+	return fileDescriptor_state_acd314f0f91777f8, []int{0}
 }
 func (m *ReplicaState) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -180,7 +180,7 @@ func (m *RangeInfo) Reset()         { *m = RangeInfo{} }
 func (m *RangeInfo) String() string { return proto.CompactTextString(m) }
 func (*RangeInfo) ProtoMessage()    {}
 func (*RangeInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_state_50e6a6403c7eff35, []int{1}
+	return fileDescriptor_state_acd314f0f91777f8, []int{1}
 }
 func (m *RangeInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -216,7 +216,7 @@ func (m *RangeInfo_CTEntry) Reset()         { *m = RangeInfo_CTEntry{} }
 func (m *RangeInfo_CTEntry) String() string { return proto.CompactTextString(m) }
 func (*RangeInfo_CTEntry) ProtoMessage()    {}
 func (*RangeInfo_CTEntry) Descriptor() ([]byte, []int) {
-	return fileDescriptor_state_50e6a6403c7eff35, []int{1, 0}
+	return fileDescriptor_state_acd314f0f91777f8, []int{1, 0}
 }
 func (m *RangeInfo_CTEntry) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -252,7 +252,7 @@ func (m *LatchManagerInfo) Reset()         { *m = LatchManagerInfo{} }
 func (m *LatchManagerInfo) String() string { return proto.CompactTextString(m) }
 func (*LatchManagerInfo) ProtoMessage()    {}
 func (*LatchManagerInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_state_50e6a6403c7eff35, []int{2}
+	return fileDescriptor_state_acd314f0f91777f8, []int{2}
 }
 func (m *LatchManagerInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1952,10 +1952,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("kv/kvserver/kvserverpb/state.proto", fileDescriptor_state_50e6a6403c7eff35)
+	proto.RegisterFile("kv/kvserver/kvserverpb/state.proto", fileDescriptor_state_acd314f0f91777f8)
 }
 
-var fileDescriptor_state_50e6a6403c7eff35 = []byte{
+var fileDescriptor_state_acd314f0f91777f8 = []byte{
 	// 1061 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x55, 0xcd, 0x6e, 0x1b, 0x37,
 	0x10, 0xf6, 0x5a, 0x2b, 0x5b, 0xa2, 0xec, 0x58, 0x61, 0x9d, 0x78, 0xe3, 0xc4, 0x92, 0x21, 0xa0,

--- a/pkg/kv/kvserver/liveness/livenesspb/liveness.pb.go
+++ b/pkg/kv/kvserver/liveness/livenesspb/liveness.pb.go
@@ -81,7 +81,7 @@ var MembershipStatus_value = map[string]int32{
 }
 
 func (MembershipStatus) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_liveness_19520db8d41703e0, []int{0}
+	return fileDescriptor_liveness_be522def84a925e5, []int{0}
 }
 
 // NodeLivenessStatus describes the status of a node from the perspective of the
@@ -140,7 +140,7 @@ func (x NodeLivenessStatus) String() string {
 	return proto.EnumName(NodeLivenessStatus_name, int32(x))
 }
 func (NodeLivenessStatus) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_liveness_19520db8d41703e0, []int{1}
+	return fileDescriptor_liveness_be522def84a925e5, []int{1}
 }
 
 // Liveness holds information about a node's latest heartbeat and epoch.
@@ -182,7 +182,7 @@ type Liveness struct {
 func (m *Liveness) Reset()      { *m = Liveness{} }
 func (*Liveness) ProtoMessage() {}
 func (*Liveness) Descriptor() ([]byte, []int) {
-	return fileDescriptor_liveness_19520db8d41703e0, []int{0}
+	return fileDescriptor_liveness_be522def84a925e5, []int{0}
 }
 func (m *Liveness) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -698,10 +698,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("kv/kvserver/liveness/livenesspb/liveness.proto", fileDescriptor_liveness_19520db8d41703e0)
+	proto.RegisterFile("kv/kvserver/liveness/livenesspb/liveness.proto", fileDescriptor_liveness_be522def84a925e5)
 }
 
-var fileDescriptor_liveness_19520db8d41703e0 = []byte{
+var fileDescriptor_liveness_be522def84a925e5 = []byte{
 	// 554 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x92, 0x4b, 0x8b, 0xd3, 0x50,
 	0x14, 0xc7, 0x73, 0xfb, 0x9a, 0x72, 0x2b, 0x33, 0xe1, 0x76, 0xc0, 0x12, 0x21, 0x09, 0xea, 0xa2,

--- a/pkg/kv/kvserver/protectedts/ptpb/protectedts.pb.go
+++ b/pkg/kv/kvserver/protectedts/ptpb/protectedts.pb.go
@@ -44,7 +44,7 @@ func (x ProtectionMode) String() string {
 	return proto.EnumName(ProtectionMode_name, int32(x))
 }
 func (ProtectionMode) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_protectedts_5535080d2f6ed5b9, []int{0}
+	return fileDescriptor_protectedts_617050e91c41f7f2, []int{0}
 }
 
 // Metadata is the system metadata. The metadata is stored explicitly and all
@@ -73,7 +73,7 @@ func (m *Metadata) Reset()         { *m = Metadata{} }
 func (m *Metadata) String() string { return proto.CompactTextString(m) }
 func (*Metadata) ProtoMessage()    {}
 func (*Metadata) Descriptor() ([]byte, []int) {
-	return fileDescriptor_protectedts_5535080d2f6ed5b9, []int{0}
+	return fileDescriptor_protectedts_617050e91c41f7f2, []int{0}
 }
 func (m *Metadata) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -132,7 +132,7 @@ func (m *Record) Reset()         { *m = Record{} }
 func (m *Record) String() string { return proto.CompactTextString(m) }
 func (*Record) ProtoMessage()    {}
 func (*Record) Descriptor() ([]byte, []int) {
-	return fileDescriptor_protectedts_5535080d2f6ed5b9, []int{1}
+	return fileDescriptor_protectedts_617050e91c41f7f2, []int{1}
 }
 func (m *Record) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -167,7 +167,7 @@ func (m *State) Reset()         { *m = State{} }
 func (m *State) String() string { return proto.CompactTextString(m) }
 func (*State) ProtoMessage()    {}
 func (*State) Descriptor() ([]byte, []int) {
-	return fileDescriptor_protectedts_5535080d2f6ed5b9, []int{2}
+	return fileDescriptor_protectedts_617050e91c41f7f2, []int{2}
 }
 func (m *State) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1023,10 +1023,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("kv/kvserver/protectedts/ptpb/protectedts.proto", fileDescriptor_protectedts_5535080d2f6ed5b9)
+	proto.RegisterFile("kv/kvserver/protectedts/ptpb/protectedts.proto", fileDescriptor_protectedts_617050e91c41f7f2)
 }
 
-var fileDescriptor_protectedts_5535080d2f6ed5b9 = []byte{
+var fileDescriptor_protectedts_617050e91c41f7f2 = []byte{
 	// 555 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x74, 0x53, 0xcf, 0x8f, 0xd2, 0x40,
 	0x14, 0x6e, 0xa1, 0x40, 0x19, 0x74, 0xa3, 0x13, 0x8d, 0x0d, 0x6a, 0x4b, 0x48, 0x34, 0xe8, 0xa1,

--- a/pkg/kv/kvserver/protectedts/ptstorage/storage.pb.go
+++ b/pkg/kv/kvserver/protectedts/ptstorage/storage.pb.go
@@ -32,7 +32,7 @@ func (m *Spans) Reset()         { *m = Spans{} }
 func (m *Spans) String() string { return proto.CompactTextString(m) }
 func (*Spans) ProtoMessage()    {}
 func (*Spans) Descriptor() ([]byte, []int) {
-	return fileDescriptor_storage_af582c1bcb16afac, []int{0}
+	return fileDescriptor_storage_3178c9ebe1d1fac9, []int{0}
 }
 func (m *Spans) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -314,10 +314,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("kv/kvserver/protectedts/ptstorage/storage.proto", fileDescriptor_storage_af582c1bcb16afac)
+	proto.RegisterFile("kv/kvserver/protectedts/ptstorage/storage.proto", fileDescriptor_storage_3178c9ebe1d1fac9)
 }
 
-var fileDescriptor_storage_af582c1bcb16afac = []byte{
+var fileDescriptor_storage_3178c9ebe1d1fac9 = []byte{
 	// 217 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0xd2, 0xcf, 0x2e, 0xd3, 0xcf,
 	0x2e, 0x2b, 0x4e, 0x2d, 0x2a, 0x4b, 0x2d, 0xd2, 0x2f, 0x28, 0xca, 0x2f, 0x49, 0x4d, 0x2e, 0x49,

--- a/pkg/kv/kvserver/raft.pb.go
+++ b/pkg/kv/kvserver/raft.pb.go
@@ -53,7 +53,7 @@ func (x SnapshotRequest_Priority) String() string {
 	return proto.EnumName(SnapshotRequest_Priority_name, int32(x))
 }
 func (SnapshotRequest_Priority) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_raft_07dfbcfbe180f4ba, []int{5, 0}
+	return fileDescriptor_raft_031413a263a2674e, []int{5, 0}
 }
 
 type SnapshotRequest_Strategy int32
@@ -77,7 +77,7 @@ func (x SnapshotRequest_Strategy) String() string {
 	return proto.EnumName(SnapshotRequest_Strategy_name, int32(x))
 }
 func (SnapshotRequest_Strategy) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_raft_07dfbcfbe180f4ba, []int{5, 1}
+	return fileDescriptor_raft_031413a263a2674e, []int{5, 1}
 }
 
 // Type is used for metrics collection on the receiver side. See
@@ -109,7 +109,7 @@ func (x SnapshotRequest_Type) String() string {
 	return proto.EnumName(SnapshotRequest_Type_name, int32(x))
 }
 func (SnapshotRequest_Type) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_raft_07dfbcfbe180f4ba, []int{5, 2}
+	return fileDescriptor_raft_031413a263a2674e, []int{5, 2}
 }
 
 type SnapshotResponse_Status int32
@@ -141,7 +141,7 @@ func (x SnapshotResponse_Status) String() string {
 	return proto.EnumName(SnapshotResponse_Status_name, int32(x))
 }
 func (SnapshotResponse_Status) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_raft_07dfbcfbe180f4ba, []int{6, 0}
+	return fileDescriptor_raft_031413a263a2674e, []int{6, 0}
 }
 
 // RaftHeartbeat is a request that contains the barebones information for a
@@ -163,7 +163,7 @@ func (m *RaftHeartbeat) Reset()         { *m = RaftHeartbeat{} }
 func (m *RaftHeartbeat) String() string { return proto.CompactTextString(m) }
 func (*RaftHeartbeat) ProtoMessage()    {}
 func (*RaftHeartbeat) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_07dfbcfbe180f4ba, []int{0}
+	return fileDescriptor_raft_031413a263a2674e, []int{0}
 }
 func (m *RaftHeartbeat) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -239,7 +239,7 @@ func (m *RaftMessageRequest) Reset()         { *m = RaftMessageRequest{} }
 func (m *RaftMessageRequest) String() string { return proto.CompactTextString(m) }
 func (*RaftMessageRequest) ProtoMessage()    {}
 func (*RaftMessageRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_07dfbcfbe180f4ba, []int{1}
+	return fileDescriptor_raft_031413a263a2674e, []int{1}
 }
 func (m *RaftMessageRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -272,7 +272,7 @@ func (m *RaftMessageRequestBatch) Reset()         { *m = RaftMessageRequestBatch
 func (m *RaftMessageRequestBatch) String() string { return proto.CompactTextString(m) }
 func (*RaftMessageRequestBatch) ProtoMessage()    {}
 func (*RaftMessageRequestBatch) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_07dfbcfbe180f4ba, []int{2}
+	return fileDescriptor_raft_031413a263a2674e, []int{2}
 }
 func (m *RaftMessageRequestBatch) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -305,7 +305,7 @@ func (m *RaftMessageResponseUnion) Reset()         { *m = RaftMessageResponseUni
 func (m *RaftMessageResponseUnion) String() string { return proto.CompactTextString(m) }
 func (*RaftMessageResponseUnion) ProtoMessage()    {}
 func (*RaftMessageResponseUnion) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_07dfbcfbe180f4ba, []int{3}
+	return fileDescriptor_raft_031413a263a2674e, []int{3}
 }
 func (m *RaftMessageResponseUnion) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -348,7 +348,7 @@ func (m *RaftMessageResponse) Reset()         { *m = RaftMessageResponse{} }
 func (m *RaftMessageResponse) String() string { return proto.CompactTextString(m) }
 func (*RaftMessageResponse) ProtoMessage()    {}
 func (*RaftMessageResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_07dfbcfbe180f4ba, []int{4}
+	return fileDescriptor_raft_031413a263a2674e, []int{4}
 }
 func (m *RaftMessageResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -389,7 +389,7 @@ func (m *SnapshotRequest) Reset()         { *m = SnapshotRequest{} }
 func (m *SnapshotRequest) String() string { return proto.CompactTextString(m) }
 func (*SnapshotRequest) ProtoMessage()    {}
 func (*SnapshotRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_07dfbcfbe180f4ba, []int{5}
+	return fileDescriptor_raft_031413a263a2674e, []int{5}
 }
 func (m *SnapshotRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -451,7 +451,7 @@ func (m *SnapshotRequest_Header) Reset()         { *m = SnapshotRequest_Header{}
 func (m *SnapshotRequest_Header) String() string { return proto.CompactTextString(m) }
 func (*SnapshotRequest_Header) ProtoMessage()    {}
 func (*SnapshotRequest_Header) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_07dfbcfbe180f4ba, []int{5, 0}
+	return fileDescriptor_raft_031413a263a2674e, []int{5, 0}
 }
 func (m *SnapshotRequest_Header) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -485,7 +485,7 @@ func (m *SnapshotResponse) Reset()         { *m = SnapshotResponse{} }
 func (m *SnapshotResponse) String() string { return proto.CompactTextString(m) }
 func (*SnapshotResponse) ProtoMessage()    {}
 func (*SnapshotResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_07dfbcfbe180f4ba, []int{6}
+	return fileDescriptor_raft_031413a263a2674e, []int{6}
 }
 func (m *SnapshotResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -522,7 +522,7 @@ func (m *ConfChangeContext) Reset()         { *m = ConfChangeContext{} }
 func (m *ConfChangeContext) String() string { return proto.CompactTextString(m) }
 func (*ConfChangeContext) ProtoMessage()    {}
 func (*ConfChangeContext) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_07dfbcfbe180f4ba, []int{7}
+	return fileDescriptor_raft_031413a263a2674e, []int{7}
 }
 func (m *ConfChangeContext) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2856,9 +2856,9 @@ var (
 	ErrIntOverflowRaft   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("kv/kvserver/raft.proto", fileDescriptor_raft_07dfbcfbe180f4ba) }
+func init() { proto.RegisterFile("kv/kvserver/raft.proto", fileDescriptor_raft_031413a263a2674e) }
 
-var fileDescriptor_raft_07dfbcfbe180f4ba = []byte{
+var fileDescriptor_raft_031413a263a2674e = []byte{
 	// 1296 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe4, 0x57, 0x4f, 0x73, 0xdb, 0x44,
 	0x14, 0xb7, 0x12, 0xc5, 0x96, 0xd7, 0x71, 0x23, 0xb6, 0x21, 0x88, 0x4c, 0xb1, 0x83, 0xa6, 0x30,

--- a/pkg/kv/kvserver/storage_services.pb.go
+++ b/pkg/kv/kvserver/storage_services.pb.go
@@ -387,10 +387,10 @@ var _PerStore_serviceDesc = grpc.ServiceDesc{
 }
 
 func init() {
-	proto.RegisterFile("kv/kvserver/storage_services.proto", fileDescriptor_storage_services_be9c06f8924f6568)
+	proto.RegisterFile("kv/kvserver/storage_services.proto", fileDescriptor_storage_services_bc1d55ecd4e3f795)
 }
 
-var fileDescriptor_storage_services_be9c06f8924f6568 = []byte{
+var fileDescriptor_storage_services_bc1d55ecd4e3f795 = []byte{
 	// 382 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x94, 0x93, 0xb1, 0x8e, 0xd3, 0x30,
 	0x18, 0xc7, 0x63, 0x06, 0x54, 0x2c, 0x24, 0xa8, 0x05, 0x0c, 0x19, 0x3c, 0x74, 0x00, 0x54, 0x89,

--- a/pkg/roachpb/api.pb.go
+++ b/pkg/roachpb/api.pb.go
@@ -74,7 +74,7 @@ func (x ReadConsistencyType) String() string {
 	return proto.EnumName(ReadConsistencyType_name, int32(x))
 }
 func (ReadConsistencyType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{0}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{0}
 }
 
 // ScanFormat is an enumeration of the available response formats for MVCCScan
@@ -102,7 +102,7 @@ func (x ScanFormat) String() string {
 	return proto.EnumName(ScanFormat_name, int32(x))
 }
 func (ScanFormat) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{1}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{1}
 }
 
 type ChecksumMode int32
@@ -149,7 +149,7 @@ func (x ChecksumMode) String() string {
 	return proto.EnumName(ChecksumMode_name, int32(x))
 }
 func (ChecksumMode) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{2}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{2}
 }
 
 // PushTxnType determines what action to take when pushing a transaction.
@@ -180,7 +180,7 @@ func (x PushTxnType) String() string {
 	return proto.EnumName(PushTxnType_name, int32(x))
 }
 func (PushTxnType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{3}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{3}
 }
 
 type ExternalStorageProvider int32
@@ -221,7 +221,7 @@ func (x ExternalStorageProvider) String() string {
 	return proto.EnumName(ExternalStorageProvider_name, int32(x))
 }
 func (ExternalStorageProvider) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{4}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{4}
 }
 
 type MVCCFilter int32
@@ -244,7 +244,7 @@ func (x MVCCFilter) String() string {
 	return proto.EnumName(MVCCFilter_name, int32(x))
 }
 func (MVCCFilter) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{5}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{5}
 }
 
 type ResponseHeader_ResumeReason int32
@@ -270,7 +270,7 @@ func (x ResponseHeader_ResumeReason) String() string {
 	return proto.EnumName(ResponseHeader_ResumeReason_name, int32(x))
 }
 func (ResponseHeader_ResumeReason) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{1, 0}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{1, 0}
 }
 
 type CheckConsistencyResponse_Status int32
@@ -312,7 +312,7 @@ func (x CheckConsistencyResponse_Status) String() string {
 	return proto.EnumName(CheckConsistencyResponse_Status_name, int32(x))
 }
 func (CheckConsistencyResponse_Status) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{25, 0}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{25, 0}
 }
 
 // RequestHeader is supplied with every storage node request.
@@ -333,7 +333,7 @@ func (m *RequestHeader) Reset()         { *m = RequestHeader{} }
 func (m *RequestHeader) String() string { return proto.CompactTextString(m) }
 func (*RequestHeader) ProtoMessage()    {}
 func (*RequestHeader) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{0}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{0}
 }
 func (m *RequestHeader) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -405,7 +405,7 @@ func (m *ResponseHeader) Reset()         { *m = ResponseHeader{} }
 func (m *ResponseHeader) String() string { return proto.CompactTextString(m) }
 func (*ResponseHeader) ProtoMessage()    {}
 func (*ResponseHeader) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{1}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{1}
 }
 func (m *ResponseHeader) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -439,7 +439,7 @@ func (m *GetRequest) Reset()         { *m = GetRequest{} }
 func (m *GetRequest) String() string { return proto.CompactTextString(m) }
 func (*GetRequest) ProtoMessage()    {}
 func (*GetRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{2}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{2}
 }
 func (m *GetRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -482,7 +482,7 @@ func (m *GetResponse) Reset()         { *m = GetResponse{} }
 func (m *GetResponse) String() string { return proto.CompactTextString(m) }
 func (*GetResponse) ProtoMessage()    {}
 func (*GetResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{3}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{3}
 }
 func (m *GetResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -525,7 +525,7 @@ func (m *PutRequest) Reset()         { *m = PutRequest{} }
 func (m *PutRequest) String() string { return proto.CompactTextString(m) }
 func (*PutRequest) ProtoMessage()    {}
 func (*PutRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{4}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{4}
 }
 func (m *PutRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -559,7 +559,7 @@ func (m *PutResponse) Reset()         { *m = PutResponse{} }
 func (m *PutResponse) String() string { return proto.CompactTextString(m) }
 func (*PutResponse) ProtoMessage()    {}
 func (*PutResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{5}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{5}
 }
 func (m *PutResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -648,7 +648,7 @@ func (m *ConditionalPutRequest) Reset()         { *m = ConditionalPutRequest{} }
 func (m *ConditionalPutRequest) String() string { return proto.CompactTextString(m) }
 func (*ConditionalPutRequest) ProtoMessage()    {}
 func (*ConditionalPutRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{6}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{6}
 }
 func (m *ConditionalPutRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -683,7 +683,7 @@ func (m *ConditionalPutResponse) Reset()         { *m = ConditionalPutResponse{}
 func (m *ConditionalPutResponse) String() string { return proto.CompactTextString(m) }
 func (*ConditionalPutResponse) ProtoMessage()    {}
 func (*ConditionalPutResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{7}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{7}
 }
 func (m *ConditionalPutResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -729,7 +729,7 @@ func (m *InitPutRequest) Reset()         { *m = InitPutRequest{} }
 func (m *InitPutRequest) String() string { return proto.CompactTextString(m) }
 func (*InitPutRequest) ProtoMessage()    {}
 func (*InitPutRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{8}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{8}
 }
 func (m *InitPutRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -763,7 +763,7 @@ func (m *InitPutResponse) Reset()         { *m = InitPutResponse{} }
 func (m *InitPutResponse) String() string { return proto.CompactTextString(m) }
 func (*InitPutResponse) ProtoMessage()    {}
 func (*InitPutResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{9}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{9}
 }
 func (m *InitPutResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -803,7 +803,7 @@ func (m *IncrementRequest) Reset()         { *m = IncrementRequest{} }
 func (m *IncrementRequest) String() string { return proto.CompactTextString(m) }
 func (*IncrementRequest) ProtoMessage()    {}
 func (*IncrementRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{10}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{10}
 }
 func (m *IncrementRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -840,7 +840,7 @@ func (m *IncrementResponse) Reset()         { *m = IncrementResponse{} }
 func (m *IncrementResponse) String() string { return proto.CompactTextString(m) }
 func (*IncrementResponse) ProtoMessage()    {}
 func (*IncrementResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{11}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{11}
 }
 func (m *IncrementResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -874,7 +874,7 @@ func (m *DeleteRequest) Reset()         { *m = DeleteRequest{} }
 func (m *DeleteRequest) String() string { return proto.CompactTextString(m) }
 func (*DeleteRequest) ProtoMessage()    {}
 func (*DeleteRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{12}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{12}
 }
 func (m *DeleteRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -908,7 +908,7 @@ func (m *DeleteResponse) Reset()         { *m = DeleteResponse{} }
 func (m *DeleteResponse) String() string { return proto.CompactTextString(m) }
 func (*DeleteResponse) ProtoMessage()    {}
 func (*DeleteResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{13}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{13}
 }
 func (m *DeleteResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -960,7 +960,7 @@ func (m *DeleteRangeRequest) Reset()         { *m = DeleteRangeRequest{} }
 func (m *DeleteRangeRequest) String() string { return proto.CompactTextString(m) }
 func (*DeleteRangeRequest) ProtoMessage()    {}
 func (*DeleteRangeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{14}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{14}
 }
 func (m *DeleteRangeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -997,7 +997,7 @@ func (m *DeleteRangeResponse) Reset()         { *m = DeleteRangeResponse{} }
 func (m *DeleteRangeResponse) String() string { return proto.CompactTextString(m) }
 func (*DeleteRangeResponse) ProtoMessage()    {}
 func (*DeleteRangeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{15}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{15}
 }
 func (m *DeleteRangeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1052,7 +1052,7 @@ func (m *ClearRangeRequest) Reset()         { *m = ClearRangeRequest{} }
 func (m *ClearRangeRequest) String() string { return proto.CompactTextString(m) }
 func (*ClearRangeRequest) ProtoMessage()    {}
 func (*ClearRangeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{16}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{16}
 }
 func (m *ClearRangeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1086,7 +1086,7 @@ func (m *ClearRangeResponse) Reset()         { *m = ClearRangeResponse{} }
 func (m *ClearRangeResponse) String() string { return proto.CompactTextString(m) }
 func (*ClearRangeResponse) ProtoMessage()    {}
 func (*ClearRangeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{17}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{17}
 }
 func (m *ClearRangeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1128,7 +1128,7 @@ func (m *RevertRangeRequest) Reset()         { *m = RevertRangeRequest{} }
 func (m *RevertRangeRequest) String() string { return proto.CompactTextString(m) }
 func (*RevertRangeRequest) ProtoMessage()    {}
 func (*RevertRangeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{18}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{18}
 }
 func (m *RevertRangeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1162,7 +1162,7 @@ func (m *RevertRangeResponse) Reset()         { *m = RevertRangeResponse{} }
 func (m *RevertRangeResponse) String() string { return proto.CompactTextString(m) }
 func (*RevertRangeResponse) ProtoMessage()    {}
 func (*RevertRangeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{19}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{19}
 }
 func (m *RevertRangeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1213,7 +1213,7 @@ func (m *ScanRequest) Reset()         { *m = ScanRequest{} }
 func (m *ScanRequest) String() string { return proto.CompactTextString(m) }
 func (*ScanRequest) ProtoMessage()    {}
 func (*ScanRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{20}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{20}
 }
 func (m *ScanRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1265,7 +1265,7 @@ func (m *ScanResponse) Reset()         { *m = ScanResponse{} }
 func (m *ScanResponse) String() string { return proto.CompactTextString(m) }
 func (*ScanResponse) ProtoMessage()    {}
 func (*ScanResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{21}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{21}
 }
 func (m *ScanResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1316,7 +1316,7 @@ func (m *ReverseScanRequest) Reset()         { *m = ReverseScanRequest{} }
 func (m *ReverseScanRequest) String() string { return proto.CompactTextString(m) }
 func (*ReverseScanRequest) ProtoMessage()    {}
 func (*ReverseScanRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{22}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{22}
 }
 func (m *ReverseScanRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1368,7 +1368,7 @@ func (m *ReverseScanResponse) Reset()         { *m = ReverseScanResponse{} }
 func (m *ReverseScanResponse) String() string { return proto.CompactTextString(m) }
 func (*ReverseScanResponse) ProtoMessage()    {}
 func (*ReverseScanResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{23}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{23}
 }
 func (m *ReverseScanResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1421,7 +1421,7 @@ func (m *CheckConsistencyRequest) Reset()         { *m = CheckConsistencyRequest
 func (m *CheckConsistencyRequest) String() string { return proto.CompactTextString(m) }
 func (*CheckConsistencyRequest) ProtoMessage()    {}
 func (*CheckConsistencyRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{24}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{24}
 }
 func (m *CheckConsistencyRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1458,7 +1458,7 @@ func (m *CheckConsistencyResponse) Reset()         { *m = CheckConsistencyRespon
 func (m *CheckConsistencyResponse) String() string { return proto.CompactTextString(m) }
 func (*CheckConsistencyResponse) ProtoMessage()    {}
 func (*CheckConsistencyResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{25}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{25}
 }
 func (m *CheckConsistencyResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1502,7 +1502,7 @@ func (m *CheckConsistencyResponse_Result) Reset()         { *m = CheckConsistenc
 func (m *CheckConsistencyResponse_Result) String() string { return proto.CompactTextString(m) }
 func (*CheckConsistencyResponse_Result) ProtoMessage()    {}
 func (*CheckConsistencyResponse_Result) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{25, 0}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{25, 0}
 }
 func (m *CheckConsistencyResponse_Result) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1550,7 +1550,7 @@ func (m *RecomputeStatsRequest) Reset()         { *m = RecomputeStatsRequest{} }
 func (m *RecomputeStatsRequest) String() string { return proto.CompactTextString(m) }
 func (*RecomputeStatsRequest) ProtoMessage()    {}
 func (*RecomputeStatsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{26}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{26}
 }
 func (m *RecomputeStatsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1586,7 +1586,7 @@ func (m *RecomputeStatsResponse) Reset()         { *m = RecomputeStatsResponse{}
 func (m *RecomputeStatsResponse) String() string { return proto.CompactTextString(m) }
 func (*RecomputeStatsResponse) ProtoMessage()    {}
 func (*RecomputeStatsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{27}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{27}
 }
 func (m *RecomputeStatsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1697,7 +1697,7 @@ func (m *EndTxnRequest) Reset()         { *m = EndTxnRequest{} }
 func (m *EndTxnRequest) String() string { return proto.CompactTextString(m) }
 func (*EndTxnRequest) ProtoMessage()    {}
 func (*EndTxnRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{28}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{28}
 }
 func (m *EndTxnRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1743,7 +1743,7 @@ func (m *EndTxnResponse) Reset()         { *m = EndTxnResponse{} }
 func (m *EndTxnResponse) String() string { return proto.CompactTextString(m) }
 func (*EndTxnResponse) ProtoMessage()    {}
 func (*EndTxnResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{29}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{29}
 }
 func (m *EndTxnResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1804,7 +1804,7 @@ func (m *AdminSplitRequest) Reset()         { *m = AdminSplitRequest{} }
 func (m *AdminSplitRequest) String() string { return proto.CompactTextString(m) }
 func (*AdminSplitRequest) ProtoMessage()    {}
 func (*AdminSplitRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{30}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{30}
 }
 func (m *AdminSplitRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1839,7 +1839,7 @@ func (m *AdminSplitResponse) Reset()         { *m = AdminSplitResponse{} }
 func (m *AdminSplitResponse) String() string { return proto.CompactTextString(m) }
 func (*AdminSplitResponse) ProtoMessage()    {}
 func (*AdminSplitResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{31}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{31}
 }
 func (m *AdminSplitResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1878,7 +1878,7 @@ func (m *AdminUnsplitRequest) Reset()         { *m = AdminUnsplitRequest{} }
 func (m *AdminUnsplitRequest) String() string { return proto.CompactTextString(m) }
 func (*AdminUnsplitRequest) ProtoMessage()    {}
 func (*AdminUnsplitRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{32}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{32}
 }
 func (m *AdminUnsplitRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1913,7 +1913,7 @@ func (m *AdminUnsplitResponse) Reset()         { *m = AdminUnsplitResponse{} }
 func (m *AdminUnsplitResponse) String() string { return proto.CompactTextString(m) }
 func (*AdminUnsplitResponse) ProtoMessage()    {}
 func (*AdminUnsplitResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{33}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{33}
 }
 func (m *AdminUnsplitResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1956,7 +1956,7 @@ func (m *AdminMergeRequest) Reset()         { *m = AdminMergeRequest{} }
 func (m *AdminMergeRequest) String() string { return proto.CompactTextString(m) }
 func (*AdminMergeRequest) ProtoMessage()    {}
 func (*AdminMergeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{34}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{34}
 }
 func (m *AdminMergeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1991,7 +1991,7 @@ func (m *AdminMergeResponse) Reset()         { *m = AdminMergeResponse{} }
 func (m *AdminMergeResponse) String() string { return proto.CompactTextString(m) }
 func (*AdminMergeResponse) ProtoMessage()    {}
 func (*AdminMergeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{35}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{35}
 }
 func (m *AdminMergeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2029,7 +2029,7 @@ func (m *AdminTransferLeaseRequest) Reset()         { *m = AdminTransferLeaseReq
 func (m *AdminTransferLeaseRequest) String() string { return proto.CompactTextString(m) }
 func (*AdminTransferLeaseRequest) ProtoMessage()    {}
 func (*AdminTransferLeaseRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{36}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{36}
 }
 func (m *AdminTransferLeaseRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2062,7 +2062,7 @@ func (m *AdminTransferLeaseResponse) Reset()         { *m = AdminTransferLeaseRe
 func (m *AdminTransferLeaseResponse) String() string { return proto.CompactTextString(m) }
 func (*AdminTransferLeaseResponse) ProtoMessage()    {}
 func (*AdminTransferLeaseResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{37}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{37}
 }
 func (m *AdminTransferLeaseResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2097,7 +2097,7 @@ func (m *ReplicationChange) Reset()         { *m = ReplicationChange{} }
 func (m *ReplicationChange) String() string { return proto.CompactTextString(m) }
 func (*ReplicationChange) ProtoMessage()    {}
 func (*ReplicationChange) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{38}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{38}
 }
 func (m *ReplicationChange) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2155,7 +2155,7 @@ func (m *AdminChangeReplicasRequest) Reset()         { *m = AdminChangeReplicasR
 func (m *AdminChangeReplicasRequest) String() string { return proto.CompactTextString(m) }
 func (*AdminChangeReplicasRequest) ProtoMessage()    {}
 func (*AdminChangeReplicasRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{39}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{39}
 }
 func (m *AdminChangeReplicasRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2190,7 +2190,7 @@ func (m *AdminChangeReplicasResponse) Reset()         { *m = AdminChangeReplicas
 func (m *AdminChangeReplicasResponse) String() string { return proto.CompactTextString(m) }
 func (*AdminChangeReplicasResponse) ProtoMessage()    {}
 func (*AdminChangeReplicasResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{40}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{40}
 }
 func (m *AdminChangeReplicasResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2228,7 +2228,7 @@ func (m *AdminRelocateRangeRequest) Reset()         { *m = AdminRelocateRangeReq
 func (m *AdminRelocateRangeRequest) String() string { return proto.CompactTextString(m) }
 func (*AdminRelocateRangeRequest) ProtoMessage()    {}
 func (*AdminRelocateRangeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{41}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{41}
 }
 func (m *AdminRelocateRangeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2261,7 +2261,7 @@ func (m *AdminRelocateRangeResponse) Reset()         { *m = AdminRelocateRangeRe
 func (m *AdminRelocateRangeResponse) String() string { return proto.CompactTextString(m) }
 func (*AdminRelocateRangeResponse) ProtoMessage()    {}
 func (*AdminRelocateRangeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{42}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{42}
 }
 func (m *AdminRelocateRangeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2303,7 +2303,7 @@ func (m *HeartbeatTxnRequest) Reset()         { *m = HeartbeatTxnRequest{} }
 func (m *HeartbeatTxnRequest) String() string { return proto.CompactTextString(m) }
 func (*HeartbeatTxnRequest) ProtoMessage()    {}
 func (*HeartbeatTxnRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{43}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{43}
 }
 func (m *HeartbeatTxnRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2340,7 +2340,7 @@ func (m *HeartbeatTxnResponse) Reset()         { *m = HeartbeatTxnResponse{} }
 func (m *HeartbeatTxnResponse) String() string { return proto.CompactTextString(m) }
 func (*HeartbeatTxnResponse) ProtoMessage()    {}
 func (*HeartbeatTxnResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{44}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{44}
 }
 func (m *HeartbeatTxnResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2378,7 +2378,7 @@ func (m *GCRequest) Reset()         { *m = GCRequest{} }
 func (m *GCRequest) String() string { return proto.CompactTextString(m) }
 func (*GCRequest) ProtoMessage()    {}
 func (*GCRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{45}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{45}
 }
 func (m *GCRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2412,7 +2412,7 @@ func (m *GCRequest_GCKey) Reset()         { *m = GCRequest_GCKey{} }
 func (m *GCRequest_GCKey) String() string { return proto.CompactTextString(m) }
 func (*GCRequest_GCKey) ProtoMessage()    {}
 func (*GCRequest_GCKey) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{45, 0}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{45, 0}
 }
 func (m *GCRequest_GCKey) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2446,7 +2446,7 @@ func (m *GCResponse) Reset()         { *m = GCResponse{} }
 func (m *GCResponse) String() string { return proto.CompactTextString(m) }
 func (*GCResponse) ProtoMessage()    {}
 func (*GCResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{46}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{46}
 }
 func (m *GCResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2515,7 +2515,7 @@ func (m *PushTxnRequest) Reset()         { *m = PushTxnRequest{} }
 func (m *PushTxnRequest) String() string { return proto.CompactTextString(m) }
 func (*PushTxnRequest) ProtoMessage()    {}
 func (*PushTxnRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{47}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{47}
 }
 func (m *PushTxnRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2558,7 +2558,7 @@ func (m *PushTxnResponse) Reset()         { *m = PushTxnResponse{} }
 func (m *PushTxnResponse) String() string { return proto.CompactTextString(m) }
 func (*PushTxnResponse) ProtoMessage()    {}
 func (*PushTxnResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{48}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{48}
 }
 func (m *PushTxnResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2605,7 +2605,7 @@ func (m *RecoverTxnRequest) Reset()         { *m = RecoverTxnRequest{} }
 func (m *RecoverTxnRequest) String() string { return proto.CompactTextString(m) }
 func (*RecoverTxnRequest) ProtoMessage()    {}
 func (*RecoverTxnRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{49}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{49}
 }
 func (m *RecoverTxnRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2641,7 +2641,7 @@ func (m *RecoverTxnResponse) Reset()         { *m = RecoverTxnResponse{} }
 func (m *RecoverTxnResponse) String() string { return proto.CompactTextString(m) }
 func (*RecoverTxnResponse) ProtoMessage()    {}
 func (*RecoverTxnResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{50}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{50}
 }
 func (m *RecoverTxnResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2685,7 +2685,7 @@ func (m *QueryTxnRequest) Reset()         { *m = QueryTxnRequest{} }
 func (m *QueryTxnRequest) String() string { return proto.CompactTextString(m) }
 func (*QueryTxnRequest) ProtoMessage()    {}
 func (*QueryTxnRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{51}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{51}
 }
 func (m *QueryTxnRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2729,7 +2729,7 @@ func (m *QueryTxnResponse) Reset()         { *m = QueryTxnResponse{} }
 func (m *QueryTxnResponse) String() string { return proto.CompactTextString(m) }
 func (*QueryTxnResponse) ProtoMessage()    {}
 func (*QueryTxnResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{52}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{52}
 }
 func (m *QueryTxnResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2789,7 +2789,7 @@ func (m *QueryIntentRequest) Reset()         { *m = QueryIntentRequest{} }
 func (m *QueryIntentRequest) String() string { return proto.CompactTextString(m) }
 func (*QueryIntentRequest) ProtoMessage()    {}
 func (*QueryIntentRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{53}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{53}
 }
 func (m *QueryIntentRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2825,7 +2825,7 @@ func (m *QueryIntentResponse) Reset()         { *m = QueryIntentResponse{} }
 func (m *QueryIntentResponse) String() string { return proto.CompactTextString(m) }
 func (*QueryIntentResponse) ProtoMessage()    {}
 func (*QueryIntentResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{54}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{54}
 }
 func (m *QueryIntentResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2872,7 +2872,7 @@ func (m *ResolveIntentRequest) Reset()         { *m = ResolveIntentRequest{} }
 func (m *ResolveIntentRequest) String() string { return proto.CompactTextString(m) }
 func (*ResolveIntentRequest) ProtoMessage()    {}
 func (*ResolveIntentRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{55}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{55}
 }
 func (m *ResolveIntentRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2907,7 +2907,7 @@ func (m *ResolveIntentResponse) Reset()         { *m = ResolveIntentResponse{} }
 func (m *ResolveIntentResponse) String() string { return proto.CompactTextString(m) }
 func (*ResolveIntentResponse) ProtoMessage()    {}
 func (*ResolveIntentResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{56}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{56}
 }
 func (m *ResolveIntentResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2958,7 +2958,7 @@ func (m *ResolveIntentRangeRequest) Reset()         { *m = ResolveIntentRangeReq
 func (m *ResolveIntentRangeRequest) String() string { return proto.CompactTextString(m) }
 func (*ResolveIntentRangeRequest) ProtoMessage()    {}
 func (*ResolveIntentRangeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{57}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{57}
 }
 func (m *ResolveIntentRangeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2993,7 +2993,7 @@ func (m *ResolveIntentRangeResponse) Reset()         { *m = ResolveIntentRangeRe
 func (m *ResolveIntentRangeResponse) String() string { return proto.CompactTextString(m) }
 func (*ResolveIntentRangeResponse) ProtoMessage()    {}
 func (*ResolveIntentRangeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{58}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{58}
 }
 func (m *ResolveIntentRangeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3030,7 +3030,7 @@ func (m *MergeRequest) Reset()         { *m = MergeRequest{} }
 func (m *MergeRequest) String() string { return proto.CompactTextString(m) }
 func (*MergeRequest) ProtoMessage()    {}
 func (*MergeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{59}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{59}
 }
 func (m *MergeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3064,7 +3064,7 @@ func (m *MergeResponse) Reset()         { *m = MergeResponse{} }
 func (m *MergeResponse) String() string { return proto.CompactTextString(m) }
 func (*MergeResponse) ProtoMessage()    {}
 func (*MergeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{60}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{60}
 }
 func (m *MergeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3109,7 +3109,7 @@ func (m *TruncateLogRequest) Reset()         { *m = TruncateLogRequest{} }
 func (m *TruncateLogRequest) String() string { return proto.CompactTextString(m) }
 func (*TruncateLogRequest) ProtoMessage()    {}
 func (*TruncateLogRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{61}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{61}
 }
 func (m *TruncateLogRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3143,7 +3143,7 @@ func (m *TruncateLogResponse) Reset()         { *m = TruncateLogResponse{} }
 func (m *TruncateLogResponse) String() string { return proto.CompactTextString(m) }
 func (*TruncateLogResponse) ProtoMessage()    {}
 func (*TruncateLogResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{62}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{62}
 }
 func (m *TruncateLogResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3187,7 +3187,7 @@ func (m *RequestLeaseRequest) Reset()         { *m = RequestLeaseRequest{} }
 func (m *RequestLeaseRequest) String() string { return proto.CompactTextString(m) }
 func (*RequestLeaseRequest) ProtoMessage()    {}
 func (*RequestLeaseRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{63}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{63}
 }
 func (m *RequestLeaseRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3236,7 +3236,7 @@ func (m *TransferLeaseRequest) Reset()         { *m = TransferLeaseRequest{} }
 func (m *TransferLeaseRequest) String() string { return proto.CompactTextString(m) }
 func (*TransferLeaseRequest) ProtoMessage()    {}
 func (*TransferLeaseRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{64}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{64}
 }
 func (m *TransferLeaseRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3273,7 +3273,7 @@ func (m *LeaseInfoRequest) Reset()         { *m = LeaseInfoRequest{} }
 func (m *LeaseInfoRequest) String() string { return proto.CompactTextString(m) }
 func (*LeaseInfoRequest) ProtoMessage()    {}
 func (*LeaseInfoRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{65}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{65}
 }
 func (m *LeaseInfoRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3310,7 +3310,7 @@ func (m *LeaseInfoResponse) Reset()         { *m = LeaseInfoResponse{} }
 func (m *LeaseInfoResponse) String() string { return proto.CompactTextString(m) }
 func (*LeaseInfoResponse) ProtoMessage()    {}
 func (*LeaseInfoResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{66}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{66}
 }
 func (m *LeaseInfoResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3345,7 +3345,7 @@ func (m *RequestLeaseResponse) Reset()         { *m = RequestLeaseResponse{} }
 func (m *RequestLeaseResponse) String() string { return proto.CompactTextString(m) }
 func (*RequestLeaseResponse) ProtoMessage()    {}
 func (*RequestLeaseResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{67}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{67}
 }
 func (m *RequestLeaseResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3400,7 +3400,7 @@ func (m *ComputeChecksumRequest) Reset()         { *m = ComputeChecksumRequest{}
 func (m *ComputeChecksumRequest) String() string { return proto.CompactTextString(m) }
 func (*ComputeChecksumRequest) ProtoMessage()    {}
 func (*ComputeChecksumRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{68}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{68}
 }
 func (m *ComputeChecksumRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3437,7 +3437,7 @@ func (m *ComputeChecksumResponse) Reset()         { *m = ComputeChecksumResponse
 func (m *ComputeChecksumResponse) String() string { return proto.CompactTextString(m) }
 func (*ComputeChecksumResponse) ProtoMessage()    {}
 func (*ComputeChecksumResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{69}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{69}
 }
 func (m *ComputeChecksumResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3477,7 +3477,7 @@ func (m *ExternalStorage) Reset()         { *m = ExternalStorage{} }
 func (m *ExternalStorage) String() string { return proto.CompactTextString(m) }
 func (*ExternalStorage) ProtoMessage()    {}
 func (*ExternalStorage) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{70}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{70}
 }
 func (m *ExternalStorage) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3511,7 +3511,7 @@ func (m *ExternalStorage_LocalFilePath) Reset()         { *m = ExternalStorage_L
 func (m *ExternalStorage_LocalFilePath) String() string { return proto.CompactTextString(m) }
 func (*ExternalStorage_LocalFilePath) ProtoMessage()    {}
 func (*ExternalStorage_LocalFilePath) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{70, 0}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{70, 0}
 }
 func (m *ExternalStorage_LocalFilePath) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3544,7 +3544,7 @@ func (m *ExternalStorage_Http) Reset()         { *m = ExternalStorage_Http{} }
 func (m *ExternalStorage_Http) String() string { return proto.CompactTextString(m) }
 func (*ExternalStorage_Http) ProtoMessage()    {}
 func (*ExternalStorage_Http) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{70, 1}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{70, 1}
 }
 func (m *ExternalStorage_Http) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3586,7 +3586,7 @@ func (m *ExternalStorage_S3) Reset()         { *m = ExternalStorage_S3{} }
 func (m *ExternalStorage_S3) String() string { return proto.CompactTextString(m) }
 func (*ExternalStorage_S3) ProtoMessage()    {}
 func (*ExternalStorage_S3) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{70, 2}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{70, 2}
 }
 func (m *ExternalStorage_S3) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3625,7 +3625,7 @@ func (m *ExternalStorage_GCS) Reset()         { *m = ExternalStorage_GCS{} }
 func (m *ExternalStorage_GCS) String() string { return proto.CompactTextString(m) }
 func (*ExternalStorage_GCS) ProtoMessage()    {}
 func (*ExternalStorage_GCS) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{70, 3}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{70, 3}
 }
 func (m *ExternalStorage_GCS) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3661,7 +3661,7 @@ func (m *ExternalStorage_Azure) Reset()         { *m = ExternalStorage_Azure{} }
 func (m *ExternalStorage_Azure) String() string { return proto.CompactTextString(m) }
 func (*ExternalStorage_Azure) ProtoMessage()    {}
 func (*ExternalStorage_Azure) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{70, 4}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{70, 4}
 }
 func (m *ExternalStorage_Azure) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3700,7 +3700,7 @@ func (m *ExternalStorage_Workload) Reset()         { *m = ExternalStorage_Worklo
 func (m *ExternalStorage_Workload) String() string { return proto.CompactTextString(m) }
 func (*ExternalStorage_Workload) ProtoMessage()    {}
 func (*ExternalStorage_Workload) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{70, 5}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{70, 5}
 }
 func (m *ExternalStorage_Workload) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3742,7 +3742,7 @@ func (m *ExternalStorage_FileTable) Reset()         { *m = ExternalStorage_FileT
 func (m *ExternalStorage_FileTable) String() string { return proto.CompactTextString(m) }
 func (*ExternalStorage_FileTable) ProtoMessage()    {}
 func (*ExternalStorage_FileTable) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{70, 6}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{70, 6}
 }
 func (m *ExternalStorage_FileTable) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3782,7 +3782,7 @@ func (m *WriteBatchRequest) Reset()         { *m = WriteBatchRequest{} }
 func (m *WriteBatchRequest) String() string { return proto.CompactTextString(m) }
 func (*WriteBatchRequest) ProtoMessage()    {}
 func (*WriteBatchRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{71}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{71}
 }
 func (m *WriteBatchRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3816,7 +3816,7 @@ func (m *WriteBatchResponse) Reset()         { *m = WriteBatchResponse{} }
 func (m *WriteBatchResponse) String() string { return proto.CompactTextString(m) }
 func (*WriteBatchResponse) ProtoMessage()    {}
 func (*WriteBatchResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{72}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{72}
 }
 func (m *WriteBatchResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3852,7 +3852,7 @@ func (m *FileEncryptionOptions) Reset()         { *m = FileEncryptionOptions{} }
 func (m *FileEncryptionOptions) String() string { return proto.CompactTextString(m) }
 func (*FileEncryptionOptions) ProtoMessage()    {}
 func (*FileEncryptionOptions) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{73}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{73}
 }
 func (m *FileEncryptionOptions) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3922,7 +3922,7 @@ func (m *ExportRequest) Reset()         { *m = ExportRequest{} }
 func (m *ExportRequest) String() string { return proto.CompactTextString(m) }
 func (*ExportRequest) ProtoMessage()    {}
 func (*ExportRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{74}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{74}
 }
 func (m *ExportRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3974,7 +3974,7 @@ func (m *BulkOpSummary) Reset()         { *m = BulkOpSummary{} }
 func (m *BulkOpSummary) String() string { return proto.CompactTextString(m) }
 func (*BulkOpSummary) ProtoMessage()    {}
 func (*BulkOpSummary) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{75}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{75}
 }
 func (m *BulkOpSummary) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4010,7 +4010,7 @@ func (m *ExportResponse) Reset()         { *m = ExportResponse{} }
 func (m *ExportResponse) String() string { return proto.CompactTextString(m) }
 func (*ExportResponse) ProtoMessage()    {}
 func (*ExportResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{76}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{76}
 }
 func (m *ExportResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4050,7 +4050,7 @@ func (m *ExportResponse_File) Reset()         { *m = ExportResponse_File{} }
 func (m *ExportResponse_File) String() string { return proto.CompactTextString(m) }
 func (*ExportResponse_File) ProtoMessage()    {}
 func (*ExportResponse_File) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{76, 0}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{76, 0}
 }
 func (m *ExportResponse_File) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4101,7 +4101,7 @@ func (m *ImportRequest) Reset()         { *m = ImportRequest{} }
 func (m *ImportRequest) String() string { return proto.CompactTextString(m) }
 func (*ImportRequest) ProtoMessage()    {}
 func (*ImportRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{77}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{77}
 }
 func (m *ImportRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4136,7 +4136,7 @@ func (m *ImportRequest_File) Reset()         { *m = ImportRequest_File{} }
 func (m *ImportRequest_File) String() string { return proto.CompactTextString(m) }
 func (*ImportRequest_File) ProtoMessage()    {}
 func (*ImportRequest_File) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{77, 0}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{77, 0}
 }
 func (m *ImportRequest_File) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4172,7 +4172,7 @@ func (m *ImportRequest_TableRekey) Reset()         { *m = ImportRequest_TableRek
 func (m *ImportRequest_TableRekey) String() string { return proto.CompactTextString(m) }
 func (*ImportRequest_TableRekey) ProtoMessage()    {}
 func (*ImportRequest_TableRekey) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{77, 1}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{77, 1}
 }
 func (m *ImportRequest_TableRekey) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4207,7 +4207,7 @@ func (m *ImportResponse) Reset()         { *m = ImportResponse{} }
 func (m *ImportResponse) String() string { return proto.CompactTextString(m) }
 func (*ImportResponse) ProtoMessage()    {}
 func (*ImportResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{78}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{78}
 }
 func (m *ImportResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4245,7 +4245,7 @@ func (m *AdminScatterRequest) Reset()         { *m = AdminScatterRequest{} }
 func (m *AdminScatterRequest) String() string { return proto.CompactTextString(m) }
 func (*AdminScatterRequest) ProtoMessage()    {}
 func (*AdminScatterRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{79}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{79}
 }
 func (m *AdminScatterRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4282,7 +4282,7 @@ func (m *AdminScatterResponse) Reset()         { *m = AdminScatterResponse{} }
 func (m *AdminScatterResponse) String() string { return proto.CompactTextString(m) }
 func (*AdminScatterResponse) ProtoMessage()    {}
 func (*AdminScatterResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{80}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{80}
 }
 func (m *AdminScatterResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4315,7 +4315,7 @@ func (m *AdminScatterResponse_Range) Reset()         { *m = AdminScatterResponse
 func (m *AdminScatterResponse_Range) String() string { return proto.CompactTextString(m) }
 func (*AdminScatterResponse_Range) ProtoMessage()    {}
 func (*AdminScatterResponse_Range) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{80, 0}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{80, 0}
 }
 func (m *AdminScatterResponse_Range) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4360,7 +4360,7 @@ func (m *AdminVerifyProtectedTimestampRequest) Reset()         { *m = AdminVerif
 func (m *AdminVerifyProtectedTimestampRequest) String() string { return proto.CompactTextString(m) }
 func (*AdminVerifyProtectedTimestampRequest) ProtoMessage()    {}
 func (*AdminVerifyProtectedTimestampRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{81}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{81}
 }
 func (m *AdminVerifyProtectedTimestampRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4398,7 +4398,7 @@ func (m *AdminVerifyProtectedTimestampResponse) Reset()         { *m = AdminVeri
 func (m *AdminVerifyProtectedTimestampResponse) String() string { return proto.CompactTextString(m) }
 func (*AdminVerifyProtectedTimestampResponse) ProtoMessage()    {}
 func (*AdminVerifyProtectedTimestampResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{82}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{82}
 }
 func (m *AdminVerifyProtectedTimestampResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4451,7 +4451,7 @@ func (m *AddSSTableRequest) Reset()         { *m = AddSSTableRequest{} }
 func (m *AddSSTableRequest) String() string { return proto.CompactTextString(m) }
 func (*AddSSTableRequest) ProtoMessage()    {}
 func (*AddSSTableRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{83}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{83}
 }
 func (m *AddSSTableRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4485,7 +4485,7 @@ func (m *AddSSTableResponse) Reset()         { *m = AddSSTableResponse{} }
 func (m *AddSSTableResponse) String() string { return proto.CompactTextString(m) }
 func (*AddSSTableResponse) ProtoMessage()    {}
 func (*AddSSTableResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{84}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{84}
 }
 func (m *AddSSTableResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4529,7 +4529,7 @@ func (m *RefreshRequest) Reset()         { *m = RefreshRequest{} }
 func (m *RefreshRequest) String() string { return proto.CompactTextString(m) }
 func (*RefreshRequest) ProtoMessage()    {}
 func (*RefreshRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{85}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{85}
 }
 func (m *RefreshRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4563,7 +4563,7 @@ func (m *RefreshResponse) Reset()         { *m = RefreshResponse{} }
 func (m *RefreshResponse) String() string { return proto.CompactTextString(m) }
 func (*RefreshResponse) ProtoMessage()    {}
 func (*RefreshResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{86}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{86}
 }
 func (m *RefreshResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4602,7 +4602,7 @@ func (m *RefreshRangeRequest) Reset()         { *m = RefreshRangeRequest{} }
 func (m *RefreshRangeRequest) String() string { return proto.CompactTextString(m) }
 func (*RefreshRangeRequest) ProtoMessage()    {}
 func (*RefreshRangeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{87}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{87}
 }
 func (m *RefreshRangeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4636,7 +4636,7 @@ func (m *RefreshRangeResponse) Reset()         { *m = RefreshRangeResponse{} }
 func (m *RefreshRangeResponse) String() string { return proto.CompactTextString(m) }
 func (*RefreshRangeResponse) ProtoMessage()    {}
 func (*RefreshRangeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{88}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{88}
 }
 func (m *RefreshRangeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4685,7 +4685,7 @@ func (m *SubsumeRequest) Reset()         { *m = SubsumeRequest{} }
 func (m *SubsumeRequest) String() string { return proto.CompactTextString(m) }
 func (*SubsumeRequest) ProtoMessage()    {}
 func (*SubsumeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{89}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{89}
 }
 func (m *SubsumeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4734,7 +4734,7 @@ func (m *SubsumeResponse) Reset()         { *m = SubsumeResponse{} }
 func (m *SubsumeResponse) String() string { return proto.CompactTextString(m) }
 func (*SubsumeResponse) ProtoMessage()    {}
 func (*SubsumeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{90}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{90}
 }
 func (m *SubsumeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4769,7 +4769,7 @@ func (m *RangeStatsRequest) Reset()         { *m = RangeStatsRequest{} }
 func (m *RangeStatsRequest) String() string { return proto.CompactTextString(m) }
 func (*RangeStatsRequest) ProtoMessage()    {}
 func (*RangeStatsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{91}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{91}
 }
 func (m *RangeStatsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4811,7 +4811,7 @@ func (m *RangeStatsResponse) Reset()         { *m = RangeStatsResponse{} }
 func (m *RangeStatsResponse) String() string { return proto.CompactTextString(m) }
 func (*RangeStatsResponse) ProtoMessage()    {}
 func (*RangeStatsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{92}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{92}
 }
 func (m *RangeStatsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4854,7 +4854,7 @@ func (m *MigrateRequest) Reset()         { *m = MigrateRequest{} }
 func (m *MigrateRequest) String() string { return proto.CompactTextString(m) }
 func (*MigrateRequest) ProtoMessage()    {}
 func (*MigrateRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{93}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{93}
 }
 func (m *MigrateRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4888,7 +4888,7 @@ func (m *MigrateResponse) Reset()         { *m = MigrateResponse{} }
 func (m *MigrateResponse) String() string { return proto.CompactTextString(m) }
 func (*MigrateResponse) ProtoMessage()    {}
 func (*MigrateResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{94}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{94}
 }
 func (m *MigrateResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4972,7 +4972,7 @@ func (m *RequestUnion) Reset()         { *m = RequestUnion{} }
 func (m *RequestUnion) String() string { return proto.CompactTextString(m) }
 func (*RequestUnion) ProtoMessage()    {}
 func (*RequestUnion) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{95}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{95}
 }
 func (m *RequestUnion) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -6453,7 +6453,7 @@ func (m *ResponseUnion) Reset()         { *m = ResponseUnion{} }
 func (m *ResponseUnion) String() string { return proto.CompactTextString(m) }
 func (*ResponseUnion) ProtoMessage()    {}
 func (*ResponseUnion) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{96}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{96}
 }
 func (m *ResponseUnion) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -8018,7 +8018,7 @@ func (m *Header) Reset()         { *m = Header{} }
 func (m *Header) String() string { return proto.CompactTextString(m) }
 func (*Header) ProtoMessage()    {}
 func (*Header) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{97}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{97}
 }
 func (m *Header) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -8056,7 +8056,7 @@ func (m *ClientRangeInfo) Reset()         { *m = ClientRangeInfo{} }
 func (m *ClientRangeInfo) String() string { return proto.CompactTextString(m) }
 func (*ClientRangeInfo) ProtoMessage()    {}
 func (*ClientRangeInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{98}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{98}
 }
 func (m *ClientRangeInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -8092,7 +8092,7 @@ type BatchRequest struct {
 func (m *BatchRequest) Reset()      { *m = BatchRequest{} }
 func (*BatchRequest) ProtoMessage() {}
 func (*BatchRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{99}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{99}
 }
 func (m *BatchRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -8129,7 +8129,7 @@ type BatchResponse struct {
 func (m *BatchResponse) Reset()      { *m = BatchResponse{} }
 func (*BatchResponse) ProtoMessage() {}
 func (*BatchResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{100}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{100}
 }
 func (m *BatchResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -8208,7 +8208,7 @@ func (m *BatchResponse_Header) Reset()         { *m = BatchResponse_Header{} }
 func (m *BatchResponse_Header) String() string { return proto.CompactTextString(m) }
 func (*BatchResponse_Header) ProtoMessage()    {}
 func (*BatchResponse_Header) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{100, 0}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{100, 0}
 }
 func (m *BatchResponse_Header) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -8246,7 +8246,7 @@ func (m *RangeLookupRequest) Reset()         { *m = RangeLookupRequest{} }
 func (m *RangeLookupRequest) String() string { return proto.CompactTextString(m) }
 func (*RangeLookupRequest) ProtoMessage()    {}
 func (*RangeLookupRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{101}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{101}
 }
 func (m *RangeLookupRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -8284,7 +8284,7 @@ func (m *RangeLookupResponse) Reset()         { *m = RangeLookupResponse{} }
 func (m *RangeLookupResponse) String() string { return proto.CompactTextString(m) }
 func (*RangeLookupResponse) ProtoMessage()    {}
 func (*RangeLookupResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{102}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{102}
 }
 func (m *RangeLookupResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -8323,7 +8323,7 @@ func (m *RangeFeedRequest) Reset()         { *m = RangeFeedRequest{} }
 func (m *RangeFeedRequest) String() string { return proto.CompactTextString(m) }
 func (*RangeFeedRequest) ProtoMessage()    {}
 func (*RangeFeedRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{103}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{103}
 }
 func (m *RangeFeedRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -8364,7 +8364,7 @@ func (m *RangeFeedValue) Reset()         { *m = RangeFeedValue{} }
 func (m *RangeFeedValue) String() string { return proto.CompactTextString(m) }
 func (*RangeFeedValue) ProtoMessage()    {}
 func (*RangeFeedValue) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{104}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{104}
 }
 func (m *RangeFeedValue) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -8405,7 +8405,7 @@ func (m *RangeFeedCheckpoint) Reset()         { *m = RangeFeedCheckpoint{} }
 func (m *RangeFeedCheckpoint) String() string { return proto.CompactTextString(m) }
 func (*RangeFeedCheckpoint) ProtoMessage()    {}
 func (*RangeFeedCheckpoint) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{105}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{105}
 }
 func (m *RangeFeedCheckpoint) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -8442,7 +8442,7 @@ func (m *RangeFeedError) Reset()         { *m = RangeFeedError{} }
 func (m *RangeFeedError) String() string { return proto.CompactTextString(m) }
 func (*RangeFeedError) ProtoMessage()    {}
 func (*RangeFeedError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{106}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{106}
 }
 func (m *RangeFeedError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -8479,7 +8479,7 @@ func (m *RangeFeedEvent) Reset()         { *m = RangeFeedEvent{} }
 func (m *RangeFeedEvent) String() string { return proto.CompactTextString(m) }
 func (*RangeFeedEvent) ProtoMessage()    {}
 func (*RangeFeedEvent) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{107}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{107}
 }
 func (m *RangeFeedEvent) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -8523,7 +8523,7 @@ func (m *ResetQuorumRequest) Reset()         { *m = ResetQuorumRequest{} }
 func (m *ResetQuorumRequest) String() string { return proto.CompactTextString(m) }
 func (*ResetQuorumRequest) ProtoMessage()    {}
 func (*ResetQuorumRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{108}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{108}
 }
 func (m *ResetQuorumRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -8555,7 +8555,7 @@ func (m *ResetQuorumResponse) Reset()         { *m = ResetQuorumResponse{} }
 func (m *ResetQuorumResponse) String() string { return proto.CompactTextString(m) }
 func (*ResetQuorumResponse) ProtoMessage()    {}
 func (*ResetQuorumResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{109}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{109}
 }
 func (m *ResetQuorumResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -8596,7 +8596,7 @@ func (m *GossipSubscriptionRequest) Reset()         { *m = GossipSubscriptionReq
 func (m *GossipSubscriptionRequest) String() string { return proto.CompactTextString(m) }
 func (*GossipSubscriptionRequest) ProtoMessage()    {}
 func (*GossipSubscriptionRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{110}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{110}
 }
 func (m *GossipSubscriptionRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -8636,7 +8636,7 @@ func (m *GossipSubscriptionEvent) Reset()         { *m = GossipSubscriptionEvent
 func (m *GossipSubscriptionEvent) String() string { return proto.CompactTextString(m) }
 func (*GossipSubscriptionEvent) ProtoMessage()    {}
 func (*GossipSubscriptionEvent) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{111}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{111}
 }
 func (m *GossipSubscriptionEvent) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -8672,7 +8672,7 @@ func (m *JoinNodeRequest) Reset()         { *m = JoinNodeRequest{} }
 func (m *JoinNodeRequest) String() string { return proto.CompactTextString(m) }
 func (*JoinNodeRequest) ProtoMessage()    {}
 func (*JoinNodeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{112}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{112}
 }
 func (m *JoinNodeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -8711,7 +8711,7 @@ func (m *JoinNodeResponse) Reset()         { *m = JoinNodeResponse{} }
 func (m *JoinNodeResponse) String() string { return proto.CompactTextString(m) }
 func (*JoinNodeResponse) ProtoMessage()    {}
 func (*JoinNodeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{113}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{113}
 }
 func (m *JoinNodeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -8754,7 +8754,7 @@ func (m *ContentionEvent) Reset()         { *m = ContentionEvent{} }
 func (m *ContentionEvent) String() string { return proto.CompactTextString(m) }
 func (*ContentionEvent) ProtoMessage()    {}
 func (*ContentionEvent) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_be6b7a2c0d1c6f44, []int{114}
+	return fileDescriptor_api_5f7f23e8e4f12d4b, []int{114}
 }
 func (m *ContentionEvent) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -39169,9 +39169,9 @@ var (
 	ErrIntOverflowApi   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("roachpb/api.proto", fileDescriptor_api_be6b7a2c0d1c6f44) }
+func init() { proto.RegisterFile("roachpb/api.proto", fileDescriptor_api_5f7f23e8e4f12d4b) }
 
-var fileDescriptor_api_be6b7a2c0d1c6f44 = []byte{
+var fileDescriptor_api_5f7f23e8e4f12d4b = []byte{
 	// 8257 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe4, 0x7d, 0x5d, 0x6c, 0x23, 0xc9,
 	0x76, 0x9e, 0x9a, 0xa4, 0x24, 0xf2, 0x50, 0xfc, 0x51, 0x69, 0x7e, 0x38, 0xdc, 0xdd, 0xd1, 0x4c,

--- a/pkg/roachpb/app_stats.pb.go
+++ b/pkg/roachpb/app_stats.pb.go
@@ -87,7 +87,7 @@ func (m *StatementStatistics) Reset()         { *m = StatementStatistics{} }
 func (m *StatementStatistics) String() string { return proto.CompactTextString(m) }
 func (*StatementStatistics) ProtoMessage()    {}
 func (*StatementStatistics) Descriptor() ([]byte, []int) {
-	return fileDescriptor_app_stats_02e0c72cac47fa1c, []int{0}
+	return fileDescriptor_app_stats_1e7bd1c14de5d1e0, []int{0}
 }
 func (m *StatementStatistics) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -136,7 +136,7 @@ func (m *TransactionStatistics) Reset()         { *m = TransactionStatistics{} }
 func (m *TransactionStatistics) String() string { return proto.CompactTextString(m) }
 func (*TransactionStatistics) ProtoMessage()    {}
 func (*TransactionStatistics) Descriptor() ([]byte, []int) {
-	return fileDescriptor_app_stats_02e0c72cac47fa1c, []int{1}
+	return fileDescriptor_app_stats_1e7bd1c14de5d1e0, []int{1}
 }
 func (m *TransactionStatistics) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -176,7 +176,7 @@ func (m *SensitiveInfo) Reset()         { *m = SensitiveInfo{} }
 func (m *SensitiveInfo) String() string { return proto.CompactTextString(m) }
 func (*SensitiveInfo) ProtoMessage()    {}
 func (*SensitiveInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_app_stats_02e0c72cac47fa1c, []int{2}
+	return fileDescriptor_app_stats_1e7bd1c14de5d1e0, []int{2}
 }
 func (m *SensitiveInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -218,7 +218,7 @@ func (m *NumericStat) Reset()         { *m = NumericStat{} }
 func (m *NumericStat) String() string { return proto.CompactTextString(m) }
 func (*NumericStat) ProtoMessage()    {}
 func (*NumericStat) Descriptor() ([]byte, []int) {
-	return fileDescriptor_app_stats_02e0c72cac47fa1c, []int{3}
+	return fileDescriptor_app_stats_1e7bd1c14de5d1e0, []int{3}
 }
 func (m *NumericStat) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -257,7 +257,7 @@ func (m *StatementStatisticsKey) Reset()         { *m = StatementStatisticsKey{}
 func (m *StatementStatisticsKey) String() string { return proto.CompactTextString(m) }
 func (*StatementStatisticsKey) ProtoMessage()    {}
 func (*StatementStatisticsKey) Descriptor() ([]byte, []int) {
-	return fileDescriptor_app_stats_02e0c72cac47fa1c, []int{4}
+	return fileDescriptor_app_stats_1e7bd1c14de5d1e0, []int{4}
 }
 func (m *StatementStatisticsKey) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -297,7 +297,7 @@ func (m *CollectedStatementStatistics) Reset()         { *m = CollectedStatement
 func (m *CollectedStatementStatistics) String() string { return proto.CompactTextString(m) }
 func (*CollectedStatementStatistics) ProtoMessage()    {}
 func (*CollectedStatementStatistics) Descriptor() ([]byte, []int) {
-	return fileDescriptor_app_stats_02e0c72cac47fa1c, []int{5}
+	return fileDescriptor_app_stats_1e7bd1c14de5d1e0, []int{5}
 }
 func (m *CollectedStatementStatistics) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -337,7 +337,7 @@ func (m *CollectedTransactionStatistics) Reset()         { *m = CollectedTransac
 func (m *CollectedTransactionStatistics) String() string { return proto.CompactTextString(m) }
 func (*CollectedTransactionStatistics) ProtoMessage()    {}
 func (*CollectedTransactionStatistics) Descriptor() ([]byte, []int) {
-	return fileDescriptor_app_stats_02e0c72cac47fa1c, []int{6}
+	return fileDescriptor_app_stats_1e7bd1c14de5d1e0, []int{6}
 }
 func (m *CollectedTransactionStatistics) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -377,7 +377,7 @@ func (m *ExplainTreePlanNode) Reset()         { *m = ExplainTreePlanNode{} }
 func (m *ExplainTreePlanNode) String() string { return proto.CompactTextString(m) }
 func (*ExplainTreePlanNode) ProtoMessage()    {}
 func (*ExplainTreePlanNode) Descriptor() ([]byte, []int) {
-	return fileDescriptor_app_stats_02e0c72cac47fa1c, []int{7}
+	return fileDescriptor_app_stats_1e7bd1c14de5d1e0, []int{7}
 }
 func (m *ExplainTreePlanNode) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -411,7 +411,7 @@ func (m *ExplainTreePlanNode_Attr) Reset()         { *m = ExplainTreePlanNode_At
 func (m *ExplainTreePlanNode_Attr) String() string { return proto.CompactTextString(m) }
 func (*ExplainTreePlanNode_Attr) ProtoMessage()    {}
 func (*ExplainTreePlanNode_Attr) Descriptor() ([]byte, []int) {
-	return fileDescriptor_app_stats_02e0c72cac47fa1c, []int{7, 0}
+	return fileDescriptor_app_stats_1e7bd1c14de5d1e0, []int{7, 0}
 }
 func (m *ExplainTreePlanNode_Attr) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -450,7 +450,7 @@ func (m *TxnStats) Reset()         { *m = TxnStats{} }
 func (m *TxnStats) String() string { return proto.CompactTextString(m) }
 func (*TxnStats) ProtoMessage()    {}
 func (*TxnStats) Descriptor() ([]byte, []int) {
-	return fileDescriptor_app_stats_02e0c72cac47fa1c, []int{8}
+	return fileDescriptor_app_stats_1e7bd1c14de5d1e0, []int{8}
 }
 func (m *TxnStats) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3167,9 +3167,9 @@ var (
 	ErrIntOverflowAppStats   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("roachpb/app_stats.proto", fileDescriptor_app_stats_02e0c72cac47fa1c) }
+func init() { proto.RegisterFile("roachpb/app_stats.proto", fileDescriptor_app_stats_1e7bd1c14de5d1e0) }
 
-var fileDescriptor_app_stats_02e0c72cac47fa1c = []byte{
+var fileDescriptor_app_stats_1e7bd1c14de5d1e0 = []byte{
 	// 1145 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x9c, 0x56, 0xcd, 0x6e, 0x23, 0x45,
 	0x10, 0xce, 0xf8, 0x27, 0xb6, 0xcb, 0x76, 0xb2, 0x3b, 0xfb, 0x37, 0x58, 0x91, 0x1d, 0xac, 0x5d,

--- a/pkg/roachpb/data.pb.go
+++ b/pkg/roachpb/data.pb.go
@@ -98,7 +98,7 @@ func (x ValueType) String() string {
 	return proto.EnumName(ValueType_name, int32(x))
 }
 func (ValueType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_data_7c13a0dbc42fb34d, []int{0}
+	return fileDescriptor_data_39a236c331769db6, []int{0}
 }
 
 // ReplicaChangeType is a parameter of ChangeReplicasTrigger.
@@ -128,7 +128,7 @@ func (x ReplicaChangeType) String() string {
 	return proto.EnumName(ReplicaChangeType_name, int32(x))
 }
 func (ReplicaChangeType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_data_7c13a0dbc42fb34d, []int{1}
+	return fileDescriptor_data_39a236c331769db6, []int{1}
 }
 
 // TransactionStatus specifies possible states for a transaction.
@@ -180,7 +180,7 @@ func (x TransactionStatus) String() string {
 	return proto.EnumName(TransactionStatus_name, int32(x))
 }
 func (TransactionStatus) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_data_7c13a0dbc42fb34d, []int{2}
+	return fileDescriptor_data_39a236c331769db6, []int{2}
 }
 
 // Span is a key range with an inclusive start Key and an exclusive end Key.
@@ -197,7 +197,7 @@ type Span struct {
 func (m *Span) Reset()      { *m = Span{} }
 func (*Span) ProtoMessage() {}
 func (*Span) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_7c13a0dbc42fb34d, []int{0}
+	return fileDescriptor_data_39a236c331769db6, []int{0}
 }
 func (m *Span) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -249,7 +249,7 @@ func (m *Value) Reset()         { *m = Value{} }
 func (m *Value) String() string { return proto.CompactTextString(m) }
 func (*Value) ProtoMessage()    {}
 func (*Value) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_7c13a0dbc42fb34d, []int{1}
+	return fileDescriptor_data_39a236c331769db6, []int{1}
 }
 func (m *Value) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -285,7 +285,7 @@ func (m *KeyValue) Reset()         { *m = KeyValue{} }
 func (m *KeyValue) String() string { return proto.CompactTextString(m) }
 func (*KeyValue) ProtoMessage()    {}
 func (*KeyValue) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_7c13a0dbc42fb34d, []int{2}
+	return fileDescriptor_data_39a236c331769db6, []int{2}
 }
 func (m *KeyValue) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -323,7 +323,7 @@ func (m *StoreIdent) Reset()         { *m = StoreIdent{} }
 func (m *StoreIdent) String() string { return proto.CompactTextString(m) }
 func (*StoreIdent) ProtoMessage()    {}
 func (*StoreIdent) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_7c13a0dbc42fb34d, []int{3}
+	return fileDescriptor_data_39a236c331769db6, []int{3}
 }
 func (m *StoreIdent) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -363,7 +363,7 @@ func (m *SplitTrigger) Reset()         { *m = SplitTrigger{} }
 func (m *SplitTrigger) String() string { return proto.CompactTextString(m) }
 func (*SplitTrigger) ProtoMessage()    {}
 func (*SplitTrigger) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_7c13a0dbc42fb34d, []int{4}
+	return fileDescriptor_data_39a236c331769db6, []int{4}
 }
 func (m *SplitTrigger) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -411,7 +411,7 @@ func (m *MergeTrigger) Reset()         { *m = MergeTrigger{} }
 func (m *MergeTrigger) String() string { return proto.CompactTextString(m) }
 func (*MergeTrigger) ProtoMessage()    {}
 func (*MergeTrigger) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_7c13a0dbc42fb34d, []int{5}
+	return fileDescriptor_data_39a236c331769db6, []int{5}
 }
 func (m *MergeTrigger) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -481,7 +481,7 @@ type ChangeReplicasTrigger struct {
 func (m *ChangeReplicasTrigger) Reset()      { *m = ChangeReplicasTrigger{} }
 func (*ChangeReplicasTrigger) ProtoMessage() {}
 func (*ChangeReplicasTrigger) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_7c13a0dbc42fb34d, []int{6}
+	return fileDescriptor_data_39a236c331769db6, []int{6}
 }
 func (m *ChangeReplicasTrigger) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -523,7 +523,7 @@ func (m *ModifiedSpanTrigger) Reset()         { *m = ModifiedSpanTrigger{} }
 func (m *ModifiedSpanTrigger) String() string { return proto.CompactTextString(m) }
 func (*ModifiedSpanTrigger) ProtoMessage()    {}
 func (*ModifiedSpanTrigger) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_7c13a0dbc42fb34d, []int{7}
+	return fileDescriptor_data_39a236c331769db6, []int{7}
 }
 func (m *ModifiedSpanTrigger) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -569,7 +569,7 @@ func (m *StickyBitTrigger) Reset()         { *m = StickyBitTrigger{} }
 func (m *StickyBitTrigger) String() string { return proto.CompactTextString(m) }
 func (*StickyBitTrigger) ProtoMessage()    {}
 func (*StickyBitTrigger) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_7c13a0dbc42fb34d, []int{8}
+	return fileDescriptor_data_39a236c331769db6, []int{8}
 }
 func (m *StickyBitTrigger) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -608,7 +608,7 @@ func (m *InternalCommitTrigger) Reset()         { *m = InternalCommitTrigger{} }
 func (m *InternalCommitTrigger) String() string { return proto.CompactTextString(m) }
 func (*InternalCommitTrigger) ProtoMessage()    {}
 func (*InternalCommitTrigger) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_7c13a0dbc42fb34d, []int{9}
+	return fileDescriptor_data_39a236c331769db6, []int{9}
 }
 func (m *InternalCommitTrigger) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -677,7 +677,7 @@ func (m *ObservedTimestamp) Reset()         { *m = ObservedTimestamp{} }
 func (m *ObservedTimestamp) String() string { return proto.CompactTextString(m) }
 func (*ObservedTimestamp) ProtoMessage()    {}
 func (*ObservedTimestamp) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_7c13a0dbc42fb34d, []int{10}
+	return fileDescriptor_data_39a236c331769db6, []int{10}
 }
 func (m *ObservedTimestamp) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -834,7 +834,7 @@ type Transaction struct {
 func (m *Transaction) Reset()      { *m = Transaction{} }
 func (*Transaction) ProtoMessage() {}
 func (*Transaction) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_7c13a0dbc42fb34d, []int{11}
+	return fileDescriptor_data_39a236c331769db6, []int{11}
 }
 func (m *Transaction) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -885,7 +885,7 @@ func (m *TransactionRecord) Reset()         { *m = TransactionRecord{} }
 func (m *TransactionRecord) String() string { return proto.CompactTextString(m) }
 func (*TransactionRecord) ProtoMessage()    {}
 func (*TransactionRecord) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_7c13a0dbc42fb34d, []int{12}
+	return fileDescriptor_data_39a236c331769db6, []int{12}
 }
 func (m *TransactionRecord) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -925,7 +925,7 @@ func (m *Intent) Reset()         { *m = Intent{} }
 func (m *Intent) String() string { return proto.CompactTextString(m) }
 func (*Intent) ProtoMessage()    {}
 func (*Intent) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_7c13a0dbc42fb34d, []int{13}
+	return fileDescriptor_data_39a236c331769db6, []int{13}
 }
 func (m *Intent) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -962,7 +962,7 @@ func (m *Intent_SingleKeySpan) Reset()         { *m = Intent_SingleKeySpan{} }
 func (m *Intent_SingleKeySpan) String() string { return proto.CompactTextString(m) }
 func (*Intent_SingleKeySpan) ProtoMessage()    {}
 func (*Intent_SingleKeySpan) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_7c13a0dbc42fb34d, []int{13, 0}
+	return fileDescriptor_data_39a236c331769db6, []int{13, 0}
 }
 func (m *Intent_SingleKeySpan) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -999,7 +999,7 @@ func (m *LockAcquisition) Reset()         { *m = LockAcquisition{} }
 func (m *LockAcquisition) String() string { return proto.CompactTextString(m) }
 func (*LockAcquisition) ProtoMessage()    {}
 func (*LockAcquisition) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_7c13a0dbc42fb34d, []int{14}
+	return fileDescriptor_data_39a236c331769db6, []int{14}
 }
 func (m *LockAcquisition) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1040,7 +1040,7 @@ func (m *LockUpdate) Reset()         { *m = LockUpdate{} }
 func (m *LockUpdate) String() string { return proto.CompactTextString(m) }
 func (*LockUpdate) ProtoMessage()    {}
 func (*LockUpdate) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_7c13a0dbc42fb34d, []int{15}
+	return fileDescriptor_data_39a236c331769db6, []int{15}
 }
 func (m *LockUpdate) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1077,7 +1077,7 @@ func (m *SequencedWrite) Reset()         { *m = SequencedWrite{} }
 func (m *SequencedWrite) String() string { return proto.CompactTextString(m) }
 func (*SequencedWrite) ProtoMessage()    {}
 func (*SequencedWrite) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_7c13a0dbc42fb34d, []int{16}
+	return fileDescriptor_data_39a236c331769db6, []int{16}
 }
 func (m *SequencedWrite) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1142,7 +1142,7 @@ type Lease struct {
 func (m *Lease) Reset()      { *m = Lease{} }
 func (*Lease) ProtoMessage() {}
 func (*Lease) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_7c13a0dbc42fb34d, []int{17}
+	return fileDescriptor_data_39a236c331769db6, []int{17}
 }
 func (m *Lease) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1187,7 +1187,7 @@ func (m *AbortSpanEntry) Reset()         { *m = AbortSpanEntry{} }
 func (m *AbortSpanEntry) String() string { return proto.CompactTextString(m) }
 func (*AbortSpanEntry) ProtoMessage()    {}
 func (*AbortSpanEntry) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_7c13a0dbc42fb34d, []int{18}
+	return fileDescriptor_data_39a236c331769db6, []int{18}
 }
 func (m *AbortSpanEntry) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1244,7 +1244,7 @@ func (m *LeafTxnInputState) Reset()         { *m = LeafTxnInputState{} }
 func (m *LeafTxnInputState) String() string { return proto.CompactTextString(m) }
 func (*LeafTxnInputState) ProtoMessage()    {}
 func (*LeafTxnInputState) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_7c13a0dbc42fb34d, []int{19}
+	return fileDescriptor_data_39a236c331769db6, []int{19}
 }
 func (m *LeafTxnInputState) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1297,7 +1297,7 @@ func (m *LeafTxnFinalState) Reset()         { *m = LeafTxnFinalState{} }
 func (m *LeafTxnFinalState) String() string { return proto.CompactTextString(m) }
 func (*LeafTxnFinalState) ProtoMessage()    {}
 func (*LeafTxnFinalState) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_7c13a0dbc42fb34d, []int{20}
+	return fileDescriptor_data_39a236c331769db6, []int{20}
 }
 func (m *LeafTxnFinalState) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1332,7 +1332,7 @@ type RangeInfo struct {
 func (m *RangeInfo) Reset()      { *m = RangeInfo{} }
 func (*RangeInfo) ProtoMessage() {}
 func (*RangeInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_7c13a0dbc42fb34d, []int{21}
+	return fileDescriptor_data_39a236c331769db6, []int{21}
 }
 func (m *RangeInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -6910,9 +6910,9 @@ var (
 	ErrIntOverflowData   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("roachpb/data.proto", fileDescriptor_data_7c13a0dbc42fb34d) }
+func init() { proto.RegisterFile("roachpb/data.proto", fileDescriptor_data_39a236c331769db6) }
 
-var fileDescriptor_data_7c13a0dbc42fb34d = []byte{
+var fileDescriptor_data_39a236c331769db6 = []byte{
 	// 2429 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xdc, 0x59, 0xdf, 0x6f, 0x1b, 0x59,
 	0xf5, 0xcf, 0x64, 0xc6, 0xf6, 0xf8, 0xf8, 0x47, 0x26, 0xb7, 0x49, 0xeb, 0xcd, 0x7e, 0xbf, 0x71,

--- a/pkg/roachpb/errors.pb.go
+++ b/pkg/roachpb/errors.pb.go
@@ -140,7 +140,7 @@ func (x *TransactionAbortedReason) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (TransactionAbortedReason) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_errors_b3c9ed361eb5091b, []int{0}
+	return fileDescriptor_errors_52db6b6dc82e2737, []int{0}
 }
 
 // TransactionRetryReason specifies what caused a transaction retry.
@@ -191,7 +191,7 @@ func (x *TransactionRetryReason) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (TransactionRetryReason) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_errors_b3c9ed361eb5091b, []int{1}
+	return fileDescriptor_errors_52db6b6dc82e2737, []int{1}
 }
 
 // TransactionRestart indicates how an error should be handled in a
@@ -242,7 +242,7 @@ func (x *TransactionRestart) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (TransactionRestart) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_errors_b3c9ed361eb5091b, []int{2}
+	return fileDescriptor_errors_52db6b6dc82e2737, []int{2}
 }
 
 // Reason specifies what caused the error.
@@ -281,7 +281,7 @@ func (x *TransactionStatusError_Reason) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (TransactionStatusError_Reason) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_errors_b3c9ed361eb5091b, []int{9, 0}
+	return fileDescriptor_errors_52db6b6dc82e2737, []int{9, 0}
 }
 
 // Reason specifies what caused the error.
@@ -337,7 +337,7 @@ func (x *RangeFeedRetryError_Reason) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (RangeFeedRetryError_Reason) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_errors_b3c9ed361eb5091b, []int{27, 0}
+	return fileDescriptor_errors_52db6b6dc82e2737, []int{27, 0}
 }
 
 // A NotLeaseHolderError indicates that the current range is not the lease
@@ -368,7 +368,7 @@ func (m *NotLeaseHolderError) Reset()         { *m = NotLeaseHolderError{} }
 func (m *NotLeaseHolderError) String() string { return proto.CompactTextString(m) }
 func (*NotLeaseHolderError) ProtoMessage()    {}
 func (*NotLeaseHolderError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_b3c9ed361eb5091b, []int{0}
+	return fileDescriptor_errors_52db6b6dc82e2737, []int{0}
 }
 func (m *NotLeaseHolderError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -403,7 +403,7 @@ func (m *NodeUnavailableError) Reset()         { *m = NodeUnavailableError{} }
 func (m *NodeUnavailableError) String() string { return proto.CompactTextString(m) }
 func (*NodeUnavailableError) ProtoMessage()    {}
 func (*NodeUnavailableError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_b3c9ed361eb5091b, []int{1}
+	return fileDescriptor_errors_52db6b6dc82e2737, []int{1}
 }
 func (m *NodeUnavailableError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -437,7 +437,7 @@ func (m *UnsupportedRequestError) Reset()         { *m = UnsupportedRequestError
 func (m *UnsupportedRequestError) String() string { return proto.CompactTextString(m) }
 func (*UnsupportedRequestError) ProtoMessage()    {}
 func (*UnsupportedRequestError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_b3c9ed361eb5091b, []int{2}
+	return fileDescriptor_errors_52db6b6dc82e2737, []int{2}
 }
 func (m *UnsupportedRequestError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -474,7 +474,7 @@ func (m *RangeNotFoundError) Reset()         { *m = RangeNotFoundError{} }
 func (m *RangeNotFoundError) String() string { return proto.CompactTextString(m) }
 func (*RangeNotFoundError) ProtoMessage()    {}
 func (*RangeNotFoundError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_b3c9ed361eb5091b, []int{3}
+	return fileDescriptor_errors_52db6b6dc82e2737, []int{3}
 }
 func (m *RangeNotFoundError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -525,7 +525,7 @@ func (m *RangeKeyMismatchError) Reset()         { *m = RangeKeyMismatchError{} }
 func (m *RangeKeyMismatchError) String() string { return proto.CompactTextString(m) }
 func (*RangeKeyMismatchError) ProtoMessage()    {}
 func (*RangeKeyMismatchError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_b3c9ed361eb5091b, []int{4}
+	return fileDescriptor_errors_52db6b6dc82e2737, []int{4}
 }
 func (m *RangeKeyMismatchError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -570,7 +570,7 @@ type ReadWithinUncertaintyIntervalError struct {
 func (m *ReadWithinUncertaintyIntervalError) Reset()      { *m = ReadWithinUncertaintyIntervalError{} }
 func (*ReadWithinUncertaintyIntervalError) ProtoMessage() {}
 func (*ReadWithinUncertaintyIntervalError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_b3c9ed361eb5091b, []int{5}
+	return fileDescriptor_errors_52db6b6dc82e2737, []int{5}
 }
 func (m *ReadWithinUncertaintyIntervalError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -613,7 +613,7 @@ func (m *TransactionAbortedError) Reset()         { *m = TransactionAbortedError
 func (m *TransactionAbortedError) String() string { return proto.CompactTextString(m) }
 func (*TransactionAbortedError) ProtoMessage()    {}
 func (*TransactionAbortedError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_b3c9ed361eb5091b, []int{6}
+	return fileDescriptor_errors_52db6b6dc82e2737, []int{6}
 }
 func (m *TransactionAbortedError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -649,7 +649,7 @@ func (m *TransactionPushError) Reset()         { *m = TransactionPushError{} }
 func (m *TransactionPushError) String() string { return proto.CompactTextString(m) }
 func (*TransactionPushError) ProtoMessage()    {}
 func (*TransactionPushError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_b3c9ed361eb5091b, []int{7}
+	return fileDescriptor_errors_52db6b6dc82e2737, []int{7}
 }
 func (m *TransactionPushError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -685,7 +685,7 @@ func (m *TransactionRetryError) Reset()         { *m = TransactionRetryError{} }
 func (m *TransactionRetryError) String() string { return proto.CompactTextString(m) }
 func (*TransactionRetryError) ProtoMessage()    {}
 func (*TransactionRetryError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_b3c9ed361eb5091b, []int{8}
+	return fileDescriptor_errors_52db6b6dc82e2737, []int{8}
 }
 func (m *TransactionRetryError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -725,7 +725,7 @@ func (m *TransactionStatusError) Reset()         { *m = TransactionStatusError{}
 func (m *TransactionStatusError) String() string { return proto.CompactTextString(m) }
 func (*TransactionStatusError) ProtoMessage()    {}
 func (*TransactionStatusError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_b3c9ed361eb5091b, []int{9}
+	return fileDescriptor_errors_52db6b6dc82e2737, []int{9}
 }
 func (m *TransactionStatusError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -763,7 +763,7 @@ func (m *WriteIntentError) Reset()         { *m = WriteIntentError{} }
 func (m *WriteIntentError) String() string { return proto.CompactTextString(m) }
 func (*WriteIntentError) ProtoMessage()    {}
 func (*WriteIntentError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_b3c9ed361eb5091b, []int{10}
+	return fileDescriptor_errors_52db6b6dc82e2737, []int{10}
 }
 func (m *WriteIntentError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -808,7 +808,7 @@ func (m *WriteTooOldError) Reset()         { *m = WriteTooOldError{} }
 func (m *WriteTooOldError) String() string { return proto.CompactTextString(m) }
 func (*WriteTooOldError) ProtoMessage()    {}
 func (*WriteTooOldError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_b3c9ed361eb5091b, []int{11}
+	return fileDescriptor_errors_52db6b6dc82e2737, []int{11}
 }
 func (m *WriteTooOldError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -844,7 +844,7 @@ func (m *OpRequiresTxnError) Reset()         { *m = OpRequiresTxnError{} }
 func (m *OpRequiresTxnError) String() string { return proto.CompactTextString(m) }
 func (*OpRequiresTxnError) ProtoMessage()    {}
 func (*OpRequiresTxnError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_b3c9ed361eb5091b, []int{12}
+	return fileDescriptor_errors_52db6b6dc82e2737, []int{12}
 }
 func (m *OpRequiresTxnError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -881,7 +881,7 @@ func (m *ConditionFailedError) Reset()         { *m = ConditionFailedError{} }
 func (m *ConditionFailedError) String() string { return proto.CompactTextString(m) }
 func (*ConditionFailedError) ProtoMessage()    {}
 func (*ConditionFailedError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_b3c9ed361eb5091b, []int{13}
+	return fileDescriptor_errors_52db6b6dc82e2737, []int{13}
 }
 func (m *ConditionFailedError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -918,7 +918,7 @@ func (m *LeaseRejectedError) Reset()         { *m = LeaseRejectedError{} }
 func (m *LeaseRejectedError) String() string { return proto.CompactTextString(m) }
 func (*LeaseRejectedError) ProtoMessage()    {}
 func (*LeaseRejectedError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_b3c9ed361eb5091b, []int{14}
+	return fileDescriptor_errors_52db6b6dc82e2737, []int{14}
 }
 func (m *LeaseRejectedError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -956,7 +956,7 @@ func (m *AmbiguousResultError) Reset()         { *m = AmbiguousResultError{} }
 func (m *AmbiguousResultError) String() string { return proto.CompactTextString(m) }
 func (*AmbiguousResultError) ProtoMessage()    {}
 func (*AmbiguousResultError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_b3c9ed361eb5091b, []int{15}
+	return fileDescriptor_errors_52db6b6dc82e2737, []int{15}
 }
 func (m *AmbiguousResultError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -990,7 +990,7 @@ func (m *RaftGroupDeletedError) Reset()         { *m = RaftGroupDeletedError{} }
 func (m *RaftGroupDeletedError) String() string { return proto.CompactTextString(m) }
 func (*RaftGroupDeletedError) ProtoMessage()    {}
 func (*RaftGroupDeletedError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_b3c9ed361eb5091b, []int{16}
+	return fileDescriptor_errors_52db6b6dc82e2737, []int{16}
 }
 func (m *RaftGroupDeletedError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1028,7 +1028,7 @@ func (m *ReplicaCorruptionError) Reset()         { *m = ReplicaCorruptionError{}
 func (m *ReplicaCorruptionError) String() string { return proto.CompactTextString(m) }
 func (*ReplicaCorruptionError) ProtoMessage()    {}
 func (*ReplicaCorruptionError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_b3c9ed361eb5091b, []int{17}
+	return fileDescriptor_errors_52db6b6dc82e2737, []int{17}
 }
 func (m *ReplicaCorruptionError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1065,7 +1065,7 @@ func (m *ReplicaTooOldError) Reset()         { *m = ReplicaTooOldError{} }
 func (m *ReplicaTooOldError) String() string { return proto.CompactTextString(m) }
 func (*ReplicaTooOldError) ProtoMessage()    {}
 func (*ReplicaTooOldError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_b3c9ed361eb5091b, []int{18}
+	return fileDescriptor_errors_52db6b6dc82e2737, []int{18}
 }
 func (m *ReplicaTooOldError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1100,7 +1100,7 @@ func (m *StoreNotFoundError) Reset()         { *m = StoreNotFoundError{} }
 func (m *StoreNotFoundError) String() string { return proto.CompactTextString(m) }
 func (*StoreNotFoundError) ProtoMessage()    {}
 func (*StoreNotFoundError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_b3c9ed361eb5091b, []int{19}
+	return fileDescriptor_errors_52db6b6dc82e2737, []int{19}
 }
 func (m *StoreNotFoundError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1145,7 +1145,7 @@ type UnhandledRetryableError struct {
 func (m *UnhandledRetryableError) Reset()      { *m = UnhandledRetryableError{} }
 func (*UnhandledRetryableError) ProtoMessage() {}
 func (*UnhandledRetryableError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_b3c9ed361eb5091b, []int{20}
+	return fileDescriptor_errors_52db6b6dc82e2737, []int{20}
 }
 func (m *UnhandledRetryableError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1197,7 +1197,7 @@ func (m *TransactionRetryWithProtoRefreshError) Reset()         { *m = Transacti
 func (m *TransactionRetryWithProtoRefreshError) String() string { return proto.CompactTextString(m) }
 func (*TransactionRetryWithProtoRefreshError) ProtoMessage()    {}
 func (*TransactionRetryWithProtoRefreshError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_b3c9ed361eb5091b, []int{21}
+	return fileDescriptor_errors_52db6b6dc82e2737, []int{21}
 }
 func (m *TransactionRetryWithProtoRefreshError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1235,7 +1235,7 @@ func (m *TxnAlreadyEncounteredErrorError) Reset()         { *m = TxnAlreadyEncou
 func (m *TxnAlreadyEncounteredErrorError) String() string { return proto.CompactTextString(m) }
 func (*TxnAlreadyEncounteredErrorError) ProtoMessage()    {}
 func (*TxnAlreadyEncounteredErrorError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_b3c9ed361eb5091b, []int{22}
+	return fileDescriptor_errors_52db6b6dc82e2737, []int{22}
 }
 func (m *TxnAlreadyEncounteredErrorError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1272,7 +1272,7 @@ func (m *IntegerOverflowError) Reset()         { *m = IntegerOverflowError{} }
 func (m *IntegerOverflowError) String() string { return proto.CompactTextString(m) }
 func (*IntegerOverflowError) ProtoMessage()    {}
 func (*IntegerOverflowError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_b3c9ed361eb5091b, []int{23}
+	return fileDescriptor_errors_52db6b6dc82e2737, []int{23}
 }
 func (m *IntegerOverflowError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1308,7 +1308,7 @@ func (m *BatchTimestampBeforeGCError) Reset()         { *m = BatchTimestampBefor
 func (m *BatchTimestampBeforeGCError) String() string { return proto.CompactTextString(m) }
 func (*BatchTimestampBeforeGCError) ProtoMessage()    {}
 func (*BatchTimestampBeforeGCError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_b3c9ed361eb5091b, []int{24}
+	return fileDescriptor_errors_52db6b6dc82e2737, []int{24}
 }
 func (m *BatchTimestampBeforeGCError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1347,7 +1347,7 @@ func (m *IntentMissingError) Reset()         { *m = IntentMissingError{} }
 func (m *IntentMissingError) String() string { return proto.CompactTextString(m) }
 func (*IntentMissingError) ProtoMessage()    {}
 func (*IntentMissingError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_b3c9ed361eb5091b, []int{25}
+	return fileDescriptor_errors_52db6b6dc82e2737, []int{25}
 }
 func (m *IntentMissingError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1384,7 +1384,7 @@ func (m *MergeInProgressError) Reset()         { *m = MergeInProgressError{} }
 func (m *MergeInProgressError) String() string { return proto.CompactTextString(m) }
 func (*MergeInProgressError) ProtoMessage()    {}
 func (*MergeInProgressError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_b3c9ed361eb5091b, []int{26}
+	return fileDescriptor_errors_52db6b6dc82e2737, []int{26}
 }
 func (m *MergeInProgressError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1419,7 +1419,7 @@ func (m *RangeFeedRetryError) Reset()         { *m = RangeFeedRetryError{} }
 func (m *RangeFeedRetryError) String() string { return proto.CompactTextString(m) }
 func (*RangeFeedRetryError) ProtoMessage()    {}
 func (*RangeFeedRetryError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_b3c9ed361eb5091b, []int{27}
+	return fileDescriptor_errors_52db6b6dc82e2737, []int{27}
 }
 func (m *RangeFeedRetryError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1458,7 +1458,7 @@ func (m *IndeterminateCommitError) Reset()         { *m = IndeterminateCommitErr
 func (m *IndeterminateCommitError) String() string { return proto.CompactTextString(m) }
 func (*IndeterminateCommitError) ProtoMessage()    {}
 func (*IndeterminateCommitError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_b3c9ed361eb5091b, []int{28}
+	return fileDescriptor_errors_52db6b6dc82e2737, []int{28}
 }
 func (m *IndeterminateCommitError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1521,7 +1521,7 @@ func (m *ErrorDetail) Reset()         { *m = ErrorDetail{} }
 func (m *ErrorDetail) String() string { return proto.CompactTextString(m) }
 func (*ErrorDetail) ProtoMessage()    {}
 func (*ErrorDetail) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_b3c9ed361eb5091b, []int{29}
+	return fileDescriptor_errors_52db6b6dc82e2737, []int{29}
 }
 func (m *ErrorDetail) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2448,7 +2448,7 @@ func (m *ErrPosition) Reset()         { *m = ErrPosition{} }
 func (m *ErrPosition) String() string { return proto.CompactTextString(m) }
 func (*ErrPosition) ProtoMessage()    {}
 func (*ErrPosition) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_b3c9ed361eb5091b, []int{30}
+	return fileDescriptor_errors_52db6b6dc82e2737, []int{30}
 }
 func (m *ErrPosition) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2510,7 +2510,7 @@ type Error struct {
 func (m *Error) Reset()      { *m = Error{} }
 func (*Error) ProtoMessage() {}
 func (*Error) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_b3c9ed361eb5091b, []int{31}
+	return fileDescriptor_errors_52db6b6dc82e2737, []int{31}
 }
 func (m *Error) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -8947,9 +8947,9 @@ var (
 	ErrIntOverflowErrors   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("roachpb/errors.proto", fileDescriptor_errors_b3c9ed361eb5091b) }
+func init() { proto.RegisterFile("roachpb/errors.proto", fileDescriptor_errors_52db6b6dc82e2737) }
 
-var fileDescriptor_errors_b3c9ed361eb5091b = []byte{
+var fileDescriptor_errors_52db6b6dc82e2737 = []byte{
 	// 2987 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x9c, 0x59, 0xcf, 0x6f, 0x1b, 0xc7,
 	0xf5, 0x27, 0x29, 0x4a, 0xa2, 0x9e, 0x7e, 0x78, 0x3d, 0x96, 0xe5, 0x95, 0x1c, 0x53, 0xca, 0xda,

--- a/pkg/roachpb/internal.pb.go
+++ b/pkg/roachpb/internal.pb.go
@@ -105,7 +105,7 @@ func (m *InternalTimeSeriesData) Reset()         { *m = InternalTimeSeriesData{}
 func (m *InternalTimeSeriesData) String() string { return proto.CompactTextString(m) }
 func (*InternalTimeSeriesData) ProtoMessage()    {}
 func (*InternalTimeSeriesData) Descriptor() ([]byte, []int) {
-	return fileDescriptor_internal_0eb56f1470bba524, []int{0}
+	return fileDescriptor_internal_596e2ddddf56cb03, []int{0}
 }
 func (m *InternalTimeSeriesData) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -169,7 +169,7 @@ func (m *InternalTimeSeriesSample) Reset()         { *m = InternalTimeSeriesSamp
 func (m *InternalTimeSeriesSample) String() string { return proto.CompactTextString(m) }
 func (*InternalTimeSeriesSample) ProtoMessage()    {}
 func (*InternalTimeSeriesSample) Descriptor() ([]byte, []int) {
-	return fileDescriptor_internal_0eb56f1470bba524, []int{1}
+	return fileDescriptor_internal_596e2ddddf56cb03, []int{1}
 }
 func (m *InternalTimeSeriesSample) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1606,9 +1606,9 @@ var (
 	ErrIntOverflowInternal   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("roachpb/internal.proto", fileDescriptor_internal_0eb56f1470bba524) }
+func init() { proto.RegisterFile("roachpb/internal.proto", fileDescriptor_internal_596e2ddddf56cb03) }
 
-var fileDescriptor_internal_0eb56f1470bba524 = []byte{
+var fileDescriptor_internal_596e2ddddf56cb03 = []byte{
 	// 414 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x74, 0x91, 0x3f, 0x6f, 0x13, 0x31,
 	0x18, 0xc6, 0xef, 0xad, 0xf3, 0x0f, 0x57, 0x95, 0x82, 0x29, 0x91, 0x15, 0x21, 0xe7, 0xd4, 0xc9,

--- a/pkg/roachpb/internal_raft.pb.go
+++ b/pkg/roachpb/internal_raft.pb.go
@@ -35,7 +35,7 @@ func (m *RaftTruncatedState) Reset()         { *m = RaftTruncatedState{} }
 func (m *RaftTruncatedState) String() string { return proto.CompactTextString(m) }
 func (*RaftTruncatedState) ProtoMessage()    {}
 func (*RaftTruncatedState) Descriptor() ([]byte, []int) {
-	return fileDescriptor_internal_raft_eb225e3f0789b512, []int{0}
+	return fileDescriptor_internal_raft_99706137a12bcb01, []int{0}
 }
 func (m *RaftTruncatedState) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -69,7 +69,7 @@ func (m *RangeTombstone) Reset()         { *m = RangeTombstone{} }
 func (m *RangeTombstone) String() string { return proto.CompactTextString(m) }
 func (*RangeTombstone) ProtoMessage()    {}
 func (*RangeTombstone) Descriptor() ([]byte, []int) {
-	return fileDescriptor_internal_raft_eb225e3f0789b512, []int{1}
+	return fileDescriptor_internal_raft_99706137a12bcb01, []int{1}
 }
 func (m *RangeTombstone) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -107,7 +107,7 @@ func (m *RaftSnapshotData) Reset()         { *m = RaftSnapshotData{} }
 func (m *RaftSnapshotData) String() string { return proto.CompactTextString(m) }
 func (*RaftSnapshotData) ProtoMessage()    {}
 func (*RaftSnapshotData) Descriptor() ([]byte, []int) {
-	return fileDescriptor_internal_raft_eb225e3f0789b512, []int{2}
+	return fileDescriptor_internal_raft_99706137a12bcb01, []int{2}
 }
 func (m *RaftSnapshotData) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -142,7 +142,7 @@ func (m *RaftSnapshotData_KeyValue) Reset()         { *m = RaftSnapshotData_KeyV
 func (m *RaftSnapshotData_KeyValue) String() string { return proto.CompactTextString(m) }
 func (*RaftSnapshotData_KeyValue) ProtoMessage()    {}
 func (*RaftSnapshotData_KeyValue) Descriptor() ([]byte, []int) {
-	return fileDescriptor_internal_raft_eb225e3f0789b512, []int{2, 0}
+	return fileDescriptor_internal_raft_99706137a12bcb01, []int{2, 0}
 }
 func (m *RaftSnapshotData_KeyValue) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1000,10 +1000,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("roachpb/internal_raft.proto", fileDescriptor_internal_raft_eb225e3f0789b512)
+	proto.RegisterFile("roachpb/internal_raft.proto", fileDescriptor_internal_raft_99706137a12bcb01)
 }
 
-var fileDescriptor_internal_raft_eb225e3f0789b512 = []byte{
+var fileDescriptor_internal_raft_99706137a12bcb01 = []byte{
 	// 422 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x64, 0x51, 0xcd, 0x6a, 0xdb, 0x40,
 	0x10, 0xd6, 0x4a, 0x36, 0x75, 0xd6, 0x4e, 0xeb, 0x2e, 0x39, 0x08, 0x97, 0xae, 0x8c, 0x4f, 0x2e,

--- a/pkg/roachpb/io-formats.pb.go
+++ b/pkg/roachpb/io-formats.pb.go
@@ -68,7 +68,7 @@ func (x *IOFileFormat_FileFormat) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (IOFileFormat_FileFormat) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_io_formats_012f11cd671e76c0, []int{0, 0}
+	return fileDescriptor_io_formats_cf12087409a41794, []int{0, 0}
 }
 
 type IOFileFormat_Compression int32
@@ -110,7 +110,7 @@ func (x *IOFileFormat_Compression) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (IOFileFormat_Compression) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_io_formats_012f11cd671e76c0, []int{0, 1}
+	return fileDescriptor_io_formats_cf12087409a41794, []int{0, 1}
 }
 
 type MySQLOutfileOptions_Enclose int32
@@ -149,7 +149,7 @@ func (x *MySQLOutfileOptions_Enclose) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (MySQLOutfileOptions_Enclose) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_io_formats_012f11cd671e76c0, []int{2, 0}
+	return fileDescriptor_io_formats_cf12087409a41794, []int{2, 0}
 }
 
 type AvroOptions_Format int32
@@ -191,7 +191,7 @@ func (x *AvroOptions_Format) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (AvroOptions_Format) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_io_formats_012f11cd671e76c0, []int{6, 0}
+	return fileDescriptor_io_formats_cf12087409a41794, []int{6, 0}
 }
 
 type IOFileFormat struct {
@@ -211,7 +211,7 @@ func (m *IOFileFormat) Reset()         { *m = IOFileFormat{} }
 func (m *IOFileFormat) String() string { return proto.CompactTextString(m) }
 func (*IOFileFormat) ProtoMessage()    {}
 func (*IOFileFormat) Descriptor() ([]byte, []int) {
-	return fileDescriptor_io_formats_012f11cd671e76c0, []int{0}
+	return fileDescriptor_io_formats_cf12087409a41794, []int{0}
 }
 func (m *IOFileFormat) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -258,7 +258,7 @@ func (m *CSVOptions) Reset()         { *m = CSVOptions{} }
 func (m *CSVOptions) String() string { return proto.CompactTextString(m) }
 func (*CSVOptions) ProtoMessage()    {}
 func (*CSVOptions) Descriptor() ([]byte, []int) {
-	return fileDescriptor_io_formats_012f11cd671e76c0, []int{1}
+	return fileDescriptor_io_formats_cf12087409a41794, []int{1}
 }
 func (m *CSVOptions) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -309,7 +309,7 @@ func (m *MySQLOutfileOptions) Reset()         { *m = MySQLOutfileOptions{} }
 func (m *MySQLOutfileOptions) String() string { return proto.CompactTextString(m) }
 func (*MySQLOutfileOptions) ProtoMessage()    {}
 func (*MySQLOutfileOptions) Descriptor() ([]byte, []int) {
-	return fileDescriptor_io_formats_012f11cd671e76c0, []int{2}
+	return fileDescriptor_io_formats_cf12087409a41794, []int{2}
 }
 func (m *MySQLOutfileOptions) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -348,7 +348,7 @@ func (m *PgCopyOptions) Reset()         { *m = PgCopyOptions{} }
 func (m *PgCopyOptions) String() string { return proto.CompactTextString(m) }
 func (*PgCopyOptions) ProtoMessage()    {}
 func (*PgCopyOptions) Descriptor() ([]byte, []int) {
-	return fileDescriptor_io_formats_012f11cd671e76c0, []int{3}
+	return fileDescriptor_io_formats_cf12087409a41794, []int{3}
 }
 func (m *PgCopyOptions) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -386,7 +386,7 @@ func (m *PgDumpOptions) Reset()         { *m = PgDumpOptions{} }
 func (m *PgDumpOptions) String() string { return proto.CompactTextString(m) }
 func (*PgDumpOptions) ProtoMessage()    {}
 func (*PgDumpOptions) Descriptor() ([]byte, []int) {
-	return fileDescriptor_io_formats_012f11cd671e76c0, []int{4}
+	return fileDescriptor_io_formats_cf12087409a41794, []int{4}
 }
 func (m *PgDumpOptions) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -421,7 +421,7 @@ func (m *MysqldumpOptions) Reset()         { *m = MysqldumpOptions{} }
 func (m *MysqldumpOptions) String() string { return proto.CompactTextString(m) }
 func (*MysqldumpOptions) ProtoMessage()    {}
 func (*MysqldumpOptions) Descriptor() ([]byte, []int) {
-	return fileDescriptor_io_formats_012f11cd671e76c0, []int{5}
+	return fileDescriptor_io_formats_cf12087409a41794, []int{5}
 }
 func (m *MysqldumpOptions) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -464,7 +464,7 @@ func (m *AvroOptions) Reset()         { *m = AvroOptions{} }
 func (m *AvroOptions) String() string { return proto.CompactTextString(m) }
 func (*AvroOptions) ProtoMessage()    {}
 func (*AvroOptions) Descriptor() ([]byte, []int) {
-	return fileDescriptor_io_formats_012f11cd671e76c0, []int{6}
+	return fileDescriptor_io_formats_cf12087409a41794, []int{6}
 }
 func (m *AvroOptions) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2181,10 +2181,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("roachpb/io-formats.proto", fileDescriptor_io_formats_012f11cd671e76c0)
+	proto.RegisterFile("roachpb/io-formats.proto", fileDescriptor_io_formats_cf12087409a41794)
 }
 
-var fileDescriptor_io_formats_012f11cd671e76c0 = []byte{
+var fileDescriptor_io_formats_cf12087409a41794 = []byte{
 	// 938 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x55, 0x5f, 0x6f, 0xe3, 0x44,
 	0x10, 0xb7, 0xf3, 0xcf, 0xf1, 0x24, 0x69, 0x97, 0x85, 0x07, 0xeb, 0x04, 0x26, 0xe4, 0x38, 0xd4,

--- a/pkg/roachpb/metadata.pb.go
+++ b/pkg/roachpb/metadata.pb.go
@@ -130,7 +130,7 @@ func (x *ReplicaType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (ReplicaType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_cb046cbdcf254331, []int{0}
+	return fileDescriptor_metadata_9a1fd6dfbd7934b7, []int{0}
 }
 
 // Attributes specifies a list of arbitrary strings describing
@@ -142,7 +142,7 @@ type Attributes struct {
 func (m *Attributes) Reset()      { *m = Attributes{} }
 func (*Attributes) ProtoMessage() {}
 func (*Attributes) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_cb046cbdcf254331, []int{0}
+	return fileDescriptor_metadata_9a1fd6dfbd7934b7, []int{0}
 }
 func (m *Attributes) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -176,7 +176,7 @@ type ReplicationTarget struct {
 func (m *ReplicationTarget) Reset()      { *m = ReplicationTarget{} }
 func (*ReplicationTarget) ProtoMessage() {}
 func (*ReplicationTarget) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_cb046cbdcf254331, []int{1}
+	return fileDescriptor_metadata_9a1fd6dfbd7934b7, []int{1}
 }
 func (m *ReplicationTarget) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -221,7 +221,7 @@ type ReplicaDescriptor struct {
 func (m *ReplicaDescriptor) Reset()      { *m = ReplicaDescriptor{} }
 func (*ReplicaDescriptor) ProtoMessage() {}
 func (*ReplicaDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_cb046cbdcf254331, []int{2}
+	return fileDescriptor_metadata_9a1fd6dfbd7934b7, []int{2}
 }
 func (m *ReplicaDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -256,7 +256,7 @@ func (m *ReplicaIdent) Reset()         { *m = ReplicaIdent{} }
 func (m *ReplicaIdent) String() string { return proto.CompactTextString(m) }
 func (*ReplicaIdent) ProtoMessage()    {}
 func (*ReplicaIdent) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_cb046cbdcf254331, []int{3}
+	return fileDescriptor_metadata_9a1fd6dfbd7934b7, []int{3}
 }
 func (m *ReplicaIdent) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -400,7 +400,7 @@ type RangeDescriptor struct {
 func (m *RangeDescriptor) Reset()      { *m = RangeDescriptor{} }
 func (*RangeDescriptor) ProtoMessage() {}
 func (*RangeDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_cb046cbdcf254331, []int{4}
+	return fileDescriptor_metadata_9a1fd6dfbd7934b7, []int{4}
 }
 func (m *RangeDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -439,7 +439,7 @@ type Percentiles struct {
 func (m *Percentiles) Reset()      { *m = Percentiles{} }
 func (*Percentiles) ProtoMessage() {}
 func (*Percentiles) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_cb046cbdcf254331, []int{5}
+	return fileDescriptor_metadata_9a1fd6dfbd7934b7, []int{5}
 }
 func (m *Percentiles) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -501,7 +501,7 @@ type StoreCapacity struct {
 func (m *StoreCapacity) Reset()      { *m = StoreCapacity{} }
 func (*StoreCapacity) ProtoMessage() {}
 func (*StoreCapacity) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_cb046cbdcf254331, []int{6}
+	return fileDescriptor_metadata_9a1fd6dfbd7934b7, []int{6}
 }
 func (m *StoreCapacity) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -546,7 +546,7 @@ func (m *NodeDescriptor) Reset()         { *m = NodeDescriptor{} }
 func (m *NodeDescriptor) String() string { return proto.CompactTextString(m) }
 func (*NodeDescriptor) ProtoMessage()    {}
 func (*NodeDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_cb046cbdcf254331, []int{7}
+	return fileDescriptor_metadata_9a1fd6dfbd7934b7, []int{7}
 }
 func (m *NodeDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -582,7 +582,7 @@ func (m *LocalityAddress) Reset()         { *m = LocalityAddress{} }
 func (m *LocalityAddress) String() string { return proto.CompactTextString(m) }
 func (*LocalityAddress) ProtoMessage()    {}
 func (*LocalityAddress) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_cb046cbdcf254331, []int{8}
+	return fileDescriptor_metadata_9a1fd6dfbd7934b7, []int{8}
 }
 func (m *LocalityAddress) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -620,7 +620,7 @@ func (m *StoreDescriptor) Reset()         { *m = StoreDescriptor{} }
 func (m *StoreDescriptor) String() string { return proto.CompactTextString(m) }
 func (*StoreDescriptor) ProtoMessage()    {}
 func (*StoreDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_cb046cbdcf254331, []int{9}
+	return fileDescriptor_metadata_9a1fd6dfbd7934b7, []int{9}
 }
 func (m *StoreDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -657,7 +657,7 @@ func (m *StoreDeadReplicas) Reset()         { *m = StoreDeadReplicas{} }
 func (m *StoreDeadReplicas) String() string { return proto.CompactTextString(m) }
 func (*StoreDeadReplicas) ProtoMessage()    {}
 func (*StoreDeadReplicas) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_cb046cbdcf254331, []int{10}
+	return fileDescriptor_metadata_9a1fd6dfbd7934b7, []int{10}
 }
 func (m *StoreDeadReplicas) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -691,7 +691,7 @@ type Locality struct {
 func (m *Locality) Reset()      { *m = Locality{} }
 func (*Locality) ProtoMessage() {}
 func (*Locality) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_cb046cbdcf254331, []int{11}
+	return fileDescriptor_metadata_9a1fd6dfbd7934b7, []int{11}
 }
 func (m *Locality) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -727,7 +727,7 @@ type Tier struct {
 func (m *Tier) Reset()      { *m = Tier{} }
 func (*Tier) ProtoMessage() {}
 func (*Tier) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_cb046cbdcf254331, []int{12}
+	return fileDescriptor_metadata_9a1fd6dfbd7934b7, []int{12}
 }
 func (m *Tier) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -767,7 +767,7 @@ type Version struct {
 func (m *Version) Reset()      { *m = Version{} }
 func (*Version) ProtoMessage() {}
 func (*Version) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metadata_cb046cbdcf254331, []int{13}
+	return fileDescriptor_metadata_9a1fd6dfbd7934b7, []int{13}
 }
 func (m *Version) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4178,9 +4178,9 @@ var (
 	ErrIntOverflowMetadata   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("roachpb/metadata.proto", fileDescriptor_metadata_cb046cbdcf254331) }
+func init() { proto.RegisterFile("roachpb/metadata.proto", fileDescriptor_metadata_9a1fd6dfbd7934b7) }
 
-var fileDescriptor_metadata_cb046cbdcf254331 = []byte{
+var fileDescriptor_metadata_9a1fd6dfbd7934b7 = []byte{
 	// 1440 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xbc, 0x56, 0xcf, 0x6f, 0x1b, 0x45,
 	0x1b, 0xf6, 0xc6, 0xeb, 0xd8, 0x7e, 0x1d, 0x27, 0xf6, 0xe8, 0xfb, 0x5a, 0xcb, 0x9f, 0x3e, 0xdb,

--- a/pkg/rpc/heartbeat.pb.go
+++ b/pkg/rpc/heartbeat.pb.go
@@ -49,7 +49,7 @@ type RemoteOffset struct {
 func (m *RemoteOffset) Reset()      { *m = RemoteOffset{} }
 func (*RemoteOffset) ProtoMessage() {}
 func (*RemoteOffset) Descriptor() ([]byte, []int) {
-	return fileDescriptor_heartbeat_565332a8a713c8ea, []int{0}
+	return fileDescriptor_heartbeat_dd667cf2a7d6ec57, []int{0}
 }
 func (m *RemoteOffset) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -99,7 +99,7 @@ func (m *PingRequest) Reset()         { *m = PingRequest{} }
 func (m *PingRequest) String() string { return proto.CompactTextString(m) }
 func (*PingRequest) ProtoMessage()    {}
 func (*PingRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_heartbeat_565332a8a713c8ea, []int{1}
+	return fileDescriptor_heartbeat_dd667cf2a7d6ec57, []int{1}
 }
 func (m *PingRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -140,7 +140,7 @@ func (m *PingResponse) Reset()         { *m = PingResponse{} }
 func (m *PingResponse) String() string { return proto.CompactTextString(m) }
 func (*PingResponse) ProtoMessage()    {}
 func (*PingResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_heartbeat_565332a8a713c8ea, []int{2}
+	return fileDescriptor_heartbeat_dd667cf2a7d6ec57, []int{2}
 }
 func (m *PingResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1193,9 +1193,9 @@ var (
 	ErrIntOverflowHeartbeat   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("rpc/heartbeat.proto", fileDescriptor_heartbeat_565332a8a713c8ea) }
+func init() { proto.RegisterFile("rpc/heartbeat.proto", fileDescriptor_heartbeat_dd667cf2a7d6ec57) }
 
-var fileDescriptor_heartbeat_565332a8a713c8ea = []byte{
+var fileDescriptor_heartbeat_dd667cf2a7d6ec57 = []byte{
 	// 635 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xac, 0x54, 0x41, 0x4f, 0xd4, 0x40,
 	0x14, 0x6e, 0xd9, 0x05, 0x61, 0x76, 0xc1, 0x38, 0x12, 0x6c, 0x16, 0xd3, 0xc5, 0x4d, 0xd0, 0x3d,

--- a/pkg/server/diagnosticspb/diagnostics.pb.go
+++ b/pkg/server/diagnosticspb/diagnostics.pb.go
@@ -48,7 +48,7 @@ func (m *DiagnosticReport) Reset()         { *m = DiagnosticReport{} }
 func (m *DiagnosticReport) String() string { return proto.CompactTextString(m) }
 func (*DiagnosticReport) ProtoMessage()    {}
 func (*DiagnosticReport) Descriptor() ([]byte, []int) {
-	return fileDescriptor_diagnostics_06065893ddb3d5bb, []int{0}
+	return fileDescriptor_diagnostics_0eb29b4a34a0a911, []int{0}
 }
 func (m *DiagnosticReport) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -95,7 +95,7 @@ func (m *NodeInfo) Reset()         { *m = NodeInfo{} }
 func (m *NodeInfo) String() string { return proto.CompactTextString(m) }
 func (*NodeInfo) ProtoMessage()    {}
 func (*NodeInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_diagnostics_06065893ddb3d5bb, []int{1}
+	return fileDescriptor_diagnostics_0eb29b4a34a0a911, []int{1}
 }
 func (m *NodeInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -136,7 +136,7 @@ func (m *StoreInfo) Reset()         { *m = StoreInfo{} }
 func (m *StoreInfo) String() string { return proto.CompactTextString(m) }
 func (*StoreInfo) ProtoMessage()    {}
 func (*StoreInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_diagnostics_06065893ddb3d5bb, []int{2}
+	return fileDescriptor_diagnostics_0eb29b4a34a0a911, []int{2}
 }
 func (m *StoreInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -176,7 +176,7 @@ func (m *SQLInstanceInfo) Reset()         { *m = SQLInstanceInfo{} }
 func (m *SQLInstanceInfo) String() string { return proto.CompactTextString(m) }
 func (*SQLInstanceInfo) ProtoMessage()    {}
 func (*SQLInstanceInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_diagnostics_06065893ddb3d5bb, []int{3}
+	return fileDescriptor_diagnostics_0eb29b4a34a0a911, []int{3}
 }
 func (m *SQLInstanceInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -224,7 +224,7 @@ func (m *Environment) Reset()         { *m = Environment{} }
 func (m *Environment) String() string { return proto.CompactTextString(m) }
 func (*Environment) ProtoMessage()    {}
 func (*Environment) Descriptor() ([]byte, []int) {
-	return fileDescriptor_diagnostics_06065893ddb3d5bb, []int{4}
+	return fileDescriptor_diagnostics_0eb29b4a34a0a911, []int{4}
 }
 func (m *Environment) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -262,7 +262,7 @@ func (m *CPUInfo) Reset()         { *m = CPUInfo{} }
 func (m *CPUInfo) String() string { return proto.CompactTextString(m) }
 func (*CPUInfo) ProtoMessage()    {}
 func (*CPUInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_diagnostics_06065893ddb3d5bb, []int{5}
+	return fileDescriptor_diagnostics_0eb29b4a34a0a911, []int{5}
 }
 func (m *CPUInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -300,7 +300,7 @@ func (m *HardwareInfo) Reset()         { *m = HardwareInfo{} }
 func (m *HardwareInfo) String() string { return proto.CompactTextString(m) }
 func (*HardwareInfo) ProtoMessage()    {}
 func (*HardwareInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_diagnostics_06065893ddb3d5bb, []int{6}
+	return fileDescriptor_diagnostics_0eb29b4a34a0a911, []int{6}
 }
 func (m *HardwareInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -335,7 +335,7 @@ func (m *OSInfo) Reset()         { *m = OSInfo{} }
 func (m *OSInfo) String() string { return proto.CompactTextString(m) }
 func (*OSInfo) ProtoMessage()    {}
 func (*OSInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_diagnostics_06065893ddb3d5bb, []int{7}
+	return fileDescriptor_diagnostics_0eb29b4a34a0a911, []int{7}
 }
 func (m *OSInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -369,7 +369,7 @@ func (m *MemInfo) Reset()         { *m = MemInfo{} }
 func (m *MemInfo) String() string { return proto.CompactTextString(m) }
 func (*MemInfo) ProtoMessage()    {}
 func (*MemInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_diagnostics_06065893ddb3d5bb, []int{8}
+	return fileDescriptor_diagnostics_0eb29b4a34a0a911, []int{8}
 }
 func (m *MemInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -403,7 +403,7 @@ func (m *TopologyInfo) Reset()         { *m = TopologyInfo{} }
 func (m *TopologyInfo) String() string { return proto.CompactTextString(m) }
 func (*TopologyInfo) ProtoMessage()    {}
 func (*TopologyInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_diagnostics_06065893ddb3d5bb, []int{9}
+	return fileDescriptor_diagnostics_0eb29b4a34a0a911, []int{9}
 }
 func (m *TopologyInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3883,10 +3883,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("server/diagnosticspb/diagnostics.proto", fileDescriptor_diagnostics_06065893ddb3d5bb)
+	proto.RegisterFile("server/diagnosticspb/diagnostics.proto", fileDescriptor_diagnostics_0eb29b4a34a0a911)
 }
 
-var fileDescriptor_diagnostics_06065893ddb3d5bb = []byte{
+var fileDescriptor_diagnostics_0eb29b4a34a0a911 = []byte{
 	// 1408 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xb4, 0x57, 0x4f, 0x6f, 0x1b, 0x45,
 	0x14, 0x8f, 0xbd, 0xfe, 0x3b, 0x4e, 0xda, 0x74, 0x1a, 0xc2, 0x92, 0x22, 0xbb, 0xb8, 0xa2, 0x14,

--- a/pkg/server/serverpb/admin.pb.go
+++ b/pkg/server/serverpb/admin.pb.go
@@ -74,7 +74,7 @@ func (x ZoneConfigurationLevel) String() string {
 	return proto.EnumName(ZoneConfigurationLevel_name, int32(x))
 }
 func (ZoneConfigurationLevel) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{0}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{0}
 }
 
 // DatabasesRequest requests a list of databases.
@@ -85,7 +85,7 @@ func (m *DatabasesRequest) Reset()         { *m = DatabasesRequest{} }
 func (m *DatabasesRequest) String() string { return proto.CompactTextString(m) }
 func (*DatabasesRequest) ProtoMessage()    {}
 func (*DatabasesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{0}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{0}
 }
 func (m *DatabasesRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -119,7 +119,7 @@ func (m *DatabasesResponse) Reset()         { *m = DatabasesResponse{} }
 func (m *DatabasesResponse) String() string { return proto.CompactTextString(m) }
 func (*DatabasesResponse) ProtoMessage()    {}
 func (*DatabasesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{1}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{1}
 }
 func (m *DatabasesResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -155,7 +155,7 @@ func (m *DatabaseDetailsRequest) Reset()         { *m = DatabaseDetailsRequest{}
 func (m *DatabaseDetailsRequest) String() string { return proto.CompactTextString(m) }
 func (*DatabaseDetailsRequest) ProtoMessage()    {}
 func (*DatabaseDetailsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{2}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{2}
 }
 func (m *DatabaseDetailsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -204,7 +204,7 @@ func (m *DatabaseDetailsResponse) Reset()         { *m = DatabaseDetailsResponse
 func (m *DatabaseDetailsResponse) String() string { return proto.CompactTextString(m) }
 func (*DatabaseDetailsResponse) ProtoMessage()    {}
 func (*DatabaseDetailsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{3}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{3}
 }
 func (m *DatabaseDetailsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -240,7 +240,7 @@ func (m *DatabaseDetailsResponse_Grant) Reset()         { *m = DatabaseDetailsRe
 func (m *DatabaseDetailsResponse_Grant) String() string { return proto.CompactTextString(m) }
 func (*DatabaseDetailsResponse_Grant) ProtoMessage()    {}
 func (*DatabaseDetailsResponse_Grant) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{3, 0}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{3, 0}
 }
 func (m *DatabaseDetailsResponse_Grant) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -280,7 +280,7 @@ func (m *TableDetailsRequest) Reset()         { *m = TableDetailsRequest{} }
 func (m *TableDetailsRequest) String() string { return proto.CompactTextString(m) }
 func (*TableDetailsRequest) ProtoMessage()    {}
 func (*TableDetailsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{4}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{4}
 }
 func (m *TableDetailsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -337,7 +337,7 @@ func (m *TableDetailsResponse) Reset()         { *m = TableDetailsResponse{} }
 func (m *TableDetailsResponse) String() string { return proto.CompactTextString(m) }
 func (*TableDetailsResponse) ProtoMessage()    {}
 func (*TableDetailsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{5}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{5}
 }
 func (m *TableDetailsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -374,7 +374,7 @@ func (m *TableDetailsResponse_Grant) Reset()         { *m = TableDetailsResponse
 func (m *TableDetailsResponse_Grant) String() string { return proto.CompactTextString(m) }
 func (*TableDetailsResponse_Grant) ProtoMessage()    {}
 func (*TableDetailsResponse_Grant) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{5, 0}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{5, 0}
 }
 func (m *TableDetailsResponse_Grant) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -418,7 +418,7 @@ func (m *TableDetailsResponse_Column) Reset()         { *m = TableDetailsRespons
 func (m *TableDetailsResponse_Column) String() string { return proto.CompactTextString(m) }
 func (*TableDetailsResponse_Column) ProtoMessage()    {}
 func (*TableDetailsResponse_Column) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{5, 1}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{5, 1}
 }
 func (m *TableDetailsResponse_Column) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -464,7 +464,7 @@ func (m *TableDetailsResponse_Index) Reset()         { *m = TableDetailsResponse
 func (m *TableDetailsResponse_Index) String() string { return proto.CompactTextString(m) }
 func (*TableDetailsResponse_Index) ProtoMessage()    {}
 func (*TableDetailsResponse_Index) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{5, 2}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{5, 2}
 }
 func (m *TableDetailsResponse_Index) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -505,7 +505,7 @@ func (m *TableStatsRequest) Reset()         { *m = TableStatsRequest{} }
 func (m *TableStatsRequest) String() string { return proto.CompactTextString(m) }
 func (*TableStatsRequest) ProtoMessage()    {}
 func (*TableStatsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{6}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{6}
 }
 func (m *TableStatsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -559,7 +559,7 @@ func (m *TableStatsResponse) Reset()         { *m = TableStatsResponse{} }
 func (m *TableStatsResponse) String() string { return proto.CompactTextString(m) }
 func (*TableStatsResponse) ProtoMessage()    {}
 func (*TableStatsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{7}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{7}
 }
 func (m *TableStatsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -597,7 +597,7 @@ func (m *TableStatsResponse_MissingNode) Reset()         { *m = TableStatsRespon
 func (m *TableStatsResponse_MissingNode) String() string { return proto.CompactTextString(m) }
 func (*TableStatsResponse_MissingNode) ProtoMessage()    {}
 func (*TableStatsResponse_MissingNode) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{7, 0}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{7, 0}
 }
 func (m *TableStatsResponse_MissingNode) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -631,7 +631,7 @@ func (m *NonTableStatsRequest) Reset()         { *m = NonTableStatsRequest{} }
 func (m *NonTableStatsRequest) String() string { return proto.CompactTextString(m) }
 func (*NonTableStatsRequest) ProtoMessage()    {}
 func (*NonTableStatsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{8}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{8}
 }
 func (m *NonTableStatsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -670,7 +670,7 @@ func (m *NonTableStatsResponse) Reset()         { *m = NonTableStatsResponse{} }
 func (m *NonTableStatsResponse) String() string { return proto.CompactTextString(m) }
 func (*NonTableStatsResponse) ProtoMessage()    {}
 func (*NonTableStatsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{9}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{9}
 }
 func (m *NonTableStatsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -703,7 +703,7 @@ func (m *UsersRequest) Reset()         { *m = UsersRequest{} }
 func (m *UsersRequest) String() string { return proto.CompactTextString(m) }
 func (*UsersRequest) ProtoMessage()    {}
 func (*UsersRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{10}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{10}
 }
 func (m *UsersRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -738,7 +738,7 @@ func (m *UsersResponse) Reset()         { *m = UsersResponse{} }
 func (m *UsersResponse) String() string { return proto.CompactTextString(m) }
 func (*UsersResponse) ProtoMessage()    {}
 func (*UsersResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{11}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{11}
 }
 func (m *UsersResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -772,7 +772,7 @@ func (m *UsersResponse_User) Reset()         { *m = UsersResponse_User{} }
 func (m *UsersResponse_User) String() string { return proto.CompactTextString(m) }
 func (*UsersResponse_User) ProtoMessage()    {}
 func (*UsersResponse_User) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{11, 0}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{11, 0}
 }
 func (m *UsersResponse_User) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -819,7 +819,7 @@ func (m *EventsRequest) Reset()         { *m = EventsRequest{} }
 func (m *EventsRequest) String() string { return proto.CompactTextString(m) }
 func (*EventsRequest) ProtoMessage()    {}
 func (*EventsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{12}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{12}
 }
 func (m *EventsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -854,7 +854,7 @@ func (m *EventsResponse) Reset()         { *m = EventsResponse{} }
 func (m *EventsResponse) String() string { return proto.CompactTextString(m) }
 func (*EventsResponse) ProtoMessage()    {}
 func (*EventsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{13}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{13}
 }
 func (m *EventsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -899,7 +899,7 @@ func (m *EventsResponse_Event) Reset()         { *m = EventsResponse_Event{} }
 func (m *EventsResponse_Event) String() string { return proto.CompactTextString(m) }
 func (*EventsResponse_Event) ProtoMessage()    {}
 func (*EventsResponse_Event) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{13, 0}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{13, 0}
 }
 func (m *EventsResponse_Event) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -935,7 +935,7 @@ func (m *SetUIDataRequest) Reset()         { *m = SetUIDataRequest{} }
 func (m *SetUIDataRequest) String() string { return proto.CompactTextString(m) }
 func (*SetUIDataRequest) ProtoMessage()    {}
 func (*SetUIDataRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{14}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{14}
 }
 func (m *SetUIDataRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -968,7 +968,7 @@ func (m *SetUIDataResponse) Reset()         { *m = SetUIDataResponse{} }
 func (m *SetUIDataResponse) String() string { return proto.CompactTextString(m) }
 func (*SetUIDataResponse) ProtoMessage()    {}
 func (*SetUIDataResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{15}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{15}
 }
 func (m *SetUIDataResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1003,7 +1003,7 @@ func (m *GetUIDataRequest) Reset()         { *m = GetUIDataRequest{} }
 func (m *GetUIDataRequest) String() string { return proto.CompactTextString(m) }
 func (*GetUIDataRequest) ProtoMessage()    {}
 func (*GetUIDataRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{16}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{16}
 }
 func (m *GetUIDataRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1040,7 +1040,7 @@ func (m *GetUIDataResponse) Reset()         { *m = GetUIDataResponse{} }
 func (m *GetUIDataResponse) String() string { return proto.CompactTextString(m) }
 func (*GetUIDataResponse) ProtoMessage()    {}
 func (*GetUIDataResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{17}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{17}
 }
 func (m *GetUIDataResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1076,7 +1076,7 @@ func (m *GetUIDataResponse_Value) Reset()         { *m = GetUIDataResponse_Value
 func (m *GetUIDataResponse_Value) String() string { return proto.CompactTextString(m) }
 func (*GetUIDataResponse_Value) ProtoMessage()    {}
 func (*GetUIDataResponse_Value) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{17, 0}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{17, 0}
 }
 func (m *GetUIDataResponse_Value) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1109,7 +1109,7 @@ func (m *ClusterRequest) Reset()         { *m = ClusterRequest{} }
 func (m *ClusterRequest) String() string { return proto.CompactTextString(m) }
 func (*ClusterRequest) ProtoMessage()    {}
 func (*ClusterRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{18}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{18}
 }
 func (m *ClusterRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1148,7 +1148,7 @@ func (m *ClusterResponse) Reset()         { *m = ClusterResponse{} }
 func (m *ClusterResponse) String() string { return proto.CompactTextString(m) }
 func (*ClusterResponse) ProtoMessage()    {}
 func (*ClusterResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{19}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{19}
 }
 func (m *ClusterResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1196,7 +1196,7 @@ func (m *DrainRequest) Reset()         { *m = DrainRequest{} }
 func (m *DrainRequest) String() string { return proto.CompactTextString(m) }
 func (*DrainRequest) ProtoMessage()    {}
 func (*DrainRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{20}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{20}
 }
 func (m *DrainRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1281,7 +1281,7 @@ func (m *DrainResponse) Reset()         { *m = DrainResponse{} }
 func (m *DrainResponse) String() string { return proto.CompactTextString(m) }
 func (*DrainResponse) ProtoMessage()    {}
 func (*DrainResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{21}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{21}
 }
 func (m *DrainResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1316,7 +1316,7 @@ func (m *DecommissionStatusRequest) Reset()         { *m = DecommissionStatusReq
 func (m *DecommissionStatusRequest) String() string { return proto.CompactTextString(m) }
 func (*DecommissionStatusRequest) ProtoMessage()    {}
 func (*DecommissionStatusRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{22}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{22}
 }
 func (m *DecommissionStatusRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1354,7 +1354,7 @@ func (m *DecommissionRequest) Reset()         { *m = DecommissionRequest{} }
 func (m *DecommissionRequest) String() string { return proto.CompactTextString(m) }
 func (*DecommissionRequest) ProtoMessage()    {}
 func (*DecommissionRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{23}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{23}
 }
 func (m *DecommissionRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1389,7 +1389,7 @@ func (m *DecommissionStatusResponse) Reset()         { *m = DecommissionStatusRe
 func (m *DecommissionStatusResponse) String() string { return proto.CompactTextString(m) }
 func (*DecommissionStatusResponse) ProtoMessage()    {}
 func (*DecommissionStatusResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{24}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{24}
 }
 func (m *DecommissionStatusResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1428,7 +1428,7 @@ func (m *DecommissionStatusResponse_Status) Reset()         { *m = DecommissionS
 func (m *DecommissionStatusResponse_Status) String() string { return proto.CompactTextString(m) }
 func (*DecommissionStatusResponse_Status) ProtoMessage()    {}
 func (*DecommissionStatusResponse_Status) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{24, 0}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{24, 0}
 }
 func (m *DecommissionStatusResponse_Status) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1470,7 +1470,7 @@ func (m *SettingsRequest) Reset()         { *m = SettingsRequest{} }
 func (m *SettingsRequest) String() string { return proto.CompactTextString(m) }
 func (*SettingsRequest) ProtoMessage()    {}
 func (*SettingsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{25}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{25}
 }
 func (m *SettingsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1504,7 +1504,7 @@ func (m *SettingsResponse) Reset()         { *m = SettingsResponse{} }
 func (m *SettingsResponse) String() string { return proto.CompactTextString(m) }
 func (*SettingsResponse) ProtoMessage()    {}
 func (*SettingsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{26}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{26}
 }
 func (m *SettingsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1540,7 +1540,7 @@ func (m *SettingsResponse_Value) Reset()         { *m = SettingsResponse_Value{}
 func (m *SettingsResponse_Value) String() string { return proto.CompactTextString(m) }
 func (*SettingsResponse_Value) ProtoMessage()    {}
 func (*SettingsResponse_Value) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{26, 0}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{26, 0}
 }
 func (m *SettingsResponse_Value) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1595,7 +1595,7 @@ func (m *HealthRequest) Reset()         { *m = HealthRequest{} }
 func (m *HealthRequest) String() string { return proto.CompactTextString(m) }
 func (*HealthRequest) ProtoMessage()    {}
 func (*HealthRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{27}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{27}
 }
 func (m *HealthRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1630,7 +1630,7 @@ func (m *HealthResponse) Reset()         { *m = HealthResponse{} }
 func (m *HealthResponse) String() string { return proto.CompactTextString(m) }
 func (*HealthResponse) ProtoMessage()    {}
 func (*HealthResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{28}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{28}
 }
 func (m *HealthResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1663,7 +1663,7 @@ func (m *LivenessRequest) Reset()         { *m = LivenessRequest{} }
 func (m *LivenessRequest) String() string { return proto.CompactTextString(m) }
 func (*LivenessRequest) ProtoMessage()    {}
 func (*LivenessRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{29}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{29}
 }
 func (m *LivenessRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1698,7 +1698,7 @@ func (m *LivenessResponse) Reset()         { *m = LivenessResponse{} }
 func (m *LivenessResponse) String() string { return proto.CompactTextString(m) }
 func (*LivenessResponse) ProtoMessage()    {}
 func (*LivenessResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{30}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{30}
 }
 func (m *LivenessResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1734,7 +1734,7 @@ func (m *JobsRequest) Reset()         { *m = JobsRequest{} }
 func (m *JobsRequest) String() string { return proto.CompactTextString(m) }
 func (*JobsRequest) ProtoMessage()    {}
 func (*JobsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{31}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{31}
 }
 func (m *JobsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1768,7 +1768,7 @@ func (m *JobsResponse) Reset()         { *m = JobsResponse{} }
 func (m *JobsResponse) String() string { return proto.CompactTextString(m) }
 func (*JobsResponse) ProtoMessage()    {}
 func (*JobsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{32}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{32}
 }
 func (m *JobsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1821,7 +1821,7 @@ func (m *JobsResponse_Job) Reset()         { *m = JobsResponse_Job{} }
 func (m *JobsResponse_Job) String() string { return proto.CompactTextString(m) }
 func (*JobsResponse_Job) ProtoMessage()    {}
 func (*JobsResponse_Job) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{32, 0}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{32, 0}
 }
 func (m *JobsResponse_Job) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1854,7 +1854,7 @@ func (m *LocationsRequest) Reset()         { *m = LocationsRequest{} }
 func (m *LocationsRequest) String() string { return proto.CompactTextString(m) }
 func (*LocationsRequest) ProtoMessage()    {}
 func (*LocationsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{33}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{33}
 }
 func (m *LocationsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1888,7 +1888,7 @@ func (m *LocationsResponse) Reset()         { *m = LocationsResponse{} }
 func (m *LocationsResponse) String() string { return proto.CompactTextString(m) }
 func (*LocationsResponse) ProtoMessage()    {}
 func (*LocationsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{34}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{34}
 }
 func (m *LocationsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1924,7 +1924,7 @@ func (m *LocationsResponse_Location) Reset()         { *m = LocationsResponse_Lo
 func (m *LocationsResponse_Location) String() string { return proto.CompactTextString(m) }
 func (*LocationsResponse_Location) ProtoMessage()    {}
 func (*LocationsResponse_Location) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{34, 0}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{34, 0}
 }
 func (m *LocationsResponse_Location) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1966,7 +1966,7 @@ func (m *RangeLogRequest) Reset()         { *m = RangeLogRequest{} }
 func (m *RangeLogRequest) String() string { return proto.CompactTextString(m) }
 func (*RangeLogRequest) ProtoMessage()    {}
 func (*RangeLogRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{35}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{35}
 }
 func (m *RangeLogRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2000,7 +2000,7 @@ func (m *RangeLogResponse) Reset()         { *m = RangeLogResponse{} }
 func (m *RangeLogResponse) String() string { return proto.CompactTextString(m) }
 func (*RangeLogResponse) ProtoMessage()    {}
 func (*RangeLogResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{36}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{36}
 }
 func (m *RangeLogResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2040,7 +2040,7 @@ func (m *RangeLogResponse_PrettyInfo) Reset()         { *m = RangeLogResponse_Pr
 func (m *RangeLogResponse_PrettyInfo) String() string { return proto.CompactTextString(m) }
 func (*RangeLogResponse_PrettyInfo) ProtoMessage()    {}
 func (*RangeLogResponse_PrettyInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{36, 0}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{36, 0}
 }
 func (m *RangeLogResponse_PrettyInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2074,7 +2074,7 @@ func (m *RangeLogResponse_Event) Reset()         { *m = RangeLogResponse_Event{}
 func (m *RangeLogResponse_Event) String() string { return proto.CompactTextString(m) }
 func (*RangeLogResponse_Event) ProtoMessage()    {}
 func (*RangeLogResponse_Event) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{36, 1}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{36, 1}
 }
 func (m *RangeLogResponse_Event) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2109,7 +2109,7 @@ func (m *QueryPlanRequest) Reset()         { *m = QueryPlanRequest{} }
 func (m *QueryPlanRequest) String() string { return proto.CompactTextString(m) }
 func (*QueryPlanRequest) ProtoMessage()    {}
 func (*QueryPlanRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{37}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{37}
 }
 func (m *QueryPlanRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2144,7 +2144,7 @@ func (m *QueryPlanResponse) Reset()         { *m = QueryPlanResponse{} }
 func (m *QueryPlanResponse) String() string { return proto.CompactTextString(m) }
 func (*QueryPlanResponse) ProtoMessage()    {}
 func (*QueryPlanResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{38}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{38}
 }
 func (m *QueryPlanResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2176,7 +2176,7 @@ func (m *DataDistributionRequest) Reset()         { *m = DataDistributionRequest
 func (m *DataDistributionRequest) String() string { return proto.CompactTextString(m) }
 func (*DataDistributionRequest) ProtoMessage()    {}
 func (*DataDistributionRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{39}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{39}
 }
 func (m *DataDistributionRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2212,7 +2212,7 @@ func (m *DataDistributionResponse) Reset()         { *m = DataDistributionRespon
 func (m *DataDistributionResponse) String() string { return proto.CompactTextString(m) }
 func (*DataDistributionResponse) ProtoMessage()    {}
 func (*DataDistributionResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{40}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{40}
 }
 func (m *DataDistributionResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2250,7 +2250,7 @@ func (m *DataDistributionResponse_ZoneConfig) Reset()         { *m = DataDistrib
 func (m *DataDistributionResponse_ZoneConfig) String() string { return proto.CompactTextString(m) }
 func (*DataDistributionResponse_ZoneConfig) ProtoMessage()    {}
 func (*DataDistributionResponse_ZoneConfig) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{40, 0}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{40, 0}
 }
 func (m *DataDistributionResponse_ZoneConfig) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2285,7 +2285,7 @@ func (m *DataDistributionResponse_TableInfo) Reset()         { *m = DataDistribu
 func (m *DataDistributionResponse_TableInfo) String() string { return proto.CompactTextString(m) }
 func (*DataDistributionResponse_TableInfo) ProtoMessage()    {}
 func (*DataDistributionResponse_TableInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{40, 1}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{40, 1}
 }
 func (m *DataDistributionResponse_TableInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2319,7 +2319,7 @@ func (m *DataDistributionResponse_DatabaseInfo) Reset()         { *m = DataDistr
 func (m *DataDistributionResponse_DatabaseInfo) String() string { return proto.CompactTextString(m) }
 func (*DataDistributionResponse_DatabaseInfo) ProtoMessage()    {}
 func (*DataDistributionResponse_DatabaseInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{40, 2}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{40, 2}
 }
 func (m *DataDistributionResponse_DatabaseInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2352,7 +2352,7 @@ func (m *MetricMetadataRequest) Reset()         { *m = MetricMetadataRequest{} }
 func (m *MetricMetadataRequest) String() string { return proto.CompactTextString(m) }
 func (*MetricMetadataRequest) ProtoMessage()    {}
 func (*MetricMetadataRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{41}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{41}
 }
 func (m *MetricMetadataRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2386,7 +2386,7 @@ func (m *MetricMetadataResponse) Reset()         { *m = MetricMetadataResponse{}
 func (m *MetricMetadataResponse) String() string { return proto.CompactTextString(m) }
 func (*MetricMetadataResponse) ProtoMessage()    {}
 func (*MetricMetadataResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{42}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{42}
 }
 func (m *MetricMetadataResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2429,7 +2429,7 @@ func (m *EnqueueRangeRequest) Reset()         { *m = EnqueueRangeRequest{} }
 func (m *EnqueueRangeRequest) String() string { return proto.CompactTextString(m) }
 func (*EnqueueRangeRequest) ProtoMessage()    {}
 func (*EnqueueRangeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{43}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{43}
 }
 func (m *EnqueueRangeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2462,7 +2462,7 @@ func (m *EnqueueRangeResponse) Reset()         { *m = EnqueueRangeResponse{} }
 func (m *EnqueueRangeResponse) String() string { return proto.CompactTextString(m) }
 func (*EnqueueRangeResponse) ProtoMessage()    {}
 func (*EnqueueRangeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{44}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{44}
 }
 func (m *EnqueueRangeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2499,7 +2499,7 @@ func (m *EnqueueRangeResponse_Details) Reset()         { *m = EnqueueRangeRespon
 func (m *EnqueueRangeResponse_Details) String() string { return proto.CompactTextString(m) }
 func (*EnqueueRangeResponse_Details) ProtoMessage()    {}
 func (*EnqueueRangeResponse_Details) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{44, 0}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{44, 0}
 }
 func (m *EnqueueRangeResponse_Details) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2532,7 +2532,7 @@ func (m *ChartCatalogRequest) Reset()         { *m = ChartCatalogRequest{} }
 func (m *ChartCatalogRequest) String() string { return proto.CompactTextString(m) }
 func (*ChartCatalogRequest) ProtoMessage()    {}
 func (*ChartCatalogRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{45}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{45}
 }
 func (m *ChartCatalogRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2566,7 +2566,7 @@ func (m *ChartCatalogResponse) Reset()         { *m = ChartCatalogResponse{} }
 func (m *ChartCatalogResponse) String() string { return proto.CompactTextString(m) }
 func (*ChartCatalogResponse) ProtoMessage()    {}
 func (*ChartCatalogResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_admin_a0ddd78db2160a9e, []int{46}
+	return fileDescriptor_admin_beba7622cc4ca35f, []int{46}
 }
 func (m *ChartCatalogResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -15681,9 +15681,9 @@ var (
 	ErrIntOverflowAdmin   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("server/serverpb/admin.proto", fileDescriptor_admin_a0ddd78db2160a9e) }
+func init() { proto.RegisterFile("server/serverpb/admin.proto", fileDescriptor_admin_beba7622cc4ca35f) }
 
-var fileDescriptor_admin_a0ddd78db2160a9e = []byte{
+var fileDescriptor_admin_beba7622cc4ca35f = []byte{
 	// 4167 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xbc, 0x3a, 0x5d, 0x73, 0x1b, 0xd7,
 	0x75, 0x5a, 0x80, 0xf8, 0x3a, 0x04, 0x48, 0xf0, 0x8a, 0xa2, 0x40, 0x48, 0x21, 0xe8, 0x55, 0x1c,

--- a/pkg/server/serverpb/authentication.pb.go
+++ b/pkg/server/serverpb/authentication.pb.go
@@ -37,7 +37,7 @@ func (m *UserLoginRequest) Reset()         { *m = UserLoginRequest{} }
 func (m *UserLoginRequest) String() string { return proto.CompactTextString(m) }
 func (*UserLoginRequest) ProtoMessage()    {}
 func (*UserLoginRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_authentication_2bd2c74a23e120dd, []int{0}
+	return fileDescriptor_authentication_70917e59fa17d661, []int{0}
 }
 func (m *UserLoginRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -72,7 +72,7 @@ func (m *UserLoginResponse) Reset()         { *m = UserLoginResponse{} }
 func (m *UserLoginResponse) String() string { return proto.CompactTextString(m) }
 func (*UserLoginResponse) ProtoMessage()    {}
 func (*UserLoginResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_authentication_2bd2c74a23e120dd, []int{1}
+	return fileDescriptor_authentication_70917e59fa17d661, []int{1}
 }
 func (m *UserLoginResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -107,7 +107,7 @@ func (m *UserLogoutRequest) Reset()         { *m = UserLogoutRequest{} }
 func (m *UserLogoutRequest) String() string { return proto.CompactTextString(m) }
 func (*UserLogoutRequest) ProtoMessage()    {}
 func (*UserLogoutRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_authentication_2bd2c74a23e120dd, []int{2}
+	return fileDescriptor_authentication_70917e59fa17d661, []int{2}
 }
 func (m *UserLogoutRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -139,7 +139,7 @@ func (m *UserLogoutResponse) Reset()         { *m = UserLogoutResponse{} }
 func (m *UserLogoutResponse) String() string { return proto.CompactTextString(m) }
 func (*UserLogoutResponse) ProtoMessage()    {}
 func (*UserLogoutResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_authentication_2bd2c74a23e120dd, []int{3}
+	return fileDescriptor_authentication_70917e59fa17d661, []int{3}
 }
 func (m *UserLogoutResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -177,7 +177,7 @@ func (m *SessionCookie) Reset()         { *m = SessionCookie{} }
 func (m *SessionCookie) String() string { return proto.CompactTextString(m) }
 func (*SessionCookie) ProtoMessage()    {}
 func (*SessionCookie) Descriptor() ([]byte, []int) {
-	return fileDescriptor_authentication_2bd2c74a23e120dd, []int{4}
+	return fileDescriptor_authentication_70917e59fa17d661, []int{4}
 }
 func (m *SessionCookie) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -216,7 +216,7 @@ func (m *OIDCState) Reset()         { *m = OIDCState{} }
 func (m *OIDCState) String() string { return proto.CompactTextString(m) }
 func (*OIDCState) ProtoMessage()    {}
 func (*OIDCState) Descriptor() ([]byte, []int) {
-	return fileDescriptor_authentication_2bd2c74a23e120dd, []int{5}
+	return fileDescriptor_authentication_70917e59fa17d661, []int{5}
 }
 func (m *OIDCState) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1208,10 +1208,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("server/serverpb/authentication.proto", fileDescriptor_authentication_2bd2c74a23e120dd)
+	proto.RegisterFile("server/serverpb/authentication.proto", fileDescriptor_authentication_70917e59fa17d661)
 }
 
-var fileDescriptor_authentication_2bd2c74a23e120dd = []byte{
+var fileDescriptor_authentication_70917e59fa17d661 = []byte{
 	// 421 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x52, 0xcf, 0x6b, 0xd4, 0x40,
 	0x18, 0xdd, 0xc9, 0x6e, 0xe3, 0xee, 0xa8, 0xb8, 0x1d, 0x97, 0xb2, 0x06, 0x19, 0x25, 0x78, 0x90,

--- a/pkg/server/serverpb/init.pb.go
+++ b/pkg/server/serverpb/init.pb.go
@@ -32,7 +32,7 @@ func (m *BootstrapRequest) Reset()         { *m = BootstrapRequest{} }
 func (m *BootstrapRequest) String() string { return proto.CompactTextString(m) }
 func (*BootstrapRequest) ProtoMessage()    {}
 func (*BootstrapRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_init_119a86c40b8bcd78, []int{0}
+	return fileDescriptor_init_057f40e7cd7e4fd2, []int{0}
 }
 func (m *BootstrapRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -64,7 +64,7 @@ func (m *BootstrapResponse) Reset()         { *m = BootstrapResponse{} }
 func (m *BootstrapResponse) String() string { return proto.CompactTextString(m) }
 func (*BootstrapResponse) ProtoMessage()    {}
 func (*BootstrapResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_init_119a86c40b8bcd78, []int{1}
+	return fileDescriptor_init_057f40e7cd7e4fd2, []int{1}
 }
 func (m *BootstrapResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -455,9 +455,9 @@ var (
 	ErrIntOverflowInit   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("server/serverpb/init.proto", fileDescriptor_init_119a86c40b8bcd78) }
+func init() { proto.RegisterFile("server/serverpb/init.proto", fileDescriptor_init_057f40e7cd7e4fd2) }
 
-var fileDescriptor_init_119a86c40b8bcd78 = []byte{
+var fileDescriptor_init_057f40e7cd7e4fd2 = []byte{
 	// 173 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x92, 0x2a, 0x4e, 0x2d, 0x2a,
 	0x4b, 0x2d, 0xd2, 0x87, 0x50, 0x05, 0x49, 0xfa, 0x99, 0x79, 0x99, 0x25, 0x7a, 0x05, 0x45, 0xf9,

--- a/pkg/server/serverpb/migration.pb.go
+++ b/pkg/server/serverpb/migration.pb.go
@@ -37,7 +37,7 @@ func (m *ValidateTargetClusterVersionRequest) Reset()         { *m = ValidateTar
 func (m *ValidateTargetClusterVersionRequest) String() string { return proto.CompactTextString(m) }
 func (*ValidateTargetClusterVersionRequest) ProtoMessage()    {}
 func (*ValidateTargetClusterVersionRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_migration_878be5ae941b79ed, []int{0}
+	return fileDescriptor_migration_e2a428f370588fbd, []int{0}
 }
 func (m *ValidateTargetClusterVersionRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -71,7 +71,7 @@ func (m *ValidateTargetClusterVersionResponse) Reset()         { *m = ValidateTa
 func (m *ValidateTargetClusterVersionResponse) String() string { return proto.CompactTextString(m) }
 func (*ValidateTargetClusterVersionResponse) ProtoMessage()    {}
 func (*ValidateTargetClusterVersionResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_migration_878be5ae941b79ed, []int{1}
+	return fileDescriptor_migration_e2a428f370588fbd, []int{1}
 }
 func (m *ValidateTargetClusterVersionResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -106,7 +106,7 @@ func (m *BumpClusterVersionRequest) Reset()         { *m = BumpClusterVersionReq
 func (m *BumpClusterVersionRequest) String() string { return proto.CompactTextString(m) }
 func (*BumpClusterVersionRequest) ProtoMessage()    {}
 func (*BumpClusterVersionRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_migration_878be5ae941b79ed, []int{2}
+	return fileDescriptor_migration_e2a428f370588fbd, []int{2}
 }
 func (m *BumpClusterVersionRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -139,7 +139,7 @@ func (m *BumpClusterVersionResponse) Reset()         { *m = BumpClusterVersionRe
 func (m *BumpClusterVersionResponse) String() string { return proto.CompactTextString(m) }
 func (*BumpClusterVersionResponse) ProtoMessage()    {}
 func (*BumpClusterVersionResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_migration_878be5ae941b79ed, []int{3}
+	return fileDescriptor_migration_e2a428f370588fbd, []int{3}
 }
 func (m *BumpClusterVersionResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -174,7 +174,7 @@ func (m *PurgeOutdatedReplicasRequest) Reset()         { *m = PurgeOutdatedRepli
 func (m *PurgeOutdatedReplicasRequest) String() string { return proto.CompactTextString(m) }
 func (*PurgeOutdatedReplicasRequest) ProtoMessage()    {}
 func (*PurgeOutdatedReplicasRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_migration_878be5ae941b79ed, []int{4}
+	return fileDescriptor_migration_e2a428f370588fbd, []int{4}
 }
 func (m *PurgeOutdatedReplicasRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -208,7 +208,7 @@ func (m *PurgeOutdatedReplicasResponse) Reset()         { *m = PurgeOutdatedRepl
 func (m *PurgeOutdatedReplicasResponse) String() string { return proto.CompactTextString(m) }
 func (*PurgeOutdatedReplicasResponse) ProtoMessage()    {}
 func (*PurgeOutdatedReplicasResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_migration_878be5ae941b79ed, []int{5}
+	return fileDescriptor_migration_e2a428f370588fbd, []int{5}
 }
 func (m *PurgeOutdatedReplicasResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -242,7 +242,7 @@ func (m *SyncAllEnginesRequest) Reset()         { *m = SyncAllEnginesRequest{} }
 func (m *SyncAllEnginesRequest) String() string { return proto.CompactTextString(m) }
 func (*SyncAllEnginesRequest) ProtoMessage()    {}
 func (*SyncAllEnginesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_migration_878be5ae941b79ed, []int{6}
+	return fileDescriptor_migration_e2a428f370588fbd, []int{6}
 }
 func (m *SyncAllEnginesRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -275,7 +275,7 @@ func (m *SyncAllEnginesResponse) Reset()         { *m = SyncAllEnginesResponse{}
 func (m *SyncAllEnginesResponse) String() string { return proto.CompactTextString(m) }
 func (*SyncAllEnginesResponse) ProtoMessage()    {}
 func (*SyncAllEnginesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_migration_878be5ae941b79ed, []int{7}
+	return fileDescriptor_migration_e2a428f370588fbd, []int{7}
 }
 func (m *SyncAllEnginesResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1399,10 +1399,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("server/serverpb/migration.proto", fileDescriptor_migration_878be5ae941b79ed)
+	proto.RegisterFile("server/serverpb/migration.proto", fileDescriptor_migration_e2a428f370588fbd)
 }
 
-var fileDescriptor_migration_878be5ae941b79ed = []byte{
+var fileDescriptor_migration_e2a428f370588fbd = []byte{
 	// 409 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x92, 0x2f, 0x4e, 0x2d, 0x2a,
 	0x4b, 0x2d, 0xd2, 0x87, 0x50, 0x05, 0x49, 0xfa, 0xb9, 0x99, 0xe9, 0x45, 0x89, 0x25, 0x99, 0xf9,

--- a/pkg/server/serverpb/status.pb.go
+++ b/pkg/server/serverpb/status.pb.go
@@ -66,7 +66,7 @@ func (x StacksType) String() string {
 	return proto.EnumName(StacksType_name, int32(x))
 }
 func (StacksType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{0}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{0}
 }
 
 // Represents the type of file.
@@ -93,7 +93,7 @@ func (x FileType) String() string {
 	return proto.EnumName(FileType_name, int32(x))
 }
 func (FileType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{1}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{1}
 }
 
 // We use an enum to allow reporting of client certs and potential others (eg:
@@ -130,7 +130,7 @@ func (x CertificateDetails_CertificateType) String() string {
 	return proto.EnumName(CertificateDetails_CertificateType_name, int32(x))
 }
 func (CertificateDetails_CertificateType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{1, 0}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{1, 0}
 }
 
 type ProfileRequest_Type int32
@@ -153,7 +153,7 @@ func (x ProfileRequest_Type) String() string {
 	return proto.EnumName(ProfileRequest_Type_name, int32(x))
 }
 func (ProfileRequest_Type) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{37, 0}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{37, 0}
 }
 
 // Enum for phase of execution.
@@ -177,7 +177,7 @@ func (x ActiveQuery_Phase) String() string {
 	return proto.EnumName(ActiveQuery_Phase_name, int32(x))
 }
 func (ActiveQuery_Phase) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{45, 0}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{45, 0}
 }
 
 type CertificatesRequest struct {
@@ -190,7 +190,7 @@ func (m *CertificatesRequest) Reset()         { *m = CertificatesRequest{} }
 func (m *CertificatesRequest) String() string { return proto.CompactTextString(m) }
 func (*CertificatesRequest) ProtoMessage()    {}
 func (*CertificatesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{0}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{0}
 }
 func (m *CertificatesRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -229,7 +229,7 @@ func (m *CertificateDetails) Reset()         { *m = CertificateDetails{} }
 func (m *CertificateDetails) String() string { return proto.CompactTextString(m) }
 func (*CertificateDetails) ProtoMessage()    {}
 func (*CertificateDetails) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{1}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{1}
 }
 func (m *CertificateDetails) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -270,7 +270,7 @@ func (m *CertificateDetails_Fields) Reset()         { *m = CertificateDetails_Fi
 func (m *CertificateDetails_Fields) String() string { return proto.CompactTextString(m) }
 func (*CertificateDetails_Fields) ProtoMessage()    {}
 func (*CertificateDetails_Fields) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{1, 0}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{1, 0}
 }
 func (m *CertificateDetails_Fields) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -303,7 +303,7 @@ func (m *CertificatesResponse) Reset()         { *m = CertificatesResponse{} }
 func (m *CertificatesResponse) String() string { return proto.CompactTextString(m) }
 func (*CertificatesResponse) ProtoMessage()    {}
 func (*CertificatesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{2}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{2}
 }
 func (m *CertificatesResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -340,7 +340,7 @@ func (m *DetailsRequest) Reset()         { *m = DetailsRequest{} }
 func (m *DetailsRequest) String() string { return proto.CompactTextString(m) }
 func (*DetailsRequest) ProtoMessage()    {}
 func (*DetailsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{3}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{3}
 }
 func (m *DetailsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -377,7 +377,7 @@ func (m *SystemInfo) Reset()         { *m = SystemInfo{} }
 func (m *SystemInfo) String() string { return proto.CompactTextString(m) }
 func (*SystemInfo) ProtoMessage()    {}
 func (*SystemInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{4}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{4}
 }
 func (m *SystemInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -414,7 +414,7 @@ func (m *DetailsResponse) Reset()         { *m = DetailsResponse{} }
 func (m *DetailsResponse) String() string { return proto.CompactTextString(m) }
 func (*DetailsResponse) ProtoMessage()    {}
 func (*DetailsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{5}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{5}
 }
 func (m *DetailsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -449,7 +449,7 @@ func (m *NodesRequest) Reset()         { *m = NodesRequest{} }
 func (m *NodesRequest) String() string { return proto.CompactTextString(m) }
 func (*NodesRequest) ProtoMessage()    {}
 func (*NodesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{6}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{6}
 }
 func (m *NodesRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -488,7 +488,7 @@ func (m *NodesResponse) Reset()         { *m = NodesResponse{} }
 func (m *NodesResponse) String() string { return proto.CompactTextString(m) }
 func (*NodesResponse) ProtoMessage()    {}
 func (*NodesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{7}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{7}
 }
 func (m *NodesResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -523,7 +523,7 @@ func (m *NodeRequest) Reset()         { *m = NodeRequest{} }
 func (m *NodeRequest) String() string { return proto.CompactTextString(m) }
 func (*NodeRequest) ProtoMessage()    {}
 func (*NodeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{8}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{8}
 }
 func (m *NodeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -568,7 +568,7 @@ func (m *RaftState) Reset()         { *m = RaftState{} }
 func (m *RaftState) String() string { return proto.CompactTextString(m) }
 func (*RaftState) ProtoMessage()    {}
 func (*RaftState) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{9}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{9}
 }
 func (m *RaftState) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -605,7 +605,7 @@ func (m *RaftState_Progress) Reset()         { *m = RaftState_Progress{} }
 func (m *RaftState_Progress) String() string { return proto.CompactTextString(m) }
 func (*RaftState_Progress) ProtoMessage()    {}
 func (*RaftState_Progress) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{9, 0}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{9, 0}
 }
 func (m *RaftState_Progress) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -650,7 +650,7 @@ func (m *RangeProblems) Reset()         { *m = RangeProblems{} }
 func (m *RangeProblems) String() string { return proto.CompactTextString(m) }
 func (*RangeProblems) ProtoMessage()    {}
 func (*RangeProblems) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{10}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{10}
 }
 func (m *RangeProblems) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -686,7 +686,7 @@ func (m *RangeStatistics) Reset()         { *m = RangeStatistics{} }
 func (m *RangeStatistics) String() string { return proto.CompactTextString(m) }
 func (*RangeStatistics) ProtoMessage()    {}
 func (*RangeStatistics) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{11}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{11}
 }
 func (m *RangeStatistics) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -720,7 +720,7 @@ func (m *PrettySpan) Reset()         { *m = PrettySpan{} }
 func (m *PrettySpan) String() string { return proto.CompactTextString(m) }
 func (*PrettySpan) ProtoMessage()    {}
 func (*PrettySpan) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{12}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{12}
 }
 func (m *PrettySpan) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -766,7 +766,7 @@ func (m *RangeInfo) Reset()         { *m = RangeInfo{} }
 func (m *RangeInfo) String() string { return proto.CompactTextString(m) }
 func (*RangeInfo) ProtoMessage()    {}
 func (*RangeInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{13}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{13}
 }
 func (m *RangeInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -802,7 +802,7 @@ func (m *RangesRequest) Reset()         { *m = RangesRequest{} }
 func (m *RangesRequest) String() string { return proto.CompactTextString(m) }
 func (*RangesRequest) ProtoMessage()    {}
 func (*RangesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{14}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{14}
 }
 func (m *RangesRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -835,7 +835,7 @@ func (m *RangesResponse) Reset()         { *m = RangesResponse{} }
 func (m *RangesResponse) String() string { return proto.CompactTextString(m) }
 func (*RangesResponse) ProtoMessage()    {}
 func (*RangesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{15}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{15}
 }
 func (m *RangesResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -870,7 +870,7 @@ func (m *GossipRequest) Reset()         { *m = GossipRequest{} }
 func (m *GossipRequest) String() string { return proto.CompactTextString(m) }
 func (*GossipRequest) ProtoMessage()    {}
 func (*GossipRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{16}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{16}
 }
 func (m *GossipRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -905,7 +905,7 @@ func (m *EngineStatsInfo) Reset()         { *m = EngineStatsInfo{} }
 func (m *EngineStatsInfo) String() string { return proto.CompactTextString(m) }
 func (*EngineStatsInfo) ProtoMessage()    {}
 func (*EngineStatsInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{17}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{17}
 }
 func (m *EngineStatsInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -940,7 +940,7 @@ func (m *EngineStatsRequest) Reset()         { *m = EngineStatsRequest{} }
 func (m *EngineStatsRequest) String() string { return proto.CompactTextString(m) }
 func (*EngineStatsRequest) ProtoMessage()    {}
 func (*EngineStatsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{18}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{18}
 }
 func (m *EngineStatsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -973,7 +973,7 @@ func (m *EngineStatsResponse) Reset()         { *m = EngineStatsResponse{} }
 func (m *EngineStatsResponse) String() string { return proto.CompactTextString(m) }
 func (*EngineStatsResponse) ProtoMessage()    {}
 func (*EngineStatsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{19}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{19}
 }
 func (m *EngineStatsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1007,7 +1007,7 @@ func (m *TraceEvent) Reset()         { *m = TraceEvent{} }
 func (m *TraceEvent) String() string { return proto.CompactTextString(m) }
 func (*TraceEvent) ProtoMessage()    {}
 func (*TraceEvent) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{20}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{20}
 }
 func (m *TraceEvent) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1041,7 +1041,7 @@ func (m *AllocatorDryRun) Reset()         { *m = AllocatorDryRun{} }
 func (m *AllocatorDryRun) String() string { return proto.CompactTextString(m) }
 func (*AllocatorDryRun) ProtoMessage()    {}
 func (*AllocatorDryRun) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{21}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{21}
 }
 func (m *AllocatorDryRun) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1074,7 +1074,7 @@ func (m *AllocatorRangeRequest) Reset()         { *m = AllocatorRangeRequest{} }
 func (m *AllocatorRangeRequest) String() string { return proto.CompactTextString(m) }
 func (*AllocatorRangeRequest) ProtoMessage()    {}
 func (*AllocatorRangeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{22}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{22}
 }
 func (m *AllocatorRangeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1110,7 +1110,7 @@ func (m *AllocatorRangeResponse) Reset()         { *m = AllocatorRangeResponse{}
 func (m *AllocatorRangeResponse) String() string { return proto.CompactTextString(m) }
 func (*AllocatorRangeResponse) ProtoMessage()    {}
 func (*AllocatorRangeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{23}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{23}
 }
 func (m *AllocatorRangeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1144,7 +1144,7 @@ func (m *AllocatorRequest) Reset()         { *m = AllocatorRequest{} }
 func (m *AllocatorRequest) String() string { return proto.CompactTextString(m) }
 func (*AllocatorRequest) ProtoMessage()    {}
 func (*AllocatorRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{24}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{24}
 }
 func (m *AllocatorRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1177,7 +1177,7 @@ func (m *AllocatorResponse) Reset()         { *m = AllocatorResponse{} }
 func (m *AllocatorResponse) String() string { return proto.CompactTextString(m) }
 func (*AllocatorResponse) ProtoMessage()    {}
 func (*AllocatorResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{25}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{25}
 }
 func (m *AllocatorResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1210,7 +1210,7 @@ func (m *JSONResponse) Reset()         { *m = JSONResponse{} }
 func (m *JSONResponse) String() string { return proto.CompactTextString(m) }
 func (*JSONResponse) ProtoMessage()    {}
 func (*JSONResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{26}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{26}
 }
 func (m *JSONResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1246,7 +1246,7 @@ func (m *ResponseError) Reset()         { *m = ResponseError{} }
 func (m *ResponseError) String() string { return proto.CompactTextString(m) }
 func (*ResponseError) ProtoMessage()    {}
 func (*ResponseError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{27}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{27}
 }
 func (m *ResponseError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1290,7 +1290,7 @@ func (m *LogsRequest) Reset()         { *m = LogsRequest{} }
 func (m *LogsRequest) String() string { return proto.CompactTextString(m) }
 func (*LogsRequest) ProtoMessage()    {}
 func (*LogsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{28}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{28}
 }
 func (m *LogsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1323,7 +1323,7 @@ func (m *LogEntriesResponse) Reset()         { *m = LogEntriesResponse{} }
 func (m *LogEntriesResponse) String() string { return proto.CompactTextString(m) }
 func (*LogEntriesResponse) ProtoMessage()    {}
 func (*LogEntriesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{29}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{29}
 }
 func (m *LogEntriesResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1358,7 +1358,7 @@ func (m *LogFilesListRequest) Reset()         { *m = LogFilesListRequest{} }
 func (m *LogFilesListRequest) String() string { return proto.CompactTextString(m) }
 func (*LogFilesListRequest) ProtoMessage()    {}
 func (*LogFilesListRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{30}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{30}
 }
 func (m *LogFilesListRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1391,7 +1391,7 @@ func (m *LogFilesListResponse) Reset()         { *m = LogFilesListResponse{} }
 func (m *LogFilesListResponse) String() string { return proto.CompactTextString(m) }
 func (*LogFilesListResponse) ProtoMessage()    {}
 func (*LogFilesListResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{31}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{31}
 }
 func (m *LogFilesListResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1431,7 +1431,7 @@ func (m *LogFileRequest) Reset()         { *m = LogFileRequest{} }
 func (m *LogFileRequest) String() string { return proto.CompactTextString(m) }
 func (*LogFileRequest) ProtoMessage()    {}
 func (*LogFileRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{32}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{32}
 }
 func (m *LogFileRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1467,7 +1467,7 @@ func (m *StacksRequest) Reset()         { *m = StacksRequest{} }
 func (m *StacksRequest) String() string { return proto.CompactTextString(m) }
 func (*StacksRequest) ProtoMessage()    {}
 func (*StacksRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{33}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{33}
 }
 func (m *StacksRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1503,7 +1503,7 @@ func (m *File) Reset()         { *m = File{} }
 func (m *File) String() string { return proto.CompactTextString(m) }
 func (*File) ProtoMessage()    {}
 func (*File) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{34}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{34}
 }
 func (m *File) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1547,7 +1547,7 @@ func (m *GetFilesRequest) Reset()         { *m = GetFilesRequest{} }
 func (m *GetFilesRequest) String() string { return proto.CompactTextString(m) }
 func (*GetFilesRequest) ProtoMessage()    {}
 func (*GetFilesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{35}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{35}
 }
 func (m *GetFilesRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1580,7 +1580,7 @@ func (m *GetFilesResponse) Reset()         { *m = GetFilesResponse{} }
 func (m *GetFilesResponse) String() string { return proto.CompactTextString(m) }
 func (*GetFilesResponse) ProtoMessage()    {}
 func (*GetFilesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{36}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{36}
 }
 func (m *GetFilesResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1618,7 +1618,7 @@ func (m *ProfileRequest) Reset()         { *m = ProfileRequest{} }
 func (m *ProfileRequest) String() string { return proto.CompactTextString(m) }
 func (*ProfileRequest) ProtoMessage()    {}
 func (*ProfileRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{37}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{37}
 }
 func (m *ProfileRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1653,7 +1653,7 @@ func (m *MetricsRequest) Reset()         { *m = MetricsRequest{} }
 func (m *MetricsRequest) String() string { return proto.CompactTextString(m) }
 func (*MetricsRequest) ProtoMessage()    {}
 func (*MetricsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{38}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{38}
 }
 func (m *MetricsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1687,7 +1687,7 @@ func (m *RaftRangeNode) Reset()         { *m = RaftRangeNode{} }
 func (m *RaftRangeNode) String() string { return proto.CompactTextString(m) }
 func (*RaftRangeNode) ProtoMessage()    {}
 func (*RaftRangeNode) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{39}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{39}
 }
 func (m *RaftRangeNode) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1720,7 +1720,7 @@ func (m *RaftRangeError) Reset()         { *m = RaftRangeError{} }
 func (m *RaftRangeError) String() string { return proto.CompactTextString(m) }
 func (*RaftRangeError) ProtoMessage()    {}
 func (*RaftRangeError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{40}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{40}
 }
 func (m *RaftRangeError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1755,7 +1755,7 @@ func (m *RaftRangeStatus) Reset()         { *m = RaftRangeStatus{} }
 func (m *RaftRangeStatus) String() string { return proto.CompactTextString(m) }
 func (*RaftRangeStatus) ProtoMessage()    {}
 func (*RaftRangeStatus) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{41}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{41}
 }
 func (m *RaftRangeStatus) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1788,7 +1788,7 @@ func (m *RaftDebugRequest) Reset()         { *m = RaftDebugRequest{} }
 func (m *RaftDebugRequest) String() string { return proto.CompactTextString(m) }
 func (*RaftDebugRequest) ProtoMessage()    {}
 func (*RaftDebugRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{42}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{42}
 }
 func (m *RaftDebugRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1822,7 +1822,7 @@ func (m *RaftDebugResponse) Reset()         { *m = RaftDebugResponse{} }
 func (m *RaftDebugResponse) String() string { return proto.CompactTextString(m) }
 func (*RaftDebugResponse) ProtoMessage()    {}
 func (*RaftDebugResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{43}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{43}
 }
 func (m *RaftDebugResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1880,7 +1880,7 @@ func (m *TxnInfo) Reset()         { *m = TxnInfo{} }
 func (m *TxnInfo) String() string { return proto.CompactTextString(m) }
 func (*TxnInfo) ProtoMessage()    {}
 func (*TxnInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{44}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{44}
 }
 func (m *TxnInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1928,7 +1928,7 @@ func (m *ActiveQuery) Reset()         { *m = ActiveQuery{} }
 func (m *ActiveQuery) String() string { return proto.CompactTextString(m) }
 func (*ActiveQuery) ProtoMessage()    {}
 func (*ActiveQuery) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{45}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{45}
 }
 func (m *ActiveQuery) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1965,7 +1965,7 @@ func (m *ListSessionsRequest) Reset()         { *m = ListSessionsRequest{} }
 func (m *ListSessionsRequest) String() string { return proto.CompactTextString(m) }
 func (*ListSessionsRequest) ProtoMessage()    {}
 func (*ListSessionsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{46}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{46}
 }
 func (m *ListSessionsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2024,7 +2024,7 @@ func (m *Session) Reset()         { *m = Session{} }
 func (m *Session) String() string { return proto.CompactTextString(m) }
 func (*Session) ProtoMessage()    {}
 func (*Session) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{47}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{47}
 }
 func (m *Session) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2061,7 +2061,7 @@ func (m *ListSessionsError) Reset()         { *m = ListSessionsError{} }
 func (m *ListSessionsError) String() string { return proto.CompactTextString(m) }
 func (*ListSessionsError) ProtoMessage()    {}
 func (*ListSessionsError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{48}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{48}
 }
 func (m *ListSessionsError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2098,7 +2098,7 @@ func (m *ListSessionsResponse) Reset()         { *m = ListSessionsResponse{} }
 func (m *ListSessionsResponse) String() string { return proto.CompactTextString(m) }
 func (*ListSessionsResponse) ProtoMessage()    {}
 func (*ListSessionsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{49}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{49}
 }
 func (m *ListSessionsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2145,7 +2145,7 @@ func (m *CancelQueryRequest) Reset()         { *m = CancelQueryRequest{} }
 func (m *CancelQueryRequest) String() string { return proto.CompactTextString(m) }
 func (*CancelQueryRequest) ProtoMessage()    {}
 func (*CancelQueryRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{50}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{50}
 }
 func (m *CancelQueryRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2182,7 +2182,7 @@ func (m *CancelQueryResponse) Reset()         { *m = CancelQueryResponse{} }
 func (m *CancelQueryResponse) String() string { return proto.CompactTextString(m) }
 func (*CancelQueryResponse) ProtoMessage()    {}
 func (*CancelQueryResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{51}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{51}
 }
 func (m *CancelQueryResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2225,7 +2225,7 @@ func (m *CancelSessionRequest) Reset()         { *m = CancelSessionRequest{} }
 func (m *CancelSessionRequest) String() string { return proto.CompactTextString(m) }
 func (*CancelSessionRequest) ProtoMessage()    {}
 func (*CancelSessionRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{52}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{52}
 }
 func (m *CancelSessionRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2259,7 +2259,7 @@ func (m *CancelSessionResponse) Reset()         { *m = CancelSessionResponse{} }
 func (m *CancelSessionResponse) String() string { return proto.CompactTextString(m) }
 func (*CancelSessionResponse) ProtoMessage()    {}
 func (*CancelSessionResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{53}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{53}
 }
 func (m *CancelSessionResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2294,7 +2294,7 @@ func (m *SpanStatsRequest) Reset()         { *m = SpanStatsRequest{} }
 func (m *SpanStatsRequest) String() string { return proto.CompactTextString(m) }
 func (*SpanStatsRequest) ProtoMessage()    {}
 func (*SpanStatsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{54}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{54}
 }
 func (m *SpanStatsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2329,7 +2329,7 @@ func (m *SpanStatsResponse) Reset()         { *m = SpanStatsResponse{} }
 func (m *SpanStatsResponse) String() string { return proto.CompactTextString(m) }
 func (*SpanStatsResponse) ProtoMessage()    {}
 func (*SpanStatsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{55}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{55}
 }
 func (m *SpanStatsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2363,7 +2363,7 @@ func (m *ProblemRangesRequest) Reset()         { *m = ProblemRangesRequest{} }
 func (m *ProblemRangesRequest) String() string { return proto.CompactTextString(m) }
 func (*ProblemRangesRequest) ProtoMessage()    {}
 func (*ProblemRangesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{56}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{56}
 }
 func (m *ProblemRangesRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2398,7 +2398,7 @@ func (m *ProblemRangesResponse) Reset()         { *m = ProblemRangesResponse{} }
 func (m *ProblemRangesResponse) String() string { return proto.CompactTextString(m) }
 func (*ProblemRangesResponse) ProtoMessage()    {}
 func (*ProblemRangesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{57}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{57}
 }
 func (m *ProblemRangesResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2439,7 +2439,7 @@ func (m *ProblemRangesResponse_NodeProblems) Reset()         { *m = ProblemRange
 func (m *ProblemRangesResponse_NodeProblems) String() string { return proto.CompactTextString(m) }
 func (*ProblemRangesResponse_NodeProblems) ProtoMessage()    {}
 func (*ProblemRangesResponse_NodeProblems) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{57, 0}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{57, 0}
 }
 func (m *ProblemRangesResponse_NodeProblems) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2483,7 +2483,7 @@ func (m *HotRangesRequest) Reset()         { *m = HotRangesRequest{} }
 func (m *HotRangesRequest) String() string { return proto.CompactTextString(m) }
 func (*HotRangesRequest) ProtoMessage()    {}
 func (*HotRangesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{58}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{58}
 }
 func (m *HotRangesRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2526,7 +2526,7 @@ func (m *HotRangesResponse) Reset()         { *m = HotRangesResponse{} }
 func (m *HotRangesResponse) String() string { return proto.CompactTextString(m) }
 func (*HotRangesResponse) ProtoMessage()    {}
 func (*HotRangesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{59}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{59}
 }
 func (m *HotRangesResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2571,7 +2571,7 @@ func (m *HotRangesResponse_HotRange) Reset()         { *m = HotRangesResponse_Ho
 func (m *HotRangesResponse_HotRange) String() string { return proto.CompactTextString(m) }
 func (*HotRangesResponse_HotRange) ProtoMessage()    {}
 func (*HotRangesResponse_HotRange) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{59, 0}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{59, 0}
 }
 func (m *HotRangesResponse_HotRange) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2614,7 +2614,7 @@ func (m *HotRangesResponse_StoreResponse) Reset()         { *m = HotRangesRespon
 func (m *HotRangesResponse_StoreResponse) String() string { return proto.CompactTextString(m) }
 func (*HotRangesResponse_StoreResponse) ProtoMessage()    {}
 func (*HotRangesResponse_StoreResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{59, 1}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{59, 1}
 }
 func (m *HotRangesResponse_StoreResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2659,7 +2659,7 @@ func (m *HotRangesResponse_NodeResponse) Reset()         { *m = HotRangesRespons
 func (m *HotRangesResponse_NodeResponse) String() string { return proto.CompactTextString(m) }
 func (*HotRangesResponse_NodeResponse) ProtoMessage()    {}
 func (*HotRangesResponse_NodeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{59, 2}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{59, 2}
 }
 func (m *HotRangesResponse_NodeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2692,7 +2692,7 @@ func (m *RangeRequest) Reset()         { *m = RangeRequest{} }
 func (m *RangeRequest) String() string { return proto.CompactTextString(m) }
 func (*RangeRequest) ProtoMessage()    {}
 func (*RangeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{60}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{60}
 }
 func (m *RangeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2728,7 +2728,7 @@ func (m *RangeResponse) Reset()         { *m = RangeResponse{} }
 func (m *RangeResponse) String() string { return proto.CompactTextString(m) }
 func (*RangeResponse) ProtoMessage()    {}
 func (*RangeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{61}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{61}
 }
 func (m *RangeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2763,7 +2763,7 @@ func (m *RangeResponse_NodeResponse) Reset()         { *m = RangeResponse_NodeRe
 func (m *RangeResponse_NodeResponse) String() string { return proto.CompactTextString(m) }
 func (*RangeResponse_NodeResponse) ProtoMessage()    {}
 func (*RangeResponse_NodeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{61, 0}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{61, 0}
 }
 func (m *RangeResponse_NodeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2799,7 +2799,7 @@ func (m *DiagnosticsRequest) Reset()         { *m = DiagnosticsRequest{} }
 func (m *DiagnosticsRequest) String() string { return proto.CompactTextString(m) }
 func (*DiagnosticsRequest) ProtoMessage()    {}
 func (*DiagnosticsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{62}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{62}
 }
 func (m *DiagnosticsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2834,7 +2834,7 @@ func (m *StoresRequest) Reset()         { *m = StoresRequest{} }
 func (m *StoresRequest) String() string { return proto.CompactTextString(m) }
 func (*StoresRequest) ProtoMessage()    {}
 func (*StoresRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{63}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{63}
 }
 func (m *StoresRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2877,7 +2877,7 @@ func (m *StoreDetails) Reset()         { *m = StoreDetails{} }
 func (m *StoreDetails) String() string { return proto.CompactTextString(m) }
 func (*StoreDetails) ProtoMessage()    {}
 func (*StoreDetails) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{64}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{64}
 }
 func (m *StoreDetails) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2910,7 +2910,7 @@ func (m *StoresResponse) Reset()         { *m = StoresResponse{} }
 func (m *StoresResponse) String() string { return proto.CompactTextString(m) }
 func (*StoresResponse) ProtoMessage()    {}
 func (*StoresResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{65}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{65}
 }
 func (m *StoresResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2943,7 +2943,7 @@ func (m *StatementsRequest) Reset()         { *m = StatementsRequest{} }
 func (m *StatementsRequest) String() string { return proto.CompactTextString(m) }
 func (*StatementsRequest) ProtoMessage()    {}
 func (*StatementsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{66}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{66}
 }
 func (m *StatementsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2984,7 +2984,7 @@ func (m *StatementsResponse) Reset()         { *m = StatementsResponse{} }
 func (m *StatementsResponse) String() string { return proto.CompactTextString(m) }
 func (*StatementsResponse) ProtoMessage()    {}
 func (*StatementsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{67}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{67}
 }
 func (m *StatementsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3022,7 +3022,7 @@ func (m *StatementsResponse_ExtendedStatementStatisticsKey) String() string {
 }
 func (*StatementsResponse_ExtendedStatementStatisticsKey) ProtoMessage() {}
 func (*StatementsResponse_ExtendedStatementStatisticsKey) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{67, 0}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{67, 0}
 }
 func (m *StatementsResponse_ExtendedStatementStatisticsKey) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3061,7 +3061,7 @@ func (m *StatementsResponse_CollectedStatementStatistics) String() string {
 }
 func (*StatementsResponse_CollectedStatementStatistics) ProtoMessage() {}
 func (*StatementsResponse_CollectedStatementStatistics) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{67, 1}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{67, 1}
 }
 func (m *StatementsResponse_CollectedStatementStatistics) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3099,7 +3099,7 @@ func (m *StatementsResponse_ExtendedCollectedTransactionStatistics) String() str
 }
 func (*StatementsResponse_ExtendedCollectedTransactionStatistics) ProtoMessage() {}
 func (*StatementsResponse_ExtendedCollectedTransactionStatistics) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{67, 2}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{67, 2}
 }
 func (m *StatementsResponse_ExtendedCollectedTransactionStatistics) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3136,7 +3136,7 @@ func (m *StatementDiagnosticsReport) Reset()         { *m = StatementDiagnostics
 func (m *StatementDiagnosticsReport) String() string { return proto.CompactTextString(m) }
 func (*StatementDiagnosticsReport) ProtoMessage()    {}
 func (*StatementDiagnosticsReport) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{68}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{68}
 }
 func (m *StatementDiagnosticsReport) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3171,7 +3171,7 @@ func (m *CreateStatementDiagnosticsReportRequest) Reset() {
 func (m *CreateStatementDiagnosticsReportRequest) String() string { return proto.CompactTextString(m) }
 func (*CreateStatementDiagnosticsReportRequest) ProtoMessage()    {}
 func (*CreateStatementDiagnosticsReportRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{69}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{69}
 }
 func (m *CreateStatementDiagnosticsReportRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3206,7 +3206,7 @@ func (m *CreateStatementDiagnosticsReportResponse) Reset() {
 func (m *CreateStatementDiagnosticsReportResponse) String() string { return proto.CompactTextString(m) }
 func (*CreateStatementDiagnosticsReportResponse) ProtoMessage()    {}
 func (*CreateStatementDiagnosticsReportResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{70}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{70}
 }
 func (m *CreateStatementDiagnosticsReportResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3238,7 +3238,7 @@ func (m *StatementDiagnosticsReportsRequest) Reset()         { *m = StatementDia
 func (m *StatementDiagnosticsReportsRequest) String() string { return proto.CompactTextString(m) }
 func (*StatementDiagnosticsReportsRequest) ProtoMessage()    {}
 func (*StatementDiagnosticsReportsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{71}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{71}
 }
 func (m *StatementDiagnosticsReportsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3271,7 +3271,7 @@ func (m *StatementDiagnosticsReportsResponse) Reset()         { *m = StatementDi
 func (m *StatementDiagnosticsReportsResponse) String() string { return proto.CompactTextString(m) }
 func (*StatementDiagnosticsReportsResponse) ProtoMessage()    {}
 func (*StatementDiagnosticsReportsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{72}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{72}
 }
 func (m *StatementDiagnosticsReportsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3307,7 +3307,7 @@ func (m *StatementDiagnostics) Reset()         { *m = StatementDiagnostics{} }
 func (m *StatementDiagnostics) String() string { return proto.CompactTextString(m) }
 func (*StatementDiagnostics) ProtoMessage()    {}
 func (*StatementDiagnostics) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{73}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{73}
 }
 func (m *StatementDiagnostics) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3340,7 +3340,7 @@ func (m *StatementDiagnosticsRequest) Reset()         { *m = StatementDiagnostic
 func (m *StatementDiagnosticsRequest) String() string { return proto.CompactTextString(m) }
 func (*StatementDiagnosticsRequest) ProtoMessage()    {}
 func (*StatementDiagnosticsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{74}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{74}
 }
 func (m *StatementDiagnosticsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3373,7 +3373,7 @@ func (m *StatementDiagnosticsResponse) Reset()         { *m = StatementDiagnosti
 func (m *StatementDiagnosticsResponse) String() string { return proto.CompactTextString(m) }
 func (*StatementDiagnosticsResponse) ProtoMessage()    {}
 func (*StatementDiagnosticsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{75}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{75}
 }
 func (m *StatementDiagnosticsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3406,7 +3406,7 @@ func (m *JobRegistryStatusRequest) Reset()         { *m = JobRegistryStatusReque
 func (m *JobRegistryStatusRequest) String() string { return proto.CompactTextString(m) }
 func (*JobRegistryStatusRequest) ProtoMessage()    {}
 func (*JobRegistryStatusRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{76}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{76}
 }
 func (m *JobRegistryStatusRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3440,7 +3440,7 @@ func (m *JobRegistryStatusResponse) Reset()         { *m = JobRegistryStatusResp
 func (m *JobRegistryStatusResponse) String() string { return proto.CompactTextString(m) }
 func (*JobRegistryStatusResponse) ProtoMessage()    {}
 func (*JobRegistryStatusResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{77}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{77}
 }
 func (m *JobRegistryStatusResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3473,7 +3473,7 @@ func (m *JobRegistryStatusResponse_Job) Reset()         { *m = JobRegistryStatus
 func (m *JobRegistryStatusResponse_Job) String() string { return proto.CompactTextString(m) }
 func (*JobRegistryStatusResponse_Job) ProtoMessage()    {}
 func (*JobRegistryStatusResponse_Job) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{77, 0}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{77, 0}
 }
 func (m *JobRegistryStatusResponse_Job) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3506,7 +3506,7 @@ func (m *JobStatusRequest) Reset()         { *m = JobStatusRequest{} }
 func (m *JobStatusRequest) String() string { return proto.CompactTextString(m) }
 func (*JobStatusRequest) ProtoMessage()    {}
 func (*JobStatusRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{78}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{78}
 }
 func (m *JobStatusRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3539,7 +3539,7 @@ func (m *JobStatusResponse) Reset()         { *m = JobStatusResponse{} }
 func (m *JobStatusResponse) String() string { return proto.CompactTextString(m) }
 func (*JobStatusResponse) ProtoMessage()    {}
 func (*JobStatusResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_e91e4bae4876eefb, []int{79}
+	return fileDescriptor_status_82425d3e4bfb8a46, []int{79}
 }
 func (m *JobStatusResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -22451,10 +22451,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("server/serverpb/status.proto", fileDescriptor_status_e91e4bae4876eefb)
+	proto.RegisterFile("server/serverpb/status.proto", fileDescriptor_status_82425d3e4bfb8a46)
 }
 
-var fileDescriptor_status_e91e4bae4876eefb = []byte{
+var fileDescriptor_status_82425d3e4bfb8a46 = []byte{
 	// 6183 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xcc, 0x5c, 0x6f, 0x6c, 0x1b, 0xc9,
 	0x75, 0xf7, 0x92, 0x14, 0x45, 0x3e, 0xea, 0x0f, 0x35, 0xfa, 0x63, 0x9a, 0xf6, 0x49, 0xbe, 0xf5,

--- a/pkg/server/status/statuspb/status.pb.go
+++ b/pkg/server/status/statuspb/status.pb.go
@@ -47,7 +47,7 @@ func (x HealthAlert_Category) String() string {
 	return proto.EnumName(HealthAlert_Category_name, int32(x))
 }
 func (HealthAlert_Category) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_status_46c3b5d63ad7300e, []int{2, 0}
+	return fileDescriptor_status_c9ef8fcbce5ee691, []int{2, 0}
 }
 
 // StoreStatus records the most recent values of metrics for a store.
@@ -62,7 +62,7 @@ func (m *StoreStatus) Reset()         { *m = StoreStatus{} }
 func (m *StoreStatus) String() string { return proto.CompactTextString(m) }
 func (*StoreStatus) ProtoMessage()    {}
 func (*StoreStatus) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_46c3b5d63ad7300e, []int{0}
+	return fileDescriptor_status_c9ef8fcbce5ee691, []int{0}
 }
 func (m *StoreStatus) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -139,7 +139,7 @@ func (m *NodeStatus) Reset()         { *m = NodeStatus{} }
 func (m *NodeStatus) String() string { return proto.CompactTextString(m) }
 func (*NodeStatus) ProtoMessage()    {}
 func (*NodeStatus) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_46c3b5d63ad7300e, []int{1}
+	return fileDescriptor_status_c9ef8fcbce5ee691, []int{1}
 }
 func (m *NodeStatus) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -174,7 +174,7 @@ func (m *NodeStatus_NetworkActivity) Reset()         { *m = NodeStatus_NetworkAc
 func (m *NodeStatus_NetworkActivity) String() string { return proto.CompactTextString(m) }
 func (*NodeStatus_NetworkActivity) ProtoMessage()    {}
 func (*NodeStatus_NetworkActivity) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_46c3b5d63ad7300e, []int{1, 2}
+	return fileDescriptor_status_c9ef8fcbce5ee691, []int{1, 2}
 }
 func (m *NodeStatus_NetworkActivity) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -213,7 +213,7 @@ func (m *HealthAlert) Reset()         { *m = HealthAlert{} }
 func (m *HealthAlert) String() string { return proto.CompactTextString(m) }
 func (*HealthAlert) ProtoMessage()    {}
 func (*HealthAlert) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_46c3b5d63ad7300e, []int{2}
+	return fileDescriptor_status_c9ef8fcbce5ee691, []int{2}
 }
 func (m *HealthAlert) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -247,7 +247,7 @@ func (m *HealthCheckResult) Reset()         { *m = HealthCheckResult{} }
 func (m *HealthCheckResult) String() string { return proto.CompactTextString(m) }
 func (*HealthCheckResult) ProtoMessage()    {}
 func (*HealthCheckResult) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_46c3b5d63ad7300e, []int{3}
+	return fileDescriptor_status_c9ef8fcbce5ee691, []int{3}
 }
 func (m *HealthCheckResult) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1952,10 +1952,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("server/status/statuspb/status.proto", fileDescriptor_status_46c3b5d63ad7300e)
+	proto.RegisterFile("server/status/statuspb/status.proto", fileDescriptor_status_c9ef8fcbce5ee691)
 }
 
-var fileDescriptor_status_46c3b5d63ad7300e = []byte{
+var fileDescriptor_status_c9ef8fcbce5ee691 = []byte{
 	// 817 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xac, 0x55, 0x5f, 0x6f, 0xe3, 0x44,
 	0x10, 0xcf, 0x36, 0x69, 0xe3, 0x8c, 0xef, 0x4a, 0x6f, 0x39, 0x90, 0x89, 0x44, 0x6a, 0x02, 0x0f,

--- a/pkg/sql/catalog/descpb/encoded_datum.pb.go
+++ b/pkg/sql/catalog/descpb/encoded_datum.pb.go
@@ -60,7 +60,7 @@ func (x *DatumEncoding) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (DatumEncoding) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_encoded_datum_a9a9da979c7d72d0, []int{0}
+	return fileDescriptor_encoded_datum_0472e76a601f5c7c, []int{0}
 }
 
 func init() {
@@ -68,10 +68,10 @@ func init() {
 }
 
 func init() {
-	proto.RegisterFile("sql/catalog/descpb/encoded_datum.proto", fileDescriptor_encoded_datum_a9a9da979c7d72d0)
+	proto.RegisterFile("sql/catalog/descpb/encoded_datum.proto", fileDescriptor_encoded_datum_0472e76a601f5c7c)
 }
 
-var fileDescriptor_encoded_datum_a9a9da979c7d72d0 = []byte{
+var fileDescriptor_encoded_datum_0472e76a601f5c7c = []byte{
 	// 190 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x52, 0x2b, 0x2e, 0xcc, 0xd1,
 	0x4f, 0x4e, 0x2c, 0x49, 0xcc, 0xc9, 0x4f, 0xd7, 0x4f, 0x49, 0x2d, 0x4e, 0x2e, 0x48, 0xd2, 0x4f,

--- a/pkg/sql/catalog/descpb/join_type.pb.go
+++ b/pkg/sql/catalog/descpb/join_type.pb.go
@@ -132,7 +132,7 @@ func (x *JoinType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (JoinType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_join_type_17eaa4747c0fb86f, []int{0}
+	return fileDescriptor_join_type_2563bd08acd844ac, []int{0}
 }
 
 func init() {
@@ -140,10 +140,10 @@ func init() {
 }
 
 func init() {
-	proto.RegisterFile("sql/catalog/descpb/join_type.proto", fileDescriptor_join_type_17eaa4747c0fb86f)
+	proto.RegisterFile("sql/catalog/descpb/join_type.proto", fileDescriptor_join_type_2563bd08acd844ac)
 }
 
-var fileDescriptor_join_type_17eaa4747c0fb86f = []byte{
+var fileDescriptor_join_type_2563bd08acd844ac = []byte{
 	// 241 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x52, 0x2a, 0x2e, 0xcc, 0xd1,
 	0x4f, 0x4e, 0x2c, 0x49, 0xcc, 0xc9, 0x4f, 0xd7, 0x4f, 0x49, 0x2d, 0x4e, 0x2e, 0x48, 0xd2, 0xcf,

--- a/pkg/sql/catalog/descpb/locking.pb.go
+++ b/pkg/sql/catalog/descpb/locking.pb.go
@@ -152,7 +152,7 @@ func (x *ScanLockingStrength) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (ScanLockingStrength) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_locking_2399db643a0152e9, []int{0}
+	return fileDescriptor_locking_ea30425e3ab7b450, []int{0}
 }
 
 // LockingWaitPolicy controls the policy used for handling conflicting locks
@@ -200,7 +200,7 @@ func (x *ScanLockingWaitPolicy) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (ScanLockingWaitPolicy) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_locking_2399db643a0152e9, []int{1}
+	return fileDescriptor_locking_ea30425e3ab7b450, []int{1}
 }
 
 func init() {
@@ -209,10 +209,10 @@ func init() {
 }
 
 func init() {
-	proto.RegisterFile("sql/catalog/descpb/locking.proto", fileDescriptor_locking_2399db643a0152e9)
+	proto.RegisterFile("sql/catalog/descpb/locking.proto", fileDescriptor_locking_ea30425e3ab7b450)
 }
 
-var fileDescriptor_locking_2399db643a0152e9 = []byte{
+var fileDescriptor_locking_ea30425e3ab7b450 = []byte{
 	// 248 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x52, 0x28, 0x2e, 0xcc, 0xd1,
 	0x4f, 0x4e, 0x2c, 0x49, 0xcc, 0xc9, 0x4f, 0xd7, 0x4f, 0x49, 0x2d, 0x4e, 0x2e, 0x48, 0xd2, 0xcf,

--- a/pkg/sql/catalog/descpb/privilege.pb.go
+++ b/pkg/sql/catalog/descpb/privilege.pb.go
@@ -33,7 +33,7 @@ func (m *UserPrivileges) Reset()         { *m = UserPrivileges{} }
 func (m *UserPrivileges) String() string { return proto.CompactTextString(m) }
 func (*UserPrivileges) ProtoMessage()    {}
 func (*UserPrivileges) Descriptor() ([]byte, []int) {
-	return fileDescriptor_privilege_f48077236b0cbe6a, []int{0}
+	return fileDescriptor_privilege_4b33ab26af3a9290, []int{0}
 }
 func (m *UserPrivileges) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -70,7 +70,7 @@ func (m *PrivilegeDescriptor) Reset()         { *m = PrivilegeDescriptor{} }
 func (m *PrivilegeDescriptor) String() string { return proto.CompactTextString(m) }
 func (*PrivilegeDescriptor) ProtoMessage()    {}
 func (*PrivilegeDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_privilege_f48077236b0cbe6a, []int{1}
+	return fileDescriptor_privilege_4b33ab26af3a9290, []int{1}
 }
 func (m *PrivilegeDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -608,10 +608,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("sql/catalog/descpb/privilege.proto", fileDescriptor_privilege_f48077236b0cbe6a)
+	proto.RegisterFile("sql/catalog/descpb/privilege.proto", fileDescriptor_privilege_4b33ab26af3a9290)
 }
 
-var fileDescriptor_privilege_f48077236b0cbe6a = []byte{
+var fileDescriptor_privilege_4b33ab26af3a9290 = []byte{
 	// 342 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x52, 0x2a, 0x2e, 0xcc, 0xd1,
 	0x4f, 0x4e, 0x2c, 0x49, 0xcc, 0xc9, 0x4f, 0xd7, 0x4f, 0x49, 0x2d, 0x4e, 0x2e, 0x48, 0xd2, 0x2f,

--- a/pkg/sql/catalog/descpb/structured.pb.go
+++ b/pkg/sql/catalog/descpb/structured.pb.go
@@ -75,7 +75,7 @@ func (x *ConstraintValidity) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (ConstraintValidity) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_a50c3bc5fe2e0c6c, []int{0}
+	return fileDescriptor_structured_62b371f3f0ee1cce, []int{0}
 }
 
 // SystemColumnKind is an enum representing the different kind of system
@@ -120,7 +120,7 @@ func (x *SystemColumnKind) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (SystemColumnKind) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_a50c3bc5fe2e0c6c, []int{1}
+	return fileDescriptor_structured_62b371f3f0ee1cce, []int{1}
 }
 
 // State indicates whether a descriptor is public (i.e., normally visible,
@@ -172,7 +172,7 @@ func (x *DescriptorState) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (DescriptorState) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_a50c3bc5fe2e0c6c, []int{2}
+	return fileDescriptor_structured_62b371f3f0ee1cce, []int{2}
 }
 
 // SurvivalGoal is the survival goal for a database.
@@ -211,7 +211,7 @@ func (x *SurvivalGoal) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (SurvivalGoal) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_a50c3bc5fe2e0c6c, []int{3}
+	return fileDescriptor_structured_62b371f3f0ee1cce, []int{3}
 }
 
 type ForeignKeyReference_Action int32
@@ -256,7 +256,7 @@ func (x *ForeignKeyReference_Action) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (ForeignKeyReference_Action) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_a50c3bc5fe2e0c6c, []int{0, 0}
+	return fileDescriptor_structured_62b371f3f0ee1cce, []int{0, 0}
 }
 
 // Match is the algorithm used to compare composite keys.
@@ -296,7 +296,7 @@ func (x *ForeignKeyReference_Match) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (ForeignKeyReference_Match) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_a50c3bc5fe2e0c6c, []int{0, 1}
+	return fileDescriptor_structured_62b371f3f0ee1cce, []int{0, 1}
 }
 
 // The direction of a column in the index.
@@ -333,7 +333,7 @@ func (x *IndexDescriptor_Direction) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (IndexDescriptor_Direction) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_a50c3bc5fe2e0c6c, []int{8, 0}
+	return fileDescriptor_structured_62b371f3f0ee1cce, []int{8, 0}
 }
 
 // The type of the index.
@@ -370,7 +370,7 @@ func (x *IndexDescriptor_Type) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (IndexDescriptor_Type) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_a50c3bc5fe2e0c6c, []int{8, 1}
+	return fileDescriptor_structured_62b371f3f0ee1cce, []int{8, 1}
 }
 
 type ConstraintToUpdate_ConstraintType int32
@@ -416,7 +416,7 @@ func (x *ConstraintToUpdate_ConstraintType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (ConstraintToUpdate_ConstraintType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_a50c3bc5fe2e0c6c, []int{9, 0}
+	return fileDescriptor_structured_62b371f3f0ee1cce, []int{9, 0}
 }
 
 // A descriptor within a mutation is unavailable for reads, writes
@@ -481,7 +481,7 @@ func (x *DescriptorMutation_State) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (DescriptorMutation_State) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_a50c3bc5fe2e0c6c, []int{13, 0}
+	return fileDescriptor_structured_62b371f3f0ee1cce, []int{13, 0}
 }
 
 // Direction of mutation.
@@ -524,7 +524,7 @@ func (x *DescriptorMutation_Direction) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (DescriptorMutation_Direction) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_a50c3bc5fe2e0c6c, []int{13, 1}
+	return fileDescriptor_structured_62b371f3f0ee1cce, []int{13, 1}
 }
 
 // AuditMode indicates which auditing actions to take when this table is used.
@@ -561,7 +561,7 @@ func (x *TableDescriptor_AuditMode) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (TableDescriptor_AuditMode) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_a50c3bc5fe2e0c6c, []int{15, 0}
+	return fileDescriptor_structured_62b371f3f0ee1cce, []int{15, 0}
 }
 
 // Represents the kind of type that this type descriptor represents.
@@ -606,7 +606,7 @@ func (x *TypeDescriptor_Kind) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (TypeDescriptor_Kind) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_a50c3bc5fe2e0c6c, []int{17, 0}
+	return fileDescriptor_structured_62b371f3f0ee1cce, []int{17, 0}
 }
 
 // Represents what operations are allowed on this ENUM member.
@@ -647,7 +647,7 @@ func (x *TypeDescriptor_EnumMember_Capability) UnmarshalJSON(data []byte) error 
 	return nil
 }
 func (TypeDescriptor_EnumMember_Capability) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_a50c3bc5fe2e0c6c, []int{17, 0, 0}
+	return fileDescriptor_structured_62b371f3f0ee1cce, []int{17, 0, 0}
 }
 
 // ForeignKeyReference is deprecated, replaced by ForeignKeyConstraint in v19.2
@@ -677,7 +677,7 @@ func (m *ForeignKeyReference) Reset()         { *m = ForeignKeyReference{} }
 func (m *ForeignKeyReference) String() string { return proto.CompactTextString(m) }
 func (*ForeignKeyReference) ProtoMessage()    {}
 func (*ForeignKeyReference) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_a50c3bc5fe2e0c6c, []int{0}
+	return fileDescriptor_structured_62b371f3f0ee1cce, []int{0}
 }
 func (m *ForeignKeyReference) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -725,7 +725,7 @@ func (m *ForeignKeyConstraint) Reset()         { *m = ForeignKeyConstraint{} }
 func (m *ForeignKeyConstraint) String() string { return proto.CompactTextString(m) }
 func (*ForeignKeyConstraint) ProtoMessage()    {}
 func (*ForeignKeyConstraint) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_a50c3bc5fe2e0c6c, []int{1}
+	return fileDescriptor_structured_62b371f3f0ee1cce, []int{1}
 }
 func (m *ForeignKeyConstraint) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -763,7 +763,7 @@ func (m *UniqueWithoutIndexConstraint) Reset()         { *m = UniqueWithoutIndex
 func (m *UniqueWithoutIndexConstraint) String() string { return proto.CompactTextString(m) }
 func (*UniqueWithoutIndexConstraint) ProtoMessage()    {}
 func (*UniqueWithoutIndexConstraint) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_a50c3bc5fe2e0c6c, []int{2}
+	return fileDescriptor_structured_62b371f3f0ee1cce, []int{2}
 }
 func (m *UniqueWithoutIndexConstraint) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -831,7 +831,7 @@ func (m *ColumnDescriptor) Reset()         { *m = ColumnDescriptor{} }
 func (m *ColumnDescriptor) String() string { return proto.CompactTextString(m) }
 func (*ColumnDescriptor) ProtoMessage()    {}
 func (*ColumnDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_a50c3bc5fe2e0c6c, []int{3}
+	return fileDescriptor_structured_62b371f3f0ee1cce, []int{3}
 }
 func (m *ColumnDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -887,7 +887,7 @@ func (m *ColumnFamilyDescriptor) Reset()         { *m = ColumnFamilyDescriptor{}
 func (m *ColumnFamilyDescriptor) String() string { return proto.CompactTextString(m) }
 func (*ColumnFamilyDescriptor) ProtoMessage()    {}
 func (*ColumnFamilyDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_a50c3bc5fe2e0c6c, []int{4}
+	return fileDescriptor_structured_62b371f3f0ee1cce, []int{4}
 }
 func (m *ColumnFamilyDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -933,7 +933,7 @@ func (m *InterleaveDescriptor) Reset()         { *m = InterleaveDescriptor{} }
 func (m *InterleaveDescriptor) String() string { return proto.CompactTextString(m) }
 func (*InterleaveDescriptor) ProtoMessage()    {}
 func (*InterleaveDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_a50c3bc5fe2e0c6c, []int{5}
+	return fileDescriptor_structured_62b371f3f0ee1cce, []int{5}
 }
 func (m *InterleaveDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -977,7 +977,7 @@ func (m *InterleaveDescriptor_Ancestor) Reset()         { *m = InterleaveDescrip
 func (m *InterleaveDescriptor_Ancestor) String() string { return proto.CompactTextString(m) }
 func (*InterleaveDescriptor_Ancestor) ProtoMessage()    {}
 func (*InterleaveDescriptor_Ancestor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_a50c3bc5fe2e0c6c, []int{5, 0}
+	return fileDescriptor_structured_62b371f3f0ee1cce, []int{5, 0}
 }
 func (m *InterleaveDescriptor_Ancestor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1032,7 +1032,7 @@ func (m *ShardedDescriptor) Reset()         { *m = ShardedDescriptor{} }
 func (m *ShardedDescriptor) String() string { return proto.CompactTextString(m) }
 func (*ShardedDescriptor) ProtoMessage()    {}
 func (*ShardedDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_a50c3bc5fe2e0c6c, []int{6}
+	return fileDescriptor_structured_62b371f3f0ee1cce, []int{6}
 }
 func (m *ShardedDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1083,7 +1083,7 @@ func (m *PartitioningDescriptor) Reset()         { *m = PartitioningDescriptor{}
 func (m *PartitioningDescriptor) String() string { return proto.CompactTextString(m) }
 func (*PartitioningDescriptor) ProtoMessage()    {}
 func (*PartitioningDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_a50c3bc5fe2e0c6c, []int{7}
+	return fileDescriptor_structured_62b371f3f0ee1cce, []int{7}
 }
 func (m *PartitioningDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1126,7 +1126,7 @@ func (m *PartitioningDescriptor_List) Reset()         { *m = PartitioningDescrip
 func (m *PartitioningDescriptor_List) String() string { return proto.CompactTextString(m) }
 func (*PartitioningDescriptor_List) ProtoMessage()    {}
 func (*PartitioningDescriptor_List) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_a50c3bc5fe2e0c6c, []int{7, 0}
+	return fileDescriptor_structured_62b371f3f0ee1cce, []int{7, 0}
 }
 func (m *PartitioningDescriptor_List) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1171,7 +1171,7 @@ func (m *PartitioningDescriptor_Range) Reset()         { *m = PartitioningDescri
 func (m *PartitioningDescriptor_Range) String() string { return proto.CompactTextString(m) }
 func (*PartitioningDescriptor_Range) ProtoMessage()    {}
 func (*PartitioningDescriptor_Range) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_a50c3bc5fe2e0c6c, []int{7, 1}
+	return fileDescriptor_structured_62b371f3f0ee1cce, []int{7, 1}
 }
 func (m *PartitioningDescriptor_Range) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1338,7 +1338,7 @@ func (m *IndexDescriptor) Reset()         { *m = IndexDescriptor{} }
 func (m *IndexDescriptor) String() string { return proto.CompactTextString(m) }
 func (*IndexDescriptor) ProtoMessage()    {}
 func (*IndexDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_a50c3bc5fe2e0c6c, []int{8}
+	return fileDescriptor_structured_62b371f3f0ee1cce, []int{8}
 }
 func (m *IndexDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1390,7 +1390,7 @@ func (m *ConstraintToUpdate) Reset()         { *m = ConstraintToUpdate{} }
 func (m *ConstraintToUpdate) String() string { return proto.CompactTextString(m) }
 func (*ConstraintToUpdate) ProtoMessage()    {}
 func (*ConstraintToUpdate) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_a50c3bc5fe2e0c6c, []int{9}
+	return fileDescriptor_structured_62b371f3f0ee1cce, []int{9}
 }
 func (m *ConstraintToUpdate) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1437,7 +1437,7 @@ func (m *PrimaryKeySwap) Reset()         { *m = PrimaryKeySwap{} }
 func (m *PrimaryKeySwap) String() string { return proto.CompactTextString(m) }
 func (*PrimaryKeySwap) ProtoMessage()    {}
 func (*PrimaryKeySwap) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_a50c3bc5fe2e0c6c, []int{10}
+	return fileDescriptor_structured_62b371f3f0ee1cce, []int{10}
 }
 func (m *PrimaryKeySwap) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1477,7 +1477,7 @@ func (m *ComputedColumnSwap) Reset()         { *m = ComputedColumnSwap{} }
 func (m *ComputedColumnSwap) String() string { return proto.CompactTextString(m) }
 func (*ComputedColumnSwap) ProtoMessage()    {}
 func (*ComputedColumnSwap) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_a50c3bc5fe2e0c6c, []int{11}
+	return fileDescriptor_structured_62b371f3f0ee1cce, []int{11}
 }
 func (m *ComputedColumnSwap) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1525,7 +1525,7 @@ func (m *MaterializedViewRefresh) Reset()         { *m = MaterializedViewRefresh
 func (m *MaterializedViewRefresh) String() string { return proto.CompactTextString(m) }
 func (*MaterializedViewRefresh) ProtoMessage()    {}
 func (*MaterializedViewRefresh) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_a50c3bc5fe2e0c6c, []int{12}
+	return fileDescriptor_structured_62b371f3f0ee1cce, []int{12}
 }
 func (m *MaterializedViewRefresh) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1582,7 +1582,7 @@ func (m *DescriptorMutation) Reset()         { *m = DescriptorMutation{} }
 func (m *DescriptorMutation) String() string { return proto.CompactTextString(m) }
 func (*DescriptorMutation) ProtoMessage()    {}
 func (*DescriptorMutation) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_a50c3bc5fe2e0c6c, []int{13}
+	return fileDescriptor_structured_62b371f3f0ee1cce, []int{13}
 }
 func (m *DescriptorMutation) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1920,7 +1920,7 @@ func (m *NameInfo) Reset()         { *m = NameInfo{} }
 func (m *NameInfo) String() string { return proto.CompactTextString(m) }
 func (*NameInfo) ProtoMessage()    {}
 func (*NameInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_a50c3bc5fe2e0c6c, []int{14}
+	return fileDescriptor_structured_62b371f3f0ee1cce, []int{14}
 }
 func (m *NameInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2110,7 +2110,7 @@ func (m *TableDescriptor) Reset()         { *m = TableDescriptor{} }
 func (m *TableDescriptor) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor) ProtoMessage()    {}
 func (*TableDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_a50c3bc5fe2e0c6c, []int{15}
+	return fileDescriptor_structured_62b371f3f0ee1cce, []int{15}
 }
 func (m *TableDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2438,7 +2438,7 @@ func (m *TableDescriptor_SchemaChangeLease) Reset()         { *m = TableDescript
 func (m *TableDescriptor_SchemaChangeLease) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_SchemaChangeLease) ProtoMessage()    {}
 func (*TableDescriptor_SchemaChangeLease) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_a50c3bc5fe2e0c6c, []int{15, 0}
+	return fileDescriptor_structured_62b371f3f0ee1cce, []int{15, 0}
 }
 func (m *TableDescriptor_SchemaChangeLease) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2484,7 +2484,7 @@ func (m *TableDescriptor_CheckConstraint) Reset()         { *m = TableDescriptor
 func (m *TableDescriptor_CheckConstraint) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_CheckConstraint) ProtoMessage()    {}
 func (*TableDescriptor_CheckConstraint) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_a50c3bc5fe2e0c6c, []int{15, 1}
+	return fileDescriptor_structured_62b371f3f0ee1cce, []int{15, 1}
 }
 func (m *TableDescriptor_CheckConstraint) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2524,7 +2524,7 @@ func (m *TableDescriptor_Reference) Reset()         { *m = TableDescriptor_Refer
 func (m *TableDescriptor_Reference) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_Reference) ProtoMessage()    {}
 func (*TableDescriptor_Reference) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_a50c3bc5fe2e0c6c, []int{15, 2}
+	return fileDescriptor_structured_62b371f3f0ee1cce, []int{15, 2}
 }
 func (m *TableDescriptor_Reference) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2561,7 +2561,7 @@ func (m *TableDescriptor_MutationJob) Reset()         { *m = TableDescriptor_Mut
 func (m *TableDescriptor_MutationJob) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_MutationJob) ProtoMessage()    {}
 func (*TableDescriptor_MutationJob) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_a50c3bc5fe2e0c6c, []int{15, 3}
+	return fileDescriptor_structured_62b371f3f0ee1cce, []int{15, 3}
 }
 func (m *TableDescriptor_MutationJob) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2604,7 +2604,7 @@ func (m *TableDescriptor_SequenceOpts) Reset()         { *m = TableDescriptor_Se
 func (m *TableDescriptor_SequenceOpts) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_SequenceOpts) ProtoMessage()    {}
 func (*TableDescriptor_SequenceOpts) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_a50c3bc5fe2e0c6c, []int{15, 4}
+	return fileDescriptor_structured_62b371f3f0ee1cce, []int{15, 4}
 }
 func (m *TableDescriptor_SequenceOpts) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2644,7 +2644,7 @@ func (m *TableDescriptor_SequenceOpts_SequenceOwner) String() string {
 }
 func (*TableDescriptor_SequenceOpts_SequenceOwner) ProtoMessage() {}
 func (*TableDescriptor_SequenceOpts_SequenceOwner) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_a50c3bc5fe2e0c6c, []int{15, 4, 0}
+	return fileDescriptor_structured_62b371f3f0ee1cce, []int{15, 4, 0}
 }
 func (m *TableDescriptor_SequenceOpts_SequenceOwner) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2684,7 +2684,7 @@ func (m *TableDescriptor_Replacement) Reset()         { *m = TableDescriptor_Rep
 func (m *TableDescriptor_Replacement) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_Replacement) ProtoMessage()    {}
 func (*TableDescriptor_Replacement) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_a50c3bc5fe2e0c6c, []int{15, 5}
+	return fileDescriptor_structured_62b371f3f0ee1cce, []int{15, 5}
 }
 func (m *TableDescriptor_Replacement) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2721,7 +2721,7 @@ func (m *TableDescriptor_GCDescriptorMutation) Reset()         { *m = TableDescr
 func (m *TableDescriptor_GCDescriptorMutation) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_GCDescriptorMutation) ProtoMessage()    {}
 func (*TableDescriptor_GCDescriptorMutation) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_a50c3bc5fe2e0c6c, []int{15, 6}
+	return fileDescriptor_structured_62b371f3f0ee1cce, []int{15, 6}
 }
 func (m *TableDescriptor_GCDescriptorMutation) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2758,7 +2758,7 @@ func (m *TableDescriptor_LocalityConfig) Reset()         { *m = TableDescriptor_
 func (m *TableDescriptor_LocalityConfig) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_LocalityConfig) ProtoMessage()    {}
 func (*TableDescriptor_LocalityConfig) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_a50c3bc5fe2e0c6c, []int{15, 7}
+	return fileDescriptor_structured_62b371f3f0ee1cce, []int{15, 7}
 }
 func (m *TableDescriptor_LocalityConfig) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2938,7 +2938,7 @@ func (m *TableDescriptor_LocalityConfig_RegionalByTable) String() string {
 }
 func (*TableDescriptor_LocalityConfig_RegionalByTable) ProtoMessage() {}
 func (*TableDescriptor_LocalityConfig_RegionalByTable) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_a50c3bc5fe2e0c6c, []int{15, 7, 0}
+	return fileDescriptor_structured_62b371f3f0ee1cce, []int{15, 7, 0}
 }
 func (m *TableDescriptor_LocalityConfig_RegionalByTable) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2974,7 +2974,7 @@ func (m *TableDescriptor_LocalityConfig_RegionalByRow) String() string {
 }
 func (*TableDescriptor_LocalityConfig_RegionalByRow) ProtoMessage() {}
 func (*TableDescriptor_LocalityConfig_RegionalByRow) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_a50c3bc5fe2e0c6c, []int{15, 7, 1}
+	return fileDescriptor_structured_62b371f3f0ee1cce, []int{15, 7, 1}
 }
 func (m *TableDescriptor_LocalityConfig_RegionalByRow) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3006,7 +3006,7 @@ func (m *TableDescriptor_LocalityConfig_Global) Reset()         { *m = TableDesc
 func (m *TableDescriptor_LocalityConfig_Global) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_LocalityConfig_Global) ProtoMessage()    {}
 func (*TableDescriptor_LocalityConfig_Global) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_a50c3bc5fe2e0c6c, []int{15, 7, 2}
+	return fileDescriptor_structured_62b371f3f0ee1cce, []int{15, 7, 2}
 }
 func (m *TableDescriptor_LocalityConfig_Global) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3057,7 +3057,7 @@ func (m *DatabaseDescriptor) Reset()         { *m = DatabaseDescriptor{} }
 func (m *DatabaseDescriptor) String() string { return proto.CompactTextString(m) }
 func (*DatabaseDescriptor) ProtoMessage()    {}
 func (*DatabaseDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_a50c3bc5fe2e0c6c, []int{16}
+	return fileDescriptor_structured_62b371f3f0ee1cce, []int{16}
 }
 func (m *DatabaseDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3165,7 +3165,7 @@ func (m *DatabaseDescriptor_SchemaInfo) Reset()         { *m = DatabaseDescripto
 func (m *DatabaseDescriptor_SchemaInfo) String() string { return proto.CompactTextString(m) }
 func (*DatabaseDescriptor_SchemaInfo) ProtoMessage()    {}
 func (*DatabaseDescriptor_SchemaInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_a50c3bc5fe2e0c6c, []int{16, 0}
+	return fileDescriptor_structured_62b371f3f0ee1cce, []int{16, 0}
 }
 func (m *DatabaseDescriptor_SchemaInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3205,7 +3205,7 @@ func (m *DatabaseDescriptor_RegionConfig) Reset()         { *m = DatabaseDescrip
 func (m *DatabaseDescriptor_RegionConfig) String() string { return proto.CompactTextString(m) }
 func (*DatabaseDescriptor_RegionConfig) ProtoMessage()    {}
 func (*DatabaseDescriptor_RegionConfig) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_a50c3bc5fe2e0c6c, []int{16, 2}
+	return fileDescriptor_structured_62b371f3f0ee1cce, []int{16, 2}
 }
 func (m *DatabaseDescriptor_RegionConfig) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3240,7 +3240,7 @@ func (m *DatabaseDescriptor_RegionConfig_Region) Reset() {
 func (m *DatabaseDescriptor_RegionConfig_Region) String() string { return proto.CompactTextString(m) }
 func (*DatabaseDescriptor_RegionConfig_Region) ProtoMessage()    {}
 func (*DatabaseDescriptor_RegionConfig_Region) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_a50c3bc5fe2e0c6c, []int{16, 2, 0}
+	return fileDescriptor_structured_62b371f3f0ee1cce, []int{16, 2, 0}
 }
 func (m *DatabaseDescriptor_RegionConfig_Region) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3303,7 +3303,7 @@ func (m *TypeDescriptor) Reset()         { *m = TypeDescriptor{} }
 func (m *TypeDescriptor) String() string { return proto.CompactTextString(m) }
 func (*TypeDescriptor) ProtoMessage()    {}
 func (*TypeDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_a50c3bc5fe2e0c6c, []int{17}
+	return fileDescriptor_structured_62b371f3f0ee1cce, []int{17}
 }
 func (m *TypeDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3451,7 +3451,7 @@ func (m *TypeDescriptor_EnumMember) Reset()         { *m = TypeDescriptor_EnumMe
 func (m *TypeDescriptor_EnumMember) String() string { return proto.CompactTextString(m) }
 func (*TypeDescriptor_EnumMember) ProtoMessage()    {}
 func (*TypeDescriptor_EnumMember) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_a50c3bc5fe2e0c6c, []int{17, 0}
+	return fileDescriptor_structured_62b371f3f0ee1cce, []int{17, 0}
 }
 func (m *TypeDescriptor_EnumMember) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3487,7 +3487,7 @@ func (m *TypeDescriptor_RegionConfig) Reset()         { *m = TypeDescriptor_Regi
 func (m *TypeDescriptor_RegionConfig) String() string { return proto.CompactTextString(m) }
 func (*TypeDescriptor_RegionConfig) ProtoMessage()    {}
 func (*TypeDescriptor_RegionConfig) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_a50c3bc5fe2e0c6c, []int{17, 1}
+	return fileDescriptor_structured_62b371f3f0ee1cce, []int{17, 1}
 }
 func (m *TypeDescriptor_RegionConfig) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3535,7 +3535,7 @@ func (m *SchemaDescriptor) Reset()         { *m = SchemaDescriptor{} }
 func (m *SchemaDescriptor) String() string { return proto.CompactTextString(m) }
 func (*SchemaDescriptor) ProtoMessage()    {}
 func (*SchemaDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_a50c3bc5fe2e0c6c, []int{18}
+	return fileDescriptor_structured_62b371f3f0ee1cce, []int{18}
 }
 func (m *SchemaDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3638,7 +3638,7 @@ func (m *Descriptor) Reset()         { *m = Descriptor{} }
 func (m *Descriptor) String() string { return proto.CompactTextString(m) }
 func (*Descriptor) ProtoMessage()    {}
 func (*Descriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_a50c3bc5fe2e0c6c, []int{19}
+	return fileDescriptor_structured_62b371f3f0ee1cce, []int{19}
 }
 func (m *Descriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -18177,10 +18177,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("sql/catalog/descpb/structured.proto", fileDescriptor_structured_a50c3bc5fe2e0c6c)
+	proto.RegisterFile("sql/catalog/descpb/structured.proto", fileDescriptor_structured_62b371f3f0ee1cce)
 }
 
-var fileDescriptor_structured_a50c3bc5fe2e0c6c = []byte{
+var fileDescriptor_structured_62b371f3f0ee1cce = []byte{
 	// 5151 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xbc, 0x3c, 0xcb, 0x73, 0x1b, 0xe7,
 	0x7d, 0xc4, 0x1b, 0xf8, 0xe1, 0xb5, 0xfc, 0x44, 0x49, 0x10, 0x23, 0x93, 0x14, 0x65, 0xc9, 0xb4,

--- a/pkg/sql/catalog/descpb/tenant.pb.go
+++ b/pkg/sql/catalog/descpb/tenant.pb.go
@@ -61,7 +61,7 @@ func (x *TenantInfo_State) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (TenantInfo_State) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_tenant_407090f618c5ec30, []int{0, 0}
+	return fileDescriptor_tenant_44277a2e609258db, []int{0, 0}
 }
 
 // TenantInfo represents a tenant in a multi-tenant cluster and is
@@ -76,7 +76,7 @@ func (m *TenantInfo) Reset()         { *m = TenantInfo{} }
 func (m *TenantInfo) String() string { return proto.CompactTextString(m) }
 func (*TenantInfo) ProtoMessage()    {}
 func (*TenantInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_tenant_407090f618c5ec30, []int{0}
+	return fileDescriptor_tenant_44277a2e609258db, []int{0}
 }
 func (m *TenantInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -383,10 +383,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("sql/catalog/descpb/tenant.proto", fileDescriptor_tenant_407090f618c5ec30)
+	proto.RegisterFile("sql/catalog/descpb/tenant.proto", fileDescriptor_tenant_44277a2e609258db)
 }
 
-var fileDescriptor_tenant_407090f618c5ec30 = []byte{
+var fileDescriptor_tenant_44277a2e609258db = []byte{
 	// 249 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x92, 0x2f, 0x2e, 0xcc, 0xd1,
 	0x4f, 0x4e, 0x2c, 0x49, 0xcc, 0xc9, 0x4f, 0xd7, 0x4f, 0x49, 0x2d, 0x4e, 0x2e, 0x48, 0xd2, 0x2f,

--- a/pkg/sql/execinfrapb/api.pb.go
+++ b/pkg/sql/execinfrapb/api.pb.go
@@ -58,7 +58,7 @@ func (m *SetupFlowRequest) Reset()         { *m = SetupFlowRequest{} }
 func (m *SetupFlowRequest) String() string { return proto.CompactTextString(m) }
 func (*SetupFlowRequest) ProtoMessage()    {}
 func (*SetupFlowRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e3358d2af00ffd7f, []int{0}
+	return fileDescriptor_api_db601d0d8134b9c6, []int{0}
 }
 func (m *SetupFlowRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -96,7 +96,7 @@ func (m *FlowSpec) Reset()         { *m = FlowSpec{} }
 func (m *FlowSpec) String() string { return proto.CompactTextString(m) }
 func (*FlowSpec) ProtoMessage()    {}
 func (*FlowSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e3358d2af00ffd7f, []int{1}
+	return fileDescriptor_api_db601d0d8134b9c6, []int{1}
 }
 func (m *FlowSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -132,7 +132,7 @@ func (m *EvalContext) Reset()         { *m = EvalContext{} }
 func (m *EvalContext) String() string { return proto.CompactTextString(m) }
 func (*EvalContext) ProtoMessage()    {}
 func (*EvalContext) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e3358d2af00ffd7f, []int{2}
+	return fileDescriptor_api_db601d0d8134b9c6, []int{2}
 }
 func (m *EvalContext) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -165,7 +165,7 @@ func (m *SimpleResponse) Reset()         { *m = SimpleResponse{} }
 func (m *SimpleResponse) String() string { return proto.CompactTextString(m) }
 func (*SimpleResponse) ProtoMessage()    {}
 func (*SimpleResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e3358d2af00ffd7f, []int{3}
+	return fileDescriptor_api_db601d0d8134b9c6, []int{3}
 }
 func (m *SimpleResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -208,7 +208,7 @@ func (m *ConsumerSignal) Reset()         { *m = ConsumerSignal{} }
 func (m *ConsumerSignal) String() string { return proto.CompactTextString(m) }
 func (*ConsumerSignal) ProtoMessage()    {}
 func (*ConsumerSignal) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e3358d2af00ffd7f, []int{4}
+	return fileDescriptor_api_db601d0d8134b9c6, []int{4}
 }
 func (m *ConsumerSignal) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -240,7 +240,7 @@ func (m *DrainRequest) Reset()         { *m = DrainRequest{} }
 func (m *DrainRequest) String() string { return proto.CompactTextString(m) }
 func (*DrainRequest) ProtoMessage()    {}
 func (*DrainRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e3358d2af00ffd7f, []int{5}
+	return fileDescriptor_api_db601d0d8134b9c6, []int{5}
 }
 func (m *DrainRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -291,7 +291,7 @@ func (m *ConsumerHandshake) Reset()         { *m = ConsumerHandshake{} }
 func (m *ConsumerHandshake) String() string { return proto.CompactTextString(m) }
 func (*ConsumerHandshake) ProtoMessage()    {}
 func (*ConsumerHandshake) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e3358d2af00ffd7f, []int{6}
+	return fileDescriptor_api_db601d0d8134b9c6, []int{6}
 }
 func (m *ConsumerHandshake) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1938,9 +1938,9 @@ var (
 	ErrIntOverflowApi   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("sql/execinfrapb/api.proto", fileDescriptor_api_e3358d2af00ffd7f) }
+func init() { proto.RegisterFile("sql/execinfrapb/api.proto", fileDescriptor_api_db601d0d8134b9c6) }
 
-var fileDescriptor_api_e3358d2af00ffd7f = []byte{
+var fileDescriptor_api_db601d0d8134b9c6 = []byte{
 	// 950 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x94, 0x55, 0xcf, 0x72, 0xdb, 0x44,
 	0x18, 0xb7, 0xe4, 0xb5, 0xad, 0xac, 0x1d, 0x57, 0xd9, 0xe9, 0x30, 0xc2, 0x07, 0xdb, 0xa3, 0x29,

--- a/pkg/sql/execinfrapb/component_stats.pb.go
+++ b/pkg/sql/execinfrapb/component_stats.pb.go
@@ -67,7 +67,7 @@ func (x *ComponentID_Type) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (ComponentID_Type) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_component_stats_023039a0fe6a29c3, []int{0, 0}
+	return fileDescriptor_component_stats_b759f3ec168a9421, []int{0, 0}
 }
 
 // ComponentID identifies a component in a flow. There are multiple types of
@@ -85,7 +85,7 @@ func (m *ComponentID) Reset()         { *m = ComponentID{} }
 func (m *ComponentID) String() string { return proto.CompactTextString(m) }
 func (*ComponentID) ProtoMessage()    {}
 func (*ComponentID) Descriptor() ([]byte, []int) {
-	return fileDescriptor_component_stats_023039a0fe6a29c3, []int{0}
+	return fileDescriptor_component_stats_b759f3ec168a9421, []int{0}
 }
 func (m *ComponentID) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -132,7 +132,7 @@ func (m *ComponentStats) Reset()         { *m = ComponentStats{} }
 func (m *ComponentStats) String() string { return proto.CompactTextString(m) }
 func (*ComponentStats) ProtoMessage()    {}
 func (*ComponentStats) Descriptor() ([]byte, []int) {
-	return fileDescriptor_component_stats_023039a0fe6a29c3, []int{1}
+	return fileDescriptor_component_stats_b759f3ec168a9421, []int{1}
 }
 func (m *ComponentStats) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -169,7 +169,7 @@ func (m *InputStats) Reset()         { *m = InputStats{} }
 func (m *InputStats) String() string { return proto.CompactTextString(m) }
 func (*InputStats) ProtoMessage()    {}
 func (*InputStats) Descriptor() ([]byte, []int) {
-	return fileDescriptor_component_stats_023039a0fe6a29c3, []int{2}
+	return fileDescriptor_component_stats_b759f3ec168a9421, []int{2}
 }
 func (m *InputStats) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -213,7 +213,7 @@ func (m *NetworkRxStats) Reset()         { *m = NetworkRxStats{} }
 func (m *NetworkRxStats) String() string { return proto.CompactTextString(m) }
 func (*NetworkRxStats) ProtoMessage()    {}
 func (*NetworkRxStats) Descriptor() ([]byte, []int) {
-	return fileDescriptor_component_stats_023039a0fe6a29c3, []int{3}
+	return fileDescriptor_component_stats_b759f3ec168a9421, []int{3}
 }
 func (m *NetworkRxStats) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -251,7 +251,7 @@ func (m *NetworkTxStats) Reset()         { *m = NetworkTxStats{} }
 func (m *NetworkTxStats) String() string { return proto.CompactTextString(m) }
 func (*NetworkTxStats) ProtoMessage()    {}
 func (*NetworkTxStats) Descriptor() ([]byte, []int) {
-	return fileDescriptor_component_stats_023039a0fe6a29c3, []int{4}
+	return fileDescriptor_component_stats_b759f3ec168a9421, []int{4}
 }
 func (m *NetworkTxStats) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -292,7 +292,7 @@ func (m *KVStats) Reset()         { *m = KVStats{} }
 func (m *KVStats) String() string { return proto.CompactTextString(m) }
 func (*KVStats) ProtoMessage()    {}
 func (*KVStats) Descriptor() ([]byte, []int) {
-	return fileDescriptor_component_stats_023039a0fe6a29c3, []int{5}
+	return fileDescriptor_component_stats_b759f3ec168a9421, []int{5}
 }
 func (m *KVStats) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -331,7 +331,7 @@ func (m *ExecStats) Reset()         { *m = ExecStats{} }
 func (m *ExecStats) String() string { return proto.CompactTextString(m) }
 func (*ExecStats) ProtoMessage()    {}
 func (*ExecStats) Descriptor() ([]byte, []int) {
-	return fileDescriptor_component_stats_023039a0fe6a29c3, []int{6}
+	return fileDescriptor_component_stats_b759f3ec168a9421, []int{6}
 }
 func (m *ExecStats) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -368,7 +368,7 @@ func (m *OutputStats) Reset()         { *m = OutputStats{} }
 func (m *OutputStats) String() string { return proto.CompactTextString(m) }
 func (*OutputStats) ProtoMessage()    {}
 func (*OutputStats) Descriptor() ([]byte, []int) {
-	return fileDescriptor_component_stats_023039a0fe6a29c3, []int{7}
+	return fileDescriptor_component_stats_b759f3ec168a9421, []int{7}
 }
 func (m *OutputStats) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -402,7 +402,7 @@ func (m *FlowStats) Reset()         { *m = FlowStats{} }
 func (m *FlowStats) String() string { return proto.CompactTextString(m) }
 func (*FlowStats) ProtoMessage()    {}
 func (*FlowStats) Descriptor() ([]byte, []int) {
-	return fileDescriptor_component_stats_023039a0fe6a29c3, []int{8}
+	return fileDescriptor_component_stats_b759f3ec168a9421, []int{8}
 }
 func (m *FlowStats) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2515,10 +2515,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("sql/execinfrapb/component_stats.proto", fileDescriptor_component_stats_023039a0fe6a29c3)
+	proto.RegisterFile("sql/execinfrapb/component_stats.proto", fileDescriptor_component_stats_b759f3ec168a9421)
 }
 
-var fileDescriptor_component_stats_023039a0fe6a29c3 = []byte{
+var fileDescriptor_component_stats_b759f3ec168a9421 = []byte{
 	// 916 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xac, 0x96, 0xcd, 0x6e, 0xdb, 0x46,
 	0x10, 0xc7, 0x45, 0x4a, 0xa2, 0xac, 0x51, 0x2c, 0x2b, 0xdb, 0x1c, 0x08, 0xa3, 0x95, 0x1d, 0xb6,

--- a/pkg/sql/execinfrapb/data.pb.go
+++ b/pkg/sql/execinfrapb/data.pb.go
@@ -71,7 +71,7 @@ func (x *Ordering_Column_Direction) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (Ordering_Column_Direction) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_data_5f75f2288136bd96, []int{2, 0, 0}
+	return fileDescriptor_data_6e2d4ee9b531ae93, []int{2, 0, 0}
 }
 
 type StreamEndpointSpec_Type int32
@@ -116,7 +116,7 @@ func (x *StreamEndpointSpec_Type) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (StreamEndpointSpec_Type) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_data_5f75f2288136bd96, []int{3, 0}
+	return fileDescriptor_data_6e2d4ee9b531ae93, []int{3, 0}
 }
 
 type InputSyncSpec_Type int32
@@ -156,7 +156,7 @@ func (x *InputSyncSpec_Type) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (InputSyncSpec_Type) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_data_5f75f2288136bd96, []int{4, 0}
+	return fileDescriptor_data_6e2d4ee9b531ae93, []int{4, 0}
 }
 
 type OutputRouterSpec_Type int32
@@ -204,7 +204,7 @@ func (x *OutputRouterSpec_Type) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (OutputRouterSpec_Type) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_data_5f75f2288136bd96, []int{5, 0}
+	return fileDescriptor_data_6e2d4ee9b531ae93, []int{5, 0}
 }
 
 // Error is a generic representation including a string message.
@@ -217,7 +217,7 @@ type Error struct {
 func (m *Error) Reset()      { *m = Error{} }
 func (*Error) ProtoMessage() {}
 func (*Error) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_5f75f2288136bd96, []int{0}
+	return fileDescriptor_data_6e2d4ee9b531ae93, []int{0}
 }
 func (m *Error) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -245,7 +245,7 @@ var xxx_messageInfo_Error proto.InternalMessageInfo
 func (m *Expression) Reset()      { *m = Expression{} }
 func (*Expression) ProtoMessage() {}
 func (*Expression) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_5f75f2288136bd96, []int{1}
+	return fileDescriptor_data_6e2d4ee9b531ae93, []int{1}
 }
 func (m *Expression) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -280,7 +280,7 @@ func (m *Ordering) Reset()         { *m = Ordering{} }
 func (m *Ordering) String() string { return proto.CompactTextString(m) }
 func (*Ordering) ProtoMessage()    {}
 func (*Ordering) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_5f75f2288136bd96, []int{2}
+	return fileDescriptor_data_6e2d4ee9b531ae93, []int{2}
 }
 func (m *Ordering) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -314,7 +314,7 @@ func (m *Ordering_Column) Reset()         { *m = Ordering_Column{} }
 func (m *Ordering_Column) String() string { return proto.CompactTextString(m) }
 func (*Ordering_Column) ProtoMessage()    {}
 func (*Ordering_Column) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_5f75f2288136bd96, []int{2, 0}
+	return fileDescriptor_data_6e2d4ee9b531ae93, []int{2, 0}
 }
 func (m *Ordering_Column) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -363,7 +363,7 @@ func (m *StreamEndpointSpec) Reset()         { *m = StreamEndpointSpec{} }
 func (m *StreamEndpointSpec) String() string { return proto.CompactTextString(m) }
 func (*StreamEndpointSpec) ProtoMessage()    {}
 func (*StreamEndpointSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_5f75f2288136bd96, []int{3}
+	return fileDescriptor_data_6e2d4ee9b531ae93, []int{3}
 }
 func (m *StreamEndpointSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -402,7 +402,7 @@ func (m *InputSyncSpec) Reset()         { *m = InputSyncSpec{} }
 func (m *InputSyncSpec) String() string { return proto.CompactTextString(m) }
 func (*InputSyncSpec) ProtoMessage()    {}
 func (*InputSyncSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_5f75f2288136bd96, []int{4}
+	return fileDescriptor_data_6e2d4ee9b531ae93, []int{4}
 }
 func (m *InputSyncSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -446,7 +446,7 @@ func (m *OutputRouterSpec) Reset()         { *m = OutputRouterSpec{} }
 func (m *OutputRouterSpec) String() string { return proto.CompactTextString(m) }
 func (*OutputRouterSpec) ProtoMessage()    {}
 func (*OutputRouterSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_5f75f2288136bd96, []int{5}
+	return fileDescriptor_data_6e2d4ee9b531ae93, []int{5}
 }
 func (m *OutputRouterSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -489,7 +489,7 @@ func (m *OutputRouterSpec_RangeRouterSpec) Reset()         { *m = OutputRouterSp
 func (m *OutputRouterSpec_RangeRouterSpec) String() string { return proto.CompactTextString(m) }
 func (*OutputRouterSpec_RangeRouterSpec) ProtoMessage()    {}
 func (*OutputRouterSpec_RangeRouterSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_5f75f2288136bd96, []int{5, 0}
+	return fileDescriptor_data_6e2d4ee9b531ae93, []int{5, 0}
 }
 func (m *OutputRouterSpec_RangeRouterSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -531,7 +531,7 @@ func (m *OutputRouterSpec_RangeRouterSpec_ColumnEncoding) String() string {
 }
 func (*OutputRouterSpec_RangeRouterSpec_ColumnEncoding) ProtoMessage() {}
 func (*OutputRouterSpec_RangeRouterSpec_ColumnEncoding) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_5f75f2288136bd96, []int{5, 0, 0}
+	return fileDescriptor_data_6e2d4ee9b531ae93, []int{5, 0, 0}
 }
 func (m *OutputRouterSpec_RangeRouterSpec_ColumnEncoding) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -568,7 +568,7 @@ func (m *OutputRouterSpec_RangeRouterSpec_Span) Reset()         { *m = OutputRou
 func (m *OutputRouterSpec_RangeRouterSpec_Span) String() string { return proto.CompactTextString(m) }
 func (*OutputRouterSpec_RangeRouterSpec_Span) ProtoMessage()    {}
 func (*OutputRouterSpec_RangeRouterSpec_Span) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_5f75f2288136bd96, []int{5, 0, 1}
+	return fileDescriptor_data_6e2d4ee9b531ae93, []int{5, 0, 1}
 }
 func (m *OutputRouterSpec_RangeRouterSpec_Span) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -602,7 +602,7 @@ func (m *DatumInfo) Reset()         { *m = DatumInfo{} }
 func (m *DatumInfo) String() string { return proto.CompactTextString(m) }
 func (*DatumInfo) ProtoMessage()    {}
 func (*DatumInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_5f75f2288136bd96, []int{6}
+	return fileDescriptor_data_6e2d4ee9b531ae93, []int{6}
 }
 func (m *DatumInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -637,7 +637,7 @@ func (m *ProducerHeader) Reset()         { *m = ProducerHeader{} }
 func (m *ProducerHeader) String() string { return proto.CompactTextString(m) }
 func (*ProducerHeader) ProtoMessage()    {}
 func (*ProducerHeader) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_5f75f2288136bd96, []int{7}
+	return fileDescriptor_data_6e2d4ee9b531ae93, []int{7}
 }
 func (m *ProducerHeader) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -680,7 +680,7 @@ func (m *ProducerData) Reset()         { *m = ProducerData{} }
 func (m *ProducerData) String() string { return proto.CompactTextString(m) }
 func (*ProducerData) ProtoMessage()    {}
 func (*ProducerData) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_5f75f2288136bd96, []int{8}
+	return fileDescriptor_data_6e2d4ee9b531ae93, []int{8}
 }
 func (m *ProducerData) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -722,7 +722,7 @@ func (m *ProducerMessage) Reset()         { *m = ProducerMessage{} }
 func (m *ProducerMessage) String() string { return proto.CompactTextString(m) }
 func (*ProducerMessage) ProtoMessage()    {}
 func (*ProducerMessage) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_5f75f2288136bd96, []int{9}
+	return fileDescriptor_data_6e2d4ee9b531ae93, []int{9}
 }
 func (m *ProducerMessage) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -769,7 +769,7 @@ func (m *RemoteProducerMetadata) Reset()         { *m = RemoteProducerMetadata{}
 func (m *RemoteProducerMetadata) String() string { return proto.CompactTextString(m) }
 func (*RemoteProducerMetadata) ProtoMessage()    {}
 func (*RemoteProducerMetadata) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_5f75f2288136bd96, []int{10}
+	return fileDescriptor_data_6e2d4ee9b531ae93, []int{10}
 }
 func (m *RemoteProducerMetadata) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1123,7 +1123,7 @@ func (m *RemoteProducerMetadata_RangeInfos) Reset()         { *m = RemoteProduce
 func (m *RemoteProducerMetadata_RangeInfos) String() string { return proto.CompactTextString(m) }
 func (*RemoteProducerMetadata_RangeInfos) ProtoMessage()    {}
 func (*RemoteProducerMetadata_RangeInfos) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_5f75f2288136bd96, []int{10, 0}
+	return fileDescriptor_data_6e2d4ee9b531ae93, []int{10, 0}
 }
 func (m *RemoteProducerMetadata_RangeInfos) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1156,7 +1156,7 @@ func (m *RemoteProducerMetadata_TraceData) Reset()         { *m = RemoteProducer
 func (m *RemoteProducerMetadata_TraceData) String() string { return proto.CompactTextString(m) }
 func (*RemoteProducerMetadata_TraceData) ProtoMessage()    {}
 func (*RemoteProducerMetadata_TraceData) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_5f75f2288136bd96, []int{10, 1}
+	return fileDescriptor_data_6e2d4ee9b531ae93, []int{10, 1}
 }
 func (m *RemoteProducerMetadata_TraceData) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1197,7 +1197,7 @@ func (m *RemoteProducerMetadata_RowNum) Reset()         { *m = RemoteProducerMet
 func (m *RemoteProducerMetadata_RowNum) String() string { return proto.CompactTextString(m) }
 func (*RemoteProducerMetadata_RowNum) ProtoMessage()    {}
 func (*RemoteProducerMetadata_RowNum) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_5f75f2288136bd96, []int{10, 2}
+	return fileDescriptor_data_6e2d4ee9b531ae93, []int{10, 2}
 }
 func (m *RemoteProducerMetadata_RowNum) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1237,7 +1237,7 @@ func (m *RemoteProducerMetadata_SamplerProgress) Reset() {
 func (m *RemoteProducerMetadata_SamplerProgress) String() string { return proto.CompactTextString(m) }
 func (*RemoteProducerMetadata_SamplerProgress) ProtoMessage()    {}
 func (*RemoteProducerMetadata_SamplerProgress) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_5f75f2288136bd96, []int{10, 3}
+	return fileDescriptor_data_6e2d4ee9b531ae93, []int{10, 3}
 }
 func (m *RemoteProducerMetadata_SamplerProgress) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1278,7 +1278,7 @@ func (m *RemoteProducerMetadata_BulkProcessorProgress) String() string {
 }
 func (*RemoteProducerMetadata_BulkProcessorProgress) ProtoMessage() {}
 func (*RemoteProducerMetadata_BulkProcessorProgress) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_5f75f2288136bd96, []int{10, 4}
+	return fileDescriptor_data_6e2d4ee9b531ae93, []int{10, 4}
 }
 func (m *RemoteProducerMetadata_BulkProcessorProgress) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1315,7 +1315,7 @@ func (m *RemoteProducerMetadata_Metrics) Reset()         { *m = RemoteProducerMe
 func (m *RemoteProducerMetadata_Metrics) String() string { return proto.CompactTextString(m) }
 func (*RemoteProducerMetadata_Metrics) ProtoMessage()    {}
 func (*RemoteProducerMetadata_Metrics) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_5f75f2288136bd96, []int{10, 5}
+	return fileDescriptor_data_6e2d4ee9b531ae93, []int{10, 5}
 }
 func (m *RemoteProducerMetadata_Metrics) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1352,7 +1352,7 @@ func (m *RemoteProducerMetadata_ContentionEvents) Reset() {
 func (m *RemoteProducerMetadata_ContentionEvents) String() string { return proto.CompactTextString(m) }
 func (*RemoteProducerMetadata_ContentionEvents) ProtoMessage()    {}
 func (*RemoteProducerMetadata_ContentionEvents) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_5f75f2288136bd96, []int{10, 6}
+	return fileDescriptor_data_6e2d4ee9b531ae93, []int{10, 6}
 }
 func (m *RemoteProducerMetadata_ContentionEvents) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1392,7 +1392,7 @@ func (m *DistSQLVersionGossipInfo) Reset()         { *m = DistSQLVersionGossipIn
 func (m *DistSQLVersionGossipInfo) String() string { return proto.CompactTextString(m) }
 func (*DistSQLVersionGossipInfo) ProtoMessage()    {}
 func (*DistSQLVersionGossipInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_5f75f2288136bd96, []int{11}
+	return fileDescriptor_data_6e2d4ee9b531ae93, []int{11}
 }
 func (m *DistSQLVersionGossipInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1428,7 +1428,7 @@ func (m *DistSQLDrainingInfo) Reset()         { *m = DistSQLDrainingInfo{} }
 func (m *DistSQLDrainingInfo) String() string { return proto.CompactTextString(m) }
 func (*DistSQLDrainingInfo) ProtoMessage()    {}
 func (*DistSQLDrainingInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_5f75f2288136bd96, []int{12}
+	return fileDescriptor_data_6e2d4ee9b531ae93, []int{12}
 }
 func (m *DistSQLDrainingInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -6136,9 +6136,9 @@ var (
 	ErrIntOverflowData   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("sql/execinfrapb/data.proto", fileDescriptor_data_5f75f2288136bd96) }
+func init() { proto.RegisterFile("sql/execinfrapb/data.proto", fileDescriptor_data_6e2d4ee9b531ae93) }
 
-var fileDescriptor_data_5f75f2288136bd96 = []byte{
+var fileDescriptor_data_6e2d4ee9b531ae93 = []byte{
 	// 2141 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xac, 0x58, 0xcd, 0x73, 0x1c, 0x47,
 	0x15, 0xdf, 0x2f, 0xed, 0xc7, 0xd3, 0xd7, 0xa8, 0xb1, 0x9d, 0x65, 0x31, 0x92, 0xb3, 0xa6, 0x52,

--- a/pkg/sql/execinfrapb/processors.pb.go
+++ b/pkg/sql/execinfrapb/processors.pb.go
@@ -77,7 +77,7 @@ func (m *ProcessorSpec) Reset()         { *m = ProcessorSpec{} }
 func (m *ProcessorSpec) String() string { return proto.CompactTextString(m) }
 func (*ProcessorSpec) ProtoMessage()    {}
 func (*ProcessorSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_29d19df42cdc68ae, []int{0}
+	return fileDescriptor_processors_f89a954727b0d81b, []int{0}
 }
 func (m *ProcessorSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -140,7 +140,7 @@ func (m *ProcessorCoreUnion) Reset()         { *m = ProcessorCoreUnion{} }
 func (m *ProcessorCoreUnion) String() string { return proto.CompactTextString(m) }
 func (*ProcessorCoreUnion) ProtoMessage()    {}
 func (*ProcessorCoreUnion) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_29d19df42cdc68ae, []int{1}
+	return fileDescriptor_processors_f89a954727b0d81b, []int{1}
 }
 func (m *ProcessorCoreUnion) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -175,7 +175,7 @@ func (m *NoopCoreSpec) Reset()         { *m = NoopCoreSpec{} }
 func (m *NoopCoreSpec) String() string { return proto.CompactTextString(m) }
 func (*NoopCoreSpec) ProtoMessage()    {}
 func (*NoopCoreSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_29d19df42cdc68ae, []int{2}
+	return fileDescriptor_processors_f89a954727b0d81b, []int{2}
 }
 func (m *NoopCoreSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -217,7 +217,7 @@ func (m *LocalPlanNodeSpec) Reset()         { *m = LocalPlanNodeSpec{} }
 func (m *LocalPlanNodeSpec) String() string { return proto.CompactTextString(m) }
 func (*LocalPlanNodeSpec) ProtoMessage()    {}
 func (*LocalPlanNodeSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_29d19df42cdc68ae, []int{3}
+	return fileDescriptor_processors_f89a954727b0d81b, []int{3}
 }
 func (m *LocalPlanNodeSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -250,7 +250,7 @@ func (m *MetadataTestSenderSpec) Reset()         { *m = MetadataTestSenderSpec{}
 func (m *MetadataTestSenderSpec) String() string { return proto.CompactTextString(m) }
 func (*MetadataTestSenderSpec) ProtoMessage()    {}
 func (*MetadataTestSenderSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_29d19df42cdc68ae, []int{4}
+	return fileDescriptor_processors_f89a954727b0d81b, []int{4}
 }
 func (m *MetadataTestSenderSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -283,7 +283,7 @@ func (m *MetadataTestReceiverSpec) Reset()         { *m = MetadataTestReceiverSp
 func (m *MetadataTestReceiverSpec) String() string { return proto.CompactTextString(m) }
 func (*MetadataTestReceiverSpec) ProtoMessage()    {}
 func (*MetadataTestReceiverSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_29d19df42cdc68ae, []int{5}
+	return fileDescriptor_processors_f89a954727b0d81b, []int{5}
 }
 func (m *MetadataTestReceiverSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3006,10 +3006,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("sql/execinfrapb/processors.proto", fileDescriptor_processors_29d19df42cdc68ae)
+	proto.RegisterFile("sql/execinfrapb/processors.proto", fileDescriptor_processors_f89a954727b0d81b)
 }
 
-var fileDescriptor_processors_29d19df42cdc68ae = []byte{
+var fileDescriptor_processors_f89a954727b0d81b = []byte{
 	// 1245 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x97, 0xdf, 0x72, 0x13, 0xb7,
 	0x17, 0xc7, 0xe3, 0xc4, 0x24, 0xb6, 0x1c, 0x13, 0xa3, 0x00, 0x3f, 0xfd, 0xdc, 0xd6, 0x49, 0x5d,

--- a/pkg/sql/execinfrapb/processors_base.pb.go
+++ b/pkg/sql/execinfrapb/processors_base.pb.go
@@ -58,7 +58,7 @@ func (m *PostProcessSpec) Reset()         { *m = PostProcessSpec{} }
 func (m *PostProcessSpec) String() string { return proto.CompactTextString(m) }
 func (*PostProcessSpec) ProtoMessage()    {}
 func (*PostProcessSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_base_2f9dd97fffc5def6, []int{0}
+	return fileDescriptor_processors_base_cb303d6d7cfab358, []int{0}
 }
 func (m *PostProcessSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -91,7 +91,7 @@ func (m *Columns) Reset()         { *m = Columns{} }
 func (m *Columns) String() string { return proto.CompactTextString(m) }
 func (*Columns) ProtoMessage()    {}
 func (*Columns) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_base_2f9dd97fffc5def6, []int{1}
+	return fileDescriptor_processors_base_cb303d6d7cfab358, []int{1}
 }
 func (m *Columns) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -127,7 +127,7 @@ func (m *TableReaderSpan) Reset()         { *m = TableReaderSpan{} }
 func (m *TableReaderSpan) String() string { return proto.CompactTextString(m) }
 func (*TableReaderSpan) ProtoMessage()    {}
 func (*TableReaderSpan) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_base_2f9dd97fffc5def6, []int{2}
+	return fileDescriptor_processors_base_cb303d6d7cfab358, []int{2}
 }
 func (m *TableReaderSpan) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -874,10 +874,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("sql/execinfrapb/processors_base.proto", fileDescriptor_processors_base_2f9dd97fffc5def6)
+	proto.RegisterFile("sql/execinfrapb/processors_base.proto", fileDescriptor_processors_base_cb303d6d7cfab358)
 }
 
-var fileDescriptor_processors_base_2f9dd97fffc5def6 = []byte{
+var fileDescriptor_processors_base_cb303d6d7cfab358 = []byte{
 	// 370 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x74, 0x91, 0xcf, 0xce, 0xd2, 0x40,
 	0x14, 0xc5, 0x3b, 0x50, 0xfe, 0x64, 0x2a, 0x42, 0x26, 0x26, 0x36, 0x0d, 0x19, 0x1b, 0x82, 0xb1,

--- a/pkg/sql/execinfrapb/processors_bulk_io.pb.go
+++ b/pkg/sql/execinfrapb/processors_bulk_io.pb.go
@@ -72,7 +72,7 @@ func (x *FileCompression) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (FileCompression) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_processors_bulk_io_c5f06ccc7e921266, []int{0}
+	return fileDescriptor_processors_bulk_io_cc3b09b6f09aacff, []int{0}
 }
 
 type BackfillerSpec_Type int32
@@ -111,7 +111,7 @@ func (x *BackfillerSpec_Type) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (BackfillerSpec_Type) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_processors_bulk_io_c5f06ccc7e921266, []int{0, 0}
+	return fileDescriptor_processors_bulk_io_cc3b09b6f09aacff, []int{0, 0}
 }
 
 // BackfillerSpec is the specification for a "schema change backfiller".
@@ -143,7 +143,7 @@ func (m *BackfillerSpec) Reset()         { *m = BackfillerSpec{} }
 func (m *BackfillerSpec) String() string { return proto.CompactTextString(m) }
 func (*BackfillerSpec) ProtoMessage()    {}
 func (*BackfillerSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_bulk_io_c5f06ccc7e921266, []int{0}
+	return fileDescriptor_processors_bulk_io_cc3b09b6f09aacff, []int{0}
 }
 func (m *BackfillerSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -183,7 +183,7 @@ func (m *JobProgress) Reset()         { *m = JobProgress{} }
 func (m *JobProgress) String() string { return proto.CompactTextString(m) }
 func (*JobProgress) ProtoMessage()    {}
 func (*JobProgress) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_bulk_io_c5f06ccc7e921266, []int{1}
+	return fileDescriptor_processors_bulk_io_cc3b09b6f09aacff, []int{1}
 }
 func (m *JobProgress) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -246,7 +246,7 @@ func (m *ReadImportDataSpec) Reset()         { *m = ReadImportDataSpec{} }
 func (m *ReadImportDataSpec) String() string { return proto.CompactTextString(m) }
 func (*ReadImportDataSpec) ProtoMessage()    {}
 func (*ReadImportDataSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_bulk_io_c5f06ccc7e921266, []int{2}
+	return fileDescriptor_processors_bulk_io_cc3b09b6f09aacff, []int{2}
 }
 func (m *ReadImportDataSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -284,7 +284,7 @@ func (m *ReadImportDataSpec_ImportTable) Reset()         { *m = ReadImportDataSp
 func (m *ReadImportDataSpec_ImportTable) String() string { return proto.CompactTextString(m) }
 func (*ReadImportDataSpec_ImportTable) ProtoMessage()    {}
 func (*ReadImportDataSpec_ImportTable) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_bulk_io_c5f06ccc7e921266, []int{2, 0}
+	return fileDescriptor_processors_bulk_io_cc3b09b6f09aacff, []int{2, 0}
 }
 func (m *ReadImportDataSpec_ImportTable) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -318,7 +318,7 @@ func (m *StreamIngestionDataSpec) Reset()         { *m = StreamIngestionDataSpec
 func (m *StreamIngestionDataSpec) String() string { return proto.CompactTextString(m) }
 func (*StreamIngestionDataSpec) ProtoMessage()    {}
 func (*StreamIngestionDataSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_bulk_io_c5f06ccc7e921266, []int{3}
+	return fileDescriptor_processors_bulk_io_cc3b09b6f09aacff, []int{3}
 }
 func (m *StreamIngestionDataSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -364,7 +364,7 @@ func (m *BackupDataSpec) Reset()         { *m = BackupDataSpec{} }
 func (m *BackupDataSpec) String() string { return proto.CompactTextString(m) }
 func (*BackupDataSpec) ProtoMessage()    {}
 func (*BackupDataSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_bulk_io_c5f06ccc7e921266, []int{4}
+	return fileDescriptor_processors_bulk_io_cc3b09b6f09aacff, []int{4}
 }
 func (m *BackupDataSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -403,7 +403,7 @@ func (m *RestoreSpanEntry) Reset()         { *m = RestoreSpanEntry{} }
 func (m *RestoreSpanEntry) String() string { return proto.CompactTextString(m) }
 func (*RestoreSpanEntry) ProtoMessage()    {}
 func (*RestoreSpanEntry) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_bulk_io_c5f06ccc7e921266, []int{5}
+	return fileDescriptor_processors_bulk_io_cc3b09b6f09aacff, []int{5}
 }
 func (m *RestoreSpanEntry) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -441,7 +441,7 @@ func (m *RestoreDataSpec) Reset()         { *m = RestoreDataSpec{} }
 func (m *RestoreDataSpec) String() string { return proto.CompactTextString(m) }
 func (*RestoreDataSpec) ProtoMessage()    {}
 func (*RestoreDataSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_bulk_io_c5f06ccc7e921266, []int{6}
+	return fileDescriptor_processors_bulk_io_cc3b09b6f09aacff, []int{6}
 }
 func (m *RestoreDataSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -475,7 +475,7 @@ func (m *SplitAndScatterSpec) Reset()         { *m = SplitAndScatterSpec{} }
 func (m *SplitAndScatterSpec) String() string { return proto.CompactTextString(m) }
 func (*SplitAndScatterSpec) ProtoMessage()    {}
 func (*SplitAndScatterSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_bulk_io_c5f06ccc7e921266, []int{7}
+	return fileDescriptor_processors_bulk_io_cc3b09b6f09aacff, []int{7}
 }
 func (m *SplitAndScatterSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -508,7 +508,7 @@ func (m *SplitAndScatterSpec_RestoreEntryChunk) Reset()         { *m = SplitAndS
 func (m *SplitAndScatterSpec_RestoreEntryChunk) String() string { return proto.CompactTextString(m) }
 func (*SplitAndScatterSpec_RestoreEntryChunk) ProtoMessage()    {}
 func (*SplitAndScatterSpec_RestoreEntryChunk) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_bulk_io_c5f06ccc7e921266, []int{7, 0}
+	return fileDescriptor_processors_bulk_io_cc3b09b6f09aacff, []int{7, 0}
 }
 func (m *SplitAndScatterSpec_RestoreEntryChunk) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -555,7 +555,7 @@ func (m *CSVWriterSpec) Reset()         { *m = CSVWriterSpec{} }
 func (m *CSVWriterSpec) String() string { return proto.CompactTextString(m) }
 func (*CSVWriterSpec) ProtoMessage()    {}
 func (*CSVWriterSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_bulk_io_c5f06ccc7e921266, []int{8}
+	return fileDescriptor_processors_bulk_io_cc3b09b6f09aacff, []int{8}
 }
 func (m *CSVWriterSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -590,7 +590,7 @@ func (m *BulkRowWriterSpec) Reset()         { *m = BulkRowWriterSpec{} }
 func (m *BulkRowWriterSpec) String() string { return proto.CompactTextString(m) }
 func (*BulkRowWriterSpec) ProtoMessage()    {}
 func (*BulkRowWriterSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_bulk_io_c5f06ccc7e921266, []int{9}
+	return fileDescriptor_processors_bulk_io_cc3b09b6f09aacff, []int{9}
 }
 func (m *BulkRowWriterSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4132,10 +4132,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("sql/execinfrapb/processors_bulk_io.proto", fileDescriptor_processors_bulk_io_c5f06ccc7e921266)
+	proto.RegisterFile("sql/execinfrapb/processors_bulk_io.proto", fileDescriptor_processors_bulk_io_cc3b09b6f09aacff)
 }
 
-var fileDescriptor_processors_bulk_io_c5f06ccc7e921266 = []byte{
+var fileDescriptor_processors_bulk_io_cc3b09b6f09aacff = []byte{
 	// 1759 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xb4, 0x58, 0xcf, 0x6e, 0x1b, 0xc7,
 	0x19, 0xd7, 0xf2, 0x9f, 0xc8, 0x8f, 0x96, 0xb4, 0x9a, 0x38, 0xc9, 0x56, 0x40, 0x25, 0x81, 0x89,

--- a/pkg/sql/execinfrapb/processors_changefeeds.pb.go
+++ b/pkg/sql/execinfrapb/processors_changefeeds.pb.go
@@ -46,7 +46,7 @@ func (m *ChangeAggregatorSpec) Reset()         { *m = ChangeAggregatorSpec{} }
 func (m *ChangeAggregatorSpec) String() string { return proto.CompactTextString(m) }
 func (*ChangeAggregatorSpec) ProtoMessage()    {}
 func (*ChangeAggregatorSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_changefeeds_b7addf517cbc7dc0, []int{0}
+	return fileDescriptor_processors_changefeeds_f6611d63ac43ab7f, []int{0}
 }
 func (m *ChangeAggregatorSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -80,7 +80,7 @@ func (m *ChangeAggregatorSpec_Watch) Reset()         { *m = ChangeAggregatorSpec
 func (m *ChangeAggregatorSpec_Watch) String() string { return proto.CompactTextString(m) }
 func (*ChangeAggregatorSpec_Watch) ProtoMessage()    {}
 func (*ChangeAggregatorSpec_Watch) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_changefeeds_b7addf517cbc7dc0, []int{0, 0}
+	return fileDescriptor_processors_changefeeds_f6611d63ac43ab7f, []int{0, 0}
 }
 func (m *ChangeAggregatorSpec_Watch) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -126,7 +126,7 @@ func (m *ChangeFrontierSpec) Reset()         { *m = ChangeFrontierSpec{} }
 func (m *ChangeFrontierSpec) String() string { return proto.CompactTextString(m) }
 func (*ChangeFrontierSpec) ProtoMessage()    {}
 func (*ChangeFrontierSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_changefeeds_b7addf517cbc7dc0, []int{1}
+	return fileDescriptor_processors_changefeeds_f6611d63ac43ab7f, []int{1}
 }
 func (m *ChangeFrontierSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -866,10 +866,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("sql/execinfrapb/processors_changefeeds.proto", fileDescriptor_processors_changefeeds_b7addf517cbc7dc0)
+	proto.RegisterFile("sql/execinfrapb/processors_changefeeds.proto", fileDescriptor_processors_changefeeds_f6611d63ac43ab7f)
 }
 
-var fileDescriptor_processors_changefeeds_b7addf517cbc7dc0 = []byte{
+var fileDescriptor_processors_changefeeds_f6611d63ac43ab7f = []byte{
 	// 500 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xb4, 0x93, 0xcf, 0x8a, 0x13, 0x41,
 	0x10, 0xc6, 0x33, 0x9b, 0xac, 0xb2, 0x1d, 0x17, 0x65, 0x58, 0x74, 0x08, 0x38, 0x09, 0x8b, 0x87,

--- a/pkg/sql/execinfrapb/processors_sql.pb.go
+++ b/pkg/sql/execinfrapb/processors_sql.pb.go
@@ -64,7 +64,7 @@ func (x *ScanVisibility) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (ScanVisibility) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_b5aca05d8faa72ff, []int{0}
+	return fileDescriptor_processors_sql_fd67541bc7b89354, []int{0}
 }
 
 // These mirror the aggregate functions supported by sql/parser. See
@@ -232,7 +232,7 @@ func (x *AggregatorSpec_Func) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (AggregatorSpec_Func) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_b5aca05d8faa72ff, []int{13, 0}
+	return fileDescriptor_processors_sql_fd67541bc7b89354, []int{13, 0}
 }
 
 type AggregatorSpec_Type int32
@@ -278,7 +278,7 @@ func (x *AggregatorSpec_Type) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (AggregatorSpec_Type) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_b5aca05d8faa72ff, []int{13, 1}
+	return fileDescriptor_processors_sql_fd67541bc7b89354, []int{13, 1}
 }
 
 type WindowerSpec_WindowFunc int32
@@ -342,7 +342,7 @@ func (x *WindowerSpec_WindowFunc) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (WindowerSpec_WindowFunc) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_b5aca05d8faa72ff, []int{15, 0}
+	return fileDescriptor_processors_sql_fd67541bc7b89354, []int{15, 0}
 }
 
 // Mode indicates which mode of framing is used.
@@ -386,7 +386,7 @@ func (x *WindowerSpec_Frame_Mode) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (WindowerSpec_Frame_Mode) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_b5aca05d8faa72ff, []int{15, 1, 0}
+	return fileDescriptor_processors_sql_fd67541bc7b89354, []int{15, 1, 0}
 }
 
 // BoundType indicates which type of boundary is used.
@@ -433,7 +433,7 @@ func (x *WindowerSpec_Frame_BoundType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (WindowerSpec_Frame_BoundType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_b5aca05d8faa72ff, []int{15, 1, 1}
+	return fileDescriptor_processors_sql_fd67541bc7b89354, []int{15, 1, 1}
 }
 
 // Exclusion specifies the type of frame exclusion.
@@ -476,7 +476,7 @@ func (x *WindowerSpec_Frame_Exclusion) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (WindowerSpec_Frame_Exclusion) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_b5aca05d8faa72ff, []int{15, 1, 2}
+	return fileDescriptor_processors_sql_fd67541bc7b89354, []int{15, 1, 2}
 }
 
 // ValuesCoreSpec is the core of a processor that has no inputs and generates
@@ -496,7 +496,7 @@ func (m *ValuesCoreSpec) Reset()         { *m = ValuesCoreSpec{} }
 func (m *ValuesCoreSpec) String() string { return proto.CompactTextString(m) }
 func (*ValuesCoreSpec) ProtoMessage()    {}
 func (*ValuesCoreSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_b5aca05d8faa72ff, []int{0}
+	return fileDescriptor_processors_sql_fd67541bc7b89354, []int{0}
 }
 func (m *ValuesCoreSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -611,7 +611,7 @@ func (m *TableReaderSpec) Reset()         { *m = TableReaderSpec{} }
 func (m *TableReaderSpec) String() string { return proto.CompactTextString(m) }
 func (*TableReaderSpec) ProtoMessage()    {}
 func (*TableReaderSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_b5aca05d8faa72ff, []int{1}
+	return fileDescriptor_processors_sql_fd67541bc7b89354, []int{1}
 }
 func (m *TableReaderSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -648,7 +648,7 @@ func (m *FiltererSpec) Reset()         { *m = FiltererSpec{} }
 func (m *FiltererSpec) String() string { return proto.CompactTextString(m) }
 func (*FiltererSpec) ProtoMessage()    {}
 func (*FiltererSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_b5aca05d8faa72ff, []int{2}
+	return fileDescriptor_processors_sql_fd67541bc7b89354, []int{2}
 }
 func (m *FiltererSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -703,7 +703,7 @@ func (m *IndexSkipTableReaderSpec) Reset()         { *m = IndexSkipTableReaderSp
 func (m *IndexSkipTableReaderSpec) String() string { return proto.CompactTextString(m) }
 func (*IndexSkipTableReaderSpec) ProtoMessage()    {}
 func (*IndexSkipTableReaderSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_b5aca05d8faa72ff, []int{3}
+	return fileDescriptor_processors_sql_fd67541bc7b89354, []int{3}
 }
 func (m *IndexSkipTableReaderSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -874,7 +874,7 @@ func (m *JoinReaderSpec) Reset()         { *m = JoinReaderSpec{} }
 func (m *JoinReaderSpec) String() string { return proto.CompactTextString(m) }
 func (*JoinReaderSpec) ProtoMessage()    {}
 func (*JoinReaderSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_b5aca05d8faa72ff, []int{4}
+	return fileDescriptor_processors_sql_fd67541bc7b89354, []int{4}
 }
 func (m *JoinReaderSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -918,7 +918,7 @@ func (m *SorterSpec) Reset()         { *m = SorterSpec{} }
 func (m *SorterSpec) String() string { return proto.CompactTextString(m) }
 func (*SorterSpec) ProtoMessage()    {}
 func (*SorterSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_b5aca05d8faa72ff, []int{5}
+	return fileDescriptor_processors_sql_fd67541bc7b89354, []int{5}
 }
 func (m *SorterSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -984,7 +984,7 @@ func (m *DistinctSpec) Reset()         { *m = DistinctSpec{} }
 func (m *DistinctSpec) String() string { return proto.CompactTextString(m) }
 func (*DistinctSpec) ProtoMessage()    {}
 func (*DistinctSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_b5aca05d8faa72ff, []int{6}
+	return fileDescriptor_processors_sql_fd67541bc7b89354, []int{6}
 }
 func (m *DistinctSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1019,7 +1019,7 @@ func (m *OrdinalitySpec) Reset()         { *m = OrdinalitySpec{} }
 func (m *OrdinalitySpec) String() string { return proto.CompactTextString(m) }
 func (*OrdinalitySpec) ProtoMessage()    {}
 func (*OrdinalitySpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_b5aca05d8faa72ff, []int{7}
+	return fileDescriptor_processors_sql_fd67541bc7b89354, []int{7}
 }
 func (m *OrdinalitySpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1077,7 +1077,7 @@ func (m *ZigzagJoinerSpec) Reset()         { *m = ZigzagJoinerSpec{} }
 func (m *ZigzagJoinerSpec) String() string { return proto.CompactTextString(m) }
 func (*ZigzagJoinerSpec) ProtoMessage()    {}
 func (*ZigzagJoinerSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_b5aca05d8faa72ff, []int{8}
+	return fileDescriptor_processors_sql_fd67541bc7b89354, []int{8}
 }
 func (m *ZigzagJoinerSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1157,7 +1157,7 @@ func (m *MergeJoinerSpec) Reset()         { *m = MergeJoinerSpec{} }
 func (m *MergeJoinerSpec) String() string { return proto.CompactTextString(m) }
 func (*MergeJoinerSpec) ProtoMessage()    {}
 func (*MergeJoinerSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_b5aca05d8faa72ff, []int{9}
+	return fileDescriptor_processors_sql_fd67541bc7b89354, []int{9}
 }
 func (m *MergeJoinerSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1230,7 +1230,7 @@ func (m *HashJoinerSpec) Reset()         { *m = HashJoinerSpec{} }
 func (m *HashJoinerSpec) String() string { return proto.CompactTextString(m) }
 func (*HashJoinerSpec) ProtoMessage()    {}
 func (*HashJoinerSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_b5aca05d8faa72ff, []int{10}
+	return fileDescriptor_processors_sql_fd67541bc7b89354, []int{10}
 }
 func (m *HashJoinerSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1346,7 +1346,7 @@ func (m *InvertedJoinerSpec) Reset()         { *m = InvertedJoinerSpec{} }
 func (m *InvertedJoinerSpec) String() string { return proto.CompactTextString(m) }
 func (*InvertedJoinerSpec) ProtoMessage()    {}
 func (*InvertedJoinerSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_b5aca05d8faa72ff, []int{11}
+	return fileDescriptor_processors_sql_fd67541bc7b89354, []int{11}
 }
 func (m *InvertedJoinerSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1407,7 +1407,7 @@ func (m *InvertedFiltererSpec) Reset()         { *m = InvertedFiltererSpec{} }
 func (m *InvertedFiltererSpec) String() string { return proto.CompactTextString(m) }
 func (*InvertedFiltererSpec) ProtoMessage()    {}
 func (*InvertedFiltererSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_b5aca05d8faa72ff, []int{12}
+	return fileDescriptor_processors_sql_fd67541bc7b89354, []int{12}
 }
 func (m *InvertedFiltererSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1445,7 +1445,7 @@ func (m *InvertedFiltererSpec_PreFiltererSpec) Reset()         { *m = InvertedFi
 func (m *InvertedFiltererSpec_PreFiltererSpec) String() string { return proto.CompactTextString(m) }
 func (*InvertedFiltererSpec_PreFiltererSpec) ProtoMessage()    {}
 func (*InvertedFiltererSpec_PreFiltererSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_b5aca05d8faa72ff, []int{12, 0}
+	return fileDescriptor_processors_sql_fd67541bc7b89354, []int{12, 0}
 }
 func (m *InvertedFiltererSpec_PreFiltererSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1491,7 +1491,7 @@ func (m *AggregatorSpec) Reset()         { *m = AggregatorSpec{} }
 func (m *AggregatorSpec) String() string { return proto.CompactTextString(m) }
 func (*AggregatorSpec) ProtoMessage()    {}
 func (*AggregatorSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_b5aca05d8faa72ff, []int{13}
+	return fileDescriptor_processors_sql_fd67541bc7b89354, []int{13}
 }
 func (m *AggregatorSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1542,7 +1542,7 @@ func (m *AggregatorSpec_Aggregation) Reset()         { *m = AggregatorSpec_Aggre
 func (m *AggregatorSpec_Aggregation) String() string { return proto.CompactTextString(m) }
 func (*AggregatorSpec_Aggregation) ProtoMessage()    {}
 func (*AggregatorSpec_Aggregation) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_b5aca05d8faa72ff, []int{13, 0}
+	return fileDescriptor_processors_sql_fd67541bc7b89354, []int{13, 0}
 }
 func (m *AggregatorSpec_Aggregation) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1582,7 +1582,7 @@ func (m *ProjectSetSpec) Reset()         { *m = ProjectSetSpec{} }
 func (m *ProjectSetSpec) String() string { return proto.CompactTextString(m) }
 func (*ProjectSetSpec) ProtoMessage()    {}
 func (*ProjectSetSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_b5aca05d8faa72ff, []int{14}
+	return fileDescriptor_processors_sql_fd67541bc7b89354, []int{14}
 }
 func (m *ProjectSetSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1624,7 +1624,7 @@ func (m *WindowerSpec) Reset()         { *m = WindowerSpec{} }
 func (m *WindowerSpec) String() string { return proto.CompactTextString(m) }
 func (*WindowerSpec) ProtoMessage()    {}
 func (*WindowerSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_b5aca05d8faa72ff, []int{15}
+	return fileDescriptor_processors_sql_fd67541bc7b89354, []int{15}
 }
 func (m *WindowerSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1660,7 +1660,7 @@ func (m *WindowerSpec_Func) Reset()         { *m = WindowerSpec_Func{} }
 func (m *WindowerSpec_Func) String() string { return proto.CompactTextString(m) }
 func (*WindowerSpec_Func) ProtoMessage()    {}
 func (*WindowerSpec_Func) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_b5aca05d8faa72ff, []int{15, 0}
+	return fileDescriptor_processors_sql_fd67541bc7b89354, []int{15, 0}
 }
 func (m *WindowerSpec_Func) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1696,7 +1696,7 @@ func (m *WindowerSpec_Frame) Reset()         { *m = WindowerSpec_Frame{} }
 func (m *WindowerSpec_Frame) String() string { return proto.CompactTextString(m) }
 func (*WindowerSpec_Frame) ProtoMessage()    {}
 func (*WindowerSpec_Frame) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_b5aca05d8faa72ff, []int{15, 1}
+	return fileDescriptor_processors_sql_fd67541bc7b89354, []int{15, 1}
 }
 func (m *WindowerSpec_Frame) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1737,7 +1737,7 @@ func (m *WindowerSpec_Frame_Bound) Reset()         { *m = WindowerSpec_Frame_Bou
 func (m *WindowerSpec_Frame_Bound) String() string { return proto.CompactTextString(m) }
 func (*WindowerSpec_Frame_Bound) ProtoMessage()    {}
 func (*WindowerSpec_Frame_Bound) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_b5aca05d8faa72ff, []int{15, 1, 0}
+	return fileDescriptor_processors_sql_fd67541bc7b89354, []int{15, 1, 0}
 }
 func (m *WindowerSpec_Frame_Bound) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1773,7 +1773,7 @@ func (m *WindowerSpec_Frame_Bounds) Reset()         { *m = WindowerSpec_Frame_Bo
 func (m *WindowerSpec_Frame_Bounds) String() string { return proto.CompactTextString(m) }
 func (*WindowerSpec_Frame_Bounds) ProtoMessage()    {}
 func (*WindowerSpec_Frame_Bounds) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_b5aca05d8faa72ff, []int{15, 1, 1}
+	return fileDescriptor_processors_sql_fd67541bc7b89354, []int{15, 1, 1}
 }
 func (m *WindowerSpec_Frame_Bounds) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1823,7 +1823,7 @@ func (m *WindowerSpec_WindowFn) Reset()         { *m = WindowerSpec_WindowFn{} }
 func (m *WindowerSpec_WindowFn) String() string { return proto.CompactTextString(m) }
 func (*WindowerSpec_WindowFn) ProtoMessage()    {}
 func (*WindowerSpec_WindowFn) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_b5aca05d8faa72ff, []int{15, 2}
+	return fileDescriptor_processors_sql_fd67541bc7b89354, []int{15, 2}
 }
 func (m *WindowerSpec_WindowFn) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -8100,10 +8100,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("sql/execinfrapb/processors_sql.proto", fileDescriptor_processors_sql_b5aca05d8faa72ff)
+	proto.RegisterFile("sql/execinfrapb/processors_sql.proto", fileDescriptor_processors_sql_fd67541bc7b89354)
 }
 
-var fileDescriptor_processors_sql_b5aca05d8faa72ff = []byte{
+var fileDescriptor_processors_sql_fd67541bc7b89354 = []byte{
 	// 2920 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xc4, 0x5a, 0xcb, 0x6f, 0x1b, 0xd7,
 	0xd5, 0x17, 0x5f, 0x12, 0x79, 0xf8, 0xd0, 0xf5, 0xb5, 0x13, 0x33, 0x4a, 0x3e, 0x59, 0xa6, 0x1d,

--- a/pkg/sql/execinfrapb/processors_table_stats.pb.go
+++ b/pkg/sql/execinfrapb/processors_table_stats.pb.go
@@ -64,7 +64,7 @@ func (x *SketchType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (SketchType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_processors_table_stats_c04eac705a3f9235, []int{0}
+	return fileDescriptor_processors_table_stats_2887a4f27d670fd1, []int{0}
 }
 
 // SketchSpec contains the specification for a generated statistic.
@@ -89,7 +89,7 @@ func (m *SketchSpec) Reset()         { *m = SketchSpec{} }
 func (m *SketchSpec) String() string { return proto.CompactTextString(m) }
 func (*SketchSpec) ProtoMessage()    {}
 func (*SketchSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_table_stats_c04eac705a3f9235, []int{0}
+	return fileDescriptor_processors_table_stats_2887a4f27d670fd1, []int{0}
 }
 func (m *SketchSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -178,7 +178,7 @@ func (m *SamplerSpec) Reset()         { *m = SamplerSpec{} }
 func (m *SamplerSpec) String() string { return proto.CompactTextString(m) }
 func (*SamplerSpec) ProtoMessage()    {}
 func (*SamplerSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_table_stats_c04eac705a3f9235, []int{1}
+	return fileDescriptor_processors_table_stats_2887a4f27d670fd1, []int{1}
 }
 func (m *SamplerSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -243,7 +243,7 @@ func (m *SampleAggregatorSpec) Reset()         { *m = SampleAggregatorSpec{} }
 func (m *SampleAggregatorSpec) String() string { return proto.CompactTextString(m) }
 func (*SampleAggregatorSpec) ProtoMessage()    {}
 func (*SampleAggregatorSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_table_stats_c04eac705a3f9235, []int{2}
+	return fileDescriptor_processors_table_stats_2887a4f27d670fd1, []int{2}
 }
 func (m *SampleAggregatorSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1287,10 +1287,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("sql/execinfrapb/processors_table_stats.proto", fileDescriptor_processors_table_stats_c04eac705a3f9235)
+	proto.RegisterFile("sql/execinfrapb/processors_table_stats.proto", fileDescriptor_processors_table_stats_2887a4f27d670fd1)
 }
 
-var fileDescriptor_processors_table_stats_c04eac705a3f9235 = []byte{
+var fileDescriptor_processors_table_stats_2887a4f27d670fd1 = []byte{
 	// 695 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xc4, 0x54, 0xcd, 0x6e, 0xdb, 0x46,
 	0x10, 0x16, 0xf5, 0x63, 0xc9, 0xab, 0xaa, 0x95, 0x59, 0x17, 0x20, 0x7c, 0xa0, 0x58, 0xd5, 0x2d,

--- a/pkg/sql/opt/invertedexpr/span_expression.pb.go
+++ b/pkg/sql/opt/invertedexpr/span_expression.pb.go
@@ -47,7 +47,7 @@ func (x SetOperator) String() string {
 	return proto.EnumName(SetOperator_name, int32(x))
 }
 func (SetOperator) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_span_expression_efa3f73e1604a2bd, []int{0}
+	return fileDescriptor_span_expression_11c64f7cb57c77cd, []int{0}
 }
 
 // SpanExpressionProto is a proto representation of an InvertedExpression
@@ -62,7 +62,7 @@ func (m *SpanExpressionProto) Reset()         { *m = SpanExpressionProto{} }
 func (m *SpanExpressionProto) String() string { return proto.CompactTextString(m) }
 func (*SpanExpressionProto) ProtoMessage()    {}
 func (*SpanExpressionProto) Descriptor() ([]byte, []int) {
-	return fileDescriptor_span_expression_efa3f73e1604a2bd, []int{0}
+	return fileDescriptor_span_expression_11c64f7cb57c77cd, []int{0}
 }
 func (m *SpanExpressionProto) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -97,7 +97,7 @@ func (m *SpanExpressionProto_Span) Reset()         { *m = SpanExpressionProto_Sp
 func (m *SpanExpressionProto_Span) String() string { return proto.CompactTextString(m) }
 func (*SpanExpressionProto_Span) ProtoMessage()    {}
 func (*SpanExpressionProto_Span) Descriptor() ([]byte, []int) {
-	return fileDescriptor_span_expression_efa3f73e1604a2bd, []int{0, 0}
+	return fileDescriptor_span_expression_11c64f7cb57c77cd, []int{0, 0}
 }
 func (m *SpanExpressionProto_Span) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -133,7 +133,7 @@ func (m *SpanExpressionProto_Node) Reset()         { *m = SpanExpressionProto_No
 func (m *SpanExpressionProto_Node) String() string { return proto.CompactTextString(m) }
 func (*SpanExpressionProto_Node) ProtoMessage()    {}
 func (*SpanExpressionProto_Node) Descriptor() ([]byte, []int) {
-	return fileDescriptor_span_expression_efa3f73e1604a2bd, []int{0, 1}
+	return fileDescriptor_span_expression_11c64f7cb57c77cd, []int{0, 1}
 }
 func (m *SpanExpressionProto_Node) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -864,10 +864,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("sql/opt/invertedexpr/span_expression.proto", fileDescriptor_span_expression_efa3f73e1604a2bd)
+	proto.RegisterFile("sql/opt/invertedexpr/span_expression.proto", fileDescriptor_span_expression_11c64f7cb57c77cd)
 }
 
-var fileDescriptor_span_expression_efa3f73e1604a2bd = []byte{
+var fileDescriptor_span_expression_11c64f7cb57c77cd = []byte{
 	// 399 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xac, 0x92, 0xc1, 0x6e, 0x13, 0x31,
 	0x10, 0x86, 0xd7, 0x89, 0x8b, 0x22, 0x27, 0x40, 0xe4, 0xe6, 0xb0, 0xca, 0xc1, 0x44, 0x9c, 0xaa,

--- a/pkg/sql/pgwire/pgerror/errors.pb.go
+++ b/pkg/sql/pgwire/pgerror/errors.pb.go
@@ -40,7 +40,7 @@ func (m *Error) Reset()         { *m = Error{} }
 func (m *Error) String() string { return proto.CompactTextString(m) }
 func (*Error) ProtoMessage()    {}
 func (*Error) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_fc85771fb5477664, []int{0}
+	return fileDescriptor_errors_e17d3410d3b0dac7, []int{0}
 }
 func (m *Error) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -75,7 +75,7 @@ func (m *Error_Source) Reset()         { *m = Error_Source{} }
 func (m *Error_Source) String() string { return proto.CompactTextString(m) }
 func (*Error_Source) ProtoMessage()    {}
 func (*Error_Source) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_fc85771fb5477664, []int{0, 0}
+	return fileDescriptor_errors_e17d3410d3b0dac7, []int{0, 0}
 }
 func (m *Error_Source) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -772,10 +772,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("sql/pgwire/pgerror/errors.proto", fileDescriptor_errors_fc85771fb5477664)
+	proto.RegisterFile("sql/pgwire/pgerror/errors.proto", fileDescriptor_errors_e17d3410d3b0dac7)
 }
 
-var fileDescriptor_errors_fc85771fb5477664 = []byte{
+var fileDescriptor_errors_e17d3410d3b0dac7 = []byte{
 	// 306 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x64, 0x51, 0xb1, 0x4e, 0xf3, 0x30,
 	0x18, 0x8c, 0xfb, 0xa7, 0x49, 0xea, 0x5f, 0x82, 0xe2, 0x01, 0x59, 0x1d, 0xdc, 0x8a, 0x85, 0xb2,

--- a/pkg/sql/sessiondatapb/session_data.pb.go
+++ b/pkg/sql/sessiondatapb/session_data.pb.go
@@ -47,7 +47,7 @@ var BytesEncodeFormat_value = map[string]int32{
 }
 
 func (BytesEncodeFormat) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_session_data_9433ac4cb00ae665, []int{0}
+	return fileDescriptor_session_data_e53021bf25081c1a, []int{0}
 }
 
 // VectorizeExecMode controls if an when the Executor executes queries using
@@ -77,7 +77,7 @@ var VectorizeExecMode_value = map[string]int32{
 }
 
 func (VectorizeExecMode) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_session_data_9433ac4cb00ae665, []int{1}
+	return fileDescriptor_session_data_e53021bf25081c1a, []int{1}
 }
 
 // SessionData contains session parameters that are easily serializable and are
@@ -128,7 +128,7 @@ func (m *SessionData) Reset()         { *m = SessionData{} }
 func (m *SessionData) String() string { return proto.CompactTextString(m) }
 func (*SessionData) ProtoMessage()    {}
 func (*SessionData) Descriptor() ([]byte, []int) {
-	return fileDescriptor_session_data_9433ac4cb00ae665, []int{0}
+	return fileDescriptor_session_data_e53021bf25081c1a, []int{0}
 }
 func (m *SessionData) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -169,7 +169,7 @@ func (m *DataConversionConfig) Reset()         { *m = DataConversionConfig{} }
 func (m *DataConversionConfig) String() string { return proto.CompactTextString(m) }
 func (*DataConversionConfig) ProtoMessage()    {}
 func (*DataConversionConfig) Descriptor() ([]byte, []int) {
-	return fileDescriptor_session_data_9433ac4cb00ae665, []int{1}
+	return fileDescriptor_session_data_e53021bf25081c1a, []int{1}
 }
 func (m *DataConversionConfig) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -206,7 +206,7 @@ func (m *SequenceState) Reset()         { *m = SequenceState{} }
 func (m *SequenceState) String() string { return proto.CompactTextString(m) }
 func (*SequenceState) ProtoMessage()    {}
 func (*SequenceState) Descriptor() ([]byte, []int) {
-	return fileDescriptor_session_data_9433ac4cb00ae665, []int{2}
+	return fileDescriptor_session_data_e53021bf25081c1a, []int{2}
 }
 func (m *SequenceState) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -241,7 +241,7 @@ func (m *SequenceState_Seq) Reset()         { *m = SequenceState_Seq{} }
 func (m *SequenceState_Seq) String() string { return proto.CompactTextString(m) }
 func (*SequenceState_Seq) ProtoMessage()    {}
 func (*SequenceState_Seq) Descriptor() ([]byte, []int) {
-	return fileDescriptor_session_data_9433ac4cb00ae665, []int{2, 0}
+	return fileDescriptor_session_data_e53021bf25081c1a, []int{2, 0}
 }
 func (m *SequenceState_Seq) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1306,10 +1306,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("sql/sessiondatapb/session_data.proto", fileDescriptor_session_data_9433ac4cb00ae665)
+	proto.RegisterFile("sql/sessiondatapb/session_data.proto", fileDescriptor_session_data_e53021bf25081c1a)
 }
 
-var fileDescriptor_session_data_9433ac4cb00ae665 = []byte{
+var fileDescriptor_session_data_e53021bf25081c1a = []byte{
 	// 786 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x84, 0x54, 0x41, 0x6f, 0xe3, 0x44,
 	0x14, 0xf6, 0x34, 0x4d, 0x49, 0x26, 0xa4, 0xeb, 0xce, 0x76, 0x91, 0xd5, 0x05, 0x27, 0xaa, 0x38,

--- a/pkg/sql/stats/histogram.pb.go
+++ b/pkg/sql/stats/histogram.pb.go
@@ -37,7 +37,7 @@ func (m *HistogramData) Reset()         { *m = HistogramData{} }
 func (m *HistogramData) String() string { return proto.CompactTextString(m) }
 func (*HistogramData) ProtoMessage()    {}
 func (*HistogramData) Descriptor() ([]byte, []int) {
-	return fileDescriptor_histogram_40b21550afd0ea12, []int{0}
+	return fileDescriptor_histogram_a205654b2eaba308, []int{0}
 }
 func (m *HistogramData) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -90,7 +90,7 @@ func (m *HistogramData_Bucket) Reset()         { *m = HistogramData_Bucket{} }
 func (m *HistogramData_Bucket) String() string { return proto.CompactTextString(m) }
 func (*HistogramData_Bucket) ProtoMessage()    {}
 func (*HistogramData_Bucket) Descriptor() ([]byte, []int) {
-	return fileDescriptor_histogram_40b21550afd0ea12, []int{0, 0}
+	return fileDescriptor_histogram_a205654b2eaba308, []int{0, 0}
 }
 func (m *HistogramData_Bucket) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -612,10 +612,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("sql/stats/histogram.proto", fileDescriptor_histogram_40b21550afd0ea12)
+	proto.RegisterFile("sql/stats/histogram.proto", fileDescriptor_histogram_a205654b2eaba308)
 }
 
-var fileDescriptor_histogram_40b21550afd0ea12 = []byte{
+var fileDescriptor_histogram_a205654b2eaba308 = []byte{
 	// 326 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x6c, 0x90, 0x31, 0x4e, 0xf3, 0x30,
 	0x18, 0x86, 0xe3, 0xa6, 0xed, 0xff, 0xe3, 0x50, 0x06, 0x43, 0xa5, 0x10, 0x24, 0x37, 0x42, 0x42,

--- a/pkg/sql/stats/table_statistic.pb.go
+++ b/pkg/sql/stats/table_statistic.pb.go
@@ -56,7 +56,7 @@ func (m *TableStatisticProto) Reset()         { *m = TableStatisticProto{} }
 func (m *TableStatisticProto) String() string { return proto.CompactTextString(m) }
 func (*TableStatisticProto) ProtoMessage()    {}
 func (*TableStatisticProto) Descriptor() ([]byte, []int) {
-	return fileDescriptor_table_statistic_b6c721e9fa79350f, []int{0}
+	return fileDescriptor_table_statistic_eb8693ae54e3d2f4, []int{0}
 }
 func (m *TableStatisticProto) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -647,10 +647,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("sql/stats/table_statistic.proto", fileDescriptor_table_statistic_b6c721e9fa79350f)
+	proto.RegisterFile("sql/stats/table_statistic.proto", fileDescriptor_table_statistic_eb8693ae54e3d2f4)
 }
 
-var fileDescriptor_table_statistic_b6c721e9fa79350f = []byte{
+var fileDescriptor_table_statistic_eb8693ae54e3d2f4 = []byte{
 	// 463 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x9c, 0x92, 0x3f, 0x6f, 0x9c, 0x30,
 	0x18, 0xc6, 0x71, 0x73, 0xc9, 0x1d, 0xbe, 0x5e, 0x2a, 0x91, 0x0e, 0xf4, 0xaa, 0x02, 0x8a, 0x54,

--- a/pkg/sql/types/types.pb.go
+++ b/pkg/sql/types/types.pb.go
@@ -431,7 +431,7 @@ func (x *Family) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (Family) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_types_39f249fb6e7f534b, []int{0}
+	return fileDescriptor_types_82a2d44015c86700, []int{0}
 }
 
 // IntervalDurationType represents a duration that can be used
@@ -495,7 +495,7 @@ func (x *IntervalDurationType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (IntervalDurationType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_types_39f249fb6e7f534b, []int{1}
+	return fileDescriptor_types_82a2d44015c86700, []int{1}
 }
 
 // IntervalDurationField represents precisions in intervals which are
@@ -517,7 +517,7 @@ func (m *IntervalDurationField) Reset()         { *m = IntervalDurationField{} }
 func (m *IntervalDurationField) String() string { return proto.CompactTextString(m) }
 func (*IntervalDurationField) ProtoMessage()    {}
 func (*IntervalDurationField) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_39f249fb6e7f534b, []int{0}
+	return fileDescriptor_types_82a2d44015c86700, []int{0}
 }
 func (m *IntervalDurationField) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -552,7 +552,7 @@ func (m *GeoMetadata) Reset()         { *m = GeoMetadata{} }
 func (m *GeoMetadata) String() string { return proto.CompactTextString(m) }
 func (*GeoMetadata) ProtoMessage()    {}
 func (*GeoMetadata) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_39f249fb6e7f534b, []int{1}
+	return fileDescriptor_types_82a2d44015c86700, []int{1}
 }
 func (m *GeoMetadata) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -590,7 +590,7 @@ func (m *PersistentUserDefinedTypeMetadata) Reset()         { *m = PersistentUse
 func (m *PersistentUserDefinedTypeMetadata) String() string { return proto.CompactTextString(m) }
 func (*PersistentUserDefinedTypeMetadata) ProtoMessage()    {}
 func (*PersistentUserDefinedTypeMetadata) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_39f249fb6e7f534b, []int{2}
+	return fileDescriptor_types_82a2d44015c86700, []int{2}
 }
 func (m *PersistentUserDefinedTypeMetadata) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -618,7 +618,7 @@ var xxx_messageInfo_PersistentUserDefinedTypeMetadata proto.InternalMessageInfo
 func (m *T) Reset()      { *m = T{} }
 func (*T) ProtoMessage() {}
 func (*T) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_39f249fb6e7f534b, []int{3}
+	return fileDescriptor_types_82a2d44015c86700, []int{3}
 }
 func (m *T) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_T.Unmarshal(m, b)
@@ -709,7 +709,7 @@ func (m *InternalType) Reset()         { *m = InternalType{} }
 func (m *InternalType) String() string { return proto.CompactTextString(m) }
 func (*InternalType) ProtoMessage()    {}
 func (*InternalType) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_39f249fb6e7f534b, []int{4}
+	return fileDescriptor_types_82a2d44015c86700, []int{4}
 }
 func (m *InternalType) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1877,9 +1877,9 @@ var (
 	ErrIntOverflowTypes   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("sql/types/types.proto", fileDescriptor_types_39f249fb6e7f534b) }
+func init() { proto.RegisterFile("sql/types/types.proto", fileDescriptor_types_82a2d44015c86700) }
 
-var fileDescriptor_types_39f249fb6e7f534b = []byte{
+var fileDescriptor_types_82a2d44015c86700 = []byte{
 	// 1119 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x9c, 0x55, 0xbf, 0x6f, 0xdb, 0x56,
 	0x10, 0x26, 0xad, 0x1f, 0x96, 0x4e, 0xbf, 0xe8, 0x17, 0x2b, 0x66, 0x3c, 0x88, 0x8a, 0xd0, 0x22,

--- a/pkg/sqlmigrations/leasemanager/lease.pb.go
+++ b/pkg/sqlmigrations/leasemanager/lease.pb.go
@@ -33,7 +33,7 @@ func (m *LeaseVal) Reset()         { *m = LeaseVal{} }
 func (m *LeaseVal) String() string { return proto.CompactTextString(m) }
 func (*LeaseVal) ProtoMessage()    {}
 func (*LeaseVal) Descriptor() ([]byte, []int) {
-	return fileDescriptor_lease_fab267a03cfd3cca, []int{0}
+	return fileDescriptor_lease_575d60f487f2d6f7, []int{0}
 }
 func (m *LeaseVal) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -341,10 +341,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("sqlmigrations/leasemanager/lease.proto", fileDescriptor_lease_fab267a03cfd3cca)
+	proto.RegisterFile("sqlmigrations/leasemanager/lease.proto", fileDescriptor_lease_575d60f487f2d6f7)
 }
 
-var fileDescriptor_lease_fab267a03cfd3cca = []byte{
+var fileDescriptor_lease_575d60f487f2d6f7 = []byte{
 	// 223 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x52, 0x2b, 0x2e, 0xcc, 0xc9,
 	0xcd, 0x4c, 0x2f, 0x4a, 0x2c, 0xc9, 0xcc, 0xcf, 0x2b, 0xd6, 0xcf, 0x49, 0x4d, 0x2c, 0x4e, 0xcd,

--- a/pkg/storage/enginepb/engine.pb.go
+++ b/pkg/storage/enginepb/engine.pb.go
@@ -38,7 +38,7 @@ var EngineType_value = map[string]int32{
 }
 
 func (EngineType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_engine_147ff271f8291d07, []int{0}
+	return fileDescriptor_engine_c3997d9635965b2b, []int{0}
 }
 
 func init() {
@@ -46,10 +46,10 @@ func init() {
 }
 
 func init() {
-	proto.RegisterFile("storage/enginepb/engine.proto", fileDescriptor_engine_147ff271f8291d07)
+	proto.RegisterFile("storage/enginepb/engine.proto", fileDescriptor_engine_c3997d9635965b2b)
 }
 
-var fileDescriptor_engine_147ff271f8291d07 = []byte{
+var fileDescriptor_engine_c3997d9635965b2b = []byte{
 	// 187 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x92, 0x2d, 0x2e, 0xc9, 0x2f,
 	0x4a, 0x4c, 0x4f, 0xd5, 0x4f, 0xcd, 0x4b, 0xcf, 0xcc, 0x4b, 0x2d, 0x48, 0x82, 0x32, 0xf4, 0x0a,

--- a/pkg/storage/enginepb/file_registry.pb.go
+++ b/pkg/storage/enginepb/file_registry.pb.go
@@ -40,7 +40,7 @@ func (x RegistryVersion) String() string {
 	return proto.EnumName(RegistryVersion_name, int32(x))
 }
 func (RegistryVersion) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_file_registry_848b8e06af99c90e, []int{0}
+	return fileDescriptor_file_registry_44f67dae837f08b2, []int{0}
 }
 
 // EnvType determines which rocksdb::Env is used and for what purpose.
@@ -73,7 +73,7 @@ func (x EnvType) String() string {
 	return proto.EnumName(EnvType_name, int32(x))
 }
 func (EnvType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_file_registry_848b8e06af99c90e, []int{1}
+	return fileDescriptor_file_registry_44f67dae837f08b2, []int{1}
 }
 
 // Registry describes how a files are handled. This includes the
@@ -92,7 +92,7 @@ func (m *FileRegistry) Reset()         { *m = FileRegistry{} }
 func (m *FileRegistry) String() string { return proto.CompactTextString(m) }
 func (*FileRegistry) ProtoMessage()    {}
 func (*FileRegistry) Descriptor() ([]byte, []int) {
-	return fileDescriptor_file_registry_848b8e06af99c90e, []int{0}
+	return fileDescriptor_file_registry_44f67dae837f08b2, []int{0}
 }
 func (m *FileRegistry) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -130,7 +130,7 @@ func (m *FileEntry) Reset()         { *m = FileEntry{} }
 func (m *FileEntry) String() string { return proto.CompactTextString(m) }
 func (*FileEntry) ProtoMessage()    {}
 func (*FileEntry) Descriptor() ([]byte, []int) {
-	return fileDescriptor_file_registry_848b8e06af99c90e, []int{1}
+	return fileDescriptor_file_registry_44f67dae837f08b2, []int{1}
 }
 func (m *FileEntry) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -708,10 +708,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("storage/enginepb/file_registry.proto", fileDescriptor_file_registry_848b8e06af99c90e)
+	proto.RegisterFile("storage/enginepb/file_registry.proto", fileDescriptor_file_registry_44f67dae837f08b2)
 }
 
-var fileDescriptor_file_registry_848b8e06af99c90e = []byte{
+var fileDescriptor_file_registry_44f67dae837f08b2 = []byte{
 	// 372 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x84, 0x92, 0x4f, 0xcb, 0xd3, 0x40,
 	0x10, 0xc6, 0xb3, 0x79, 0xad, 0x6d, 0xe6, 0xad, 0x1a, 0x56, 0x0f, 0xa5, 0xc2, 0x52, 0xaa, 0x42,

--- a/pkg/storage/enginepb/mvcc.pb.go
+++ b/pkg/storage/enginepb/mvcc.pb.go
@@ -78,7 +78,7 @@ type MVCCMetadata struct {
 func (m *MVCCMetadata) Reset()      { *m = MVCCMetadata{} }
 func (*MVCCMetadata) ProtoMessage() {}
 func (*MVCCMetadata) Descriptor() ([]byte, []int) {
-	return fileDescriptor_mvcc_33d1719bb1dfaf1f, []int{0}
+	return fileDescriptor_mvcc_69eca97822587899, []int{0}
 }
 func (m *MVCCMetadata) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -118,7 +118,7 @@ type MVCCMetadata_SequencedIntent struct {
 func (m *MVCCMetadata_SequencedIntent) Reset()      { *m = MVCCMetadata_SequencedIntent{} }
 func (*MVCCMetadata_SequencedIntent) ProtoMessage() {}
 func (*MVCCMetadata_SequencedIntent) Descriptor() ([]byte, []int) {
-	return fileDescriptor_mvcc_33d1719bb1dfaf1f, []int{0, 0}
+	return fileDescriptor_mvcc_69eca97822587899, []int{0, 0}
 }
 func (m *MVCCMetadata_SequencedIntent) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -162,7 +162,7 @@ func (m *MVCCMetadataSubsetForMergeSerialization) Reset() {
 }
 func (*MVCCMetadataSubsetForMergeSerialization) ProtoMessage() {}
 func (*MVCCMetadataSubsetForMergeSerialization) Descriptor() ([]byte, []int) {
-	return fileDescriptor_mvcc_33d1719bb1dfaf1f, []int{1}
+	return fileDescriptor_mvcc_69eca97822587899, []int{1}
 }
 func (m *MVCCMetadataSubsetForMergeSerialization) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -292,7 +292,7 @@ func (m *MVCCStats) Reset()         { *m = MVCCStats{} }
 func (m *MVCCStats) String() string { return proto.CompactTextString(m) }
 func (*MVCCStats) ProtoMessage()    {}
 func (*MVCCStats) Descriptor() ([]byte, []int) {
-	return fileDescriptor_mvcc_33d1719bb1dfaf1f, []int{2}
+	return fileDescriptor_mvcc_69eca97822587899, []int{2}
 }
 func (m *MVCCStats) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -346,7 +346,7 @@ func (m *MVCCStatsLegacyRepresentation) Reset()         { *m = MVCCStatsLegacyRe
 func (m *MVCCStatsLegacyRepresentation) String() string { return proto.CompactTextString(m) }
 func (*MVCCStatsLegacyRepresentation) ProtoMessage()    {}
 func (*MVCCStatsLegacyRepresentation) Descriptor() ([]byte, []int) {
-	return fileDescriptor_mvcc_33d1719bb1dfaf1f, []int{3}
+	return fileDescriptor_mvcc_69eca97822587899, []int{3}
 }
 func (m *MVCCStatsLegacyRepresentation) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2289,9 +2289,9 @@ var (
 	ErrIntOverflowMvcc   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("storage/enginepb/mvcc.proto", fileDescriptor_mvcc_33d1719bb1dfaf1f) }
+func init() { proto.RegisterFile("storage/enginepb/mvcc.proto", fileDescriptor_mvcc_69eca97822587899) }
 
-var fileDescriptor_mvcc_33d1719bb1dfaf1f = []byte{
+var fileDescriptor_mvcc_69eca97822587899 = []byte{
 	// 780 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xec, 0x95, 0x31, 0x4f, 0xdb, 0x4c,
 	0x18, 0xc7, 0xe3, 0x37, 0x01, 0x9c, 0x4b, 0x48, 0xc0, 0x2f, 0xd2, 0x1b, 0x85, 0xb7, 0x4e, 0x0a,

--- a/pkg/storage/enginepb/mvcc3.pb.go
+++ b/pkg/storage/enginepb/mvcc3.pb.go
@@ -129,7 +129,7 @@ type TxnMeta struct {
 func (m *TxnMeta) Reset()      { *m = TxnMeta{} }
 func (*TxnMeta) ProtoMessage() {}
 func (*TxnMeta) Descriptor() ([]byte, []int) {
-	return fileDescriptor_mvcc3_73a4c82b9e7a6d40, []int{0}
+	return fileDescriptor_mvcc3_91f8cd28159ee686, []int{0}
 }
 func (m *TxnMeta) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -165,7 +165,7 @@ func (m *IgnoredSeqNumRange) Reset()         { *m = IgnoredSeqNumRange{} }
 func (m *IgnoredSeqNumRange) String() string { return proto.CompactTextString(m) }
 func (*IgnoredSeqNumRange) ProtoMessage()    {}
 func (*IgnoredSeqNumRange) Descriptor() ([]byte, []int) {
-	return fileDescriptor_mvcc3_73a4c82b9e7a6d40, []int{1}
+	return fileDescriptor_mvcc3_91f8cd28159ee686, []int{1}
 }
 func (m *IgnoredSeqNumRange) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -215,7 +215,7 @@ func (m *MVCCStatsDelta) Reset()         { *m = MVCCStatsDelta{} }
 func (m *MVCCStatsDelta) String() string { return proto.CompactTextString(m) }
 func (*MVCCStatsDelta) ProtoMessage()    {}
 func (*MVCCStatsDelta) Descriptor() ([]byte, []int) {
-	return fileDescriptor_mvcc3_73a4c82b9e7a6d40, []int{2}
+	return fileDescriptor_mvcc3_91f8cd28159ee686, []int{2}
 }
 func (m *MVCCStatsDelta) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -266,7 +266,7 @@ func (m *MVCCPersistentStats) Reset()         { *m = MVCCPersistentStats{} }
 func (m *MVCCPersistentStats) String() string { return proto.CompactTextString(m) }
 func (*MVCCPersistentStats) ProtoMessage()    {}
 func (*MVCCPersistentStats) Descriptor() ([]byte, []int) {
-	return fileDescriptor_mvcc3_73a4c82b9e7a6d40, []int{3}
+	return fileDescriptor_mvcc3_91f8cd28159ee686, []int{3}
 }
 func (m *MVCCPersistentStats) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -311,7 +311,7 @@ func (m *RangeAppliedState) Reset()         { *m = RangeAppliedState{} }
 func (m *RangeAppliedState) String() string { return proto.CompactTextString(m) }
 func (*RangeAppliedState) ProtoMessage()    {}
 func (*RangeAppliedState) Descriptor() ([]byte, []int) {
-	return fileDescriptor_mvcc3_73a4c82b9e7a6d40, []int{4}
+	return fileDescriptor_mvcc3_91f8cd28159ee686, []int{4}
 }
 func (m *RangeAppliedState) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -349,7 +349,7 @@ func (m *MVCCWriteValueOp) Reset()         { *m = MVCCWriteValueOp{} }
 func (m *MVCCWriteValueOp) String() string { return proto.CompactTextString(m) }
 func (*MVCCWriteValueOp) ProtoMessage()    {}
 func (*MVCCWriteValueOp) Descriptor() ([]byte, []int) {
-	return fileDescriptor_mvcc3_73a4c82b9e7a6d40, []int{5}
+	return fileDescriptor_mvcc3_91f8cd28159ee686, []int{5}
 }
 func (m *MVCCWriteValueOp) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -387,7 +387,7 @@ func (m *MVCCWriteIntentOp) Reset()         { *m = MVCCWriteIntentOp{} }
 func (m *MVCCWriteIntentOp) String() string { return proto.CompactTextString(m) }
 func (*MVCCWriteIntentOp) ProtoMessage()    {}
 func (*MVCCWriteIntentOp) Descriptor() ([]byte, []int) {
-	return fileDescriptor_mvcc3_73a4c82b9e7a6d40, []int{6}
+	return fileDescriptor_mvcc3_91f8cd28159ee686, []int{6}
 }
 func (m *MVCCWriteIntentOp) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -423,7 +423,7 @@ func (m *MVCCUpdateIntentOp) Reset()         { *m = MVCCUpdateIntentOp{} }
 func (m *MVCCUpdateIntentOp) String() string { return proto.CompactTextString(m) }
 func (*MVCCUpdateIntentOp) ProtoMessage()    {}
 func (*MVCCUpdateIntentOp) Descriptor() ([]byte, []int) {
-	return fileDescriptor_mvcc3_73a4c82b9e7a6d40, []int{7}
+	return fileDescriptor_mvcc3_91f8cd28159ee686, []int{7}
 }
 func (m *MVCCUpdateIntentOp) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -462,7 +462,7 @@ func (m *MVCCCommitIntentOp) Reset()         { *m = MVCCCommitIntentOp{} }
 func (m *MVCCCommitIntentOp) String() string { return proto.CompactTextString(m) }
 func (*MVCCCommitIntentOp) ProtoMessage()    {}
 func (*MVCCCommitIntentOp) Descriptor() ([]byte, []int) {
-	return fileDescriptor_mvcc3_73a4c82b9e7a6d40, []int{8}
+	return fileDescriptor_mvcc3_91f8cd28159ee686, []int{8}
 }
 func (m *MVCCCommitIntentOp) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -502,7 +502,7 @@ func (m *MVCCAbortIntentOp) Reset()         { *m = MVCCAbortIntentOp{} }
 func (m *MVCCAbortIntentOp) String() string { return proto.CompactTextString(m) }
 func (*MVCCAbortIntentOp) ProtoMessage()    {}
 func (*MVCCAbortIntentOp) Descriptor() ([]byte, []int) {
-	return fileDescriptor_mvcc3_73a4c82b9e7a6d40, []int{9}
+	return fileDescriptor_mvcc3_91f8cd28159ee686, []int{9}
 }
 func (m *MVCCAbortIntentOp) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -538,7 +538,7 @@ func (m *MVCCAbortTxnOp) Reset()         { *m = MVCCAbortTxnOp{} }
 func (m *MVCCAbortTxnOp) String() string { return proto.CompactTextString(m) }
 func (*MVCCAbortTxnOp) ProtoMessage()    {}
 func (*MVCCAbortTxnOp) Descriptor() ([]byte, []int) {
-	return fileDescriptor_mvcc3_73a4c82b9e7a6d40, []int{10}
+	return fileDescriptor_mvcc3_91f8cd28159ee686, []int{10}
 }
 func (m *MVCCAbortTxnOp) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -577,7 +577,7 @@ func (m *MVCCLogicalOp) Reset()         { *m = MVCCLogicalOp{} }
 func (m *MVCCLogicalOp) String() string { return proto.CompactTextString(m) }
 func (*MVCCLogicalOp) ProtoMessage()    {}
 func (*MVCCLogicalOp) Descriptor() ([]byte, []int) {
-	return fileDescriptor_mvcc3_73a4c82b9e7a6d40, []int{11}
+	return fileDescriptor_mvcc3_91f8cd28159ee686, []int{11}
 }
 func (m *MVCCLogicalOp) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4236,10 +4236,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("storage/enginepb/mvcc3.proto", fileDescriptor_mvcc3_73a4c82b9e7a6d40)
+	proto.RegisterFile("storage/enginepb/mvcc3.proto", fileDescriptor_mvcc3_91f8cd28159ee686)
 }
 
-var fileDescriptor_mvcc3_73a4c82b9e7a6d40 = []byte{
+var fileDescriptor_mvcc3_91f8cd28159ee686 = []byte{
 	// 1194 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xcc, 0x57, 0x41, 0x6f, 0xe3, 0x44,
 	0x14, 0x8e, 0x63, 0xa7, 0x75, 0x26, 0x69, 0x9b, 0xcc, 0xae, 0x44, 0xb4, 0xec, 0x26, 0x25, 0x07,

--- a/pkg/storage/enginepb/rocksdb.pb.go
+++ b/pkg/storage/enginepb/rocksdb.pb.go
@@ -37,7 +37,7 @@ func (m *SSTUserProperties) Reset()         { *m = SSTUserProperties{} }
 func (m *SSTUserProperties) String() string { return proto.CompactTextString(m) }
 func (*SSTUserProperties) ProtoMessage()    {}
 func (*SSTUserProperties) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rocksdb_e0dede928993ad0c, []int{0}
+	return fileDescriptor_rocksdb_d0de3f5554d674cd, []int{0}
 }
 func (m *SSTUserProperties) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -73,7 +73,7 @@ func (m *SSTUserPropertiesCollection) Reset()         { *m = SSTUserPropertiesCo
 func (m *SSTUserPropertiesCollection) String() string { return proto.CompactTextString(m) }
 func (*SSTUserPropertiesCollection) ProtoMessage()    {}
 func (*SSTUserPropertiesCollection) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rocksdb_e0dede928993ad0c, []int{1}
+	return fileDescriptor_rocksdb_d0de3f5554d674cd, []int{1}
 }
 func (m *SSTUserPropertiesCollection) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -114,7 +114,7 @@ func (m *HistogramData) Reset()         { *m = HistogramData{} }
 func (m *HistogramData) String() string { return proto.CompactTextString(m) }
 func (*HistogramData) ProtoMessage()    {}
 func (*HistogramData) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rocksdb_e0dede928993ad0c, []int{2}
+	return fileDescriptor_rocksdb_d0de3f5554d674cd, []int{2}
 }
 func (m *HistogramData) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -150,7 +150,7 @@ func (m *TickersAndHistograms) Reset()         { *m = TickersAndHistograms{} }
 func (m *TickersAndHistograms) String() string { return proto.CompactTextString(m) }
 func (*TickersAndHistograms) ProtoMessage()    {}
 func (*TickersAndHistograms) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rocksdb_e0dede928993ad0c, []int{3}
+	return fileDescriptor_rocksdb_d0de3f5554d674cd, []int{3}
 }
 func (m *TickersAndHistograms) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1293,10 +1293,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("storage/enginepb/rocksdb.proto", fileDescriptor_rocksdb_e0dede928993ad0c)
+	proto.RegisterFile("storage/enginepb/rocksdb.proto", fileDescriptor_rocksdb_d0de3f5554d674cd)
 }
 
-var fileDescriptor_rocksdb_e0dede928993ad0c = []byte{
+var fileDescriptor_rocksdb_d0de3f5554d674cd = []byte{
 	// 495 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x94, 0x53, 0x41, 0x6b, 0x13, 0x41,
 	0x14, 0xde, 0x49, 0xb6, 0xa9, 0x9d, 0x28, 0xea, 0x92, 0xc3, 0xb2, 0xe2, 0x18, 0x72, 0x8a, 0x82,

--- a/pkg/ts/catalog/chart_catalog.pb.go
+++ b/pkg/ts/catalog/chart_catalog.pb.go
@@ -70,7 +70,7 @@ func (x *AxisUnits) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (AxisUnits) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_chart_catalog_38c5478e18a7ed60, []int{0}
+	return fileDescriptor_chart_catalog_cee66ed43a96ddd0, []int{0}
 }
 
 // DescribeAggregator works as a proxy for cockroach.ts.tspb.TimeSeriesQueryAggregator
@@ -123,7 +123,7 @@ func (x *DescribeAggregator) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (DescribeAggregator) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_chart_catalog_38c5478e18a7ed60, []int{1}
+	return fileDescriptor_chart_catalog_cee66ed43a96ddd0, []int{1}
 }
 
 // DescribeDerivative works as a proxy for cockroach.ts.tspb.TimeSeriesQueryDerivative
@@ -175,7 +175,7 @@ func (x *DescribeDerivative) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (DescribeDerivative) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_chart_catalog_38c5478e18a7ed60, []int{2}
+	return fileDescriptor_chart_catalog_cee66ed43a96ddd0, []int{2}
 }
 
 // ChartMetric converts cockroach.util.metric.Metadata
@@ -200,7 +200,7 @@ func (m *ChartMetric) Reset()         { *m = ChartMetric{} }
 func (m *ChartMetric) String() string { return proto.CompactTextString(m) }
 func (*ChartMetric) ProtoMessage()    {}
 func (*ChartMetric) Descriptor() ([]byte, []int) {
-	return fileDescriptor_chart_catalog_38c5478e18a7ed60, []int{0}
+	return fileDescriptor_chart_catalog_cee66ed43a96ddd0, []int{0}
 }
 func (m *ChartMetric) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -256,7 +256,7 @@ func (m *IndividualChart) Reset()         { *m = IndividualChart{} }
 func (m *IndividualChart) String() string { return proto.CompactTextString(m) }
 func (*IndividualChart) ProtoMessage()    {}
 func (*IndividualChart) Descriptor() ([]byte, []int) {
-	return fileDescriptor_chart_catalog_38c5478e18a7ed60, []int{1}
+	return fileDescriptor_chart_catalog_cee66ed43a96ddd0, []int{1}
 }
 func (m *IndividualChart) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -306,7 +306,7 @@ func (m *ChartSection) Reset()         { *m = ChartSection{} }
 func (m *ChartSection) String() string { return proto.CompactTextString(m) }
 func (*ChartSection) ProtoMessage()    {}
 func (*ChartSection) Descriptor() ([]byte, []int) {
-	return fileDescriptor_chart_catalog_38c5478e18a7ed60, []int{2}
+	return fileDescriptor_chart_catalog_cee66ed43a96ddd0, []int{2}
 }
 func (m *ChartSection) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1516,10 +1516,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("ts/catalog/chart_catalog.proto", fileDescriptor_chart_catalog_38c5478e18a7ed60)
+	proto.RegisterFile("ts/catalog/chart_catalog.proto", fileDescriptor_chart_catalog_cee66ed43a96ddd0)
 }
 
-var fileDescriptor_chart_catalog_38c5478e18a7ed60 = []byte{
+var fileDescriptor_chart_catalog_cee66ed43a96ddd0 = []byte{
 	// 726 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xbc, 0x54, 0xc1, 0x6e, 0xda, 0x58,
 	0x14, 0xb5, 0x0d, 0x04, 0xb8, 0x64, 0x88, 0xf5, 0x14, 0x69, 0xac, 0x8c, 0xe4, 0x30, 0x48, 0x89,

--- a/pkg/ts/tspb/timeseries.pb.go
+++ b/pkg/ts/tspb/timeseries.pb.go
@@ -93,7 +93,7 @@ func (x *TimeSeriesQueryAggregator) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (TimeSeriesQueryAggregator) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_timeseries_c77223425ab37933, []int{0}
+	return fileDescriptor_timeseries_60a254ced0e4361c, []int{0}
 }
 
 // TimeSeriesQueryDerivative describes a derivative function used to convert
@@ -139,7 +139,7 @@ func (x *TimeSeriesQueryDerivative) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (TimeSeriesQueryDerivative) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_timeseries_c77223425ab37933, []int{1}
+	return fileDescriptor_timeseries_60a254ced0e4361c, []int{1}
 }
 
 // TimeSeriesResolution is used to enumerate the different resolution values
@@ -180,7 +180,7 @@ func (x *TimeSeriesResolution) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (TimeSeriesResolution) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_timeseries_c77223425ab37933, []int{2}
+	return fileDescriptor_timeseries_60a254ced0e4361c, []int{2}
 }
 
 // TimeSeriesDatapoint is a single point of time series data; a value associated
@@ -197,7 +197,7 @@ func (m *TimeSeriesDatapoint) Reset()         { *m = TimeSeriesDatapoint{} }
 func (m *TimeSeriesDatapoint) String() string { return proto.CompactTextString(m) }
 func (*TimeSeriesDatapoint) ProtoMessage()    {}
 func (*TimeSeriesDatapoint) Descriptor() ([]byte, []int) {
-	return fileDescriptor_timeseries_c77223425ab37933, []int{0}
+	return fileDescriptor_timeseries_60a254ced0e4361c, []int{0}
 }
 func (m *TimeSeriesDatapoint) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -240,7 +240,7 @@ func (m *TimeSeriesData) Reset()         { *m = TimeSeriesData{} }
 func (m *TimeSeriesData) String() string { return proto.CompactTextString(m) }
 func (*TimeSeriesData) ProtoMessage()    {}
 func (*TimeSeriesData) Descriptor() ([]byte, []int) {
-	return fileDescriptor_timeseries_c77223425ab37933, []int{1}
+	return fileDescriptor_timeseries_60a254ced0e4361c, []int{1}
 }
 func (m *TimeSeriesData) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -288,7 +288,7 @@ func (m *Query) Reset()         { *m = Query{} }
 func (m *Query) String() string { return proto.CompactTextString(m) }
 func (*Query) ProtoMessage()    {}
 func (*Query) Descriptor() ([]byte, []int) {
-	return fileDescriptor_timeseries_c77223425ab37933, []int{2}
+	return fileDescriptor_timeseries_60a254ced0e4361c, []int{2}
 }
 func (m *Query) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -374,7 +374,7 @@ func (m *TimeSeriesQueryRequest) Reset()         { *m = TimeSeriesQueryRequest{}
 func (m *TimeSeriesQueryRequest) String() string { return proto.CompactTextString(m) }
 func (*TimeSeriesQueryRequest) ProtoMessage()    {}
 func (*TimeSeriesQueryRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_timeseries_c77223425ab37933, []int{3}
+	return fileDescriptor_timeseries_60a254ced0e4361c, []int{3}
 }
 func (m *TimeSeriesQueryRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -412,7 +412,7 @@ func (m *TimeSeriesQueryResponse) Reset()         { *m = TimeSeriesQueryResponse
 func (m *TimeSeriesQueryResponse) String() string { return proto.CompactTextString(m) }
 func (*TimeSeriesQueryResponse) ProtoMessage()    {}
 func (*TimeSeriesQueryResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_timeseries_c77223425ab37933, []int{4}
+	return fileDescriptor_timeseries_60a254ced0e4361c, []int{4}
 }
 func (m *TimeSeriesQueryResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -447,7 +447,7 @@ func (m *TimeSeriesQueryResponse_Result) Reset()         { *m = TimeSeriesQueryR
 func (m *TimeSeriesQueryResponse_Result) String() string { return proto.CompactTextString(m) }
 func (*TimeSeriesQueryResponse_Result) ProtoMessage()    {}
 func (*TimeSeriesQueryResponse_Result) Descriptor() ([]byte, []int) {
-	return fileDescriptor_timeseries_c77223425ab37933, []int{4, 0}
+	return fileDescriptor_timeseries_60a254ced0e4361c, []int{4, 0}
 }
 func (m *TimeSeriesQueryResponse_Result) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -494,7 +494,7 @@ func (m *DumpRequest) Reset()         { *m = DumpRequest{} }
 func (m *DumpRequest) String() string { return proto.CompactTextString(m) }
 func (*DumpRequest) ProtoMessage()    {}
 func (*DumpRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_timeseries_c77223425ab37933, []int{5}
+	return fileDescriptor_timeseries_60a254ced0e4361c, []int{5}
 }
 func (m *DumpRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2319,10 +2319,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("ts/tspb/timeseries.proto", fileDescriptor_timeseries_c77223425ab37933)
+	proto.RegisterFile("ts/tspb/timeseries.proto", fileDescriptor_timeseries_60a254ced0e4361c)
 }
 
-var fileDescriptor_timeseries_c77223425ab37933 = []byte{
+var fileDescriptor_timeseries_60a254ced0e4361c = []byte{
 	// 808 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xac, 0x54, 0x41, 0x8f, 0xdb, 0x44,
 	0x14, 0xf6, 0xd8, 0xce, 0x26, 0x79, 0xa9, 0x82, 0x3b, 0xac, 0xa8, 0x09, 0x95, 0x37, 0x8d, 0x44,

--- a/pkg/util/hlc/legacy_timestamp.pb.go
+++ b/pkg/util/hlc/legacy_timestamp.pb.go
@@ -47,7 +47,7 @@ type LegacyTimestamp struct {
 func (m *LegacyTimestamp) Reset()      { *m = LegacyTimestamp{} }
 func (*LegacyTimestamp) ProtoMessage() {}
 func (*LegacyTimestamp) Descriptor() ([]byte, []int) {
-	return fileDescriptor_legacy_timestamp_7e009b38ac9b864a, []int{0}
+	return fileDescriptor_legacy_timestamp_7c5b7692f4330421, []int{0}
 }
 func (m *LegacyTimestamp) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -487,10 +487,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("util/hlc/legacy_timestamp.proto", fileDescriptor_legacy_timestamp_7e009b38ac9b864a)
+	proto.RegisterFile("util/hlc/legacy_timestamp.proto", fileDescriptor_legacy_timestamp_7c5b7692f4330421)
 }
 
-var fileDescriptor_legacy_timestamp_7e009b38ac9b864a = []byte{
+var fileDescriptor_legacy_timestamp_7c5b7692f4330421 = []byte{
 	// 226 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x92, 0x2f, 0x2d, 0xc9, 0xcc,
 	0xd1, 0xcf, 0xc8, 0x49, 0xd6, 0xcf, 0x49, 0x4d, 0x4f, 0x4c, 0xae, 0x8c, 0x2f, 0xc9, 0xcc, 0x4d,

--- a/pkg/util/hlc/timestamp.pb.go
+++ b/pkg/util/hlc/timestamp.pb.go
@@ -66,7 +66,7 @@ type Timestamp struct {
 func (m *Timestamp) Reset()      { *m = Timestamp{} }
 func (*Timestamp) ProtoMessage() {}
 func (*Timestamp) Descriptor() ([]byte, []int) {
-	return fileDescriptor_timestamp_018bda073af0c1c7, []int{0}
+	return fileDescriptor_timestamp_e3db50d085ffaa11, []int{0}
 }
 func (m *Timestamp) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -504,10 +504,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("util/hlc/timestamp.proto", fileDescriptor_timestamp_018bda073af0c1c7)
+	proto.RegisterFile("util/hlc/timestamp.proto", fileDescriptor_timestamp_e3db50d085ffaa11)
 }
 
-var fileDescriptor_timestamp_018bda073af0c1c7 = []byte{
+var fileDescriptor_timestamp_e3db50d085ffaa11 = []byte{
 	// 213 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x92, 0x28, 0x2d, 0xc9, 0xcc,
 	0xd1, 0xcf, 0xc8, 0x49, 0xd6, 0x2f, 0xc9, 0xcc, 0x4d, 0x2d, 0x2e, 0x49, 0xcc, 0x2d, 0xd0, 0x2b,

--- a/pkg/util/log/eventpb/cluster_events.pb.go
+++ b/pkg/util/log/eventpb/cluster_events.pb.go
@@ -35,7 +35,7 @@ func (m *CommonNodeEventDetails) Reset()         { *m = CommonNodeEventDetails{}
 func (m *CommonNodeEventDetails) String() string { return proto.CompactTextString(m) }
 func (*CommonNodeEventDetails) ProtoMessage()    {}
 func (*CommonNodeEventDetails) Descriptor() ([]byte, []int) {
-	return fileDescriptor_cluster_events_b40f75192836174e, []int{0}
+	return fileDescriptor_cluster_events_10690454bf71dc4a, []int{0}
 }
 func (m *CommonNodeEventDetails) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -70,7 +70,7 @@ func (m *NodeJoin) Reset()         { *m = NodeJoin{} }
 func (m *NodeJoin) String() string { return proto.CompactTextString(m) }
 func (*NodeJoin) ProtoMessage()    {}
 func (*NodeJoin) Descriptor() ([]byte, []int) {
-	return fileDescriptor_cluster_events_b40f75192836174e, []int{1}
+	return fileDescriptor_cluster_events_10690454bf71dc4a, []int{1}
 }
 func (m *NodeJoin) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -106,7 +106,7 @@ func (m *NodeRestart) Reset()         { *m = NodeRestart{} }
 func (m *NodeRestart) String() string { return proto.CompactTextString(m) }
 func (*NodeRestart) ProtoMessage()    {}
 func (*NodeRestart) Descriptor() ([]byte, []int) {
-	return fileDescriptor_cluster_events_b40f75192836174e, []int{2}
+	return fileDescriptor_cluster_events_10690454bf71dc4a, []int{2}
 }
 func (m *NodeRestart) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -149,7 +149,7 @@ func (m *CommonNodeDecommissionDetails) Reset()         { *m = CommonNodeDecommi
 func (m *CommonNodeDecommissionDetails) String() string { return proto.CompactTextString(m) }
 func (*CommonNodeDecommissionDetails) ProtoMessage()    {}
 func (*CommonNodeDecommissionDetails) Descriptor() ([]byte, []int) {
-	return fileDescriptor_cluster_events_b40f75192836174e, []int{3}
+	return fileDescriptor_cluster_events_10690454bf71dc4a, []int{3}
 }
 func (m *CommonNodeDecommissionDetails) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -185,7 +185,7 @@ func (m *NodeDecommissioning) Reset()         { *m = NodeDecommissioning{} }
 func (m *NodeDecommissioning) String() string { return proto.CompactTextString(m) }
 func (*NodeDecommissioning) ProtoMessage()    {}
 func (*NodeDecommissioning) Descriptor() ([]byte, []int) {
-	return fileDescriptor_cluster_events_b40f75192836174e, []int{4}
+	return fileDescriptor_cluster_events_10690454bf71dc4a, []int{4}
 }
 func (m *NodeDecommissioning) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -221,7 +221,7 @@ func (m *NodeDecommissioned) Reset()         { *m = NodeDecommissioned{} }
 func (m *NodeDecommissioned) String() string { return proto.CompactTextString(m) }
 func (*NodeDecommissioned) ProtoMessage()    {}
 func (*NodeDecommissioned) Descriptor() ([]byte, []int) {
-	return fileDescriptor_cluster_events_b40f75192836174e, []int{5}
+	return fileDescriptor_cluster_events_10690454bf71dc4a, []int{5}
 }
 func (m *NodeDecommissioned) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -257,7 +257,7 @@ func (m *NodeRecommissioned) Reset()         { *m = NodeRecommissioned{} }
 func (m *NodeRecommissioned) String() string { return proto.CompactTextString(m) }
 func (*NodeRecommissioned) ProtoMessage()    {}
 func (*NodeRecommissioned) Descriptor() ([]byte, []int) {
-	return fileDescriptor_cluster_events_b40f75192836174e, []int{6}
+	return fileDescriptor_cluster_events_10690454bf71dc4a, []int{6}
 }
 func (m *NodeRecommissioned) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1493,10 +1493,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("util/log/eventpb/cluster_events.proto", fileDescriptor_cluster_events_b40f75192836174e)
+	proto.RegisterFile("util/log/eventpb/cluster_events.proto", fileDescriptor_cluster_events_10690454bf71dc4a)
 }
 
-var fileDescriptor_cluster_events_b40f75192836174e = []byte{
+var fileDescriptor_cluster_events_10690454bf71dc4a = []byte{
 	// 463 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xd4, 0x94, 0xc1, 0x6a, 0xd4, 0x40,
 	0x18, 0xc7, 0x33, 0x6d, 0xcd, 0xea, 0xd7, 0xa5, 0x94, 0x51, 0x24, 0x2c, 0x74, 0x52, 0x02, 0x62,

--- a/pkg/util/log/eventpb/ddl_events.pb.go
+++ b/pkg/util/log/eventpb/ddl_events.pb.go
@@ -32,7 +32,7 @@ func (m *CreateDatabase) Reset()         { *m = CreateDatabase{} }
 func (m *CreateDatabase) String() string { return proto.CompactTextString(m) }
 func (*CreateDatabase) ProtoMessage()    {}
 func (*CreateDatabase) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_aabab53a2111ee03, []int{0}
+	return fileDescriptor_ddl_events_7e7f11b9ac9cec04, []int{0}
 }
 func (m *CreateDatabase) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -71,7 +71,7 @@ func (m *DropDatabase) Reset()         { *m = DropDatabase{} }
 func (m *DropDatabase) String() string { return proto.CompactTextString(m) }
 func (*DropDatabase) ProtoMessage()    {}
 func (*DropDatabase) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_aabab53a2111ee03, []int{1}
+	return fileDescriptor_ddl_events_7e7f11b9ac9cec04, []int{1}
 }
 func (m *DropDatabase) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -110,7 +110,7 @@ func (m *AlterDatabaseAddRegion) Reset()         { *m = AlterDatabaseAddRegion{}
 func (m *AlterDatabaseAddRegion) String() string { return proto.CompactTextString(m) }
 func (*AlterDatabaseAddRegion) ProtoMessage()    {}
 func (*AlterDatabaseAddRegion) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_aabab53a2111ee03, []int{2}
+	return fileDescriptor_ddl_events_7e7f11b9ac9cec04, []int{2}
 }
 func (m *AlterDatabaseAddRegion) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -149,7 +149,7 @@ func (m *AlterDatabasePrimaryRegion) Reset()         { *m = AlterDatabasePrimary
 func (m *AlterDatabasePrimaryRegion) String() string { return proto.CompactTextString(m) }
 func (*AlterDatabasePrimaryRegion) ProtoMessage()    {}
 func (*AlterDatabasePrimaryRegion) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_aabab53a2111ee03, []int{3}
+	return fileDescriptor_ddl_events_7e7f11b9ac9cec04, []int{3}
 }
 func (m *AlterDatabasePrimaryRegion) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -188,7 +188,7 @@ func (m *RenameDatabase) Reset()         { *m = RenameDatabase{} }
 func (m *RenameDatabase) String() string { return proto.CompactTextString(m) }
 func (*RenameDatabase) ProtoMessage()    {}
 func (*RenameDatabase) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_aabab53a2111ee03, []int{4}
+	return fileDescriptor_ddl_events_7e7f11b9ac9cec04, []int{4}
 }
 func (m *RenameDatabase) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -227,7 +227,7 @@ func (m *ConvertToSchema) Reset()         { *m = ConvertToSchema{} }
 func (m *ConvertToSchema) String() string { return proto.CompactTextString(m) }
 func (*ConvertToSchema) ProtoMessage()    {}
 func (*ConvertToSchema) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_aabab53a2111ee03, []int{5}
+	return fileDescriptor_ddl_events_7e7f11b9ac9cec04, []int{5}
 }
 func (m *ConvertToSchema) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -266,7 +266,7 @@ func (m *CreateSchema) Reset()         { *m = CreateSchema{} }
 func (m *CreateSchema) String() string { return proto.CompactTextString(m) }
 func (*CreateSchema) ProtoMessage()    {}
 func (*CreateSchema) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_aabab53a2111ee03, []int{6}
+	return fileDescriptor_ddl_events_7e7f11b9ac9cec04, []int{6}
 }
 func (m *CreateSchema) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -303,7 +303,7 @@ func (m *DropSchema) Reset()         { *m = DropSchema{} }
 func (m *DropSchema) String() string { return proto.CompactTextString(m) }
 func (*DropSchema) ProtoMessage()    {}
 func (*DropSchema) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_aabab53a2111ee03, []int{7}
+	return fileDescriptor_ddl_events_7e7f11b9ac9cec04, []int{7}
 }
 func (m *DropSchema) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -342,7 +342,7 @@ func (m *RenameSchema) Reset()         { *m = RenameSchema{} }
 func (m *RenameSchema) String() string { return proto.CompactTextString(m) }
 func (*RenameSchema) ProtoMessage()    {}
 func (*RenameSchema) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_aabab53a2111ee03, []int{8}
+	return fileDescriptor_ddl_events_7e7f11b9ac9cec04, []int{8}
 }
 func (m *RenameSchema) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -381,7 +381,7 @@ func (m *CreateTable) Reset()         { *m = CreateTable{} }
 func (m *CreateTable) String() string { return proto.CompactTextString(m) }
 func (*CreateTable) ProtoMessage()    {}
 func (*CreateTable) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_aabab53a2111ee03, []int{9}
+	return fileDescriptor_ddl_events_7e7f11b9ac9cec04, []int{9}
 }
 func (m *CreateTable) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -420,7 +420,7 @@ func (m *DropTable) Reset()         { *m = DropTable{} }
 func (m *DropTable) String() string { return proto.CompactTextString(m) }
 func (*DropTable) ProtoMessage()    {}
 func (*DropTable) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_aabab53a2111ee03, []int{10}
+	return fileDescriptor_ddl_events_7e7f11b9ac9cec04, []int{10}
 }
 func (m *DropTable) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -459,7 +459,7 @@ func (m *RenameTable) Reset()         { *m = RenameTable{} }
 func (m *RenameTable) String() string { return proto.CompactTextString(m) }
 func (*RenameTable) ProtoMessage()    {}
 func (*RenameTable) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_aabab53a2111ee03, []int{11}
+	return fileDescriptor_ddl_events_7e7f11b9ac9cec04, []int{11}
 }
 func (m *RenameTable) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -496,7 +496,7 @@ func (m *TruncateTable) Reset()         { *m = TruncateTable{} }
 func (m *TruncateTable) String() string { return proto.CompactTextString(m) }
 func (*TruncateTable) ProtoMessage()    {}
 func (*TruncateTable) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_aabab53a2111ee03, []int{12}
+	return fileDescriptor_ddl_events_7e7f11b9ac9cec04, []int{12}
 }
 func (m *TruncateTable) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -537,7 +537,7 @@ func (m *AlterTable) Reset()         { *m = AlterTable{} }
 func (m *AlterTable) String() string { return proto.CompactTextString(m) }
 func (*AlterTable) ProtoMessage()    {}
 func (*AlterTable) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_aabab53a2111ee03, []int{13}
+	return fileDescriptor_ddl_events_7e7f11b9ac9cec04, []int{13}
 }
 func (m *AlterTable) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -580,7 +580,7 @@ func (m *CommentOnColumn) Reset()         { *m = CommentOnColumn{} }
 func (m *CommentOnColumn) String() string { return proto.CompactTextString(m) }
 func (*CommentOnColumn) ProtoMessage()    {}
 func (*CommentOnColumn) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_aabab53a2111ee03, []int{14}
+	return fileDescriptor_ddl_events_7e7f11b9ac9cec04, []int{14}
 }
 func (m *CommentOnColumn) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -621,7 +621,7 @@ func (m *CommentOnDatabase) Reset()         { *m = CommentOnDatabase{} }
 func (m *CommentOnDatabase) String() string { return proto.CompactTextString(m) }
 func (*CommentOnDatabase) ProtoMessage()    {}
 func (*CommentOnDatabase) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_aabab53a2111ee03, []int{15}
+	return fileDescriptor_ddl_events_7e7f11b9ac9cec04, []int{15}
 }
 func (m *CommentOnDatabase) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -662,7 +662,7 @@ func (m *CommentOnTable) Reset()         { *m = CommentOnTable{} }
 func (m *CommentOnTable) String() string { return proto.CompactTextString(m) }
 func (*CommentOnTable) ProtoMessage()    {}
 func (*CommentOnTable) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_aabab53a2111ee03, []int{16}
+	return fileDescriptor_ddl_events_7e7f11b9ac9cec04, []int{16}
 }
 func (m *CommentOnTable) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -705,7 +705,7 @@ func (m *CommentOnIndex) Reset()         { *m = CommentOnIndex{} }
 func (m *CommentOnIndex) String() string { return proto.CompactTextString(m) }
 func (*CommentOnIndex) ProtoMessage()    {}
 func (*CommentOnIndex) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_aabab53a2111ee03, []int{17}
+	return fileDescriptor_ddl_events_7e7f11b9ac9cec04, []int{17}
 }
 func (m *CommentOnIndex) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -746,7 +746,7 @@ func (m *CreateIndex) Reset()         { *m = CreateIndex{} }
 func (m *CreateIndex) String() string { return proto.CompactTextString(m) }
 func (*CreateIndex) ProtoMessage()    {}
 func (*CreateIndex) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_aabab53a2111ee03, []int{18}
+	return fileDescriptor_ddl_events_7e7f11b9ac9cec04, []int{18}
 }
 func (m *CreateIndex) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -789,7 +789,7 @@ func (m *DropIndex) Reset()         { *m = DropIndex{} }
 func (m *DropIndex) String() string { return proto.CompactTextString(m) }
 func (*DropIndex) ProtoMessage()    {}
 func (*DropIndex) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_aabab53a2111ee03, []int{19}
+	return fileDescriptor_ddl_events_7e7f11b9ac9cec04, []int{19}
 }
 func (m *DropIndex) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -830,7 +830,7 @@ func (m *AlterIndex) Reset()         { *m = AlterIndex{} }
 func (m *AlterIndex) String() string { return proto.CompactTextString(m) }
 func (*AlterIndex) ProtoMessage()    {}
 func (*AlterIndex) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_aabab53a2111ee03, []int{20}
+	return fileDescriptor_ddl_events_7e7f11b9ac9cec04, []int{20}
 }
 func (m *AlterIndex) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -871,7 +871,7 @@ func (m *CreateView) Reset()         { *m = CreateView{} }
 func (m *CreateView) String() string { return proto.CompactTextString(m) }
 func (*CreateView) ProtoMessage()    {}
 func (*CreateView) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_aabab53a2111ee03, []int{21}
+	return fileDescriptor_ddl_events_7e7f11b9ac9cec04, []int{21}
 }
 func (m *CreateView) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -910,7 +910,7 @@ func (m *DropView) Reset()         { *m = DropView{} }
 func (m *DropView) String() string { return proto.CompactTextString(m) }
 func (*DropView) ProtoMessage()    {}
 func (*DropView) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_aabab53a2111ee03, []int{22}
+	return fileDescriptor_ddl_events_7e7f11b9ac9cec04, []int{22}
 }
 func (m *DropView) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -949,7 +949,7 @@ func (m *CreateSequence) Reset()         { *m = CreateSequence{} }
 func (m *CreateSequence) String() string { return proto.CompactTextString(m) }
 func (*CreateSequence) ProtoMessage()    {}
 func (*CreateSequence) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_aabab53a2111ee03, []int{23}
+	return fileDescriptor_ddl_events_7e7f11b9ac9cec04, []int{23}
 }
 func (m *CreateSequence) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -986,7 +986,7 @@ func (m *DropSequence) Reset()         { *m = DropSequence{} }
 func (m *DropSequence) String() string { return proto.CompactTextString(m) }
 func (*DropSequence) ProtoMessage()    {}
 func (*DropSequence) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_aabab53a2111ee03, []int{24}
+	return fileDescriptor_ddl_events_7e7f11b9ac9cec04, []int{24}
 }
 func (m *DropSequence) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1023,7 +1023,7 @@ func (m *AlterSequence) Reset()         { *m = AlterSequence{} }
 func (m *AlterSequence) String() string { return proto.CompactTextString(m) }
 func (*AlterSequence) ProtoMessage()    {}
 func (*AlterSequence) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_aabab53a2111ee03, []int{25}
+	return fileDescriptor_ddl_events_7e7f11b9ac9cec04, []int{25}
 }
 func (m *AlterSequence) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1071,7 +1071,7 @@ func (m *CommonSchemaChangeEventDetails) Reset()         { *m = CommonSchemaChan
 func (m *CommonSchemaChangeEventDetails) String() string { return proto.CompactTextString(m) }
 func (*CommonSchemaChangeEventDetails) ProtoMessage()    {}
 func (*CommonSchemaChangeEventDetails) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_aabab53a2111ee03, []int{26}
+	return fileDescriptor_ddl_events_7e7f11b9ac9cec04, []int{26}
 }
 func (m *CommonSchemaChangeEventDetails) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1112,7 +1112,7 @@ func (m *ReverseSchemaChange) Reset()         { *m = ReverseSchemaChange{} }
 func (m *ReverseSchemaChange) String() string { return proto.CompactTextString(m) }
 func (*ReverseSchemaChange) ProtoMessage()    {}
 func (*ReverseSchemaChange) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_aabab53a2111ee03, []int{27}
+	return fileDescriptor_ddl_events_7e7f11b9ac9cec04, []int{27}
 }
 func (m *ReverseSchemaChange) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1148,7 +1148,7 @@ func (m *FinishSchemaChange) Reset()         { *m = FinishSchemaChange{} }
 func (m *FinishSchemaChange) String() string { return proto.CompactTextString(m) }
 func (*FinishSchemaChange) ProtoMessage()    {}
 func (*FinishSchemaChange) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_aabab53a2111ee03, []int{28}
+	return fileDescriptor_ddl_events_7e7f11b9ac9cec04, []int{28}
 }
 func (m *FinishSchemaChange) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1184,7 +1184,7 @@ func (m *FinishSchemaChangeRollback) Reset()         { *m = FinishSchemaChangeRo
 func (m *FinishSchemaChangeRollback) String() string { return proto.CompactTextString(m) }
 func (*FinishSchemaChangeRollback) ProtoMessage()    {}
 func (*FinishSchemaChangeRollback) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_aabab53a2111ee03, []int{29}
+	return fileDescriptor_ddl_events_7e7f11b9ac9cec04, []int{29}
 }
 func (m *FinishSchemaChangeRollback) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1223,7 +1223,7 @@ func (m *CreateType) Reset()         { *m = CreateType{} }
 func (m *CreateType) String() string { return proto.CompactTextString(m) }
 func (*CreateType) ProtoMessage()    {}
 func (*CreateType) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_aabab53a2111ee03, []int{30}
+	return fileDescriptor_ddl_events_7e7f11b9ac9cec04, []int{30}
 }
 func (m *CreateType) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1260,7 +1260,7 @@ func (m *DropType) Reset()         { *m = DropType{} }
 func (m *DropType) String() string { return proto.CompactTextString(m) }
 func (*DropType) ProtoMessage()    {}
 func (*DropType) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_aabab53a2111ee03, []int{31}
+	return fileDescriptor_ddl_events_7e7f11b9ac9cec04, []int{31}
 }
 func (m *DropType) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1297,7 +1297,7 @@ func (m *AlterType) Reset()         { *m = AlterType{} }
 func (m *AlterType) String() string { return proto.CompactTextString(m) }
 func (*AlterType) ProtoMessage()    {}
 func (*AlterType) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_aabab53a2111ee03, []int{32}
+	return fileDescriptor_ddl_events_7e7f11b9ac9cec04, []int{32}
 }
 func (m *AlterType) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1336,7 +1336,7 @@ func (m *RenameType) Reset()         { *m = RenameType{} }
 func (m *RenameType) String() string { return proto.CompactTextString(m) }
 func (*RenameType) ProtoMessage()    {}
 func (*RenameType) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_aabab53a2111ee03, []int{33}
+	return fileDescriptor_ddl_events_7e7f11b9ac9cec04, []int{33}
 }
 func (m *RenameType) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1377,7 +1377,7 @@ func (m *CreateStatistics) Reset()         { *m = CreateStatistics{} }
 func (m *CreateStatistics) String() string { return proto.CompactTextString(m) }
 func (*CreateStatistics) ProtoMessage()    {}
 func (*CreateStatistics) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_aabab53a2111ee03, []int{34}
+	return fileDescriptor_ddl_events_7e7f11b9ac9cec04, []int{34}
 }
 func (m *CreateStatistics) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1417,7 +1417,7 @@ func (m *UnsafeUpsertDescriptor) Reset()         { *m = UnsafeUpsertDescriptor{}
 func (m *UnsafeUpsertDescriptor) String() string { return proto.CompactTextString(m) }
 func (*UnsafeUpsertDescriptor) ProtoMessage()    {}
 func (*UnsafeUpsertDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_aabab53a2111ee03, []int{35}
+	return fileDescriptor_ddl_events_7e7f11b9ac9cec04, []int{35}
 }
 func (m *UnsafeUpsertDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1461,7 +1461,7 @@ func (m *UnsafeDeleteDescriptor) Reset()         { *m = UnsafeDeleteDescriptor{}
 func (m *UnsafeDeleteDescriptor) String() string { return proto.CompactTextString(m) }
 func (*UnsafeDeleteDescriptor) ProtoMessage()    {}
 func (*UnsafeDeleteDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_aabab53a2111ee03, []int{36}
+	return fileDescriptor_ddl_events_7e7f11b9ac9cec04, []int{36}
 }
 func (m *UnsafeDeleteDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1507,7 +1507,7 @@ func (m *UnsafeUpsertNamespaceEntry) Reset()         { *m = UnsafeUpsertNamespac
 func (m *UnsafeUpsertNamespaceEntry) String() string { return proto.CompactTextString(m) }
 func (*UnsafeUpsertNamespaceEntry) ProtoMessage()    {}
 func (*UnsafeUpsertNamespaceEntry) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_aabab53a2111ee03, []int{37}
+	return fileDescriptor_ddl_events_7e7f11b9ac9cec04, []int{37}
 }
 func (m *UnsafeUpsertNamespaceEntry) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1551,7 +1551,7 @@ func (m *UnsafeDeleteNamespaceEntry) Reset()         { *m = UnsafeDeleteNamespac
 func (m *UnsafeDeleteNamespaceEntry) String() string { return proto.CompactTextString(m) }
 func (*UnsafeDeleteNamespaceEntry) ProtoMessage()    {}
 func (*UnsafeDeleteNamespaceEntry) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ddl_events_aabab53a2111ee03, []int{38}
+	return fileDescriptor_ddl_events_7e7f11b9ac9cec04, []int{38}
 }
 func (m *UnsafeDeleteNamespaceEntry) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -11209,10 +11209,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("util/log/eventpb/ddl_events.proto", fileDescriptor_ddl_events_aabab53a2111ee03)
+	proto.RegisterFile("util/log/eventpb/ddl_events.proto", fileDescriptor_ddl_events_7e7f11b9ac9cec04)
 }
 
-var fileDescriptor_ddl_events_aabab53a2111ee03 = []byte{
+var fileDescriptor_ddl_events_7e7f11b9ac9cec04 = []byte{
 	// 1488 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xec, 0x5a, 0xcd, 0x6f, 0x1b, 0x45,
 	0x14, 0xcf, 0xae, 0xe3, 0xc4, 0x7e, 0xfe, 0x68, 0xb2, 0x69, 0x2b, 0xcb, 0x02, 0x3b, 0xac, 0x7a,

--- a/pkg/util/log/eventpb/events.pb.go
+++ b/pkg/util/log/eventpb/events.pb.go
@@ -33,7 +33,7 @@ func (m *CommonEventDetails) Reset()         { *m = CommonEventDetails{} }
 func (m *CommonEventDetails) String() string { return proto.CompactTextString(m) }
 func (*CommonEventDetails) ProtoMessage()    {}
 func (*CommonEventDetails) Descriptor() ([]byte, []int) {
-	return fileDescriptor_events_6670628996377969, []int{0}
+	return fileDescriptor_events_bc33ca9fad1c48ba, []int{0}
 }
 func (m *CommonEventDetails) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -78,7 +78,7 @@ func (m *CommonSQLEventDetails) Reset()         { *m = CommonSQLEventDetails{} }
 func (m *CommonSQLEventDetails) String() string { return proto.CompactTextString(m) }
 func (*CommonSQLEventDetails) ProtoMessage()    {}
 func (*CommonSQLEventDetails) Descriptor() ([]byte, []int) {
-	return fileDescriptor_events_6670628996377969, []int{1}
+	return fileDescriptor_events_bc33ca9fad1c48ba, []int{1}
 }
 func (m *CommonSQLEventDetails) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -599,10 +599,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("util/log/eventpb/events.proto", fileDescriptor_events_6670628996377969)
+	proto.RegisterFile("util/log/eventpb/events.proto", fileDescriptor_events_bc33ca9fad1c48ba)
 }
 
-var fileDescriptor_events_6670628996377969 = []byte{
+var fileDescriptor_events_bc33ca9fad1c48ba = []byte{
 	// 365 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x6c, 0x91, 0xc1, 0xaa, 0xd3, 0x40,
 	0x14, 0x86, 0x33, 0xde, 0x8b, 0x92, 0xe1, 0x5e, 0x95, 0xe0, 0x85, 0x50, 0x70, 0x52, 0xb2, 0xb1,

--- a/pkg/util/log/eventpb/misc_sql_events.pb.go
+++ b/pkg/util/log/eventpb/misc_sql_events.pb.go
@@ -34,7 +34,7 @@ func (m *SetClusterSetting) Reset()         { *m = SetClusterSetting{} }
 func (m *SetClusterSetting) String() string { return proto.CompactTextString(m) }
 func (*SetClusterSetting) ProtoMessage()    {}
 func (*SetClusterSetting) Descriptor() ([]byte, []int) {
-	return fileDescriptor_misc_sql_events_a7ef825afe3b6935, []int{0}
+	return fileDescriptor_misc_sql_events_6ec127076976da30, []int{0}
 }
 func (m *SetClusterSetting) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -425,10 +425,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("util/log/eventpb/misc_sql_events.proto", fileDescriptor_misc_sql_events_a7ef825afe3b6935)
+	proto.RegisterFile("util/log/eventpb/misc_sql_events.proto", fileDescriptor_misc_sql_events_6ec127076976da30)
 }
 
-var fileDescriptor_misc_sql_events_a7ef825afe3b6935 = []byte{
+var fileDescriptor_misc_sql_events_6ec127076976da30 = []byte{
 	// 327 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x84, 0xd0, 0x4d, 0x4b, 0x3a, 0x41,
 	0x1c, 0x07, 0xf0, 0x1d, 0xfd, 0xff, 0x8d, 0x46, 0x09, 0x5a, 0x0a, 0x16, 0xa1, 0x59, 0x91, 0x28,

--- a/pkg/util/log/eventpb/privilege_events.pb.go
+++ b/pkg/util/log/eventpb/privilege_events.pb.go
@@ -35,7 +35,7 @@ func (m *CommonSQLPrivilegeEventDetails) Reset()         { *m = CommonSQLPrivile
 func (m *CommonSQLPrivilegeEventDetails) String() string { return proto.CompactTextString(m) }
 func (*CommonSQLPrivilegeEventDetails) ProtoMessage()    {}
 func (*CommonSQLPrivilegeEventDetails) Descriptor() ([]byte, []int) {
-	return fileDescriptor_privilege_events_d0155a7b365833c5, []int{0}
+	return fileDescriptor_privilege_events_d93131cacd196a45, []int{0}
 }
 func (m *CommonSQLPrivilegeEventDetails) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -74,7 +74,7 @@ func (m *ChangeDatabasePrivilege) Reset()         { *m = ChangeDatabasePrivilege
 func (m *ChangeDatabasePrivilege) String() string { return proto.CompactTextString(m) }
 func (*ChangeDatabasePrivilege) ProtoMessage()    {}
 func (*ChangeDatabasePrivilege) Descriptor() ([]byte, []int) {
-	return fileDescriptor_privilege_events_d0155a7b365833c5, []int{1}
+	return fileDescriptor_privilege_events_d93131cacd196a45, []int{1}
 }
 func (m *ChangeDatabasePrivilege) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -113,7 +113,7 @@ func (m *ChangeTablePrivilege) Reset()         { *m = ChangeTablePrivilege{} }
 func (m *ChangeTablePrivilege) String() string { return proto.CompactTextString(m) }
 func (*ChangeTablePrivilege) ProtoMessage()    {}
 func (*ChangeTablePrivilege) Descriptor() ([]byte, []int) {
-	return fileDescriptor_privilege_events_d0155a7b365833c5, []int{2}
+	return fileDescriptor_privilege_events_d93131cacd196a45, []int{2}
 }
 func (m *ChangeTablePrivilege) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -152,7 +152,7 @@ func (m *ChangeSchemaPrivilege) Reset()         { *m = ChangeSchemaPrivilege{} }
 func (m *ChangeSchemaPrivilege) String() string { return proto.CompactTextString(m) }
 func (*ChangeSchemaPrivilege) ProtoMessage()    {}
 func (*ChangeSchemaPrivilege) Descriptor() ([]byte, []int) {
-	return fileDescriptor_privilege_events_d0155a7b365833c5, []int{3}
+	return fileDescriptor_privilege_events_d93131cacd196a45, []int{3}
 }
 func (m *ChangeSchemaPrivilege) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -191,7 +191,7 @@ func (m *ChangeTypePrivilege) Reset()         { *m = ChangeTypePrivilege{} }
 func (m *ChangeTypePrivilege) String() string { return proto.CompactTextString(m) }
 func (*ChangeTypePrivilege) ProtoMessage()    {}
 func (*ChangeTypePrivilege) Descriptor() ([]byte, []int) {
-	return fileDescriptor_privilege_events_d0155a7b365833c5, []int{4}
+	return fileDescriptor_privilege_events_d93131cacd196a45, []int{4}
 }
 func (m *ChangeTypePrivilege) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -230,7 +230,7 @@ func (m *AlterDatabaseOwner) Reset()         { *m = AlterDatabaseOwner{} }
 func (m *AlterDatabaseOwner) String() string { return proto.CompactTextString(m) }
 func (*AlterDatabaseOwner) ProtoMessage()    {}
 func (*AlterDatabaseOwner) Descriptor() ([]byte, []int) {
-	return fileDescriptor_privilege_events_d0155a7b365833c5, []int{5}
+	return fileDescriptor_privilege_events_d93131cacd196a45, []int{5}
 }
 func (m *AlterDatabaseOwner) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -269,7 +269,7 @@ func (m *AlterSchemaOwner) Reset()         { *m = AlterSchemaOwner{} }
 func (m *AlterSchemaOwner) String() string { return proto.CompactTextString(m) }
 func (*AlterSchemaOwner) ProtoMessage()    {}
 func (*AlterSchemaOwner) Descriptor() ([]byte, []int) {
-	return fileDescriptor_privilege_events_d0155a7b365833c5, []int{6}
+	return fileDescriptor_privilege_events_d93131cacd196a45, []int{6}
 }
 func (m *AlterSchemaOwner) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -308,7 +308,7 @@ func (m *AlterTypeOwner) Reset()         { *m = AlterTypeOwner{} }
 func (m *AlterTypeOwner) String() string { return proto.CompactTextString(m) }
 func (*AlterTypeOwner) ProtoMessage()    {}
 func (*AlterTypeOwner) Descriptor() ([]byte, []int) {
-	return fileDescriptor_privilege_events_d0155a7b365833c5, []int{7}
+	return fileDescriptor_privilege_events_d93131cacd196a45, []int{7}
 }
 func (m *AlterTypeOwner) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -347,7 +347,7 @@ func (m *AlterTableOwner) Reset()         { *m = AlterTableOwner{} }
 func (m *AlterTableOwner) String() string { return proto.CompactTextString(m) }
 func (*AlterTableOwner) ProtoMessage()    {}
 func (*AlterTableOwner) Descriptor() ([]byte, []int) {
-	return fileDescriptor_privilege_events_d0155a7b365833c5, []int{8}
+	return fileDescriptor_privilege_events_d93131cacd196a45, []int{8}
 }
 func (m *AlterTableOwner) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2611,10 +2611,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("util/log/eventpb/privilege_events.proto", fileDescriptor_privilege_events_d0155a7b365833c5)
+	proto.RegisterFile("util/log/eventpb/privilege_events.proto", fileDescriptor_privilege_events_d93131cacd196a45)
 }
 
-var fileDescriptor_privilege_events_d0155a7b365833c5 = []byte{
+var fileDescriptor_privilege_events_d93131cacd196a45 = []byte{
 	// 583 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xec, 0x96, 0x41, 0x6f, 0x12, 0x4f,
 	0x14, 0xc0, 0x77, 0x67, 0xff, 0x6d, 0xff, 0xbc, 0xd6, 0xaa, 0x63, 0x1b, 0x09, 0x89, 0x4b, 0xb3,

--- a/pkg/util/log/eventpb/role_events.pb.go
+++ b/pkg/util/log/eventpb/role_events.pb.go
@@ -32,7 +32,7 @@ func (m *CreateRole) Reset()         { *m = CreateRole{} }
 func (m *CreateRole) String() string { return proto.CompactTextString(m) }
 func (*CreateRole) ProtoMessage()    {}
 func (*CreateRole) Descriptor() ([]byte, []int) {
-	return fileDescriptor_role_events_ba060246133a76c4, []int{0}
+	return fileDescriptor_role_events_4e2bb77c7c1dbf21, []int{0}
 }
 func (m *CreateRole) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -69,7 +69,7 @@ func (m *DropRole) Reset()         { *m = DropRole{} }
 func (m *DropRole) String() string { return proto.CompactTextString(m) }
 func (*DropRole) ProtoMessage()    {}
 func (*DropRole) Descriptor() ([]byte, []int) {
-	return fileDescriptor_role_events_ba060246133a76c4, []int{1}
+	return fileDescriptor_role_events_4e2bb77c7c1dbf21, []int{1}
 }
 func (m *DropRole) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -108,7 +108,7 @@ func (m *AlterRole) Reset()         { *m = AlterRole{} }
 func (m *AlterRole) String() string { return proto.CompactTextString(m) }
 func (*AlterRole) ProtoMessage()    {}
 func (*AlterRole) Descriptor() ([]byte, []int) {
-	return fileDescriptor_role_events_ba060246133a76c4, []int{2}
+	return fileDescriptor_role_events_4e2bb77c7c1dbf21, []int{2}
 }
 func (m *AlterRole) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -904,10 +904,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("util/log/eventpb/role_events.proto", fileDescriptor_role_events_ba060246133a76c4)
+	proto.RegisterFile("util/log/eventpb/role_events.proto", fileDescriptor_role_events_4e2bb77c7c1dbf21)
 }
 
-var fileDescriptor_role_events_ba060246133a76c4 = []byte{
+var fileDescriptor_role_events_4e2bb77c7c1dbf21 = []byte{
 	// 340 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xdc, 0x93, 0x31, 0x4b, 0xf3, 0x40,
 	0x1c, 0xc6, 0x73, 0xed, 0x4b, 0xdb, 0xdc, 0x2b, 0x0e, 0x41, 0x21, 0x14, 0xbc, 0x94, 0x2c, 0x56,

--- a/pkg/util/log/eventpb/session_events.pb.go
+++ b/pkg/util/log/eventpb/session_events.pb.go
@@ -68,7 +68,7 @@ func (x AuthFailReason) String() string {
 	return proto.EnumName(AuthFailReason_name, int32(x))
 }
 func (AuthFailReason) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_session_events_c72e6f577bb945ef, []int{0}
+	return fileDescriptor_session_events_b1678b19750b168c, []int{0}
 }
 
 // CommonConnectionDetails are payload fields common to all
@@ -91,7 +91,7 @@ func (m *CommonConnectionDetails) Reset()         { *m = CommonConnectionDetails
 func (m *CommonConnectionDetails) String() string { return proto.CompactTextString(m) }
 func (*CommonConnectionDetails) ProtoMessage()    {}
 func (*CommonConnectionDetails) Descriptor() ([]byte, []int) {
-	return fileDescriptor_session_events_c72e6f577bb945ef, []int{0}
+	return fileDescriptor_session_events_b1678b19750b168c, []int{0}
 }
 func (m *CommonConnectionDetails) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -133,7 +133,7 @@ func (m *CommonSessionDetails) Reset()         { *m = CommonSessionDetails{} }
 func (m *CommonSessionDetails) String() string { return proto.CompactTextString(m) }
 func (*CommonSessionDetails) ProtoMessage()    {}
 func (*CommonSessionDetails) Descriptor() ([]byte, []int) {
-	return fileDescriptor_session_events_c72e6f577bb945ef, []int{1}
+	return fileDescriptor_session_events_b1678b19750b168c, []int{1}
 }
 func (m *CommonSessionDetails) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -173,7 +173,7 @@ func (m *ClientConnectionStart) Reset()         { *m = ClientConnectionStart{} }
 func (m *ClientConnectionStart) String() string { return proto.CompactTextString(m) }
 func (*ClientConnectionStart) ProtoMessage()    {}
 func (*ClientConnectionStart) Descriptor() ([]byte, []int) {
-	return fileDescriptor_session_events_c72e6f577bb945ef, []int{2}
+	return fileDescriptor_session_events_b1678b19750b168c, []int{2}
 }
 func (m *ClientConnectionStart) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -215,7 +215,7 @@ func (m *ClientConnectionEnd) Reset()         { *m = ClientConnectionEnd{} }
 func (m *ClientConnectionEnd) String() string { return proto.CompactTextString(m) }
 func (*ClientConnectionEnd) ProtoMessage()    {}
 func (*ClientConnectionEnd) Descriptor() ([]byte, []int) {
-	return fileDescriptor_session_events_c72e6f577bb945ef, []int{3}
+	return fileDescriptor_session_events_b1678b19750b168c, []int{3}
 }
 func (m *ClientConnectionEnd) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -257,7 +257,7 @@ func (m *ClientSessionEnd) Reset()         { *m = ClientSessionEnd{} }
 func (m *ClientSessionEnd) String() string { return proto.CompactTextString(m) }
 func (*ClientSessionEnd) ProtoMessage()    {}
 func (*ClientSessionEnd) Descriptor() ([]byte, []int) {
-	return fileDescriptor_session_events_c72e6f577bb945ef, []int{4}
+	return fileDescriptor_session_events_b1678b19750b168c, []int{4}
 }
 func (m *ClientSessionEnd) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -303,7 +303,7 @@ func (m *ClientAuthenticationFailed) Reset()         { *m = ClientAuthentication
 func (m *ClientAuthenticationFailed) String() string { return proto.CompactTextString(m) }
 func (*ClientAuthenticationFailed) ProtoMessage()    {}
 func (*ClientAuthenticationFailed) Descriptor() ([]byte, []int) {
-	return fileDescriptor_session_events_c72e6f577bb945ef, []int{5}
+	return fileDescriptor_session_events_b1678b19750b168c, []int{5}
 }
 func (m *ClientAuthenticationFailed) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -345,7 +345,7 @@ func (m *ClientAuthenticationOk) Reset()         { *m = ClientAuthenticationOk{}
 func (m *ClientAuthenticationOk) String() string { return proto.CompactTextString(m) }
 func (*ClientAuthenticationOk) ProtoMessage()    {}
 func (*ClientAuthenticationOk) Descriptor() ([]byte, []int) {
-	return fileDescriptor_session_events_c72e6f577bb945ef, []int{6}
+	return fileDescriptor_session_events_b1678b19750b168c, []int{6}
 }
 func (m *ClientAuthenticationOk) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -389,7 +389,7 @@ func (m *ClientAuthenticationInfo) Reset()         { *m = ClientAuthenticationIn
 func (m *ClientAuthenticationInfo) String() string { return proto.CompactTextString(m) }
 func (*ClientAuthenticationInfo) ProtoMessage()    {}
 func (*ClientAuthenticationInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_session_events_c72e6f577bb945ef, []int{7}
+	return fileDescriptor_session_events_b1678b19750b168c, []int{7}
 }
 func (m *ClientAuthenticationInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2268,10 +2268,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("util/log/eventpb/session_events.proto", fileDescriptor_session_events_c72e6f577bb945ef)
+	proto.RegisterFile("util/log/eventpb/session_events.proto", fileDescriptor_session_events_b1678b19750b168c)
 }
 
-var fileDescriptor_session_events_c72e6f577bb945ef = []byte{
+var fileDescriptor_session_events_b1678b19750b168c = []byte{
 	// 745 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xec, 0x96, 0xb1, 0x4f, 0xdb, 0x5a,
 	0x14, 0xc6, 0xe3, 0x24, 0x24, 0x8f, 0x9b, 0xf7, 0x22, 0xeb, 0x12, 0x1e, 0x51, 0xf4, 0x9e, 0x83,

--- a/pkg/util/log/eventpb/zone_events.pb.go
+++ b/pkg/util/log/eventpb/zone_events.pb.go
@@ -34,7 +34,7 @@ func (m *CommonZoneConfigDetails) Reset()         { *m = CommonZoneConfigDetails
 func (m *CommonZoneConfigDetails) String() string { return proto.CompactTextString(m) }
 func (*CommonZoneConfigDetails) ProtoMessage()    {}
 func (*CommonZoneConfigDetails) Descriptor() ([]byte, []int) {
-	return fileDescriptor_zone_events_f93c01e91b797e1b, []int{0}
+	return fileDescriptor_zone_events_2d4516fba6e1eac7, []int{0}
 }
 func (m *CommonZoneConfigDetails) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -70,7 +70,7 @@ func (m *SetZoneConfig) Reset()         { *m = SetZoneConfig{} }
 func (m *SetZoneConfig) String() string { return proto.CompactTextString(m) }
 func (*SetZoneConfig) ProtoMessage()    {}
 func (*SetZoneConfig) Descriptor() ([]byte, []int) {
-	return fileDescriptor_zone_events_f93c01e91b797e1b, []int{1}
+	return fileDescriptor_zone_events_2d4516fba6e1eac7, []int{1}
 }
 func (m *SetZoneConfig) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -106,7 +106,7 @@ func (m *RemoveZoneConfig) Reset()         { *m = RemoveZoneConfig{} }
 func (m *RemoveZoneConfig) String() string { return proto.CompactTextString(m) }
 func (*RemoveZoneConfig) ProtoMessage()    {}
 func (*RemoveZoneConfig) Descriptor() ([]byte, []int) {
-	return fileDescriptor_zone_events_f93c01e91b797e1b, []int{2}
+	return fileDescriptor_zone_events_2d4516fba6e1eac7, []int{2}
 }
 func (m *RemoveZoneConfig) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -863,10 +863,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("util/log/eventpb/zone_events.proto", fileDescriptor_zone_events_f93c01e91b797e1b)
+	proto.RegisterFile("util/log/eventpb/zone_events.proto", fileDescriptor_zone_events_2d4516fba6e1eac7)
 }
 
-var fileDescriptor_zone_events_f93c01e91b797e1b = []byte{
+var fileDescriptor_zone_events_2d4516fba6e1eac7 = []byte{
 	// 342 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xec, 0x92, 0x41, 0x4a, 0xc3, 0x40,
 	0x14, 0x86, 0x33, 0x0d, 0xb4, 0x38, 0x55, 0x91, 0x20, 0x58, 0x0a, 0x4e, 0x4a, 0x16, 0x52, 0x41,

--- a/pkg/util/log/logpb/log.pb.go
+++ b/pkg/util/log/logpb/log.pb.go
@@ -77,7 +77,7 @@ func (x Severity) String() string {
 	return proto.EnumName(Severity_name, int32(x))
 }
 func (Severity) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_log_1138047630abb4e3, []int{0}
+	return fileDescriptor_log_cdb914dacde7ffc4, []int{0}
 }
 
 // Channel is the logical logging channel on which a message is sent.
@@ -234,7 +234,7 @@ func (x Channel) String() string {
 	return proto.EnumName(Channel_name, int32(x))
 }
 func (Channel) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_log_1138047630abb4e3, []int{1}
+	return fileDescriptor_log_cdb914dacde7ffc4, []int{1}
 }
 
 // Entry represents a cockroach log entry in the following two cases:
@@ -283,7 +283,7 @@ func (m *Entry) Reset()         { *m = Entry{} }
 func (m *Entry) String() string { return proto.CompactTextString(m) }
 func (*Entry) ProtoMessage()    {}
 func (*Entry) Descriptor() ([]byte, []int) {
-	return fileDescriptor_log_1138047630abb4e3, []int{0}
+	return fileDescriptor_log_cdb914dacde7ffc4, []int{0}
 }
 func (m *Entry) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -322,7 +322,7 @@ func (m *FileDetails) Reset()         { *m = FileDetails{} }
 func (m *FileDetails) String() string { return proto.CompactTextString(m) }
 func (*FileDetails) ProtoMessage()    {}
 func (*FileDetails) Descriptor() ([]byte, []int) {
-	return fileDescriptor_log_1138047630abb4e3, []int{1}
+	return fileDescriptor_log_cdb914dacde7ffc4, []int{1}
 }
 func (m *FileDetails) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -358,7 +358,7 @@ func (m *FileInfo) Reset()         { *m = FileInfo{} }
 func (m *FileInfo) String() string { return proto.CompactTextString(m) }
 func (*FileInfo) ProtoMessage()    {}
 func (*FileInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_log_1138047630abb4e3, []int{2}
+	return fileDescriptor_log_cdb914dacde7ffc4, []int{2}
 }
 func (m *FileInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1364,9 +1364,9 @@ var (
 	ErrIntOverflowLog   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("util/log/logpb/log.proto", fileDescriptor_log_1138047630abb4e3) }
+func init() { proto.RegisterFile("util/log/logpb/log.proto", fileDescriptor_log_cdb914dacde7ffc4) }
 
-var fileDescriptor_log_1138047630abb4e3 = []byte{
+var fileDescriptor_log_cdb914dacde7ffc4 = []byte{
 	// 682 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x6c, 0x53, 0xd1, 0x6e, 0xf3, 0x34,
 	0x18, 0x6d, 0x9a, 0xa4, 0x49, 0xbe, 0xfe, 0x9a, 0x8c, 0x35, 0xa4, 0xc0, 0x46, 0x56, 0x4d, 0x48,

--- a/pkg/util/metric/metric.pb.go
+++ b/pkg/util/metric/metric.pb.go
@@ -88,7 +88,7 @@ func (x *Unit) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (Unit) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_metric_b503c306ceb5c7a7, []int{0}
+	return fileDescriptor_metric_8c37a0980d6f0be7, []int{0}
 }
 
 // metric.LabelPair is a proxy for io.prometheus.client.LabelPair.
@@ -106,7 +106,7 @@ func (m *LabelPair) Reset()         { *m = LabelPair{} }
 func (m *LabelPair) String() string { return proto.CompactTextString(m) }
 func (*LabelPair) ProtoMessage()    {}
 func (*LabelPair) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metric_b503c306ceb5c7a7, []int{0}
+	return fileDescriptor_metric_8c37a0980d6f0be7, []int{0}
 }
 func (m *LabelPair) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -147,7 +147,7 @@ func (m *Metadata) Reset()         { *m = Metadata{} }
 func (m *Metadata) String() string { return proto.CompactTextString(m) }
 func (*Metadata) ProtoMessage()    {}
 func (*Metadata) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metric_b503c306ceb5c7a7, []int{1}
+	return fileDescriptor_metric_8c37a0980d6f0be7, []int{1}
 }
 func (m *Metadata) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -755,9 +755,9 @@ var (
 	ErrIntOverflowMetric   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("util/metric/metric.proto", fileDescriptor_metric_b503c306ceb5c7a7) }
+func init() { proto.RegisterFile("util/metric/metric.proto", fileDescriptor_metric_8c37a0980d6f0be7) }
 
-var fileDescriptor_metric_b503c306ceb5c7a7 = []byte{
+var fileDescriptor_metric_8c37a0980d6f0be7 = []byte{
 	// 429 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x74, 0x90, 0x41, 0x8b, 0xd3, 0x40,
 	0x14, 0xc7, 0x33, 0x69, 0xda, 0xdd, 0xbe, 0xea, 0x3a, 0x0e, 0x2b, 0x0c, 0x2b, 0xc4, 0xb0, 0xa0,

--- a/pkg/util/optional/optional.pb.go
+++ b/pkg/util/optional/optional.pb.go
@@ -37,7 +37,7 @@ type Uint struct {
 func (m *Uint) Reset()      { *m = Uint{} }
 func (*Uint) ProtoMessage() {}
 func (*Uint) Descriptor() ([]byte, []int) {
-	return fileDescriptor_optional_f4a12db9d9a11104, []int{0}
+	return fileDescriptor_optional_54aad6c1a90b0a1e, []int{0}
 }
 func (m *Uint) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -75,7 +75,7 @@ type Duration struct {
 func (m *Duration) Reset()      { *m = Duration{} }
 func (*Duration) ProtoMessage() {}
 func (*Duration) Descriptor() ([]byte, []int) {
-	return fileDescriptor_optional_f4a12db9d9a11104, []int{1}
+	return fileDescriptor_optional_54aad6c1a90b0a1e, []int{1}
 }
 func (m *Duration) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -453,10 +453,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("util/optional/optional.proto", fileDescriptor_optional_f4a12db9d9a11104)
+	proto.RegisterFile("util/optional/optional.proto", fileDescriptor_optional_54aad6c1a90b0a1e)
 }
 
-var fileDescriptor_optional_f4a12db9d9a11104 = []byte{
+var fileDescriptor_optional_54aad6c1a90b0a1e = []byte{
 	// 229 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x92, 0x29, 0x2d, 0xc9, 0xcc,
 	0xd1, 0xcf, 0x2f, 0x28, 0xc9, 0xcc, 0xcf, 0x4b, 0x44, 0x30, 0xf4, 0x0a, 0x8a, 0xf2, 0x4b, 0xf2,

--- a/pkg/util/protoutil/clone.pb.go
+++ b/pkg/util/protoutil/clone.pb.go
@@ -31,7 +31,7 @@ func (m *RecursiveAndUncloneable) Reset()         { *m = RecursiveAndUncloneable
 func (m *RecursiveAndUncloneable) String() string { return proto.CompactTextString(m) }
 func (*RecursiveAndUncloneable) ProtoMessage()    {}
 func (*RecursiveAndUncloneable) Descriptor() ([]byte, []int) {
-	return fileDescriptor_clone_96c900215ff8e4e9, []int{0}
+	return fileDescriptor_clone_e4042f116845b24f, []int{0}
 }
 func (m *RecursiveAndUncloneable) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -350,9 +350,9 @@ var (
 	ErrIntOverflowClone   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("util/protoutil/clone.proto", fileDescriptor_clone_96c900215ff8e4e9) }
+func init() { proto.RegisterFile("util/protoutil/clone.proto", fileDescriptor_clone_e4042f116845b24f) }
 
-var fileDescriptor_clone_96c900215ff8e4e9 = []byte{
+var fileDescriptor_clone_e4042f116845b24f = []byte{
 	// 226 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x92, 0x2a, 0x2d, 0xc9, 0xcc,
 	0xd1, 0x2f, 0x28, 0xca, 0x2f, 0xc9, 0x07, 0xb3, 0x92, 0x73, 0xf2, 0xf3, 0x52, 0xf5, 0xc0, 0x7c,

--- a/pkg/util/tracing/tracingpb/recorded_span.pb.go
+++ b/pkg/util/tracing/tracingpb/recorded_span.pb.go
@@ -39,7 +39,7 @@ func (m *LogRecord) Reset()         { *m = LogRecord{} }
 func (m *LogRecord) String() string { return proto.CompactTextString(m) }
 func (*LogRecord) ProtoMessage()    {}
 func (*LogRecord) Descriptor() ([]byte, []int) {
-	return fileDescriptor_recorded_span_00644d603767e262, []int{0}
+	return fileDescriptor_recorded_span_91eb39344bb7b1f1, []int{0}
 }
 func (m *LogRecord) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -73,7 +73,7 @@ func (m *LogRecord_Field) Reset()         { *m = LogRecord_Field{} }
 func (m *LogRecord_Field) String() string { return proto.CompactTextString(m) }
 func (*LogRecord_Field) ProtoMessage()    {}
 func (*LogRecord_Field) Descriptor() ([]byte, []int) {
-	return fileDescriptor_recorded_span_00644d603767e262, []int{0, 0}
+	return fileDescriptor_recorded_span_91eb39344bb7b1f1, []int{0, 0}
 }
 func (m *LogRecord_Field) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -142,7 +142,7 @@ type RecordedSpan struct {
 func (m *RecordedSpan) Reset()      { *m = RecordedSpan{} }
 func (*RecordedSpan) ProtoMessage() {}
 func (*RecordedSpan) Descriptor() ([]byte, []int) {
-	return fileDescriptor_recorded_span_00644d603767e262, []int{1}
+	return fileDescriptor_recorded_span_91eb39344bb7b1f1, []int{1}
 }
 func (m *RecordedSpan) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -185,7 +185,7 @@ func (m *NormalizedSpan) Reset()         { *m = NormalizedSpan{} }
 func (m *NormalizedSpan) String() string { return proto.CompactTextString(m) }
 func (*NormalizedSpan) ProtoMessage()    {}
 func (*NormalizedSpan) Descriptor() ([]byte, []int) {
-	return fileDescriptor_recorded_span_00644d603767e262, []int{2}
+	return fileDescriptor_recorded_span_91eb39344bb7b1f1, []int{2}
 }
 func (m *NormalizedSpan) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1828,10 +1828,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("util/tracing/tracingpb/recorded_span.proto", fileDescriptor_recorded_span_00644d603767e262)
+	proto.RegisterFile("util/tracing/tracingpb/recorded_span.proto", fileDescriptor_recorded_span_91eb39344bb7b1f1)
 }
 
-var fileDescriptor_recorded_span_00644d603767e262 = []byte{
+var fileDescriptor_recorded_span_91eb39344bb7b1f1 = []byte{
 	// 668 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xa4, 0x93, 0xcd, 0x6e, 0xd3, 0x4e,
 	0x14, 0xc5, 0xe3, 0xc4, 0xf9, 0xba, 0x89, 0xfa, 0xaf, 0xe6, 0xdf, 0x85, 0x1b, 0x21, 0xbb, 0x2a,

--- a/pkg/util/unresolved_addr.pb.go
+++ b/pkg/util/unresolved_addr.pb.go
@@ -29,7 +29,7 @@ type UnresolvedAddr struct {
 func (m *UnresolvedAddr) Reset()      { *m = UnresolvedAddr{} }
 func (*UnresolvedAddr) ProtoMessage() {}
 func (*UnresolvedAddr) Descriptor() ([]byte, []int) {
-	return fileDescriptor_unresolved_addr_d5da3e94d4806572, []int{0}
+	return fileDescriptor_unresolved_addr_5a54c22f2a6fdd9e, []int{0}
 }
 func (m *UnresolvedAddr) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -359,10 +359,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("util/unresolved_addr.proto", fileDescriptor_unresolved_addr_d5da3e94d4806572)
+	proto.RegisterFile("util/unresolved_addr.proto", fileDescriptor_unresolved_addr_5a54c22f2a6fdd9e)
 }
 
-var fileDescriptor_unresolved_addr_d5da3e94d4806572 = []byte{
+var fileDescriptor_unresolved_addr_5a54c22f2a6fdd9e = []byte{
 	// 193 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x92, 0x2a, 0x2d, 0xc9, 0xcc,
 	0xd1, 0x2f, 0xcd, 0x2b, 0x4a, 0x2d, 0xce, 0xcf, 0x29, 0x4b, 0x4d, 0x89, 0x4f, 0x4c, 0x49, 0x29,


### PR DESCRIPTION
The old version of `protobuf` that we had doesn't contain some utilities
that we need for Bazel (namely, the file `protobuf_deps.bzl`), so move
to a more recent version. Also update `WORKSPACE` so that our Bazel
build uses the same version of `protobuf`, and point to our fork rather
than upstream.

Fixes #58227.

Release note (general change): Upgrade to v3.9.2 of `protobuf` to consume new changes for Bazel.