### PR TITLE
build: assert minimum bazel version in use

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -74,6 +74,11 @@ go_rules_dependencies()
 
 go_register_toolchains(go_version = "1.15.6")
 
+# NB: @bazel_skylib comes from go_rules_dependencies().
+load("@bazel_skylib//lib:versions.bzl", "versions")
+
+versions.check(minimum_bazel_version = "3.5.0")
+
 # Load gazelle dependencies.
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
 


### PR DESCRIPTION
Use `bazel_skylib`'s built-in functionality to assert the minimum
supported Bazel version. We could also use `.bazelversion` to specify an
*exact* version that must be used, but that seems unnecessarily
restrictive.

v3.5.0 was arbitrarily chosen as being probably "recent enough", but I
did verify that a build does work with that version of Bazel.

Fixes #56059.

Release note: None