### PR TITLE
make: fix kerberos build on gcc10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -625,8 +625,9 @@ $(KRB5_DIR)/Makefile: $(C_DEPS_DIR)/krb5-rebuild $(KRB5_SRC_DIR)/src/configure
 	mkdir -p $(KRB5_DIR)
 	@# NOTE: If you change the configure flags below, bump the version in
 	@# $(C_DEPS_DIR)/krb5-rebuild. See above for rationale.
-	@# If CFLAGS is set to -g1 then make will fail. Use "env -" to clear the environment.
-	cd $(KRB5_DIR) && env -u CFLAGS -u CXXFLAGS $(KRB5_SRC_DIR)/src/configure $(xconfigure-flags) --enable-static --disable-shared
+	@# If CFLAGS is set to -g1 then make will fail.
+	@# We specify -fcommon to get around duplicate definition errors in recent gcc.
+	cd $(KRB5_DIR) && env -u CXXFLAGS CFLAGS="-fcommon"  $(KRB5_SRC_DIR)/src/configure $(xconfigure-flags) --enable-static --disable-shared
 
 $(PROTOBUF_DIR)/Makefile: $(C_DEPS_DIR)/protobuf-rebuild | bin/.submodules-initialized
 	rm -rf $(PROTOBUF_DIR)

--- a/c-deps/krb5-rebuild
+++ b/c-deps/krb5-rebuild
@@ -1,4 +1,4 @@
 Bump the version below when changing krb5 configure flags. Search for "BUILD
 ARTIFACT CACHING" in build/common.mk for rationale.
 
-2
+3


### PR DESCRIPTION
gcc-10 switched the default to -fno-common, which makes kerberos fail to
build with --enable-static because of duplicate definitions.

Fixes #49734

Release note (build change): CRDB now builds on Ubuntu 20.10 and other
distos using gcc-10.