### PR TITLE
tabledesc: omit implicit columns from auto-generated index names

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
@@ -57,13 +57,13 @@ CREATE TABLE public.t (
   c INT8 NULL,
   d INT8 NULL,
   CONSTRAINT "primary" PRIMARY KEY (pk ASC),
-  INDEX t_a_b_idx (b ASC) PARTITION BY LIST (a) (
+  INDEX t_b_idx (b ASC) PARTITION BY LIST (a) (
     PARTITION b_implicit VALUES IN ((2))
   ),
-  UNIQUE INDEX t_a_c_key (c ASC) PARTITION BY LIST (a) (
+  UNIQUE INDEX t_c_key (c ASC) PARTITION BY LIST (a) (
     PARTITION c_implicit VALUES IN ((3))
   ),
-  INDEX t_d_a_b_c_idx (a ASC, b ASC, c ASC) PARTITION BY LIST (d) (
+  INDEX t_a_b_c_idx (a ASC, b ASC, c ASC) PARTITION BY LIST (d) (
     PARTITION a_b_c_implicit VALUES IN ((4))
   ),
   FAMILY fam_0_pk_a_b_c_d (pk, a, b, c, d)
@@ -87,13 +87,13 @@ CREATE TABLE public.t (
   c INT8 NULL,
   d INT8 NULL,
   CONSTRAINT "primary" PRIMARY KEY (pk ASC),
-  INDEX t_a_b_idx (b ASC) PARTITION BY LIST (a) (
+  INDEX t_b_idx (b ASC) PARTITION BY LIST (a) (
     PARTITION b_implicit VALUES IN ((2))
   ),
-  UNIQUE INDEX t_a_c_key (c ASC) PARTITION BY LIST (a) (
+  UNIQUE INDEX t_c_key (c ASC) PARTITION BY LIST (a) (
     PARTITION c_implicit VALUES IN ((3))
   ),
-  INDEX t_d_a_b_c_idx (a ASC, b ASC, c ASC) PARTITION BY LIST (d) (
+  INDEX t_a_b_c_idx (a ASC, b ASC, c ASC) PARTITION BY LIST (d) (
     PARTITION a_b_c_implicit VALUES IN ((4))
   ),
   INDEX new_idx (d ASC) PARTITION BY LIST (a) (
@@ -124,19 +124,19 @@ SELECT index_name, column_name, implicit FROM crdb_internal.index_columns
 WHERE descriptor_name = 't' AND column_type = 'key'
 ORDER BY 1, 2
 ----
-index_name     column_name  implicit
-new_idx        a            true
-new_idx        d            false
-primary        a            true
-primary        pk           false
-t_a_b_idx      a            true
-t_a_b_idx      b            false
-t_a_c_key      a            true
-t_a_c_key      c            false
-t_d_a_b_c_idx  a            false
-t_d_a_b_c_idx  b            false
-t_d_a_b_c_idx  c            false
-t_d_a_b_c_idx  d            true
+index_name   column_name  implicit
+new_idx      a            true
+new_idx      d            false
+primary      a            true
+primary      pk           false
+t_a_b_c_idx  a            false
+t_a_b_c_idx  b            false
+t_a_b_c_idx  c            false
+t_a_b_c_idx  d            true
+t_b_idx      a            true
+t_b_idx      b            false
+t_c_key      a            true
+t_c_key      c            false
 
 query TTT colnames
 SELECT
@@ -145,12 +145,12 @@ FROM pg_indexes
 WHERE tablename = 't'
 ORDER BY 1, 2, 3
 ----
-tablename  indexname      indexdef
-t          new_idx        CREATE INDEX new_idx ON test.public.t USING btree (d ASC)
-t          primary        CREATE UNIQUE INDEX "primary" ON test.public.t USING btree (pk ASC)
-t          t_a_b_idx      CREATE INDEX t_a_b_idx ON test.public.t USING btree (b ASC)
-t          t_a_c_key      CREATE UNIQUE INDEX t_a_c_key ON test.public.t USING btree (c ASC)
-t          t_d_a_b_c_idx  CREATE INDEX t_d_a_b_c_idx ON test.public.t USING btree (a ASC, b ASC, c ASC)
+tablename  indexname    indexdef
+t          new_idx      CREATE INDEX new_idx ON test.public.t USING btree (d ASC)
+t          primary      CREATE UNIQUE INDEX "primary" ON test.public.t USING btree (pk ASC)
+t          t_a_b_c_idx  CREATE INDEX t_a_b_c_idx ON test.public.t USING btree (a ASC, b ASC, c ASC)
+t          t_b_idx      CREATE INDEX t_b_idx ON test.public.t USING btree (b ASC)
+t          t_c_key      CREATE UNIQUE INDEX t_c_key ON test.public.t USING btree (c ASC)
 
 statement error cannot ALTER INDEX PARTITION BY on index which already has implicit column partitioning
 ALTER INDEX new_idx PARTITION BY LIST (a) (

--- a/pkg/sql/catalog/tabledesc/structured.go
+++ b/pkg/sql/catalog/tabledesc/structured.go
@@ -362,7 +362,7 @@ func (desc *wrapper) AllNonDropColumns() []descpb.ColumnDescriptor {
 func allocateIndexName(tableDesc *Mutable, idx *descpb.IndexDescriptor) {
 	segments := make([]string, 0, len(idx.ColumnNames)+2)
 	segments = append(segments, tableDesc.Name)
-	segments = append(segments, idx.ColumnNames...)
+	segments = append(segments, idx.ColumnNames[idx.ExplicitColumnStartIdx():]...)
 	if idx.Unique {
 		segments = append(segments, "key")
 	} else {

--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key
@@ -572,13 +572,13 @@ t  CREATE TABLE public.t (
    y INT8 NOT NULL,
    z INT8 NULL,
    CONSTRAINT "primary" PRIMARY KEY (y ASC),
-   UNIQUE INDEX t_crdb_internal_x_shard_5_x_key (x ASC) USING HASH WITH BUCKET_COUNT = 5,
+   UNIQUE INDEX t_x_key (x ASC) USING HASH WITH BUCKET_COUNT = 5,
    INDEX i (z ASC),
    FAMILY fam_0_x_y_z_crdb_internal_x_shard_5 (x, y, z, crdb_internal_x_shard_5)
 )
 
 query III
-SELECT * FROM t@t_crdb_internal_x_shard_5_x_key
+SELECT * FROM t@t_x_key
 ----
 1 2 3
 
@@ -1187,7 +1187,7 @@ t  CREATE TABLE public.t (
    x INT8 NOT NULL,
    y INT8 NOT NULL,
    CONSTRAINT "primary" PRIMARY KEY (y ASC) USING HASH WITH BUCKET_COUNT = 2,
-   UNIQUE INDEX t_crdb_internal_x_shard_2_x_key (x ASC) USING HASH WITH BUCKET_COUNT = 2,
+   UNIQUE INDEX t_x_key (x ASC) USING HASH WITH BUCKET_COUNT = 2,
    FAMILY fam_0_x_y_crdb_internal_x_shard_2 (x, y, crdb_internal_x_shard_2, crdb_internal_y_shard_2)
 )
 

--- a/pkg/sql/logictest/testdata/logic_test/create_table
+++ b/pkg/sql/logictest/testdata/logic_test/create_table
@@ -321,7 +321,7 @@ SHOW CREATE TABLE like_hash
 ----
 like_hash  CREATE TABLE public.like_hash (
            a INT8 NULL,
-           INDEX like_hash_base_crdb_internal_a_shard_4_a_idx (a ASC) USING HASH WITH BUCKET_COUNT = 4,
+           INDEX like_hash_base_a_idx (a ASC) USING HASH WITH BUCKET_COUNT = 4,
            FAMILY "primary" (a, crdb_internal_a_shard_4, rowid)
 )
 

--- a/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
+++ b/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
@@ -79,16 +79,16 @@ CREATE TABLE specific_family (
     b INT,
     INDEX (b) USING HASH WITH BUCKET_COUNT=10,
     FAMILY "a_family" (a),
-    FAMILY "b_family" (b) 
+    FAMILY "b_family" (b)
 )
 
 query TT
-SHOW CREATE TABLE specific_family 
+SHOW CREATE TABLE specific_family
 ----
 specific_family  CREATE TABLE public.specific_family (
                  a INT8 NULL,
                  b INT8 NULL,
-                 INDEX specific_family_crdb_internal_b_shard_10_b_idx (b ASC) USING HASH WITH BUCKET_COUNT = 10,
+                 INDEX specific_family_b_idx (b ASC) USING HASH WITH BUCKET_COUNT = 10,
                  FAMILY a_family (a, rowid),
                  FAMILY b_family (b, crdb_internal_b_shard_10)
 )
@@ -102,7 +102,7 @@ SHOW CREATE TABLE sharded_secondary
 ----
 sharded_secondary  CREATE TABLE public.sharded_secondary (
                    a INT8 NULL,
-                   INDEX sharded_secondary_crdb_internal_a_shard_4_a_idx (a ASC) USING HASH WITH BUCKET_COUNT = 4,
+                   INDEX sharded_secondary_a_idx (a ASC) USING HASH WITH BUCKET_COUNT = 4,
                    FAMILY "primary" (a, crdb_internal_a_shard_4, rowid)
 )
 
@@ -147,7 +147,7 @@ SHOW CREATE TABLE sharded_secondary
 ----
 sharded_secondary  CREATE TABLE public.sharded_secondary (
                    a INT8 NULL,
-                   INDEX sharded_secondary_crdb_internal_a_shard_10_a_idx (a ASC) USING HASH WITH BUCKET_COUNT = 10,
+                   INDEX sharded_secondary_a_idx (a ASC) USING HASH WITH BUCKET_COUNT = 10,
                    FAMILY "primary" (a, rowid, crdb_internal_a_shard_10)
 )
 
@@ -163,26 +163,26 @@ SHOW CREATE TABLE sharded_secondary
 ----
 sharded_secondary  CREATE TABLE public.sharded_secondary (
                    a INT8 NULL,
-                   INDEX sharded_secondary_crdb_internal_a_shard_10_a_idx (a ASC) USING HASH WITH BUCKET_COUNT = 10,
-                   INDEX sharded_secondary_crdb_internal_a_shard_4_a_idx (a ASC) USING HASH WITH BUCKET_COUNT = 4,
+                   INDEX sharded_secondary_a_idx (a ASC) USING HASH WITH BUCKET_COUNT = 10,
+                   INDEX sharded_secondary_a_idx1 (a ASC) USING HASH WITH BUCKET_COUNT = 4,
                    FAMILY "primary" (a, rowid, crdb_internal_a_shard_10, crdb_internal_a_shard_4)
 )
 
 # Drop a sharded index and ensure that the shard column is dropped with it.
 statement ok
-DROP INDEX sharded_secondary_crdb_internal_a_shard_4_a_idx
+DROP INDEX sharded_secondary_a_idx
 
 query TT
 SHOW CREATE TABLE sharded_secondary
 ----
 sharded_secondary  CREATE TABLE public.sharded_secondary (
                    a INT8 NULL,
-                   INDEX sharded_secondary_crdb_internal_a_shard_10_a_idx (a ASC) USING HASH WITH BUCKET_COUNT = 10,
-                   FAMILY "primary" (a, rowid, crdb_internal_a_shard_10)
+                   INDEX sharded_secondary_a_idx1 (a ASC) USING HASH WITH BUCKET_COUNT = 4,
+                   FAMILY "primary" (a, rowid, crdb_internal_a_shard_4)
 )
 
 statement ok
-DROP INDEX sharded_secondary_crdb_internal_a_shard_10_a_idx 
+DROP INDEX sharded_secondary_a_idx1
 
 
 query TT
@@ -213,14 +213,14 @@ SELECT crdb_internal_a_shard_3 FROM sharded_secondary
 statement ok
 ROLLBACK
 
-statement ok 
+statement ok
 DROP INDEX sharded_secondary@idx
 
 # Ensure that multiple (> 2) identical indexes can be created.
 statement ok
 CREATE INDEX ON sharded_secondary (a) USING HASH WITH BUCKET_COUNT=10
 
-statement ok 
+statement ok
 CREATE INDEX ON sharded_secondary (a) USING HASH WITH BUCKET_COUNT=10
 
 statement ok
@@ -231,20 +231,20 @@ SHOW CREATE TABLE sharded_secondary
 ----
 sharded_secondary  CREATE TABLE public.sharded_secondary (
                    a INT8 NULL,
-                   INDEX sharded_secondary_crdb_internal_a_shard_10_a_idx (a ASC) USING HASH WITH BUCKET_COUNT = 10,
-                   INDEX sharded_secondary_crdb_internal_a_shard_10_a_idx1 (a ASC) USING HASH WITH BUCKET_COUNT = 10,
-                   INDEX sharded_secondary_crdb_internal_a_shard_10_a_idx2 (a ASC) USING HASH WITH BUCKET_COUNT = 10,
+                   INDEX sharded_secondary_a_idx (a ASC) USING HASH WITH BUCKET_COUNT = 10,
+                   INDEX sharded_secondary_a_idx1 (a ASC) USING HASH WITH BUCKET_COUNT = 10,
+                   INDEX sharded_secondary_a_idx2 (a ASC) USING HASH WITH BUCKET_COUNT = 10,
                    FAMILY "primary" (a, rowid, crdb_internal_a_shard_10)
 )
 
 
 # Ensure that the table descriptor was left in a "valid" state
-query I 
+query I
 SELECT count(*) FROM sharded_secondary
 ----
 6
 
-statement ok 
+statement ok
 CREATE INDEX ON sharded_primary (a) USING HASH WITH BUCKET_COUNT = 4;
 
 query TT
@@ -253,12 +253,12 @@ SHOW CREATE TABLE sharded_primary
 sharded_primary  CREATE TABLE public.sharded_primary (
                  a INT8 NOT NULL,
                  CONSTRAINT "primary" PRIMARY KEY (a ASC) USING HASH WITH BUCKET_COUNT = 10,
-                 INDEX sharded_primary_crdb_internal_a_shard_4_a_idx (a ASC) USING HASH WITH BUCKET_COUNT = 4,
+                 INDEX sharded_primary_a_idx (a ASC) USING HASH WITH BUCKET_COUNT = 4,
                  FAMILY "primary" (crdb_internal_a_shard_10, a, crdb_internal_a_shard_4)
 )
 
 statement ok
-DROP INDEX sharded_primary_crdb_internal_a_shard_4_a_idx
+DROP INDEX sharded_primary_a_idx
 
 statement ok
 SELECT count(*) FROM sharded_primary
@@ -281,12 +281,12 @@ SHOW CREATE TABLE sharded_primary
 sharded_primary  CREATE TABLE public.sharded_primary (
                  a INT8 NOT NULL,
                  CONSTRAINT "primary" PRIMARY KEY (a ASC) USING HASH WITH BUCKET_COUNT = 10,
-                 INDEX sharded_primary_crdb_internal_a_shard_10_a_idx (a ASC) USING HASH WITH BUCKET_COUNT = 10,
+                 INDEX sharded_primary_a_idx (a ASC) USING HASH WITH BUCKET_COUNT = 10,
                  FAMILY "primary" (crdb_internal_a_shard_10, a)
 )
 
 statement ok
-DROP INDEX sharded_primary_crdb_internal_a_shard_10_a_idx
+DROP INDEX sharded_primary_a_idx
 
 # Ensure that the table descriptor was left in a "valid" state
 statement ok
@@ -337,7 +337,7 @@ ALTER TABLE sharded_secondary ADD COLUMN d INT AS (mod(a, 100)) STORED
 statement error cannot create a sharded index on a computed column
 CREATE INDEX ON sharded_secondary (a, d) USING HASH WITH BUCKET_COUNT=12;
 
-statement ok 
+statement ok
 ROLLBACK TRANSACTION
 
 # Ensure that the shard column isn't dropped even if its being used by a non-sharded index
@@ -385,7 +385,7 @@ column_used_on_unsharded_create_table  CREATE TABLE public.column_used_on_unshar
 )
 
 statement ok
-DROP INDEX column_used_on_unsharded_create_table_crdb_internal_a_shard_10_idx 
+DROP INDEX column_used_on_unsharded_create_table_crdb_internal_a_shard_10_idx
 
 statement ok
 DROP TABLE sharded_primary
@@ -407,7 +407,7 @@ CREATE TABLE disabled (k INT, INDEX (k) USING HASH WITH BUCKET_COUNT = 10)
 
 # Ensure everything works with weird column names
 statement ok
-SET experimental_enable_hash_sharded_indexes = true 
+SET experimental_enable_hash_sharded_indexes = true
 
 statement ok
 CREATE TABLE weird_names (
@@ -527,7 +527,7 @@ rename_column  CREATE TABLE public.rename_column (
                c1 INT8 NOT NULL,
                c2 INT8 NULL,
                CONSTRAINT "primary" PRIMARY KEY (c0 ASC, c1 ASC) USING HASH WITH BUCKET_COUNT = 8,
-               INDEX rename_column_crdb_internal_c2_shard_8_c2_idx (c2 ASC) USING HASH WITH BUCKET_COUNT = 8,
+               INDEX rename_column_c2_idx (c2 ASC) USING HASH WITH BUCKET_COUNT = 8,
                FAMILY "primary" (c0, c1, c2, crdb_internal_c0_c1_shard_8, crdb_internal_c2_shard_8)
 )
 
@@ -549,7 +549,7 @@ rename_column  CREATE TABLE public.rename_column (
                c2 INT8 NOT NULL,
                c3 INT8 NULL,
                CONSTRAINT "primary" PRIMARY KEY (c1 ASC, c2 ASC) USING HASH WITH BUCKET_COUNT = 8,
-               INDEX rename_column_crdb_internal_c2_shard_8_c2_idx (c3 ASC) USING HASH WITH BUCKET_COUNT = 8,
+               INDEX rename_column_c2_idx (c3 ASC) USING HASH WITH BUCKET_COUNT = 8,
                FAMILY "primary" (c1, c2, c3, crdb_internal_c1_c2_shard_8, crdb_internal_c3_shard_8)
 )
 
@@ -570,7 +570,7 @@ rename_column  CREATE TABLE public.rename_column (
                c1 INT8 NOT NULL,
                c2 INT8 NULL,
                CONSTRAINT "primary" PRIMARY KEY (c0 ASC, c1 ASC) USING HASH WITH BUCKET_COUNT = 8,
-               INDEX rename_column_crdb_internal_c2_shard_8_c2_idx (c2 ASC) USING HASH WITH BUCKET_COUNT = 8,
+               INDEX rename_column_c2_idx (c2 ASC) USING HASH WITH BUCKET_COUNT = 8,
                FAMILY "primary" (c0, c1, c2, crdb_internal_c0_c1_shard_8, crdb_internal_c2_shard_8)
 )
 
@@ -599,10 +599,10 @@ CREATE TABLE IF NOT EXISTS drop_earlier_hash_column (
 );
 
 statement ok
-CREATE INDEX h1 ON drop_earlier_hash_column(j) USING HASH WITH BUCKET_COUNT = 8;
+CREATE INDEX h1 ON drop_earlier_hash_column(j) USING HASH WITH BUCKET_COUNT = 8
 
 statement ok
-CREATE INDEX h2 ON drop_earlier_hash_column(k) USING HASH WITH BUCKET_COUNT = 8;
+CREATE INDEX h2 ON drop_earlier_hash_column(k) USING HASH WITH BUCKET_COUNT = 8
 
 statement ok
-DROP INDEX h1;
+DROP INDEX h1


### PR DESCRIPTION
Release note (sql change): Omit the inclusion of implicit columns or
hash sharded index columns from automatically generated index names.