### PR TITLE
tracing,testutils: detect span leaks

### DIFF
--- a/pkg/ccl/importccl/import_processor.go
+++ b/pkg/ccl/importccl/import_processor.go
@@ -134,16 +134,15 @@ func (idp *readImportDataProcessor) Next() (rowenc.EncDatumRow, *execinfrapb.Pro
 	// Once the import is done, send back to the controller the serialized
 	// summary of the import operation. For more info see roachpb.BulkOpSummary.
 	countsBytes, err := protoutil.Marshal(idp.summary)
+	idp.MoveToDraining(err)
 	if err != nil {
-		idp.MoveToDraining(err)
 		return nil, idp.DrainHelper()
 	}
 
-	idp.MoveToDraining(nil /* err */)
 	return rowenc.EncDatumRow{
 		rowenc.DatumToEncDatum(types.Bytes, tree.NewDBytes(tree.DBytes(countsBytes))),
 		rowenc.DatumToEncDatum(types.Bytes, tree.NewDBytes(tree.DBytes([]byte{}))),
-	}, idp.DrainHelper()
+	}, nil
 }
 
 // ConsumerDone is part of the RowSource interface.

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -1264,6 +1264,11 @@ func (ts *TestServer) ExecutorConfig() interface{} {
 	return *ts.sqlServer.execCfg
 }
 
+// Tracer is part of the TestServerInterface
+func (ts *TestServer) Tracer() interface{} {
+	return ts.node.storeCfg.AmbientCtx.Tracer
+}
+
 // GCSystemLog deletes entries in the given system log table between
 // timestamp and timestampUpperBound if the server is the lease holder
 // for range 1.

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -1496,11 +1496,12 @@ func (ex *connExecutor) recordTransaction(ev txnEvent, implicit bool, txnStart t
 // child span if one is found. A context derived from parentCtx which
 // additionally contains the new span is also returned.
 func createRootOrChildSpan(
-	parentCtx context.Context, opName string, tr *tracing.Tracer,
+	parentCtx context.Context, opName string, tr *tracing.Tracer, os ...tracing.SpanOption,
 ) (context.Context, *tracing.Span) {
 	// WithForceRealSpan is used to support the use of session tracing, which
 	// may start recording on this span.
-	return tracing.EnsureChildSpan(parentCtx, tr, opName, tracing.WithForceRealSpan())
+	os = append(os, tracing.WithForceRealSpan())
+	return tracing.EnsureChildSpan(parentCtx, tr, opName, os...)
 }
 
 // logTraceAboveThreshold logs a span's recording if the duration is above a

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -644,8 +644,7 @@ func (r *DistSQLReceiver) Push(
 		if len(meta.TraceData) > 0 {
 			span := tracing.SpanFromContext(r.ctx)
 			if span == nil {
-				r.resultWriter.SetError(
-					errors.New("trying to ingest remote spans but there is no recording span set up"))
+				// Nothing to do.
 			} else if err := span.ImportRemoteSpans(meta.TraceData); err != nil {
 				r.resultWriter.SetError(errors.Errorf("error ingesting remote spans: %s", err))
 			}

--- a/pkg/sql/execinfra/processorsbase.go
+++ b/pkg/sql/execinfra/processorsbase.go
@@ -575,7 +575,7 @@ const (
 // returned from now on. In this state, the processor is expected to drain its
 // inputs (commonly by using DrainHelper()).
 //
-// If the processor has no input (ProcStateOpts.intputToDrain was not specified
+// If the processor has no input (ProcStateOpts.inputToDrain was not specified
 // at init() time), then we move straight to the StateTrailingMeta.
 //
 // An error can be optionally passed. It will be the first piece of metadata

--- a/pkg/sql/flowinfra/cluster_test.go
+++ b/pkg/sql/flowinfra/cluster_test.go
@@ -271,6 +271,7 @@ func TestClusterFlow(t *testing.T) {
 	metas = ignoreMisplannedRanges(metas)
 	metas = ignoreLeafTxnState(metas)
 	metas = ignoreMetricsMeta(metas)
+	metas = ignoreTraceData(metas)
 	if len(metas) != 0 {
 		t.Fatalf("unexpected metadata (%d): %+v", len(metas), metas)
 	}
@@ -321,6 +322,18 @@ func ignoreMetricsMeta(metas []execinfrapb.ProducerMetadata) []execinfrapb.Produ
 	res := make([]execinfrapb.ProducerMetadata, 0)
 	for _, m := range metas {
 		if m.Metrics == nil {
+			res = append(res, m)
+		}
+	}
+	return res
+}
+
+// ignoreTraceData takes a slice of metadata and returns the entries
+// excluding the ones with trace data.
+func ignoreTraceData(metas []execinfrapb.ProducerMetadata) []execinfrapb.ProducerMetadata {
+	res := make([]execinfrapb.ProducerMetadata, 0)
+	for _, m := range metas {
+		if m.TraceData == nil {
 			res = append(res, m)
 		}
 	}
@@ -545,6 +558,7 @@ func TestLimitedBufferingDeadlock(t *testing.T) {
 	metas = ignoreMisplannedRanges(metas)
 	metas = ignoreLeafTxnState(metas)
 	metas = ignoreMetricsMeta(metas)
+	metas = ignoreTraceData(metas)
 	if len(metas) != 0 {
 		t.Errorf("unexpected metadata (%d): %+v", len(metas), metas)
 	}
@@ -852,6 +866,7 @@ func BenchmarkInfrastructure(b *testing.B) {
 						metas = ignoreMisplannedRanges(metas)
 						metas = ignoreLeafTxnState(metas)
 						metas = ignoreMetricsMeta(metas)
+						metas = ignoreTraceData(metas)
 						if len(metas) != 0 {
 							b.Fatalf("unexpected metadata (%d): %+v", len(metas), metas)
 						}

--- a/pkg/sql/flowinfra/server_test.go
+++ b/pkg/sql/flowinfra/server_test.go
@@ -108,6 +108,7 @@ func TestServer(t *testing.T) {
 	}
 	metas = ignoreLeafTxnState(metas)
 	metas = ignoreMetricsMeta(metas)
+	metas = ignoreTraceData(metas)
 	if len(metas) != 0 {
 		t.Errorf("unexpected metadata: %v", metas)
 	}

--- a/pkg/sql/physicalplan/aggregator_funcs_test.go
+++ b/pkg/sql/physicalplan/aggregator_funcs_test.go
@@ -92,7 +92,7 @@ func runTestFlow(
 	for {
 		row, meta := rowBuf.Next()
 		if meta != nil {
-			if meta.LeafTxnFinalState != nil || meta.Metrics != nil {
+			if meta.LeafTxnFinalState != nil || meta.Metrics != nil || meta.TraceData != nil {
 				continue
 			}
 			t.Fatalf("unexpected metadata: %v", meta)

--- a/pkg/sql/txn_state.go
+++ b/pkg/sql/txn_state.go
@@ -157,7 +157,7 @@ func (ts *txnState) resetForNewSQLTxn(
 	// TODO(andrei): figure out how to close these spans on server shutdown? Ties
 	// into a larger discussion about how to drain SQL and rollback open txns.
 	opName := sqlTxnName
-	txnCtx, sp := createRootOrChildSpan(connCtx, opName, tranCtx.tracer)
+	txnCtx, sp := createRootOrChildSpan(connCtx, opName, tranCtx.tracer, tracing.WithBypassRegistry())
 	if txnType == implicitTxn {
 		sp.SetTag("implicit", "true")
 	}

--- a/pkg/testutils/serverutils/test_server_shim.go
+++ b/pkg/testutils/serverutils/test_server_shim.go
@@ -92,6 +92,9 @@ type TestServerInterface interface {
 	// The real return type is sql.ExecutorConfig.
 	ExecutorConfig() interface{}
 
+	// Tracer returns a *tracing.Tracer as an interface{}.
+	Tracer() interface{}
+
 	// GossipI returns the gossip used by the TestServer.
 	// The real return type is *gossip.Gossip.
 	GossipI() interface{}

--- a/pkg/testutils/testcluster/BUILD.bazel
+++ b/pkg/testutils/testcluster/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "//pkg/util/stop",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
+        "//pkg/util/tracing",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_logtags//:logtags",
     ],

--- a/pkg/util/tracing/span.go
+++ b/pkg/util/tracing/span.go
@@ -97,6 +97,10 @@ type SpanMeta struct {
 	Baggage map[string]string
 }
 
+func (sm *SpanMeta) String() string {
+	return fmt.Sprintf("[spanID: %d, traceID: %d]", sm.spanID, sm.traceID)
+}
+
 func (s *Span) isNoop() bool {
 	return s.crdb == nil && s.netTr == nil && s.ot == (otSpan{})
 }
@@ -172,8 +176,8 @@ func (s *Span) IsBlackHole() bool {
 // isNilOrNoop returns true if the Span context is either nil
 // or corresponds to a "no-op" Span. If this is true, any Span
 // derived from this context will be a "black hole Span".
-func (sc *SpanMeta) isNilOrNoop() bool {
-	return sc == nil || (sc.recordingType == RecordingOff && sc.shadowTracerType == "")
+func (sm *SpanMeta) isNilOrNoop() bool {
+	return sm == nil || (sm.recordingType == RecordingOff && sm.shadowTracerType == "")
 }
 
 // SpanStats are stats that can be added to a Span.

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -62,32 +62,30 @@ const (
 	modeBackground
 )
 
-// tracingMode informs the creation of noop spans
-// and the default recording mode of created spans.
+// tracingMode informs the creation of noop spans and the default recording mode
+// of created spans.
+//
+// If set to 'background', trace spans will be created for all operations, but
+// these will record sparse structured information, unless an operation
+// explicitly requests the verbose from. It's optimized for low overhead, and
+// powers fine-grained statistics and alerts.
+//
+// If set to 'legacy', trace spans will not be created by default. This is
+// unless an internal code path explicitly requests for it, or if an auxiliary
+// tracer (such as lightstep or zipkin) is configured. This tracing mode always
+// records in the verbose form. Using this mode has two effects: the
+// observability of the cluster may be degraded (as most trace spans are elided)
+// and where trace spans are created, they may consume large amounts of memory.
+//
+// Note that regardless of this setting, configuring an auxiliary trace sink
+// will cause verbose traces to be created for all operations, which may lead to
+// high memory consumption. It is not currently possible to send non-verbose
+// traces to auxiliary sinks.
 var tracingMode = settings.RegisterEnumSetting(
 	"trace.mode",
-	`configures the CockroachDB-internal tracing subsystem.
-
-If set to 'background', trace spans will be created for all operations, but
-these trace spans will only be recording sparse structured information,
-unless an operation explicitly requests verbose recording. This is
-optimized for low overhead, and powers fine-grained statistics and alerts.
-
-If set to 'legacy', trace spans will not be created (unless an
-auxiliary tracer such as Lightstep or Zipkin, is configured, or an
-internal code path explicitly requests a trace to be created) but
-when they are, they record verbose information. This has two effects:
-the observability of the cluster may be degraded (as some trace spans
-are elided) and where trace spans are created, they may consume large
-amounts of memory. This mode should not be used with auxiliary tracing
-sinks as that leads to expensive trace spans being created throughout.
-
-Note that regardless of this setting, configuring an auxiliary
-trace sink will cause verbose traces to be created for all
-operations, which may lead to high memory consumption. It is not
-currently possible to send non-verbose traces to auxiliary sinks.
-`,
-	"legacy",
+	"if set to 'background', traces will be created for all operations (in"+
+		"'legacy' mode it's created when explicitly requested or when auxiliary tracers are configured)",
+	"background",
 	map[int64]string{
 		int64(modeLegacy):     "legacy",
 		int64(modeBackground): "background",


### PR DESCRIPTION
With always-on tracing, we're maintaining in-memory registry of active
spans (#58490). Spans are added and removed from this registry when
they're Start()-ed and Finish()-ed. Spans that not explicitly finished
(typically using `defer sp.Finish()`) are now a resource-leak, as they
take up room in the registry. We'll want to find instances of this leak
as soon as they crop up.

To that end we add a check in our TestCluster.Stop codepaths that
asserts against the registry being empty. This should give us wide
coverage given it's usage throughout. We expect this change to capture
the cases described in #58721.

---

This check is currently failing, given we're actually leaking spans in
`txnState.resetForNewSQLTxn`. Fixing that doesn't look simple, it ties
into questions around draining SQL and rolling back open txns.

Release note: None