### PR TITLE
kvnemesis: fix and unskip TestKVNemesisMultiNode

### DIFF
--- a/pkg/kv/kvnemesis/kvnemesis_test.go
+++ b/pkg/kv/kvnemesis/kvnemesis_test.go
@@ -55,7 +55,6 @@ func TestKVNemesisSingleNode(t *testing.T) {
 
 func TestKVNemesisMultiNode(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	skip.WithIssue(t, 58624, "flaky test")
 	skip.UnderRace(t)
 
 	defer log.Scope(t).Close(t)

--- a/pkg/kv/kvnemesis/validator.go
+++ b/pkg/kv/kvnemesis/validator.go
@@ -310,7 +310,8 @@ func (v *validator) processOp(txnID *string, op Operation) {
 			// However, I think the right thing to do is sniff this inside the
 			// AdminMerge code and retry so the client never sees it. In the meantime,
 			// no-op. #44377
-		} else if resultIsError(t.Result, `merge failed: cannot merge range with non-voter replicas`) {
+		} else if resultIsError(t.Result,
+			`merge failed: cannot merge ranges when (rhs)|(lhs) is in a joint state or has learners`) {
 			// This operation executed concurrently with one that was changing
 			// replicas.
 		} else if resultIsError(t.Result, `merge failed: ranges not collocated`) {


### PR DESCRIPTION
Before this patch, #56197 broke this test because it changed a range
merge error string that let the KV nemesis validator ignore the error.
This patch updates the regexp the validator uses to match the error and
unskips the test.

Fixes #58624.

Release note: None