### PR TITLE
sql: support NOT VISIBLE in CREATE TABLE for user-defined hidden columns

### DIFF
--- a/docs/generated/sql/bnf/col_qualification.bnf
+++ b/docs/generated/sql/bnf/col_qualification.bnf
@@ -1,6 +1,7 @@
 col_qualification ::=
 	'CONSTRAINT' constraint_name 'NOT' 'NULL'
 	| 'CONSTRAINT' constraint_name 'NULL'
+	| 'CONSTRAINT' constraint_name 'NOT' 'VISIBLE'
 	| 'CONSTRAINT' constraint_name 'UNIQUE' opt_without_index
 	| 'CONSTRAINT' constraint_name 'PRIMARY' 'KEY'
 	| 'CONSTRAINT' constraint_name 'PRIMARY' 'KEY' 'USING' 'HASH' 'WITH' 'BUCKET_COUNT' '=' n_buckets
@@ -13,6 +14,7 @@ col_qualification ::=
 	| 'CONSTRAINT' constraint_name 'GENERATED_ALWAYS' 'ALWAYS' 'AS' '(' a_expr ')' 'VIRTUAL'
 	| 'NOT' 'NULL'
 	| 'NULL'
+	| 'NOT' 'VISIBLE'
 	| 'UNIQUE' opt_without_index
 	| 'PRIMARY' 'KEY'
 	| 'PRIMARY' 'KEY' 'USING' 'HASH' 'WITH' 'BUCKET_COUNT' '=' n_buckets

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -2110,6 +2110,7 @@ reserved_keyword ::=
 	| 'USER'
 	| 'USING'
 	| 'VARIADIC'
+	| 'VISIBLE'
 	| 'WHEN'
 	| 'WHERE'
 	| 'WINDOW'
@@ -2873,6 +2874,7 @@ create_as_constraint_elem ::=
 col_qualification_elem ::=
 	'NOT' 'NULL'
 	| 'NULL'
+	| 'NOT' 'VISIBLE'
 	| 'UNIQUE' opt_without_index
 	| 'PRIMARY' 'KEY'
 	| 'PRIMARY' 'KEY' 'USING' 'HASH' 'WITH' 'BUCKET_COUNT' '=' a_expr

--- a/pkg/sql/catalog/schemaexpr/column.go
+++ b/pkg/sql/catalog/schemaexpr/column.go
@@ -87,6 +87,9 @@ func FormatColumnForDisplay(
 	f.FormatNameP(&desc.Name)
 	f.WriteByte(' ')
 	f.WriteString(desc.Type.SQLString())
+	if desc.Hidden {
+		f.WriteString(" NOT VISIBLE")
+	}
 	if desc.Nullable {
 		f.WriteString(" NULL")
 	} else {

--- a/pkg/sql/catalog/tabledesc/table.go
+++ b/pkg/sql/catalog/tabledesc/table.go
@@ -69,6 +69,7 @@ func MakeColumnDefDescs(
 		Name:     string(d.Name),
 		Nullable: d.Nullable.Nullability != tree.NotNull && !d.PrimaryKey.IsPrimaryKey,
 		Virtual:  d.IsVirtual(),
+		Hidden:   d.Hidden,
 	}
 
 	// Validate and assign column type.

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1249,7 +1249,11 @@ func newTableDescIfAs(
 		for _, colRes := range resultColumns {
 			var d *tree.ColumnTableDef
 			var ok bool
-			var tableDef tree.TableDef = &tree.ColumnTableDef{Name: tree.Name(colRes.Name), Type: colRes.Typ}
+			var tableDef tree.TableDef = &tree.ColumnTableDef{
+				Name:   tree.Name(colRes.Name),
+				Type:   colRes.Typ,
+				Hidden: colRes.Hidden,
+			}
 			if d, ok = tableDef.(*tree.ColumnTableDef); !ok {
 				return nil, errors.Errorf("failed to cast type to ColumnTableDef\n")
 			}

--- a/pkg/sql/logictest/testdata/logic_test/hidden_columns
+++ b/pkg/sql/logictest/testdata/logic_test/hidden_columns
@@ -1,0 +1,123 @@
+statement ok
+CREATE TABLE t (x INT NOT VISIBLE);
+CREATE TABLE kv (
+    k INT PRIMARY KEY NOT VISIBLE,
+    v INT NOT VISIBLE
+  )
+
+# Verify that hidden columns can be explicitly inserted into.
+
+statement ok
+INSERT INTO t(x) VALUES (123)
+
+statement ok
+INSERT INTO kv(k,v) VALUES (123,456);
+
+# Verify that hidden columns cannot be implicitly inserted into
+
+statement error INSERT has more expressions than target columns, 1 expressions for 0 targets
+INSERT INTO t VALUES (123)
+
+statement error INSERT has more expressions than target columns, 2 expressions for 0 targets
+INSERT INTO kv VALUES (111, 222)
+
+# Verify the right columns are hidden.
+
+query TT
+SHOW CREATE TABLE t
+----
+t  CREATE TABLE public.t (FAMILY "primary" (x, rowid)
+)
+
+# Check that stars expand to no columns.
+
+query I
+SELECT 42, * FROM t
+----
+42
+
+query I
+SELECT 42, * FROM kv
+----
+42
+
+# Check that the hidden column can be selected explicitly.
+
+query II
+SELECT 42, x FROM t
+----
+42  123
+
+# Check that the hidden column can be renamed
+
+statement ok
+ALTER TABLE kv RENAME COLUMN v to x;
+
+query I
+SELECT x FROM t
+----
+123
+
+# Verify indexes can be created on hidden columns
+
+statement ok
+CREATE INDEX ON kv(x);
+
+# Check that the hidden column can be droped
+
+statement ok
+ALTER TABLE kv DROP COLUMN x;
+
+statement error column "x" does not exist
+SELECT x FROM kv;
+
+# adding a foreign key constraint on a hidden column
+
+statement ok
+CREATE TABLE t1(a INT, b INT, c INT NOT VISIBLE , PRIMARY KEY(b));
+CREATE TABLE t2(b INT NOT VISIBLE, c INT, d INT, PRIMARY KEY (d));
+CREATE TABLE t5(b INT NOT VISIBLE, c INT, d INT, PRIMARY KEY (d), FOREIGN KEY(b) REFERENCES t1(b));
+
+query TTTTB
+SHOW CONSTRAINTS FROM t2
+----
+t2 primary PRIMARY KEY PRIMARY KEY (d ASC) true
+
+statement ok
+ALTER TABLE t2 ADD FOREIGN KEY (b) REFERENCES t2
+
+query TTTTB
+SHOW CONSTRAINTS FROM t2
+----
+t2 fk_b_ref_t2 FOREIGN KEY  FOREIGN KEY (b) REFERENCES t2(d) true
+t2 primary     PRIMARY KEY  PRIMARY KEY (d ASC)              true
+
+# adding a foreign key constraint that references a hidden column
+
+statement ok
+CREATE TABLE t3(a INT, b INT NOT NULL, c INT NOT VISIBLE, PRIMARY KEY(c));
+CREATE TABLE t4(c INT, d INT, e INT NOT NULL NOT VISIBLE, PRIMARY KEY(d));
+CREATE TABLE t6(c INT, d INT, e INT NOT NULL NOT VISIBLE, PRIMARY KEY(d), FOREIGN KEY(c) REFERENCES t3(c));
+
+# ALTER PRIMARY KEY on a primary key with hidden columns
+
+statement ok
+ALTER TABLE t3 ALTER PRIMARY KEY USING COLUMNS(b);
+
+query TTTTB
+SHOW CONSTRAINTS FROM t3
+----
+t3 primary PRIMARY KEY PRIMARY KEY (b ASC) true
+
+query TTTTB
+SHOW CONSTRAINTS FROM t4
+----
+t4 primary PRIMARY KEY PRIMARY KEY (d ASC) true
+
+statement ok
+ALTER TABLE t4 ALTER PRIMARY KEY USING COLUMNS(e);
+
+query TTTTB
+SHOW CONSTRAINTS FROM t4
+----
+t4 t4_d_key UNIQUE UNIQUE (d ASC) true

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -200,6 +200,8 @@ func TestParse(t *testing.T) {
 		{`CREATE TABLE a (a INT8 DEFAULT 1 CONSTRAINT positive CHECK (a > 0))`},
 		{`CREATE TABLE a (a INT8 CONSTRAINT one DEFAULT 1 CONSTRAINT positive CHECK (a > 0))`},
 		{`CREATE TABLE a (a INT8 CONSTRAINT one CHECK (a > 0) CONSTRAINT two CHECK (a < 10))`},
+		{`CREATE TABLE a (b INT8 NOT VISIBLE)`},
+		{`CREATE TABLE a (b INT8 NOT VISIBLE NULL)`},
 		// "0" lost quotes previously.
 		{`CREATE TABLE a (b INT8, c STRING, PRIMARY KEY (b, c, "0"))`},
 		{`CREATE TABLE a (b INT8, c STRING, FOREIGN KEY (b) REFERENCES other)`},

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -690,7 +690,7 @@ func (u *sqlSymUnion) objectNamePrefixList() tree.ObjectNamePrefixList {
 %token <str> UNBOUNDED UNCOMMITTED UNION UNIQUE UNKNOWN UNLOGGED UNSPLIT
 %token <str> UPDATE UPSERT UNTIL USE USER USERS USING UUID
 
-%token <str> VALID VALIDATE VALUE VALUES VARBIT VARCHAR VARIADIC VIEW VARYING VIEWACTIVITY VIRTUAL
+%token <str> VALID VALIDATE VALUE VALUES VARBIT VARCHAR VARIADIC VIEW VARYING VIEWACTIVITY VIRTUAL VISIBLE
 
 %token <str> WHEN WHERE WINDOW WITH WITHIN WITHOUT WORK WRITE
 
@@ -5641,7 +5641,7 @@ alter_schema_stmt:
 //    CHECK ( <expr> )
 //
 // Column qualifiers:
-//   [CONSTRAINT <constraintname>] {NULL | NOT NULL | UNIQUE [WITHOUT INDEX] | PRIMARY KEY | CHECK (<expr>) | DEFAULT <expr>}
+//   [CONSTRAINT <constraintname>] {NULL | NOT NULL | NOT VISIBLE |UNIQUE [WITHOUT INDEX] | PRIMARY KEY | CHECK (<expr>) | DEFAULT <expr>}
 //   FAMILY <familyname>, CREATE [IF NOT EXISTS] FAMILY [<familyname>]
 //   REFERENCES <tablename> [( <colnames...> )] [ON DELETE {NO ACTION | RESTRICT}] [ON UPDATE {NO ACTION | RESTRICT}]
 //   COLLATE <collationname>
@@ -6093,6 +6093,10 @@ col_qualification_elem:
 | NULL
   {
     $$.val = tree.NullConstraint{}
+  }
+| NOT VISIBLE
+  {
+    $$.val = tree.HiddenConstraint{}
   }
 | UNIQUE opt_without_index
   {
@@ -12535,6 +12539,7 @@ reserved_keyword:
 | USER
 | USING
 | VARIADIC
+| VISIBLE
 | WHEN
 | WHERE
 | WINDOW

--- a/pkg/sql/sem/tree/pretty.go
+++ b/pkg/sql/sem/tree/pretty.go
@@ -1857,6 +1857,12 @@ func (node *ColumnTableDef) docRow(p *PrettyCfg) pretty.TableRow {
 			pretty.ConcatSpace(pretty.Keyword("DEFAULT"), p.Doc(node.DefaultExpr.Expr))))
 	}
 
+	// [NOT] VISIBLE constraint.
+	if node.Hidden {
+		hiddenConstraint := pretty.Keyword("NOT VISIBLE")
+		clauses = append(clauses, p.maybePrependConstraintName(&node.Nullable.ConstraintName, hiddenConstraint))
+	}
+
 	// NULL/NOT NULL constraint.
 	nConstraint := pretty.Nil
 	switch node.Nullable.Nullability {


### PR DESCRIPTION
Informs #53428 
Informs #58440

Release note (sql change): It is now possible to use the `NOT VISIBLE`
qualifier for new column definitions in CREATE TABLE. This causes the
column to become 'hidden'. Hiddens columns are not considered when
using `*` in SELECT clauses.

(Note that CockroachDB already supported hidden columns previously,
such as `rowid` which is added automatically when a table definition
has no PRIMARY KEY constraint. This change merely adds the opportunity
for end-users to define their own hidden columns.)

This feature is intended for use in combination with other features
related to geo-partitioning introduced in v21.1, to offer more control
about how geo-partitioning keys get exposed to client ORMs and other
automated tools that inspect the SQL schema.

