### PR TITLE
.github: improve issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,9 @@
 ---
-name: Bug or crash report
-about: Report unexpected behavior to help us improve
-
+name: 'Bug or crash report'
+title: ''
+about: 'Report unexpected behavior to help us improve'
+labels: 'C-bug'
+assignees: ''
 ---
 
 **Describe the problem**

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: CockroachDB Community Forum
+    url: https://forum.cockroachlabs.com/
+    about: "For general questions about CockroachDB"
+  - name: Enterprise Support
+    url: https://support.cockroachlabs.com
+    about: "Enterprise Support"

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,9 @@
 ---
-name: Feature request
-about: Suggest an idea for this project
-
+name: 'Feature request'
+title: ''
+about: 'Suggest an idea for this project'
+labels: 'C-enhancement'
+assignees: ''
 ---
 
 **Is your feature request related to a problem? Please describe.**

--- a/.github/ISSUE_TEMPLATE/performance-inquiry.md
+++ b/.github/ISSUE_TEMPLATE/performance-inquiry.md
@@ -1,7 +1,8 @@
 ---
-name: Performance inquiry
-about: You have a question about CockroachDB's performance and it is not a bug or
-  a feature request
+name: 'Performance inquiry'
+title: ''
+about: 'You have a question about CockroachDB's performance and it is not a bug or a feature request'
+labels: 'C-question'
 
 ---
 


### PR DESCRIPTION
Disable the blank issue template, add C-{bug,enhancement,question}
labels depending on the issue type, and suggest the community forum and
enterprise support as alternatives to consult.

You can see this in action [here](https://github.com/tbg/cockroach/issues/new/choose).

![image](https://user-images.githubusercontent.com/5076964/104440946-4b7d7a00-5593-11eb-85ec-e55c61312b61.png)

![image](https://user-images.githubusercontent.com/5076964/104440970-559f7880-5593-11eb-9d28-a02b20f36de5.png)

Release note: None