### PR TITLE
sql: remove stale comment

### DIFF
--- a/pkg/sql/region_util.go
+++ b/pkg/sql/region_util.go
@@ -276,8 +276,7 @@ func (p *planner) initializeMultiRegionDatabase(ctx context.Context, desc *dbdes
 	for _, region := range desc.RegionConfig.Regions {
 		regionLabels = append(regionLabels, tree.EnumValue(region.Name))
 	}
-	// TODO(#multiregion): See github issue:
-	// https://github.com/cockroachdb/cockroach/issues/56877.
+
 	if err := p.createEnumWithID(
 		p.RunParams(ctx),
 		desc.RegionConfig.RegionEnumID,


### PR DESCRIPTION
This patch removes a stale TODO referencing issue #56877. The
resolution of that issue was to keep the multi region enum in the
public schema, which means no code change is required.

Release note: None