### PR TITLE
release-20.2: ensure that `cockroach mt start-sql` knows about log flags

### DIFF
--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -829,6 +829,15 @@ func init() {
 
 		stringSliceFlag(f, &serverCfg.SQLConfig.TenantKVAddrs, cliflags.KVAddrs)
 		varFlag(f, &startCtx.logDir, cliflags.LogDir)
+		varFlag(f,
+			pflag.PFlagFromGoFlag(flag.Lookup(logflags.LogFilesCombinedMaxSizeName)).Value,
+			cliflags.LogDirMaxSize)
+		varFlag(f,
+			pflag.PFlagFromGoFlag(flag.Lookup(logflags.LogFileMaxSizeName)).Value,
+			cliflags.LogFileMaxSize)
+		varFlag(f,
+			pflag.PFlagFromGoFlag(flag.Lookup(logflags.LogFileVerbosityThresholdName)).Value,
+			cliflags.LogFileVerbosity)
 	}
 }
 


### PR DESCRIPTION
Fixes #58723. 

Since `mt start-sql` already supports `--log-dir` it should support
`--log-file-max-size`, `--log-group-max-size` and
`--log-file-verbosity`.

Note: this change is not needed in the v21.1 branch because it is
already covered by the new `--log` flag.

Release note: None