### PR TITLE
release-20.1: sql: fix the dedup of aggregates during physical planning

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/distsql_agg
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_agg
@@ -613,3 +613,14 @@ query RI
 SELECT corr(DISTINCT y, x), count(y) FROM t55837
 ----
 0.866025403784439 4
+
+# Regression test for incorrectly populating the type schema produced by the
+# final stage of aggregators (#58683).
+statement ok
+CREATE TABLE table58683_1 (col1 INT8 PRIMARY KEY);
+INSERT INTO table58683_1 SELECT i FROM generate_series(1, 5) AS g(i);
+ALTER TABLE table58683_1 SPLIT AT SELECT i FROM generate_series(1, 5) AS g(i);
+ALTER TABLE table58683_1 EXPERIMENTAL_RELOCATE SELECT ARRAY[i], i FROM generate_series(1, 5) AS g(i);
+CREATE TABLE table58683_2 (col2 BOOL);
+ALTER TABLE table58683_2 EXPERIMENTAL_RELOCATE SELECT ARRAY[2], 2;
+SELECT every(col2) FROM table58683_1 JOIN table58683_2 ON col1 = (table58683_2.rowid)::INT8 GROUP BY col2 HAVING bool_and(col2);


### PR DESCRIPTION
Backport 1/1 commits from #58901.

/cc @cockroachdb/release

---

During the physical planning of the aggregates, we are performing
a de-duplication of aggregate functions in order to not have redundant
computations, and we handle the required "projection" via
a `PlanToStreamColMap` (this is a separate projection from the one in
the post-processing spec). As a result, a stage of aggregator
processors might produce less columns than we expected it to because
some duplicate functions were removed. Previously, this would result in
an incorrectly computed output schema of the aggregators.

The issue represented itself because we started relying on the recently
added `ResultTypes` field of a processor spec in the vectorized engine,
and I'm not sure whether it could result in an error in stable releases
(the field is also present on the physical plan).

The fix is rather simple - use the projection of the post-processing
spec, so I think it'll be worth backporting this even if we don't have
a repro of an issue on stable branches.

Fixes: #58683.

Release note: None
