### PR TITLE
release-20.2: opt: fix fold column access null type

### DIFF
--- a/pkg/sql/opt/norm/fold_constants_funcs.go
+++ b/pkg/sql/opt/norm/fold_constants_funcs.go
@@ -514,8 +514,8 @@ func (c *CustomFuncs) FoldColumnAccess(input opt.ScalarExpr, idx memo.TupleOrdin
 	// Case 1: The input is NULL. This is possible when FoldIndirection has
 	// already folded an Indirection expression with an out-of-bounds index to
 	// Null.
-	if _, ok := input.(*memo.NullExpr); ok {
-		return input
+	if n, ok := input.(*memo.NullExpr); ok {
+		return c.f.ConstructNull(n.Typ.TupleContents()[idx])
 	}
 
 	// Case 2: The input is a static tuple constructor.

--- a/pkg/sql/opt/norm/testdata/rules/fold_constants
+++ b/pkg/sql/opt/norm/testdata/rules/fold_constants
@@ -1019,25 +1019,25 @@ values
 
 # Fold when input is Null. This is possible when FoldIndirection has already
 # folded an Indirection with an out-of-bounds index to Null.
-norm expect=FoldColumnAccess
+norm expect=FoldColumnAccess format=show-types
 SELECT (ARRAY[(('foo', i) AS foo, bar)][0]).foo FROM a
 ----
 project
- ├── columns: foo:8
+ ├── columns: foo:8(string)
  ├── fd: ()-->(8)
  ├── scan a
  └── projections
-      └── NULL [as=foo:8]
+      └── CAST(NULL AS STRING) [as=foo:8, type=string]
 
-norm expect=FoldColumnAccess
+norm expect=FoldColumnAccess format=show-types
 SELECT (ARRAY[(('foo', i) AS foo, bar)][0]).bar FROM a
 ----
 project
- ├── columns: bar:8
+ ├── columns: bar:8(int)
  ├── fd: ()-->(8)
  ├── scan a
  └── projections
-      └── NULL [as=bar:8]
+      └── CAST(NULL AS INT8) [as=bar:8, type=int]
 
 # --------------------------------------------------
 # FoldEqualsAnyNull


### PR DESCRIPTION
Backport 1/1 commits from #58962.

/cc @cockroachdb/release

---

The backport of #58439 to 20.1, #58899, revealed a bug in the original
fix: the type of the null-folded value is a tuple, rather than the type
of the tuple element at the given tuple ordinal. This has been fixed.

Release note: None
