### PR TITLE
cli: Fix for a race condition in the teardown of demo cluster

### DIFF
--- a/pkg/cli/demo_cluster.go
+++ b/pkg/cli/demo_cluster.go
@@ -210,13 +210,12 @@ func (c *transientCluster) start(
 			<-servReadyFnCh
 			errCh <- nil
 		}
-
-		// Ensure we close all sticky stores we've created.
-		c.stopper.AddCloser(stop.CloserFn(func() {
-			c.stickyEngineRegistry.CloseAllStickyInMemEngines()
-		}))
 	}
 
+	// Ensure we close all sticky stores we've created.
+	c.stopper.AddCloser(stop.CloserFn(func() {
+		c.stickyEngineRegistry.CloseAllStickyInMemEngines()
+	}))
 	c.servers = servers
 
 	if demoCtx.simulateLatency {


### PR DESCRIPTION
Fixes #58959
A change made in #57123 introduced a race condition into the tear
down of the demo cluster. On shutdown the storage engines for
some servers could get closed, before the server itself is stopped,
which leads to panics in Pebble. This change makes sure that all the
servers are stopped before we close the in memory sticky storage engines.

Release note: None