### PR TITLE
opt: suppress logs in benchmarks

### DIFF
--- a/pkg/sql/opt/bench/BUILD.bazel
+++ b/pkg/sql/opt/bench/BUILD.bazel
@@ -32,6 +32,7 @@ go_test(
         "//pkg/testutils/serverutils",
         "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
+        "//pkg/util/log",
         "//pkg/util/randutil",
         "//pkg/util/timeutil",
     ],

--- a/pkg/sql/opt/bench/bench_test.go
+++ b/pkg/sql/opt/bench/bench_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
@@ -278,7 +279,7 @@ var profileQuery = flag.String("profile-query", "kv-read", "name of query to run
 func TestCPUProfile(t *testing.T) {
 	skip.IgnoreLint(t,
 		"Remove this when profiling. Use profile flags above to configure. Sample command line: \n"+
-			"GOMAXPROCS=1 go test -run TestCPUProfile --logtostderr NONE && go tool pprof bench.test cpu.out",
+			"GOMAXPROCS=1 go test -run TestCPUProfile && go tool pprof cpu.out",
 	)
 
 	h := newHarness()
@@ -319,6 +320,8 @@ func BenchmarkPhases(b *testing.B) {
 
 // BenchmarkEndToEnd measures the time to execute a query end-to-end.
 func BenchmarkEndToEnd(b *testing.B) {
+	defer log.Scope(b).Close(b)
+
 	h := newHarness()
 	defer h.close()
 

--- a/pkg/sql/opt/bench/fk_test.go
+++ b/pkg/sql/opt/bench/fk_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
 func runFKBench(
@@ -53,6 +54,8 @@ func runFKBench(
 }
 
 func BenchmarkFKInsert(b *testing.B) {
+	defer log.Scope(b).Close(b)
+
 	const parentRows = 1000
 	setup := func(b *testing.B, r *sqlutils.SQLRunner, setupFKs bool) {
 		r.Exec(b, "CREATE TABLE child (k int primary key, p int)")


### PR DESCRIPTION
As of #57134 passing `-logtostderr=false` as a `TESTFLAG` in benchmarks
errs: `flag provided but not defined: -logtostderr`. The preferred
method for suppressing logs in tests and benchmarks to is add
`defer log.Scope(t).Close(t)` to the top of the test/benchmark
(see #57979).

This commit uses this new method to suppress logs in optimizer
benchmarks.

Release note: None