### PR TITLE
logictest: fix flaky test

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/unique
+++ b/pkg/sql/logictest/testdata/logic_test/unique
@@ -191,7 +191,7 @@ statement error pgcode 23505 pq: duplicate key value violates unique constraint 
 INSERT INTO uniq_fk_child VALUES (1, 1, 1), (2, 2, 2)
 
 # This fails the foreign key checks but passes the uniqueness checks.
-statement error pgcode 23503 pq: insert on table "uniq_fk_child" violates foreign key constraint "fk_b_ref_uniq_fk_parent"\nDETAIL: Key \(b, c\)=\(3, 3\) is not present in table "uniq_fk_parent"\.
+statement error pgcode 23503 pq: insert on table "uniq_fk_child" violates foreign key constraint "fk_b_ref_uniq_fk_parent"\nDETAIL: Key \(b, c\)=\(., .\) is not present in table "uniq_fk_parent"\.
 INSERT INTO uniq_fk_child VALUES (3, 3, 3), (4, 4, 4)
 
 # This fails both types of checks.


### PR DESCRIPTION
When evaluating the foreign key constraint, the vectorized engine might
reorder the input tuples (i.e. the order might be different from the one
specified in the VALUES clause), so having multiple tuples there can
cause the test to be flaky (namely, the error message details are
non-deterministic). This commit relaxes the comparison so that either of
the tuples could be mentioned in the error message.

Release note: None