### PR TITLE
schemaexpr: have Validate() stop mutating the table descriptor

### DIFF
--- a/pkg/sql/add_column.go
+++ b/pkg/sql/add_column.go
@@ -152,9 +152,11 @@ func (p *planner) addColumnImpl(
 			&params.p.semaCtx,
 			tn,
 		)
-		if err := computedColValidator.Validate(d); err != nil {
+		serializedExpr, err := computedColValidator.Validate(d)
+		if err != nil {
 			return err
 		}
+		col.ComputeExpr = &serializedExpr
 	}
 
 	return nil

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1959,9 +1959,15 @@ func NewTableDesc(
 		switch d := def.(type) {
 		case *tree.ColumnTableDef:
 			if d.IsComputed() {
-				if err := computedColValidator.Validate(d); err != nil {
+				serializedExpr, err := computedColValidator.Validate(d)
+				if err != nil {
 					return nil, err
 				}
+				col, _, err := desc.FindColumnByName(d.Name)
+				if err != nil {
+					return nil, err
+				}
+				col.ComputeExpr = &serializedExpr
 			}
 		}
 	}


### PR DESCRIPTION
This commit updates `ComputedColumnValidator.Validate()` to return the
serialized expression rather than mutate the table's column descriptor
(which was also unsafe, since the table is a `catalog.TableDescriptor`
and not meant to be mutable).

Release note: None