### PR TITLE
sql: implement REGIONAL BY ROW logic on CREATE TABLE

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
@@ -1,0 +1,217 @@
+# LogicTest: multiregion-9node-3region-3azs
+
+statement ok
+CREATE DATABASE multi_region_test_db PRIMARY REGION "ca-central-1" REGIONS "ap-southeast-2", "us-east-1" SURVIVE REGION FAILURE
+
+statement error REGIONAL BY ROW is currently experimental
+CREATE TABLE regional_by_row_table (pk int) LOCALITY REGIONAL BY ROW
+
+statement ok
+SET experimental_enable_implicit_column_partitioning = true
+
+statement error cannot set LOCALITY on a database that is not multi-region enabled
+CREATE TABLE regional_by_row_table (pk int) LOCALITY REGIONAL BY ROW
+
+statement ok
+USE multi_region_test_db
+
+statement error REGIONAL BY ROW on a TABLE containing PARTITION BY is not supported
+CREATE TABLE regional_by_row_table (
+  pk int
+)
+PARTITION BY LIST (pk) (PARTITION one VALUES IN ((1)))
+LOCALITY REGIONAL BY ROW
+
+statement error REGIONAL BY ROW AS is not yet supported
+CREATE TABLE regional_by_row_table_on_col (a int) LOCALITY REGIONAL BY ROW AS a
+
+statement error REGIONAL BY ROW on a table with an INDEX containing PARTITION BY is not supported
+CREATE TABLE regional_by_row_table (
+  pk int,
+  a int,
+  INDEX (a) PARTITION BY LIST (a) (PARTITION one VALUES IN ((1)))
+)
+LOCALITY REGIONAL BY ROW
+
+statement error REGIONAL BY ROW on a table with an UNIQUE constraint containing PARTITION BY is not supported
+CREATE TABLE regional_by_row_table (
+  pk int,
+  a int,
+  UNIQUE (a) PARTITION BY LIST (a) (PARTITION one VALUES IN ((1)))
+)
+LOCALITY REGIONAL BY ROW
+
+statement ok
+CREATE TABLE regional_by_row_table (
+  pk int PRIMARY KEY,
+  a int,
+  b int,
+  INDEX (a),
+  UNIQUE (b),
+  FAMILY (pk, a, b)
+) LOCALITY REGIONAL BY ROW
+
+# TODO(#multiregion): determine how we should display the presence of a crdb_region column
+# to the user.
+# TODO(#multiregion): ensure this CREATE TABLE statement round trips.
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE regional_by_row_table]
+----
+CREATE TABLE public.regional_by_row_table (
+  pk INT8 NOT NULL,
+  a INT8 NULL,
+  b INT8 NULL,
+  crdb_region public.crdb_internal_region NOT NULL DEFAULT gateway_region()::public.crdb_internal_region,
+  CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+  INDEX regional_by_row_table_a_idx (a ASC),
+  UNIQUE INDEX regional_by_row_table_b_key (b ASC),
+  FAMILY fam_0_pk_a_b_crdb_region (pk, a, b, crdb_region)
+) LOCALITY REGIONAL BY ROW;
+ALTER PARTITION "ap-southeast-2" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
+  num_replicas = 3,
+  constraints = '{+region=ap-southeast-2: 1}',
+  lease_preferences = '[[+region=ap-southeast-2]]';
+ALTER PARTITION "ap-southeast-2" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
+  num_replicas = 3,
+  constraints = '{+region=ap-southeast-2: 1}',
+  lease_preferences = '[[+region=ap-southeast-2]]';
+ALTER PARTITION "ap-southeast-2" OF INDEX multi_region_test_db.public.regional_by_row_table@primary CONFIGURE ZONE USING
+  num_replicas = 3,
+  constraints = '{+region=ap-southeast-2: 1}',
+  lease_preferences = '[[+region=ap-southeast-2]]';
+ALTER PARTITION "ca-central-1" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
+  num_replicas = 3,
+  constraints = '{+region=ca-central-1: 1}',
+  lease_preferences = '[[+region=ca-central-1]]';
+ALTER PARTITION "ca-central-1" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
+  num_replicas = 3,
+  constraints = '{+region=ca-central-1: 1}',
+  lease_preferences = '[[+region=ca-central-1]]';
+ALTER PARTITION "ca-central-1" OF INDEX multi_region_test_db.public.regional_by_row_table@primary CONFIGURE ZONE USING
+  num_replicas = 3,
+  constraints = '{+region=ca-central-1: 1}',
+  lease_preferences = '[[+region=ca-central-1]]';
+ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
+  num_replicas = 3,
+  constraints = '{+region=us-east-1: 1}',
+  lease_preferences = '[[+region=us-east-1]]';
+ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
+  num_replicas = 3,
+  constraints = '{+region=us-east-1: 1}',
+  lease_preferences = '[[+region=us-east-1]]';
+ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row_table@primary CONFIGURE ZONE USING
+  num_replicas = 3,
+  constraints = '{+region=us-east-1: 1}',
+  lease_preferences = '[[+region=us-east-1]]'
+
+query TTB colnames
+SELECT index_name, column_name, implicit FROM crdb_internal.index_columns
+WHERE descriptor_name = 'regional_by_row_table' AND column_type = 'key'
+ORDER BY 1, 2
+----
+index_name                   column_name  implicit
+primary                      crdb_region  true
+primary                      pk           false
+regional_by_row_table_a_idx  a            false
+regional_by_row_table_a_idx  crdb_region  true
+regional_by_row_table_b_key  b            false
+regional_by_row_table_b_key  crdb_region  true
+
+query TTTTIT colnames
+SHOW TABLES
+----
+schema_name  table_name             type   owner  estimated_row_count  locality
+public       regional_by_row_table  table  root   0                    REGIONAL BY ROW
+
+query TI
+INSERT INTO regional_by_row_table (pk, a, b) VALUES
+(1, 2, 3), (4, 5, 6)
+RETURNING crdb_region, pk
+----
+ap-southeast-2  1
+ap-southeast-2  4
+
+query TI
+INSERT INTO regional_by_row_table (crdb_region, pk, a, b) VALUES
+('ca-central-1', 7, 8, 9)
+RETURNING crdb_region, pk
+----
+ca-central-1  7
+
+query TI nodeidx=3
+INSERT INTO multi_region_test_db.regional_by_row_table (pk, a, b) VALUES
+(10, 11, 12)
+RETURNING crdb_region, pk
+----
+ca-central-1  10
+
+query TI nodeidx=6
+INSERT INTO multi_region_test_db.regional_by_row_table (pk, a, b) VALUES
+(20, 21, 22)
+RETURNING crdb_region, pk
+----
+us-east-1  20
+
+query TI
+INSERT INTO regional_by_row_table (crdb_region, pk, a, b) VALUES
+(gateway_region()::crdb_internal_region, 23, 24, 25)
+RETURNING crdb_region, pk
+----
+ap-southeast-2  23
+
+query TIII
+SELECT crdb_region, pk, a, b FROM regional_by_row_table
+ORDER BY pk
+----
+ap-southeast-2  1   2   3
+ap-southeast-2  4   5   6
+ca-central-1    7   8   9
+ca-central-1    10  11  12
+us-east-1       20  21  22
+ap-southeast-2  23  24  25
+
+# Create some tables to validate that their zone configurations are adjusted appropriately.
+statement ok
+CREATE DATABASE alter_survive_db PRIMARY REGION "us-east-1" REGIONS "ca-central-1", "ap-southeast-2" SURVIVE REGION FAILURE
+
+statement ok
+USE alter_survive_db
+
+statement ok
+CREATE TABLE t_regional_by_row () LOCALITY REGIONAL BY ROW
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE t_regional_by_row PARTITION "us-east-1"
+----
+PARTITION "us-east-1" OF TABLE t_regional_by_row  ALTER PARTITION "us-east-1" OF TABLE t_regional_by_row CONFIGURE ZONE USING
+                                                  range_min_bytes = 134217728,
+                                                  range_max_bytes = 536870912,
+                                                  gc.ttlseconds = 90000,
+                                                  num_replicas = 3,
+                                                  constraints = '{+region=us-east-1: 1}',
+                                                  lease_preferences = '[[+region=us-east-1]]'
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE t_regional_by_row
+----
+DATABASE alter_survive_db  ALTER DATABASE alter_survive_db CONFIGURE ZONE USING
+                           range_min_bytes = 134217728,
+                           range_max_bytes = 536870912,
+                           gc.ttlseconds = 90000,
+                           num_replicas = 3,
+                           constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                           lease_preferences = '[[+region=us-east-1]]'
+
+statement ok
+ALTER DATABASE alter_survive_db SURVIVE ZONE FAILURE
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE t_regional_by_row PARTITION "us-east-1"
+----
+PARTITION "us-east-1" OF TABLE t_regional_by_row  ALTER PARTITION "us-east-1" OF TABLE t_regional_by_row CONFIGURE ZONE USING
+                                                  range_min_bytes = 134217728,
+                                                  range_max_bytes = 536870912,
+                                                  gc.ttlseconds = 90000,
+                                                  num_replicas = 3,
+                                                  constraints = '{+region=us-east-1: 3}',
+                                                  lease_preferences = '[[+region=us-east-1]]'

--- a/pkg/sql/catalog/descriptor.go
+++ b/pkg/sql/catalog/descriptor.go
@@ -246,6 +246,8 @@ type TableDescriptor interface {
 	ForeachInboundFK(f func(fk *descpb.ForeignKeyConstraint) error) error
 	FindActiveColumnByName(s string) (*descpb.ColumnDescriptor, error)
 	WritableColumns() []descpb.ColumnDescriptor
+
+	GetLocalityConfig() *descpb.TableDescriptor_LocalityConfig
 }
 
 // Index is an interface around the index descriptor types.

--- a/pkg/sql/logictest/testdata/logic_test/multiregion
+++ b/pkg/sql/logictest/testdata/logic_test/multiregion
@@ -289,31 +289,6 @@ TABLE "regional_us-east-1_table"  ALTER TABLE "regional_us-east-1_table" CONFIGU
 statement error region "test4" has not been added to database "multi_region_test_db"\nHINT: available regions: ap-southeast-2, ca-central-1, us-east-1
 CREATE TABLE regional_test4_table (a int) LOCALITY REGIONAL BY TABLE IN "test4"
 
-statement error REGIONAL BY ROW AS is not yet supported
-CREATE TABLE regional_by_row_table_on_col (a int) LOCALITY REGIONAL BY ROW AS a
-
-statement ok
-CREATE TABLE regional_by_row_table (a int) LOCALITY REGIONAL BY ROW
-
-query T
-SELECT create_statement FROM [SHOW CREATE TABLE regional_by_row_table]
-----
-CREATE TABLE public.regional_by_row_table (
-                            a INT8 NULL,
-                            FAMILY "primary" (a, rowid)
-) LOCALITY REGIONAL BY ROW
-
-query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_row_table
-----
-TABLE regional_by_row_table  ALTER TABLE regional_by_row_table CONFIGURE ZONE USING
-                             range_min_bytes = 134217728,
-                             range_max_bytes = 536870912,
-                             gc.ttlseconds = 90000,
-                             num_replicas = 3,
-                             constraints = '[]',
-                             lease_preferences = '[]'
-
 statement ok
 CREATE TABLE global_table (a int) LOCALITY GLOBAL
 
@@ -341,7 +316,6 @@ SHOW TABLES
 ----
 schema_name  table_name                              type   owner  estimated_row_count  locality
 public       global_table                            table  root   0                    GLOBAL
-public       regional_by_row_table                   table  root   0                    REGIONAL BY ROW
 public       regional_implicit_primary_region_table  table  root   0                    REGIONAL BY TABLE IN PRIMARY REGION
 public       regional_primary_region_table           table  root   0                    REGIONAL BY TABLE IN PRIMARY REGION
 public       regional_us-east-1_table                table  root   0                    REGIONAL BY TABLE IN "us-east-1"
@@ -436,9 +410,6 @@ ALTER DATABASE new_db ADD REGION "us-west-1"
 
 statement error implementation pending
 ALTER DATABASE new_db DROP REGION "us-west-1"
-
-statement error implementation pending
-ALTER TABLE a SET LOCALITY REGIONAL BY ROW
 
 statement ok
 CREATE DATABASE alter_primary_region_db
@@ -576,9 +547,6 @@ statement ok
 alter database alter_survive_db add region "us-east-1"
 
 # Create some tables to validate that their zone configurations are adjusted appropriately.
-statement ok
-create table t_regional_by_table_in_us_east_1 (i int) locality regional by table in "us-east-1"
-
 query TT
 SHOW ZONE CONFIGURATION FOR DATABASE alter_survive_db
 ----
@@ -589,17 +557,6 @@ DATABASE alter_survive_db  ALTER DATABASE alter_survive_db CONFIGURE ZONE USING
                                   num_replicas = 3,
                                   constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
                                   lease_preferences = '[[+region=ca-central-1]]'
-
-query TT
-SHOW ZONE CONFIGURATION FOR TABLE t_regional_by_table_in_us_east_1
-----
-TABLE t_regional_by_table_in_us_east_1  ALTER TABLE t_regional_by_table_in_us_east_1 CONFIGURE ZONE USING
-                                        range_min_bytes = 134217728,
-                                        range_max_bytes = 536870912,
-                                        gc.ttlseconds = 90000,
-                                        num_replicas = 3,
-                                        constraints = '{+region=us-east-1: 3}',
-                                        lease_preferences = '[[+region=us-east-1]]'
 
 statement ok
 create table t_no_locality (i int)
@@ -628,20 +585,6 @@ TABLE t_global  ALTER TABLE t_global CONFIGURE ZONE USING
                 num_replicas = 3,
                 constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
                 lease_preferences = '[[+region=ca-central-1]]'
-
-statement ok
-create table t_regional_by_row (i int) locality regional by row
-
-query TT
-SHOW ZONE CONFIGURATION FOR TABLE t_regional_by_row
-----
-TABLE t_regional_by_row  ALTER TABLE t_regional_by_row CONFIGURE ZONE USING
-                         range_min_bytes = 134217728,
-                         range_max_bytes = 536870912,
-                         gc.ttlseconds = 90000,
-                         num_replicas = 3,
-                         constraints = '[]',
-                         lease_preferences = '[]'
 
 query TTTTT colnames
 SHOW DATABASES
@@ -703,17 +646,6 @@ DATABASE alter_survive_db  ALTER DATABASE alter_survive_db CONFIGURE ZONE USING
                                   lease_preferences = '[[+region=ca-central-1]]'
 
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE t_regional_by_table_in_us_east_1
-----
-TABLE t_regional_by_table_in_us_east_1  ALTER TABLE t_regional_by_table_in_us_east_1 CONFIGURE ZONE USING
-                                        range_min_bytes = 134217728,
-                                        range_max_bytes = 536870912,
-                                        gc.ttlseconds = 90000,
-                                        num_replicas = 3,
-                                        constraints = '{+region=us-east-1: 1}',
-                                        lease_preferences = '[[+region=us-east-1]]'
-
-query TT
 SHOW ZONE CONFIGURATION FOR TABLE t_no_locality
 ----
 DATABASE alter_survive_db  ALTER DATABASE alter_survive_db CONFIGURE ZONE USING
@@ -734,17 +666,6 @@ TABLE t_global  ALTER TABLE t_global CONFIGURE ZONE USING
                 num_replicas = 3,
                 constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
                 lease_preferences = '[[+region=ca-central-1]]'
-
-query TT
-SHOW ZONE CONFIGURATION FOR TABLE t_regional_by_row
-----
-TABLE t_regional_by_row  ALTER TABLE t_regional_by_row CONFIGURE ZONE USING
-                         range_min_bytes = 134217728,
-                         range_max_bytes = 536870912,
-                         gc.ttlseconds = 90000,
-                         num_replicas = 3,
-                         constraints = '[]',
-                         lease_preferences = '[]'
 
 statement ok
 alter database alter_survive_db survive zone failure
@@ -778,17 +699,6 @@ DATABASE alter_survive_db  ALTER DATABASE alter_survive_db CONFIGURE ZONE USING
                            lease_preferences = '[[+region=ca-central-1]]'
 
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE t_regional_by_table_in_us_east_1
-----
-TABLE t_regional_by_table_in_us_east_1  ALTER TABLE t_regional_by_table_in_us_east_1 CONFIGURE ZONE USING
-                                        range_min_bytes = 134217728,
-                                        range_max_bytes = 536870912,
-                                        gc.ttlseconds = 90000,
-                                        num_replicas = 3,
-                                        constraints = '{+region=us-east-1: 3}',
-                                        lease_preferences = '[[+region=us-east-1]]'
-
-query TT
 SHOW ZONE CONFIGURATION FOR TABLE t_no_locality
 ----
 DATABASE alter_survive_db  ALTER DATABASE alter_survive_db CONFIGURE ZONE USING
@@ -809,14 +719,3 @@ TABLE t_global  ALTER TABLE t_global CONFIGURE ZONE USING
                 num_replicas = 3,
                 constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
                 lease_preferences = '[[+region=ca-central-1]]'
-
-query TT
-SHOW ZONE CONFIGURATION FOR TABLE t_regional_by_row
-----
-TABLE t_regional_by_row  ALTER TABLE t_regional_by_row CONFIGURE ZONE USING
-                         range_min_bytes = 134217728,
-                         range_max_bytes = 536870912,
-                         gc.ttlseconds = 90000,
-                         num_replicas = 3,
-                         constraints = '[]',
-                         lease_preferences = '[]'

--- a/pkg/sql/sem/tree/name_resolution.go
+++ b/pkg/sql/sem/tree/name_resolution.go
@@ -116,9 +116,6 @@ const (
 	PublicSchema string = sessiondata.PublicSchemaName
 	// PublicSchemaName is the same, typed as Name.
 	PublicSchemaName Name = Name(PublicSchema)
-	// RegionEnum is the name of the per-database region enum required for
-	// multi-region.
-	RegionEnum string = "crdb_internal_region"
 )
 
 // NumResolutionResults represents the number of results in the lookup

--- a/pkg/sql/sem/tree/region.go
+++ b/pkg/sql/sem/tree/region.go
@@ -27,6 +27,17 @@ const (
 	LocalityLevelRow
 )
 
+const (
+	// RegionEnum is the name of the per-database region enum required for
+	// multi-region.
+	RegionEnum string = "crdb_internal_region"
+	// RegionalByRowRegionDefaultCol is the default name of the REGIONAL BY ROW
+	// column name if the AS field is not populated.
+	RegionalByRowRegionDefaultCol string = "crdb_region"
+	// RegionalByRowRegionDefaultColName is the same, typed as Name.
+	RegionalByRowRegionDefaultColName Name = Name(RegionalByRowRegionDefaultCol)
+)
+
 // Locality defines the locality for a given table.
 type Locality struct {
 	LocalityLevel LocalityLevel

--- a/pkg/sql/show_create_clauses.go
+++ b/pkg/sql/show_create_clauses.go
@@ -336,6 +336,13 @@ func ShowCreatePartitioning(
 	if tableDesc.IsPartitionAllBy() && tableDesc.GetPrimaryIndexID() != idxDesc.ID {
 		return nil
 	}
+	// Do not print PARTITION ALL BY if we are a REGIONAL BY ROW table.
+	if c := tableDesc.GetLocalityConfig(); c != nil {
+		switch c.Locality.(type) {
+		case *descpb.TableDescriptor_LocalityConfig_RegionalByRow_:
+			return nil
+		}
+	}
 
 	// We don't need real prefixes in the DecodePartitionTuple calls because we
 	// only use the tree.Datums part of the output.


### PR DESCRIPTION
Resolves #58335 
Resolves #57672 

Release note (sql change): Implemented REGIONAL BY ROW logic on create
table. This is gated behind the experimental session variable
`experimental_enable_implicit_column_partitioning`.