### PR TITLE
sql: CREATE INDEX inherits PARTITION BY on PARTITION ALL BY tables

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
@@ -233,6 +233,14 @@ CREATE TABLE public.t (
   PARTITION two VALUES IN (2)
 )
 
+statement error cannot define PARTITION BY on an index if the table has a PARTITION ALL BY definition
+CREATE INDEX created_idx ON t(c) PARTITION BY LIST (d) (
+  PARTITION one VALUES IN ((1))
+)
+
+statement ok
+CREATE INDEX created_idx ON t(c)
+
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE t]
 ----
@@ -247,6 +255,7 @@ CREATE TABLE public.t (
   INDEX t_a_idx (a ASC),
   UNIQUE INDEX t_b_key (b ASC),
   INDEX t_partition_by_c_idx (partition_by ASC, c ASC),
+  INDEX created_idx (c ASC),
   FAMILY fam_0_pk_partition_by_a_b_c_d (pk, partition_by, a, b, c, d)
 ) PARTITION ALL BY LIST (partition_by) (
   PARTITION one VALUES IN ((1)),
@@ -260,6 +269,8 @@ WHERE descriptor_name = 't' AND column_type = 'key'
 ORDER BY 1, 2
 ----
 index_name            column_name   implicit
+created_idx           c             false
+created_idx           partition_by  true
 primary               partition_by  true
 primary               pk            false
 t_a_idx               a             false


### PR DESCRIPTION
Resolves #58734 

Release note (sql change): CREATE INDEX will now inherit PARTITION BY
clauses from PARTITION ALL BY tables.