### PR TITLE
release-20.2: cli/interactive_tests: deflake test_force_auth_log.tcl

### DIFF
--- a/pkg/cli/interactive_tests/test_force_auth_log.tcl
+++ b/pkg/cli/interactive_tests/test_force_auth_log.tcl
@@ -38,9 +38,9 @@ system "grep -q 'authentication failed' $logfile"
 
 end_test
 
-start_test "Check that the auth events have both node ID and cluster ID"
+start_test "Check that the auth events include the cluster ID"
 
-system "grep -q '\\\[n1,.*clusterID=........-....-....-....-............\\\] . authentication' $logfile"
+system "grep -q '\\\[n1,.*clusterID=........-....-....-....-............\\\] \[0-9\]* authentication' $logfile"
 
 end_test
 


### PR DESCRIPTION
Fixes #58976. 

There may be more than 10 events in the auth log before the `grep`
command is run. So we can't match with just 1 character for the entry
counter.

Release note: None