### PR TITLE
util/log: stop syncing writes excessively

### DIFF
--- a/pkg/cli/log_flags_test.go
+++ b/pkg/cli/log_flags_test.go
@@ -35,21 +35,22 @@ func TestSetupLogging(t *testing.T) {
 	reSimplify := regexp.MustCompile(`(?ms:^\s*(auditable: false|redact: false|exit-on-error: true|max-group-size: 100MiB)\n)`)
 
 	const defaultFluentConfig = `fluent-defaults: {` +
+		`buffered-writes: true, ` +
 		`filter: INFO, ` +
 		`format: json-fluent-compact, ` +
 		`redactable: true, ` +
 		`exit-on-error: false` +
 		`}, `
 	stdFileDefaultsRe := regexp.MustCompile(
-		`file-defaults: \{dir: (?P<path>[^,]+), max-file-size: 10MiB, filter: INFO, format: crdb-v1, redactable: true\}`)
+		`file-defaults: \{dir: (?P<path>[^,]+), max-file-size: 10MiB, buffered-writes: true, filter: INFO, format: crdb-v1, redactable: true\}`)
 	fileDefaultsNoMaxSizeRe := regexp.MustCompile(
-		`file-defaults: \{dir: (?P<path>[^,]+), filter: INFO, format: crdb-v1, redactable: true\}`)
-	const fileDefaultsNoDir = `file-defaults: {filter: INFO, format: crdb-v1, redactable: true}`
+		`file-defaults: \{dir: (?P<path>[^,]+), buffered-writes: true, filter: INFO, format: crdb-v1, redactable: true\}`)
+	const fileDefaultsNoDir = `file-defaults: {buffered-writes: true, filter: INFO, format: crdb-v1, redactable: true}`
 	const defaultLogDir = `PWD/cockroach-data/logs`
 	stdCaptureFd2Re := regexp.MustCompile(
 		`capture-stray-errors: \{enable: true, dir: (?P<path>[^}]+)\}`)
 	fileCfgRe := regexp.MustCompile(
-		`\{channels: (?P<chans>[^ ]+), dir: (?P<path>[^,]+), max-file-size: 10MiB, sync-writes: (?P<sync>[^,]+), filter: INFO, format: (?P<format>[^,]+), redactable: true\}`)
+		`\{channels: (?P<chans>[^ ]+), dir: (?P<path>[^,]+), max-file-size: 10MiB, buffered-writes: (?P<buf>[^,]+), filter: INFO, format: (?P<format>[^,]+), redactable: true\}`)
 
 	stderrCfgRe := regexp.MustCompile(
 		`stderr: {channels: all, filter: (?P<level>[^,]+), format: crdb-v1-tty, redactable: (?P<redactable>[^}]+)}`)
@@ -110,7 +111,7 @@ func TestSetupLogging(t *testing.T) {
 		actual = fileDefaultsNoMaxSizeRe.ReplaceAllString(actual, "<fileDefaultsNoMaxSize($path)>")
 		actual = strings.ReplaceAll(actual, fileDefaultsNoDir, "<fileDefaultsNoDir>")
 		actual = stdCaptureFd2Re.ReplaceAllString(actual, "<stdCaptureFd2($path)>")
-		actual = fileCfgRe.ReplaceAllString(actual, "<fileCfg([$chans],$path,$sync,$format)>")
+		actual = fileCfgRe.ReplaceAllString(actual, "<fileCfg([$chans],$path,$buf,$format)>")
 		actual = stderrCfgRe.ReplaceAllString(actual, "<stderrCfg($level,$redactable)>")
 		actual = strings.ReplaceAll(actual, `<stderrCfg(NONE,true)>`, `<stderrDisabled>`)
 		actual = strings.ReplaceAll(actual, `<stderrCfg(INFO,false)>`, `<stderrEnabledInfoNoRedaction>`)

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -717,24 +717,26 @@ If problems persist, please see %s.`
 	// is stopped externally (for example, via the quit endpoint).
 	select {
 	case err := <-errChan:
-		// SetSync both flushes and ensures that subsequent log writes are flushed too.
-		log.StartSync()
+		// StartAlwaysFlush both flushes and ensures that subsequent log
+		// writes are flushed too.
+		log.StartAlwaysFlush()
 		return err
 
 	case <-stopper.ShouldStop():
 		// Server is being stopped externally and our job is finished
 		// here since we don't know if it's a graceful shutdown or not.
 		<-stopper.IsStopped()
-		// StartSync both flushes and ensures that subsequent log writes are flushed too.
-		log.StartSync()
+		// StartAlwaysFlush both flushes and ensures that subsequent log
+		// writes are flushed too.
+		log.StartAlwaysFlush()
 		return nil
 
 	case sig := <-signalCh:
-		// We start synchronizing log writes from here, because if a
+		// We start flushing log writes from here, because if a
 		// signal was received there is a non-zero chance the sender of
 		// this signal will follow up with SIGKILL if the shutdown is not
 		// timely, and we don't want logs to be lost.
-		log.StartSync()
+		log.StartAlwaysFlush()
 
 		log.Ops.Infof(shutdownCtx, "received signal '%s'", sig)
 		switch sig {

--- a/pkg/cli/testdata/logflags
+++ b/pkg/cli/testdata/logflags
@@ -13,13 +13,13 @@ run
 start
 ----
 config: {<stdFileDefaults(<defaultLogDir>)>,
-sinks: {file-groups: {default: <fileCfg(['DEV,OPS,HEALTH,SQL_SCHEMA,USER_ADMIN,PRIVILEGES'],<defaultLogDir>,false,crdb-v1)>,
-pebble: <fileCfg([STORAGE],<defaultLogDir>,false,crdb-v1)>,
-sql-audit: <fileCfg([SENSITIVE_ACCESS],<defaultLogDir>,true,crdb-v1-count)>,
-sql-auth: <fileCfg([SESSIONS],<defaultLogDir>,true,crdb-v1-count)>,
-sql-exec: <fileCfg([SQL_EXEC],<defaultLogDir>,false,crdb-v1)>,
-sql-slow: <fileCfg([SQL_PERF],<defaultLogDir>,false,crdb-v1)>,
-sql-slow-internal-only: <fileCfg([SQL_INTERNAL_PERF],<defaultLogDir>,false,crdb-v1)>},
+sinks: {file-groups: {default: <fileCfg(['DEV,OPS,HEALTH,SQL_SCHEMA,USER_ADMIN,PRIVILEGES'],<defaultLogDir>,true,crdb-v1)>,
+pebble: <fileCfg([STORAGE],<defaultLogDir>,true,crdb-v1)>,
+sql-audit: <fileCfg([SENSITIVE_ACCESS],<defaultLogDir>,false,crdb-v1-count)>,
+sql-auth: <fileCfg([SESSIONS],<defaultLogDir>,false,crdb-v1-count)>,
+sql-exec: <fileCfg([SQL_EXEC],<defaultLogDir>,true,crdb-v1)>,
+sql-slow: <fileCfg([SQL_PERF],<defaultLogDir>,true,crdb-v1)>,
+sql-slow-internal-only: <fileCfg([SQL_INTERNAL_PERF],<defaultLogDir>,true,crdb-v1)>},
 <stderrDisabled>},
 <stdCaptureFd2(<defaultLogDir>)>}
 
@@ -28,13 +28,13 @@ run
 start-single-node
 ----
 config: {<stdFileDefaults(<defaultLogDir>)>,
-sinks: {file-groups: {default: <fileCfg(['DEV,OPS,HEALTH,SQL_SCHEMA,USER_ADMIN,PRIVILEGES'],<defaultLogDir>,false,crdb-v1)>,
-pebble: <fileCfg([STORAGE],<defaultLogDir>,false,crdb-v1)>,
-sql-audit: <fileCfg([SENSITIVE_ACCESS],<defaultLogDir>,true,crdb-v1-count)>,
-sql-auth: <fileCfg([SESSIONS],<defaultLogDir>,true,crdb-v1-count)>,
-sql-exec: <fileCfg([SQL_EXEC],<defaultLogDir>,false,crdb-v1)>,
-sql-slow: <fileCfg([SQL_PERF],<defaultLogDir>,false,crdb-v1)>,
-sql-slow-internal-only: <fileCfg([SQL_INTERNAL_PERF],<defaultLogDir>,false,crdb-v1)>},
+sinks: {file-groups: {default: <fileCfg(['DEV,OPS,HEALTH,SQL_SCHEMA,USER_ADMIN,PRIVILEGES'],<defaultLogDir>,true,crdb-v1)>,
+pebble: <fileCfg([STORAGE],<defaultLogDir>,true,crdb-v1)>,
+sql-audit: <fileCfg([SENSITIVE_ACCESS],<defaultLogDir>,false,crdb-v1-count)>,
+sql-auth: <fileCfg([SESSIONS],<defaultLogDir>,false,crdb-v1-count)>,
+sql-exec: <fileCfg([SQL_EXEC],<defaultLogDir>,true,crdb-v1)>,
+sql-slow: <fileCfg([SQL_PERF],<defaultLogDir>,true,crdb-v1)>,
+sql-slow-internal-only: <fileCfg([SQL_INTERNAL_PERF],<defaultLogDir>,true,crdb-v1)>},
 <stderrDisabled>},
 <stdCaptureFd2(<defaultLogDir>)>}
 
@@ -98,13 +98,13 @@ start
 --store=path=/pathB
 ----
 config: {<stdFileDefaults(/pathA/logs)>,
-sinks: {file-groups: {default: <fileCfg(['DEV,OPS,HEALTH,SQL_SCHEMA,USER_ADMIN,PRIVILEGES'],/pathA/logs,false,crdb-v1)>,
-pebble: <fileCfg([STORAGE],/pathA/logs,false,crdb-v1)>,
-sql-audit: <fileCfg([SENSITIVE_ACCESS],/pathA/logs,true,crdb-v1-count)>,
-sql-auth: <fileCfg([SESSIONS],/pathA/logs,true,crdb-v1-count)>,
-sql-exec: <fileCfg([SQL_EXEC],/pathA/logs,false,crdb-v1)>,
-sql-slow: <fileCfg([SQL_PERF],/pathA/logs,false,crdb-v1)>,
-sql-slow-internal-only: <fileCfg([SQL_INTERNAL_PERF],/pathA/logs,false,crdb-v1)>},
+sinks: {file-groups: {default: <fileCfg(['DEV,OPS,HEALTH,SQL_SCHEMA,USER_ADMIN,PRIVILEGES'],/pathA/logs,true,crdb-v1)>,
+pebble: <fileCfg([STORAGE],/pathA/logs,true,crdb-v1)>,
+sql-audit: <fileCfg([SENSITIVE_ACCESS],/pathA/logs,false,crdb-v1-count)>,
+sql-auth: <fileCfg([SESSIONS],/pathA/logs,false,crdb-v1-count)>,
+sql-exec: <fileCfg([SQL_EXEC],/pathA/logs,true,crdb-v1)>,
+sql-slow: <fileCfg([SQL_PERF],/pathA/logs,true,crdb-v1)>,
+sql-slow-internal-only: <fileCfg([SQL_INTERNAL_PERF],/pathA/logs,true,crdb-v1)>},
 <stderrDisabled>},
 <stdCaptureFd2(/pathA/logs)>}
 
@@ -115,13 +115,13 @@ start
 --log=file-defaults: {dir: /mypath}
 ----
 config: {<stdFileDefaults(/mypath)>,
-sinks: {file-groups: {default: <fileCfg(['DEV,OPS,HEALTH,SQL_SCHEMA,USER_ADMIN,PRIVILEGES'],/mypath,false,crdb-v1)>,
-pebble: <fileCfg([STORAGE],/mypath,false,crdb-v1)>,
-sql-audit: <fileCfg([SENSITIVE_ACCESS],/mypath,true,crdb-v1-count)>,
-sql-auth: <fileCfg([SESSIONS],/mypath,true,crdb-v1-count)>,
-sql-exec: <fileCfg([SQL_EXEC],/mypath,false,crdb-v1)>,
-sql-slow: <fileCfg([SQL_PERF],/mypath,false,crdb-v1)>,
-sql-slow-internal-only: <fileCfg([SQL_INTERNAL_PERF],/mypath,false,crdb-v1)>},
+sinks: {file-groups: {default: <fileCfg(['DEV,OPS,HEALTH,SQL_SCHEMA,USER_ADMIN,PRIVILEGES'],/mypath,true,crdb-v1)>,
+pebble: <fileCfg([STORAGE],/mypath,true,crdb-v1)>,
+sql-audit: <fileCfg([SENSITIVE_ACCESS],/mypath,false,crdb-v1-count)>,
+sql-auth: <fileCfg([SESSIONS],/mypath,false,crdb-v1-count)>,
+sql-exec: <fileCfg([SQL_EXEC],/mypath,true,crdb-v1)>,
+sql-slow: <fileCfg([SQL_PERF],/mypath,true,crdb-v1)>,
+sql-slow-internal-only: <fileCfg([SQL_INTERNAL_PERF],/mypath,true,crdb-v1)>},
 <stderrDisabled>},
 <stdCaptureFd2(/mypath)>}
 
@@ -133,13 +133,13 @@ start
 --log=file-defaults: {dir: /pathA/logs}
 ----
 config: {<stdFileDefaults(/pathA/logs)>,
-sinks: {file-groups: {default: <fileCfg(['DEV,OPS,HEALTH,SQL_SCHEMA,USER_ADMIN,PRIVILEGES'],/pathA/logs,false,crdb-v1)>,
-pebble: <fileCfg([STORAGE],/pathA/logs,false,crdb-v1)>,
-sql-audit: <fileCfg([SENSITIVE_ACCESS],/pathA/logs,true,crdb-v1-count)>,
-sql-auth: <fileCfg([SESSIONS],/pathA/logs,true,crdb-v1-count)>,
-sql-exec: <fileCfg([SQL_EXEC],/pathA/logs,false,crdb-v1)>,
-sql-slow: <fileCfg([SQL_PERF],/pathA/logs,false,crdb-v1)>,
-sql-slow-internal-only: <fileCfg([SQL_INTERNAL_PERF],/pathA/logs,false,crdb-v1)>},
+sinks: {file-groups: {default: <fileCfg(['DEV,OPS,HEALTH,SQL_SCHEMA,USER_ADMIN,PRIVILEGES'],/pathA/logs,true,crdb-v1)>,
+pebble: <fileCfg([STORAGE],/pathA/logs,true,crdb-v1)>,
+sql-audit: <fileCfg([SENSITIVE_ACCESS],/pathA/logs,false,crdb-v1-count)>,
+sql-auth: <fileCfg([SESSIONS],/pathA/logs,false,crdb-v1-count)>,
+sql-exec: <fileCfg([SQL_EXEC],/pathA/logs,true,crdb-v1)>,
+sql-slow: <fileCfg([SQL_PERF],/pathA/logs,true,crdb-v1)>,
+sql-slow-internal-only: <fileCfg([SQL_INTERNAL_PERF],/pathA/logs,true,crdb-v1)>},
 <stderrDisabled>},
 <stdCaptureFd2(/pathA/logs)>}
 
@@ -156,13 +156,13 @@ start
 --log=file-defaults: {dir: /mypath}
 ----
 config: {<stdFileDefaults(/mypath)>,
-sinks: {file-groups: {default: <fileCfg(['DEV,OPS,HEALTH,SQL_SCHEMA,USER_ADMIN,PRIVILEGES'],/mypath,false,crdb-v1)>,
-pebble: <fileCfg([STORAGE],/mypath,false,crdb-v1)>,
-sql-audit: <fileCfg([SENSITIVE_ACCESS],/mypath,true,crdb-v1-count)>,
-sql-auth: <fileCfg([SESSIONS],/mypath,true,crdb-v1-count)>,
-sql-exec: <fileCfg([SQL_EXEC],/mypath,false,crdb-v1)>,
-sql-slow: <fileCfg([SQL_PERF],/mypath,false,crdb-v1)>,
-sql-slow-internal-only: <fileCfg([SQL_INTERNAL_PERF],/mypath,false,crdb-v1)>},
+sinks: {file-groups: {default: <fileCfg(['DEV,OPS,HEALTH,SQL_SCHEMA,USER_ADMIN,PRIVILEGES'],/mypath,true,crdb-v1)>,
+pebble: <fileCfg([STORAGE],/mypath,true,crdb-v1)>,
+sql-audit: <fileCfg([SENSITIVE_ACCESS],/mypath,false,crdb-v1-count)>,
+sql-auth: <fileCfg([SESSIONS],/mypath,false,crdb-v1-count)>,
+sql-exec: <fileCfg([SQL_EXEC],/mypath,true,crdb-v1)>,
+sql-slow: <fileCfg([SQL_PERF],/mypath,true,crdb-v1)>,
+sql-slow-internal-only: <fileCfg([SQL_INTERNAL_PERF],/mypath,true,crdb-v1)>},
 <stderrDisabled>},
 <stdCaptureFd2(/mypath)>}
 
@@ -172,13 +172,13 @@ start
 --log=sinks: {stderr: {filter: ERROR}}
 ----
 config: {<stdFileDefaults(<defaultLogDir>)>,
-sinks: {file-groups: {default: <fileCfg(['DEV,OPS,HEALTH,SQL_SCHEMA,USER_ADMIN,PRIVILEGES'],<defaultLogDir>,false,crdb-v1)>,
-pebble: <fileCfg([STORAGE],<defaultLogDir>,false,crdb-v1)>,
-sql-audit: <fileCfg([SENSITIVE_ACCESS],<defaultLogDir>,true,crdb-v1-count)>,
-sql-auth: <fileCfg([SESSIONS],<defaultLogDir>,true,crdb-v1-count)>,
-sql-exec: <fileCfg([SQL_EXEC],<defaultLogDir>,false,crdb-v1)>,
-sql-slow: <fileCfg([SQL_PERF],<defaultLogDir>,false,crdb-v1)>,
-sql-slow-internal-only: <fileCfg([SQL_INTERNAL_PERF],<defaultLogDir>,false,crdb-v1)>},
+sinks: {file-groups: {default: <fileCfg(['DEV,OPS,HEALTH,SQL_SCHEMA,USER_ADMIN,PRIVILEGES'],<defaultLogDir>,true,crdb-v1)>,
+pebble: <fileCfg([STORAGE],<defaultLogDir>,true,crdb-v1)>,
+sql-audit: <fileCfg([SENSITIVE_ACCESS],<defaultLogDir>,false,crdb-v1-count)>,
+sql-auth: <fileCfg([SESSIONS],<defaultLogDir>,false,crdb-v1-count)>,
+sql-exec: <fileCfg([SQL_EXEC],<defaultLogDir>,true,crdb-v1)>,
+sql-slow: <fileCfg([SQL_PERF],<defaultLogDir>,true,crdb-v1)>,
+sql-slow-internal-only: <fileCfg([SQL_INTERNAL_PERF],<defaultLogDir>,true,crdb-v1)>},
 <stderrCfg(ERROR,true)>},
 <stdCaptureFd2(<defaultLogDir>)>}
 
@@ -189,13 +189,13 @@ start
 --log=capture-stray-errors: {enable: false}
 ----
 config: {<stdFileDefaults(<defaultLogDir>)>,
-sinks: {file-groups: {default: <fileCfg(['DEV,OPS,HEALTH,SQL_SCHEMA,USER_ADMIN,PRIVILEGES'],<defaultLogDir>,false,crdb-v1)>,
-pebble: <fileCfg([STORAGE],<defaultLogDir>,false,crdb-v1)>,
-sql-audit: <fileCfg([SENSITIVE_ACCESS],<defaultLogDir>,true,crdb-v1-count)>,
-sql-auth: <fileCfg([SESSIONS],<defaultLogDir>,true,crdb-v1-count)>,
-sql-exec: <fileCfg([SQL_EXEC],<defaultLogDir>,false,crdb-v1)>,
-sql-slow: <fileCfg([SQL_PERF],<defaultLogDir>,false,crdb-v1)>,
-sql-slow-internal-only: <fileCfg([SQL_INTERNAL_PERF],<defaultLogDir>,false,crdb-v1)>},
+sinks: {file-groups: {default: <fileCfg(['DEV,OPS,HEALTH,SQL_SCHEMA,USER_ADMIN,PRIVILEGES'],<defaultLogDir>,true,crdb-v1)>,
+pebble: <fileCfg([STORAGE],<defaultLogDir>,true,crdb-v1)>,
+sql-audit: <fileCfg([SENSITIVE_ACCESS],<defaultLogDir>,false,crdb-v1-count)>,
+sql-auth: <fileCfg([SESSIONS],<defaultLogDir>,false,crdb-v1-count)>,
+sql-exec: <fileCfg([SQL_EXEC],<defaultLogDir>,true,crdb-v1)>,
+sql-slow: <fileCfg([SQL_PERF],<defaultLogDir>,true,crdb-v1)>,
+sql-slow-internal-only: <fileCfg([SQL_INTERNAL_PERF],<defaultLogDir>,true,crdb-v1)>},
 <stderrDisabled>}}
 
 # Logging to stderr without stderr capture causes an error in the default config.
@@ -236,13 +236,13 @@ start
 --log-dir=/mypath
 ----
 config: {<stdFileDefaults(/mypath)>,
-sinks: {file-groups: {default: <fileCfg(['DEV,OPS,HEALTH,SQL_SCHEMA,USER_ADMIN,PRIVILEGES'],/mypath,false,crdb-v1)>,
-pebble: <fileCfg([STORAGE],/mypath,false,crdb-v1)>,
-sql-audit: <fileCfg([SENSITIVE_ACCESS],/mypath,true,crdb-v1-count)>,
-sql-auth: <fileCfg([SESSIONS],/mypath,true,crdb-v1-count)>,
-sql-exec: <fileCfg([SQL_EXEC],/mypath,false,crdb-v1)>,
-sql-slow: <fileCfg([SQL_PERF],/mypath,false,crdb-v1)>,
-sql-slow-internal-only: <fileCfg([SQL_INTERNAL_PERF],/mypath,false,crdb-v1)>},
+sinks: {file-groups: {default: <fileCfg(['DEV,OPS,HEALTH,SQL_SCHEMA,USER_ADMIN,PRIVILEGES'],/mypath,true,crdb-v1)>,
+pebble: <fileCfg([STORAGE],/mypath,true,crdb-v1)>,
+sql-audit: <fileCfg([SENSITIVE_ACCESS],/mypath,false,crdb-v1-count)>,
+sql-auth: <fileCfg([SESSIONS],/mypath,false,crdb-v1-count)>,
+sql-exec: <fileCfg([SQL_EXEC],/mypath,true,crdb-v1)>,
+sql-slow: <fileCfg([SQL_PERF],/mypath,true,crdb-v1)>,
+sql-slow-internal-only: <fileCfg([SQL_INTERNAL_PERF],/mypath,true,crdb-v1)>},
 <stderrDisabled>},
 <stdCaptureFd2(/mypath)>}
 
@@ -254,13 +254,13 @@ start
 --log-dir=/pathA
 ----
 config: {<stdFileDefaults(/pathA)>,
-sinks: {file-groups: {default: <fileCfg(['DEV,OPS,HEALTH,SQL_SCHEMA,USER_ADMIN,PRIVILEGES'],/pathA,false,crdb-v1)>,
-pebble: <fileCfg([STORAGE],/pathA,false,crdb-v1)>,
-sql-audit: <fileCfg([SENSITIVE_ACCESS],/pathA,true,crdb-v1-count)>,
-sql-auth: <fileCfg([SESSIONS],/pathA,true,crdb-v1-count)>,
-sql-exec: <fileCfg([SQL_EXEC],/pathA,false,crdb-v1)>,
-sql-slow: <fileCfg([SQL_PERF],/pathA,false,crdb-v1)>,
-sql-slow-internal-only: <fileCfg([SQL_INTERNAL_PERF],/pathA,false,crdb-v1)>},
+sinks: {file-groups: {default: <fileCfg(['DEV,OPS,HEALTH,SQL_SCHEMA,USER_ADMIN,PRIVILEGES'],/pathA,true,crdb-v1)>,
+pebble: <fileCfg([STORAGE],/pathA,true,crdb-v1)>,
+sql-audit: <fileCfg([SENSITIVE_ACCESS],/pathA,false,crdb-v1-count)>,
+sql-auth: <fileCfg([SESSIONS],/pathA,false,crdb-v1-count)>,
+sql-exec: <fileCfg([SQL_EXEC],/pathA,true,crdb-v1)>,
+sql-slow: <fileCfg([SQL_PERF],/pathA,true,crdb-v1)>,
+sql-slow-internal-only: <fileCfg([SQL_INTERNAL_PERF],/pathA,true,crdb-v1)>},
 <stderrDisabled>},
 <stdCaptureFd2(/pathA)>}
 
@@ -274,7 +274,7 @@ init
 config: {<fileDefaultsNoMaxSize(/mypath)>,
 sinks: {file-groups: {default: {channels: all,
 dir: /mypath,
-sync-writes: false,
+buffered-writes: true,
 filter: INFO,
 format: crdb-v1,
 redactable: true}},
@@ -287,13 +287,13 @@ start
 --logtostderr=INFO
 ----
 config: {<stdFileDefaults(<defaultLogDir>)>,
-sinks: {file-groups: {default: <fileCfg(['DEV,OPS,HEALTH,SQL_SCHEMA,USER_ADMIN,PRIVILEGES'],<defaultLogDir>,false,crdb-v1)>,
-pebble: <fileCfg([STORAGE],<defaultLogDir>,false,crdb-v1)>,
-sql-audit: <fileCfg([SENSITIVE_ACCESS],<defaultLogDir>,true,crdb-v1-count)>,
-sql-auth: <fileCfg([SESSIONS],<defaultLogDir>,true,crdb-v1-count)>,
-sql-exec: <fileCfg([SQL_EXEC],<defaultLogDir>,false,crdb-v1)>,
-sql-slow: <fileCfg([SQL_PERF],<defaultLogDir>,false,crdb-v1)>,
-sql-slow-internal-only: <fileCfg([SQL_INTERNAL_PERF],<defaultLogDir>,false,crdb-v1)>},
+sinks: {file-groups: {default: <fileCfg(['DEV,OPS,HEALTH,SQL_SCHEMA,USER_ADMIN,PRIVILEGES'],<defaultLogDir>,true,crdb-v1)>,
+pebble: <fileCfg([STORAGE],<defaultLogDir>,true,crdb-v1)>,
+sql-audit: <fileCfg([SENSITIVE_ACCESS],<defaultLogDir>,false,crdb-v1-count)>,
+sql-auth: <fileCfg([SESSIONS],<defaultLogDir>,false,crdb-v1-count)>,
+sql-exec: <fileCfg([SQL_EXEC],<defaultLogDir>,true,crdb-v1)>,
+sql-slow: <fileCfg([SQL_PERF],<defaultLogDir>,true,crdb-v1)>,
+sql-slow-internal-only: <fileCfg([SQL_INTERNAL_PERF],<defaultLogDir>,true,crdb-v1)>},
 <stderrCfg(INFO,true)>},
 <stdCaptureFd2(<defaultLogDir>)>}
 
@@ -303,13 +303,13 @@ start
 --logtostderr
 ----
 config: {<stdFileDefaults(<defaultLogDir>)>,
-sinks: {file-groups: {default: <fileCfg(['DEV,OPS,HEALTH,SQL_SCHEMA,USER_ADMIN,PRIVILEGES'],<defaultLogDir>,false,crdb-v1)>,
-pebble: <fileCfg([STORAGE],<defaultLogDir>,false,crdb-v1)>,
-sql-audit: <fileCfg([SENSITIVE_ACCESS],<defaultLogDir>,true,crdb-v1-count)>,
-sql-auth: <fileCfg([SESSIONS],<defaultLogDir>,true,crdb-v1-count)>,
-sql-exec: <fileCfg([SQL_EXEC],<defaultLogDir>,false,crdb-v1)>,
-sql-slow: <fileCfg([SQL_PERF],<defaultLogDir>,false,crdb-v1)>,
-sql-slow-internal-only: <fileCfg([SQL_INTERNAL_PERF],<defaultLogDir>,false,crdb-v1)>},
+sinks: {file-groups: {default: <fileCfg(['DEV,OPS,HEALTH,SQL_SCHEMA,USER_ADMIN,PRIVILEGES'],<defaultLogDir>,true,crdb-v1)>,
+pebble: <fileCfg([STORAGE],<defaultLogDir>,true,crdb-v1)>,
+sql-audit: <fileCfg([SENSITIVE_ACCESS],<defaultLogDir>,false,crdb-v1-count)>,
+sql-auth: <fileCfg([SESSIONS],<defaultLogDir>,false,crdb-v1-count)>,
+sql-exec: <fileCfg([SQL_EXEC],<defaultLogDir>,true,crdb-v1)>,
+sql-slow: <fileCfg([SQL_PERF],<defaultLogDir>,true,crdb-v1)>,
+sql-slow-internal-only: <fileCfg([SQL_INTERNAL_PERF],<defaultLogDir>,true,crdb-v1)>},
 <stderrCfg(INFO,true)>},
 <stdCaptureFd2(<defaultLogDir>)>}
 

--- a/pkg/util/log/clog.go
+++ b/pkg/util/log/clog.go
@@ -264,10 +264,10 @@ func (l *loggerT) outputLogEntry(entry logEntry) {
 	// are disabled. See IsActive() and its callers for details.
 	setActive()
 	var fatalTrigger chan struct{}
-	extraSync := false
+	extraFlush := false
 
 	if entry.sev == severity.FATAL {
-		extraSync = true
+		extraFlush = true
 		logging.signalFatalCh()
 
 		switch traceback {
@@ -377,7 +377,7 @@ func (l *loggerT) outputLogEntry(entry logEntry) {
 				// The sink was not accepting entries at this level. Nothing to do.
 				continue
 			}
-			if err := s.sink.output(extraSync, bufs.b[i].Bytes()); err != nil {
+			if err := s.sink.output(extraFlush, bufs.b[i].Bytes()); err != nil {
 				if !s.criticality {
 					// An error on this sink is not critical. Just report
 					// the error and move on.

--- a/pkg/util/log/file_log_gc_test.go
+++ b/pkg/util/log/file_log_gc_test.go
@@ -47,13 +47,13 @@ func TestSecondaryGC(t *testing.T) {
 	f := logconfig.DefaultFileFormat
 	common := logconfig.DefaultConfig().FileDefaults.CommonSinkConfig
 	common.Format = &f
-	bt := true
+	bf := false
 	fc := logconfig.FileConfig{
 		CommonSinkConfig: common,
 		Dir:              &s.logDir,
 		MaxFileSize:      &m,
 		MaxGroupSize:     &m,
-		SyncWrites:       &bt,
+		BufferedWrites:   &bf,
 	}
 	logger := &loggerT{}
 	si, fileSink, err := newFileSinkInfo("gctest", fc)

--- a/pkg/util/log/flags.go
+++ b/pkg/util/log/flags.go
@@ -30,10 +30,10 @@ type config struct {
 	// used for testing.
 	showLogs bool
 
-	// syncWrites can be set asynchronously to force all file output to
-	// synchronize to disk. This is set via SetSync() and used e.g. in
-	// start.go upon encountering errors.
-	syncWrites syncutil.AtomicBool
+	// flushWrites can be set asynchronously to force all file output to
+	// be flushed to disk immediately. This is set via SetAlwaysFlush()
+	// and used e.g. in start.go upon encountering errors.
+	flushWrites syncutil.AtomicBool
 }
 
 var debugLog *loggerT
@@ -165,10 +165,10 @@ func ApplyConfig(config logconfig.Config) (cleanupFn func(), err error) {
 				// impression to the entry parser.
 				Redactable: &bf,
 			},
-			Dir:          config.CaptureFd2.Dir,
-			MaxGroupSize: config.CaptureFd2.MaxGroupSize,
-			MaxFileSize:  &mf,
-			SyncWrites:   &bt,
+			Dir:            config.CaptureFd2.Dir,
+			MaxGroupSize:   config.CaptureFd2.MaxGroupSize,
+			MaxFileSize:    &mf,
+			BufferedWrites: &bf,
 		}
 		fileSinkInfo, fileSink, err := newFileSinkInfo("stderr", fakeConfig)
 		if err != nil {
@@ -295,7 +295,7 @@ func newFileSinkInfo(fileNamePrefix string, c logconfig.FileConfig) (*sinkInfo, 
 	fileSink := newFileSink(
 		*c.Dir,
 		fileNamePrefix,
-		*c.SyncWrites,
+		*c.BufferedWrites,
 		int64(*c.MaxFileSize),
 		int64(*c.MaxGroupSize),
 		info.getStartLines)
@@ -404,7 +404,7 @@ func DescribeAppliedConfig() string {
 		dir := fileSink.mu.logDir
 		fileSink.mu.Unlock()
 		fc.Dir = &dir
-		fc.SyncWrites = &fileSink.syncWrites
+		fc.BufferedWrites = &fileSink.bufferedWrites
 
 		// Describe the connections to this file sink.
 		for ch, logger := range chans {

--- a/pkg/util/log/log_flush.go
+++ b/pkg/util/log/log_flush.go
@@ -32,7 +32,7 @@ type flushSyncWriter interface {
 // user signal.
 func Flush() {
 	_ = allSinkInfos.iterFileSinks(func(l *fileSink) error {
-		l.lockAndFlushAndSync(true /*doSync*/)
+		l.lockAndFlushAndMaybeSync(true /*doSync*/)
 		return nil
 	})
 }
@@ -84,7 +84,7 @@ func flushDaemon() {
 		if !disableDaemons {
 			// Flush the loggers.
 			_ = allSinkInfos.iterFileSinks(func(l *fileSink) error {
-				l.lockAndFlushAndSync(doSync)
+				l.lockAndFlushAndMaybeSync(doSync)
 				return nil
 			})
 		}
@@ -101,13 +101,13 @@ func signalFlusher() {
 	}
 }
 
-// StartSync configures all loggers to start synchronizing writes.
+// StartAlwaysFlush configures all loggers to start flushing writes.
 // This is used e.g. in `cockroach start` when an error occurs,
 // to ensure that all log writes from the point the error
 // occurs are flushed to logs (in case the error degenerates
 // into a panic / segfault on the way out).
-func StartSync() {
-	logging.syncWrites.Set(true)
+func StartAlwaysFlush() {
+	logging.flushWrites.Set(true)
 	// There may be something in the buffers already; flush it.
 	Flush()
 }

--- a/pkg/util/log/logconfig/config.go
+++ b/pkg/util/log/logconfig/config.go
@@ -43,6 +43,7 @@ file-defaults:
     max-file-size: 10mib
     max-group-size: 100mib
     exit-on-error: true
+    buffered-writes: true
 sinks:
   stderr:
     filter: NONE
@@ -188,9 +189,10 @@ type FileDefaults struct {
 	// If zero, old files are not removed.
 	MaxGroupSize ByteSize `yaml:"max-group-size,omitempty"`
 
-	// SyncWrites stores the default setting for sync-writes on file
-	// sinks, which implies synchronization on every log write.
-	SyncWrites bool `yaml:"sync-writes,omitempty"`
+	// BufferedWrites stores the default setting for buffered-writes on
+	// file sinks, which implies keeping a buffer of log entries in memory.
+	// Conversely, setting this to false flushes log writes upon every entry.
+	BufferedWrites *bool `yaml:"buffered-writes,omitempty"`
 
 	// CommonSinkConfig is the configuration common to all sinks. Note
 	// that although the idiom in Go is to place embedded fields at the
@@ -220,8 +222,8 @@ type FileConfig struct {
 	// beyond this specified size.
 	MaxGroupSize *ByteSize `yaml:"max-group-size,omitempty"`
 
-	// SyncWrites specifies whether to sync on every log write.
-	SyncWrites *bool `yaml:"sync-writes,omitempty"`
+	// BufferedWrites specifies whether to flush on every log write.
+	BufferedWrites *bool `yaml:"buffered-writes,omitempty"`
 
 	// CommonSinkConfig is the configuration common to all sinks. Note
 	// that although the idiom in Go is to place embedded fields at the

--- a/pkg/util/log/logconfig/export.go
+++ b/pkg/util/log/logconfig/export.go
@@ -121,10 +121,10 @@ func (c *Config) Export(onlyChans ChannelList) (string, string) {
 		target := fileKey
 
 		var syncproc, synclink []string
-		if *fc.SyncWrites {
-			skey := fmt.Sprintf("sync%d", fileNum)
+		if *fc.BufferedWrites {
+			skey := fmt.Sprintf("buffer%d", fileNum)
 			fileNum++
-			syncproc = append(syncproc, fmt.Sprintf("card %s as \"sync\"", skey))
+			syncproc = append(syncproc, fmt.Sprintf("card %s as \"buffer\"", skey))
 			synclink = append(synclink, fmt.Sprintf("%s --> %s", skey, target))
 			fileNum++
 			target = skey

--- a/pkg/util/log/logconfig/testdata/export
+++ b/pkg/util/log/logconfig/testdata/export
@@ -19,6 +19,7 @@ component sources {
 cloud stray as "stray\nerrors"
 }
 queue stderr
+card buffer2 as "buffer"
 card p__1 as "format:crdb-v1"
 artifact files {
  folder "/default-dir" {
@@ -38,17 +39,18 @@ SENSITIVE_ACCESS --> p__1
 SQL_EXEC --> p__1
 SQL_PERF --> p__1
 SQL_INTERNAL_PERF --> p__1
-p__1 --> f1
+p__1 --> buffer2
+buffer2 --> f1
 stray --> stderrfile
 @enduml
-# http://www.plantuml.com/plantuml/uml/L59DZvim5BpxLpnnQW-qohM7QX5vtI1bWMAAUgY4N7_ieXAyVPXALPN_NjcGTJXvPjxmW1a_p4wGMouZ6xLnu2pGyFpYG0safHlinAIzlDf9Jmvckv3KC_nZxzx34Jj_L3NtnmcpStloYBTLaprYWCXvKPN1mB-UUvwVy2dpx1l7fi-EJqNfMTqKNN76HroTMFAYBJhiipn7_lOqViVyXcjiljnmKRRObDacoj4k2cP7uY-86PA0VaoQoDASi2lxlUX5m-oK9c9Ia8BNlZy4hx5q4UwJ9FKp_ND8c20t624Tc64Clmt6ZaeJ91-LDc8PNQe6IlmWMC2iUwILlyWA-V9XjC_9RRY-Ci2TALq7c_VAhko87QJfv_1XhAfv96lCaMzXtmbRv7VAM_1HY_57BPPmlsrVnNwhBsIl-0RsogwSE0gHUsOEREtAavWGUz2JyfVoVm000F__
+# http://www.plantuml.com/plantuml/uml/L99FZzCm4CNl_XIZdE0GK3boG1krmpPIDornYJWWHLx_sOr8usNY827Kxuvi9tLpydjlNYnhVdaOdI0tNNhMQ-F0MQ3kvTM1waXBrzc1INjviuCU78ns8gb7-CVUlOSTDluudhW_zbWSpdkl-FbO5uyO979U7gjGuDyEBT_kyQdmxZl7kYrsJsNbtQakc_A0ZnYRMF7oN3RO5jijyjlN-0EtYpvX_NNHPNN6kYhcKFPsKZ0w4dz1Z905zNFGH9R6Z5tPxqbF6aQdD16JWXGyJyPe-XJgKMTnyDQscv0QInVXFajIp_cVJSO4kSu8wS1qVTW76DihJP1zLDg8gNUvwYZpWr014--HLluYA-JhXzw-PCimlYN8LIcFWxbxPLUsmmRo_4ju63kUU39n_ydF5Ew2cSLTSYEIiiGbPOdE_MrhHkjRFQbruj6ianMrD0ehzsw6mXOuFZCR5i5waxR67lIW_1_yFm00__y0
 
 # Capture everything to one file with sync and warnings only to stderr.
 yaml only-channels=DEV,SESSIONS
 sinks:
   file-groups:
     everything:
-      sync-writes: true
+      buffered-writes: false
       redact: true
       channels: ALL
   stderr:
@@ -62,7 +64,6 @@ component sources {
 cloud stray as "stray\nerrors"
 }
 queue stderr
-card sync2 as "sync"
 card p__1 as "redact"
 card p__2 as "format:crdb-v1"
 card p__3 as "format:crdb-v1-tty"
@@ -75,13 +76,12 @@ artifact files {
 }
 DEV --> p__2
 SESSIONS --> p__2
-p__1 --> sync2
+p__1 --> f1
 p__2 --> p__1
-sync2 --> f1
 stray --> stderrfile
 DEV --> p__4
 SESSIONS --> p__4
 p__3 --> stderr
 p__4 --> p__3
 @enduml
-# http://www.plantuml.com/plantuml/uml/R98nJ_Cm48Rt-nKdJzyt11JQgGFgq0uiC4Gg2r9bx7DhuThbVAaKeVvt5Bib89XYl-yJ9_V8oooQfJy42EG49I7xtLxGUYOZFaKmwN1CaQ9WJZqRolW1__xZQhqP7zswwnwU7Zim8VKMix0UK6TKPVKIYJbnLd26zvvwmYoMcC5ejfY7QEugF4IZQdZSRjkICLbjP4ehwH8Vj2mCszVcr4xjx8-s4HacObu97uHuyQn0itYdZQ3peGo5BWLBZEhMajDzaCPwLcDH47JrlqmoRvoqsJTq8Xvax-Fk9gITkd9rnBByoTVYmfxX3Alr1flclam7LvDJKbICko8AYeDBsKALDsvT2rLxGRy-_ltq-Q_Jvr2aJQz0KNHfPx2aQCTRyHa00F__
+# http://www.plantuml.com/plantuml/uml/R94nJpCn38Pt_mehq_SD1phQgGFgq0uiC9nK5gGg94uRaPwBuwjKeVvtTBah1u8fjjydZlrccTMATeS4YOAYCahSxHLz578QkGN7XoEtr2fcxiHHnW_uznzNwqr_DEkcUNXwRC0bxZnc5Nj6cz6KwAKb4PPiu0Bl7NM4MJs9WBFYyRZTreKLyjQf-QhUbMfWELXTEF6lrQcUrDaVQgLwdeZvGCIa98jd0rOq1kiKGqnbVWoSF0cQMq_1Taah7yNqGa4m37CvTc_2rkqhEf6STH_RtKtYdRbompOb_CaFmiXUu0AhzGQhwhvi1rVJfagneiz23SM0KQbXSBHFfyU-Tvl_wZQ7Oj9q1Oebepg39RM-__3F0000__y0

--- a/pkg/util/log/logconfig/testdata/validate
+++ b/pkg/util/log/logconfig/testdata/validate
@@ -5,6 +5,7 @@ file-defaults:
   dir: /default-dir
   max-file-size: 10MiB
   max-group-size: 100MiB
+  buffered-writes: true
   filter: INFO
   format: crdb-v1
   redact: false
@@ -18,7 +19,7 @@ sinks:
       dir: /default-dir
       max-file-size: 10MiB
       max-group-size: 100MiB
-      sync-writes: false
+      buffered-writes: true
       filter: INFO
       format: crdb-v1
       redact: false
@@ -47,6 +48,7 @@ file-defaults:
   dir: /default-dir
   max-file-size: 10MiB
   max-group-size: 100MiB
+  buffered-writes: true
   filter: INFO
   format: crdb-v1
   redact: false
@@ -60,7 +62,7 @@ sinks:
       dir: /default-dir
       max-file-size: 10MiB
       max-group-size: 100MiB
-      sync-writes: false
+      buffered-writes: true
       filter: INFO
       format: crdb-v1
       redact: false
@@ -91,6 +93,7 @@ file-defaults:
   dir: /custom
   max-file-size: 10MiB
   max-group-size: 100MiB
+  buffered-writes: true
   filter: INFO
   format: crdb-v1
   redact: false
@@ -104,7 +107,7 @@ sinks:
       dir: /custom
       max-file-size: 10MiB
       max-group-size: 100MiB
-      sync-writes: false
+      buffered-writes: true
       filter: INFO
       format: crdb-v1
       redact: false
@@ -136,6 +139,7 @@ file-defaults:
   dir: /default-dir
   max-file-size: 10MiB
   max-group-size: 100MiB
+  buffered-writes: true
   filter: WARNING
   format: crdb-v1
   redact: false
@@ -149,7 +153,7 @@ sinks:
       dir: /default-dir
       max-file-size: 10MiB
       max-group-size: 100MiB
-      sync-writes: false
+      buffered-writes: true
       filter: WARNING
       format: crdb-v1
       redact: false
@@ -179,6 +183,7 @@ file-defaults:
   dir: /default-dir
   max-file-size: 10MiB
   max-group-size: 100MiB
+  buffered-writes: true
   filter: INFO
   format: crdb-v1
   redact: false
@@ -192,7 +197,7 @@ sinks:
       dir: /default-dir
       max-file-size: 10MiB
       max-group-size: 100MiB
-      sync-writes: false
+      buffered-writes: true
       filter: INFO
       format: crdb-v1
       redact: false
@@ -222,6 +227,7 @@ file-defaults:
   dir: /default-dir
   max-file-size: 10MiB
   max-group-size: 100MiB
+  buffered-writes: true
   filter: INFO
   format: crdb-v1
   redact: false
@@ -235,7 +241,7 @@ sinks:
       dir: /default-dir
       max-file-size: 10MiB
       max-group-size: 100MiB
-      sync-writes: true
+      buffered-writes: false
       filter: INFO
       format: crdb-v1-count
       redact: false
@@ -266,6 +272,7 @@ file-defaults:
   dir: /default-dir
   max-file-size: 10MiB
   max-group-size: 100MiB
+  buffered-writes: true
   filter: INFO
   format: crdb-v1
   redact: false
@@ -279,7 +286,7 @@ sinks:
       dir: /default-dir
       max-file-size: 10MiB
       max-group-size: 100MiB
-      sync-writes: false
+      buffered-writes: true
       filter: INFO
       format: crdb-v1
       redact: false
@@ -305,6 +312,7 @@ file-defaults:
   dir: /default-dir
   max-file-size: 10MiB
   max-group-size: 100MiB
+  buffered-writes: true
   filter: NONE
   format: crdb-v1
   redact: false

--- a/pkg/util/log/logconfig/validate.go
+++ b/pkg/util/log/logconfig/validate.go
@@ -50,6 +50,10 @@ func (c *Config) Validate(defaultLogDir *string) (resErr error) {
 	if c.FileDefaults.Auditable == nil {
 		c.FileDefaults.Auditable = &bf
 	}
+	// File sinks are buffered by default.
+	if c.FileDefaults.BufferedWrites == nil {
+		c.FileDefaults.BufferedWrites = &bt
+	}
 	// No format -> populate defaults.
 	if c.FileDefaults.Format == nil {
 		s := DefaultFileFormat
@@ -229,8 +233,8 @@ func (c *Config) validateFileConfig(fc *FileConfig, defaultLogDir *string) error
 	if fc.MaxGroupSize == nil {
 		fc.MaxGroupSize = &c.FileDefaults.MaxGroupSize
 	}
-	if fc.SyncWrites == nil {
-		fc.SyncWrites = &c.FileDefaults.SyncWrites
+	if fc.BufferedWrites == nil {
+		fc.BufferedWrites = c.FileDefaults.BufferedWrites
 	}
 
 	// Set up the directory.
@@ -253,8 +257,8 @@ func (c *Config) validateFileConfig(fc *FileConfig, defaultLogDir *string) error
 
 	// Apply the auditable flag if set.
 	if *fc.Auditable {
-		bt := true
-		fc.SyncWrites = &bt
+		bf, bt := false, true
+		fc.BufferedWrites = &bf
 		fc.Criticality = &bt
 		if *fc.Format == DefaultFileFormat {
 			s := DefaultFileFormat + "-count"

--- a/pkg/util/log/testdata/config
+++ b/pkg/util/log/testdata/config
@@ -8,7 +8,7 @@ sinks:
       dir: TMPDIR
       max-file-size: 10MiB
       max-group-size: 100MiB
-      sync-writes: false
+      buffered-writes: true
       filter: INFO
       format: crdb-v1
       redact: false
@@ -40,7 +40,7 @@ sinks:
       dir: TMPDIR
       max-file-size: 10MiB
       max-group-size: 100MiB
-      sync-writes: true
+      buffered-writes: false
       filter: INFO
       format: crdb-v1-count
       redact: false
@@ -50,7 +50,7 @@ sinks:
       dir: TMPDIR
       max-file-size: 10MiB
       max-group-size: 100MiB
-      sync-writes: false
+      buffered-writes: true
       filter: INFO
       format: crdb-v1
       redact: false


### PR DESCRIPTION
Requested by @bdarnell 

Fixes #58025 

Release note (cli change): Previously, for certain log files
CockroachDB would both flush individual writes (i.e. propagate them
from within the `cockroach` process to the OS) and also synchronize
writes (i.e. ask the OS to confirm the log data was written to
disk). The per-write synchronization part was unnecessary and, in
fact, found to be possibly detrimental to performance and operating
cost, so it was removed. Meanwhile, the log data continues to be
flushed as previously, and CockroachDB also periodically (every 30s)
request synchronization, also as previously.

Release note (cli change): The parameter `sync-writes` for file sink
configurations has been removed. (This is not a backward-incompatible
change because the configuration feature is new in v21.1.)


Release note (cli change): The parameter `buffered-writes` for file
sink configurations has been added. It is set to `true` (writes are
buffered) by default; and set to `false` (i.e. avoid buffering and
flush every log entry) when the `auditable` flag is requested.