### PR TITLE
build: always specify PORTABLE=1 when building RocksDB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -637,8 +637,11 @@ $(ROCKSDB_DIR)/Makefile: $(C_DEPS_DIR)/rocksdb-rebuild | bin/.submodules-initial
 	mkdir -p $(ROCKSDB_DIR)
 	@# NOTE: If you change the CMake flags below, bump the version in
 	@# $(C_DEPS_DIR)/rocksdb-rebuild. See above for rationale.
+	@#
+	@# NOTE 2: We pass PORTABLE=ON to RocksDB in order to disable usage of -march=native which can
+	@# create non-portable binaries that die with "illegal instruction" when run on some x86 CPUs.
 	cd $(ROCKSDB_DIR) && CFLAGS+=" $(sse)" && CXXFLAGS+=" $(sse)" && cmake $(xcmake-flags) $(ROCKSDB_SRC_DIR) \
-	  $(if $(findstring release,$(BUILDTYPE)),-DPORTABLE=ON) -DWITH_GFLAGS=OFF \
+	  -DPORTABLE=ON -DWITH_GFLAGS=OFF \
 	  -DSNAPPY_LIBRARIES=$(LIBSNAPPY) -DSNAPPY_INCLUDE_DIR="$(SNAPPY_SRC_DIR);$(SNAPPY_DIR)" -DWITH_SNAPPY=ON \
 	  $(if $(use-stdmalloc),,-DJEMALLOC_LIBRARIES=$(LIBJEMALLOC) -DJEMALLOC_INCLUDE_DIR=$(JEMALLOC_DIR)/include -DWITH_JEMALLOC=ON) \
 	  -DCMAKE_BUILD_TYPE=$(if $(ENABLE_ROCKSDB_ASSERTIONS),Debug,Release) \


### PR DESCRIPTION
Something recently changed on the TC agents (presumably usage of a new
machine type with a different CPU) so that using `-march=native` when
building RocksDB causes AVX512 instructions to be used which are not
present on roachprod machines. The result is that binaries built in this
way will die with "illegal instruction". RocksDB has a mechanism to
disable the use of `-march=native`: pass `PORTABLE=1` to the make
command. We were already doing this for release builds. Now we're doing
it for all builds.

Fixes #58754

Release note: none