### PR TITLE
release-20.2: sql: fix nil pointer panics in FilterDescriptorState

### DIFF
--- a/pkg/ccl/backupccl/targets.go
+++ b/pkg/ccl/backupccl/targets.go
@@ -282,7 +282,10 @@ func descriptorsMatchingTargets(
 			return nil
 		}
 		if _, ok := alreadyRequestedSchemas[id]; !ok {
-			schemaDesc := resolver.descByID[id]
+			schemaDesc, ok := resolver.descByID[id]
+			if !ok {
+				return catalog.ErrDescriptorNotFound
+			}
 			if err := catalog.FilterDescriptorState(
 				schemaDesc, tree.CommonLookupFlags{},
 			); err != nil {

--- a/pkg/sql/catalog/catalogkv/physical_accessor.go
+++ b/pkg/sql/catalog/catalogkv/physical_accessor.go
@@ -310,9 +310,9 @@ func (a UncachedPhysicalAccessor) GetObjectDesc(
 		}
 	}
 
-	// Look up the object using the discovered database descriptor.
-	desc, err := GetAnyDescriptorByID(ctx, txn, codec, descID, Mutability(flags.RequireMutable))
-	if err != nil {
+	// Look up the descriptor using the discovered ID.
+	desc, err := GetDescriptorByID(ctx, txn, codec, descID, Mutability(flags.RequireMutable), AnyDescriptorKind, flags.Required)
+	if err != nil || desc == nil {
 		return nil, err
 	}
 	// We have a descriptor, allow it to be in the PUBLIC or ADD state. Possibly

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -772,3 +772,17 @@ testdb         root      ALL
 
 statement ok
 SET DATABASE = test
+
+subtest regression_57639
+
+statement ok
+CREATE TABLE t57639();
+
+statement ok
+SELECT crdb_internal.unsafe_delete_descriptor(id) FROM system.namespace WHERE name = 't57639'
+
+statement error pq: relation "t57639" does not exist
+SELECT count(*) FROM t57639;
+
+statement ok
+SELECT crdb_internal.unsafe_delete_namespace_entry("parentID", "parentSchemaID", name, id) FROM (SELECT * FROM system.namespace WHERE name = 't57639');


### PR DESCRIPTION
Previously, catalog.FilterDescriptorState was sometimes called with
a nil descriptor interface. This patch adds the missing nil checks. This
bug only affects v20.2.x.

Fixes #57639.

Release note (bug fix): Fixed a nil pointer panic bug involving
catalog.FilterDescriptorState. This bug affected version 20.2 since
v20.2.0.