### PR TITLE
release-20.2: sql: don't overwrite ctx with nil on failure

### DIFF
--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -262,12 +262,7 @@ func (dsp *DistSQLPlanner) setupFlows(
 	localReq := setupReq
 	localReq.Flow = *flows[thisNodeID]
 	defer physicalplan.ReleaseSetupFlowRequest(&localReq)
-	ctx, flow, err := dsp.distSQLSrv.SetupLocalSyncFlow(ctx, evalCtx.Mon, &localReq, recv, localState)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return ctx, flow, nil
+	return dsp.distSQLSrv.SetupLocalSyncFlow(ctx, evalCtx.Mon, &localReq, recv, localState)
 }
 
 // Run executes a physical plan. The plan should have been finalized using


### PR DESCRIPTION
Backport 1/1 commits from #59002.

/cc @cockroachdb/release

---

SetupLocalSyncFlow would return a nil ctx with an error in setupFlows if an
error occurred. The previous version would overwrite a ctx in the outer scope
just to return it. This commit no longer overwrites ctx and simply returns the
new ctx when there is no error. On master, this nil ctx would not have any
consequences although this commit is good hygiene, but 20.2 uses this ctx in a
defer, which would cause a panic.

Release note (bug fix): Fix a nil pointer panic edge case in query setup code.
