### PR TITLE
opt: normalize !st_disjoint -> st_intersects

### DIFF
--- a/pkg/sql/opt/norm/rules/scalar.opt
+++ b/pkg/sql/opt/norm/rules/scalar.opt
@@ -317,3 +317,10 @@ $input
 )
 =>
 (And (Is $left (Null (TypeOf $left))) (Null (BoolType)))
+
+# SimplifyNotDisjoint converts !st_disjoint to st_intersects so that
+# the query can be index-accelerated if a suitable inverted index exists.
+[SimplifyNotDisjoint, Normalize]
+(Not (Function $args:* $private:(FunctionPrivate "st_disjoint")))
+=>
+(MakeIntersectionFunction $args)

--- a/pkg/sql/opt/norm/testdata/rules/scalar
+++ b/pkg/sql/opt/norm/testdata/rules/scalar
@@ -1834,3 +1834,51 @@ project
  │    └── key: (1)
  └── projections
       └── (k:1 IS NOT DISTINCT FROM CAST(NULL AS INT8)) AND CAST(NULL AS BOOL) [as="?column?":7, outer=(1)]
+
+# --------------------------------------------------
+# SimplifyNotDisjoint
+# --------------------------------------------------
+
+exec-ddl
+CREATE TABLE g
+(
+    id1 INT PRIMARY KEY,
+    geom1 GEOMETRY,
+    geom2 GEOMETRY,
+    INVERTED INDEX (geom1),
+    INVERTED INDEX (geom2)
+)
+----
+
+norm expect=SimplifyNotDisjoint
+SELECT NOT st_disjoint(geom1, geom2) FROM g;
+----
+project
+ ├── columns: "?column?":7
+ ├── immutable
+ ├── scan g
+ │    └── columns: geom1:2 geom2:3
+ └── projections
+      └── st_intersects(geom1:2, geom2:3) [as="?column?":7, outer=(2,3), immutable]
+
+norm expect-not=SimplifyNotDisjoint
+SELECT st_disjoint(geom1, geom2) FROM g;
+----
+project
+ ├── columns: st_disjoint:7
+ ├── immutable
+ ├── scan g
+ │    └── columns: geom1:2 geom2:3
+ └── projections
+      └── st_disjoint(geom1:2, geom2:3) [as=st_disjoint:7, outer=(2,3), immutable]
+
+norm expect-not=SimplifyNotDisjoint
+SELECT NOT st_intersects(geom1, geom2) FROM g;
+----
+project
+ ├── columns: "?column?":7
+ ├── immutable
+ ├── scan g
+ │    └── columns: geom1:2 geom2:3
+ └── projections
+      └── NOT st_intersects(geom1:2, geom2:3) [as="?column?":7, outer=(2,3), immutable]


### PR DESCRIPTION
This change creates the SimplifyNotDisjoint rule to convert NOT 
st_disjoint(a, b) to st_intersects(a, b), supporting the use of inverted 
indexes when available.

Fixes #55976.

Release note: None