### PR TITLE
sql,tabledesc: do some validation on virtual tables

### DIFF
--- a/pkg/sql/catalog/tabledesc/structured.go
+++ b/pkg/sql/catalog/tabledesc/structured.go
@@ -1778,19 +1778,30 @@ func (desc *wrapper) ValidateTable(ctx context.Context) error {
 		return errors.AssertionFailedf("invalid table ID %d", errors.Safe(desc.ID))
 	}
 
-	// TODO(dt, nathan): virtual descs don't validate (missing privs, PK, etc).
-	if desc.IsVirtualTable() {
-		return nil
+	// ParentID is the ID of the database holding this table.
+	// It is often < ID, except when a table gets moved across databases.
+	if desc.ParentID == 0 {
+		return errors.AssertionFailedf("invalid parent ID %d", errors.Safe(desc.ParentID))
 	}
 
 	if desc.IsSequence() {
 		return nil
 	}
 
-	// ParentID is the ID of the database holding this table.
-	// It is often < ID, except when a table gets moved across databases.
-	if desc.ParentID == 0 {
-		return errors.AssertionFailedf("invalid parent ID %d", errors.Safe(desc.ParentID))
+	if len(desc.Columns) == 0 {
+		return ErrMissingColumns
+	}
+
+	columnNames := make(map[string]descpb.ColumnID, len(desc.Columns))
+	columnIDs := make(map[descpb.ColumnID]*descpb.ColumnDescriptor, len(desc.Columns))
+	if err := desc.validateColumns(columnNames, columnIDs); err != nil {
+		return err
+	}
+
+	// TODO(dt, nathan): virtual descs don't validate on a lot of dimensions
+	// (missing parent, privs, PK, etc).
+	if desc.IsVirtualTable() {
+		return nil
 	}
 
 	// We maintain forward compatibility, so if you see this error message with a
@@ -1810,17 +1821,7 @@ func (desc *wrapper) ValidateTable(ctx context.Context) error {
 			errors.Safe(descpb.FamilyFormatVersion), errors.Safe(descpb.InterleavedFormatVersion))
 	}
 
-	if len(desc.Columns) == 0 {
-		return ErrMissingColumns
-	}
-
 	if err := desc.CheckUniqueConstraints(); err != nil {
-		return err
-	}
-
-	columnNames := make(map[string]descpb.ColumnID, len(desc.Columns))
-	columnIDs := make(map[descpb.ColumnID]*descpb.ColumnDescriptor, len(desc.Columns))
-	if err := desc.validateColumns(columnNames, columnIDs); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This commit makes it harder to make a bad definition for a virtual table.
We still don't validate much on virtual tables, just that there aren't
duplicate columns.

After this change, if there's a duplicate column in a virtual table,
startup will fail like:

```
$ ./cockroach demo
*
* ERROR: creating virtual schema holder: failed to initialize
* CREATE TABLE pg_catalog.pg_user (
* 	usename NAME,
*       usename NAME,
* 	usesysid OID,
* 	usecreatedb BOOL,
* 	usesuper BOOL,
* 	userepl  BOOL,
* 	usebypassrls BOOL,
* 	passwd TEXT,
* 	valuntil TIMESTAMP,
* 	useconfig TEXT[]
* ): duplicate column name: "usename"
*
ERROR: creating virtual schema holder: failed to initialize
```

Fixes #59006.

Release note: None