### PR TITLE
release-20.2: tree: fix serialization of null values in tuples with enums

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -1166,3 +1166,16 @@ DROP DATABASE to_drop CASCADE;
 # the referenced type no longer exists.
 statement ok
 SELECT * FROM crdb_internal.tables
+
+# Regression test for incorrectly serializing NULL expression type annotation in
+# a enum tuple.
+statement ok
+CREATE TYPE greeting58889 AS ENUM ('hello', 'howdy', 'hi', 'good day', 'morning');
+CREATE TABLE t58889 AS SELECT enum_range('hello'::greeting58889)[g] as _enum FROM generate_series(1, 5) as g;
+ALTER TABLE t58889 SPLIT AT SELECT i FROM generate_series(1, 5) as g(i);
+ALTER TABLE t58889 SCATTER;
+
+query T
+SELECT _enum FROM t58889 WHERE _enum::greeting58889 IN (NULL, 'hi':::greeting58889);
+----
+hi

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -3477,6 +3477,7 @@ func (d *DTuple) Format(ctx *FmtCtx) {
 	}
 
 	typ := d.ResolvedType()
+	tupleContents := typ.TupleContents()
 	showLabels := len(typ.TupleLabels()) > 0
 	if showLabels {
 		ctx.WriteByte('(')
@@ -3487,14 +3488,20 @@ func (d *DTuple) Format(ctx *FmtCtx) {
 	for i, v := range d.D {
 		ctx.WriteString(comma)
 		ctx.FormatNode(v)
-		if parsable && (v == DNull) && len(typ.TupleContents()) > i {
+		if parsable && (v == DNull) && len(tupleContents) > i {
 			// If Tuple has types.Unknown for this slot, then we can't determine
 			// the column type to write this annotation. Somebody else will provide
 			// an error message in this case, if necessary, so just skip the
 			// annotation and continue.
-			if typ.TupleContents()[i].Family() != types.UnknownFamily {
-				ctx.WriteString("::")
-				ctx.WriteString(typ.TupleContents()[i].SQLString())
+			if tupleContents[i].Family() != types.UnknownFamily {
+				nullType := tupleContents[i]
+				if ctx.HasFlags(fmtDisambiguateDatumTypes) {
+					ctx.WriteString(":::")
+					ctx.FormatTypeReference(nullType)
+				} else {
+					ctx.WriteString("::")
+					ctx.WriteString(nullType.SQLString())
+				}
 			}
 		}
 		comma = ", "


### PR DESCRIPTION
Backport 1/1 commits from #58894.

/cc @cockroachdb/release

---

Enum values need to be serialized in a special way - with the type
annotation containing an Oid type reference. Previously, NULL values
when used in a tuple with enum values had a different type annotation
which caused the remote nodes to hit an assertion about not being able
to resolve the type by name.

Fixes: #58889.

Release note (bug fix): Previously, CockroachDB could encounter an
internal error when executing queries with tuples containing null values
and enums in a distributed setting, and this is now fixed.
