### PR TITLE
kv: avoid thrashing and livelocking on multiple concurrent Range merge txns

### DIFF
--- a/docs/tech-notes/range-merges.md
+++ b/docs/tech-notes/range-merges.md
@@ -244,6 +244,20 @@ merge transaction is careful to update the local copy of the LHS descriptor as
 its first operation, since the local copy of the LHS descriptor lives on the
 LHS.
 
+---
+**UPDATE in v21.1:**
+
+As of v21.1, the merge transaction uses a locking read on the LHS range's
+transaction record as its first course of action. This eliminates thrashing and
+livelock in the face of concurrent merge attempts, which we typically only see
+in testing scenarios but which we'd like to handle effectively. It also has the
+effect of locating the transaction record on the LHS earlier in the transaction.
+Because of this, the merge transaction no longer needs to be quite as deliberate
+about the order in which it updates descriptors later on because that order does
+not impact the location of the transaction record.
+
+---
+
 Second, the merge transaction must ensure that, when it issues the delete
 request to remove the local copy of the RHS descriptor, the resulting intent is
 actually written to disk. (See the [transfer of power](#transfer-of-power)


### PR DESCRIPTION
Fixes #46639.

This commit updates the Range merge transaction to perform a locking read on the left-hand side's range descriptor. Locking the descriptor early (i.e. on the read instead of the write of the read-modify-write operation) helps prevent multiple concurrent Range merges from thrashing. Thrashing is especially detrimental for Range merges because any restart results in an abort, so thrashing can result in indefinite livelock.

Before this change, I was easily able to reproduce the livelock discussed in #46639 by stressing `TestKVNemesisMultiNode` with the merge probability increased by 10x. When stressing on a 20 node roachprod cluster and using a 60s timeout, the test would typically fail after about 6,000 iterations. With this change and under the same setup, I have yet to see the failure over 125,000 iterations.