### PR TITLE
sql/catalog: rename deprecated descs.Collection methods

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -1041,7 +1041,7 @@ func createImportingDescriptors(
 				// Write the updated databases.
 				for dbID, schemas := range existingDBsWithNewSchemas {
 					log.Infof(ctx, "writing %d schema entries to database %d", len(schemas), dbID)
-					desc, err := descsCol.GetMutableDescriptorByID(ctx, dbID, txn)
+					desc, err := descsCol.GetMutableDescriptorByIDDeprecated(ctx, dbID, txn)
 					if err != nil {
 						return err
 					}
@@ -1078,7 +1078,7 @@ func createImportingDescriptors(
 							continue
 						}
 						// Otherwise, add a backreference to this table.
-						typDesc, err := descsCol.GetMutableTypeVersionByID(ctx, txn, id)
+						typDesc, err := descsCol.GetMutableTypeByIDDeprecated(ctx, txn, id)
 						if err != nil {
 							return err
 						}
@@ -1404,7 +1404,7 @@ func (r *restoreResumer) publishDescriptors(
 	// Write the new TableDescriptors and flip state over to public so they can be
 	// accessed.
 	for _, tbl := range details.TableDescs {
-		mutTable, err := descsCol.GetMutableTableVersionByID(ctx, tbl.GetID(), txn)
+		mutTable, err := descsCol.GetMutableTableByIDDeprecated(ctx, tbl.GetID(), txn)
 		if err != nil {
 			return newDescriptorChangeJobs, err
 		}
@@ -1430,7 +1430,7 @@ func (r *restoreResumer) publishDescriptors(
 	// For all of the newly created types, make type schema change jobs for any
 	// type descriptors that were backed up in the middle of a type schema change.
 	for _, typDesc := range details.TypeDescs {
-		typ, err := descsCol.GetMutableTypeVersionByID(ctx, txn, typDesc.GetID())
+		typ, err := descsCol.GetMutableTypeByIDDeprecated(ctx, txn, typDesc.GetID())
 		if err != nil {
 			return newDescriptorChangeJobs, err
 		}
@@ -1448,7 +1448,7 @@ func (r *restoreResumer) publishDescriptors(
 		}
 	}
 	for _, sc := range details.SchemaDescs {
-		mutDesc, err := descsCol.GetMutableDescriptorByID(ctx, sc.ID, txn)
+		mutDesc, err := descsCol.GetMutableDescriptorByIDDeprecated(ctx, sc.ID, txn)
 		if err != nil {
 			return newDescriptorChangeJobs, err
 		}
@@ -1464,7 +1464,7 @@ func (r *restoreResumer) publishDescriptors(
 		// an offline state.
 		// TODO(lucy): Should we make this more explicit with a format version
 		// field in the details?
-		mutDesc, err := descsCol.GetMutableDescriptorByID(ctx, dbDesc.ID, txn)
+		mutDesc, err := descsCol.GetMutableDescriptorByIDDeprecated(ctx, dbDesc.ID, txn)
 		if err != nil {
 			return newDescriptorChangeJobs, err
 		}
@@ -1563,7 +1563,7 @@ func (r *restoreResumer) dropDescriptors(
 	mutableTables := make([]*tabledesc.Mutable, len(details.TableDescs))
 	for i := range details.TableDescs {
 		var err error
-		mutableTables[i], err = descsCol.GetMutableTableVersionByID(ctx, details.TableDescs[i].ID, txn)
+		mutableTables[i], err = descsCol.GetMutableTableByIDDeprecated(ctx, details.TableDescs[i].ID, txn)
 		if err != nil {
 			return err
 		}
@@ -1718,7 +1718,7 @@ func (r *restoreResumer) dropDescriptors(
 	// delete the now-deleted child schema from its schema map.
 	for dbID, schemas := range dbsWithDeletedSchemas {
 		log.Infof(ctx, "deleting %d schema entries from database %d", len(schemas), dbID)
-		desc, err := descsCol.GetMutableDescriptorByID(ctx, dbID, txn)
+		desc, err := descsCol.GetMutableDescriptorByIDDeprecated(ctx, dbID, txn)
 		if err != nil {
 			return err
 		}
@@ -1774,7 +1774,7 @@ func (r *restoreResumer) removeExistingTypeBackReferences(
 				return restored, nil
 			}
 			// Finally, look it up using the transaction.
-			typ, err := descsCol.GetMutableTypeVersionByID(ctx, txn, id)
+			typ, err := descsCol.GetMutableTypeByIDDeprecated(ctx, txn, id)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -1120,7 +1120,7 @@ func prepareExistingTableDescForIngestion(
 	}
 
 	// Note that desc is just used to verify that the version matches.
-	importing, err := descsCol.GetMutableTableVersionByID(ctx, desc.ID, txn)
+	importing, err := descsCol.GetMutableTableByIDDeprecated(ctx, desc.ID, txn)
 	if err != nil {
 		return nil, err
 	}
@@ -1520,7 +1520,7 @@ func (r *importResumer) publishTables(ctx context.Context, execCfg *sql.Executor
 	) error {
 		b := txn.NewBatch()
 		for _, tbl := range details.Tables {
-			newTableDesc, err := descsCol.GetMutableTableVersionByID(ctx, tbl.Desc.ID, txn)
+			newTableDesc, err := descsCol.GetMutableTableByIDDeprecated(ctx, tbl.Desc.ID, txn)
 			if err != nil {
 				return err
 			}
@@ -1638,7 +1638,7 @@ func (r *importResumer) dropTables(
 	var empty []*tabledesc.Immutable
 	for _, tbl := range details.Tables {
 		if !tbl.IsNew {
-			desc, err := descsCol.GetMutableTableVersionByID(ctx, tbl.Desc.ID, txn)
+			desc, err := descsCol.GetMutableTableByIDDeprecated(ctx, tbl.Desc.ID, txn)
 			if err != nil {
 				return err
 			}
@@ -1680,7 +1680,7 @@ func (r *importResumer) dropTables(
 	dropTime := int64(1)
 	tablesToGC := make([]descpb.ID, 0, len(details.Tables))
 	for _, tbl := range details.Tables {
-		newTableDesc, err := descsCol.GetMutableTableVersionByID(ctx, tbl.Desc.ID, txn)
+		newTableDesc, err := descsCol.GetMutableTableByIDDeprecated(ctx, tbl.Desc.ID, txn)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/alter_database.go
+++ b/pkg/sql/alter_database.go
@@ -174,7 +174,7 @@ func (n *alterDatabaseAddRegionNode) startExec(params runParams) error {
 	}
 
 	// Get the type descriptor for the multi-region enum.
-	typeDesc, err := params.p.Descriptors().GetMutableTypeVersionByID(
+	typeDesc, err := params.p.Descriptors().GetMutableTypeByIDDeprecated(
 		params.ctx,
 		params.p.txn,
 		n.desc.RegionConfig.RegionEnumID,
@@ -327,7 +327,7 @@ func (n *alterDatabasePrimaryRegionNode) switchPrimaryRegion(params runParams) e
 	}
 
 	// Get the type descriptor for the multi-region enum.
-	typeDesc, err := params.p.Descriptors().GetMutableTypeVersionByID(
+	typeDesc, err := params.p.Descriptors().GetMutableTypeByIDDeprecated(
 		params.ctx,
 		params.p.txn,
 		n.desc.RegionConfig.RegionEnumID)

--- a/pkg/sql/alter_schema.go
+++ b/pkg/sql/alter_schema.go
@@ -146,7 +146,7 @@ func (p *planner) checkCanAlterSchemaAndSetNewOwner(
 	}
 
 	// The user must also have CREATE privilege on the schema's database.
-	parentDBDesc, err := p.Descriptors().GetMutableDescriptorByID(ctx, scDesc.GetParentID(), p.txn)
+	parentDBDesc, err := p.Descriptors().GetMutableDescriptorByIDDeprecated(ctx, scDesc.GetParentID(), p.txn)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -1267,7 +1267,7 @@ func (p *planner) updateFKBackReferenceName(
 	if tableDesc.ID == ref.ReferencedTableID {
 		referencedTableDesc = tableDesc
 	} else {
-		lookup, err := p.Descriptors().GetMutableTableVersionByID(ctx, ref.ReferencedTableID, p.txn)
+		lookup, err := p.Descriptors().GetMutableTableByIDDeprecated(ctx, ref.ReferencedTableID, p.txn)
 		if err != nil {
 			return errors.Errorf("error resolving referenced table ID %d: %v", ref.ReferencedTableID, err)
 		}

--- a/pkg/sql/alter_type.go
+++ b/pkg/sql/alter_type.go
@@ -209,7 +209,7 @@ func (p *planner) renameType(ctx context.Context, n *alterTypeNode, newName stri
 	if err != nil {
 		return err
 	}
-	arrayDesc, err := p.Descriptors().GetMutableTypeVersionByID(ctx, p.txn, n.desc.ArrayTypeID)
+	arrayDesc, err := p.Descriptors().GetMutableTypeByIDDeprecated(ctx, p.txn, n.desc.ArrayTypeID)
 	if err != nil {
 		return err
 	}
@@ -316,7 +316,7 @@ func (p *planner) setTypeSchema(ctx context.Context, n *alterTypeNode, schema st
 		return err
 	}
 
-	arrayDesc, err := p.Descriptors().GetMutableTypeVersionByID(ctx, p.txn, n.desc.ArrayTypeID)
+	arrayDesc, err := p.Descriptors().GetMutableTypeByIDDeprecated(ctx, p.txn, n.desc.ArrayTypeID)
 	if err != nil {
 		return err
 	}
@@ -338,7 +338,7 @@ func (p *planner) alterTypeOwner(
 		return nil
 	}
 
-	arrayDesc, err := p.Descriptors().GetMutableTypeVersionByID(ctx, p.txn, typeDesc.ArrayTypeID)
+	arrayDesc, err := p.Descriptors().GetMutableTypeByIDDeprecated(ctx, p.txn, typeDesc.ArrayTypeID)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -360,7 +360,7 @@ func (sc *SchemaChanger) dropConstraints(
 
 	// Create update closure for the table and all other tables with backreferences.
 	if err := sc.txn(ctx, func(ctx context.Context, txn *kv.Txn, descsCol *descs.Collection) error {
-		scTable, err := descsCol.GetMutableTableVersionByID(ctx, sc.descID, txn)
+		scTable, err := descsCol.GetMutableTableByIDDeprecated(ctx, sc.descID, txn)
 		if err != nil {
 			return err
 		}
@@ -392,7 +392,7 @@ func (sc *SchemaChanger) dropConstraints(
 					if def.Name != constraint.Name {
 						continue
 					}
-					backrefTable, err := descsCol.GetMutableTableVersionByID(ctx,
+					backrefTable, err := descsCol.GetMutableTableByIDDeprecated(ctx,
 						constraint.ForeignKey.ReferencedTableID, txn)
 					if err != nil {
 						return err
@@ -485,7 +485,7 @@ func (sc *SchemaChanger) addConstraints(
 	if err := sc.txn(ctx, func(
 		ctx context.Context, txn *kv.Txn, descsCol *descs.Collection,
 	) error {
-		scTable, err := descsCol.GetMutableTableVersionByID(ctx, sc.descID, txn)
+		scTable, err := descsCol.GetMutableTableByIDDeprecated(ctx, sc.descID, txn)
 		if err != nil {
 			return err
 		}
@@ -536,7 +536,7 @@ func (sc *SchemaChanger) addConstraints(
 				}
 				if !foundExisting {
 					scTable.OutboundFKs = append(scTable.OutboundFKs, constraint.ForeignKey)
-					backrefTable, err := descsCol.GetMutableTableVersionByID(ctx, constraint.ForeignKey.ReferencedTableID, txn)
+					backrefTable, err := descsCol.GetMutableTableByIDDeprecated(ctx, constraint.ForeignKey.ReferencedTableID, txn)
 					if err != nil {
 						return err
 					}
@@ -1900,7 +1900,7 @@ func runSchemaChangesInTxn(
 				}
 				if oldIndex.NumInterleaveAncestors() != 0 {
 					ancestorInfo := oldIndex.GetInterleaveAncestor(oldIndex.NumInterleaveAncestors() - 1)
-					ancestor, err := planner.Descriptors().GetMutableTableVersionByID(ctx, ancestorInfo.TableID, planner.txn)
+					ancestor, err := planner.Descriptors().GetMutableTableByIDDeprecated(ctx, ancestorInfo.TableID, planner.txn)
 					if err != nil {
 						return err
 					}
@@ -1986,7 +1986,7 @@ func runSchemaChangesInTxn(
 			if selfReference {
 				referencedTableDesc = tableDesc
 			} else {
-				lookup, err := planner.Descriptors().GetMutableTableVersionByID(ctx, fk.ReferencedTableID, planner.Txn())
+				lookup, err := planner.Descriptors().GetMutableTableByIDDeprecated(ctx, fk.ReferencedTableID, planner.Txn())
 				if err != nil {
 					return errors.Errorf("error resolving referenced table ID %d: %v", fk.ReferencedTableID, err)
 				}

--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -1028,12 +1028,13 @@ func (tc *Collection) getDescriptorByIDMaybeSetTxnDeadline(
 	return desc, nil
 }
 
-// GetMutableTableVersionByID is a variant of sqlbase.getTableDescFromID which returns a mutable
-// table descriptor of the table modified in the same transaction.
+// GetMutableTableByIDDeprecated is a variant of sqlbase.getTableDescFromID
+// which returns a mutable table descriptor of the table modified in the same
+// transaction.
 // Deprecated in favor of GetMutableTableByID.
 // TODO (lucy): Usages should be replaced with GetMutableTableByID, but this
 // needs a careful look at what flags should be passed in at each call site.
-func (tc *Collection) GetMutableTableVersionByID(
+func (tc *Collection) GetMutableTableByIDDeprecated(
 	ctx context.Context, tableID descpb.ID, txn *kv.Txn,
 ) (*tabledesc.Mutable, error) {
 	return tc.GetMutableTableByID(ctx, txn, tableID, tree.ObjectLookupFlags{
@@ -1044,23 +1045,22 @@ func (tc *Collection) GetMutableTableVersionByID(
 	})
 }
 
-// GetMutableDescriptorByID returns a mutable implementation of the descriptor
-// with the requested id. An error is returned if no descriptor exists.
-// Deprecated in favor of GetMutableDescriptorByIDWithFlags.
-func (tc *Collection) GetMutableDescriptorByID(
+// GetMutableDescriptorByIDDeprecated returns a mutable implementation of the
+// descriptor with the requested id. An error is returned if no descriptor
+// exists.
+// Deprecated in favor of GetMutableDescriptorByID.
+func (tc *Collection) GetMutableDescriptorByIDDeprecated(
 	ctx context.Context, id descpb.ID, txn *kv.Txn,
 ) (catalog.MutableDescriptor, error) {
-	return tc.GetMutableDescriptorByIDWithFlags(ctx, txn, id, tree.CommonLookupFlags{
+	return tc.GetMutableDescriptorByID(ctx, txn, id, tree.CommonLookupFlags{
 		IncludeOffline: true,
 		IncludeDropped: true,
 	})
 }
 
-// GetMutableDescriptorByIDWithFlags returns a mutable implementation of the
+// GetMutableDescriptorByID returns a mutable implementation of the
 // descriptor with the requested id. An error is returned if no descriptor exists.
-// TODO (lucy): This is meant to replace GetMutableDescriptorByID. Once it does,
-// rename this function.
-func (tc *Collection) GetMutableDescriptorByIDWithFlags(
+func (tc *Collection) GetMutableDescriptorByID(
 	ctx context.Context, txn *kv.Txn, id descpb.ID, flags tree.CommonLookupFlags,
 ) (catalog.MutableDescriptor, error) {
 	log.VEventf(ctx, 2, "planner getting mutable descriptor for id %d", id)
@@ -1165,11 +1165,11 @@ func (tc *Collection) hydrateTypesInTableDesc(
 		// not shared. When hydrating mutable descriptors, use the mutable access
 		// method to access types.
 		getType := func(ctx context.Context, id descpb.ID) (tree.TypeName, catalog.TypeDescriptor, error) {
-			desc, err := tc.GetMutableTypeVersionByID(ctx, txn, id)
+			desc, err := tc.GetMutableTypeByIDDeprecated(ctx, txn, id)
 			if err != nil {
 				return tree.TypeName{}, nil, err
 			}
-			dbDesc, err := tc.GetMutableDescriptorByID(ctx, desc.ParentID, txn)
+			dbDesc, err := tc.GetMutableDescriptorByIDDeprecated(ctx, desc.ParentID, txn)
 			if err != nil {
 				return tree.TypeName{}, nil, err
 			}
@@ -1394,12 +1394,12 @@ func (tc *Collection) GetUncommittedTables() (tables []*tabledesc.Immutable) {
 
 // User defined type accessors.
 
-// GetMutableTypeVersionByID is the equivalent of GetMutableTableDescriptorByID
+// GetMutableTypeByIDDeprecated is the equivalent of GetMutableTableByIDDeprecated
 // but for accessing types.
 // Deprecated in favor of GetMutableTypeByID.
 // TODO (lucy): Usages should be replaced with GetMutableTypeByID, but this
 // needs a careful look at what flags should be passed in at each call site.
-func (tc *Collection) GetMutableTypeVersionByID(
+func (tc *Collection) GetMutableTypeByIDDeprecated(
 	ctx context.Context, txn *kv.Txn, typeID descpb.ID,
 ) (*typedesc.Mutable, error) {
 	return tc.GetMutableTypeByID(ctx, txn, typeID, tree.ObjectLookupFlags{

--- a/pkg/sql/catalog/descs/collection_test.go
+++ b/pkg/sql/catalog/descs/collection_test.go
@@ -194,7 +194,7 @@ func TestAddUncommittedDescriptorAndMutableResolution(t *testing.T) {
 
 			require.Same(t, db, resolved)
 
-			byID, err := descriptors.GetMutableDescriptorByID(ctx, db.GetID(), txn)
+			byID, err := descriptors.GetMutableDescriptorByIDDeprecated(ctx, db.GetID(), txn)
 			require.NoError(t, err)
 			require.Same(t, db, byID)
 
@@ -261,7 +261,7 @@ func TestAddUncommittedDescriptorAndMutableResolution(t *testing.T) {
 
 			require.Same(t, schema.Desc, resolved.Desc)
 
-			byID, err := descriptors.GetMutableDescriptorByID(ctx, schema.ID, txn)
+			byID, err := descriptors.GetMutableDescriptorByIDDeprecated(ctx, schema.ID, txn)
 			require.NoError(t, err)
 
 			require.Same(t, schema.Desc, byID)
@@ -285,7 +285,7 @@ func TestAddUncommittedDescriptorAndMutableResolution(t *testing.T) {
 
 			require.Same(t, tab, resolved)
 
-			byID, err := descriptors.GetMutableDescriptorByID(ctx, tab.GetID(), txn)
+			byID, err := descriptors.GetMutableDescriptorByIDDeprecated(ctx, tab.GetID(), txn)
 			require.NoError(t, err)
 
 			require.Same(t, tab, byID)
@@ -308,7 +308,7 @@ func TestAddUncommittedDescriptorAndMutableResolution(t *testing.T) {
 
 			require.Same(t, typ, resolved)
 
-			byID, err := descriptors.GetMutableTypeVersionByID(ctx, txn, typ.GetID())
+			byID, err := descriptors.GetMutableTypeByIDDeprecated(ctx, txn, typ.GetID())
 			require.NoError(t, err)
 
 			require.Same(t, typ, byID)

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1117,7 +1117,7 @@ func (p *planner) finalizeInterleave(
 		ancestorTable = desc
 	} else {
 		var err error
-		ancestorTable, err = p.Descriptors().GetMutableTableVersionByID(ctx, ancestor.TableID, p.txn)
+		ancestorTable, err = p.Descriptors().GetMutableTableByIDDeprecated(ctx, ancestor.TableID, p.txn)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -117,7 +117,7 @@ func (n *createViewNode) startExec(params runParams) error {
 			if err != nil {
 				return err
 			}
-			desc, err := params.p.Descriptors().GetMutableTableVersionByID(params.ctx, id, params.p.txn)
+			desc, err := params.p.Descriptors().GetMutableTableByIDDeprecated(params.ctx, id, params.p.txn)
 			if err != nil {
 				return err
 			}
@@ -342,7 +342,7 @@ func (p *planner) replaceViewDesc(
 		desc, ok := backRefMutables[id]
 		if !ok {
 			var err error
-			desc, err = p.Descriptors().GetMutableTableVersionByID(ctx, id, p.txn)
+			desc, err = p.Descriptors().GetMutableTableByIDDeprecated(ctx, id, p.txn)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/sql/drop_database.go
+++ b/pkg/sql/drop_database.go
@@ -266,7 +266,7 @@ func (p *planner) accumulateOwnedSequences(
 ) error {
 	for colID := range desc.GetColumns() {
 		for _, seqID := range desc.GetColumns()[colID].OwnsSequenceIds {
-			ownedSeqDesc, err := p.Descriptors().GetMutableTableVersionByID(ctx, seqID, p.txn)
+			ownedSeqDesc, err := p.Descriptors().GetMutableTableByIDDeprecated(ctx, seqID, p.txn)
 			if err != nil {
 				// Special case error swallowing for #50711 and #50781, which can
 				// cause columns to own sequences that have been dropped/do not
@@ -293,7 +293,7 @@ func (p *planner) accumulateCascadingViews(
 	ctx context.Context, dependentObjects map[descpb.ID]*tabledesc.Mutable, desc *tabledesc.Mutable,
 ) error {
 	for _, ref := range desc.DependedOnBy {
-		dependentDesc, err := p.Descriptors().GetMutableTableVersionByID(ctx, ref.ID, p.txn)
+		dependentDesc, err := p.Descriptors().GetMutableTableByIDDeprecated(ctx, ref.ID, p.txn)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/drop_table.go
+++ b/pkg/sql/drop_table.go
@@ -217,7 +217,7 @@ func (p *planner) canDropTable(
 func (p *planner) canRemoveFKBackreference(
 	ctx context.Context, from string, ref *descpb.ForeignKeyConstraint, behavior tree.DropBehavior,
 ) error {
-	table, err := p.Descriptors().GetMutableTableVersionByID(ctx, ref.OriginTableID, p.txn)
+	table, err := p.Descriptors().GetMutableTableByIDDeprecated(ctx, ref.OriginTableID, p.txn)
 	if err != nil {
 		return err
 	}
@@ -232,7 +232,7 @@ func (p *planner) canRemoveFKBackreference(
 func (p *planner) canRemoveInterleave(
 	ctx context.Context, from string, ref descpb.ForeignKeyReference, behavior tree.DropBehavior,
 ) error {
-	table, err := p.Descriptors().GetMutableTableVersionByID(ctx, ref.Table, p.txn)
+	table, err := p.Descriptors().GetMutableTableByIDDeprecated(ctx, ref.Table, p.txn)
 	if err != nil {
 		return err
 	}
@@ -250,7 +250,7 @@ func (p *planner) canRemoveInterleave(
 }
 
 func (p *planner) removeInterleave(ctx context.Context, ref descpb.ForeignKeyReference) error {
-	table, err := p.Descriptors().GetMutableTableVersionByID(ctx, ref.Table, p.txn)
+	table, err := p.Descriptors().GetMutableTableByIDDeprecated(ctx, ref.Table, p.txn)
 	if err != nil {
 		return err
 	}
@@ -520,7 +520,7 @@ func (p *planner) removeFKForBackReference(
 	if tableDesc.ID == ref.OriginTableID {
 		originTableDesc = tableDesc
 	} else {
-		lookup, err := p.Descriptors().GetMutableTableVersionByID(ctx, ref.OriginTableID, p.txn)
+		lookup, err := p.Descriptors().GetMutableTableByIDDeprecated(ctx, ref.OriginTableID, p.txn)
 		if err != nil {
 			return errors.Errorf("error resolving origin table ID %d: %v", ref.OriginTableID, err)
 		}
@@ -578,7 +578,7 @@ func (p *planner) removeFKBackReference(
 	if tableDesc.ID == ref.ReferencedTableID {
 		referencedTableDesc = tableDesc
 	} else {
-		lookup, err := p.Descriptors().GetMutableTableVersionByID(ctx, ref.ReferencedTableID, p.txn)
+		lookup, err := p.Descriptors().GetMutableTableByIDDeprecated(ctx, ref.ReferencedTableID, p.txn)
 		if err != nil {
 			return errors.Errorf("error resolving referenced table ID %d: %v", ref.ReferencedTableID, err)
 		}
@@ -634,7 +634,7 @@ func (p *planner) removeInterleaveBackReference(
 	if ancestor.TableID == tableDesc.ID {
 		t = tableDesc
 	} else {
-		lookup, err := p.Descriptors().GetMutableTableVersionByID(ctx, ancestor.TableID, p.txn)
+		lookup, err := p.Descriptors().GetMutableTableByIDDeprecated(ctx, ancestor.TableID, p.txn)
 		if err != nil {
 			return errors.Errorf("error resolving referenced table ID %d: %v", ancestor.TableID, err)
 		}

--- a/pkg/sql/drop_type.go
+++ b/pkg/sql/drop_type.go
@@ -97,7 +97,7 @@ func (p *planner) DropType(ctx context.Context, n *tree.DropType) (planNode, err
 		}
 
 		// Get the array type that needs to be dropped as well.
-		mutArrayDesc, err := p.Descriptors().GetMutableTypeVersionByID(ctx, p.txn, typeDesc.ArrayTypeID)
+		mutArrayDesc, err := p.Descriptors().GetMutableTypeByIDDeprecated(ctx, p.txn, typeDesc.ArrayTypeID)
 		if err != nil {
 			return nil, err
 		}
@@ -135,7 +135,7 @@ func (p *planner) canDropTypeDesc(
 	if len(desc.ReferencingDescriptorIDs) > 0 && behavior != tree.DropCascade {
 		var dependentNames []string
 		for _, id := range desc.ReferencingDescriptorIDs {
-			desc, err := p.Descriptors().GetMutableTableVersionByID(ctx, id, p.txn)
+			desc, err := p.Descriptors().GetMutableTableByIDDeprecated(ctx, id, p.txn)
 			if err != nil {
 				return errors.Wrapf(err, "type has dependent objects")
 			}
@@ -172,7 +172,7 @@ func (n *dropTypeNode) startExec(params runParams) error {
 func (p *planner) addTypeBackReference(
 	ctx context.Context, typeID, ref descpb.ID, jobDesc string,
 ) error {
-	mutDesc, err := p.Descriptors().GetMutableTypeVersionByID(ctx, p.txn, typeID)
+	mutDesc, err := p.Descriptors().GetMutableTypeByIDDeprecated(ctx, p.txn, typeID)
 	if err != nil {
 		return err
 	}
@@ -191,7 +191,7 @@ func (p *planner) addTypeBackReference(
 func (p *planner) removeTypeBackReference(
 	ctx context.Context, typeID, ref descpb.ID, jobDesc string,
 ) error {
-	mutDesc, err := p.Descriptors().GetMutableTypeVersionByID(ctx, p.txn, typeID)
+	mutDesc, err := p.Descriptors().GetMutableTypeByIDDeprecated(ctx, p.txn, typeID)
 	if err != nil {
 		return err
 	}
@@ -203,7 +203,7 @@ func (p *planner) addBackRefsFromAllTypesInTable(
 	ctx context.Context, desc *tabledesc.Mutable,
 ) error {
 	typeIDs, err := desc.GetAllReferencedTypeIDs(func(id descpb.ID) (catalog.TypeDescriptor, error) {
-		mutDesc, err := p.Descriptors().GetMutableTypeVersionByID(ctx, p.txn, id)
+		mutDesc, err := p.Descriptors().GetMutableTypeByIDDeprecated(ctx, p.txn, id)
 		if err != nil {
 			return nil, err
 		}
@@ -225,7 +225,7 @@ func (p *planner) removeBackRefsFromAllTypesInTable(
 	ctx context.Context, desc *tabledesc.Mutable,
 ) error {
 	typeIDs, err := desc.GetAllReferencedTypeIDs(func(id descpb.ID) (catalog.TypeDescriptor, error) {
-		mutDesc, err := p.Descriptors().GetMutableTypeVersionByID(ctx, p.txn, id)
+		mutDesc, err := p.Descriptors().GetMutableTypeByIDDeprecated(ctx, p.txn, id)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/drop_view.go
+++ b/pkg/sql/drop_view.go
@@ -194,7 +194,7 @@ func (p *planner) dropViewImpl(
 	// Remove back-references from the tables/views this view depends on.
 	dependedOn := append([]descpb.ID(nil), viewDesc.DependsOn...)
 	for _, depID := range dependedOn {
-		dependencyDesc, err := p.Descriptors().GetMutableTableVersionByID(ctx, depID, p.txn)
+		dependencyDesc, err := p.Descriptors().GetMutableTableByIDDeprecated(ctx, depID, p.txn)
 		if err != nil {
 			return cascadeDroppedViews,
 				errors.Errorf("error resolving dependency relation ID %d: %v", depID, err)
@@ -252,7 +252,7 @@ func (p *planner) getViewDescForCascade(
 	parentID, viewID descpb.ID,
 	behavior tree.DropBehavior,
 ) (*tabledesc.Mutable, error) {
-	viewDesc, err := p.Descriptors().GetMutableTableVersionByID(ctx, viewID, p.txn)
+	viewDesc, err := p.Descriptors().GetMutableTableByIDDeprecated(ctx, viewID, p.txn)
 	if err != nil {
 		log.Warningf(ctx, "unable to retrieve descriptor for view %d: %v", viewID, err)
 		return nil, errors.Wrapf(err, "error resolving dependent view ID %d", viewID)

--- a/pkg/sql/gcjob/descriptor_utils.go
+++ b/pkg/sql/gcjob/descriptor_utils.go
@@ -36,7 +36,7 @@ func updateDescriptorGCMutations(
 		execCfg.DB, func(
 			ctx context.Context, txn *kv.Txn, descsCol *descs.Collection,
 		) error {
-			tbl, err := descsCol.GetMutableTableVersionByID(ctx, tableID, txn)
+			tbl, err := descsCol.GetMutableTableByIDDeprecated(ctx, tableID, txn)
 			if err != nil {
 				return err
 			}

--- a/pkg/sql/reassign_owned_by.go
+++ b/pkg/sql/reassign_owned_by.go
@@ -110,7 +110,7 @@ func (n *reassignOwnedByNode) startExec(params runParams) error {
 func (n *reassignOwnedByNode) reassignDatabaseOwner(
 	dbDesc *dbdesc.Immutable, params runParams,
 ) error {
-	mutableDbDesc, err := params.p.Descriptors().GetMutableDescriptorByID(params.ctx, dbDesc.ID, params.p.txn)
+	mutableDbDesc, err := params.p.Descriptors().GetMutableDescriptorByIDDeprecated(params.ctx, dbDesc.ID, params.p.txn)
 	if err != nil {
 		return err
 	}
@@ -131,7 +131,7 @@ func (n *reassignOwnedByNode) reassignDatabaseOwner(
 func (n *reassignOwnedByNode) reassignSchemaOwner(
 	schemaDesc *schemadesc.Immutable, params runParams,
 ) error {
-	mutableSchemaDesc, err := params.p.Descriptors().GetMutableDescriptorByID(
+	mutableSchemaDesc, err := params.p.Descriptors().GetMutableDescriptorByIDDeprecated(
 		params.ctx, schemaDesc.ID, params.p.txn)
 	if err != nil {
 		return err
@@ -152,7 +152,7 @@ func (n *reassignOwnedByNode) reassignSchemaOwner(
 func (n *reassignOwnedByNode) reassignTableOwner(
 	tbDesc *tabledesc.Immutable, params runParams,
 ) error {
-	mutableTbDesc, err := params.p.Descriptors().GetMutableDescriptorByID(
+	mutableTbDesc, err := params.p.Descriptors().GetMutableDescriptorByIDDeprecated(
 		params.ctx, tbDesc.ID, params.p.txn)
 	if err != nil {
 		return err
@@ -172,12 +172,12 @@ func (n *reassignOwnedByNode) reassignTableOwner(
 func (n *reassignOwnedByNode) reassignTypeOwner(
 	typDesc *typedesc.Immutable, params runParams,
 ) error {
-	mutableTypDesc, err := params.p.Descriptors().GetMutableDescriptorByID(
+	mutableTypDesc, err := params.p.Descriptors().GetMutableDescriptorByIDDeprecated(
 		params.ctx, typDesc.ID, params.p.txn)
 	if err != nil {
 		return err
 	}
-	arrayDesc, err := params.p.Descriptors().GetMutableTypeVersionByID(
+	arrayDesc, err := params.p.Descriptors().GetMutableTypeByIDDeprecated(
 		params.ctx, params.p.txn, typDesc.ArrayTypeID)
 	if err != nil {
 		return err

--- a/pkg/sql/repair.go
+++ b/pkg/sql/repair.go
@@ -72,7 +72,7 @@ func (p *planner) UnsafeUpsertDescriptor(
 
 	// Fetch the existing descriptor.
 
-	existing, err := p.Descriptors().GetMutableDescriptorByID(ctx, id, p.txn)
+	existing, err := p.Descriptors().GetMutableDescriptorByIDDeprecated(ctx, id, p.txn)
 	var forceNoticeString string // for the event
 	if !errors.Is(err, catalog.ErrDescriptorNotFound) && err != nil {
 		if force {
@@ -190,7 +190,7 @@ func (p *planner) UnsafeUpsertNamespaceEntry(
 		existingID = descpb.ID(val.ValueInt())
 	}
 	validateDescriptor := func() error {
-		desc, err := p.Descriptors().GetMutableDescriptorByID(ctx, descID, p.txn)
+		desc, err := p.Descriptors().GetMutableDescriptorByIDDeprecated(ctx, descID, p.txn)
 		if err != nil && descID != keys.PublicSchemaID {
 			return errors.Wrapf(err, "failed to retrieve descriptor %d", descID)
 		}
@@ -229,7 +229,7 @@ func (p *planner) UnsafeUpsertNamespaceEntry(
 		if parentID == 0 {
 			return nil
 		}
-		parent, err := p.Descriptors().GetMutableDescriptorByID(
+		parent, err := p.Descriptors().GetMutableDescriptorByIDDeprecated(
 			ctx, parentID, p.txn,
 		)
 		if err != nil {
@@ -245,7 +245,7 @@ func (p *planner) UnsafeUpsertNamespaceEntry(
 		if parentSchemaID == 0 || parentSchemaID == keys.PublicSchemaID {
 			return nil
 		}
-		schema, err := p.Descriptors().GetMutableDescriptorByID(
+		schema, err := p.Descriptors().GetMutableDescriptorByIDDeprecated(
 			ctx, parentID, p.txn,
 		)
 		if err != nil {
@@ -329,7 +329,7 @@ func (p *planner) UnsafeDeleteNamespaceEntry(
 				parentID, parentSchemaID, name, existingID, descID)
 		}
 	}
-	desc, err := p.Descriptors().GetMutableDescriptorByID(ctx, descID, p.txn)
+	desc, err := p.Descriptors().GetMutableDescriptorByIDDeprecated(ctx, descID, p.txn)
 	var forceNoticeString string // for the event
 	if err != nil && !errors.Is(err, catalog.ErrDescriptorNotFound) {
 		if force {
@@ -371,7 +371,7 @@ func (p *planner) UnsafeDeleteDescriptor(ctx context.Context, descID int64, forc
 		return err
 	}
 	id := descpb.ID(descID)
-	mut, err := p.Descriptors().GetMutableDescriptorByID(ctx, id, p.txn)
+	mut, err := p.Descriptors().GetMutableDescriptorByIDDeprecated(ctx, id, p.txn)
 	var forceNoticeString string // for the event
 	if err != nil {
 		if !errors.Is(err, catalog.ErrDescriptorNotFound) && force {

--- a/pkg/sql/reparent_database.go
+++ b/pkg/sql/reparent_database.go
@@ -189,7 +189,7 @@ func (n *reparentDatabaseNode) startExec(params runParams) error {
 					return errors.Wrapf(err, errStr, n.db.Name, tbl.Name)
 				}
 				for _, ref := range tbl.GetDependedOnBy() {
-					dep, err := p.Descriptors().GetMutableTableVersionByID(ctx, ref.ID, p.txn)
+					dep, err := p.Descriptors().GetMutableTableByIDDeprecated(ctx, ref.ID, p.txn)
 					if err != nil {
 						return errors.Wrapf(err, errStr, n.db.Name, tblName.String())
 					}

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -1425,7 +1425,7 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT);
 		if err := descs.Txn(ctx, s.ClusterSettings(), leaseMgr, ie, kvDB, func(
 			ctx context.Context, txn *kv.Txn, descsCol *descs.Collection,
 		) error {
-			table, err := descsCol.GetMutableTableVersionByID(ctx, id, txn)
+			table, err := descsCol.GetMutableTableByIDDeprecated(ctx, id, txn)
 			if err != nil {
 				return err
 			}

--- a/pkg/sql/sequence.go
+++ b/pkg/sql/sequence.go
@@ -379,7 +379,7 @@ func removeSequenceOwnerIfExists(
 	if !opts.HasOwner() {
 		return nil
 	}
-	tableDesc, err := p.Descriptors().GetMutableTableVersionByID(ctx, opts.SequenceOwner.OwnerTableID, p.txn)
+	tableDesc, err := p.Descriptors().GetMutableTableByIDDeprecated(ctx, opts.SequenceOwner.OwnerTableID, p.txn)
 	if err != nil {
 		// Special case error swallowing for #50711 and #50781, which can cause a
 		// column to own sequences that have been dropped/do not exist.
@@ -539,7 +539,7 @@ func (p *planner) dropSequencesOwnedByCol(
 	// back around and update the descriptor from underneath us.
 	ownsSequenceIDs := append([]descpb.ID(nil), col.OwnsSequenceIds...)
 	for _, sequenceID := range ownsSequenceIDs {
-		seqDesc, err := p.Descriptors().GetMutableTableVersionByID(ctx, sequenceID, p.txn)
+		seqDesc, err := p.Descriptors().GetMutableTableByIDDeprecated(ctx, sequenceID, p.txn)
 		// Special case error swallowing for #50781, which can cause a
 		// column to own sequences that do not exist.
 		if err != nil {
@@ -577,7 +577,7 @@ func (p *planner) removeSequenceDependencies(
 ) error {
 	for _, sequenceID := range col.UsesSequenceIds {
 		// Get the sequence descriptor so we can remove the reference from it.
-		seqDesc, err := p.Descriptors().GetMutableTableVersionByID(ctx, sequenceID, p.txn)
+		seqDesc, err := p.Descriptors().GetMutableTableByIDDeprecated(ctx, sequenceID, p.txn)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -105,7 +105,7 @@ func (t *truncateNode) startExec(params runParams) error {
 			if _, ok := toTruncate[tableID]; ok {
 				return nil
 			}
-			other, err := p.Descriptors().GetMutableTableVersionByID(ctx, tableID, p.txn)
+			other, err := p.Descriptors().GetMutableTableByIDDeprecated(ctx, tableID, p.txn)
 			if err != nil {
 				return err
 			}
@@ -183,7 +183,7 @@ func (p *planner) truncateTable(
 ) error {
 	// Read the table descriptor because it might have changed
 	// while another table in the truncation list was truncated.
-	tableDesc, err := p.Descriptors().GetMutableTableVersionByID(ctx, id, p.txn)
+	tableDesc, err := p.Descriptors().GetMutableTableByIDDeprecated(ctx, id, p.txn)
 	if err != nil {
 		return err
 	}
@@ -356,7 +356,7 @@ func (p *planner) findAllReferencingInterleaves(
 		if id == table.ID {
 			continue
 		}
-		t, err := p.Descriptors().GetMutableTableVersionByID(ctx, id, p.txn)
+		t, err := p.Descriptors().GetMutableTableByIDDeprecated(ctx, id, p.txn)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/type_change.go
+++ b/pkg/sql/type_change.go
@@ -156,7 +156,7 @@ func (t *typeSchemaChanger) exec(ctx context.Context) error {
 		// The version of the array type needs to get bumped as well so that
 		// changes to the underlying type are picked up.
 		run := func(ctx context.Context, txn *kv.Txn, descsCol *descs.Collection) error {
-			typeDesc, err := descsCol.GetMutableTypeVersionByID(ctx, txn, t.typeID)
+			typeDesc, err := descsCol.GetMutableTypeByIDDeprecated(ctx, txn, t.typeID)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
This commit renames methods on `descs.Collection`, to clearly indicate
deprecated methods and to make their non-deprecated replacements conform
to the established naming convention:

- `GetMutableTableVersionByID` -> `GetMutableTableByIDDeprecated`
- `GetMutableDescriptorByID` -> `GetMutableDescriptorByIDDeprecated`
- `GetMutableTypeVersionByID` -> `GetMutableTypeByIDDeprecated`
- `GetMutableDescriptorByIDWithFlags` -> `GetMutableDescriptorByID`

Release note: None