### PR TITLE
colexec,coldata: use Vec.Copy instead of Vec.Append

### DIFF
--- a/pkg/col/coldata/batch.go
+++ b/pkg/col/coldata/batch.go
@@ -303,9 +303,6 @@ func (m *MemBatch) Reset(typs []*types.T, length int, factory ColumnFactory) {
 	// since those will get reset in ResetInternalBatch anyway.
 	m.length = length
 	m.b = m.b[:len(typs)]
-	for i := range m.b {
-		m.b[i].SetLength(length)
-	}
 	m.sel = m.sel[:length]
 	for i, ok := m.bytesVecIdxs.Next(0); ok; i, ok = m.bytesVecIdxs.Next(i + 1) {
 		if i >= len(typs) {

--- a/pkg/col/coldata/bytes.go
+++ b/pkg/col/coldata/bytes.go
@@ -357,16 +357,6 @@ func (b *Bytes) AppendVal(v []byte) {
 	b.offsets = append(b.offsets, int32(len(b.data)))
 }
 
-// SetLength sets the length of this Bytes. Note that it will panic if there is
-// not enough capacity.
-func (b *Bytes) SetLength(l int) {
-	if b.isWindow {
-		panic("SetLength is called on a window into Bytes")
-	}
-	// We need +1 for an extra offset at the end.
-	b.offsets = b.offsets[:l+1]
-}
-
 // Len returns how many []byte values the receiver contains.
 func (b *Bytes) Len() int {
 	return len(b.offsets) - 1

--- a/pkg/col/coldata/vec.eg.go
+++ b/pkg/col/coldata/vec.eg.go
@@ -69,13 +69,6 @@ func (m *memColumn) Append(args SliceArgs) {
 				// We need to truncate toCol before appending to it, so in case of Bytes,
 				// we append an empty slice.
 				toCol.AppendSlice(toCol, args.DestIdx, 0, 0)
-				// We will be getting all values below to be appended, regardless of
-				// whether the value is NULL. It is possible that Bytes' invariant of
-				// non-decreasing offsets on the source is currently not maintained, so
-				// we explicitly enforce it.
-				// Note that here we rely on the fact that selection vectors are
-				// increasing sequences.
-				fromCol.UpdateOffsetsToBeNonDecreasing(sel[len(sel)-1] + 1)
 				for _, selIdx := range sel {
 					val := fromCol.Get(selIdx)
 					toCol.AppendVal(val)

--- a/pkg/col/coldata/vec.go
+++ b/pkg/col/coldata/vec.go
@@ -129,10 +129,6 @@ type Vec interface {
 	// Length returns the length of the slice that is underlying this Vec.
 	Length() int
 
-	// SetLength sets the length of the slice that is underlying this Vec. Note
-	// that the length of the batch which this Vec belongs to "takes priority".
-	SetLength(int)
-
 	// Capacity returns the capacity of the Golang's slice that is underlying
 	// this Vec. Note that if there is no "slice" (like in case of flat bytes),
 	// then "capacity" of such object is equal to the number of elements.
@@ -301,38 +297,6 @@ func (m *memColumn) Length() int {
 		return len(m.col.(Durations))
 	case typeconv.DatumVecCanonicalTypeFamily:
 		return m.col.(DatumVec).Len()
-	default:
-		panic(fmt.Sprintf("unhandled type %s", m.t))
-	}
-}
-
-func (m *memColumn) SetLength(l int) {
-	switch m.CanonicalTypeFamily() {
-	case types.BoolFamily:
-		m.col = m.col.(Bools)[:l]
-	case types.BytesFamily:
-		m.Bytes().SetLength(l)
-	case types.IntFamily:
-		switch m.t.Width() {
-		case 16:
-			m.col = m.col.(Int16s)[:l]
-		case 32:
-			m.col = m.col.(Int32s)[:l]
-		case 0, 64:
-			m.col = m.col.(Int64s)[:l]
-		default:
-			panic(fmt.Sprintf("unexpected int width: %d", m.t.Width()))
-		}
-	case types.FloatFamily:
-		m.col = m.col.(Float64s)[:l]
-	case types.DecimalFamily:
-		m.col = m.col.(Decimals)[:l]
-	case types.TimestampTZFamily:
-		m.col = m.col.(Times)[:l]
-	case types.IntervalFamily:
-		m.col = m.col.(Durations)[:l]
-	case typeconv.DatumVecCanonicalTypeFamily:
-		m.col.(DatumVec).SetLength(l)
 	default:
 		panic(fmt.Sprintf("unhandled type %s", m.t))
 	}

--- a/pkg/col/coldata/vec_tmpl.go
+++ b/pkg/col/coldata/vec_tmpl.go
@@ -71,14 +71,6 @@ func (m *memColumn) Append(args SliceArgs) {
 				// We need to truncate toCol before appending to it, so in case of Bytes,
 				// we append an empty slice.
 				execgen.APPENDSLICE(toCol, toCol, args.DestIdx, 0, 0)
-				// We will be getting all values below to be appended, regardless of
-				// whether the value is NULL. It is possible that Bytes' invariant of
-				// non-decreasing offsets on the source is currently not maintained, so
-				// we explicitly enforce it.
-				//
-				// Note that here we rely on the fact that selection vectors are
-				// increasing sequences.
-				fromCol.UpdateOffsetsToBeNonDecreasing(sel[len(sel)-1] + 1)
 				// {{else}}
 				// {{/* Here WINDOW means slicing which allows us to use APPENDVAL below. */}}
 				toCol = execgen.WINDOW(toCol, 0, args.DestIdx)

--- a/pkg/sql/colflow/colrpc/colrpc_test.go
+++ b/pkg/sql/colflow/colrpc/colrpc_test.go
@@ -289,10 +289,12 @@ func TestOutboxInbox(t *testing.T) {
 					batchCopy := testAllocator.NewMemBatchWithFixedCapacity(typs, outputBatch.Length())
 					testAllocator.PerformOperation(batchCopy.ColVecs(), func() {
 						for i := range typs {
-							batchCopy.ColVec(i).Append(
-								coldata.SliceArgs{
-									Src:       outputBatch.ColVec(i),
-									SrcEndIdx: outputBatch.Length(),
+							batchCopy.ColVec(i).Copy(
+								coldata.CopySliceArgs{
+									SliceArgs: coldata.SliceArgs{
+										Src:       outputBatch.ColVec(i),
+										SrcEndIdx: outputBatch.Length(),
+									},
 								},
 							)
 						}


### PR DESCRIPTION
This commit switches several usages of `Vec.Append` method to `Vec.Copy`
instead, the most notable change is in the ordered aggregator. In order
to facilitate that we introduced another temporary batch as a scratch
space for the case when the second part of the internal batch needs to
be moved to the beginning. This also allows us to remove `Vec.SetLength`
method introduced for the use of `Append` in the ordered aggregator.
Usage of `Append` is now prohibited in `sql/col*` packages (enforced by
a linter rule).

The reason for making this change is that in pretty much all cases
whenever we need to copy over some tuples, we already know that there is
enough capacity in the batch, and if that's not the case, it is likely
that `appendOnlyBufferedBatch` should be used.

This commit also removes the updating of the offsets on the source of
`Vec.Append` for Bytes vectors since I believe it is no longer necessary
given the recent fix to `Batch.SetLength`.

Release note: None