### PR TITLE
stopper: remove RunWorker and ShouldStop

### DIFF
--- a/pkg/acceptance/cluster/dockercluster.go
+++ b/pkg/acceptance/cluster/dockercluster.go
@@ -150,7 +150,7 @@ func CreateDocker(
 	ctx context.Context, cfg TestConfig, volumesDir string, stopper *stop.Stopper,
 ) *DockerCluster {
 	select {
-	case <-stopper.ShouldStop():
+	case <-stopper.ShouldQuiesce():
 		// The stopper was already closed, exit early.
 		os.Exit(1)
 	default:
@@ -563,7 +563,7 @@ func (l *DockerCluster) processEvent(ctx context.Context, event events.Message) 
 
 	// An event on any other container is unexpected. Die.
 	select {
-	case <-l.stopper.ShouldStop():
+	case <-l.stopper.ShouldQuiesce():
 	case <-l.monitorCtx.Done():
 	default:
 		// There is a very tiny race here: the signal handler might be closing the
@@ -698,7 +698,7 @@ func (l *DockerCluster) AssertAndStop(ctx context.Context, t testing.TB) {
 func (l *DockerCluster) stop(ctx context.Context) {
 	if *waitOnStop {
 		log.Infof(ctx, "waiting for interrupt")
-		<-l.stopper.ShouldStop()
+		<-l.stopper.ShouldQuiesce()
 	}
 
 	log.Infof(ctx, "stopping")

--- a/pkg/acceptance/test_acceptance.go
+++ b/pkg/acceptance/test_acceptance.go
@@ -51,13 +51,7 @@ func RunTests(m *testing.M) int {
 		sig := make(chan os.Signal, 1)
 		signal.Notify(sig, os.Interrupt)
 		<-sig
-		select {
-		case <-stopper.ShouldStop():
-		default:
-			// There is a very tiny race here: the cluster might be closing
-			// the stopper simultaneously.
-			stopper.Stop(ctx)
-		}
+		stopper.Stop(ctx)
 	}()
 	return m.Run()
 }

--- a/pkg/acceptance/util_cluster.go
+++ b/pkg/acceptance/util_cluster.go
@@ -98,7 +98,7 @@ func StartCluster(ctx context.Context, t *testing.T, cfg cluster.TestConfig) (c 
 
 			testutils.SucceedsSoon(t, func() error {
 				select {
-				case <-stopper.ShouldStop():
+				case <-stopper.ShouldQuiesce():
 					t.Fatal("interrupted")
 				case <-time.After(time.Second):
 				}

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -3414,7 +3414,7 @@ func TestBackupRestoreWithConcurrentWrites(t *testing.T) {
 	var allowErrors int32
 	for task := 0; task < numBackgroundTasks; task++ {
 		taskNum := task
-		tc.Stopper().RunWorker(context.Background(), func(context.Context) {
+		_ = tc.Stopper().RunAsyncTask(context.Background(), "bg-task", func(context.Context) {
 			conn := tc.Conns[taskNum%len(tc.Conns)]
 			// Use different sql gateways to make sure leasing is right.
 			if err := startBackgroundWrites(tc.Stopper(), conn, rows, bgActivity, &allowErrors); err != nil {

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -187,14 +187,7 @@ func (c *cliTest) stopServer() {
 	if c.TestServer != nil {
 		log.Infof(context.Background(), "stopping server at %s / %s",
 			c.ServingRPCAddr(), c.ServingSQLAddr())
-		select {
-		case <-c.Stopper().ShouldStop():
-			// If ShouldStop() doesn't block, that means someone has already
-			// called Stop(). We just need to wait.
-			<-c.Stopper().IsStopped()
-		default:
-			c.Stopper().Stop(context.Background())
-		}
+		c.Stopper().Stop(context.Background())
 	}
 }
 

--- a/pkg/cli/debug_synctest.go
+++ b/pkg/cli/debug_synctest.go
@@ -156,7 +156,7 @@ func runSyncer(
 
 	waitFailure := time.After(time.Duration(rand.Int63n(5 * time.Second.Nanoseconds())))
 
-	stopper.RunWorker(ctx, func(ctx context.Context) {
+	if err := stopper.RunAsyncTask(ctx, "syncer", func(ctx context.Context) {
 		<-waitFailure
 		if err := nemesis.On(); err != nil {
 			panic(err)
@@ -167,7 +167,9 @@ func runSyncer(
 			}
 		}()
 		<-stopper.ShouldQuiesce()
-	})
+	}); err != nil {
+		return 0, err
+	}
 
 	ch := make(chan os.Signal, 1)
 	signal.Notify(ch, drainSignals...)

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -715,7 +715,7 @@ If problems persist, please see %s.`
 		log.StartAlwaysFlush()
 		return err
 
-	case <-stopper.ShouldStop():
+	case <-stopper.ShouldQuiesce():
 		// Server is being stopped externally and our job is finished
 		// here since we don't know if it's a graceful shutdown or not.
 		<-stopper.IsStopped()
@@ -826,7 +826,7 @@ If problems persist, please see %s.`
 			select {
 			case <-ticker.C:
 				log.Ops.Infof(context.Background(), "%d running tasks", stopper.NumTasks())
-			case <-stopper.ShouldStop():
+			case <-stopper.IsStopped():
 				return
 			case <-stopWithoutDrain:
 				return

--- a/pkg/gossip/client.go
+++ b/pkg/gossip/client.go
@@ -81,7 +81,7 @@ func (c *client) startLocked(
 	g.outgoing.addPlaceholder()
 
 	ctx, cancel := context.WithCancel(c.AnnotateCtx(context.Background()))
-	stopper.RunWorker(ctx, func(ctx context.Context) {
+	if err := stopper.RunAsyncTask(ctx, "gossip-client", func(ctx context.Context) {
 		var wg sync.WaitGroup
 		defer func() {
 			// This closes the outgoing stream, causing any attempt to send or
@@ -133,7 +133,9 @@ func (c *client) startLocked(
 				g.mu.RUnlock()
 			}
 		}
-	})
+	}); err != nil {
+		disconnected <- c
+	}
 }
 
 // close stops the client gossip loop and returns immediately.
@@ -311,7 +313,7 @@ func (c *client) gossip(
 	// This wait group is used to allow the caller to wait until gossip
 	// processing is terminated.
 	wg.Add(1)
-	stopper.RunWorker(ctx, func(ctx context.Context) {
+	if err := stopper.RunAsyncTask(ctx, "client-gossip", func(ctx context.Context) {
 		defer wg.Done()
 
 		errCh <- func() error {
@@ -335,7 +337,10 @@ func (c *client) gossip(
 				}
 			}
 		}()
-	})
+	}); err != nil {
+		wg.Done()
+		return err
+	}
 
 	// We attempt to defer registration of the callback until we've heard a
 	// response from the remote node which will contain the remote's high water
@@ -366,7 +371,7 @@ func (c *client) gossip(
 		select {
 		case <-c.closer:
 			return nil
-		case <-stopper.ShouldStop():
+		case <-stopper.ShouldQuiesce():
 			return nil
 		case err := <-errCh:
 			return err

--- a/pkg/gossip/infostore.go
+++ b/pkg/gossip/infostore.go
@@ -171,7 +171,7 @@ func newInfoStore(
 		callbackCh:      make(chan struct{}, 1),
 	}
 
-	is.stopper.RunWorker(context.Background(), func(ctx context.Context) {
+	_ = is.stopper.RunAsyncTask(context.Background(), "infostore", func(ctx context.Context) {
 		for {
 			for {
 				is.callbackWorkMu.Lock()

--- a/pkg/jobs/job_scheduler.go
+++ b/pkg/jobs/job_scheduler.go
@@ -344,7 +344,7 @@ func (s *jobScheduler) executeSchedules(
 }
 
 func (s *jobScheduler) runDaemon(ctx context.Context, stopper *stop.Stopper) {
-	stopper.RunWorker(ctx, func(ctx context.Context) {
+	_ = stopper.RunAsyncTask(ctx, "job-scheduler", func(ctx context.Context) {
 		initialDelay := getInitialScanDelay(s.TestingKnobs)
 		log.Infof(ctx, "waiting %v before scheduled jobs daemon start", initialDelay)
 

--- a/pkg/jobs/job_scheduler_test.go
+++ b/pkg/jobs/job_scheduler_test.go
@@ -303,7 +303,7 @@ func TestJobSchedulerCanBeDisabledWhileSleeping(t *testing.T) {
 		// Notify main thread and return some small delay for daemon to sleep.
 		select {
 		case getWaitPeriodCalled <- struct{}{}:
-		case <-stopper.ShouldStop():
+		case <-stopper.ShouldQuiesce():
 		}
 
 		return 10 * time.Millisecond

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -902,7 +902,8 @@ func (sj *StartableJob) Run(ctx context.Context) error {
 		case <-ctx.Done():
 			// Launch a goroutine to continue consuming results from the job.
 			if resultsFromJob != nil {
-				sj.registry.stopper.RunWorker(ctx, func(ctx context.Context) {
+				// TODO(ajwerner): ctx is done; we shouldn't pass it to RunAsyncTask.
+				_ = sj.registry.stopper.RunAsyncTask(ctx, "job-results", func(ctx context.Context) {
 					for {
 						select {
 						case <-errCh:
@@ -911,6 +912,8 @@ func (sj *StartableJob) Run(ctx context.Context) error {
 							if !ok {
 								return
 							}
+						case <-sj.registry.stopper.ShouldQuiesce():
+							return
 						}
 					}
 				})

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -902,7 +902,7 @@ func (sj *StartableJob) Run(ctx context.Context) error {
 		case <-ctx.Done():
 			// Launch a goroutine to continue consuming results from the job.
 			if resultsFromJob != nil {
-				go sj.registry.stopper.RunWorker(ctx, func(ctx context.Context) {
+				sj.registry.stopper.RunWorker(ctx, func(ctx context.Context) {
 					for {
 						select {
 						case <-errCh:

--- a/pkg/kv/kvclient/kvcoord/transport_race.go
+++ b/pkg/kv/kvclient/kvcoord/transport_race.go
@@ -97,8 +97,6 @@ func GRPCTransportFactory(
 	opts SendOptions, nodeDialer *nodedialer.Dialer, replicas ReplicaSlice,
 ) (Transport, error) {
 	if atomic.AddInt32(&running, 1) <= 1 {
-		// NB: We can't use Stopper.RunWorker because doing so would race with
-		// calling Stopper.Stop.
 		if err := nodeDialer.Stopper().RunAsyncTask(
 			context.TODO(), "transport racer", func(ctx context.Context) {
 				var iters int

--- a/pkg/kv/kvserver/closedts/provider/provider.go
+++ b/pkg/kv/kvserver/closedts/provider/provider.go
@@ -76,12 +76,12 @@ func NewProvider(cfg *Config) *Provider {
 }
 
 // Start implements closedts.Provider.
-//
-// TODO(tschottdorf): the closer functionality could be extracted into its own
-// component, which would make the interfaces a little cleaner. Decide whether
-// it's worth it during testing.
 func (p *Provider) Start() {
-	p.cfg.Stopper.RunWorker(logtags.AddTag(context.Background(), "ct-closer", nil), p.runCloser)
+	if err := p.cfg.Stopper.RunAsyncTask(
+		logtags.AddTag(context.Background(), "ct-closer", nil), "ct-closer", p.runCloser,
+	); err != nil {
+		p.drain()
+	}
 }
 
 func (p *Provider) drain() {
@@ -186,7 +186,11 @@ func (p *Provider) runCloser(ctx context.Context) {
 			// TODO(tschottdorf): the transport should ignore connection requests from
 			// the node to itself. Those connections would pointlessly loop this around
 			// once more.
-			ch <- entry
+			select {
+			case ch <- entry:
+			case <-p.cfg.Stopper.ShouldQuiesce():
+				return
+			}
 		}
 	}
 }
@@ -196,7 +200,7 @@ func (p *Provider) runCloser(ctx context.Context) {
 func (p *Provider) Notify(nodeID roachpb.NodeID) chan<- ctpb.Entry {
 	ch := make(chan ctpb.Entry)
 
-	p.cfg.Stopper.RunWorker(context.Background(), func(ctx context.Context) {
+	_ = p.cfg.Stopper.RunAsyncTask(context.Background(), "provider-notify", func(ctx context.Context) {
 		handle := func(entry ctpb.Entry) {
 			p.cfg.Storage.Add(nodeID, entry)
 		}
@@ -220,8 +224,16 @@ func (p *Provider) Notify(nodeID roachpb.NodeID) chan<- ctpb.Entry {
 				p.mu.Broadcast()
 			}
 		}
-		for entry := range ch {
-			handle(entry)
+		for {
+			select {
+			case entry, ok := <-ch:
+				if !ok {
+					return
+				}
+				handle(entry)
+			case <-p.cfg.Stopper.ShouldQuiesce():
+				return
+			}
 		}
 	})
 

--- a/pkg/kv/kvserver/closedts/transport/server.go
+++ b/pkg/kv/kvserver/closedts/transport/server.go
@@ -59,8 +59,6 @@ func (s *Server) Get(client ctpb.InboundClient) error {
 	const closedTimestampNoUpdateWarnThreshold = 10 * time.Second
 	t := timeutil.NewTimer()
 
-	// NB: We can't use Stopper.RunWorker because doing so would race with
-	// calling Stopper.Stop.
 	if err := s.stopper.RunAsyncTask(ctx, "closedts-subscription", func(ctx context.Context) {
 		s.p.Subscribe(ctx, ch)
 	}); err != nil {

--- a/pkg/kv/kvserver/closedts/transport/testutils/chan_dialer.go
+++ b/pkg/kv/kvserver/closedts/transport/testutils/chan_dialer.go
@@ -66,9 +66,11 @@ func (d *ChanDialer) Dial(ctx context.Context, nodeID roachpb.NodeID) (ctpb.Clie
 		},
 	}
 
-	d.stopper.RunWorker(ctx, func(ctx context.Context) {
+	if err := d.stopper.RunAsyncTask(ctx, "closedts-dial", func(ctx context.Context) {
 		_ = d.server.Get((*incomingClient)(c))
-	})
+	}); err != nil {
+		return nil, err
+	}
 	return c, nil
 
 }

--- a/pkg/kv/kvserver/closedts/transport/transport_util_test.go
+++ b/pkg/kv/kvserver/closedts/transport/transport_util_test.go
@@ -76,7 +76,7 @@ func newTestNotifyee(stopper *stop.Stopper) *TestNotifyee {
 
 func (tn *TestNotifyee) Notify(nodeID roachpb.NodeID) chan<- ctpb.Entry {
 	ch := make(chan ctpb.Entry)
-	tn.stopper.RunWorker(context.Background(), func(ctx context.Context) {
+	_ = tn.stopper.RunAsyncTask(context.Background(), "test-notify", func(ctx context.Context) {
 		for entry := range ch {
 			tn.mu.Lock()
 			tn.mu.entries[nodeID] = append(tn.mu.entries[nodeID], entry)

--- a/pkg/kv/kvserver/consistency_queue_test.go
+++ b/pkg/kv/kvserver/consistency_queue_test.go
@@ -622,7 +622,7 @@ func testConsistencyQueueRecomputeStatsImpl(t *testing.T, hadEstimates bool) {
 	// RecomputeStats does not see any skew in its MVCC stats when they are
 	// modified concurrently. Note that these writes don't interfere with the
 	// field we modified (SysCount).
-	tc.Stopper().RunWorker(ctx, func(ctx context.Context) {
+	_ = tc.Stopper().RunAsyncTask(ctx, "recompute-loop", func(ctx context.Context) {
 		// This channel terminates the loop early if the test takes more than five
 		// seconds. This is useful for stress race runs in CI where the tight loop
 		// can starve the actual work to be done.

--- a/pkg/kv/kvserver/intentresolver/intent_resolver.go
+++ b/pkg/kv/kvserver/intentresolver/intent_resolver.go
@@ -854,6 +854,8 @@ func (ir *IntentResolver) ResolveIntents(
 			_ = resp.Resp // ignore the response
 		case <-ctx.Done():
 			return roachpb.NewError(ctx.Err())
+		case <-ir.stopper.ShouldQuiesce():
+			return roachpb.NewErrorf("stopping")
 		}
 	}
 	return nil

--- a/pkg/kv/kvserver/raft_transport.go
+++ b/pkg/kv/kvserver/raft_transport.go
@@ -190,7 +190,7 @@ func NewRaftTransport(
 	}
 	if t.stopper != nil && log.V(1) {
 		ctx := t.AnnotateCtx(context.Background())
-		t.stopper.RunWorker(ctx, func(ctx context.Context) {
+		_ = t.stopper.RunAsyncTask(ctx, "raft-transport", func(ctx context.Context) {
 			ticker := time.NewTicker(10 * time.Second)
 			defer ticker.Stop()
 			lastStats := make(map[roachpb.NodeID]raftTransportStats)
@@ -254,7 +254,7 @@ func NewRaftTransport(
 					}
 					lastTime = now
 					log.Infof(ctx, "stats:\n%s", buf.String())
-				case <-t.stopper.ShouldStop():
+				case <-t.stopper.ShouldQuiesce():
 					return
 				}
 			}
@@ -330,52 +330,50 @@ func (t *RaftTransport) RaftMessageBatch(stream MultiRaft_RaftMessageBatchServer
 	errCh := make(chan error, 1)
 
 	// Node stopping error is caught below in the select.
-	if err := t.stopper.RunTask(
+	if err := t.stopper.RunAsyncTask(
 		stream.Context(), "storage.RaftTransport: processing batch",
 		func(ctx context.Context) {
-			t.stopper.RunWorker(ctx, func(ctx context.Context) {
-				errCh <- func() error {
-					var stats *raftTransportStats
-					stream := &lockedRaftMessageResponseStream{wrapped: stream}
-					for {
-						batch, err := stream.Recv()
-						if err != nil {
-							return err
-						}
-						if len(batch.Requests) == 0 {
-							continue
-						}
+			errCh <- func() error {
+				var stats *raftTransportStats
+				stream := &lockedRaftMessageResponseStream{wrapped: stream}
+				for {
+					batch, err := stream.Recv()
+					if err != nil {
+						return err
+					}
+					if len(batch.Requests) == 0 {
+						continue
+					}
 
-						// This code always uses the DefaultClass. Class is primarily a
-						// client construct and the server has no way to determine which
-						// class an inbound connection holds on the client side. Because of
-						// this we associate all server receives and sends with the
-						// DefaultClass. This data is exclusively used to print a debug
-						// log message periodically. Using this policy may lead to a
-						// DefaultClass log line showing a high rate of server recv but
-						// a low rate of client sends if most of the traffic is due to
-						// system ranges.
-						//
-						// TODO(ajwerner): consider providing transport metadata to inform
-						// the server of the connection class or keep shared stats for all
-						// connection with a host.
-						if stats == nil {
-							stats = t.getStats(batch.Requests[0].FromReplica.NodeID, rpc.DefaultClass)
-						}
+					// This code always uses the DefaultClass. Class is primarily a
+					// client construct and the server has no way to determine which
+					// class an inbound connection holds on the client side. Because of
+					// this we associate all server receives and sends with the
+					// DefaultClass. This data is exclusively used to print a debug
+					// log message periodically. Using this policy may lead to a
+					// DefaultClass log line showing a high rate of server recv but
+					// a low rate of client sends if most of the traffic is due to
+					// system ranges.
+					//
+					// TODO(ajwerner): consider providing transport metadata to inform
+					// the server of the connection class or keep shared stats for all
+					// connection with a host.
+					if stats == nil {
+						stats = t.getStats(batch.Requests[0].FromReplica.NodeID, rpc.DefaultClass)
+					}
 
-						for i := range batch.Requests {
-							req := &batch.Requests[i]
-							atomic.AddInt64(&stats.serverRecv, 1)
-							if pErr := t.handleRaftRequest(ctx, req, stream); pErr != nil {
-								atomic.AddInt64(&stats.serverSent, 1)
-								if err := stream.Send(newRaftMessageResponse(req, pErr)); err != nil {
-									return err
-								}
+					for i := range batch.Requests {
+						req := &batch.Requests[i]
+						atomic.AddInt64(&stats.serverRecv, 1)
+						if pErr := t.handleRaftRequest(ctx, req, stream); pErr != nil {
+							atomic.AddInt64(&stats.serverSent, 1)
+							if err := stream.Send(newRaftMessageResponse(req, pErr)); err != nil {
+								return err
 							}
 						}
 					}
-				}()
-			})
+				}
+			}()
 		}); err != nil {
 		return err
 	}
@@ -417,7 +415,7 @@ func (t *RaftTransport) RaftSnapshot(stream MultiRaft_RaftSnapshotServer) error 
 		return err
 	}
 	select {
-	case <-t.stopper.ShouldStop():
+	case <-t.stopper.ShouldQuiesce():
 		return nil
 	case err := <-errCh:
 		return err
@@ -448,30 +446,29 @@ func (t *RaftTransport) processQueue(
 ) error {
 	errCh := make(chan error, 1)
 
-	// Starting workers in a task prevents data races during shutdown.
-	if err := t.stopper.RunTask(
-		stream.Context(), "storage.RaftTransport: processing queue",
+	ctx := stream.Context()
+
+	if err := t.stopper.RunAsyncTask(
+		ctx, "storage.RaftTransport: processing queue",
 		func(ctx context.Context) {
-			t.stopper.RunWorker(ctx, func(ctx context.Context) {
-				errCh <- func() error {
-					for {
-						resp, err := stream.Recv()
-						if err != nil {
-							return err
-						}
-						atomic.AddInt64(&stats.clientRecv, 1)
-						handler, ok := t.getHandler(resp.ToReplica.StoreID)
-						if !ok {
-							log.Warningf(ctx, "no handler found for store %s in response %s",
-								resp.ToReplica.StoreID, resp)
-							continue
-						}
-						if err := handler.HandleRaftResponse(ctx, resp); err != nil {
-							return err
-						}
+			errCh <- func() error {
+				for {
+					resp, err := stream.Recv()
+					if err != nil {
+						return err
 					}
-				}()
-			})
+					atomic.AddInt64(&stats.clientRecv, 1)
+					handler, ok := t.getHandler(resp.ToReplica.StoreID)
+					if !ok {
+						log.Warningf(ctx, "no handler found for store %s in response %s",
+							resp.ToReplica.StoreID, resp)
+						continue
+					}
+					if err := handler.HandleRaftResponse(ctx, resp); err != nil {
+						return err
+					}
+				}
+			}()
 		}); err != nil {
 		return err
 	}
@@ -482,7 +479,7 @@ func (t *RaftTransport) processQueue(
 	for {
 		raftIdleTimer.Reset(raftIdleTimeout)
 		select {
-		case <-t.stopper.ShouldStop():
+		case <-t.stopper.ShouldQuiesce():
 			return nil
 		case <-raftIdleTimer.C:
 			raftIdleTimer.Read = true
@@ -636,11 +633,7 @@ func (t *RaftTransport) startProcessNewQueue(
 			log.Warningf(ctx, "while processing outgoing Raft queue to node %d: %s:", toNodeID, err)
 		}
 	}
-	// Starting workers in a task prevents data races during shutdown.
-	workerTask := func(ctx context.Context) {
-		t.stopper.RunWorker(ctx, worker)
-	}
-	err := t.stopper.RunTask(ctx, "storage.RaftTransport: sending messages", workerTask)
+	err := t.stopper.RunAsyncTask(ctx, "storage.RaftTransport: sending messages", worker)
 	if err != nil {
 		t.queues[class].Delete(int64(toNodeID))
 		return false

--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -1117,7 +1117,7 @@ func (r *Replica) redirectOnOrAcquireLease(
 					log.VErrEventf(ctx, 2, "lease acquisition failed: %s", ctx.Err())
 					return roachpb.NewError(newNotLeaseHolderError(nil, r.store.StoreID(), r.Desc(),
 						"lease acquisition canceled because context canceled"))
-				case <-r.store.Stopper().ShouldStop():
+				case <-r.store.Stopper().ShouldQuiesce():
 					llHandle.Cancel()
 					return roachpb.NewError(newNotLeaseHolderError(nil, r.store.StoreID(), r.Desc(),
 						"lease acquisition canceled because node is stopping"))

--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -569,7 +569,7 @@ func TestTransferLeaseToLaggingNode(t *testing.T) {
 
 	workerReady := make(chan bool)
 	// Create persistent range load.
-	tc.Stopper().RunWorker(ctx, func(ctx context.Context) {
+	require.NoError(t, tc.Stopper().RunAsyncTask(ctx, "load", func(ctx context.Context) {
 		s = sqlutils.MakeSQLRunner(tc.Conns[remoteNodeID-1])
 		workerReady <- true
 		for {
@@ -584,7 +584,7 @@ func TestTransferLeaseToLaggingNode(t *testing.T) {
 			case <-time.After(queryInterval):
 			}
 		}
-	})
+	}))
 	<-workerReady
 	// Wait until we see remote making progress
 	leaseHolderRepl, err := leaseHolderStore.GetReplica(rangeID)

--- a/pkg/kv/kvserver/reports/reporter.go
+++ b/pkg/kv/kvserver/reports/reporter.go
@@ -115,7 +115,7 @@ func (stats *Reporter) Start(ctx context.Context, stopper *stop.Stopper) {
 		stats.frequencyMu.changeCh = make(chan struct{})
 		stats.frequencyMu.interval = ReporterInterval.Get(&stats.settings.SV)
 	})
-	stopper.RunWorker(ctx, func(ctx context.Context) {
+	_ = stopper.RunAsyncTask(ctx, "stats-reporter", func(ctx context.Context) {
 		var timer timeutil.Timer
 		defer timer.Stop()
 		ctx = logtags.AddTag(ctx, "replication-reporter", nil /* value */)

--- a/pkg/kv/kvserver/scanner.go
+++ b/pkg/kv/kvserver/scanner.go
@@ -235,7 +235,7 @@ func (rs *replicaScanner) waitAndProcess(
 		case repl := <-rs.removed:
 			rs.removeReplica(repl)
 
-		case <-stopper.ShouldStop():
+		case <-stopper.ShouldQuiesce():
 			return true
 		}
 	}
@@ -259,7 +259,7 @@ func (rs *replicaScanner) removeReplica(repl *Replica) {
 // is paced to complete a full scan in approximately the scan interval.
 func (rs *replicaScanner) scanLoop(stopper *stop.Stopper) {
 	ctx := rs.AnnotateCtx(context.Background())
-	stopper.RunWorker(ctx, func(ctx context.Context) {
+	_ = stopper.RunAsyncTask(ctx, "scan-loop", func(ctx context.Context) {
 		start := timeutil.Now()
 
 		// waitTimer is reset in each call to waitAndProcess.
@@ -324,7 +324,7 @@ func (rs *replicaScanner) waitEnabled(stopper *stop.Stopper) bool {
 		case repl := <-rs.removed:
 			rs.removeReplica(repl)
 
-		case <-stopper.ShouldStop():
+		case <-stopper.ShouldQuiesce():
 			return true
 		}
 	}

--- a/pkg/kv/kvserver/single_key_test.go
+++ b/pkg/kv/kvserver/single_key_test.go
@@ -104,7 +104,7 @@ func TestSingleKey(t *testing.T) {
 	var results []result
 	for len(results) < num {
 		select {
-		case <-tc.Stopper().ShouldStop():
+		case <-tc.Stopper().ShouldQuiesce():
 			t.Fatalf("interrupted")
 		case r := <-resultCh:
 			if r.err != nil {

--- a/pkg/kv/kvserver/store_rebalancer.go
+++ b/pkg/kv/kvserver/store_rebalancer.go
@@ -177,7 +177,7 @@ func (sr *StoreRebalancer) Start(ctx context.Context, stopper *stop.Stopper) {
 
 	// Start a goroutine that watches and proactively renews certain
 	// expiration-based leases.
-	stopper.RunWorker(ctx, func(ctx context.Context) {
+	_ = stopper.RunAsyncTask(ctx, "store-rebalancer", func(ctx context.Context) {
 		timer := timeutil.NewTimer()
 		defer timer.Stop()
 		timer.Reset(jitteredInterval(storeRebalancerTimerDuration))

--- a/pkg/kv/kvserver/store_snapshot.go
+++ b/pkg/kv/kvserver/store_snapshot.go
@@ -524,7 +524,7 @@ func (s *Store) reserveSnapshot(
 		case s.snapshotApplySem <- struct{}{}:
 		case <-ctx.Done():
 			return nil, "", ctx.Err()
-		case <-s.stopper.ShouldStop():
+		case <-s.stopper.ShouldQuiesce():
 			return nil, "", errors.Errorf("stopped")
 		default:
 			return nil, snapshotApplySemBusyMsg, nil
@@ -534,7 +534,7 @@ func (s *Store) reserveSnapshot(
 		case s.snapshotApplySem <- struct{}{}:
 		case <-ctx.Done():
 			return nil, "", ctx.Err()
-		case <-s.stopper.ShouldStop():
+		case <-s.stopper.ShouldQuiesce():
 			return nil, "", errors.Errorf("stopped")
 		}
 	}

--- a/pkg/rpc/context_test.go
+++ b/pkg/rpc/context_test.go
@@ -328,7 +328,7 @@ func TestHeartbeatHealth(t *testing.T) {
 			}
 
 			select {
-			case <-stopper.ShouldStop():
+			case <-stopper.ShouldQuiesce():
 				return
 			case heartbeat.ready <- err:
 			}
@@ -599,14 +599,14 @@ func TestHeartbeatHealthTransport(t *testing.T) {
 			}}
 	}()
 
-	stopper.RunWorker(ctx, func(context.Context) {
+	_ = stopper.RunAsyncTask(ctx, "wait-quiesce", func(context.Context) {
 		<-stopper.ShouldQuiesce()
 		netutil.FatalIfUnexpected(ln.Close())
-		<-stopper.ShouldStop()
+		<-stopper.ShouldQuiesce()
 		s.Stop()
 	})
 
-	stopper.RunWorker(ctx, func(context.Context) {
+	_ = stopper.RunAsyncTask(ctx, "serve", func(context.Context) {
 		netutil.FatalIfUnexpected(s.Serve(ln))
 	})
 

--- a/pkg/rpc/heartbeat_test.go
+++ b/pkg/rpc/heartbeat_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"github.com/cockroachdb/errors"
 )
 
 func TestRemoteOffsetString(t *testing.T) {
@@ -92,7 +93,8 @@ func (mhs *ManualHeartbeatService) Ping(
 		}
 	case <-ctx.Done():
 		return nil, ctx.Err()
-	case <-mhs.stopper.ShouldStop():
+	case <-mhs.stopper.ShouldQuiesce():
+		return nil, errors.New("quiesce")
 	}
 	hs := HeartbeatService{
 		clock:              mhs.clock,

--- a/pkg/security/certificate_manager.go
+++ b/pkg/security/certificate_manager.go
@@ -230,7 +230,7 @@ func (cm *CertificateManager) RegisterSignalHandler(stopper *stop.Stopper) {
 		ch := sysutil.RefreshSignaledChan()
 		for {
 			select {
-			case <-stopper.ShouldStop():
+			case <-stopper.ShouldQuiesce():
 				return
 			case sig := <-ch:
 				log.Infof(context.Background(), "received signal %q, triggering certificate reload", sig)

--- a/pkg/server/diagnostics/reporter.go
+++ b/pkg/server/diagnostics/reporter.go
@@ -90,7 +90,7 @@ type Reporter struct {
 // PeriodicallyReportDiagnostics starts a background worker that periodically
 // phones home to report usage and diagnostics.
 func (r *Reporter) PeriodicallyReportDiagnostics(ctx context.Context, stopper *stop.Stopper) {
-	stopper.RunWorker(ctx, func(ctx context.Context) {
+	_ = stopper.RunAsyncTask(ctx, "diagnostics", func(ctx context.Context) {
 		defer logcrash.RecoverAndReportNonfatalPanic(ctx, &r.Settings.SV)
 		nextReport := r.StartTime
 

--- a/pkg/server/diagnostics/update_checker.go
+++ b/pkg/server/diagnostics/update_checker.go
@@ -72,7 +72,7 @@ type UpdateChecker struct {
 // PeriodicallyCheckForUpdates starts a background worker that periodically
 // phones home to check for updates.
 func (u *UpdateChecker) PeriodicallyCheckForUpdates(ctx context.Context, stopper *stop.Stopper) {
-	stopper.RunWorker(ctx, func(ctx context.Context) {
+	_ = stopper.RunAsyncTask(ctx, "update-checker", func(ctx context.Context) {
 		defer logcrash.RecoverAndReportNonfatalPanic(ctx, &u.Settings.SV)
 		nextUpdateCheck := u.StartTime
 

--- a/pkg/server/init.go
+++ b/pkg/server/init.go
@@ -215,16 +215,15 @@ func (s *initServer) ServeAndWait(
 		joinCtx, cancelJoin = context.WithCancel(ctx)
 		defer cancelJoin()
 
-		err := stopper.RunTask(joinCtx, "init server: join loop",
-			func(joinCtx context.Context) {
-				stopper.RunWorker(joinCtx, func(joinCtx context.Context) {
-					defer wg.Done()
+		err := stopper.RunAsyncTask(joinCtx, "init server: join loop",
+			func(ctx context.Context) {
+				defer wg.Done()
 
-					state, err := s.startJoinLoop(joinCtx, stopper)
-					joinCh <- joinResult{state: state, err: err}
-				})
+				state, err := s.startJoinLoop(ctx, stopper)
+				joinCh <- joinResult{state: state, err: err}
 			})
 		if err != nil {
+			wg.Done()
 			return nil, false, err
 		}
 	}

--- a/pkg/server/node_engine_health.go
+++ b/pkg/server/node_engine_health.go
@@ -29,7 +29,7 @@ func (n *Node) startAssertEngineHealth(
 ) {
 	maxSyncDuration := storage.MaxSyncDuration.Get(&settings.SV)
 	fatalOnExceeded := storage.MaxSyncDurationFatalOnExceeded.Get(&settings.SV)
-	n.stopper.RunWorker(ctx, func(ctx context.Context) {
+	_ = n.stopper.RunAsyncTask(ctx, "engine-health", func(ctx context.Context) {
 		t := timeutil.NewTimer()
 		t.Reset(0)
 

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -1860,7 +1860,7 @@ func (s *statusServer) iterateNodes(
 
 	// Issue the requests concurrently.
 	sem := quotapool.NewIntPool("node status", maxConcurrentRequests)
-	ctx, cancel := s.stopper.WithCancelOnStop(ctx)
+	ctx, cancel := s.stopper.WithCancelOnQuiesce(ctx)
 	defer cancel()
 	for nodeID := range nodeStatuses {
 		nodeID := nodeID // needed to ensure the closure below captures a copy.

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -699,24 +699,36 @@ func StartTenant(
 		return nil, "", "", err
 	}
 
-	args.stopper.RunWorker(ctx, func(ctx context.Context) {
-		<-args.stopper.ShouldQuiesce()
-		// NB: we can't do this as a Closer because (*Server).ServeWith is
-		// running in a worker and usually sits on accept(pgL) which unblocks
-		// only when pgL closes. In other words, pgL needs to close when
-		// quiescing starts to allow that worker to shut down.
-		_ = pgL.Close()
-	})
+	{
+		waitQuiesce := func(ctx context.Context) {
+			<-args.stopper.ShouldQuiesce()
+			// NB: we can't do this as a Closer because (*Server).ServeWith is
+			// running in a worker and usually sits on accept(pgL) which unblocks
+			// only when pgL closes. In other words, pgL needs to close when
+			// quiescing starts to allow that worker to shut down.
+			_ = pgL.Close()
+		}
+		if err := args.stopper.RunAsyncTask(ctx, "wait-quiesce-pgl", waitQuiesce); err != nil {
+			waitQuiesce(ctx)
+			return nil, "", "", err
+		}
+	}
 
 	httpL, err := listen(ctx, &args.Config.HTTPAddr, &args.Config.HTTPAdvertiseAddr, "http")
 	if err != nil {
 		return nil, "", "", err
 	}
 
-	args.stopper.RunWorker(ctx, func(ctx context.Context) {
-		<-args.stopper.ShouldQuiesce()
-		_ = httpL.Close()
-	})
+	{
+		waitQuiesce := func(ctx context.Context) {
+			<-args.stopper.ShouldQuiesce()
+			_ = httpL.Close()
+		}
+		if err := args.stopper.RunAsyncTask(ctx, "wait-quiesce-http", waitQuiesce); err != nil {
+			waitQuiesce(ctx)
+			return nil, "", "", err
+		}
+	}
 
 	pgLAddr := pgL.Addr().String()
 	httpLAddr := httpL.Addr().String()
@@ -729,7 +741,7 @@ func StartTenant(
 		pgLAddr,   // sql addr
 	)
 
-	args.stopper.RunWorker(ctx, func(ctx context.Context) {
+	if err := args.stopper.RunAsyncTask(ctx, "serve-http", func(ctx context.Context) {
 		mux := http.NewServeMux()
 		debugServer := debug.NewServer(args.Settings, s.pgServer.HBADebugFn())
 		mux.Handle("/", debugServer)
@@ -743,7 +755,9 @@ func StartTenant(
 		f := varsHandler{metricSource: args.recorder, st: args.Settings}.handleVars
 		mux.Handle(statusVars, http.HandlerFunc(f))
 		_ = http.Serve(httpL, mux)
-	})
+	}); err != nil {
+		return nil, "", "", err
+	}
 
 	const (
 		socketFile = "" // no unix socket

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -736,7 +736,7 @@ func (s *Server) PeriodicallyClearSQLStats(
 	stats *sqlStats,
 	reset func(ctx context.Context),
 ) {
-	stopper.RunWorker(ctx, func(ctx context.Context) {
+	_ = stopper.RunAsyncTask(ctx, "sql-stats-clearer", func(ctx context.Context) {
 		var timer timeutil.Timer
 		for {
 			s.sqlStats.Lock()

--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -152,12 +152,12 @@ func TestPlanningDuringSplitsAndMerges(t *testing.T) {
 	)
 
 	// Start a worker that continuously performs splits in the background.
-	tc.Stopper().RunWorker(context.Background(), func(ctx context.Context) {
+	_ = tc.Stopper().RunAsyncTask(context.Background(), "splitter", func(ctx context.Context) {
 		rng, _ := randutil.NewPseudoRand()
 		cdb := tc.Server(0).DB()
 		for {
 			select {
-			case <-tc.Stopper().ShouldStop():
+			case <-tc.Stopper().ShouldQuiesce():
 				return
 			default:
 				// Split the table at a random row.

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -96,9 +96,9 @@ func (dsp *DistSQLPlanner) initRunners(ctx context.Context) {
 	// requests if a worker is actually there to receive them.
 	dsp.runnerChan = make(chan runnerRequest)
 	for i := 0; i < numRunners; i++ {
-		dsp.stopper.RunWorker(ctx, func(context.Context) {
+		_ = dsp.stopper.RunAsyncTask(ctx, "distslq-runner", func(context.Context) {
 			runnerChan := dsp.runnerChan
-			stopChan := dsp.stopper.ShouldStop()
+			stopChan := dsp.stopper.ShouldQuiesce()
 			for {
 				select {
 				case req := <-runnerChan:

--- a/pkg/sql/flowinfra/flow_scheduler.go
+++ b/pkg/sql/flowinfra/flow_scheduler.go
@@ -146,7 +146,9 @@ func (fs *FlowScheduler) ScheduleFlow(ctx context.Context, f Flow) error {
 // Start launches the main loop of the scheduler.
 func (fs *FlowScheduler) Start() {
 	ctx := fs.AnnotateCtx(context.Background())
-	fs.stopper.RunWorker(ctx, func(context.Context) {
+	// TODO(radu): we may end up with a few flows in the queue that will
+	// never be processed. Is that an issue?
+	_ = fs.stopper.RunAsyncTask(ctx, "flow-scheduler", func(context.Context) {
 		stopped := false
 		fs.mu.Lock()
 		defer fs.mu.Unlock()
@@ -188,7 +190,7 @@ func (fs *FlowScheduler) Start() {
 					atomic.AddInt32(&fs.atomics.numRunning, -1)
 				}
 
-			case <-fs.stopper.ShouldStop():
+			case <-fs.stopper.ShouldQuiesce():
 				fs.mu.Lock()
 				stopped = true
 			}

--- a/pkg/sql/rowexec/sampler.go
+++ b/pkg/sql/rowexec/sampler.go
@@ -308,7 +308,7 @@ func (s *samplerProcessor) mainLoop(ctx context.Context) (earlyExit bool, err er
 					case <-timer.C:
 						timer.Read = true
 						break
-					case <-s.flowCtx.Stopper().ShouldStop():
+					case <-s.flowCtx.Stopper().ShouldQuiesce():
 						break
 					}
 				}

--- a/pkg/sql/stats/automatic_stats.go
+++ b/pkg/sql/stats/automatic_stats.go
@@ -244,7 +244,7 @@ func MakeRefresher(
 func (r *Refresher) Start(
 	ctx context.Context, stopper *stop.Stopper, refreshInterval time.Duration,
 ) error {
-	stopper.RunWorker(context.Background(), func(ctx context.Context) {
+	_ = stopper.RunAsyncTask(context.Background(), "refresher", func(ctx context.Context) {
 		// We always sleep for r.asOfTime at the beginning of each refresh, so
 		// subtract it from the refreshInterval.
 		refreshInterval -= r.asOfTime
@@ -306,7 +306,7 @@ func (r *Refresher) Start(
 			case mut := <-r.mutations:
 				r.mutationCounts[mut.tableID] += int64(mut.rowsAffected)
 
-			case <-stopper.ShouldStop():
+			case <-stopper.ShouldQuiesce():
 				return
 			}
 		}

--- a/pkg/sql/temporary_schema.go
+++ b/pkg/sql/temporary_schema.go
@@ -585,7 +585,7 @@ func (c *TemporaryObjectCleaner) doTemporaryObjectCleanup(
 
 // Start initializes the background thread which periodically cleans up leftover temporary objects.
 func (c *TemporaryObjectCleaner) Start(ctx context.Context, stopper *stop.Stopper) {
-	stopper.RunWorker(ctx, func(ctx context.Context) {
+	_ = stopper.RunAsyncTask(ctx, "object-cleaner", func(ctx context.Context) {
 		nextTick := timeutil.Now()
 		for {
 			nextTickCh := time.After(nextTick.Sub(timeutil.Now()))

--- a/pkg/sql/tests/monotonic_insert_test.go
+++ b/pkg/sql/tests/monotonic_insert_test.go
@@ -230,7 +230,7 @@ RETURNING val, sts, node, tb`,
 	for {
 		select {
 		case sem <- struct{}{}:
-		case <-tc.Stopper().ShouldStop():
+		case <-tc.Stopper().ShouldQuiesce():
 			return
 		case <-timer:
 			return

--- a/pkg/ts/db.go
+++ b/pkg/ts/db.go
@@ -157,7 +157,7 @@ func (db *DB) PollSource(
 // start begins the goroutine for this poller, which will periodically request
 // time series data from the DataSource and store it.
 func (p *poller) start() {
-	p.stopper.RunWorker(context.TODO(), func(context.Context) {
+	_ = p.stopper.RunAsyncTask(context.TODO(), "ts-poller", func(context.Context) {
 		// Poll once immediately.
 		p.poll()
 		ticker := time.NewTicker(p.frequency)
@@ -166,7 +166,7 @@ func (p *poller) start() {
 			select {
 			case <-ticker.C:
 				p.poll()
-			case <-p.stopper.ShouldStop():
+			case <-p.stopper.ShouldQuiesce():
 				return
 			}
 		}

--- a/pkg/util/stop/stopper_test.go
+++ b/pkg/util/stop/stopper_test.go
@@ -38,7 +38,7 @@ func TestStopper(t *testing.T) {
 	cleanup := make(chan struct{})
 	ctx := context.Background()
 
-	s.RunWorker(ctx, func(context.Context) {
+	_ = s.RunAsyncTask(ctx, "task", func(context.Context) {
 		<-running
 	})
 
@@ -48,7 +48,7 @@ func TestStopper(t *testing.T) {
 		<-cleanup
 	}()
 
-	<-s.ShouldStop()
+	<-s.ShouldQuiesce()
 	select {
 	case <-waiting:
 		close(cleanup)
@@ -91,7 +91,7 @@ func TestStopperIsStopped(t *testing.T) {
 	go s.Stop(context.Background())
 
 	select {
-	case <-s.ShouldStop():
+	case <-s.ShouldQuiesce():
 	case <-time.After(time.Second):
 		t.Fatal("stopper should have finished waiting")
 	}
@@ -112,16 +112,16 @@ func TestStopperIsStopped(t *testing.T) {
 	s.Stop(context.Background())
 }
 
-func TestStopperMultipleStopees(t *testing.T) {
+func TestStopperMultipleTasks(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	const count = 3
 	s := stop.NewStopper()
 	ctx := context.Background()
 
 	for i := 0; i < count; i++ {
-		s.RunWorker(ctx, func(context.Context) {
-			<-s.ShouldStop()
-		})
+		require.NoError(t, s.RunAsyncTask(ctx, "task", func(context.Context) {
+			<-s.ShouldQuiesce()
+		}))
 	}
 
 	done := make(chan struct{})
@@ -144,8 +144,8 @@ func TestStopperStartFinishTasks(t *testing.T) {
 		go s.Stop(ctx)
 
 		select {
-		case <-s.ShouldStop():
-			t.Fatal("expected stopper to be quiesceing")
+		case <-s.IsStopped():
+			t.Fatal("stopper not fully stopped")
 		case <-time.After(100 * time.Millisecond):
 			// Expected.
 		}
@@ -153,27 +153,7 @@ func TestStopperStartFinishTasks(t *testing.T) {
 		t.Error(err)
 	}
 	select {
-	case <-s.ShouldStop():
-		// Success.
-	case <-time.After(time.Second):
-		t.Fatal("stopper should be ready to stop")
-	}
-}
-
-func TestStopperRunWorker(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	s := stop.NewStopper()
-	ctx := context.Background()
-	s.RunWorker(ctx, func(context.Context) {
-		<-s.ShouldStop()
-	})
-	closer := make(chan struct{})
-	go func() {
-		s.Stop(ctx)
-		close(closer)
-	}()
-	select {
-	case <-closer:
+	case <-s.IsStopped():
 		// Success.
 	case <-time.After(time.Second):
 		t.Fatal("stopper should be ready to stop")
@@ -197,17 +177,17 @@ func TestStopperQuiesce(t *testing.T) {
 		quiesceDone = append(quiesceDone, qc)
 		sc := make(chan struct{})
 		runTaskDone = append(runTaskDone, sc)
-		thisStopper.RunWorker(ctx, func(ctx context.Context) {
+		go func() {
 			// Wait until Quiesce() is called.
 			<-qc
-			err := thisStopper.RunTask(ctx, "test", func(context.Context) {})
+			err := thisStopper.RunTask(ctx, "inner", func(context.Context) {})
 			if !errors.HasType(err, (*roachpb.NodeUnavailableError)(nil)) {
 				t.Error(err)
 			}
 			// Make the stoppers call Stop().
 			close(sc)
-			<-thisStopper.ShouldStop()
-		})
+			<-thisStopper.ShouldQuiesce()
+		}()
 	}
 
 	done := make(chan struct{})
@@ -368,9 +348,6 @@ func TestStopperRunTaskPanic(t *testing.T) {
 				func(ctx context.Context) { explode(ctx) },
 			)
 		},
-		func() {
-			s.RunWorker(ctx, explode)
-		},
 	} {
 		go test()
 		recovered := <-ch
@@ -385,35 +362,20 @@ func TestStopperWithCancel(t *testing.T) {
 	s := stop.NewStopper()
 	ctx := context.Background()
 	ctx1, _ := s.WithCancelOnQuiesce(ctx)
-	ctx2, _ := s.WithCancelOnStop(ctx)
 	ctx3, cancel3 := s.WithCancelOnQuiesce(ctx)
-	ctx4, cancel4 := s.WithCancelOnStop(ctx)
 
 	if err := ctx1.Err(); err != nil {
-		t.Fatalf("should not be canceled: %v", err)
-	}
-	if err := ctx2.Err(); err != nil {
 		t.Fatalf("should not be canceled: %v", err)
 	}
 	if err := ctx3.Err(); err != nil {
 		t.Fatalf("should not be canceled: %v", err)
 	}
-	if err := ctx4.Err(); err != nil {
-		t.Fatalf("should not be canceled: %v", err)
-	}
 
 	cancel3()
-	cancel4()
 	if err := ctx1.Err(); err != nil {
 		t.Fatalf("should not be canceled: %v", err)
 	}
-	if err := ctx2.Err(); err != nil {
-		t.Fatalf("should not be canceled: %v", err)
-	}
 	if err := ctx3.Err(); !errors.Is(err, context.Canceled) {
-		t.Fatalf("should be canceled: %v", err)
-	}
-	if err := ctx4.Err(); !errors.Is(err, context.Canceled) {
 		t.Fatalf("should be canceled: %v", err)
 	}
 
@@ -421,14 +383,8 @@ func TestStopperWithCancel(t *testing.T) {
 	if err := ctx1.Err(); !errors.Is(err, context.Canceled) {
 		t.Fatalf("should be canceled: %v", err)
 	}
-	if err := ctx2.Err(); err != nil {
-		t.Fatalf("should not be canceled: %v", err)
-	}
 
 	s.Stop(ctx)
-	if err := ctx2.Err(); !errors.Is(err, context.Canceled) {
-		t.Fatalf("should be canceled: %v", err)
-	}
 }
 
 func TestStopperWithCancelConcurrent(t *testing.T) {
@@ -437,21 +393,16 @@ func TestStopperWithCancelConcurrent(t *testing.T) {
 	for i := 0; i < trials; i++ {
 		s := stop.NewStopper()
 		ctx := context.Background()
-		var ctx1, ctx2 context.Context
+		var ctx1 context.Context
 
-		// Tie two contexts to the Stopper and Stop concurrently. There should
+		// Tie a context to the Stopper and Stop concurrently. There should
 		// be no circumstance where either Context is not canceled.
 		var wg sync.WaitGroup
-		wg.Add(3)
+		wg.Add(2)
 		go func() {
 			defer wg.Done()
 			runtime.Gosched()
 			ctx1, _ = s.WithCancelOnQuiesce(ctx)
-		}()
-		go func() {
-			defer wg.Done()
-			runtime.Gosched()
-			ctx2, _ = s.WithCancelOnStop(ctx)
 		}()
 		go func() {
 			defer wg.Done()
@@ -463,27 +414,17 @@ func TestStopperWithCancelConcurrent(t *testing.T) {
 		if err := ctx1.Err(); !errors.Is(err, context.Canceled) {
 			t.Errorf("should be canceled: %v", err)
 		}
-		if err := ctx2.Err(); !errors.Is(err, context.Canceled) {
-			t.Errorf("should be canceled: %v", err)
-		}
 	}
 }
 
 func TestStopperShouldQuiesce(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s := stop.NewStopper()
-	running := make(chan struct{})
 	runningTask := make(chan struct{})
 	waiting := make(chan struct{})
 	cleanup := make(chan struct{})
 	ctx := context.Background()
 
-	// Run a worker. A call to stopper.Stop(context.Background()) will not close until all workers
-	// have completed, and this worker will complete when the "running" channel
-	// is closed.
-	s.RunWorker(ctx, func(context.Context) {
-		<-running
-	})
 	// Run an asynchronous task. A stopper which has been Stop()ed will not
 	// close it's ShouldStop() channel until all tasks have completed. This task
 	// will complete when the "runningTask" channel is closed.
@@ -502,33 +443,15 @@ func TestStopperShouldQuiesce(t *testing.T) {
 	// The ShouldQuiesce() channel should close as soon as the stopper is
 	// Stop()ed.
 	<-s.ShouldQuiesce()
-	// However, the ShouldStop() channel should still be blocked because the
-	// async task started above is still running, meaning we haven't quiesceed
-	// yet.
-	select {
-	case <-s.ShouldStop():
-		close(cleanup)
-		t.Fatal("expected ShouldStop() to block until quiesceing complete")
-	default:
-		// Expected.
-	}
 	// After completing the running task, the ShouldStop() channel should
 	// now close.
 	close(runningTask)
-	<-s.ShouldStop()
-	// However, the working running above prevents the call to Stop() from
-	// returning; it blocks until the runner's goroutine is finished. We
-	// use the "waiting" channel to detect this.
 	select {
-	case <-waiting:
-		close(cleanup)
-		t.Fatal("expected stopper to have blocked")
-	default:
-		// Expected.
+	case <-s.IsStopped():
+	// Good.
+	case <-time.After(10 * time.Second):
+		t.Fatal("stopper did not fully stop in time")
 	}
-	// Finally, close the "running" channel, which should cause the original
-	// call to Stop() to return.
-	close(running)
 	<-waiting
 	close(cleanup)
 }


### PR DESCRIPTION
`Stopper` has grown organically over the years. Initially, we were
trying really hard to give us an ordered shutdown regimen in which a
cluster would continue to "work" at a basic level but would only shed
incoming load (until no more load was there). This was ultimately
abandoned (today we have higher-level primitives for such things, like
the Drain RPC), but the corresponding unwiedly APIs not phased out.

Roughly we were left with two types of goroutines:

- "Workers", which were expected to be long-running and would not be blocked
from starting by the stopper (we probably initially assumed that they
would all be spun up by the time the stopper could possibly stop, which
has not been true for a long time and will likely never be again), and
- "Tasks", which are everything else and which are no longer allowed to
start once `stopper.Stop()` has been called.

In practice, this lead to a lot of confusion and undesired behavior. In
particular, a common workaround in our code was to retrofit the "don't
allow starting if already shutting down" behavior for workers by
wrapping their creation in a synchronous task.

It also complicated the shutdown semantics because there were three
stages:

- quiescing: i.e. no more new tasks but there are still tasks running
- stopping: i.e. no more tasks, but there could still be workers
- stopped-A: the workers are gone now, but we still have to run the
  closers!
- stopped-B: the closers have also run (signals `IsStopped`).

This commit rips off the band-aid:

1. there are no more workers. Everything is a task and can run as long
   as it likes.
2. there is no more `ShouldStop` and consequently no confusion about
   which one to listen to (listening to `ShouldStop` only in a task
   is a deadlock - no longer possible).

The `stop` package hasn't gotten TLC in many years, so there is a lot
more one might want to do, but that is for another day.

Release note: None
