### PR TITLE
githooks: new release note category `ops changes`

### DIFF
--- a/githooks/commit-msg
+++ b/githooks/commit-msg
@@ -138,6 +138,7 @@ else
             for lcat in "${cats[@]}"; do
                 case $lcat in
                     "cli change") ;;
+                    "ops change") ;;
                     "sql change") ;;
                     "api change") ;;
                     "ui change") ;;
@@ -148,6 +149,8 @@ else
                     "performance improvement") ;;
                     "bug fix") ;;
                     "security update") ;;
+                    operational*)
+                        hint "Try 'Release note ($lcat)' -> 'Release note (ops change)'" ;;
                     bugfix)
                         hint "Try 'Release note (bugfix)' -> 'Release note (bug fix)'" ;;
                     security*)

--- a/githooks/prepare-commit-msg
+++ b/githooks/prepare-commit-msg
@@ -146,6 +146,7 @@ $cchar   over-replicated. This bug was present since version 19.2.\\
 $cchar\\
 $cchar Categories for release notes:\\
 $cchar   - cli change\\
+$cchar   - ops change\\
 $cchar   - sql change\\
 $cchar   - api change\\
 $cchar   - ui change\\

--- a/scripts/release-notes.py
+++ b/scripts/release-notes.py
@@ -155,6 +155,7 @@ def lookup_person(name, email):
 # Section titles for release notes.
 relnotetitles = {
     'cli change': "Command-line changes",
+    'ops change': "Operational changes",
     'sql change': "SQL language changes",
     'api change': "API endpoint changes",
     'ui change': "DB Console changes",
@@ -174,6 +175,7 @@ relnote_sec_order = [
     'general change',
     'enterprise change',
     'sql change',
+    'ops change',
     'cli change',
     'api change',
     'ui change',
@@ -191,6 +193,7 @@ cat_misspells = {
     'performance change': 'performance improvement',
     'performance': 'performance improvement',
     'ui': 'ui change',
+    'operational change': 'ops change',
     'admin ui': 'ui change',
     'api': 'api change',
     'http': 'api change',


### PR DESCRIPTION
Fixes #57898 

This new release note category is meant to cover changes that interest
primarily the folk responsible for running production clusters and
integrating CockroachDB into a larger IT deployment.

Note that this new category takes over certain things that would
previously be attributed to "cli changes". From now on "cli changes"
covers changes that primarily interest app developers, crdb developers
and operators that are currently trying out features or setting up
experiments in development/staging environments.

See this page for more details:
https://wiki.crdb.io/wiki/spaces/CRDB/pages/186548364/Release+notes

Release note: None