### PR TITLE
util/log: Avoid logging output on stderr under `go test -bench`

### DIFF
--- a/pkg/sql/colexec/main_test.go
+++ b/pkg/sql/colexec/main_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
@@ -68,8 +69,8 @@ func TestMain(m *testing.M) {
 		defer testDiskAcc.Close(ctx)
 
 		flag.Parse()
-		if f := flag.Lookup("test.bench"); f == nil || f.Value.String() == "" {
-			// If we're running benchmarks, don't set a random batch size.
+		if !skip.UnderBench() {
+			// (If we're running benchmarks, don't set a random batch size.)
 			// Pick a random batch size in [minBatchSize, coldata.MaxBatchSize]
 			// range. The randomization can be disabled using COCKROACH_RANDOMIZE_BATCH_SIZE=false.
 			randomBatchSize := generateBatchSize()

--- a/pkg/testutils/skip/skip.go
+++ b/pkg/testutils/skip/skip.go
@@ -11,6 +11,7 @@
 package skip
 
 import (
+	"flag"
 	"fmt"
 	"testing"
 
@@ -97,4 +98,15 @@ func UnderMetamorphic(t SkippableTest, args ...interface{}) {
 	if util.IsMetamorphicBuild() {
 		t.Skip(append([]interface{}{"disabled under metamorphic"}, args...))
 	}
+}
+
+// UnderBench returns true iff a test is currently running under `go
+// test -bench`.  When true, tests should avoid writing data on
+// stdout/stderr from goroutines that run asynchronously with the
+// test.
+func UnderBench() bool {
+	// We use here the understanding that `go test -bench` runs the
+	// test executable with `-test.bench 1`.
+	f := flag.Lookup("test.bench")
+	return f != nil && f.Value.String() != ""
 }

--- a/pkg/util/log/BUILD.bazel
+++ b/pkg/util/log/BUILD.bazel
@@ -44,6 +44,7 @@ go_library(
     deps = [
         "//pkg/build",
         "//pkg/cli/exit",
+        "//pkg/testutils/skip",
         "//pkg/util",
         "//pkg/util/caller",
         "//pkg/util/encoding/encodingtype",

--- a/pkg/util/log/test_log_scope.go
+++ b/pkg/util/log/test_log_scope.go
@@ -18,6 +18,7 @@ import (
 	"runtime"
 
 	"github.com/cockroachdb/cockroach/pkg/cli/exit"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/fileutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logconfig"
 	"github.com/cockroachdb/cockroach/pkg/util/log/severity"
@@ -148,11 +149,22 @@ func ScopeWithoutShowLogs(t tShim) (sc *TestLogScope) {
 
 	// Create a fresh configuration.
 	cfg := logconfig.DefaultConfig()
-	// Make all logged errors go to the external stderr, in addition to
-	// the log file.
-	cfg.Sinks.Stderr.Filter = severity.ERROR
-	// Disable the internal fd2 capture.
+
+	if skip.UnderBench() {
+		// Avoid logging anything to stderr, to avoid polluting the output
+		// of benchmarks. This is necessary because 'go test' unhelpfully
+		// merges stdout and stderr writes together.
+		cfg.Sinks.Stderr.Filter = severity.NONE
+	} else {
+		// Normal case: make all logged errors/fatal calls go to the
+		// external stderr, in addition to the log file.
+		cfg.Sinks.Stderr.Filter = severity.ERROR
+	}
+	// Disable the internal fd2 capture to file, to ensure that panic
+	// objects get reported to stderr.
 	cfg.CaptureFd2.Enable = false
+	// We cannot enable redactable markers on stderr when fd2 capture is
+	// disabled.
 	bf := false
 	cfg.Sinks.Stderr.Redactable = &bf
 
@@ -256,7 +268,6 @@ func (l *TestLogScope) Close(t tShim) {
 			"bug in TestLogScope - previous config:\n%s\nafter restore:\n%s",
 			l.previous.appliedConfig, restoredConfig)
 	}
-	//	t.Logf("restored configuration:\n%s", restoredConfig)
 }
 
 // calledDuringPanic returns true if panic() is one of its callers.


### PR DESCRIPTION
Fixes #57979 

We have found that logging output can interleave with benchmark
results, which makes it awkward to run `benchstat` and the like on the
output.

This change ensures that log.Scope disables stderr logging for
benchmarks.

Release note: None