### PR TITLE
colexec: fix external aggregator fallback and bool agg functions reset

### DIFF
--- a/pkg/sql/colexec/colexecagg/ordered_bool_and_or_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_bool_and_or_agg.eg.go
@@ -31,9 +31,11 @@ func newBoolAndOrderedAggAlloc(
 
 type boolAndOrderedAgg struct {
 	orderedAggregateFuncBase
-	col        []bool
-	sawNonNull bool
-	curAgg     bool
+	col    []bool
+	curAgg bool
+	// foundNonNullForCurrentGroup tracks if we have seen any non-null values
+	// for the group that is currently being aggregated.
+	foundNonNullForCurrentGroup bool
 }
 
 var _ AggregateFunc = &boolAndOrderedAgg{}
@@ -62,14 +64,14 @@ func (a *boolAndOrderedAgg) Compute(
 					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
-							if !a.sawNonNull {
+							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
 								a.col[a.curIdx] = a.curAgg
 							}
 							a.curIdx++
 							a.curAgg = true
-							a.sawNonNull = false
+							a.foundNonNullForCurrentGroup = false
 						}
 						a.isFirstGroup = false
 					}
@@ -79,7 +81,7 @@ func (a *boolAndOrderedAgg) Compute(
 					if !isNull {
 						//gcassert:bce
 						a.curAgg = a.curAgg && col[i]
-						a.sawNonNull = true
+						a.foundNonNullForCurrentGroup = true
 					}
 
 				}
@@ -88,14 +90,14 @@ func (a *boolAndOrderedAgg) Compute(
 					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
-							if !a.sawNonNull {
+							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
 								a.col[a.curIdx] = a.curAgg
 							}
 							a.curIdx++
 							a.curAgg = true
-							a.sawNonNull = false
+							a.foundNonNullForCurrentGroup = false
 						}
 						a.isFirstGroup = false
 					}
@@ -105,7 +107,7 @@ func (a *boolAndOrderedAgg) Compute(
 					if !isNull {
 						//gcassert:bce
 						a.curAgg = a.curAgg && col[i]
-						a.sawNonNull = true
+						a.foundNonNullForCurrentGroup = true
 					}
 
 				}
@@ -116,14 +118,14 @@ func (a *boolAndOrderedAgg) Compute(
 				for _, i := range sel {
 					if groups[i] {
 						if !a.isFirstGroup {
-							if !a.sawNonNull {
+							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
 								a.col[a.curIdx] = a.curAgg
 							}
 							a.curIdx++
 							a.curAgg = true
-							a.sawNonNull = false
+							a.foundNonNullForCurrentGroup = false
 						}
 						a.isFirstGroup = false
 					}
@@ -132,7 +134,7 @@ func (a *boolAndOrderedAgg) Compute(
 					isNull = nulls.NullAt(i)
 					if !isNull {
 						a.curAgg = a.curAgg && col[i]
-						a.sawNonNull = true
+						a.foundNonNullForCurrentGroup = true
 					}
 
 				}
@@ -140,14 +142,14 @@ func (a *boolAndOrderedAgg) Compute(
 				for _, i := range sel {
 					if groups[i] {
 						if !a.isFirstGroup {
-							if !a.sawNonNull {
+							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
 								a.col[a.curIdx] = a.curAgg
 							}
 							a.curIdx++
 							a.curAgg = true
-							a.sawNonNull = false
+							a.foundNonNullForCurrentGroup = false
 						}
 						a.isFirstGroup = false
 					}
@@ -156,7 +158,7 @@ func (a *boolAndOrderedAgg) Compute(
 					isNull = false
 					if !isNull {
 						a.curAgg = a.curAgg && col[i]
-						a.sawNonNull = true
+						a.foundNonNullForCurrentGroup = true
 					}
 
 				}
@@ -175,7 +177,7 @@ func (a *boolAndOrderedAgg) Flush(outputIdx int) {
 	_ = outputIdx
 	outputIdx = a.curIdx
 	a.curIdx++
-	if !a.sawNonNull {
+	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
 		a.col[outputIdx] = a.curAgg
@@ -185,6 +187,7 @@ func (a *boolAndOrderedAgg) Flush(outputIdx int) {
 func (a *boolAndOrderedAgg) Reset() {
 	a.orderedAggregateFuncBase.Reset()
 	a.curAgg = true
+	a.foundNonNullForCurrentGroup = false
 }
 
 type boolAndOrderedAggAlloc struct {
@@ -220,9 +223,11 @@ func newBoolOrOrderedAggAlloc(
 
 type boolOrOrderedAgg struct {
 	orderedAggregateFuncBase
-	col        []bool
-	sawNonNull bool
-	curAgg     bool
+	col    []bool
+	curAgg bool
+	// foundNonNullForCurrentGroup tracks if we have seen any non-null values
+	// for the group that is currently being aggregated.
+	foundNonNullForCurrentGroup bool
 }
 
 var _ AggregateFunc = &boolOrOrderedAgg{}
@@ -251,14 +256,14 @@ func (a *boolOrOrderedAgg) Compute(
 					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
-							if !a.sawNonNull {
+							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
 								a.col[a.curIdx] = a.curAgg
 							}
 							a.curIdx++
 							a.curAgg = false
-							a.sawNonNull = false
+							a.foundNonNullForCurrentGroup = false
 						}
 						a.isFirstGroup = false
 					}
@@ -268,7 +273,7 @@ func (a *boolOrOrderedAgg) Compute(
 					if !isNull {
 						//gcassert:bce
 						a.curAgg = a.curAgg || col[i]
-						a.sawNonNull = true
+						a.foundNonNullForCurrentGroup = true
 					}
 
 				}
@@ -277,14 +282,14 @@ func (a *boolOrOrderedAgg) Compute(
 					//gcassert:bce
 					if groups[i] {
 						if !a.isFirstGroup {
-							if !a.sawNonNull {
+							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
 								a.col[a.curIdx] = a.curAgg
 							}
 							a.curIdx++
 							a.curAgg = false
-							a.sawNonNull = false
+							a.foundNonNullForCurrentGroup = false
 						}
 						a.isFirstGroup = false
 					}
@@ -294,7 +299,7 @@ func (a *boolOrOrderedAgg) Compute(
 					if !isNull {
 						//gcassert:bce
 						a.curAgg = a.curAgg || col[i]
-						a.sawNonNull = true
+						a.foundNonNullForCurrentGroup = true
 					}
 
 				}
@@ -305,14 +310,14 @@ func (a *boolOrOrderedAgg) Compute(
 				for _, i := range sel {
 					if groups[i] {
 						if !a.isFirstGroup {
-							if !a.sawNonNull {
+							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
 								a.col[a.curIdx] = a.curAgg
 							}
 							a.curIdx++
 							a.curAgg = false
-							a.sawNonNull = false
+							a.foundNonNullForCurrentGroup = false
 						}
 						a.isFirstGroup = false
 					}
@@ -321,7 +326,7 @@ func (a *boolOrOrderedAgg) Compute(
 					isNull = nulls.NullAt(i)
 					if !isNull {
 						a.curAgg = a.curAgg || col[i]
-						a.sawNonNull = true
+						a.foundNonNullForCurrentGroup = true
 					}
 
 				}
@@ -329,14 +334,14 @@ func (a *boolOrOrderedAgg) Compute(
 				for _, i := range sel {
 					if groups[i] {
 						if !a.isFirstGroup {
-							if !a.sawNonNull {
+							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
 								a.col[a.curIdx] = a.curAgg
 							}
 							a.curIdx++
 							a.curAgg = false
-							a.sawNonNull = false
+							a.foundNonNullForCurrentGroup = false
 						}
 						a.isFirstGroup = false
 					}
@@ -345,7 +350,7 @@ func (a *boolOrOrderedAgg) Compute(
 					isNull = false
 					if !isNull {
 						a.curAgg = a.curAgg || col[i]
-						a.sawNonNull = true
+						a.foundNonNullForCurrentGroup = true
 					}
 
 				}
@@ -364,7 +369,7 @@ func (a *boolOrOrderedAgg) Flush(outputIdx int) {
 	_ = outputIdx
 	outputIdx = a.curIdx
 	a.curIdx++
-	if !a.sawNonNull {
+	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
 		a.col[outputIdx] = a.curAgg
@@ -374,6 +379,7 @@ func (a *boolOrOrderedAgg) Flush(outputIdx int) {
 func (a *boolOrOrderedAgg) Reset() {
 	a.orderedAggregateFuncBase.Reset()
 	a.curAgg = false
+	a.foundNonNullForCurrentGroup = false
 }
 
 type boolOrOrderedAggAlloc struct {

--- a/pkg/sql/colexec/external_sort_test.go
+++ b/pkg/sql/colexec/external_sort_test.go
@@ -49,7 +49,8 @@ func TestExternalSort(t *testing.T) {
 		},
 	}
 
-	const numForcedRepartitions = 3
+	rng, _ := randutil.NewPseudoRand()
+	numForcedRepartitions := rng.Intn(5)
 	queueCfg, cleanup := colcontainerutils.NewTestingDiskQueueCfg(t, true /* inMem */)
 	defer cleanup()
 
@@ -71,7 +72,7 @@ func TestExternalSort(t *testing.T) {
 		}
 		for _, tcs := range [][]sortTestCase{sortAllTestCases, topKSortTestCases, sortChunksTestCases} {
 			for _, tc := range tcs {
-				log.Infof(context.Background(), "spillForced=%t/%s", spillForced, tc.description)
+				log.Infof(context.Background(), "spillForced=%t/numRepartitions=%d/%s", spillForced, numForcedRepartitions, tc.description)
 				var semsToCheck []semaphore.Semaphore
 				runTestsWithTyps(
 					t,

--- a/pkg/sql/colexec/ordered_aggregator.go
+++ b/pkg/sql/colexec/ordered_aggregator.go
@@ -367,7 +367,9 @@ func (a *orderedAggregator) reset(ctx context.Context) {
 		r.reset(ctx)
 	}
 	a.state = orderedAggregatorAggregating
-	a.scratch.shouldResetInternalBatch = true
+	// In some cases we might reset the aggregator before Next() is called for
+	// the first time, so there might not be a scratch batch allocated yet.
+	a.scratch.shouldResetInternalBatch = a.scratch.Batch != nil
 	a.scratch.resumeIdx = 0
 	a.lastReadBatch = nil
 	a.seenNonEmptyBatch = false


### PR DESCRIPTION
Previously, `reset` method of the ordered aggregator would always set
the flag to reset the internal batch to `true`. However, that batch is
only allocated when `Next` is called at least once with a non-zero batch
coming from the input, which is not the case when the fallback to the
disk-backed strategy occurs in the external aggregator (there, we call
`reset` before we use the operator every time). This would lead to
a nil pointer exception, and it is now fixed.

Our unit tests didn't catch it because we forgot to set the forced
number of repartitions which is now also fixed.

This also revealed a bug with resetting of `bool_and` and `bool_or`
aggregates - we forgot to reset whether they have seen a non-null value
or not.

Fixes: #59043.

Release note: None (no stable release with these bugs)