### PR TITLE
bazel,colexec: generate crossjoiner.eg.go within bazel 

### DIFF
--- a/pkg/sql/colexec/COLEXEC.bzl
+++ b/pkg/sql/colexec/COLEXEC.bzl
@@ -3,6 +3,7 @@ targets = [
     ('and_or_projection.eg.go', 'and_or_projection_tmpl.go'),
     ('cast.eg.go', 'cast_tmpl.go'),
     ('const.eg.go', 'const_tmpl.go'),
+    ('crossjoiner.eg.go', 'crossjoiner_tmpl.go'),
     ('default_cmp_expr.eg.go', 'default_cmp_expr_tmpl.go'),
     ('default_cmp_proj_ops.eg.go', 'default_cmp_proj_ops_tmpl.go'),
     ('default_cmp_sel_ops.eg.go', 'default_cmp_sel_ops_tmpl.go'),

--- a/pkg/sql/colexec/crossjoiner.eg.go
+++ b/pkg/sql/colexec/crossjoiner.eg.go
@@ -19,6 +19,12 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
+// Workaround for bazel auto-generated code. goimports does not automatically
+// pick up the right packages when run within the bazel sandbox.
+var (
+	_ = typeconv.DatumVecCanonicalTypeFamily
+)
+
 // buildFromLeftInput builds part of the output of a cross join that comes from
 // the vectors of the left input. The new output tuples are put starting at
 // index destStartIdx and will not exceed the capacity of the output batch. It

--- a/pkg/sql/colexec/crossjoiner_tmpl.go
+++ b/pkg/sql/colexec/crossjoiner_tmpl.go
@@ -23,9 +23,17 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase/colexecerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/errors"
+)
+
+// Workaround for bazel auto-generated code. goimports does not automatically
+// pick up the right packages when run within the bazel sandbox.
+var (
+	_ = typeconv.DatumVecCanonicalTypeFamily
 )
 
 // buildFromLeftInput builds part of the output of a cross join that comes from


### PR DESCRIPTION
We broke the bazel build in 52c5f51 when we introduced a new .eg.go
file, without updating the bazel target. We do that here.

Fixes #59052