### PR TITLE
colexec: fix coalescing logic in the spilling queue

### DIFF
--- a/pkg/sql/colexec/routers_test.go
+++ b/pkg/sql/colexec/routers_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/colcontainerutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -861,7 +860,6 @@ func TestHashRouterOneOutput(t *testing.T) {
 
 func TestHashRouterRandom(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	skip.WithIssue(t, 58956, "flaky test")
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 


### PR DESCRIPTION
In a recently merged change to the spilling queue we introduced a bug in
the coalescing logic - we incorrectly computed the index of the "tail"
batch in case when it is the last one in the in-memory buffer. This
could lead to multiple problems (modification of the filled-up batch, of
the already dequeued batch, etc). This is now fixed.

Additionally, this commit switches to using `Copy` instead of `Append`
in that coalescing logic (since we know that there is enough capacity
for all of the tuples we're appending) and sets the item to `nil` when
it was dequeued.

Addresses: #47652.
Fixes: #58913.
Fixes: #58915.
Fixes: #58934.
Fixes: #58935.
Fixes: #58936.
Fixes: #58956.

Release note: None (no stable release with this bug)