### PR TITLE
util/log: do not populate channel/severity fields in file headers to avoid confusion

### DIFF
--- a/docs/generated/logformats.md
+++ b/docs/generated/logformats.md
@@ -54,6 +54,18 @@ the following caveats apply:
   entries larger than 64KiB successfully. Generally, use of this internal
   log entry parser is discouraged.
 
+### Header lines
+
+At the beginning of each file, a header is printed using a similar format as
+regular log entries. This header reports when the file was created,
+which parameters were used to start the server, the server identifiers
+if known, and other metadata about the running process.
+
+This header appears to be logged at severity INFO (with an I prefix at the
+start of the line) even though it does not really have a severity. The
+header is printed unconditionally even when a filter is configured to
+omit entries at the INFO level.
+
 ### Common log entry prefix
 
 Each line of output starts with the following prefix:
@@ -106,6 +118,18 @@ the following caveats apply:
   and is unable to recognize the aforementioned pitfall; nor can it read
   entries larger than 64KiB successfully. Generally, use of this internal
   log entry parser is discouraged.
+
+### Header lines
+
+At the beginning of each file, a header is printed using a similar format as
+regular log entries. This header reports when the file was created,
+which parameters were used to start the server, the server identifiers
+if known, and other metadata about the running process.
+
+This header appears to be logged at severity INFO (with an I prefix at the
+start of the line) even though it does not really have a severity. The
+header is printed unconditionally even when a filter is configured to
+omit entries at the INFO level.
 
 ### Common log entry prefix
 
@@ -168,16 +192,23 @@ Each entry contains at least the following fields:
 
 | Field | Description |
 |-------|-------------|
-| `channel` | The name of the logging channel where the event was sent. |
-| `severity` | The severity of the event. |
-| `channel_numeric` | The numeric identifier for the logging channel where the event was sent. |
 | `file` | The name of the source file where the event was emitted. |
 | `goroutine` | The identifier of the goroutine where the event was emitted. |
 | `line` | The line number where the event was emitted in the source. |
-| `entry_counter` | The entry number on this logging sink, relative to the last process restart. |
 | `redactable` | Whether the payload is redactable (see below for details). |
-| `severity_numeric` | The numeric value of the severity of the event. |
 | `timestamp` | The timestamp at which the event was emitted on the logging channel. |
+
+
+After a couple of *header* entries written at the beginning of each log sink,
+all subsequent log entries also contain the following fields:
+
+| Field               | Description |
+|---------------------|-------------|
+| `channel` | The name of the logging channel where the event was sent. |
+| `severity` | The severity of the event. |
+| `channel_numeric` | The numeric identifier for the logging channel where the event was sent. |
+| `entry_counter` | The entry number on this logging sink, relative to the last process restart. |
+| `severity_numeric` | The numeric value of the severity of the event. |
 
 
 Additionally, the following fields are conditionally present:
@@ -218,16 +249,23 @@ Each entry contains at least the following fields:
 
 | Field | Description |
 |-------|-------------|
-| `C` | The name of the logging channel where the event was sent. |
-| `sev` | The severity of the event. |
-| `c` | The numeric identifier for the logging channel where the event was sent. |
 | `f` | The name of the source file where the event was emitted. |
 | `g` | The identifier of the goroutine where the event was emitted. |
 | `l` | The line number where the event was emitted in the source. |
-| `n` | The entry number on this logging sink, relative to the last process restart. |
 | `r` | Whether the payload is redactable (see below for details). |
-| `s` | The numeric value of the severity of the event. |
 | `t` | The timestamp at which the event was emitted on the logging channel. |
+
+
+After a couple of *header* entries written at the beginning of each log sink,
+all subsequent log entries also contain the following fields:
+
+| Field               | Description |
+|---------------------|-------------|
+| `C` | The name of the logging channel where the event was sent. |
+| `sev` | The severity of the event. |
+| `c` | The numeric identifier for the logging channel where the event was sent. |
+| `n` | The entry number on this logging sink, relative to the last process restart. |
+| `s` | The numeric value of the severity of the event. |
 
 
 Additionally, the following fields are conditionally present:
@@ -269,16 +307,23 @@ Each entry contains at least the following fields:
 | Field | Description |
 |-------|-------------|
 | `tag` | A Fluent tag for the event, formed by the process name and the logging channel. |
-| `channel` | The name of the logging channel where the event was sent. |
-| `severity` | The severity of the event. |
-| `channel_numeric` | The numeric identifier for the logging channel where the event was sent. |
 | `file` | The name of the source file where the event was emitted. |
 | `goroutine` | The identifier of the goroutine where the event was emitted. |
 | `line` | The line number where the event was emitted in the source. |
-| `entry_counter` | The entry number on this logging sink, relative to the last process restart. |
 | `redactable` | Whether the payload is redactable (see below for details). |
-| `severity_numeric` | The numeric value of the severity of the event. |
 | `timestamp` | The timestamp at which the event was emitted on the logging channel. |
+
+
+After a couple of *header* entries written at the beginning of each log sink,
+all subsequent log entries also contain the following fields:
+
+| Field               | Description |
+|---------------------|-------------|
+| `channel` | The name of the logging channel where the event was sent. |
+| `severity` | The severity of the event. |
+| `channel_numeric` | The numeric identifier for the logging channel where the event was sent. |
+| `entry_counter` | The entry number on this logging sink, relative to the last process restart. |
+| `severity_numeric` | The numeric value of the severity of the event. |
 
 
 Additionally, the following fields are conditionally present:
@@ -320,16 +365,23 @@ Each entry contains at least the following fields:
 | Field | Description |
 |-------|-------------|
 | `tag` | A Fluent tag for the event, formed by the process name and the logging channel. |
-| `C` | The name of the logging channel where the event was sent. |
-| `sev` | The severity of the event. |
-| `c` | The numeric identifier for the logging channel where the event was sent. |
 | `f` | The name of the source file where the event was emitted. |
 | `g` | The identifier of the goroutine where the event was emitted. |
 | `l` | The line number where the event was emitted in the source. |
-| `n` | The entry number on this logging sink, relative to the last process restart. |
 | `r` | Whether the payload is redactable (see below for details). |
-| `s` | The numeric value of the severity of the event. |
 | `t` | The timestamp at which the event was emitted on the logging channel. |
+
+
+After a couple of *header* entries written at the beginning of each log sink,
+all subsequent log entries also contain the following fields:
+
+| Field               | Description |
+|---------------------|-------------|
+| `C` | The name of the logging channel where the event was sent. |
+| `sev` | The severity of the event. |
+| `c` | The numeric identifier for the logging channel where the event was sent. |
+| `n` | The entry number on this logging sink, relative to the last process restart. |
+| `s` | The numeric value of the severity of the event. |
 
 
 Additionally, the following fields are conditionally present:

--- a/pkg/util/log/format_json_test.go
+++ b/pkg/util/log/format_json_test.go
@@ -36,6 +36,13 @@ func TestJSONFormats(t *testing.T) {
 	ctx = logtags.AddTag(ctx, "long", "2")
 
 	testCases := []logEntry{
+		// Header entry.
+		func() logEntry {
+			e := makeUnstructuredEntry(ctx, 0, 0, 0, true, "hello %s", "world")
+			e.header = true
+			return e
+		}(),
+		// Normal (non-header) entries.
 		{},
 		{idPayload: idPayload{clusterID: "abc", nodeID: 123}},
 		{idPayload: idPayload{tenantID: "abc", sqlInstanceID: 123}},

--- a/pkg/util/log/testdata/json
+++ b/pkg/util/log/testdata/json
@@ -1,6 +1,11 @@
 run
 ----
 #
+json-fluent-compact: {"tag":"log_test.unknown","header":1,"t":"1136214245.654321000","g":11,"f":"util/log/format_json_test.go","l":123,"r":1,"tags":{"noval":"","s":"‹1›","long":"‹2›"},"message":"hello ‹world›"}
+        json-fluent: {"tag":"log_test.unknown","header":1,"timestamp":"1136214245.654321000","goroutine":11,"file":"util/log/format_json_test.go","line":123,"redactable":1,"tags":{"noval":"","s":"‹1›","long":"‹2›"},"message":"hello ‹world›"}
+       json-compact: {"header":1,"t":"1136214245.654321000","g":11,"f":"util/log/format_json_test.go","l":123,"r":1,"tags":{"noval":"","s":"‹1›","long":"‹2›"},"message":"hello ‹world›"}
+               json: {"header":1,"timestamp":"1136214245.654321000","goroutine":11,"file":"util/log/format_json_test.go","line":123,"redactable":1,"tags":{"noval":"","s":"‹1›","long":"‹2›"},"message":"hello ‹world›"}
+#
 json-fluent-compact: {"tag":"log_test.dev","c":0,"t":"1136214245.654321000","s":0,"g":11,"f":"","l":123,"n":0,"r":0,"message":""}
         json-fluent: {"tag":"log_test.dev","channel_numeric":0,"channel":"DEV","timestamp":"1136214245.654321000","severity_numeric":0,"severity":"UNKNOWN","goroutine":11,"file":"","line":123,"entry_counter":0,"redactable":0,"message":""}
        json-compact: {"c":0,"t":"1136214245.654321000","s":0,"g":11,"f":"","l":123,"n":0,"r":0,"message":""}


### PR DESCRIPTION
Fixes #58970. 
Fixes #59004. 
cc @thtruo @piyush-singh 

When using file sinks, each file may be recipient for entries from
multiple channels. Or perhaps the file has been configured to exclude
entries on the DEV channel.

Within that context, it is confusing to see that the header lines,
which are unconditionally written at the start of every new log file,
seem to originate from channel DEV. In reality, there is no such event
on the DEV channel, nor are these header lines subject to channel
routing and filtering.

So this change omits the channel indicator from header lines in the
JSON format. (In `crdb-v1`, the channel indicator was automatically
omitted because DEV entries don't get a channel indicator, for the
sake of backward-compatibility.)

Additionally, the header lines are printed unconditionally, regardless
of the severity filter. In fact, they do not really correspond to log
information subject to severity.

Within that context, it is confusing to see that the header lines
appear to be emitted at severity level INFO. In particular if the
output is set to omit entries at that level, the headers line remain.

So this change omits the severity indicator from header lines in the
JSON format. (In `crdb-v1`, we document instead that header lines
start with `I` for backward-compatibility.)

There is no release note because this affects behavior which has not
yet been released in a stable version of CockroachDB.

Release note: None