### PR TITLE
cmd/roachtest: add workload F to pebble roachtest

### DIFF
--- a/pkg/cmd/roachtest/pebble.go
+++ b/pkg/cmd/roachtest/pebble.go
@@ -61,7 +61,7 @@ func registerPebble(r *testRegistry) {
 				"rm -f %s && tar cvPf %s %s) > init.log 2>&1",
 			benchDir, size, initialKeys, cache, dataTar, dataTar, benchDir))
 
-		for _, workload := range []string{"A", "B", "C", "D", "E"} {
+		for _, workload := range []string{"A", "B", "C", "D", "E", "F"} {
 			keys := "zipf"
 			switch workload {
 			case "D":


### PR DESCRIPTION
Run workload F (100% inserts) in the nightly Pebble benchmarks. A
performance regression in the 100%-insert workload went unnoticed.
Adding it to the nightly benchmarks will help detect future regressions.

Release note: none