### PR TITLE
colexec: clean up spilling queue and improve its unit test

### DIFF
--- a/pkg/sql/colexec/BUILD.bazel
+++ b/pkg/sql/colexec/BUILD.bazel
@@ -82,6 +82,7 @@ go_library(
         "//pkg/sql/sqlerrors",
         "//pkg/sql/sqltelemetry",  # keep
         "//pkg/sql/types",
+        "//pkg/util",
         "//pkg/util/cancelchecker",
         "//pkg/util/duration",  # keep
         "//pkg/util/encoding",  # keep


### PR DESCRIPTION
This commit cleans up the spilling queue by removing the logic for
estimating the number of batches that could be kept in the in-memory
`items` buffer. This logic is no longer needed since we are growing that
slice dynamically and since we are paying attention to the amount of RAM
used by the spilling queue anyway.

It also improves the unit test to cover more cases (by increasing the
number of batches, randomizing the initial length of `items` slice,
adding extra memory limit) and to verify more assumptions (if the
spilling queue doesn't spill, then we expect all dequeued batches to
equal to all of the input tuples).

That increased coverage reliably reproduces a recent bug with a minor
change that now, whenever we're dequeueing from the in-memory buffer,
we're setting that slice spot to `nil` (which is somewhat beneficial on
its own).

Release note: None