### PR TITLE
sql: users can alter table/schema/database owner to current owner without privileges

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -1303,6 +1303,11 @@ func (p *planner) alterTableOwner(
 		return false, nil
 	}
 
+	if p.User() != privs.Owner() {
+		return false, pgerror.Newf(pgcode.InsufficientPrivilege,
+			"must be owner of table %s", n.tableDesc.Name)
+	}
+
 	if err := p.checkCanAlterTableAndSetNewOwner(ctx, n.tableDesc, newOwner); err != nil {
 		return false, err
 	}

--- a/pkg/sql/logictest/testdata/logic_test/alter_table_owner
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table_owner
@@ -18,16 +18,17 @@ ALTER TABLE s.t OWNER TO testuser
 
 statement ok
 GRANT CREATE ON DATABASE test TO testuser, testuser2;
-GRANT CREATE ON SCHEMA s TO testuser, testuser2
+GRANT CREATE ON SCHEMA s TO testuser, testuser2;
+GRANT CREATE ON t TO testuser, testuser2;
+
 
 statement ok
 ALTER TABLE t OWNER TO testuser;
 ALTER TABLE s.t OWNER TO testuser;
-ALTER TABLE t OWNER TO root;
-ALTER TABLE s.t OWNER TO root
+
 
 # Other users must be owner to alter the owner.
-user testuser
+user testuser2
 
 statement error must be owner of table t
 ALTER TABLE t OWNER TO testuser2


### PR DESCRIPTION
Add validation for user session must be the same with table owner before executing ALTER TABLE OWNER

Fixes #58975.
Release note (sql change): Add validation user session on ALTER TABLE OWNER