### PR TITLE
kvserver: fix rangelog event logging for non-voter additions

### DIFF
--- a/pkg/kv/kvserver/log.go
+++ b/pkg/kv/kvserver/log.go
@@ -179,10 +179,10 @@ func (s *Store) logChange(
 	case roachpb.ADD_NON_VOTER:
 		logType = kvserverpb.RangeLogEventType_add_non_voter
 		info = kvserverpb.RangeLogEvent_Info{
-			RemovedReplica: &replica,
-			UpdatedDesc:    &desc,
-			Reason:         reason,
-			Details:        details,
+			AddedReplica: &replica,
+			UpdatedDesc:  &desc,
+			Reason:       reason,
+			Details:      details,
 		}
 	case roachpb.REMOVE_NON_VOTER:
 		logType = kvserverpb.RangeLogEventType_remove_non_voter


### PR DESCRIPTION
Before this patch, we were incorrectly logging non-voter additions as
removals.

Release note: None