### PR TITLE
tracing: link child into parent, even if not verbose

### DIFF
--- a/pkg/util/tracing/crdbspan.go
+++ b/pkg/util/tracing/crdbspan.go
@@ -98,12 +98,16 @@ func (s *crdbSpan) recordingType() RecordingType {
 // If separate recording is specified, the child is not registered with the
 // parent. Thus, the parent's recording will not include this child.
 func (s *crdbSpan) enableRecording(parent *crdbSpan, recType RecordingType) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.mu.recording.recordingType.swap(recType)
 	if parent != nil {
 		parent.addChild(s)
 	}
+	if recType == RecordingOff {
+		return
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.mu.recording.recordingType.swap(recType)
 	if recType == RecordingVerbose {
 		s.setBaggageItemLocked(verboseTracingBaggageKey, "1")
 	}

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -394,16 +394,16 @@ func (t *Tracer) startSpanGeneric(
 
 	s := &helper.span
 
-	// Start recording if necessary. We inherit the recording type of the local parent, if any,
-	// over the remote parent, if any. If neither are specified, we're not recording.
-	recordingType := opts.recordingType()
-
-	if recordingType != RecordingOff {
+	{
+		// Link the newly created span to the parent, if necessary,
+		// and start recording, if requested.
+		// We inherit the recording type of the local parent, if any,
+		// over the remote parent, if any. If neither are specified, we're not recording.
 		var p *crdbSpan
 		if opts.Parent != nil {
 			p = opts.Parent.crdb
 		}
-		s.crdb.enableRecording(p, recordingType)
+		s.crdb.enableRecording(p, opts.recordingType())
 	}
 
 	// Set initial tags. These will propagate to the crdbSpan, ot, and netTr


### PR DESCRIPTION
Prior to this change, when a child was derived from a local parent, we
would not register the child with the parent. In effect, this meant that
any payloads in the child would not be collected.

Release note: None
