### PR TITLE
roachtest: skip acceptance/version-upgrade

### DIFF
--- a/pkg/cmd/roachtest/acceptance.go
+++ b/pkg/cmd/roachtest/acceptance.go
@@ -78,6 +78,7 @@ func registerAcceptance(r *testRegistry) {
 			// to head after 19.2 fails.
 			minVersion: "v19.2.0",
 			timeout:    30 * time.Minute,
+			skip:       "https://github.com/cockroachdb/cockroach/issues/58489",
 		},
 	}
 	tags := []string{"default", "quick"}


### PR DESCRIPTION
This has been failing a lot on master, and we're investigating actively
in #58489. Let's skip it in the interim.

Release note: None