### PR TITLE
ccl/sqlproxyccl: connection abruptly closed without ErrorResponse 

### DIFF
--- a/pkg/ccl/sqlproxyccl/proxy_test.go
+++ b/pkg/ccl/sqlproxyccl/proxy_test.go
@@ -31,6 +31,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const FrontendError = "Frontend error!"
+const BackendError = "Backend error!"
+
 func setupTestProxyWithCerts(
 	t *testing.T, opts *Options,
 ) (server *Server, addr string, done func()) {
@@ -402,13 +405,16 @@ func TestProxyModifyRequestParams(t *testing.T) {
 }
 
 func newInsecureProxyServer(
-	t *testing.T, outgoingAddr string, outgoingTLSConfig *tls.Config,
+	t *testing.T, outgoingAddr string, outgoingTLSConfig *tls.Config, customOptions ...func(*Options),
 ) (server *Server, addr string, cleanup func()) {
-	s := NewServer(Options{
+	op := Options{
 		BackendDialer: func(message *pgproto3.StartupMessage) (net.Conn, error) {
 			return BackendDial(message, outgoingAddr, outgoingTLSConfig)
-		},
-	})
+		}}
+	for _, opt := range customOptions {
+		opt(&op)
+	}
+	s := NewServer(op)
 	const listenAddress = "127.0.0.1:0"
 	ln, err := net.Listen("tcp", listenAddress)
 	require.NoError(t, err)
@@ -435,7 +441,7 @@ func TestInsecureProxy(t *testing.T) {
 	sqlDB.Exec(t, `CREATE USER bob WITH PASSWORD 'builder'`)
 
 	s, addr, cleanup := newInsecureProxyServer(
-		t, tc.Server(0).ServingSQLAddr(), &tls.Config{InsecureSkipVerify: true})
+		t, tc.Server(0).ServingSQLAddr(), &tls.Config{InsecureSkipVerify: true}, func(op *Options) {} /* custom options */)
 	defer cleanup()
 
 	u := fmt.Sprintf("postgres://bob:wrong@%s?sslmode=disable", addr)
@@ -467,9 +473,9 @@ func TestInsecureDoubleProxy(t *testing.T) {
 
 	// Test multiple proxies:  proxyB -> proxyA -> tc
 	_, proxyA, cleanupA := newInsecureProxyServer(t, tc.Server(0).ServingSQLAddr(),
-		nil /* tls config */)
+		nil /* tls config */, func(op *Options) {} /* custom server options */)
 	defer cleanupA()
-	_, proxyB, cleanupB := newInsecureProxyServer(t, proxyA, nil /* tls config */)
+	_, proxyB, cleanupB := newInsecureProxyServer(t, proxyA, nil /* tls config */, func(op *Options) {} /* custom server options */)
 	defer cleanupB()
 
 	u := fmt.Sprintf("postgres://root:admin@%s/?sslmode=disable", proxyB)
@@ -479,6 +485,54 @@ func TestInsecureDoubleProxy(t *testing.T) {
 		require.NoError(t, conn.Close(ctx))
 	}()
 	require.NoError(t, runTestQuery(conn))
+}
+
+func TestErroneousFrontend(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	tc := serverutils.StartNewTestCluster(t, 1, base.TestClusterArgs{})
+	defer tc.Stopper().Stop(ctx)
+
+	_, addr, cleanup := newInsecureProxyServer(
+		t, tc.Server(0).ServingSQLAddr(), nil, /* tls config */
+		func(op *Options) {
+			op.FrontendAdmitter = func(incoming net.Conn) (net.Conn, *pgproto3.StartupMessage, error) {
+				return nil, nil, errors.New(FrontendError)
+			}
+		})
+	defer cleanup()
+
+	u := fmt.Sprintf("postgres://bob:builder@%s/?sslmode=disable", addr)
+
+	_, err := pgx.Connect(ctx, u)
+	require.Error(t, err)
+	require.True(t, testutils.IsError(err, FrontendError))
+}
+
+func TestErroneousBackend(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	tc := serverutils.StartNewTestCluster(t, 1, base.TestClusterArgs{})
+	defer tc.Stopper().Stop(ctx)
+
+	_, addr, cleanup := newInsecureProxyServer(
+		t, tc.Server(0).ServingSQLAddr(), nil, /* tls config */
+		func(op *Options) {
+			op.BackendDialer = func(message *pgproto3.StartupMessage) (net.Conn, error) {
+				return nil, errors.New(BackendError)
+			}
+		})
+	defer cleanup()
+
+	u := fmt.Sprintf("postgres://bob:builder@%s/?sslmode=disable", addr)
+
+	_, err := pgx.Connect(ctx, u)
+	require.Error(t, err)
+	require.True(t, testutils.IsError(err, BackendError))
 }
 
 func TestProxyRefuseConn(t *testing.T) {


### PR DESCRIPTION
Fixes #58711

If an error occurs in the SQL Proxy while deciding whether to admit a connection or dialing the backend server, the incoming connection is closed. For some classes of errors, an appropriate PostgreSQL-wire ErrorResponse is sent to the client. For other classes of errors, the connection is just abruptly terminated and the client observes an unexpected EOF. We should always return a meaningful, useful ErrorResponse.