### PR TITLE
importccl: account for the RowSource return constraint

### DIFF
--- a/pkg/ccl/importccl/import_processor.go
+++ b/pkg/ccl/importccl/import_processor.go
@@ -134,16 +134,15 @@ func (idp *readImportDataProcessor) Next() (rowenc.EncDatumRow, *execinfrapb.Pro
 	// Once the import is done, send back to the controller the serialized
 	// summary of the import operation. For more info see roachpb.BulkOpSummary.
 	countsBytes, err := protoutil.Marshal(idp.summary)
+	idp.MoveToDraining(err)
 	if err != nil {
-		idp.MoveToDraining(err)
 		return nil, idp.DrainHelper()
 	}
 
-	idp.MoveToDraining(nil /* err */)
 	return rowenc.EncDatumRow{
 		rowenc.DatumToEncDatum(types.Bytes, tree.NewDBytes(tree.DBytes(countsBytes))),
 		rowenc.DatumToEncDatum(types.Bytes, tree.NewDBytes(tree.DBytes([]byte{}))),
-	}, idp.DrainHelper()
+	}, nil
 }
 
 // ConsumerDone is part of the RowSource interface.


### PR DESCRIPTION
...in the import processor. The contract of `RowSource.Next` requires
that at most one of the return values will be non-empty. This wasn't the
case here, and caused opaque failures in #58897. #58897 tries to enable
background tracing by default, which for us means that the trailing meta
can be non-empty (they'll contain span recordings). That behaviour ends
up tickling this bug, tripping up TestCSVImportCanBeResumed.

Release note: None