### PR TITLE
roachtest: rattle unhealthy cached conns

### DIFF
--- a/pkg/cmd/roachtest/versionupgrade.go
+++ b/pkg/cmd/roachtest/versionupgrade.go
@@ -219,7 +219,11 @@ func (u *versionUpgradeTest) conn(ctx context.Context, t *test, i int) *gosql.DB
 			u.conns = append(u.conns, u.c.Conn(ctx, i))
 		}
 	}
-	return u.conns[i-1]
+	db := u.conns[i-1]
+	// Run a trivial query to shake out errors that can occur when the server has
+	// restarted in the meantime.
+	_ = db.PingContext(ctx)
+	return db
 }
 
 func (u *versionUpgradeTest) uploadVersion(


### PR DESCRIPTION
At least on some systems (my Linux desktop for example), using a sql
connection pool whose target node has restarted leads to a spurious
"broken pipe" error on the next attempt to use the connection.

I think this is a bug in whatever driver we're using, but for now
work around it by running a `SELECT 1` before returning the conn
to the caller.

Release note: None
