### PR TITLE
opt: allow ON CONFLICT to reference UNIQUE WITHOUT INDEX constraints

### DIFF
--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -796,7 +796,8 @@ func (e *distSQLSpecExecFactory) ConstructShowTrace(
 func (e *distSQLSpecExecFactory) ConstructInsert(
 	input exec.Node,
 	table cat.Table,
-	arbiters cat.IndexOrdinals,
+	arbiterIndexes cat.IndexOrdinals,
+	arbiterConstraints cat.UniqueOrdinals,
 	insertCols exec.TableColumnOrdinalSet,
 	returnCols exec.TableColumnOrdinalSet,
 	checkCols exec.CheckOrdinalSet,
@@ -833,7 +834,8 @@ func (e *distSQLSpecExecFactory) ConstructUpdate(
 func (e *distSQLSpecExecFactory) ConstructUpsert(
 	input exec.Node,
 	table cat.Table,
-	arbiters cat.IndexOrdinals,
+	arbiterIndexes cat.IndexOrdinals,
+	arbiterConstraints cat.UniqueOrdinals,
 	canaryCol exec.NodeColumnOrdinal,
 	insertCols exec.TableColumnOrdinalSet,
 	fetchCols exec.TableColumnOrdinalSet,

--- a/pkg/sql/logictest/testdata/logic_test/unique
+++ b/pkg/sql/logictest/testdata/logic_test/unique
@@ -74,6 +74,13 @@ CREATE TABLE uniq_enum (
 )
 
 statement ok
+CREATE TABLE uniq_partial (
+  i INT,
+  UNIQUE WITHOUT INDEX (i),
+  UNIQUE INDEX (i) WHERE i > 0
+)
+
+statement ok
 CREATE TABLE other (k INT, v INT, w INT NOT NULL, x INT, y INT)
 
 # Insert some data into the other table.
@@ -120,23 +127,29 @@ statement error pgcode 23505 pq: duplicate key value violates unique constraint 
 INSERT INTO uniq SELECT k, v, w, x, y FROM other
 
 # On conflict do nothing with constant input, conflict on UNIQUE WITHOUT INDEX
-# column.
-# TODO(rytaft): Allow ON CONFLICT to reference UNIQUE WITHOUT INDEX columns
-# (see #58246).
-query error pq: there is no unique or exclusion constraint matching the ON CONFLICT specification
-INSERT INTO uniq VALUES (100, 10, 1), (200, 20, 2) ON CONFLICT (w) DO NOTHING
+# column. The only row that is successfully inserted here is (400, 40, 4).
+statement ok
+INSERT INTO uniq VALUES (100, 10, 1), (200, 20, 2), (400, 40, 4) ON CONFLICT (w) DO NOTHING
+
+# On conflict do nothing with constant input, no conflict columns.
+# The only row that is successfully inserted here is (20, 20, 20, 20, 20).
+statement ok
+INSERT INTO uniq VALUES (1, 20, 20, 20, 20), (20, 1, 20, 20, 20), (20, 20, 20, 20, 20),
+                        (20, 20, 1, 20, 20), (20, 20, 20, 1, 1) ON CONFLICT DO NOTHING
 
 query IIIII colnames,rowsort
 SELECT * FROM uniq
 ----
-k  v  w     x     y
-1  1  1     1     1
-2  2  2     2     2
-3  3  3     3     1
-4  4  NULL  NULL  1
-5  5  NULL  2     NULL
-6  6  NULL  NULL  1
-7  7  NULL  2     NULL
+k    v   w     x     y
+1    1   1     1     1
+2    2   2     2     2
+3    3   3     3     1
+4    4   NULL  NULL  1
+5    5   NULL  2     NULL
+6    6   NULL  NULL  1
+7    7   NULL  2     NULL
+20   20  20    20    20
+400  40  4     NULL  5
 
 
 # Insert into a table in which the primary key overlaps some of the unique
@@ -255,15 +268,17 @@ UPDATE uniq SET k = 11, v = 11 WHERE k = 10
 query IIIII colnames,rowsort
 SELECT * FROM uniq
 ----
-k   v   w     x     y
-1   1   1     2     1
-2   2   2     2     2
-3   3   3     3     1
-4   4   NULL  NULL  1
-5   5   NULL  2     NULL
-6   6   NULL  NULL  1
-7   7   NULL  2     NULL
-11  11  10    NULL  2
+k    v   w     x     y
+1    1   1     2     1
+2    2   2     2     2
+3    3   3     3     1
+4    4   NULL  NULL  1
+5    5   NULL  2     NULL
+6    6   NULL  NULL  1
+7    7   NULL  2     NULL
+11   11  10    NULL  2
+20   20  20    20    20
+400  40  4     NULL  5
 
 
 # Update a table with multiple primary key columns.
@@ -387,26 +402,37 @@ INSERT INTO uniq SELECT k, v FROM other ON CONFLICT (v) DO UPDATE SET x = 5
 
 # On conflict do update with constant input, conflict on UNIQUE WITHOUT INDEX
 # column.
-# TODO(rytaft): Allow ON CONFLICT to reference UNIQUE WITHOUT INDEX columns
-# (see #58246).
-query error pq: there is no unique or exclusion constraint matching the ON CONFLICT specification
-INSERT INTO uniq VALUES (100, 10, 1), (200, 20, 2) ON CONFLICT (w) DO UPDATE SET w = 10
+statement error pgcode 23505 pq: duplicate key value violates unique constraint "unique_w"\nDETAIL: Key \(w\)=\(10\) already exists\.
+INSERT INTO uniq VALUES (100, 100, 1), (200, 200, 2) ON CONFLICT (w) DO UPDATE SET w = 10
+
+# On conflict do update with constant input, conflict on UNIQUE WITHOUT INDEX
+# column.
+statement ok
+INSERT INTO uniq VALUES (100, 100, 1), (200, 200, 2) ON CONFLICT (w) DO UPDATE SET w = 12
+
+# On conflict do update with constant input, conflict on UNIQUE WITHOUT INDEX
+# columns.
+statement ok
+INSERT INTO uniq (k, v, x, y) VALUES (200, 200, 5, 5) ON CONFLICT (x, y) DO UPDATE SET w = 13, y = excluded.y + 1
 
 query IIIII colnames,rowsort
 SELECT * FROM uniq
 ----
-k   v   w     x     y
-1   1   NULL  1     1
-2   2   2     2     2
-3   3   3     3     2
-4   4   NULL  NULL  1
-5   5   5     5     5
-6   6   NULL  NULL  1
-7   7   NULL  2     NULL
-8   8   NULL  NULL  1
-9   9   NULL  1     NULL
-10  10  11    NULL  5
-11  11  10    NULL  2
+k    v    w     x     y
+1    1    NULL  1     1
+2    2    12    2     2
+3    3    3     3     2
+4    4    NULL  NULL  1
+5    5    13    5     6
+6    6    NULL  NULL  1
+7    7    NULL  2     NULL
+8    8    NULL  NULL  1
+9    9    NULL  1     NULL
+10   10   11    NULL  5
+11   11   10    NULL  2
+20   20   20    20    20
+100  100  1     NULL  5
+400  40   4     NULL  5
 
 
 # Upsert into a table in which the primary key overlaps some of the unique
@@ -492,6 +518,18 @@ SELECT * FROM uniq_enum
 r        s    i  j
 us-west  foo  1  1
 eu-west  bar  2  2
+
+# Ensure that we do not choose a partial index as the arbiter when there is a
+# UNIQUE WITHOUT INDEX constraint.
+statement ok
+INSERT INTO uniq_partial VALUES (-1) ON CONFLICT (i) WHERE i > 0 DO UPDATE SET i = 1;
+INSERT INTO uniq_partial VALUES (-1) ON CONFLICT (i) WHERE i > 0 DO UPDATE SET i = 2
+
+query I colnames
+SELECT * FROM uniq_partial
+----
+i
+2
 
 # -- Tests with DELETE --
 subtest Delete

--- a/pkg/sql/opt/cat/table.go
+++ b/pkg/sql/opt/cat/table.go
@@ -130,7 +130,7 @@ type Table interface {
 
 	// Unique returns the ith unique constraint defined on this table, where
 	// i < UniqueCount.
-	Unique(i int) UniqueConstraint
+	Unique(i UniqueOrdinal) UniqueConstraint
 }
 
 // CheckConstraint contains the SQL text and the validity status for a check
@@ -278,3 +278,10 @@ type UniqueConstraint interface {
 	// needs to be enforced on new mutations.
 	Validated() bool
 }
+
+// UniqueOrdinal identifies a unique constraint (in the context of a Table).
+type UniqueOrdinal = int
+
+// UniqueOrdinals identifies a list of unique constraints (in the context of
+// a Table).
+type UniqueOrdinals = []UniqueOrdinal

--- a/pkg/sql/opt/exec/execbuilder/mutation.go
+++ b/pkg/sql/opt/exec/execbuilder/mutation.go
@@ -99,7 +99,8 @@ func (b *Builder) buildInsert(ins *memo.InsertExpr) (execPlan, error) {
 	node, err := b.factory.ConstructInsert(
 		input.root,
 		tab,
-		ins.Arbiters,
+		ins.ArbiterIndexes,
+		ins.ArbiterConstraints,
 		insertOrds,
 		returnOrds,
 		checkOrds,
@@ -417,7 +418,8 @@ func (b *Builder) buildUpsert(ups *memo.UpsertExpr) (execPlan, error) {
 	node, err := b.factory.ConstructUpsert(
 		input.root,
 		tab,
-		ups.Arbiters,
+		ups.ArbiterIndexes,
+		ups.ArbiterConstraints,
 		canaryCol,
 		insertColOrds,
 		fetchColOrds,

--- a/pkg/sql/opt/exec/execbuilder/testdata/unique
+++ b/pkg/sql/opt/exec/execbuilder/testdata/unique
@@ -163,6 +163,132 @@ vectorized: true
             └── • scan buffer
                   label: buffer 1
 
+# Use all the unique indexes and constraints as arbiters for DO NOTHING with no
+# conflict columns.
+# TODO(rytaft): we should be able to remove the unique checks in this case
+# (see #59119).
+query T
+EXPLAIN (VERBOSE) INSERT INTO uniq VALUES (1, 2, 3, 4, 5) ON CONFLICT DO NOTHING
+----
+distribution: local
+vectorized: true
+·
+• root
+│ columns: ()
+│
+├── • insert
+│   │ columns: ()
+│   │ estimated row count: 0 (missing stats)
+│   │ into: uniq(k, v, w, x, y)
+│   │ arbiter indexes: primary, uniq_v_key
+│   │ arbiter constraints: unique_w, unique_x_y
+│   │
+│   └── • buffer
+│       │ columns: (column1, column2, column3, column4, column5)
+│       │ label: buffer 1
+│       │
+│       └── • cross join (right anti)
+│           │ columns: (column1, column2, column3, column4, column5)
+│           │ estimated row count: 0 (missing stats)
+│           │
+│           ├── • scan
+│           │     columns: (k)
+│           │     estimated row count: 1 (missing stats)
+│           │     table: uniq@primary
+│           │     spans: /1/0-/1/1
+│           │
+│           └── • hash join (right anti)
+│               │ columns: (column1, column2, column3, column4, column5)
+│               │ estimated row count: 0 (missing stats)
+│               │ equality: (w) = (column3)
+│               │ right cols are key
+│               │
+│               ├── • scan
+│               │     columns: (w)
+│               │     estimated row count: 1,000 (missing stats)
+│               │     table: uniq@primary
+│               │     spans: FULL SCAN
+│               │
+│               └── • lookup join (anti)
+│                   │ columns: (column1, column2, column3, column4, column5)
+│                   │ estimated row count: 0 (missing stats)
+│                   │ table: uniq@uniq_v_key
+│                   │ equality: (column2) = (v)
+│                   │ equality cols are key
+│                   │
+│                   └── • hash join (right anti)
+│                       │ columns: (column1, column2, column3, column4, column5)
+│                       │ estimated row count: 0 (missing stats)
+│                       │ equality: (x, y) = (column4, column5)
+│                       │ right cols are key
+│                       │
+│                       ├── • scan
+│                       │     columns: (x, y)
+│                       │     estimated row count: 1,000 (missing stats)
+│                       │     table: uniq@primary
+│                       │     spans: FULL SCAN
+│                       │
+│                       └── • values
+│                             columns: (column1, column2, column3, column4, column5)
+│                             size: 5 columns, 1 row
+│                             row 0, expr 0: 1
+│                             row 0, expr 1: 2
+│                             row 0, expr 2: 3
+│                             row 0, expr 3: 4
+│                             row 0, expr 4: 5
+│
+├── • constraint-check
+│   │
+│   └── • error if rows
+│       │ columns: ()
+│       │
+│       └── • hash join (right semi)
+│           │ columns: (column3, column1)
+│           │ estimated row count: 0 (missing stats)
+│           │ equality: (w) = (column3)
+│           │ right cols are key
+│           │ pred: column1 != k
+│           │
+│           ├── • scan
+│           │     columns: (k, w)
+│           │     estimated row count: 1,000 (missing stats)
+│           │     table: uniq@primary
+│           │     spans: FULL SCAN
+│           │
+│           └── • project
+│               │ columns: (column3, column1)
+│               │ estimated row count: 0 (missing stats)
+│               │
+│               └── • scan buffer
+│                     columns: (column1, column2, column3, column4, column5)
+│                     label: buffer 1
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │ columns: ()
+        │
+        └── • hash join (right semi)
+            │ columns: (column4, column5, column1)
+            │ estimated row count: 0 (missing stats)
+            │ equality: (x, y) = (column4, column5)
+            │ right cols are key
+            │ pred: column1 != k
+            │
+            ├── • scan
+            │     columns: (k, x, y)
+            │     estimated row count: 1,000 (missing stats)
+            │     table: uniq@primary
+            │     spans: FULL SCAN
+            │
+            └── • project
+                │ columns: (column4, column5, column1)
+                │ estimated row count: 0 (missing stats)
+                │
+                └── • scan buffer
+                      columns: (column1, column2, column3, column4, column5)
+                      label: buffer 1
+
 # Insert with non-constant input.
 query T
 EXPLAIN INSERT INTO uniq SELECT k, v, w, x, y FROM other
@@ -658,6 +784,174 @@ vectorized: true
                               columns: (column9, column1, column2, column10, check1)
                               label: buffer 1
 
+# Test that we use the index when available for the ON CONFLICT checks.
+query T
+EXPLAIN (VERBOSE) INSERT INTO uniq_enum VALUES ('us-west', 'foo', 1, 1), ('us-east', 'bar', 2, 2)
+ON CONFLICT DO NOTHING
+----
+distribution: local
+vectorized: true
+·
+• root
+│ columns: ()
+│
+├── • insert
+│   │ columns: ()
+│   │ estimated row count: 0 (missing stats)
+│   │ into: uniq_enum(r, s, i, j)
+│   │ arbiter indexes: primary, uniq_enum_r_s_j_key
+│   │ arbiter constraints: unique_i, unique_s_j
+│   │
+│   └── • buffer
+│       │ columns: (column1, column2, column3, column4, check1)
+│       │ label: buffer 1
+│       │
+│       └── • render
+│           │ columns: (column1, column2, column3, column4, check1)
+│           │ estimated row count: 0 (missing stats)
+│           │ render 0: column1 IN ('us-east', 'us-west', 'eu-west')
+│           │ render 1: column1
+│           │ render 2: column2
+│           │ render 3: column3
+│           │ render 4: column4
+│           │
+│           └── • project
+│               │ columns: (column1, column2, column3, column4)
+│               │ estimated row count: 0 (missing stats)
+│               │
+│               └── • lookup join (anti)
+│                   │ columns: ("lookup_join_const_col_@29", column1, column2, column3, column4)
+│                   │ table: uniq_enum@uniq_enum_r_s_j_key
+│                   │ equality: (lookup_join_const_col_@29, column2, column4) = (r,s,j)
+│                   │ equality cols are key
+│                   │
+│                   └── • cross join (inner)
+│                       │ columns: ("lookup_join_const_col_@29", column1, column2, column3, column4)
+│                       │ estimated row count: 0 (missing stats)
+│                       │
+│                       ├── • values
+│                       │     columns: ("lookup_join_const_col_@29")
+│                       │     size: 1 column, 3 rows
+│                       │     row 0, expr 0: 'us-east'
+│                       │     row 1, expr 0: 'us-west'
+│                       │     row 2, expr 0: 'eu-west'
+│                       │
+│                       └── • project
+│                           │ columns: (column1, column2, column3, column4)
+│                           │ estimated row count: 0 (missing stats)
+│                           │
+│                           └── • lookup join (anti)
+│                               │ columns: ("lookup_join_const_col_@23", column1, column2, column3, column4)
+│                               │ table: uniq_enum@primary
+│                               │ equality: (lookup_join_const_col_@23, column3) = (r,i)
+│                               │ equality cols are key
+│                               │
+│                               └── • cross join (inner)
+│                                   │ columns: ("lookup_join_const_col_@23", column1, column2, column3, column4)
+│                                   │ estimated row count: 0 (missing stats)
+│                                   │
+│                                   ├── • values
+│                                   │     columns: ("lookup_join_const_col_@23")
+│                                   │     size: 1 column, 3 rows
+│                                   │     row 0, expr 0: 'us-east'
+│                                   │     row 1, expr 0: 'us-west'
+│                                   │     row 2, expr 0: 'eu-west'
+│                                   │
+│                                   └── • lookup join (anti)
+│                                       │ columns: (column1, column2, column3, column4)
+│                                       │ estimated row count: 0 (missing stats)
+│                                       │ table: uniq_enum@primary
+│                                       │ equality: (column1, column3) = (r,i)
+│                                       │ equality cols are key
+│                                       │
+│                                       └── • lookup join (anti)
+│                                           │ columns: (column1, column2, column3, column4)
+│                                           │ estimated row count: 0 (missing stats)
+│                                           │ table: uniq_enum@uniq_enum_r_s_j_key
+│                                           │ equality: (column1, column2, column4) = (r,s,j)
+│                                           │ equality cols are key
+│                                           │
+│                                           └── • values
+│                                                 columns: (column1, column2, column3, column4)
+│                                                 size: 4 columns, 2 rows
+│                                                 row 0, expr 0: 'us-west'
+│                                                 row 0, expr 1: 'foo'
+│                                                 row 0, expr 2: 1
+│                                                 row 0, expr 3: 1
+│                                                 row 1, expr 0: 'us-east'
+│                                                 row 1, expr 1: 'bar'
+│                                                 row 1, expr 2: 2
+│                                                 row 1, expr 3: 2
+│
+├── • constraint-check
+│   │
+│   └── • error if rows
+│       │ columns: ()
+│       │
+│       └── • project
+│           │ columns: (column3, column1)
+│           │ estimated row count: 0 (missing stats)
+│           │
+│           └── • lookup join (semi)
+│               │ columns: ("lookup_join_const_col_@38", column3, column1)
+│               │ table: uniq_enum@primary
+│               │ equality: (lookup_join_const_col_@38, column3) = (r,i)
+│               │ equality cols are key
+│               │ pred: column1 != r
+│               │
+│               └── • cross join (inner)
+│                   │ columns: ("lookup_join_const_col_@38", column3, column1)
+│                   │ estimated row count: 0 (missing stats)
+│                   │
+│                   ├── • values
+│                   │     columns: ("lookup_join_const_col_@38")
+│                   │     size: 1 column, 3 rows
+│                   │     row 0, expr 0: 'us-east'
+│                   │     row 1, expr 0: 'us-west'
+│                   │     row 2, expr 0: 'eu-west'
+│                   │
+│                   └── • project
+│                       │ columns: (column3, column1)
+│                       │ estimated row count: 0 (missing stats)
+│                       │
+│                       └── • scan buffer
+│                             columns: (column1, column2, column3, column4, check1)
+│                             label: buffer 1
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │ columns: ()
+        │
+        └── • project
+            │ columns: (column2, column4, column1, column3)
+            │ estimated row count: 0 (missing stats)
+            │
+            └── • lookup join (semi)
+                │ columns: ("lookup_join_const_col_@48", column2, column4, column1, column3)
+                │ table: uniq_enum@uniq_enum_r_s_j_key
+                │ equality: (lookup_join_const_col_@48, column2, column4) = (r,s,j)
+                │ equality cols are key
+                │ pred: (column1 != r) OR (column3 != i)
+                │
+                └── • cross join (inner)
+                    │ columns: ("lookup_join_const_col_@48", column2, column4, column1, column3)
+                    │ estimated row count: 0 (missing stats)
+                    │
+                    ├── • values
+                    │     columns: ("lookup_join_const_col_@48")
+                    │     size: 1 column, 3 rows
+                    │     row 0, expr 0: 'us-east'
+                    │     row 1, expr 0: 'us-west'
+                    │     row 2, expr 0: 'eu-west'
+                    │
+                    └── • project
+                        │ columns: (column2, column4, column1, column3)
+                        │ estimated row count: 0 (missing stats)
+                        │
+                        └── • scan buffer
+                              columns: (column1, column2, column3, column4, check1)
+                              label: buffer 1
 
 # -- Tests with UPDATE --
 subtest Update
@@ -1510,10 +1804,67 @@ vectorized: true
 
 # On conflict do update with constant input, conflict on UNIQUE WITHOUT INDEX
 # column.
-# TODO(rytaft): Allow ON CONFLICT to reference UNIQUE WITHOUT INDEX columns
-# (see #58246).
-query error pq: there is no unique or exclusion constraint matching the ON CONFLICT specification
+query T
 EXPLAIN INSERT INTO uniq VALUES (100, 10, 1), (200, 20, 2) ON CONFLICT (w) DO UPDATE SET w = 10
+----
+distribution: local
+vectorized: true
+·
+• root
+│
+├── • upsert
+│   │ into: uniq(k, v, w, x, y)
+│   │ arbiter constraints: unique_w
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • render
+│           │
+│           └── • hash join (right outer)
+│               │ equality: (w) = (column3)
+│               │
+│               ├── • scan
+│               │     missing stats
+│               │     table: uniq@primary
+│               │     spans: FULL SCAN
+│               │
+│               └── • render
+│                   │
+│                   └── • values
+│                         size: 3 columns, 2 rows
+│
+├── • constraint-check
+│   │
+│   └── • error if rows
+│       │
+│       └── • hash join (right semi)
+│           │ equality: (w) = (upsert_w)
+│           │ pred: upsert_k != k
+│           │
+│           ├── • scan
+│           │     missing stats
+│           │     table: uniq@primary
+│           │     spans: FULL SCAN
+│           │
+│           └── • scan buffer
+│                 label: buffer 1
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │
+        └── • hash join (right semi)
+            │ equality: (x, y) = (upsert_x, upsert_y)
+            │ pred: upsert_k != k
+            │
+            ├── • scan
+            │     missing stats
+            │     table: uniq@primary
+            │     spans: FULL SCAN
+            │
+            └── • scan buffer
+                  label: buffer 1
 
 # Upsert with non-constant input.
 # Add inequality filters for the primary key columns that are not part of each
@@ -1939,4 +2290,164 @@ vectorized: true
                         │
                         └── • scan buffer
                               columns: (column1, column2, column3, column4, r, s, i, j, column2, column4, r, check1, upsert_r, upsert_i)
+                              label: buffer 1
+
+# Test that we use the index when available for the ON CONFLICT checks.
+query T
+EXPLAIN (VERBOSE) INSERT INTO uniq_enum VALUES ('us-west', 'foo', 1, 1), ('us-east', 'bar', 2, 2)
+ON CONFLICT (s, j) DO UPDATE SET i = 3
+----
+distribution: local
+vectorized: true
+·
+• root
+│ columns: ()
+│
+├── • upsert
+│   │ columns: ()
+│   │ estimated row count: 0 (missing stats)
+│   │ into: uniq_enum(r, s, i, j)
+│   │ arbiter constraints: unique_s_j
+│   │
+│   └── • buffer
+│       │ columns: (column1, column2, column3, column4, r, s, i, j, upsert_i, r, check1, upsert_r, upsert_s, upsert_j)
+│       │ label: buffer 1
+│       │
+│       └── • project
+│           │ columns: (column1, column2, column3, column4, r, s, i, j, upsert_i, r, check1, upsert_r, upsert_s, upsert_j)
+│           │
+│           └── • render
+│               │ columns: (check1, column1, column2, column3, column4, r, s, i, j, upsert_r, upsert_s, upsert_i, upsert_j)
+│               │ estimated row count: 2 (missing stats)
+│               │ render 0: upsert_r IN ('us-east', 'us-west', 'eu-west')
+│               │ render 1: column1
+│               │ render 2: column2
+│               │ render 3: column3
+│               │ render 4: column4
+│               │ render 5: r
+│               │ render 6: s
+│               │ render 7: i
+│               │ render 8: j
+│               │ render 9: upsert_r
+│               │ render 10: upsert_s
+│               │ render 11: upsert_i
+│               │ render 12: upsert_j
+│               │
+│               └── • render
+│                   │ columns: (upsert_r, upsert_s, upsert_i, upsert_j, column1, column2, column3, column4, r, s, i, j)
+│                   │ estimated row count: 2 (missing stats)
+│                   │ render 0: CASE WHEN r IS NULL THEN column1 ELSE r END
+│                   │ render 1: CASE WHEN r IS NULL THEN column2 ELSE s END
+│                   │ render 2: CASE WHEN r IS NULL THEN column3 ELSE 3 END
+│                   │ render 3: CASE WHEN r IS NULL THEN column4 ELSE j END
+│                   │ render 4: column1
+│                   │ render 5: column2
+│                   │ render 6: column3
+│                   │ render 7: column4
+│                   │ render 8: r
+│                   │ render 9: s
+│                   │ render 10: i
+│                   │ render 11: j
+│                   │
+│                   └── • project
+│                       │ columns: (column1, column2, column3, column4, r, s, i, j)
+│                       │ estimated row count: 2 (missing stats)
+│                       │
+│                       └── • lookup join (left outer)
+│                           │ columns: ("lookup_join_const_col_@11", column1, column2, column3, column4, r, s, i, j)
+│                           │ table: uniq_enum@uniq_enum_r_s_j_key
+│                           │ equality: (lookup_join_const_col_@11, column2, column4) = (r,s,j)
+│                           │ equality cols are key
+│                           │
+│                           └── • cross join (inner)
+│                               │ columns: ("lookup_join_const_col_@11", column1, column2, column3, column4)
+│                               │ estimated row count: 6
+│                               │
+│                               ├── • values
+│                               │     columns: ("lookup_join_const_col_@11")
+│                               │     size: 1 column, 3 rows
+│                               │     row 0, expr 0: 'us-east'
+│                               │     row 1, expr 0: 'us-west'
+│                               │     row 2, expr 0: 'eu-west'
+│                               │
+│                               └── • values
+│                                     columns: (column1, column2, column3, column4)
+│                                     size: 4 columns, 2 rows
+│                                     row 0, expr 0: 'us-west'
+│                                     row 0, expr 1: 'foo'
+│                                     row 0, expr 2: 1
+│                                     row 0, expr 3: 1
+│                                     row 1, expr 0: 'us-east'
+│                                     row 1, expr 1: 'bar'
+│                                     row 1, expr 2: 2
+│                                     row 1, expr 3: 2
+│
+├── • constraint-check
+│   │
+│   └── • error if rows
+│       │ columns: ()
+│       │
+│       └── • project
+│           │ columns: (upsert_i, upsert_r)
+│           │ estimated row count: 1 (missing stats)
+│           │
+│           └── • lookup join (semi)
+│               │ columns: ("lookup_join_const_col_@25", upsert_i, upsert_r)
+│               │ table: uniq_enum@primary
+│               │ equality: (lookup_join_const_col_@25, upsert_i) = (r,i)
+│               │ equality cols are key
+│               │ pred: upsert_r != r
+│               │
+│               └── • cross join (inner)
+│                   │ columns: ("lookup_join_const_col_@25", upsert_i, upsert_r)
+│                   │ estimated row count: 6 (missing stats)
+│                   │
+│                   ├── • values
+│                   │     columns: ("lookup_join_const_col_@25")
+│                   │     size: 1 column, 3 rows
+│                   │     row 0, expr 0: 'us-east'
+│                   │     row 1, expr 0: 'us-west'
+│                   │     row 2, expr 0: 'eu-west'
+│                   │
+│                   └── • project
+│                       │ columns: (upsert_i, upsert_r)
+│                       │ estimated row count: 2 (missing stats)
+│                       │
+│                       └── • scan buffer
+│                             columns: (column1, column2, column3, column4, r, s, i, j, upsert_i, r, check1, upsert_r, upsert_s, upsert_j)
+│                             label: buffer 1
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │ columns: ()
+        │
+        └── • project
+            │ columns: (upsert_s, upsert_j, upsert_r, upsert_i)
+            │ estimated row count: 1 (missing stats)
+            │
+            └── • lookup join (semi)
+                │ columns: ("lookup_join_const_col_@35", upsert_s, upsert_j, upsert_r, upsert_i)
+                │ table: uniq_enum@uniq_enum_r_s_j_key
+                │ equality: (lookup_join_const_col_@35, upsert_s, upsert_j) = (r,s,j)
+                │ equality cols are key
+                │ pred: (upsert_r != r) OR (upsert_i != i)
+                │
+                └── • cross join (inner)
+                    │ columns: ("lookup_join_const_col_@35", upsert_s, upsert_j, upsert_r, upsert_i)
+                    │ estimated row count: 6 (missing stats)
+                    │
+                    ├── • values
+                    │     columns: ("lookup_join_const_col_@35")
+                    │     size: 1 column, 3 rows
+                    │     row 0, expr 0: 'us-east'
+                    │     row 1, expr 0: 'us-west'
+                    │     row 2, expr 0: 'eu-west'
+                    │
+                    └── • project
+                        │ columns: (upsert_s, upsert_j, upsert_r, upsert_i)
+                        │ estimated row count: 2 (missing stats)
+                        │
+                        └── • scan buffer
+                              columns: (column1, column2, column3, column4, r, s, i, j, upsert_i, r, check1, upsert_r, upsert_s, upsert_j)
                               label: buffer 1

--- a/pkg/sql/opt/exec/explain/emit.go
+++ b/pkg/sql/opt/exec/explain/emit.go
@@ -590,9 +590,9 @@ func (e *emitter) emitNodeAttributes(n *Node) error {
 		if a.AutoCommit {
 			ob.Attr("auto commit", "")
 		}
-		if len(a.Arbiters) > 0 {
+		if len(a.ArbiterIndexes) > 0 {
 			var sb strings.Builder
-			for i, idx := range a.Arbiters {
+			for i, idx := range a.ArbiterIndexes {
 				index := a.Table.Index(idx)
 				if i > 0 {
 					sb.WriteString(", ")
@@ -600,6 +600,17 @@ func (e *emitter) emitNodeAttributes(n *Node) error {
 				sb.WriteString(string(index.Name()))
 			}
 			ob.Attr("arbiter indexes", sb.String())
+		}
+		if len(a.ArbiterConstraints) > 0 {
+			var sb strings.Builder
+			for i, uc := range a.ArbiterConstraints {
+				uniqueConstraint := a.Table.Unique(uc)
+				if i > 0 {
+					sb.WriteString(", ")
+				}
+				sb.WriteString(uniqueConstraint.Name())
+			}
+			ob.Attr("arbiter constraints", sb.String())
 		}
 
 	case insertFastPathOp:
@@ -629,9 +640,9 @@ func (e *emitter) emitNodeAttributes(n *Node) error {
 		if a.AutoCommit {
 			ob.Attr("auto commit", "")
 		}
-		if len(a.Arbiters) > 0 {
+		if len(a.ArbiterIndexes) > 0 {
 			var sb strings.Builder
-			for i, idx := range a.Arbiters {
+			for i, idx := range a.ArbiterIndexes {
 				index := a.Table.Index(idx)
 				if i > 0 {
 					sb.WriteString(", ")
@@ -639,6 +650,17 @@ func (e *emitter) emitNodeAttributes(n *Node) error {
 				sb.WriteString(string(index.Name()))
 			}
 			ob.Attr("arbiter indexes", sb.String())
+		}
+		if len(a.ArbiterConstraints) > 0 {
+			var sb strings.Builder
+			for i, uc := range a.ArbiterConstraints {
+				uniqueConstraint := a.Table.Unique(uc)
+				if i > 0 {
+					sb.WriteString(", ")
+				}
+				sb.WriteString(uniqueConstraint.Name())
+			}
+			ob.Attr("arbiter constraints", sb.String())
 		}
 
 	case updateOp:

--- a/pkg/sql/opt/exec/factory.opt
+++ b/pkg/sql/opt/exec/factory.opt
@@ -350,7 +350,8 @@ define ShowTrace {
 define Insert {
     Input exec.Node
     Table cat.Table
-    Arbiters cat.IndexOrdinals
+    ArbiterIndexes cat.IndexOrdinals
+    ArbiterConstraints cat.UniqueOrdinals
     InsertCols exec.TableColumnOrdinalSet
     ReturnCols exec.TableColumnOrdinalSet
     CheckCols exec.CheckOrdinalSet
@@ -448,7 +449,8 @@ define Update {
 define Upsert {
     Input exec.Node
     Table cat.Table
-    Arbiters cat.IndexOrdinals
+    ArbiterIndexes cat.IndexOrdinals
+    ArbiterConstraints cat.UniqueOrdinals
     CanaryCol exec.NodeColumnOrdinal
     InsertCols exec.TableColumnOrdinalSet
     FetchCols exec.TableColumnOrdinalSet

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -509,7 +509,8 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 			if len(colList) == 0 {
 				tp.Child("columns: <none>")
 			}
-			f.formatArbiters(tp, t.Arbiters, t.Table)
+			f.formatArbiterIndexes(tp, t.ArbiterIndexes, t.Table)
+			f.formatArbiterConstraints(tp, t.ArbiterConstraints, t.Table)
 			f.formatMutationCols(e, tp, "insert-mapping:", t.InsertCols, t.Table)
 			f.formatOptionalColList(e, tp, "check columns:", t.CheckCols)
 			f.formatOptionalColList(e, tp, "partial index put columns:", t.PartialIndexPutCols)
@@ -535,7 +536,8 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 				tp.Child("columns: <none>")
 			}
 			if t.CanaryCol != 0 {
-				f.formatArbiters(tp, t.Arbiters, t.Table)
+				f.formatArbiterIndexes(tp, t.ArbiterIndexes, t.Table)
+				f.formatArbiterConstraints(tp, t.ArbiterConstraints, t.Table)
 				f.formatColList(e, tp, "canary column:", opt.ColList{t.CanaryCol})
 				f.formatOptionalColList(e, tp, "fetch columns:", t.FetchCols)
 				f.formatMutationCols(e, tp, "insert-mapping:", t.InsertCols, t.Table)
@@ -1099,9 +1101,9 @@ func (f *ExprFmtCtx) formatIndex(tabID opt.TableID, idxOrd cat.IndexOrdinal, rev
 	}
 }
 
-// formatArbiters constructs a new treeprinter child containing the
+// formatArbiterIndexes constructs a new treeprinter child containing the
 // specified list of arbiter indexes.
-func (f *ExprFmtCtx) formatArbiters(
+func (f *ExprFmtCtx) formatArbiterIndexes(
 	tp treeprinter.Node, arbiters cat.IndexOrdinals, tabID opt.TableID,
 ) {
 	md := f.Memo.Metadata()
@@ -1112,6 +1114,26 @@ func (f *ExprFmtCtx) formatArbiters(
 		f.Buffer.WriteString("arbiter indexes:")
 		for _, idx := range arbiters {
 			name := string(tab.Index(idx).Name())
+			f.space()
+			f.Buffer.WriteString(name)
+		}
+		tp.Child(f.Buffer.String())
+	}
+}
+
+// formatArbiterConstraints constructs a new treeprinter child containing the
+// specified list of arbiter constraints.
+func (f *ExprFmtCtx) formatArbiterConstraints(
+	tp treeprinter.Node, arbiters cat.UniqueOrdinals, tabID opt.TableID,
+) {
+	md := f.Memo.Metadata()
+	tab := md.Table(tabID)
+
+	if len(arbiters) > 0 {
+		f.Buffer.Reset()
+		f.Buffer.WriteString("arbiter constraints:")
+		for _, uc := range arbiters {
+			name := tab.Unique(uc).Name()
 			f.space()
 			f.Buffer.WriteString(name)
 		}

--- a/pkg/sql/opt/memo/interner.go
+++ b/pkg/sql/opt/memo/interner.go
@@ -553,6 +553,15 @@ func (h *hasher) HashIndexOrdinals(val cat.IndexOrdinals) {
 	h.hash = hash
 }
 
+func (h *hasher) HashUniqueOrdinals(val cat.UniqueOrdinals) {
+	hash := h.hash
+	for _, ord := range val {
+		hash ^= internHash(ord)
+		hash *= prime64
+	}
+	h.hash = hash
+}
+
 func (h *hasher) HashViewDeps(val opt.ViewDeps) {
 	// Hash the length and address of the first element.
 	h.HashInt(len(val))
@@ -933,6 +942,18 @@ func (h *hasher) IsIndexOrdinalEqual(l, r cat.IndexOrdinal) bool {
 }
 
 func (h *hasher) IsIndexOrdinalsEqual(l, r cat.IndexOrdinals) bool {
+	if len(l) != len(r) {
+		return false
+	}
+	for i := range l {
+		if l[i] != r[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func (h *hasher) IsUniqueOrdinalsEqual(l, r cat.UniqueOrdinals) bool {
 	if len(l) != len(r) {
 		return false
 	}

--- a/pkg/sql/opt/ops/mutation.opt
+++ b/pkg/sql/opt/ops/mutation.opt
@@ -142,10 +142,15 @@ define MutationPrivate {
     # overwrites an existing row.
     CanaryCol ColumnID
 
-    # Arbiters is used only with the Insert and Upsert operators. It identifies
-    # the unique indexes used to detect conflicts for UPSERT and INSERT ON
-    # CONFLICT statements.
-    Arbiters IndexOrdinals
+    # ArbiterIndexes is used only with the Insert and Upsert operators. It
+    # identifies the unique indexes used to detect conflicts for UPSERT and
+    # INSERT ON CONFLICT statements.
+    ArbiterIndexes IndexOrdinals
+
+    # ArbiterConstraints is used only with the Insert and Upsert operators. It
+    # identifies the unique without index constraints used to detect conflicts
+    # for UPSERT and INSERT ON CONFLICT statements.
+    ArbiterConstraints UniqueOrdinals
 
     # ReturnCols are the set of columns returned by the mutation operator when
     # the RETURNING clause has been specified. By default, the return columns

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -674,9 +674,11 @@ func (mb *mutationBuilder) buildInsert(returning tree.ReturningExprs) {
 func (mb *mutationBuilder) buildInputForDoNothing(
 	inScope *scope, conflictOrds util.FastIntSet, arbiterPredicate tree.Expr,
 ) {
-	// Determine the set of arbiter indexes to use to check for conflicts.
-	arbiterIndexes := mb.arbiterIndexes(conflictOrds, arbiterPredicate)
-	mb.arbiters = arbiterIndexes.Ordered()
+	// Determine the set of arbiter indexes and constraints to use to check for
+	// conflicts.
+	arbiterIndexes, arbiterConstraints := mb.arbiterIndexesAndConstraints(conflictOrds, arbiterPredicate)
+	mb.arbiterIndexes = arbiterIndexes.Ordered()
+	mb.arbiterConstraints = arbiterConstraints.Ordered()
 
 	insertColScope := mb.outScope.replace()
 	insertColScope.appendColumnsFromScope(mb.outScope)
@@ -685,21 +687,17 @@ func (mb *mutationBuilder) buildInputForDoNothing(
 	// TODO(andyk): do we need to do more here?
 	mb.outScope.ordering = nil
 
-	// Loop over each arbiter index, potentially creating an anti-join for each
-	// one.
-	for idx, idxCount := 0, mb.tab.IndexCount(); idx < idxCount; idx++ {
-		// Skip non-arbiter indexes.
-		if !arbiterIndexes.Contains(idx) {
-			continue
-		}
-
-		index := mb.tab.Index(idx)
-		_, isPartial := index.Predicate()
-		var predExpr tree.Expr
-		if isPartial {
-			predExpr = mb.parsePartialIndexPredicateExpr(idx)
-		}
-
+	// buildInputForArbiter builds the input for a single arbiter index or
+	// constraint.
+	// - colCount is the number of columns in the constraint or lax key columns
+	//   in the index.
+	// - colOrdinal is a function that returns the position of the ith constraint
+	//   or index column in its table.
+	// - predExpr is the partial index predicate. If the arbiter is not a partial
+	//   index, predExpr is nil.
+	buildInputForArbiter := func(
+		colCount int, colOrdinal func(i int) int, predExpr tree.Expr,
+	) {
 		// Build the right side of the anti-join. Use a new metadata instance
 		// of the mutation table so that a different set of column IDs are used for
 		// the two tables in the self-join.
@@ -720,7 +718,7 @@ func (mb *mutationBuilder) buildInputForDoNothing(
 		// partial index cannot conflict with insert rows. Therefore, a Select
 		// wraps the scan on the right side of the anti-join with the partial
 		// index predicate expression as the filter.
-		if isPartial {
+		if predExpr != nil {
 			texpr := fetchScope.resolveAndRequireType(predExpr, types.Bool)
 			predScalar := mb.b.buildScalar(texpr, fetchScope, nil, nil, nil)
 			fetchScope.expr = mb.b.factory.ConstructSelect(
@@ -735,12 +733,12 @@ func (mb *mutationBuilder) buildInputForDoNothing(
 		//   ON ins.x = scan.a AND ins.y = scan.b
 		//
 		var on memo.FiltersExpr
-		for i, n := 0, index.LaxKeyColumnCount(); i < n; i++ {
-			indexCol := index.Column(i)
-			scanColID := fetchScope.cols[indexCol.Ordinal()].id
+		for i := 0; i < colCount; i++ {
+			ord := colOrdinal(i)
+			scanColID := fetchScope.cols[ord].id
 
 			condition := mb.b.factory.ConstructEq(
-				mb.b.factory.ConstructVariable(mb.insertColIDs[indexCol.Ordinal()]),
+				mb.b.factory.ConstructVariable(mb.insertColIDs[ord]),
 				mb.b.factory.ConstructVariable(scanColID),
 			)
 			on = append(on, mb.b.factory.ConstructFiltersItem(condition))
@@ -750,7 +748,7 @@ func (mb *mutationBuilder) buildInputForDoNothing(
 		// satisfy the partial index predicate cannot conflict with existing
 		// rows in the unique partial index. Therefore, the partial index
 		// predicate expression is added to the ON filters.
-		if isPartial {
+		if predExpr != nil {
 			texpr := mb.outScope.resolveAndRequireType(predExpr, types.Bool)
 			predScalar := mb.b.buildScalar(texpr, mb.outScope, nil, nil, nil)
 			on = append(on, mb.b.factory.ConstructFiltersItem(predScalar))
@@ -765,34 +763,24 @@ func (mb *mutationBuilder) buildInputForDoNothing(
 		)
 	}
 
-	// Loop over each arbiter index, creating an upsert-distinct-on for each one.
-	// This must happen after all conflicting rows are removed with the anti-joins
-	// created above, to avoid removing valid rows (see #59125).
-	for idx, idxCount := 0, mb.tab.IndexCount(); idx < idxCount; idx++ {
-		// Skip non-arbiter indexes.
-		if !arbiterIndexes.Contains(idx) {
-			continue
-		}
-
-		index := mb.tab.Index(idx)
-		_, isPartial := index.Predicate()
-
-		// If the index is a partial index, project a new column that allows the
-		// UpsertDistinctOn to only de-duplicate insert rows that satisfy the
-		// partial index predicate. See projectPartialIndexDistinctColumn for more
-		// details.
-		var partialIndexDistinctCol *scopeColumn
-		if isPartial {
-			partialIndexDistinctCol = mb.projectPartialIndexDistinctColumn(insertColScope, idx)
-		}
-
+	// buildDistinctOnForArbiter adds an UpsertDistinctOn operator for a single
+	// arbiter index or constraint.
+	// - colCount is the number of columns in the constraint or lax key columns
+	//   in the index.
+	// - colOrdinal is a function that returns the position of the ith constraint
+	//   or index column in its table.
+	// - partialIndexDistinctCol is a column that allows the UpsertDistinctOn to
+	//   only de-duplicate insert rows that satisfy the partial index predicate.
+	//   If the arbiter is not a partial index, partialIndexDistinctCol is nil.
+	buildDistinctOnForArbiter := func(
+		colCount int, colOrdinal func(int) int, partialIndexDistinctCol *scopeColumn,
+	) {
 		// Add an UpsertDistinctOn operator to ensure there are no duplicate input
-		// rows for this unique index. Duplicate rows can trigger conflict errors
-		// at runtime, which DO NOTHING is not supposed to do. See issue #37880.
+		// rows for this arbiter. Duplicate rows can trigger conflict errors at
+		// runtime, which DO NOTHING is not supposed to do. See issue #37880.
 		var conflictCols opt.ColSet
-		for i, n := 0, index.LaxKeyColumnCount(); i < n; i++ {
-			indexCol := index.Column(i)
-			conflictCols.Add(mb.insertColIDs[indexCol.Ordinal()])
+		for i := 0; i < colCount; i++ {
+			conflictCols.Add(mb.insertColIDs[colOrdinal(i)])
 		}
 		if partialIndexDistinctCol != nil {
 			conflictCols.Add(partialIndexDistinctCol.id)
@@ -804,13 +792,60 @@ func (mb *mutationBuilder) buildInputForDoNothing(
 			conflictCols, mb.outScope, true /* nullsAreDistinct */, "" /* errorOnDup */)
 
 		// Remove the partialIndexDistinctCol from the output.
-		if isPartial {
+		if partialIndexDistinctCol != nil {
 			projectionScope := mb.outScope.replace()
 			projectionScope.appendColumnsFromScope(insertColScope)
 			mb.b.constructProjectForScope(mb.outScope, projectionScope)
 			mb.outScope = projectionScope
 		}
 	}
+
+	// Loop over each arbiter index and constraint, creating an anti-join for
+	// each one.
+	arbiterIndexes.ForEach(func(idx int) {
+		index := mb.tab.Index(idx)
+		_, isPartial := index.Predicate()
+		var predExpr tree.Expr
+		if isPartial {
+			predExpr = mb.parsePartialIndexPredicateExpr(idx)
+		}
+
+		buildInputForArbiter(index.LaxKeyColumnCount(), func(i int) int {
+			return index.Column(i).Ordinal()
+		}, predExpr)
+	})
+	arbiterConstraints.ForEach(func(uc int) {
+		uniqueConstraint := mb.tab.Unique(uc)
+		buildInputForArbiter(uniqueConstraint.ColumnCount(), func(i int) int {
+			return uniqueConstraint.ColumnOrdinal(mb.tab, i)
+		}, nil /* predExpr */)
+	})
+
+	// Loop over each arbiter index and constraint, creating an UpsertDistinctOn
+	// for each one. This must happen after all conflicting rows are removed with
+	// the anti-joins created above, to avoid removing valid rows (see #59125).
+	arbiterIndexes.ForEach(func(idx int) {
+		index := mb.tab.Index(idx)
+		_, isPartial := index.Predicate()
+
+		// If the index is a partial index, project a new column that allows the
+		// UpsertDistinctOn to only de-duplicate insert rows that satisfy the
+		// partial index predicate. See projectPartialIndexDistinctColumn for more
+		// details.
+		var partialIndexDistinctCol *scopeColumn
+		if isPartial {
+			partialIndexDistinctCol = mb.projectPartialIndexDistinctColumn(insertColScope, idx)
+		}
+		buildDistinctOnForArbiter(index.LaxKeyColumnCount(), func(i int) int {
+			return index.Column(i).Ordinal()
+		}, partialIndexDistinctCol)
+	})
+	arbiterConstraints.ForEach(func(uc int) {
+		uniqueConstraint := mb.tab.Unique(uc)
+		buildDistinctOnForArbiter(uniqueConstraint.ColumnCount(), func(i int) int {
+			return uniqueConstraint.ColumnOrdinal(mb.tab, i)
+		}, nil /* partialIndexDistinctCol */)
+	})
 
 	mb.targetColList = make(opt.ColList, 0, mb.tab.ColumnCount())
 	mb.targetColSet = opt.ColSet{}
@@ -825,13 +860,16 @@ func (mb *mutationBuilder) buildInputForDoNothing(
 func (mb *mutationBuilder) buildInputForUpsert(
 	inScope *scope, conflictOrds util.FastIntSet, arbiterPredicate tree.Expr, whereClause *tree.Where,
 ) {
-	// Determine the set of arbiter indexes to use to check for conflicts.
-	arbiterIndexes := mb.arbiterIndexes(conflictOrds, arbiterPredicate)
-	mb.arbiters = arbiterIndexes.Ordered()
+	// Determine the set of arbiter indexes and constraints to use to check for
+	// conflicts.
+	arbiterIndexes, arbiterConstraints := mb.arbiterIndexesAndConstraints(conflictOrds, arbiterPredicate)
+	mb.arbiterIndexes = arbiterIndexes.Ordered()
+	mb.arbiterConstraints = arbiterConstraints.Ordered()
 
-	// TODO(mgartner): Add support for multiple arbiter indexes, similar to
-	// buildInputForDoNothing.
-	if arbiterIndexes.Len() > 1 {
+	// TODO(mgartner): Add support for multiple arbiter indexes or constraints,
+	//  similar to buildInputForDoNothing.
+	if arbiterIndexes.Len() > 1 || arbiterConstraints.Len() > 1 ||
+		(!arbiterIndexes.Empty() && !arbiterConstraints.Empty()) {
 		panic(unimplemented.NewWithIssue(53170,
 			"there are multiple unique or exclusion constraints matching the ON CONFLICT specification"))
 	}
@@ -842,152 +880,183 @@ func (mb *mutationBuilder) buildInputForUpsert(
 	// Ignore any ordering requested by the input.
 	mb.outScope.ordering = nil
 
-	idx, _ := arbiterIndexes.Next(0)
-	index := mb.tab.Index(idx)
+	// buildInputForArbiter builds the input for a single arbiter index or
+	// constraint.
+	// - colCount is the number of columns in the constraint or lax key columns
+	//   in the index.
+	// - colOrdinal is a function that returns the position of the ith constraint
+	//   or index column in its table.
+	// - predExpr is the partial index predicate. If the arbiter is not a partial
+	//   index, predExpr is nil.
+	// - partialIndexDistinctCol is a column that allows the UpsertDistinctOn to
+	//   only de-duplicate insert rows that satisfy the partial index predicate.
+	//   If the arbiter is not a partial index, partialIndexDistinctCol is nil.
+	buildInputForArbiter := func(
+		getCanaryCol func() *scopeColumn, predExpr tree.Expr, partialIndexDistinctCol *scopeColumn,
+	) {
+		// Ensure that input is distinct on the conflict columns. Otherwise, the
+		// Upsert could affect the same row more than once, which can lead to index
+		// corruption. See issue #44466 for more context.
+		//
+		// Ignore any ordering requested by the input. Since the
+		// EnsureUpsertDistinctOn operator does not allow multiple rows in distinct
+		// groupings, the internal ordering is meaningless (and can trigger a
+		// misleading error in buildDistinctOn if present).
+		var conflictCols opt.ColSet
+		for ord, ok := conflictOrds.Next(0); ok; ord, ok = conflictOrds.Next(ord + 1) {
+			conflictCols.Add(mb.insertColIDs[ord])
+		}
+		if partialIndexDistinctCol != nil {
+			conflictCols.Add(partialIndexDistinctCol.id)
+		}
 
-	_, isPartial := index.Predicate()
-	var predExpr tree.Expr
-	if isPartial {
-		predExpr = mb.parsePartialIndexPredicateExpr(idx)
-	}
+		mb.outScope = mb.b.buildDistinctOn(
+			conflictCols, mb.outScope, true /* nullsAreDistinct */, duplicateUpsertErrText)
 
-	// If the index is a partial index, project a new column that allows the
-	// UpsertDistinctOn to only de-duplicate insert rows that satisfy the
-	// partial index predicate. See projectPartialIndexDistinctColumn for more
-	// details.
-	var partialIndexDistinctCol *scopeColumn
-	if isPartial {
-		partialIndexDistinctCol = mb.projectPartialIndexDistinctColumn(insertColScope, idx)
-	}
+		// Remove the partialIndexDistinctCol from the output.
+		if partialIndexDistinctCol != nil {
+			projectionScope := mb.outScope.replace()
+			projectionScope.appendColumnsFromScope(insertColScope)
+			mb.b.constructProjectForScope(mb.outScope, projectionScope)
+			mb.outScope = projectionScope
+		}
 
-	// Ensure that input is distinct on the conflict columns. Otherwise, the
-	// Upsert could affect the same row more than once, which can lead to index
-	// corruption. See issue #44466 for more context.
-	//
-	// Ignore any ordering requested by the input. Since the
-	// EnsureUpsertDistinctOn operator does not allow multiple rows in distinct
-	// groupings, the internal ordering is meaningless (and can trigger a
-	// misleading error in buildDistinctOn if present).
-	var conflictCols opt.ColSet
-	for ord, ok := conflictOrds.Next(0); ok; ord, ok = conflictOrds.Next(ord + 1) {
-		conflictCols.Add(mb.insertColIDs[ord])
-	}
-	if partialIndexDistinctCol != nil {
-		conflictCols.Add(partialIndexDistinctCol.id)
-	}
+		// Re-alias all INSERT columns so that they are accessible as if they were
+		// part of a special data source named "crdb_internal.excluded".
+		for i := range mb.outScope.cols {
+			mb.outScope.cols[i].table = excludedTableName
+		}
 
-	mb.outScope = mb.b.buildDistinctOn(
-		conflictCols, mb.outScope, true /* nullsAreDistinct */, duplicateUpsertErrText)
-
-	// Remove the partialIndexDistinctCol from the output.
-	if isPartial {
-		projectionScope := mb.outScope.replace()
-		projectionScope.appendColumnsFromScope(insertColScope)
-		mb.b.constructProjectForScope(mb.outScope, projectionScope)
-		mb.outScope = projectionScope
-	}
-
-	// Re-alias all INSERT columns so that they are accessible as if they were
-	// part of a special data source named "crdb_internal.excluded".
-	for i := range mb.outScope.cols {
-		mb.outScope.cols[i].table = excludedTableName
-	}
-
-	// Build the right side of the left outer join. Use a different instance of
-	// table metadata so that col IDs do not overlap.
-	//
-	// NOTE: Include mutation columns, but be careful to never use them for any
-	//       reason other than as "fetch columns". See buildScan comment.
-	// TODO(andyk): Why does execution engine need mutation columns for Insert?
-	mb.fetchScope = mb.b.buildScan(
-		mb.b.addTable(mb.tab, &mb.alias),
-		tableOrdinals(mb.tab, columnKinds{
-			includeMutations:       true,
-			includeSystem:          true,
-			includeVirtualInverted: false,
-			includeVirtualComputed: false,
-		}),
-		nil, /* indexFlags */
-		noRowLocking,
-		inScope,
-	)
-
-	// If the index is a unique partial index, then rows that are not in the
-	// partial index cannot conflict with insert rows. Therefore, a Select wraps
-	// the scan on the right side of the left outer join with the partial index
-	// predicate expression as the filter.
-	if isPartial {
-		texpr := mb.fetchScope.resolveAndRequireType(predExpr, types.Bool)
-		predScalar := mb.b.buildScalar(texpr, mb.fetchScope, nil, nil, nil)
-		mb.fetchScope.expr = mb.b.factory.ConstructSelect(
-			mb.fetchScope.expr,
-			memo.FiltersExpr{mb.b.factory.ConstructFiltersItem(predScalar)},
+		// Build the right side of the left outer join. Use a different instance of
+		// table metadata so that col IDs do not overlap.
+		//
+		// NOTE: Include mutation columns, but be careful to never use them for any
+		//       reason other than as "fetch columns". See buildScan comment.
+		// TODO(andyk): Why does execution engine need mutation columns for Insert?
+		mb.fetchScope = mb.b.buildScan(
+			mb.b.addTable(mb.tab, &mb.alias),
+			tableOrdinals(mb.tab, columnKinds{
+				includeMutations:       true,
+				includeSystem:          true,
+				includeVirtualInverted: false,
+				includeVirtualComputed: false,
+			}),
+			nil, /* indexFlags */
+			noRowLocking,
+			inScope,
 		)
-	}
 
-	// Record a not-null "canary" column. After the left-join, this will be null
-	// if no conflict has been detected, or not null otherwise. At least one not-
-	// null column must exist, since primary key columns are not-null.
-	canaryScopeCol := &mb.fetchScope.cols[findNotNullIndexCol(index)]
-	mb.canaryColID = canaryScopeCol.id
-
-	// Set fetchColIDs to reference the columns created for the fetch values.
-	mb.setFetchColIDs(mb.fetchScope.cols)
-
-	// Add the fetch columns to the current scope. It's OK to modify the current
-	// scope because it contains only INSERT columns that were added by the
-	// mutationBuilder, and which aren't needed for any other purpose.
-	mb.outScope.appendColumnsFromScope(mb.fetchScope)
-
-	// Build the join condition by creating a conjunction of equality conditions
-	// that test each conflict column:
-	//
-	//   ON ins.x = scan.a AND ins.y = scan.b
-	//
-	var on memo.FiltersExpr
-	for i := range mb.fetchScope.cols {
-		// Include fetch columns with ordinal positions in conflictOrds.
-		if conflictOrds.Contains(i) {
-			condition := mb.b.factory.ConstructEq(
-				mb.b.factory.ConstructVariable(mb.insertColIDs[i]),
-				mb.b.factory.ConstructVariable(mb.fetchScope.cols[i].id),
+		// If the index is a unique partial index, then rows that are not in the
+		// partial index cannot conflict with insert rows. Therefore, a Select wraps
+		// the scan on the right side of the left outer join with the partial index
+		// predicate expression as the filter.
+		if predExpr != nil {
+			texpr := mb.fetchScope.resolveAndRequireType(predExpr, types.Bool)
+			predScalar := mb.b.buildScalar(texpr, mb.fetchScope, nil, nil, nil)
+			mb.fetchScope.expr = mb.b.factory.ConstructSelect(
+				mb.fetchScope.expr,
+				memo.FiltersExpr{mb.b.factory.ConstructFiltersItem(predScalar)},
 			)
-			on = append(on, mb.b.factory.ConstructFiltersItem(condition))
 		}
-	}
 
-	// If the index is a unique partial index, then insert rows that do not
-	// satisfy the partial index predicate cannot conflict with existing rows in
-	// the unique partial index. Therefore, the partial index predicate
-	// expression is added to the ON filters.
-	if isPartial {
-		texpr := insertColScope.resolveAndRequireType(predExpr, types.Bool)
-		predScalar := mb.b.buildScalar(texpr, insertColScope, nil, nil, nil)
-		on = append(on, mb.b.factory.ConstructFiltersItem(predScalar))
-	}
+		// Record a not-null "canary" column. After the left-join, this will be null
+		// if no conflict has been detected, or not null otherwise. At least one not-
+		// null column must exist, since primary key columns are not-null.
+		canaryScopeCol := getCanaryCol()
+		mb.canaryColID = canaryScopeCol.id
 
-	// Construct the left join.
-	mb.outScope.expr = mb.b.factory.ConstructLeftJoin(
-		mb.outScope.expr,
-		mb.fetchScope.expr,
-		on,
-		memo.EmptyJoinPrivate,
-	)
+		// Set fetchColIDs to reference the columns created for the fetch values.
+		mb.setFetchColIDs(mb.fetchScope.cols)
 
-	// Add a filter from the WHERE clause if one exists.
-	if whereClause != nil {
-		where := &tree.Where{
-			Type: whereClause.Type,
-			Expr: &tree.OrExpr{
-				Left: &tree.ComparisonExpr{
-					Operator: tree.IsNotDistinctFrom,
-					Left:     canaryScopeCol,
-					Right:    tree.DNull,
+		// Add the fetch columns to the current scope. It's OK to modify the current
+		// scope because it contains only INSERT columns that were added by the
+		// mutationBuilder, and which aren't needed for any other purpose.
+		mb.outScope.appendColumnsFromScope(mb.fetchScope)
+
+		// Build the join condition by creating a conjunction of equality conditions
+		// that test each conflict column:
+		//
+		//   ON ins.x = scan.a AND ins.y = scan.b
+		//
+		var on memo.FiltersExpr
+		for i := range mb.fetchScope.cols {
+			// Include fetch columns with ordinal positions in conflictOrds.
+			if conflictOrds.Contains(i) {
+				condition := mb.b.factory.ConstructEq(
+					mb.b.factory.ConstructVariable(mb.insertColIDs[i]),
+					mb.b.factory.ConstructVariable(mb.fetchScope.cols[i].id),
+				)
+				on = append(on, mb.b.factory.ConstructFiltersItem(condition))
+			}
+		}
+
+		// If the index is a unique partial index, then insert rows that do not
+		// satisfy the partial index predicate cannot conflict with existing rows in
+		// the unique partial index. Therefore, the partial index predicate
+		// expression is added to the ON filters.
+		if predExpr != nil {
+			texpr := insertColScope.resolveAndRequireType(predExpr, types.Bool)
+			predScalar := mb.b.buildScalar(texpr, insertColScope, nil, nil, nil)
+			on = append(on, mb.b.factory.ConstructFiltersItem(predScalar))
+		}
+
+		// Construct the left join.
+		mb.outScope.expr = mb.b.factory.ConstructLeftJoin(
+			mb.outScope.expr,
+			mb.fetchScope.expr,
+			on,
+			memo.EmptyJoinPrivate,
+		)
+
+		// Add a filter from the WHERE clause if one exists.
+		if whereClause != nil {
+			where := &tree.Where{
+				Type: whereClause.Type,
+				Expr: &tree.OrExpr{
+					Left: &tree.ComparisonExpr{
+						Operator: tree.IsNotDistinctFrom,
+						Left:     canaryScopeCol,
+						Right:    tree.DNull,
+					},
+					Right: whereClause.Expr,
 				},
-				Right: whereClause.Expr,
-			},
+			}
+			mb.b.buildWhere(where, mb.outScope)
 		}
-		mb.b.buildWhere(where, mb.outScope)
+	}
+
+	if arbiterIndexes.Len() > 0 {
+		idx, _ := arbiterIndexes.Next(0)
+		index := mb.tab.Index(idx)
+
+		_, isPartial := index.Predicate()
+		var predExpr tree.Expr
+		if isPartial {
+			predExpr = mb.parsePartialIndexPredicateExpr(idx)
+		}
+
+		// If the index is a partial index, project a new column that allows the
+		// UpsertDistinctOn to only de-duplicate insert rows that satisfy the
+		// partial index predicate. See projectPartialIndexDistinctColumn for more
+		// details.
+		var partialIndexDistinctCol *scopeColumn
+		if isPartial {
+			partialIndexDistinctCol = mb.projectPartialIndexDistinctColumn(insertColScope, idx)
+		}
+
+		buildInputForArbiter(func() *scopeColumn {
+			return &mb.fetchScope.cols[findNotNullIndexCol(index)]
+		}, predExpr, partialIndexDistinctCol)
+	} else if arbiterConstraints.Len() > 0 {
+		buildInputForArbiter(func() *scopeColumn {
+			// Use the primary index, since we don't know at this point whether
+			// another index will be used for this plan. This should select one
+			// of the primary keys.
+			return &mb.fetchScope.cols[findNotNullIndexCol(mb.tab.Index(cat.PrimaryIndex))]
+		}, nil /* predExpr */, nil /* partialIndexDistinctCol */)
+	} else {
+		// This should never happen.
+		panic(errors.AssertionFailedf("no arbiter index or constraint available"))
 	}
 
 	mb.targetColList = make(opt.ColList, 0, mb.tab.ColumnCount())
@@ -1175,14 +1244,16 @@ func (mb *mutationBuilder) projectUpsertColumns() {
 	mb.outScope = projectionsScope
 }
 
-// arbiterIndexes returns the set of index ordinals to be used as arbiter
-// indexes for an INSERT ON CONFLICT statement. This function panics if no
-// arbiter indexes are found.
+// arbiterIndexesAndConstraints returns sets of index ordinals and unique
+// constraint ordinals to be used as arbiter constraints for an INSERT ON
+// CONFLICT statement. This function panics if no arbiter indexes or constraints
+// are found.
 //
-// Arbiter indexes ensure that the columns designated by conflictOrds reference
-// at most one target row of a UNIQUE index. Using ANTI JOINs and LEFT OUTER
-// JOINs to detect conflicts relies upon this being true (otherwise result
-// cardinality could increase). This is also a Postgres requirement.
+// Arbiter constraints ensure that the columns designated by conflictOrds
+// reference at most one target row of a UNIQUE index or constraint. Using ANTI
+// JOINs and LEFT OUTER JOINs to detect conflicts relies upon this being true
+// (otherwise result cardinality could increase). This is also a Postgres
+// requirement.
 //
 // An arbiter index:
 //
@@ -1190,25 +1261,38 @@ func (mb *mutationBuilder) projectUpsertColumns() {
 //   2. If it is a partial index, its predicate must be implied by the
 //      arbiterPredicate supplied by the user.
 //
-// If conflictOrds is empty then all unique indexes are returned as arbiters.
-// This is required to support a DO NOTHING with no ON CONFLICT columns. In this
-// case, all unique indexes are used to check for conflicts.
+// An arbiter constraint must have columns that match the columns in
+// conflictOrds. Unique constraints without an index cannot be "partial",
+// so they have no predicate to check for implication with arbiterPredicate.
+// TODO(rytaft): revisit this for the case of implicitly partitioned partial
+//  unique indexes (see #59195).
+//
+// If conflictOrds is empty then all unique indexes and unique without index
+// constraints are returned as arbiters. This is required to support a
+// DO NOTHING with no ON CONFLICT columns. In this case, all unique indexes
+// and constraints are used to check for conflicts.
 //
 // If a non-partial or pseudo-partial arbiter index is found, the return set
 // contains only that index. No other arbiter is necessary because a non-partial
-// or pseudo-partial index guarantee uniqueness of their columns across all
+// or pseudo-partial index guarantees uniqueness of its columns across all
 // rows.
-func (mb *mutationBuilder) arbiterIndexes(
+func (mb *mutationBuilder) arbiterIndexesAndConstraints(
 	conflictOrds util.FastIntSet, arbiterPredicate tree.Expr,
-) (arbiters util.FastIntSet) {
-	// If conflictOrds is empty, then all unique indexes are arbiters.
+) (indexes util.FastIntSet, uniqueConstraints util.FastIntSet) {
+	// If conflictOrds is empty, then all unique indexes and unique without index
+	// constraints are arbiters.
 	if conflictOrds.Empty() {
 		for idx, idxCount := 0, mb.tab.IndexCount(); idx < idxCount; idx++ {
 			if mb.tab.Index(idx).IsUnique() {
-				arbiters.Add(idx)
+				indexes.Add(idx)
 			}
 		}
-		return arbiters
+		for uc, ucCount := 0, mb.tab.UniqueCount(); uc < ucCount; uc++ {
+			if mb.tab.Unique(uc).WithoutIndex() {
+				uniqueConstraints.Add(uc)
+			}
+		}
+		return indexes, uniqueConstraints
 	}
 
 	tabMeta := mb.md.TableMeta(mb.tabID)
@@ -1239,7 +1323,7 @@ func (mb *mutationBuilder) arbiterIndexes(
 		// Furthermore, it is the only arbiter needed because it guarantees
 		// uniqueness of its columns across all rows.
 		if !isPartial {
-			return util.MakeFastIntSet(idx)
+			return util.MakeFastIntSet(idx), util.FastIntSet{}
 		}
 
 		// Initialize tableScope once and only if needed. We need to build a scan
@@ -1269,7 +1353,7 @@ func (mb *mutationBuilder) arbiterIndexes(
 			panic(err)
 		}
 		if predFilter.IsTrue() {
-			return util.MakeFastIntSet(idx)
+			return util.MakeFastIntSet(idx), util.FastIntSet{}
 		}
 
 		// If the index is a partial index, then it can only be an arbiter if
@@ -1296,17 +1380,44 @@ func (mb *mutationBuilder) arbiterIndexes(
 			}
 
 			if _, ok := im.FiltersImplyPredicate(arbiterFilters, predFilter); ok {
-				arbiters.Add(idx)
+				indexes.Add(idx)
 			}
 		}
 	}
 
-	if arbiters.Empty() {
-		panic(pgerror.Newf(pgcode.InvalidColumnReference,
-			"there is no unique or exclusion constraint matching the ON CONFLICT specification"))
+	// Try to find a matching unique constraint. We should always return a full
+	// unique constraint if it exists before returning any partial indexes.
+	for uc, ucCount := 0, mb.tab.UniqueCount(); uc < ucCount; uc++ {
+		uniqueConstraint := mb.tab.Unique(uc)
+		if !uniqueConstraint.WithoutIndex() {
+			// Unique constraints with an index were handled above.
+			continue
+		}
+
+		if uniqueConstraint.ColumnCount() != conflictOrds.Len() {
+			continue
+		}
+
+		// Determine whether the conflict columns match the columns in the unique
+		// constraint. If not, the constraint cannot be an arbiter.
+		var ucOrds util.FastIntSet
+		for i, n := 0, uniqueConstraint.ColumnCount(); i < n; i++ {
+			ucOrds.Add(uniqueConstraint.ColumnOrdinal(mb.tab, i))
+		}
+
+		if ucOrds.Equals(conflictOrds) {
+			return util.FastIntSet{}, util.MakeFastIntSet(uc)
+		}
 	}
 
-	return arbiters
+	// There are no full indexes or constraints, so return any partial indexes
+	// that were found.
+	if !indexes.Empty() {
+		return indexes, util.FastIntSet{}
+	}
+
+	panic(pgerror.Newf(pgcode.InvalidColumnReference,
+		"there is no unique or exclusion constraint matching the ON CONFLICT specification"))
 }
 
 // projectPartialIndexDistinctColumn projects a column to facilitate

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -132,9 +132,14 @@ type mutationBuilder struct {
 	// an insert; otherwise it's an update.
 	canaryColID opt.ColumnID
 
-	// arbiters stores the ordinals of indexes that are used to detect conflicts
-	// for UPSERT and INSERT ON CONFLICT statements.
-	arbiters cat.IndexOrdinals
+	// arbiterIndexes stores the ordinals of indexes that are used to detect
+	// conflicts for UPSERT and INSERT ON CONFLICT statements.
+	arbiterIndexes cat.IndexOrdinals
+
+	// arbiterConstraints stores the ordinals of unique without index constraints
+	// that are used to detect conflicts for UPSERT and INSERT ON CONFLICT
+	// statements.
+	arbiterConstraints cat.UniqueOrdinals
 
 	// roundedDecimalCols is the set of columns that have already been rounded.
 	// Keeping this set avoids rounding the same column multiple times.
@@ -994,7 +999,8 @@ func (mb *mutationBuilder) makeMutationPrivate(needResults bool) *memo.MutationP
 		FetchCols:           checkEmptyList(mb.fetchColIDs),
 		UpdateCols:          checkEmptyList(mb.updateColIDs),
 		CanaryCol:           mb.canaryColID,
-		Arbiters:            mb.arbiters,
+		ArbiterIndexes:      mb.arbiterIndexes,
+		ArbiterConstraints:  mb.arbiterConstraints,
 		CheckCols:           checkEmptyList(mb.checkColIDs),
 		PartialIndexPutCols: checkEmptyList(mb.partialIndexPutColIDs),
 		PartialIndexDelCols: checkEmptyList(mb.partialIndexDelColIDs),

--- a/pkg/sql/opt/optbuilder/testdata/unique-checks-insert
+++ b/pkg/sql/opt/optbuilder/testdata/unique-checks-insert
@@ -219,6 +219,195 @@ insert uniq
       ├── (1, 1, NULL::INT8, NULL::INT8, NULL::INT8)
       └── (2, 2, NULL::INT8, NULL::INT8, NULL::INT8)
 
+# Use all the unique indexes and constraints as arbiters for DO NOTHING with no
+# conflict columns.
+# TODO(rytaft): we should be able to remove the unique checks in this case
+# (see #59119).
+build
+INSERT INTO uniq VALUES (1, 2, 3, 4, 5) ON CONFLICT DO NOTHING
+----
+insert uniq
+ ├── columns: <none>
+ ├── arbiter indexes: primary uniq_v_key
+ ├── arbiter constraints: unique_w unique_x_y
+ ├── insert-mapping:
+ │    ├── column1:7 => k:1
+ │    ├── column2:8 => v:2
+ │    ├── column3:9 => w:3
+ │    ├── column4:10 => x:4
+ │    └── column5:11 => y:5
+ ├── input binding: &1
+ ├── upsert-distinct-on
+ │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null column5:11!null
+ │    ├── grouping columns: column4:10!null column5:11!null
+ │    ├── upsert-distinct-on
+ │    │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null column5:11!null
+ │    │    ├── grouping columns: column3:9!null
+ │    │    ├── upsert-distinct-on
+ │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null column5:11!null
+ │    │    │    ├── grouping columns: column2:8!null
+ │    │    │    ├── upsert-distinct-on
+ │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null column5:11!null
+ │    │    │    │    ├── grouping columns: column1:7!null
+ │    │    │    │    ├── anti-join (hash)
+ │    │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null column5:11!null
+ │    │    │    │    │    ├── anti-join (hash)
+ │    │    │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null column5:11!null
+ │    │    │    │    │    │    ├── anti-join (hash)
+ │    │    │    │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null column5:11!null
+ │    │    │    │    │    │    │    ├── anti-join (hash)
+ │    │    │    │    │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null column5:11!null
+ │    │    │    │    │    │    │    │    ├── values
+ │    │    │    │    │    │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null column5:11!null
+ │    │    │    │    │    │    │    │    │    └── (1, 2, 3, 4, 5)
+ │    │    │    │    │    │    │    │    ├── scan uniq
+ │    │    │    │    │    │    │    │    │    └── columns: k:12!null v:13 w:14 x:15 y:16
+ │    │    │    │    │    │    │    │    └── filters
+ │    │    │    │    │    │    │    │         └── column1:7 = k:12
+ │    │    │    │    │    │    │    ├── scan uniq
+ │    │    │    │    │    │    │    │    └── columns: k:18!null v:19 w:20 x:21 y:22
+ │    │    │    │    │    │    │    └── filters
+ │    │    │    │    │    │    │         └── column2:8 = v:19
+ │    │    │    │    │    │    ├── scan uniq
+ │    │    │    │    │    │    │    └── columns: k:24!null v:25 w:26 x:27 y:28
+ │    │    │    │    │    │    └── filters
+ │    │    │    │    │    │         └── column3:9 = w:26
+ │    │    │    │    │    ├── scan uniq
+ │    │    │    │    │    │    └── columns: k:30!null v:31 w:32 x:33 y:34
+ │    │    │    │    │    └── filters
+ │    │    │    │    │         ├── column4:10 = x:33
+ │    │    │    │    │         └── column5:11 = y:34
+ │    │    │    │    └── aggregations
+ │    │    │    │         ├── first-agg [as=column2:8]
+ │    │    │    │         │    └── column2:8
+ │    │    │    │         ├── first-agg [as=column3:9]
+ │    │    │    │         │    └── column3:9
+ │    │    │    │         ├── first-agg [as=column4:10]
+ │    │    │    │         │    └── column4:10
+ │    │    │    │         └── first-agg [as=column5:11]
+ │    │    │    │              └── column5:11
+ │    │    │    └── aggregations
+ │    │    │         ├── first-agg [as=column1:7]
+ │    │    │         │    └── column1:7
+ │    │    │         ├── first-agg [as=column3:9]
+ │    │    │         │    └── column3:9
+ │    │    │         ├── first-agg [as=column4:10]
+ │    │    │         │    └── column4:10
+ │    │    │         └── first-agg [as=column5:11]
+ │    │    │              └── column5:11
+ │    │    └── aggregations
+ │    │         ├── first-agg [as=column1:7]
+ │    │         │    └── column1:7
+ │    │         ├── first-agg [as=column2:8]
+ │    │         │    └── column2:8
+ │    │         ├── first-agg [as=column4:10]
+ │    │         │    └── column4:10
+ │    │         └── first-agg [as=column5:11]
+ │    │              └── column5:11
+ │    └── aggregations
+ │         ├── first-agg [as=column1:7]
+ │         │    └── column1:7
+ │         ├── first-agg [as=column2:8]
+ │         │    └── column2:8
+ │         └── first-agg [as=column3:9]
+ │              └── column3:9
+ └── unique-checks
+      ├── unique-checks-item: uniq(w)
+      │    └── semi-join (hash)
+      │         ├── columns: column3:36!null column1:37!null
+      │         ├── with-scan &1
+      │         │    ├── columns: column3:36!null column1:37!null
+      │         │    └── mapping:
+      │         │         ├──  column3:9 => column3:36
+      │         │         └──  column1:7 => column1:37
+      │         ├── scan uniq
+      │         │    └── columns: k:38!null w:40
+      │         └── filters
+      │              ├── column3:36 = w:40
+      │              └── column1:37 != k:38
+      └── unique-checks-item: uniq(x,y)
+           └── semi-join (hash)
+                ├── columns: column4:44!null column5:45!null column1:46!null
+                ├── with-scan &1
+                │    ├── columns: column4:44!null column5:45!null column1:46!null
+                │    └── mapping:
+                │         ├──  column4:10 => column4:44
+                │         ├──  column5:11 => column5:45
+                │         └──  column1:7 => column1:46
+                ├── scan uniq
+                │    └── columns: k:47!null x:50 y:51
+                └── filters
+                     ├── column4:44 = x:50
+                     ├── column5:45 = y:51
+                     └── column1:46 != k:47
+
+# On conflict clause references unique without index constraint.
+# TODO(rytaft): we should be able to remove the unique check for w in this case
+# (see #59119).
+build
+INSERT INTO uniq VALUES (1, 2, 3, 4, 5) ON CONFLICT (w) DO NOTHING
+----
+insert uniq
+ ├── columns: <none>
+ ├── arbiter constraints: unique_w
+ ├── insert-mapping:
+ │    ├── column1:7 => k:1
+ │    ├── column2:8 => v:2
+ │    ├── column3:9 => w:3
+ │    ├── column4:10 => x:4
+ │    └── column5:11 => y:5
+ ├── input binding: &1
+ ├── upsert-distinct-on
+ │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null column5:11!null
+ │    ├── grouping columns: column3:9!null
+ │    ├── anti-join (hash)
+ │    │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null column5:11!null
+ │    │    ├── values
+ │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null column5:11!null
+ │    │    │    └── (1, 2, 3, 4, 5)
+ │    │    ├── scan uniq
+ │    │    │    └── columns: k:12!null v:13 w:14 x:15 y:16
+ │    │    └── filters
+ │    │         └── column3:9 = w:14
+ │    └── aggregations
+ │         ├── first-agg [as=column1:7]
+ │         │    └── column1:7
+ │         ├── first-agg [as=column2:8]
+ │         │    └── column2:8
+ │         ├── first-agg [as=column4:10]
+ │         │    └── column4:10
+ │         └── first-agg [as=column5:11]
+ │              └── column5:11
+ └── unique-checks
+      ├── unique-checks-item: uniq(w)
+      │    └── semi-join (hash)
+      │         ├── columns: column3:18!null column1:19!null
+      │         ├── with-scan &1
+      │         │    ├── columns: column3:18!null column1:19!null
+      │         │    └── mapping:
+      │         │         ├──  column3:9 => column3:18
+      │         │         └──  column1:7 => column1:19
+      │         ├── scan uniq
+      │         │    └── columns: k:20!null w:22
+      │         └── filters
+      │              ├── column3:18 = w:22
+      │              └── column1:19 != k:20
+      └── unique-checks-item: uniq(x,y)
+           └── semi-join (hash)
+                ├── columns: column4:26!null column5:27!null column1:28!null
+                ├── with-scan &1
+                │    ├── columns: column4:26!null column5:27!null column1:28!null
+                │    └── mapping:
+                │         ├──  column4:10 => column4:26
+                │         ├──  column5:11 => column5:27
+                │         └──  column1:7 => column1:28
+                ├── scan uniq
+                │    └── columns: k:29!null x:32 y:33
+                └── filters
+                     ├── column4:26 = x:32
+                     ├── column5:27 = y:33
+                     └── column1:28 != k:29
+
 exec-ddl
 CREATE TABLE other (k INT, v INT, w INT NOT NULL, x INT, y INT)
 ----

--- a/pkg/sql/opt/optbuilder/testdata/unique-checks-upsert
+++ b/pkg/sql/opt/optbuilder/testdata/unique-checks-upsert
@@ -518,19 +518,182 @@ upsert uniq
 
 # On conflict do update with constant input, conflict on UNIQUE WITHOUT INDEX
 # column.
-# TODO(rytaft): Allow ON CONFLICT to reference UNIQUE WITHOUT INDEX columns
-# (see #58246).
 build
 INSERT INTO uniq VALUES (100, 10, 1), (200, 20, 2) ON CONFLICT (w) DO UPDATE SET w = 10
 ----
-error (42P10): there is no unique or exclusion constraint matching the ON CONFLICT specification
+upsert uniq
+ ├── columns: <none>
+ ├── arbiter constraints: unique_w
+ ├── canary column: k:12
+ ├── fetch columns: k:12 v:13 w:14 x:15 y:16
+ ├── insert-mapping:
+ │    ├── column1:7 => k:1
+ │    ├── column2:8 => v:2
+ │    ├── column3:9 => w:3
+ │    ├── column10:10 => x:4
+ │    └── column11:11 => y:5
+ ├── update-mapping:
+ │    └── upsert_w:21 => w:3
+ ├── input binding: &1
+ ├── project
+ │    ├── columns: upsert_k:19 upsert_v:20 upsert_w:21!null upsert_x:22 upsert_y:23 column1:7!null column2:8!null column3:9!null column10:10 column11:11!null k:12 v:13 w:14 x:15 y:16 crdb_internal_mvcc_timestamp:17 w_new:18!null
+ │    ├── project
+ │    │    ├── columns: w_new:18!null column1:7!null column2:8!null column3:9!null column10:10 column11:11!null k:12 v:13 w:14 x:15 y:16 crdb_internal_mvcc_timestamp:17
+ │    │    ├── left-join (hash)
+ │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null column10:10 column11:11!null k:12 v:13 w:14 x:15 y:16 crdb_internal_mvcc_timestamp:17
+ │    │    │    ├── ensure-upsert-distinct-on
+ │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null column10:10 column11:11!null
+ │    │    │    │    ├── grouping columns: column3:9!null
+ │    │    │    │    ├── project
+ │    │    │    │    │    ├── columns: column10:10 column11:11!null column1:7!null column2:8!null column3:9!null
+ │    │    │    │    │    ├── values
+ │    │    │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null
+ │    │    │    │    │    │    ├── (100, 10, 1)
+ │    │    │    │    │    │    └── (200, 20, 2)
+ │    │    │    │    │    └── projections
+ │    │    │    │    │         ├── NULL::INT8 [as=column10:10]
+ │    │    │    │    │         └── 5 [as=column11:11]
+ │    │    │    │    └── aggregations
+ │    │    │    │         ├── first-agg [as=column1:7]
+ │    │    │    │         │    └── column1:7
+ │    │    │    │         ├── first-agg [as=column2:8]
+ │    │    │    │         │    └── column2:8
+ │    │    │    │         ├── first-agg [as=column10:10]
+ │    │    │    │         │    └── column10:10
+ │    │    │    │         └── first-agg [as=column11:11]
+ │    │    │    │              └── column11:11
+ │    │    │    ├── scan uniq
+ │    │    │    │    └── columns: k:12!null v:13 w:14 x:15 y:16 crdb_internal_mvcc_timestamp:17
+ │    │    │    └── filters
+ │    │    │         └── column3:9 = w:14
+ │    │    └── projections
+ │    │         └── 10 [as=w_new:18]
+ │    └── projections
+ │         ├── CASE WHEN k:12 IS NULL THEN column1:7 ELSE k:12 END [as=upsert_k:19]
+ │         ├── CASE WHEN k:12 IS NULL THEN column2:8 ELSE v:13 END [as=upsert_v:20]
+ │         ├── CASE WHEN k:12 IS NULL THEN column3:9 ELSE w_new:18 END [as=upsert_w:21]
+ │         ├── CASE WHEN k:12 IS NULL THEN column10:10 ELSE x:15 END [as=upsert_x:22]
+ │         └── CASE WHEN k:12 IS NULL THEN column11:11 ELSE y:16 END [as=upsert_y:23]
+ └── unique-checks
+      ├── unique-checks-item: uniq(w)
+      │    └── semi-join (hash)
+      │         ├── columns: upsert_w:24!null upsert_k:25
+      │         ├── with-scan &1
+      │         │    ├── columns: upsert_w:24!null upsert_k:25
+      │         │    └── mapping:
+      │         │         ├──  upsert_w:21 => upsert_w:24
+      │         │         └──  upsert_k:19 => upsert_k:25
+      │         ├── scan uniq
+      │         │    └── columns: k:26!null w:28
+      │         └── filters
+      │              ├── upsert_w:24 = w:28
+      │              └── upsert_k:25 != k:26
+      └── unique-checks-item: uniq(x,y)
+           └── semi-join (hash)
+                ├── columns: upsert_x:32 upsert_y:33 upsert_k:34
+                ├── with-scan &1
+                │    ├── columns: upsert_x:32 upsert_y:33 upsert_k:34
+                │    └── mapping:
+                │         ├──  upsert_x:22 => upsert_x:32
+                │         ├──  upsert_y:23 => upsert_y:33
+                │         └──  upsert_k:19 => upsert_k:34
+                ├── scan uniq
+                │    └── columns: k:35!null x:38 y:39
+                └── filters
+                     ├── upsert_x:32 = x:38
+                     ├── upsert_y:33 = y:39
+                     └── upsert_k:34 != k:35
 
 # On conflict do update with constant input, conflict on UNIQUE WITHOUT INDEX
 # columns.
-# TODO(rytaft): Allow ON CONFLICT to reference UNIQUE WITHOUT INDEX columns
-# (see #58246).
 build
 INSERT INTO uniq VALUES (1, 2, 3, 4, 5) ON CONFLICT (x, y) DO UPDATE SET v = 10
+----
+upsert uniq
+ ├── columns: <none>
+ ├── arbiter constraints: unique_x_y
+ ├── canary column: k:12
+ ├── fetch columns: k:12 v:13 w:14 x:15 y:16
+ ├── insert-mapping:
+ │    ├── column1:7 => k:1
+ │    ├── column2:8 => v:2
+ │    ├── column3:9 => w:3
+ │    ├── column4:10 => x:4
+ │    └── column5:11 => y:5
+ ├── update-mapping:
+ │    └── upsert_v:20 => v:2
+ ├── input binding: &1
+ ├── project
+ │    ├── columns: upsert_k:19 upsert_v:20!null upsert_w:21 upsert_x:22 upsert_y:23 column1:7!null column2:8!null column3:9!null column4:10!null column5:11!null k:12 v:13 w:14 x:15 y:16 crdb_internal_mvcc_timestamp:17 v_new:18!null
+ │    ├── project
+ │    │    ├── columns: v_new:18!null column1:7!null column2:8!null column3:9!null column4:10!null column5:11!null k:12 v:13 w:14 x:15 y:16 crdb_internal_mvcc_timestamp:17
+ │    │    ├── left-join (hash)
+ │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null column5:11!null k:12 v:13 w:14 x:15 y:16 crdb_internal_mvcc_timestamp:17
+ │    │    │    ├── ensure-upsert-distinct-on
+ │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null column5:11!null
+ │    │    │    │    ├── grouping columns: column4:10!null column5:11!null
+ │    │    │    │    ├── values
+ │    │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null column5:11!null
+ │    │    │    │    │    └── (1, 2, 3, 4, 5)
+ │    │    │    │    └── aggregations
+ │    │    │    │         ├── first-agg [as=column1:7]
+ │    │    │    │         │    └── column1:7
+ │    │    │    │         ├── first-agg [as=column2:8]
+ │    │    │    │         │    └── column2:8
+ │    │    │    │         └── first-agg [as=column3:9]
+ │    │    │    │              └── column3:9
+ │    │    │    ├── scan uniq
+ │    │    │    │    └── columns: k:12!null v:13 w:14 x:15 y:16 crdb_internal_mvcc_timestamp:17
+ │    │    │    └── filters
+ │    │    │         ├── column4:10 = x:15
+ │    │    │         └── column5:11 = y:16
+ │    │    └── projections
+ │    │         └── 10 [as=v_new:18]
+ │    └── projections
+ │         ├── CASE WHEN k:12 IS NULL THEN column1:7 ELSE k:12 END [as=upsert_k:19]
+ │         ├── CASE WHEN k:12 IS NULL THEN column2:8 ELSE v_new:18 END [as=upsert_v:20]
+ │         ├── CASE WHEN k:12 IS NULL THEN column3:9 ELSE w:14 END [as=upsert_w:21]
+ │         ├── CASE WHEN k:12 IS NULL THEN column4:10 ELSE x:15 END [as=upsert_x:22]
+ │         └── CASE WHEN k:12 IS NULL THEN column5:11 ELSE y:16 END [as=upsert_y:23]
+ └── unique-checks
+      ├── unique-checks-item: uniq(w)
+      │    └── semi-join (hash)
+      │         ├── columns: upsert_w:24 upsert_k:25
+      │         ├── with-scan &1
+      │         │    ├── columns: upsert_w:24 upsert_k:25
+      │         │    └── mapping:
+      │         │         ├──  upsert_w:21 => upsert_w:24
+      │         │         └──  upsert_k:19 => upsert_k:25
+      │         ├── scan uniq
+      │         │    └── columns: k:26!null w:28
+      │         └── filters
+      │              ├── upsert_w:24 = w:28
+      │              └── upsert_k:25 != k:26
+      └── unique-checks-item: uniq(x,y)
+           └── semi-join (hash)
+                ├── columns: upsert_x:32 upsert_y:33 upsert_k:34
+                ├── with-scan &1
+                │    ├── columns: upsert_x:32 upsert_y:33 upsert_k:34
+                │    └── mapping:
+                │         ├──  upsert_x:22 => upsert_x:32
+                │         ├──  upsert_y:23 => upsert_y:33
+                │         └──  upsert_k:19 => upsert_k:34
+                ├── scan uniq
+                │    └── columns: k:35!null x:38 y:39
+                └── filters
+                     ├── upsert_x:32 = x:38
+                     ├── upsert_y:33 = y:39
+                     └── upsert_k:34 != k:35
+
+# Cannot conflict on a subset of columns in a unique constraint.
+build
+INSERT INTO uniq VALUES (1, 2, 3, 4, 5) ON CONFLICT (x) DO UPDATE SET v = 10
+----
+error (42P10): there is no unique or exclusion constraint matching the ON CONFLICT specification
+
+# Cannot conflict on a superset of columns in a unique constraint.
+build
+INSERT INTO uniq VALUES (1, 2, 3, 4, 5) ON CONFLICT (w, x, y) DO UPDATE SET v = 10
 ----
 error (42P10): there is no unique or exclusion constraint matching the ON CONFLICT specification
 
@@ -667,21 +830,191 @@ upsert uniq_overlaps_pk
 
 # On conflict do update with constant input, conflict on UNIQUE WITHOUT INDEX
 # column.
-# TODO(rytaft): Allow ON CONFLICT to reference UNIQUE WITHOUT INDEX columns
-# (see #58246).
 build
 INSERT INTO uniq_overlaps_pk VALUES (100, 10, 1, 1), (200, 20, 2, 2) ON CONFLICT (a) DO UPDATE SET a = 10
 ----
-error (42P10): there is no unique or exclusion constraint matching the ON CONFLICT specification
+upsert uniq_overlaps_pk
+ ├── columns: <none>
+ ├── arbiter constraints: unique_a
+ ├── canary column: a:10
+ ├── fetch columns: a:10 b:11 c:12 d:13
+ ├── insert-mapping:
+ │    ├── column1:6 => a:1
+ │    ├── column2:7 => b:2
+ │    ├── column3:8 => c:3
+ │    └── column4:9 => d:4
+ ├── update-mapping:
+ │    └── upsert_a:16 => a:1
+ ├── input binding: &1
+ ├── project
+ │    ├── columns: upsert_a:16!null upsert_b:17 upsert_c:18 upsert_d:19 column1:6!null column2:7!null column3:8!null column4:9!null a:10 b:11 c:12 d:13 crdb_internal_mvcc_timestamp:14 a_new:15!null
+ │    ├── project
+ │    │    ├── columns: a_new:15!null column1:6!null column2:7!null column3:8!null column4:9!null a:10 b:11 c:12 d:13 crdb_internal_mvcc_timestamp:14
+ │    │    ├── left-join (hash)
+ │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null column4:9!null a:10 b:11 c:12 d:13 crdb_internal_mvcc_timestamp:14
+ │    │    │    ├── ensure-upsert-distinct-on
+ │    │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null column4:9!null
+ │    │    │    │    ├── grouping columns: column1:6!null
+ │    │    │    │    ├── values
+ │    │    │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null column4:9!null
+ │    │    │    │    │    ├── (100, 10, 1, 1)
+ │    │    │    │    │    └── (200, 20, 2, 2)
+ │    │    │    │    └── aggregations
+ │    │    │    │         ├── first-agg [as=column2:7]
+ │    │    │    │         │    └── column2:7
+ │    │    │    │         ├── first-agg [as=column3:8]
+ │    │    │    │         │    └── column3:8
+ │    │    │    │         └── first-agg [as=column4:9]
+ │    │    │    │              └── column4:9
+ │    │    │    ├── scan uniq_overlaps_pk
+ │    │    │    │    └── columns: a:10!null b:11!null c:12 d:13 crdb_internal_mvcc_timestamp:14
+ │    │    │    └── filters
+ │    │    │         └── column1:6 = a:10
+ │    │    └── projections
+ │    │         └── 10 [as=a_new:15]
+ │    └── projections
+ │         ├── CASE WHEN a:10 IS NULL THEN column1:6 ELSE a_new:15 END [as=upsert_a:16]
+ │         ├── CASE WHEN a:10 IS NULL THEN column2:7 ELSE b:11 END [as=upsert_b:17]
+ │         ├── CASE WHEN a:10 IS NULL THEN column3:8 ELSE c:12 END [as=upsert_c:18]
+ │         └── CASE WHEN a:10 IS NULL THEN column4:9 ELSE d:13 END [as=upsert_d:19]
+ └── unique-checks
+      ├── unique-checks-item: uniq_overlaps_pk(b,c)
+      │    └── semi-join (hash)
+      │         ├── columns: upsert_b:20 upsert_c:21 upsert_a:22!null
+      │         ├── with-scan &1
+      │         │    ├── columns: upsert_b:20 upsert_c:21 upsert_a:22!null
+      │         │    └── mapping:
+      │         │         ├──  upsert_b:17 => upsert_b:20
+      │         │         ├──  upsert_c:18 => upsert_c:21
+      │         │         └──  upsert_a:16 => upsert_a:22
+      │         ├── scan uniq_overlaps_pk
+      │         │    └── columns: a:23!null b:24!null c:25
+      │         └── filters
+      │              ├── upsert_b:20 = b:24
+      │              ├── upsert_c:21 = c:25
+      │              └── upsert_a:22 != a:23
+      ├── unique-checks-item: uniq_overlaps_pk(a)
+      │    └── semi-join (hash)
+      │         ├── columns: upsert_a:28!null upsert_b:29
+      │         ├── with-scan &1
+      │         │    ├── columns: upsert_a:28!null upsert_b:29
+      │         │    └── mapping:
+      │         │         ├──  upsert_a:16 => upsert_a:28
+      │         │         └──  upsert_b:17 => upsert_b:29
+      │         ├── scan uniq_overlaps_pk
+      │         │    └── columns: a:30!null b:31!null
+      │         └── filters
+      │              ├── upsert_a:28 = a:30
+      │              └── upsert_b:29 != b:31
+      └── unique-checks-item: uniq_overlaps_pk(c,d)
+           └── semi-join (hash)
+                ├── columns: upsert_c:35 upsert_d:36 upsert_a:37!null upsert_b:38
+                ├── with-scan &1
+                │    ├── columns: upsert_c:35 upsert_d:36 upsert_a:37!null upsert_b:38
+                │    └── mapping:
+                │         ├──  upsert_c:18 => upsert_c:35
+                │         ├──  upsert_d:19 => upsert_d:36
+                │         ├──  upsert_a:16 => upsert_a:37
+                │         └──  upsert_b:17 => upsert_b:38
+                ├── scan uniq_overlaps_pk
+                │    └── columns: a:39!null b:40!null c:41 d:42
+                └── filters
+                     ├── upsert_c:35 = c:41
+                     ├── upsert_d:36 = d:42
+                     └── (upsert_a:37 != a:39) OR (upsert_b:38 != b:40)
 
 # On conflict do update with constant input, conflict on UNIQUE WITHOUT INDEX
 # columns.
-# TODO(rytaft): Allow ON CONFLICT to reference UNIQUE WITHOUT INDEX columns
-# (see #58246).
 build
 INSERT INTO uniq_overlaps_pk VALUES (1, 2, 3, 4) ON CONFLICT (c, d) DO UPDATE SET b = 10
 ----
-error (42P10): there is no unique or exclusion constraint matching the ON CONFLICT specification
+upsert uniq_overlaps_pk
+ ├── columns: <none>
+ ├── arbiter constraints: unique_c_d
+ ├── canary column: a:10
+ ├── fetch columns: a:10 b:11 c:12 d:13
+ ├── insert-mapping:
+ │    ├── column1:6 => a:1
+ │    ├── column2:7 => b:2
+ │    ├── column3:8 => c:3
+ │    └── column4:9 => d:4
+ ├── update-mapping:
+ │    └── upsert_b:17 => b:2
+ ├── input binding: &1
+ ├── project
+ │    ├── columns: upsert_a:16 upsert_b:17!null upsert_c:18 upsert_d:19 column1:6!null column2:7!null column3:8!null column4:9!null a:10 b:11 c:12 d:13 crdb_internal_mvcc_timestamp:14 b_new:15!null
+ │    ├── project
+ │    │    ├── columns: b_new:15!null column1:6!null column2:7!null column3:8!null column4:9!null a:10 b:11 c:12 d:13 crdb_internal_mvcc_timestamp:14
+ │    │    ├── left-join (hash)
+ │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null column4:9!null a:10 b:11 c:12 d:13 crdb_internal_mvcc_timestamp:14
+ │    │    │    ├── ensure-upsert-distinct-on
+ │    │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null column4:9!null
+ │    │    │    │    ├── grouping columns: column3:8!null column4:9!null
+ │    │    │    │    ├── values
+ │    │    │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null column4:9!null
+ │    │    │    │    │    └── (1, 2, 3, 4)
+ │    │    │    │    └── aggregations
+ │    │    │    │         ├── first-agg [as=column1:6]
+ │    │    │    │         │    └── column1:6
+ │    │    │    │         └── first-agg [as=column2:7]
+ │    │    │    │              └── column2:7
+ │    │    │    ├── scan uniq_overlaps_pk
+ │    │    │    │    └── columns: a:10!null b:11!null c:12 d:13 crdb_internal_mvcc_timestamp:14
+ │    │    │    └── filters
+ │    │    │         ├── column3:8 = c:12
+ │    │    │         └── column4:9 = d:13
+ │    │    └── projections
+ │    │         └── 10 [as=b_new:15]
+ │    └── projections
+ │         ├── CASE WHEN a:10 IS NULL THEN column1:6 ELSE a:10 END [as=upsert_a:16]
+ │         ├── CASE WHEN a:10 IS NULL THEN column2:7 ELSE b_new:15 END [as=upsert_b:17]
+ │         ├── CASE WHEN a:10 IS NULL THEN column3:8 ELSE c:12 END [as=upsert_c:18]
+ │         └── CASE WHEN a:10 IS NULL THEN column4:9 ELSE d:13 END [as=upsert_d:19]
+ └── unique-checks
+      ├── unique-checks-item: uniq_overlaps_pk(b,c)
+      │    └── semi-join (hash)
+      │         ├── columns: upsert_b:20!null upsert_c:21 upsert_a:22
+      │         ├── with-scan &1
+      │         │    ├── columns: upsert_b:20!null upsert_c:21 upsert_a:22
+      │         │    └── mapping:
+      │         │         ├──  upsert_b:17 => upsert_b:20
+      │         │         ├──  upsert_c:18 => upsert_c:21
+      │         │         └──  upsert_a:16 => upsert_a:22
+      │         ├── scan uniq_overlaps_pk
+      │         │    └── columns: a:23!null b:24!null c:25
+      │         └── filters
+      │              ├── upsert_b:20 = b:24
+      │              ├── upsert_c:21 = c:25
+      │              └── upsert_a:22 != a:23
+      ├── unique-checks-item: uniq_overlaps_pk(a)
+      │    └── semi-join (hash)
+      │         ├── columns: upsert_a:28 upsert_b:29!null
+      │         ├── with-scan &1
+      │         │    ├── columns: upsert_a:28 upsert_b:29!null
+      │         │    └── mapping:
+      │         │         ├──  upsert_a:16 => upsert_a:28
+      │         │         └──  upsert_b:17 => upsert_b:29
+      │         ├── scan uniq_overlaps_pk
+      │         │    └── columns: a:30!null b:31!null
+      │         └── filters
+      │              ├── upsert_a:28 = a:30
+      │              └── upsert_b:29 != b:31
+      └── unique-checks-item: uniq_overlaps_pk(c,d)
+           └── semi-join (hash)
+                ├── columns: upsert_c:35 upsert_d:36 upsert_a:37 upsert_b:38!null
+                ├── with-scan &1
+                │    ├── columns: upsert_c:35 upsert_d:36 upsert_a:37 upsert_b:38!null
+                │    └── mapping:
+                │         ├──  upsert_c:18 => upsert_c:35
+                │         ├──  upsert_d:19 => upsert_d:36
+                │         ├──  upsert_a:16 => upsert_a:37
+                │         └──  upsert_b:17 => upsert_b:38
+                ├── scan uniq_overlaps_pk
+                │    └── columns: a:39!null b:40!null c:41 d:42
+                └── filters
+                     ├── upsert_c:35 = c:41
+                     ├── upsert_d:36 = d:42
+                     └── (upsert_a:37 != a:39) OR (upsert_b:38 != b:40)
 
 exec-ddl
 CREATE TABLE uniq_hidden_pk (
@@ -866,12 +1199,104 @@ upsert uniq_hidden_pk
 
 # On conflict do update with constant input, conflict on UNIQUE WITHOUT INDEX
 # columns.
-# TODO(rytaft): Allow ON CONFLICT to reference UNIQUE WITHOUT INDEX columns
-# (see #58246).
 build
 INSERT INTO uniq_hidden_pk VALUES (1, 2, 3, 4) ON CONFLICT (a, b, d) DO UPDATE SET a = 10
 ----
-error (42P10): there is no unique or exclusion constraint matching the ON CONFLICT specification
+upsert uniq_hidden_pk
+ ├── columns: <none>
+ ├── arbiter constraints: unique_a_b_d
+ ├── canary column: rowid:16
+ ├── fetch columns: a:12 b:13 c:14 d:15 rowid:16
+ ├── insert-mapping:
+ │    ├── column1:7 => a:1
+ │    ├── column2:8 => b:2
+ │    ├── column3:9 => c:3
+ │    ├── column4:10 => d:4
+ │    └── column11:11 => rowid:5
+ ├── update-mapping:
+ │    └── upsert_a:19 => a:1
+ ├── input binding: &1
+ ├── project
+ │    ├── columns: upsert_a:19!null upsert_b:20 upsert_c:21 upsert_d:22 upsert_rowid:23 column1:7!null column2:8!null column3:9!null column4:10!null column11:11 a:12 b:13 c:14 d:15 rowid:16 crdb_internal_mvcc_timestamp:17 a_new:18!null
+ │    ├── project
+ │    │    ├── columns: a_new:18!null column1:7!null column2:8!null column3:9!null column4:10!null column11:11 a:12 b:13 c:14 d:15 rowid:16 crdb_internal_mvcc_timestamp:17
+ │    │    ├── left-join (hash)
+ │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null column11:11 a:12 b:13 c:14 d:15 rowid:16 crdb_internal_mvcc_timestamp:17
+ │    │    │    ├── ensure-upsert-distinct-on
+ │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null column11:11
+ │    │    │    │    ├── grouping columns: column1:7!null column2:8!null column4:10!null
+ │    │    │    │    ├── project
+ │    │    │    │    │    ├── columns: column11:11 column1:7!null column2:8!null column3:9!null column4:10!null
+ │    │    │    │    │    ├── values
+ │    │    │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null
+ │    │    │    │    │    │    └── (1, 2, 3, 4)
+ │    │    │    │    │    └── projections
+ │    │    │    │    │         └── unique_rowid() [as=column11:11]
+ │    │    │    │    └── aggregations
+ │    │    │    │         ├── first-agg [as=column3:9]
+ │    │    │    │         │    └── column3:9
+ │    │    │    │         └── first-agg [as=column11:11]
+ │    │    │    │              └── column11:11
+ │    │    │    ├── scan uniq_hidden_pk
+ │    │    │    │    └── columns: a:12 b:13 c:14 d:15 rowid:16!null crdb_internal_mvcc_timestamp:17
+ │    │    │    └── filters
+ │    │    │         ├── column1:7 = a:12
+ │    │    │         ├── column2:8 = b:13
+ │    │    │         └── column4:10 = d:15
+ │    │    └── projections
+ │    │         └── 10 [as=a_new:18]
+ │    └── projections
+ │         ├── CASE WHEN rowid:16 IS NULL THEN column1:7 ELSE a_new:18 END [as=upsert_a:19]
+ │         ├── CASE WHEN rowid:16 IS NULL THEN column2:8 ELSE b:13 END [as=upsert_b:20]
+ │         ├── CASE WHEN rowid:16 IS NULL THEN column3:9 ELSE c:14 END [as=upsert_c:21]
+ │         ├── CASE WHEN rowid:16 IS NULL THEN column4:10 ELSE d:15 END [as=upsert_d:22]
+ │         └── CASE WHEN rowid:16 IS NULL THEN column11:11 ELSE rowid:16 END [as=upsert_rowid:23]
+ └── unique-checks
+      ├── unique-checks-item: uniq_hidden_pk(b,c)
+      │    └── semi-join (hash)
+      │         ├── columns: upsert_b:24 upsert_c:25 upsert_rowid:26
+      │         ├── with-scan &1
+      │         │    ├── columns: upsert_b:24 upsert_c:25 upsert_rowid:26
+      │         │    └── mapping:
+      │         │         ├──  upsert_b:20 => upsert_b:24
+      │         │         ├──  upsert_c:21 => upsert_c:25
+      │         │         └──  upsert_rowid:23 => upsert_rowid:26
+      │         ├── scan uniq_hidden_pk
+      │         │    └── columns: b:28 c:29 rowid:31!null
+      │         └── filters
+      │              ├── upsert_b:24 = b:28
+      │              ├── upsert_c:25 = c:29
+      │              └── upsert_rowid:26 != rowid:31
+      ├── unique-checks-item: uniq_hidden_pk(a,b,d)
+      │    └── semi-join (hash)
+      │         ├── columns: upsert_a:33!null upsert_b:34 upsert_d:35 upsert_rowid:36
+      │         ├── with-scan &1
+      │         │    ├── columns: upsert_a:33!null upsert_b:34 upsert_d:35 upsert_rowid:36
+      │         │    └── mapping:
+      │         │         ├──  upsert_a:19 => upsert_a:33
+      │         │         ├──  upsert_b:20 => upsert_b:34
+      │         │         ├──  upsert_d:22 => upsert_d:35
+      │         │         └──  upsert_rowid:23 => upsert_rowid:36
+      │         ├── scan uniq_hidden_pk
+      │         │    └── columns: a:37 b:38 d:40 rowid:41!null
+      │         └── filters
+      │              ├── upsert_a:33 = a:37
+      │              ├── upsert_b:34 = b:38
+      │              ├── upsert_d:35 = d:40
+      │              └── upsert_rowid:36 != rowid:41
+      └── unique-checks-item: uniq_hidden_pk(a)
+           └── semi-join (hash)
+                ├── columns: upsert_a:43!null upsert_rowid:44
+                ├── with-scan &1
+                │    ├── columns: upsert_a:43!null upsert_rowid:44
+                │    └── mapping:
+                │         ├──  upsert_a:19 => upsert_a:43
+                │         └──  upsert_rowid:23 => upsert_rowid:44
+                ├── scan uniq_hidden_pk
+                │    └── columns: a:45 rowid:49!null
+                └── filters
+                     ├── upsert_a:43 = a:45
+                     └── upsert_rowid:44 != rowid:49
 
 exec-ddl
 CREATE TABLE uniq_fk_parent (
@@ -991,3 +1416,82 @@ upsert uniq_fk_child
                 │    └── columns: uniq_fk_parent.a:7
                 └── filters
                      └── column2:6 = uniq_fk_parent.a:7
+
+# Check that we choose the unique without index constraint as the arbiter.
+exec-ddl
+CREATE TABLE t (
+  i INT,
+  CONSTRAINT i1 UNIQUE (i) WHERE i > 0,
+  CONSTRAINT i2 UNIQUE WITHOUT INDEX(i)
+)
+----
+
+build
+INSERT INTO t VALUES (1) ON CONFLICT (i) WHERE i > 0 DO UPDATE SET i = 2
+----
+upsert t
+ ├── columns: <none>
+ ├── arbiter constraints: i2
+ ├── canary column: rowid:7
+ ├── fetch columns: i:6 rowid:7
+ ├── insert-mapping:
+ │    ├── column1:4 => i:1
+ │    └── column5:5 => rowid:2
+ ├── update-mapping:
+ │    └── upsert_i:10 => i:1
+ ├── partial index put columns: partial_index_put1:12
+ ├── partial index del columns: partial_index_del1:13
+ ├── input binding: &1
+ ├── project
+ │    ├── columns: partial_index_put1:12!null partial_index_del1:13 column1:4!null column5:5 i:6 rowid:7 crdb_internal_mvcc_timestamp:8 i_new:9!null upsert_i:10!null upsert_rowid:11
+ │    ├── project
+ │    │    ├── columns: upsert_i:10!null upsert_rowid:11 column1:4!null column5:5 i:6 rowid:7 crdb_internal_mvcc_timestamp:8 i_new:9!null
+ │    │    ├── project
+ │    │    │    ├── columns: i_new:9!null column1:4!null column5:5 i:6 rowid:7 crdb_internal_mvcc_timestamp:8
+ │    │    │    ├── left-join (hash)
+ │    │    │    │    ├── columns: column1:4!null column5:5 i:6 rowid:7 crdb_internal_mvcc_timestamp:8
+ │    │    │    │    ├── ensure-upsert-distinct-on
+ │    │    │    │    │    ├── columns: column1:4!null column5:5
+ │    │    │    │    │    ├── grouping columns: column1:4!null
+ │    │    │    │    │    ├── project
+ │    │    │    │    │    │    ├── columns: column5:5 column1:4!null
+ │    │    │    │    │    │    ├── values
+ │    │    │    │    │    │    │    ├── columns: column1:4!null
+ │    │    │    │    │    │    │    └── (1,)
+ │    │    │    │    │    │    └── projections
+ │    │    │    │    │    │         └── unique_rowid() [as=column5:5]
+ │    │    │    │    │    └── aggregations
+ │    │    │    │    │         └── first-agg [as=column5:5]
+ │    │    │    │    │              └── column5:5
+ │    │    │    │    ├── scan t
+ │    │    │    │    │    ├── columns: i:6 rowid:7!null crdb_internal_mvcc_timestamp:8
+ │    │    │    │    │    └── partial index predicates
+ │    │    │    │    │         └── i1: filters
+ │    │    │    │    │              └── i:6 > 0
+ │    │    │    │    └── filters
+ │    │    │    │         └── column1:4 = i:6
+ │    │    │    └── projections
+ │    │    │         └── 2 [as=i_new:9]
+ │    │    └── projections
+ │    │         ├── CASE WHEN rowid:7 IS NULL THEN column1:4 ELSE i_new:9 END [as=upsert_i:10]
+ │    │         └── CASE WHEN rowid:7 IS NULL THEN column5:5 ELSE rowid:7 END [as=upsert_rowid:11]
+ │    └── projections
+ │         ├── upsert_i:10 > 0 [as=partial_index_put1:12]
+ │         └── i:6 > 0 [as=partial_index_del1:13]
+ └── unique-checks
+      └── unique-checks-item: t(i)
+           └── semi-join (hash)
+                ├── columns: upsert_i:14!null upsert_rowid:15
+                ├── with-scan &1
+                │    ├── columns: upsert_i:14!null upsert_rowid:15
+                │    └── mapping:
+                │         ├──  upsert_i:10 => upsert_i:14
+                │         └──  upsert_rowid:11 => upsert_rowid:15
+                ├── scan t
+                │    ├── columns: i:16 rowid:17!null
+                │    └── partial index predicates
+                │         └── i1: filters
+                │              └── i:16 > 0
+                └── filters
+                     ├── upsert_i:14 = i:16
+                     └── upsert_rowid:15 != rowid:17

--- a/pkg/sql/opt/optgen/cmd/optgen/metadata.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/metadata.go
@@ -235,6 +235,7 @@ func newMetadata(compiled *lang.CompiledExpr, pkg string) *metadata {
 		"ScheduleCommand":   {fullName: "tree.ScheduleCommand", passByVal: true},
 		"IndexOrdinal":      {fullName: "cat.IndexOrdinal", passByVal: true},
 		"IndexOrdinals":     {fullName: "cat.IndexOrdinals", passByVal: true},
+		"UniqueOrdinals":    {fullName: "cat.UniqueOrdinals", passByVal: true},
 		"ViewDeps":          {fullName: "opt.ViewDeps", passByVal: true},
 		"LockingItem":       {fullName: "tree.LockingItem", isPointer: true},
 		"MaterializeClause": {fullName: "tree.MaterializeClause", passByVal: true},

--- a/pkg/sql/opt/testutils/testcat/create_table.go
+++ b/pkg/sql/opt/testutils/testcat/create_table.go
@@ -11,6 +11,7 @@
 package testcat
 
 import (
+	"bytes"
 	"fmt"
 	"reflect"
 	"sort"
@@ -500,7 +501,7 @@ func (tt *Table) addUniqueConstraint(
 
 	// We didn't find an existing constraint, so add a new one.
 	u := UniqueConstraint{
-		name:           string(name),
+		name:           tt.makeUniqueConstraintName(name, columns),
 		tabID:          tt.TabID,
 		columnOrdinals: cols,
 		withoutIndex:   withoutIndex,
@@ -761,6 +762,20 @@ func (tt *Table) makeIndexName(defName tree.Name, typ indexType) string {
 		} else {
 			name = "secondary"
 		}
+	}
+	return name
+}
+
+func (tt *Table) makeUniqueConstraintName(defName tree.Name, columns tree.IndexElemList) string {
+	name := string(defName)
+	if name == "" {
+		var buf bytes.Buffer
+		buf.WriteString("unique")
+		for i := range columns {
+			buf.WriteRune('_')
+			buf.WriteString(string(columns[i].Column))
+		}
+		name = buf.String()
 	}
 	return name
 }

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -732,7 +732,7 @@ func (tt *Table) UniqueCount() int {
 }
 
 // Unique is part of the cat.Table interface.
-func (tt *Table) Unique(i int) cat.UniqueConstraint {
+func (tt *Table) Unique(i cat.UniqueOrdinal) cat.UniqueConstraint {
 	return &tt.uniqueConstraints[i]
 }
 

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -1068,7 +1068,7 @@ func (ot *optTable) UniqueCount() int {
 }
 
 // Unique is part of the cat.Table interface.
-func (ot *optTable) Unique(i int) cat.UniqueConstraint {
+func (ot *optTable) Unique(i cat.UniqueOrdinal) cat.UniqueConstraint {
 	return &ot.uniqueConstraints[i]
 }
 
@@ -1891,7 +1891,7 @@ func (ot *optVirtualTable) UniqueCount() int {
 }
 
 // Unique is part of the cat.Table interface.
-func (ot *optVirtualTable) Unique(i int) cat.UniqueConstraint {
+func (ot *optVirtualTable) Unique(i cat.UniqueOrdinal) cat.UniqueConstraint {
 	panic(errors.AssertionFailedf("no unique constraints"))
 }
 

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1148,7 +1148,8 @@ func (ef *execFactory) ConstructShowTrace(typ tree.ShowTraceType, compact bool) 
 func (ef *execFactory) ConstructInsert(
 	input exec.Node,
 	table cat.Table,
-	arbiters cat.IndexOrdinals,
+	arbiterIndexes cat.IndexOrdinals,
+	arbiterConstraints cat.UniqueOrdinals,
 	insertColOrdSet exec.TableColumnOrdinalSet,
 	returnColOrdSet exec.TableColumnOrdinalSet,
 	checkOrdSet exec.CheckOrdinalSet,
@@ -1399,7 +1400,8 @@ func (ef *execFactory) ConstructUpdate(
 func (ef *execFactory) ConstructUpsert(
 	input exec.Node,
 	table cat.Table,
-	arbiters cat.IndexOrdinals,
+	arbiterIndexes cat.IndexOrdinals,
+	arbiterConstraints cat.UniqueOrdinals,
 	canaryCol exec.NodeColumnOrdinal,
 	insertColOrdSet exec.TableColumnOrdinalSet,
 	fetchColOrdSet exec.TableColumnOrdinalSet,


### PR DESCRIPTION
Prior to this commit, attempting to specify an `ON CONFLICT` clause referencing
a `UNIQUE WITHOUT INDEX` constraint caused an error "there is no unique or
exclusion constraint matching the ON CONFLICT specification".

This commit allows `ON CONFLICT` clauses to reference these constraints, and
also ensures that the unique constraints are checked for `ON CONFLICT DO NOTHING`
clauses when there are no columns specified.

Fixes #58246

There is no release note since `UNIQUE WITHOUT INDEX` is still gated behind the
`experimental_enable_unique_without_index_constraints` session variable.

Release note: None