### PR TITLE
sql: disallow type unknown[], make ARRAY[NULL] have type string[]

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/suboperators
+++ b/pkg/sql/logictest/testdata/logic_test/suboperators
@@ -169,7 +169,7 @@ SELECT 1 = ANY(SELECT * FROM unnest(ARRAY[2, NULL]))
 NULL
 
 query T
-SELECT 1 = ANY(SELECT * FROM unnest(ARRAY[NULL, NULL]))
+SELECT 1 = ANY(SELECT * FROM unnest(ARRAY[NULL, NULL]::int[]))
 ----
 NULL
 
@@ -218,7 +218,7 @@ SELECT * FROM abc WHERE a = ANY(SELECT * FROM unnest(ARRAY[4, NULL]))
 ----
 
 query III
-SELECT * FROM abc WHERE a = ANY(SELECT * FROM unnest(ARRAY[NULL, NULL]))
+SELECT * FROM abc WHERE a = ANY(SELECT * FROM unnest(ARRAY[NULL, NULL]::int[]))
 ----
 
 query error unsupported comparison operator: <int> = ANY <tuple\{string\}>
@@ -333,7 +333,7 @@ SELECT 1 = ALL(SELECT * FROM unnest(ARRAY[1, NULL]))
 NULL
 
 query T
-SELECT 1 = ALL(SELECT * FROM unnest(ARRAY[NULL, NULL]))
+SELECT 1 = ALL(SELECT * FROM unnest(ARRAY[NULL, NULL]::int[]))
 ----
 NULL
 
@@ -358,7 +358,7 @@ SELECT * FROM abc WHERE a > ALL(SELECT * FROM unnest(ARRAY[1, NULL]))
 ----
 
 query III
-SELECT * FROM abc WHERE a > ALL(SELECT * FROM unnest(ARRAY[NULL, NULL]))
+SELECT * FROM abc WHERE a > ALL(SELECT * FROM unnest(ARRAY[NULL, NULL]::int[]))
 ----
 
 query error unsupported comparison operator: <int> = ALL <tuple\{string\}>

--- a/pkg/sql/opt/exec/execbuilder/testdata/scalar
+++ b/pkg/sql/opt/exec/execbuilder/testdata/scalar
@@ -1189,3 +1189,22 @@ vectorized: true
   estimated row count: 330 (missing stats)
   table: t0@t0_c0_key
   spans: /!NULL-/-1/PrefixEnd
+
+# Regression test for #57959. This should not cause an error due to
+# "comparison overload not found".
+query T
+EXPLAIN (VERBOSE) SELECT * FROM t0 WHERE (CASE WHEN (t0.c0) IN (t0.c0) THEN ARRAY[NULL] ELSE ARRAY[] END) IS NULL
+----
+distribution: local
+vectorized: true
+·
+• filter
+│ columns: (c0)
+│ estimated row count: 333 (missing stats)
+│ filter: CASE WHEN c0 IN (c0,) THEN ARRAY[NULL] ELSE ARRAY[] END IS NULL
+│
+└── • scan
+      columns: (c0)
+      estimated row count: 1,000 (missing stats)
+      table: t0@primary
+      spans: FULL SCAN

--- a/pkg/sql/opt/optbuilder/testdata/scalar
+++ b/pkg/sql/opt/optbuilder/testdata/scalar
@@ -1397,3 +1397,21 @@ build-scalar vars=(a geometry[], b geometry)
 a && b
 ----
 error: unsupported comparison operator: <geometry[]> && <geometry>
+
+# Regression test for #57959. Ensure that the CASE statement is typed as
+# string[].
+build-scalar vars=(a varbit)
+(CASE WHEN (a) IN (a) THEN ARRAY[NULL] ELSE ARRAY[] END) IS NULL
+----
+is [type=bool]
+ ├── case [type=string[]]
+ │    ├── true [type=bool]
+ │    ├── when [type=string[]]
+ │    │    ├── in [type=bool]
+ │    │    │    ├── variable: a:1 [type=varbit]
+ │    │    │    └── tuple [type=tuple{varbit}]
+ │    │    │         └── variable: a:1 [type=varbit]
+ │    │    └── array: [type=string[]]
+ │    │         └── null [type=unknown]
+ │    └── array: [type=string[]]
+ └── null [type=unknown]

--- a/pkg/sql/parser/parse.go
+++ b/pkg/sql/parser/parse.go
@@ -447,6 +447,10 @@ func arrayOf(
 	// If the reference is a statically known type, then return an array type,
 	// rather than an array type reference.
 	if typ, ok := tree.GetStaticallyKnownType(ref); ok {
+		// Do not allow type unknown[]. This is consistent with Postgres' behavior.
+		if typ.Family() == types.UnknownFamily {
+			return nil, pgerror.Newf(pgcode.UndefinedObject, "type unknown[] does not exist")
+		}
 		if err := types.CheckArrayElementType(typ); err != nil {
 			return nil, err
 		}

--- a/pkg/sql/parser/testdata/errors
+++ b/pkg/sql/parser/testdata/errors
@@ -741,3 +741,11 @@ at or near "detached": syntax error: detached option specified multiple times
 DETAIL: source SQL:
 RESTORE foo FROM 'bar' WITH detached, skip_missing_views, detached
                                                           ^
+
+error
+SELECT ARRAY[]::unknown[]
+----
+at or near "EOF": syntax error: type unknown[] does not exist
+DETAIL: source SQL:
+SELECT ARRAY[]::unknown[]
+                         ^

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -2315,7 +2315,7 @@ func addPGTypeRow(
 			typElem = tree.NewDOid(tree.DInt(typ.ArrayContents().Oid()))
 		}
 	default:
-		typArray = tree.NewDOid(tree.DInt(types.MakeArray(typ).Oid()))
+		typArray = tree.NewDOid(tree.DInt(types.CalcArrayOid(typ)))
 	}
 	if typ.Family() == types.EnumFamily {
 		builtinPrefix = "enum_"

--- a/pkg/sql/sem/tree/type_check_test.go
+++ b/pkg/sql/sem/tree/type_check_test.go
@@ -96,7 +96,7 @@ func TestTypeCheck(t *testing.T) {
 		{`count(3)`, `count(3:::INT8)`},
 		{`ARRAY['a', 'b', 'c']`, `ARRAY['a':::STRING, 'b':::STRING, 'c':::STRING]:::STRING[]`},
 		{`ARRAY[1.5, 2.5, 3.5]`, `ARRAY[1.5:::DECIMAL, 2.5:::DECIMAL, 3.5:::DECIMAL]:::DECIMAL[]`},
-		{`ARRAY[NULL]`, `ARRAY[NULL]`},
+		{`ARRAY[NULL]`, `ARRAY[NULL]:::STRING[]`},
 		{`ARRAY[NULL]:::int[]`, `ARRAY[NULL]:::INT8[]`},
 		{`ARRAY[NULL, NULL]:::int[]`, `ARRAY[NULL, NULL]:::INT8[]`},
 		{`ARRAY[]::INT8[]`, `ARRAY[]:::INT8[]`},

--- a/pkg/sql/types/oid.go
+++ b/pkg/sql/types/oid.go
@@ -180,9 +180,9 @@ func init() {
 	}
 }
 
-// calcArrayOid returns the OID of the array type having elements of the given
+// CalcArrayOid returns the OID of the array type having elements of the given
 // type.
-func calcArrayOid(elemTyp *T) oid.Oid {
+func CalcArrayOid(elemTyp *T) oid.Oid {
 	o := elemTyp.Oid()
 	switch elemTyp.Family() {
 	case ArrayFamily:

--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -1056,9 +1056,14 @@ func MakeEnum(typeOID, arrayTypeOID oid.Oid) *T {
 // MakeArray constructs a new instance of an ArrayFamily type with the given
 // element type (which may itself be an ArrayFamily type).
 func MakeArray(typ *T) *T {
+	// Do not make an array of type unknown[]. Follow Postgres' behavior and
+	// convert this to type string[].
+	if typ.Family() == UnknownFamily {
+		typ = String
+	}
 	arr := &T{InternalType: InternalType{
 		Family:        ArrayFamily,
-		Oid:           calcArrayOid(typ),
+		Oid:           CalcArrayOid(typ),
 		ArrayContents: typ,
 		Locale:        &emptyLocale,
 	}}
@@ -2108,7 +2113,7 @@ func (t *T) upgradeType() error {
 				return err
 			}
 			t.InternalType.ArrayContents = &arrayContents
-			t.InternalType.Oid = calcArrayOid(t.ArrayContents())
+			t.InternalType.Oid = CalcArrayOid(t.ArrayContents())
 		}
 
 		// Marshaling/unmarshaling nested arrays is not yet supported.


### PR DESCRIPTION
Prior to this commit, it was possible to create an array with type `unknown[]`,
either by constructing it directly with `ARRAY[NULL]`, or by applying a cast
(e.g., `ARRAY[]::unknown[]`). This could cause issues since many operators do not
have an overload for `unknown[]`. Furthermore, it was incompatible with Postgres.

This commit fixes the problem by disallowing casts to `unknown[]`, and converts
all implicitly created arrays with type `unknown[]` to `string[]`. Casts to
`unknown[]` such as `ARRAY[]::unknown[]` now fail with "ERROR:  type "unknown[]"
does not exist", just like in Postgres. And `ARRAY[NULL]` now has type `string[]`,
just like in Postgres.

Fixes #57959

Release note (bug fix): Fixed an internal error that could occur when
`ARRAY[NULL]` was used in a query due to incorrect typing. `ARRAY[NULL]` is now
typed as `string[]` if the type cannot be otherwise inferred from the context.
This is the same logic that Postgres uses, thus improving compatibility in
addition to fixing the internal error.

Release note (sql change): Casts to type `unknown[]` are no longer accepted in
CockroachDB. Any such casts will fail to parse and return the error "ERROR:
type "unknown[]" does not exist". This is consistent with Postgres' behavior.