### PR TITLE
release-20.2: sql: set running status for GC jobs

### DIFF
--- a/pkg/sql/gcjob_test/gc_job_test.go
+++ b/pkg/sql/gcjob_test/gc_job_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkeys"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -168,6 +169,7 @@ func TestSchemaChangeGCJob(t *testing.T) {
 				DescriptorIDs: descpb.IDs{myTableID},
 				Details:       details,
 				Progress:      jobspb.SchemaChangeGCProgress{},
+				RunningStatus: sql.RunningStatusWaitingGC,
 				NonCancelable: true,
 			}
 
@@ -187,7 +189,7 @@ func TestSchemaChangeGCJob(t *testing.T) {
 
 			// Check that the job started.
 			jobIDStr := strconv.Itoa(int(*job.ID()))
-			if err := jobutils.VerifySystemJob(t, sqlDB, 0, jobspb.TypeSchemaChangeGC, jobs.StatusRunning, lookupJR); err != nil {
+			if err := jobutils.VerifyRunningSystemJob(t, sqlDB, 0, jobspb.TypeSchemaChangeGC, sql.RunningStatusWaitingGC, lookupJR); err != nil {
 				t.Fatal(err)
 			}
 
@@ -276,12 +278,14 @@ SELECT parent_id, table_id
 	// Now we should be able to find our GC job
 	var jobID int64
 	var status jobs.Status
+	var runningStatus jobs.RunningStatus
 	sqlDB.QueryRow(t, `
-SELECT job_id, status
+SELECT job_id, status, running_status
   FROM crdb_internal.jobs
  WHERE description LIKE 'GC for DROP TABLE db.public.foo';
-`).Scan(&jobID, &status)
+`).Scan(&jobID, &status, &runningStatus)
 	require.Equal(t, jobs.StatusRunning, status)
+	require.Equal(t, sql.RunningStatusWaitingGC, runningStatus)
 
 	// Manually delete the table.
 	require.NoError(t, kvDB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -75,8 +75,8 @@ WHERE job_type = 'SCHEMA CHANGE' OR job_type = 'SCHEMA CHANGE GC'
 ORDER BY created DESC
 LIMIT 2
 ----
-SCHEMA CHANGE GC  GC for ROLLBACK of ALTER TABLE test.public.t ADD CONSTRAINT bar UNIQUE (c)  root  running   NULL  0.00
-SCHEMA CHANGE     ALTER TABLE test.public.t ADD CONSTRAINT bar UNIQUE (c)                     root  failed    NULL  0.00
+SCHEMA CHANGE GC  GC for ROLLBACK of ALTER TABLE test.public.t ADD CONSTRAINT bar UNIQUE (c)  root  running  waiting for GC TTL  0.00
+SCHEMA CHANGE     ALTER TABLE test.public.t ADD CONSTRAINT bar UNIQUE (c)                     root  failed   NULL                0.00
 
 query IIII colnames,rowsort
 SELECT * FROM t
@@ -196,8 +196,8 @@ WHERE job_type = 'SCHEMA CHANGE' OR job_type = 'SCHEMA CHANGE GC'
 ORDER BY created DESC
 LIMIT 2
 ----
-SCHEMA CHANGE GC  GC for DROP INDEX test.public.t@foo CASCADE  root  running    NULL  0  ·
-SCHEMA CHANGE     DROP INDEX test.public.t@foo CASCADE         root  succeeded  NULL  1  ·
+SCHEMA CHANGE GC  GC for DROP INDEX test.public.t@foo CASCADE  root  running    waiting for GC TTL  0  ·
+SCHEMA CHANGE     DROP INDEX test.public.t@foo CASCADE         root  succeeded  NULL                1  ·
 
 query TTBITTBB colnames
 SHOW INDEXES FROM t
@@ -278,8 +278,8 @@ WHERE job_type = 'SCHEMA CHANGE' OR job_type = 'SCHEMA CHANGE GC'
 ORDER BY created DESC
 LIMIT 2
 ----
-SCHEMA CHANGE GC  GC for DROP INDEX test.public.t@t_f_idx   root  running    NULL  0  ·
-SCHEMA CHANGE     DROP INDEX test.public.t@t_f_idx          root  succeeded  NULL  1  ·
+SCHEMA CHANGE GC  GC for DROP INDEX test.public.t@t_f_idx  root  running    waiting for GC TTL  0  ·
+SCHEMA CHANGE     DROP INDEX test.public.t@t_f_idx         root  succeeded  NULL                1  ·
 
 statement ok
 ALTER TABLE t DROP COLUMN f

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -1820,6 +1820,7 @@ func CreateGCJobRecord(
 		DescriptorIDs: descriptorIDs,
 		Details:       details,
 		Progress:      jobspb.SchemaChangeGCProgress{},
+		RunningStatus: RunningStatusWaitingGC,
 		NonCancelable: true,
 	}
 }


### PR DESCRIPTION
Backport 1/1 commits from #58612.

/cc @cockroachdb/release

---

Previously GC jobs didn't populate their RunningStatus leaving users
confused. This change addresses this by setting it to
sql.RunningStatusWaitingGC, as it was pre-20.1

Fixes #57826.

Release note (bug fix): GC jobs now populate the running_status column
for SHOW JOBS. This bug has been present since v20.1.
