### PR TITLE
release 20.2: backupccl: skip flaky progress test

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -1367,6 +1367,8 @@ func TestBackupRestoreSystemJobsProgress(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	defer jobs.TestingSetProgressThresholds()()
 
+	skip.WithIssue(t, 58427, "flaky test")
+
 	checkFraction := func(ctx context.Context, ip inProgressState) error {
 		jobID, err := ip.latestJobID()
 		if err != nil {


### PR DESCRIPTION
This flake should be resolved by https://github.com/cockroachdb/cockroach/pull/58663, but that PR needs a bit of massaging, so skipping it in the interim.

Release note: None