### PR TITLE
ui: upgrade admin-ui-components to new dep

### DIFF
--- a/pkg/ui/ccl/src/views/clusterviz/containers/map/breadcrumbs.tsx
+++ b/pkg/ui/ccl/src/views/clusterviz/containers/map/breadcrumbs.tsx
@@ -12,7 +12,7 @@ import { Link } from "react-router-dom";
 
 import { generateLocalityRoute } from "src/util/localities";
 import { LocalityTier } from "src/redux/localities";
-import { util } from "@cockroachlabs/admin-ui-components";
+import { util } from "@cockroachlabs/cluster-ui";
 import { getLocalityLabel } from "src/util/localities";
 import mapPinIcon from "!!raw-loader!assets/mapPin.svg";
 import { trustIcon } from "src/util/trust";

--- a/pkg/ui/ccl/src/views/clusterviz/containers/map/index.tsx
+++ b/pkg/ui/ccl/src/views/clusterviz/containers/map/index.tsx
@@ -17,7 +17,7 @@ import NodeCanvasContainer from "src/views/clusterviz/containers/map/nodeCanvasC
 import TimeScaleDropdown from "src/views/cluster/containers/timescale";
 import swapByLicense from "src/views/shared/containers/licenseSwap";
 import { parseLocalityRoute } from "src/util/localities";
-import { Loading } from "@cockroachlabs/admin-ui-components";
+import { Loading } from "@cockroachlabs/cluster-ui";
 import { AdminUIState } from "src/redux/state";
 import { selectEnterpriseEnabled } from "src/redux/license";
 import { Dropdown } from "src/components/dropdown";

--- a/pkg/ui/ccl/src/views/clusterviz/containers/map/nodeCanvasContainer.tsx
+++ b/pkg/ui/ccl/src/views/clusterviz/containers/map/nodeCanvasContainer.tsx
@@ -40,7 +40,7 @@ import {
 import { AdminUIState } from "src/redux/state";
 import { CLUSTERVIZ_ROOT } from "src/routes/visualization";
 import { getLocality } from "src/util/localities";
-import { Loading } from "@cockroachlabs/admin-ui-components";
+import { Loading } from "@cockroachlabs/cluster-ui";
 import { NodeCanvas } from "./nodeCanvas";
 
 type Liveness = cockroach.kv.kvserver.liveness.livenesspb.ILiveness;

--- a/pkg/ui/package.json
+++ b/pkg/ui/package.json
@@ -15,7 +15,7 @@
     "cypress:update-snapshots": "yarn cypress run --env updateSnapshots=true --spec 'cypress/integration/**/*.visual.spec.ts'"
   },
   "dependencies": {
-    "@cockroachlabs/admin-ui-components": "^0.1.37",
+    "@cockroachlabs/cluster-ui": "^0.1.38",
     "analytics-node": "^3.4.0-beta.1",
     "antd": "^3.25.2",
     "babel-polyfill": "^6.26.0",

--- a/pkg/ui/src/app.spec.tsx
+++ b/pkg/ui/src/app.spec.tsx
@@ -32,10 +32,7 @@ import {
 } from "src/views/databases/containers/databases";
 import { TableMain } from "src/views/databases/containers/tableDetails";
 import { DataDistributionPage } from "src/views/cluster/containers/dataDistribution";
-import {
-  StatementsPage,
-  StatementDetails,
-} from "@cockroachlabs/admin-ui-components";
+import { StatementsPage, StatementDetails } from "@cockroachlabs/cluster-ui";
 import Debug from "src/views/reports/containers/debug";
 import { ReduxDebug } from "src/views/reports/containers/redux";
 import { CustomChart } from "src/views/reports/containers/customChart";

--- a/pkg/ui/src/redux/nodes.ts
+++ b/pkg/ui/src/redux/nodes.ts
@@ -13,7 +13,7 @@ import { createSelector } from "reselect";
 
 import * as protos from "src/js/protos";
 import { AdminUIState } from "./state";
-import { util } from "@cockroachlabs/admin-ui-components";
+import { util } from "@cockroachlabs/cluster-ui";
 import { Pick } from "src/util/pick";
 import { NoConnection } from "src/views/reports/containers/network";
 import { nullOfReturnType } from "src/util/types";

--- a/pkg/ui/src/views/cluster/containers/dataDistribution/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/dataDistribution/index.tsx
@@ -15,7 +15,7 @@ import { connect } from "react-redux";
 import Helmet from "react-helmet";
 import { withRouter } from "react-router-dom";
 
-import { Loading } from "@cockroachlabs/admin-ui-components";
+import { Loading } from "@cockroachlabs/cluster-ui";
 import { ToolTipWrapper } from "src/views/shared/components/toolTip";
 import * as docsURL from "src/util/docs";
 import { FixLong } from "src/util/fixLong";

--- a/pkg/ui/src/views/cluster/containers/events/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/events/index.tsx
@@ -29,7 +29,7 @@ import { DATE_FORMAT } from "src/util/format";
 import { SortSetting } from "src/views/shared/components/sortabletable";
 import { SortedTable } from "src/views/shared/components/sortedtable";
 import { ToolTipWrapper } from "src/views/shared/components/toolTip";
-import { Loading } from "@cockroachlabs/admin-ui-components";
+import { Loading } from "@cockroachlabs/cluster-ui";
 import "./events.styl";
 
 type Event$Properties = protos.cockroach.server.serverpb.EventsResponse.IEvent;

--- a/pkg/ui/src/views/cluster/containers/nodeLogs/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeLogs/index.tsx
@@ -25,7 +25,7 @@ import { refreshLogs, refreshNodes } from "src/redux/apiReducers";
 import { currentNode } from "src/views/cluster/containers/nodeOverview";
 import { CachedDataReducerState } from "src/redux/cachedDataReducer";
 import { getDisplayName } from "src/redux/nodes";
-import { Loading } from "@cockroachlabs/admin-ui-components";
+import { Loading } from "@cockroachlabs/cluster-ui";
 import { getMatchParamByName } from "src/util/query";
 import "./logs.styl";
 

--- a/pkg/ui/src/views/cluster/containers/nodeOverview/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeOverview/index.tsx
@@ -33,7 +33,7 @@ import {
   SummaryLabel,
   SummaryValue,
 } from "src/views/shared/components/summaryBar";
-import { Button } from "@cockroachlabs/admin-ui-components";
+import { Button } from "@cockroachlabs/cluster-ui";
 import { ArrowLeft } from "@cockroachlabs/icons";
 import "./nodeOverview.styl";
 import {

--- a/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
@@ -29,7 +29,7 @@ import { SortSetting } from "src/views/shared/components/sortabletable";
 import { LongToMoment } from "src/util/convert";
 import { INodeStatus, MetricConstants } from "src/util/proto";
 import { Text, TextTypes, Tooltip, Badge, BadgeProps } from "src/components";
-import { ColumnsConfig, Table } from "@cockroachlabs/admin-ui-components";
+import { ColumnsConfig, Table } from "@cockroachlabs/cluster-ui";
 import { Percentage } from "src/util/format";
 import { FixLong } from "src/util/fixLong";
 import { getNodeLocalityTiers } from "src/util/localities";
@@ -155,7 +155,6 @@ const getBadgeTypeByNodeStatus = (
   }
 };
 
-// tslint:disable-next-line:variable-name
 const NodeNameColumn: React.FC<{
   record: NodeStatusRow | DecommissionedNodeStatusRow;
 }> = ({ record }) => {
@@ -167,7 +166,6 @@ const NodeNameColumn: React.FC<{
   );
 };
 
-// tslint:disable-next-line:variable-name
 const NodeLocalityColumn: React.FC<{ record: NodeStatusRow }> = ({
   record,
 }) => {
@@ -601,7 +599,6 @@ export const decommissionedNodesTableDataSelector = createSelector(
 /**
  * LiveNodesConnected is a redux-connected HOC of LiveNodeList.
  */
-// tslint:disable-next-line:variable-name
 const NodesConnected = connect(
   (state: AdminUIState) => {
     const liveNodes = partitionedStatuses(state).live || [];
@@ -621,7 +618,6 @@ const NodesConnected = connect(
 /**
  * DecommissionedNodesConnected is a redux-connected HOC of NotLiveNodeList.
  */
-// tslint:disable-next-line:variable-name
 const DecommissionedNodesConnected = connect(
   (state: AdminUIState) => {
     return {

--- a/pkg/ui/src/views/databases/containers/databases/nonTableSummary.spec.tsx
+++ b/pkg/ui/src/views/databases/containers/databases/nonTableSummary.spec.tsx
@@ -18,7 +18,7 @@ import "src/enzymeInit";
 import { NonTableSummary } from "./nonTableSummary";
 import { refreshNonTableStats } from "src/redux/apiReducers";
 import { cockroach } from "src/js/protos";
-import { Loading } from "@cockroachlabs/admin-ui-components";
+import { Loading } from "@cockroachlabs/cluster-ui";
 import NonTableStatsResponse = cockroach.server.serverpb.NonTableStatsResponse;
 
 describe("NonTableSummary", () => {

--- a/pkg/ui/src/views/databases/containers/databases/nonTableSummary.tsx
+++ b/pkg/ui/src/views/databases/containers/databases/nonTableSummary.tsx
@@ -15,7 +15,7 @@ import { refreshNonTableStats } from "src/redux/apiReducers";
 import { AdminUIState } from "src/redux/state";
 import { FixLong } from "src/util/fixLong";
 import { Bytes } from "src/util/format";
-import { Loading } from "@cockroachlabs/admin-ui-components";
+import { Loading } from "@cockroachlabs/cluster-ui";
 import { CachedDataReducerState } from "src/redux/cachedDataReducer";
 import { NonTableStatsResponseMessage } from "src/util/api";
 import { TimeSeriesTooltip } from "src/views/databases/containers/databases/tooltips";

--- a/pkg/ui/src/views/databases/containers/tableDetails/index.tsx
+++ b/pkg/ui/src/views/databases/containers/tableDetails/index.tsx
@@ -31,7 +31,7 @@ import { SortedTable } from "src/views/shared/components/sortedtable";
 const { TabPane } = Tabs;
 import { getMatchParamByName } from "src/util/query";
 import { databaseDetails } from "../databaseSummary";
-import { Button } from "@cockroachlabs/admin-ui-components";
+import { Button } from "@cockroachlabs/cluster-ui";
 import { ArrowLeft } from "@cockroachlabs/icons";
 import SqlBox from "src/views/shared/components/sql/box";
 

--- a/pkg/ui/src/views/jobs/index.tsx
+++ b/pkg/ui/src/views/jobs/index.tsx
@@ -20,7 +20,7 @@ import { CachedDataReducerState } from "src/redux/cachedDataReducer";
 import { LocalSetting } from "src/redux/localsettings";
 import { AdminUIState } from "src/redux/state";
 import Dropdown, { DropdownOption } from "src/views/shared/components/dropdown";
-import { Loading } from "@cockroachlabs/admin-ui-components";
+import { Loading } from "@cockroachlabs/cluster-ui";
 import {
   PageConfig,
   PageConfigItem,

--- a/pkg/ui/src/views/jobs/jobDetails.tsx
+++ b/pkg/ui/src/views/jobs/jobDetails.tsx
@@ -24,14 +24,14 @@ import {
 import { AdminUIState } from "src/redux/state";
 import { getMatchParamByName } from "src/util/query";
 import { showSetting, statusSetting, typeSetting } from ".";
-import { Loading } from "@cockroachlabs/admin-ui-components";
+import { Loading } from "@cockroachlabs/cluster-ui";
 import SqlBox from "../shared/components/sql/box";
 import { SummaryCard } from "../shared/components/summaryCard";
 
 import Job = cockroach.server.serverpb.JobsResponse.IJob;
 import JobsRequest = cockroach.server.serverpb.JobsRequest;
 import JobsResponse = cockroach.server.serverpb.JobsResponse;
-import { Button } from "@cockroachlabs/admin-ui-components";
+import { Button } from "@cockroachlabs/cluster-ui";
 import { ArrowLeft } from "@cockroachlabs/icons";
 import { DATE_FORMAT } from "src/util/format";
 import { JobStatusCell } from "./jobStatusCell";

--- a/pkg/ui/src/views/jobs/jobTable.tsx
+++ b/pkg/ui/src/views/jobs/jobTable.tsx
@@ -23,13 +23,10 @@ import { isEqual, map } from "lodash";
 import { JobDescriptionCell } from "src/views/jobs/jobDescriptionCell";
 import Job = cockroach.server.serverpb.JobsResponse.IJob;
 import JobsResponse = cockroach.server.serverpb.JobsResponse;
-import {
-  Pagination,
-  ResultsPerPageLabel,
-} from "@cockroachlabs/admin-ui-components";
+import { Pagination, ResultsPerPageLabel } from "@cockroachlabs/cluster-ui";
 import { jobTable } from "src/util/docs";
 import { trackDocsLink } from "src/util/analytics";
-import { EmptyTable } from "@cockroachlabs/admin-ui-components";
+import { EmptyTable } from "@cockroachlabs/cluster-ui";
 import { Anchor } from "src/components";
 import emptyTableResultsIcon from "assets/emptyState/empty-table-results.svg";
 import magnifyingGlassIcon from "assets/emptyState/magnifying-glass.svg";

--- a/pkg/ui/src/views/reports/containers/certificates/index.tsx
+++ b/pkg/ui/src/views/reports/containers/certificates/index.tsx
@@ -22,7 +22,7 @@ import {
 import { AdminUIState } from "src/redux/state";
 import { nodeIDAttr } from "src/util/constants";
 import { LongToMoment } from "src/util/convert";
-import { Loading } from "@cockroachlabs/admin-ui-components";
+import { Loading } from "@cockroachlabs/cluster-ui";
 import { getMatchParamByName } from "src/util/query";
 
 interface CertificatesOwnProps {

--- a/pkg/ui/src/views/reports/containers/localities/index.tsx
+++ b/pkg/ui/src/views/reports/containers/localities/index.tsx
@@ -29,7 +29,7 @@ import { selectNodeRequestStatus } from "src/redux/nodes";
 import { AdminUIState } from "src/redux/state";
 import { getNodeLocalityTiers } from "src/util/localities";
 import { findMostSpecificLocation, hasLocation } from "src/util/locations";
-import { Loading } from "@cockroachlabs/admin-ui-components";
+import { Loading } from "@cockroachlabs/cluster-ui";
 import "./localities.styl";
 import { CachedDataReducerState } from "src/redux/cachedDataReducer";
 

--- a/pkg/ui/src/views/reports/containers/network/index.tsx
+++ b/pkg/ui/src/views/reports/containers/network/index.tsx
@@ -35,7 +35,7 @@ import {
   NodeFilterList,
   NodeFilterListProps,
 } from "src/views/reports/components/nodeFilterList";
-import { Loading } from "@cockroachlabs/admin-ui-components";
+import { Loading } from "@cockroachlabs/cluster-ui";
 import { Latency } from "./latency";
 import { Legend } from "./legend";
 import Sort from "./sort";

--- a/pkg/ui/src/views/reports/containers/nodeHistory/decommissionedNodeHistory.tsx
+++ b/pkg/ui/src/views/reports/containers/nodeHistory/decommissionedNodeHistory.tsx
@@ -25,7 +25,7 @@ import { LocalSetting } from "src/redux/localsettings";
 
 import "./decommissionedNodeHistory.styl";
 import { Text } from "src/components";
-import { ColumnsConfig, Table } from "@cockroachlabs/admin-ui-components";
+import { ColumnsConfig, Table } from "@cockroachlabs/cluster-ui";
 import { createSelector } from "reselect";
 
 const decommissionedNodesSortSetting = new LocalSetting<

--- a/pkg/ui/src/views/reports/containers/problemRanges/index.tsx
+++ b/pkg/ui/src/views/reports/containers/problemRanges/index.tsx
@@ -24,7 +24,7 @@ import { AdminUIState } from "src/redux/state";
 import { nodeIDAttr } from "src/util/constants";
 import { FixLong } from "src/util/fixLong";
 import ConnectionsTable from "src/views/reports/containers/problemRanges/connectionsTable";
-import { Loading } from "@cockroachlabs/admin-ui-components";
+import { Loading } from "@cockroachlabs/cluster-ui";
 import { getMatchParamByName } from "src/util/query";
 
 type NodeProblems$Properties = protos.cockroach.server.serverpb.ProblemRangesResponse.INodeProblems;

--- a/pkg/ui/src/views/reports/containers/range/allocator.tsx
+++ b/pkg/ui/src/views/reports/containers/range/allocator.tsx
@@ -15,7 +15,7 @@ import * as protos from "src/js/protos";
 import { CachedDataReducerState } from "src/redux/cachedDataReducer";
 import { REMOTE_DEBUGGING_ERROR_TEXT } from "src/util/constants";
 import Print from "src/views/reports/containers/range/print";
-import { Loading } from "@cockroachlabs/admin-ui-components";
+import { Loading } from "@cockroachlabs/cluster-ui";
 
 interface AllocatorOutputProps {
   allocator: CachedDataReducerState<protos.cockroach.server.serverpb.AllocatorRangeResponse>;

--- a/pkg/ui/src/views/reports/containers/range/connectionsTable.tsx
+++ b/pkg/ui/src/views/reports/containers/range/connectionsTable.tsx
@@ -14,7 +14,7 @@ import React from "react";
 
 import * as protos from "src/js/protos";
 import { CachedDataReducerState } from "src/redux/cachedDataReducer";
-import { Loading } from "@cockroachlabs/admin-ui-components";
+import { Loading } from "@cockroachlabs/cluster-ui";
 
 interface ConnectionsTableProps {
   range: CachedDataReducerState<protos.cockroach.server.serverpb.RangeResponse>;

--- a/pkg/ui/src/views/reports/containers/range/logTable.tsx
+++ b/pkg/ui/src/views/reports/containers/range/logTable.tsx
@@ -15,7 +15,7 @@ import * as protos from "src/js/protos";
 import { CachedDataReducerState } from "src/redux/cachedDataReducer";
 import { FixLong } from "src/util/fixLong";
 import Print from "src/views/reports/containers/range/print";
-import { Loading } from "@cockroachlabs/admin-ui-components";
+import { Loading } from "@cockroachlabs/cluster-ui";
 import { TimestampToMoment } from "src/util/convert";
 
 interface LogTableProps {

--- a/pkg/ui/src/views/reports/containers/settings/index.tsx
+++ b/pkg/ui/src/views/reports/containers/settings/index.tsx
@@ -17,7 +17,7 @@ import { withRouter } from "react-router-dom";
 import * as protos from "src/js/protos";
 import { refreshSettings } from "src/redux/apiReducers";
 import { AdminUIState } from "src/redux/state";
-import { Loading } from "@cockroachlabs/admin-ui-components";
+import { Loading } from "@cockroachlabs/cluster-ui";
 import "./index.styl";
 import { CachedDataReducerState } from "src/redux/cachedDataReducer";
 

--- a/pkg/ui/src/views/reports/containers/statementDiagnosticsHistory/index.tsx
+++ b/pkg/ui/src/views/reports/containers/statementDiagnosticsHistory/index.tsx
@@ -52,7 +52,7 @@ import {
   EmptyTable,
   shortStatement,
   getDiagnosticsStatus,
-} from "@cockroachlabs/admin-ui-components";
+} from "@cockroachlabs/cluster-ui";
 
 type StatementDiagnosticsHistoryViewProps = MapStateToProps &
   MapDispatchToProps;

--- a/pkg/ui/src/views/reports/containers/stores/index.tsx
+++ b/pkg/ui/src/views/reports/containers/stores/index.tsx
@@ -20,7 +20,7 @@ import { storesRequestKey, refreshStores } from "src/redux/apiReducers";
 import { AdminUIState } from "src/redux/state";
 import { nodeIDAttr } from "src/util/constants";
 import EncryptionStatus from "src/views/reports/containers/stores/encryption";
-import { Loading } from "@cockroachlabs/admin-ui-components";
+import { Loading } from "@cockroachlabs/cluster-ui";
 import { getMatchParamByName } from "src/util/query";
 
 interface StoresOwnProps {

--- a/pkg/ui/src/views/sessions/sessionDetails.tsx
+++ b/pkg/ui/src/views/sessions/sessionDetails.tsx
@@ -19,11 +19,7 @@ import { SessionsResponseMessage } from "src/util/api";
 import { connect } from "react-redux";
 import { CachedDataReducerState, refreshSessions } from "src/redux/apiReducers";
 import { nodeDisplayNameByIDSelector } from "src/redux/nodes";
-
-import {
-  SessionDetails,
-  byteArrayToUuid,
-} from "@cockroachlabs/admin-ui-components";
+import { SessionDetails, byteArrayToUuid } from "@cockroachlabs/cluster-ui";
 import { terminateQueryAction } from "src/redux/sessions/sessionsSagas";
 
 type SessionsState = Pick<AdminUIState, "cachedData", "sessions">;
@@ -46,7 +42,6 @@ export const selectSession = createSelector(
     };
   },
 );
-// tslint:disable-next-line:variable-name
 const SessionDetailsPageConnected = withRouter(
   connect(
     (state: AdminUIState, props: RouteComponentProps) => ({

--- a/pkg/ui/src/views/sessions/sessionsPage.tsx
+++ b/pkg/ui/src/views/sessions/sessionsPage.tsx
@@ -17,7 +17,7 @@ import { CachedDataReducerState, refreshSessions } from "src/redux/apiReducers";
 import { createSelector } from "reselect";
 import { SessionsResponseMessage } from "src/util/api";
 
-import { SessionsPage } from "@cockroachlabs/admin-ui-components";
+import { SessionsPage } from "@cockroachlabs/cluster-ui";
 import { terminateQueryAction } from "src/redux/sessions/sessionsSagas";
 
 type SessionsState = Pick<AdminUIState, "cachedData", "sessions">;
@@ -38,7 +38,6 @@ export const selectSessions = createSelector(
   },
 );
 
-// tslint:disable-next-line:variable-name
 const SessionsPageConnected = withRouter(
   connect(
     (state: AdminUIState, props: RouteComponentProps) => ({

--- a/pkg/ui/src/views/shared/components/sortabletable/index.tsx
+++ b/pkg/ui/src/views/shared/components/sortabletable/index.tsx
@@ -287,7 +287,7 @@ export class SortableTable extends React.Component<TableProps> {
                   classes.push(cx("sort-table__cell--sortable"));
                   onClick = () => {
                     // TODO (koorosh): `title` field has ReactNode type isn't correct field to
-                    // track column name. `SortableColumn` has to be imported from `@cockroachlabs/admin-ui-components`
+                    // track column name. `SortableColumn` has to be imported from `@cockroachlabs/cluster-ui`
                     // package which has extended field to track column name.
                     trackTableSort(
                       className,

--- a/pkg/ui/src/views/statements/statementDetails.tsx
+++ b/pkg/ui/src/views/statements/statementDetails.tsx
@@ -38,7 +38,7 @@ import {
   StatementDetailsStateProps,
   StatementDetailsProps,
   AggregateStatistics,
-} from "@cockroachlabs/admin-ui-components";
+} from "@cockroachlabs/cluster-ui";
 import { createStatementDiagnosticsReportAction } from "src/redux/statements";
 import { createStatementDiagnosticsAlertLocalSetting } from "src/redux/alerts";
 import {

--- a/pkg/ui/src/views/statements/statementsPage.fixture.ts
+++ b/pkg/ui/src/views/statements/statementsPage.fixture.ts
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import { StatementsPageProps } from "@cockroachlabs/admin-ui-components";
+import { StatementsPageProps } from "@cockroachlabs/cluster-ui";
 import { createMemoryHistory } from "history";
 import Long from "long";
 import * as protos from "src/js/protos";

--- a/pkg/ui/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/src/views/statements/statementsPage.tsx
@@ -33,10 +33,7 @@ import { selectDiagnosticsReportsPerStatement } from "src/redux/statements/state
 import { createStatementDiagnosticsAlertLocalSetting } from "src/redux/alerts";
 import { getMatchParamByName } from "src/util/query";
 
-import {
-  StatementsPage,
-  AggregateStatistics,
-} from "@cockroachlabs/admin-ui-components";
+import { StatementsPage, AggregateStatistics } from "@cockroachlabs/cluster-ui";
 import {
   createOpenDiagnosticsModalAction,
   createStatementDiagnosticsReportAction,

--- a/pkg/ui/src/views/transactions/transactionsPage.tsx
+++ b/pkg/ui/src/views/transactions/transactionsPage.tsx
@@ -19,7 +19,7 @@ import { StatementsResponseMessage } from "src/util/api";
 import { TimestampToMoment } from "src/util/convert";
 import { PrintTime } from "src/views/reports/containers/range/print";
 
-import { TransactionsPage } from "@cockroachlabs/admin-ui-components";
+import { TransactionsPage } from "@cockroachlabs/cluster-ui";
 
 // selectStatements returns the array of AggregateStatistics to show on the
 // TransactionsPage, based on if the appAttr route parameter is set.

--- a/pkg/ui/yarn.lock
+++ b/pkg/ui/yarn.lock
@@ -1806,10 +1806,10 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@cockroachlabs/admin-ui-components@^0.1.37":
-  version "0.1.37"
-  resolved "https://registry.yarnpkg.com/@cockroachlabs/admin-ui-components/-/admin-ui-components-0.1.37.tgz#0862de4864777e0ddf1201febba24cfbd7f897f8"
-  integrity sha512-tvZ0skbITu4uky9xPxrq5kVXbSgLKikOKqUflH05o/Li8wudoJX4Br71S3lwENeTKlOB2FF3YvXwQYtdDhdB9A==
+"@cockroachlabs/cluster-ui@^0.1.38":
+  version "0.1.39"
+  resolved "https://registry.yarnpkg.com/@cockroachlabs/cluster-ui/-/cluster-ui-0.1.39.tgz#609f7983568b59e8ab0bb82580df47612ea1dfb9"
+  integrity sha512-eMQ76DA+rkFhGVP0sWaWUlPoEdOz8ARCaoniPSAxlqtohRLXm+rl+3PB5OzT+Qcb6w0o6lsH3hiVg1lxrH3fFw==
   dependencies:
     "@cockroachlabs/crdb-protobuf-client" "^0.0.4"
     "@cockroachlabs/icons" "0.3.0"


### PR DESCRIPTION
We renamed the `admin-ui-components` package
to `cluster-ui`.

Release note: None