### PR TITLE
sql: Enable ALTER TABLE ... SET LOCALITY REGIONAL BY TABLE

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/alter_table_locality
+++ b/pkg/ccl/logictestccl/testdata/logic_test/alter_table_locality
@@ -1,0 +1,490 @@
+# LogicTest: multiregion-9node-3region-3azs
+
+statement ok
+CREATE DATABASE alter_locality_test primary region "ca-central-1" regions "ap-southeast-2", "us-east-1"
+
+statement ok
+CREATE TABLE no_table_locality (i int)
+
+statement error cannot alter a table's LOCALITY if its database is not multi-region enabled
+ALTER TABLE no_table_locality SET LOCALITY REGIONAL BY TABLE
+
+statement ok
+ALTER TABLE IF EXISTS table_does_not_exist SET LOCALITY REGIONAL BY TABLE
+
+statement ok
+use alter_locality_test
+
+# Turn on experimental flag to allow REGIONAL BY ROW table creation
+# TODO(#multiregion): remove this once flag is no longer needed for REGIONAL BY ROW tables
+statement ok
+SET experimental_enable_implicit_column_partitioning = true
+
+statement ok
+CREATE TABLE regional_by_row (i int) LOCALITY REGIONAL BY ROW
+
+query TT
+SHOW CREATE TABLE regional_by_row
+----
+regional_by_row  CREATE TABLE public.regional_by_row (
+                 i INT8 NULL,
+                 crdb_region public.crdb_internal_region NOT NULL DEFAULT gateway_region()::public.crdb_internal_region,
+                 CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
+                 FAMILY "primary" (i, crdb_region, rowid)
+) LOCALITY REGIONAL BY ROW;
+ALTER PARTITION "ap-southeast-2" OF INDEX alter_locality_test.public.regional_by_row@primary CONFIGURE ZONE USING
+  num_replicas = 3,
+  constraints = '{+region=ap-southeast-2: 3}',
+  lease_preferences = '[[+region=ap-southeast-2]]';
+ALTER PARTITION "ca-central-1" OF INDEX alter_locality_test.public.regional_by_row@primary CONFIGURE ZONE USING
+  num_replicas = 3,
+  constraints = '{+region=ca-central-1: 3}',
+  lease_preferences = '[[+region=ca-central-1]]';
+ALTER PARTITION "us-east-1" OF INDEX alter_locality_test.public.regional_by_row@primary CONFIGURE ZONE USING
+  num_replicas = 3,
+  constraints = '{+region=us-east-1: 3}',
+  lease_preferences = '[[+region=us-east-1]]'
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE regional_by_row
+----
+DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
+                              range_min_bytes = 134217728,
+                              range_max_bytes = 536870912,
+                              gc.ttlseconds = 90000,
+                              num_replicas = 3,
+                              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                              lease_preferences = '[[+region=ca-central-1]]'
+
+statement ok
+CREATE TABLE regional_by_table_in_primary_region (i int) LOCALITY REGIONAL BY TABLE IN PRIMARY REGION
+
+query TT
+SHOW CREATE TABLE regional_by_table_in_primary_region
+----
+regional_by_table_in_primary_region             CREATE TABLE public.regional_by_table_in_primary_region (
+                                                i INT8 NULL,
+                                                FAMILY "primary" (i, rowid)
+) LOCALITY REGIONAL BY TABLE IN PRIMARY REGION
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE regional_by_table_in_primary_region
+----
+DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
+                              range_min_bytes = 134217728,
+                              range_max_bytes = 536870912,
+                              gc.ttlseconds = 90000,
+                              num_replicas = 3,
+                              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                              lease_preferences = '[[+region=ca-central-1]]'
+
+statement ok
+CREATE TABLE regional_by_table_no_region (i int) LOCALITY REGIONAL BY TABLE
+
+query TT
+SHOW CREATE TABLE regional_by_table_no_region
+----
+regional_by_table_no_region                     CREATE TABLE public.regional_by_table_no_region (
+                                                i INT8 NULL,
+                                                FAMILY "primary" (i, rowid)
+) LOCALITY REGIONAL BY TABLE IN PRIMARY REGION
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE regional_by_table_no_region
+----
+DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
+                              range_min_bytes = 134217728,
+                              range_max_bytes = 536870912,
+                              gc.ttlseconds = 90000,
+                              num_replicas = 3,
+                              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                              lease_preferences = '[[+region=ca-central-1]]'
+
+statement ok
+CREATE TABLE regional_by_table_in_us_east (i int) LOCALITY REGIONAL BY TABLE IN "us-east-1"
+
+query TT
+SHOW CREATE TABLE regional_by_table_in_us_east
+----
+regional_by_table_in_us_east                 CREATE TABLE public.regional_by_table_in_us_east (
+                                             i INT8 NULL,
+                                             FAMILY "primary" (i, rowid)
+) LOCALITY REGIONAL BY TABLE IN "us-east-1"
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE regional_by_table_in_us_east
+----
+TABLE regional_by_table_in_us_east  ALTER TABLE regional_by_table_in_us_east CONFIGURE ZONE USING
+                                    range_min_bytes = 134217728,
+                                    range_max_bytes = 536870912,
+                                    gc.ttlseconds = 90000,
+                                    num_replicas = 3,
+                                    constraints = '{+region=us-east-1: 3}',
+                                    lease_preferences = '[[+region=us-east-1]]'
+
+statement ok
+CREATE TABLE global (i int) LOCALITY GLOBAL
+
+query TT
+SHOW CREATE TABLE global
+----
+global             CREATE TABLE public.global (
+                   i INT8 NULL,
+                   FAMILY "primary" (i, rowid)
+) LOCALITY GLOBAL
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE global
+----
+TABLE global  ALTER TABLE global CONFIGURE ZONE USING
+              range_min_bytes = 134217728,
+              range_max_bytes = 536870912,
+              gc.ttlseconds = 90000,
+              num_replicas = 3,
+              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+              lease_preferences = '[[+region=ca-central-1]]'
+
+statement error unimplemented: implementation pending
+ALTER TABLE regional_by_row SET LOCALITY REGIONAL BY TABLE
+
+statement error unimplemented: implementation pending
+ALTER TABLE regional_by_row SET LOCALITY REGIONAL BY TABLE in "ap-southeast"
+
+statement error unimplemented: implementation pending
+ALTER TABLE regional_by_row SET LOCALITY REGIONAL BY TABLE in PRIMARY REGION
+
+statement error unimplemented: implementation pending
+ALTER TABLE regional_by_row SET LOCALITY GLOBAL
+
+statement error unimplemented: implementation pending
+ALTER TABLE regional_by_row SET LOCALITY REGIONAL BY ROW
+
+query TT
+SHOW CREATE TABLE regional_by_row
+----
+regional_by_row  CREATE TABLE public.regional_by_row (
+                 i INT8 NULL,
+                 crdb_region public.crdb_internal_region NOT NULL DEFAULT gateway_region()::public.crdb_internal_region,
+                 CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
+                 FAMILY "primary" (i, crdb_region, rowid)
+) LOCALITY REGIONAL BY ROW;
+ALTER PARTITION "ap-southeast-2" OF INDEX alter_locality_test.public.regional_by_row@primary CONFIGURE ZONE USING
+  num_replicas = 3,
+  constraints = '{+region=ap-southeast-2: 3}',
+  lease_preferences = '[[+region=ap-southeast-2]]';
+ALTER PARTITION "ca-central-1" OF INDEX alter_locality_test.public.regional_by_row@primary CONFIGURE ZONE USING
+  num_replicas = 3,
+  constraints = '{+region=ca-central-1: 3}',
+  lease_preferences = '[[+region=ca-central-1]]';
+ALTER PARTITION "us-east-1" OF INDEX alter_locality_test.public.regional_by_row@primary CONFIGURE ZONE USING
+  num_replicas = 3,
+  constraints = '{+region=us-east-1: 3}',
+  lease_preferences = '[[+region=us-east-1]]'
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE regional_by_row
+----
+DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
+                              range_min_bytes = 134217728,
+                              range_max_bytes = 536870912,
+                              gc.ttlseconds = 90000,
+                              num_replicas = 3,
+                              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                              lease_preferences = '[[+region=ca-central-1]]'
+
+statement error unimplemented: implementation pending
+ALTER TABLE global SET LOCALITY REGIONAL BY TABLE
+
+statement error unimplemented: implementation pending
+ALTER TABLE global SET LOCALITY REGIONAL BY TABLE in "ap-southeast"
+
+statement error unimplemented: implementation pending
+ALTER TABLE global SET LOCALITY REGIONAL BY TABLE in PRIMARY REGION
+
+statement ok
+ALTER TABLE global SET LOCALITY GLOBAL
+
+query TT
+SHOW CREATE TABLE global
+----
+global             CREATE TABLE public.global (
+                   i INT8 NULL,
+                   FAMILY "primary" (i, rowid)
+) LOCALITY GLOBAL
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE global
+----
+TABLE global  ALTER TABLE global CONFIGURE ZONE USING
+              range_min_bytes = 134217728,
+              range_max_bytes = 536870912,
+              gc.ttlseconds = 90000,
+              num_replicas = 3,
+              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+              lease_preferences = '[[+region=ca-central-1]]'
+
+statement error unimplemented: implementation pending
+ALTER TABLE global SET LOCALITY REGIONAL BY ROW
+
+statement error region "invalid-region" has not been added to database "alter_locality_test"
+ALTER TABLE regional_by_table_in_primary_region SET LOCALITY REGIONAL BY TABLE in "invalid-region"
+
+statement ok
+ALTER TABLE regional_by_table_in_primary_region SET LOCALITY REGIONAL BY TABLE in "ap-southeast-2"
+
+query TT
+SHOW CREATE TABLE regional_by_table_in_primary_region
+----
+regional_by_table_in_primary_region               CREATE TABLE public.regional_by_table_in_primary_region (
+                                                  i INT8 NULL,
+                                                  FAMILY "primary" (i, rowid)
+) LOCALITY REGIONAL BY TABLE IN "ap-southeast-2"
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE regional_by_table_in_primary_region
+----
+TABLE regional_by_table_in_primary_region  ALTER TABLE regional_by_table_in_primary_region CONFIGURE ZONE USING
+                                           range_min_bytes = 134217728,
+                                           range_max_bytes = 536870912,
+                                           gc.ttlseconds = 90000,
+                                           num_replicas = 3,
+                                           constraints = '{+region=ap-southeast-2: 3}',
+                                           lease_preferences = '[[+region=ap-southeast-2]]'
+
+# Alter back to original state
+statement ok
+ALTER TABLE regional_by_table_in_primary_region SET LOCALITY REGIONAL BY TABLE in PRIMARY REGION
+
+query TT
+SHOW CREATE TABLE regional_by_table_in_primary_region
+----
+regional_by_table_in_primary_region  CREATE TABLE public.regional_by_table_in_primary_region (
+                                     i INT8 NULL,
+                                     FAMILY "primary" (i, rowid)
+) LOCALITY REGIONAL BY TABLE IN PRIMARY REGION
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE regional_by_table_in_primary_region
+----
+DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
+                              range_min_bytes = 134217728,
+                              range_max_bytes = 536870912,
+                              gc.ttlseconds = 90000,
+                              num_replicas = 3,
+                              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                              lease_preferences = '[[+region=ca-central-1]]'
+
+# Alter to same state
+statement ok
+ALTER TABLE regional_by_table_in_primary_region SET LOCALITY REGIONAL BY TABLE in PRIMARY REGION
+
+query TT
+SHOW CREATE TABLE regional_by_table_in_primary_region
+----
+regional_by_table_in_primary_region  CREATE TABLE public.regional_by_table_in_primary_region (
+                                     i INT8 NULL,
+                                     FAMILY "primary" (i, rowid)
+) LOCALITY REGIONAL BY TABLE IN PRIMARY REGION
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE regional_by_table_in_primary_region
+----
+DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
+                              range_min_bytes = 134217728,
+                              range_max_bytes = 536870912,
+                              gc.ttlseconds = 90000,
+                              num_replicas = 3,
+                              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                              lease_preferences = '[[+region=ca-central-1]]'
+
+statement ok
+ALTER TABLE regional_by_table_in_primary_region SET LOCALITY REGIONAL BY TABLE
+
+query TT
+SHOW CREATE TABLE regional_by_table_in_primary_region
+----
+regional_by_table_in_primary_region  CREATE TABLE public.regional_by_table_in_primary_region (
+                                     i INT8 NULL,
+                                     FAMILY "primary" (i, rowid)
+) LOCALITY REGIONAL BY TABLE IN PRIMARY REGION
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE regional_by_table_in_primary_region
+----
+DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
+                              range_min_bytes = 134217728,
+                              range_max_bytes = 536870912,
+                              gc.ttlseconds = 90000,
+                              num_replicas = 3,
+                              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                              lease_preferences = '[[+region=ca-central-1]]'
+
+statement error unimplemented: implementation pending
+ALTER TABLE regional_by_table_in_primary_region SET LOCALITY GLOBAL
+
+statement error unimplemented: implementation pending
+ALTER TABLE regional_by_table_in_primary_region SET LOCALITY REGIONAL BY ROW
+
+statement ok
+ALTER TABLE regional_by_table_no_region SET LOCALITY REGIONAL BY TABLE
+
+query TT
+SHOW CREATE TABLE regional_by_table_no_region
+----
+regional_by_table_no_region                     CREATE TABLE public.regional_by_table_no_region (
+                                                i INT8 NULL,
+                                                FAMILY "primary" (i, rowid)
+) LOCALITY REGIONAL BY TABLE IN PRIMARY REGION
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE regional_by_table_no_region
+----
+DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
+                              range_min_bytes = 134217728,
+                              range_max_bytes = 536870912,
+                              gc.ttlseconds = 90000,
+                              num_replicas = 3,
+                              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                              lease_preferences = '[[+region=ca-central-1]]'
+
+# drop and recreate the table to get it back to the "no region" state
+statement ok
+DROP TABLE regional_by_table_no_region
+
+statement ok
+CREATE TABLE regional_by_table_no_region (i int)
+
+statement ok
+ALTER TABLE regional_by_table_no_region SET LOCALITY REGIONAL BY TABLE in "ap-southeast-2"
+
+query TT
+SHOW CREATE TABLE regional_by_table_no_region
+----
+regional_by_table_no_region                       CREATE TABLE public.regional_by_table_no_region (
+                                                  i INT8 NULL,
+                                                  FAMILY "primary" (i, rowid)
+) LOCALITY REGIONAL BY TABLE IN "ap-southeast-2"
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE regional_by_table_no_region
+----
+TABLE regional_by_table_no_region  ALTER TABLE regional_by_table_no_region CONFIGURE ZONE USING
+                                   range_min_bytes = 134217728,
+                                   range_max_bytes = 536870912,
+                                   gc.ttlseconds = 90000,
+                                   num_replicas = 3,
+                                   constraints = '{+region=ap-southeast-2: 3}',
+                                   lease_preferences = '[[+region=ap-southeast-2]]'
+
+# drop and recreate the table to get it back to the "no region" state
+statement ok
+DROP TABLE regional_by_table_no_region
+
+statement ok
+CREATE TABLE regional_by_table_no_region (i int)
+
+statement ok
+ALTER TABLE regional_by_table_no_region SET LOCALITY REGIONAL BY TABLE in PRIMARY REGION
+
+query TT
+SHOW CREATE TABLE regional_by_table_no_region
+----
+regional_by_table_no_region  CREATE TABLE public.regional_by_table_no_region (
+                             i INT8 NULL,
+                             FAMILY "primary" (i, rowid)
+) LOCALITY REGIONAL BY TABLE IN PRIMARY REGION
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE regional_by_table_no_region
+----
+DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
+                              range_min_bytes = 134217728,
+                              range_max_bytes = 536870912,
+                              gc.ttlseconds = 90000,
+                              num_replicas = 3,
+                              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                              lease_preferences = '[[+region=ca-central-1]]'
+
+statement error unimplemented: implementation pending
+ALTER TABLE regional_by_table_no_region SET LOCALITY GLOBAL
+
+statement error unimplemented: implementation pending
+ALTER TABLE regional_by_table_no_region SET LOCALITY REGIONAL BY ROW
+
+statement ok
+ALTER TABLE regional_by_table_in_us_east SET LOCALITY REGIONAL BY TABLE
+
+query TT
+SHOW CREATE TABLE regional_by_table_in_us_east
+----
+regional_by_table_in_us_east  CREATE TABLE public.regional_by_table_in_us_east (
+                              i INT8 NULL,
+                              FAMILY "primary" (i, rowid)
+) LOCALITY REGIONAL BY TABLE IN PRIMARY REGION
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE regional_by_table_in_us_east
+----
+DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
+                              range_min_bytes = 134217728,
+                              range_max_bytes = 536870912,
+                              gc.ttlseconds = 90000,
+                              num_replicas = 3,
+                              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                              lease_preferences = '[[+region=ca-central-1]]'
+
+statement ok
+ALTER TABLE regional_by_table_in_us_east SET LOCALITY REGIONAL BY TABLE in "us-east-1"
+
+statement ok
+ALTER TABLE regional_by_table_in_us_east SET LOCALITY REGIONAL BY TABLE in "ap-southeast-2"
+
+query TT
+SHOW CREATE TABLE regional_by_table_in_us_east
+----
+regional_by_table_in_us_east                      CREATE TABLE public.regional_by_table_in_us_east (
+                                                  i INT8 NULL,
+                                                  FAMILY "primary" (i, rowid)
+) LOCALITY REGIONAL BY TABLE IN "ap-southeast-2"
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE regional_by_table_in_us_east
+----
+TABLE regional_by_table_in_us_east  ALTER TABLE regional_by_table_in_us_east CONFIGURE ZONE USING
+                                    range_min_bytes = 134217728,
+                                    range_max_bytes = 536870912,
+                                    gc.ttlseconds = 90000,
+                                    num_replicas = 3,
+                                    constraints = '{+region=ap-southeast-2: 3}',
+                                    lease_preferences = '[[+region=ap-southeast-2]]'
+
+statement ok
+ALTER TABLE regional_by_table_in_us_east SET LOCALITY REGIONAL BY TABLE in "us-east-1"
+
+statement ok
+ALTER TABLE regional_by_table_in_us_east SET LOCALITY REGIONAL BY TABLE in PRIMARY REGION
+
+query TT
+SHOW CREATE TABLE regional_by_table_in_us_east
+----
+regional_by_table_in_us_east  CREATE TABLE public.regional_by_table_in_us_east (
+                              i INT8 NULL,
+                              FAMILY "primary" (i, rowid)
+) LOCALITY REGIONAL BY TABLE IN PRIMARY REGION
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE regional_by_table_in_us_east
+----
+DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
+                              range_min_bytes = 134217728,
+                              range_max_bytes = 536870912,
+                              gc.ttlseconds = 90000,
+                              num_replicas = 3,
+                              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                              lease_preferences = '[[+region=ca-central-1]]'
+
+statement error unimplemented: implementation pending
+ALTER TABLE regional_by_table_in_us_east SET LOCALITY GLOBAL
+
+statement error unimplemented: implementation pending
+ALTER TABLE regional_by_table_in_us_east SET LOCALITY REGIONAL BY ROW

--- a/pkg/sql/alter_table_locality.go
+++ b/pkg/sql/alter_table_locality.go
@@ -12,10 +12,25 @@ package sql
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
+	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
+	"github.com/cockroachdb/errors"
 )
+
+type alterTableSetLocalityNode struct {
+	n         tree.AlterTableLocality
+	tableDesc *tabledesc.Mutable
+}
 
 // AlterTableLocality transforms a tree.AlterTableLocality into a plan node.
 func (p *planner) AlterTableLocality(
@@ -28,5 +43,246 @@ func (p *planner) AlterTableLocality(
 	); err != nil {
 		return nil, err
 	}
-	return nil, unimplemented.New("alter table locality", "implementation pending")
+
+	tableDesc, err := p.ResolveMutableTableDescriptorEx(
+		ctx, n.Name, !n.IfExists, tree.ResolveRequireTableDesc,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if tableDesc == nil {
+		return newZeroNode(nil /* columns */), nil
+	}
+
+	// This check for CREATE privilege is kept for backwards compatibility.
+	if err := p.CheckPrivilege(ctx, tableDesc, privilege.CREATE); err != nil {
+		return nil, pgerror.Newf(pgcode.InsufficientPrivilege,
+			"must be owner of table %s or have CREATE privilege on table %s",
+			tree.Name(tableDesc.GetName()), tree.Name(tableDesc.GetName()))
+	}
+
+	return &alterTableSetLocalityNode{
+		n:         *n,
+		tableDesc: tableDesc,
+	}, nil
+}
+
+func (n *alterTableSetLocalityNode) Next(runParams) (bool, error) { return false, nil }
+func (n *alterTableSetLocalityNode) Values() tree.Datums          { return tree.Datums{} }
+func (n *alterTableSetLocalityNode) Close(context.Context)        {}
+
+func (n *alterTableSetLocalityNode) alterTableLocalityGlobalToRegionalByTable(
+	params runParams,
+) error {
+	return unimplemented.New("alter table locality from GLOBAL to REGIONAL BY TABLE", "implementation pending")
+}
+
+func (n *alterTableSetLocalityNode) alterTableLocalityRegionalByTableToGlobal(
+	params runParams,
+) error {
+	return unimplemented.New("alter table locality from REGIONAL BY TABLE to GLOBAL", "implementation pending")
+}
+
+func (n *alterTableSetLocalityNode) alterTableLocalityRegionalByTableToRegionalByTable(
+	params runParams,
+) error {
+	// Ensure that the database is multi-region enabled.
+	dbDesc, err := catalogkv.MustGetDatabaseDescByID(
+		params.ctx,
+		params.extendedEvalCtx.Txn,
+		params.extendedEvalCtx.EvalContext.Codec,
+		n.tableDesc.GetParentID(),
+	)
+	if err != nil {
+		return err
+	}
+	if !dbDesc.IsMultiRegion() {
+		return errors.AssertionFailedf(
+			"invalid call to alter the table locality on a non-multi-region database. %v %v",
+			dbDesc,
+			n,
+		)
+	}
+
+	var newRegion *descpb.RegionName = nil
+	newRegionName := descpb.RegionName(n.n.Locality.TableRegion)
+
+	// If we haven't been provided a new region, we're altering to the PRIMARY REGION.
+	alterToPrimaryRegion := newRegionName == ""
+	// If we're altering to the primary region, leave the newRegion as nil.
+	if !alterToPrimaryRegion {
+		newRegion = &newRegionName
+	}
+
+	// In all cases if we get down here we need to update the Locality info in the table
+	// descriptor. It's possible here that the LocalityConfig is nil, if we're altering
+	// from a table that was not provided a table locality at creation. Allocate a
+	// LocalityConfig here to be used below. Note that all ALTERs which change the
+	// table locality will result in a LocalityConfig existing on the table (i.e. there
+	// currently is no way to remove the LocalityConfig from a table via ALTER).
+	if n.tableDesc.LocalityConfig == nil {
+		n.tableDesc.LocalityConfig = &descpb.TableDescriptor_LocalityConfig{}
+	}
+
+	// Setup the Locality and Region fields of the LocalityConfig. In cases where we're
+	// altering to the PRIMARY REGION, the Region will be set to nil so that SHOW CREATE
+	// TABLE will show "REGIONAL BY TABLE IN PRIMARY REGION".
+	n.tableDesc.LocalityConfig.Locality =
+		&descpb.TableDescriptor_LocalityConfig_RegionalByTable_{
+			RegionalByTable: &descpb.TableDescriptor_LocalityConfig_RegionalByTable{
+				Region: newRegion,
+			},
+		}
+
+	// Validate the new locality before updating the table descriptor.
+	tableName := tree.MakeTableName(tree.Name(dbDesc.Name), tree.Name(n.tableDesc.GetName()))
+	if err := tabledesc.ValidateTableLocalityConfig(
+		tableName.String(),
+		n.tableDesc.LocalityConfig,
+		dbDesc,
+	); err != nil {
+		return err
+	}
+
+	// Write out the table descriptor update.
+	if err := params.p.writeSchemaChange(
+		params.ctx,
+		n.tableDesc,
+		descpb.InvalidMutationID,
+		tree.AsStringWithFQNames(&n.n, params.Ann()),
+	); err != nil {
+		return err
+	}
+
+	// Update the table's zone configuration. If we're altering to the PRIMARY REGION,
+	// we don't want to set a zone configuration (in fact, we'll remove any existing zone
+	// configuration below).
+	if !alterToPrimaryRegion {
+		if err := params.p.applyZoneConfigFromTableLocalityConfig(
+			params.ctx,
+			tableName,
+			n.tableDesc.TableDesc(),
+			*dbDesc.RegionConfig,
+		); err != nil {
+			return err
+		}
+	} else {
+		// TODO(#multiregion): We should check to see if the zone configuration has been updated
+		// by the user. If it has, we need to warn, and only proceed if sql_safe_updates is disabled.
+
+		// Table is placed in the PRIMARY REGION. Remove the table's zone configuration so
+		// that it can be inherited from the database.
+		fullTableName := tree.MakeTableNameWithSchema(
+			tableName.CatalogName,
+			tableName.SchemaName,
+			tableName.ObjectName,
+		)
+		sql := fmt.Sprintf("ALTER TABLE %s CONFIGURE ZONE DISCARD", fullTableName.String())
+		if _, err := params.p.ExtendedEvalContext().ExecCfg.InternalExecutor.ExecEx(
+			params.ctx,
+			"table-multiregion-discard-zone-config",
+			params.extendedEvalCtx.Txn,
+			sessiondata.InternalExecutorOverride{
+				User: params.p.SessionData().User(),
+			},
+			sql,
+		); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	return nil
+}
+
+func (n *alterTableSetLocalityNode) startExec(params runParams) error {
+	// Ensure that the database is multi-region enabled.
+	dbDesc, err := catalogkv.MustGetDatabaseDescByID(
+		params.ctx,
+		params.extendedEvalCtx.Txn,
+		params.extendedEvalCtx.EvalContext.Codec,
+		n.tableDesc.GetParentID(),
+	)
+	if err != nil {
+		return err
+	}
+	if !dbDesc.IsMultiRegion() {
+		return pgerror.Newf(
+			pgcode.InvalidTableDefinition,
+			"cannot alter a table's LOCALITY if its database is not multi-region enabled",
+		)
+	}
+
+	newLocality := n.n.Locality
+	existingLocality := n.tableDesc.LocalityConfig
+
+	// If the table's LocalityConfig is nil, it means that the table is REGIONAL BY
+	// TABLE in the PRIMARY REGION. Construct a dummy LocalityConfig to mimic that.
+	if existingLocality == nil {
+		existingLocality = &descpb.TableDescriptor_LocalityConfig{
+			Locality: &descpb.TableDescriptor_LocalityConfig_RegionalByTable_{
+				RegionalByTable: &descpb.TableDescriptor_LocalityConfig_RegionalByTable{},
+			},
+		}
+	}
+
+	// Look at the existing locality, and implement any changes required to move to
+	// the new locality.
+	switch existingLocality.Locality.(type) {
+	case *descpb.TableDescriptor_LocalityConfig_Global_:
+		switch newLocality.LocalityLevel {
+		case tree.LocalityLevelGlobal:
+			// GLOBAL to GLOBAL - no op.
+			return nil
+		case tree.LocalityLevelRow:
+			// GLOBAL to REGIONAL BY ROW
+			return unimplemented.New("alter table locality to REGIONAL BY ROW", "implementation pending")
+		case tree.LocalityLevelTable:
+			if err = n.alterTableLocalityGlobalToRegionalByTable(params); err != nil {
+				return err
+			}
+		default:
+			return errors.AssertionFailedf("unknown table locality: %v", newLocality)
+		}
+	case *descpb.TableDescriptor_LocalityConfig_RegionalByTable_:
+		switch newLocality.LocalityLevel {
+		case tree.LocalityLevelGlobal:
+			err = n.alterTableLocalityRegionalByTableToGlobal(params)
+			if err != nil {
+				return err
+			}
+		case tree.LocalityLevelRow:
+			return unimplemented.New("alter table locality to REGIONAL BY ROW", "implementation pending")
+		case tree.LocalityLevelTable:
+			err = n.alterTableLocalityRegionalByTableToRegionalByTable(params)
+			if err != nil {
+				return err
+			}
+		default:
+			return errors.AssertionFailedf("unknown table locality: %v", newLocality)
+		}
+	case *descpb.TableDescriptor_LocalityConfig_RegionalByRow_:
+		switch newLocality.LocalityLevel {
+		case tree.LocalityLevelGlobal:
+			return unimplemented.New("alter table locality from REGIONAL BY ROW", "implementation pending")
+		case tree.LocalityLevelRow:
+			// Altering to same table locality pattern. We're done.
+			return unimplemented.New("alter table locality from REGIONAL BY ROW", "implementation pending")
+		case tree.LocalityLevelTable:
+			return unimplemented.New("alter table locality from REGIONAL BY ROW", "implementation pending")
+		default:
+			return errors.AssertionFailedf("unknown table locality: %v", newLocality)
+		}
+	default:
+		return errors.AssertionFailedf("unknown table locality: %v", existingLocality)
+	}
+
+	// Record this table alteration in the event log. This is an auditable log
+	// event and is recorded in the same transaction as the table descriptor
+	// update.
+	return params.p.logEvent(params.ctx,
+		n.tableDesc.ID,
+		&eventpb.AlterTable{
+			TableName: n.n.Name.String(),
+		})
 }

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -332,6 +332,7 @@ var planNodeNames = map[reflect.Type]string{
 	reflect.TypeOf(&alterSchemaNode{}):                "alter schema",
 	reflect.TypeOf(&alterTableNode{}):                 "alter table",
 	reflect.TypeOf(&alterTableOwnerNode{}):            "alter table owner",
+	reflect.TypeOf(&alterTableSetLocalityNode{}):      "alter table set locality",
 	reflect.TypeOf(&alterTableSetSchemaNode{}):        "alter table set schema",
 	reflect.TypeOf(&alterTypeNode{}):                  "alter type",
 	reflect.TypeOf(&alterRoleNode{}):                  "alter role",


### PR DESCRIPTION
Release note (sql change): Enables altering of table locality for tables
that are REGIONAL BY TABLE to REGIONAL BY TABLE (but in a different
region).