### PR TITLE
bazel: generate `//go:generate stringer` files sandbox

### DIFF
--- a/pkg/STRINGER.bzl
+++ b/pkg/STRINGER.bzl
@@ -1,0 +1,18 @@
+# Common function to create //go:generate stringer files within bazel sandbox
+
+def stringer(file, typ, name):
+   native.genrule(
+      name = name, 
+      srcs = [
+          file,
+      ],
+      outs = [typ.lower() + "_string.go"],
+      cmd = """
+         env PATH=`dirname $(location @go_sdk//:bin/go)` HOME=$(GENDIR) \
+         $(location @org_golang_x_tools//cmd/stringer:stringer) -output=$@ -type={} $<
+      """.format(typ),
+      tools = [
+         "@go_sdk//:bin/go",
+         "@org_golang_x_tools//cmd/stringer",
+       ],
+   )

--- a/pkg/base/BUILD.bazel
+++ b/pkg/base/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("//pkg:STRINGER.bzl", "stringer")
 
 go_library(
     name = "base",
@@ -14,6 +15,7 @@ go_library(
         "testclusterreplicationmode_string.go",
         "testing_knobs.go",
         "zone.go",
+        ":gen-clusterreplication-stringer",  # keep
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/base",
     visibility = ["//visibility:public"],
@@ -63,4 +65,10 @@ go_test(
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
     ],
+)
+
+stringer(
+    name = "gen-clusterreplication-stringer",
+    file = "test_server_args.go",
+    typ = "TestClusterReplicationMode",
 )

--- a/pkg/ccl/sqlproxyccl/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("//pkg:STRINGER.bzl", "stringer")
 
 go_library(
     name = "sqlproxyccl",
@@ -12,6 +13,7 @@ go_library(
         "metrics.go",
         "proxy.go",
         "server.go",
+        ":gen-errorcode-stringer",  # keep
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl",
     visibility = ["//visibility:public"],
@@ -57,4 +59,10 @@ go_test(
         "@com_github_jackc_pgx_v4//:pgx",
         "@com_github_stretchr_testify//require",
     ],
+)
+
+stringer(
+    name = "gen-errorcode-stringer",
+    file = "error.go",
+    typ = "ErrorCode",
 )

--- a/pkg/cli/BUILD.bazel
+++ b/pkg/cli/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("//pkg:STRINGER.bzl", "stringer")
 
 go_library(
     name = "cli",
@@ -51,6 +52,7 @@ go_library(
         "tsdump.go",
         "userfile.go",
         "zip.go",
+        ":gen-keytype-stringer",  # keep
     ],
     # keep
     cdeps = [
@@ -335,4 +337,10 @@ go_test(
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],
+)
+
+stringer(
+    name = "gen-keytype-stringer",
+    file = "flags_util.go",
+    typ = "keyType",
 )

--- a/pkg/clusterversion/BUILD.bazel
+++ b/pkg/clusterversion/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("//pkg:STRINGER.bzl", "stringer")
 
 go_library(
     name = "clusterversion",
@@ -11,6 +12,7 @@ go_library(
         "keyed_versions.go",
         "setting.go",
         "testutils.go",
+        ":gen-key-stringer",  # keep
     ],
     embed = [":clusterversion_go_proto"],
     importpath = "github.com/cockroachdb/cockroach/pkg/clusterversion",
@@ -60,4 +62,10 @@ go_proto_library(
         "//pkg/roachpb",
         "@com_github_gogo_protobuf//gogoproto",
     ],
+)
+
+stringer(
+    name = "gen-key-stringer",
+    file = "cockroach_versions.go",
+    typ = "Key",
 )

--- a/pkg/kv/kvclient/kvcoord/BUILD.bazel
+++ b/pkg/kv/kvclient/kvcoord/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("//pkg:STRINGER.bzl", "stringer")
 
 go_library(
     name = "kvcoord",
@@ -28,6 +29,7 @@ go_library(
         "txn_lock_gatekeeper.go",
         "txn_metrics.go",
         "txnstate_string.go",
+        ":gen-txnstate-stringer",  # keep
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord",
     visibility = ["//visibility:public"],
@@ -148,4 +150,10 @@ go_test(
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_x_sync//errgroup",
     ],
+)
+
+stringer(
+    name = "gen-txnstate-stringer",
+    file = "txn_coord_sender.go",
+    typ = "txnState",
 )

--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("//pkg:STRINGER.bzl", "stringer")
 
 go_library(
     name = "kvserver",
@@ -91,6 +92,7 @@ go_library(
         "testing_knobs.go",
         "track_raft_protos.go",
         "ts_maintenance_queue.go",
+        ":gen-refreshraftreason-stringer",  # keep
     ],
     embed = [":kvserver_go_proto"],
     importpath = "github.com/cockroachdb/cockroach/pkg/kv/kvserver",
@@ -426,4 +428,10 @@ go_proto_library(
         "@com_github_gogo_protobuf//gogoproto",
         "@io_etcd_go_etcd_raft_v3//raftpb",
     ],
+)
+
+stringer(
+    name = "gen-refreshraftreason-stringer",
+    file = "replica_raft.go",
+    typ = "refreshRaftReason",
 )

--- a/pkg/roachpb/BUILD.bazel
+++ b/pkg/roachpb/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("//pkg:STRINGER.bzl", "stringer")
 
 go_library(
     name = "roachpb",
@@ -21,6 +22,8 @@ go_library(
         "span_group.go",
         "tenant.go",
         "version.go",
+        ":gen-errordetailtype-stringer",  # keep
+        ":gen-method-stringer",  # keep
     ],
     embed = [":roachpb_go_proto"],
     importpath = "github.com/cockroachdb/cockroach/pkg/roachpb",
@@ -145,4 +148,18 @@ go_proto_library(
         "@com_github_cockroachdb_errors//errorspb",
         "@com_github_gogo_protobuf//gogoproto",
     ],
+)
+
+# Using common function for stringer to create method_string.go
+stringer(
+    name = "gen-method-stringer",
+    file = "method.go",
+    typ = "Method",
+)
+
+# Using common function for stringer to create errordetailtype_string.go
+stringer(
+    name = "gen-errordetailtype-stringer",
+    file = "errors.go",
+    typ = "ErrorDetailType",
 )

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("//pkg:STRINGER.bzl", "stringer")
 
 go_library(
     name = "sql",
@@ -218,6 +219,10 @@ go_library(
         "zero.go",
         "zigzag_join.go",
         "zone_config.go",
+        ":gen-advancecode-stringer",  # keep
+        ":gen-nodestatus-stringer",  # keep
+        ":gen-txnevent-stringer",  # keep
+        ":gen-txntype-stringer",  # keep
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql",
     visibility = ["//visibility:public"],
@@ -587,4 +592,28 @@ go_test(
         "@in_gopkg_yaml_v2//:yaml_v2",
         "@org_golang_x_sync//errgroup",
     ],
+)
+
+stringer(
+    name = "gen-txnevent-stringer",
+    file = "txn_state.go",
+    typ = "txnEvent",
+)
+
+stringer(
+    name = "gen-txntype-stringer",
+    file = "txn_state.go",
+    typ = "txnType",
+)
+
+stringer(
+    name = "gen-advancecode-stringer",
+    file = "txn_state.go",
+    typ = "advanceCode",
+)
+
+stringer(
+    name = "gen-nodestatus-stringer",
+    file = "distsql_physical_planner.go",
+    typ = "NodeStatus",
 )

--- a/pkg/sql/catalog/catalogkv/BUILD.bazel
+++ b/pkg/sql/catalog/catalogkv/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("//pkg:STRINGER.bzl", "stringer")
 
 go_library(
     name = "catalogkv",
@@ -7,6 +8,7 @@ go_library(
         "descriptorkind_string.go",
         "namespace.go",
         "test_utils.go",
+        ":gen-descriptorkind-stringer",  # keep
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv",
     visibility = ["//visibility:public"],
@@ -48,4 +50,10 @@ go_test(
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
     ],
+)
+
+stringer(
+    name = "gen-descriptorkind-stringer",
+    file = "catalogkv.go",
+    typ = "DescriptorKind",
 )

--- a/pkg/sql/catalog/descpb/BUILD.bazel
+++ b/pkg/sql/catalog/descpb/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("//pkg:STRINGER.bzl", "stringer")
 
 go_library(
     name = "descpb",
@@ -16,6 +17,8 @@ go_library(
         "privilegedescversion_string.go",
         "region_name.go",
         "structured.go",
+        ":gen-formatversion-stringer",  # keep
+        ":gen-privilegedescversion-stringer",  # keep
     ],
     embed = [":descpb_go_proto"],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb",
@@ -82,4 +85,16 @@ go_proto_library(
         "//pkg/util/hlc",
         "@com_github_gogo_protobuf//gogoproto",
     ],
+)
+
+stringer(
+    name = "gen-privilegedescversion-stringer",
+    file = "privilege.go",
+    typ = "PrivilegeDescVersion",
+)
+
+stringer(
+    name = "gen-formatversion-stringer",
+    file = "structured.go",
+    typ = "FormatVersion",
 )

--- a/pkg/sql/colfetcher/BUILD.bazel
+++ b/pkg/sql/colfetcher/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//pkg:STRINGER.bzl", "stringer")
 
 go_library(
     name = "colfetcher",
@@ -6,6 +7,7 @@ go_library(
         "cfetcher.go",
         "colbatch_scan.go",
         "fetcherstate_string.go",
+        ":gen-fetcherstate-stringer",  # keep
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/colfetcher",
     visibility = ["//visibility:public"],
@@ -37,4 +39,10 @@ go_library(
         "@com_github_cockroachdb_apd_v2//:apd",
         "@com_github_cockroachdb_errors//:errors",
     ],
+)
+
+stringer(
+    name = "gen-fetcherstate-stringer",
+    file = "cfetcher.go",
+    typ = "fetcherState",
 )

--- a/pkg/sql/execinfra/BUILD.bazel
+++ b/pkg/sql/execinfra/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("//pkg:STRINGER.bzl", "stringer")
 
 go_library(
     name = "execinfra",
@@ -18,6 +19,8 @@ go_library(
         "server_config.go",
         "testutils.go",
         "version.go",
+        ":gen-consumerstatus-stringer",  # keep
+        ":gen-procstate-stringer",  # keep
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/execinfra",
     visibility = ["//visibility:public"],
@@ -87,4 +90,16 @@ go_test(
         "//pkg/util/leaktest",
         "//pkg/util/randutil",
     ],
+)
+
+stringer(
+    name = "gen-procstate-stringer",
+    file = "processorsbase.go",
+    typ = "procState",
+)
+
+stringer(
+    name = "gen-consumerstatus-stringer",
+    file = "base.go",
+    typ = "ConsumerStatus",
 )

--- a/pkg/sql/opt/optgen/lang/BUILD.bazel
+++ b/pkg/sql/opt/optgen/lang/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("//pkg:STRINGER.bzl", "stringer")
 
 go_library(
     name = "lang",
@@ -13,6 +14,8 @@ go_library(
         "token_string.go",
         ":gen-expr",  # keep
         ":gen-operator",  # keep
+        ":gen-operator-stringer",  # keep
+        ":gen-token-stringer",  # keep
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/opt/optgen/lang",
     visibility = ["//visibility:public"],
@@ -77,4 +80,16 @@ genrule(
       $(location //pkg/sql/opt/optgen/cmd/langgen) -out $@ ops $(location lang.opt)
     """,
     tools = ["//pkg/sql/opt/optgen/cmd/langgen"],
+)
+
+stringer(
+    name = "gen-token-stringer",
+    file = "scanner.go",
+    typ = "Token",
+)
+
+stringer(
+    name = "gen-operator-stringer",
+    file = "operator.og.go",
+    typ = "Operator",
 )

--- a/pkg/sql/pgwire/pgwirebase/BUILD.bazel
+++ b/pkg/sql/pgwire/pgwirebase/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//pkg:STRINGER.bzl", "stringer")
 
 go_library(
     name = "pgwirebase",
@@ -14,6 +15,12 @@ go_library(
         "servererrfieldtype_string.go",
         "servermessagetype_string.go",
         "too_big_error.go",
+        ":gen-clientmessagetype-stringer",  # keep
+        ":gen-formatcode-stringer",  # keep
+        ":gen-pgnumericsign-stringer",  # keep
+        ":gen-preparetype-stringer",  # keep
+        ":gen-servererrfieldtype-stringer",  # keep
+        ":gen-servermessagetype-stringer",  # keep
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirebase",
     visibility = ["//visibility:public"],
@@ -38,4 +45,40 @@ go_library(
         "@com_github_jackc_pgx//pgtype",
         "@com_github_lib_pq//oid",
     ],
+)
+
+stringer(
+    name = "gen-pgnumericsign-stringer",
+    file = "encoding.go",
+    typ = "PGNumericSign",
+)
+
+stringer(
+    name = "gen-formatcode-stringer",
+    file = "encoding.go",
+    typ = "FormatCode",
+)
+
+stringer(
+    name = "gen-clientmessagetype-stringer",
+    file = "msg.go",
+    typ = "ClientMessageType",
+)
+
+stringer(
+    name = "gen-servermessagetype-stringer",
+    file = "msg.go",
+    typ = "ServerMessageType",
+)
+
+stringer(
+    name = "gen-servererrfieldtype-stringer",
+    file = "msg.go",
+    typ = "ServerErrFieldType",
+)
+
+stringer(
+    name = "gen-preparetype-stringer",
+    file = "msg.go",
+    typ = "PrepareType",
 )

--- a/pkg/sql/privilege/BUILD.bazel
+++ b/pkg/sql/privilege/BUILD.bazel
@@ -1,10 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("//pkg:STRINGER.bzl", "stringer")
 
 go_library(
     name = "privilege",
     srcs = [
         "kind_string.go",
         "privilege.go",
+        ":gen-kind-stringer",  # keep
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/privilege",
     visibility = ["//visibility:public"],
@@ -26,4 +28,10 @@ go_test(
         "//pkg/util/leaktest",
         "//pkg/util/log",
     ],
+)
+
+stringer(
+    name = "gen-kind-stringer",
+    file = "privilege.go",
+    typ = "Kind",
 )

--- a/pkg/sql/roleoption/BUILD.bazel
+++ b/pkg/sql/roleoption/BUILD.bazel
@@ -1,10 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//pkg:STRINGER.bzl", "stringer")
 
 go_library(
     name = "roleoption",
     srcs = [
         "option_string.go",
         "role_option.go",
+        ":gen-option-stringer",  # keep
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/roleoption",
     visibility = ["//visibility:public"],
@@ -14,4 +16,10 @@ go_library(
         "//pkg/sql/sqltelemetry",
         "@com_github_cockroachdb_errors//:errors",
     ],
+)
+
+stringer(
+    name = "gen-option-stringer",
+    file = "role_option.go",
+    typ = "Option",
 )

--- a/pkg/sql/schemachange/BUILD.bazel
+++ b/pkg/sql/schemachange/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "alter_column_type.go",
         "columnconversionkind_string.go",
+        ":gen-columnconversionkind-stringer",  # keep
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/schemachange",
     visibility = ["//visibility:public"],
@@ -40,5 +41,22 @@ go_test(
         "//pkg/util/log",
         "//pkg/util/randutil",
         "//pkg/util/uuid",
+    ],
+)
+
+# Keep this genrule and not ussing common string function due to extra flags eg: trimprefix
+genrule(
+    name = "gen-columnconversionkind-stringer",
+    srcs = [
+        "alter_column_type.go",
+    ],
+    outs = ["columnconversionkind_string.go"],
+    cmd = """
+       env PATH=`dirname $(location @go_sdk//:bin/go)` HOME=$(GENDIR) \
+       $(location @org_golang_x_tools//cmd/stringer:stringer) -output=$@ -type=ColumnConversionKind -trimprefix ColumnConversion $<
+    """,
+    tools = [
+        "@go_sdk//:bin/go",
+        "@org_golang_x_tools//cmd/stringer",
     ],
 )

--- a/pkg/sql/sem/tree/BUILD.bazel
+++ b/pkg/sql/sem/tree/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("//pkg:STRINGER.bzl", "stringer")
 
 go_library(
     name = "tree",
@@ -96,6 +97,8 @@ go_library(
         "window_funcs_util.go",
         "with.go",
         "zone.go",
+        ":gen-createtypevariety-stringer",  # keep
+        ":gen-statementtype-stringer",  # keep
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/sem/tree",
     visibility = ["//visibility:public"],
@@ -226,4 +229,16 @@ go_test(
         "@com_github_stretchr_testify//require",
         "@org_golang_x_sync//errgroup",
     ],
+)
+
+stringer(
+    name = "gen-createtypevariety-stringer",
+    file = "create.go",
+    typ = "CreateTypeVariety",
+)
+
+stringer(
+    name = "gen-statementtype-stringer",
+    file = "stmt.go",
+    typ = "StatementType",
 )

--- a/pkg/util/encoding/BUILD.bazel
+++ b/pkg/util/encoding/BUILD.bazel
@@ -58,3 +58,27 @@ go_test(
         "@com_github_stretchr_testify//require",
     ],
 )
+
+# TODO (alanmas): Solve stringer issue "stringer: can't handle non-integer constant type Type"
+# Seems that we need to include pkg/util/encoding/encodingtype somehow.
+# We already tried to copy the source files over so bazel source now are enconding and encodingtype
+# but it is still failing due to the same error.
+
+# genrule(
+#     name = "gen-type-stringer",
+#     srcs = [
+#         "//pkg/util/encoding/encodingtype:encoding_type.go",
+#         "encoding.go",
+#     ],
+#     outs = ["type_string.go"],
+#     cmd = """
+#        cp $(location encoding.go) `dirname $(location //pkg/util/encoding/encodingtype:encoding_type.go)`/encoding.go
+#        env PATH=`dirname $(location @go_sdk//:bin/go)` HOME=$(GENDIR) \
+#        $(location @org_golang_x_tools//cmd/stringer:stringer) -output=$@ \
+#        -type=Type `dirname $(location //pkg/util/encoding/encodingtype:encoding_type.go)`/encoding.go $(location //pkg/util/encoding/encodingtype:encoding_type.go)
+#     """,
+#     tools = [
+#         "@go_sdk//:bin/go",
+#         "@org_golang_x_tools//cmd/stringer",
+#     ],
+# )

--- a/pkg/util/encoding/encodingtype/BUILD.bazel
+++ b/pkg/util/encoding/encodingtype/BUILD.bazel
@@ -6,3 +6,10 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/util/encoding/encodingtype",
     visibility = ["//visibility:public"],
 )
+
+exports_files(
+    [
+        "encoding_type.go",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/util/timeutil/pgdate/BUILD.bazel
+++ b/pkg/util/timeutil/pgdate/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("//pkg:STRINGER.bzl", "stringer")
 
 go_library(
     name = "pgdate",
@@ -12,6 +13,8 @@ go_library(
         "pgdate.go",
         "setters.go",
         "zone_cache.go",
+        ":gen-field-stringer",  # keep
+        ":gen-parsemode-stringer",  # keep
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/util/timeutil/pgdate",
     visibility = ["//visibility:public"],
@@ -39,4 +42,16 @@ go_test(
         "//pkg/util/timeutil",
         "@com_github_lib_pq//:pq",
     ],
+)
+
+stringer(
+    name = "gen-field-stringer",
+    file = "fields.go",
+    typ = "field",
+)
+
+stringer(
+    name = "gen-parsemode-stringer",
+    file = "parsing.go",
+    typ = "ParseMode",
 )

--- a/pkg/workload/schemachange/BUILD.bazel
+++ b/pkg/workload/schemachange/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//pkg:STRINGER.bzl", "stringer")
 
 go_library(
     name = "schemachange",
@@ -11,6 +12,7 @@ go_library(
         "schemachange.go",
         "txstatus_string.go",
         "type_resolver.go",
+        ":gen-optype-stringer",  # keep
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/workload/schemachange",
     visibility = ["//visibility:public"],
@@ -34,3 +36,31 @@ go_library(
         "@com_github_spf13_pflag//:pflag",
     ],
 )
+
+stringer(
+    name = "gen-optype-stringer",
+    file = "operation_generator.go",
+    typ = "opType",
+)
+
+# TODO (alanmas): Solve stringer issue "stringer: can't happen: constant is not an integer TxStatusInFailure"
+# Seems that we need to include github.com/jackc/pgx somehow.
+# We already tried to copy the source files over so bazel source now are enconding and encodingtype
+# but it is still failing due to the same error.
+
+# genrule(
+#     name = "gen-txstatus-stringer",
+#     srcs = [
+#         "schemachange.go",
+#     ],
+#     outs = ["txstatus_string.go"],
+#     cmd = """
+#        env PATH=`dirname $(location @go_sdk//:bin/go)` HOME=$(GENDIR) \
+#        $(location @org_golang_x_tools//cmd/stringer:stringer) -output=$@ -type TxStatus $(location @com_github_jackc_pgx//:pgx) $(location schemachange.go)
+#     """,
+#     tools = [
+#         "@go_sdk//:bin/go",
+#         "@org_golang_x_tools//cmd/stringer",
+#         "@com_github_jackc_pgx//:pgx",
+#     ],
+# )


### PR DESCRIPTION
First part of #57787 work.

As `gazelle` is not taking care by itself in any changes related to `//go:generate stringer` we are creating a
`genrule` to handle it.

From all the `//go:generate stringer` files, there are some that are having troubles during bazel build:
```
-pkg/util/encoding/encoding.go
-pkg/util/encoding/BUILD.bazel
"stringer: can't handle non-integer constant type Type"

-pkg/workload/schemachange/schemachange.go
-pkg/workload/schemachange/BUILD.bazel
"stringer: can't happen: constant is not an integer TxStatusInFailure"
```

Release note: None