### PR TITLE
roachtest: persist encryption flag in roachtests that restart clusters

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2169,6 +2169,8 @@ func (c *cluster) StartE(ctx context.Context, opts ...option) error {
 			if rng.Intn(2) == 1 {
 				c.l.Printf("starting with encryption at rest enabled")
 				args = append(args, "--encrypt")
+				// Force encryption in future calls of Start with the same cluster.
+				c.encryptDefault = true
 			}
 		}
 	}


### PR DESCRIPTION
Currently, if cluster.encryptAtRandom is true, we make the random
determination on whether the cluster should be encrypted or not,
every time Start is called. This doesn't work well for roachtests
that call Start multiple times, such as `clearrange/*`, as it could
result in the encryption flag not being passed in on restarts on
encrypted store directories.

Fixes #59038.
Fixes #59040.
Fixes #58917.

Release note: None.