### PR TITLE
sql,doctor: fix nil pointer dereference in ExamineDescriptors

### DIFF
--- a/pkg/sql/doctor/doctor.go
+++ b/pkg/sql/doctor/doctor.go
@@ -142,6 +142,8 @@ func ExamineDescriptors(
 
 		_, parentExists := descGetter[desc.GetParentID()]
 		parentSchema, parentSchemaExists := descGetter[desc.GetParentSchemaID()]
+		var skipParentIDCheck bool
+		skipParentSchemaCheck := desc.Dropped()
 		switch d := desc.(type) {
 		case catalog.TableDescriptor:
 			if err := d.Validate(ctx, descGetter); err != nil {
@@ -149,8 +151,7 @@ func ExamineDescriptors(
 				fmt.Fprint(stdout, reportMsg(desc, "%s", err))
 			}
 			// Table has been already validated.
-			parentExists = true
-			parentSchemaExists = true
+			skipParentIDCheck = true
 		case catalog.TypeDescriptor:
 			typ := typedesc.NewImmutable(*d.TypeDesc())
 			if err := typ.Validate(ctx, descGetter); err != nil {
@@ -159,20 +160,38 @@ func ExamineDescriptors(
 			}
 		case catalog.SchemaDescriptor:
 			// parent schema id is always 0.
-			parentSchemaExists = true
+			skipParentSchemaCheck = true
 		}
-		var invalidParentID bool
-		if desc.GetParentID() != descpb.InvalidID && !parentExists {
+
+		// TODO(postamar): The following descriptor checks on parent id, parent
+		// schema id and parent schema parent id should instead be performed by the
+		// descriptor validation logic.
+		// For doctor to still be useful this will require rewriting it such that it
+		// return multiple errors instead of only the first it encounters.
+		invalidParentID := !parentExists &&
+			desc.GetParentID() != descpb.InvalidID
+
+		if !skipParentIDCheck && invalidParentID {
 			problemsFound = true
-			invalidParentID = true
 			fmt.Fprint(stdout, reportMsg(desc, "invalid parent id %d", desc.GetParentID()))
 		}
-		if desc.GetParentSchemaID() != descpb.InvalidID &&
-			desc.GetParentSchemaID() != keys.PublicSchemaID {
-			if !parentSchemaExists {
+
+		invalidParentSchemaID := !parentSchemaExists &&
+			desc.GetParentSchemaID() != descpb.InvalidID &&
+			desc.GetParentSchemaID() != keys.PublicSchemaID
+
+		invalidParentSchemaParentID := !invalidParentID &&
+			desc.GetParentSchemaID() != descpb.InvalidID &&
+			desc.GetParentSchemaID() != keys.PublicSchemaID &&
+			parentSchemaExists &&
+			parentSchema.GetParentID() != desc.GetParentID()
+
+		if !skipParentSchemaCheck {
+			if invalidParentSchemaID {
 				problemsFound = true
 				fmt.Fprint(stdout, reportMsg(desc, "invalid parent schema id %d", desc.GetParentSchemaID()))
-			} else if !invalidParentID && parentSchema.GetParentID() != desc.GetParentID() {
+			}
+			if invalidParentSchemaParentID {
 				problemsFound = true
 				fmt.Fprint(stdout, reportMsg(desc, "invalid parent id of parent schema, expected %d, found %d", desc.GetParentID(), parentSchema.GetParentID()))
 			}


### PR DESCRIPTION
Previously, the doctor could panic when comparing the parent id
of a table or type and that of the parent schema, due to wrongly
assuming the success of a prior descriptor lookup. This patch addresses
this bug.

Furthermore, the doctor would skip certain ID checks on the assumption
that these would already have been performed by the descriptor's
validation logic. Upon closer examination this assumption was not always
correct, for instance it turns out that the validation of a
TableDescriptor never checks the ParentSchemaID.

This patch therefore also broadens the scope of these ID checks somewhat.
The right thing to do would be to have the validation logic perform
these checks but this would require many changes outside the scope of
this fix.

Relates to #59042.

Release note: None