### PR TITLE
acceptance: skip TestDocker* flaky tests

### DIFF
--- a/pkg/acceptance/adapter_test.go
+++ b/pkg/acceptance/adapter_test.go
@@ -49,6 +49,7 @@ func TestDockerCSharp(t *testing.T) {
 }
 
 func TestDockerJava(t *testing.T) {
+	skip.WithIssue(t, 58955, "flaky test")
 	s := log.Scope(t)
 	defer s.Close(t)
 
@@ -69,6 +70,7 @@ func TestDockerElixir(t *testing.T) {
 }
 
 func TestDockerNodeJS(t *testing.T) {
+	skip.WithIssue(t, 58955, "flaky test")
 	s := log.Scope(t)
 	defer s.Close(t)
 
@@ -97,6 +99,7 @@ func TestDockerPHP(t *testing.T) {
 }
 
 func TestDockerPSQL(t *testing.T) {
+	skip.WithIssue(t, 58955, "flaky test")
 	s := log.Scope(t)
 	defer s.Close(t)
 


### PR DESCRIPTION
These tests all flake with the same failure.

Informs #58955.

Release note: None