### PR TITLE
sql: fix interactions of PARTITION BY NOTHING and PARTITION BY ALL

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning
@@ -1146,3 +1146,26 @@ gc.ttlseconds = 90000,
 num_replicas = 5,
 constraints = '[]',
 lease_preferences = '[]'
+
+statement ok
+CREATE TABLE partition_by_nothing (
+  pk INT PRIMARY KEY,
+  a INT,
+  UNIQUE(b) PARTITION BY NOTHING,
+  b INT,
+  INDEX(b) PARTITION BY NOTHING,
+  FAMILY (pk, a, b)
+) PARTITION BY NOTHING
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE partition_by_nothing]
+----
+CREATE TABLE public.partition_by_nothing (
+   pk INT8 NOT NULL,
+   a INT8 NULL,
+   b INT8 NULL,
+   CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+   UNIQUE INDEX partition_by_nothing_b_key (b ASC),
+   INDEX partition_by_nothing_b_idx (b ASC),
+   FAMILY fam_0_pk_a_b (pk, a, b)
+)

--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_all_by_nothing
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_all_by_nothing
@@ -1,0 +1,57 @@
+# LogicTest: local
+#
+statement ok
+SET experimental_enable_implicit_column_partitioning = true
+
+statement error cannot define PARTITION BY on an unique constraint if the table has a PARTITION ALL BY definition
+CREATE TABLE partition_all_by_nothing_with_partition (
+  pk INT PRIMARY KEY,
+  a INT,
+  UNIQUE(b) PARTITION BY NOTHING,
+  b INT,
+  INDEX(b) PARTITION BY LIST(b) (PARTITION one VALUES IN (1)),
+  FAMILY (pk, a, b)
+) PARTITION ALL BY NOTHING
+
+statement ok
+CREATE TABLE partition_all_by_nothing (
+  pk INT PRIMARY KEY,
+  a INT,
+  UNIQUE(b),
+  b INT,
+  INDEX(b),
+  FAMILY (pk, a, b)
+) PARTITION ALL BY NOTHING
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE partition_all_by_nothing]
+----
+CREATE TABLE public.partition_all_by_nothing (
+                            pk INT8 NOT NULL,
+                            a INT8 NULL,
+                            b INT8 NULL,
+                            CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+                            UNIQUE INDEX partition_all_by_nothing_b_key (b ASC),
+                            INDEX partition_all_by_nothing_b_idx (b ASC),
+                            FAMILY fam_0_pk_a_b (pk, a, b)
+) PARTITION ALL BY NOTHING
+
+statement error cannot define PARTITION BY on an index if the table has a PARTITION ALL BY definition
+CREATE INDEX idx ON partition_all_by_nothing(pk) PARTITION BY LIST(pk) (PARTITION one VALUES IN (1))
+
+statement ok
+CREATE INDEX idx ON partition_all_by_nothing(pk)
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE partition_all_by_nothing]
+----
+CREATE TABLE public.partition_all_by_nothing (
+                            pk INT8 NOT NULL,
+                            a INT8 NULL,
+                            b INT8 NULL,
+                            CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+                            UNIQUE INDEX partition_all_by_nothing_b_key (b ASC),
+                            INDEX partition_all_by_nothing_b_idx (b ASC),
+                            INDEX idx (pk ASC),
+                            FAMILY fam_0_pk_a_b (pk, a, b)
+) PARTITION ALL BY NOTHING

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
@@ -30,11 +30,26 @@ CREATE TABLE regional_by_row_table (
 )
 LOCALITY REGIONAL BY ROW
 
+statement error REGIONAL BY ROW on a TABLE containing PARTITION BY is not supported
+CREATE TABLE regional_by_row_table (
+  pk int
+)
+PARTITION BY NOTHING
+LOCALITY REGIONAL BY ROW
+
 statement error REGIONAL BY ROW on a table with an INDEX containing PARTITION BY is not supported
 CREATE TABLE regional_by_row_table (
   pk int,
   a int,
   INDEX (a) PARTITION BY LIST (a) (PARTITION one VALUES IN ((1)))
+)
+LOCALITY REGIONAL BY ROW
+
+statement error REGIONAL BY ROW on a table with an INDEX containing PARTITION BY is not supported
+CREATE TABLE regional_by_row_table (
+  pk int,
+  a int,
+  INDEX (a) PARTITION BY NOTHING
 )
 LOCALITY REGIONAL BY ROW
 
@@ -45,6 +60,15 @@ CREATE TABLE regional_by_row_table (
   UNIQUE (a) PARTITION BY LIST (a) (PARTITION one VALUES IN ((1)))
 )
 LOCALITY REGIONAL BY ROW
+
+statement error REGIONAL BY ROW on a table with an UNIQUE constraint containing PARTITION BY is not supported
+CREATE TABLE regional_by_row_table (
+  pk int,
+  a int,
+  UNIQUE (a) PARTITION BY NOTHING
+)
+LOCALITY REGIONAL BY ROW
+
 
 statement ok
 CREATE TABLE regional_by_row_table (

--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -427,46 +427,48 @@ func (n *createIndexNode) startExec(params runParams) error {
 	}
 	indexDesc.Version = encodingVersion
 
-	var partitionByAll *tree.PartitionBy
-	if n.tableDesc.IsPartitionAllBy() {
-		partitionByAll, err = partitionByFromTableDesc(params.p.ExecCfg().Codec, n.tableDesc)
-		if err != nil {
-			return err
-		}
-	}
-	if n.n.PartitionByIndex.ContainsPartitions() || partitionByAll != nil {
-		partitionBy := partitionByAll
-		if partitionByAll == nil {
-			partitionBy = n.n.PartitionByIndex.PartitionBy
-		} else if n.n.PartitionByIndex.ContainsPartitions() {
+	if n.n.PartitionByIndex.ContainsPartitioningClause() || n.tableDesc.IsPartitionAllBy() {
+		var partitionBy *tree.PartitionBy
+		if !n.tableDesc.IsPartitionAllBy() {
+			if n.n.PartitionByIndex.ContainsPartitions() {
+				partitionBy = n.n.PartitionByIndex.PartitionBy
+			}
+		} else if n.n.PartitionByIndex.ContainsPartitioningClause() {
 			return pgerror.New(
 				pgcode.FeatureNotSupported,
 				"cannot define PARTITION BY on an index if the table has a PARTITION ALL BY definition",
 			)
+		} else {
+			partitionBy, err = partitionByFromTableDesc(params.p.ExecCfg().Codec, n.tableDesc)
+			if err != nil {
+				return err
+			}
 		}
-		newIndexDesc, numImplicitColumns, err := detectImplicitPartitionColumns(
-			params.p.EvalContext(),
-			n.tableDesc,
-			*indexDesc,
-			partitionBy,
-		)
-		if err != nil {
-			return err
+		if partitionBy != nil {
+			newIndexDesc, numImplicitColumns, err := detectImplicitPartitionColumns(
+				params.p.EvalContext(),
+				n.tableDesc,
+				*indexDesc,
+				partitionBy,
+			)
+			if err != nil {
+				return err
+			}
+			indexDesc = &newIndexDesc
+			partitioning, err := CreatePartitioning(
+				params.ctx,
+				params.p.ExecCfg().Settings,
+				params.EvalContext(),
+				n.tableDesc,
+				indexDesc,
+				numImplicitColumns,
+				partitionBy,
+			)
+			if err != nil {
+				return err
+			}
+			indexDesc.Partitioning = partitioning
 		}
-		indexDesc = &newIndexDesc
-		partitioning, err := CreatePartitioning(
-			params.ctx,
-			params.p.ExecCfg().Settings,
-			params.EvalContext(),
-			n.tableDesc,
-			indexDesc,
-			numImplicitColumns,
-			partitionBy,
-		)
-		if err != nil {
-			return err
-		}
-		indexDesc.Partitioning = partitioning
 	}
 
 	mutationIdx := len(n.tableDesc.Mutations)

--- a/pkg/sql/sem/tree/create.go
+++ b/pkg/sql/sem/tree/create.go
@@ -1109,6 +1109,12 @@ func (node *PartitionByIndex) ContainsPartitions() bool {
 	return node != nil && node.PartitionBy != nil
 }
 
+// ContainsPartitioningClause determines if the partition by table contains
+// a partitioning clause, including PARTITION BY NOTHING.
+func (node *PartitionByIndex) ContainsPartitioningClause() bool {
+	return node != nil
+}
+
 // PartitionByTable represents a PARTITION [ALL] BY definition within
 // a CREATE/ALTER TABLE statement.
 type PartitionByTable struct {
@@ -1136,6 +1142,12 @@ func (node *PartitionByTable) Format(ctx *FmtCtx) {
 // a partition clause which is not PARTITION BY NOTHING.
 func (node *PartitionByTable) ContainsPartitions() bool {
 	return node != nil && node.PartitionBy != nil
+}
+
+// ContainsPartitioningClause determines if the partition by table contains
+// a partitioning clause, including PARTITION BY NOTHING.
+func (node *PartitionByTable) ContainsPartitioningClause() bool {
+	return node != nil
 }
 
 // PartitionBy represents an PARTITION BY definition within a CREATE/ALTER


### PR DESCRIPTION
Before this PR, specifying PARTITION BY NOTHING whilst having PARTITION
BY ALL would be allowed. However, upon closer inspection, we shouldn't
allow someone to specify PARTITION BY NOTHING if PARTITION ALL BY is
defined on the table. This PR introduces proper checks for this.

Furthermore, introduce support for PARTITION ALL BY NOTHING, which
ensures the entire table has no PARTITION BY.

Release note: None