### PR TITLE
release-20.2: opt: fix bug where ON CONFLICT DO NOTHING ignores some input

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/upsert
+++ b/pkg/sql/logictest/testdata/logic_test/upsert
@@ -1247,3 +1247,29 @@ query I
 WITH cte(c) AS (UPSERT INTO t54456 SELECT i FROM generate_series(25001, 40000) AS i RETURNING c) SELECT count(*) FROM cte
 ----
 15000
+
+# Regression test for #59125. Ensure that valid rows don't get filtered out
+# from ON CONFLICT DO NOTHING.
+statement ok
+CREATE TABLE uniq (
+  x STRING PRIMARY KEY,
+  y STRING UNIQUE,
+  z STRING UNIQUE
+)
+
+statement ok
+INSERT INTO uniq VALUES ('x1', 'y1', 'z1');
+
+# The first row has a conflict due to the unique index on y, so it should be
+# discarded. The second row does not conflict with the existing row, so it
+# should be inserted. The third row is a duplicate of the second row, so it
+# should be discarded.
+statement ok
+INSERT INTO uniq VALUES ('x2', 'y1', 'z2'), ('x2', 'y2', 'z2'), ('x2', 'y2', 'z2')
+ON CONFLICT DO NOTHING
+
+query TTT rowsort
+SELECT * FROM uniq
+----
+x1  y1  z1
+x2  y2  z2

--- a/pkg/sql/opt/memo/testdata/logprops/upsert
+++ b/pkg/sql/opt/memo/testdata/logprops/upsert
@@ -236,198 +236,200 @@ project
            ├── volatile
            ├── key: (6)
            ├── fd: (6)-->(7,10,11), (7)-->(11), (10)~~>(6,7,11), (7,11)~~>(6,10)
-           ├── project
+           ├── upsert-distinct-on
            │    ├── columns: x:6(int!null) y:7(int) column10:10(int) column11:11(int)
+           │    ├── grouping columns: x:6(int!null)
            │    ├── volatile
            │    ├── key: (6)
            │    ├── fd: (6)-->(7,10,11), (7)-->(11), (10)~~>(6,7,11)
-           │    ├── prune: (6,7,10,11)
-           │    └── select
-           │         ├── columns: x:6(int!null) y:7(int) column10:10(int) column11:11(int) a:22(int) b:23(int) c:24(int) rowid:25(int)
-           │         ├── volatile
-           │         ├── key: (6)
-           │         ├── fd: ()-->(22-25), (6)-->(7,10,11), (7)-->(11), (10)~~>(6,7,11)
-           │         ├── prune: (22)
-           │         ├── interesting orderings: (+25) (+22) (+23,+24,+25)
-           │         ├── left-join (hash)
-           │         │    ├── columns: x:6(int!null) y:7(int) column10:10(int) column11:11(int) a:22(int) b:23(int) c:24(int) rowid:25(int)
-           │         │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
-           │         │    ├── volatile
-           │         │    ├── key: (6,25)
-           │         │    ├── fd: (6)-->(7,10,11), (7)-->(11), (10)~~>(6,7,11), (25)-->(22-24), (22)-->(23-25), (23,24)~~>(22,25)
-           │         │    ├── prune: (22,25)
-           │         │    ├── reject-nulls: (22-25)
-           │         │    ├── interesting orderings: (+25) (+22) (+23,+24,+25)
-           │         │    ├── upsert-distinct-on
-           │         │    │    ├── columns: x:6(int!null) y:7(int) column10:10(int) column11:11(int)
-           │         │    │    ├── grouping columns: x:6(int!null)
-           │         │    │    ├── volatile
-           │         │    │    ├── key: (6)
-           │         │    │    ├── fd: (6)-->(7,10,11), (7)-->(11), (10)~~>(6,7,11)
-           │         │    │    ├── project
-           │         │    │    │    ├── columns: x:6(int!null) y:7(int) column10:10(int) column11:11(int)
-           │         │    │    │    ├── volatile
-           │         │    │    │    ├── key: (6)
-           │         │    │    │    ├── fd: (6)-->(7,10), (7)-->(11), (10)~~>(6,7,11)
-           │         │    │    │    ├── prune: (6,7,10,11)
-           │         │    │    │    └── select
-           │         │    │    │         ├── columns: x:6(int!null) y:7(int) column10:10(int) column11:11(int) a:17(int) b:18(int) c:19(int) rowid:20(int)
-           │         │    │    │         ├── volatile
-           │         │    │    │         ├── key: (6)
-           │         │    │    │         ├── fd: ()-->(17-20), (6)-->(7,10), (7)-->(11), (10)~~>(6,7,11)
-           │         │    │    │         ├── prune: (18-20)
-           │         │    │    │         ├── interesting orderings: (+20) (+17) (+18,+19,+20)
-           │         │    │    │         ├── left-join (hash)
-           │         │    │    │         │    ├── columns: x:6(int!null) y:7(int) column10:10(int) column11:11(int) a:17(int) b:18(int) c:19(int) rowid:20(int)
-           │         │    │    │         │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
-           │         │    │    │         │    ├── volatile
-           │         │    │    │         │    ├── key: (6)
-           │         │    │    │         │    ├── fd: (6)-->(7,10,17-20), (7)-->(11), (10)~~>(6,7,11), (20)-->(17-19), (17)-->(18-20), (18,19)~~>(17,20)
-           │         │    │    │         │    ├── prune: (18-20)
-           │         │    │    │         │    ├── reject-nulls: (17-20)
-           │         │    │    │         │    ├── interesting orderings: (+20) (+17) (+18,+19,+20)
-           │         │    │    │         │    ├── upsert-distinct-on
-           │         │    │    │         │    │    ├── columns: x:6(int!null) y:7(int) column10:10(int) column11:11(int)
-           │         │    │    │         │    │    ├── grouping columns: column10:10(int)
-           │         │    │    │         │    │    ├── volatile
-           │         │    │    │         │    │    ├── key: (6)
-           │         │    │    │         │    │    ├── fd: (6)-->(7,10), (7)-->(11), (10)~~>(6,7,11)
-           │         │    │    │         │    │    ├── project
-           │         │    │    │         │    │    │    ├── columns: x:6(int!null) y:7(int) column10:10(int) column11:11(int)
-           │         │    │    │         │    │    │    ├── volatile
-           │         │    │    │         │    │    │    ├── key: (6)
-           │         │    │    │         │    │    │    ├── fd: (6)-->(7,10), (7)-->(11)
-           │         │    │    │         │    │    │    ├── prune: (6,7,10,11)
-           │         │    │    │         │    │    │    ├── interesting orderings: (+6) (+7)
-           │         │    │    │         │    │    │    └── select
-           │         │    │    │         │    │    │         ├── columns: x:6(int!null) y:7(int) column10:10(int) column11:11(int) a:12(int) b:13(int) c:14(int) rowid:15(int)
-           │         │    │    │         │    │    │         ├── volatile
-           │         │    │    │         │    │    │         ├── key: (6)
-           │         │    │    │         │    │    │         ├── fd: ()-->(12-15), (6)-->(7,10), (7)-->(11)
-           │         │    │    │         │    │    │         ├── prune: (6,7,11-14)
-           │         │    │    │         │    │    │         ├── interesting orderings: (+6) (+7) (+15) (+12) (+13,+14,+15)
-           │         │    │    │         │    │    │         ├── left-join (hash)
-           │         │    │    │         │    │    │         │    ├── columns: x:6(int!null) y:7(int) column10:10(int) column11:11(int) a:12(int) b:13(int) c:14(int) rowid:15(int)
-           │         │    │    │         │    │    │         │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
-           │         │    │    │         │    │    │         │    ├── volatile
-           │         │    │    │         │    │    │         │    ├── key: (6)
-           │         │    │    │         │    │    │         │    ├── fd: (6)-->(7,10,12-15), (7)-->(11), (15)-->(12-14), (12)-->(13-15), (13,14)~~>(12,15)
-           │         │    │    │         │    │    │         │    ├── prune: (6,7,11-14)
-           │         │    │    │         │    │    │         │    ├── reject-nulls: (12-15)
-           │         │    │    │         │    │    │         │    ├── interesting orderings: (+6) (+7) (+15) (+12) (+13,+14,+15)
-           │         │    │    │         │    │    │         │    ├── project
-           │         │    │    │         │    │    │         │    │    ├── columns: column11:11(int) x:6(int!null) y:7(int) column10:10(int)
-           │         │    │    │         │    │    │         │    │    ├── volatile
-           │         │    │    │         │    │    │         │    │    ├── key: (6)
-           │         │    │    │         │    │    │         │    │    ├── fd: (6)-->(7,10), (7)-->(11)
-           │         │    │    │         │    │    │         │    │    ├── prune: (6,7,10,11)
-           │         │    │    │         │    │    │         │    │    ├── interesting orderings: (+6) (+7)
-           │         │    │    │         │    │    │         │    │    ├── unfiltered-cols: (6-9)
-           │         │    │    │         │    │    │         │    │    ├── project
-           │         │    │    │         │    │    │         │    │    │    ├── columns: column10:10(int) x:6(int!null) y:7(int)
-           │         │    │    │         │    │    │         │    │    │    ├── volatile
-           │         │    │    │         │    │    │         │    │    │    ├── key: (6)
-           │         │    │    │         │    │    │         │    │    │    ├── fd: (6)-->(7,10)
-           │         │    │    │         │    │    │         │    │    │    ├── prune: (6,7,10)
-           │         │    │    │         │    │    │         │    │    │    ├── interesting orderings: (+6) (+7)
-           │         │    │    │         │    │    │         │    │    │    ├── unfiltered-cols: (6-9)
-           │         │    │    │         │    │    │         │    │    │    ├── project
-           │         │    │    │         │    │    │         │    │    │    │    ├── columns: x:6(int!null) y:7(int)
-           │         │    │    │         │    │    │         │    │    │    │    ├── key: (6)
-           │         │    │    │         │    │    │         │    │    │    │    ├── fd: (6)-->(7)
-           │         │    │    │         │    │    │         │    │    │    │    ├── prune: (6,7)
-           │         │    │    │         │    │    │         │    │    │    │    ├── interesting orderings: (+6) (+7)
-           │         │    │    │         │    │    │         │    │    │    │    ├── unfiltered-cols: (6-9)
-           │         │    │    │         │    │    │         │    │    │    │    └── scan xyz
-           │         │    │    │         │    │    │         │    │    │    │         ├── columns: x:6(int!null) y:7(int) z:8(int) xyz.crdb_internal_mvcc_timestamp:9(decimal)
-           │         │    │    │         │    │    │         │    │    │    │         ├── key: (6)
-           │         │    │    │         │    │    │         │    │    │    │         ├── fd: (6)-->(7-9), (7,8)~~>(6,9)
-           │         │    │    │         │    │    │         │    │    │    │         ├── prune: (6-9)
-           │         │    │    │         │    │    │         │    │    │    │         ├── interesting orderings: (+6) (+7,+8,+6) (+8,+7,+6)
-           │         │    │    │         │    │    │         │    │    │    │         └── unfiltered-cols: (6-9)
-           │         │    │    │         │    │    │         │    │    │    └── projections
-           │         │    │    │         │    │    │         │    │    │         └── function: unique_rowid [as=column10:10, type=int, volatile]
-           │         │    │    │         │    │    │         │    │    └── projections
-           │         │    │    │         │    │    │         │    │         └── plus [as=column11:11, type=int, outer=(7), immutable]
-           │         │    │    │         │    │    │         │    │              ├── variable: y:7 [type=int]
-           │         │    │    │         │    │    │         │    │              └── const: 1 [type=int]
-           │         │    │    │         │    │    │         │    ├── scan abc
-           │         │    │    │         │    │    │         │    │    ├── columns: a:12(int!null) b:13(int) c:14(int) rowid:15(int!null)
-           │         │    │    │         │    │    │         │    │    ├── computed column expressions
-           │         │    │    │         │    │    │         │    │    │    └── c:14
-           │         │    │    │         │    │    │         │    │    │         └── plus [type=int]
-           │         │    │    │         │    │    │         │    │    │              ├── variable: b:13 [type=int]
-           │         │    │    │         │    │    │         │    │    │              └── const: 1 [type=int]
-           │         │    │    │         │    │    │         │    │    ├── key: (15)
-           │         │    │    │         │    │    │         │    │    ├── fd: (15)-->(12-14), (12)-->(13-15), (13,14)~~>(12,15)
-           │         │    │    │         │    │    │         │    │    ├── prune: (12-15)
-           │         │    │    │         │    │    │         │    │    ├── interesting orderings: (+15) (+12) (+13,+14,+15)
-           │         │    │    │         │    │    │         │    │    └── unfiltered-cols: (12-16)
-           │         │    │    │         │    │    │         │    └── filters
-           │         │    │    │         │    │    │         │         └── eq [type=bool, outer=(10,15), constraints=(/10: (/NULL - ]; /15: (/NULL - ]), fd=(10)==(15), (15)==(10)]
-           │         │    │    │         │    │    │         │              ├── variable: column10:10 [type=int]
-           │         │    │    │         │    │    │         │              └── variable: rowid:15 [type=int]
-           │         │    │    │         │    │    │         └── filters
-           │         │    │    │         │    │    │              └── is [type=bool, outer=(15), constraints=(/15: [/NULL - /NULL]; tight), fd=()-->(15)]
-           │         │    │    │         │    │    │                   ├── variable: rowid:15 [type=int]
-           │         │    │    │         │    │    │                   └── null [type=unknown]
-           │         │    │    │         │    │    └── aggregations
-           │         │    │    │         │    │         ├── first-agg [as=x:6, type=int, outer=(6)]
-           │         │    │    │         │    │         │    └── variable: x:6 [type=int]
-           │         │    │    │         │    │         ├── first-agg [as=y:7, type=int, outer=(7)]
-           │         │    │    │         │    │         │    └── variable: y:7 [type=int]
-           │         │    │    │         │    │         └── first-agg [as=column11:11, type=int, outer=(11)]
-           │         │    │    │         │    │              └── variable: column11:11 [type=int]
-           │         │    │    │         │    ├── scan abc
-           │         │    │    │         │    │    ├── columns: a:17(int!null) b:18(int) c:19(int) rowid:20(int!null)
-           │         │    │    │         │    │    ├── computed column expressions
-           │         │    │    │         │    │    │    └── c:19
-           │         │    │    │         │    │    │         └── plus [type=int]
-           │         │    │    │         │    │    │              ├── variable: b:18 [type=int]
-           │         │    │    │         │    │    │              └── const: 1 [type=int]
-           │         │    │    │         │    │    ├── key: (20)
-           │         │    │    │         │    │    ├── fd: (20)-->(17-19), (17)-->(18-20), (18,19)~~>(17,20)
-           │         │    │    │         │    │    ├── prune: (17-20)
-           │         │    │    │         │    │    ├── interesting orderings: (+20) (+17) (+18,+19,+20)
-           │         │    │    │         │    │    └── unfiltered-cols: (17-21)
-           │         │    │    │         │    └── filters
-           │         │    │    │         │         └── eq [type=bool, outer=(6,17), constraints=(/6: (/NULL - ]; /17: (/NULL - ]), fd=(6)==(17), (17)==(6)]
-           │         │    │    │         │              ├── variable: x:6 [type=int]
-           │         │    │    │         │              └── variable: a:17 [type=int]
-           │         │    │    │         └── filters
-           │         │    │    │              └── is [type=bool, outer=(17), constraints=(/17: [/NULL - /NULL]; tight), fd=()-->(17)]
-           │         │    │    │                   ├── variable: a:17 [type=int]
-           │         │    │    │                   └── null [type=unknown]
-           │         │    │    └── aggregations
-           │         │    │         ├── first-agg [as=y:7, type=int, outer=(7)]
-           │         │    │         │    └── variable: y:7 [type=int]
-           │         │    │         ├── first-agg [as=column10:10, type=int, outer=(10)]
-           │         │    │         │    └── variable: column10:10 [type=int]
-           │         │    │         └── first-agg [as=column11:11, type=int, outer=(11)]
-           │         │    │              └── variable: column11:11 [type=int]
-           │         │    ├── scan abc
-           │         │    │    ├── columns: a:22(int!null) b:23(int) c:24(int) rowid:25(int!null)
-           │         │    │    ├── computed column expressions
-           │         │    │    │    └── c:24
-           │         │    │    │         └── plus [type=int]
-           │         │    │    │              ├── variable: b:23 [type=int]
-           │         │    │    │              └── const: 1 [type=int]
-           │         │    │    ├── key: (25)
-           │         │    │    ├── fd: (25)-->(22-24), (22)-->(23-25), (23,24)~~>(22,25)
-           │         │    │    ├── prune: (22-25)
-           │         │    │    ├── interesting orderings: (+25) (+22) (+23,+24,+25)
-           │         │    │    └── unfiltered-cols: (22-26)
-           │         │    └── filters
-           │         │         ├── eq [type=bool, outer=(7,23), constraints=(/7: (/NULL - ]; /23: (/NULL - ]), fd=(7)==(23), (23)==(7)]
-           │         │         │    ├── variable: y:7 [type=int]
-           │         │         │    └── variable: b:23 [type=int]
-           │         │         └── eq [type=bool, outer=(11,24), constraints=(/11: (/NULL - ]; /24: (/NULL - ]), fd=(11)==(24), (24)==(11)]
-           │         │              ├── variable: column11:11 [type=int]
-           │         │              └── variable: c:24 [type=int]
-           │         └── filters
-           │              └── is [type=bool, outer=(25), constraints=(/25: [/NULL - /NULL]; tight), fd=()-->(25)]
-           │                   ├── variable: rowid:25 [type=int]
-           │                   └── null [type=unknown]
+           │    ├── upsert-distinct-on
+           │    │    ├── columns: x:6(int!null) y:7(int) column10:10(int) column11:11(int)
+           │    │    ├── grouping columns: column10:10(int)
+           │    │    ├── volatile
+           │    │    ├── key: (6)
+           │    │    ├── fd: (6)-->(7,10), (7)-->(11), (10)~~>(6,7,11)
+           │    │    ├── project
+           │    │    │    ├── columns: x:6(int!null) y:7(int) column10:10(int) column11:11(int)
+           │    │    │    ├── volatile
+           │    │    │    ├── key: (6)
+           │    │    │    ├── fd: (6)-->(7,10), (7)-->(11)
+           │    │    │    ├── prune: (6,7,10,11)
+           │    │    │    ├── interesting orderings: (+6) (+7)
+           │    │    │    └── select
+           │    │    │         ├── columns: x:6(int!null) y:7(int) column10:10(int) column11:11(int) a:22(int) b:23(int) c:24(int) rowid:25(int)
+           │    │    │         ├── volatile
+           │    │    │         ├── key: (6)
+           │    │    │         ├── fd: ()-->(22-25), (6)-->(7,10), (7)-->(11)
+           │    │    │         ├── prune: (6,10,22)
+           │    │    │         ├── interesting orderings: (+6) (+7) (+25) (+22) (+23,+24,+25)
+           │    │    │         ├── left-join (hash)
+           │    │    │         │    ├── columns: x:6(int!null) y:7(int) column10:10(int) column11:11(int) a:22(int) b:23(int) c:24(int) rowid:25(int)
+           │    │    │         │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
+           │    │    │         │    ├── volatile
+           │    │    │         │    ├── key: (6,25)
+           │    │    │         │    ├── fd: (6)-->(7,10), (7)-->(11), (25)-->(22-24), (22)-->(23-25), (23,24)~~>(22,25)
+           │    │    │         │    ├── prune: (6,10,22,25)
+           │    │    │         │    ├── reject-nulls: (22-25)
+           │    │    │         │    ├── interesting orderings: (+6) (+7) (+25) (+22) (+23,+24,+25)
+           │    │    │         │    ├── project
+           │    │    │         │    │    ├── columns: x:6(int!null) y:7(int) column10:10(int) column11:11(int)
+           │    │    │         │    │    ├── volatile
+           │    │    │         │    │    ├── key: (6)
+           │    │    │         │    │    ├── fd: (6)-->(7,10), (7)-->(11)
+           │    │    │         │    │    ├── prune: (6,7,10,11)
+           │    │    │         │    │    ├── interesting orderings: (+6) (+7)
+           │    │    │         │    │    └── select
+           │    │    │         │    │         ├── columns: x:6(int!null) y:7(int) column10:10(int) column11:11(int) a:17(int) b:18(int) c:19(int) rowid:20(int)
+           │    │    │         │    │         ├── volatile
+           │    │    │         │    │         ├── key: (6)
+           │    │    │         │    │         ├── fd: ()-->(17-20), (6)-->(7,10), (7)-->(11)
+           │    │    │         │    │         ├── prune: (7,10,11,18-20)
+           │    │    │         │    │         ├── interesting orderings: (+6) (+7) (+20) (+17) (+18,+19,+20)
+           │    │    │         │    │         ├── left-join (hash)
+           │    │    │         │    │         │    ├── columns: x:6(int!null) y:7(int) column10:10(int) column11:11(int) a:17(int) b:18(int) c:19(int) rowid:20(int)
+           │    │    │         │    │         │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
+           │    │    │         │    │         │    ├── volatile
+           │    │    │         │    │         │    ├── key: (6)
+           │    │    │         │    │         │    ├── fd: (6)-->(7,10,17-20), (7)-->(11), (20)-->(17-19), (17)-->(18-20), (18,19)~~>(17,20)
+           │    │    │         │    │         │    ├── prune: (7,10,11,18-20)
+           │    │    │         │    │         │    ├── reject-nulls: (17-20)
+           │    │    │         │    │         │    ├── interesting orderings: (+6) (+7) (+20) (+17) (+18,+19,+20)
+           │    │    │         │    │         │    ├── project
+           │    │    │         │    │         │    │    ├── columns: x:6(int!null) y:7(int) column10:10(int) column11:11(int)
+           │    │    │         │    │         │    │    ├── volatile
+           │    │    │         │    │         │    │    ├── key: (6)
+           │    │    │         │    │         │    │    ├── fd: (6)-->(7,10), (7)-->(11)
+           │    │    │         │    │         │    │    ├── prune: (6,7,10,11)
+           │    │    │         │    │         │    │    ├── interesting orderings: (+6) (+7)
+           │    │    │         │    │         │    │    └── select
+           │    │    │         │    │         │    │         ├── columns: x:6(int!null) y:7(int) column10:10(int) column11:11(int) a:12(int) b:13(int) c:14(int) rowid:15(int)
+           │    │    │         │    │         │    │         ├── volatile
+           │    │    │         │    │         │    │         ├── key: (6)
+           │    │    │         │    │         │    │         ├── fd: ()-->(12-15), (6)-->(7,10), (7)-->(11)
+           │    │    │         │    │         │    │         ├── prune: (6,7,11-14)
+           │    │    │         │    │         │    │         ├── interesting orderings: (+6) (+7) (+15) (+12) (+13,+14,+15)
+           │    │    │         │    │         │    │         ├── left-join (hash)
+           │    │    │         │    │         │    │         │    ├── columns: x:6(int!null) y:7(int) column10:10(int) column11:11(int) a:12(int) b:13(int) c:14(int) rowid:15(int)
+           │    │    │         │    │         │    │         │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
+           │    │    │         │    │         │    │         │    ├── volatile
+           │    │    │         │    │         │    │         │    ├── key: (6)
+           │    │    │         │    │         │    │         │    ├── fd: (6)-->(7,10,12-15), (7)-->(11), (15)-->(12-14), (12)-->(13-15), (13,14)~~>(12,15)
+           │    │    │         │    │         │    │         │    ├── prune: (6,7,11-14)
+           │    │    │         │    │         │    │         │    ├── reject-nulls: (12-15)
+           │    │    │         │    │         │    │         │    ├── interesting orderings: (+6) (+7) (+15) (+12) (+13,+14,+15)
+           │    │    │         │    │         │    │         │    ├── project
+           │    │    │         │    │         │    │         │    │    ├── columns: column11:11(int) x:6(int!null) y:7(int) column10:10(int)
+           │    │    │         │    │         │    │         │    │    ├── volatile
+           │    │    │         │    │         │    │         │    │    ├── key: (6)
+           │    │    │         │    │         │    │         │    │    ├── fd: (6)-->(7,10), (7)-->(11)
+           │    │    │         │    │         │    │         │    │    ├── prune: (6,7,10,11)
+           │    │    │         │    │         │    │         │    │    ├── interesting orderings: (+6) (+7)
+           │    │    │         │    │         │    │         │    │    ├── unfiltered-cols: (6-9)
+           │    │    │         │    │         │    │         │    │    ├── project
+           │    │    │         │    │         │    │         │    │    │    ├── columns: column10:10(int) x:6(int!null) y:7(int)
+           │    │    │         │    │         │    │         │    │    │    ├── volatile
+           │    │    │         │    │         │    │         │    │    │    ├── key: (6)
+           │    │    │         │    │         │    │         │    │    │    ├── fd: (6)-->(7,10)
+           │    │    │         │    │         │    │         │    │    │    ├── prune: (6,7,10)
+           │    │    │         │    │         │    │         │    │    │    ├── interesting orderings: (+6) (+7)
+           │    │    │         │    │         │    │         │    │    │    ├── unfiltered-cols: (6-9)
+           │    │    │         │    │         │    │         │    │    │    ├── project
+           │    │    │         │    │         │    │         │    │    │    │    ├── columns: x:6(int!null) y:7(int)
+           │    │    │         │    │         │    │         │    │    │    │    ├── key: (6)
+           │    │    │         │    │         │    │         │    │    │    │    ├── fd: (6)-->(7)
+           │    │    │         │    │         │    │         │    │    │    │    ├── prune: (6,7)
+           │    │    │         │    │         │    │         │    │    │    │    ├── interesting orderings: (+6) (+7)
+           │    │    │         │    │         │    │         │    │    │    │    ├── unfiltered-cols: (6-9)
+           │    │    │         │    │         │    │         │    │    │    │    └── scan xyz
+           │    │    │         │    │         │    │         │    │    │    │         ├── columns: x:6(int!null) y:7(int) z:8(int) xyz.crdb_internal_mvcc_timestamp:9(decimal)
+           │    │    │         │    │         │    │         │    │    │    │         ├── key: (6)
+           │    │    │         │    │         │    │         │    │    │    │         ├── fd: (6)-->(7-9), (7,8)~~>(6,9)
+           │    │    │         │    │         │    │         │    │    │    │         ├── prune: (6-9)
+           │    │    │         │    │         │    │         │    │    │    │         ├── interesting orderings: (+6) (+7,+8,+6) (+8,+7,+6)
+           │    │    │         │    │         │    │         │    │    │    │         └── unfiltered-cols: (6-9)
+           │    │    │         │    │         │    │         │    │    │    └── projections
+           │    │    │         │    │         │    │         │    │    │         └── function: unique_rowid [as=column10:10, type=int, volatile]
+           │    │    │         │    │         │    │         │    │    └── projections
+           │    │    │         │    │         │    │         │    │         └── plus [as=column11:11, type=int, outer=(7), immutable]
+           │    │    │         │    │         │    │         │    │              ├── variable: y:7 [type=int]
+           │    │    │         │    │         │    │         │    │              └── const: 1 [type=int]
+           │    │    │         │    │         │    │         │    ├── scan abc
+           │    │    │         │    │         │    │         │    │    ├── columns: a:12(int!null) b:13(int) c:14(int) rowid:15(int!null)
+           │    │    │         │    │         │    │         │    │    ├── computed column expressions
+           │    │    │         │    │         │    │         │    │    │    └── c:14
+           │    │    │         │    │         │    │         │    │    │         └── plus [type=int]
+           │    │    │         │    │         │    │         │    │    │              ├── variable: b:13 [type=int]
+           │    │    │         │    │         │    │         │    │    │              └── const: 1 [type=int]
+           │    │    │         │    │         │    │         │    │    ├── key: (15)
+           │    │    │         │    │         │    │         │    │    ├── fd: (15)-->(12-14), (12)-->(13-15), (13,14)~~>(12,15)
+           │    │    │         │    │         │    │         │    │    ├── prune: (12-15)
+           │    │    │         │    │         │    │         │    │    ├── interesting orderings: (+15) (+12) (+13,+14,+15)
+           │    │    │         │    │         │    │         │    │    └── unfiltered-cols: (12-16)
+           │    │    │         │    │         │    │         │    └── filters
+           │    │    │         │    │         │    │         │         └── eq [type=bool, outer=(10,15), constraints=(/10: (/NULL - ]; /15: (/NULL - ]), fd=(10)==(15), (15)==(10)]
+           │    │    │         │    │         │    │         │              ├── variable: column10:10 [type=int]
+           │    │    │         │    │         │    │         │              └── variable: rowid:15 [type=int]
+           │    │    │         │    │         │    │         └── filters
+           │    │    │         │    │         │    │              └── is [type=bool, outer=(15), constraints=(/15: [/NULL - /NULL]; tight), fd=()-->(15)]
+           │    │    │         │    │         │    │                   ├── variable: rowid:15 [type=int]
+           │    │    │         │    │         │    │                   └── null [type=unknown]
+           │    │    │         │    │         │    ├── scan abc
+           │    │    │         │    │         │    │    ├── columns: a:17(int!null) b:18(int) c:19(int) rowid:20(int!null)
+           │    │    │         │    │         │    │    ├── computed column expressions
+           │    │    │         │    │         │    │    │    └── c:19
+           │    │    │         │    │         │    │    │         └── plus [type=int]
+           │    │    │         │    │         │    │    │              ├── variable: b:18 [type=int]
+           │    │    │         │    │         │    │    │              └── const: 1 [type=int]
+           │    │    │         │    │         │    │    ├── key: (20)
+           │    │    │         │    │         │    │    ├── fd: (20)-->(17-19), (17)-->(18-20), (18,19)~~>(17,20)
+           │    │    │         │    │         │    │    ├── prune: (17-20)
+           │    │    │         │    │         │    │    ├── interesting orderings: (+20) (+17) (+18,+19,+20)
+           │    │    │         │    │         │    │    └── unfiltered-cols: (17-21)
+           │    │    │         │    │         │    └── filters
+           │    │    │         │    │         │         └── eq [type=bool, outer=(6,17), constraints=(/6: (/NULL - ]; /17: (/NULL - ]), fd=(6)==(17), (17)==(6)]
+           │    │    │         │    │         │              ├── variable: x:6 [type=int]
+           │    │    │         │    │         │              └── variable: a:17 [type=int]
+           │    │    │         │    │         └── filters
+           │    │    │         │    │              └── is [type=bool, outer=(17), constraints=(/17: [/NULL - /NULL]; tight), fd=()-->(17)]
+           │    │    │         │    │                   ├── variable: a:17 [type=int]
+           │    │    │         │    │                   └── null [type=unknown]
+           │    │    │         │    ├── scan abc
+           │    │    │         │    │    ├── columns: a:22(int!null) b:23(int) c:24(int) rowid:25(int!null)
+           │    │    │         │    │    ├── computed column expressions
+           │    │    │         │    │    │    └── c:24
+           │    │    │         │    │    │         └── plus [type=int]
+           │    │    │         │    │    │              ├── variable: b:23 [type=int]
+           │    │    │         │    │    │              └── const: 1 [type=int]
+           │    │    │         │    │    ├── key: (25)
+           │    │    │         │    │    ├── fd: (25)-->(22-24), (22)-->(23-25), (23,24)~~>(22,25)
+           │    │    │         │    │    ├── prune: (22-25)
+           │    │    │         │    │    ├── interesting orderings: (+25) (+22) (+23,+24,+25)
+           │    │    │         │    │    └── unfiltered-cols: (22-26)
+           │    │    │         │    └── filters
+           │    │    │         │         ├── eq [type=bool, outer=(7,23), constraints=(/7: (/NULL - ]; /23: (/NULL - ]), fd=(7)==(23), (23)==(7)]
+           │    │    │         │         │    ├── variable: y:7 [type=int]
+           │    │    │         │         │    └── variable: b:23 [type=int]
+           │    │    │         │         └── eq [type=bool, outer=(11,24), constraints=(/11: (/NULL - ]; /24: (/NULL - ]), fd=(11)==(24), (24)==(11)]
+           │    │    │         │              ├── variable: column11:11 [type=int]
+           │    │    │         │              └── variable: c:24 [type=int]
+           │    │    │         └── filters
+           │    │    │              └── is [type=bool, outer=(25), constraints=(/25: [/NULL - /NULL]; tight), fd=()-->(25)]
+           │    │    │                   ├── variable: rowid:25 [type=int]
+           │    │    │                   └── null [type=unknown]
+           │    │    └── aggregations
+           │    │         ├── first-agg [as=x:6, type=int, outer=(6)]
+           │    │         │    └── variable: x:6 [type=int]
+           │    │         ├── first-agg [as=y:7, type=int, outer=(7)]
+           │    │         │    └── variable: y:7 [type=int]
+           │    │         └── first-agg [as=column11:11, type=int, outer=(11)]
+           │    │              └── variable: column11:11 [type=int]
+           │    └── aggregations
+           │         ├── first-agg [as=y:7, type=int, outer=(7)]
+           │         │    └── variable: y:7 [type=int]
+           │         ├── first-agg [as=column10:10, type=int, outer=(10)]
+           │         │    └── variable: column10:10 [type=int]
+           │         └── first-agg [as=column11:11, type=int, outer=(11)]
+           │              └── variable: column11:11 [type=int]
            └── aggregations
                 ├── first-agg [as=x:6, type=int, outer=(6)]
                 │    └── variable: x:6 [type=int]

--- a/pkg/sql/opt/norm/testdata/rules/groupby
+++ b/pkg/sql/opt/norm/testdata/rules/groupby
@@ -2462,25 +2462,23 @@ insert a
       ├── columns: column1:7!null column2:8!null column3:9!null column10:10 column11:11
       ├── grouping columns: column3:9!null column10:10
       ├── cardinality: [0 - 3]
-      ├── lax-key: (9,10)
+      ├── lax-key: (8,10)
       ├── fd: ()-->(10,11), (8,10)~~>(7,9), (9,10)~~>(7,8,11)
-      ├── select
-      │    ├── columns: column1:7!null column2:8!null column3:9!null column10:10 column11:11 i:25 f:26
+      ├── upsert-distinct-on
+      │    ├── columns: column1:7!null column2:8!null column3:9!null column10:10 column11:11
+      │    ├── grouping columns: column2:8!null column10:10
       │    ├── cardinality: [0 - 3]
-      │    ├── lax-key: (8,10,25,26)
-      │    ├── fd: ()-->(10,11,25), (8,10)~~>(7,9)
-      │    ├── left-join (hash)
-      │    │    ├── columns: column1:7!null column2:8!null column3:9!null column10:10 column11:11 i:25 f:26
+      │    ├── lax-key: (8,10)
+      │    ├── fd: ()-->(10,11), (8,10)~~>(7,9,11)
+      │    ├── select
+      │    │    ├── columns: column1:7!null column2:8!null column3:9!null column10:10 column11:11 k:12 i:19 s:21 i:25 f:26
       │    │    ├── cardinality: [0 - 3]
-      │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
-      │    │    ├── lax-key: (8,10,25,26)
-      │    │    ├── fd: ()-->(10,11), (8,10)~~>(7,9)
-      │    │    ├── upsert-distinct-on
-      │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null column10:10 column11:11
-      │    │    │    ├── grouping columns: column2:8!null column10:10
+      │    │    ├── fd: ()-->(10-12,21,25)
+      │    │    ├── left-join (hash)
+      │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null column10:10 column11:11 k:12 i:19 s:21 i:25 f:26
       │    │    │    ├── cardinality: [0 - 3]
-      │    │    │    ├── lax-key: (8,10)
-      │    │    │    ├── fd: ()-->(10,11), (8,10)~~>(7,9,11)
+      │    │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
+      │    │    │    ├── fd: ()-->(10-12,21)
       │    │    │    ├── select
       │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null column10:10 column11:11 k:12 i:19 s:21
       │    │    │    │    ├── cardinality: [0 - 3]
@@ -2527,21 +2525,21 @@ insert a
       │    │    │    │    │         └── column10:10 = i:19 [outer=(10,19), constraints=(/10: (/NULL - ]; /19: (/NULL - ]), fd=(10)==(19), (19)==(10)]
       │    │    │    │    └── filters
       │    │    │    │         └── s:21 IS NULL [outer=(21), constraints=(/21: [/NULL - /NULL]; tight), fd=()-->(21)]
-      │    │    │    └── aggregations
-      │    │    │         ├── first-agg [as=column1:7, outer=(7)]
-      │    │    │         │    └── column1:7
-      │    │    │         ├── first-agg [as=column3:9, outer=(9)]
-      │    │    │         │    └── column3:9
-      │    │    │         └── first-agg [as=column11:11, outer=(11)]
-      │    │    │              └── column11:11
-      │    │    ├── scan a
-      │    │    │    ├── columns: i:25!null f:26
-      │    │    │    └── lax-key: (25,26)
+      │    │    │    ├── scan a
+      │    │    │    │    ├── columns: i:25!null f:26
+      │    │    │    │    └── lax-key: (25,26)
+      │    │    │    └── filters
+      │    │    │         ├── column3:9 = f:26 [outer=(9,26), constraints=(/9: (/NULL - ]; /26: (/NULL - ]), fd=(9)==(26), (26)==(9)]
+      │    │    │         └── column10:10 = i:25 [outer=(10,25), constraints=(/10: (/NULL - ]; /25: (/NULL - ]), fd=(10)==(25), (25)==(10)]
       │    │    └── filters
-      │    │         ├── column3:9 = f:26 [outer=(9,26), constraints=(/9: (/NULL - ]; /26: (/NULL - ]), fd=(9)==(26), (26)==(9)]
-      │    │         └── column10:10 = i:25 [outer=(10,25), constraints=(/10: (/NULL - ]; /25: (/NULL - ]), fd=(10)==(25), (25)==(10)]
-      │    └── filters
-      │         └── i:25 IS NULL [outer=(25), constraints=(/25: [/NULL - /NULL]; tight), fd=()-->(25)]
+      │    │         └── i:25 IS NULL [outer=(25), constraints=(/25: [/NULL - /NULL]; tight), fd=()-->(25)]
+      │    └── aggregations
+      │         ├── first-agg [as=column1:7, outer=(7)]
+      │         │    └── column1:7
+      │         ├── first-agg [as=column3:9, outer=(9)]
+      │         │    └── column3:9
+      │         └── first-agg [as=column11:11, outer=(11)]
+      │              └── column11:11
       └── aggregations
            ├── first-agg [as=column1:7, outer=(7)]
            │    └── column1:7
@@ -2568,100 +2566,91 @@ insert a
  │    └── column11:11 => j:5
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
- └── project
+ └── upsert-distinct-on
       ├── columns: column1:7 column2:8!null column3:9!null column4:10!null column11:11
+      ├── grouping columns: column1:7
       ├── cardinality: [0 - 2]
       ├── volatile
-      ├── fd: ()-->(11), (7)~~>(8-10)
-      └── select
-           ├── columns: column1:7 column2:8!null column3:9!null column4:10!null column11:11 i:19 s:21 i:25 f:26
-           ├── cardinality: [0 - 2]
-           ├── volatile
-           ├── lax-key: (7,19,21,25,26)
-           ├── fd: ()-->(11,21,25), (7)~~>(8-10)
-           ├── left-join (hash)
-           │    ├── columns: column1:7 column2:8!null column3:9!null column4:10!null column11:11 i:19 s:21 i:25 f:26
-           │    ├── cardinality: [0 - 2]
-           │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
-           │    ├── volatile
-           │    ├── lax-key: (7,19,21,25,26)
-           │    ├── fd: ()-->(11,21), (7)~~>(8-10)
-           │    ├── select
-           │    │    ├── columns: column1:7 column2:8!null column3:9!null column4:10!null column11:11 i:19 s:21
-           │    │    ├── cardinality: [0 - 2]
-           │    │    ├── volatile
-           │    │    ├── lax-key: (7,19,21)
-           │    │    ├── fd: ()-->(11,21), (7)~~>(8-10)
-           │    │    ├── left-join (hash)
-           │    │    │    ├── columns: column1:7 column2:8!null column3:9!null column4:10!null column11:11 i:19 s:21
-           │    │    │    ├── cardinality: [0 - 2]
-           │    │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
-           │    │    │    ├── volatile
-           │    │    │    ├── lax-key: (7,19,21)
-           │    │    │    ├── fd: ()-->(11), (7)~~>(8-10)
-           │    │    │    ├── upsert-distinct-on
-           │    │    │    │    ├── columns: column1:7 column2:8!null column3:9!null column4:10!null column11:11
-           │    │    │    │    ├── grouping columns: column1:7
-           │    │    │    │    ├── cardinality: [0 - 2]
-           │    │    │    │    ├── volatile
-           │    │    │    │    ├── lax-key: (7)
-           │    │    │    │    ├── fd: ()-->(11), (7)~~>(8-11)
-           │    │    │    │    ├── select
-           │    │    │    │    │    ├── columns: column1:7 column2:8!null column3:9!null column4:10!null column11:11 k:12
-           │    │    │    │    │    ├── cardinality: [0 - 2]
-           │    │    │    │    │    ├── volatile
-           │    │    │    │    │    ├── fd: ()-->(11,12)
-           │    │    │    │    │    ├── left-join (hash)
-           │    │    │    │    │    │    ├── columns: column1:7 column2:8!null column3:9!null column4:10!null column11:11 k:12
-           │    │    │    │    │    │    ├── cardinality: [2 - 2]
-           │    │    │    │    │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
-           │    │    │    │    │    │    ├── volatile
-           │    │    │    │    │    │    ├── fd: ()-->(11)
-           │    │    │    │    │    │    ├── project
-           │    │    │    │    │    │    │    ├── columns: column11:11 column1:7 column2:8!null column3:9!null column4:10!null
-           │    │    │    │    │    │    │    ├── cardinality: [2 - 2]
-           │    │    │    │    │    │    │    ├── volatile
-           │    │    │    │    │    │    │    ├── fd: ()-->(11)
-           │    │    │    │    │    │    │    ├── values
-           │    │    │    │    │    │    │    │    ├── columns: column1:7 column2:8!null column3:9!null column4:10!null
-           │    │    │    │    │    │    │    │    ├── cardinality: [2 - 2]
-           │    │    │    │    │    │    │    │    ├── volatile
-           │    │    │    │    │    │    │    │    ├── (unique_rowid(), 'foo', 1, 1.0)
-           │    │    │    │    │    │    │    │    └── (unique_rowid(), 'bar', 2, 2.0)
-           │    │    │    │    │    │    │    └── projections
-           │    │    │    │    │    │    │         └── CAST(NULL AS JSONB) [as=column11:11]
-           │    │    │    │    │    │    ├── scan a
-           │    │    │    │    │    │    │    ├── columns: k:12!null
-           │    │    │    │    │    │    │    └── key: (12)
-           │    │    │    │    │    │    └── filters
-           │    │    │    │    │    │         └── column1:7 = k:12 [outer=(7,12), constraints=(/7: (/NULL - ]; /12: (/NULL - ]), fd=(7)==(12), (12)==(7)]
-           │    │    │    │    │    └── filters
-           │    │    │    │    │         └── k:12 IS NULL [outer=(12), constraints=(/12: [/NULL - /NULL]; tight), fd=()-->(12)]
-           │    │    │    │    └── aggregations
-           │    │    │    │         ├── first-agg [as=column2:8, outer=(8)]
-           │    │    │    │         │    └── column2:8
-           │    │    │    │         ├── first-agg [as=column3:9, outer=(9)]
-           │    │    │    │         │    └── column3:9
-           │    │    │    │         ├── first-agg [as=column4:10, outer=(10)]
-           │    │    │    │         │    └── column4:10
-           │    │    │    │         └── first-agg [as=column11:11, outer=(11)]
-           │    │    │    │              └── column11:11
-           │    │    │    ├── scan a
-           │    │    │    │    ├── columns: i:19!null s:21!null
-           │    │    │    │    └── key: (19,21)
-           │    │    │    └── filters
-           │    │    │         ├── column2:8 = s:21 [outer=(8,21), constraints=(/8: (/NULL - ]; /21: (/NULL - ]), fd=(8)==(21), (21)==(8)]
-           │    │    │         └── column3:9 = i:19 [outer=(9,19), constraints=(/9: (/NULL - ]; /19: (/NULL - ]), fd=(9)==(19), (19)==(9)]
-           │    │    └── filters
-           │    │         └── s:21 IS NULL [outer=(21), constraints=(/21: [/NULL - /NULL]; tight), fd=()-->(21)]
-           │    ├── scan a
-           │    │    ├── columns: i:25!null f:26
-           │    │    └── lax-key: (25,26)
-           │    └── filters
-           │         ├── column4:10 = f:26 [outer=(10,26), constraints=(/10: (/NULL - ]; /26: (/NULL - ]), fd=(10)==(26), (26)==(10)]
-           │         └── column3:9 = i:25 [outer=(9,25), constraints=(/9: (/NULL - ]; /25: (/NULL - ]), fd=(9)==(25), (25)==(9)]
-           └── filters
-                └── i:25 IS NULL [outer=(25), constraints=(/25: [/NULL - /NULL]; tight), fd=()-->(25)]
+      ├── lax-key: (7)
+      ├── fd: ()-->(11), (7)~~>(8-11)
+      ├── select
+      │    ├── columns: column1:7 column2:8!null column3:9!null column4:10!null column11:11 k:12 i:19 s:21 i:25 f:26
+      │    ├── cardinality: [0 - 2]
+      │    ├── volatile
+      │    ├── fd: ()-->(11,12,21,25)
+      │    ├── left-join (hash)
+      │    │    ├── columns: column1:7 column2:8!null column3:9!null column4:10!null column11:11 k:12 i:19 s:21 i:25 f:26
+      │    │    ├── cardinality: [0 - 2]
+      │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
+      │    │    ├── volatile
+      │    │    ├── fd: ()-->(11,12,21)
+      │    │    ├── select
+      │    │    │    ├── columns: column1:7 column2:8!null column3:9!null column4:10!null column11:11 k:12 i:19 s:21
+      │    │    │    ├── cardinality: [0 - 2]
+      │    │    │    ├── volatile
+      │    │    │    ├── fd: ()-->(11,12,21)
+      │    │    │    ├── left-join (hash)
+      │    │    │    │    ├── columns: column1:7 column2:8!null column3:9!null column4:10!null column11:11 k:12 i:19 s:21
+      │    │    │    │    ├── cardinality: [0 - 2]
+      │    │    │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
+      │    │    │    │    ├── volatile
+      │    │    │    │    ├── fd: ()-->(11,12)
+      │    │    │    │    ├── select
+      │    │    │    │    │    ├── columns: column1:7 column2:8!null column3:9!null column4:10!null column11:11 k:12
+      │    │    │    │    │    ├── cardinality: [0 - 2]
+      │    │    │    │    │    ├── volatile
+      │    │    │    │    │    ├── fd: ()-->(11,12)
+      │    │    │    │    │    ├── left-join (hash)
+      │    │    │    │    │    │    ├── columns: column1:7 column2:8!null column3:9!null column4:10!null column11:11 k:12
+      │    │    │    │    │    │    ├── cardinality: [2 - 2]
+      │    │    │    │    │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
+      │    │    │    │    │    │    ├── volatile
+      │    │    │    │    │    │    ├── fd: ()-->(11)
+      │    │    │    │    │    │    ├── project
+      │    │    │    │    │    │    │    ├── columns: column11:11 column1:7 column2:8!null column3:9!null column4:10!null
+      │    │    │    │    │    │    │    ├── cardinality: [2 - 2]
+      │    │    │    │    │    │    │    ├── volatile
+      │    │    │    │    │    │    │    ├── fd: ()-->(11)
+      │    │    │    │    │    │    │    ├── values
+      │    │    │    │    │    │    │    │    ├── columns: column1:7 column2:8!null column3:9!null column4:10!null
+      │    │    │    │    │    │    │    │    ├── cardinality: [2 - 2]
+      │    │    │    │    │    │    │    │    ├── volatile
+      │    │    │    │    │    │    │    │    ├── (unique_rowid(), 'foo', 1, 1.0)
+      │    │    │    │    │    │    │    │    └── (unique_rowid(), 'bar', 2, 2.0)
+      │    │    │    │    │    │    │    └── projections
+      │    │    │    │    │    │    │         └── CAST(NULL AS JSONB) [as=column11:11]
+      │    │    │    │    │    │    ├── scan a
+      │    │    │    │    │    │    │    ├── columns: k:12!null
+      │    │    │    │    │    │    │    └── key: (12)
+      │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │         └── column1:7 = k:12 [outer=(7,12), constraints=(/7: (/NULL - ]; /12: (/NULL - ]), fd=(7)==(12), (12)==(7)]
+      │    │    │    │    │    └── filters
+      │    │    │    │    │         └── k:12 IS NULL [outer=(12), constraints=(/12: [/NULL - /NULL]; tight), fd=()-->(12)]
+      │    │    │    │    ├── scan a
+      │    │    │    │    │    ├── columns: i:19!null s:21!null
+      │    │    │    │    │    └── key: (19,21)
+      │    │    │    │    └── filters
+      │    │    │    │         ├── column2:8 = s:21 [outer=(8,21), constraints=(/8: (/NULL - ]; /21: (/NULL - ]), fd=(8)==(21), (21)==(8)]
+      │    │    │    │         └── column3:9 = i:19 [outer=(9,19), constraints=(/9: (/NULL - ]; /19: (/NULL - ]), fd=(9)==(19), (19)==(9)]
+      │    │    │    └── filters
+      │    │    │         └── s:21 IS NULL [outer=(21), constraints=(/21: [/NULL - /NULL]; tight), fd=()-->(21)]
+      │    │    ├── scan a
+      │    │    │    ├── columns: i:25!null f:26
+      │    │    │    └── lax-key: (25,26)
+      │    │    └── filters
+      │    │         ├── column4:10 = f:26 [outer=(10,26), constraints=(/10: (/NULL - ]; /26: (/NULL - ]), fd=(10)==(26), (26)==(10)]
+      │    │         └── column3:9 = i:25 [outer=(9,25), constraints=(/9: (/NULL - ]; /25: (/NULL - ]), fd=(9)==(25), (25)==(9)]
+      │    └── filters
+      │         └── i:25 IS NULL [outer=(25), constraints=(/25: [/NULL - /NULL]; tight), fd=()-->(25)]
+      └── aggregations
+           ├── first-agg [as=column2:8, outer=(8)]
+           │    └── column2:8
+           ├── first-agg [as=column3:9, outer=(9)]
+           │    └── column3:9
+           ├── first-agg [as=column4:10, outer=(10)]
+           │    └── column4:10
+           └── first-agg [as=column11:11, outer=(11)]
+                └── column11:11
 
 # DO NOTHING case with explicit conflict columns (only add upsert-distinct-on
 # for one index).

--- a/pkg/sql/opt/optbuilder/testdata/upsert
+++ b/pkg/sql/opt/optbuilder/testdata/upsert
@@ -65,6 +65,14 @@ CREATE TABLE decimals (
 )
 ----
 
+exec-ddl
+CREATE TABLE uniq (
+  x STRING PRIMARY KEY,
+  y STRING UNIQUE,
+  z STRING UNIQUE
+)
+----
+
 # ------------------------------------------------------------------------------
 # Basic tests.
 # ------------------------------------------------------------------------------
@@ -544,62 +552,62 @@ insert xyz
  └── upsert-distinct-on
       ├── columns: column1:5!null column2:6!null column3:7!null
       ├── grouping columns: column2:6!null column3:7!null
-      ├── project
+      ├── upsert-distinct-on
       │    ├── columns: column1:5!null column2:6!null column3:7!null
-      │    └── select
-      │         ├── columns: column1:5!null column2:6!null column3:7!null x:16 y:17 z:18
-      │         ├── left-join (hash)
-      │         │    ├── columns: column1:5!null column2:6!null column3:7!null x:16 y:17 z:18
-      │         │    ├── upsert-distinct-on
-      │         │    │    ├── columns: column1:5!null column2:6!null column3:7!null
-      │         │    │    ├── grouping columns: column2:6!null column3:7!null
-      │         │    │    ├── project
-      │         │    │    │    ├── columns: column1:5!null column2:6!null column3:7!null
-      │         │    │    │    └── select
-      │         │    │    │         ├── columns: column1:5!null column2:6!null column3:7!null x:12 y:13 z:14
-      │         │    │    │         ├── left-join (hash)
-      │         │    │    │         │    ├── columns: column1:5!null column2:6!null column3:7!null x:12 y:13 z:14
-      │         │    │    │         │    ├── upsert-distinct-on
-      │         │    │    │         │    │    ├── columns: column1:5!null column2:6!null column3:7!null
-      │         │    │    │         │    │    ├── grouping columns: column1:5!null
-      │         │    │    │         │    │    ├── project
-      │         │    │    │         │    │    │    ├── columns: column1:5!null column2:6!null column3:7!null
-      │         │    │    │         │    │    │    └── select
-      │         │    │    │         │    │    │         ├── columns: column1:5!null column2:6!null column3:7!null x:8 y:9 z:10
-      │         │    │    │         │    │    │         ├── left-join (hash)
-      │         │    │    │         │    │    │         │    ├── columns: column1:5!null column2:6!null column3:7!null x:8 y:9 z:10
-      │         │    │    │         │    │    │         │    ├── values
-      │         │    │    │         │    │    │         │    │    ├── columns: column1:5!null column2:6!null column3:7!null
-      │         │    │    │         │    │    │         │    │    ├── (1, 2, 3)
-      │         │    │    │         │    │    │         │    │    └── (4, 5, 6)
-      │         │    │    │         │    │    │         │    ├── scan xyz
-      │         │    │    │         │    │    │         │    │    └── columns: x:8!null y:9 z:10
-      │         │    │    │         │    │    │         │    └── filters
-      │         │    │    │         │    │    │         │         └── column1:5 = x:8
-      │         │    │    │         │    │    │         └── filters
-      │         │    │    │         │    │    │              └── x:8 IS NULL
-      │         │    │    │         │    │    └── aggregations
-      │         │    │    │         │    │         ├── first-agg [as=column2:6]
-      │         │    │    │         │    │         │    └── column2:6
-      │         │    │    │         │    │         └── first-agg [as=column3:7]
-      │         │    │    │         │    │              └── column3:7
-      │         │    │    │         │    ├── scan xyz
-      │         │    │    │         │    │    └── columns: x:12!null y:13 z:14
-      │         │    │    │         │    └── filters
-      │         │    │    │         │         ├── column2:6 = y:13
-      │         │    │    │         │         └── column3:7 = z:14
-      │         │    │    │         └── filters
-      │         │    │    │              └── x:12 IS NULL
-      │         │    │    └── aggregations
-      │         │    │         └── first-agg [as=column1:5]
-      │         │    │              └── column1:5
-      │         │    ├── scan xyz
-      │         │    │    └── columns: x:16!null y:17 z:18
-      │         │    └── filters
-      │         │         ├── column3:7 = z:18
-      │         │         └── column2:6 = y:17
-      │         └── filters
-      │              └── x:16 IS NULL
+      │    ├── grouping columns: column2:6!null column3:7!null
+      │    ├── upsert-distinct-on
+      │    │    ├── columns: column1:5!null column2:6!null column3:7!null
+      │    │    ├── grouping columns: column1:5!null
+      │    │    ├── project
+      │    │    │    ├── columns: column1:5!null column2:6!null column3:7!null
+      │    │    │    └── select
+      │    │    │         ├── columns: column1:5!null column2:6!null column3:7!null x:16 y:17 z:18
+      │    │    │         ├── left-join (hash)
+      │    │    │         │    ├── columns: column1:5!null column2:6!null column3:7!null x:16 y:17 z:18
+      │    │    │         │    ├── project
+      │    │    │         │    │    ├── columns: column1:5!null column2:6!null column3:7!null
+      │    │    │         │    │    └── select
+      │    │    │         │    │         ├── columns: column1:5!null column2:6!null column3:7!null x:12 y:13 z:14
+      │    │    │         │    │         ├── left-join (hash)
+      │    │    │         │    │         │    ├── columns: column1:5!null column2:6!null column3:7!null x:12 y:13 z:14
+      │    │    │         │    │         │    ├── project
+      │    │    │         │    │         │    │    ├── columns: column1:5!null column2:6!null column3:7!null
+      │    │    │         │    │         │    │    └── select
+      │    │    │         │    │         │    │         ├── columns: column1:5!null column2:6!null column3:7!null x:8 y:9 z:10
+      │    │    │         │    │         │    │         ├── left-join (hash)
+      │    │    │         │    │         │    │         │    ├── columns: column1:5!null column2:6!null column3:7!null x:8 y:9 z:10
+      │    │    │         │    │         │    │         │    ├── values
+      │    │    │         │    │         │    │         │    │    ├── columns: column1:5!null column2:6!null column3:7!null
+      │    │    │         │    │         │    │         │    │    ├── (1, 2, 3)
+      │    │    │         │    │         │    │         │    │    └── (4, 5, 6)
+      │    │    │         │    │         │    │         │    ├── scan xyz
+      │    │    │         │    │         │    │         │    │    └── columns: x:8!null y:9 z:10
+      │    │    │         │    │         │    │         │    └── filters
+      │    │    │         │    │         │    │         │         └── column1:5 = x:8
+      │    │    │         │    │         │    │         └── filters
+      │    │    │         │    │         │    │              └── x:8 IS NULL
+      │    │    │         │    │         │    ├── scan xyz
+      │    │    │         │    │         │    │    └── columns: x:12!null y:13 z:14
+      │    │    │         │    │         │    └── filters
+      │    │    │         │    │         │         ├── column2:6 = y:13
+      │    │    │         │    │         │         └── column3:7 = z:14
+      │    │    │         │    │         └── filters
+      │    │    │         │    │              └── x:12 IS NULL
+      │    │    │         │    ├── scan xyz
+      │    │    │         │    │    └── columns: x:16!null y:17 z:18
+      │    │    │         │    └── filters
+      │    │    │         │         ├── column3:7 = z:18
+      │    │    │         │         └── column2:6 = y:17
+      │    │    │         └── filters
+      │    │    │              └── x:16 IS NULL
+      │    │    └── aggregations
+      │    │         ├── first-agg [as=column2:6]
+      │    │         │    └── column2:6
+      │    │         └── first-agg [as=column3:7]
+      │    │              └── column3:7
+      │    └── aggregations
+      │         └── first-agg [as=column1:5]
+      │              └── column1:5
       └── aggregations
            └── first-agg [as=column1:5]
                 └── column1:5
@@ -640,6 +648,83 @@ insert xyz
       └── aggregations
            └── first-agg [as=column1:5]
                 └── column1:5
+
+build
+INSERT INTO uniq VALUES ('x2', 'y1', 'z2'), ('x2', 'y2', 'z2'), ('x2', 'y2', 'z2')
+ON CONFLICT DO NOTHING
+----
+insert uniq
+ ├── columns: <none>
+ ├── arbiter indexes: primary uniq_y_key uniq_z_key
+ ├── insert-mapping:
+ │    ├── column1:5 => x:1
+ │    ├── column2:6 => y:2
+ │    └── column3:7 => z:3
+ └── upsert-distinct-on
+      ├── columns: column1:5!null column2:6!null column3:7!null
+      ├── grouping columns: column3:7!null
+      ├── upsert-distinct-on
+      │    ├── columns: column1:5!null column2:6!null column3:7!null
+      │    ├── grouping columns: column2:6!null
+      │    ├── upsert-distinct-on
+      │    │    ├── columns: column1:5!null column2:6!null column3:7!null
+      │    │    ├── grouping columns: column1:5!null
+      │    │    ├── project
+      │    │    │    ├── columns: column1:5!null column2:6!null column3:7!null
+      │    │    │    └── select
+      │    │    │         ├── columns: column1:5!null column2:6!null column3:7!null x:16 y:17 z:18
+      │    │    │         ├── left-join (hash)
+      │    │    │         │    ├── columns: column1:5!null column2:6!null column3:7!null x:16 y:17 z:18
+      │    │    │         │    ├── project
+      │    │    │         │    │    ├── columns: column1:5!null column2:6!null column3:7!null
+      │    │    │         │    │    └── select
+      │    │    │         │    │         ├── columns: column1:5!null column2:6!null column3:7!null x:12 y:13 z:14
+      │    │    │         │    │         ├── left-join (hash)
+      │    │    │         │    │         │    ├── columns: column1:5!null column2:6!null column3:7!null x:12 y:13 z:14
+      │    │    │         │    │         │    ├── project
+      │    │    │         │    │         │    │    ├── columns: column1:5!null column2:6!null column3:7!null
+      │    │    │         │    │         │    │    └── select
+      │    │    │         │    │         │    │         ├── columns: column1:5!null column2:6!null column3:7!null x:8 y:9 z:10
+      │    │    │         │    │         │    │         ├── left-join (hash)
+      │    │    │         │    │         │    │         │    ├── columns: column1:5!null column2:6!null column3:7!null x:8 y:9 z:10
+      │    │    │         │    │         │    │         │    ├── values
+      │    │    │         │    │         │    │         │    │    ├── columns: column1:5!null column2:6!null column3:7!null
+      │    │    │         │    │         │    │         │    │    ├── ('x2', 'y1', 'z2')
+      │    │    │         │    │         │    │         │    │    ├── ('x2', 'y2', 'z2')
+      │    │    │         │    │         │    │         │    │    └── ('x2', 'y2', 'z2')
+      │    │    │         │    │         │    │         │    ├── scan uniq
+      │    │    │         │    │         │    │         │    │    └── columns: x:8!null y:9 z:10
+      │    │    │         │    │         │    │         │    └── filters
+      │    │    │         │    │         │    │         │         └── column1:5 = x:8
+      │    │    │         │    │         │    │         └── filters
+      │    │    │         │    │         │    │              └── x:8 IS NULL
+      │    │    │         │    │         │    ├── scan uniq
+      │    │    │         │    │         │    │    └── columns: x:12!null y:13 z:14
+      │    │    │         │    │         │    └── filters
+      │    │    │         │    │         │         └── column2:6 = y:13
+      │    │    │         │    │         └── filters
+      │    │    │         │    │              └── x:12 IS NULL
+      │    │    │         │    ├── scan uniq
+      │    │    │         │    │    └── columns: x:16!null y:17 z:18
+      │    │    │         │    └── filters
+      │    │    │         │         └── column3:7 = z:18
+      │    │    │         └── filters
+      │    │    │              └── x:16 IS NULL
+      │    │    └── aggregations
+      │    │         ├── first-agg [as=column2:6]
+      │    │         │    └── column2:6
+      │    │         └── first-agg [as=column3:7]
+      │    │              └── column3:7
+      │    └── aggregations
+      │         ├── first-agg [as=column1:5]
+      │         │    └── column1:5
+      │         └── first-agg [as=column3:7]
+      │              └── column3:7
+      └── aggregations
+           ├── first-agg [as=column1:5]
+           │    └── column1:5
+           └── first-agg [as=column2:6]
+                └── column2:6
 
 # ------------------------------------------------------------------------------
 # Test excluded columns.
@@ -1930,52 +2015,52 @@ insert partial_indexes
       ├── upsert-distinct-on
       │    ├── columns: column1:5!null column2:6!null column3:7!null
       │    ├── grouping columns: column2:6!null column3:7!null
-      │    ├── project
+      │    ├── upsert-distinct-on
       │    │    ├── columns: column1:5!null column2:6!null column3:7!null
-      │    │    └── select
-      │    │         ├── columns: column1:5!null column2:6!null column3:7!null a:12 b:13 c:14
-      │    │         ├── left-join (hash)
-      │    │         │    ├── columns: column1:5!null column2:6!null column3:7!null a:12 b:13 c:14
-      │    │         │    ├── upsert-distinct-on
-      │    │         │    │    ├── columns: column1:5!null column2:6!null column3:7!null
-      │    │         │    │    ├── grouping columns: column1:5!null
-      │    │         │    │    ├── project
-      │    │         │    │    │    ├── columns: column1:5!null column2:6!null column3:7!null
-      │    │         │    │    │    └── select
-      │    │         │    │    │         ├── columns: column1:5!null column2:6!null column3:7!null a:8 b:9 c:10
-      │    │         │    │    │         ├── left-join (hash)
-      │    │         │    │    │         │    ├── columns: column1:5!null column2:6!null column3:7!null a:8 b:9 c:10
-      │    │         │    │    │         │    ├── values
-      │    │         │    │    │         │    │    ├── columns: column1:5!null column2:6!null column3:7!null
-      │    │         │    │    │         │    │    └── (2, 1, 'bar')
-      │    │         │    │    │         │    ├── scan partial_indexes
-      │    │         │    │    │         │    │    ├── columns: a:8!null b:9 c:10
-      │    │         │    │    │         │    │    └── partial index predicates
-      │    │         │    │    │         │    │         ├── secondary: filters
-      │    │         │    │    │         │    │         │    └── c:10 = 'foo'
-      │    │         │    │    │         │    │         └── secondary: filters
-      │    │         │    │    │         │    │              └── (a:8 > b:9) AND (c:10 = 'bar')
-      │    │         │    │    │         │    └── filters
-      │    │         │    │    │         │         └── column1:5 = a:8
-      │    │         │    │    │         └── filters
-      │    │         │    │    │              └── a:8 IS NULL
-      │    │         │    │    └── aggregations
-      │    │         │    │         ├── first-agg [as=column2:6]
-      │    │         │    │         │    └── column2:6
-      │    │         │    │         └── first-agg [as=column3:7]
-      │    │         │    │              └── column3:7
-      │    │         │    ├── scan partial_indexes
-      │    │         │    │    ├── columns: a:12!null b:13 c:14
-      │    │         │    │    └── partial index predicates
-      │    │         │    │         ├── secondary: filters
-      │    │         │    │         │    └── c:14 = 'foo'
-      │    │         │    │         └── secondary: filters
-      │    │         │    │              └── (a:12 > b:13) AND (c:14 = 'bar')
-      │    │         │    └── filters
-      │    │         │         ├── column2:6 = b:13
-      │    │         │         └── column3:7 = c:14
-      │    │         └── filters
-      │    │              └── a:12 IS NULL
+      │    │    ├── grouping columns: column1:5!null
+      │    │    ├── project
+      │    │    │    ├── columns: column1:5!null column2:6!null column3:7!null
+      │    │    │    └── select
+      │    │    │         ├── columns: column1:5!null column2:6!null column3:7!null a:12 b:13 c:14
+      │    │    │         ├── left-join (hash)
+      │    │    │         │    ├── columns: column1:5!null column2:6!null column3:7!null a:12 b:13 c:14
+      │    │    │         │    ├── project
+      │    │    │         │    │    ├── columns: column1:5!null column2:6!null column3:7!null
+      │    │    │         │    │    └── select
+      │    │    │         │    │         ├── columns: column1:5!null column2:6!null column3:7!null a:8 b:9 c:10
+      │    │    │         │    │         ├── left-join (hash)
+      │    │    │         │    │         │    ├── columns: column1:5!null column2:6!null column3:7!null a:8 b:9 c:10
+      │    │    │         │    │         │    ├── values
+      │    │    │         │    │         │    │    ├── columns: column1:5!null column2:6!null column3:7!null
+      │    │    │         │    │         │    │    └── (2, 1, 'bar')
+      │    │    │         │    │         │    ├── scan partial_indexes
+      │    │    │         │    │         │    │    ├── columns: a:8!null b:9 c:10
+      │    │    │         │    │         │    │    └── partial index predicates
+      │    │    │         │    │         │    │         ├── secondary: filters
+      │    │    │         │    │         │    │         │    └── c:10 = 'foo'
+      │    │    │         │    │         │    │         └── secondary: filters
+      │    │    │         │    │         │    │              └── (a:8 > b:9) AND (c:10 = 'bar')
+      │    │    │         │    │         │    └── filters
+      │    │    │         │    │         │         └── column1:5 = a:8
+      │    │    │         │    │         └── filters
+      │    │    │         │    │              └── a:8 IS NULL
+      │    │    │         │    ├── scan partial_indexes
+      │    │    │         │    │    ├── columns: a:12!null b:13 c:14
+      │    │    │         │    │    └── partial index predicates
+      │    │    │         │    │         ├── secondary: filters
+      │    │    │         │    │         │    └── c:14 = 'foo'
+      │    │    │         │    │         └── secondary: filters
+      │    │    │         │    │              └── (a:12 > b:13) AND (c:14 = 'bar')
+      │    │    │         │    └── filters
+      │    │    │         │         ├── column2:6 = b:13
+      │    │    │         │         └── column3:7 = c:14
+      │    │    │         └── filters
+      │    │    │              └── a:12 IS NULL
+      │    │    └── aggregations
+      │    │         ├── first-agg [as=column2:6]
+      │    │         │    └── column2:6
+      │    │         └── first-agg [as=column3:7]
+      │    │              └── column3:7
       │    └── aggregations
       │         └── first-agg [as=column1:5]
       │              └── column1:5
@@ -2142,52 +2227,52 @@ insert unique_partial_indexes
       │         ├── grouping columns: column2:6!null upsert_partial_index_distinct1:16
       │         ├── project
       │         │    ├── columns: upsert_partial_index_distinct1:16 column1:5!null column2:6!null column3:7!null
-      │         │    ├── project
+      │         │    ├── upsert-distinct-on
       │         │    │    ├── columns: column1:5!null column2:6!null column3:7!null
-      │         │    │    └── select
-      │         │    │         ├── columns: column1:5!null column2:6!null column3:7!null a:12 b:13 c:14
-      │         │    │         ├── left-join (hash)
-      │         │    │         │    ├── columns: column1:5!null column2:6!null column3:7!null a:12 b:13 c:14
-      │         │    │         │    ├── upsert-distinct-on
-      │         │    │         │    │    ├── columns: column1:5!null column2:6!null column3:7!null
-      │         │    │         │    │    ├── grouping columns: column1:5!null
-      │         │    │         │    │    ├── project
-      │         │    │         │    │    │    ├── columns: column1:5!null column2:6!null column3:7!null
-      │         │    │         │    │    │    └── select
-      │         │    │         │    │    │         ├── columns: column1:5!null column2:6!null column3:7!null a:8 b:9 c:10
-      │         │    │         │    │    │         ├── left-join (hash)
-      │         │    │         │    │    │         │    ├── columns: column1:5!null column2:6!null column3:7!null a:8 b:9 c:10
-      │         │    │         │    │    │         │    ├── values
-      │         │    │         │    │    │         │    │    ├── columns: column1:5!null column2:6!null column3:7!null
-      │         │    │         │    │    │         │    │    └── (1, 1, 'bar')
-      │         │    │         │    │    │         │    ├── scan unique_partial_indexes
-      │         │    │         │    │    │         │    │    ├── columns: a:8!null b:9 c:10
-      │         │    │         │    │    │         │    │    └── partial index predicates
-      │         │    │         │    │    │         │    │         └── secondary: filters
-      │         │    │         │    │    │         │    │              └── c:10 = 'foo'
-      │         │    │         │    │    │         │    └── filters
-      │         │    │         │    │    │         │         └── column1:5 = a:8
-      │         │    │         │    │    │         └── filters
-      │         │    │         │    │    │              └── a:8 IS NULL
-      │         │    │         │    │    └── aggregations
-      │         │    │         │    │         ├── first-agg [as=column2:6]
-      │         │    │         │    │         │    └── column2:6
-      │         │    │         │    │         └── first-agg [as=column3:7]
-      │         │    │         │    │              └── column3:7
-      │         │    │         │    ├── select
-      │         │    │         │    │    ├── columns: a:12!null b:13 c:14!null
-      │         │    │         │    │    ├── scan unique_partial_indexes
-      │         │    │         │    │    │    ├── columns: a:12!null b:13 c:14
-      │         │    │         │    │    │    └── partial index predicates
-      │         │    │         │    │    │         └── secondary: filters
-      │         │    │         │    │    │              └── c:14 = 'foo'
-      │         │    │         │    │    └── filters
-      │         │    │         │    │         └── c:14 = 'foo'
-      │         │    │         │    └── filters
-      │         │    │         │         ├── column2:6 = b:13
-      │         │    │         │         └── column3:7 = 'foo'
-      │         │    │         └── filters
-      │         │    │              └── a:12 IS NULL
+      │         │    │    ├── grouping columns: column1:5!null
+      │         │    │    ├── project
+      │         │    │    │    ├── columns: column1:5!null column2:6!null column3:7!null
+      │         │    │    │    └── select
+      │         │    │    │         ├── columns: column1:5!null column2:6!null column3:7!null a:12 b:13 c:14
+      │         │    │    │         ├── left-join (hash)
+      │         │    │    │         │    ├── columns: column1:5!null column2:6!null column3:7!null a:12 b:13 c:14
+      │         │    │    │         │    ├── project
+      │         │    │    │         │    │    ├── columns: column1:5!null column2:6!null column3:7!null
+      │         │    │    │         │    │    └── select
+      │         │    │    │         │    │         ├── columns: column1:5!null column2:6!null column3:7!null a:8 b:9 c:10
+      │         │    │    │         │    │         ├── left-join (hash)
+      │         │    │    │         │    │         │    ├── columns: column1:5!null column2:6!null column3:7!null a:8 b:9 c:10
+      │         │    │    │         │    │         │    ├── values
+      │         │    │    │         │    │         │    │    ├── columns: column1:5!null column2:6!null column3:7!null
+      │         │    │    │         │    │         │    │    └── (1, 1, 'bar')
+      │         │    │    │         │    │         │    ├── scan unique_partial_indexes
+      │         │    │    │         │    │         │    │    ├── columns: a:8!null b:9 c:10
+      │         │    │    │         │    │         │    │    └── partial index predicates
+      │         │    │    │         │    │         │    │         └── secondary: filters
+      │         │    │    │         │    │         │    │              └── c:10 = 'foo'
+      │         │    │    │         │    │         │    └── filters
+      │         │    │    │         │    │         │         └── column1:5 = a:8
+      │         │    │    │         │    │         └── filters
+      │         │    │    │         │    │              └── a:8 IS NULL
+      │         │    │    │         │    ├── select
+      │         │    │    │         │    │    ├── columns: a:12!null b:13 c:14!null
+      │         │    │    │         │    │    ├── scan unique_partial_indexes
+      │         │    │    │         │    │    │    ├── columns: a:12!null b:13 c:14
+      │         │    │    │         │    │    │    └── partial index predicates
+      │         │    │    │         │    │    │         └── secondary: filters
+      │         │    │    │         │    │    │              └── c:14 = 'foo'
+      │         │    │    │         │    │    └── filters
+      │         │    │    │         │    │         └── c:14 = 'foo'
+      │         │    │    │         │    └── filters
+      │         │    │    │         │         ├── column2:6 = b:13
+      │         │    │    │         │         └── column3:7 = 'foo'
+      │         │    │    │         └── filters
+      │         │    │    │              └── a:12 IS NULL
+      │         │    │    └── aggregations
+      │         │    │         ├── first-agg [as=column2:6]
+      │         │    │         │    └── column2:6
+      │         │    │         └── first-agg [as=column3:7]
+      │         │    │              └── column3:7
       │         │    └── projections
       │         │         └── (column3:7 = 'foo') OR NULL::BOOL [as=upsert_partial_index_distinct1:16]
       │         └── aggregations
@@ -2225,17 +2310,17 @@ insert unique_partial_indexes
       │         │    ├── columns: upsert_partial_index_distinct2:17 column1:5!null column2:6!null column3:7!null
       │         │    ├── project
       │         │    │    ├── columns: column1:5!null column2:6!null column3:7!null
-      │         │    │    └── select
-      │         │    │         ├── columns: column1:5!null column2:6!null column3:7!null a:13 b:14 c:15
-      │         │    │         ├── left-join (hash)
-      │         │    │         │    ├── columns: column1:5!null column2:6!null column3:7!null a:13 b:14 c:15
+      │         │    │    └── upsert-distinct-on
+      │         │    │         ├── columns: column1:5!null column2:6!null column3:7!null upsert_partial_index_distinct1:16
+      │         │    │         ├── grouping columns: column2:6!null upsert_partial_index_distinct1:16
+      │         │    │         ├── project
+      │         │    │         │    ├── columns: upsert_partial_index_distinct1:16 column1:5!null column2:6!null column3:7!null
       │         │    │         │    ├── project
       │         │    │         │    │    ├── columns: column1:5!null column2:6!null column3:7!null
-      │         │    │         │    │    └── upsert-distinct-on
-      │         │    │         │    │         ├── columns: column1:5!null column2:6!null column3:7!null upsert_partial_index_distinct1:12
-      │         │    │         │    │         ├── grouping columns: column2:6!null upsert_partial_index_distinct1:12
-      │         │    │         │    │         ├── project
-      │         │    │         │    │         │    ├── columns: upsert_partial_index_distinct1:12 column1:5!null column2:6!null column3:7!null
+      │         │    │         │    │    └── select
+      │         │    │         │    │         ├── columns: column1:5!null column2:6!null column3:7!null a:12 b:13 c:14
+      │         │    │         │    │         ├── left-join (hash)
+      │         │    │         │    │         │    ├── columns: column1:5!null column2:6!null column3:7!null a:12 b:13 c:14
       │         │    │         │    │         │    ├── project
       │         │    │         │    │         │    │    ├── columns: column1:5!null column2:6!null column3:7!null
       │         │    │         │    │         │    │    └── select
@@ -2261,29 +2346,29 @@ insert unique_partial_indexes
       │         │    │         │    │         │    │         │         └── column3:7 = 'foo'
       │         │    │         │    │         │    │         └── filters
       │         │    │         │    │         │    │              └── a:8 IS NULL
-      │         │    │         │    │         │    └── projections
-      │         │    │         │    │         │         └── (column3:7 = 'foo') OR NULL::BOOL [as=upsert_partial_index_distinct1:12]
-      │         │    │         │    │         └── aggregations
-      │         │    │         │    │              ├── first-agg [as=column1:5]
-      │         │    │         │    │              │    └── column1:5
-      │         │    │         │    │              └── first-agg [as=column3:7]
-      │         │    │         │    │                   └── column3:7
-      │         │    │         │    ├── select
-      │         │    │         │    │    ├── columns: a:13!null b:14 c:15!null
-      │         │    │         │    │    ├── scan unique_partial_indexes
-      │         │    │         │    │    │    ├── columns: a:13!null b:14 c:15
-      │         │    │         │    │    │    └── partial index predicates
-      │         │    │         │    │    │         ├── secondary: filters
-      │         │    │         │    │    │         │    └── c:15 = 'foo'
-      │         │    │         │    │    │         └── u2: filters
-      │         │    │         │    │    │              └── c:15 = 'bar'
-      │         │    │         │    │    └── filters
-      │         │    │         │    │         └── c:15 = 'bar'
-      │         │    │         │    └── filters
-      │         │    │         │         ├── column2:6 = b:14
-      │         │    │         │         └── column3:7 = 'bar'
-      │         │    │         └── filters
-      │         │    │              └── a:13 IS NULL
+      │         │    │         │    │         │    ├── select
+      │         │    │         │    │         │    │    ├── columns: a:12!null b:13 c:14!null
+      │         │    │         │    │         │    │    ├── scan unique_partial_indexes
+      │         │    │         │    │         │    │    │    ├── columns: a:12!null b:13 c:14
+      │         │    │         │    │         │    │    │    └── partial index predicates
+      │         │    │         │    │         │    │    │         ├── secondary: filters
+      │         │    │         │    │         │    │    │         │    └── c:14 = 'foo'
+      │         │    │         │    │         │    │    │         └── u2: filters
+      │         │    │         │    │         │    │    │              └── c:14 = 'bar'
+      │         │    │         │    │         │    │    └── filters
+      │         │    │         │    │         │    │         └── c:14 = 'bar'
+      │         │    │         │    │         │    └── filters
+      │         │    │         │    │         │         ├── column2:6 = b:13
+      │         │    │         │    │         │         └── column3:7 = 'bar'
+      │         │    │         │    │         └── filters
+      │         │    │         │    │              └── a:12 IS NULL
+      │         │    │         │    └── projections
+      │         │    │         │         └── (column3:7 = 'foo') OR NULL::BOOL [as=upsert_partial_index_distinct1:16]
+      │         │    │         └── aggregations
+      │         │    │              ├── first-agg [as=column1:5]
+      │         │    │              │    └── column1:5
+      │         │    │              └── first-agg [as=column3:7]
+      │         │    │                   └── column3:7
       │         │    └── projections
       │         │         └── (column3:7 = 'bar') OR NULL::BOOL [as=upsert_partial_index_distinct2:17]
       │         └── aggregations


### PR DESCRIPTION
Backport 1/1 commits from #59147.

/cc @cockroachdb/release

---

Prior to this patch, it was possible for some valid input to an
`INSERT ... ON CONFLICT DO NOTHING` to be discarded. For example,
consider the following example:
```
CREATE TABLE uniq (
  k INT PRIMARY KEY,
  v INT UNIQUE,
  w INT UNIQUE,
  x INT,
  y INT DEFAULT 5,
  UNIQUE (x, y)
);

INSERT INTO uniq VALUES (1, 1, 1, 1, 1);

INSERT INTO uniq VALUES (1, 20, 20, 20, 20),
                        (20, 1, 20, 20, 20),
                        (20, 20, 20, 20, 20)
ON CONFLICT DO NOTHING;
```
Since row `(20, 20, 20, 20, 20)` does not conflict with the existing
row in uniq, it should be inserted. However, prior to this patch, all
three rows in the second `INSERT` statement were discarded.

This commit fixes the problem by applying the `upsert-distinct-on`
operators for each index after all conflicting rows are removed by
left-joins and filters.

Fixes #59125

Release note (bug fix): Fixed a bug in which some non-conflicting rows
provided as input to an `INSERT ... ON CONFLICT DO NOTHING` statement could
be discarded, and not inserted. This could happen in cases where the
table had one or more unique indexes in addition to the primary index,
and some of the rows in the input conflicted with existing values in one
or more unique index. This scenario could cause the rows that did not
conflict to be erroneously discarded. This has now been fixed.
