### PR TITLE
opt: build stats and logical props for multi-column inverted joins

### DIFF
--- a/pkg/sql/opt/memo/testdata/stats/inverted-join
+++ b/pkg/sql/opt/memo/testdata/stats/inverted-join
@@ -270,12 +270,12 @@ project
       ├── stats: [rows=3]
       ├── fd: (1)-->(2,3)
       ├── inner-join (inverted json_multi_col@sj_idx [as=t1])
-      │    ├── columns: t1.k:1(int!null) s:3(string) t2.j:8(jsonb) "inverted_join_const_col_@3":11(string!null)
+      │    ├── columns: t1.k:1(int!null) s:3(string!null) t2.j:8(jsonb) "inverted_join_const_col_@3":11(string!null)
       │    ├── prefix key columns: [11] = [3]
       │    ├── inverted-expr
       │    │    └── t1.j:2 @> t2.j:8 [type=bool]
-      │    ├── stats: [rows=9, distinct(1)=8.9609594, null(1)=0, distinct(3)=3, null(3)=0]
-      │    ├── fd: (1)-->(3)
+      │    ├── stats: [rows=3, distinct(1)=2.99565406, null(1)=0, distinct(3)=3, null(3)=0, distinct(11)=3, null(11)=0]
+      │    ├── fd: (1)-->(3), (3)==(11), (11)==(3)
       │    ├── inner-join (cross)
       │    │    ├── columns: t2.j:8(jsonb) "inverted_join_const_col_@3":11(string!null)
       │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
@@ -321,12 +321,12 @@ project
       ├── stats: [rows=0.3]
       ├── fd: ()-->(4), (1)-->(2,3)
       ├── inner-join (inverted json_multi_col@sij_idx [as=t1])
-      │    ├── columns: t1.k:1(int!null) s:3(string) i:4(int) t2.j:9(jsonb) "inverted_join_const_col_@3":12(string!null) "inverted_join_const_col_@4":13(int!null)
+      │    ├── columns: t1.k:1(int!null) s:3(string!null) i:4(int!null) t2.j:9(jsonb) "inverted_join_const_col_@3":12(string!null) "inverted_join_const_col_@4":13(int!null)
       │    ├── prefix key columns: [12 13] = [3 4]
       │    ├── inverted-expr
       │    │    └── t1.j:2 @> t2.j:9 [type=bool]
-      │    ├── stats: [rows=0.9, distinct(1)=0.89960861, null(1)=0, distinct(3)=0.9, null(3)=0, distinct(4)=0.9, null(4)=0, distinct(3,4)=0.9, null(3,4)=0]
-      │    ├── fd: ()-->(13), (1)-->(3,4)
+      │    ├── stats: [rows=0.3, distinct(1)=0.299956504, null(1)=0, distinct(3)=0.3, null(3)=0, distinct(4)=0.3, null(4)=0, distinct(12)=0.3, null(12)=0, distinct(13)=0.3, null(13)=0, distinct(3,4)=0.3, null(3,4)=0]
+      │    ├── fd: ()-->(4,13), (1)-->(3), (3)==(12), (12)==(3), (4)==(13), (13)==(4)
       │    ├── project
       │    │    ├── columns: "inverted_join_const_col_@4":13(int!null) t2.j:9(jsonb) "inverted_join_const_col_@3":12(string!null)
       │    │    ├── stats: [rows=30, distinct(12)=3, null(12)=0, distinct(13)=1, null(13)=0]
@@ -380,13 +380,13 @@ project
       ├── key: (1)
       ├── fd: (1)-->(2,4), (9)-->(10), (4)==(9), (9)==(4)
       ├── inner-join (inverted json_multi_col@ij_idx [as=t1])
-      │    ├── columns: t1.k:1(int!null) i:4(int) t2.k:9(int!null) t2.j:10(jsonb)
+      │    ├── columns: t1.k:1(int!null) i:4(int!null) t2.k:9(int!null) t2.j:10(jsonb)
       │    ├── prefix key columns: [9] = [4]
       │    ├── inverted-expr
       │    │    └── t1.j:2 @> t2.j:10 [type=bool]
-      │    ├── stats: [rows=100, distinct(1)=95.617925, null(1)=0, distinct(9)=9.99956829, null(9)=0]
-      │    ├── key: (1,9)
-      │    ├── fd: (9)-->(10), (1)-->(4)
+      │    ├── stats: [rows=10, distinct(1)=9.95511979, null(1)=0, distinct(4)=10, null(4)=0, distinct(9)=10, null(9)=0]
+      │    ├── key: (1)
+      │    ├── fd: (9)-->(10), (1)-->(4), (4)==(9), (9)==(4)
       │    ├── scan json_arr2 [as=t2]
       │    │    ├── columns: t2.k:9(int!null) t2.j:10(jsonb)
       │    │    ├── stats: [rows=10, distinct(9)=10, null(9)=0]

--- a/pkg/sql/opt/memo/testdata/stats/inverted-join
+++ b/pkg/sql/opt/memo/testdata/stats/inverted-join
@@ -215,3 +215,183 @@ project
       └── filters
            ├── t1.a:3 @> t2.a:9 [type=bool, outer=(3,9), immutable]
            └── t1.j:2 @> t2.j:8 [type=bool, outer=(2,8), immutable]
+
+exec-ddl
+CREATE TABLE json_multi_col (
+  k INT PRIMARY KEY,
+  j JSONB,
+  s STRING,
+  i INT,
+  INVERTED INDEX sj_idx (s, j)
+)
+----
+
+exec-ddl
+ALTER TABLE json_multi_col INJECT STATISTICS '[
+  {
+    "columns": ["j"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1000,
+    "distinct_count": 1000,
+    "null_count": 0
+  },
+  {
+    "columns": ["s"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1000,
+    "distinct_count": 100,
+    "null_count": 0
+  },
+  {
+    "columns": ["i"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1000,
+    "distinct_count": 10,
+    "null_count": 0
+  }
+]'
+----
+
+opt
+SELECT t1.k
+FROM json_multi_col AS t1
+JOIN json_arr2 AS t2
+ON t1.s IN ('foo', 'bar', 'baz') AND t1.j @> t2.j
+----
+project
+ ├── columns: k:1(int!null)
+ ├── immutable
+ ├── stats: [rows=3]
+ └── inner-join (lookup json_multi_col [as=t1])
+      ├── columns: t1.k:1(int!null) t1.j:2(jsonb) s:3(string!null) t2.j:8(jsonb)
+      ├── key columns: [1] = [1]
+      ├── lookup columns are key
+      ├── immutable
+      ├── stats: [rows=3]
+      ├── fd: (1)-->(2,3)
+      ├── inner-join (inverted json_multi_col@sj_idx [as=t1])
+      │    ├── columns: t1.k:1(int!null) s:3(string) t2.j:8(jsonb) "inverted_join_const_col_@3":11(string!null)
+      │    ├── prefix key columns: [11] = [3]
+      │    ├── inverted-expr
+      │    │    └── t1.j:2 @> t2.j:8 [type=bool]
+      │    ├── stats: [rows=9, distinct(1)=8.9609594, null(1)=0, distinct(3)=3, null(3)=0]
+      │    ├── fd: (1)-->(3)
+      │    ├── inner-join (cross)
+      │    │    ├── columns: t2.j:8(jsonb) "inverted_join_const_col_@3":11(string!null)
+      │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
+      │    │    ├── stats: [rows=30, distinct(11)=3, null(11)=0]
+      │    │    ├── scan json_arr2 [as=t2]
+      │    │    │    ├── columns: t2.j:8(jsonb)
+      │    │    │    └── stats: [rows=10]
+      │    │    ├── values
+      │    │    │    ├── columns: "inverted_join_const_col_@3":11(string!null)
+      │    │    │    ├── cardinality: [3 - 3]
+      │    │    │    ├── stats: [rows=3, distinct(11)=3, null(11)=0]
+      │    │    │    ├── ('bar',) [type=tuple{string}]
+      │    │    │    ├── ('baz',) [type=tuple{string}]
+      │    │    │    └── ('foo',) [type=tuple{string}]
+      │    │    └── filters (true)
+      │    └── filters (true)
+      └── filters
+           └── t1.j:2 @> t2.j:8 [type=bool, outer=(2,8), immutable]
+
+exec-ddl
+DROP INDEX sj_idx
+----
+
+exec-ddl
+CREATE INVERTED INDEX sij_idx ON json_multi_col (s, i, j)
+----
+
+opt
+SELECT t1.k
+FROM json_multi_col AS t1
+JOIN json_arr2 AS t2
+ON t1.s IN ('foo', 'bar', 'baz') AND i = 10 AND t1.j @> t2.j
+----
+project
+ ├── columns: k:1(int!null)
+ ├── immutable
+ ├── stats: [rows=0.3]
+ └── inner-join (lookup json_multi_col [as=t1])
+      ├── columns: t1.k:1(int!null) t1.j:2(jsonb) s:3(string!null) i:4(int!null) t2.j:9(jsonb)
+      ├── key columns: [1] = [1]
+      ├── lookup columns are key
+      ├── immutable
+      ├── stats: [rows=0.3]
+      ├── fd: ()-->(4), (1)-->(2,3)
+      ├── inner-join (inverted json_multi_col@sij_idx [as=t1])
+      │    ├── columns: t1.k:1(int!null) s:3(string) i:4(int) t2.j:9(jsonb) "inverted_join_const_col_@3":12(string!null) "inverted_join_const_col_@4":13(int!null)
+      │    ├── prefix key columns: [12 13] = [3 4]
+      │    ├── inverted-expr
+      │    │    └── t1.j:2 @> t2.j:9 [type=bool]
+      │    ├── stats: [rows=0.9, distinct(1)=0.89960861, null(1)=0, distinct(3)=0.9, null(3)=0, distinct(4)=0.9, null(4)=0, distinct(3,4)=0.9, null(3,4)=0]
+      │    ├── fd: ()-->(13), (1)-->(3,4)
+      │    ├── project
+      │    │    ├── columns: "inverted_join_const_col_@4":13(int!null) t2.j:9(jsonb) "inverted_join_const_col_@3":12(string!null)
+      │    │    ├── stats: [rows=30, distinct(12)=3, null(12)=0, distinct(13)=1, null(13)=0]
+      │    │    ├── fd: ()-->(13)
+      │    │    ├── inner-join (cross)
+      │    │    │    ├── columns: t2.j:9(jsonb) "inverted_join_const_col_@3":12(string!null)
+      │    │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
+      │    │    │    ├── stats: [rows=30, distinct(12)=3, null(12)=0]
+      │    │    │    ├── scan json_arr2 [as=t2]
+      │    │    │    │    ├── columns: t2.j:9(jsonb)
+      │    │    │    │    └── stats: [rows=10]
+      │    │    │    ├── values
+      │    │    │    │    ├── columns: "inverted_join_const_col_@3":12(string!null)
+      │    │    │    │    ├── cardinality: [3 - 3]
+      │    │    │    │    ├── stats: [rows=3, distinct(12)=3, null(12)=0]
+      │    │    │    │    ├── ('bar',) [type=tuple{string}]
+      │    │    │    │    ├── ('baz',) [type=tuple{string}]
+      │    │    │    │    └── ('foo',) [type=tuple{string}]
+      │    │    │    └── filters (true)
+      │    │    └── projections
+      │    │         └── 10 [as="inverted_join_const_col_@4":13, type=int]
+      │    └── filters (true)
+      └── filters
+           └── t1.j:2 @> t2.j:9 [type=bool, outer=(2,9), immutable]
+
+exec-ddl
+DROP INDEX sij_idx
+----
+
+exec-ddl
+CREATE INVERTED INDEX ij_idx ON json_multi_col (i, j)
+----
+
+opt
+SELECT t1.k
+FROM json_multi_col AS t1
+JOIN json_arr2 AS t2
+ON t1.i = t2.k AND t1.j @> t2.j
+----
+project
+ ├── columns: k:1(int!null)
+ ├── immutable
+ ├── stats: [rows=10]
+ ├── key: (1)
+ └── inner-join (lookup json_multi_col [as=t1])
+      ├── columns: t1.k:1(int!null) t1.j:2(jsonb) i:4(int!null) t2.k:9(int!null) t2.j:10(jsonb)
+      ├── key columns: [1] = [1]
+      ├── lookup columns are key
+      ├── immutable
+      ├── stats: [rows=10, distinct(4)=10, null(4)=0, distinct(9)=10, null(9)=0]
+      ├── key: (1)
+      ├── fd: (1)-->(2,4), (9)-->(10), (4)==(9), (9)==(4)
+      ├── inner-join (inverted json_multi_col@ij_idx [as=t1])
+      │    ├── columns: t1.k:1(int!null) i:4(int) t2.k:9(int!null) t2.j:10(jsonb)
+      │    ├── prefix key columns: [9] = [4]
+      │    ├── inverted-expr
+      │    │    └── t1.j:2 @> t2.j:10 [type=bool]
+      │    ├── stats: [rows=100, distinct(1)=95.617925, null(1)=0, distinct(9)=9.99956829, null(9)=0]
+      │    ├── key: (1,9)
+      │    ├── fd: (9)-->(10), (1)-->(4)
+      │    ├── scan json_arr2 [as=t2]
+      │    │    ├── columns: t2.k:9(int!null) t2.j:10(jsonb)
+      │    │    ├── stats: [rows=10, distinct(9)=10, null(9)=0]
+      │    │    ├── key: (9)
+      │    │    └── fd: (9)-->(10)
+      │    └── filters (true)
+      └── filters
+           └── t1.j:2 @> t2.j:10 [type=bool, outer=(2,10), immutable]

--- a/pkg/sql/opt/ordering/inverted_join_test.go
+++ b/pkg/sql/opt/ordering/inverted_join_test.go
@@ -55,9 +55,9 @@ func TestInvertedJoinProvided(t *testing.T) {
 		t.Fatal(err)
 	}
 	tn = tree.NewUnqualifiedTableName("t2")
-	tab = md.AddTable(tc.Table(tn), tn)
+	inputTab := md.AddTable(tc.Table(tn), tn)
 
-	if c6 := tab.ColumnID(0); c6 != 6 {
+	if c6 := inputTab.ColumnID(0); c6 != 6 {
 		t.Fatalf("unexpected ID for column c6: %d\n", c6)
 	}
 

--- a/pkg/sql/opt/xform/join_funcs.go
+++ b/pkg/sql/opt/xform/join_funcs.go
@@ -129,7 +129,7 @@ func (c *CustomFuncs) GenerateMergeJoins(
 //  1. The index has all the columns we need; this is the simple case, where we
 //     generate a LookupJoin expression in the current group:
 //
-//         Join                       LookupJoin(t@idx))
+//         Join                       LookupJoin(t@idx)
 //         /   \                           |
 //        /     \            ->            |
 //      Input  Scan(t)                   Input

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -5052,12 +5052,12 @@ project
       ├── immutable
       ├── fd: ()-->(14), (1)-->(10)
       ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n])
-      │    ├── columns: c.gid:1!null c.geom:10 n.gid:13!null n.boroname:14 "inverted_join_const_col_@14":20!null
+      │    ├── columns: c.gid:1!null c.geom:10 n.gid:13!null n.boroname:14!null "inverted_join_const_col_@14":20!null
       │    ├── prefix key columns: [20] = [14]
       │    ├── inverted-expr
       │    │    └── st_covers(c.geom:10, n.geom:16)
       │    ├── key: (1,13)
-      │    ├── fd: ()-->(20), (1)-->(10), (13)-->(14)
+      │    ├── fd: ()-->(14,20), (1)-->(10), (14)==(20), (20)==(14)
       │    ├── project
       │    │    ├── columns: "inverted_join_const_col_@14":20!null c.gid:1!null c.geom:10
       │    │    ├── key: (1)
@@ -5095,7 +5095,7 @@ project
       │    ├── prefix key columns: [18] = [6]
       │    ├── inverted-expr
       │    │    └── t1.a:9 @> t2.a:4
-      │    ├── fd: ()-->(18)
+      │    ├── fd: ()-->(6,18), (6)==(18), (18)==(6)
       │    ├── project
       │    │    ├── columns: "inverted_join_const_col_@6":18!null t2.a:4
       │    │    ├── fd: ()-->(18)
@@ -5130,7 +5130,7 @@ project
       │    ├── prefix key columns: [17] = [6]
       │    ├── inverted-expr
       │    │    └── t1.j:8 @> t2.j:3
-      │    ├── fd: ()-->(17)
+      │    ├── fd: ()-->(6,17), (6)==(17), (17)==(6)
       │    ├── project
       │    │    ├── columns: "inverted_join_const_col_@6":17!null t2.j:3
       │    │    ├── fd: ()-->(17)
@@ -5165,7 +5165,7 @@ project
       │    ├── prefix key columns: [17] = [6]
       │    ├── inverted-expr
       │    │    └── t1.j:8 @> t2.j:3
-      │    ├── fd: ()-->(17)
+      │    ├── fd: ()-->(6,17), (6)==(17), (17)==(6)
       │    ├── project
       │    │    ├── columns: "inverted_join_const_col_@6":17!null t2.j:3
       │    │    ├── fd: ()-->(17)
@@ -5200,6 +5200,7 @@ project
       │    ├── prefix key columns: [17] = [6]
       │    ├── inverted-expr
       │    │    └── t1.j:8 @> t2.j:3
+      │    ├── fd: (6)==(17), (17)==(6)
       │    ├── inner-join (cross)
       │    │    ├── columns: t2.j:3 "inverted_join_const_col_@6":17!null
       │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
@@ -5240,8 +5241,8 @@ project
       │    ├── prefix key columns: [1] = [6]
       │    ├── inverted-expr
       │    │    └── t1.j:8 @> t2.j:3
-      │    ├── key: (1,6)
-      │    ├── fd: (1)-->(3)
+      │    ├── key: (6)
+      │    ├── fd: (1)-->(3), (1)==(6), (6)==(1)
       │    ├── scan json_arr2 [as=t2]
       │    │    ├── columns: t2.k:1!null t2.j:3
       │    │    ├── key: (1)
@@ -5305,12 +5306,12 @@ project
       ├── immutable
       ├── fd: (6)-->(7,8)
       ├── inner-join (inverted json_arr1@j_idx [as=t1])
-      │    ├── columns: t2.j:3 t1.k:6!null i:7 "inverted_join_const_col_@6":19!null "inverted_join_const_col_@7":20!null
+      │    ├── columns: t2.j:3 t1.k:6!null i:7!null "inverted_join_const_col_@6":19!null "inverted_join_const_col_@7":20!null
       │    ├── flags: force inverted join (into right side)
       │    ├── prefix key columns: [19 20] = [6 7]
       │    ├── inverted-expr
       │    │    └── t1.j:8 @> t2.j:3
-      │    ├── fd: (6)-->(7)
+      │    ├── fd: (6)-->(7), (6)==(19), (19)==(6), (7)==(20), (20)==(7)
       │    ├── inner-join (cross)
       │    │    ├── columns: t2.j:3 "inverted_join_const_col_@6":19!null "inverted_join_const_col_@7":20!null
       │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
@@ -5355,12 +5356,12 @@ project
       ├── key: (6)
       ├── fd: (1)-->(3), (6)-->(7,8), (1)==(6), (6)==(1)
       ├── inner-join (inverted json_arr1@j_idx [as=t1])
-      │    ├── columns: t2.k:1!null t2.j:3 t1.k:6!null i:7 "inverted_join_const_col_@7":18!null
+      │    ├── columns: t2.k:1!null t2.j:3 t1.k:6!null i:7!null "inverted_join_const_col_@7":18!null
       │    ├── flags: force inverted join (into right side)
       │    ├── prefix key columns: [1 18] = [6 7]
       │    ├── inverted-expr
       │    │    └── t1.j:8 @> t2.j:3
-      │    ├── fd: (1)-->(3), (6)-->(7)
+      │    ├── fd: (1)-->(3), (6)-->(7), (1)==(6), (6)==(1), (7)==(18), (18)==(7)
       │    ├── inner-join (cross)
       │    │    ├── columns: t2.k:1!null t2.j:3 "inverted_join_const_col_@7":18!null
       │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
@@ -5404,8 +5405,8 @@ project
       │    ├── prefix key columns: [1 2] = [6 7]
       │    ├── inverted-expr
       │    │    └── t1.j:8 @> t2.j:3
-      │    ├── key: (1,6)
-      │    ├── fd: (1)-->(2,3), (6)-->(7), (2)==(7), (7)==(2)
+      │    ├── key: (6)
+      │    ├── fd: (1)-->(2,3), (6)-->(7), (2)==(7), (7)==(2), (1)==(6), (6)==(1)
       │    ├── scan json_arr2 [as=t2]
       │    │    ├── columns: t2.k:1!null l:2 t2.j:3
       │    │    ├── key: (1)
@@ -5473,17 +5474,17 @@ project
  ├── key: (1)
  ├── fd: (1)-->(2-4)
  └── semi-join (lookup json_arr1 [as=t1])
-      ├── columns: t2.k:1!null l:2 t2.j:3 t2.a:4 i:7
+      ├── columns: t2.k:1!null l:2 t2.j:3 t2.a:4 i:7!null
       ├── key columns: [6] = [6]
       ├── lookup columns are key
       ├── immutable
       ├── fd: (1)-->(2-4)
       ├── inner-join (inverted json_arr1@j_idx [as=t1])
-      │    ├── columns: t2.k:1!null l:2 t2.j:3 t2.a:4 t1.k:6!null i:7 "inverted_join_const_col_@7":19!null continuation:20
+      │    ├── columns: t2.k:1!null l:2 t2.j:3 t2.a:4 t1.k:6!null i:7!null "inverted_join_const_col_@7":19!null continuation:20
       │    ├── prefix key columns: [19] = [7]
       │    ├── inverted-expr
       │    │    └── t1.j:8 @> t2.j:3
-      │    ├── fd: (1)-->(2-4), (6)-->(7,20)
+      │    ├── fd: (1)-->(2-4), (6)-->(7,20), (7)==(19), (19)==(7)
       │    ├── inner-join (cross)
       │    │    ├── columns: t2.k:1!null l:2 t2.j:3 t2.a:4 "inverted_join_const_col_@7":19!null
       │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
@@ -5515,43 +5516,26 @@ project
  ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-4)
- └── distinct-on
-      ├── columns: t2.k:1!null l:2 t2.j:3 t2.a:4
-      ├── grouping columns: t2.k:1!null
-      ├── internal-ordering: +(1|7)
+ └── semi-join (lookup json_arr1 [as=t1])
+      ├── columns: t2.k:1!null l:2 t2.j:3 t2.a:4 i:7!null
+      ├── key columns: [6] = [6]
+      ├── lookup columns are key
       ├── immutable
-      ├── key: (1)
-      ├── fd: (1)-->(2-4)
-      ├── inner-join (lookup json_arr1 [as=t1])
-      │    ├── columns: t2.k:1!null l:2 t2.j:3 t2.a:4 i:7!null t1.j:8
-      │    ├── key columns: [6] = [6]
-      │    ├── lookup columns are key
-      │    ├── immutable
-      │    ├── fd: (1)-->(2-4), (1)==(7), (7)==(1)
-      │    ├── ordering: +(1|7) [actual: +1]
-      │    ├── inner-join (inverted json_arr1@j_idx [as=t1])
-      │    │    ├── columns: t2.k:1!null l:2 t2.j:3 t2.a:4 t1.k:6!null i:7
-      │    │    ├── prefix key columns: [1] = [7]
-      │    │    ├── inverted-expr
-      │    │    │    └── t1.j:8 @> t2.j:3
-      │    │    ├── key: (1,6)
-      │    │    ├── fd: (1)-->(2-4), (6)-->(7)
-      │    │    ├── ordering: +1
-      │    │    ├── scan json_arr2 [as=t2]
-      │    │    │    ├── columns: t2.k:1!null l:2 t2.j:3 t2.a:4
-      │    │    │    ├── key: (1)
-      │    │    │    ├── fd: (1)-->(2-4)
-      │    │    │    └── ordering: +1
-      │    │    └── filters (true)
-      │    └── filters
-      │         └── t1.j:8 @> t2.j:3 [outer=(3,8), immutable]
-      └── aggregations
-           ├── const-agg [as=l:2, outer=(2)]
-           │    └── l:2
-           ├── const-agg [as=t2.j:3, outer=(3)]
-           │    └── t2.j:3
-           └── const-agg [as=t2.a:4, outer=(4)]
-                └── t2.a:4
+      ├── fd: (1)-->(2-4), (1)==(7), (7)==(1)
+      ├── inner-join (inverted json_arr1@j_idx [as=t1])
+      │    ├── columns: t2.k:1!null l:2 t2.j:3 t2.a:4 t1.k:6!null i:7!null continuation:19
+      │    ├── prefix key columns: [1] = [7]
+      │    ├── inverted-expr
+      │    │    └── t1.j:8 @> t2.j:3
+      │    ├── key: (6)
+      │    ├── fd: (1)-->(2-4), (6)-->(7,19), (1)==(7), (7)==(1)
+      │    ├── scan json_arr2 [as=t2]
+      │    │    ├── columns: t2.k:1!null l:2 t2.j:3 t2.a:4
+      │    │    ├── key: (1)
+      │    │    └── fd: (1)-->(2-4)
+      │    └── filters (true)
+      └── filters
+           └── t1.j:8 @> t2.j:3 [outer=(3,8), immutable]
 
 # Generate an inverted anti-join on a multi-column inverted index.
 opt expect=GenerateInvertedJoinsFromSelect


### PR DESCRIPTION
#### opt: add stats tests for multi-column inverted joins

The statistics builder was updated in #58054 to consider constant
filters on non-inverted prefix columns when building stats for
multi-column inverted joins. This commit adds additional tests for this.

There is no release note because multi-column inverted indexes are gated
behind the `experimental_enable_multi_column_inverted_indexes` session
setting.

Release note: None

#### opt: consider inverted join prefix key columns when building logical props

This commit updates the logical props builder to consider inverted join
prefix key columns when building logical props for inverted join
expressions.

There is no release note because multi-column inverted indexes are gated
behind the `experimental_enable_multi_column_inverted_indexes` session
setting.

Release note: None
