### PR TITLE
release-20.1: opt: fix bug where ON CONFLICT DO NOTHING ignores some input

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/upsert
+++ b/pkg/sql/logictest/testdata/logic_test/upsert
@@ -1249,3 +1249,29 @@ query I
 WITH cte(c) AS (UPSERT INTO t54456 SELECT i FROM generate_series(25001, 40000) AS i RETURNING c) SELECT count(*) FROM cte
 ----
 15000
+
+# Regression test for #59125. Ensure that valid rows don't get filtered out
+# from ON CONFLICT DO NOTHING.
+statement ok
+CREATE TABLE uniq (
+  x STRING PRIMARY KEY,
+  y STRING UNIQUE,
+  z STRING UNIQUE
+)
+
+statement ok
+INSERT INTO uniq VALUES ('x1', 'y1', 'z1');
+
+# The first row has a conflict due to the unique index on y, so it should be
+# discarded. The second row does not conflict with the existing row, so it
+# should be inserted. The third row is a duplicate of the second row, so it
+# should be discarded.
+statement ok
+INSERT INTO uniq VALUES ('x2', 'y1', 'z2'), ('x2', 'y2', 'z2'), ('x2', 'y2', 'z2')
+ON CONFLICT DO NOTHING
+
+query TTT rowsort
+SELECT * FROM uniq
+----
+x1  y1  z1
+x2  y2  z2

--- a/pkg/sql/opt/memo/testdata/logprops/upsert
+++ b/pkg/sql/opt/memo/testdata/logprops/upsert
@@ -226,188 +226,190 @@ project
            ├── side-effects
            ├── key: (5)
            ├── fd: (5)-->(6,8,9), (6)-->(9), (8)~~>(5,6,9), (6,9)~~>(5,8)
-           ├── project
+           ├── upsert-distinct-on
            │    ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int)
+           │    ├── grouping columns: x:5(int!null)
            │    ├── side-effects
            │    ├── key: (5)
            │    ├── fd: (5)-->(6,8,9), (6)-->(9), (8)~~>(5,6,9)
-           │    ├── prune: (5,6,8,9)
-           │    └── select
-           │         ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:18(int) b:19(int) c:20(int) rowid:21(int)
-           │         ├── side-effects
-           │         ├── key: (5)
-           │         ├── fd: ()-->(18-21), (5)-->(6,8,9), (6)-->(9), (8)~~>(5,6,9)
-           │         ├── prune: (18)
-           │         ├── interesting orderings: (+21) (+18) (+19,+20,+21)
-           │         ├── left-join (hash)
-           │         │    ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:18(int) b:19(int) c:20(int) rowid:21(int)
-           │         │    ├── side-effects
-           │         │    ├── key: (5,21)
-           │         │    ├── fd: (5)-->(6,8,9), (6)-->(9), (8)~~>(5,6,9), (21)-->(18-20), (18)-->(19-21), (19,20)~~>(18,21)
-           │         │    ├── prune: (18,21)
-           │         │    ├── reject-nulls: (18-21)
-           │         │    ├── interesting orderings: (+21) (+18) (+19,+20,+21)
-           │         │    ├── upsert-distinct-on
-           │         │    │    ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int)
-           │         │    │    ├── grouping columns: x:5(int!null)
-           │         │    │    ├── side-effects
-           │         │    │    ├── key: (5)
-           │         │    │    ├── fd: (5)-->(6,8,9), (6)-->(9), (8)~~>(5,6,9)
-           │         │    │    ├── project
-           │         │    │    │    ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int)
-           │         │    │    │    ├── side-effects
-           │         │    │    │    ├── key: (5)
-           │         │    │    │    ├── fd: (5)-->(6,8), (6)-->(9), (8)~~>(5,6,9)
-           │         │    │    │    ├── prune: (5,6,8,9)
-           │         │    │    │    └── select
-           │         │    │    │         ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:14(int) b:15(int) c:16(int) rowid:17(int)
-           │         │    │    │         ├── side-effects
-           │         │    │    │         ├── key: (5)
-           │         │    │    │         ├── fd: ()-->(14-17), (5)-->(6,8), (6)-->(9), (8)~~>(5,6,9)
-           │         │    │    │         ├── prune: (15-17)
-           │         │    │    │         ├── interesting orderings: (+17) (+14) (+15,+16,+17)
-           │         │    │    │         ├── left-join (hash)
-           │         │    │    │         │    ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:14(int) b:15(int) c:16(int) rowid:17(int)
-           │         │    │    │         │    ├── side-effects
-           │         │    │    │         │    ├── key: (5,17)
-           │         │    │    │         │    ├── fd: (5)-->(6,8), (6)-->(9), (8)~~>(5,6,9), (17)-->(14-16), (14)-->(15-17), (15,16)~~>(14,17)
-           │         │    │    │         │    ├── prune: (15-17)
-           │         │    │    │         │    ├── reject-nulls: (14-17)
-           │         │    │    │         │    ├── interesting orderings: (+17) (+14) (+15,+16,+17)
-           │         │    │    │         │    ├── upsert-distinct-on
-           │         │    │    │         │    │    ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int)
-           │         │    │    │         │    │    ├── grouping columns: column8:8(int)
-           │         │    │    │         │    │    ├── side-effects
-           │         │    │    │         │    │    ├── key: (5)
-           │         │    │    │         │    │    ├── fd: (5)-->(6,8), (6)-->(9), (8)~~>(5,6,9)
-           │         │    │    │         │    │    ├── project
-           │         │    │    │         │    │    │    ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int)
-           │         │    │    │         │    │    │    ├── side-effects
-           │         │    │    │         │    │    │    ├── key: (5)
-           │         │    │    │         │    │    │    ├── fd: (5)-->(6,8), (6)-->(9)
-           │         │    │    │         │    │    │    ├── prune: (5,6,8,9)
-           │         │    │    │         │    │    │    ├── interesting orderings: (+5) (+6)
-           │         │    │    │         │    │    │    └── select
-           │         │    │    │         │    │    │         ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:10(int) b:11(int) c:12(int) rowid:13(int)
-           │         │    │    │         │    │    │         ├── side-effects
-           │         │    │    │         │    │    │         ├── key: (5)
-           │         │    │    │         │    │    │         ├── fd: ()-->(10-13), (5)-->(6,8), (6)-->(9)
-           │         │    │    │         │    │    │         ├── prune: (5,6,9-12)
-           │         │    │    │         │    │    │         ├── interesting orderings: (+5) (+6) (+13) (+10) (+11,+12,+13)
-           │         │    │    │         │    │    │         ├── left-join (hash)
-           │         │    │    │         │    │    │         │    ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:10(int) b:11(int) c:12(int) rowid:13(int)
-           │         │    │    │         │    │    │         │    ├── side-effects
-           │         │    │    │         │    │    │         │    ├── key: (5,13)
-           │         │    │    │         │    │    │         │    ├── fd: (5)-->(6,8), (6)-->(9), (13)-->(10-12), (10)-->(11-13), (11,12)~~>(10,13)
-           │         │    │    │         │    │    │         │    ├── prune: (5,6,9-12)
-           │         │    │    │         │    │    │         │    ├── reject-nulls: (10-13)
-           │         │    │    │         │    │    │         │    ├── interesting orderings: (+5) (+6) (+13) (+10) (+11,+12,+13)
-           │         │    │    │         │    │    │         │    ├── project
-           │         │    │    │         │    │    │         │    │    ├── columns: column9:9(int) x:5(int!null) y:6(int) column8:8(int)
-           │         │    │    │         │    │    │         │    │    ├── side-effects
-           │         │    │    │         │    │    │         │    │    ├── key: (5)
-           │         │    │    │         │    │    │         │    │    ├── fd: (5)-->(6,8), (6)-->(9)
-           │         │    │    │         │    │    │         │    │    ├── prune: (5,6,8,9)
-           │         │    │    │         │    │    │         │    │    ├── interesting orderings: (+5) (+6)
-           │         │    │    │         │    │    │         │    │    ├── project
-           │         │    │    │         │    │    │         │    │    │    ├── columns: column8:8(int) x:5(int!null) y:6(int)
-           │         │    │    │         │    │    │         │    │    │    ├── side-effects
-           │         │    │    │         │    │    │         │    │    │    ├── key: (5)
-           │         │    │    │         │    │    │         │    │    │    ├── fd: (5)-->(6,8)
-           │         │    │    │         │    │    │         │    │    │    ├── prune: (5,6,8)
-           │         │    │    │         │    │    │         │    │    │    ├── interesting orderings: (+5) (+6)
-           │         │    │    │         │    │    │         │    │    │    ├── project
-           │         │    │    │         │    │    │         │    │    │    │    ├── columns: x:5(int!null) y:6(int)
-           │         │    │    │         │    │    │         │    │    │    │    ├── key: (5)
-           │         │    │    │         │    │    │         │    │    │    │    ├── fd: (5)-->(6)
-           │         │    │    │         │    │    │         │    │    │    │    ├── prune: (5,6)
-           │         │    │    │         │    │    │         │    │    │    │    ├── interesting orderings: (+5) (+6)
-           │         │    │    │         │    │    │         │    │    │    │    └── scan xyz
-           │         │    │    │         │    │    │         │    │    │    │         ├── columns: x:5(int!null) y:6(int) z:7(int)
-           │         │    │    │         │    │    │         │    │    │    │         ├── key: (5)
-           │         │    │    │         │    │    │         │    │    │    │         ├── fd: (5)-->(6,7), (6,7)~~>(5)
-           │         │    │    │         │    │    │         │    │    │    │         ├── prune: (5-7)
-           │         │    │    │         │    │    │         │    │    │    │         └── interesting orderings: (+5) (+6,+7,+5) (+7,+6,+5)
-           │         │    │    │         │    │    │         │    │    │    └── projections
-           │         │    │    │         │    │    │         │    │    │         └── function: unique_rowid [as=column8:8, type=int, side-effects]
-           │         │    │    │         │    │    │         │    │    └── projections
-           │         │    │    │         │    │    │         │    │         └── plus [as=column9:9, type=int, outer=(6)]
-           │         │    │    │         │    │    │         │    │              ├── variable: y:6 [type=int]
-           │         │    │    │         │    │    │         │    │              └── const: 1 [type=int]
-           │         │    │    │         │    │    │         │    ├── scan abc
-           │         │    │    │         │    │    │         │    │    ├── columns: a:10(int!null) b:11(int) c:12(int) rowid:13(int!null)
-           │         │    │    │         │    │    │         │    │    ├── computed column expressions
-           │         │    │    │         │    │    │         │    │    │    └── c:12
-           │         │    │    │         │    │    │         │    │    │         └── plus [type=int]
-           │         │    │    │         │    │    │         │    │    │              ├── variable: b:11 [type=int]
-           │         │    │    │         │    │    │         │    │    │              └── const: 1 [type=int]
-           │         │    │    │         │    │    │         │    │    ├── key: (13)
-           │         │    │    │         │    │    │         │    │    ├── fd: (13)-->(10-12), (10)-->(11-13), (11,12)~~>(10,13)
-           │         │    │    │         │    │    │         │    │    ├── prune: (10-13)
-           │         │    │    │         │    │    │         │    │    └── interesting orderings: (+13) (+10) (+11,+12,+13)
-           │         │    │    │         │    │    │         │    └── filters
-           │         │    │    │         │    │    │         │         └── eq [type=bool, outer=(8,13), constraints=(/8: (/NULL - ]; /13: (/NULL - ]), fd=(8)==(13), (13)==(8)]
-           │         │    │    │         │    │    │         │              ├── variable: column8:8 [type=int]
-           │         │    │    │         │    │    │         │              └── variable: rowid:13 [type=int]
-           │         │    │    │         │    │    │         └── filters
-           │         │    │    │         │    │    │              └── is [type=bool, outer=(13), constraints=(/13: [/NULL - /NULL]; tight), fd=()-->(13)]
-           │         │    │    │         │    │    │                   ├── variable: rowid:13 [type=int]
-           │         │    │    │         │    │    │                   └── null [type=unknown]
-           │         │    │    │         │    │    └── aggregations
-           │         │    │    │         │    │         ├── first-agg [as=x:5, type=int, outer=(5)]
-           │         │    │    │         │    │         │    └── variable: x:5 [type=int]
-           │         │    │    │         │    │         ├── first-agg [as=y:6, type=int, outer=(6)]
-           │         │    │    │         │    │         │    └── variable: y:6 [type=int]
-           │         │    │    │         │    │         └── first-agg [as=column9:9, type=int, outer=(9)]
-           │         │    │    │         │    │              └── variable: column9:9 [type=int]
-           │         │    │    │         │    ├── scan abc
-           │         │    │    │         │    │    ├── columns: a:14(int!null) b:15(int) c:16(int) rowid:17(int!null)
-           │         │    │    │         │    │    ├── computed column expressions
-           │         │    │    │         │    │    │    └── c:16
-           │         │    │    │         │    │    │         └── plus [type=int]
-           │         │    │    │         │    │    │              ├── variable: b:15 [type=int]
-           │         │    │    │         │    │    │              └── const: 1 [type=int]
-           │         │    │    │         │    │    ├── key: (17)
-           │         │    │    │         │    │    ├── fd: (17)-->(14-16), (14)-->(15-17), (15,16)~~>(14,17)
-           │         │    │    │         │    │    ├── prune: (14-17)
-           │         │    │    │         │    │    └── interesting orderings: (+17) (+14) (+15,+16,+17)
-           │         │    │    │         │    └── filters
-           │         │    │    │         │         └── eq [type=bool, outer=(5,14), constraints=(/5: (/NULL - ]; /14: (/NULL - ]), fd=(5)==(14), (14)==(5)]
-           │         │    │    │         │              ├── variable: x:5 [type=int]
-           │         │    │    │         │              └── variable: a:14 [type=int]
-           │         │    │    │         └── filters
-           │         │    │    │              └── is [type=bool, outer=(14), constraints=(/14: [/NULL - /NULL]; tight), fd=()-->(14)]
-           │         │    │    │                   ├── variable: a:14 [type=int]
-           │         │    │    │                   └── null [type=unknown]
-           │         │    │    └── aggregations
-           │         │    │         ├── first-agg [as=y:6, type=int, outer=(6)]
-           │         │    │         │    └── variable: y:6 [type=int]
-           │         │    │         ├── first-agg [as=column8:8, type=int, outer=(8)]
-           │         │    │         │    └── variable: column8:8 [type=int]
-           │         │    │         └── first-agg [as=column9:9, type=int, outer=(9)]
-           │         │    │              └── variable: column9:9 [type=int]
-           │         │    ├── scan abc
-           │         │    │    ├── columns: a:18(int!null) b:19(int) c:20(int) rowid:21(int!null)
-           │         │    │    ├── computed column expressions
-           │         │    │    │    └── c:20
-           │         │    │    │         └── plus [type=int]
-           │         │    │    │              ├── variable: b:19 [type=int]
-           │         │    │    │              └── const: 1 [type=int]
-           │         │    │    ├── key: (21)
-           │         │    │    ├── fd: (21)-->(18-20), (18)-->(19-21), (19,20)~~>(18,21)
-           │         │    │    ├── prune: (18-21)
-           │         │    │    └── interesting orderings: (+21) (+18) (+19,+20,+21)
-           │         │    └── filters
-           │         │         ├── eq [type=bool, outer=(6,19), constraints=(/6: (/NULL - ]; /19: (/NULL - ]), fd=(6)==(19), (19)==(6)]
-           │         │         │    ├── variable: y:6 [type=int]
-           │         │         │    └── variable: b:19 [type=int]
-           │         │         └── eq [type=bool, outer=(9,20), constraints=(/9: (/NULL - ]; /20: (/NULL - ]), fd=(9)==(20), (20)==(9)]
-           │         │              ├── variable: column9:9 [type=int]
-           │         │              └── variable: c:20 [type=int]
-           │         └── filters
-           │              └── is [type=bool, outer=(21), constraints=(/21: [/NULL - /NULL]; tight), fd=()-->(21)]
-           │                   ├── variable: rowid:21 [type=int]
-           │                   └── null [type=unknown]
+           │    ├── upsert-distinct-on
+           │    │    ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int)
+           │    │    ├── grouping columns: column8:8(int)
+           │    │    ├── side-effects
+           │    │    ├── key: (5)
+           │    │    ├── fd: (5)-->(6,8), (6)-->(9), (8)~~>(5,6,9)
+           │    │    ├── project
+           │    │    │    ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int)
+           │    │    │    ├── side-effects
+           │    │    │    ├── key: (5)
+           │    │    │    ├── fd: (5)-->(6,8), (6)-->(9)
+           │    │    │    ├── prune: (5,6,8,9)
+           │    │    │    ├── interesting orderings: (+5) (+6)
+           │    │    │    └── select
+           │    │    │         ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:18(int) b:19(int) c:20(int) rowid:21(int)
+           │    │    │         ├── side-effects
+           │    │    │         ├── key: (5)
+           │    │    │         ├── fd: ()-->(18-21), (5)-->(6,8), (6)-->(9)
+           │    │    │         ├── prune: (5,8,18)
+           │    │    │         ├── interesting orderings: (+5) (+6) (+21) (+18) (+19,+20,+21)
+           │    │    │         ├── left-join (hash)
+           │    │    │         │    ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:18(int) b:19(int) c:20(int) rowid:21(int)
+           │    │    │         │    ├── side-effects
+           │    │    │         │    ├── key: (5,21)
+           │    │    │         │    ├── fd: (5)-->(6,8), (6)-->(9), (21)-->(18-20), (18)-->(19-21), (19,20)~~>(18,21)
+           │    │    │         │    ├── prune: (5,8,18,21)
+           │    │    │         │    ├── reject-nulls: (18-21)
+           │    │    │         │    ├── interesting orderings: (+5) (+6) (+21) (+18) (+19,+20,+21)
+           │    │    │         │    ├── project
+           │    │    │         │    │    ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int)
+           │    │    │         │    │    ├── side-effects
+           │    │    │         │    │    ├── key: (5)
+           │    │    │         │    │    ├── fd: (5)-->(6,8), (6)-->(9)
+           │    │    │         │    │    ├── prune: (5,6,8,9)
+           │    │    │         │    │    ├── interesting orderings: (+5) (+6)
+           │    │    │         │    │    └── select
+           │    │    │         │    │         ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:14(int) b:15(int) c:16(int) rowid:17(int)
+           │    │    │         │    │         ├── side-effects
+           │    │    │         │    │         ├── key: (5)
+           │    │    │         │    │         ├── fd: ()-->(14-17), (5)-->(6,8), (6)-->(9)
+           │    │    │         │    │         ├── prune: (6,8,9,15-17)
+           │    │    │         │    │         ├── interesting orderings: (+5) (+6) (+17) (+14) (+15,+16,+17)
+           │    │    │         │    │         ├── left-join (hash)
+           │    │    │         │    │         │    ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:14(int) b:15(int) c:16(int) rowid:17(int)
+           │    │    │         │    │         │    ├── side-effects
+           │    │    │         │    │         │    ├── key: (5,17)
+           │    │    │         │    │         │    ├── fd: (5)-->(6,8), (6)-->(9), (17)-->(14-16), (14)-->(15-17), (15,16)~~>(14,17)
+           │    │    │         │    │         │    ├── prune: (6,8,9,15-17)
+           │    │    │         │    │         │    ├── reject-nulls: (14-17)
+           │    │    │         │    │         │    ├── interesting orderings: (+5) (+6) (+17) (+14) (+15,+16,+17)
+           │    │    │         │    │         │    ├── project
+           │    │    │         │    │         │    │    ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int)
+           │    │    │         │    │         │    │    ├── side-effects
+           │    │    │         │    │         │    │    ├── key: (5)
+           │    │    │         │    │         │    │    ├── fd: (5)-->(6,8), (6)-->(9)
+           │    │    │         │    │         │    │    ├── prune: (5,6,8,9)
+           │    │    │         │    │         │    │    ├── interesting orderings: (+5) (+6)
+           │    │    │         │    │         │    │    └── select
+           │    │    │         │    │         │    │         ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:10(int) b:11(int) c:12(int) rowid:13(int)
+           │    │    │         │    │         │    │         ├── side-effects
+           │    │    │         │    │         │    │         ├── key: (5)
+           │    │    │         │    │         │    │         ├── fd: ()-->(10-13), (5)-->(6,8), (6)-->(9)
+           │    │    │         │    │         │    │         ├── prune: (5,6,9-12)
+           │    │    │         │    │         │    │         ├── interesting orderings: (+5) (+6) (+13) (+10) (+11,+12,+13)
+           │    │    │         │    │         │    │         ├── left-join (hash)
+           │    │    │         │    │         │    │         │    ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:10(int) b:11(int) c:12(int) rowid:13(int)
+           │    │    │         │    │         │    │         │    ├── side-effects
+           │    │    │         │    │         │    │         │    ├── key: (5,13)
+           │    │    │         │    │         │    │         │    ├── fd: (5)-->(6,8), (6)-->(9), (13)-->(10-12), (10)-->(11-13), (11,12)~~>(10,13)
+           │    │    │         │    │         │    │         │    ├── prune: (5,6,9-12)
+           │    │    │         │    │         │    │         │    ├── reject-nulls: (10-13)
+           │    │    │         │    │         │    │         │    ├── interesting orderings: (+5) (+6) (+13) (+10) (+11,+12,+13)
+           │    │    │         │    │         │    │         │    ├── project
+           │    │    │         │    │         │    │         │    │    ├── columns: column9:9(int) x:5(int!null) y:6(int) column8:8(int)
+           │    │    │         │    │         │    │         │    │    ├── side-effects
+           │    │    │         │    │         │    │         │    │    ├── key: (5)
+           │    │    │         │    │         │    │         │    │    ├── fd: (5)-->(6,8), (6)-->(9)
+           │    │    │         │    │         │    │         │    │    ├── prune: (5,6,8,9)
+           │    │    │         │    │         │    │         │    │    ├── interesting orderings: (+5) (+6)
+           │    │    │         │    │         │    │         │    │    ├── project
+           │    │    │         │    │         │    │         │    │    │    ├── columns: column8:8(int) x:5(int!null) y:6(int)
+           │    │    │         │    │         │    │         │    │    │    ├── side-effects
+           │    │    │         │    │         │    │         │    │    │    ├── key: (5)
+           │    │    │         │    │         │    │         │    │    │    ├── fd: (5)-->(6,8)
+           │    │    │         │    │         │    │         │    │    │    ├── prune: (5,6,8)
+           │    │    │         │    │         │    │         │    │    │    ├── interesting orderings: (+5) (+6)
+           │    │    │         │    │         │    │         │    │    │    ├── project
+           │    │    │         │    │         │    │         │    │    │    │    ├── columns: x:5(int!null) y:6(int)
+           │    │    │         │    │         │    │         │    │    │    │    ├── key: (5)
+           │    │    │         │    │         │    │         │    │    │    │    ├── fd: (5)-->(6)
+           │    │    │         │    │         │    │         │    │    │    │    ├── prune: (5,6)
+           │    │    │         │    │         │    │         │    │    │    │    ├── interesting orderings: (+5) (+6)
+           │    │    │         │    │         │    │         │    │    │    │    └── scan xyz
+           │    │    │         │    │         │    │         │    │    │    │         ├── columns: x:5(int!null) y:6(int) z:7(int)
+           │    │    │         │    │         │    │         │    │    │    │         ├── key: (5)
+           │    │    │         │    │         │    │         │    │    │    │         ├── fd: (5)-->(6,7), (6,7)~~>(5)
+           │    │    │         │    │         │    │         │    │    │    │         ├── prune: (5-7)
+           │    │    │         │    │         │    │         │    │    │    │         └── interesting orderings: (+5) (+6,+7,+5) (+7,+6,+5)
+           │    │    │         │    │         │    │         │    │    │    └── projections
+           │    │    │         │    │         │    │         │    │    │         └── function: unique_rowid [as=column8:8, type=int, side-effects]
+           │    │    │         │    │         │    │         │    │    └── projections
+           │    │    │         │    │         │    │         │    │         └── plus [as=column9:9, type=int, outer=(6)]
+           │    │    │         │    │         │    │         │    │              ├── variable: y:6 [type=int]
+           │    │    │         │    │         │    │         │    │              └── const: 1 [type=int]
+           │    │    │         │    │         │    │         │    ├── scan abc
+           │    │    │         │    │         │    │         │    │    ├── columns: a:10(int!null) b:11(int) c:12(int) rowid:13(int!null)
+           │    │    │         │    │         │    │         │    │    ├── computed column expressions
+           │    │    │         │    │         │    │         │    │    │    └── c:12
+           │    │    │         │    │         │    │         │    │    │         └── plus [type=int]
+           │    │    │         │    │         │    │         │    │    │              ├── variable: b:11 [type=int]
+           │    │    │         │    │         │    │         │    │    │              └── const: 1 [type=int]
+           │    │    │         │    │         │    │         │    │    ├── key: (13)
+           │    │    │         │    │         │    │         │    │    ├── fd: (13)-->(10-12), (10)-->(11-13), (11,12)~~>(10,13)
+           │    │    │         │    │         │    │         │    │    ├── prune: (10-13)
+           │    │    │         │    │         │    │         │    │    └── interesting orderings: (+13) (+10) (+11,+12,+13)
+           │    │    │         │    │         │    │         │    └── filters
+           │    │    │         │    │         │    │         │         └── eq [type=bool, outer=(8,13), constraints=(/8: (/NULL - ]; /13: (/NULL - ]), fd=(8)==(13), (13)==(8)]
+           │    │    │         │    │         │    │         │              ├── variable: column8:8 [type=int]
+           │    │    │         │    │         │    │         │              └── variable: rowid:13 [type=int]
+           │    │    │         │    │         │    │         └── filters
+           │    │    │         │    │         │    │              └── is [type=bool, outer=(13), constraints=(/13: [/NULL - /NULL]; tight), fd=()-->(13)]
+           │    │    │         │    │         │    │                   ├── variable: rowid:13 [type=int]
+           │    │    │         │    │         │    │                   └── null [type=unknown]
+           │    │    │         │    │         │    ├── scan abc
+           │    │    │         │    │         │    │    ├── columns: a:14(int!null) b:15(int) c:16(int) rowid:17(int!null)
+           │    │    │         │    │         │    │    ├── computed column expressions
+           │    │    │         │    │         │    │    │    └── c:16
+           │    │    │         │    │         │    │    │         └── plus [type=int]
+           │    │    │         │    │         │    │    │              ├── variable: b:15 [type=int]
+           │    │    │         │    │         │    │    │              └── const: 1 [type=int]
+           │    │    │         │    │         │    │    ├── key: (17)
+           │    │    │         │    │         │    │    ├── fd: (17)-->(14-16), (14)-->(15-17), (15,16)~~>(14,17)
+           │    │    │         │    │         │    │    ├── prune: (14-17)
+           │    │    │         │    │         │    │    └── interesting orderings: (+17) (+14) (+15,+16,+17)
+           │    │    │         │    │         │    └── filters
+           │    │    │         │    │         │         └── eq [type=bool, outer=(5,14), constraints=(/5: (/NULL - ]; /14: (/NULL - ]), fd=(5)==(14), (14)==(5)]
+           │    │    │         │    │         │              ├── variable: x:5 [type=int]
+           │    │    │         │    │         │              └── variable: a:14 [type=int]
+           │    │    │         │    │         └── filters
+           │    │    │         │    │              └── is [type=bool, outer=(14), constraints=(/14: [/NULL - /NULL]; tight), fd=()-->(14)]
+           │    │    │         │    │                   ├── variable: a:14 [type=int]
+           │    │    │         │    │                   └── null [type=unknown]
+           │    │    │         │    ├── scan abc
+           │    │    │         │    │    ├── columns: a:18(int!null) b:19(int) c:20(int) rowid:21(int!null)
+           │    │    │         │    │    ├── computed column expressions
+           │    │    │         │    │    │    └── c:20
+           │    │    │         │    │    │         └── plus [type=int]
+           │    │    │         │    │    │              ├── variable: b:19 [type=int]
+           │    │    │         │    │    │              └── const: 1 [type=int]
+           │    │    │         │    │    ├── key: (21)
+           │    │    │         │    │    ├── fd: (21)-->(18-20), (18)-->(19-21), (19,20)~~>(18,21)
+           │    │    │         │    │    ├── prune: (18-21)
+           │    │    │         │    │    └── interesting orderings: (+21) (+18) (+19,+20,+21)
+           │    │    │         │    └── filters
+           │    │    │         │         ├── eq [type=bool, outer=(6,19), constraints=(/6: (/NULL - ]; /19: (/NULL - ]), fd=(6)==(19), (19)==(6)]
+           │    │    │         │         │    ├── variable: y:6 [type=int]
+           │    │    │         │         │    └── variable: b:19 [type=int]
+           │    │    │         │         └── eq [type=bool, outer=(9,20), constraints=(/9: (/NULL - ]; /20: (/NULL - ]), fd=(9)==(20), (20)==(9)]
+           │    │    │         │              ├── variable: column9:9 [type=int]
+           │    │    │         │              └── variable: c:20 [type=int]
+           │    │    │         └── filters
+           │    │    │              └── is [type=bool, outer=(21), constraints=(/21: [/NULL - /NULL]; tight), fd=()-->(21)]
+           │    │    │                   ├── variable: rowid:21 [type=int]
+           │    │    │                   └── null [type=unknown]
+           │    │    └── aggregations
+           │    │         ├── first-agg [as=x:5, type=int, outer=(5)]
+           │    │         │    └── variable: x:5 [type=int]
+           │    │         ├── first-agg [as=y:6, type=int, outer=(6)]
+           │    │         │    └── variable: y:6 [type=int]
+           │    │         └── first-agg [as=column9:9, type=int, outer=(9)]
+           │    │              └── variable: column9:9 [type=int]
+           │    └── aggregations
+           │         ├── first-agg [as=y:6, type=int, outer=(6)]
+           │         │    └── variable: y:6 [type=int]
+           │         ├── first-agg [as=column8:8, type=int, outer=(8)]
+           │         │    └── variable: column8:8 [type=int]
+           │         └── first-agg [as=column9:9, type=int, outer=(9)]
+           │              └── variable: column9:9 [type=int]
            └── aggregations
                 ├── first-agg [as=x:5, type=int, outer=(5)]
                 │    └── variable: x:5 [type=int]

--- a/pkg/sql/opt/norm/testdata/rules/groupby
+++ b/pkg/sql/opt/norm/testdata/rules/groupby
@@ -1704,21 +1704,19 @@ insert a
  └── upsert-distinct-on
       ├── columns: column1:6!null column2:7!null column3:8!null column9:9 column10:10
       ├── grouping columns: column3:8!null column9:9
-      ├── lax-key: (8,9)
+      ├── lax-key: (7,9)
       ├── fd: ()-->(9,10), (7,9)~~>(6,8), (8,9)~~>(6,7,10)
-      ├── select
-      │    ├── columns: column1:6!null column2:7!null column3:8!null column9:9 column10:10 i:22 f:23
-      │    ├── lax-key: (7,9,22,23)
-      │    ├── fd: ()-->(9,10,22), (7,9)~~>(6,8)
-      │    ├── left-join (hash)
-      │    │    ├── columns: column1:6!null column2:7!null column3:8!null column9:9 column10:10 i:22 f:23
-      │    │    ├── lax-key: (7,9,22,23)
-      │    │    ├── fd: ()-->(9,10), (7,9)~~>(6,8)
-      │    │    ├── upsert-distinct-on
-      │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null column9:9 column10:10
-      │    │    │    ├── grouping columns: column2:7!null column9:9
-      │    │    │    ├── lax-key: (7,9)
-      │    │    │    ├── fd: ()-->(9,10), (7,9)~~>(6,8,10)
+      ├── upsert-distinct-on
+      │    ├── columns: column1:6!null column2:7!null column3:8!null column9:9 column10:10
+      │    ├── grouping columns: column2:7!null column9:9
+      │    ├── lax-key: (7,9)
+      │    ├── fd: ()-->(9,10), (7,9)~~>(6,8,10)
+      │    ├── select
+      │    │    ├── columns: column1:6!null column2:7!null column3:8!null column9:9 column10:10 k:11 i:17 s:19 i:22 f:23
+      │    │    ├── fd: ()-->(9-11,19,22)
+      │    │    ├── left-join (hash)
+      │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null column9:9 column10:10 k:11 i:17 s:19 i:22 f:23
+      │    │    │    ├── fd: ()-->(9-11,19)
       │    │    │    ├── select
       │    │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null column9:9 column10:10 k:11 i:17 s:19
       │    │    │    │    ├── fd: ()-->(9-11,19)
@@ -1760,21 +1758,21 @@ insert a
       │    │    │    │    │         └── column9:9 = i:17 [outer=(9,17), constraints=(/9: (/NULL - ]; /17: (/NULL - ]), fd=(9)==(17), (17)==(9)]
       │    │    │    │    └── filters
       │    │    │    │         └── s:19 IS NULL [outer=(19), constraints=(/19: [/NULL - /NULL]; tight), fd=()-->(19)]
-      │    │    │    └── aggregations
-      │    │    │         ├── first-agg [as=column1:6, outer=(6)]
-      │    │    │         │    └── column1:6
-      │    │    │         ├── first-agg [as=column3:8, outer=(8)]
-      │    │    │         │    └── column3:8
-      │    │    │         └── first-agg [as=column10:10, outer=(10)]
-      │    │    │              └── column10:10
-      │    │    ├── scan a
-      │    │    │    ├── columns: i:22!null f:23
-      │    │    │    └── lax-key: (22,23)
+      │    │    │    ├── scan a
+      │    │    │    │    ├── columns: i:22!null f:23
+      │    │    │    │    └── lax-key: (22,23)
+      │    │    │    └── filters
+      │    │    │         ├── column3:8 = f:23 [outer=(8,23), constraints=(/8: (/NULL - ]; /23: (/NULL - ]), fd=(8)==(23), (23)==(8)]
+      │    │    │         └── column9:9 = i:22 [outer=(9,22), constraints=(/9: (/NULL - ]; /22: (/NULL - ]), fd=(9)==(22), (22)==(9)]
       │    │    └── filters
-      │    │         ├── column3:8 = f:23 [outer=(8,23), constraints=(/8: (/NULL - ]; /23: (/NULL - ]), fd=(8)==(23), (23)==(8)]
-      │    │         └── column9:9 = i:22 [outer=(9,22), constraints=(/9: (/NULL - ]; /22: (/NULL - ]), fd=(9)==(22), (22)==(9)]
-      │    └── filters
-      │         └── i:22 IS NULL [outer=(22), constraints=(/22: [/NULL - /NULL]; tight), fd=()-->(22)]
+      │    │         └── i:22 IS NULL [outer=(22), constraints=(/22: [/NULL - /NULL]; tight), fd=()-->(22)]
+      │    └── aggregations
+      │         ├── first-agg [as=column1:6, outer=(6)]
+      │         │    └── column1:6
+      │         ├── first-agg [as=column3:8, outer=(8)]
+      │         │    └── column3:8
+      │         └── first-agg [as=column10:10, outer=(10)]
+      │              └── column10:10
       └── aggregations
            ├── first-agg [as=column1:6, outer=(6)]
            │    └── column1:6
@@ -1800,90 +1798,82 @@ insert a
  │    └── column10:10 => j:5
  ├── cardinality: [0 - 0]
  ├── side-effects, mutations
- └── project
+ └── upsert-distinct-on
       ├── columns: column1:6 column2:7!null column3:8!null column4:9!null column10:10
+      ├── grouping columns: column1:6
       ├── side-effects
-      ├── fd: ()-->(10), (6)~~>(7-9)
-      └── select
-           ├── columns: column1:6 column2:7!null column3:8!null column4:9!null column10:10 i:17 s:19 i:22 f:23
-           ├── side-effects
-           ├── lax-key: (6,17,19,22,23)
-           ├── fd: ()-->(10,19,22), (6)~~>(7-9)
-           ├── left-join (hash)
-           │    ├── columns: column1:6 column2:7!null column3:8!null column4:9!null column10:10 i:17 s:19 i:22 f:23
-           │    ├── side-effects
-           │    ├── lax-key: (6,17,19,22,23)
-           │    ├── fd: ()-->(10,19), (6)~~>(7-9)
-           │    ├── select
-           │    │    ├── columns: column1:6 column2:7!null column3:8!null column4:9!null column10:10 i:17 s:19
-           │    │    ├── side-effects
-           │    │    ├── lax-key: (6,17,19)
-           │    │    ├── fd: ()-->(10,19), (6)~~>(7-9)
-           │    │    ├── left-join (hash)
-           │    │    │    ├── columns: column1:6 column2:7!null column3:8!null column4:9!null column10:10 i:17 s:19
-           │    │    │    ├── side-effects
-           │    │    │    ├── lax-key: (6,17,19)
-           │    │    │    ├── fd: ()-->(10), (6)~~>(7-9)
-           │    │    │    ├── upsert-distinct-on
-           │    │    │    │    ├── columns: column1:6 column2:7!null column3:8!null column4:9!null column10:10
-           │    │    │    │    ├── grouping columns: column1:6
-           │    │    │    │    ├── side-effects
-           │    │    │    │    ├── lax-key: (6)
-           │    │    │    │    ├── fd: ()-->(10), (6)~~>(7-10)
-           │    │    │    │    ├── select
-           │    │    │    │    │    ├── columns: column1:6 column2:7!null column3:8!null column4:9!null column10:10 k:11
-           │    │    │    │    │    ├── side-effects
-           │    │    │    │    │    ├── fd: ()-->(10,11)
-           │    │    │    │    │    ├── left-join (hash)
-           │    │    │    │    │    │    ├── columns: column1:6 column2:7!null column3:8!null column4:9!null column10:10 k:11
-           │    │    │    │    │    │    ├── cardinality: [2 - ]
-           │    │    │    │    │    │    ├── side-effects
-           │    │    │    │    │    │    ├── fd: ()-->(10)
-           │    │    │    │    │    │    ├── project
-           │    │    │    │    │    │    │    ├── columns: column10:10 column1:6 column2:7!null column3:8!null column4:9!null
-           │    │    │    │    │    │    │    ├── cardinality: [2 - 2]
-           │    │    │    │    │    │    │    ├── side-effects
-           │    │    │    │    │    │    │    ├── fd: ()-->(10)
-           │    │    │    │    │    │    │    ├── values
-           │    │    │    │    │    │    │    │    ├── columns: column1:6 column2:7!null column3:8!null column4:9!null
-           │    │    │    │    │    │    │    │    ├── cardinality: [2 - 2]
-           │    │    │    │    │    │    │    │    ├── side-effects
-           │    │    │    │    │    │    │    │    ├── (unique_rowid(), 'foo', 1, 1.0)
-           │    │    │    │    │    │    │    │    └── (unique_rowid(), 'bar', 2, 2.0)
-           │    │    │    │    │    │    │    └── projections
-           │    │    │    │    │    │    │         └── CAST(NULL AS JSONB) [as=column10:10]
-           │    │    │    │    │    │    ├── scan a
-           │    │    │    │    │    │    │    ├── columns: k:11!null
-           │    │    │    │    │    │    │    └── key: (11)
-           │    │    │    │    │    │    └── filters
-           │    │    │    │    │    │         └── column1:6 = k:11 [outer=(6,11), constraints=(/6: (/NULL - ]; /11: (/NULL - ]), fd=(6)==(11), (11)==(6)]
-           │    │    │    │    │    └── filters
-           │    │    │    │    │         └── k:11 IS NULL [outer=(11), constraints=(/11: [/NULL - /NULL]; tight), fd=()-->(11)]
-           │    │    │    │    └── aggregations
-           │    │    │    │         ├── first-agg [as=column2:7, outer=(7)]
-           │    │    │    │         │    └── column2:7
-           │    │    │    │         ├── first-agg [as=column3:8, outer=(8)]
-           │    │    │    │         │    └── column3:8
-           │    │    │    │         ├── first-agg [as=column4:9, outer=(9)]
-           │    │    │    │         │    └── column4:9
-           │    │    │    │         └── first-agg [as=column10:10, outer=(10)]
-           │    │    │    │              └── column10:10
-           │    │    │    ├── scan a
-           │    │    │    │    ├── columns: i:17!null s:19!null
-           │    │    │    │    └── key: (17,19)
-           │    │    │    └── filters
-           │    │    │         ├── column2:7 = s:19 [outer=(7,19), constraints=(/7: (/NULL - ]; /19: (/NULL - ]), fd=(7)==(19), (19)==(7)]
-           │    │    │         └── column3:8 = i:17 [outer=(8,17), constraints=(/8: (/NULL - ]; /17: (/NULL - ]), fd=(8)==(17), (17)==(8)]
-           │    │    └── filters
-           │    │         └── s:19 IS NULL [outer=(19), constraints=(/19: [/NULL - /NULL]; tight), fd=()-->(19)]
-           │    ├── scan a
-           │    │    ├── columns: i:22!null f:23
-           │    │    └── lax-key: (22,23)
-           │    └── filters
-           │         ├── column4:9 = f:23 [outer=(9,23), constraints=(/9: (/NULL - ]; /23: (/NULL - ]), fd=(9)==(23), (23)==(9)]
-           │         └── column3:8 = i:22 [outer=(8,22), constraints=(/8: (/NULL - ]; /22: (/NULL - ]), fd=(8)==(22), (22)==(8)]
-           └── filters
-                └── i:22 IS NULL [outer=(22), constraints=(/22: [/NULL - /NULL]; tight), fd=()-->(22)]
+      ├── lax-key: (6)
+      ├── fd: ()-->(10), (6)~~>(7-10)
+      ├── select
+      │    ├── columns: column1:6 column2:7!null column3:8!null column4:9!null column10:10 k:11 i:17 s:19 i:22 f:23
+      │    ├── side-effects
+      │    ├── fd: ()-->(10,11,19,22)
+      │    ├── left-join (hash)
+      │    │    ├── columns: column1:6 column2:7!null column3:8!null column4:9!null column10:10 k:11 i:17 s:19 i:22 f:23
+      │    │    ├── side-effects
+      │    │    ├── fd: ()-->(10,11,19)
+      │    │    ├── select
+      │    │    │    ├── columns: column1:6 column2:7!null column3:8!null column4:9!null column10:10 k:11 i:17 s:19
+      │    │    │    ├── side-effects
+      │    │    │    ├── fd: ()-->(10,11,19)
+      │    │    │    ├── left-join (hash)
+      │    │    │    │    ├── columns: column1:6 column2:7!null column3:8!null column4:9!null column10:10 k:11 i:17 s:19
+      │    │    │    │    ├── side-effects
+      │    │    │    │    ├── fd: ()-->(10,11)
+      │    │    │    │    ├── select
+      │    │    │    │    │    ├── columns: column1:6 column2:7!null column3:8!null column4:9!null column10:10 k:11
+      │    │    │    │    │    ├── side-effects
+      │    │    │    │    │    ├── fd: ()-->(10,11)
+      │    │    │    │    │    ├── left-join (hash)
+      │    │    │    │    │    │    ├── columns: column1:6 column2:7!null column3:8!null column4:9!null column10:10 k:11
+      │    │    │    │    │    │    ├── cardinality: [2 - ]
+      │    │    │    │    │    │    ├── side-effects
+      │    │    │    │    │    │    ├── fd: ()-->(10)
+      │    │    │    │    │    │    ├── project
+      │    │    │    │    │    │    │    ├── columns: column10:10 column1:6 column2:7!null column3:8!null column4:9!null
+      │    │    │    │    │    │    │    ├── cardinality: [2 - 2]
+      │    │    │    │    │    │    │    ├── side-effects
+      │    │    │    │    │    │    │    ├── fd: ()-->(10)
+      │    │    │    │    │    │    │    ├── values
+      │    │    │    │    │    │    │    │    ├── columns: column1:6 column2:7!null column3:8!null column4:9!null
+      │    │    │    │    │    │    │    │    ├── cardinality: [2 - 2]
+      │    │    │    │    │    │    │    │    ├── side-effects
+      │    │    │    │    │    │    │    │    ├── (unique_rowid(), 'foo', 1, 1.0)
+      │    │    │    │    │    │    │    │    └── (unique_rowid(), 'bar', 2, 2.0)
+      │    │    │    │    │    │    │    └── projections
+      │    │    │    │    │    │    │         └── CAST(NULL AS JSONB) [as=column10:10]
+      │    │    │    │    │    │    ├── scan a
+      │    │    │    │    │    │    │    ├── columns: k:11!null
+      │    │    │    │    │    │    │    └── key: (11)
+      │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │         └── column1:6 = k:11 [outer=(6,11), constraints=(/6: (/NULL - ]; /11: (/NULL - ]), fd=(6)==(11), (11)==(6)]
+      │    │    │    │    │    └── filters
+      │    │    │    │    │         └── k:11 IS NULL [outer=(11), constraints=(/11: [/NULL - /NULL]; tight), fd=()-->(11)]
+      │    │    │    │    ├── scan a
+      │    │    │    │    │    ├── columns: i:17!null s:19!null
+      │    │    │    │    │    └── key: (17,19)
+      │    │    │    │    └── filters
+      │    │    │    │         ├── column2:7 = s:19 [outer=(7,19), constraints=(/7: (/NULL - ]; /19: (/NULL - ]), fd=(7)==(19), (19)==(7)]
+      │    │    │    │         └── column3:8 = i:17 [outer=(8,17), constraints=(/8: (/NULL - ]; /17: (/NULL - ]), fd=(8)==(17), (17)==(8)]
+      │    │    │    └── filters
+      │    │    │         └── s:19 IS NULL [outer=(19), constraints=(/19: [/NULL - /NULL]; tight), fd=()-->(19)]
+      │    │    ├── scan a
+      │    │    │    ├── columns: i:22!null f:23
+      │    │    │    └── lax-key: (22,23)
+      │    │    └── filters
+      │    │         ├── column4:9 = f:23 [outer=(9,23), constraints=(/9: (/NULL - ]; /23: (/NULL - ]), fd=(9)==(23), (23)==(9)]
+      │    │         └── column3:8 = i:22 [outer=(8,22), constraints=(/8: (/NULL - ]; /22: (/NULL - ]), fd=(8)==(22), (22)==(8)]
+      │    └── filters
+      │         └── i:22 IS NULL [outer=(22), constraints=(/22: [/NULL - /NULL]; tight), fd=()-->(22)]
+      └── aggregations
+           ├── first-agg [as=column2:7, outer=(7)]
+           │    └── column2:7
+           ├── first-agg [as=column3:8, outer=(8)]
+           │    └── column3:8
+           ├── first-agg [as=column4:9, outer=(9)]
+           │    └── column4:9
+           └── first-agg [as=column10:10, outer=(10)]
+                └── column10:10
 
 # DO NOTHING case with explicit conflict columns (only add upsert-distinct-on
 # for one index).

--- a/pkg/sql/opt/optbuilder/testdata/upsert
+++ b/pkg/sql/opt/optbuilder/testdata/upsert
@@ -65,6 +65,14 @@ CREATE TABLE decimals (
 )
 ----
 
+exec-ddl
+CREATE TABLE uniq (
+  x STRING PRIMARY KEY,
+  y STRING UNIQUE,
+  z STRING UNIQUE
+)
+----
+
 # ------------------------------------------------------------------------------
 # Basic tests.
 # ------------------------------------------------------------------------------
@@ -535,62 +543,62 @@ insert xyz
  └── upsert-distinct-on
       ├── columns: column1:4!null column2:5!null column3:6!null
       ├── grouping columns: column2:5!null column3:6!null
-      ├── project
+      ├── upsert-distinct-on
       │    ├── columns: column1:4!null column2:5!null column3:6!null
-      │    └── select
-      │         ├── columns: column1:4!null column2:5!null column3:6!null x:13 y:14 z:15
-      │         ├── left-join (hash)
-      │         │    ├── columns: column1:4!null column2:5!null column3:6!null x:13 y:14 z:15
-      │         │    ├── upsert-distinct-on
-      │         │    │    ├── columns: column1:4!null column2:5!null column3:6!null
-      │         │    │    ├── grouping columns: column2:5!null column3:6!null
-      │         │    │    ├── project
-      │         │    │    │    ├── columns: column1:4!null column2:5!null column3:6!null
-      │         │    │    │    └── select
-      │         │    │    │         ├── columns: column1:4!null column2:5!null column3:6!null x:10 y:11 z:12
-      │         │    │    │         ├── left-join (hash)
-      │         │    │    │         │    ├── columns: column1:4!null column2:5!null column3:6!null x:10 y:11 z:12
-      │         │    │    │         │    ├── upsert-distinct-on
-      │         │    │    │         │    │    ├── columns: column1:4!null column2:5!null column3:6!null
-      │         │    │    │         │    │    ├── grouping columns: column1:4!null
-      │         │    │    │         │    │    ├── project
-      │         │    │    │         │    │    │    ├── columns: column1:4!null column2:5!null column3:6!null
-      │         │    │    │         │    │    │    └── select
-      │         │    │    │         │    │    │         ├── columns: column1:4!null column2:5!null column3:6!null x:7 y:8 z:9
-      │         │    │    │         │    │    │         ├── left-join (hash)
-      │         │    │    │         │    │    │         │    ├── columns: column1:4!null column2:5!null column3:6!null x:7 y:8 z:9
-      │         │    │    │         │    │    │         │    ├── values
-      │         │    │    │         │    │    │         │    │    ├── columns: column1:4!null column2:5!null column3:6!null
-      │         │    │    │         │    │    │         │    │    ├── (1, 2, 3)
-      │         │    │    │         │    │    │         │    │    └── (4, 5, 6)
-      │         │    │    │         │    │    │         │    ├── scan xyz
-      │         │    │    │         │    │    │         │    │    └── columns: x:7!null y:8 z:9
-      │         │    │    │         │    │    │         │    └── filters
-      │         │    │    │         │    │    │         │         └── column1:4 = x:7
-      │         │    │    │         │    │    │         └── filters
-      │         │    │    │         │    │    │              └── x:7 IS NULL
-      │         │    │    │         │    │    └── aggregations
-      │         │    │    │         │    │         ├── first-agg [as=column2:5]
-      │         │    │    │         │    │         │    └── column2:5
-      │         │    │    │         │    │         └── first-agg [as=column3:6]
-      │         │    │    │         │    │              └── column3:6
-      │         │    │    │         │    ├── scan xyz
-      │         │    │    │         │    │    └── columns: x:10!null y:11 z:12
-      │         │    │    │         │    └── filters
-      │         │    │    │         │         ├── column2:5 = y:11
-      │         │    │    │         │         └── column3:6 = z:12
-      │         │    │    │         └── filters
-      │         │    │    │              └── x:10 IS NULL
-      │         │    │    └── aggregations
-      │         │    │         └── first-agg [as=column1:4]
-      │         │    │              └── column1:4
-      │         │    ├── scan xyz
-      │         │    │    └── columns: x:13!null y:14 z:15
-      │         │    └── filters
-      │         │         ├── column3:6 = z:15
-      │         │         └── column2:5 = y:14
-      │         └── filters
-      │              └── x:13 IS NULL
+      │    ├── grouping columns: column2:5!null column3:6!null
+      │    ├── upsert-distinct-on
+      │    │    ├── columns: column1:4!null column2:5!null column3:6!null
+      │    │    ├── grouping columns: column1:4!null
+      │    │    ├── project
+      │    │    │    ├── columns: column1:4!null column2:5!null column3:6!null
+      │    │    │    └── select
+      │    │    │         ├── columns: column1:4!null column2:5!null column3:6!null x:13 y:14 z:15
+      │    │    │         ├── left-join (hash)
+      │    │    │         │    ├── columns: column1:4!null column2:5!null column3:6!null x:13 y:14 z:15
+      │    │    │         │    ├── project
+      │    │    │         │    │    ├── columns: column1:4!null column2:5!null column3:6!null
+      │    │    │         │    │    └── select
+      │    │    │         │    │         ├── columns: column1:4!null column2:5!null column3:6!null x:10 y:11 z:12
+      │    │    │         │    │         ├── left-join (hash)
+      │    │    │         │    │         │    ├── columns: column1:4!null column2:5!null column3:6!null x:10 y:11 z:12
+      │    │    │         │    │         │    ├── project
+      │    │    │         │    │         │    │    ├── columns: column1:4!null column2:5!null column3:6!null
+      │    │    │         │    │         │    │    └── select
+      │    │    │         │    │         │    │         ├── columns: column1:4!null column2:5!null column3:6!null x:7 y:8 z:9
+      │    │    │         │    │         │    │         ├── left-join (hash)
+      │    │    │         │    │         │    │         │    ├── columns: column1:4!null column2:5!null column3:6!null x:7 y:8 z:9
+      │    │    │         │    │         │    │         │    ├── values
+      │    │    │         │    │         │    │         │    │    ├── columns: column1:4!null column2:5!null column3:6!null
+      │    │    │         │    │         │    │         │    │    ├── (1, 2, 3)
+      │    │    │         │    │         │    │         │    │    └── (4, 5, 6)
+      │    │    │         │    │         │    │         │    ├── scan xyz
+      │    │    │         │    │         │    │         │    │    └── columns: x:7!null y:8 z:9
+      │    │    │         │    │         │    │         │    └── filters
+      │    │    │         │    │         │    │         │         └── column1:4 = x:7
+      │    │    │         │    │         │    │         └── filters
+      │    │    │         │    │         │    │              └── x:7 IS NULL
+      │    │    │         │    │         │    ├── scan xyz
+      │    │    │         │    │         │    │    └── columns: x:10!null y:11 z:12
+      │    │    │         │    │         │    └── filters
+      │    │    │         │    │         │         ├── column2:5 = y:11
+      │    │    │         │    │         │         └── column3:6 = z:12
+      │    │    │         │    │         └── filters
+      │    │    │         │    │              └── x:10 IS NULL
+      │    │    │         │    ├── scan xyz
+      │    │    │         │    │    └── columns: x:13!null y:14 z:15
+      │    │    │         │    └── filters
+      │    │    │         │         ├── column3:6 = z:15
+      │    │    │         │         └── column2:5 = y:14
+      │    │    │         └── filters
+      │    │    │              └── x:13 IS NULL
+      │    │    └── aggregations
+      │    │         ├── first-agg [as=column2:5]
+      │    │         │    └── column2:5
+      │    │         └── first-agg [as=column3:6]
+      │    │              └── column3:6
+      │    └── aggregations
+      │         └── first-agg [as=column1:4]
+      │              └── column1:4
       └── aggregations
            └── first-agg [as=column1:4]
                 └── column1:4
@@ -630,6 +638,82 @@ insert xyz
       └── aggregations
            └── first-agg [as=column1:4]
                 └── column1:4
+
+build
+INSERT INTO uniq VALUES ('x2', 'y1', 'z2'), ('x2', 'y2', 'z2'), ('x2', 'y2', 'z2')
+ON CONFLICT DO NOTHING
+----
+insert uniq
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:4 => x:1
+ │    ├── column2:5 => y:2
+ │    └── column3:6 => z:3
+ └── upsert-distinct-on
+      ├── columns: column1:4!null column2:5!null column3:6!null
+      ├── grouping columns: column3:6!null
+      ├── upsert-distinct-on
+      │    ├── columns: column1:4!null column2:5!null column3:6!null
+      │    ├── grouping columns: column2:5!null
+      │    ├── upsert-distinct-on
+      │    │    ├── columns: column1:4!null column2:5!null column3:6!null
+      │    │    ├── grouping columns: column1:4!null
+      │    │    ├── project
+      │    │    │    ├── columns: column1:4!null column2:5!null column3:6!null
+      │    │    │    └── select
+      │    │    │         ├── columns: column1:4!null column2:5!null column3:6!null x:13 y:14 z:15
+      │    │    │         ├── left-join (hash)
+      │    │    │         │    ├── columns: column1:4!null column2:5!null column3:6!null x:13 y:14 z:15
+      │    │    │         │    ├── project
+      │    │    │         │    │    ├── columns: column1:4!null column2:5!null column3:6!null
+      │    │    │         │    │    └── select
+      │    │    │         │    │         ├── columns: column1:4!null column2:5!null column3:6!null x:10 y:11 z:12
+      │    │    │         │    │         ├── left-join (hash)
+      │    │    │         │    │         │    ├── columns: column1:4!null column2:5!null column3:6!null x:10 y:11 z:12
+      │    │    │         │    │         │    ├── project
+      │    │    │         │    │         │    │    ├── columns: column1:4!null column2:5!null column3:6!null
+      │    │    │         │    │         │    │    └── select
+      │    │    │         │    │         │    │         ├── columns: column1:4!null column2:5!null column3:6!null x:7 y:8 z:9
+      │    │    │         │    │         │    │         ├── left-join (hash)
+      │    │    │         │    │         │    │         │    ├── columns: column1:4!null column2:5!null column3:6!null x:7 y:8 z:9
+      │    │    │         │    │         │    │         │    ├── values
+      │    │    │         │    │         │    │         │    │    ├── columns: column1:4!null column2:5!null column3:6!null
+      │    │    │         │    │         │    │         │    │    ├── ('x2', 'y1', 'z2')
+      │    │    │         │    │         │    │         │    │    ├── ('x2', 'y2', 'z2')
+      │    │    │         │    │         │    │         │    │    └── ('x2', 'y2', 'z2')
+      │    │    │         │    │         │    │         │    ├── scan uniq
+      │    │    │         │    │         │    │         │    │    └── columns: x:7!null y:8 z:9
+      │    │    │         │    │         │    │         │    └── filters
+      │    │    │         │    │         │    │         │         └── column1:4 = x:7
+      │    │    │         │    │         │    │         └── filters
+      │    │    │         │    │         │    │              └── x:7 IS NULL
+      │    │    │         │    │         │    ├── scan uniq
+      │    │    │         │    │         │    │    └── columns: x:10!null y:11 z:12
+      │    │    │         │    │         │    └── filters
+      │    │    │         │    │         │         └── column2:5 = y:11
+      │    │    │         │    │         └── filters
+      │    │    │         │    │              └── x:10 IS NULL
+      │    │    │         │    ├── scan uniq
+      │    │    │         │    │    └── columns: x:13!null y:14 z:15
+      │    │    │         │    └── filters
+      │    │    │         │         └── column3:6 = z:15
+      │    │    │         └── filters
+      │    │    │              └── x:13 IS NULL
+      │    │    └── aggregations
+      │    │         ├── first-agg [as=column2:5]
+      │    │         │    └── column2:5
+      │    │         └── first-agg [as=column3:6]
+      │    │              └── column3:6
+      │    └── aggregations
+      │         ├── first-agg [as=column1:4]
+      │         │    └── column1:4
+      │         └── first-agg [as=column3:6]
+      │              └── column3:6
+      └── aggregations
+           ├── first-agg [as=column1:4]
+           │    └── column1:4
+           └── first-agg [as=column2:5]
+                └── column2:5
 
 # ------------------------------------------------------------------------------
 # Test excluded columns.


### PR DESCRIPTION
Backport 1/1 commits from #59147.

/cc @cockroachdb/release

---

Prior to this patch, it was possible for some valid input to an
`INSERT ... ON CONFLICT DO NOTHING` to be discarded. For example,
consider the following example:
```
CREATE TABLE uniq (
  k INT PRIMARY KEY,
  v INT UNIQUE,
  w INT UNIQUE,
  x INT,
  y INT DEFAULT 5,
  UNIQUE (x, y)
);

INSERT INTO uniq VALUES (1, 1, 1, 1, 1);

INSERT INTO uniq VALUES (1, 20, 20, 20, 20),
                        (20, 1, 20, 20, 20),
                        (20, 20, 20, 20, 20)
ON CONFLICT DO NOTHING;
```
Since row `(20, 20, 20, 20, 20)` does not conflict with the existing
row in uniq, it should be inserted. However, prior to this patch, all
three rows in the second `INSERT` statement were discarded.

This commit fixes the problem by applying the `upsert-distinct-on`
operators for each index after all conflicting rows are removed by
left-joins + filters.

Fixes #59125

Release note (bug fix): Fixed a bug in which some non-conflicting rows
provided as input to an `INSERT ... ON CONFLICT DO NOTHING` statement could
be discarded, and not inserted. This could happen in cases where the
table had one or more unique indexes in addition to the primary index,
and some of the rows in the input conflicted with existing values in one
or more unique index. This scenario could cause the rows that did not
conflict to be erroneously discarded. This has now been fixed.
