### PR TITLE
sql: apply PARTITION ALL BY when using ALTER PRIMARY KEY

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
@@ -219,6 +219,7 @@ CREATE TABLE public.t (
 statement ok
 CREATE TABLE public.t (
   pk int PRIMARY KEY,
+  pk2 int NOT NULL,
   partition_by int,
   a int,
   b int,
@@ -227,7 +228,7 @@ CREATE TABLE public.t (
   INDEX (a),
   UNIQUE (b),
   INDEX (partition_by, c),
-  FAMILY (pk, partition_by, a, b, c, d)
+  FAMILY (pk, pk2, partition_by, a, b, c, d)
 ) PARTITION ALL BY LIST (partition_by) (
   PARTITION one VALUES IN (1),
   PARTITION two VALUES IN (2)
@@ -246,6 +247,7 @@ SELECT create_statement FROM [SHOW CREATE TABLE t]
 ----
 CREATE TABLE public.t (
   pk INT8 NOT NULL,
+  pk2 INT8 NOT NULL,
   partition_by INT8 NULL,
   a INT8 NULL,
   b INT8 NULL,
@@ -256,7 +258,7 @@ CREATE TABLE public.t (
   UNIQUE INDEX t_b_key (b ASC),
   INDEX t_partition_by_c_idx (partition_by ASC, c ASC),
   INDEX created_idx (c ASC),
-  FAMILY fam_0_pk_partition_by_a_b_c_d (pk, partition_by, a, b, c, d)
+  FAMILY fam_0_pk_pk2_partition_by_a_b_c_d (pk, pk2, partition_by, a, b, c, d)
 ) PARTITION ALL BY LIST (partition_by) (
   PARTITION one VALUES IN ((1)),
   PARTITION two VALUES IN ((2))
@@ -279,3 +281,49 @@ t_b_key               b             false
 t_b_key               partition_by  true
 t_partition_by_c_idx  c             false
 t_partition_by_c_idx  partition_by  false
+
+statement ok
+ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (pk2)
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE t]
+----
+CREATE TABLE public.t (
+  pk INT8 NOT NULL,
+  pk2 INT8 NOT NULL,
+  partition_by INT8 NULL,
+  a INT8 NULL,
+  b INT8 NULL,
+  c INT8 NULL,
+  d INT8 NULL,
+  CONSTRAINT "primary" PRIMARY KEY (pk2 ASC),
+  UNIQUE INDEX t_pk_key (pk ASC),
+  INDEX t_a_idx (a ASC),
+  UNIQUE INDEX t_b_key (b ASC),
+  INDEX t_partition_by_c_idx (partition_by ASC, c ASC),
+  INDEX created_idx (c ASC),
+  FAMILY fam_0_pk_pk2_partition_by_a_b_c_d (pk, pk2, partition_by, a, b, c, d)
+) PARTITION ALL BY LIST (partition_by) (
+  PARTITION one VALUES IN ((1)),
+  PARTITION two VALUES IN ((2))
+)
+-- Warning: Partitioned table with no zone configurations.
+
+query TTB colnames
+SELECT index_name, column_name, implicit FROM crdb_internal.index_columns
+WHERE descriptor_name = 't' AND column_type = 'key'
+ORDER BY 1, 2
+----
+index_name            column_name   implicit
+created_idx           c             false
+created_idx           partition_by  true
+primary               partition_by  true
+primary               pk2           false
+t_a_idx               a             false
+t_a_idx               partition_by  true
+t_b_key               b             false
+t_b_key               partition_by  true
+t_partition_by_c_idx  c             false
+t_partition_by_c_idx  partition_by  false
+t_pk_key              partition_by  true
+t_pk_key              pk            false

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -118,6 +118,7 @@ go_library(
         "opt_catalog.go",
         "opt_exec_factory.go",
         "ordinality.go",
+        "partition.go",
         "partition_utils.go",
         "pg_catalog.go",
         "pg_extension.go",

--- a/pkg/sql/partition.go
+++ b/pkg/sql/partition.go
@@ -1,0 +1,51 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/errors"
+)
+
+// partitionByFromTableDesc constructs a PartitionBy clause from a table descriptor.
+func partitionByFromTableDesc(
+	codec keys.SQLCodec, tableDesc *tabledesc.Mutable,
+) (*tree.PartitionBy, error) {
+	// Convert the PartitioningDescriptor back into tree.PartitionBy by
+	// re-parsing the SHOW CREATE partitioning statement.
+	// TODO(#multiregion): clean this up by translating the descriptor back into
+	// tree.PartitionBy directly.
+	a := &rowenc.DatumAlloc{}
+	f := tree.NewFmtCtx(tree.FmtSimple)
+	if err := ShowCreatePartitioning(
+		a,
+		codec,
+		tableDesc,
+		tableDesc.GetPrimaryIndex().IndexDesc(),
+		&tableDesc.GetPrimaryIndex().IndexDesc().Partitioning,
+		&f.Buffer,
+		0, /* indent */
+		0, /* colOffset */
+	); err != nil {
+		return nil, errors.Wrap(err, "error recreating PARTITION BY clause for PARTITION ALL BY affected index")
+	}
+	stmt, err := parser.ParseOne(fmt.Sprintf("ALTER TABLE t %s", f.CloseAndGetString()))
+	if err != nil {
+		return nil, errors.Wrap(err, "error recreating PARTITION BY clause for PARTITION ALL BY affected index")
+	}
+	return stmt.AST.(*tree.AlterTable).Cmds[0].(*tree.AlterTablePartitionByTable).PartitionByTable.PartitionBy, nil
+}


### PR DESCRIPTION
Release note (sql change): PARTITION ALL BY statements will now apply
for tables when using ALTER PRIMARY KEY.