### PR TITLE
release-20.2: backport cgroup related changes to account for CPU and memory limits

### DIFF
--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -41,6 +41,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/util/cgroups"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/grpcutil"
@@ -353,6 +354,11 @@ func runStart(cmd *cobra.Command, args []string, disableReplication bool) (retur
 	// We don't care about GRPCs fairly verbose logs in most client commands,
 	// but when actually starting a server, we enable them.
 	grpcutil.SetSeverity(log.Severity_WARNING)
+
+	// Tweak GOMAXPROCS if we're in a cgroup / container that has cpu limits set.
+	// The GO default for GOMAXPROCS is runtime.NumCPU(), however this is less
+	// than ideal if the cgruop is limited to a number lower than that.
+	cgroups.AdjustMaxProcs(ctx)
 
 	// Check the --join flag.
 	if !flagSetForCmd(cmd).Lookup(cliflags.Join.Name).Changed {

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -446,6 +446,7 @@ func TestLint(t *testing.T) {
 					":!ccl/workloadccl/fixture_test.go",
 					":!internal/gopath/gopath.go",
 					":!cmd",
+					":!util/cgroups/cgroups.go",
 					":!nightly",
 					":!testutils/lint",
 					":!util/envutil/env.go",

--- a/pkg/util/cgroups/cgroups.go
+++ b/pkg/util/cgroups/cgroups.go
@@ -13,19 +13,29 @@ package cgroups
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"math"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
+	"strings"
 
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 )
 
 const (
 	cgroupV1MemLimitFilename = "memory.stat"
 	cgroupV2MemLimitFilename = "memory.max"
+	cgroupV1CPUQuotaFilename     = "cpu.cfs_quota_us"
+	cgroupV1CPUPeriodFilename    = "cpu.cfs_period_us"
+	cgroupV1CPUSysUsageFilename  = "cpuacct.usage_sys"
+	cgroupV1CPUUserUsageFilename = "cpuacct.usage_user"
+	cgroupV2CPUMaxFilename       = "cpu.max"
+	cgroupV2CPUStatFilename      = "cpu.stat"
 )
 
 // GetMemoryLimit attempts to retrieve the cgroup memory limit for the current
@@ -38,7 +48,7 @@ func GetMemoryLimit() (limit int64, warnings string, err error) {
 // cgroup memory limit detection path implemented here as
 // /proc/self/cgroup file -> /proc/self/mountinfo mounts -> cgroup version -> version specific limit check
 func getCgroupMem(root string) (limit int64, warnings string, err error) {
-	path, err := detectMemCntrlPath(filepath.Join(root, "/proc/self/cgroup"))
+	path, err := detectCntrlPath(filepath.Join(root, "/proc/self/cgroup"), "memory")
 	if err != nil {
 		return 0, "", err
 	}
@@ -48,16 +58,16 @@ func getCgroupMem(root string) (limit int64, warnings string, err error) {
 		return 0, "no cgroup memory controller detected", nil
 	}
 
-	mount, ver, err := getCgroupDetails(filepath.Join(root, "/proc/self/mountinfo"), path)
+	mount, ver, err := getCgroupDetails(filepath.Join(root, "/proc/self/mountinfo"), path, "memory")
 	if err != nil {
 		return 0, "", err
 	}
 
 	switch ver {
 	case 1:
-		limit, warnings, err = detectLimitInV1(filepath.Join(root, mount))
+		limit, warnings, err = detectMemLimitInV1(filepath.Join(root, mount))
 	case 2:
-		limit, warnings, err = detectLimitInV2(filepath.Join(root, mount, path))
+		limit, warnings, err = detectMemLimitInV2(filepath.Join(root, mount, path))
 	default:
 		limit, err = 0, fmt.Errorf("detected unknown cgroup version index: %d", ver)
 	}
@@ -65,8 +75,136 @@ func getCgroupMem(root string) (limit int64, warnings string, err error) {
 	return limit, warnings, err
 }
 
+func readFile(filepath string) (res []byte, err error) {
+	var f *os.File
+	f, err = os.Open(filepath)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		err = errors.CombineErrors(err, f.Close())
+	}()
+	res, err = ioutil.ReadAll(f)
+	return res, err
+}
 // Finds memory limit for cgroup V1 via looking in [contoller mount path]/memory.stat
-func detectLimitInV1(cRoot string) (limit int64, warnings string, err error) {
+func cgroupFileToUint64(filepath, desc string) (res uint64, err error) {
+	contents, err := readFile(filepath)
+	if err != nil {
+		return 0, errors.Wrapf(err, "error when reading %s from cgroup v1 at %s", desc, filepath)
+	}
+	res, err = strconv.ParseUint(string(bytes.TrimSpace(contents)), 10, 64)
+	if err != nil {
+		return 0, errors.Wrapf(err, "error when parsing %s from cgroup v1 at %s", desc, filepath)
+	}
+	return res, err
+}
+
+func cgroupFileToInt64(filepath, desc string) (res int64, err error) {
+	contents, err := readFile(filepath)
+	if err != nil {
+		return 0, errors.Wrapf(err, "error when reading %s from cgroup v1 at %s", desc, filepath)
+	}
+	res, err = strconv.ParseInt(string(bytes.TrimSpace(contents)), 10, 64)
+	if err != nil {
+		return 0, errors.Wrapf(err, "error when parsing %s from cgroup v1 at %s", desc, filepath)
+	}
+	return res, nil
+}
+
+func detectCPUQuotaInV1(cRoot string) (period, quota int64, err error) {
+	quotaFilePath := filepath.Join(cRoot, cgroupV1CPUQuotaFilename)
+	periodFilePath := filepath.Join(cRoot, cgroupV1CPUPeriodFilename)
+	quota, err = cgroupFileToInt64(quotaFilePath, "cpu quota")
+	if err != nil {
+		return 0, 0, err
+	}
+	period, err = cgroupFileToInt64(periodFilePath, "cpu period")
+	if err != nil {
+		return 0, 0, err
+	}
+
+	return period, quota, err
+}
+
+func detectCPUUsageInV1(cRoot string) (stime, utime uint64, err error) {
+	sysFilePath := filepath.Join(cRoot, cgroupV1CPUSysUsageFilename)
+	userFilePath := filepath.Join(cRoot, cgroupV1CPUUserUsageFilename)
+	stime, err = cgroupFileToUint64(sysFilePath, "cpu system time")
+	if err != nil {
+		return 0, 0, err
+	}
+	utime, err = cgroupFileToUint64(userFilePath, "cpu user time")
+	if err != nil {
+		return 0, 0, err
+	}
+
+	return stime, utime, err
+}
+
+func detectCPUQuotaInV2(cRoot string) (period, quota int64, err error) {
+	maxFilePath := filepath.Join(cRoot, cgroupV2CPUMaxFilename)
+	contents, err := readFile(maxFilePath)
+	if err != nil {
+		return 0, 0, errors.Wrapf(err, "error when read cpu quota from cgroup v2 at %s", maxFilePath)
+	}
+	fields := strings.Fields(string(contents))
+	if len(fields) > 2 || len(fields) == 0 {
+		return 0, 0, errors.Errorf("unexpected format when reading cpu quota from cgroup v2 at %s: %s", maxFilePath, contents)
+	}
+	if fields[0] == "max" {
+		// Negative quota denotes no limit.
+		quota = -1
+	} else {
+		quota, err = strconv.ParseInt(fields[0], 10, 64)
+		if err != nil {
+			return 0, 0, errors.Wrapf(err, "error when reading cpu quota from cgroup v2 at %s", maxFilePath)
+		}
+	}
+	if len(fields) == 2 {
+		period, err = strconv.ParseInt(fields[1], 10, 64)
+		if err != nil {
+			return 0, 0, errors.Wrapf(err, "error when reading cpu period from cgroup v2 at %s", maxFilePath)
+		}
+	}
+	return period, quota, nil
+}
+
+func detectCPUUsageInV2(cRoot string) (stime, utime uint64, err error) {
+	statFilePath := filepath.Join(cRoot, cgroupV2CPUStatFilename)
+	var stat *os.File
+	stat, err = os.Open(statFilePath)
+	if err != nil {
+		return 0, 0, errors.Wrapf(err, "can't read cpu usage from cgroup v2 at %s", statFilePath)
+	}
+	defer func() {
+		err = errors.CombineErrors(err, stat.Close())
+	}()
+
+	scanner := bufio.NewScanner(stat)
+	for scanner.Scan() {
+		fields := bytes.Fields(scanner.Bytes())
+		if len(fields) != 2 || (string(fields[0]) != "user_usec" && string(fields[0]) != "system_usec") {
+			continue
+		}
+		keyField := string(fields[0])
+
+		trimmed := string(bytes.TrimSpace(fields[1]))
+		usageVar := &stime
+		if keyField == "user_usec" {
+			usageVar = &utime
+		}
+		*usageVar, err = strconv.ParseUint(trimmed, 10, 64)
+		if err != nil {
+			return 0, 0, errors.Wrapf(err, "can't read cpu usage %s from cgroup v1 at %s", keyField, statFilePath)
+		}
+	}
+
+	return stime, utime, err
+}
+
+// Finds memory limit for cgroup V1 via looking in [contoller mount path]/memory.stat
+func detectMemLimitInV1(cRoot string) (limit int64, warnings string, err error) {
 	statFilePath := filepath.Join(cRoot, cgroupV1MemLimitFilename)
 	stat, err := os.Open(statFilePath)
 	if err != nil {
@@ -98,7 +236,7 @@ func detectLimitInV1(cRoot string) (limit int64, warnings string, err error) {
 // Finds memory limit for cgroup V2 via looking into [controller mount path]/[leaf path]/memory.max
 // TODO(vladdy): this implementation was based on podman+criu environment. It may cover not
 // all the cases when v2 becomes more widely used in container world.
-func detectLimitInV2(cRoot string) (limit int64, warnings string, err error) {
+func detectMemLimitInV2(cRoot string) (limit int64, warnings string, err error) {
 	limitFilePath := filepath.Join(cRoot, cgroupV2MemLimitFilename)
 
 	var buf []byte
@@ -120,10 +258,10 @@ func detectLimitInV2(cRoot string) (limit int64, warnings string, err error) {
 
 // The controller is defined via either type `memory` for cgroup v1 or via empty type for cgroup v2,
 // where the type is the second field in /proc/[pid]/cgroup file
-func detectMemCntrlPath(cgroupFilePath string) (string, error) {
+func detectCntrlPath(cgroupFilePath string, controller string) (string, error) {
 	cgroup, err := os.Open(cgroupFilePath)
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to read memory cgroup from cgroups file: %s", cgroupFilePath)
+		return "", errors.Wrapf(err, "failed to read %s cgroup from cgroups file: %s", controller, cgroupFilePath)
 	}
 	defer func() { _ = cgroup.Close() }()
 
@@ -142,7 +280,7 @@ func detectMemCntrlPath(cgroupFilePath string) (string, error) {
 		// but no known container solutions support it afaik
 		if f0 == "0" && f1 == "" {
 			unifiedPathIfFound = string(fields[2])
-		} else if f1 == "memory" {
+		} else if f1 == controller {
 			return string(fields[2]), nil
 		}
 	}
@@ -152,7 +290,7 @@ func detectMemCntrlPath(cgroupFilePath string) (string, error) {
 
 // Reads /proc/[pid]/mountinfo for cgoup or cgroup2 mount which defines the used version.
 // See http://man7.org/linux/man-pages/man5/proc.5.html for `mountinfo` format.
-func getCgroupDetails(mountinfoPath string, cRoot string) (string, int, error) {
+func getCgroupDetails(mountinfoPath string, cRoot string, controller string) (string, int, error) {
 	info, err := os.Open(mountinfoPath)
 	if err != nil {
 		return "", 0, errors.Wrapf(err, "failed to read mounts info from file: %s", mountinfoPath)
@@ -168,9 +306,30 @@ func getCgroupDetails(mountinfoPath string, cRoot string) (string, int, error) {
 			continue
 		}
 
-		ver, ok := detectCgroupVersion(fields)
-		if ok && (ver == 1 && string(fields[3]) == cRoot) || ver == 2 {
-			return string(fields[4]), ver, nil
+		ver, ok := detectCgroupVersion(fields, controller)
+		if ok {
+			mountPoint := string(fields[4])
+			if ver == 2 {
+				return mountPoint, ver, nil
+			}
+			// It is possible that the controller mount and the cgroup path are not the same (both are relative to the NS root).
+			// So start with the mount and construct the relative path of the cgroup.
+			// To test:
+			//   cgcreate -t $USER:$USER -a $USER:$USER -g memory:crdb_test
+			//   echo 3999997952 > /sys/fs/cgroup/memory/crdb_test/memory.limit_in_bytes
+			//   cgexec -g memory:crdb_test ./cockroach start-single-node
+			// cockroach.log -> server/config.go:433 ⋮ system total memory: ‹3.7 GiB›
+			//   without constructing the relative path
+			// cockroach.log -> server/config.go:433 ⋮ system total memory: ‹63 GiB›
+			nsRelativePath := string(fields[3])
+			if !strings.Contains(nsRelativePath, "..") {
+				// We don't expect to see err here ever but in case that it happens
+				// the best action is to ignore the line and hope that the rest of the lines
+				// will allow us to extract a valid path.
+				if relPath, err := filepath.Rel(nsRelativePath, cRoot); err == nil {
+					return filepath.Join(mountPoint, relPath), ver, nil
+				}
+			}
 		}
 	}
 
@@ -178,7 +337,7 @@ func getCgroupDetails(mountinfoPath string, cRoot string) (string, int, error) {
 }
 
 // Return version of cgroup mount for memory controller if found
-func detectCgroupVersion(fields [][]byte) (_ int, found bool) {
+func detectCgroupVersion(fields [][]byte, controller string) (_ int, found bool) {
 	if len(fields) < 10 {
 		return 0, false
 	}
@@ -203,11 +362,102 @@ func detectCgroupVersion(fields [][]byte) (_ int, found bool) {
 
 	// Check for memory controller specifically in cgroup v1 (it is listed in super options field),
 	// as the limit can't be found if it is not enforced
-	if bytes.Equal(fields[pos], []byte("cgroup")) && bytes.Contains(fields[pos+2], []byte("memory")) {
+	if bytes.Equal(fields[pos], []byte("cgroup")) && bytes.Contains(fields[pos+2], []byte(controller)) {
 		return 1, true
 	} else if bytes.Equal(fields[pos], []byte("cgroup2")) {
 		return 2, true
 	}
 
 	return 0, false
+}
+type CPUUsage struct {
+	// System time and user time taken by this cgroup or process. In nanoseconds.
+	Stime, Utime uint64
+	// CPU period and quota for this process, in microseconds. This cgroup has
+	// access to up to (quota/period) proportion of CPU resources on the system.
+	// For instance, if there are 4 CPUs, quota = 150000, period = 100000,
+	// this cgroup can use around ~1.5 CPUs, or 37.5% of total scheduler time.
+	// If quota is -1, it's unlimited.
+	Period, Quota int64
+	// NumCPUs is the number of CPUs in the system. Always returned even if
+	// not called from a cgroup.
+	NumCPU int
+}
+
+// CPUShares returns the number of CPUs this cgroup can be expected to
+// max out. If there's no limit, NumCPU is returned.
+func (c CPUUsage) CPUShares() float64 {
+	if c.Period <= 0 || c.Quota <= 0 {
+		return float64(c.NumCPU)
+	}
+	return float64(c.Quota) / float64(c.Period)
+}
+
+// GetCgroupCPU returns the CPU usage and quota for the current cgroup.
+func GetCgroupCPU() (CPUUsage, error) {
+	cpuusage, err := getCgroupCPU("/")
+	cpuusage.NumCPU = runtime.NumCPU()
+	return cpuusage, err
+}
+
+// Helper function for getCgroupCPU. Root is always "/", except in tests.
+func getCgroupCPU(root string) (CPUUsage, error) {
+	path, err := detectCntrlPath(filepath.Join(root, "/proc/self/cgroup"), "cpu,cpuacct")
+	if err != nil {
+		return CPUUsage{}, err
+	}
+
+	// No CPU controller detected
+	if path == "" {
+		return CPUUsage{}, errors.New("no cpu controller detected")
+	}
+
+	mount, ver, err := getCgroupDetails(filepath.Join(root, "/proc/self/mountinfo"), path, "cpu,cpuacct")
+	if err != nil {
+		return CPUUsage{}, err
+	}
+
+	var res CPUUsage
+
+	switch ver {
+	case 1:
+		res.Period, res.Quota, err = detectCPUQuotaInV1(filepath.Join(root, mount))
+		if err != nil {
+			return res, err
+		}
+		res.Stime, res.Utime, err = detectCPUUsageInV1(filepath.Join(root, mount))
+		if err != nil {
+			return res, err
+		}
+	case 2:
+		res.Period, res.Quota, err = detectCPUQuotaInV2(filepath.Join(root, mount, path))
+		if err != nil {
+			return res, err
+		}
+		res.Stime, res.Utime, err = detectCPUUsageInV2(filepath.Join(root, mount, path))
+		if err != nil {
+			return res, err
+		}
+	default:
+		return CPUUsage{}, fmt.Errorf("detected unknown cgroup version index: %d", ver)
+	}
+
+	return res, nil
+}
+
+// AdjustMaxProcs sets GOMAXPROCS (if not overridden by env variables) to be
+// the CPU limit of the current cgroup, if running inside a cgroup with a cpu
+// limit lower than runtime.NumCPU(). This is preferable to letting it fall back
+// to Go default, which is runtime.NumCPU(), as the Go scheduler would be
+// running more OS-level threads than can ever be concurrently scheduled.
+func AdjustMaxProcs(ctx context.Context) {
+	if _, set := os.LookupEnv("GOMAXPROCS"); !set {
+		if cpuInfo, err := GetCgroupCPU(); err == nil {
+			numCPUToUse := int(math.Ceil(cpuInfo.CPUShares()))
+			if numCPUToUse < runtime.NumCPU() && numCPUToUse > 0 {
+				log.Infof(ctx, "running in a container; setting GOMAXPROCS to %d", numCPUToUse)
+				runtime.GOMAXPROCS(numCPUToUse)
+			}
+		}
+	}
 }

--- a/pkg/util/cgroups/cgroups_test.go
+++ b/pkg/util/cgroups/cgroups_test.go
@@ -67,6 +67,15 @@ func TestCgroupsGetMemory(t *testing.T) {
 			limit: 2936016896,
 		},
 		{
+			name: "fetches the limit for cgroup v1 when the NS relative paths of mount and cgroup don't match",
+			paths: map[string]string{
+				"/proc/self/cgroup":                             v1CgroupWithMemoryControllerNS,
+				"/proc/self/mountinfo":                          v1MountsWithMemControllerNS,
+				"/sys/fs/cgroup/memory/cgroup_test/memory.stat": v1MemoryStat,
+			},
+			limit: 2936016896,
+		},
+		{
 			name: "fails when the stat file is missing for cgroup v2",
 			paths: map[string]string{
 				"/proc/self/cgroup":    v2CgroupWithMemoryController,
@@ -115,6 +124,192 @@ func TestCgroupsGetMemory(t *testing.T) {
 	}
 }
 
+func TestCgroupsGetCPU(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		paths  map[string]string
+		errMsg string
+		period int64
+		quota  int64
+		user   uint64
+		system uint64
+	}{
+		{
+			name:   "fails to find cgroup version when cgroup file is not present",
+			errMsg: "failed to read cpu,cpuacct cgroup from cgroups file:",
+		},
+		{
+			name: "doesn't detect limit for cgroup v1 without cpu controller",
+			paths: map[string]string{
+				"/proc/self/cgroup":    v1CgroupWithoutCPUController,
+				"/proc/self/mountinfo": v1MountsWithoutCPUController,
+			},
+			errMsg: "no cpu controller detected",
+		},
+		{
+			name: "fails to find mount details when mountinfo is not present",
+			paths: map[string]string{
+				"/proc/self/cgroup": v1CgroupWithCPUController,
+			},
+			errMsg: "failed to read mounts info from file:",
+		},
+		{
+			name: "fails to find cgroup v1 version when there is no cpu mount",
+			paths: map[string]string{
+				"/proc/self/cgroup":    v1CgroupWithCPUController,
+				"/proc/self/mountinfo": v1MountsWithoutCPUController,
+			},
+			errMsg: "failed to detect cgroup root mount and version",
+		},
+		{
+			name: "fetches the cpu quota and usage for cgroup v1",
+			paths: map[string]string{
+				"/proc/self/cgroup":                             v1CgroupWithCPUController,
+				"/proc/self/mountinfo":                          v1MountsWithCPUController,
+				"/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_quota_us":   "12345",
+				"/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_period_us":  "67890",
+				"/sys/fs/cgroup/cpu,cpuacct/cpuacct.usage_sys":  "123",
+				"/sys/fs/cgroup/cpu,cpuacct/cpuacct.usage_user": "456",
+			},
+			quota:  int64(12345),
+			period: int64(67890),
+			system: uint64(123),
+			user:   uint64(456),
+		},
+		{
+			name: "fetches the cpu quota and usage for cgroup v1 where the mount and cgroup path don't match",
+			paths: map[string]string{
+				"/proc/self/cgroup":    v1CgroupWithCPUControllerNS,
+				"/proc/self/mountinfo": v1MountsWithCPUControllerNS,
+				"/sys/fs/cgroup/cpu,cpuacct/crdb_test/cpu.cfs_quota_us":   "12345",
+				"/sys/fs/cgroup/cpu,cpuacct/crdb_test/cpu.cfs_period_us":  "67890",
+				"/sys/fs/cgroup/cpu,cpuacct/crdb_test/cpuacct.usage_sys":  "123",
+				"/sys/fs/cgroup/cpu,cpuacct/crdb_test/cpuacct.usage_user": "456",
+			},
+			quota:  int64(12345),
+			period: int64(67890),
+			system: uint64(123),
+			user:   uint64(456),
+		},
+		{
+			name: "fetches the cpu quota and usage for cgroup v1 where the mount is relative",
+			paths: map[string]string{
+				"/proc/self/cgroup":    v1CgroupWithCPUControllerNSMountRel,
+				"/proc/self/mountinfo": v1MountsWithCPUControllerNSMountRel,
+			},
+			errMsg: "failed to detect cgroup root mount and version",
+		},
+		{
+			name: "fetches the cpu quota and usage for cgroup v1 where the mount and cgroup match but there is extra mount",
+			paths: map[string]string{
+				"/proc/self/cgroup":    v1CgroupWithCPUControllerNSMountRelRemount,
+				"/proc/self/mountinfo": v1MountsWithCPUControllerNSMountRelRemount,
+				"/sys/fs/cgroup/cpu,cpuacct/crdb_test/cpu.cfs_quota_us":   "12345",
+				"/sys/fs/cgroup/cpu,cpuacct/crdb_test/cpu.cfs_period_us":  "67890",
+				"/sys/fs/cgroup/cpu,cpuacct/crdb_test/cpuacct.usage_sys":  "123",
+				"/sys/fs/cgroup/cpu,cpuacct/crdb_test/cpuacct.usage_user": "456",
+			},
+			quota:  int64(12345),
+			period: int64(67890),
+			system: uint64(123),
+			user:   uint64(456),
+		},
+		{
+			name: "fetches the cpu quota and usage for cgroup v1 where the mount and cgroup match",
+			paths: map[string]string{
+				"/proc/self/cgroup":    v1CgroupWithCPUControllerNS2,
+				"/proc/self/mountinfo": v1MountsWithCPUControllerNS2,
+				"/sys/fs/cgroup/cpu,cpuacct/crdb_test/cpu.cfs_quota_us":   "12345",
+				"/sys/fs/cgroup/cpu,cpuacct/crdb_test/cpu.cfs_period_us":  "67890",
+				"/sys/fs/cgroup/cpu,cpuacct/crdb_test/cpuacct.usage_sys":  "123",
+				"/sys/fs/cgroup/cpu,cpuacct/crdb_test/cpuacct.usage_user": "456",
+			},
+			quota:  int64(12345),
+			period: int64(67890),
+			system: uint64(123),
+			user:   uint64(456),
+		},
+		{
+			name: "fetches the cpu quota for cgroup v1 even if usage nonexistent",
+			paths: map[string]string{
+				"/proc/self/cgroup":                            v1CgroupWithCPUController,
+				"/proc/self/mountinfo":                         v1MountsWithCPUController,
+				"/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_quota_us":  "-1",
+				"/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_period_us": "67890",
+			},
+			quota:  int64(-1),
+			period: int64(67890),
+			errMsg: "error when reading cpu system time from cgroup v1",
+		},
+		{
+			name: "fails when the stat file is missing for cgroup v2",
+			paths: map[string]string{
+				"/proc/self/cgroup":    v2CgroupWithMemoryController,
+				"/proc/self/mountinfo": v2Mounts,
+			},
+			errMsg: "error when read cpu quota from cgroup v2",
+		},
+		{
+			name: "fails when unable to parse limit for cgroup v2",
+			paths: map[string]string{
+				"/proc/self/cgroup":    v2CgroupWithMemoryController,
+				"/proc/self/mountinfo": v2Mounts,
+				"/sys/fs/cgroup/machine.slice/libpod-f1c6b44c0d61f273952b8daecf154cee1be2d503b7e9184ebf7fcaf48e139810.scope/cpu.max": "foo bar\n",
+			},
+			errMsg: "error when reading cpu quota from cgroup v2 at",
+		},
+		{
+			name: "fetches the cpu quota and usage for cgroup v2",
+			paths: map[string]string{
+				"/proc/self/cgroup":    v2CgroupWithMemoryController,
+				"/proc/self/mountinfo": v2Mounts,
+				"/sys/fs/cgroup/machine.slice/libpod-f1c6b44c0d61f273952b8daecf154cee1be2d503b7e9184ebf7fcaf48e139810.scope/cpu.max":  "100 1000\n",
+				"/sys/fs/cgroup/machine.slice/libpod-f1c6b44c0d61f273952b8daecf154cee1be2d503b7e9184ebf7fcaf48e139810.scope/cpu.stat": "user_usec 100\nsystem_usec 200",
+			},
+			quota:  int64(100),
+			period: int64(1000),
+			user:   uint64(100),
+			system: uint64(200),
+		},
+		{
+			name: "recognizes `max` as the cpu quota for cgroup v2",
+			paths: map[string]string{
+				"/proc/self/cgroup":    v2CgroupWithMemoryController,
+				"/proc/self/mountinfo": v2Mounts,
+				"/sys/fs/cgroup/machine.slice/libpod-f1c6b44c0d61f273952b8daecf154cee1be2d503b7e9184ebf7fcaf48e139810.scope/cpu.max":  "max 1000\n",
+				"/sys/fs/cgroup/machine.slice/libpod-f1c6b44c0d61f273952b8daecf154cee1be2d503b7e9184ebf7fcaf48e139810.scope/cpu.stat": "user_usec 100\nsystem_usec 200",
+			},
+			quota:  int64(-1),
+			period: int64(1000),
+			user:   uint64(100),
+			system: uint64(200),
+		},
+		{
+			name: "fetches the cpu quota for cgroup v2 even if usage nonexistent",
+			paths: map[string]string{
+				"/proc/self/cgroup":    v2CgroupWithMemoryController,
+				"/proc/self/mountinfo": v2Mounts,
+				"/sys/fs/cgroup/machine.slice/libpod-f1c6b44c0d61f273952b8daecf154cee1be2d503b7e9184ebf7fcaf48e139810.scope/cpu.max": "100 1000\n",
+			},
+			quota:  int64(100),
+			period: int64(1000),
+			errMsg: "can't read cpu usage from cgroup v2",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := createFiles(t, tc.paths)
+			defer func() { _ = os.RemoveAll(dir) }()
+
+			cpuusage, err := getCgroupCPU(dir)
+			require.True(t, testutils.IsError(err, tc.errMsg),
+				"%v %v", err, tc.errMsg)
+			require.Equal(t, tc.quota, cpuusage.Quota)
+			require.Equal(t, tc.period, cpuusage.Period)
+			require.Equal(t, tc.system, cpuusage.Stime)
+			require.Equal(t, tc.user, cpuusage.Utime)
+		})
+	}
+}
 func createFiles(t *testing.T, paths map[string]string) (dir string) {
 	dir, err := ioutil.TempDir("", "")
 	require.NoError(t, err)
@@ -146,6 +341,29 @@ const (
 7:cpu,cpuacct:/kubepods/besteffort/pod1bf924dd-3f6f-11ea-983d-0abc95f90166/c17eb535a47774285717e40bbda777ee72e81471272a5b8ebffd51fdf7f624e3
 6:pids:/kubepods/besteffort/pod1bf924dd-3f6f-11ea-983d-0abc95f90166/c17eb535a47774285717e40bbda777ee72e81471272a5b8ebffd51fdf7f624e3
 5:cpuset:/kubepods/besteffort/pod1bf924dd-3f6f-11ea-983d-0abc95f90166/c17eb535a47774285717e40bbda777ee72e81471272a5b8ebffd51fdf7f624e3
+4:net_cls,net_prio:/kubepods/besteffort/pod1bf924dd-3f6f-11ea-983d-0abc95f90166/c17eb535a47774285717e40bbda777ee72e81471272a5b8ebffd51fdf7f624e3
+3:hugetlb:/kubepods/besteffort/pod1bf924dd-3f6f-11ea-983d-0abc95f90166/c17eb535a47774285717e40bbda777ee72e81471272a5b8ebffd51fdf7f624e3
+2:freezer:/kubepods/besteffort/pod1bf924dd-3f6f-11ea-983d-0abc95f90166/c17eb535a47774285717e40bbda777ee72e81471272a5b8ebffd51fdf7f624e3
+1:name=systemd:/kubepods/besteffort/pod1bf924dd-3f6f-11ea-983d-0abc95f90166/c17eb535a47774285717e40bbda777ee72e81471272a5b8ebffd51fdf7f624e3
+`
+	v1CgroupWithCPUController = `11:blkio:/kubepods/besteffort/pod1bf924dd-3f6f-11ea-983d-0abc95f90166/c17eb535a47774285717e40bbda777ee72e81471272a5b8ebffd51fdf7f624e3
+10:devices:/kubepods/besteffort/pod1bf924dd-3f6f-11ea-983d-0abc95f90166/c17eb535a47774285717e40bbda777ee72e81471272a5b8ebffd51fdf7f624e3
+9:perf_event:/kubepods/besteffort/pod1bf924dd-3f6f-11ea-983d-0abc95f90166/c17eb535a47774285717e40bbda777ee72e81471272a5b8ebffd51fdf7f624e3
+8:cpu,cpuacct:/kubepods/besteffort/pod1bf924dd-3f6f-11ea-983d-0abc95f90166/c17eb535a47774285717e40bbda777ee72e81471272a5b8ebffd51fdf7f624e3
+7:pids:/kubepods/besteffort/pod1bf924dd-3f6f-11ea-983d-0abc95f90166/c17eb535a47774285717e40bbda777ee72e81471272a5b8ebffd51fdf7f624e3
+6:cpuset:/kubepods/besteffort/pod1bf924dd-3f6f-11ea-983d-0abc95f90166/c17eb535a47774285717e40bbda777ee72e81471272a5b8ebffd51fdf7f624e3
+5:memory:/kubepods/besteffort/pod1bf924dd-3f6f-11ea-983d-0abc95f90166/c17eb535a47774285717e40bbda777ee72e81471272a5b8ebffd51fdf7f624e3
+4:net_cls,net_prio:/kubepods/besteffort/pod1bf924dd-3f6f-11ea-983d-0abc95f90166/c17eb535a47774285717e40bbda777ee72e81471272a5b8ebffd51fdf7f624e3
+3:hugetlb:/kubepods/besteffort/pod1bf924dd-3f6f-11ea-983d-0abc95f90166/c17eb535a47774285717e40bbda777ee72e81471272a5b8ebffd51fdf7f624e3
+2:freezer:/kubepods/besteffort/pod1bf924dd-3f6f-11ea-983d-0abc95f90166/c17eb535a47774285717e40bbda777ee72e81471272a5b8ebffd51fdf7f624e3
+1:name=systemd:/kubepods/besteffort/pod1bf924dd-3f6f-11ea-983d-0abc95f90166/c17eb535a47774285717e40bbda777ee72e81471272a5b8ebffd51fdf7f624e3
+`
+	v1CgroupWithoutCPUController = `10:blkio:/kubepods/besteffort/pod1bf924dd-3f6f-11ea-983d-0abc95f90166/c17eb535a47774285717e40bbda777ee72e81471272a5b8ebffd51fdf7f624e3
+9:devices:/kubepods/besteffort/pod1bf924dd-3f6f-11ea-983d-0abc95f90166/c17eb535a47774285717e40bbda777ee72e81471272a5b8ebffd51fdf7f624e3
+8:perf_event:/kubepods/besteffort/pod1bf924dd-3f6f-11ea-983d-0abc95f90166/c17eb535a47774285717e40bbda777ee72e81471272a5b8ebffd51fdf7f624e3
+7:pids:/kubepods/besteffort/pod1bf924dd-3f6f-11ea-983d-0abc95f90166/c17eb535a47774285717e40bbda777ee72e81471272a5b8ebffd51fdf7f624e3
+6:cpuset:/kubepods/besteffort/pod1bf924dd-3f6f-11ea-983d-0abc95f90166/c17eb535a47774285717e40bbda777ee72e81471272a5b8ebffd51fdf7f624e3
+5:memory:/kubepods/besteffort/pod1bf924dd-3f6f-11ea-983d-0abc95f90166/c17eb535a47774285717e40bbda777ee72e81471272a5b8ebffd51fdf7f624e3
 4:net_cls,net_prio:/kubepods/besteffort/pod1bf924dd-3f6f-11ea-983d-0abc95f90166/c17eb535a47774285717e40bbda777ee72e81471272a5b8ebffd51fdf7f624e3
 3:hugetlb:/kubepods/besteffort/pod1bf924dd-3f6f-11ea-983d-0abc95f90166/c17eb535a47774285717e40bbda777ee72e81471272a5b8ebffd51fdf7f624e3
 2:freezer:/kubepods/besteffort/pod1bf924dd-3f6f-11ea-983d-0abc95f90166/c17eb535a47774285717e40bbda777ee72e81471272a5b8ebffd51fdf7f624e3
@@ -207,6 +425,84 @@ const (
 734 703 0:29 /kubepods/besteffort/pod1bf924dd-3f6f-11ea-983d-0abc95f90166/c17eb535a47774285717e40bbda777ee72e81471272a5b8ebffd51fdf7f624e3 /sys/fs/cgroup/cpuset ro,nosuid,nodev,noexec,relatime master:14 - cgroup cgroup rw,cpuset
 735 703 0:30 /kubepods/besteffort/pod1bf924dd-3f6f-11ea-983d-0abc95f90166/c17eb535a47774285717e40bbda777ee72e81471272a5b8ebffd51fdf7f624e3 /sys/fs/cgroup/pids ro,nosuid,nodev,noexec,relatime master:15 - cgroup cgroup rw,pids
 736 703 0:31 /kubepods/besteffort/pod1bf924dd-3f6f-11ea-983d-0abc95f90166/c17eb535a47774285717e40bbda777ee72e81471272a5b8ebffd51fdf7f624e3 /sys/fs/cgroup/cpu,cpuacct ro,nosuid,nodev,noexec,relatime master:16 - cgroup cgroup rw,cpu,cpuacct
+737 703 0:32 /kubepods/besteffort/pod1bf924dd-3f6f-11ea-983d-0abc95f90166/c17eb535a47774285717e40bbda777ee72e81471272a5b8ebffd51fdf7f624e3 /sys/fs/cgroup/perf_event ro,nosuid,nodev,noexec,relatime master:17 - cgroup cgroup rw,perf_event
+740 703 0:33 /kubepods/besteffort/pod1bf924dd-3f6f-11ea-983d-0abc95f90166/c17eb535a47774285717e40bbda777ee72e81471272a5b8ebffd51fdf7f624e3 /sys/fs/cgroup/devices ro,nosuid,nodev,noexec,relatime master:18 - cgroup cgroup rw,devices
+742 703 0:34 /kubepods/besteffort/pod1bf924dd-3f6f-11ea-983d-0abc95f90166/c17eb535a47774285717e40bbda777ee72e81471272a5b8ebffd51fdf7f624e3 /sys/fs/cgroup/blkio ro,nosuid,nodev,noexec,relatime master:19 - cgroup cgroup rw,blkio
+744 687 0:78 / /dev/mqueue rw,nosuid,nodev,noexec,relatime - mqueue mqueue rw
+746 625 259:1 /var/lib/kubelet/pods/1bf924dd-3f6f-11ea-983d-0abc95f90166/volumes/kubernetes.io~empty-dir/cockroach-env /etc/cockroach-env ro,noatime - xfs /dev/nvme0n1p1 rw,attr2,inode64,noquota
+760 687 259:1 /var/lib/kubelet/pods/1bf924dd-3f6f-11ea-983d-0abc95f90166/containers/cockroachdb/3e868c1f /dev/termination-log rw,noatime - xfs /dev/nvme0n1p1 rw,attr2,inode64,noquota
+776 625 259:3 / /cockroach/cockroach-data rw,relatime - ext4 /dev/nvme2n1 rw,data=ordered
+814 625 0:68 / /cockroach/cockroach-certs ro,relatime - tmpfs tmpfs rw
+815 625 259:1 /var/lib/docker/containers/b7d4d62b68384b4adb9b76bbe156e7a7bcd469c6d40cdd0e70f1949184260683/resolv.conf /etc/resolv.conf rw,noatime - xfs /dev/nvme0n1p1 rw,attr2,inode64,noquota
+816 625 259:1 /var/lib/docker/containers/b7d4d62b68384b4adb9b76bbe156e7a7bcd469c6d40cdd0e70f1949184260683/hostname /etc/hostname rw,noatime - xfs /dev/nvme0n1p1 rw,attr2,inode64,noquota
+817 625 259:1 /var/lib/kubelet/pods/1bf924dd-3f6f-11ea-983d-0abc95f90166/etc-hosts /etc/hosts rw,noatime - xfs /dev/nvme0n1p1 rw,attr2,inode64,noquota
+818 687 0:77 / /dev/shm rw,nosuid,nodev,noexec,relatime - tmpfs shm rw,size=65536k
+819 625 0:69 / /run/secrets/kubernetes.io/serviceaccount ro,relatime - tmpfs tmpfs rw
+368 626 0:79 /bus /proc/bus ro,relatime - proc proc rw
+375 626 0:79 /fs /proc/fs ro,relatime - proc proc rw
+376 626 0:79 /irq /proc/irq ro,relatime - proc proc rw
+381 626 0:79 /sys /proc/sys ro,relatime - proc proc rw
+397 626 0:79 /sysrq-trigger /proc/sysrq-trigger ro,relatime - proc proc rw
+213 626 0:70 / /proc/acpi ro,relatime - tmpfs tmpfs ro
+216 626 0:75 /null /proc/kcore rw,nosuid - tmpfs tmpfs rw,size=65536k,mode=755
+217 626 0:75 /null /proc/keys rw,nosuid - tmpfs tmpfs rw,size=65536k,mode=755
+218 626 0:75 /null /proc/latency_stats rw,nosuid - tmpfs tmpfs rw,size=65536k,mode=755
+222 626 0:75 /null /proc/timer_list rw,nosuid - tmpfs tmpfs rw,size=65536k,mode=755
+223 626 0:75 /null /proc/sched_debug rw,nosuid - tmpfs tmpfs rw,size=65536k,mode=755
+224 702 0:101 / /sys/firmware ro,relatime - tmpfs tmpfs ro
+`
+	v1MountsWithCPUController = `625 367 0:71 / / rw,relatime master:85 - overlay overlay rw,lowerdir=/var/lib/docker/overlay2/l/DOLSFLPSKANL4GJ7XKF3OG6PKN:/var/lib/docker/overlay2/l/P7UJPLDFEUSRQ7CZILB7L4T5OP:/var/lib/docker/overlay2/l/FSKO5FFFNQ6XOSVF7T6R2DWZVZ:/var/lib/docker/overlay2/l/YNE4EZZE2GW2DIXRBUP47LB3GU:/var/lib/docker/overlay2/l/F2JNS7YWT5CU7FUXHNV5JUJWQY,upperdir=/var/lib/docker/overlay2/b12d4d510f3eaf4552a749f9d4f6da182d55bfcdc75755f1972fd8ca33f51278/diff,workdir=/var/lib/docker/overlay2/b12d4d510f3eaf4552a749f9d4f6da182d55bfcdc75755f1972fd8ca33f51278/work
+626 625 0:79 / /proc rw,nosuid,nodev,noexec,relatime - proc proc rw
+687 625 0:75 / /dev rw,nosuid - tmpfs tmpfs rw,size=65536k,mode=755
+691 687 0:82 / /dev/pts rw,nosuid,noexec,relatime - devpts devpts rw,gid=5,mode=620,ptmxmode=666
+702 625 0:159 / /sys ro,nosuid,nodev,noexec,relatime - sysfs sysfs ro
+703 702 0:99 / /sys/fs/cgroup ro,nosuid,nodev,noexec,relatime - tmpfs tmpfs rw,mode=755
+705 703 0:23 /kubepods/besteffort/pod1bf924dd-3f6f-11ea-983d-0abc95f90166/c17eb535a47774285717e40bbda777ee72e81471272a5b8ebffd51fdf7f624e3 /sys/fs/cgroup/systemd ro,nosuid,nodev,noexec,relatime master:9 - cgroup cgroup rw,xattr,release_agent=/usr/lib/systemd/systemd-cgroups-agent,name=systemd
+711 703 0:25 /kubepods/besteffort/pod1bf924dd-3f6f-11ea-983d-0abc95f90166/c17eb535a47774285717e40bbda777ee72e81471272a5b8ebffd51fdf7f624e3 /sys/fs/cgroup/freezer ro,nosuid,nodev,noexec,relatime master:10 - cgroup cgroup rw,freezer
+726 703 0:26 /kubepods/besteffort/pod1bf924dd-3f6f-11ea-983d-0abc95f90166/c17eb535a47774285717e40bbda777ee72e81471272a5b8ebffd51fdf7f624e3 /sys/fs/cgroup/hugetlb ro,nosuid,nodev,noexec,relatime master:11 - cgroup cgroup rw,hugetlb
+727 703 0:27 /kubepods/besteffort/pod1bf924dd-3f6f-11ea-983d-0abc95f90166/c17eb535a47774285717e40bbda777ee72e81471272a5b8ebffd51fdf7f624e3 /sys/fs/cgroup/net_cls,net_prio ro,nosuid,nodev,noexec,relatime master:12 - cgroup cgroup rw,net_cls,net_prio
+733 703 0:28 /kubepods/besteffort/pod1bf924dd-3f6f-11ea-983d-0abc95f90166/c17eb535a47774285717e40bbda777ee72e81471272a5b8ebffd51fdf7f624e3 /sys/fs/cgroup/memory ro,nosuid,nodev,noexec,relatime master:13 - cgroup cgroup rw,memory
+734 703 0:29 /kubepods/besteffort/pod1bf924dd-3f6f-11ea-983d-0abc95f90166/c17eb535a47774285717e40bbda777ee72e81471272a5b8ebffd51fdf7f624e3 /sys/fs/cgroup/cpuset ro,nosuid,nodev,noexec,relatime master:14 - cgroup cgroup rw,cpuset
+735 703 0:30 /kubepods/besteffort/pod1bf924dd-3f6f-11ea-983d-0abc95f90166/c17eb535a47774285717e40bbda777ee72e81471272a5b8ebffd51fdf7f624e3 /sys/fs/cgroup/pids ro,nosuid,nodev,noexec,relatime master:15 - cgroup cgroup rw,pids
+736 703 0:31 /kubepods/besteffort/pod1bf924dd-3f6f-11ea-983d-0abc95f90166/c17eb535a47774285717e40bbda777ee72e81471272a5b8ebffd51fdf7f624e3 /sys/fs/cgroup/cpu,cpuacct ro,nosuid,nodev,noexec,relatime master:16 - cgroup cgroup rw,cpu,cpuacct
+737 703 0:32 /kubepods/besteffort/pod1bf924dd-3f6f-11ea-983d-0abc95f90166/c17eb535a47774285717e40bbda777ee72e81471272a5b8ebffd51fdf7f624e3 /sys/fs/cgroup/perf_event ro,nosuid,nodev,noexec,relatime master:17 - cgroup cgroup rw,perf_event
+740 703 0:33 /kubepods/besteffort/pod1bf924dd-3f6f-11ea-983d-0abc95f90166/c17eb535a47774285717e40bbda777ee72e81471272a5b8ebffd51fdf7f624e3 /sys/fs/cgroup/devices ro,nosuid,nodev,noexec,relatime master:18 - cgroup cgroup rw,devices
+742 703 0:34 /kubepods/besteffort/pod1bf924dd-3f6f-11ea-983d-0abc95f90166/c17eb535a47774285717e40bbda777ee72e81471272a5b8ebffd51fdf7f624e3 /sys/fs/cgroup/blkio ro,nosuid,nodev,noexec,relatime master:19 - cgroup cgroup rw,blkio
+744 687 0:78 / /dev/mqueue rw,nosuid,nodev,noexec,relatime - mqueue mqueue rw
+746 625 259:1 /var/lib/kubelet/pods/1bf924dd-3f6f-11ea-983d-0abc95f90166/volumes/kubernetes.io~empty-dir/cockroach-env /etc/cockroach-env ro,noatime - xfs /dev/nvme0n1p1 rw,attr2,inode64,noquota
+760 687 259:1 /var/lib/kubelet/pods/1bf924dd-3f6f-11ea-983d-0abc95f90166/containers/cockroachdb/3e868c1f /dev/termination-log rw,noatime - xfs /dev/nvme0n1p1 rw,attr2,inode64,noquota
+776 625 259:3 / /cockroach/cockroach-data rw,relatime - ext4 /dev/nvme2n1 rw,data=ordered
+814 625 0:68 / /cockroach/cockroach-certs ro,relatime - tmpfs tmpfs rw
+815 625 259:1 /var/lib/docker/containers/b7d4d62b68384b4adb9b76bbe156e7a7bcd469c6d40cdd0e70f1949184260683/resolv.conf /etc/resolv.conf rw,noatime - xfs /dev/nvme0n1p1 rw,attr2,inode64,noquota
+816 625 259:1 /var/lib/docker/containers/b7d4d62b68384b4adb9b76bbe156e7a7bcd469c6d40cdd0e70f1949184260683/hostname /etc/hostname rw,noatime - xfs /dev/nvme0n1p1 rw,attr2,inode64,noquota
+817 625 259:1 /var/lib/kubelet/pods/1bf924dd-3f6f-11ea-983d-0abc95f90166/etc-hosts /etc/hosts rw,noatime - xfs /dev/nvme0n1p1 rw,attr2,inode64,noquota
+818 687 0:77 / /dev/shm rw,nosuid,nodev,noexec,relatime - tmpfs shm rw,size=65536k
+819 625 0:69 / /run/secrets/kubernetes.io/serviceaccount ro,relatime - tmpfs tmpfs rw
+368 626 0:79 /bus /proc/bus ro,relatime - proc proc rw
+375 626 0:79 /fs /proc/fs ro,relatime - proc proc rw
+376 626 0:79 /irq /proc/irq ro,relatime - proc proc rw
+381 626 0:79 /sys /proc/sys ro,relatime - proc proc rw
+397 626 0:79 /sysrq-trigger /proc/sysrq-trigger ro,relatime - proc proc rw
+213 626 0:70 / /proc/acpi ro,relatime - tmpfs tmpfs ro
+216 626 0:75 /null /proc/kcore rw,nosuid - tmpfs tmpfs rw,size=65536k,mode=755
+217 626 0:75 /null /proc/keys rw,nosuid - tmpfs tmpfs rw,size=65536k,mode=755
+218 626 0:75 /null /proc/latency_stats rw,nosuid - tmpfs tmpfs rw,size=65536k,mode=755
+222 626 0:75 /null /proc/timer_list rw,nosuid - tmpfs tmpfs rw,size=65536k,mode=755
+223 626 0:75 /null /proc/sched_debug rw,nosuid - tmpfs tmpfs rw,size=65536k,mode=755
+224 702 0:101 / /sys/firmware ro,relatime - tmpfs tmpfs ro
+`
+	v1MountsWithoutCPUController = `625 367 0:71 / / rw,relatime master:85 - overlay overlay rw,lowerdir=/var/lib/docker/overlay2/l/DOLSFLPSKANL4GJ7XKF3OG6PKN:/var/lib/docker/overlay2/l/P7UJPLDFEUSRQ7CZILB7L4T5OP:/var/lib/docker/overlay2/l/FSKO5FFFNQ6XOSVF7T6R2DWZVZ:/var/lib/docker/overlay2/l/YNE4EZZE2GW2DIXRBUP47LB3GU:/var/lib/docker/overlay2/l/F2JNS7YWT5CU7FUXHNV5JUJWQY,upperdir=/var/lib/docker/overlay2/b12d4d510f3eaf4552a749f9d4f6da182d55bfcdc75755f1972fd8ca33f51278/diff,workdir=/var/lib/docker/overlay2/b12d4d510f3eaf4552a749f9d4f6da182d55bfcdc75755f1972fd8ca33f51278/work
+626 625 0:79 / /proc rw,nosuid,nodev,noexec,relatime - proc proc rw
+687 625 0:75 / /dev rw,nosuid - tmpfs tmpfs rw,size=65536k,mode=755
+691 687 0:82 / /dev/pts rw,nosuid,noexec,relatime - devpts devpts rw,gid=5,mode=620,ptmxmode=666
+702 625 0:159 / /sys ro,nosuid,nodev,noexec,relatime - sysfs sysfs ro
+703 702 0:99 / /sys/fs/cgroup ro,nosuid,nodev,noexec,relatime - tmpfs tmpfs rw,mode=755
+705 703 0:23 /kubepods/besteffort/pod1bf924dd-3f6f-11ea-983d-0abc95f90166/c17eb535a47774285717e40bbda777ee72e81471272a5b8ebffd51fdf7f624e3 /sys/fs/cgroup/systemd ro,nosuid,nodev,noexec,relatime master:9 - cgroup cgroup rw,xattr,release_agent=/usr/lib/systemd/systemd-cgroups-agent,name=systemd
+711 703 0:25 /kubepods/besteffort/pod1bf924dd-3f6f-11ea-983d-0abc95f90166/c17eb535a47774285717e40bbda777ee72e81471272a5b8ebffd51fdf7f624e3 /sys/fs/cgroup/freezer ro,nosuid,nodev,noexec,relatime master:10 - cgroup cgroup rw,freezer
+726 703 0:26 /kubepods/besteffort/pod1bf924dd-3f6f-11ea-983d-0abc95f90166/c17eb535a47774285717e40bbda777ee72e81471272a5b8ebffd51fdf7f624e3 /sys/fs/cgroup/hugetlb ro,nosuid,nodev,noexec,relatime master:11 - cgroup cgroup rw,hugetlb
+727 703 0:27 /kubepods/besteffort/pod1bf924dd-3f6f-11ea-983d-0abc95f90166/c17eb535a47774285717e40bbda777ee72e81471272a5b8ebffd51fdf7f624e3 /sys/fs/cgroup/net_cls,net_prio ro,nosuid,nodev,noexec,relatime master:12 - cgroup cgroup rw,net_cls,net_prio
+734 703 0:29 /kubepods/besteffort/pod1bf924dd-3f6f-11ea-983d-0abc95f90166/c17eb535a47774285717e40bbda777ee72e81471272a5b8ebffd51fdf7f624e3 /sys/fs/cgroup/cpuset ro,nosuid,nodev,noexec,relatime master:14 - cgroup cgroup rw,cpuset
+735 703 0:30 /kubepods/besteffort/pod1bf924dd-3f6f-11ea-983d-0abc95f90166/c17eb535a47774285717e40bbda777ee72e81471272a5b8ebffd51fdf7f624e3 /sys/fs/cgroup/pids ro,nosuid,nodev,noexec,relatime master:15 - cgroup cgroup rw,pids
 737 703 0:32 /kubepods/besteffort/pod1bf924dd-3f6f-11ea-983d-0abc95f90166/c17eb535a47774285717e40bbda777ee72e81471272a5b8ebffd51fdf7f624e3 /sys/fs/cgroup/perf_event ro,nosuid,nodev,noexec,relatime master:17 - cgroup cgroup rw,perf_event
 740 703 0:33 /kubepods/besteffort/pod1bf924dd-3f6f-11ea-983d-0abc95f90166/c17eb535a47774285717e40bbda777ee72e81471272a5b8ebffd51fdf7f624e3 /sys/fs/cgroup/devices ro,nosuid,nodev,noexec,relatime master:18 - cgroup cgroup rw,devices
 742 703 0:34 /kubepods/besteffort/pod1bf924dd-3f6f-11ea-983d-0abc95f90166/c17eb535a47774285717e40bbda777ee72e81471272a5b8ebffd51fdf7f624e3 /sys/fs/cgroup/blkio ro,nosuid,nodev,noexec,relatime master:19 - cgroup cgroup rw,blkio
@@ -299,4 +595,34 @@ total_inactive_file 1363746816
 total_active_file 308867072
 total_unevictable 0
 `
+
+	// Both /proc/<pid>/mountinfo and /proc/<pid>/cgroup will show the mount and the cgroup relative to the cgroup NS root
+	// This tests the case where the memory controller mount and the cgroup are not exactly the same (as is with k8s pods).
+	v1CgroupWithMemoryControllerNS = "12:memory:/cgroup_test"
+	v1MountsWithMemControllerNS    = "50 35 0:44 / /sys/fs/cgroup/memory rw,nosuid,nodev,noexec,relatime shared:25 - cgroup cgroup rw,memory"
+
+	// Example where the paths in /proc/self/mountinfo and /proc/self/cgroup are not the same for the cpu controller
+	//
+	// sudo cgcreate -t $USER:$USER -a $USER:$USER -g cpu:crdb_test
+	// echo 100000 > /sys/fs/cgroup/cpu/crdb_test/cpu.cfs_period_us
+	// echo 33300 > /sys/fs/cgroup/cpu/crdb_test/cpu.cfs_quota_us
+	// cgexec -g cpu:crdb_test ./cockroach ...
+	v1CgroupWithCPUControllerNS = "5:cpu,cpuacct:/crdb_test"
+	v1MountsWithCPUControllerNS = "43 35 0:37 / /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime shared:18 - cgroup cgroup rw,cpu,cpuacct"
+
+	// Same as above but with unshare -C
+	// Can't determine the location of the mount
+	v1CgroupWithCPUControllerNSMountRel = "5:cpu,cpuacct:/"
+	v1MountsWithCPUControllerNSMountRel = "43 35 0:37 /.. /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime shared:18 - cgroup cgroup rw,cpu,cpuacct"
+
+	// Same as above but with mounting the cgroup fs one more time in the NS
+	// sudo mount -t cgroup -o cpu,cpuacct none /sys/fs/cgroup/cpu,cpuacct/crdb_test
+	v1CgroupWithCPUControllerNSMountRelRemount = "5:cpu,cpuacct:/"
+	v1MountsWithCPUControllerNSMountRelRemount = `
+43 35 0:37 /.. /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime shared:18 - cgroup cgroup rw,cpu,cpuacct
+161 43 0:37 / /sys/fs/cgroup/cpu,cpuacct/crdb_test rw,relatime shared:95 - cgroup none rw,cpu,cpuacct
+`
+	// Same as above but exiting the NS w/o unmounting
+	v1CgroupWithCPUControllerNS2 = "5:cpu,cpuacct:/crdb_test"
+	v1MountsWithCPUControllerNS2 = "161 43 0:37 /crdb_test /sys/fs/cgroup/cpu,cpuacct/crdb_test rw,relatime shared:95 - cgroup none rw,cpu,cpuacct"
 )

--- a/pkg/util/cgroups/cgroups_test.go
+++ b/pkg/util/cgroups/cgroups_test.go
@@ -67,15 +67,6 @@ func TestCgroupsGetMemory(t *testing.T) {
 			limit: 2936016896,
 		},
 		{
-			name: "fetches the limit for cgroup v1 when the NS relative paths of mount and cgroup don't match",
-			paths: map[string]string{
-				"/proc/self/cgroup":                             v1CgroupWithMemoryControllerNS,
-				"/proc/self/mountinfo":                          v1MountsWithMemControllerNS,
-				"/sys/fs/cgroup/memory/cgroup_test/memory.stat": v1MemoryStat,
-			},
-			limit: 2936016896,
-		},
-		{
 			name: "fails when the stat file is missing for cgroup v2",
 			paths: map[string]string{
 				"/proc/self/cgroup":    v2CgroupWithMemoryController,
@@ -177,59 +168,6 @@ func TestCgroupsGetCPU(t *testing.T) {
 			user:   uint64(456),
 		},
 		{
-			name: "fetches the cpu quota and usage for cgroup v1 where the mount and cgroup path don't match",
-			paths: map[string]string{
-				"/proc/self/cgroup":    v1CgroupWithCPUControllerNS,
-				"/proc/self/mountinfo": v1MountsWithCPUControllerNS,
-				"/sys/fs/cgroup/cpu,cpuacct/crdb_test/cpu.cfs_quota_us":   "12345",
-				"/sys/fs/cgroup/cpu,cpuacct/crdb_test/cpu.cfs_period_us":  "67890",
-				"/sys/fs/cgroup/cpu,cpuacct/crdb_test/cpuacct.usage_sys":  "123",
-				"/sys/fs/cgroup/cpu,cpuacct/crdb_test/cpuacct.usage_user": "456",
-			},
-			quota:  int64(12345),
-			period: int64(67890),
-			system: uint64(123),
-			user:   uint64(456),
-		},
-		{
-			name: "fetches the cpu quota and usage for cgroup v1 where the mount is relative",
-			paths: map[string]string{
-				"/proc/self/cgroup":    v1CgroupWithCPUControllerNSMountRel,
-				"/proc/self/mountinfo": v1MountsWithCPUControllerNSMountRel,
-			},
-			errMsg: "failed to detect cgroup root mount and version",
-		},
-		{
-			name: "fetches the cpu quota and usage for cgroup v1 where the mount and cgroup match but there is extra mount",
-			paths: map[string]string{
-				"/proc/self/cgroup":    v1CgroupWithCPUControllerNSMountRelRemount,
-				"/proc/self/mountinfo": v1MountsWithCPUControllerNSMountRelRemount,
-				"/sys/fs/cgroup/cpu,cpuacct/crdb_test/cpu.cfs_quota_us":   "12345",
-				"/sys/fs/cgroup/cpu,cpuacct/crdb_test/cpu.cfs_period_us":  "67890",
-				"/sys/fs/cgroup/cpu,cpuacct/crdb_test/cpuacct.usage_sys":  "123",
-				"/sys/fs/cgroup/cpu,cpuacct/crdb_test/cpuacct.usage_user": "456",
-			},
-			quota:  int64(12345),
-			period: int64(67890),
-			system: uint64(123),
-			user:   uint64(456),
-		},
-		{
-			name: "fetches the cpu quota and usage for cgroup v1 where the mount and cgroup match",
-			paths: map[string]string{
-				"/proc/self/cgroup":    v1CgroupWithCPUControllerNS2,
-				"/proc/self/mountinfo": v1MountsWithCPUControllerNS2,
-				"/sys/fs/cgroup/cpu,cpuacct/crdb_test/cpu.cfs_quota_us":   "12345",
-				"/sys/fs/cgroup/cpu,cpuacct/crdb_test/cpu.cfs_period_us":  "67890",
-				"/sys/fs/cgroup/cpu,cpuacct/crdb_test/cpuacct.usage_sys":  "123",
-				"/sys/fs/cgroup/cpu,cpuacct/crdb_test/cpuacct.usage_user": "456",
-			},
-			quota:  int64(12345),
-			period: int64(67890),
-			system: uint64(123),
-			user:   uint64(456),
-		},
-		{
 			name: "fetches the cpu quota for cgroup v1 even if usage nonexistent",
 			paths: map[string]string{
 				"/proc/self/cgroup":                            v1CgroupWithCPUController,
@@ -310,6 +248,7 @@ func TestCgroupsGetCPU(t *testing.T) {
 		})
 	}
 }
+
 func createFiles(t *testing.T, paths map[string]string) (dir string) {
 	dir, err := ioutil.TempDir("", "")
 	require.NoError(t, err)
@@ -595,34 +534,4 @@ total_inactive_file 1363746816
 total_active_file 308867072
 total_unevictable 0
 `
-
-	// Both /proc/<pid>/mountinfo and /proc/<pid>/cgroup will show the mount and the cgroup relative to the cgroup NS root
-	// This tests the case where the memory controller mount and the cgroup are not exactly the same (as is with k8s pods).
-	v1CgroupWithMemoryControllerNS = "12:memory:/cgroup_test"
-	v1MountsWithMemControllerNS    = "50 35 0:44 / /sys/fs/cgroup/memory rw,nosuid,nodev,noexec,relatime shared:25 - cgroup cgroup rw,memory"
-
-	// Example where the paths in /proc/self/mountinfo and /proc/self/cgroup are not the same for the cpu controller
-	//
-	// sudo cgcreate -t $USER:$USER -a $USER:$USER -g cpu:crdb_test
-	// echo 100000 > /sys/fs/cgroup/cpu/crdb_test/cpu.cfs_period_us
-	// echo 33300 > /sys/fs/cgroup/cpu/crdb_test/cpu.cfs_quota_us
-	// cgexec -g cpu:crdb_test ./cockroach ...
-	v1CgroupWithCPUControllerNS = "5:cpu,cpuacct:/crdb_test"
-	v1MountsWithCPUControllerNS = "43 35 0:37 / /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime shared:18 - cgroup cgroup rw,cpu,cpuacct"
-
-	// Same as above but with unshare -C
-	// Can't determine the location of the mount
-	v1CgroupWithCPUControllerNSMountRel = "5:cpu,cpuacct:/"
-	v1MountsWithCPUControllerNSMountRel = "43 35 0:37 /.. /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime shared:18 - cgroup cgroup rw,cpu,cpuacct"
-
-	// Same as above but with mounting the cgroup fs one more time in the NS
-	// sudo mount -t cgroup -o cpu,cpuacct none /sys/fs/cgroup/cpu,cpuacct/crdb_test
-	v1CgroupWithCPUControllerNSMountRelRemount = "5:cpu,cpuacct:/"
-	v1MountsWithCPUControllerNSMountRelRemount = `
-43 35 0:37 /.. /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime shared:18 - cgroup cgroup rw,cpu,cpuacct
-161 43 0:37 / /sys/fs/cgroup/cpu,cpuacct/crdb_test rw,relatime shared:95 - cgroup none rw,cpu,cpuacct
-`
-	// Same as above but exiting the NS w/o unmounting
-	v1CgroupWithCPUControllerNS2 = "5:cpu,cpuacct:/crdb_test"
-	v1MountsWithCPUControllerNS2 = "161 43 0:37 /crdb_test /sys/fs/cgroup/cpu,cpuacct/crdb_test rw,relatime shared:95 - cgroup none rw,cpu,cpuacct"
 )


### PR DESCRIPTION
Backport:
  * 1/1 commits from "cli: Set GOMAXPROCS on start if in a CPU-limited cgroup" (#57390)
  * 1/1 commits from "util, server: fix memory detection with non-root cgroups" (#56840)
  * 1/1 commits from "util, server: Add GetCgroupCPU, use it to reflect cpu usage" (#56461)

Please see individual PRs for details.

/cc @cockroachdb/release
