### PR TITLE
server: add SQL checks to the `/health?ready=1` probe

### DIFF
--- a/pkg/server/drain.go
+++ b/pkg/server/drain.go
@@ -188,6 +188,7 @@ func (s *Server) drainClients(ctx context.Context, reporter func(int, redact.Saf
 	// Mark the server as draining in a way that probes to
 	// /health?ready=1 will notice.
 	s.grpc.setMode(modeDraining)
+	s.sqlServer.acceptingClients.Set(false)
 	// Wait for drainUnreadyWait. This will fail load balancer checks and
 	// delay draining so that client traffic can move off this node.
 	time.Sleep(drainWait.Get(&s.st.SV))

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -2001,6 +2001,9 @@ func (s *SQLServer) startServeSQL(
 			}))
 		})
 	}
+
+	s.acceptingClients.Set(true)
+
 	return nil
 }
 

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -70,6 +70,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/netutil"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/marusama/semaphore"
@@ -111,6 +112,10 @@ type SQLServer struct {
 	// connManager is the connection manager to use to set up additional
 	// SQL listeners in AcceptClients().
 	connManager netutil.Server
+
+	// set to true when the server has started accepting client conns.
+	// Used by health checks.
+	acceptingClients syncutil.AtomicBool
 }
 
 // sqlServerOptionalKVArgs are the arguments supplied to newSQLServer which are


### PR DESCRIPTION
Fixes #58864. 

Previously, it was possible for the `/health?ready=1` probe
to return "OK" when the SQL service was unavailable.

This patch changes this by performing some crude, basic SQL checks on
system tables as part of the check.

Release note (api change): the health API now includes basic
SQL checks as part of readiness checks.