### PR TITLE
logictest: improve non-metamorphic test handling

### DIFF
--- a/pkg/sql/ambiguous_commit_test.go
+++ b/pkg/sql/ambiguous_commit_test.go
@@ -64,7 +64,7 @@ func TestAmbiguousCommit(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	if mutations.MaxBatchSize() == 1 {
+	if mutations.MaxBatchSize(false /* forceProductionMaxBatchSize */) == 1 {
 		// This test relies on the fact that the mutation batch consisting of a
 		// single row also contains an EndTxn which is the case only when the
 		// max batch size is at least 2, so we'll skip it.

--- a/pkg/sql/backfill/backfill.go
+++ b/pkg/sql/backfill/backfill.go
@@ -288,7 +288,8 @@ func (cb *ColumnBackfiller) RunColumnBackfillChunk(
 	// populated and deleted by the OLTP commands but not otherwise
 	// read or used
 	if err := cb.fetcher.StartScan(
-		ctx, txn, []roachpb.Span{sp}, true /* limitBatches */, chunkSize, traceKV,
+		ctx, txn, []roachpb.Span{sp}, true /* limitBatches */, chunkSize,
+		traceKV, false, /* forceProductionKVBatchSize */
 	); err != nil {
 		log.Errorf(ctx, "scan error: %s", err)
 		return roachpb.Key{}, err
@@ -688,7 +689,8 @@ func (ib *IndexBackfiller) BuildIndexEntriesChunk(
 	// populated and deleted by the OLTP commands but not otherwise
 	// read or used
 	if err := ib.fetcher.StartScan(
-		ctx, txn, []roachpb.Span{sp}, true /* limitBatches */, initBufferSize, traceKV,
+		ctx, txn, []roachpb.Span{sp}, true /* limitBatches */, initBufferSize,
+		traceKV, false, /* forceProductionKVBatchSize */
 	); err != nil {
 		log.Errorf(ctx, "scan error: %s", err)
 		return nil, nil, 0, err

--- a/pkg/sql/colfetcher/cfetcher.go
+++ b/pkg/sql/colfetcher/cfetcher.go
@@ -613,6 +613,7 @@ func (rf *cFetcher) StartScan(
 	limitBatches bool,
 	limitHint int64,
 	traceKV bool,
+	forceProductionKVBatchSize bool,
 ) error {
 	if len(spans) == 0 {
 		return errors.AssertionFailedf("no spans")
@@ -645,6 +646,7 @@ func (rf *cFetcher) StartScan(
 		rf.lockStrength,
 		rf.lockWaitPolicy,
 		nil, /* memMonitor */
+		forceProductionKVBatchSize,
 	)
 	if err != nil {
 		return err

--- a/pkg/sql/colfetcher/colbatch_scan.go
+++ b/pkg/sql/colfetcher/colbatch_scan.go
@@ -71,8 +71,8 @@ func (s *ColBatchScan) Init() {
 	s.init = true
 	limitBatches := !s.parallelize
 	if err := s.rf.StartScan(
-		s.ctx, s.flowCtx.Txn, s.spans,
-		limitBatches, s.limitHint, s.flowCtx.TraceKV,
+		s.ctx, s.flowCtx.Txn, s.spans, limitBatches, s.limitHint, s.flowCtx.TraceKV,
+		s.flowCtx.EvalCtx.TestingKnobs.ForceProductionBatchSizes,
 	); err != nil {
 		colexecerror.InternalError(err)
 	}

--- a/pkg/sql/mutations/mutations_util.go
+++ b/pkg/sql/mutations/mutations_util.go
@@ -16,19 +16,29 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util"
 )
 
+const productionMaxBatchSize = 10000
+
 var maxBatchSize = defaultMaxBatchSize
 
 var defaultMaxBatchSize = int64(util.ConstantWithMetamorphicTestRange(
-	10000, /* defaultValue */
-	1,     /* min */
-	10000, /* max */
+	productionMaxBatchSize, /* defaultValue */
+	1,                      /* min */
+	productionMaxBatchSize, /* max */
 ))
 
 // MaxBatchSize returns the max number of entries in the KV batch for a
 // mutation operation (delete, insert, update, upsert) - including secondary
 // index updates, FK cascading updates, etc - before the current KV batch is
 // executed and a new batch is started.
-func MaxBatchSize() int {
+//
+// If forceProductionMaxBatchSize is true, then the "production" value will be
+// returned regardless of whether the build is metamorphic or not. This should
+// only be used by tests the output of which differs if maxBatchSize is
+// randomized.
+func MaxBatchSize(forceProductionMaxBatchSize bool) int {
+	if forceProductionMaxBatchSize {
+		return productionMaxBatchSize
+	}
 	return int(atomic.LoadInt64(&maxBatchSize))
 }
 

--- a/pkg/sql/opt/exec/execbuilder/mutation.go
+++ b/pkg/sql/opt/exec/execbuilder/mutation.go
@@ -146,7 +146,7 @@ func (b *Builder) tryBuildFastPathInsert(ins *memo.InsertExpr) (_ execPlan, ok b
 	//     that we send, not a number of rows. We use this as a guideline only,
 	//     and there is no guarantee that we won't produce a bigger batch.)
 	values, ok := ins.Input.(*memo.ValuesExpr)
-	if !ok || values.ChildCount() > mutations.MaxBatchSize() || values.Relational().HasSubquery {
+	if !ok || values.ChildCount() > mutations.MaxBatchSize(false /* forceProductionMaxBatchSize */) || values.Relational().HasSubquery {
 		return execPlan{}, false, nil
 	}
 

--- a/pkg/sql/row/fetcher.go
+++ b/pkg/sql/row/fetcher.go
@@ -569,6 +569,7 @@ func (rf *Fetcher) StartScan(
 	limitBatches bool,
 	limitHint int64,
 	traceKV bool,
+	forceProductionKVBatchSize bool,
 ) error {
 	if len(spans) == 0 {
 		return errors.AssertionFailedf("no spans")
@@ -584,6 +585,7 @@ func (rf *Fetcher) StartScan(
 		rf.lockStrength,
 		rf.lockWaitPolicy,
 		rf.mon,
+		forceProductionKVBatchSize,
 	)
 	if err != nil {
 		return err
@@ -609,6 +611,7 @@ func (rf *Fetcher) StartInconsistentScan(
 	limitBatches bool,
 	limitHint int64,
 	traceKV bool,
+	forceProductionKVBatchSize bool,
 ) error {
 	if len(spans) == 0 {
 		return errors.AssertionFailedf("no spans")
@@ -665,6 +668,7 @@ func (rf *Fetcher) StartInconsistentScan(
 		rf.lockStrength,
 		rf.lockWaitPolicy,
 		rf.mon,
+		forceProductionKVBatchSize,
 	)
 	if err != nil {
 		return err

--- a/pkg/sql/row/fetcher_test.go
+++ b/pkg/sql/row/fetcher_test.go
@@ -173,6 +173,7 @@ func TestNextRowSingle(t *testing.T) {
 				false, /*limitBatches*/
 				0,     /*limitHint*/
 				false, /*traceKV*/
+				false, /*forceProductionKVBatchSize*/
 			); err != nil {
 				t.Fatal(err)
 			}
@@ -293,6 +294,7 @@ func TestNextRowBatchLimiting(t *testing.T) {
 				true,  /*limitBatches*/
 				10,    /*limitHint*/
 				false, /*traceKV*/
+				false, /*forceProductionKVBatchSize*/
 			); err != nil {
 				t.Fatal(err)
 			}
@@ -403,6 +405,7 @@ func TestRowFetcherMemoryLimits(t *testing.T) {
 		false, /*limitBatches*/
 		0,     /*limitHint*/
 		false, /*traceKV*/
+		false, /*forceProductionKVBatchSize*/
 	)
 	assert.Error(t, err)
 	assert.Equal(t, pgerror.GetPGCode(err), pgcode.OutOfMemory)
@@ -490,6 +493,7 @@ INDEX(c)
 		// batch that ends between rows.
 		1,     /*limitHint*/
 		false, /*traceKV*/
+		false, /*forceProductionKVBatchSize*/
 	); err != nil {
 		t.Fatal(err)
 	}
@@ -650,6 +654,7 @@ func TestNextRowSecondaryIndex(t *testing.T) {
 				false, /*limitBatches*/
 				0,     /*limitHint*/
 				false, /*traceKV*/
+				false, /*forceProductionKVBatchSize*/
 			); err != nil {
 				t.Fatal(err)
 			}
@@ -1007,6 +1012,7 @@ func TestNextRowInterleaved(t *testing.T) {
 				false, /*limitBatches*/
 				0,     /*limitHint*/
 				false, /*traceKV*/
+				false, /*forceProductionKVBatchSize*/
 			); err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/sql/row/kv_batch_fetcher.go
+++ b/pkg/sql/row/kv_batch_fetcher.go
@@ -25,21 +25,35 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-// kvBatchSize is the number of keys we request at a time.
+// getKVBatchSize returns the number of keys we request at a time.
 // On a single node, 1000 was enough to avoid any performance degradation. On
 // multi-node clusters, we want bigger chunks to make up for the higher latency.
+//
+// If forceProductionKVBatchSize is true, then the "production" value will be
+// returned regardless of whether the build is metamorphic or not. This should
+// only be used by tests the output of which differs if defaultKVBatchSize is
+// randomized.
 // TODO(radu): parameters like this should be configurable
-var kvBatchSize int64 = int64(util.ConstantWithMetamorphicTestValue(
-	10000, /* defaultValue */
-	1,     /* metamorphicValue */
+func getKVBatchSize(forceProductionKVBatchSize bool) int64 {
+	if forceProductionKVBatchSize {
+		return productionKVBatchSize
+	}
+	return defaultKVBatchSize
+}
+
+var defaultKVBatchSize = int64(util.ConstantWithMetamorphicTestValue(
+	productionKVBatchSize, /* defaultValue */
+	1,                     /* metamorphicValue */
 ))
+
+const productionKVBatchSize = 10000
 
 // TestingSetKVBatchSize changes the kvBatchFetcher batch size, and returns a function that restores it.
 // This is to be used only in tests - we have no test coverage for arbitrary kv batch sizes at this time.
 func TestingSetKVBatchSize(val int64) func() {
-	oldVal := kvBatchSize
-	kvBatchSize = val
-	return func() { kvBatchSize = oldVal }
+	oldVal := defaultKVBatchSize
+	defaultKVBatchSize = val
+	return func() { defaultKVBatchSize = oldVal }
 }
 
 // sendFunc is the function used to execute a KV batch; normally
@@ -79,6 +93,9 @@ type txnKVFetcher struct {
 	remainingBatches [][]byte
 	mon              *mon.BytesMonitor
 	acc              mon.BoundAccount
+
+	// If set, we will use the production value for kvBatchSize.
+	forceProductionKVBatchSize bool
 }
 
 var _ kvBatchFetcher = &txnKVFetcher{}
@@ -92,6 +109,7 @@ func (f *txnKVFetcher) getBatchSizeForIdx(batchIdx int) int64 {
 	if !f.useBatchLimit {
 		return 0
 	}
+	kvBatchSize := getKVBatchSize(f.forceProductionKVBatchSize)
 	if f.firstBatchLimit == 0 || f.firstBatchLimit >= kvBatchSize {
 		return kvBatchSize
 	}
@@ -192,6 +210,7 @@ func makeKVBatchFetcher(
 	lockStrength descpb.ScanLockingStrength,
 	lockWaitPolicy descpb.ScanLockingWaitPolicy,
 	mon *mon.BytesMonitor,
+	forceProductionKVBatchSize bool,
 ) (txnKVFetcher, error) {
 	sendFn := func(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.BatchResponse, error) {
 		res, err := txn.Send(ctx, ba)
@@ -201,7 +220,8 @@ func makeKVBatchFetcher(
 		return res, nil
 	}
 	return makeKVBatchFetcherWithSendFunc(
-		sendFn, spans, reverse, useBatchLimit, firstBatchLimit, lockStrength, lockWaitPolicy, mon,
+		sendFn, spans, reverse, useBatchLimit, firstBatchLimit, lockStrength,
+		lockWaitPolicy, mon, forceProductionKVBatchSize,
 	)
 }
 
@@ -216,6 +236,7 @@ func makeKVBatchFetcherWithSendFunc(
 	lockStrength descpb.ScanLockingStrength,
 	lockWaitPolicy descpb.ScanLockingWaitPolicy,
 	mon *mon.BytesMonitor,
+	forceProductionKVBatchSize bool,
 ) (txnKVFetcher, error) {
 	if firstBatchLimit < 0 || (!useBatchLimit && firstBatchLimit != 0) {
 		return txnKVFetcher{}, errors.Errorf("invalid batch limit %d (useBatchLimit: %t)",
@@ -261,15 +282,16 @@ func makeKVBatchFetcherWithSendFunc(
 	}
 
 	return txnKVFetcher{
-		sendFn:          sendFn,
-		spans:           copySpans,
-		reverse:         reverse,
-		useBatchLimit:   useBatchLimit,
-		firstBatchLimit: firstBatchLimit,
-		lockStrength:    lockStrength,
-		lockWaitPolicy:  lockWaitPolicy,
-		mon:             mon,
-		acc:             mon.MakeBoundAccount(),
+		sendFn:                     sendFn,
+		spans:                      copySpans,
+		reverse:                    reverse,
+		useBatchLimit:              useBatchLimit,
+		firstBatchLimit:            firstBatchLimit,
+		lockStrength:               lockStrength,
+		lockWaitPolicy:             lockWaitPolicy,
+		mon:                        mon,
+		acc:                        mon.MakeBoundAccount(),
+		forceProductionKVBatchSize: forceProductionKVBatchSize,
 	}, nil
 }
 

--- a/pkg/sql/row/kv_fetcher.go
+++ b/pkg/sql/row/kv_fetcher.go
@@ -54,9 +54,11 @@ func NewKVFetcher(
 	lockStrength descpb.ScanLockingStrength,
 	lockWaitPolicy descpb.ScanLockingWaitPolicy,
 	mon *mon.BytesMonitor,
+	forceProductionKVBatchSize bool,
 ) (*KVFetcher, error) {
 	kvBatchFetcher, err := makeKVBatchFetcher(
-		txn, spans, reverse, useBatchLimit, firstBatchLimit, lockStrength, lockWaitPolicy, mon,
+		txn, spans, reverse, useBatchLimit, firstBatchLimit, lockStrength,
+		lockWaitPolicy, mon, forceProductionKVBatchSize,
 	)
 	return newKVFetcher(&kvBatchFetcher), err
 }

--- a/pkg/sql/rowexec/inverted_joiner.go
+++ b/pkg/sql/rowexec/inverted_joiner.go
@@ -437,7 +437,8 @@ func (ij *invertedJoiner) readInput() (invertedJoinerState, *execinfrapb.Produce
 	log.VEventf(ij.Ctx, 1, "scanning %d spans", len(indexSpans))
 	if err = ij.fetcher.StartScan(
 		ij.Ctx, ij.FlowCtx.Txn, indexSpans, false /* limitBatches */, 0, /* limitHint */
-		ij.FlowCtx.TraceKV); err != nil {
+		ij.FlowCtx.TraceKV, ij.EvalCtx.TestingKnobs.ForceProductionBatchSizes,
+	); err != nil {
 		ij.MoveToDraining(err)
 		return ijStateUnknown, ij.DrainHelper()
 	}

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -577,7 +577,8 @@ func (jr *joinReader) readInput() (
 	log.VEventf(jr.Ctx, 1, "scanning %d spans", len(spans))
 	if err := jr.fetcher.StartScan(
 		jr.Ctx, jr.FlowCtx.Txn, spans, jr.shouldLimitBatches, 0, /* limitHint */
-		jr.FlowCtx.TraceKV); err != nil {
+		jr.FlowCtx.TraceKV, jr.EvalCtx.TestingKnobs.ForceProductionBatchSizes,
+	); err != nil {
 		jr.MoveToDraining(err)
 		return jrStateUnknown, nil, jr.DrainHelper()
 	}

--- a/pkg/sql/rowexec/rowfetcher.go
+++ b/pkg/sql/rowexec/rowfetcher.go
@@ -32,7 +32,8 @@ import (
 // collector wrapper can be plugged in.
 type rowFetcher interface {
 	StartScan(
-		_ context.Context, _ *kv.Txn, _ roachpb.Spans, limitBatches bool, limitHint int64, traceKV bool,
+		_ context.Context, _ *kv.Txn, _ roachpb.Spans, limitBatches bool,
+		limitHint int64, traceKV bool, forceProductionKVBatchSize bool,
 	) error
 	StartInconsistentScan(
 		_ context.Context,
@@ -43,6 +44,7 @@ type rowFetcher interface {
 		limitBatches bool,
 		limitHint int64,
 		traceKV bool,
+		forceProductionKVBatchSize bool,
 	) error
 
 	NextRow(ctx context.Context) (

--- a/pkg/sql/rowexec/scrub_tablereader.go
+++ b/pkg/sql/rowexec/scrub_tablereader.go
@@ -219,8 +219,8 @@ func (tr *scrubTableReader) Start(ctx context.Context) context.Context {
 	log.VEventf(ctx, 1, "starting")
 
 	if err := tr.fetcher.StartScan(
-		ctx, tr.FlowCtx.Txn, tr.spans,
-		true /* limit batches */, tr.limitHint, tr.FlowCtx.TraceKV,
+		ctx, tr.FlowCtx.Txn, tr.spans, true /* limit batches */, tr.limitHint,
+		tr.FlowCtx.TraceKV, tr.EvalCtx.TestingKnobs.ForceProductionBatchSizes,
 	); err != nil {
 		tr.MoveToDraining(err)
 	}

--- a/pkg/sql/rowexec/stats.go
+++ b/pkg/sql/rowexec/stats.go
@@ -112,9 +112,10 @@ func (c *rowFetcherStatCollector) StartScan(
 	limitBatches bool,
 	limitHint int64,
 	traceKV bool,
+	forceProductionKVBatchSize bool,
 ) error {
 	start := timeutil.Now()
-	err := c.Fetcher.StartScan(ctx, txn, spans, limitBatches, limitHint, traceKV)
+	err := c.Fetcher.StartScan(ctx, txn, spans, limitBatches, limitHint, traceKV, forceProductionKVBatchSize)
 	c.startScanStallTime += timeutil.Since(start)
 	return err
 }
@@ -129,10 +130,11 @@ func (c *rowFetcherStatCollector) StartInconsistentScan(
 	limitBatches bool,
 	limitHint int64,
 	traceKV bool,
+	forceProductionKVBatchSize bool,
 ) error {
 	start := timeutil.Now()
 	err := c.Fetcher.StartInconsistentScan(
-		ctx, db, initialTimestamp, maxTimestampAge, spans, limitBatches, limitHint, traceKV,
+		ctx, db, initialTimestamp, maxTimestampAge, spans, limitBatches, limitHint, traceKV, forceProductionKVBatchSize,
 	)
 	c.startScanStallTime += timeutil.Since(start)
 	return err

--- a/pkg/sql/rowexec/tablereader.go
+++ b/pkg/sql/rowexec/tablereader.go
@@ -188,15 +188,16 @@ func (tr *tableReader) Start(ctx context.Context) context.Context {
 	var err error
 	if tr.maxTimestampAge == 0 {
 		err = tr.fetcher.StartScan(
-			ctx, tr.FlowCtx.Txn, tr.spans,
-			limitBatches, tr.limitHint, tr.FlowCtx.TraceKV,
+			ctx, tr.FlowCtx.Txn, tr.spans, limitBatches, tr.limitHint,
+			tr.FlowCtx.TraceKV,
+			tr.EvalCtx.TestingKnobs.ForceProductionBatchSizes,
 		)
 	} else {
 		initialTS := tr.FlowCtx.Txn.ReadTimestamp()
 		err = tr.fetcher.StartInconsistentScan(
-			ctx, tr.FlowCtx.Cfg.DB, initialTS,
-			tr.maxTimestampAge, tr.spans,
+			ctx, tr.FlowCtx.Cfg.DB, initialTS, tr.maxTimestampAge, tr.spans,
 			limitBatches, tr.limitHint, tr.FlowCtx.TraceKV,
+			tr.EvalCtx.TestingKnobs.ForceProductionBatchSizes,
 		)
 	}
 

--- a/pkg/sql/rowexec/zigzagjoiner.go
+++ b/pkg/sql/rowexec/zigzagjoiner.go
@@ -764,6 +764,7 @@ func (z *zigzagJoiner) nextRow(ctx context.Context, txn *kv.Txn) (rowenc.EncDatu
 			true, /* batch limit */
 			zigzagJoinerBatchSize,
 			z.FlowCtx.TraceKV,
+			z.EvalCtx.TestingKnobs.ForceProductionBatchSizes,
 		)
 		if err != nil {
 			return nil, err
@@ -908,6 +909,7 @@ func (z *zigzagJoiner) maybeFetchInitialRow() error {
 			true, /* batch limit */
 			zigzagJoinerBatchSize,
 			z.FlowCtx.TraceKV,
+			z.EvalCtx.TestingKnobs.ForceProductionBatchSizes,
 		)
 		if err != nil {
 			log.Errorf(z.Ctx, "scan error: %s", err)

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3223,6 +3223,9 @@ type EvalContextTestingKnobs struct {
 	// cost of each expression in the query tree for the purpose of creating
 	// alternate query plans in the optimizer.
 	OptimizerCostPerturbation float64
+	// If set, mutations.MaxBatchSize and row.getKVBatchSize will be overridden
+	// to use the non-test value.
+	ForceProductionBatchSizes bool
 
 	CallbackGenerators map[string]*CallbackValueGenerator
 }

--- a/pkg/sql/tablewriter_delete.go
+++ b/pkg/sql/tablewriter_delete.go
@@ -42,8 +42,8 @@ func (*tableDeleter) desc() string { return "deleter" }
 func (td *tableDeleter) walkExprs(_ func(desc string, index int, expr tree.TypedExpr)) {}
 
 // init is part of the tableWriter interface.
-func (td *tableDeleter) init(_ context.Context, txn *kv.Txn, _ *tree.EvalContext) error {
-	td.tableWriterBase.init(txn, td.tableDesc())
+func (td *tableDeleter) init(_ context.Context, txn *kv.Txn, evalCtx *tree.EvalContext) error {
+	td.tableWriterBase.init(txn, td.tableDesc(), evalCtx)
 	return nil
 }
 
@@ -145,7 +145,9 @@ func (td *tableDeleter) deleteAllRowsScan(
 	); err != nil {
 		return resume, err
 	}
-	if err := rf.StartScan(ctx, td.txn, roachpb.Spans{resume}, true /* limit batches */, 0, traceKV); err != nil {
+	if err := rf.StartScan(
+		ctx, td.txn, roachpb.Spans{resume}, true /* limit batches */, 0, traceKV, td.forceProductionBatchSizes,
+	); err != nil {
 		return resume, err
 	}
 
@@ -276,7 +278,9 @@ func (td *tableDeleter) deleteIndexScan(
 	); err != nil {
 		return resume, err
 	}
-	if err := rf.StartScan(ctx, td.txn, roachpb.Spans{resume}, true /* limit batches */, 0, traceKV); err != nil {
+	if err := rf.StartScan(
+		ctx, td.txn, roachpb.Spans{resume}, true /* limit batches */, 0, traceKV, td.forceProductionBatchSizes,
+	); err != nil {
 		return resume, err
 	}
 

--- a/pkg/sql/tablewriter_insert.go
+++ b/pkg/sql/tablewriter_insert.go
@@ -31,8 +31,8 @@ var _ tableWriter = &tableInserter{}
 func (*tableInserter) desc() string { return "inserter" }
 
 // init is part of the tableWriter interface.
-func (ti *tableInserter) init(_ context.Context, txn *kv.Txn, _ *tree.EvalContext) error {
-	ti.tableWriterBase.init(txn, ti.tableDesc())
+func (ti *tableInserter) init(_ context.Context, txn *kv.Txn, evalCtx *tree.EvalContext) error {
+	ti.tableWriterBase.init(txn, ti.tableDesc(), evalCtx)
 	return nil
 }
 

--- a/pkg/sql/tablewriter_update.go
+++ b/pkg/sql/tablewriter_update.go
@@ -31,8 +31,8 @@ var _ tableWriter = &tableUpdater{}
 func (*tableUpdater) desc() string { return "updater" }
 
 // init is part of the tableWriter interface.
-func (tu *tableUpdater) init(_ context.Context, txn *kv.Txn, _ *tree.EvalContext) error {
-	tu.tableWriterBase.init(txn, tu.tableDesc())
+func (tu *tableUpdater) init(_ context.Context, txn *kv.Txn, evalCtx *tree.EvalContext) error {
+	tu.tableWriterBase.init(txn, tu.tableDesc(), evalCtx)
 	return nil
 }
 

--- a/pkg/sql/tablewriter_upsert_opt.go
+++ b/pkg/sql/tablewriter_upsert_opt.go
@@ -99,7 +99,7 @@ var _ tableWriter = &optTableUpserter{}
 func (tu *optTableUpserter) init(
 	ctx context.Context, txn *kv.Txn, evalCtx *tree.EvalContext,
 ) error {
-	tu.tableWriterBase.init(txn, tu.ri.Helper.TableDesc)
+	tu.tableWriterBase.init(txn, tu.ri.Helper.TableDesc, evalCtx)
 
 	// rowsNeeded, set upon initialization, indicates whether or not we want
 	// rows returned from the operation.

--- a/pkg/sql/upsert_test.go
+++ b/pkg/sql/upsert_test.go
@@ -34,7 +34,7 @@ func TestUpsertFastPath(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	if mutations.MaxBatchSize() == 1 {
+	if mutations.MaxBatchSize(false /* forceProductionMaxBatchSize */) == 1 {
 		// The fast path requires that the max batch size is at least 2, so
 		// we'll skip the test.
 		skip.UnderMetamorphic(t)


### PR DESCRIPTION
This commit refactors how non-metamorphic logic tests are handled.
Previously, if a logic test file had `!metamorphic` directive, then they
would be skipped when the build happened to be metamorphic (which occurs
in 80% of the time). However, this led to multiple flakes when PRs were
merged with green CI, but they didn't update the corresponding tests
(this happened because those tests were skipped).

Looking over all of those issues, we see that they are due to a couple
of randomizations - of `mutations.MaxBatchSize` and `row.kvBatchSize`,
so this commit adds a testing knob to override both of them. Now, for
every config and for every logic test file path we remember whether
non-metamorphic directive was specified and possibly disable the
randomizations of `mutations.MaxBatchSize` and `row.kvBatchSize`. This
required a bit of plumbing, but it looks acceptable.

Fixes: #59186.

Release note: None