### PR TITLE
storage: fixed URL path issue for http_storage.go

### DIFF
--- a/pkg/storage/cloudimpl/http_storage.go
+++ b/pkg/storage/cloudimpl/http_storage.go
@@ -20,7 +20,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
-	"path/filepath"
+	"path"
 	"strconv"
 	"strings"
 	"time"
@@ -350,7 +350,7 @@ func (h *httpStorage) req(
 		}
 		dest.Host = h.hosts[int(hash.Sum32())%hosts]
 	}
-	dest.Path = filepath.Join(dest.Path, file)
+	dest.Path = path.Join(dest.Path, file)
 	url := dest.String()
 	req, err := http.NewRequest(method, url, body)
 


### PR DESCRIPTION
Resolves: #59096 

`http_storage.go` should use `path` instead of `filepath` to concatenate path for URL.

Release note (bug fix): fixed a bug in URL handling of HTTP external storage paths on Windows