### PR TITLE
build,bazel: fix bazel build w/ broken dependencies

### DIFF
--- a/pkg/jobs/jobspb/BUILD.bazel
+++ b/pkg/jobs/jobspb/BUILD.bazel
@@ -40,6 +40,7 @@ go_proto_library(
     proto = ":jobspb_proto",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/ccl/streamingccl",  # keep
         "//pkg/ccl/streamingccl/streamclient",  # keep
         "//pkg/roachpb",
         "//pkg/security",  # keep

--- a/pkg/sql/execinfrapb/BUILD.bazel
+++ b/pkg/sql/execinfrapb/BUILD.bazel
@@ -141,6 +141,7 @@ go_proto_library(
     proto = ":execinfrapb_proto",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/ccl/streamingccl",  # keep
         "//pkg/jobs/jobspb",
         "//pkg/roachpb",
         "//pkg/sql/catalog/descpb",


### PR DESCRIPTION
Gazelle can't automatically track these imports and insert the right
dependencies, so we insert them manually.

Release note: None