### PR TITLE
sql,gcjob: set RunningStatus when GC job performs

### DIFF
--- a/pkg/sql/gcjob/gc_job.go
+++ b/pkg/sql/gcjob/gc_job.go
@@ -149,11 +149,16 @@ func (r schemaChangeGCResumer) Resume(ctx context.Context, execCtx interface{}) 
 
 		if expired {
 			// Some elements have been marked as DELETING so save the progress.
-			persistProgress(ctx, execCfg, r.jobID, progress)
+			persistProgress(ctx, execCfg, r.jobID, progress, runningStatusGC(progress))
+			if fn := execCfg.GCJobTestingKnobs.RunBeforePerformGC; fn != nil {
+				if err := fn(r.jobID); err != nil {
+					return err
+				}
+			}
 			if err := performGC(ctx, execCfg, details, progress); err != nil {
 				return err
 			}
-			persistProgress(ctx, execCfg, r.jobID, progress)
+			persistProgress(ctx, execCfg, r.jobID, progress, sql.RunningStatusWaitingGC)
 
 			// Trigger immediate re-run in case of more expired elements.
 			timerDuration = 0

--- a/pkg/sql/gcjob/refresh_statuses.go
+++ b/pkg/sql/gcjob/refresh_statuses.go
@@ -64,7 +64,7 @@ func refreshTables(
 	}
 
 	if expired || haveAnyMissing {
-		persistProgress(ctx, execCfg, jobID, progress)
+		persistProgress(ctx, execCfg, jobID, progress, sql.RunningStatusWaitingGC)
 	}
 
 	return expired, earliestDeadline

--- a/pkg/sql/gcjob_test/gc_job_test.go
+++ b/pkg/sql/gcjob_test/gc_job_test.go
@@ -62,7 +62,15 @@ func TestSchemaChangeGCJob(t *testing.T) {
 
 	for _, dropItem := range []DropItem{INDEX, TABLE, DATABASE} {
 		for _, ttlTime := range []TTLTime{PAST, SOON, FUTURE} {
-			s, db, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
+			params := base.TestServerArgs{}
+			blockGC := make(chan struct{}, 1)
+			params.Knobs.GCJob = &sql.GCJobTestingKnobs{
+				RunBeforePerformGC: func(_ int64) error {
+					<-blockGC
+					return nil
+				},
+			}
+			s, db, kvDB := serverutils.StartServer(t, params)
 			ctx := context.Background()
 			defer s.Stopper().Stop(ctx)
 			sqlDB := sqlutils.MakeSQLRunner(db)
@@ -107,6 +115,7 @@ func TestSchemaChangeGCJob(t *testing.T) {
 				dropTime = 1
 			}
 			var details jobspb.SchemaChangeGCDetails
+			var expectedRunningStatus string
 			switch dropItem {
 			case INDEX:
 				details = jobspb.SchemaChangeGCDetails{
@@ -122,6 +131,7 @@ func TestSchemaChangeGCJob(t *testing.T) {
 				myTableDesc.GCMutations = append(myTableDesc.GCMutations, descpb.TableDescriptor_GCDescriptorMutation{
 					IndexID: descpb.IndexID(2),
 				})
+				expectedRunningStatus = "performing garbage collection on index 2"
 			case TABLE:
 				details = jobspb.SchemaChangeGCDetails{
 					Tables: []jobspb.SchemaChangeGCDetails_DroppedID{
@@ -133,6 +143,7 @@ func TestSchemaChangeGCJob(t *testing.T) {
 				}
 				myTableDesc.State = descpb.DescriptorState_DROP
 				myTableDesc.DropTime = dropTime
+				expectedRunningStatus = fmt.Sprintf("performing garbage collection on table %d", myTableID)
 			case DATABASE:
 				details = jobspb.SchemaChangeGCDetails{
 					Tables: []jobspb.SchemaChangeGCDetails_DroppedID{
@@ -151,6 +162,7 @@ func TestSchemaChangeGCJob(t *testing.T) {
 				myTableDesc.DropTime = dropTime
 				myOtherTableDesc.State = descpb.DescriptorState_DROP
 				myOtherTableDesc.DropTime = dropTime
+				expectedRunningStatus = fmt.Sprintf("performing garbage collection on tables %d, %d", myTableID, myOtherTableID)
 			}
 
 			if err := kvDB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
@@ -195,6 +207,15 @@ func TestSchemaChangeGCJob(t *testing.T) {
 			if err := jobutils.VerifyRunningSystemJob(t, sqlDB, 0, jobspb.TypeSchemaChangeGC, sql.RunningStatusWaitingGC, lookupJR); err != nil {
 				t.Fatal(err)
 			}
+
+			if ttlTime != FUTURE {
+				// Check that the job eventually blocks right before performing GC, due to the testing knob.
+				sqlDB.CheckQueryResultsRetry(
+					t,
+					fmt.Sprintf("SELECT status, running_status FROM [SHOW JOBS] WHERE job_id = %s", jobIDStr),
+					[][]string{{"running", expectedRunningStatus}})
+			}
+			blockGC <- struct{}{}
 
 			if ttlTime == FUTURE {
 				time.Sleep(500 * time.Millisecond)

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -2009,7 +2009,8 @@ func CreateGCJobRecord(
 // Note that this is defined here for testing purposes to avoid cyclic
 // dependencies.
 type GCJobTestingKnobs struct {
-	RunBeforeResume func(jobID int64) error
+	RunBeforeResume    func(jobID int64) error
+	RunBeforePerformGC func(jobID int64) error
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.


### PR DESCRIPTION
Previously, the RunningStatus of a GC job was always set to "waiting for
GC TTL". This patch sets it to a more meaningful value when the GC job
is actually performing garbage collection.

Release note (sql change): SHOW JOBS now displays a meaningful value
in the running_status column for GC jobs which are actually performing
garbage collection, as opposed to waiting on a timer.