### PR TITLE
sql: correctly handle CREATE INDEX on REGIONAL BY ROW tables

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
@@ -327,3 +327,73 @@ t_partition_by_c_idx  c             false
 t_partition_by_c_idx  partition_by  false
 t_pk_key              partition_by  true
 t_pk_key              pk            false
+
+statement ok
+DROP TABLE t
+
+# Tests for PARTITION ALL BY RANGE
+statement ok
+CREATE TABLE public.t (
+  pk int PRIMARY KEY,
+  pk2 int NOT NULL,
+  partition_by int,
+  a int,
+  b int,
+  c int,
+  d int,
+  INDEX (a),
+  UNIQUE (b),
+  INDEX (partition_by, c),
+  FAMILY (pk, pk2, partition_by, a, b, c, d)
+) PARTITION ALL BY RANGE (partition_by) (
+  PARTITION one VALUES FROM (minvalue) TO (2),
+  PARTITION two VALUES FROM (2) TO (maxvalue)
+)
+
+statement error cannot define PARTITION BY on an index if the table has a PARTITION ALL BY definition
+CREATE INDEX created_idx ON t(c) PARTITION BY LIST (d) (
+  PARTITION one VALUES IN ((1))
+)
+
+statement ok
+CREATE INDEX created_idx ON t(c)
+
+query TTB colnames
+SELECT index_name, column_name, implicit FROM crdb_internal.index_columns
+WHERE descriptor_name = 't' AND column_type = 'key'
+ORDER BY 1, 2
+----
+index_name            column_name   implicit
+created_idx           c             false
+created_idx           partition_by  true
+primary               partition_by  true
+primary               pk            false
+t_a_idx               a             false
+t_a_idx               partition_by  true
+t_b_key               b             false
+t_b_key               partition_by  true
+t_partition_by_c_idx  c             false
+t_partition_by_c_idx  partition_by  false
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE t]
+----
+CREATE TABLE public.t (
+  pk INT8 NOT NULL,
+  pk2 INT8 NOT NULL,
+  partition_by INT8 NULL,
+  a INT8 NULL,
+  b INT8 NULL,
+  c INT8 NULL,
+  d INT8 NULL,
+  CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+  INDEX t_a_idx (a ASC),
+  UNIQUE INDEX t_b_key (b ASC),
+  INDEX t_partition_by_c_idx (partition_by ASC, c ASC),
+  INDEX created_idx (c ASC),
+  FAMILY fam_0_pk_pk2_partition_by_a_b_c_d (pk, pk2, partition_by, a, b, c, d)
+) PARTITION ALL BY RANGE (partition_by) (
+  PARTITION one VALUES FROM (MINVALUE) TO (2),
+  PARTITION two VALUES FROM (2) TO (MAXVALUE)
+)
+-- Warning: Partitioned table with no zone configurations.

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
@@ -82,7 +82,7 @@ CREATE TABLE regional_by_row_table (
 
 # TODO(#multiregion): determine how we should display the presence of a crdb_region column
 # to the user.
-# TODO(#multiregion): ensure this CREATE TABLE statement round trips.
+# TODO(#59362): ensure this CREATE TABLE statement round trips.
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE regional_by_row_table]
 ----
@@ -199,6 +199,90 @@ ca-central-1    10  11  12
 us-east-1       20  21  22
 ap-southeast-2  23  24  25
 
+# Tests creating a index on a REGIONAL BY ROW table.
+statement ok
+CREATE INDEX new_idx ON regional_by_row_table(a, b)
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE regional_by_row_table]
+----
+CREATE TABLE public.regional_by_row_table (
+  pk INT8 NOT NULL,
+  a INT8 NULL,
+  b INT8 NULL,
+  crdb_region public.crdb_internal_region NOT NULL DEFAULT gateway_region()::public.crdb_internal_region,
+  CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+  INDEX regional_by_row_table_a_idx (a ASC),
+  UNIQUE INDEX regional_by_row_table_b_key (b ASC),
+  INDEX new_idx (a ASC, b ASC),
+  FAMILY fam_0_pk_a_b_crdb_region (pk, a, b, crdb_region)
+) LOCALITY REGIONAL BY ROW;
+ALTER PARTITION "ap-southeast-2" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
+  num_replicas = 3,
+  constraints = '{+region=ap-southeast-2: 1}',
+  lease_preferences = '[[+region=ap-southeast-2]]';
+ALTER PARTITION "ap-southeast-2" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
+  num_replicas = 3,
+  constraints = '{+region=ap-southeast-2: 1}',
+  lease_preferences = '[[+region=ap-southeast-2]]';
+ALTER PARTITION "ap-southeast-2" OF INDEX multi_region_test_db.public.regional_by_row_table@primary CONFIGURE ZONE USING
+  num_replicas = 3,
+  constraints = '{+region=ap-southeast-2: 1}',
+  lease_preferences = '[[+region=ap-southeast-2]]';
+ALTER PARTITION "ca-central-1" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
+  num_replicas = 3,
+  constraints = '{+region=ca-central-1: 1}',
+  lease_preferences = '[[+region=ca-central-1]]';
+ALTER PARTITION "ca-central-1" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
+  num_replicas = 3,
+  constraints = '{+region=ca-central-1: 1}',
+  lease_preferences = '[[+region=ca-central-1]]';
+ALTER PARTITION "ca-central-1" OF INDEX multi_region_test_db.public.regional_by_row_table@primary CONFIGURE ZONE USING
+  num_replicas = 3,
+  constraints = '{+region=ca-central-1: 1}',
+  lease_preferences = '[[+region=ca-central-1]]';
+ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
+  num_replicas = 3,
+  constraints = '{+region=us-east-1: 1}',
+  lease_preferences = '[[+region=us-east-1]]';
+ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
+  num_replicas = 3,
+  constraints = '{+region=us-east-1: 1}',
+  lease_preferences = '[[+region=us-east-1]]';
+ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row_table@primary CONFIGURE ZONE USING
+  num_replicas = 3,
+  constraints = '{+region=us-east-1: 1}',
+  lease_preferences = '[[+region=us-east-1]]';
+ALTER PARTITION "ap-southeast-2" OF INDEX multi_region_test_db.public.regional_by_row_table@new_idx CONFIGURE ZONE USING
+  num_replicas = 3,
+  constraints = '{+region=ap-southeast-2: 1}',
+  lease_preferences = '[[+region=ap-southeast-2]]';
+ALTER PARTITION "ca-central-1" OF INDEX multi_region_test_db.public.regional_by_row_table@new_idx CONFIGURE ZONE USING
+  num_replicas = 3,
+  constraints = '{+region=ca-central-1: 1}',
+  lease_preferences = '[[+region=ca-central-1]]';
+ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row_table@new_idx CONFIGURE ZONE USING
+  num_replicas = 3,
+  constraints = '{+region=us-east-1: 1}',
+  lease_preferences = '[[+region=us-east-1]]'
+
+query TTB colnames
+SELECT index_name, column_name, implicit FROM crdb_internal.index_columns
+WHERE descriptor_name = 'regional_by_row_table' AND column_type = 'key'
+ORDER BY 1, 2
+----
+index_name                   column_name  implicit
+new_idx                      a            false
+new_idx                      b            false
+new_idx                      crdb_region  true
+primary                      crdb_region  true
+primary                      pk           false
+regional_by_row_table_a_idx  a            false
+regional_by_row_table_a_idx  crdb_region  true
+regional_by_row_table_b_key  b            false
+regional_by_row_table_b_key  crdb_region  true
+
+# Tests for REGIONAL BY TABLE AS
 statement error  cannot use column crdb_region_col which has type INT8 in REGIONAL BY ROW AS\nDETAIL:\s+REGIONAL BY ROW AS must reference a column of type crdb_internal_region.
 CREATE TABLE regional_by_row_table_as (
   pk int PRIMARY KEY,
@@ -284,13 +368,14 @@ us-east-1       1
 us-east-1       10
 ap-southeast-2  20
 
-# Create some tables to validate that their zone configurations are adjusted appropriately.
+# Tests for altering the survivability of a REGIONAL BY ROW table.
 statement ok
 CREATE DATABASE alter_survive_db PRIMARY REGION "us-east-1" REGIONS "ca-central-1", "ap-southeast-2" SURVIVE REGION FAILURE
 
 statement ok
 USE alter_survive_db
 
+# Create some tables to validate that their zone configurations are adjusted appropriately.
 statement ok
 CREATE TABLE t_regional_by_row () LOCALITY REGIONAL BY ROW
 

--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -427,48 +427,14 @@ func (n *createIndexNode) startExec(params runParams) error {
 	}
 	indexDesc.Version = encodingVersion
 
-	if n.n.PartitionByIndex.ContainsPartitioningClause() || n.tableDesc.IsPartitionAllBy() {
-		var partitionBy *tree.PartitionBy
-		if !n.tableDesc.IsPartitionAllBy() {
-			if n.n.PartitionByIndex.ContainsPartitions() {
-				partitionBy = n.n.PartitionByIndex.PartitionBy
-			}
-		} else if n.n.PartitionByIndex.ContainsPartitioningClause() {
-			return pgerror.New(
-				pgcode.FeatureNotSupported,
-				"cannot define PARTITION BY on an index if the table has a PARTITION ALL BY definition",
-			)
-		} else {
-			partitionBy, err = partitionByFromTableDesc(params.p.ExecCfg().Codec, n.tableDesc)
-			if err != nil {
-				return err
-			}
-		}
-		if partitionBy != nil {
-			newIndexDesc, numImplicitColumns, err := detectImplicitPartitionColumns(
-				params.p.EvalContext(),
-				n.tableDesc,
-				*indexDesc,
-				partitionBy,
-			)
-			if err != nil {
-				return err
-			}
-			indexDesc = &newIndexDesc
-			partitioning, err := CreatePartitioning(
-				params.ctx,
-				params.p.ExecCfg().Settings,
-				params.EvalContext(),
-				n.tableDesc,
-				indexDesc,
-				numImplicitColumns,
-				partitionBy,
-			)
-			if err != nil {
-				return err
-			}
-			indexDesc.Partitioning = partitioning
-		}
+	*indexDesc, err = params.p.configureIndexDescForNewIndexPartitioning(
+		params.ctx,
+		n.tableDesc,
+		*indexDesc,
+		n.n.PartitionByIndex,
+	)
+	if err != nil {
+		return err
 	}
 
 	mutationIdx := len(n.tableDesc.Mutations)
@@ -478,6 +444,14 @@ func (n *createIndexNode) startExec(params runParams) error {
 	if err := n.tableDesc.AllocateIDs(params.ctx); err != nil {
 		return err
 	}
+	if err := params.p.configureZoneConfigForNewIndexPartitioning(
+		params.ctx,
+		n.tableDesc,
+		*indexDesc,
+	); err != nil {
+		return err
+	}
+
 	// The index name may have changed as a result of
 	// AllocateIDs(). Retrieve it for the event log below.
 	index := n.tableDesc.Mutations[mutationIdx].GetIndex()
@@ -519,3 +493,89 @@ func (n *createIndexNode) startExec(params runParams) error {
 func (*createIndexNode) Next(runParams) (bool, error) { return false, nil }
 func (*createIndexNode) Values() tree.Datums          { return tree.Datums{} }
 func (*createIndexNode) Close(context.Context)        {}
+
+// configureIndexDescForNewIndexPartitioning returns a new copy of an index descriptor
+// containing modifications needed if partitioning is configured.
+func (p *planner) configureIndexDescForNewIndexPartitioning(
+	ctx context.Context,
+	tableDesc *tabledesc.Mutable,
+	indexDesc descpb.IndexDescriptor,
+	partitionByIndex *tree.PartitionByIndex,
+) (descpb.IndexDescriptor, error) {
+	var err error
+	if partitionByIndex.ContainsPartitioningClause() || tableDesc.IsPartitionAllBy() {
+		var partitionBy *tree.PartitionBy
+		if !tableDesc.IsPartitionAllBy() {
+			if partitionByIndex.ContainsPartitions() {
+				partitionBy = partitionByIndex.PartitionBy
+			}
+		} else if partitionByIndex.ContainsPartitioningClause() {
+			return indexDesc, pgerror.New(
+				pgcode.FeatureNotSupported,
+				"cannot define PARTITION BY on an index if the table has a PARTITION ALL BY definition",
+			)
+		} else {
+			partitionBy, err = partitionByFromTableDesc(p.ExecCfg().Codec, tableDesc)
+			if err != nil {
+				return indexDesc, err
+			}
+		}
+
+		if partitionBy != nil {
+			var numImplicitColumns int
+			indexDesc, numImplicitColumns, err = detectImplicitPartitionColumns(
+				p.EvalContext(),
+				tableDesc,
+				indexDesc,
+				partitionBy,
+			)
+			if err != nil {
+				return indexDesc, err
+			}
+			if indexDesc.Partitioning, err = CreatePartitioning(
+				ctx,
+				p.ExecCfg().Settings,
+				p.EvalContext(),
+				tableDesc,
+				&indexDesc,
+				numImplicitColumns,
+				partitionBy,
+			); err != nil {
+				return indexDesc, err
+			}
+		}
+	}
+	return indexDesc, nil
+}
+
+// configureZoneConfigForNewIndexPartitioning configures the zone config for any new index
+// in a REGIONAL BY ROW table.
+// This *must* be done after the index ID has been allocated.
+func (p *planner) configureZoneConfigForNewIndexPartitioning(
+	ctx context.Context, tableDesc *tabledesc.Mutable, indexDesc descpb.IndexDescriptor,
+) error {
+	if indexDesc.ID == 0 {
+		return errors.AssertionFailedf("index %s does not have id", indexDesc.Name)
+	}
+	// For REGIONAL BY ROW tables, correctly configure relevant zone configurations.
+	if tableDesc.LocalityConfig != nil && tableDesc.LocalityConfig.GetRegionalByRow() != nil {
+		dbDesc, err := p.Descriptors().GetImmutableDatabaseByID(
+			ctx,
+			p.txn,
+			tableDesc.ParentID,
+			tree.DatabaseLookupFlags{},
+		)
+		if err != nil {
+			return err
+		}
+		if err := p.addNewZoneConfigSubzonesForIndex(
+			ctx,
+			tableDesc,
+			indexDesc.ID,
+			*dbDesc.RegionConfig,
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/sql/partition.go
+++ b/pkg/sql/partition.go
@@ -11,11 +11,9 @@
 package sql
 
 import (
-	"fmt"
-
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
-	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/errors"
@@ -25,27 +23,133 @@ import (
 func partitionByFromTableDesc(
 	codec keys.SQLCodec, tableDesc *tabledesc.Mutable,
 ) (*tree.PartitionBy, error) {
-	// Convert the PartitioningDescriptor back into tree.PartitionBy by
-	// re-parsing the SHOW CREATE partitioning statement.
-	// TODO(#multiregion): clean this up by translating the descriptor back into
-	// tree.PartitionBy directly.
+	idxDesc := tableDesc.GetPrimaryIndex().IndexDesc()
+	partDesc := idxDesc.Partitioning
+	return partitionByFromTableDescImpl(codec, tableDesc, idxDesc, &partDesc, 0)
+}
+
+// partitionByFromTableDescImpl contains the inner logic of partitionByFromTableDesc.
+// We derive the Fields, LIST and RANGE clauses from the table descriptor, recursing
+// into the subpartitions as required for LIST partitions.
+func partitionByFromTableDescImpl(
+	codec keys.SQLCodec,
+	tableDesc *tabledesc.Mutable,
+	idxDesc *descpb.IndexDescriptor,
+	partDesc *descpb.PartitioningDescriptor,
+	colOffset int,
+) (*tree.PartitionBy, error) {
+	if partDesc.NumColumns == 0 {
+		return nil, nil
+	}
+
+	// We don't need real prefixes in the DecodePartitionTuple calls because we
+	// only use the tree.Datums part of the output.
+	fakePrefixDatums := make([]tree.Datum, colOffset)
+	for i := range fakePrefixDatums {
+		fakePrefixDatums[i] = tree.DNull
+	}
+
+	partitionBy := &tree.PartitionBy{
+		Fields: make(tree.NameList, partDesc.NumColumns),
+		List:   make([]tree.ListPartition, len(partDesc.List)),
+		Range:  make([]tree.RangePartition, len(partDesc.Range)),
+	}
+	for i := 0; i < int(partDesc.NumColumns); i++ {
+		partitionBy.Fields[i] = tree.Name(idxDesc.ColumnNames[colOffset+i])
+	}
+
+	// Copy the LIST of the PARTITION BY clause.
 	a := &rowenc.DatumAlloc{}
-	f := tree.NewFmtCtx(tree.FmtSimple)
-	if err := ShowCreatePartitioning(
-		a,
-		codec,
-		tableDesc,
-		tableDesc.GetPrimaryIndex().IndexDesc(),
-		&tableDesc.GetPrimaryIndex().IndexDesc().Partitioning,
-		&f.Buffer,
-		0, /* indent */
-		0, /* colOffset */
-	); err != nil {
-		return nil, errors.Wrap(err, "error recreating PARTITION BY clause for PARTITION ALL BY affected index")
+	for i := range partDesc.List {
+		part := &partDesc.List[i]
+		partitionBy.List[i].Name = tree.UnrestrictedName(part.Name)
+		partitionBy.List[i].Exprs = make(tree.Exprs, len(part.Values))
+		for j, values := range part.Values {
+			tuple, _, err := rowenc.DecodePartitionTuple(
+				a,
+				codec,
+				tableDesc,
+				idxDesc,
+				partDesc,
+				values,
+				fakePrefixDatums,
+			)
+			if err != nil {
+				return nil, err
+			}
+			exprs, err := partitionTupleToExprs(tuple)
+			if err != nil {
+				return nil, err
+			}
+			partitionBy.List[i].Exprs[j] = &tree.Tuple{
+				Exprs: exprs,
+			}
+		}
+		var err error
+		if partitionBy.List[i].Subpartition, err = partitionByFromTableDescImpl(
+			codec,
+			tableDesc,
+			idxDesc,
+			&part.Subpartitioning,
+			colOffset+int(partDesc.NumColumns),
+		); err != nil {
+			return nil, err
+		}
 	}
-	stmt, err := parser.ParseOne(fmt.Sprintf("ALTER TABLE t %s", f.CloseAndGetString()))
-	if err != nil {
-		return nil, errors.Wrap(err, "error recreating PARTITION BY clause for PARTITION ALL BY affected index")
+
+	// Copy the RANGE of the PARTITION BY clause.
+	for i, part := range partDesc.Range {
+		partitionBy.Range[i].Name = tree.UnrestrictedName(part.Name)
+		fromTuple, _, err := rowenc.DecodePartitionTuple(
+			a,
+			codec,
+			tableDesc,
+			idxDesc,
+			partDesc,
+			part.FromInclusive,
+			fakePrefixDatums,
+		)
+		if err != nil {
+			return nil, err
+		}
+		if partitionBy.Range[i].From, err = partitionTupleToExprs(fromTuple); err != nil {
+			return nil, err
+		}
+		toTuple, _, err := rowenc.DecodePartitionTuple(
+			a,
+			codec,
+			tableDesc,
+			idxDesc,
+			partDesc,
+			part.ToExclusive,
+			fakePrefixDatums,
+		)
+		if err != nil {
+			return nil, err
+		}
+		if partitionBy.Range[i].To, err = partitionTupleToExprs(toTuple); err != nil {
+			return nil, err
+		}
 	}
-	return stmt.AST.(*tree.AlterTable).Cmds[0].(*tree.AlterTablePartitionByTable).PartitionByTable.PartitionBy, nil
+	return partitionBy, nil
+}
+
+func partitionTupleToExprs(t *rowenc.PartitionTuple) (tree.Exprs, error) {
+	exprs := make(tree.Exprs, len(t.Datums)+t.SpecialCount)
+	for i, d := range t.Datums {
+		exprs[i] = d
+	}
+	for i := 0; i < t.SpecialCount; i++ {
+		switch t.Special {
+		case rowenc.PartitionDefaultVal:
+			exprs[i+len(t.Datums)] = &tree.DefaultVal{}
+		case rowenc.PartitionMinVal:
+			exprs[i+len(t.Datums)] = &tree.PartitionMinVal{}
+		case rowenc.PartitionMaxVal:
+			exprs[i+len(t.Datums)] = &tree.PartitionMaxVal{}
+		default:
+			return nil, errors.AssertionFailedf("unknown special value found: %v", t.Special)
+		}
+	}
+	return exprs, nil
 }

--- a/pkg/sql/region_util.go
+++ b/pkg/sql/region_util.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/dbdesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
@@ -126,8 +127,8 @@ func zoneConfigFromRegionConfigForDatabase(
 func zoneConfigFromRegionConfigForPartition(
 	partitionRegion descpb.DatabaseDescriptor_RegionConfig_Region,
 	regionConfig descpb.DatabaseDescriptor_RegionConfig,
-) (*zonepb.ZoneConfig, error) {
-	zc := &zonepb.ZoneConfig{
+) (zonepb.ZoneConfig, error) {
+	zc := zonepb.ZoneConfig{
 		NumReplicas: proto.Int32(zoneConfigNumReplicasFromRegionConfig(regionConfig)),
 		LeasePreferences: []zonepb.LeasePreference{
 			{Constraints: []zonepb.Constraint{makeRequiredZoneConstraintForRegion(partitionRegion.Name)}},
@@ -138,7 +139,7 @@ func zoneConfigFromRegionConfigForPartition(
 		partitionRegion.Name,
 		regionConfig,
 	); err != nil {
-		return nil, err
+		return zc, err
 	}
 	return zc, err
 }
@@ -222,6 +223,12 @@ func zoneConfigFromTableLocalityConfig(
 	return &ret, nil
 }
 
+// TODO(#multiregion): everything using this should instead use getZoneConfigRaw
+// and writeZoneConfig instead of calling SQL for each query.
+// This removes the requirement to only call this function after writeSchemaChange
+// is called on creation of tables, and potentially removes the need for ReadingOwnWrites
+// for some subcommands.
+// Requires some logic to "inherit" from parents.
 func (p *planner) applyZoneConfigForMultiRegion(
 	ctx context.Context, zs tree.ZoneSpecifier, zc *zonepb.ZoneConfig, desc string,
 ) error {
@@ -283,7 +290,7 @@ func (p *planner) applyZoneConfigFromTableLocalityConfig(
 						},
 						Partition: tree.Name(region.Name),
 					},
-					zc,
+					&zc,
 					"index-multiregion-set-zone-config",
 				); err != nil {
 					return err
@@ -299,7 +306,7 @@ func (p *planner) applyZoneConfigFromTableLocalityConfig(
 					},
 					Partition: tree.Name(region.Name),
 				},
-				zc,
+				&zc,
 				"primary-index-multiregion-set-zone-config",
 			); err != nil {
 				return err
@@ -325,6 +332,50 @@ func (p *planner) applyZoneConfigFromTableLocalityConfig(
 		localityZoneConfig,
 		"table-multiregion-set-zone-config",
 	)
+}
+
+// addNewZoneConfigSubzonesForIndex updates the ZoneConfig for the given index,
+// assuming a zone config already exists for the given table and that the index
+// has previously not had a subzone defined.
+func (p *planner) addNewZoneConfigSubzonesForIndex(
+	ctx context.Context,
+	table catalog.TableDescriptor,
+	indexID descpb.IndexID,
+	regionConfig descpb.DatabaseDescriptor_RegionConfig,
+) error {
+	tableID := table.GetID()
+	zone, err := getZoneConfigRaw(ctx, p.txn, p.ExecCfg().Codec, tableID)
+	if err != nil {
+		return err
+	}
+	if zone == nil {
+		return errors.AssertionFailedf("expected zone config for table %d", tableID)
+	}
+	for _, region := range regionConfig.Regions {
+		zc, err := zoneConfigFromRegionConfigForPartition(region, regionConfig)
+		if err != nil {
+			return err
+		}
+		zone.SetSubzone(zonepb.Subzone{
+			IndexID:       uint32(indexID),
+			PartitionName: string(region.Name),
+			Config:        zc,
+		})
+	}
+
+	if _, err = writeZoneConfig(
+		ctx,
+		p.txn,
+		tableID,
+		table,
+		zone,
+		p.ExecCfg(),
+		true, /* hasNewSubzones */
+	); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (p *planner) applyZoneConfigFromDatabaseRegionConfig(

--- a/pkg/sql/region_util_test.go
+++ b/pkg/sql/region_util_test.go
@@ -388,7 +388,7 @@ func TestZoneConfigFromRegionConfigForPartition(t *testing.T) {
 		desc         string
 		region       descpb.DatabaseDescriptor_RegionConfig_Region
 		regionConfig descpb.DatabaseDescriptor_RegionConfig
-		expected     *zonepb.ZoneConfig
+		expected     zonepb.ZoneConfig
 	}{
 		{
 			desc: "4-region table with zone survivability",
@@ -405,7 +405,7 @@ func TestZoneConfigFromRegionConfigForPartition(t *testing.T) {
 				PrimaryRegion: "region_b",
 				SurvivalGoal:  descpb.SurvivalGoal_ZONE_FAILURE,
 			},
-			expected: &zonepb.ZoneConfig{
+			expected: zonepb.ZoneConfig{
 				NumReplicas: proto.Int32(4),
 				Constraints: []zonepb.ConstraintsConjunction{
 					{
@@ -434,7 +434,7 @@ func TestZoneConfigFromRegionConfigForPartition(t *testing.T) {
 			},
 		},
 		{
-			desc: "4-region global table with region survivaability",
+			desc: "4-region global table with region survivability",
 			region: descpb.DatabaseDescriptor_RegionConfig_Region{
 				Name: "region_a",
 			},
@@ -448,7 +448,7 @@ func TestZoneConfigFromRegionConfigForPartition(t *testing.T) {
 				PrimaryRegion: "region_b",
 				SurvivalGoal:  descpb.SurvivalGoal_REGION_FAILURE,
 			},
-			expected: &zonepb.ZoneConfig{
+			expected: zonepb.ZoneConfig{
 				NumReplicas: proto.Int32(4),
 				Constraints: []zonepb.ConstraintsConjunction{
 					{


### PR DESCRIPTION
sql: correctly handle CREATE INDEX on REGIONAL BY ROW tables

* Refactored the code that translates from TableDesc to tree.PartitionBy
  without needing a parsing layer, because it does not work for REGIONAL
  BY ROW tables as the clause is omitted entirely.
* Introduce a way of altering the zone configurations without shelling
  out to another SQL call. We should update our other code to do the
  same logic, which I've added a TODO for.
* Modify CREATE INDEX to set the partitioning on the newly created
  indexes.

Release note (sql change): CREATE INDEX on REGIONAL BY ROW tables will
now correctly include the implicit partitioning and inherit the correct
zone configurations.



Resolves #58337 
