### PR TITLE
opt: introduce invisible columns to opt catalog

### DIFF
--- a/pkg/sql/opt/cat/column.go
+++ b/pkg/sql/opt/cat/column.go
@@ -30,7 +30,7 @@ type Column struct {
 	datumType                   *types.T
 	kind                        ColumnKind
 	nullable                    bool
-	hidden                      bool
+	visibility                  ColumnVisibility
 	virtualComputed             bool
 	defaultExpr                 string
 	computedExpr                string
@@ -74,12 +74,6 @@ func (c *Column) IsMutation() bool {
 	return c.kind == WriteOnly || c.kind == DeleteOnly
 }
 
-// IsSelectable returns true if this column should be accessible from user
-// queries (based on its Kind).
-func (c *Column) IsSelectable() bool {
-	return c.kind == Ordinary || c.kind == System
-}
-
 // DatumType returns the data type of the column.
 func (c *Column) DatumType() *types.T {
 	return c.datumType
@@ -90,10 +84,9 @@ func (c *Column) IsNullable() bool {
 	return c.nullable
 }
 
-// IsHidden returns true if the column is hidden (e.g., there is always a hidden
-// column called rowid if there is no primary key on the table).
-func (c *Column) IsHidden() bool {
-	return c.hidden
+// Visibility returns the column visibility.
+func (c *Column) Visibility() ColumnVisibility {
+	return c.visibility
 }
 
 // HasDefault returns true if the column has a default value. DefaultExprStr
@@ -169,6 +162,32 @@ const (
 	VirtualInverted
 )
 
+// ColumnVisibility controls if a column is visible for queries and if it is
+// part of the star expansion.
+type ColumnVisibility uint8
+
+const (
+	// Visible columns are visible to queries and are part of the star expansion
+	// (e.g. SELECT * FROM t).
+	Visible ColumnVisibility = iota
+
+	// Hidden columns are visible to queries by name, but are not part of the star
+	// expansion (e.g. implicit PK column "rowid").
+	Hidden
+
+	// Inaccessible columns are not visible to queries in any way.
+	Inaccessible
+)
+
+// MaybeHidden is a helper constructor for either Visible or Hidden, depending
+// on a flag.
+func MaybeHidden(hidden bool) ColumnVisibility {
+	if hidden {
+		return Hidden
+	}
+	return Visible
+}
+
 // InitNonVirtual is used by catalog implementations to populate a non-virtual
 // Column. It should not be used anywhere else.
 func (c *Column) InitNonVirtual(
@@ -178,12 +197,15 @@ func (c *Column) InitNonVirtual(
 	kind ColumnKind,
 	datumType *types.T,
 	nullable bool,
-	hidden bool,
+	visibility ColumnVisibility,
 	defaultExpr *string,
 	computedExpr *string,
 ) {
 	if kind == VirtualInverted {
 		panic(errors.AssertionFailedf("incorrect init method"))
+	}
+	if (kind == WriteOnly || kind == DeleteOnly) && visibility != Inaccessible {
+		panic(errors.AssertionFailedf("mutation columns should always be inaccessible"))
 	}
 	// This initialization pattern ensures that fields are not unwittingly
 	// reused. Field reuse must be explicit.
@@ -194,7 +216,7 @@ func (c *Column) InitNonVirtual(
 		kind:                        kind,
 		datumType:                   datumType,
 		nullable:                    nullable,
-		hidden:                      hidden,
+		visibility:                  visibility,
 		invertedSourceColumnOrdinal: -1,
 	}
 	if defaultExpr != nil {
@@ -219,7 +241,7 @@ func (c *Column) InitVirtualInverted(
 		kind:                        VirtualInverted,
 		datumType:                   datumType,
 		nullable:                    nullable,
-		hidden:                      true,
+		visibility:                  Inaccessible,
 		invertedSourceColumnOrdinal: invertedSourceColumnOrdinal,
 	}
 }
@@ -232,7 +254,7 @@ func (c *Column) InitVirtualComputed(
 	name tree.Name,
 	datumType *types.T,
 	nullable bool,
-	hidden bool,
+	visibility ColumnVisibility,
 	computedExpr string,
 ) {
 	// This initialization pattern ensures that fields are not unwittingly
@@ -244,7 +266,7 @@ func (c *Column) InitVirtualComputed(
 		kind:                        Ordinary,
 		datumType:                   datumType,
 		nullable:                    nullable,
-		hidden:                      hidden,
+		visibility:                  visibility,
 		computedExpr:                computedExpr,
 		virtualComputed:             true,
 		invertedSourceColumnOrdinal: -1,

--- a/pkg/sql/opt/cat/utils.go
+++ b/pkg/sql/opt/cat/utils.go
@@ -315,14 +315,28 @@ func formatColumn(col *Column, buf *bytes.Buffer) {
 	if col.HasDefault() {
 		fmt.Fprintf(buf, " default (%s)", col.DefaultExprStr())
 	}
-	if col.IsHidden() {
-		fmt.Fprintf(buf, " [hidden]")
+	kind := col.Kind()
+	// Omit the visibility for mutation and virtual inverted columns, which are
+	// always inacessible.
+	if kind != WriteOnly && kind != DeleteOnly && kind != VirtualInverted {
+		switch col.Visibility() {
+		case Hidden:
+			fmt.Fprintf(buf, " [hidden]")
+		case Inaccessible:
+			fmt.Fprintf(buf, " [inaccessible]")
+		}
 	}
-	switch col.Kind() {
-	case WriteOnly, DeleteOnly:
-		fmt.Fprintf(buf, " [mutation]")
+
+	switch kind {
+	case WriteOnly:
+		fmt.Fprintf(buf, " [write-only]")
+
+	case DeleteOnly:
+		fmt.Fprintf(buf, " [delete-only]")
+
 	case System:
 		fmt.Fprintf(buf, " [system]")
+
 	case VirtualInverted:
 		fmt.Fprintf(buf, " [virtual-inverted]")
 	}

--- a/pkg/sql/opt/metadata_test.go
+++ b/pkg/sql/opt/metadata_test.go
@@ -192,9 +192,9 @@ func TestMetadataTables(t *testing.T) {
 			cat.Ordinary,
 			types.Int,
 			false, /* nullable */
-			false, /* hidden */
-			nil,   /* defaultExpr */
-			nil,   /* computedExpr */
+			cat.Visible,
+			nil, /* defaultExpr */
+			nil, /* computedExpr */
 		)
 		return c
 	}

--- a/pkg/sql/opt/optbuilder/BUILD.bazel
+++ b/pkg/sql/opt/optbuilder/BUILD.bazel
@@ -86,6 +86,7 @@ go_test(
     embed = [":optbuilder"],
     deps = [
         "//pkg/settings/cluster",
+        "//pkg/sql/opt/cat",
         "//pkg/sql/opt/memo",
         "//pkg/sql/opt/testutils",
         "//pkg/sql/opt/testutils/opttester",

--- a/pkg/sql/opt/optbuilder/distinct.go
+++ b/pkg/sql/opt/optbuilder/distinct.go
@@ -12,6 +12,7 @@ package optbuilder
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -24,7 +25,7 @@ func (b *Builder) constructDistinct(inScope *scope) memo.RelExpr {
 	// We are doing a distinct along all the projected columns.
 	var private memo.GroupingPrivate
 	for i := range inScope.cols {
-		if !inScope.cols[i].hidden {
+		if inScope.cols[i].visibility == cat.Visible {
 			private.GroupingCols.Add(inScope.cols[i].id)
 		}
 	}

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -531,7 +531,7 @@ func (mb *mutationBuilder) addTargetTableColsForInsert(maxCols int) {
 	for i, n := 0, mb.tab.ColumnCount(); i < n && numCols < maxCols; i++ {
 		// Skip mutation, hidden or system columns.
 		col := mb.tab.Column(i)
-		if col.Kind() != cat.Ordinary || col.IsHidden() {
+		if col.Kind() != cat.Ordinary || col.Visibility() != cat.Visible {
 			continue
 		}
 
@@ -578,7 +578,7 @@ func (mb *mutationBuilder) buildInputForInsert(inScope *scope, inputRows *tree.S
 	} else {
 		desiredTypes = make([]*types.T, 0, mb.tab.ColumnCount())
 		for i, n := 0, mb.tab.ColumnCount(); i < n; i++ {
-			if tabCol := mb.tab.Column(i); !tabCol.IsHidden() && tabCol.Kind() == cat.Ordinary {
+			if tabCol := mb.tab.Column(i); tabCol.Visibility() == cat.Visible && tabCol.Kind() == cat.Ordinary {
 				desiredTypes = append(desiredTypes, tabCol.DatumType())
 			}
 		}

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -332,7 +332,9 @@ func (mb *mutationBuilder) buildInputForUpdate(
 		for i := 0; i < primaryIndex.KeyColumnCount(); i++ {
 			// If the primary key column is hidden, then we don't need to use it
 			// for the distinct on.
-			if col := primaryIndex.Column(i); !col.IsHidden() {
+			// TODO(radu): this logic seems fragile, is it assuming that only an
+			// implicit `rowid` column can be a hidden PK column?
+			if col := primaryIndex.Column(i); col.Visibility() != cat.Hidden {
 				pkCols.Add(mb.fetchColIDs[col.Ordinal()])
 			}
 		}

--- a/pkg/sql/opt/optbuilder/name_resolution_test.go
+++ b/pkg/sql/opt/optbuilder/name_resolution_test.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 )
@@ -45,7 +46,7 @@ func (s *scope) ResolveQualifiedStarTestResults(
 	nl := make(tree.NameList, 0, len(s.cols))
 	for i := range s.cols {
 		col := s.cols[i]
-		if col.table == *srcName && !col.hidden {
+		if col.table == *srcName && col.visibility == cat.Visible {
 			nl = append(nl, col.name)
 		}
 	}

--- a/pkg/sql/opt/optbuilder/scope_column.go
+++ b/pkg/sql/opt/optbuilder/scope_column.go
@@ -35,10 +35,7 @@ type scopeColumn struct {
 	// columns in the query.
 	id opt.ColumnID
 
-	// hidden is true if the column is not selected by a '*' wildcard operator.
-	// The column must be explicitly referenced by name, or otherwise is not
-	// included.
-	hidden bool
+	visibility cat.ColumnVisibility
 
 	// tableOrdinal is set to the table ordinal corresponding to this column, if
 	// this is a column from a scan.

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -357,7 +357,7 @@ func (b *Builder) renameSource(as tree.AliasClause, scope *scope) {
 					))
 				}
 				col := &scope.cols[colIdx]
-				if col.hidden {
+				if col.visibility != cat.Visible {
 					continue
 				}
 				col.name = colAlias[aliasIdx]
@@ -477,7 +477,7 @@ func (b *Builder) buildScan(
 			name:         name,
 			table:        tabMeta.Alias,
 			typ:          col.DatumType(),
-			hidden:       col.IsHidden() || kind != cat.Ordinary,
+			visibility:   col.Visibility(),
 			kind:         kind,
 			mutation:     kind == cat.WriteOnly || kind == cat.DeleteOnly,
 			tableOrdinal: ord,

--- a/pkg/sql/opt/optbuilder/testdata/inverted-indexes
+++ b/pkg/sql/opt/optbuilder/testdata/inverted-indexes
@@ -25,11 +25,11 @@ TABLE kj
  ├── k int not null
  ├── j jsonb
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
- ├── j_inverted_key jsonb not null [hidden] [virtual-inverted]
+ ├── j_inverted_key jsonb not null [virtual-inverted]
  ├── INDEX primary
  │    └── k int not null
  ├── INVERTED INDEX secondary
- │    ├── j_inverted_key jsonb not null [hidden] [virtual-inverted]
+ │    ├── j_inverted_key jsonb not null [virtual-inverted]
  │    └── k int not null
  └── UNIQUE (k)
 

--- a/pkg/sql/opt/optbuilder/testdata/select
+++ b/pkg/sql/opt/optbuilder/testdata/select
@@ -1412,3 +1412,94 @@ project
            │    └── u:2 = 1
            └── v: filters
                 └── ((v:3 > 100) AND (v:3 < 200)) AND (u:2 > 50)
+
+exec-ddl
+CREATE TABLE inaccessible (
+    k INT PRIMARY KEY,
+    "v:inaccessible" INT
+)
+----
+
+build
+SELECT * FROM inaccessible
+----
+project
+ ├── columns: k:1!null
+ └── scan inaccessible
+      └── columns: k:1!null v:2 crdb_internal_mvcc_timestamp:3
+
+build
+SELECT v FROM inaccessible
+----
+error (42703): column "v" does not exist
+
+build
+INSERT INTO inaccessible VALUES (1)
+----
+insert inaccessible
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:4 => k:1
+ │    └── column5:5 => v:2
+ └── project
+      ├── columns: column5:5 column1:4!null
+      ├── values
+      │    ├── columns: column1:4!null
+      │    └── (1,)
+      └── projections
+           └── NULL::INT8 [as=column5:5]
+
+build
+INSERT INTO inaccessible VALUES (1) RETURNING v
+----
+error (42703): column "v" does not exist
+
+build
+INSERT INTO inaccessible(k, v) VALUES (1, 1)
+----
+error (42703): column "v" does not exist
+
+build
+UPSERT INTO inaccessible(k, v) VALUES (1, 1)
+----
+error (42703): column "v" does not exist
+
+build
+UPDATE inaccessible SET k=k+1
+----
+update inaccessible
+ ├── columns: <none>
+ ├── fetch columns: k:4 v:5
+ ├── update-mapping:
+ │    └── k_new:7 => k:1
+ └── project
+      ├── columns: k_new:7!null k:4!null v:5 crdb_internal_mvcc_timestamp:6
+      ├── scan inaccessible
+      │    └── columns: k:4!null v:5 crdb_internal_mvcc_timestamp:6
+      └── projections
+           └── k:4 + 1 [as=k_new:7]
+
+build
+UPDATE inaccessible SET k=k+1 WHERE v=1
+----
+error (42703): column "v" does not exist
+
+build
+UPDATE inaccessible SET k=v+1
+----
+error (42703): column "v" does not exist
+
+build
+UPDATE inaccessible SET v=1
+----
+error (42703): column "v" does not exist
+
+build
+DELETE FROM inaccessible WHERE v=1
+----
+error (42703): column "v" does not exist
+
+build
+DELETE FROM inaccessible RETURNING v
+----
+error (42703): column "v" does not exist

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -119,7 +119,7 @@ func (b *Builder) expandStar(
 		aliases = make([]string, 0, len(refScope.cols))
 		for i := range refScope.cols {
 			col := &refScope.cols[i]
-			if col.table == *src && !col.hidden {
+			if col.table == *src && col.visibility == cat.Visible {
 				exprs = append(exprs, col)
 				aliases = append(aliases, string(col.name))
 			}
@@ -134,7 +134,7 @@ func (b *Builder) expandStar(
 		aliases = make([]string, 0, len(inScope.cols))
 		for i := range inScope.cols {
 			col := &inScope.cols[i]
-			if !col.hidden {
+			if col.visibility == cat.Visible {
 				exprs = append(exprs, col)
 				aliases = append(aliases, string(col.name))
 			}
@@ -248,7 +248,7 @@ func (b *Builder) synthesizeResultColumns(scope *scope, cols colinfo.ResultColum
 	for i := range cols {
 		c := b.synthesizeColumn(scope, cols[i].Name, cols[i].Typ, nil /* expr */, nil /* scalar */)
 		if cols[i].Hidden {
-			c.hidden = true
+			c.visibility = cat.Hidden
 		}
 	}
 }
@@ -639,7 +639,7 @@ func resolveNumericColumnRefs(tab cat.Table, columns []tree.ColumnID) (ordinals 
 		cnt := tab.ColumnCount()
 		for ord < cnt {
 			col := tab.Column(ord)
-			if col.IsSelectable() && col.ColID() == cat.StableID(c) {
+			if col.ColID() == cat.StableID(c) && col.Visibility() != cat.Inaccessible {
 				break
 			}
 			ord++
@@ -658,7 +658,7 @@ func resolveNumericColumnRefs(tab cat.Table, columns []tree.ColumnID) (ordinals 
 func findPublicTableColumnByName(tab cat.Table, name tree.Name) int {
 	for ord, n := 0, tab.ColumnCount(); ord < n; ord++ {
 		col := tab.Column(ord)
-		if col.ColName() == name && !col.IsMutation() {
+		if col.ColName() == name && col.Visibility() != cat.Inaccessible {
 			return ord
 		}
 	}

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -1475,9 +1475,9 @@ func (ot *OptTester) createTableAs(name tree.TableName, rel memo.RelExpr) (*test
 			cat.Ordinary,
 			colMeta.Type,
 			!relProps.NotNullCols.Contains(col),
-			false, /* hidden */
-			nil,   /* defaultExpr */
-			nil,   /* computedExpr */
+			cat.Visible,
+			nil, /* defaultExpr */
+			nil, /* computedExpr */
 		)
 
 		// Make sure we have estimated stats for this column.

--- a/pkg/sql/opt/testutils/testcat/create_table.go
+++ b/pkg/sql/opt/testutils/testcat/create_table.go
@@ -118,8 +118,8 @@ func (tc *Catalog) CreateTable(stmt *tree.CreateTable) *Table {
 			"rowid",
 			cat.Ordinary,
 			types.Int,
-			false,              /* nullable */
-			true,               /* hidden */
+			false, /* nullable */
+			cat.Hidden,
 			&uniqueRowIDString, /* defaultExpr */
 			nil,                /* computedExpr */
 		)
@@ -146,9 +146,9 @@ func (tc *Catalog) CreateTable(stmt *tree.CreateTable) *Table {
 		cat.System,
 		colinfo.MVCCTimestampColumnType,
 		true, /* nullable */
-		true, /* hidden */
-		nil,  /* defaultExpr */
-		nil,  /* computedExpr */
+		cat.Hidden,
+		nil, /* defaultExpr */
+		nil, /* computedExpr */
 	)
 	tab.Columns = append(tab.Columns, mvcc)
 
@@ -275,9 +275,9 @@ func (tc *Catalog) createVirtualTable(stmt *tree.CreateTable) *Table {
 		cat.Ordinary,
 		types.Int,
 		false, /* nullable */
-		true,  /* hidden */
-		nil,   /* defaultExpr */
-		nil,   /* computedExpr */
+		cat.Hidden,
+		nil, /* defaultExpr */
+		nil, /* computedExpr */
 	)
 
 	tab.Columns = []cat.Column{pk}
@@ -330,8 +330,8 @@ func (tc *Catalog) CreateTableAs(name tree.TableName, columns []cat.Column) *Tab
 		"rowid",
 		cat.Ordinary,
 		types.Int,
-		false,              /* nullable */
-		true,               /* hidden */
+		false, /* nullable */
+		cat.Hidden,
 		&uniqueRowIDString, /* defaultExpr */
 		nil,                /* computedExpr */
 	)
@@ -516,14 +516,20 @@ func (tt *Table) addColumn(def *tree.ColumnTableDef) {
 
 	name := def.Name
 	kind := cat.Ordinary
+	visibility := cat.Visible
 
-	// Look for name suffixes indicating this is a mutation column.
-	if n, ok := extractWriteOnlyColumn(def); ok {
+	// Look for name suffixes indicating this is a special column.
+	if n, ok := extractInaccessibleColumn(def); ok {
+		name = n
+		visibility = cat.Inaccessible
+	} else if n, ok := extractWriteOnlyColumn(def); ok {
 		name = n
 		kind = cat.WriteOnly
+		visibility = cat.Inaccessible
 	} else if n, ok := extractDeleteOnlyColumn(def); ok {
 		name = n
 		kind = cat.DeleteOnly
+		visibility = cat.Inaccessible
 	}
 
 	var defaultExpr, computedExpr *string
@@ -545,7 +551,7 @@ func (tt *Table) addColumn(def *tree.ColumnTableDef) {
 			name,
 			typ,
 			nullable,
-			false, /* hidden */
+			visibility,
 			*computedExpr,
 		)
 	} else {
@@ -556,7 +562,7 @@ func (tt *Table) addColumn(def *tree.ColumnTableDef) {
 			kind,
 			typ,
 			nullable,
-			false, /* hidden */
+			visibility,
 			defaultExpr,
 			computedExpr,
 		)
@@ -862,7 +868,7 @@ func columnForIndexElemExpr(tt *Table, expr tree.Expr) cat.Column {
 		name,
 		typ,
 		true, /* nullable */
-		true, /* hidden */
+		cat.Hidden,
 		exprStr,
 	)
 	tt.Columns = append(tt.Columns, col)
@@ -912,6 +918,13 @@ func (tt *Table) addPrimaryColumnIndex(colName string) {
 		Columns: tree.IndexElemList{{Column: tree.Name(colName), Direction: tree.Ascending}},
 	}
 	tt.addIndex(&def, primaryIndex)
+}
+
+func extractInaccessibleColumn(def *tree.ColumnTableDef) (name tree.Name, ok bool) {
+	if !strings.HasSuffix(string(def.Name), ":inaccessible") {
+		return "", false
+	}
+	return tree.Name(strings.TrimSuffix(string(def.Name), ":inaccessible")), true
 }
 
 func extractWriteOnlyColumn(def *tree.ColumnTableDef) (name tree.Name, ok bool) {

--- a/pkg/sql/opt/testutils/testcat/testdata/index
+++ b/pkg/sql/opt/testutils/testcat/testdata/index
@@ -83,18 +83,18 @@ TABLE g
  ├── b int
  ├── geog geography
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
- ├── geog_inverted_key geography not null [hidden] [virtual-inverted]
- ├── geog_inverted_key geography not null [hidden] [virtual-inverted]
+ ├── geog_inverted_key geography not null [virtual-inverted]
+ ├── geog_inverted_key geography not null [virtual-inverted]
  ├── INDEX primary
  │    └── k int not null
  ├── INVERTED INDEX secondary
  │    ├── a int
- │    ├── geog_inverted_key geography not null [hidden] [virtual-inverted]
+ │    ├── geog_inverted_key geography not null [virtual-inverted]
  │    └── k int not null
  ├── INVERTED INDEX secondary
  │    ├── a int
  │    ├── b int
- │    ├── geog_inverted_key geography not null [hidden] [virtual-inverted]
+ │    ├── geog_inverted_key geography not null [virtual-inverted]
  │    └── k int not null
  └── UNIQUE (k)
 

--- a/pkg/sql/opt/testutils/testcat/testdata/table
+++ b/pkg/sql/opt/testutils/testcat/testdata/table
@@ -186,15 +186,15 @@ TABLE inv
  ├── j jsonb
  ├── g geometry
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
- ├── j_inverted_key jsonb not null [hidden] [virtual-inverted]
- ├── g_inverted_key geometry not null [hidden] [virtual-inverted]
+ ├── j_inverted_key jsonb not null [virtual-inverted]
+ ├── g_inverted_key geometry not null [virtual-inverted]
  ├── INDEX primary
  │    └── k int not null
  ├── INVERTED INDEX secondary
- │    ├── j_inverted_key jsonb not null [hidden] [virtual-inverted]
+ │    ├── j_inverted_key jsonb not null [virtual-inverted]
  │    └── k int not null
  ├── INVERTED INDEX secondary
- │    ├── g_inverted_key geometry not null [hidden] [virtual-inverted]
+ │    ├── g_inverted_key geometry not null [virtual-inverted]
  │    └── k int not null
  └── UNIQUE (k)
 
@@ -218,15 +218,15 @@ TABLE inv2
  ├── g geometry
  ├── rowid int not null default (unique_rowid()) [hidden]
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
- ├── j_inverted_key jsonb not null [hidden] [virtual-inverted]
- ├── g_inverted_key geometry not null [hidden] [virtual-inverted]
+ ├── j_inverted_key jsonb not null [virtual-inverted]
+ ├── g_inverted_key geometry not null [virtual-inverted]
  ├── INDEX primary
  │    └── rowid int not null default (unique_rowid()) [hidden]
  ├── INVERTED INDEX secondary
- │    ├── j_inverted_key jsonb not null [hidden] [virtual-inverted]
+ │    ├── j_inverted_key jsonb not null [virtual-inverted]
  │    └── rowid int not null default (unique_rowid()) [hidden]
  ├── INVERTED INDEX secondary
- │    ├── g_inverted_key geometry not null [hidden] [virtual-inverted]
+ │    ├── g_inverted_key geometry not null [virtual-inverted]
  │    └── rowid int not null default (unique_rowid()) [hidden]
  └── UNIQUE (rowid)
 
@@ -270,3 +270,36 @@ TABLE uniq
  ├── UNIQUE WITHOUT INDEX (j)
  ├── UNIQUE (j, k)
  └── UNIQUE WITHOUT INDEX (l, m)
+
+exec-ddl
+CREATE TABLE mutations (
+  a INT,
+  "b:inaccessible" INT,
+  "c:write-only" INT,
+  "d:delete-only" INT,
+  "v:inaccessible" INT AS (a+1) VIRTUAL,
+  INDEX "idxa:write-only" (a),
+  INDEX "idxb:delete-only" (b)
+)
+----
+
+exec-ddl
+SHOW CREATE mutations
+----
+TABLE mutations
+ ├── a int
+ ├── b int [inaccessible]
+ ├── v int as (a + 1) virtual [inaccessible]
+ ├── rowid int not null default (unique_rowid()) [hidden]
+ ├── c int [write-only]
+ ├── d int [delete-only]
+ ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
+ ├── INDEX primary
+ │    └── rowid int not null default (unique_rowid()) [hidden]
+ ├── INDEX idxa (mutation)
+ │    ├── a int
+ │    └── rowid int not null default (unique_rowid()) [hidden]
+ ├── INDEX idxb (mutation)
+ │    ├── b int [inaccessible]
+ │    └── rowid int not null default (unique_rowid()) [hidden]
+ └── UNIQUE (rowid)


### PR DESCRIPTION
There is a need to introduce a new column state during schema changes:
a state in which a column has been backfilled and is readable for
internal operations (like updating an index on that column during an
UPDATE), but is still not public.

Adding a new ColumnKind would complicate a lot of the optimizer code
and add more combinations that need testing. To avoid this, we note
that there is effectively no difference between such a column and an
ordinary column, other than it not being visible to queries.

This change extends the `IsHidden()` column property to a
`ColumnVisibility` which has three values (Visible, Hidden,
Invisible). The new column state will be presented as an Ordinary,
Invisible column.

There could be other usecases for Invisible in the future, perhaps
for the internal virtual columns used by hash-sharded indexes or
expression-based indexes.

Release note: None