### PR TITLE
cli: add GEOS initialization to mt start-sql

### DIFF
--- a/pkg/cli/demo.go
+++ b/pkg/cli/demo.go
@@ -18,11 +18,9 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cli/cliflags"
-	"github.com/cockroachdb/cockroach/pkg/geo/geos"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/cockroach/pkg/workload"
 	"github.com/cockroachdb/errors"
@@ -274,12 +272,7 @@ func runDemo(cmd *cobra.Command, gen workload.Generator) (err error) {
 	}
 	defer c.cleanup(ctx)
 
-	loc, err := geos.EnsureInit(geos.EnsureInitErrorDisplayPrivate, startCtx.geoLibsDir)
-	if err != nil {
-		log.Infof(ctx, "could not initialize GEOS - spatial functions may not be available: %v", err)
-	} else {
-		log.Infof(ctx, "GEOS loaded from directory %s", loc)
-	}
+	initGEOS(ctx)
 
 	if err := c.start(ctx, cmd, gen); err != nil {
 		return checkAndMaybeShout(err)

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -827,6 +827,8 @@ func init() {
 		varFlag(f, addrSetter{&serverSQLAddr, &serverSQLPort}, cliflags.ListenSQLAddr)
 		varFlag(f, addrSetter{&serverHTTPAddr, &serverHTTPPort}, cliflags.ListenHTTPAddr)
 
+		stringFlag(f, &startCtx.geoLibsDir, cliflags.GeoLibsDir)
+
 		stringSliceFlag(f, &serverCfg.SQLConfig.TenantKVAddrs, cliflags.KVAddrs)
 	}
 }

--- a/pkg/cli/mt_start_sql.go
+++ b/pkg/cli/mt_start_sql.go
@@ -98,6 +98,8 @@ func runStartSQL(cmd *cobra.Command, args []string) error {
 		tempStorageMaxSizeBytes,
 	)
 
+	initGEOS(ctx)
+
 	sqlServer, addr, httpAddr, err := server.StartTenant(
 		ctx,
 		stopper,

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -500,14 +500,7 @@ If problems persist, please see %s.`
 		}
 	}
 
-	// Set up the Geospatial library.
-	// We need to make sure this happens before any queries involving geospatial data is executed.
-	loc, err := geos.EnsureInit(geos.EnsureInitErrorDisplayPrivate, startCtx.geoLibsDir)
-	if err != nil {
-		log.Ops.Infof(ctx, "could not initialize GEOS - spatial functions may not be available: %v", err)
-	} else {
-		log.Ops.Infof(ctx, "GEOS loaded from directory %s", loc)
-	}
+	initGEOS(ctx)
 
 	// Beyond this point, the configuration is set and the server is
 	// ready to start.
@@ -1100,4 +1093,15 @@ func getClientGRPCConn(
 		stopper.Stop(ctx)
 	}
 	return conn, clock, closer, nil
+}
+
+// initGEOS sets up the Geospatial library.
+// We need to make sure this happens before any queries involving geospatial data is executed.
+func initGEOS(ctx context.Context) {
+	loc, err := geos.EnsureInit(geos.EnsureInitErrorDisplayPrivate, startCtx.geoLibsDir)
+	if err != nil {
+		log.Ops.Warningf(ctx, "could not initialize GEOS - spatial functions may not be available: %v", err)
+	} else {
+		log.Ops.Infof(ctx, "GEOS loaded from directory %s", loc)
+	}
 }


### PR DESCRIPTION
Release note (bug fix): Fix a bug where multi-tenancy sql pods do
not start up correctly as it does not initialise the GEOS library
correctly.

Resolves #59254 