### PR TITLE
release-20.2: cli: add GEOS initialization to mt start-sql

### DIFF
--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -827,6 +827,8 @@ func init() {
 		varFlag(f, addrSetter{&serverSQLAddr, &serverSQLPort}, cliflags.ListenSQLAddr)
 		varFlag(f, addrSetter{&serverHTTPAddr, &serverHTTPPort}, cliflags.ListenHTTPAddr)
 
+		stringFlag(f, &startCtx.geoLibsDir, cliflags.GeoLibsDir)
+
 		stringSliceFlag(f, &serverCfg.SQLConfig.TenantKVAddrs, cliflags.KVAddrs)
 		varFlag(f, &startCtx.logDir, cliflags.LogDir)
 		varFlag(f,

--- a/pkg/cli/mt_start_sql.go
+++ b/pkg/cli/mt_start_sql.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/geo/geos"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -97,6 +98,13 @@ func runStartSQL(cmd *cobra.Command, args []string) error {
 		"", // parentDir
 		tempStorageMaxSizeBytes,
 	)
+
+	loc, err := geos.EnsureInit(geos.EnsureInitErrorDisplayPrivate, startCtx.geoLibsDir)
+	if err != nil {
+		log.Infof(ctx, "could not initialize GEOS - spatial functions may not be available: %v", err)
+	} else {
+		log.Infof(ctx, "GEOS loaded from directory %s", loc)
+	}
 
 	sqlServer, addr, httpAddr, err := server.StartTenant(
 		ctx,


### PR DESCRIPTION
Backport 1/1 commits from #59259.

/cc @cockroachdb/release

---

Release note (bug fix): Fix a bug where multi-tenancy sql pods do
not start up correctly as it does not initialise the GEOS library
correctly.

Resolves #59254 
