### PR TITLE
sql: Forbid setting zone config for non physical tables

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/zone_config
+++ b/pkg/sql/logictest/testdata/logic_test/zone_config
@@ -195,3 +195,22 @@ ORDER BY feature_name
 ----
 sql.schema.alter_range.configure_zone
 sql.schema.alter_table.configure_zone
+
+# Check entities for which we can set zone configs
+
+subtest test_entity_validity
+
+statement ok
+CREATE TABLE zc (
+  a INT PRIMARY KEY,
+  b INT
+)
+
+statement ok
+ALTER TABLE zc CONFIGURE ZONE USING gc.ttlseconds = 100000;
+
+statement ok
+CREATE MATERIALIZED VIEW vm(x,y) AS SELECT a,b FROM zc ; ALTER TABLE vm CONFIGURE ZONE USING gc.ttlseconds = 100000;
+
+statement error pgcode 42809 "v" is not a physical table
+CREATE VIEW v(x,y) AS SELECT a, b FROM zc; ALTER TABLE v CONFIGURE ZONE USING gc.ttlseconds = 100000;

--- a/pkg/sql/set_zone_config.go
+++ b/pkg/sql/set_zone_config.go
@@ -328,6 +328,11 @@ func (n *setZoneConfigNode) startExec(params runParams) error {
 		return err
 	}
 
+	// If the table descriptor is resolved but is not a
+	// physical table(stored in the kv layer) then return an error
+	if table != nil && !table.IsPhysicalTable() {
+		return pgerror.Newf(pgcode.WrongObjectType, `"%v" is not a physical table`, table.GetName())
+	}
 	if n.zoneSpecifier.TargetsPartition() && len(n.zoneSpecifier.TableOrIndex.Index) == 0 && !n.allIndexes {
 		// Backward compatibility for ALTER PARTITION ... OF TABLE. Determine which
 		// index has the specified partition.


### PR DESCRIPTION
Fixes #57478.

Release note (sql change): Setting of zone configs for non physical tables is
now forbidden .