### PR TITLE
opt: build scan InvertedConstraints from JSON FetchVal operator

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/inverted_index
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index
@@ -753,6 +753,22 @@ SELECT j FROM f@i WHERE j->'a' = '1' ORDER BY k
 {"a": 1, "b": 2}
 {"a": 1, "c": 3}
 
+query T
+SELECT j FROM f@i WHERE j->'a' = '1' OR j->'b' = '2' ORDER BY k
+----
+{"a": 1}
+{"b": 2}
+{"a": 1, "b": 2}
+{"a": 1, "c": 3}
+
+query T
+SELECT j FROM f@i WHERE j->'a' = '1' OR j @> '{"b": 2}' ORDER BY k
+----
+{"a": 1}
+{"b": 2}
+{"a": 1, "b": 2}
+{"a": 1, "c": 3}
+
 subtest arrays
 
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
@@ -350,7 +350,7 @@ vectorized: true
 │
 └── • scan
       columns: (a)
-      estimated row count: 110 (missing stats)
+      estimated row count: 111 (missing stats)
       table: d@foo_inv
       spans: /"a"/"b"-/"a"/"b"/PrefixEnd
 
@@ -399,7 +399,7 @@ vectorized: true
 │
 └── • scan
       columns: (a)
-      estimated row count: 110 (missing stats)
+      estimated row count: 111 (missing stats)
       table: d@foo_inv
       spans: /"a"/"b"-/"a"/"b"/PrefixEnd
 

--- a/pkg/sql/opt/invertedidx/BUILD.bazel
+++ b/pkg/sql/opt/invertedidx/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",
         "//pkg/util/encoding",
+        "//pkg/util/json",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_golang_geo//r1",
         "@com_github_golang_geo//s1",

--- a/pkg/sql/opt/invertedidx/geo_test.go
+++ b/pkg/sql/opt/invertedidx/geo_test.go
@@ -491,7 +491,13 @@ func TestTryFilterGeoIndex(t *testing.T) {
 		// that is tested elsewhere. This is just testing that we are constraining
 		// the index when we expect to.
 		spanExpr, _, remainingFilters, pfState, ok := invertedidx.TryFilterInvertedIndex(
-			evalCtx, &f, filters, nil /* optionalFilters */, tab, md.Table(tab).Index(tc.indexOrd),
+			evalCtx,
+			&f,
+			filters,
+			nil, /* optionalFilters */
+			tab,
+			md.Table(tab).Index(tc.indexOrd),
+			nil, /* computedColumns */
 		)
 		if tc.ok != ok {
 			t.Fatalf("expected %v, got %v", tc.ok, ok)

--- a/pkg/sql/opt/invertedidx/inverted_index_expr.go
+++ b/pkg/sql/opt/invertedidx/inverted_index_expr.go
@@ -497,3 +497,21 @@ func extractInvertedFilterCondition(
 		return filterPlanner.extractInvertedFilterConditionFromLeaf(evalCtx, filterCond)
 	}
 }
+
+// indexColumnVariable returns a variable expression (a type-asserted form of e)
+// and ok=true if e is a variable expression that corresponds to the inverted
+// index column.
+func indexColumnVariable(
+	tabID opt.TableID, index cat.Index, e opt.Expr,
+) (_ *memo.VariableExpr, ok bool) {
+	variable, ok := e.(*memo.VariableExpr)
+	if !ok {
+		return nil, false
+	}
+	invertedIndexCol := tabID.ColumnID(index.VirtualInvertedColumn().InvertedSourceColumnOrdinal())
+	if variable.Col != invertedIndexCol {
+		// The column does not match the index column.
+		return nil, false
+	}
+	return variable, true
+}

--- a/pkg/sql/opt/invertedidx/json_array.go
+++ b/pkg/sql/opt/invertedidx/json_array.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/json"
 	"github.com/cockroachdb/errors"
 )
 
@@ -270,24 +271,32 @@ func (j *jsonOrArrayFilterPlanner) extractInvertedFilterConditionFromLeaf(
 	_ *invertedexpr.PreFiltererStateForInvertedFilterer,
 ) {
 	switch t := expr.(type) {
-	// TODO(rytaft): Support JSON fetch val operator (->).
 	case *memo.ContainsExpr:
-		invertedExpr := j.extractJSONOrArrayContainsCondition(evalCtx, t.Left, t.Right)
-		if !invertedExpr.IsTight() {
-			remainingFilters = expr
+		invertedExpr = j.extractJSONOrArrayContainsCondition(evalCtx, t.Left, t.Right)
+	case *memo.EqExpr:
+		if fetch, ok := t.Left.(*memo.FetchValExpr); ok {
+			invertedExpr = j.extractJSONFetchValEqCondition(evalCtx, fetch, t.Right)
 		}
+	}
 
-		// We do not currently support pre-filtering for JSON and Array indexes, so
-		// the returned pre-filter state is nil.
-		return invertedExpr, remainingFilters, nil
-
-	default:
+	if invertedExpr == nil {
+		// An inverted expression could not be extracted.
 		return invertedexpr.NonInvertedColExpression{}, expr, nil
 	}
+
+	// If the extracted inverted expression is not tight then remaining filters
+	// must be applied after the inverted index scan.
+	if !invertedExpr.IsTight() {
+		remainingFilters = expr
+	}
+
+	// We do not currently support pre-filtering for JSON and Array indexes, so
+	// the returned pre-filter state is nil.
+	return invertedExpr, remainingFilters, nil
 }
 
 // extractJSONOrArrayContainsCondition extracts an InvertedExpression
-// representing an inverted filter over the given inverted index, based
+// representing an inverted filter over the planner's inverted index, based
 // on the given left and right expression arguments. Returns an empty
 // InvertedExpression if no inverted filter could be extracted.
 func (j *jsonOrArrayFilterPlanner) extractJSONOrArrayContainsCondition(
@@ -315,4 +324,58 @@ func (j *jsonOrArrayFilterPlanner) extractJSONOrArrayContainsCondition(
 	}
 
 	return getSpanExprForJSONOrArrayIndex(evalCtx, d)
+}
+
+// extractJSONFetchValEqCondition extracts an InvertedExpression representing an
+// inverted filter over the planner's inverted index, based on equality between
+// a fetch val expression and a right scalar expression. If the following criteria
+// are not met, an empty InvertedExpression is returned.
+//
+//   1. The fetch value operator's left expression must be a variable
+//      referencing the inverted column in the index.
+//   2. The fetch value operator's right expression must be a constant string.
+//   3. The right expression in the equality expression must be a constant JSON
+//      value that is not an object or an array.
+//
+// TODO(mgartner): Support chained fetch val operators, e.g., j->'a'->'b' = '1'.
+func (j *jsonOrArrayFilterPlanner) extractJSONFetchValEqCondition(
+	evalCtx *tree.EvalContext, fetch *memo.FetchValExpr, right opt.ScalarExpr,
+) invertedexpr.InvertedExpression {
+	// The left side of the fetch val expression, the Json field, should be a
+	// variable corresponding to the index column.
+	variable, ok := indexColumnVariable(j.tabID, j.index, fetch.Json)
+	if !ok {
+		return invertedexpr.NonInvertedColExpression{}
+	}
+
+	// The right side of the fetch val expression, the Index field, should be a
+	// constant string.
+	if !memo.CanExtractConstDatum(fetch.Index) {
+		return invertedexpr.NonInvertedColExpression{}
+	}
+	key, ok := memo.ExtractConstDatum(fetch.Index).(*tree.DString)
+	if !ok {
+		return invertedexpr.NonInvertedColExpression{}
+	}
+
+	// The right side of the equals expression should be a constant JSON value
+	// that is not an object or array.
+	if !memo.CanExtractConstDatum(right) {
+		return invertedexpr.NonInvertedColExpression{}
+	}
+	val, ok := memo.ExtractConstDatum(right).(*tree.DJSON)
+	if !ok {
+		return invertedexpr.NonInvertedColExpression{}
+	}
+	typ := val.JSON.Type()
+	if typ == json.ObjectJSONType || typ == json.ArrayJSONType {
+		return invertedexpr.NonInvertedColExpression{}
+	}
+
+	// Build a new JSON object of the form: {<key>: <right>}.
+	b := json.NewObjectBuilder(1)
+	b.Add(string(*key), val.JSON)
+	obj := tree.NewDJSON(b.Build())
+
+	return getSpanExprForJSONOrArrayIndex(evalCtx, obj)
 }

--- a/pkg/sql/opt/invertedidx/json_array.go
+++ b/pkg/sql/opt/invertedidx/json_array.go
@@ -277,7 +277,7 @@ func (j *jsonOrArrayFilterPlanner) extractInvertedFilterConditionFromLeaf(
 	switch t := expr.(type) {
 	// TODO(rytaft): Support JSON fetch val operator (->).
 	case *memo.ContainsExpr:
-		invertedExpr := j.extractJSONOrArrayFilterCondition(evalCtx, t.Left, t.Right)
+		invertedExpr := j.extractJSONOrArrayContainsCondition(evalCtx, t.Left, t.Right)
 		if !invertedExpr.IsTight() {
 			remainingFilters = expr
 		}
@@ -291,11 +291,11 @@ func (j *jsonOrArrayFilterPlanner) extractInvertedFilterConditionFromLeaf(
 	}
 }
 
-// extractJSONOrArrayFilterCondition extracts an InvertedExpression
+// extractJSONOrArrayContainsCondition extracts an InvertedExpression
 // representing an inverted filter over the given inverted index, based
 // on the given left and right expression arguments. Returns an empty
 // InvertedExpression if no inverted filter could be extracted.
-func (j *jsonOrArrayFilterPlanner) extractJSONOrArrayFilterCondition(
+func (j *jsonOrArrayFilterPlanner) extractJSONOrArrayContainsCondition(
 	evalCtx *tree.EvalContext, left, right opt.ScalarExpr,
 ) invertedexpr.InvertedExpression {
 	// The first argument should be a variable corresponding to the index

--- a/pkg/sql/opt/invertedidx/json_array.go
+++ b/pkg/sql/opt/invertedidx/json_array.go
@@ -58,13 +58,8 @@ func (j *jsonOrArrayJoinPlanner) canExtractJSONOrArrayJoinCondition(
 ) bool {
 	// The first argument should be a variable corresponding to the index
 	// column.
-	variable, ok := left.(*memo.VariableExpr)
+	variable, ok := indexColumnVariable(j.tabID, j.index, left)
 	if !ok {
-		return false
-	}
-	if variable.Col != j.tabID.ColumnID(
-		j.index.VirtualInvertedColumn().InvertedSourceColumnOrdinal(),
-	) {
 		// The column does not match the index column.
 		return false
 	}
@@ -300,14 +295,8 @@ func (j *jsonOrArrayFilterPlanner) extractJSONOrArrayContainsCondition(
 ) invertedexpr.InvertedExpression {
 	// The first argument should be a variable corresponding to the index
 	// column.
-	variable, ok := left.(*memo.VariableExpr)
+	variable, ok := indexColumnVariable(j.tabID, j.index, left)
 	if !ok {
-		return invertedexpr.NonInvertedColExpression{}
-	}
-	if variable.Col != j.tabID.ColumnID(
-		j.index.VirtualInvertedColumn().InvertedSourceColumnOrdinal(),
-	) {
-		// The column does not match the index column.
 		return invertedexpr.NonInvertedColExpression{}
 	}
 

--- a/pkg/sql/opt/invertedidx/json_array_test.go
+++ b/pkg/sql/opt/invertedidx/json_array_test.go
@@ -391,6 +391,73 @@ func TestTryFilterJsonOrArrayIndex(t *testing.T) {
 			unique:           false,
 			remainingFilters: "j @> '[[1, 2]]'",
 		},
+		{
+			filters:  "j->'a' = '1'",
+			indexOrd: jsonOrd,
+			ok:       true,
+			tight:    true,
+			unique:   true,
+		},
+		{
+			// Integer indexes are not yet supported.
+			filters:  "j->0 = '1'",
+			indexOrd: jsonOrd,
+			ok:       false,
+		},
+		{
+			// Arrays on the right side of the equality are not yet supported.
+			filters:  "j->'a' = '[1]'",
+			indexOrd: jsonOrd,
+			ok:       false,
+		},
+		{
+			// Objects on the right side of the equality are not yet supported.
+			filters:  `j->'a' = '{"b": "c"}'`,
+			indexOrd: jsonOrd,
+			ok:       false,
+		},
+		{
+			// Wrong index ordinal.
+			filters:  "j->'a' = '1'",
+			indexOrd: arrayOrd,
+			ok:       false,
+		},
+		{
+			filters:  "j->'a' = '1' AND j->'b' = '2'",
+			indexOrd: jsonOrd,
+			ok:       true,
+			tight:    true,
+			unique:   false,
+		},
+		{
+			filters:  "j->'a' = '1' OR j->'b' = '2'",
+			indexOrd: jsonOrd,
+			ok:       true,
+			tight:    true,
+			unique:   false,
+		},
+		{
+			filters:  `j->'a' = '1' AND j @> '{"b": "c"}'`,
+			indexOrd: jsonOrd,
+			ok:       true,
+			tight:    true,
+			unique:   false,
+		},
+		{
+			filters:  `j->'a' = '1' OR j @> '{"b": "c"}'`,
+			indexOrd: jsonOrd,
+			ok:       true,
+			tight:    true,
+			unique:   false,
+		},
+		{
+			filters:          `j->'a' = '1' AND j @> '[[1, 2]]'`,
+			indexOrd:         jsonOrd,
+			ok:               true,
+			tight:            false,
+			unique:           false,
+			remainingFilters: "j @> '[[1, 2]]'",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/sql/opt/invertedidx/json_array_test.go
+++ b/pkg/sql/opt/invertedidx/json_array_test.go
@@ -469,7 +469,13 @@ func TestTryFilterJsonOrArrayIndex(t *testing.T) {
 		// the index when we expect to and we have the correct values for tight,
 		// unique, and remainingFilters.
 		spanExpr, _, remainingFilters, _, ok := invertedidx.TryFilterInvertedIndex(
-			evalCtx, &f, filters, nil /* optionalFilters */, tab, md.Table(tab).Index(tc.indexOrd),
+			evalCtx,
+			&f,
+			filters,
+			nil, /* optionalFilters */
+			tab,
+			md.Table(tab).Index(tc.indexOrd),
+			nil, /* computedColumns */
 		)
 		if tc.ok != ok {
 			t.Fatalf("expected %v, got %v", tc.ok, ok)

--- a/pkg/sql/opt/xform/select_funcs.go
+++ b/pkg/sql/opt/xform/select_funcs.go
@@ -297,7 +297,6 @@ func (c *CustomFuncs) GenerateConstrainedScans(
 			append(optionalFilters, partitionFilters...),
 			scanPrivate.Table,
 			index.Ordinal(),
-			false, /* isInverted */
 		)
 		if !ok {
 			return
@@ -309,7 +308,6 @@ func (c *CustomFuncs) GenerateConstrainedScans(
 				append(optionalFilters, inBetweenFilters...),
 				scanPrivate.Table,
 				index.Ordinal(),
-				false, /* isInverted */
 			)
 			if !ok {
 				panic(errors.AssertionFailedf("in-between filters didn't yield a constraint"))
@@ -732,50 +730,35 @@ func (c *CustomFuncs) GenerateInvertedIndexScans(
 	var iter scanIndexIter
 	iter.Init(c.e.mem, &c.im, scanPrivate, filters, rejectNonInvertedIndexes)
 	iter.ForEach(func(index cat.Index, filters memo.FiltersExpr, indexCols opt.ColSet, isCovering bool) {
-		var spanExpr *invertedexpr.SpanExpression
-		var pfState *invertedexpr.PreFiltererStateForInvertedFilterer
-		var spansToRead invertedexpr.InvertedSpans
-		var constraint *constraint.Constraint
-		var filterOk, constraintOk bool
-
 		// Check whether the filter can constrain the index.
-		// TODO(rytaft): Unify these two cases so both return a spanExpr.
-		spanExpr, constraint, remainingFilters, pfState, filterOk := invertedidx.TryFilterInvertedIndex(
+		spanExpr, constraint, remainingFilters, pfState, ok := invertedidx.TryFilterInvertedIndex(
 			c.e.evalCtx, c.e.f, filters, optionalFilters, scanPrivate.Table, index, tabMeta.ComputedCols,
 		)
-		if filterOk {
-			spansToRead = spanExpr.SpansToRead
-			// Override the filters with remainingFilters. If the index is a
-			// multi-column inverted index, the non-inverted prefix columns are
-			// constrained by the constraint. It may be possible to reduce the
-			// filters if the constraint fully describes some of
-			// sub-expressions. The remainingFilters are the filters that are
-			// not fully expressed by the constraint.
-			//
-			// Consider the example:
-			//
-			//   CREATE TABLE t (a INT, b INT, g GEOMETRY, INVERTED INDEX (b, g))
-			//
-			//   SELECT * FROM t WHERE a = 1 AND b = 2 AND ST_Intersects(.., g)
-			//
-			// The constraint would constrain b to [/2 - /2], guaranteeing that
-			// the inverted index scan would only produce rows where (b = 2).
-			// Reapplying the (b = 2) filter after the scan would be
-			// unnecessary, so the remainingFilters in this case would be
-			// (a = 1 AND ST_Intersects(.., g)).
-			filters = remainingFilters
-		} else {
-			constraint, filters, constraintOk = c.tryConstrainIndex(
-				filters,
-				nil, /* optionalFilters */
-				scanPrivate.Table,
-				index.Ordinal(),
-				true, /* isInverted */
-			)
-			if !constraintOk {
-				return
-			}
+		if !ok {
+			// A span expression to constrain the inverted index could not be
+			// generated.
+			return
 		}
+		spansToRead := spanExpr.SpansToRead
+		// Override the filters with remainingFilters. If the index is a
+		// multi-column inverted index, the non-inverted prefix columns are
+		// constrained by the constraint. In this case, it may be possible to
+		// reduce the filters if the constraint fully describes some of
+		// sub-expressions. The remainingFilters are the filters that are not
+		// fully expressed by the constraint.
+		//
+		// Consider the example:
+		//
+		//   CREATE TABLE t (a INT, b INT, g GEOMETRY, INVERTED INDEX (b, g))
+		//
+		//   SELECT * FROM t WHERE a = 1 AND b = 2 AND ST_Intersects(.., g)
+		//
+		// The constraint would constrain b to [/2 - /2], guaranteeing that
+		// the inverted index scan would only produce rows where (b = 2).
+		// Reapplying the (b = 2) filter after the scan would be
+		// unnecessary, so the remainingFilters in this case would be
+		// (a = 1 AND ST_Intersects(.., g)).
+		filters = remainingFilters
 
 		// Construct new ScanOpDef with the new index and constraint.
 		newScanPrivate := *scanPrivate
@@ -787,8 +770,7 @@ func (c *CustomFuncs) GenerateInvertedIndexScans(
 		// produce duplicate primary keys or requires at least one UNION or
 		// INTERSECTION. In this case, we must scan both the primary key columns
 		// and the inverted key column.
-		needInvertedFilter := spanExpr != nil &&
-			(!spanExpr.Unique || spanExpr.Operator != invertedexpr.None)
+		needInvertedFilter := !spanExpr.Unique || spanExpr.Operator != invertedexpr.None
 		pkCols := sb.primaryKeyCols()
 		newScanPrivate.Cols = pkCols.Copy()
 		var invertedCol opt.ColumnID
@@ -826,19 +808,15 @@ func (c *CustomFuncs) GenerateInvertedIndexScans(
 // filter remaining after extracting the constraint. If no constraint can be
 // derived, then tryConstrainIndex returns ok = false.
 func (c *CustomFuncs) tryConstrainIndex(
-	requiredFilters, optionalFilters memo.FiltersExpr,
-	tabID opt.TableID,
-	indexOrd int,
-	isInverted bool,
+	requiredFilters, optionalFilters memo.FiltersExpr, tabID opt.TableID, indexOrd int,
 ) (constraint *constraint.Constraint, remainingFilters memo.FiltersExpr, ok bool) {
 	// Start with fast check to rule out indexes that cannot be constrained.
-	if !isInverted &&
-		!c.canMaybeConstrainNonInvertedIndex(requiredFilters, tabID, indexOrd) &&
+	if !c.canMaybeConstrainNonInvertedIndex(requiredFilters, tabID, indexOrd) &&
 		!c.canMaybeConstrainNonInvertedIndex(optionalFilters, tabID, indexOrd) {
 		return nil, nil, false
 	}
 
-	ic := c.initIdxConstraintForIndex(requiredFilters, optionalFilters, tabID, indexOrd, isInverted)
+	ic := c.initIdxConstraintForIndex(requiredFilters, optionalFilters, tabID, indexOrd, false /* isInverted */)
 	constraint = ic.Constraint()
 	if constraint.IsUnconstrained() {
 		return nil, nil, false

--- a/pkg/sql/opt/xform/select_funcs.go
+++ b/pkg/sql/opt/xform/select_funcs.go
@@ -720,6 +720,7 @@ func (c *CustomFuncs) GenerateInvertedIndexScans(
 ) {
 	var sb indexScanBuilder
 	sb.init(c, scanPrivate.Table)
+	tabMeta := c.e.mem.Metadata().TableMeta(scanPrivate.Table)
 
 	// Generate implicit filters from constraints and computed columns as
 	// optional filters to help constrain an index scan.
@@ -740,7 +741,7 @@ func (c *CustomFuncs) GenerateInvertedIndexScans(
 		// Check whether the filter can constrain the index.
 		// TODO(rytaft): Unify these two cases so both return a spanExpr.
 		spanExpr, constraint, remainingFilters, pfState, filterOk := invertedidx.TryFilterInvertedIndex(
-			c.e.evalCtx, c.e.f, filters, optionalFilters, scanPrivate.Table, index,
+			c.e.evalCtx, c.e.f, filters, optionalFilters, scanPrivate.Table, index, tabMeta.ComputedCols,
 		)
 		if filterOk {
 			spansToRead = spanExpr.SpansToRead

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -1937,6 +1937,162 @@ index-join b
       │    └── spans: ["7a\x00\x02\x00\x03\x00\x03b\x00\x02c\x00\x02\x00\x03d\x00\x01\x12e\x00\x01", "7a\x00\x02\x00\x03\x00\x03b\x00\x02c\x00\x02\x00\x03d\x00\x01\x12e\x00\x01"]
       └── key: (1)
 
+# Query using the fetch val and equality operators.
+opt expect=GenerateInvertedIndexScans
+SELECT k FROM b WHERE j->'a' = '"b"'
+----
+project
+ ├── columns: k:1!null
+ ├── immutable
+ ├── key: (1)
+ └── scan b@j_inv_idx
+      ├── columns: k:1!null
+      ├── inverted constraint: /6/1
+      │    └── spans: ["7a\x00\x01\x12b\x00\x01", "7a\x00\x01\x12b\x00\x01"]
+      └── key: (1)
+
+# Do not generate an inverted scan when the index of the fetch val operator is
+# not a string.
+opt expect-not=GenerateInvertedIndexScans
+SELECT k FROM b WHERE j->0 = '"b"'
+----
+project
+ ├── columns: k:1!null
+ ├── immutable
+ ├── key: (1)
+ └── select
+      ├── columns: k:1!null j:4
+      ├── immutable
+      ├── key: (1)
+      ├── fd: (1)-->(4)
+      ├── scan b
+      │    ├── columns: k:1!null j:4
+      │    ├── key: (1)
+      │    └── fd: (1)-->(4)
+      └── filters
+           └── (j:4->0) = '"b"' [outer=(4), immutable]
+
+# Do not generate an inverted scan when right side of the equality is an array.
+opt expect-not=GenerateInvertedIndexScans
+SELECT k FROM b WHERE j->'a' = '["b"]'
+----
+project
+ ├── columns: k:1!null
+ ├── immutable
+ ├── key: (1)
+ └── select
+      ├── columns: k:1!null j:4
+      ├── immutable
+      ├── key: (1)
+      ├── fd: (1)-->(4)
+      ├── scan b
+      │    ├── columns: k:1!null j:4
+      │    ├── key: (1)
+      │    └── fd: (1)-->(4)
+      └── filters
+           └── (j:4->'a') = '["b"]' [outer=(4), immutable]
+
+# Do not generate an inverted scan when right side of the equality is an object.
+opt expect-not=GenerateInvertedIndexScans
+SELECT k FROM b WHERE j->'a' = '{"b": "c"}'
+----
+project
+ ├── columns: k:1!null
+ ├── immutable
+ ├── key: (1)
+ └── select
+      ├── columns: k:1!null j:4
+      ├── immutable
+      ├── key: (1)
+      ├── fd: (1)-->(4)
+      ├── scan b
+      │    ├── columns: k:1!null j:4
+      │    ├── key: (1)
+      │    └── fd: (1)-->(4)
+      └── filters
+           └── (j:4->'a') = '{"b": "c"}' [outer=(4), immutable]
+
+# Query using the fetch val and equality operators in a conjunction.
+opt expect=GenerateInvertedIndexScans disable=GenerateInvertedIndexZigzagJoins
+SELECT k FROM b WHERE j->'a' = '"b"' AND j->'c' = '"d"'
+----
+project
+ ├── columns: k:1!null
+ ├── immutable
+ ├── key: (1)
+ └── inverted-filter
+      ├── columns: k:1!null
+      ├── inverted expression: /6
+      │    ├── tight: true, unique: false
+      │    ├── union spans: empty
+      │    └── INTERSECTION
+      │         ├── span expression
+      │         │    ├── tight: true, unique: true
+      │         │    └── union spans: ["7a\x00\x01\x12b\x00\x01", "7a\x00\x01\x12b\x00\x01"]
+      │         └── span expression
+      │              ├── tight: true, unique: true
+      │              └── union spans: ["7c\x00\x01\x12d\x00\x01", "7c\x00\x01\x12d\x00\x01"]
+      ├── key: (1)
+      └── scan b@j_inv_idx
+           ├── columns: k:1!null j_inverted_key:6!null
+           ├── inverted constraint: /6/1
+           │    └── spans
+           │         ├── ["7a\x00\x01\x12b\x00\x01", "7a\x00\x01\x12b\x00\x01"]
+           │         └── ["7c\x00\x01\x12d\x00\x01", "7c\x00\x01\x12d\x00\x01"]
+           ├── key: (1)
+           └── fd: (1)-->(6)
+
+# Query using the fetch val and equality operators in a disjunction.
+opt expect=GenerateInvertedIndexScans
+SELECT k FROM b WHERE j->'a' = '"b"' OR j->'c' = '"d"'
+----
+project
+ ├── columns: k:1!null
+ ├── immutable
+ ├── key: (1)
+ └── inverted-filter
+      ├── columns: k:1!null
+      ├── inverted expression: /6
+      │    ├── tight: true, unique: false
+      │    └── union spans
+      │         ├── ["7a\x00\x01\x12b\x00\x01", "7a\x00\x01\x12b\x00\x01"]
+      │         └── ["7c\x00\x01\x12d\x00\x01", "7c\x00\x01\x12d\x00\x01"]
+      ├── key: (1)
+      └── scan b@j_inv_idx
+           ├── columns: k:1!null j_inverted_key:6!null
+           ├── inverted constraint: /6/1
+           │    └── spans
+           │         ├── ["7a\x00\x01\x12b\x00\x01", "7a\x00\x01\x12b\x00\x01"]
+           │         └── ["7c\x00\x01\x12d\x00\x01", "7c\x00\x01\x12d\x00\x01"]
+           ├── key: (1)
+           └── fd: (1)-->(6)
+
+# Query using the fetch val and equality operators in a disjunction with a
+# contains operator.
+opt expect=GenerateInvertedIndexScans
+SELECT k FROM b WHERE j->'a' = '"b"' OR j @> '{"c": "d"}'
+----
+project
+ ├── columns: k:1!null
+ ├── immutable
+ ├── key: (1)
+ └── inverted-filter
+      ├── columns: k:1!null
+      ├── inverted expression: /6
+      │    ├── tight: true, unique: false
+      │    └── union spans
+      │         ├── ["7a\x00\x01\x12b\x00\x01", "7a\x00\x01\x12b\x00\x01"]
+      │         └── ["7c\x00\x01\x12d\x00\x01", "7c\x00\x01\x12d\x00\x01"]
+      ├── key: (1)
+      └── scan b@j_inv_idx
+           ├── columns: k:1!null j_inverted_key:6!null
+           ├── inverted constraint: /6/1
+           │    └── spans
+           │         ├── ["7a\x00\x01\x12b\x00\x01", "7a\x00\x01\x12b\x00\x01"]
+           │         └── ["7c\x00\x01\x12d\x00\x01", "7c\x00\x01\x12d\x00\x01"]
+           ├── key: (1)
+           └── fd: (1)-->(6)
+
 # GenerateInvertedIndexScans propagates row-level locking information.
 opt expect=GenerateInvertedIndexScans
 SELECT k FROM b WHERE j @> '{"a": "b"}' FOR UPDATE
@@ -4783,7 +4939,8 @@ SELECT k FROM inv_zz_partial WHERE j->'a' = '1' AND j->'b' = '2'
 ----
 project
  └── scan inv_zz_partial@zz_idx,partial
-      └── constraint: /2/1: [/'{"b": 2}' - /'{"b": 2}']
+      └── inverted constraint: /7/1
+           └── spans: ["7b\x00\x01*\x04\x00", "7b\x00\x01*\x04\x00"]
 
 # --------------------------------------------------
 # SplitDisjunction

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -1663,7 +1663,7 @@ project
 # --------------------------------------------------
 
 # Query only the primary key with no remaining filter.
-opt
+opt expect=GenerateInvertedIndexScans
 SELECT k FROM b WHERE j @> '{"a": "b"}'
 ----
 project
@@ -1676,7 +1676,7 @@ project
       │    └── spans: ["7a\x00\x01\x12b\x00\x01", "7a\x00\x01\x12b\x00\x01"]
       └── key: (1)
 
-memo
+memo expect=GenerateInvertedIndexScans
 SELECT k FROM b WHERE j @> '{"a": "b"}'
 ----
 memo (optimized, ~7KB, required=[presentation: k:1])
@@ -1703,7 +1703,7 @@ memo (optimized, ~7KB, required=[presentation: k:1])
  └── G9: (const '{"a": "b"}')
 
 # Query requiring an index join with no remaining filter.
-opt
+opt expect=GenerateInvertedIndexScans
 SELECT u, k FROM b WHERE j @> '{"a": "b"}'
 ----
 project
@@ -1722,7 +1722,7 @@ project
            │    └── spans: ["7a\x00\x01\x12b\x00\x01", "7a\x00\x01\x12b\x00\x01"]
            └── key: (1)
 
-opt
+opt expect=GenerateInvertedIndexScans
 SELECT j, k FROM b WHERE j @> '{"a": "b"}'
 ----
 index-join b
@@ -1736,7 +1736,7 @@ index-join b
       │    └── spans: ["7a\x00\x01\x12b\x00\x01", "7a\x00\x01\x12b\x00\x01"]
       └── key: (1)
 
-opt
+opt expect=GenerateInvertedIndexScans
 SELECT * FROM b WHERE j @> '{"a": "b"}'
 ----
 index-join b
@@ -1750,7 +1750,7 @@ index-join b
       │    └── spans: ["7a\x00\x01\x12b\x00\x01", "7a\x00\x01\x12b\x00\x01"]
       └── key: (1)
 
-opt
+opt expect=GenerateInvertedIndexScans
 SELECT * FROM b WHERE j @> '2'
 ----
 index-join b
@@ -1767,7 +1767,7 @@ index-join b
       └── key: (1)
 
 # Disjunction.
-opt
+opt expect=GenerateInvertedIndexScans
 SELECT k FROM b WHERE j @> '2' OR j @> '1'
 ----
 project
@@ -1796,7 +1796,7 @@ project
            └── fd: (1)-->(6)
 
 # Disjunction with non-tight predicate.
-opt
+opt expect=GenerateInvertedIndexScans
 SELECT * FROM b WHERE j @> '[[1, 2]]' OR j @> '[[3, 4]]'
 ----
 select
@@ -1848,7 +1848,7 @@ select
  └── filters
       └── (j:4 @> '[[1, 2]]') OR (j:4 @> '[[3, 4]]') [outer=(4), immutable, constraints=(/4: (/NULL - ])]
 
-opt
+opt expect=GenerateInvertedIndexScans
 SELECT * FROM b WHERE j @> '[{}]'
 ----
 index-join b
@@ -1873,7 +1873,7 @@ index-join b
            ├── key: (1)
            └── fd: (1)-->(6)
 
-opt
+opt expect=GenerateInvertedIndexScans
 SELECT * FROM b WHERE j @> '{"a": {}}'
 ----
 index-join b
@@ -1898,7 +1898,7 @@ index-join b
            ├── key: (1)
            └── fd: (1)-->(6)
 
-opt
+opt expect=GenerateInvertedIndexScans
 SELECT * FROM b WHERE j @> '{"a": []}'
 ----
 index-join b
@@ -1923,7 +1923,7 @@ index-join b
            ├── key: (1)
            └── fd: (1)-->(6)
 
-opt
+opt expect=GenerateInvertedIndexScans
 SELECT * FROM b WHERE j @> '{"a":[[{"b":{"c":[{"d":"e"}]}}]]}'
 ----
 index-join b
@@ -1938,7 +1938,7 @@ index-join b
       └── key: (1)
 
 # GenerateInvertedIndexScans propagates row-level locking information.
-opt
+opt expect=GenerateInvertedIndexScans
 SELECT k FROM b WHERE j @> '{"a": "b"}' FOR UPDATE
 ----
 project
@@ -1954,7 +1954,7 @@ project
       └── key: (1)
 
 # Tests for array inverted indexes.
-opt
+opt expect=GenerateInvertedIndexScans
 SELECT k FROM c WHERE a @> ARRAY[1]
 ----
 project
@@ -1968,7 +1968,7 @@ project
       └── key: (1)
 
 # Disjunction.
-opt
+opt expect=GenerateInvertedIndexScans
 SELECT k FROM c WHERE a @> ARRAY[1] OR a @> ARRAY[2]
 ----
 project
@@ -1988,7 +1988,7 @@ project
            ├── key: (1)
            └── fd: (1)-->(5)
 
-opt
+opt expect=GenerateInvertedIndexScans
 SELECT k FROM c WHERE a @> ARRAY[]::INT[]
 ----
 project
@@ -2008,7 +2008,7 @@ project
            ├── key: (1)
            └── fd: (1)-->(5)
 
-opt
+opt expect-not=GenerateInvertedIndexScans
 SELECT k FROM c WHERE a IS NULL
 ----
 project
@@ -2121,7 +2121,7 @@ CREATE INVERTED INDEX a_inv_idx ON c (a)
 ----
 
 # Tests for geospatial constrained scans.
-opt
+opt expect=GenerateInvertedIndexScans
 SELECT k FROM g WHERE ST_Intersects('SRID=4326;POINT(-43.23456 72.4567772)'::geography, geog)
 ----
 project
@@ -2161,7 +2161,7 @@ project
            └── st_intersects('0101000020E61000009279E40F069E45C0BEE36FD63B1D5240', geog:4) [outer=(4), immutable, constraints=(/4: (/NULL - ])]
 
 # Same test as above, but with commuted arguments.
-opt
+opt expect=GenerateInvertedIndexScans
 SELECT k FROM g WHERE ST_Intersects(geog, 'SRID=4326;POINT(-43.23456 72.4567772)'::geography)
 ----
 project
@@ -2200,7 +2200,7 @@ project
       └── filters
            └── st_intersects(geog:4, '0101000020E61000009279E40F069E45C0BEE36FD63B1D5240') [outer=(4), immutable, constraints=(/4: (/NULL - ])]
 
-opt
+opt expect=GenerateInvertedIndexScans
 SELECT k FROM g WHERE ST_CoveredBy('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))'::geometry, geom)
 ----
 project
@@ -2240,7 +2240,7 @@ project
            └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:3) [outer=(3), immutable, constraints=(/3: (/NULL - ])]
 
 # Same test as above, but with commuted arguments.
-opt
+opt expect=GenerateInvertedIndexScans
 SELECT k FROM g WHERE ST_CoveredBy(geom, 'POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))'::geometry)
 ----
 project
@@ -2273,7 +2273,7 @@ project
       └── filters
            └── st_coveredby(geom:3, '0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000') [outer=(3), immutable, constraints=(/3: (/NULL - ])]
 
-opt
+opt expect=GenerateInvertedIndexScans
 SELECT k FROM g WHERE ST_DWithin('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))'::geometry, geom, 2)
 ----
 project
@@ -2306,7 +2306,7 @@ project
       └── filters
            └── st_dwithin('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:3, 2.0) [outer=(3), immutable, constraints=(/3: (/NULL - ])]
 
-opt
+opt expect=GenerateInvertedIndexScans
 SELECT k FROM g WHERE ST_DFullyWithin('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))'::geometry, geom, 2)
 ----
 project
@@ -2339,7 +2339,7 @@ project
       └── filters
            └── st_dfullywithin('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:3, 2.0) [outer=(3), immutable, constraints=(/3: (/NULL - ])]
 
-opt
+opt expect=GenerateInvertedIndexScans
 SELECT k FROM g WHERE ST_DWithin('SRID=4326;POINT(-43.23456 72.4567772)'::geography, geog, 2000)
 ----
 project
@@ -2392,7 +2392,7 @@ project
       └── filters
            └── st_dwithin('0101000020E61000009279E40F069E45C0BEE36FD63B1D5240', geog:4, 2000.0) [outer=(4), immutable, constraints=(/4: (/NULL - ])]
 
-opt
+opt expect=GenerateInvertedIndexScans
 SELECT k FROM g WHERE ST_DWithin('SRID=4326;POINT(-43.23456 72.4567772)'::geography, geog, 2000, false)
 ----
 project
@@ -2446,7 +2446,7 @@ project
            └── st_dwithin('0101000020E61000009279E40F069E45C0BEE36FD63B1D5240', geog:4, 2000.0, false) [outer=(4), immutable, constraints=(/4: (/NULL - ])]
 
 # Test for ST_DWithinExclusive
-opt
+opt expect=GenerateInvertedIndexScans
 SELECT k FROM g WHERE ST_DWithinExclusive('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))'::geometry, geom, 2)
 ----
 project
@@ -2480,7 +2480,7 @@ project
            └── st_dwithinexclusive('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:3, 2.0) [outer=(3), immutable, constraints=(/3: (/NULL - ])]
 
 # Commuted version of previous test.
-opt
+opt expect=GenerateInvertedIndexScans
 SELECT k FROM g WHERE ST_DWithinExclusive(geom, 'POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))'::geometry, 2)
 ----
 project
@@ -2513,7 +2513,7 @@ project
       └── filters
            └── st_dwithinexclusive(geom:3, '0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', 2.0) [outer=(3), immutable, constraints=(/3: (/NULL - ])]
 
-opt
+opt expect=GenerateInvertedIndexScans
 SELECT k FROM g WHERE ST_DFullyWithinExclusive('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))'::geometry, geom, 2)
 ----
 project
@@ -2549,7 +2549,7 @@ project
 # Multiple geospatial functions.
 # NB: the union spans for the following query are a subset of the spans. This is a
 # consequence of how intersectSpanExpression does simplification.
-opt
+opt expect=GenerateInvertedIndexScans
 SELECT k FROM g
 WHERE ST_Covers('SRID=4326;POINT(-43.23456 72.4567772)'::geography, geog)
 AND ST_CoveredBy('SRID=4326;POINT(-40.23456 70.4567772)'::geography, geog)
@@ -2590,7 +2590,7 @@ project
            ├── st_covers('0101000020E61000009279E40F069E45C0BEE36FD63B1D5240', geog:4) [outer=(4), immutable, constraints=(/4: (/NULL - ])]
            └── st_coveredby('0101000020E61000009279E40F061E44C0BEE36FD63B9D5140', geog:4) [outer=(4), immutable, constraints=(/4: (/NULL - ])]
 
-opt
+opt expect=GenerateInvertedIndexScans
 SELECT k FROM g
 WHERE ST_Covers('SRID=4326;POINT(-43.23456 72.4567772)'::geography, geog)
 OR ST_CoveredBy('SRID=4326;POINT(-40.23456 70.4567772)'::geography, geog)
@@ -2627,7 +2627,7 @@ project
       └── filters
            └── st_covers('0101000020E61000009279E40F069E45C0BEE36FD63B1D5240', geog:4) OR st_coveredby('0101000020E61000009279E40F061E44C0BEE36FD63B9D5140', geog:4) [outer=(4), immutable, constraints=(/4: (/NULL - ])]
 
-opt
+opt expect=GenerateInvertedIndexScans
 SELECT k FROM g
 WHERE ST_Covers('SRID=4326;POINT(-43.23456 72.4567772)'::geography, geog)
 OR (ST_CoveredBy('SRID=4326;LINESTRING(-118.4079 33.9434, 2.5559 49.0083)'::geography, geog)
@@ -2695,7 +2695,7 @@ project
            └── st_covers('0101000020E61000009279E40F069E45C0BEE36FD63B1D5240', geog:4) OR (st_coveredby('0102000020E61000000200000075029A081B9A5DC0F085C954C1F840406DC5FEB27B720440454772F90F814840', geog:4) AND st_coveredby('0101000020E610000058569A94821E46C07BC7DFAC773A4E40', geog:4)) [outer=(4), immutable, constraints=(/4: (/NULL - ])]
 
 # Multiple geospatial functions on different indexes.
-opt
+opt expect=GenerateInvertedIndexScans
 SELECT k FROM g
 WHERE ST_Covers('SRID=4326;POINT(-43.23456 72.4567772)'::geography, geog)
 AND ST_Overlaps('LINESTRING ( 0 0, 0 2 )'::geometry, geom)
@@ -2753,7 +2753,7 @@ project
       └── filters
            └── st_covers('0101000020E61000009279E40F069E45C0BEE36FD63B1D5240', geog:4) OR st_touches('0102000000020000000000000000000000000000000000000000000000000000000000000000000040', geom:3) [outer=(3,4), immutable]
 
-opt
+opt expect=GenerateInvertedIndexScans
 SELECT k FROM g
 WHERE ST_Covers('SRID=4326;POINT(-43.23456 72.4567772)'::geography, geog)
 OR (ST_Intersects('SRID=4326;POINT(-40.23456 70.4567772)'::geography, geog)
@@ -2792,7 +2792,7 @@ project
            └── st_covers('0101000020E61000009279E40F069E45C0BEE36FD63B1D5240', geog:4) OR (st_intersects('0101000020E61000009279E40F061E44C0BEE36FD63B9D5140', geog:4) AND st_crosses('0102000000020000000000000000000000000000000000000000000000000000000000000000000040', geom:3)) [outer=(3,4), immutable, constraints=(/4: (/NULL - ])]
 
 # Filters on other columns.
-opt
+opt expect=GenerateInvertedIndexScans
 SELECT k FROM g
 WHERE ST_Covers('SRID=4326;POINT(-43.23456 72.4567772)'::geography, geog)
 AND v = 3 AND k > 100
@@ -2841,7 +2841,7 @@ project
            └── v:2 = 3 [outer=(2), constraints=(/2: [/3 - /3]; tight), fd=()-->(2)]
 
 # Bounding box operations.
-opt
+opt expect=GenerateInvertedIndexScans
 SELECT k FROM g WHERE 'BOX(1 2, 3 4)'::box2d ~ geom
 ----
 project
@@ -2878,7 +2878,7 @@ project
       └── filters
            └── 'BOX(1 2,3 4)' ~ geom:3 [outer=(3), immutable]
 
-opt
+opt expect=GenerateInvertedIndexScans
 SELECT k FROM g WHERE geom ~ 'BOX(1 2, 3 4)'::box2d
 ----
 project
@@ -2915,7 +2915,7 @@ project
       └── filters
            └── geom:3 ~ 'BOX(1 2,3 4)' [outer=(3), immutable, constraints=(/3: (/NULL - ])]
 
-opt
+opt expect=GenerateInvertedIndexScans
 SELECT k FROM g WHERE geom ~ 'MULTIPOINT((2.2 2.2), (3.0 3.0))'::geometry
 ----
 project
@@ -2977,7 +2977,7 @@ exec-ddl
 CREATE INVERTED INDEX idx ON pi (j) WHERE s = 'foo'
 ----
 
-opt
+opt expect=GenerateInvertedIndexScans
 SELECT k FROM pi WHERE j @> '{"a": "b"}' AND s = 'foo'
 ----
 project
@@ -3000,7 +3000,7 @@ exec-ddl
 CREATE INVERTED INDEX idx ON pi (j) WHERE j @> '{"group": 1}'
 ----
 
-opt
+opt expect=GenerateInvertedIndexScans
 SELECT k FROM pi WHERE j @> '{"a": "b"}' AND j @> '{"group": 1}'
 ----
 project
@@ -3023,7 +3023,7 @@ exec-ddl
 CREATE INVERTED INDEX idx ON pi (j) WHERE s = 'foo'
 ----
 
-opt
+opt expect=GenerateInvertedIndexScans
 SELECT * FROM pi WHERE j @> '{"a": "b"}' AND s = 'foo'
 ----
 index-join pi
@@ -3047,7 +3047,7 @@ exec-ddl
 CREATE INVERTED INDEX idx ON pi (j) WHERE s IN ('foo', 'bar')
 ----
 
-opt
+opt expect=GenerateInvertedIndexScans
 SELECT * FROM pi WHERE j @> '{"a": "b"}' AND j @> '{"group": 1}' AND s = 'foo'
 ----
 select
@@ -3098,7 +3098,7 @@ exec-ddl
 CREATE INVERTED INDEX idx2 ON pi (j) WHERE s = 'bar'
 ----
 
-memo
+memo expect=GenerateInvertedIndexScans
 SELECT * FROM pi WHERE j @> '{"a": "b"}' AND s = 'bar'
 ----
 memo (optimized, ~10KB, required=[presentation: k:1,s:2,j:3])
@@ -3172,7 +3172,7 @@ DROP INDEX idx
 
 # Check that we can generate constraints by recognizing computed column
 # expressions.
-opt
+opt expect=GenerateInvertedIndexScans
 SELECT k FROM computed WHERE (j->'foo') @> '{"a": "b"}'
 ----
 project

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -3337,7 +3337,21 @@ project
  ├── key: (1)
  └── scan computed@field_inv_idx
       ├── columns: k:1!null
-      ├── constraint: /5/1: [/'{"a": "b"}' - /'{"a": "b"}']
+      ├── inverted constraint: /8/1
+      │    └── spans: ["7a\x00\x01\x12b\x00\x01", "7a\x00\x01\x12b\x00\x01"]
+      └── key: (1)
+
+opt expect=GenerateInvertedIndexScans
+SELECT k FROM computed WHERE (j->'foo')->'a' = '1'
+----
+project
+ ├── columns: k:1!null
+ ├── immutable
+ ├── key: (1)
+ └── scan computed@field_inv_idx
+      ├── columns: k:1!null
+      ├── inverted constraint: /8/1
+      │    └── spans: ["7a\x00\x01*\x02\x00", "7a\x00\x01*\x02\x00"]
       └── key: (1)
 
 # Tests for multi-column inverted indexes.
@@ -3841,6 +3855,44 @@ select
  │              └── fd: (1)-->(9)
  └── filters
       ├── a:2 = 'foo' [outer=(2), constraints=(/2: [/'foo' - /'foo']; tight), fd=()-->(2)]
+      └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:5) [outer=(5), immutable, constraints=(/5: (/NULL - ])]
+
+# Constrain a prefix computed column when the computed expression matches a
+# filter expression.
+opt expect=GenerateInvertedIndexScans
+SELECT * FROM mc WHERE upper(a) = 'FOO' AND ST_CoveredBy('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))'::geometry, geom)
+----
+select
+ ├── columns: k:1!null a:2!null b:3!null c:4 geom:5!null
+ ├── immutable
+ ├── key: (1)
+ ├── fd: (1)-->(2-5)
+ ├── index-join mc
+ │    ├── columns: k:1!null a:2!null b:3!null c:4 geom:5
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-5)
+ │    └── inverted-filter
+ │         ├── columns: k:1!null
+ │         ├── inverted expression: /9
+ │         │    ├── tight: false, unique: false
+ │         │    └── union spans
+ │         │         ├── ["B\xfd\x10\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x10\x00\x00\x00\x00\x00\x00\x00"]
+ │         │         ├── ["B\xfd\x11\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x11\x00\x00\x00\x00\x00\x00\x00"]
+ │         │         └── ["B\xfd\x14\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x14\x00\x00\x00\x00\x00\x00\x00"]
+ │         ├── pre-filterer expression
+ │         │    └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:5)
+ │         ├── key: (1)
+ │         └── scan mc@mc_idx
+ │              ├── columns: k:1!null geom_inverted_key:9!null
+ │              ├── constraint: /4: [/'FOO' - /'FOO']
+ │              ├── inverted constraint: /9/1
+ │              │    └── spans
+ │              │         ├── ["B\xfd\x10\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x10\x00\x00\x00\x00\x00\x00\x00"]
+ │              │         ├── ["B\xfd\x11\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x11\x00\x00\x00\x00\x00\x00\x00"]
+ │              │         └── ["B\xfd\x14\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x14\x00\x00\x00\x00\x00\x00\x00"]
+ │              ├── key: (1)
+ │              └── fd: (1)-->(9)
+ └── filters
       └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:5) [outer=(5), immutable, constraints=(/5: (/NULL - ])]
 
 exec-ddl


### PR DESCRIPTION
#### opt: rename inverted constraint contains extraction function

The function name now reflects that it specifically deals with the
Contains expression, `@>`.

Release note: None

#### opt: add rule expectations for GenerateInvertedIndexScan tests

Release note: None

#### invertedidx: add convenience function for extracting index column variable

Release note: None

#### opt: build inverted index scan constraints from JSON fetch val operator

GenerateInvertedIndexScans now generates InvertedConstraints from
equality expressions with a JSON FetchVal operator on the left side and
a constant on the right side, like `j->'a' = '1'`. Previously
Constraints were built for these expressions with the `idxconstraint`
package.

By building InvertedConstraints from FetchVal operators, the optimizer
now has the ability to generate inverted index scans with conjunctive
and disjunctive filters containing FetchVal operators. For example, the
optimizer will plan an inverted index scan with the query below.

    CREATE TABLE t (k INT PRIMARY KEY, j JSON, INVERTED INDEX (j))

    SELECT k FROM t WHERE j->'a' = '1' AND j->'b' = 2

This change also brings us a step closer to cleaning up the
`idxconstraint` by removing code related to inverted indexes.

Informs #47340

Release note (performance improvement): The query optimizer now plans
scans over inverted indexes on JSON columns for query filters that
constrain the JSON column with equality and fetch value operators (`->`)
inside conjunctions and disjunctions, like
`j->'a' = '1' AND j->'b' = '2'`.

#### opt: build InvertedConstraints for inverted index scans on computed columns

GenerateInvertedIndexScans now builds InvertedConstraints over inverted
indexes on computed columns when a filter constrains an expression that
is equivalent to the computed column expression. Previously Constraints
were built for these expressions with the `idxconstraint` package.

This change provides no functional change, but brings us a step closer
to cleaning up the `idxconstraint` by removing code related to inverted
indexes.

Release note: None

#### opt: do not build Constraints in GenerateInvertedIndexScans

InvertedConstraints can be built for inverted index scans in all cases
that Constraints could be built. Therefore there is no longer a need to
build Constraints in GenerateInvertedIndexScans. This commit removes the
code related to this.

Release note: None
