### PR TITLE
util: add names to metamorphic constants

### DIFF
--- a/pkg/col/coldata/batch.go
+++ b/pkg/col/coldata/batch.go
@@ -79,6 +79,7 @@ var _ Batch = &MemBatch{}
 // (the best number according to that benchmark was 1280, but it was negligibly
 // better, so we decided to keep 1024 as it is a power of 2).
 var defaultBatchSize = int64(util.ConstantWithMetamorphicTestRange(
+	"coldata-batch-size",
 	1024, /* defaultValue */
 	// min is set to 3 to match colexec's minBatchSize setting.
 	3, /* min */

--- a/pkg/sql/colexec/spilling_queue.go
+++ b/pkg/sql/colexec/spilling_queue.go
@@ -85,6 +85,7 @@ type spillingQueue struct {
 // spillingQueueInitialItemsLen is the initial capacity of the in-memory buffer
 // of the spilling queues (memory limit permitting).
 var spillingQueueInitialItemsLen = int64(util.ConstantWithMetamorphicTestRange(
+	"spilling-queue-initial-len",
 	64 /* defaultValue */, 1 /* min */, 16, /* max */
 ))
 

--- a/pkg/sql/mutations/mutations_util.go
+++ b/pkg/sql/mutations/mutations_util.go
@@ -21,6 +21,7 @@ const productionMaxBatchSize = 10000
 var maxBatchSize = defaultMaxBatchSize
 
 var defaultMaxBatchSize = int64(util.ConstantWithMetamorphicTestRange(
+	"max-batch-size",
 	productionMaxBatchSize, /* defaultValue */
 	1,                      /* min */
 	productionMaxBatchSize, /* max */

--- a/pkg/sql/row/kv_batch_fetcher.go
+++ b/pkg/sql/row/kv_batch_fetcher.go
@@ -42,6 +42,7 @@ func getKVBatchSize(forceProductionKVBatchSize bool) int64 {
 }
 
 var defaultKVBatchSize = int64(util.ConstantWithMetamorphicTestValue(
+	"kv-batch-size",
 	productionKVBatchSize, /* defaultValue */
 	1,                     /* metamorphicValue */
 ))

--- a/pkg/sql/row/row_converter.go
+++ b/pkg/sql/row/row_converter.go
@@ -229,6 +229,7 @@ type DatumRowConverter struct {
 }
 
 var kvDatumRowConverterBatchSize = util.ConstantWithMetamorphicTestValue(
+	"datum-row-converter-batch-size",
 	5000, /* defaultValue */
 	1,    /* metamorphicValue */
 )

--- a/pkg/sql/rowcontainer/datum_row_container.go
+++ b/pkg/sql/rowcontainer/datum_row_container.go
@@ -101,6 +101,7 @@ func NewRowContainerWithCapacity(
 }
 
 var rowsPerChunkShift = uint(util.ConstantWithMetamorphicTestValue(
+	"row-container-rows-per-chunk-shift",
 	6, /* defaultValue */
 	1, /* metamorphicValue */
 ))

--- a/pkg/sql/rowexec/inverted_joiner.go
+++ b/pkg/sql/rowexec/inverted_joiner.go
@@ -40,6 +40,7 @@ import (
 // scanned rows to disk. The spilling cost will probably be dominated by
 // the de-duping cost, since it incurs a read.
 var invertedJoinerBatchSize = util.ConstantWithMetamorphicTestValue(
+	"invered-joiner-batch-size",
 	100, /* defaultValue */
 	1,   /* metamorphicValue */
 )

--- a/pkg/sql/rowexec/zigzagjoiner.go
+++ b/pkg/sql/rowexec/zigzagjoiner.go
@@ -253,6 +253,7 @@ type zigzagJoiner struct {
 // matched rows are grouped together, but increasing this too much will result
 // in fetching too many rows and therefore skipping less rows.
 var zigzagJoinerBatchSize = int64(util.ConstantWithMetamorphicTestValue(
+	"zig-zag-joiner-batch-size",
 	5, /* defaultValue */
 	1, /* metamorphicValue */
 ))

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -56,14 +56,16 @@ const (
 //
 // you should write:
 //
-// var batchSize = util.ConstantWithMetamorphicTestValue(64, 1)
+// var batchSize = util.ConstantWithMetamorphicTestValue("batch-size", 64, 1)
 //
 // This will often give your code a batch size of 1 in the crdb_test build
 // configuration, increasing the amount of exercise the edge conditions get.
-func ConstantWithMetamorphicTestValue(defaultValue, metamorphicValue int) int {
+//
+// The given name is used for logging.
+func ConstantWithMetamorphicTestValue(name string, defaultValue, metamorphicValue int) int {
 	if metamorphicBuild {
 		if rng.Float64() < metamorphicValueProbability {
-			logMetamorphicValue(metamorphicValue)
+			logMetamorphicValue(name, metamorphicValue)
 			return metamorphicValue
 		}
 	}
@@ -83,21 +85,22 @@ func init() {
 // ConstantWithMetamorphicTestRange is like ConstantWithMetamorphicTestValue
 // except instead of returning a single metamorphic test value, it returns a
 // random test value in a range.
-func ConstantWithMetamorphicTestRange(defaultValue, min, max int) int {
+//
+// The given name is used for logging.
+func ConstantWithMetamorphicTestRange(name string, defaultValue, min, max int) int {
 	if metamorphicBuild {
 		if rng.Float64() < metamorphicValueProbability {
 			ret := min
 			if max > min {
 				ret = int(rng.Int31())%(max-min) + min
 			}
-			logMetamorphicValue(ret)
+			logMetamorphicValue(name, ret)
 			return ret
 		}
 	}
 	return defaultValue
 }
 
-func logMetamorphicValue(value int) {
-	fmt.Fprintf(os.Stderr, "initialized metamorphic constant with value %d: %s\n",
-		value, GetSmallTrace(1))
+func logMetamorphicValue(name string, value int) {
+	fmt.Fprintf(os.Stderr, "initialized metamorphic constant %q with value %d\n", name, value)
 }


### PR DESCRIPTION
We currently print a compact stack trace to identify metamorphic
constants in logs, which is very hard to read. Improving this by
requiring the caller to pass in a user-friendly name.

Release note: None