### PR TITLE
release-20.2: sql: fix ALTER INDEX ... SPLIT/UNSPLIT AT in error cases

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/ranges
+++ b/pkg/sql/logictest/testdata/logic_test/ranges
@@ -552,3 +552,15 @@ CREATE TABLE err_msg (x INT, y INT, z INT, PRIMARY KEY (x, y), INDEX i (z))
 
 statement error HINT: columns \[x y\] are implicitly part of index "i"'s key, include columns \[z x y\] in this order
 SHOW RANGE FROM INDEX err_msg@i FOR ROW (1)
+
+# Regression test for incorrectly handling an excessive number of values in
+# SPLIT/UNSPLIT AT statements (#59011).
+statement ok
+CREATE TABLE t59011 (id UUID NOT NULL DEFAULT gen_random_uuid(), level INT8 NULL DEFAULT 0:::INT8, CONSTRAINT "primary" PRIMARY KEY (id ASC), INDEX i59011 (level ASC));
+INSERT INTO t59011(level) SELECT 2 FROM generate_series(1, 10);
+
+statement error excessive number of values provided: expected 1, got 2
+ALTER INDEX i59011 SPLIT AT VALUES (2, '6cf22b39-a1eb-43ee-8edf-0da8543c5c38'::UUID);
+
+statement error excessive number of values provided: expected 1, got 2
+ALTER INDEX i59011 UNSPLIT AT VALUES (2, '6cf22b39-a1eb-43ee-8edf-0da8543c5c38'::UUID);

--- a/pkg/sql/split.go
+++ b/pkg/sql/split.go
@@ -17,6 +17,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -91,6 +93,9 @@ func getRowKey(
 	index *descpb.IndexDescriptor,
 	values []tree.Datum,
 ) ([]byte, error) {
+	if len(index.ColumnIDs) < len(values) {
+		return nil, pgerror.Newf(pgcode.Syntax, "excessive number of values provided: expected %d, got %d", len(index.ColumnIDs), len(values))
+	}
 	colMap := make(map[descpb.ColumnID]int)
 	for i := range values {
 		colMap[index.ColumnIDs[i]] = i


### PR DESCRIPTION
Backport 1/1 commits from #59213.

/cc @cockroachdb/release

---

The root cause is that the optimizer thinks that hidden columns that are
part of the key in the index (like primary key columns) are in scope,
yet we expect the values for those columns to not be present.

Fixes: #59011.

Release note (bug fix): CockroachDB previously could crash when
executing `ALTER INDEX ... SPLIT/UNSPLIT AT` statement when more values
are provided than are explicitly specified in the index, and now this
has been fixed.
