### PR TITLE
release-20.1: sql: fix ALTER INDEX ... SPLIT/UNSPLIT AT in error cases

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/ranges
+++ b/pkg/sql/logictest/testdata/logic_test/ranges
@@ -538,3 +538,15 @@ SHOW RANGES FROM TABLE crdb_internal.tables
 
 query error \"crdb_internal.tables\" is a virtual table
 SHOW RANGE FROM TABLE crdb_internal.tables FOR ROW (0, 0)
+
+# Regression test for incorrectly handling an excessive number of values in
+# SPLIT/UNSPLIT AT statements (#59011).
+statement ok
+CREATE TABLE t59011 (id UUID NOT NULL DEFAULT gen_random_uuid(), level INT8 NULL DEFAULT 0:::INT8, CONSTRAINT "primary" PRIMARY KEY (id ASC), INDEX i59011 (level ASC));
+INSERT INTO t59011(level) SELECT 2 FROM generate_series(1, 10);
+
+statement error excessive number of values provided: expected 1, got 2
+ALTER INDEX i59011 SPLIT AT VALUES (2, '6cf22b39-a1eb-43ee-8edf-0da8543c5c38'::UUID);
+
+statement error excessive number of values provided: expected 1, got 2
+ALTER INDEX i59011 UNSPLIT AT VALUES (2, '6cf22b39-a1eb-43ee-8edf-0da8543c5c38'::UUID);


### PR DESCRIPTION
Backport 1/1 commits from #59213.

/cc @cockroachdb/release

---

The root cause is that the optimizer thinks that hidden columns that are
part of the key in the index (like primary key columns) are in scope,
yet we expect the values for those columns to not be present.

Fixes: #59011.

Release note (bug fix): CockroachDB previously could crash when
executing `ALTER INDEX ... SPLIT/UNSPLIT AT` statement when more values
are provided than are explicitly specified in the index, and now this
has been fixed.
