### PR TITLE
opt: deflake distsql_automatic_stats

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/distsql_automatic_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_automatic_stats
@@ -1,4 +1,4 @@
-# LogicTest: !metamorphic, !3node-tenant
+# LogicTest: !metamorphic
 
 # Disable automatic stats
 statement ok
@@ -18,9 +18,13 @@ INSERT INTO data SELECT a, b, c::FLOAT, NULL FROM
    generate_series(1, 10) AS b(b),
    generate_series(1, 10) AS c(c)
 
+# The query uses DISTINCT ON and ORDER BY to only show the latest statistic
+# available for each set of column names. This is important in order to
+# tolerate the rare case of multiple auto stats jobs running between two retry
+# iterations.
 query TTIII colnames,rowsort,retry
-SELECT statistics_name, column_names, row_count, distinct_count, null_count
-FROM [SHOW STATISTICS FOR TABLE data] ORDER BY column_names::STRING, created
+SELECT DISTINCT ON (column_names) statistics_name, column_names, row_count, distinct_count, null_count
+FROM [SHOW STATISTICS FOR TABLE data] ORDER BY column_names, created
 ----
 statistics_name  column_names  row_count  distinct_count  null_count
 __auto__         {a,b,c}       1000       1000            0
@@ -40,8 +44,8 @@ UPDATE data SET d = 10 WHERE (a = 1 OR a = 2 OR a = 3) AND b > 1
 
 # There should be no change to stats.
 query TTIII colnames,rowsort
-SELECT statistics_name, column_names, row_count, distinct_count, null_count
-FROM [SHOW STATISTICS FOR TABLE data] ORDER BY column_names::STRING, created
+SELECT DISTINCT ON (column_names) statistics_name, column_names, row_count, distinct_count, null_count
+FROM [SHOW STATISTICS FOR TABLE data] ORDER BY column_names ASC, created DESC
 ----
 statistics_name  column_names  row_count  distinct_count  null_count
 __auto__         {a,b,c}       1000       1000            0
@@ -60,21 +64,15 @@ statement ok
 UPDATE data SET d = 12 WHERE d = 10
 
 query TTIII colnames,rowsort,retry
-SELECT statistics_name, column_names, row_count, distinct_count, null_count
-FROM [SHOW STATISTICS FOR TABLE data] ORDER BY column_names::STRING, created
+SELECT DISTINCT ON (column_names) statistics_name, column_names, row_count, distinct_count, null_count
+FROM [SHOW STATISTICS FOR TABLE data] ORDER BY column_names ASC, created DESC
 ----
 statistics_name  column_names  row_count  distinct_count  null_count
 __auto__         {a,b,c}       1000       1000            0
-__auto__         {a,b,c}       1000       1000            0
-__auto__         {a,b}         1000       100             0
 __auto__         {a,b}         1000       100             0
 __auto__         {a}           1000       10              0
-__auto__         {a}           1000       10              0
-__auto__         {b}           1000       10              0
 __auto__         {b}           1000       10              0
 __auto__         {c}           1000       10              0
-__auto__         {c}           1000       10              0
-__auto__         {d}           1000       1               1000
 __auto__         {d}           1000       2               730
 
 # Upsert more than 20% of the table.
@@ -85,27 +83,15 @@ generate_series(1, 10) AS b(b),
 generate_series(1, 5) AS c(c)
 
 query TTIII colnames,rowsort,retry
-SELECT statistics_name, column_names, row_count, distinct_count, null_count
-FROM [SHOW STATISTICS FOR TABLE data] ORDER BY column_names::STRING, created
+SELECT DISTINCT ON (column_names) statistics_name, column_names, row_count, distinct_count, null_count
+FROM [SHOW STATISTICS FOR TABLE data] ORDER BY column_names ASC, created DESC
 ----
 statistics_name  column_names  row_count  distinct_count  null_count
-__auto__         {a,b,c}       1000       1000            0
-__auto__         {a,b,c}       1000       1000            0
 __auto__         {a,b,c}       1050       1050            0
-__auto__         {a,b}         1000       100             0
-__auto__         {a,b}         1000       100             0
 __auto__         {a,b}         1050       110             0
-__auto__         {a}           1000       10              0
-__auto__         {a}           1000       10              0
 __auto__         {a}           1050       11              0
-__auto__         {b}           1000       10              0
-__auto__         {b}           1000       10              0
 __auto__         {b}           1050       10              0
-__auto__         {c}           1000       10              0
-__auto__         {c}           1000       10              0
 __auto__         {c}           1050       10              0
-__auto__         {d}           1000       1               1000
-__auto__         {d}           1000       2               730
 __auto__         {d}           1050       3               365
 
 # Delete more than 20% of the table.
@@ -113,33 +99,15 @@ statement ok
 DELETE FROM data WHERE c > 5
 
 query TTIII colnames,rowsort,retry
-SELECT statistics_name, column_names, row_count, distinct_count, null_count
-FROM [SHOW STATISTICS FOR TABLE data] ORDER BY column_names::STRING, created
+SELECT DISTINCT ON (column_names) statistics_name, column_names, row_count, distinct_count, null_count
+FROM [SHOW STATISTICS FOR TABLE data] ORDER BY column_names ASC, created DESC
 ----
 statistics_name  column_names  row_count  distinct_count  null_count
-__auto__         {a,b,c}       1000       1000            0
-__auto__         {a,b,c}       1000       1000            0
-__auto__         {a,b,c}       1050       1050            0
 __auto__         {a,b,c}       550        550             0
-__auto__         {a,b}         1000       100             0
-__auto__         {a,b}         1000       100             0
-__auto__         {a,b}         1050       110             0
 __auto__         {a,b}         550        110             0
-__auto__         {a}           1000       10              0
-__auto__         {a}           1000       10              0
-__auto__         {a}           1050       11              0
 __auto__         {a}           550        11              0
-__auto__         {b}           1000       10              0
-__auto__         {b}           1000       10              0
-__auto__         {b}           1050       10              0
 __auto__         {b}           550        10              0
-__auto__         {c}           1000       10              0
-__auto__         {c}           1000       10              0
-__auto__         {c}           1050       10              0
 __auto__         {c}           550        5               0
-__auto__         {d}           1000       1               1000
-__auto__         {d}           1000       2               730
-__auto__         {d}           1050       3               365
 __auto__         {d}           550        1               0
 
 # Test CREATE TABLE ... AS
@@ -149,8 +117,8 @@ CREATE TABLE copy AS SELECT * FROM data
 # Distinct count for rowid can be flaky, so don't show it. The estimate is
 # almost always 550, but occasionally it is 549...
 query TTII colnames,rowsort,retry
-SELECT statistics_name, column_names, row_count, null_count
-FROM [SHOW STATISTICS FOR TABLE copy] ORDER BY column_names::STRING, created
+SELECT DISTINCT ON (column_names) statistics_name, column_names, row_count, null_count
+FROM [SHOW STATISTICS FOR TABLE copy] ORDER BY column_names ASC, created DESC
 ----
 statistics_name  column_names  row_count  null_count
 __auto__         {a}           550        0
@@ -163,8 +131,8 @@ statement ok
 CREATE TABLE test_create (x INT PRIMARY KEY, y CHAR)
 
 query TTIII colnames,rowsort,retry
-SELECT statistics_name, column_names, row_count, distinct_count, null_count
-FROM [SHOW STATISTICS FOR TABLE test_create] ORDER BY column_names::STRING, created
+SELECT DISTINCT ON (column_names) statistics_name, column_names, row_count, distinct_count, null_count
+FROM [SHOW STATISTICS FOR TABLE test_create] ORDER BY column_names ASC, created DESC
 ----
 statistics_name  column_names  row_count  distinct_count  null_count
 __auto__         {x}           0          0               0
@@ -175,19 +143,14 @@ statement ok
 DELETE FROM copy WHERE true
 
 query TTII colnames,rowsort,retry
-SELECT statistics_name, column_names, row_count, null_count
-FROM [SHOW STATISTICS FOR TABLE copy] ORDER BY column_names::STRING, created
+SELECT DISTINCT ON (column_names) statistics_name, column_names, row_count, null_count
+FROM [SHOW STATISTICS FOR TABLE copy] ORDER BY column_names ASC, created DESC
 ----
 statistics_name  column_names  row_count  null_count
-__auto__         {a}           550        0
 __auto__         {a}           0          0
-__auto__         {b}           550        0
 __auto__         {b}           0          0
-__auto__         {c}           550        0
 __auto__         {c}           0          0
-__auto__         {d}           550        0
 __auto__         {d}           0          0
-__auto__         {rowid}       550        0
 __auto__         {rowid}       0          0
 
 
@@ -211,8 +174,8 @@ INSERT INTO my_schema.my_table SELECT k, NULL FROM
    generate_series(1, 10) AS k(k)
 
 query TTIII colnames,rowsort,retry
-SELECT statistics_name, column_names, row_count, distinct_count, null_count
-FROM [SHOW STATISTICS FOR TABLE my_schema.my_table] ORDER BY column_names::STRING, created
+SELECT DISTINCT ON (column_names) statistics_name, column_names, row_count, distinct_count, null_count
+FROM [SHOW STATISTICS FOR TABLE my_schema.my_table] ORDER BY column_names ASC, created DESC
 ----
 statistics_name  column_names  row_count  distinct_count  null_count
 __auto__         {k}           10         10              0


### PR DESCRIPTION
This test recently started running with some metamorphic constants
enabled and it flakes. The failure mode suggests that multiple stat
jobs run in-between two retry iterations. This change fixes the test
to use queries that only show the latest statistics; this tolerates
extra stat collection jobs.

Fixes #59263.
Fixes #56700.

Release note: None