### PR TITLE
colexec: fix memory management of the spilling queue

### DIFF
--- a/pkg/sql/colexec/crossjoiner.eg.go
+++ b/pkg/sql/colexec/crossjoiner.eg.go
@@ -1270,7 +1270,6 @@ func (b *crossJoinerBase) buildFromLeftInput(ctx context.Context, destStartIdx i
 				}
 				// We have processed all tuples in the current batch from the
 				// buffered group, so we need to dequeue the next one.
-				b.left.unlimitedAllocator.ReleaseBatch(currentBatch)
 				currentBatch, err = b.left.tuples.dequeue(ctx)
 				if err != nil {
 					colexecerror.InternalError(err)
@@ -1625,7 +1624,6 @@ func (b *crossJoinerBase) buildFromRightInput(ctx context.Context, destStartIdx 
 					}
 					// We have fully processed the current batch, so we need to
 					// get the next one.
-					b.right.unlimitedAllocator.ReleaseBatch(currentBatch)
 					currentBatch, err = b.right.tuples.dequeue(ctx)
 					if err != nil {
 						colexecerror.InternalError(err)

--- a/pkg/sql/colexec/crossjoiner_tmpl.go
+++ b/pkg/sql/colexec/crossjoiner_tmpl.go
@@ -26,7 +26,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase/colexecerror"
-	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/errors"
 )
 
@@ -213,7 +212,6 @@ func (b *crossJoinerBase) buildFromLeftInput(ctx context.Context, destStartIdx i
 				}
 				// We have processed all tuples in the current batch from the
 				// buffered group, so we need to dequeue the next one.
-				b.left.unlimitedAllocator.ReleaseBatch(currentBatch)
 				currentBatch, err = b.left.tuples.dequeue(ctx)
 				if err != nil {
 					colexecerror.InternalError(err)
@@ -319,7 +317,6 @@ func (b *crossJoinerBase) buildFromRightInput(ctx context.Context, destStartIdx 
 					}
 					// We have fully processed the current batch, so we need to
 					// get the next one.
-					b.right.unlimitedAllocator.ReleaseBatch(currentBatch)
 					currentBatch, err = b.right.tuples.dequeue(ctx)
 					if err != nil {
 						colexecerror.InternalError(err)

--- a/pkg/sql/colexec/ordered_aggregator.go
+++ b/pkg/sql/colexec/ordered_aggregator.go
@@ -275,9 +275,7 @@ func (a *orderedAggregator) Next(ctx context.Context) coldata.Batch {
 				// coldata.BatchSize(), but we actually want a batch with larger
 				// capacity, so we choose to instantiate the batch with fixed
 				// maximal capacity that can be needed by the aggregator.
-				if a.scratch.Batch != nil {
-					a.allocator.ReleaseBatch(a.scratch.Batch)
-				}
+				a.allocator.ReleaseMemory(colmem.GetBatchMemSize(a.scratch.Batch))
 				a.scratch.Batch = a.allocator.NewMemBatchWithFixedCapacity(a.outputTypes, 2*coldata.BatchSize())
 			} else {
 				a.scratch.Batch, _ = a.allocator.ResetMaybeReallocate(a.outputTypes, a.scratch.Batch, newMinCapacity)

--- a/pkg/sql/colexec/routers_test.go
+++ b/pkg/sql/colexec/routers_test.go
@@ -1285,6 +1285,16 @@ func BenchmarkHashRouter(b *testing.B) {
 						}
 					}
 					copy(actualDistribution, zeroDistribution)
+					// Sanity check the spilling queues' memory management.
+					for i := range outputs {
+						sq := outputs[i].(*routerOutputOp).mu.data
+						if sq.spilled() {
+							b.Fatal("unexpectedly spilling queue spilled to disk")
+						}
+						if sq.unlimitedAllocator.Used() > 0 {
+							b.Fatal("unexpectedly spilling queue's allocator has non-zero usage")
+						}
+					}
 				}
 			})
 		}

--- a/pkg/sql/colexec/spilling_queue.go
+++ b/pkg/sql/colexec/spilling_queue.go
@@ -29,16 +29,6 @@ import (
 // spills to disk if the allocator reports that more memory than the
 // caller-provided maxMemoryLimit is in use. spillingQueue.items is growing
 // dynamically.
-// When spilling to disk, a DiskQueue will be created. When spilling batches to
-// disk, their memory will first be released using the allocator. When batches
-// are read from disk back into memory, that memory will be reclaimed.
-// NOTE: When a batch is returned, that batch's memory will still be tracked
-// using the allocator. Since the memory in use is fixed, a previously returned
-// batch may be overwritten by a batch read from disk. This new batch's memory
-// footprint will replace the footprint of the previously returned batch. Since
-// batches are unsafe for reuse, it is assumed that the previously returned
-// batch is not kept around and thus its referenced memory will be GCed as soon
-// as the batch is updated.
 type spillingQueue struct {
 	unlimitedAllocator *colmem.Allocator
 	maxMemoryLimit     int64
@@ -61,6 +51,17 @@ type spillingQueue struct {
 	diskQueueDeselectionScratch coldata.Batch
 	fdSemaphore                 semaphore.Semaphore
 	dequeueScratch              coldata.Batch
+	// lastDequeuedBatchMemUsage is the memory footprint of the last batch
+	// returned by dequeue().
+	//
+	// We track the size instead of the reference to the batch because it is
+	// possible that the caller appends new columns, and the memory footprint of
+	// those columns is registered with the caller's allocator; therefore, if
+	// after the columns have been appended to the last dequeued batch, its
+	// footprint would be higher than what the spilling queue's allocator was
+	// registered with, and we could mistakenly release excessive amount of
+	// memory.
+	lastDequeuedBatchMemUsage int64
 
 	rewindable      bool
 	rewindableState struct {
@@ -107,6 +108,10 @@ type NewSpillingQueueArgs struct {
 func newSpillingQueue(args *NewSpillingQueueArgs) *spillingQueue {
 	// Reduce the memory limit by what the DiskQueue may need to buffer
 	// writes/reads.
+	// TODO(yuzefovich): the memory limit should only be reduced by the buffer
+	// size if/when the spilling to disk occurs. Until that point the spilling
+	// queue should be free to use the whole limit for the in-memory batch
+	// buffer.
 	memoryLimit := args.MemoryLimit
 	memoryLimit -= int64(args.DiskQueueCfg.BufferSizeBytes)
 	var items []coldata.Batch
@@ -128,6 +133,10 @@ func newSpillingQueue(args *NewSpillingQueueArgs) *spillingQueue {
 // in order to dequeue all enqueued batches all over again. An unlimited
 // allocator must be passed in. The queue will use this allocator to check
 // whether memory usage exceeds the given memory limit and use disk if so.
+//
+// WARNING: when using a rewindable queue all enqueue() operations *must* occur
+// before any dequeue() calls (it is a limitation of
+// colcontainer.RewindableQueue interface).
 func newRewindableSpillingQueue(args *NewSpillingQueueArgs) *spillingQueue {
 	q := newSpillingQueue(args)
 	q.rewindable = true
@@ -141,7 +150,15 @@ func newRewindableSpillingQueue(args *NewSpillingQueueArgs) *spillingQueue {
 // The spilling queue coalesces all input tuples into the batches of dynamically
 // increasing capacity when those are kept in-memory. It also performs a
 // deselection step if necessary when adding the batch to the disk queue.
+//
+// The ownership of the batch still lies with the caller, so the caller is
+// responsible for accounting for the memory used by batch (although the
+// spilling queue will account for memory used by the in-memory copies).
 func (q *spillingQueue) enqueue(ctx context.Context, batch coldata.Batch) error {
+	if q.rewindable && q.rewindableState.numItemsDequeued > 0 {
+		return errors.Errorf("attempted to enqueue to rewindable spillingQueue after dequeue has been called")
+	}
+
 	n := batch.Length()
 	if n == 0 {
 		if q.diskQueue != nil {
@@ -167,7 +184,6 @@ func (q *spillingQueue) enqueue(ctx context.Context, batch coldata.Batch) error 
 		if err := q.maybeSpillToDisk(ctx); err != nil {
 			return err
 		}
-		q.unlimitedAllocator.ReleaseBatch(batch)
 		if sel := batch.Selection(); sel != nil {
 			// We need to perform the deselection since the disk queue
 			// ignores the selection vectors.
@@ -298,13 +314,24 @@ func (q *spillingQueue) enqueue(ctx context.Context, batch coldata.Batch) error 
 }
 
 // dequeue returns the next batch from the queue which is valid only until the
-// next call to dequeue().
+// next call to dequeue(). The memory usage of the returned batch is still
+// retained by the spilling queue's allocator, so the caller doesn't have to be
+// concerned with memory management.
+//
 // If the spilling queue is rewindable, the batch *cannot* be modified
 // (otherwise, after rewind(), the queue will contain the corrupted data).
+//
 // If the spilling queue is not rewindable, the caller is free to modify the
 // batch.
 func (q *spillingQueue) dequeue(ctx context.Context) (coldata.Batch, error) {
 	if q.empty() {
+		if (!q.rewindable || q.numOnDiskItems != 0) && q.lastDequeuedBatchMemUsage != 0 {
+			// We need to release the memory used by the last dequeued batch in
+			// all cases except for when that batch came from the in-memory
+			// buffer of the rewindable queue.
+			q.unlimitedAllocator.ReleaseMemory(q.lastDequeuedBatchMemUsage)
+			q.lastDequeuedBatchMemUsage = 0
+		}
 		return coldata.ZeroBatch, nil
 	}
 
@@ -320,11 +347,17 @@ func (q *spillingQueue) dequeue(ctx context.Context) (coldata.Batch, error) {
 		// up until a new file region is loaded (which will overwrite the memory of
 		// the previous batches), but Dequeue calls are already amortized, so this
 		// is acceptable.
-		// Release a batch to make space for a new batch from disk.
-		if q.dequeueScratch != nil {
-			q.unlimitedAllocator.ReleaseBatch(q.dequeueScratch)
-		} else {
+		if q.dequeueScratch == nil {
+			// In order to have precise memory accounting, we use the following
+			// scheme for the newly allocated dequeueScratch.
+			// 1. a new batch is allocated, its estimated memory usage is
+			//    registered with the allocator
+			// 2. we release the batch's memory right away so that the estimate
+			//    is unregistered
+			// 3. once the actual data is dequeued from disk into the batch, we
+			//    update the allocator with the actual memory usage.
 			q.dequeueScratch = q.unlimitedAllocator.NewMemBatchWithFixedCapacity(q.typs, coldata.BatchSize())
+			q.unlimitedAllocator.ReleaseMemory(colmem.GetBatchMemSize(q.dequeueScratch))
 		}
 		ok, err := q.diskQueue.Dequeue(ctx, q.dequeueScratch)
 		if err != nil {
@@ -335,8 +368,15 @@ func (q *spillingQueue) dequeue(ctx context.Context) (coldata.Batch, error) {
 			// happen, as it should have been caught by the q.empty() check above.
 			colexecerror.InternalError(errors.AssertionFailedf("disk queue was not empty but failed to dequeue element in spillingQueue"))
 		}
-		// Account for this batch's memory.
-		q.unlimitedAllocator.RetainBatch(q.dequeueScratch)
+		// Release the memory used by the batch returned on the previous call
+		// to dequeue() since that batch is no longer valid. Note that it
+		// doesn't matter whether that previous batch came from the in-memory
+		// buffer or from the disk queue since in the former case the reference
+		// to the batch is lost and in the latter case we've just reused the
+		// batch to Dequeue() from disk into it.
+		q.unlimitedAllocator.ReleaseMemory(q.lastDequeuedBatchMemUsage)
+		q.lastDequeuedBatchMemUsage = colmem.GetBatchMemSize(q.dequeueScratch)
+		q.unlimitedAllocator.AdjustMemoryUsage(q.lastDequeuedBatchMemUsage)
 		if q.rewindable {
 			q.rewindableState.numItemsDequeued++
 		} else {
@@ -347,10 +387,20 @@ func (q *spillingQueue) dequeue(ctx context.Context) (coldata.Batch, error) {
 
 	res := q.items[q.curHeadIdx]
 	if q.rewindable {
+		// Note that in case of a rewindable queue we do not update the memory
+		// accounting since all of the batches in the in-memory buffer are still
+		// kept.
 		q.rewindableState.numItemsDequeued++
 	} else {
 		// Release the reference to the batch eagerly.
 		q.items[q.curHeadIdx] = nil
+		// Release the memory used by the batch returned on the previous call
+		// to dequeue() since that batch is no longer valid. Since res came from
+		// the in-memory buffer, the previous batch must have come from the
+		// in-memory buffer too and we released the reference to it on the
+		// previous call.
+		q.unlimitedAllocator.ReleaseMemory(q.lastDequeuedBatchMemUsage)
+		q.lastDequeuedBatchMemUsage = colmem.GetBatchMemSize(res)
 		q.numInMemoryItems--
 	}
 	q.curHeadIdx++
@@ -437,6 +487,7 @@ func (q *spillingQueue) rewind() error {
 		}
 	}
 	q.curHeadIdx = 0
+	q.lastDequeuedBatchMemUsage = 0
 	q.rewindableState.numItemsDequeued = 0
 	return nil
 }
@@ -452,6 +503,7 @@ func (q *spillingQueue) reset(ctx context.Context) {
 	q.curHeadIdx = 0
 	q.curTailIdx = 0
 	q.nextInMemBatchCapacity = 0
+	q.lastDequeuedBatchMemUsage = 0
 	q.rewindableState.numItemsDequeued = 0
 	q.testingKnobs.numEnqueues = 0
 }

--- a/pkg/sql/colexec/spilling_queue_test.go
+++ b/pkg/sql/colexec/spilling_queue_test.go
@@ -18,11 +18,13 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coldatatestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/colcontainer"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils/colcontainerutils"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/stretchr/testify/require"
 )
@@ -34,6 +36,7 @@ func TestSpillingQueue(t *testing.T) {
 	queueCfg, cleanup := colcontainerutils.NewTestingDiskQueueCfg(t, true /* inMem */)
 	defer cleanup()
 
+	ctx := context.Background()
 	rng, _ := randutil.NewPseudoRand()
 	for _, rewindable := range []bool{false, true} {
 		for _, memoryLimit := range []int64{
@@ -105,12 +108,20 @@ func TestSpillingQueue(t *testing.T) {
 			queueCfg.SetDefaultBufferSizeBytesForCacheMode()
 			queueCfg.TestingKnobs.AlwaysCompress = alwaysCompress
 
+			// We need to create a separate unlimited allocator for the spilling
+			// queue so that it could measure only its own memory usage
+			// (testAllocator might account for other things, thus confusing the
+			// spilling queue).
+			memAcc := testMemMonitor.MakeBoundAccount()
+			defer memAcc.Close(ctx)
+			spillingQueueUnlimitedAllocator := colmem.NewAllocator(ctx, &memAcc, testColumnFactory)
+
 			// Create queue.
 			var q *spillingQueue
 			if rewindable {
 				q = newRewindableSpillingQueue(
 					&NewSpillingQueueArgs{
-						UnlimitedAllocator: testAllocator,
+						UnlimitedAllocator: spillingQueueUnlimitedAllocator,
 						Types:              typs,
 						MemoryLimit:        memoryLimit,
 						DiskQueueCfg:       queueCfg,
@@ -121,7 +132,7 @@ func TestSpillingQueue(t *testing.T) {
 			} else {
 				q = newSpillingQueue(
 					&NewSpillingQueueArgs{
-						UnlimitedAllocator: testAllocator,
+						UnlimitedAllocator: spillingQueueUnlimitedAllocator,
 						Types:              typs,
 						MemoryLimit:        memoryLimit,
 						DiskQueueCfg:       queueCfg,
@@ -167,7 +178,6 @@ func TestSpillingQueue(t *testing.T) {
 				return windowedBatch
 			}
 
-			ctx := context.Background()
 			for {
 				b = op.Next(ctx)
 				require.NoError(t, q.enqueue(ctx, b))
@@ -228,6 +238,181 @@ func TestSpillingQueue(t *testing.T) {
 			require.NoError(t, q.close(ctx))
 
 			// Verify no directories are left over.
+			directories, err := queueCfg.FS.List(queueCfg.GetPather.GetPath(ctx))
+			require.NoError(t, err)
+			require.Equal(t, 0, len(directories))
+		}
+	}
+}
+
+// TestSpillingQueueDidntSpill verifies that in a scenario when every enqueue()
+// is followed by dequeue() the non-rewindable spilling queue doesn't actually
+// spill to disk.
+func TestSpillingQueueDidntSpill(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	queueCfg, cleanup := colcontainerutils.NewTestingDiskQueueCfg(t, true /* inMem */)
+	defer cleanup()
+	queueCfg.CacheMode = colcontainer.DiskQueueCacheModeDefault
+	// We don't expect to spill to disk and we want to give the whole memory
+	// limit to the spilling queue's in-memory batch buffer.
+	queueCfg.BufferSizeBytes = 1
+
+	rng, _ := randutil.NewPseudoRand()
+	numBatches := int(spillingQueueInitialItemsLen)*(1+rng.Intn(4)) + rng.Intn(int(spillingQueueInitialItemsLen))
+	op := coldatatestutils.NewRandomDataOp(testAllocator, rng, coldatatestutils.RandomDataOpArgs{
+		// TODO(yuzefovich): for some types (e.g. types.MakeArray(types.Int))
+		// the memory estimation diverges from 0 after enqueue() / dequeue()
+		// sequence. Figure it out.
+		DeterministicTyps: []*types.T{types.Int},
+		NumBatches:        numBatches,
+		BatchSize:         1 + rng.Intn(coldata.BatchSize()),
+		Nulls:             true,
+	})
+
+	typs := op.Typs()
+	// Choose a memory limit such that at most two batches can be kept in the
+	// in-memory buffer at a time (single batch is not enough because the queue
+	// delays the release of the memory by one batch).
+	memoryLimit := int64(2*colmem.EstimateBatchSizeBytes(typs, coldata.BatchSize()) + queueCfg.BufferSizeBytes)
+	if memoryLimit < mon.DefaultPoolAllocationSize {
+		memoryLimit = mon.DefaultPoolAllocationSize
+	}
+
+	// We need to create a separate unlimited allocator for the spilling queue
+	// so that it could measure only its own memory usage (testAllocator might
+	// account for other things, thus confusing the spilling queue).
+	memAcc := testMemMonitor.MakeBoundAccount()
+	defer memAcc.Close(ctx)
+	spillingQueueUnlimitedAllocator := colmem.NewAllocator(ctx, &memAcc, testColumnFactory)
+
+	q := newSpillingQueue(
+		&NewSpillingQueueArgs{
+			UnlimitedAllocator: spillingQueueUnlimitedAllocator,
+			Types:              typs,
+			MemoryLimit:        memoryLimit,
+			DiskQueueCfg:       queueCfg,
+			FDSemaphore:        colexecbase.NewTestingSemaphore(2),
+			DiskAcc:            testDiskAcc,
+		},
+	)
+
+	for {
+		b := op.Next(ctx)
+		require.NoError(t, q.enqueue(ctx, b))
+		b, err := q.dequeue(ctx)
+		require.NoError(t, err)
+		if b.Length() == 0 {
+			break
+		}
+	}
+
+	// Ensure that the spilling didn't occur.
+	require.False(t, q.spilled())
+
+	// Close queue.
+	require.NoError(t, q.close(ctx))
+
+	// Verify no directories are left over.
+	directories, err := queueCfg.FS.List(queueCfg.GetPather.GetPath(ctx))
+	require.NoError(t, err)
+	require.Equal(t, 0, len(directories))
+}
+
+// TestSpillingQueueMemoryAccounting is a simple check of the memory accounting
+// of the spilling queue that performs a series of enqueue() and dequeue()
+// operations and verifies that the reported memory usage is as expected.
+//
+// Note that this test intentionally doesn't randomize many things (e.g. the
+// size of input batches, the types of the vectors) since those randomizations
+// would make it hard to compute the expected memory usage (the spilling queue
+// has coalescing logic, etc). Thus, the test is more of a sanity check, yet it
+// should be sufficient to catch any regressions.
+func TestSpillingQueueMemoryAccounting(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	rng, _ := randutil.NewPseudoRand()
+	typs := []*types.T{types.Int}
+	queueCfg, cleanup := colcontainerutils.NewTestingDiskQueueCfg(t, true /* inMem */)
+	defer cleanup()
+
+	for _, rewindable := range []bool{false, true} {
+		for _, dequeueProbability := range []float64{0, 0.2} {
+			if rewindable && dequeueProbability != 0 {
+				// For rewindable queues we require that all enqueues occur
+				// before any dequeue() call.
+				continue
+			}
+			// We need to create a separate unlimited allocator for the spilling
+			// queue so that it could measure only its own memory usage
+			// (testAllocator might account for other things, thus confusing the
+			// spilling queue).
+			memAcc := testMemMonitor.MakeBoundAccount()
+			defer memAcc.Close(ctx)
+			spillingQueueUnlimitedAllocator := colmem.NewAllocator(ctx, &memAcc, testColumnFactory)
+
+			newQueueArgs := &NewSpillingQueueArgs{
+				UnlimitedAllocator: spillingQueueUnlimitedAllocator,
+				Types:              typs,
+				MemoryLimit:        defaultMemoryLimit,
+				DiskQueueCfg:       queueCfg,
+				FDSemaphore:        colexecbase.NewTestingSemaphore(2),
+				DiskAcc:            testDiskAcc,
+			}
+			var q *spillingQueue
+			if rewindable {
+				q = newRewindableSpillingQueue(newQueueArgs)
+			} else {
+				q = newSpillingQueue(newQueueArgs)
+			}
+
+			numInputBatches := int(spillingQueueInitialItemsLen)*(1+rng.Intn(4)) + rng.Intn(int(spillingQueueInitialItemsLen))
+			numDequeuedBatches := 0
+			batch := coldatatestutils.RandomBatch(testAllocator, rng, typs, coldata.BatchSize(), coldata.BatchSize(), nullProbability)
+			batchSize := colmem.GetBatchMemSize(batch)
+			getExpectedMemUsage := func(numEnqueuedBatches int) int64 {
+				batchesAccountedFor := numEnqueuedBatches
+				if !rewindable && numDequeuedBatches > 0 {
+					// We release the memory under the dequeued batches only
+					// from the non-rewindable queue, and that release is
+					// lagging by one batch, so we have -1 here.
+					//
+					// Note that this logic also works correctly when zero batch
+					// has been dequeued once.
+					batchesAccountedFor -= numDequeuedBatches - 1
+				}
+				return int64(batchesAccountedFor) * batchSize
+			}
+			for numEnqueuedBatches := 1; numEnqueuedBatches <= numInputBatches; numEnqueuedBatches++ {
+				require.NoError(t, q.enqueue(ctx, batch))
+				if rng.Float64() < dequeueProbability {
+					b, err := q.dequeue(ctx)
+					require.NoError(t, err)
+					coldata.AssertEquivalentBatches(t, batch, b)
+					numDequeuedBatches++
+				}
+				require.Equal(t, getExpectedMemUsage(numEnqueuedBatches), q.unlimitedAllocator.Used())
+			}
+			require.NoError(t, q.enqueue(ctx, coldata.ZeroBatch))
+			for {
+				b, err := q.dequeue(ctx)
+				require.NoError(t, err)
+				numDequeuedBatches++
+				require.Equal(t, getExpectedMemUsage(numInputBatches), q.unlimitedAllocator.Used())
+				if b.Length() == 0 {
+					break
+				}
+				coldata.AssertEquivalentBatches(t, batch, b)
+			}
+
+			// Some sanity checks.
+			require.False(t, q.spilled())
+			require.NoError(t, q.close(ctx))
 			directories, err := queueCfg.FS.List(queueCfg.GetPather.GetPath(ctx))
 			require.NoError(t, err)
 			require.Equal(t, 0, len(directories))


### PR DESCRIPTION
**colexec: clean up spilling queue's dequeue from the disk**

Previously, if the spilling queue was not rewindable, whenever we
dequeued from the disk queue, we would put the batch into the in-memory
buffer and return it from there. This was done in order to reuse some of
the code that updated the internal state to advance the head of the
queue; however, this doesn't make much sense to do so - we can just
return the batch directly (as we do in the rewindable case) with no need
to update almost any internal state. This simplifies things a bit and
will make it easier to add more precise memory accounting in the
follow-up commit.

Release note: None

**colexec: fix memory management of the spilling queue**

Previously, we had a bug in the memory management of the non-rewindable
spilling queue when batches are dequeued from the in-memory buffer (the
memory usage of them was never released) which could lead the spilling
queue to spill to disk even if it actually didn't reach the memory
limit. This commit fixes the spilling queue's memory management which is
now fully contained within `dequeue()` method, so the callers don't need
to concern themselves with it.

If the spilling queue is rewindable, then we never release the memory
used by the batches kept in the memory buffer. In all other cases on
each `dequeue()` call we release the memory used by the batch returned
on the previous call since it is no longer valid for reuse and/or
keeping reference to it.

Such strategy works well since
- if that last dequeued batch came from the in-memory buffer, we lost
the reference to it
- if that last dequeued batch came from the disk queue, we are reusing
the same batch to dequeue into (and registered the updated memory usage
accordingly).

Fixes: #59235.

Release note: None