### PR TITLE
build: add crdb_test_off tag temporarily to sqllite logic tests

### DIFF
--- a/build/teamcity-sqllogictest.sh
+++ b/build/teamcity-sqllogictest.sh
@@ -14,11 +14,13 @@ export BUILDER_HIDE_GOPATH_SRC=0
 # Run SqlLite tests.
 # Need to specify the flex-types flag in order to skip past variations that have
 # numeric typing differences.
+# TODO(yuzefovich): remove crdb_test_off tag once sqllite tests have been
+# adjusted to run in reasonable time with batch size randomizations.
 run_json_test build/builder.sh \
   stdbuf -oL -eL \
-  make test GOTESTFLAGS=-json TESTFLAGS="-v -bigtest -flex-types" TESTTIMEOUT='24h' PKG='./pkg/sql/logictest' TESTS='^TestSqlLiteLogic$$'
+  make test GOTESTFLAGS=-json TESTFLAGS="-v -bigtest -flex-types" TESTTIMEOUT='24h' PKG='./pkg/sql/logictest' TESTS='^TestSqlLiteLogic$$' TAGS=crdb_test_off
 
 # Run the tests with a multitenant configuration.
 run_json_test build/builder.sh \
   stdbuf -oL -eL \
-  make test GOTESTFLAGS=-json TESTFLAGS="-v -bigtest -flex-types" TESTTIMEOUT='24h' PKG='./pkg/ccl/logictestccl' TESTS='^TestTenantSQLLiteLogic$$'
+  make test GOTESTFLAGS=-json TESTFLAGS="-v -bigtest -flex-types" TESTTIMEOUT='24h' PKG='./pkg/ccl/logictestccl' TESTS='^TestTenantSQLLiteLogic$$' TAGS=crdb_test_off


### PR DESCRIPTION
SQLLite logic tests have been failing since we introduced the
randomizations of the batch sizes (with a timeout). It is not
immediately clear what exactly needs to be adjusted, so let's disable
the randomizations for now (so that we at least get some value out of
the tests).

Informs: #58089.

Release note: None