### PR TITLE
sql: add event logs for privilege changes in crdb_internal.unsafe_xxx

### DIFF
--- a/pkg/sql/repair.go
+++ b/pkg/sql/repair.go
@@ -13,6 +13,7 @@ package sql
 import (
 	"context"
 	"encoding/hex"
+	"sort"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
@@ -25,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
+	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/errors"
@@ -88,6 +90,8 @@ func (p *planner) UnsafeUpsertDescriptor(
 	// Validate that existing is sane and store its hex serialization into
 	// existingStr to be written to the event log.
 	var existingStr string
+	var previousOwner string
+	var previousUserPrivileges []descpb.UserPrivileges
 	if existing != nil {
 		if existing.IsUncommittedVersion() {
 			return pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
@@ -103,27 +107,38 @@ func (p *planner) UnsafeUpsertDescriptor(
 			return errors.AssertionFailedf("failed to marshal existing descriptor %v: %v", existing, err)
 		}
 		existingStr = hex.EncodeToString(marshaled)
+		previousOwner = existing.GetPrivileges().Owner().Normalized()
+		previousUserPrivileges = existing.GetPrivileges().Users
 	}
 
+	var objectType privilege.ObjectType
 	switch md := existing.(type) {
 	case *tabledesc.Mutable:
 		md.TableDescriptor = *desc.GetTable() // nolint:descriptormarshal
+		objectType = privilege.Table
 	case *schemadesc.Mutable:
 		md.SchemaDescriptor = *desc.GetSchema()
+		objectType = privilege.Schema
 	case *dbdesc.Mutable:
 		md.DatabaseDescriptor = *desc.GetDatabase()
+		objectType = privilege.Database
 	case *typedesc.Mutable:
 		md.TypeDescriptor = *desc.GetType()
+		objectType = privilege.Type
 	case nil:
 		// nolint:descriptormarshal
 		if tableDesc := desc.GetTable(); tableDesc != nil {
 			existing = tabledesc.NewCreatedMutable(*tableDesc)
+			objectType = privilege.Table
 		} else if schemaDesc := desc.GetSchema(); schemaDesc != nil {
 			existing = schemadesc.NewCreatedMutable(*schemaDesc)
+			objectType = privilege.Schema
 		} else if dbDesc := desc.GetDatabase(); dbDesc != nil {
 			existing = dbdesc.NewCreatedMutable(*dbDesc)
+			objectType = privilege.Database
 		} else if typeDesc := desc.GetType(); typeDesc != nil {
 			existing = typedesc.NewCreatedMutable(*typeDesc)
+			objectType = privilege.Type
 		} else {
 			return pgerror.New(pgcode.InvalidTableDefinition, "invalid ")
 		}
@@ -141,13 +156,185 @@ func (p *planner) UnsafeUpsertDescriptor(
 			return err
 		}
 	}
-	return p.logEvent(ctx, id,
-		&eventpb.UnsafeUpsertDescriptor{
-			PreviousDescriptor: existingStr,
-			NewDescriptor:      hex.EncodeToString(encodedDesc),
-			Force:              force,
-			ForceNotice:        forceNoticeString,
+
+	// Log any ownership changes.
+	newOwner := existing.GetPrivileges().Owner().Normalized()
+	if previousOwner != newOwner {
+		if err := logOwnerEvents(ctx, p, newOwner, existing); err != nil {
+			return err
+		}
+	}
+
+	// Log any privilege changes.
+	if err := comparePrivileges(
+		ctx, p, existing, previousUserPrivileges, objectType,
+	); err != nil {
+		return err
+	}
+
+	return p.logEvent(ctx, id, &eventpb.UnsafeUpsertDescriptor{
+		PreviousDescriptor: existingStr,
+		NewDescriptor:      hex.EncodeToString(encodedDesc),
+		Force:              force,
+		ForceNotice:        forceNoticeString,
+	})
+}
+
+// comparePrivileges iterates through all users and for each user, compares
+// their old privileges to their new privileges.
+// It then logs the granted and/or revoked privileges for that user.
+func comparePrivileges(
+	ctx context.Context,
+	p *planner,
+	existing catalog.MutableDescriptor,
+	prevUserPrivileges []descpb.UserPrivileges,
+	objectType privilege.ObjectType,
+) error {
+	computePrivilegeChanges := func(prev, cur *descpb.UserPrivileges) (granted, revoked []string) {
+		// User has no privileges anymore after upsert, all privileges revoked.
+		if cur == nil {
+			revoked = privilege.ListFromBitField(prev.Privileges, objectType).SortedNames()
+			return nil, revoked
+		}
+
+		// User privileges have not changed.
+		if prev.Privileges == cur.Privileges {
+			return nil, nil
+		}
+
+		// Construct a set of this user's old privileges (before upsert).
+		prevPrivilegeSet := make(map[string]struct{})
+		for _, priv := range privilege.ListFromBitField(prev.Privileges, objectType).SortedNames() {
+			prevPrivilegeSet[priv] = struct{}{}
+		}
+
+		// Compare with this user's new privileges.
+		for _, priv := range privilege.ListFromBitField(cur.Privileges, objectType).SortedNames() {
+			if _, ok := prevPrivilegeSet[priv]; !ok {
+				// New privileges that do not exist in the old privileges set imply that they have been granted.
+				granted = append(granted, priv)
+			} else {
+				// Old privilege still exists, remove it from set.
+				delete(prevPrivilegeSet, priv)
+			}
+		}
+
+		// Any remaining old privileges imply they do not exist in
+		// the new privilege set, so they have been revoked.
+		for priv := range prevPrivilegeSet {
+			revoked = append(revoked, priv)
+		}
+		sort.Strings(revoked)
+
+		return granted, revoked
+	}
+
+	curUserPrivileges := existing.GetPrivileges().Users
+	curUserMap := make(map[string]*descpb.UserPrivileges)
+	for i := range curUserPrivileges {
+		curUser := &curUserPrivileges[i]
+		curUserMap[curUser.User().Normalized()] = curUser
+	}
+
+	for i := range prevUserPrivileges {
+		prev := &prevUserPrivileges[i]
+		username := prev.User().Normalized()
+		cur := curUserMap[username]
+		granted, revoked := computePrivilegeChanges(prev, cur)
+		delete(curUserMap, username)
+
+		// Log events.
+		if err := logPrivilegeEvents(
+			ctx, p, existing, granted, revoked, username,
+		); err != nil {
+			return err
+		}
+	}
+
+	// Any leftovers in the new users map indicate privileges for a new user.
+	for i := range curUserPrivileges {
+		username := curUserPrivileges[i].User().Normalized()
+		if _, ok := curUserMap[username]; ok {
+			granted := privilege.ListFromBitField(curUserPrivileges[i].Privileges, objectType).SortedNames()
+			if err := logPrivilegeEvents(
+				ctx, p, existing, granted, nil, username,
+			); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// logPrivilegeEvents logs the privilege event for each user.
+func logPrivilegeEvents(
+	ctx context.Context,
+	p *planner,
+	existing catalog.MutableDescriptor,
+	grantedPrivileges []string,
+	revokedPrivileges []string,
+	grantee string,
+) error {
+
+	eventDetails := eventpb.CommonSQLPrivilegeEventDetails{
+		Grantee:           grantee,
+		GrantedPrivileges: grantedPrivileges,
+		RevokedPrivileges: revokedPrivileges,
+	}
+
+	switch md := existing.(type) {
+	case *tabledesc.Mutable:
+		return p.logEvent(ctx, existing.GetID(), &eventpb.ChangeTablePrivilege{
+			CommonSQLPrivilegeEventDetails: eventDetails,
+			TableName:                      md.GetName(),
 		})
+	case *schemadesc.Mutable:
+		return p.logEvent(ctx, existing.GetID(), &eventpb.ChangeSchemaPrivilege{
+			CommonSQLPrivilegeEventDetails: eventDetails,
+			SchemaName:                     md.GetName(),
+		})
+	case *dbdesc.Mutable:
+		return p.logEvent(ctx, existing.GetID(), &eventpb.ChangeDatabasePrivilege{
+			CommonSQLPrivilegeEventDetails: eventDetails,
+			DatabaseName:                   md.GetName(),
+		})
+	case *typedesc.Mutable:
+		return p.logEvent(ctx, existing.GetID(), &eventpb.ChangeTypePrivilege{
+			CommonSQLPrivilegeEventDetails: eventDetails,
+			TypeName:                       md.GetName(),
+		})
+	}
+	return nil
+}
+
+// logPrivilegeEvents logs the owner event for a descriptor.
+func logOwnerEvents(
+	ctx context.Context, p *planner, newOwner string, existing catalog.MutableDescriptor,
+) error {
+	switch md := existing.(type) {
+	case *tabledesc.Mutable:
+		return p.logEvent(ctx, md.GetID(), &eventpb.AlterTableOwner{
+			TableName: md.GetName(),
+			Owner:     newOwner,
+		})
+	case *schemadesc.Mutable:
+		return p.logEvent(ctx, md.GetID(), &eventpb.AlterSchemaOwner{
+			SchemaName: md.GetName(),
+			Owner:      newOwner,
+		})
+	case *dbdesc.Mutable:
+		return p.logEvent(ctx, md.GetID(), &eventpb.AlterDatabaseOwner{
+			DatabaseName: md.GetName(),
+			Owner:        newOwner,
+		})
+	case *typedesc.Mutable:
+		return p.logEvent(ctx, md.GetID(), &eventpb.AlterTypeOwner{
+			TypeName: md.GetName(),
+			Owner:    newOwner,
+		})
+	}
+	return nil
 }
 
 // UnsafeUpsertNamespaceEntry powers the repair builtin of the same name. The


### PR DESCRIPTION
Fixes https://github.com/cockroachdb/cockroach/issues/57573.

Previously, when a user uses a crdb_internal_unsafe_xxx
function to overwrite a descriptor, we did not log owner and
privilege changes.
This patch adds the appropriate logging for these commands.

Release note (bug fix): add event logs for privilege changes
in crdb_internal.unsafe_xxx