### PR TITLE
sql: code generation for missing pg_catalog columns 

### DIFF
--- a/pkg/cmd/generate-postgres-metadata-tables/main.go
+++ b/pkg/cmd/generate-postgres-metadata-tables/main.go
@@ -57,6 +57,10 @@ func main() {
 			panic(err)
 		}
 		pgCatalogFile.PGMetadata.AddColumnMetadata(table, column, dataType, dataTypeOid)
+		columnType := pgCatalogFile.PGMetadata[table][column]
+		if !columnType.IsImplemented() {
+			pgCatalogFile.AddUnimplementedType(columnType)
+		}
 	}
 
 	pgCatalogFile.Save(os.Stdout)

--- a/pkg/sql/pg_metadata_diff.go
+++ b/pkg/sql/pg_metadata_diff.go
@@ -67,8 +67,9 @@ type PGMetadataTables map[string]PGMetadataColumns
 // PGMetadataFile is used to export pg_catalog from postgres and store the representation of this structure as a
 // json file
 type PGMetadataFile struct {
-	PGVersion  string           `json:"pgVersion"`
-	PGMetadata PGMetadataTables `json:"pgMetadata"`
+	PGVersion          string             `json:"pgVersion"`
+	PGMetadata         PGMetadataTables   `json:"pgMetadata"`
+	UnimplementedTypes map[oid.Oid]string `json:"unimplementedTypes"`
 }
 
 func (p PGMetadataTables) addColumn(tableName, columnName string, column *PGMetadataColumnType) {
@@ -215,6 +216,50 @@ func (p PGMetadataTables) getUnimplementedTables(source PGMetadataTables) PGMeta
 	return notImplemented
 }
 
+// getUnimplementedColumns is used by diffs as it might not be in sync with
+// already implemented columns.
+func (p PGMetadataTables) getUnimplementedColumns(target PGMetadataTables) PGMetadataTables {
+	unimplementedColumns := make(PGMetadataTables)
+	for tableName, columns := range p {
+		for columnName, columnType := range columns {
+			if columnType != nil {
+				// dataType mismatch (Not a new column).
+				continue
+			}
+			sourceType := target[tableName][columnName]
+			typeOid := oid.Oid(sourceType.Oid)
+			if _, ok := types.OidToType[typeOid]; !ok || typeOid == oid.T_anyarray {
+				// can't implement this column due to missing type.
+				continue
+			}
+			unimplementedColumns.AddColumnMetadata(tableName, columnName, sourceType.DataType, sourceType.Oid)
+		}
+	}
+	return unimplementedColumns
+}
+
+// removeImplementedColumns removes diff columns that are marked as expected
+// diff (or unimplemented column) but is already implemented in CRDB.
+func (p PGMetadataTables) removeImplementedColumns(source PGMetadataTables) {
+	for tableName, columns := range source {
+		pColumns, exists := p[tableName]
+		if !exists {
+			continue
+		}
+		for columnName := range columns {
+			columnType, exists := pColumns[columnName]
+			if !exists {
+				continue
+			}
+			if columnType != nil {
+				continue
+			}
+
+			delete(pColumns, columnName)
+		}
+	}
+}
+
 // getUnimplementedTypes verifies that all the types are implemented in cockroach db.
 func (c PGMetadataColumns) getUnimplementedTypes() map[oid.Oid]string {
 	unimplemented := make(map[oid.Oid]string)
@@ -226,4 +271,23 @@ func (c PGMetadataColumns) getUnimplementedTypes() map[oid.Oid]string {
 	}
 
 	return unimplemented
+}
+
+// AddUnimplementedType reports a type that is not implemented in cockroachdb.
+func (f *PGMetadataFile) AddUnimplementedType(columnType *PGMetadataColumnType) {
+	typeOid := oid.Oid(columnType.Oid)
+	if f.UnimplementedTypes == nil {
+		f.UnimplementedTypes = make(map[oid.Oid]string)
+	}
+
+	f.UnimplementedTypes[typeOid] = columnType.DataType
+}
+
+// IsImplemented determines whether the type is implemented or not in
+// cockroachdb.
+func (t *PGMetadataColumnType) IsImplemented() bool {
+	typeOid := oid.Oid(t.Oid)
+	_, ok := types.OidToType[typeOid]
+	// Cannot use type oid.T_anyarray in CREATE TABLE
+	return ok && typeOid != oid.T_anyarray
 }

--- a/pkg/sql/pg_metadata_test.go
+++ b/pkg/sql/pg_metadata_test.go
@@ -33,12 +33,16 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"go/ast"
+	goParser "go/parser"
+	"go/token"
 	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
 	"regexp"
+	"runtime"
 	"sort"
 	"strings"
 	"testing"
@@ -67,7 +71,7 @@ const (
 	pgCatalogGo     = "pg_catalog.go"
 )
 
-// When running test with -rewrite-diffs test will pass and re-create pg_catalog_test-diffs.json
+// When running test with -rewrite-diffs test will pass and re-create pg_catalog_test-diffs.json.
 var (
 	rewriteFlag = flag.Bool("rewrite-diffs", false, "This will re-create the expected diffs file")
 	catalogName = flag.String("catalog", "pg_catalog", "Catalog or namespace, default: pg_catalog")
@@ -83,26 +87,45 @@ const (
 	undefinedTablesDeclaration = `undefinedTables: buildStringSet(`
 	undefinedTablesTerminal    = `),`
 	virtualTablePosition       = `// typOid is the only OID generation approach that does not use oidHasher, because`
-	virtualTableTemplate       = `var %s = virtualSchemaTable{
+	virtualTableSchemaField    = "schema"
+	virtualTablePopulateField  = "populate"
+)
+
+// virtualTableTemplate is used to create new virtualSchemaTable objects when
+// adding new tables.
+var virtualTableTemplate = fmt.Sprintf(`var %s = virtualSchemaTable{
 	comment: "%s was created for compatibility and is currently unimplemented",
-	schema:  vtable.%s,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	%s:  vtable.%s,
+	%s: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		return nil
 	},
 	unimplemented: true,
 }
 
-`
+`, "%s", "%s", virtualTableSchemaField, "%s", virtualTablePopulateField)
+
+// Name of functions that may need modifications when new columns are added.
+const (
+	makeAllRelationsVirtualTableWithDescriptorIDIndexFunc = "makeAllRelationsVirtualTableWithDescriptorIDIndex"
 )
 
 var addMissingTables = flag.Bool(
 	"add-missing-tables",
 	false,
-	"add-missing-tables will complete pg_catalog tables in the go code",
+	"add-missing-tables will complete pg_catalog tables and columns in the go code",
 )
 
 var (
 	tableFinderRE = regexp.MustCompile(`(?i)CREATE TABLE pg_catalog\.([^\s]+)\s`)
+	constNameRE   = regexp.MustCompile(`const ([^\s]+)\s`)
+	indentationRE = regexp.MustCompile(`^(\s*)`)
+	indexRE       = regexp.MustCompile(`(?i)INDEX\s*\([^\)]+\)`)
+)
+
+// Types.
+var (
+	virtualSchemaType      = reflect.TypeOf((*virtualSchema)(nil)).Elem()
+	virtualSchemaTableType = reflect.TypeOf((*virtualSchemaTable)(nil)).Elem()
 )
 
 var none = struct{}{}
@@ -129,7 +152,7 @@ func (sum *summary) report(t *testing.T) {
 	}
 }
 
-// loadTestData retrieves the pg_catalog from the dumpfile generated from Postgres
+// loadTestData retrieves the pg_catalog from the dumpfile generated from Postgres.
 func loadTestData(t testing.TB) PGMetadataTables {
 	var pgCatalogFile PGMetadataFile
 	testdataFile := filepath.Join(testdata, fmt.Sprintf(catalogDump, *catalogName))
@@ -151,7 +174,7 @@ func loadTestData(t testing.TB) PGMetadataTables {
 	return pgCatalogFile.PGMetadata
 }
 
-// loadCockroachPgCatalog retrieves pg_catalog schema from cockroach db
+// loadCockroachPgCatalog retrieves pg_catalog schema from cockroach db.
 func loadCockroachPgCatalog(t testing.TB) PGMetadataTables {
 	crdbTables := make(PGMetadataTables)
 	ctx := context.Background()
@@ -172,7 +195,7 @@ func loadCockroachPgCatalog(t testing.TB) PGMetadataTables {
 	return crdbTables
 }
 
-// loadExpectedDiffs get all differences that will be skipped by the this test
+// loadExpectedDiffs get all differences that will be skipped by the this test.
 func loadExpectedDiffs(t *testing.T) (diffs PGMetadataTables) {
 	diffs = PGMetadataTables{}
 
@@ -226,18 +249,21 @@ func rewriteDiffs(t *testing.T, diffs PGMetadataTables, diffsFile string) {
 // fixConstants updates catconstants that are needed for pgCatalog.
 func fixConstants(t *testing.T, notImplemented PGMetadataTables) {
 	constantsFileName := filepath.Join(".", catalogPkg, catconstantsPkg, constantsGo)
-	// pgConstants will contains all the pgCatalog tableID constant adding the new tables and preventing duplicates
+	// pgConstants will contains all the pgCatalog tableID constant adding the
+	// new tables and preventing duplicates.
 	pgConstants := getPgCatalogConstants(t, constantsFileName, notImplemented)
 	sort.Strings(pgConstants)
 
-	// Rewrite will place all the pgConstants in alphabetical order after PgCatalogID
+	// Rewrite will place all the pgConstants in alphabetical order after
+	// PgCatalogID.
 	rewriteFile(constantsFileName, func(input *os.File, output outputFile) {
 		reader := bufio.NewScanner(input)
 		for reader.Scan() {
 			text := reader.Text()
 			trimText := strings.TrimSpace(text)
 
-			// Skips PgCatalog constants (except PgCatalogID) as these will be written from pgConstants slice
+			// Skips PgCatalog constants (except PgCatalogID) as these will be
+			// written from pgConstants slice.
 			if strings.HasPrefix(trimText, pgCatalogPrefix) && trimText != pgCatalogIDConstant {
 				continue
 			}
@@ -257,25 +283,63 @@ func fixConstants(t *testing.T, notImplemented PGMetadataTables) {
 }
 
 // fixVtable adds missing table's create table constants.
-func fixVtable(t *testing.T, notImplemented PGMetadataTables) {
+func fixVtable(
+	t *testing.T,
+	unimplemented PGMetadataTables,
+	unimplementedColumns PGMetadataTables,
+	pgCode *pgCatalogCode,
+) {
 	fileName := filepath.Join(vtablePkg, pgCatalogGo)
 
-	// rewriteFile first will check existing create table constants to avoid duplicates.
+	// rewriteFile first will check existing create table constants to avoid
+	// duplicates.
 	rewriteFile(fileName, func(input *os.File, output outputFile) {
 		existingTables := make(map[string]struct{})
 		reader := bufio.NewScanner(input)
+		var constName string
+		var tableName string
+		fixedTables := make(map[string]struct{})
+		var sb strings.Builder
+
 		for reader.Scan() {
 			text := reader.Text()
-			output.appendString(text)
-			output.appendString("\n")
+			trimText := strings.TrimSpace(text)
+			// vTable file lists a set of constants with the create tables. Constants
+			// are referred in virtualSchemaTable, so first we find the constant name
+			// to map with the table name later.
+			constDecl := constNameRE.FindStringSubmatch(text)
+			if constDecl != nil {
+				constName = constDecl[1]
+			}
+
 			createTable := tableFinderRE.FindStringSubmatch(text)
 			if createTable != nil {
-				tableName := createTable[1]
+				tableName = createTable[1]
 				existingTables[tableName] = none
 			}
+
+			// nextIsIndex helps to avoid detecting an INDEX line as column name.
+			nextIsIndex := indexRE.MatchString(strings.ToUpper(trimText))
+			// fixedTables keep track of all the tables which we added new columns.
+			if _, fixed := fixedTables[tableName]; !fixed && (text == ")`" || nextIsIndex) {
+				missingColumnsText := getMissingColumnsText(constName, tableName, nextIsIndex, unimplementedColumns, pgCode)
+				if len(missingColumnsText) > 0 {
+					// Right parenthesis is already printed in the output, but we need to
+					// add new columns before that.
+					output.seekRelative(-1)
+				}
+				output.appendString(missingColumnsText)
+				fixedTables[tableName] = none
+				pgCode.addRowPositions.removeIfNoMissingColumns(constName)
+				pgCode.addRowPositions.reportNewColumns(&sb, constName, tableName)
+			}
+
+			output.appendString(text)
+			output.appendString("\n")
 		}
 
-		for tableName, columns := range notImplemented {
+		first := true
+		for tableName, columns := range unimplemented {
 			if _, ok := existingTables[tableName]; ok {
 				// Table already implemented.
 				continue
@@ -286,9 +350,55 @@ func fixVtable(t *testing.T, notImplemented PGMetadataTables) {
 				t.Log(err)
 				continue
 			}
+			reportNewTable(&sb, tableName, &first)
 			output.appendString(createTable)
 		}
 	})
+}
+
+func reportNewTable(sb *strings.Builder, tableName string, first *bool) {
+	if *first {
+		sb.WriteString("New Tables:\n")
+		*first = false
+	}
+	sb.WriteString("\t")
+	sb.WriteString(tableName)
+	sb.WriteString("\n")
+}
+
+// getMissingColumnsText creates the text used by a vTable constant to add the
+// new (or missing) columns.
+func getMissingColumnsText(
+	constName string,
+	tableName string,
+	nextIsIndex bool,
+	unimplementedColumns PGMetadataTables,
+	pgCode *pgCatalogCode,
+) string {
+	nilPopulateTables := pgCode.fixableTables
+	if _, fixable := nilPopulateTables[constName]; !fixable {
+		return ""
+	}
+	columns, found := unimplementedColumns[tableName]
+	if !found {
+		return ""
+	}
+	var sb strings.Builder
+	prefix := ",\n"
+	if nextIsIndex {
+		// Previous line already had comma.
+		prefix = "\n"
+	}
+	for columnName, columnType := range columns {
+		formatColumn(&sb, prefix, columnName, columnType)
+		pgCode.addRowPositions.addMissingColumn(constName, columnName)
+		prefix = ",\n"
+	}
+	if nextIsIndex {
+		sb.WriteString(",")
+	}
+	sb.WriteString("\n")
+	return sb.String()
 }
 
 // fixPgCatalogGo will update pgCatalog.undefinedTables, pgCatalog.tableDefs and
@@ -306,7 +416,8 @@ func fixPgCatalogGo(t *testing.T, notImplemented PGMetadataTables) {
 			text := reader.Text()
 			trimText := strings.TrimSpace(text)
 			if trimText == virtualTablePosition {
-				//VirtualSchemas doesn't have a particular place to start we just print it before virtualTablePosition
+				//VirtualSchemas doesn't have a particular place to start we just print
+				// it before virtualTablePosition.
 				output.appendString(printVirtualSchemas(notImplemented))
 			}
 			output.appendString(text)
@@ -322,7 +433,56 @@ func fixPgCatalogGo(t *testing.T, notImplemented PGMetadataTables) {
 	})
 }
 
-// printBeforeTerminalString will skip all the lines and print `s` text when finds the terminal string.
+func fixPgCatalogGoColumns(positions addRowPositionList) {
+	rewriteFile(pgCatalogGo, func(input *os.File, output outputFile) {
+		reader := bufio.NewScanner(input)
+		scannedUntil := 0
+		currentPosition := 0
+		for reader.Scan() {
+			text := reader.Text()
+			count := len(text) + 1
+
+			if currentPosition < len(positions) && int64(scannedUntil+count) > positions[currentPosition].insertPosition {
+				relativeIndex := int(positions[currentPosition].insertPosition-int64(scannedUntil)) - 1
+				left := text[:relativeIndex]
+				indentation := indentationRE.FindStringSubmatch(text)[1] //The way it is it should at least give ""
+				if len(strings.TrimSpace(left)) > 0 {
+					// Parenthesis is right after the last variable in this case
+					// indentation is correct.
+					output.appendString(left)
+					output.appendString(",\n")
+				} else {
+					// Parenthesis is after a new line, we got to add one tab.
+					indentation += "\t"
+				}
+
+				output.appendString(indentation)
+				output.appendString("// These columns were automatically created by pg_catalog_test's missing column generator.")
+				output.appendString("\n")
+
+				for _, columnName := range positions[currentPosition].missingColumns {
+					output.appendString(indentation)
+					output.appendString("tree.DNull,")
+					output.appendString(" // ")
+					output.appendString(columnName)
+					output.appendString("\n")
+				}
+
+				output.appendString(indentation[:len(indentation)-1])
+				output.appendString(text[relativeIndex:])
+				currentPosition++
+			} else {
+				// No insertion point, just write what-ever have been read.
+				output.appendString(text)
+			}
+			output.appendString("\n")
+			scannedUntil += count
+		}
+	})
+}
+
+// printBeforeTerminalString will skip all the lines and print `s` text when
+// finds the terminal string.
 func printBeforeTerminalString(
 	reader *bufio.Scanner, output outputFile, terminalString string, s string,
 ) {
@@ -348,7 +508,8 @@ func printBeforeTerminalString(
 	}
 }
 
-// getPgCatalogConstants reads catconstant and retrieves all the constant with `PgCatalog` prefix.
+// getPgCatalogConstants reads catconstant and retrieves all the constant with
+// `PgCatalog` prefix.
 func getPgCatalogConstants(
 	t *testing.T, inputFileName string, notImplemented PGMetadataTables,
 ) []string {
@@ -379,15 +540,24 @@ func getPgCatalogConstants(
 	return pgConstants
 }
 
-// outputFile wraps an *os.file to avoid explicit error checks on every WriteString.
+// outputFile wraps an *os.file to avoid explicit error checks on every
+// WriteString.
 type outputFile struct {
 	f *os.File
 }
 
-// appendString calls WriteString and panics on error
+// appendString calls WriteString and panics on error.
 func (o outputFile) appendString(s string) {
 	if _, err := o.f.WriteString(s); err != nil {
 		panic(fmt.Errorf("error while writing string: %s: %v", s, err))
+	}
+}
+
+// seekRelative Allows outputFile wrapper to use Seek function in the wrapped
+// file.
+func (o outputFile) seekRelative(offset int64) {
+	if _, err := o.f.Seek(offset, io.SeekCurrent); err != nil {
+		panic(fmt.Errorf("could not seek file"))
 	}
 }
 
@@ -562,6 +732,7 @@ func getUndefinedTablesList(newTables PGMetadataTables, vs virtualSchema) ([]str
 	return undefinedTablesList, nil
 }
 
+// formatUndefinedTablesText gets the text to be printed as undefinedTables.
 func formatUndefinedTablesText(newTableNameList []string) string {
 	var sb strings.Builder
 	for _, tableName := range newTableNameList {
@@ -650,6 +821,334 @@ func getSortedDefKeys(tableDefs map[string]string) []string {
 	return keys
 }
 
+// goParsePgCatalogGo parses pg_catalog.go using go/parser to get the list of
+// tables that are unimplemented (return zero rows) and get where to insert
+// new columns (if needed) by mapping all the addRow calls with the table.
+func goParsePgCatalogGo(t *testing.T) *pgCatalogCode {
+	fs := token.NewFileSet()
+	f, err := goParser.ParseFile(fs, pgCatalogGo, nil, goParser.AllErrors)
+	if err != nil {
+		t.Fatal(err)
+	}
+	srcFile, err := os.Open(pgCatalogGo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dClose(srcFile)
+	pgCode := &pgCatalogCode{
+		fixableTables:   make(map[string]struct{}),
+		addRowPositions: make(map[string]addRowPositionList),
+		schemaParam:     -1, // This value will be calculated later and once
+		srcFile:         srcFile,
+		t:               t,
+	}
+
+	ast.Walk(&pgCatalogCodeVisitor{
+		pgCode:         pgCode,
+		schema:         "",
+		addRowFuncName: "",
+		bodyStmts:      0,
+	}, f)
+
+	return pgCode
+}
+
+// addRowPosition describes an insertion point for new columns.
+type addRowPosition struct {
+	schema         string
+	argSize        int
+	insertPosition int64
+	missingColumns []string
+}
+
+type addRowPositionList []*addRowPosition
+
+type mappedRowPositions map[string]addRowPositionList
+
+// pgCatalogCode describes pg_catalog.go insertion points for addRow calls and
+// virtualSchemaTables which its populate func returns nil.
+type pgCatalogCode struct {
+	fixableTables   map[string]struct{}
+	addRowPositions mappedRowPositions
+	schemaParam     int // Index where we expect to find schema at makeAllRelationsVirtualTableWithDescriptorIDIndex.
+	srcFile         *os.File
+	t               *testing.T
+}
+
+// pgCatalogCodeVisitor implements ast.Visitor for traversing pg_catalog.go.
+type pgCatalogCodeVisitor struct {
+	pgCode         *pgCatalogCode
+	schema         string
+	addRowFuncName string
+	bodyStmts      int
+}
+
+// nextWithSchema will set the schema for inner nodes visitors.
+func (v pgCatalogCodeVisitor) nextWithSchema(schema string) pgCatalogCodeVisitor {
+	next := v
+	next.schema = schema
+	return next
+}
+
+// Visit implements ast.Visitor and sets the rules for detecting schema,
+// matching schema with addRow calls and finding which schemas have "return
+// nil" at populate function.
+//
+// The code is parsed and creating a tree structure that is being traversed by
+// ast.Walk() function, to visit a particular node this method is being called
+// from the ast.Visitor.
+//
+// The nodes may have different kind of token types (like variable or functions
+// declarations, function calls, arguments, types, etc) so this Visitor is
+// looking at specific tokens to find calls of "addRow" in populate function
+// from virtualSchemaTable, and match this calls and positions to a table
+// schema which later is used to modify addRows if there are new columns to
+// add.
+func (v pgCatalogCodeVisitor) Visit(node ast.Node) ast.Visitor {
+	if node == nil {
+		return nil
+	}
+
+	switch n := node.(type) {
+	case *ast.KeyValueExpr:
+		// KeyValueExpr nodes contains attribute setting on structures. Here we are
+		// looking at specific attributes contained at virtualSchemaTable struct,
+		// like schema and populate function.
+		key, ok := n.Key.(*ast.Ident)
+		if !ok {
+			return v
+		}
+		switch key.Name {
+		case virtualTableSchemaField:
+			// Schema value usually comes with SelectorExpr (something like
+			// vtable.PGCatalogRange) which constant name string is relevant to us
+			// (PGCatalogRange) addRow calls are being matched to this constant name.
+			val, ok := n.Value.(*ast.SelectorExpr)
+			if !ok {
+				return v
+			}
+			v.schema = val.Sel.String()
+		case virtualTablePopulateField:
+			// FuncLit is a function definition, we can look for addRow if this is
+			// a function definition.
+			val, ok := n.Value.(*ast.FuncLit)
+			if !ok {
+				return v
+			}
+			v.bodyStmts = len(val.Body.List)
+			index := v.findAddRowFuncName(val)
+			if index <= -1 {
+				v.pgCode.t.Fatal("populate function does not have a parameter with 'func(...tree.Datum) error' signature")
+			}
+		}
+	case *ast.ReturnStmt:
+		result, ok := n.Results[0].(*ast.Ident)
+		if !ok {
+			return v
+		}
+
+		// This validates the ReturnStmt comes from populate function and it is the
+		// only statement.
+		if result.String() == "nil" && v.schema != "" && v.bodyStmts == 1 {
+			// Populate function just returns nil.
+			v.pgCode.fixableTables[v.schema] = none
+		}
+	case *ast.CallExpr:
+		// These are actual function calls, we look for specifc function calls
+		// to see where to insert new columns.
+		fun, ok := n.Fun.(*ast.Ident)
+		if !ok {
+			return v
+		}
+
+		switch fun.Name {
+		case v.addRowFuncName:
+			if v.schema == "" || v.addRowFuncName == "" {
+				// Could not match addRow with schema
+				return v
+			}
+
+			if _, ok = v.pgCode.fixableTables[v.schema]; !ok {
+				v.pgCode.fixableTables[v.schema] = none
+			}
+			if _, ok = v.pgCode.addRowPositions[v.schema]; !ok {
+				// Capacity of 3 is decided based on the maximum number of calls of
+				// addRow function at any populate function to cover most of the cases.
+				v.pgCode.addRowPositions[v.schema] = make([]*addRowPosition, 0, 3)
+			}
+
+			// missingColumns capacity of 5 is based on the maximum number of new
+			// columns to cover most of the cases without growing the internal array
+			// in the missingColumns slice.
+			addRow := &addRowPosition{
+				schema:         v.schema,
+				argSize:        len(n.Args), // Number of arguments must match with amount of columns
+				insertPosition: int64(n.Rparen),
+				missingColumns: make([]string, 0, 5), // This will be filled when fixing vtable and used to comment nils
+			}
+			addRowList := v.pgCode.addRowPositions[v.schema]
+			v.pgCode.addRowPositions[v.schema] = append(addRowList, addRow)
+		case makeAllRelationsVirtualTableWithDescriptorIDIndexFunc:
+			// This special case when the table definition is in this function and
+			// passed the populate function as an argument.
+			schemaIndex := v.findSchemaIndex(n)
+			if schemaIndex < 0 || len(n.Args) <= schemaIndex {
+				// This is not probably that happen but just in case to avoid hitting an index out of bounds
+				return v
+			}
+			val, ok := n.Args[schemaIndex].(*ast.SelectorExpr)
+			if !ok || val == nil {
+				return v
+			}
+
+			return v.nextWithSchema(val.Sel.String())
+		}
+	}
+
+	return v
+}
+
+// singleSortedList will retrieve all the positions at ascending order to fix
+// columns sequentially by reading the file.
+func (m mappedRowPositions) singleSortedList() addRowPositionList {
+	positions := make(addRowPositionList, 0, len(m))
+	for _, val := range m {
+		positions = append(positions, val...)
+	}
+	sort.Slice(positions, func(i int, j int) bool {
+		return positions[i].insertPosition < positions[j].insertPosition
+	})
+	return positions
+}
+
+// removeIfNoMissingColumns will clean up addRow calls positions that doesn't
+// require any column adding.
+func (m mappedRowPositions) removeIfNoMissingColumns(constName string) {
+	if addRowList, ok := m[constName]; ok && len(addRowList) > 0 {
+		addRow := addRowList[0]
+		if len(addRow.missingColumns) == 0 {
+			delete(m, constName)
+		}
+	}
+}
+
+// addMissingColumn adds columnName for specific constName (schema).
+func (m mappedRowPositions) addMissingColumn(constName, columnName string) {
+	if addRows, ok := m[constName]; ok {
+		for _, addRow := range addRows {
+			addRow.missingColumns = append(addRow.missingColumns, columnName)
+		}
+	}
+}
+
+func (m mappedRowPositions) reportNewColumns(sb *strings.Builder, constName, tableName string) {
+	if addRowList, ok := m[constName]; ok && len(addRowList) > 0 {
+		addRow := addRowList[0]
+		if len(addRow.missingColumns) > 0 {
+			sb.WriteString("New columns in table ")
+			sb.WriteString(tableName)
+			sb.WriteString(":\n")
+			for _, columnName := range addRow.missingColumns {
+				sb.WriteString("\t")
+				sb.WriteString(columnName)
+				sb.WriteString("\n")
+			}
+		}
+	}
+}
+
+// findSchemaIndex is a helper function to retrieve what is the parameter index for schemaDef at function
+// makeAllRelationsVirtualTableWithDescriptorIDIndex.
+func (v *pgCatalogCodeVisitor) findSchemaIndex(call *ast.CallExpr) int {
+	if v.pgCode.schemaParam != -1 {
+		return v.pgCode.schemaParam
+	}
+
+	fun, ok := call.Fun.(*ast.Ident)
+	if !ok {
+		return -1
+	}
+	decl, ok := fun.Obj.Decl.(*ast.FuncDecl)
+	if !ok {
+		return -1
+	}
+	_, index := v.findInFunctionParameters(decl.Type, "schemaDef", "string")
+	if index > -1 {
+		v.pgCode.schemaParam = index
+	}
+
+	return index
+}
+
+// findAddRowFuncName will retrieve the function name used by populate function
+// with func(...tree.Datum) error signature, which is used to populate
+// virtualSchemaTable.
+func (v *pgCatalogCodeVisitor) findAddRowFuncName(funcLit *ast.FuncLit) int {
+	paramName, index := v.findInFunctionParameters(funcLit.Type, "", "func(...tree.Datum) error")
+	if index > -1 {
+		v.addRowFuncName = paramName
+	}
+
+	return index
+}
+
+// findInFunctionParameters search for name and type of the parameters used
+// by the given function, use empty string if search for type only. Return
+// gives the name of the parameter and index or number of the parameter. If
+// parameter not found returns empty string and -1.
+func (v *pgCatalogCodeVisitor) findInFunctionParameters(
+	funcType *ast.FuncType, name, paramTypeName string,
+) (string, int) {
+	var paramTypeString string
+	var err error
+	for index, param := range funcType.Params.List {
+		if len(param.Names) != 1 || param.Names[0] == nil {
+			continue
+		}
+
+		switch paramType := param.Type.(type) {
+		case *ast.Ident:
+			paramTypeString = paramType.String()
+		case *ast.FuncType:
+			// When it is a function type there is no direct way to get the parameter
+			// type as string, in this case this access the source code file using
+			// token positions to retrieve the text that defines the type.
+			paramTypeString, err = readSourcePortion(v.pgCode.srcFile, paramType.Pos(), paramType.End())
+			if err != nil {
+				panic(err)
+			}
+		default:
+			continue
+		}
+
+		if (name == "" || name == param.Names[0].String()) && (paramTypeString == paramTypeName) {
+			return param.Names[0].String(), index
+		}
+	}
+
+	return "", -1
+}
+
+// readSourcePortion uses direct access to specific position (given by tokens)
+// to access a portion of the source code
+func readSourcePortion(srcFile *os.File, start, end token.Pos) (string, error) {
+	length := int(end - start)
+	bytes := make([]byte, end-start)
+	// Whence zero to Seek from beginning of the file.
+	_, err := srcFile.Seek(int64(start)-1, io.SeekStart)
+	if err != nil {
+		return "", err
+	}
+	read, err := srcFile.Read(bytes)
+	if err != nil {
+		return "", err
+	}
+	if read != length {
+		return "", fmt.Errorf("expected to read %d but read %d", length, read)
+	}
+	return string(bytes), nil
+}
+
 // TestPGCatalog is the pg_catalog diff tool test which compares pg_catalog
 // with postgres and cockroach.
 func TestPGCatalog(t *testing.T) {
@@ -710,13 +1209,17 @@ func TestPGCatalog(t *testing.T) {
 	}
 
 	sum.report(t)
+	diffs.removeImplementedColumns(crdbTables)
 	rewriteDiffs(t, diffs, filepath.Join(testdata, fmt.Sprintf(expectedDiffs, *catalogName)))
 
 	if *addMissingTables {
 		validateUndefinedTablesField(t)
 		unimplemented := diffs.getUnimplementedTables(pgTables)
+		unimplementedColumns := diffs.getUnimplementedColumns(pgTables)
+		pgCode := goParsePgCatalogGo(t)
 		fixConstants(t, unimplemented)
-		fixVtable(t, unimplemented)
+		fixVtable(t, unimplemented, unimplementedColumns, pgCode)
+		fixPgCatalogGoColumns(pgCode.addRowPositions.singleSortedList())
 		fixPgCatalogGo(t, unimplemented)
 	}
 }
@@ -727,9 +1230,11 @@ func TestPGCatalog(t *testing.T) {
 func TestPGMetadataCanFixCode(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	// TODO: Add more checks, for now adding the test that is relevant for
 	// rewrite undefinedTables.
 	validateUndefinedTablesField(t)
+	validateTableDefsField(t)
+	validateVirtualSchemaTable(t)
+	validateFunctionNames(t)
 }
 
 // validateUndefinedTablesField checks the definition of virtualSchema objects
@@ -738,21 +1243,64 @@ func TestPGMetadataCanFixCode(t *testing.T) {
 func validateUndefinedTablesField(t *testing.T) {
 	propertyIndex := strings.IndexRune(undefinedTablesDeclaration, ':')
 	property := undefinedTablesDeclaration[:propertyIndex]
-	// Using pgCatalog but information_schema is a virtualSchema as well
-	assertProperty(t, property, pgCatalog)
+	// Using pgCatalog but information_schema is a virtualSchema as well.
+	assertProperty(t, property, virtualSchemaType)
+}
+
+// validateTableDefsField checkes the definition of virtualSchema that
+// have a tableDefs field which can be rewritten by this code.
+func validateTableDefsField(t *testing.T) {
+	propertyIndex := strings.IndexRune(tableDefsDeclaration, ':')
+	property := tableDefsDeclaration[:propertyIndex]
+	assertProperty(t, property, virtualSchemaType)
+}
+
+// validateVirtualSchemaTable checks that the template on virtualTableTemplate
+// can produce a valid object.
+func validateVirtualSchemaTable(t *testing.T) {
+	lines := strings.Split(virtualTableTemplate, "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		semicolonIndex := strings.IndexRune(line, ':')
+		switch {
+		case strings.HasPrefix(line, "var"):
+			equalIndex := strings.IndexRune(line, '=')
+			bracketIndex := strings.IndexRune(line, '{')
+			templateTypeName := line[equalIndex+1 : bracketIndex]
+			templateTypeName = strings.TrimSpace(templateTypeName)
+			actualTypeName := virtualSchemaTableType.Name()
+			if actualTypeName != templateTypeName {
+				t.Fatalf(
+					"virtualTableTemplate have a wrong name of type %s but actual type name is %s",
+					templateTypeName,
+					actualTypeName,
+				)
+			}
+		case semicolonIndex != -1:
+			property := strings.TrimSpace(line[:semicolonIndex])
+			assertProperty(t, property, virtualSchemaTableType)
+		}
+	}
+}
+
+// validateFunctionNames prevents refactoring function names without changing
+// the constants that looks for these names.
+func validateFunctionNames(t *testing.T) {
+	name := runtime.FuncForPC(reflect.ValueOf(makeAllRelationsVirtualTableWithDescriptorIDIndex).Pointer()).Name()
+	// removing 'github.com/cockroachdb/cockroach/pkg/sql.' from the name.
+	lastDotIndex := strings.LastIndex(name, ".")
+	name = name[lastDotIndex+1:]
+	if name != makeAllRelationsVirtualTableWithDescriptorIDIndexFunc {
+		t.Fatalf("makeAllRelationsVirtualTableWithDescriptorIDIndexFunc constant value should be %s", name)
+	}
 }
 
 // assertProperty checks the property (or field) exists in the given interface.
-func assertProperty(t *testing.T, property string, i interface{}) {
+func assertProperty(t *testing.T, property string, rtype reflect.Type) {
 	t.Run(fmt.Sprintf("assertProperty/%s", property), func(t *testing.T) {
-		value := reflect.ValueOf(i)
-		if value.Type().Kind() != reflect.Ptr {
-			value = reflect.New(reflect.TypeOf(i))
-		}
-
-		field := value.Elem().FieldByName(property)
-		if !field.IsValid() {
-			t.Fatalf("field %s is not a field of type %T", property, i)
+		_, ok := rtype.FieldByName(property)
+		if !ok {
+			t.Fatalf("field %s is not a field of type %s", property, rtype.Name())
 		}
 	})
 }

--- a/pkg/sql/testdata/information_schema_tables.json
+++ b/pkg/sql/testdata/information_schema_tables.json
@@ -4103,5 +4103,12 @@
         "expectedDataType": null
       }
     }
+  },
+  "unimplementedTypes": {
+    "13438": "cardinal_number",
+    "13441": "character_data",
+    "13443": "sql_identifier",
+    "13448": "time_stamp",
+    "13450": "yes_or_no"
   }
 }

--- a/pkg/sql/testdata/pg_catalog_tables.json
+++ b/pkg/sql/testdata/pg_catalog_tables.json
@@ -7411,5 +7411,16 @@
         "expectedDataType": null
       }
     }
+  },
+  "unimplementedTypes": {
+    "1034": "_aclitem",
+    "194": "pg_node_tree",
+    "2275": "cstring",
+    "2277": "anyarray",
+    "28": "xid",
+    "3220": "pg_lsn",
+    "3361": "pg_ndistinct",
+    "3402": "pg_dependencies",
+    "5017": "pg_mcv_list"
   }
 }


### PR DESCRIPTION
Previously, keeping up with postgres by adding the same columns in pg_catalog
was a manual process
This was inadequate because from version to version the list of missing
columns might increase a lot
To address this, this patch closes the gap between postgres and cockroachdb
by adding the missing columns automatically with nil values

Release note: None

Fixes: #58001