### PR TITLE
build,bazel: fix bazel build

### DIFF
--- a/pkg/server/diagnostics/diagnosticspb/BUILD.bazel
+++ b/pkg/server/diagnostics/diagnosticspb/BUILD.bazel
@@ -23,6 +23,7 @@ go_proto_library(
     proto = ":diagnosticspb_proto",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/base",  # keep
         "//pkg/build",
         "//pkg/config/zonepb",
         "//pkg/roachpb",

--- a/pkg/server/serverpb/BUILD.bazel
+++ b/pkg/server/serverpb/BUILD.bazel
@@ -1,3 +1,5 @@
+# gazelle:go_grpc_compilers //pkg/cmd/protoc-gen-gogoroach:protoc-gen-gogoroach_grpc_compiler,  @com_github_grpc_ecosystem_grpc_gateway//protoc-gen-grpc-gateway:go_gen_grpc_gateway
+
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
@@ -38,7 +40,10 @@ proto_library(
 
 go_proto_library(
     name = "serverpb_go_proto",
-    compilers = ["//pkg/cmd/protoc-gen-gogoroach:protoc-gen-gogoroach_grpc_compiler"],
+    compilers = [
+        "//pkg/cmd/protoc-gen-gogoroach:protoc-gen-gogoroach_grpc_compiler",
+        "@com_github_grpc_ecosystem_grpc_gateway//protoc-gen-grpc-gateway:go_gen_grpc_gateway",
+    ],
     importpath = "github.com/cockroachdb/cockroach/pkg/server/serverpb",
     proto = ":serverpb_proto",
     visibility = ["//visibility:public"],
@@ -53,12 +58,16 @@ go_proto_library(
         "//pkg/roachpb",
         "//pkg/server/diagnostics/diagnosticspb",
         "//pkg/server/status/statuspb:statuspb_go_proto",
+        "//pkg/sql/catalog/descpb",  # keep
         "//pkg/storage/enginepb",
         "//pkg/ts/catalog",
         "//pkg/util",
         "//pkg/util/log/logpb",
         "//pkg/util/metric",
         "@com_github_gogo_protobuf//gogoproto",
+        # NB: The grpc-gateway compiler injects a dependency on the descriptor
+        # package that Gazelle isn't prepared to deal with.
+        "@com_github_golang_protobuf//descriptor:go_default_library_gen",  # keep
         "@io_etcd_go_etcd_raft_v3//raftpb",
         "@org_golang_google_genproto//googleapis/api/annotations:go_default_library",
     ],


### PR DESCRIPTION
Add missing dependencies. Also re-add a `gazelle:` directive that was
accidentally stripped out in #59073.

Release note: None