### PR TITLE
opt: improve EXPLAIN for render

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/aggregate
+++ b/pkg/sql/opt/exec/execbuilder/testdata/aggregate
@@ -49,11 +49,11 @@ vectorized: true
 └── • render
     │ columns: (column7 int, column10 unknown, column17 bool, column19 bool, column21 bytes)
     │ estimated row count: 1,000 (missing stats)
-    │ render 0: (1)[int]
-    │ render 1: (NULL)[unknown]
-    │ render 2: (true)[bool]
-    │ render 3: (false)[bool]
-    │ render 4: ('\x01')[bytes]
+    │ render column7: (1)[int]
+    │ render column10: (NULL)[unknown]
+    │ render column17: (true)[bool]
+    │ render column19: (false)[bool]
+    │ render column21: ('\x01')[bytes]
     │
     └── • scan
           columns: ()
@@ -102,11 +102,11 @@ vectorized: true
 └── • render
     │ columns: (column10 int, column16 bool, column19 bytes, k int, v int)
     │ estimated row count: 1,000 (missing stats)
-    │ render 0: (1)[int]
-    │ render 1: ((v)[int] = (1)[int])[bool]
-    │ render 2: ((s)[string]::BYTES)[bytes]
-    │ render 3: (k)[int]
-    │ render 4: (v)[int]
+    │ render column10: (1)[int]
+    │ render column16: ((v)[int] = (1)[int])[bool]
+    │ render column19: ((s)[string]::BYTES)[bytes]
+    │ render k: (k)[int]
+    │ render v: (v)[int]
     │
     └── • scan
           columns: (k int, v int, s string)
@@ -127,30 +127,30 @@ vectorized: true
 • render
 │ columns: (min int, count int, max int, sum_int int, avg float, sum decimal, stddev decimal, variance decimal, bool_and bool, bool_or bool, to_hex string, corr float, covar_pop float, covar_samp float, sqrdiff decimal, regr_intercept float, regr_r2 float, regr_slope float, regr_sxx float, regr_sxy float, regr_syy float, regr_count int, regr_avgx float, regr_avgy float)
 │ estimated row count: 1
-│ render 0: ((avg)[decimal]::FLOAT8)[float]
-│ render 1: (to_hex((xor_agg)[bytes]))[string]
-│ render 2: (min)[int]
-│ render 3: (count)[int]
-│ render 4: (max)[int]
-│ render 5: (sum_int)[int]
-│ render 6: (sum)[decimal]
-│ render 7: (stddev)[decimal]
-│ render 8: (variance)[decimal]
-│ render 9: (bool_and)[bool]
-│ render 10: (bool_or)[bool]
-│ render 11: (corr)[float]
-│ render 12: (covar_pop)[float]
-│ render 13: (covar_samp)[float]
-│ render 14: (sqrdiff)[decimal]
-│ render 15: (regr_intercept)[float]
-│ render 16: (regr_r2)[float]
-│ render 17: (regr_slope)[float]
-│ render 18: (regr_sxx)[float]
-│ render 19: (regr_sxy)[float]
-│ render 20: (regr_syy)[float]
-│ render 21: (count_rows)[int]
-│ render 22: (regr_avgx)[float]
-│ render 23: (regr_avgy)[float]
+│ render avg: ((avg)[decimal]::FLOAT8)[float]
+│ render to_hex: (to_hex((xor_agg)[bytes]))[string]
+│ render min: (min)[int]
+│ render count: (count)[int]
+│ render max: (max)[int]
+│ render sum_int: (sum_int)[int]
+│ render sum: (sum)[decimal]
+│ render stddev: (stddev)[decimal]
+│ render variance: (variance)[decimal]
+│ render bool_and: (bool_and)[bool]
+│ render bool_or: (bool_or)[bool]
+│ render corr: (corr)[float]
+│ render covar_pop: (covar_pop)[float]
+│ render covar_samp: (covar_samp)[float]
+│ render sqrdiff: (sqrdiff)[decimal]
+│ render regr_intercept: (regr_intercept)[float]
+│ render regr_r2: (regr_r2)[float]
+│ render regr_slope: (regr_slope)[float]
+│ render regr_sxx: (regr_sxx)[float]
+│ render regr_sxy: (regr_sxy)[float]
+│ render regr_syy: (regr_syy)[float]
+│ render regr_count: (count_rows)[int]
+│ render regr_avgx: (regr_avgx)[float]
+│ render regr_avgy: (regr_avgy)[float]
 │
 └── • group (scalar)
     │ columns: (min int, count int, max int, sum_int int, avg decimal, sum decimal, stddev decimal, variance decimal, bool_and bool, bool_or bool, xor_agg bytes, corr float, covar_pop float, covar_samp float, sqrdiff decimal, regr_intercept float, regr_r2 float, regr_slope float, regr_sxx float, regr_sxy float, regr_syy float, count_rows int, regr_avgx float, regr_avgy float)
@@ -224,7 +224,7 @@ vectorized: true
 └── • render
     │ columns: (column8 int)
     │ estimated row count: 1,000 (missing stats)
-    │ render 0: ((k)[int] + (v)[int])[int]
+    │ render column8: ((k)[int] + (v)[int])[int]
     │
     └── • scan
           columns: (k int, v int)
@@ -242,8 +242,8 @@ vectorized: true
 • render
 │ columns: (count int, r int)
 │ estimated row count: 1,000 (missing stats)
-│ render 0: ((k)[int] + (any_not_null)[int])[int]
-│ render 1: (count_rows)[int]
+│ render r: ((k)[int] + (any_not_null)[int])[int]
+│ render count_rows: (count_rows)[int]
 │
 └── • group
     │ columns: (k int, count_rows int, any_not_null int)
@@ -337,7 +337,7 @@ vectorized: true
     └── • render
         │ columns: (column13)
         │ estimated row count: 1,000,000 (missing stats)
-        │ render 0: ((k, v, w, s) AS k, v, w, s)
+        │ render column13: ((k, v, w, s) AS k, v, w, s)
         │
         └── • cross join (inner)
             │ columns: (k, v, w, s)
@@ -881,8 +881,8 @@ vectorized: true
         └── • render
             │ columns: (column7 unknown, v int)
             │ estimated row count: 1,000 (missing stats)
-            │ render 0: (NULL)[unknown]
-            │ render 1: (v)[int]
+            │ render column7: (NULL)[unknown]
+            │ render v: (v)[int]
             │
             └── • scan
                   columns: (v int)
@@ -906,8 +906,8 @@ vectorized: true
 └── • render
     │ columns: (column7, v)
     │ estimated row count: 333 (missing stats)
-    │ render 0: NULL
-    │ render 1: v
+    │ render column7: NULL
+    │ render v: v
     │
     └── • filter
         │ columns: (v)
@@ -950,9 +950,9 @@ vectorized: true
     └── • render
         │ columns: (column7, column8, v)
         │ estimated row count: 1,000 (missing stats)
-        │ render 0: true
-        │ render 1: k > 5
-        │ render 2: v
+        │ render column7: true
+        │ render column8: k > 5
+        │ render v: v
         │
         └── • scan
               columns: (k, v)
@@ -979,9 +979,9 @@ vectorized: true
     └── • render
         │ columns: (column7, column8, v)
         │ estimated row count: 1,000 (missing stats)
-        │ render 0: true
-        │ render 1: k > 5
-        │ render 2: v
+        │ render column7: true
+        │ render column8: k > 5
+        │ render v: v
         │
         └── • scan
               columns: (k, v)
@@ -999,7 +999,7 @@ vectorized: true
 • render
 │ columns: (a int)
 │ estimated row count: 1,000 (missing stats)
-│ render 0: (1)[int]
+│ render a: (1)[int]
 │
 └── • scan
       columns: ()
@@ -1114,7 +1114,7 @@ vectorized: true
 └── • render
     │ columns: (column5 int)
     │ estimated row count: 1,000 (missing stats)
-    │ render 0: ((v)[int] + (1)[int])[int]
+    │ render column5: ((v)[int] + (1)[int])[int]
     │
     └── • scan
           columns: (v int)
@@ -1159,7 +1159,7 @@ vectorized: true
 • render
 │ columns: (r tuple{int, int})
 │ estimated row count: 1,000 (missing stats)
-│ render 0: (((b)[int], (a)[int]))[tuple{int, int}]
+│ render r: (((b)[int], (a)[int]))[tuple{int, int}]
 │
 └── • scan
       columns: (a int, b int)
@@ -1176,8 +1176,8 @@ vectorized: true
 • render
 │ columns: (min string, r tuple{int, int})
 │ estimated row count: 100,000 (missing stats)
-│ render 0: (((any_not_null)[int], (a)[int]))[tuple{int, int}]
-│ render 1: (min)[string]
+│ render r: (((any_not_null)[int], (a)[int]))[tuple{int, int}]
+│ render min: (min)[string]
 │
 └── • group
     │ columns: (a int, x string, min string, any_not_null int)
@@ -1326,7 +1326,7 @@ vectorized: true
 • render
 │ columns: (a int)
 │ estimated row count: 333 (missing stats)
-│ render 0: (1)[int]
+│ render a: (1)[int]
 │
 └── • distinct
     │ columns: (column7 decimal, v int)
@@ -1341,8 +1341,8 @@ vectorized: true
         └── • render
             │ columns: (column7 decimal, v int)
             │ estimated row count: 1,000 (missing stats)
-            │ render 0: ((w)[int]::DECIMAL)[decimal]
-            │ render 1: (v)[int]
+            │ render column7: ((w)[int]::DECIMAL)[decimal]
+            │ render v: (v)[int]
             │
             └── • scan
                   columns: (v int, w int)
@@ -1373,8 +1373,8 @@ vectorized: true
     └── • render
         │ columns: (column7, a)
         │ estimated row count: 1,000 (missing stats)
-        │ render 0: a
-        │ render 1: a
+        │ render column7: a
+        │ render a: a
         │
         └── • scan
               columns: (a)
@@ -1401,8 +1401,8 @@ vectorized: true
     └── • render
         │ columns: (column7, a)
         │ estimated row count: 1,000 (missing stats)
-        │ render 0: b
-        │ render 1: a
+        │ render column7: b
+        │ render a: a
         │
         └── • scan
               columns: (a, b)
@@ -1510,9 +1510,9 @@ vectorized: true
     │ columns: (column7, k, s)
     │ ordering: +k
     │ estimated row count: 1,000 (missing stats)
-    │ render 0: ','
-    │ render 1: k
-    │ render 2: s
+    │ render column7: ','
+    │ render k: k
+    │ render s: s
     │
     └── • scan
           columns: (k, s)
@@ -1593,8 +1593,8 @@ vectorized: true
 └── • render
     │ columns: (column7, s)
     │ estimated row count: 1,000 (missing stats)
-    │ render 0: ', '
-    │ render 1: s
+    │ render column7: ', '
+    │ render s: s
     │
     └── • scan
           columns: (s)
@@ -1638,9 +1638,9 @@ vectorized: true
     └── • render
         │ columns: (column6, company_id, employee)
         │ estimated row count: 1,000 (missing stats)
-        │ render 0: ','
-        │ render 1: company_id
-        │ render 2: employee
+        │ render column6: ','
+        │ render company_id: company_id
+        │ render employee: employee
         │
         └── • scan
               columns: (company_id, employee)
@@ -1677,9 +1677,9 @@ vectorized: true
     └── • render
         │ columns: (column6, column7, company_id)
         │ estimated row count: 1,000 (missing stats)
-        │ render 0: employee::BYTES
-        │ render 1: '\x2c'
-        │ render 2: company_id
+        │ render column6: employee::BYTES
+        │ render column7: '\x2c'
+        │ render company_id: company_id
         │
         └── • scan
               columns: (company_id, employee)
@@ -1716,9 +1716,9 @@ vectorized: true
     └── • render
         │ columns: (column6, company_id, employee)
         │ estimated row count: 1,000 (missing stats)
-        │ render 0: NULL
-        │ render 1: company_id
-        │ render 2: employee
+        │ render column6: NULL
+        │ render company_id: company_id
+        │ render employee: employee
         │
         └── • scan
               columns: (company_id, employee)
@@ -1755,9 +1755,9 @@ vectorized: true
     └── • render
         │ columns: (column6, column7, company_id)
         │ estimated row count: 1,000 (missing stats)
-        │ render 0: employee::BYTES
-        │ render 1: NULL
-        │ render 2: company_id
+        │ render column6: employee::BYTES
+        │ render column7: NULL
+        │ render company_id: company_id
         │
         └── • scan
               columns: (company_id, employee)

--- a/pkg/sql/opt/exec/execbuilder/testdata/check_constraints
+++ b/pkg/sql/opt/exec/execbuilder/testdata/check_constraints
@@ -34,17 +34,17 @@ vectorized: true
 └── • render
     │ columns: (a, b, b_new, check1)
     │ estimated row count: 1 (missing stats)
-    │ render 0: a > b_new
-    │ render 1: a
-    │ render 2: b
-    │ render 3: b_new
+    │ render check1: a > b_new
+    │ render a: a
+    │ render b: b
+    │ render b_new: b_new
     │
     └── • render
         │ columns: (b_new, a, b)
         │ estimated row count: 1 (missing stats)
-        │ render 0: b + 1
-        │ render 1: a
-        │ render 2: b
+        │ render b_new: b + 1
+        │ render a: a
+        │ render b: b
         │
         └── • scan
               columns: (a, b)
@@ -68,13 +68,13 @@ vectorized: true
 └── • render
     │ columns: (a, b, c, d, e, a_new, check1)
     │ estimated row count: 1 (missing stats)
-    │ render 0: b < 2
-    │ render 1: 2
-    │ render 2: a
-    │ render 3: b
-    │ render 4: c
-    │ render 5: d
-    │ render 6: e
+    │ render check1: b < 2
+    │ render a_new: 2
+    │ render a: a
+    │ render b: b
+    │ render c: c
+    │ render d: d
+    │ render e: e
     │
     └── • scan
           columns: (a, b, c, d, e)

--- a/pkg/sql/opt/exec/execbuilder/testdata/dist_union
+++ b/pkg/sql/opt/exec/execbuilder/testdata/dist_union
@@ -134,9 +134,9 @@ vectorized: true
 • render
 │ columns: ("?column?", "?column?", "?column?")
 │ estimated row count: 1
-│ render 0: "?column?"
-│ render 1: "?column?"
-│ render 2: "?column?"
+│ render ?column?: "?column?"
+│ render ?column?: "?column?"
+│ render ?column?: "?column?"
 │
 └── • except
     │ columns: ("?column?", "?column?", "?column?")

--- a/pkg/sql/opt/exec/execbuilder/testdata/distinct
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distinct
@@ -200,9 +200,9 @@ vectorized: true
 │ columns: (z, d, b)
 │ ordering: +d,+b
 │ estimated row count: 1,000 (missing stats)
-│ render 0: 1
-│ render 1: b
-│ render 2: d
+│ render z: 1
+│ render b: b
+│ render d: d
 │
 └── • scan
       columns: (b, d)

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_merge_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_merge_join
@@ -833,11 +833,11 @@ vectorized: true
 • render
 │ columns: (pid1, pa1, cid1, cid2, ca1)
 │ estimated row count: 1,000 (missing stats)
-│ render 0: COALESCE(pid1, pid1)
-│ render 1: pa1
-│ render 2: cid1
-│ render 3: cid2
-│ render 4: ca1
+│ render pid1: COALESCE(pid1, pid1)
+│ render pa1: pa1
+│ render cid1: cid1
+│ render cid2: cid2
+│ render ca1: ca1
 │
 └── • merge join (full outer)
     │ columns: (pid1, pa1, pid1, cid1, cid2, ca1)
@@ -893,12 +893,12 @@ vectorized: true
 • render
 │ columns: (pid1, cid1, cid2, gcid1, gca1, ca1)
 │ estimated row count: 1,999 (missing stats)
-│ render 0: COALESCE(pid1, pid1)
-│ render 1: COALESCE(cid1, cid1)
-│ render 2: COALESCE(cid2, cid2)
-│ render 3: gcid1
-│ render 4: gca1
-│ render 5: ca1
+│ render pid1: COALESCE(pid1, pid1)
+│ render cid1: COALESCE(cid1, cid1)
+│ render cid2: COALESCE(cid2, cid2)
+│ render gcid1: gcid1
+│ render gca1: gca1
+│ render ca1: ca1
 │
 └── • merge join (full outer)
     │ columns: (pid1, cid1, cid2, gcid1, gca1, pid1, cid1, cid2, ca1)

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_numtables
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_numtables
@@ -362,9 +362,9 @@ vectorized: true
 └── • render
     │ columns: (res, y, str)
     │ estimated row count: 1,000 (missing stats)
-    │ render 0: repeat('test', y)
-    │ render 1: y
-    │ render 2: str
+    │ render res: repeat('test', y)
+    │ render y: y
+    │ render str: str
     │
     └── • scan
           columns: (y, str)
@@ -392,9 +392,9 @@ vectorized: true
     └── • render
         │ columns: (res, y, str)
         │ estimated row count: 1,000 (missing stats)
-        │ render 0: repeat('test', y)
-        │ render 1: y
-        │ render 2: str
+        │ render res: repeat('test', y)
+        │ render y: y
+        │ render str: str
         │
         └── • scan
               columns: (y, str)

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -576,7 +576,7 @@ vectorized: true
 • render
 │ columns: ("?column?")
 │ estimated row count: 1
-│ render 0: last_value
+│ render ?column?: last_value
 │
 └── • sequence select
       columns: (last_value, log_cnt, is_called)
@@ -873,8 +873,8 @@ vectorized: true
 • render
 │ columns: (z int, v int)
 │ estimated row count: 0
-│ render 0: ((count)[int] * (2)[int])[int]
-│ render 1: (v)[int]
+│ render z: ((count)[int] * (2)[int])[int]
+│ render v: (v)[int]
 │
 └── • norows
       columns: (v int, count int)
@@ -921,9 +921,9 @@ vectorized: true
 └── • render
     │ columns: (k int, v int, v_new int)
     │ estimated row count: 333 (missing stats)
-    │ render 0: ((k)[int] + (1)[int])[int]
-    │ render 1: (k)[int]
-    │ render 2: (v)[int]
+    │ render v_new: ((k)[int] + (1)[int])[int]
+    │ render k: (k)[int]
+    │ render v: (v)[int]
     │
     └── • filter
         │ columns: (k int, v int)

--- a/pkg/sql/opt/exec/execbuilder/testdata/hash_sharded_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/hash_sharded_index
@@ -21,15 +21,15 @@ vectorized: true
 └── • render
     │ columns: (column6, column1, check1)
     │ estimated row count: 2
-    │ render 0: column6 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
-    │ render 1: column1
-    │ render 2: column6
+    │ render check1: column6 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+    │ render column1: column1
+    │ render column6: column6
     │
     └── • render
         │ columns: (column6, column1)
         │ estimated row count: 2
-        │ render 0: mod(fnv32(COALESCE(column1::STRING, '')), 11)
-        │ render 1: column1
+        │ render column6: mod(fnv32(COALESCE(column1::STRING, '')), 11)
+        │ render column1: column1
         │
         └── • values
               columns: (column1)
@@ -55,17 +55,17 @@ vectorized: true
 └── • render
     │ columns: (column1, column8, column7, check1)
     │ estimated row count: 2
-    │ render 0: column8 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)
-    │ render 1: column1
-    │ render 2: column7
-    │ render 3: column8
+    │ render check1: column8 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)
+    │ render column1: column1
+    │ render column7: column7
+    │ render column8: column8
     │
     └── • render
         │ columns: (column8, column7, column1)
         │ estimated row count: 2
-        │ render 0: mod(fnv32(COALESCE(column1::STRING, '')), 12)
-        │ render 1: unique_rowid()
-        │ render 2: column1
+        │ render column8: mod(fnv32(COALESCE(column1::STRING, '')), 12)
+        │ render column7: unique_rowid()
+        │ render column1: column1
         │
         └── • values
               columns: (column1)

--- a/pkg/sql/opt/exec/execbuilder/testdata/insert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/insert
@@ -317,9 +317,9 @@ vectorized: true
 └── • render
     │ columns: (x, v, column11)
     │ estimated row count: 10 (missing stats)
-    │ render 0: unique_rowid()
-    │ render 1: x
-    │ render 2: v
+    │ render column11: unique_rowid()
+    │ render x: x
+    │ render v: v
     │
     └── • limit
         │ columns: (x, v)
@@ -354,9 +354,9 @@ vectorized: true
 └── • render
     │ columns: (x, v, column11)
     │ estimated row count: 1 (missing stats)
-    │ render 0: unique_rowid()
-    │ render 1: x
-    │ render 2: v
+    │ render column11: unique_rowid()
+    │ render x: x
+    │ render v: v
     │
     └── • scan
           columns: (x, v)
@@ -458,7 +458,7 @@ vectorized: true
 • render
 │ columns: ("?column?")
 │ estimated row count: 10 (missing stats)
-│ render 0: x + v
+│ render ?column?: x + v
 │
 └── • insert
     │ columns: (x, v, rowid)
@@ -468,9 +468,9 @@ vectorized: true
     └── • render
         │ columns: (length, "?column?", column13)
         │ estimated row count: 10 (missing stats)
-        │ render 0: unique_rowid()
-        │ render 1: length
-        │ render 2: "?column?"
+        │ render column13: unique_rowid()
+        │ render length: length
+        │ render ?column?: "?column?"
         │
         └── • limit
             │ columns: (length, "?column?", column12)
@@ -486,9 +486,9 @@ vectorized: true
                 └── • render
                     │ columns: (length, "?column?", column12)
                     │ estimated row count: 1,000 (missing stats)
-                    │ render 0: length(k)
-                    │ render 1: 2
-                    │ render 2: k::STRING || v::STRING
+                    │ render length: length(k)
+                    │ render ?column?: 2
+                    │ render column12: k::STRING || v::STRING
                     │
                     └── • scan
                           columns: (k, v)
@@ -601,10 +601,10 @@ vectorized: true
                 └── • render
                     │ columns: (a, b, c, column13)
                     │ estimated row count: 1,000 (missing stats)
-                    │ render 0: unique_rowid()
-                    │ render 1: a
-                    │ render 2: b
-                    │ render 3: c
+                    │ render column13: unique_rowid()
+                    │ render a: a
+                    │ render b: b
+                    │ render c: c
                     │
                     └── • scan
                           columns: (a, b, c)

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_join_geospatial
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_join_geospatial
@@ -317,8 +317,8 @@ vectorized: true
 ├── • render
 │   │ columns: (count, count)
 │   │ estimated row count: 333 (missing stats)
-│   │ render 0: @S2
-│   │ render 1: count_rows
+│   │ render count: @S2
+│   │ render count_rows: count_rows
 │   │
 │   └── • group
 │       │ columns: (lk, count_rows)

--- a/pkg/sql/opt/exec/execbuilder/testdata/join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join
@@ -261,9 +261,9 @@ vectorized: true
 • render
 │ columns: (x, two, plus1)
 │ estimated row count: 10,000 (missing stats)
-│ render 0: COALESCE(x, x)
-│ render 1: two
-│ render 2: plus1
+│ render x: COALESCE(x, x)
+│ render two: two
+│ render plus1: plus1
 │
 └── • hash join (full outer)
     │ columns: (two, x, plus1, x)
@@ -273,8 +273,8 @@ vectorized: true
     ├── • render
     │   │ columns: (two, x)
     │   │ estimated row count: 1,000 (missing stats)
-    │   │ render 0: 2
-    │   │ render 1: x
+    │   │ render two: 2
+    │   │ render x: x
     │   │
     │   └── • scan
     │         columns: (x)
@@ -285,8 +285,8 @@ vectorized: true
     └── • render
         │ columns: (plus1, x)
         │ estimated row count: 1,000 (missing stats)
-        │ render 0: y + 1
-        │ render 1: x
+        │ render plus1: y + 1
+        │ render x: x
         │
         └── • scan
               columns: (x, y)
@@ -416,19 +416,19 @@ vectorized: true
     └── • render
         │ columns: (pktable_cat, update_rule, delete_rule, deferrability, nspname, relname, attname, nspname, relname, attname, conname, generate_series, relname)
         │ estimated row count: 110,908 (missing stats)
-        │ render 0: CAST(NULL AS STRING)
-        │ render 1: CASE confupdtype WHEN 'c' THEN 0 WHEN 'n' THEN 2 WHEN 'd' THEN 4 WHEN 'r' THEN 1 WHEN 'a' THEN 3 ELSE CAST(NULL AS INT8) END
-        │ render 2: CASE confdeltype WHEN 'c' THEN 0 WHEN 'n' THEN 2 WHEN 'd' THEN 4 WHEN 'r' THEN 1 WHEN 'a' THEN 3 ELSE CAST(NULL AS INT8) END
-        │ render 3: CASE WHEN condeferrable AND condeferred THEN 5 WHEN condeferrable THEN 6 ELSE 7 END
-        │ render 4: nspname
-        │ render 5: relname
-        │ render 6: attname
-        │ render 7: nspname
-        │ render 8: relname
-        │ render 9: attname
-        │ render 10: conname
-        │ render 11: generate_series
-        │ render 12: relname
+        │ render pktable_cat: CAST(NULL AS STRING)
+        │ render update_rule: CASE confupdtype WHEN 'c' THEN 0 WHEN 'n' THEN 2 WHEN 'd' THEN 4 WHEN 'r' THEN 1 WHEN 'a' THEN 3 ELSE CAST(NULL AS INT8) END
+        │ render delete_rule: CASE confdeltype WHEN 'c' THEN 0 WHEN 'n' THEN 2 WHEN 'd' THEN 4 WHEN 'r' THEN 1 WHEN 'a' THEN 3 ELSE CAST(NULL AS INT8) END
+        │ render deferrability: CASE WHEN condeferrable AND condeferred THEN 5 WHEN condeferrable THEN 6 ELSE 7 END
+        │ render nspname: nspname
+        │ render relname: relname
+        │ render attname: attname
+        │ render nspname: nspname
+        │ render relname: relname
+        │ render attname: attname
+        │ render conname: conname
+        │ render generate_series: generate_series
+        │ render relname: relname
         │
         └── • hash join (inner)
             │ columns: (attrelid, attname, attnum, attrelid, attname, attnum, oid, relname, relnamespace, oid, conname, contype, condeferrable, condeferred, conrelid, confrelid, confupdtype, confdeltype, conkey, confkey, oid, nspname, generate_series, oid, relname, relnamespace, oid, nspname, objid, refobjid, oid, relname, relkind)
@@ -621,9 +621,9 @@ vectorized: true
     ├── • render
     │   │ columns: (column10, a, b)
     │   │ estimated row count: 1,000 (missing stats)
-    │   │ render 0: a + b
-    │   │ render 1: a
-    │   │ render 2: b
+    │   │ render column10: a + b
+    │   │ render a: a
+    │   │ render b: b
     │   │
     │   └── • scan
     │         columns: (a, b)
@@ -657,11 +657,11 @@ vectorized: true
     └── • render
         │ columns: (div, a, b, n, sq)
         │ estimated row count: 1,000,000 (missing stats)
-        │ render 0: (a * b) / 2
-        │ render 1: a
-        │ render 2: b
-        │ render 3: n
-        │ render 4: sq
+        │ render div: (a * b) / 2
+        │ render a: a
+        │ render b: b
+        │ render n: n
+        │ render sq: sq
         │
         └── • cross join (inner)
             │ columns: (a, b, n, sq)
@@ -698,9 +698,9 @@ vectorized: true
     ├── • render
     │   │ columns: (column10, a, b)
     │   │ estimated row count: 1,000 (missing stats)
-    │   │ render 0: a + b
-    │   │ render 1: a
-    │   │ render 2: b
+    │   │ render column10: a + b
+    │   │ render a: a
+    │   │ render b: b
     │   │
     │   └── • scan
     │         columns: (a, b)
@@ -737,9 +737,9 @@ vectorized: true
         ├── • render
         │   │ columns: (column10, a, b)
         │   │ estimated row count: 1,000 (missing stats)
-        │   │ render 0: a + b
-        │   │ render 1: a
-        │   │ render 2: b
+        │   │ render column10: a + b
+        │   │ render a: a
+        │   │ render b: b
         │   │
         │   └── • scan
         │         columns: (a, b)
@@ -1096,9 +1096,9 @@ vectorized: true
 • render
 │ columns: (s, s, s)
 │ estimated row count: 10,000 (missing stats)
-│ render 0: COALESCE(s, s)
-│ render 1: s
-│ render 2: s
+│ render s: COALESCE(s, s)
+│ render s: s
+│ render s: s
 │
 └── • hash join (left outer)
     │ columns: (s, s)
@@ -1126,9 +1126,9 @@ vectorized: true
 • render
 │ columns: (s, s, s)
 │ estimated row count: 10,000 (missing stats)
-│ render 0: COALESCE(s, s)
-│ render 1: s
-│ render 2: s
+│ render s: COALESCE(s, s)
+│ render s: s
+│ render s: s
 │
 └── • hash join (full outer)
     │ columns: (s, s)
@@ -1158,8 +1158,8 @@ vectorized: true
 • render
 │ columns: (a, s)
 │ estimated row count: 1,000 (missing stats)
-│ render 0: COALESCE(s, s)
-│ render 1: a
+│ render s: COALESCE(s, s)
+│ render a: a
 │
 └── • hash join (left outer)
     │ columns: (a, s, a, s)
@@ -1291,10 +1291,10 @@ vectorized: true
 └── • render
     │ columns: (x, y, u, v)
     │ estimated row count: 1,900 (missing stats)
-    │ render 0: COALESCE(x, x)
-    │ render 1: COALESCE(y, y)
-    │ render 2: u
-    │ render 3: v
+    │ render x: COALESCE(x, x)
+    │ render y: COALESCE(y, y)
+    │ render u: u
+    │ render v: v
     │
     └── • merge join (full outer)
         │ columns: (x, y, u, x, y, v)
@@ -1498,10 +1498,10 @@ vectorized: true
 └── • render
     │ columns: (x, y, u, v)
     │ estimated row count: 1,900 (missing stats)
-    │ render 0: COALESCE(x, x)
-    │ render 1: COALESCE(y, y)
-    │ render 2: u
-    │ render 3: v
+    │ render x: COALESCE(x, x)
+    │ render y: COALESCE(y, y)
+    │ render u: u
+    │ render v: v
     │
     └── • merge join (full outer)
         │ columns: (x, y, u, x, y, v)

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
@@ -1782,10 +1782,10 @@ vectorized: true
         └── • render
             │ columns: ("lookup_join_const_col_@15", pk, col0, col3)
             │ estimated row count: 10 (missing stats)
-            │ render 0: 495.6
-            │ render 1: pk
-            │ render 2: col0
-            │ render 3: col3
+            │ render lookup_join_const_col_@15: 495.6
+            │ render pk: pk
+            │ render col0: col0
+            │ render col3: col3
             │
             └── • index join
                 │ columns: (pk, col0, col3)

--- a/pkg/sql/opt/exec/execbuilder/testdata/orderby
+++ b/pkg/sql/opt/exec/execbuilder/testdata/orderby
@@ -252,7 +252,7 @@ vectorized: true
 └── • render
     │ columns: (r)
     │ estimated row count: 1,000 (missing stats)
-    │ render 0: b + 2
+    │ render r: b + 2
     │
     └── • scan
           columns: (b)
@@ -276,7 +276,7 @@ vectorized: true
 └── • render
     │ columns: (y)
     │ estimated row count: 1,000 (missing stats)
-    │ render 0: b + 2
+    │ render y: b + 2
     │
     └── • scan
           columns: (b)
@@ -774,10 +774,10 @@ vectorized: true
     └── • render
         │ columns: (a, b, c, c_new)
         │ estimated row count: 1,000 (missing stats)
-        │ render 0: true
-        │ render 1: a
-        │ render 2: b
-        │ render 3: c
+        │ render c_new: true
+        │ render a: a
+        │ render b: b
+        │ render c: c
         │
         └── • scan
               columns: (a, b, c)
@@ -867,9 +867,9 @@ vectorized: true
     └── • render
         │ columns: (column6, a, b)
         │ estimated row count: 1,000 (missing stats)
-        │ render 0: a
-        │ render 1: a
-        │ render 2: b
+        │ render column6: a
+        │ render a: a
+        │ render b: b
         │
         └── • scan
               columns: (a, b)
@@ -895,9 +895,9 @@ vectorized: true
     └── • render
         │ columns: (column6, a, b)
         │ estimated row count: 1,000 (missing stats)
-        │ render 0: b
-        │ render 1: a
-        │ render 2: b
+        │ render column6: b
+        │ render a: a
+        │ render b: b
         │
         └── • scan
               columns: (a, b)

--- a/pkg/sql/opt/exec/execbuilder/testdata/scalar
+++ b/pkg/sql/opt/exec/execbuilder/testdata/scalar
@@ -71,7 +71,7 @@ vectorized: true
 • render
 │ columns: (r)
 │ estimated row count: 1,000 (missing stats)
-│ render 0: 3
+│ render r: 3
 │
 └── • scan
       columns: ()
@@ -88,7 +88,7 @@ vectorized: true
 • render
 │ columns: (r)
 │ estimated row count: 1,000 (missing stats)
-│ render 0: a + 2
+│ render r: a + 2
 │
 └── • scan
       columns: (a)
@@ -105,7 +105,7 @@ vectorized: true
 • render
 │ columns: (r)
 │ estimated row count: 1,000 (missing stats)
-│ render 0: ((a >= 5) AND (b <= 10)) AND (c < 4)
+│ render r: ((a >= 5) AND (b <= 10)) AND (c < 4)
 │
 └── • scan
       columns: (a, b, c)
@@ -122,7 +122,7 @@ vectorized: true
 • render
 │ columns: (r)
 │ estimated row count: 1,000 (missing stats)
-│ render 0: ((a >= 5) OR (b <= 10)) OR (c < 4)
+│ render r: ((a >= 5) OR (b <= 10)) OR (c < 4)
 │
 └── • scan
       columns: (a, b, c)
@@ -139,7 +139,7 @@ vectorized: true
 • render
 │ columns: (r)
 │ estimated row count: 1,000 (missing stats)
-│ render 0: a != 5
+│ render r: a != 5
 │
 └── • scan
       columns: (a)
@@ -156,7 +156,7 @@ vectorized: true
 • render
 │ columns: (r)
 │ estimated row count: 1,000 (missing stats)
-│ render 0: (a <= 5) OR (b < 10)
+│ render r: (a <= 5) OR (b < 10)
 │
 └── • scan
       columns: (a, b)
@@ -173,7 +173,7 @@ vectorized: true
 • render
 │ columns: (r)
 │ estimated row count: 1,000 (missing stats)
-│ render 0: ((a >= 5) AND (b <= 10)) OR ((a <= 10) AND (c > 5))
+│ render r: ((a >= 5) AND (b <= 10)) OR ((a <= 10) AND (c > 5))
 │
 └── • scan
       columns: (a, b, c)
@@ -190,7 +190,7 @@ vectorized: true
 • render
 │ columns: (r)
 │ estimated row count: 1,000 (missing stats)
-│ render 0: ((a < 5) AND (b > 10)) AND (c < 10)
+│ render r: ((a < 5) AND (b > 10)) AND (c < 10)
 │
 └── • scan
       columns: (a, b, c)
@@ -207,7 +207,7 @@ vectorized: true
 • render
 │ columns: (r)
 │ estimated row count: 1,000 (missing stats)
-│ render 0: (a = 1) AND (b = 2)
+│ render r: (a = 1) AND (b = 2)
 │
 └── • scan
       columns: (a, b)
@@ -224,7 +224,7 @@ vectorized: true
 • render
 │ columns: (r)
 │ estimated row count: 1,000 (missing stats)
-│ render 0: a IN (1, 2)
+│ render r: a IN (1, 2)
 │
 └── • scan
       columns: (a)
@@ -241,7 +241,7 @@ vectorized: true
 • render
 │ columns: (r)
 │ estimated row count: 1,000 (missing stats)
-│ render 0: (a, b) IN ((1, 2), (3, 4))
+│ render r: (a, b) IN ((1, 2), (3, 4))
 │
 └── • scan
       columns: (a, b)
@@ -258,7 +258,7 @@ vectorized: true
 • render
 │ columns: (r)
 │ estimated row count: 1,000 (missing stats)
-│ render 0: ((a = (b + c)) AND ((b + c) = 8)) AND (((d * 2) + 5) = (a - c))
+│ render r: ((a = (b + c)) AND ((b + c) = 8)) AND (((d * 2) + 5) = (a - c))
 │
 └── • scan
       columns: (a, b, c, d)
@@ -275,7 +275,7 @@ vectorized: true
 • render
 │ columns: (r)
 │ estimated row count: 1,000 (missing stats)
-│ render 0: (((a = 1) AND (b = 2)) AND (c = 3)) AND (d = 4)
+│ render r: (((a = 1) AND (b = 2)) AND (c = 3)) AND (d = 4)
 │
 └── • scan
       columns: (a, b, c, d)
@@ -292,7 +292,7 @@ vectorized: true
 • render
 │ columns: (r)
 │ estimated row count: 1,000 (missing stats)
-│ render 0: (((((a = 9) AND (b = (a + c))) AND (s = 'a')) AND (c = 5)) AND (s = 'b')) AND (a = 5)
+│ render r: (((((a = 9) AND (b = (a + c))) AND (s = 'a')) AND (c = 5)) AND (s = 'b')) AND (a = 5)
 │
 └── • scan
       columns: (a, b, c, s)
@@ -309,7 +309,7 @@ vectorized: true
 • render
 │ columns: (r)
 │ estimated row count: 1,000 (missing stats)
-│ render 0: a IS NULL
+│ render r: a IS NULL
 │
 └── • scan
       columns: (a)
@@ -326,7 +326,7 @@ vectorized: true
 • render
 │ columns: (r)
 │ estimated row count: 1,000 (missing stats)
-│ render 0: a IS NULL
+│ render r: a IS NULL
 │
 └── • scan
       columns: (a)
@@ -343,7 +343,7 @@ vectorized: true
 • render
 │ columns: (r)
 │ estimated row count: 1,000 (missing stats)
-│ render 0: (a, b) IS NULL
+│ render r: (a, b) IS NULL
 │
 └── • scan
       columns: (a, b)
@@ -360,7 +360,7 @@ vectorized: true
 • render
 │ columns: (r)
 │ estimated row count: 1,000 (missing stats)
-│ render 0: false
+│ render r: false
 │
 └── • scan
       columns: ()
@@ -377,7 +377,7 @@ vectorized: true
 • render
 │ columns: (r)
 │ estimated row count: 1,000 (missing stats)
-│ render 0: a IS NOT DISTINCT FROM b
+│ render r: a IS NOT DISTINCT FROM b
 │
 └── • scan
       columns: (a, b)
@@ -394,7 +394,7 @@ vectorized: true
 • render
 │ columns: (r)
 │ estimated row count: 1,000 (missing stats)
-│ render 0: a IS NOT NULL
+│ render r: a IS NOT NULL
 │
 └── • scan
       columns: (a)
@@ -411,7 +411,7 @@ vectorized: true
 • render
 │ columns: (r)
 │ estimated row count: 1,000 (missing stats)
-│ render 0: a IS NOT NULL
+│ render r: a IS NOT NULL
 │
 └── • scan
       columns: (a)
@@ -428,7 +428,7 @@ vectorized: true
 • render
 │ columns: (r)
 │ estimated row count: 1,000 (missing stats)
-│ render 0: (a, b) IS NOT NULL
+│ render r: (a, b) IS NOT NULL
 │
 └── • scan
       columns: (a, b)
@@ -445,7 +445,7 @@ vectorized: true
 • render
 │ columns: (r)
 │ estimated row count: 1,000 (missing stats)
-│ render 0: true
+│ render r: true
 │
 └── • scan
       columns: ()
@@ -462,7 +462,7 @@ vectorized: true
 • render
 │ columns: (r)
 │ estimated row count: 1,000 (missing stats)
-│ render 0: a IS DISTINCT FROM b
+│ render r: a IS DISTINCT FROM b
 │
 └── • scan
       columns: (a, b)
@@ -479,7 +479,7 @@ vectorized: true
 • render
 │ columns: (r)
 │ estimated row count: 1,000 (missing stats)
-│ render 0: a + (-b)
+│ render r: a + (-b)
 │
 └── • scan
       columns: (a, b)
@@ -496,7 +496,7 @@ vectorized: true
 • render
 │ columns: (r)
 │ estimated row count: 1,000 (missing stats)
-│ render 0: CASE a WHEN 1 THEN 2 WHEN 2 THEN 3 ELSE 4 END
+│ render r: CASE a WHEN 1 THEN 2 WHEN 2 THEN 3 ELSE 4 END
 │
 └── • scan
       columns: (a)
@@ -513,7 +513,7 @@ vectorized: true
 • render
 │ columns: (r)
 │ estimated row count: 1,000 (missing stats)
-│ render 0: CASE WHEN a = 2 THEN 1 ELSE 2 END
+│ render r: CASE WHEN a = 2 THEN 1 ELSE 2 END
 │
 └── • scan
       columns: (a)
@@ -530,7 +530,7 @@ vectorized: true
 • render
 │ columns: (r)
 │ estimated row count: 1,000 (missing stats)
-│ render 0: CASE a + 3 WHEN b * 5 THEN 1 % b WHEN 6 THEN 2 ELSE -1 END
+│ render r: CASE a + 3 WHEN b * 5 THEN 1 % b WHEN 6 THEN 2 ELSE -1 END
 │
 └── • scan
       columns: (a, b)
@@ -548,7 +548,7 @@ vectorized: true
 • render
 │ columns: (r)
 │ estimated row count: 1,000 (missing stats)
-│ render 0: CASE WHEN a = 2 THEN 1 ELSE CAST(NULL AS INT8) END
+│ render r: CASE WHEN a = 2 THEN 1 ELSE CAST(NULL AS INT8) END
 │
 └── • scan
       columns: (a)
@@ -565,7 +565,7 @@ vectorized: true
 • render
 │ columns: (r)
 │ estimated row count: 1,000 (missing stats)
-│ render 0: CASE a WHEN 2 THEN 1 ELSE CAST(NULL AS INT8) END
+│ render r: CASE a WHEN 2 THEN 1 ELSE CAST(NULL AS INT8) END
 │
 └── • scan
       columns: (a)
@@ -592,7 +592,7 @@ vectorized: true
 • render
 │ columns: (length)
 │ estimated row count: 1,000 (missing stats)
-│ render 0: length(s)
+│ render length: length(s)
 │
 └── • scan
       columns: (s)
@@ -609,7 +609,7 @@ vectorized: true
 • render
 │ columns: (r)
 │ estimated row count: 1,000 (missing stats)
-│ render 0: j @> '{"a": 1}'
+│ render r: j @> '{"a": 1}'
 │
 └── • scan
       columns: (j)
@@ -626,7 +626,7 @@ vectorized: true
 • render
 │ columns: (r)
 │ estimated row count: 1,000 (missing stats)
-│ render 0: j @> '{"a": 1}'
+│ render r: j @> '{"a": 1}'
 │
 └── • scan
       columns: (j)
@@ -643,7 +643,7 @@ vectorized: true
 • render
 │ columns: (r)
 │ estimated row count: 1,000 (missing stats)
-│ render 0: j->>'a'
+│ render r: j->>'a'
 │
 └── • scan
       columns: (j)
@@ -660,7 +660,7 @@ vectorized: true
 • render
 │ columns: (r)
 │ estimated row count: 1,000 (missing stats)
-│ render 0: j->'a'
+│ render r: j->'a'
 │
 └── • scan
       columns: (j)
@@ -677,7 +677,7 @@ vectorized: true
 • render
 │ columns: (r)
 │ estimated row count: 1,000 (missing stats)
-│ render 0: j ? 'a'
+│ render r: j ? 'a'
 │
 └── • scan
       columns: (j)
@@ -694,7 +694,7 @@ vectorized: true
 • render
 │ columns: (r)
 │ estimated row count: 1,000 (missing stats)
-│ render 0: j ?| ARRAY['a','b','c']
+│ render r: j ?| ARRAY['a','b','c']
 │
 └── • scan
       columns: (j)
@@ -711,7 +711,7 @@ vectorized: true
 • render
 │ columns: (r)
 │ estimated row count: 1,000 (missing stats)
-│ render 0: j ?& ARRAY['a','b','c']
+│ render r: j ?& ARRAY['a','b','c']
 │
 └── • scan
       columns: (j)
@@ -728,7 +728,7 @@ vectorized: true
 • render
 │ columns: (r)
 │ estimated row count: 1,000 (missing stats)
-│ render 0: j#>ARRAY['a']
+│ render r: j#>ARRAY['a']
 │
 └── • scan
       columns: (j)
@@ -745,7 +745,7 @@ vectorized: true
 • render
 │ columns: (r)
 │ estimated row count: 1,000 (missing stats)
-│ render 0: j#>>ARRAY['a']
+│ render r: j#>>ARRAY['a']
 │
 └── • scan
       columns: (j)
@@ -763,8 +763,8 @@ vectorized: true
 • render
 │ columns: (a, b)
 │ estimated row count: 1,000 (missing stats)
-│ render 0: a::STRING
-│ render 1: b::FLOAT8
+│ render a: a::STRING
+│ render b: b::FLOAT8
 │
 └── • scan
       columns: (a, b)
@@ -781,7 +781,7 @@ vectorized: true
 • render
 │ columns: (text)
 │ estimated row count: 1,000 (missing stats)
-│ render 0: (c + (a + b))::STRING
+│ render text: (c + (a + b))::STRING
 │
 └── • scan
       columns: (a, b, c)
@@ -798,7 +798,7 @@ vectorized: true
 • render
 │ columns: (s)
 │ estimated row count: 1,000 (missing stats)
-│ render 0: s::VARCHAR(2)
+│ render s: s::VARCHAR(2)
 │
 └── • scan
       columns: (s)
@@ -815,7 +815,7 @@ vectorized: true
 • render
 │ columns: ("coalesce")
 │ estimated row count: 4
-│ render 0: COALESCE(column1, column2)
+│ render coalesce: COALESCE(column1, column2)
 │
 └── • values
       columns: (column1, column2)
@@ -838,7 +838,7 @@ vectorized: true
 • render
 │ columns: ("coalesce")
 │ estimated row count: 4
-│ render 0: COALESCE(column1, column2, column3)
+│ render coalesce: COALESCE(column1, column2, column3)
 │
 └── • values
       columns: (column1, column2, column3)
@@ -907,7 +907,7 @@ vectorized: true
 • render
 │ columns: (r)
 │ estimated row count: 1,000 (missing stats)
-│ render 0: ((a >= b) AND (a <= d)) OR ((a >= d) AND (a <= b))
+│ render r: ((a >= b) AND (a <= d)) OR ((a >= d) AND (a <= b))
 │
 └── • scan
       columns: (a, b, d)
@@ -924,7 +924,7 @@ vectorized: true
 • render
 │ columns: (r)
 │ estimated row count: 1,000 (missing stats)
-│ render 0: ((a < b) OR (a > d)) AND ((a < d) OR (a > b))
+│ render r: ((a < b) OR (a > d)) AND ((a < d) OR (a > b))
 │
 └── • scan
       columns: (a, b, d)
@@ -941,7 +941,7 @@ vectorized: true
 • render
 │ columns: ("array")
 │ estimated row count: 1,000 (missing stats)
-│ render 0: ARRAY[]
+│ render array: ARRAY[]
 │
 └── • scan
       columns: ()
@@ -958,7 +958,7 @@ vectorized: true
 • render
 │ columns: ("array")
 │ estimated row count: 1,000 (missing stats)
-│ render 0: ARRAY[1,2,3]
+│ render array: ARRAY[1,2,3]
 │
 └── • scan
       columns: ()
@@ -975,7 +975,7 @@ vectorized: true
 • render
 │ columns: ("array")
 │ estimated row count: 1,000 (missing stats)
-│ render 0: ARRAY[a + 1, 2, 3]
+│ render array: ARRAY[a + 1, 2, 3]
 │
 └── • scan
       columns: (a)
@@ -992,7 +992,7 @@ vectorized: true
 • render
 │ columns: ("?column?")
 │ estimated row count: 1,000 (missing stats)
-│ render 0: 1 > ANY ARRAY[a + 1, 2, 3]
+│ render ?column?: 1 > ANY ARRAY[a + 1, 2, 3]
 │
 └── • scan
       columns: (a)
@@ -1009,7 +1009,7 @@ vectorized: true
 • render
 │ columns: ("?column?")
 │ estimated row count: 1,000 (missing stats)
-│ render 0: true
+│ render ?column?: true
 │
 └── • scan
       columns: ()
@@ -1026,7 +1026,7 @@ vectorized: true
 • render
 │ columns: ("?column?")
 │ estimated row count: 1,000 (missing stats)
-│ render 0: false
+│ render ?column?: false
 │
 └── • scan
       columns: ()
@@ -1043,7 +1043,7 @@ vectorized: true
 • render
 │ columns: ("least")
 │ estimated row count: 1,000 (missing stats)
-│ render 0: least(NULL, 3, 6, a)
+│ render least: least(NULL, 3, 6, a)
 │
 └── • scan
       columns: (a)
@@ -1098,8 +1098,8 @@ vectorized: true
 • render
 │ columns: (r1, r2)
 │ estimated row count: 1,000 (missing stats)
-│ render 0: 4.0
-│ render 1: length(upper(concat('a', 'b', s)))::FLOAT8 + 1.0
+│ render r1: 4.0
+│ render r2: length(upper(concat('a', 'b', s)))::FLOAT8 + 1.0
 │
 └── • scan
       columns: (s)

--- a/pkg/sql/opt/exec/execbuilder/testdata/select
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select
@@ -385,7 +385,7 @@ vectorized: true
 • render
 │ columns: (r)
 │ estimated row count: 1,000 (missing stats)
-│ render 0: x + 1
+│ render r: x + 1
 │
 └── • scan
       columns: (x)
@@ -402,11 +402,11 @@ vectorized: true
 • render
 │ columns: (a, b, y, c, d)
 │ estimated row count: 1,000 (missing stats)
-│ render 0: x + 1
-│ render 1: y + 1
-│ render 2: x + y
-│ render 3: x
-│ render 4: y
+│ render b: x + 1
+│ render c: y + 1
+│ render d: x + y
+│ render x: x
+│ render y: y
 │
 └── • scan
       columns: (x, y)
@@ -423,13 +423,13 @@ vectorized: true
 • render
 │ columns: (r)
 │ estimated row count: 1,000 (missing stats)
-│ render 0: "?column?" + ("?column?" * "?column?")
+│ render r: "?column?" + ("?column?" * "?column?")
 │
 └── • render
     │ columns: ("?column?", "?column?")
     │ estimated row count: 1,000 (missing stats)
-    │ render 0: x + 3
-    │ render 1: y + 10
+    │ render ?column?: x + 3
+    │ render ?column?: y + 10
     │
     └── • scan
           columns: (x, y)
@@ -461,8 +461,8 @@ vectorized: true
 • render
 │ columns: (a, b)
 │ estimated row count: 333 (missing stats)
-│ render 0: x + 1
-│ render 1: x + y
+│ render a: x + 1
+│ render b: x + y
 │
 └── • filter
     │ columns: (x, y)
@@ -717,7 +717,7 @@ vectorized: true
 • render
 │ columns: (a)
 │ estimated row count: 1,000 (missing stats)
-│ render 0: 1
+│ render a: 1
 │
 └── • scan
       columns: ()
@@ -1317,8 +1317,8 @@ vectorized: true
     │ columns: ("?column?", a)
     │ ordering: +a
     │ estimated row count: 1,000 (missing stats)
-    │ render 0: a + (b + c)
-    │ render 1: a
+    │ render ?column?: a + (b + c)
+    │ render a: a
     │
     └── • scan
           columns: (a, b, c)
@@ -1345,8 +1345,8 @@ vectorized: true
     └── • render
         │ columns: ("?column?", b)
         │ estimated row count: 1,000 (missing stats)
-        │ render 0: a + (c + (a + b))
-        │ render 1: b
+        │ render ?column?: a + (c + (a + b))
+        │ render b: b
         │
         └── • scan
               columns: (a, b, c)
@@ -1368,9 +1368,9 @@ vectorized: true
     │ columns: ("?column?", a, b)
     │ ordering: -a,-b
     │ estimated row count: 1,000 (missing stats)
-    │ render 0: a + (c + (a + b))
-    │ render 1: a
-    │ render 2: b
+    │ render ?column?: a + (c + (a + b))
+    │ render a: a
+    │ render b: b
     │
     └── • revscan
           columns: (a, b, c)
@@ -1452,8 +1452,8 @@ vectorized: true
 │ columns: (a, x)
 │ ordering: +a
 │ estimated row count: 3 (missing stats)
-│ render 0: c + (a + b)
-│ render 1: a
+│ render x: c + (a + b)
+│ render a: a
 │
 └── • filter
     │ columns: (a, b, c)

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_for_update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_for_update
@@ -129,7 +129,7 @@ vectorized: true
 • render
 │ columns: ("?column?")
 │ estimated row count: 1,000 (missing stats)
-│ render 0: 1
+│ render ?column?: 1
 │
 └── • scan
       columns: ()
@@ -254,7 +254,7 @@ vectorized: true
 • render
 │ columns: ("?column?")
 │ estimated row count: 1 (missing stats)
-│ render 0: 1
+│ render ?column?: 1
 │
 └── • scan
       columns: (a)
@@ -838,7 +838,7 @@ vectorized: true
 • render
 │ columns: (a)
 │ estimated row count: 1,000 (missing stats)
-│ render 0: a
+│ render a: a
 │
 └── • scan
       columns: (a)
@@ -855,7 +855,7 @@ vectorized: true
 • render
 │ columns: (a)
 │ estimated row count: 1,000 (missing stats)
-│ render 0: a
+│ render a: a
 │
 └── • scan
       columns: (a)
@@ -1749,7 +1749,7 @@ vectorized: true
 • render
 │ columns: ("?column?")
 │ estimated row count: 1,000 (missing stats)
-│ render 0: 1
+│ render ?column?: 1
 │
 └── • scan
       columns: ()
@@ -1883,7 +1883,7 @@ vectorized: true
 • render
 │ columns: ("?column?")
 │ estimated row count: 1 (missing stats)
-│ render 0: 1
+│ render ?column?: 1
 │
 └── • scan
       columns: (a)

--- a/pkg/sql/opt/exec/execbuilder/testdata/sql_fn
+++ b/pkg/sql/opt/exec/execbuilder/testdata/sql_fn
@@ -187,9 +187,9 @@ vectorized: true
 ├── • render
 │   │ columns: (k, addgeometrycolumn, addgeometrycolumn)
 │   │ estimated row count: 1,000 (missing stats)
-│   │ render 0: addgeometrycolumn('my_spatial_table', 'geom7', 4326, 'POINT', 2)
-│   │ render 1: addgeometrycolumn('my_spatial_table', 'geom8', 4326, 'POINT', 2)
-│   │ render 2: k
+│   │ render addgeometrycolumn: addgeometrycolumn('my_spatial_table', 'geom7', 4326, 'POINT', 2)
+│   │ render addgeometrycolumn: addgeometrycolumn('my_spatial_table', 'geom8', 4326, 'POINT', 2)
+│   │ render k: k
 │   │
 │   └── • scan
 │         columns: (k)

--- a/pkg/sql/opt/exec/execbuilder/testdata/srfs
+++ b/pkg/sql/opt/exec/execbuilder/testdata/srfs
@@ -152,10 +152,10 @@ vectorized: true
 └── • render
     │ columns: ("information_schema._pg_expandarray", x, y, z)
     │ estimated row count: 3,267 (missing stats)
-    │ render 0: ((x, n) AS x, n)
-    │ render 1: x
-    │ render 2: y
-    │ render 3: z
+    │ render information_schema._pg_expandarray: ((x, n) AS x, n)
+    │ render x: x
+    │ render y: y
+    │ render z: z
     │
     └── • project set
         │ columns: (x, y, x, z, x, n)
@@ -330,8 +330,8 @@ vectorized: true
 • render
 │ columns: (group_name, jsonb_array_elements)
 │ estimated row count: 100,000 (missing stats)
-│ render 0: data->>'name'
-│ render 1: jsonb_array_elements
+│ render group_name: data->>'name'
+│ render jsonb_array_elements: jsonb_array_elements
 │
 └── • project set
     │ columns: (id, data, "?column?", jsonb_array_elements)
@@ -355,9 +355,9 @@ vectorized: true
                 ├── • render
                 │   │ columns: (column12, id, data)
                 │   │ estimated row count: 1,000 (missing stats)
-                │   │ render 0: data->>'name'
-                │   │ render 1: id
-                │   │ render 2: data
+                │   │ render column12: data->>'name'
+                │   │ render id: id
+                │   │ render data: data
                 │   │
                 │   └── • scan
                 │         columns: (id, data)
@@ -368,8 +368,8 @@ vectorized: true
                 └── • render
                     │ columns: (column13, "?column?")
                     │ estimated row count: 1,000 (missing stats)
-                    │ render 0: data->>'name'
-                    │ render 1: data->'members'
+                    │ render column13: data->>'name'
+                    │ render ?column?: data->'members'
                     │
                     └── • scan
                           columns: (data)

--- a/pkg/sql/opt/exec/execbuilder/testdata/subquery
+++ b/pkg/sql/opt/exec/execbuilder/testdata/subquery
@@ -220,10 +220,10 @@ vectorized: true
     └── • render
         │ columns: (col0, col3, col4, rowid)
         │ estimated row count: 311 (missing stats)
-        │ render 0: col0
-        │ render 1: col3
-        │ render 2: col4
-        │ render 3: rowid
+        │ render col0: col0
+        │ render col3: col3
+        │ render col4: col4
+        │ render rowid: rowid
         │
         └── • filter
             │ columns: (col0, col3, col4, rowid)
@@ -292,7 +292,7 @@ vectorized: true
 └── • render
     │ columns: (column9)
     │ estimated row count: 1,000 (missing stats)
-    │ render 0: x - 1
+    │ render column9: x - 1
     │
     └── • scan
           columns: (x)
@@ -349,7 +349,7 @@ vectorized: true
 └── • render
     │ columns: (column9)
     │ estimated row count: 1,000 (missing stats)
-    │ render 0: x - 1
+    │ render column9: x - 1
     │
     └── • scan
           columns: (x)

--- a/pkg/sql/opt/exec/execbuilder/testdata/tuple
+++ b/pkg/sql/opt/exec/execbuilder/testdata/tuple
@@ -187,7 +187,7 @@ vectorized: true
 • render
 │ columns: (x tuple{int AS a, int AS b, int AS c})
 │ estimated row count: 1,000 (missing stats)
-│ render 0: ((((v)[int], (v)[int], (v)[int]) AS a, b, c))[tuple{int AS a, int AS b, int AS c}]
+│ render x: ((((v)[int], (v)[int], (v)[int]) AS a, b, c))[tuple{int AS a, int AS b, int AS c}]
 │
 └── • scan
       columns: (v int)
@@ -204,14 +204,14 @@ vectorized: true
 • render
 │ columns: (a int, b int, c int)
 │ estimated row count: 1,000 (missing stats)
-│ render 0: (((x)[tuple{int AS a, int AS b, int AS c}]).a)[int]
-│ render 1: (((x)[tuple{int AS a, int AS b, int AS c}]).b)[int]
-│ render 2: (((x)[tuple{int AS a, int AS b, int AS c}]).c)[int]
+│ render a: (((x)[tuple{int AS a, int AS b, int AS c}]).a)[int]
+│ render b: (((x)[tuple{int AS a, int AS b, int AS c}]).b)[int]
+│ render c: (((x)[tuple{int AS a, int AS b, int AS c}]).c)[int]
 │
 └── • render
     │ columns: (x tuple{int AS a, int AS b, int AS c})
     │ estimated row count: 1,000 (missing stats)
-    │ render 0: ((((v)[int], (v)[int], (v)[int]) AS a, b, c))[tuple{int AS a, int AS b, int AS c}]
+    │ render x: ((((v)[int], (v)[int], (v)[int]) AS a, b, c))[tuple{int AS a, int AS b, int AS c}]
     │
     └── • scan
           columns: (v int)

--- a/pkg/sql/opt/exec/execbuilder/testdata/union
+++ b/pkg/sql/opt/exec/execbuilder/testdata/union
@@ -134,9 +134,9 @@ vectorized: true
 • render
 │ columns: ("?column?", "?column?", "?column?")
 │ estimated row count: 1
-│ render 0: "?column?"
-│ render 1: "?column?"
-│ render 2: "?column?"
+│ render ?column?: "?column?"
+│ render ?column?: "?column?"
+│ render ?column?: "?column?"
 │
 └── • except
     │ columns: ("?column?", "?column?", "?column?")
@@ -168,7 +168,7 @@ vectorized: true
 • render
 │ columns: ("?column?")
 │ estimated row count: 1,333 (missing stats)
-│ render 0: 1
+│ render ?column?: 1
 │
 └── • union all
     │ columns: ()

--- a/pkg/sql/opt/exec/execbuilder/testdata/unique
+++ b/pkg/sql/opt/exec/execbuilder/testdata/unique
@@ -636,11 +636,11 @@ vectorized: true
 │       └── • render
 │           │ columns: (column1, column2, column3, column4, check1)
 │           │ estimated row count: 2
-│           │ render 0: column1 IN ('us-east', 'us-west', 'eu-west')
-│           │ render 1: column1
-│           │ render 2: column2
-│           │ render 3: column3
-│           │ render 4: column4
+│           │ render check1: column1 IN ('us-east', 'us-west', 'eu-west')
+│           │ render column1: column1
+│           │ render column2: column2
+│           │ render column3: column3
+│           │ render column4: column4
 │           │
 │           └── • values
 │                 columns: (column1, column2, column3, column4)
@@ -747,19 +747,19 @@ vectorized: true
 │       └── • render
 │           │ columns: (column9, column1, column2, column10, check1)
 │           │ estimated row count: 2
-│           │ render 0: column9 IN ('us-east', 'us-west', 'eu-west')
-│           │ render 1: column1
-│           │ render 2: column2
-│           │ render 3: column9
-│           │ render 4: column10
+│           │ render check1: column9 IN ('us-east', 'us-west', 'eu-west')
+│           │ render column1: column1
+│           │ render column2: column2
+│           │ render column9: column9
+│           │ render column10: column10
 │           │
 │           └── • render
 │               │ columns: (column9, column10, column1, column2)
 │               │ estimated row count: 2
-│               │ render 0: CASE (random() * 3.0)::INT8 WHEN 0 THEN 'us-east' WHEN 1 THEN 'us-west' ELSE 'eu-west' END
-│               │ render 1: CAST(NULL AS INT8)
-│               │ render 2: column1
-│               │ render 3: column2
+│               │ render column9: CASE (random() * 3.0)::INT8 WHEN 0 THEN 'us-east' WHEN 1 THEN 'us-west' ELSE 'eu-west' END
+│               │ render column10: CAST(NULL AS INT8)
+│               │ render column1: column1
+│               │ render column2: column2
 │               │
 │               └── • values
 │                     columns: (column1, column2)
@@ -829,11 +829,11 @@ vectorized: true
 │       └── • render
 │           │ columns: (column1, column2, column3, column4, check1)
 │           │ estimated row count: 0 (missing stats)
-│           │ render 0: column1 IN ('us-east', 'us-west', 'eu-west')
-│           │ render 1: column1
-│           │ render 2: column2
-│           │ render 3: column3
-│           │ render 4: column4
+│           │ render check1: column1 IN ('us-east', 'us-west', 'eu-west')
+│           │ render column1: column1
+│           │ render column2: column2
+│           │ render column3: column3
+│           │ render column4: column4
 │           │
 │           └── • project
 │               │ columns: (column1, column2, column3, column4)
@@ -1406,25 +1406,25 @@ vectorized: true
 │       └── • render
 │           │ columns: (r, s, i, j, r_new, s_new, i_new, check1)
 │           │ estimated row count: 10 (missing stats)
-│           │ render 0: r_new IN ('us-east', 'us-west', 'eu-west')
-│           │ render 1: r
-│           │ render 2: s
-│           │ render 3: i
-│           │ render 4: j
-│           │ render 5: r_new
-│           │ render 6: s_new
-│           │ render 7: i_new
+│           │ render check1: r_new IN ('us-east', 'us-west', 'eu-west')
+│           │ render r: r
+│           │ render s: s
+│           │ render i: i
+│           │ render j: j
+│           │ render r_new: r_new
+│           │ render s_new: s_new
+│           │ render i_new: i_new
 │           │
 │           └── • render
 │               │ columns: (r_new, s_new, i_new, r, s, i, j)
 │               │ estimated row count: 10 (missing stats)
-│               │ render 0: CASE (random() * 3.0)::INT8 WHEN 0 THEN 'us-east' WHEN 1 THEN 'us-west' ELSE 'eu-west' END
-│               │ render 1: 'baz'
-│               │ render 2: 3
-│               │ render 3: r
-│               │ render 4: s
-│               │ render 5: i
-│               │ render 6: j
+│               │ render r_new: CASE (random() * 3.0)::INT8 WHEN 0 THEN 'us-east' WHEN 1 THEN 'us-west' ELSE 'eu-west' END
+│               │ render s_new: 'baz'
+│               │ render i_new: 3
+│               │ render r: r
+│               │ render s: s
+│               │ render i: i
+│               │ render j: j
 │               │
 │               └── • scan
 │                     columns: (r, s, i, j)
@@ -2197,31 +2197,31 @@ vectorized: true
 │           └── • render
 │               │ columns: (check1, column1, column2, column3, column4, r, s, i, j, upsert_r, upsert_i)
 │               │ estimated row count: 2 (missing stats)
-│               │ render 0: upsert_r IN ('us-east', 'us-west', 'eu-west')
-│               │ render 1: column1
-│               │ render 2: column2
-│               │ render 3: column3
-│               │ render 4: column4
-│               │ render 5: r
-│               │ render 6: s
-│               │ render 7: i
-│               │ render 8: j
-│               │ render 9: upsert_r
-│               │ render 10: upsert_i
+│               │ render check1: upsert_r IN ('us-east', 'us-west', 'eu-west')
+│               │ render column1: column1
+│               │ render column2: column2
+│               │ render column3: column3
+│               │ render column4: column4
+│               │ render r: r
+│               │ render s: s
+│               │ render i: i
+│               │ render j: j
+│               │ render upsert_r: upsert_r
+│               │ render upsert_i: upsert_i
 │               │
 │               └── • render
 │                   │ columns: (upsert_r, upsert_i, column1, column2, column3, column4, r, s, i, j)
 │                   │ estimated row count: 2 (missing stats)
-│                   │ render 0: CASE WHEN r IS NULL THEN column1 ELSE r END
-│                   │ render 1: CASE WHEN r IS NULL THEN column3 ELSE i END
-│                   │ render 2: column1
-│                   │ render 3: column2
-│                   │ render 4: column3
-│                   │ render 5: column4
-│                   │ render 6: r
-│                   │ render 7: s
-│                   │ render 8: i
-│                   │ render 9: j
+│                   │ render upsert_r: CASE WHEN r IS NULL THEN column1 ELSE r END
+│                   │ render upsert_i: CASE WHEN r IS NULL THEN column3 ELSE i END
+│                   │ render column1: column1
+│                   │ render column2: column2
+│                   │ render column3: column3
+│                   │ render column4: column4
+│                   │ render r: r
+│                   │ render s: s
+│                   │ render i: i
+│                   │ render j: j
 │                   │
 │                   └── • lookup join (left outer)
 │                       │ columns: (column1, column2, column3, column4, r, s, i, j)
@@ -2339,35 +2339,35 @@ vectorized: true
 │           └── • render
 │               │ columns: (check1, column1, column2, column3, column4, r, s, i, j, upsert_r, upsert_s, upsert_i, upsert_j)
 │               │ estimated row count: 2 (missing stats)
-│               │ render 0: upsert_r IN ('us-east', 'us-west', 'eu-west')
-│               │ render 1: column1
-│               │ render 2: column2
-│               │ render 3: column3
-│               │ render 4: column4
-│               │ render 5: r
-│               │ render 6: s
-│               │ render 7: i
-│               │ render 8: j
-│               │ render 9: upsert_r
-│               │ render 10: upsert_s
-│               │ render 11: upsert_i
-│               │ render 12: upsert_j
+│               │ render check1: upsert_r IN ('us-east', 'us-west', 'eu-west')
+│               │ render column1: column1
+│               │ render column2: column2
+│               │ render column3: column3
+│               │ render column4: column4
+│               │ render r: r
+│               │ render s: s
+│               │ render i: i
+│               │ render j: j
+│               │ render upsert_r: upsert_r
+│               │ render upsert_s: upsert_s
+│               │ render upsert_i: upsert_i
+│               │ render upsert_j: upsert_j
 │               │
 │               └── • render
 │                   │ columns: (upsert_r, upsert_s, upsert_i, upsert_j, column1, column2, column3, column4, r, s, i, j)
 │                   │ estimated row count: 2 (missing stats)
-│                   │ render 0: CASE WHEN r IS NULL THEN column1 ELSE r END
-│                   │ render 1: CASE WHEN r IS NULL THEN column2 ELSE s END
-│                   │ render 2: CASE WHEN r IS NULL THEN column3 ELSE 3 END
-│                   │ render 3: CASE WHEN r IS NULL THEN column4 ELSE j END
-│                   │ render 4: column1
-│                   │ render 5: column2
-│                   │ render 6: column3
-│                   │ render 7: column4
-│                   │ render 8: r
-│                   │ render 9: s
-│                   │ render 10: i
-│                   │ render 11: j
+│                   │ render upsert_r: CASE WHEN r IS NULL THEN column1 ELSE r END
+│                   │ render upsert_s: CASE WHEN r IS NULL THEN column2 ELSE s END
+│                   │ render upsert_i: CASE WHEN r IS NULL THEN column3 ELSE 3 END
+│                   │ render upsert_j: CASE WHEN r IS NULL THEN column4 ELSE j END
+│                   │ render column1: column1
+│                   │ render column2: column2
+│                   │ render column3: column3
+│                   │ render column4: column4
+│                   │ render r: r
+│                   │ render s: s
+│                   │ render i: i
+│                   │ render j: j
 │                   │
 │                   └── • project
 │                       │ columns: (column1, column2, column3, column4, r, s, i, j)

--- a/pkg/sql/opt/exec/execbuilder/testdata/update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update
@@ -131,11 +131,11 @@ vectorized: true
 └── • render
     │ columns: (x, y, z, x_new, y_new)
     │ estimated row count: 1,000 (missing stats)
-    │ render 0: 1
-    │ render 1: 2
-    │ render 2: x
-    │ render 3: y
-    │ render 4: z
+    │ render x_new: 1
+    │ render y_new: 2
+    │ render x: x
+    │ render y: y
+    │ render z: z
     │
     └── • scan
           columns: (x, y, z)
@@ -186,10 +186,10 @@ vectorized: true
     └── • render
         │ columns: (x_new, x, y, z)
         │ estimated row count: 1,000 (missing stats)
-        │ render 0: 2
-        │ render 1: x
-        │ render 2: y
-        │ render 3: z
+        │ render x_new: 2
+        │ render x: x
+        │ render y: y
+        │ render z: z
         │
         └── • scan
               columns: (x, y, z)
@@ -385,10 +385,10 @@ vectorized: true
 └── • render
     │ columns: (a, b, c, c_new)
     │ estimated row count: 1 (missing stats)
-    │ render 0: 2
-    │ render 1: a
-    │ render 2: b
-    │ render 3: c
+    │ render c_new: 2
+    │ render a: a
+    │ render b: b
+    │ render c: c
     │
     └── • filter
         │ columns: (a, b, c)
@@ -589,11 +589,11 @@ vectorized: true
 └── • render
     │ columns: (x, y, z, x_new, y_new)
     │ estimated row count: 1,000 (missing stats)
-    │ render 0: 1
-    │ render 1: 2
-    │ render 2: x
-    │ render 3: y
-    │ render 4: z
+    │ render x_new: 1
+    │ render y_new: 2
+    │ render x: x
+    │ render y: y
+    │ render z: z
     │
     └── • scan
           columns: (x, y, z)

--- a/pkg/sql/opt/exec/execbuilder/testdata/update_from
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update_from
@@ -118,14 +118,14 @@ vectorized: true
 └── • render
     │ columns: (a, b, c, b_new, c_new, a, b, c)
     │ estimated row count: 1,000 (missing stats)
-    │ render 0: b + 1
-    │ render 1: c + 2
-    │ render 2: a
-    │ render 3: b
-    │ render 4: c
-    │ render 5: a
-    │ render 6: b
-    │ render 7: c
+    │ render b_new: b + 1
+    │ render c_new: c + 2
+    │ render a: a
+    │ render b: b
+    │ render c: c
+    │ render a: a
+    │ render b: b
+    │ render c: c
     │
     └── • merge join (inner)
         │ columns: (a, b, c, a, b, c)

--- a/pkg/sql/opt/exec/execbuilder/testdata/update_nonmetamorphic
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update_nonmetamorphic
@@ -24,10 +24,10 @@ vectorized: true
 └── • render
     │ columns: (a, c, d, c_new)
     │ estimated row count: 1,000 (missing stats)
-    │ render 0: c + 1
-    │ render 1: a
-    │ render 2: c
-    │ render 3: d
+    │ render c_new: c + 1
+    │ render a: a
+    │ render c: c
+    │ render d: d
     │
     └── • scan
           columns: (a, c, d)

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -136,8 +136,8 @@ vectorized: true
         └── • render
             │ columns: (column9, k)
             │ estimated row count: 2 (missing stats)
-            │ render 0: CAST(NULL AS INT8)
-            │ render 1: k
+            │ render column9: CAST(NULL AS INT8)
+            │ render k: k
             │
             └── • limit
                 │ columns: (k, v)
@@ -189,15 +189,15 @@ vectorized: true
     └── • render
         │ columns: (check1, column1, column8, column9, column10, a, b, c, d)
         │ estimated row count: 1 (missing stats)
-        │ render 0: column9 > 0
-        │ render 1: column1
-        │ render 2: column8
-        │ render 3: column9
-        │ render 4: column10
-        │ render 5: a
-        │ render 6: b
-        │ render 7: c
-        │ render 8: d
+        │ render check1: column9 > 0
+        │ render column1: column1
+        │ render column8: column8
+        │ render column9: column9
+        │ render column10: column10
+        │ render a: a
+        │ render b: b
+        │ render c: c
+        │ render d: d
         │
         └── • cross join (left outer)
             │ columns: (column1, column8, column9, column10, a, b, c, d)
@@ -237,15 +237,15 @@ vectorized: true
     └── • render
         │ columns: (check1, column1, column8, column9, column10, a, b, c, d)
         │ estimated row count: 4 (missing stats)
-        │ render 0: column9 > 0
-        │ render 1: column1
-        │ render 2: column8
-        │ render 3: column9
-        │ render 4: column10
-        │ render 5: a
-        │ render 6: b
-        │ render 7: c
-        │ render 8: d
+        │ render check1: column9 > 0
+        │ render column1: column1
+        │ render column8: column8
+        │ render column9: column9
+        │ render column10: column10
+        │ render a: a
+        │ render b: b
+        │ render c: c
+        │ render d: d
         │
         └── • lookup join (left outer)
             │ columns: (column10, column8, column9, column1, a, b, c, d)
@@ -258,10 +258,10 @@ vectorized: true
             └── • render
                 │ columns: (column10, column8, column9, column1)
                 │ estimated row count: 4
-                │ render 0: column1 + 10
-                │ render 1: CAST(NULL AS INT8)
-                │ render 2: 10
-                │ render 3: column1
+                │ render column10: column1 + 10
+                │ render column8: CAST(NULL AS INT8)
+                │ render column9: 10
+                │ render column1: column1
                 │
                 └── • values
                       columns: (column1)
@@ -399,10 +399,10 @@ vectorized: true
                     └── • render
                         │ columns: (column13, a, b, c)
                         │ estimated row count: 1,000 (missing stats)
-                        │ render 0: unique_rowid()
-                        │ render 1: a
-                        │ render 2: b
-                        │ render 3: c
+                        │ render column13: unique_rowid()
+                        │ render a: a
+                        │ render b: b
+                        │ render c: c
                         │
                         └── • scan
                               columns: (a, b, c)
@@ -513,13 +513,13 @@ vectorized: true
     └── • render
         │ columns: (upsert_z, column1, column2, column3, x, y, z)
         │ estimated row count: 2 (missing stats)
-        │ render 0: CASE WHEN x IS NULL THEN column3 ELSE 1 END
-        │ render 1: column1
-        │ render 2: column2
-        │ render 3: column3
-        │ render 4: x
-        │ render 5: y
-        │ render 6: z
+        │ render upsert_z: CASE WHEN x IS NULL THEN column3 ELSE 1 END
+        │ render column1: column1
+        │ render column2: column2
+        │ render column3: column3
+        │ render x: x
+        │ render y: y
+        │ render z: z
         │
         └── • lookup join (left outer)
             │ columns: (column1, column2, column3, x, y, z)
@@ -574,13 +574,13 @@ vectorized: true
     └── • render
         │ columns: (upsert_b, x, y, z, a, b, c)
         │ estimated row count: 311 (missing stats)
-        │ render 0: CASE WHEN a IS NULL THEN y ELSE 5 END
-        │ render 1: x
-        │ render 2: y
-        │ render 3: z
-        │ render 4: a
-        │ render 5: b
-        │ render 6: c
+        │ render upsert_b: CASE WHEN a IS NULL THEN y ELSE 5 END
+        │ render x: x
+        │ render y: y
+        │ render z: z
+        │ render a: a
+        │ render b: b
+        │ render c: c
         │
         └── • merge join (right outer)
             │ columns: (a, b, c, x, y, z)

--- a/pkg/sql/opt/exec/execbuilder/testdata/values
+++ b/pkg/sql/opt/exec/execbuilder/testdata/values
@@ -62,7 +62,7 @@ vectorized: true
 • render
 │ columns: (r)
 │ estimated row count: 3
-│ render 0: column1 + column2
+│ render r: column1 + column2
 │
 └── • values
       columns: (column1, column2)

--- a/pkg/sql/opt/exec/execbuilder/testdata/virtual_columns
+++ b/pkg/sql/opt/exec/execbuilder/testdata/virtual_columns
@@ -80,9 +80,9 @@ vectorized: true
 • render
 │ columns: (a, b, v)
 │ estimated row count: 1,000 (missing stats)
-│ render 0: a + b
-│ render 1: a
-│ render 2: b
+│ render v: a + b
+│ render a: a
+│ render b: b
 │
 └── • scan
       columns: (a, b)
@@ -124,8 +124,8 @@ vectorized: true
 • render
 │ columns: (a, v)
 │ estimated row count: 333 (missing stats)
-│ render 0: a + b
-│ render 1: a
+│ render v: a + b
+│ render a: a
 │
 └── • index join
     │ columns: (a, b)
@@ -227,8 +227,8 @@ vectorized: true
     └── • render
         │ columns: (a, v)
         │ estimated row count: 333 (missing stats)
-        │ render 0: a + b
-        │ render 1: a
+        │ render v: a + b
+        │ render a: a
         │
         └── • scan
               columns: (a, b)
@@ -278,8 +278,8 @@ vectorized: true
 └── • render
     │ columns: (a, v)
     │ estimated row count: 333 (missing stats)
-    │ render 0: a + b
-    │ render 1: a
+    │ render v: a + b
+    │ render a: a
     │
     └── • scan
           columns: (a, b)
@@ -306,8 +306,8 @@ vectorized: true
     └── • render
         │ columns: (a, v)
         │ estimated row count: 333 (missing stats)
-        │ render 0: a + b
-        │ render 1: a
+        │ render v: a + b
+        │ render a: a
         │
         └── • scan
               columns: (a, b)
@@ -330,8 +330,8 @@ vectorized: true
 └── • render
     │ columns: (a, v)
     │ estimated row count: 333 (missing stats)
-    │ render 0: a + b
-    │ render 1: a
+    │ render v: a + b
+    │ render a: a
     │
     └── • index join
         │ columns: (a, b)
@@ -360,8 +360,8 @@ vectorized: true
 └── • render
     │ columns: (a, v)
     │ estimated row count: 333 (missing stats)
-    │ render 0: a + b
-    │ render 1: a
+    │ render v: a + b
+    │ render a: a
     │
     └── • index join
         │ columns: (a, b)

--- a/pkg/sql/opt/exec/execbuilder/testdata/window
+++ b/pkg/sql/opt/exec/execbuilder/testdata/window
@@ -73,7 +73,7 @@ vectorized: true
     └── • render
         │ columns: (ntile_1_arg1)
         │ estimated row count: 1,000 (missing stats)
-        │ render 0: 1
+        │ render ntile_1_arg1: 1
         │
         └── • scan
               columns: ()
@@ -99,8 +99,8 @@ vectorized: true
     └── • render
         │ columns: (nth_value_1_arg1, nth_value_1_arg2)
         │ estimated row count: 1,000 (missing stats)
-        │ render 0: 1
-        │ render 1: 2
+        │ render nth_value_1_arg1: 1
+        │ render nth_value_1_arg2: 2
         │
         └── • scan
               columns: ()
@@ -238,9 +238,9 @@ vectorized: true
     └── • render
         │ columns: ("?column?" decimal, k int, variance decimal)
         │ estimated row count: 1,000 (missing stats)
-        │ render 0: ((k)[int] + (stddev)[decimal])[decimal]
-        │ render 1: (k)[int]
-        │ render 2: (variance)[decimal]
+        │ render ?column?: ((k)[int] + (stddev)[decimal])[decimal]
+        │ render k: (k)[int]
+        │ render variance: (variance)[decimal]
         │
         └── • window
             │ columns: (k int, v int, d decimal, stddev decimal, variance decimal)
@@ -276,9 +276,9 @@ vectorized: true
     └── • render
         │ columns: ("?column?" decimal, max int, variance decimal)
         │ estimated row count: 1,000 (missing stats)
-        │ render 0: ((max)[int] + (stddev)[decimal])[decimal]
-        │ render 1: (max)[int]
-        │ render 2: (variance)[decimal]
+        │ render ?column?: ((max)[int] + (stddev)[decimal])[decimal]
+        │ render max: (max)[int]
+        │ render variance: (variance)[decimal]
         │
         └── • window
             │ columns: (v int, d decimal, max int, stddev decimal, variance decimal)
@@ -360,9 +360,9 @@ vectorized: true
         └── • render
             │ columns: (lag_1_arg1, lag_1_arg3, lag_1_partition_1)
             │ estimated row count: 1,000 (missing stats)
-            │ render 0: 1
-            │ render 1: CAST(NULL AS INT8)
-            │ render 2: 2
+            │ render lag_1_arg1: 1
+            │ render lag_1_arg3: CAST(NULL AS INT8)
+            │ render lag_1_partition_1: 2
             │
             └── • scan
                   columns: ()

--- a/pkg/sql/opt/exec/execbuilder/testdata/with
+++ b/pkg/sql/opt/exec/execbuilder/testdata/with
@@ -55,7 +55,7 @@ vectorized: true
 • render
 │ columns: (a)
 │ estimated row count: 1,000 (missing stats)
-│ render 0: a
+│ render a: a
 │
 └── • scan
       columns: (a)
@@ -155,7 +155,7 @@ vectorized: true
 └── • render
     │ columns: (n)
     │ estimated row count: 10 (missing stats)
-    │ render 0: column1
+    │ render n: column1
     │
     └── • recursive cte
         │ columns: (column1)

--- a/pkg/sql/opt/exec/explain/emit.go
+++ b/pkg/sql/opt/exec/explain/emit.go
@@ -403,7 +403,7 @@ func (e *emitter) emitNodeAttributes(n *Node) error {
 		if ob.flags.Verbose {
 			a := n.args.(*renderArgs)
 			for i := range a.Exprs {
-				ob.Expr(fmt.Sprintf("render %d", i), a.Exprs[i], a.Input.Columns())
+				ob.Expr(fmt.Sprintf("render %s", a.Columns[i].Name), a.Exprs[i], a.Input.Columns())
 			}
 		}
 

--- a/pkg/sql/testdata/explain_tree
+++ b/pkg/sql/testdata/explain_tree
@@ -84,9 +84,9 @@ vectorized: false
     └── • render
         │ columns: (column8 decimal, cid int, sum decimal)
         │ estimated row count: 98 (missing stats)
-        │ render 0: ((1)[decimal] - (sum)[decimal])[decimal]
-        │ render 1: (cid)[int]
-        │ render 2: (sum)[decimal]
+        │ render column8: ((1)[decimal] - (sum)[decimal])[decimal]
+        │ render cid: (cid)[int]
+        │ render sum: (sum)[decimal]
         │
         └── • group
             │ columns: (cid int, sum decimal)
@@ -274,9 +274,9 @@ vectorized: false
 ├── • render
 │   │ columns: (movie_id int, title string, name string)
 │   │ estimated row count: 1,000 (missing stats)
-│   │ render 0: (@S1)[string]
-│   │ render 1: (id)[int]
-│   │ render 2: (title)[string]
+│   │ render name: (@S1)[string]
+│   │ render id: (id)[int]
+│   │ render title: (title)[string]
 │   │
 │   └── • scan
 │         columns: (id int, title string)


### PR DESCRIPTION
When we EXPLAIN a render node, we show the renders in order.
Because we coalesce simple column rearrangements, this order might not
correspond to the order of the shown columns.

This change improves the output to mention the target column instead
of an index.

Release note (sql change): Minor improvement to EXPLAIN output for
"render" node.