### PR TITLE
[DNM] sqlutils: add test to demonstrate bad pgx interop with testcluster

### DIFF
--- a/pkg/testutils/sqlutils/wat_test.go
+++ b/pkg/testutils/sqlutils/wat_test.go
@@ -1,0 +1,54 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sqlutils_test
+
+import (
+	"context"
+	"net/url"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/jackc/pgx"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPGXWorksWithTestCluster was written to demonstrate some problem with
+// using the testcluster with PGX.
+func TestPGXWorksWithTestCluster(t *testing.T) {
+	defer leaktest.AfterTest(t)
+	security.SetAssetLoader(securitytest.EmbeddedAssets)
+	ctx := context.Background()
+	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{})
+	defer tc.Stopper().Stop(ctx)
+	tdb := sqlutils.MakeSQLRunner(tc.ServerConn(0))
+	tdb.Exec(t, "CREATE USER testuser")
+	pgURL, cleanup := sqlutils.PGUrl(t, tc.Server(0).ServingSQLAddr(), "", url.User("testuser"))
+	defer cleanup()
+	cfg, err := pgx.ParseConnectionString(pgURL.String())
+	require.NoError(t, err)
+	cp, err := pgx.NewConnPool(pgx.ConnPoolConfig{
+		ConnConfig:     cfg,
+		MaxConnections: 1,
+	})
+	require.NoError(t, err)
+
+	{
+		var one int
+		err := cp.QueryRow(`SELECT 1`).Scan(&one)
+		require.NoError(t, err)
+		require.Equal(t, 1, one)
+	}
+}


### PR DESCRIPTION
What in the world is going on here? This fails with:

```
--- FAIL: TestPGXWorksWithTestCluster (0.28s)
    wat_test.go:51:
        	Error Trace:	wat_test.go:51
        	Error:      	Received unexpected error:
        	            	unknown oid: 20, name: ?column?
        	            	github.com/jackc/pgx.(*Conn).prepareEx
        	            		/home/ajwerner/src/github.com/cockroachdb/cockroach/vendor/github.com/jackc/pgx/conn.go:1518
        	            	github.com/jackc/pgx.(*Conn).QueryEx
        	            		/home/ajwerner/src/github.com/cockroachdb/cockroach/vendor/github.com/jackc/pgx/query.go:477
        	            	github.com/jackc/pgx.(*Conn).Query
        	            		/home/ajwerner/src/github.com/cockroachdb/cockroach/vendor/github.com/jackc/pgx/query.go:353
        	            	github.com/jackc/pgx.(*ConnPool).Query
        	            		/home/ajwerner/src/github.com/cockroachdb/cockroach/vendor/github.com/jackc/pgx/conn_pool.go:403
        	            	github.com/jackc/pgx.(*ConnPool).QueryRow
        	            		/home/ajwerner/src/github.com/cockroachdb/cockroach/vendor/github.com/jackc/pgx/conn_pool.go:436
        	            	github.com/cockroachdb/cockroach/pkg/testutils/sqlutils_test.TestPGXWorksWithTestCluster
        	            		/home/ajwerner/src/github.com/cockroachdb/cockroach/pkg/testutils/sqlutils/wat_test.go:50
        	            	testing.tRunner
        	            		/usr/local/go/src/testing/testing.go:1123
        	            	runtime.goexit
        	            		/usr/local/go/src/runtime/asm_amd64.s:1374
        	Test:       	TestPGXWorksWithTestCluster
FAIL
FAIL	github.com/cockroachdb/cockroach/pkg/testutils/sqlutils	1.063s
```

Release note: None