### PR TITLE
sql/catalog/lease: increase `sql.tablecache.lease.refresh_limit` to 500

### DIFF
--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -1993,7 +1993,7 @@ func (m *Manager) getResolvedTimestamp() hlc.Timestamp {
 var leaseRefreshLimit = settings.RegisterIntSetting(
 	"sql.tablecache.lease.refresh_limit",
 	"maximum number of descriptors to periodically refresh leases for",
-	50,
+	500,
 )
 
 // PeriodicallyRefreshSomeLeases so that leases are fresh and can serve


### PR DESCRIPTION
The cluster setting `sql.tablecache.lease.refresh_limit` is used to decide
how many leases the sql descriptor lease manager will refresh every interval,
which is defined by the sql table lease duration (and is very much static).

This increase means that we'll refresh up to this many leases per node every
~2.5 minutes. There's already a semaphore in place to ensure that the
concurrency is not more than 5 per node. This has become ever more important
as more people are using cockroach with larger schemas. It's also become more
important because descriptors, schemas, and types are also leased.

Fixes #59316.

Release note (general change): Increased the default value of
`sql.tablecache.lease.refresh_limit` to 500 in order to accomodate larger
schemas without encountering `RETRY_COMMIT_DEADLINE_EXCEEDED` errors and
generally higher latency.