### PR TITLE
[dnm] bulk: make disallowShadowing apply to keys in the same batch

### DIFF
--- a/pkg/kv/bulk/sst_batcher.go
+++ b/pkg/kv/bulk/sst_batcher.go
@@ -148,6 +148,10 @@ func (b *SSTBatcher) AddMVCCKey(ctx context.Context, key storage.MVCCKey, value 
 			return nil
 		}
 
+		if !b.disallowShadowing {
+			return nil
+		}
+
 		err := &kvserverbase.DuplicateKeyError{}
 		err.Key = append(err.Key, key.Key...)
 		err.Value = append(err.Value, value...)


### PR DESCRIPTION
Previously, when disallowShadowing was set to false, if a batch
contained 2 keys which shadowed each other, the batcher would return a
duplicate key error.

Now a duplicate key errors is returned only when disallowShadowing is
set to true. skipDuplicates will still ignore keys with identical keys
and values.

TODO:
- Take into account that disallow shadowing doesn't apply to exact matches

Release note: None