### PR TITLE
sql: fix schema change failure test

### DIFF
--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -1667,7 +1667,7 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT);
 	// Disable strict GC TTL enforcement because we're going to shove a zero-value
 	// TTL into the system with AddImmediateGCZoneConfig.
 	defer sqltestutils.DisableGCTTLStrictEnforcement(t, sqlDB)()
-	if _, err := sqltestutils.AddImmediateGCZoneConfig(sqlDB, tableDesc.ID); err != nil {
+	if _, err := sqltestutils.AddImmediateGCZoneConfig(sqlDB, tableDesc.GetID()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1694,6 +1694,13 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT);
 	// A schema change that fails after the first mutation has completed. The
 	// column is backfilled and the index backfill fails requiring the column
 	// backfill to be rolled back.
+	//
+	// The schema changer may detect a unique constraint violation in 2 ways.
+	//  1. If a duplicate key is processed in the same BulkAdder batch, a
+	//     duplicate key error is returned.
+	//
+	//  2. If the number of index entries we added does not equal the table
+	//     row count, we detect we've violated the constraint.
 	if _, err := sqlDB.Exec(
 		`ALTER TABLE t.test ADD column e INT DEFAULT 0 UNIQUE CREATE FAMILY F4, ADD CHECK (e >= 0)`,
 	); !testutils.IsError(err, ` violates unique constraint`) {
@@ -1705,7 +1712,9 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT);
 		return checkTableKeyCount(context.Background(), kvDB, 1, maxValue)
 	})
 
-	// Check that constraints are cleaned up.
+	// Check that constraints are cleaned up on the latest version of the
+	// descriptor.
+	tableDesc = catalogkv.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, "t", "test")
 	if checks := tableDesc.AllActiveAndInactiveChecks(); len(checks) > 0 {
 		t.Fatalf("found checks %+v", checks)
 	}
@@ -4472,9 +4481,9 @@ INSERT INTO t.test (k, v) VALUES (1, 99), (2, 99);
 	}
 
 	if err := tx.Commit(); !testutils.IsError(
-		err, `duplicate key value`,
+		err, `unique constraint "v_unique"`,
 	) {
-		t.Fatal(err)
+		t.Fatalf(`expected 'unique constraint "v_unique"', got %+v`, err)
 	}
 }
 


### PR DESCRIPTION
This schema change test relied on the backfiller not ingesting any of
the keys that violated the unique constraint, rather than on the
ROLLBACK job cleaning up the KVs generated.

Changing `schemachanger.backfiller.buffer_size` and
`schemachanger.backfiller.max_buffer_size` to 1 triggered a failure on
this test. This simulates what happens when a batch that does not
contain a violating key is ingested and flushed in the backfiller.

After this change, the test waits for the rollback job and corresponding
GC job to complete before checking for any garbage.

Release note: None