### PR TITLE
release-20.2: opt: fix exponential blowup of semi-join ordering

### DIFF
--- a/pkg/sql/opt/memo/testdata/memo
+++ b/pkg/sql/opt/memo/testdata/memo
@@ -128,7 +128,7 @@ WHERE a.y>1 AND a.x::string=b.x
 ORDER BY y
 LIMIT 10
 ----
-memo (optimized, ~20KB, required=[presentation: y:2,x:4,c:8] [ordering: +2])
+memo (optimized, ~21KB, required=[presentation: y:2,x:4,c:8] [ordering: +2])
  ├── G1: (project G2 G3 y x)
  │    ├── [presentation: y:2,x:4,c:8] [ordering: +2]
  │    │    ├── best: (project G2="[ordering: +2]" G3 y x)
@@ -144,7 +144,7 @@ memo (optimized, ~20KB, required=[presentation: y:2,x:4,c:8] [ordering: +2])
  │         ├── best: (limit G4="[ordering: +2] [limit hint: 10.00]" G5 ordering=+2)
  │         └── cost: 1727.39
  ├── G3: (projections G6)
- ├── G4: (inner-join G7 G8 G9) (inner-join G8 G7 G9) (lookup-join G7 G10 b,keyCols=[7],outCols=(2,4,7)) (merge-join G8 G7 G10 inner-join,+4,+7)
+ ├── G4: (inner-join G7 G8 G9) (inner-join G7 G8 G9) (inner-join G8 G7 G9) (lookup-join G7 G10 b,keyCols=[7],outCols=(2,4,7)) (lookup-join G7 G10 b,keyCols=[7],outCols=(2,4,7)) (merge-join G8 G7 G10 inner-join,+4,+7)
  │    ├── [ordering: +2] [limit hint: 10.00]
  │    │    ├── best: (lookup-join G7="[ordering: +2] [limit hint: 100.00]" G10 b,keyCols=[7],outCols=(2,4,7))
  │    │    └── cost: 1727.28

--- a/pkg/sql/opt/norm/testdata/rules/combo
+++ b/pkg/sql/opt/norm/testdata/rules/combo
@@ -417,6 +417,41 @@ GenerateMergeJoins (higher cost)
          ├── columns: k:1!null i:2!null s:4 x:7!null
   -      ├── key columns: [1] = [7]
   -      ├── lookup columns are key
+  +      ├── left ordering: +1
+  +      ├── right ordering: +7
+         ├── key: (7)
+         ├── fd: ()-->(2), (1)-->(4), (1)==(7), (7)==(1)
+         ├── select
+         │    ├── columns: k:1!null i:2!null s:4
+         │    ├── key: (1)
+         │    ├── fd: ()-->(2), (1)-->(4)
+  +      │    ├── ordering: +1 opt(2) [actual: +1]
+         │    ├── scan a
+         │    │    ├── columns: k:1!null i:2 s:4
+         │    │    ├── key: (1)
+  -      │    │    └── fd: (1)-->(2,4)
+  +      │    │    ├── fd: (1)-->(2,4)
+  +      │    │    └── ordering: +1 opt(2) [actual: +1]
+         │    └── filters
+         │         └── i:2 = 9 [outer=(2), constraints=(/2: [/9 - /9]; tight), fd=()-->(2)]
+  +      ├── scan xy
+  +      │    ├── columns: x:7!null
+  +      │    ├── key: (7)
+  +      │    └── ordering: +7
+         └── filters (true)
+--------------------------------------------------------------------------------
+GenerateLookupJoins (no changes)
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+GenerateMergeJoins (higher cost)
+--------------------------------------------------------------------------------
+   project
+    ├── columns: s:4
+  - └── inner-join (lookup xy)
+  + └── inner-join (merge)
+         ├── columns: k:1!null i:2!null s:4 x:7!null
+  -      ├── key columns: [1] = [7]
+  -      ├── lookup columns are key
   +      ├── left ordering: +7
   +      ├── right ordering: +1
          ├── key: (7)
@@ -1031,6 +1066,18 @@ ReorderJoins (no changes)
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
 GenerateMergeJoins (no changes)
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+GenerateMergeJoins (no changes)
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+GenerateMergeJoins (no changes)
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+GenerateLookupJoins (no changes)
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+CommuteSemiJoin (no changes)
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
 GenerateMergeJoins (no changes)
@@ -2981,6 +3028,61 @@ GenerateMergeJoins
     └── projections
          └── CASE WHEN bool_or:12 THEN true WHEN bool_or:12 IS NULL THEN false ELSE CAST(NULL AS BOOL) END [as=r:10, outer=(12)]
 --------------------------------------------------------------------------------
+CommuteLeftJoin (higher cost)
+--------------------------------------------------------------------------------
+   project
+    ├── columns: r:10
+    ├── group-by
+    │    ├── columns: x:1!null bool_or:12
+    │    ├── grouping columns: x:1!null
+    │    ├── key: (1)
+    │    ├── fd: (1)-->(12)
+  - │    ├── left-join (merge)
+  + │    ├── right-join (hash)
+    │    │    ├── columns: x:1!null k:4 notnull:11
+  - │    │    ├── left ordering: +1
+  - │    │    ├── right ordering: +4
+    │    │    ├── key: (1)
+    │    │    ├── fd: (4)-->(11), (1)-->(4,11)
+  - │    │    ├── scan xy
+  - │    │    │    ├── columns: x:1!null
+  - │    │    │    ├── key: (1)
+  - │    │    │    └── ordering: +1
+    │    │    ├── project
+    │    │    │    ├── columns: notnull:11!null k:4!null
+    │    │    │    ├── key: (4)
+    │    │    │    ├── fd: (4)-->(11)
+  - │    │    │    ├── ordering: +4
+    │    │    │    ├── select
+    │    │    │    │    ├── columns: k:4!null i:5
+    │    │    │    │    ├── key: (4)
+    │    │    │    │    ├── fd: (4)-->(5)
+  - │    │    │    │    ├── ordering: +4
+    │    │    │    │    ├── scan a
+    │    │    │    │    │    ├── columns: k:4!null i:5
+    │    │    │    │    │    ├── key: (4)
+  - │    │    │    │    │    ├── fd: (4)-->(5)
+  - │    │    │    │    │    └── ordering: +4
+  + │    │    │    │    │    └── fd: (4)-->(5)
+    │    │    │    │    └── filters
+    │    │    │    │         └── (i:5 = 5) IS NOT false [outer=(5)]
+    │    │    │    └── projections
+    │    │    │         └── i:5 IS NOT NULL [as=notnull:11, outer=(5)]
+  - │    │    └── filters (true)
+  + │    │    ├── scan xy
+  + │    │    │    ├── columns: x:1!null
+  + │    │    │    └── key: (1)
+  + │    │    └── filters
+  + │    │         └── k:4 = x:1 [outer=(1,4), constraints=(/1: (/NULL - ]; /4: (/NULL - ]), fd=(1)==(4), (4)==(1)]
+    │    └── aggregations
+    │         └── bool-or [as=bool_or:12, outer=(11)]
+    │              └── notnull:11
+    └── projections
+         └── CASE WHEN bool_or:12 THEN true WHEN bool_or:12 IS NULL THEN false ELSE CAST(NULL AS BOOL) END [as=r:10, outer=(12)]
+--------------------------------------------------------------------------------
+GenerateMergeJoins (no changes)
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
 GenerateMergeJoins (higher cost)
 --------------------------------------------------------------------------------
    project
@@ -3032,6 +3134,9 @@ GenerateMergeJoins (higher cost)
     │              └── notnull:11
     └── projections
          └── CASE WHEN bool_or:12 THEN true WHEN bool_or:12 IS NULL THEN false ELSE CAST(NULL AS BOOL) END [as=r:10, outer=(12)]
+--------------------------------------------------------------------------------
+GenerateMergeJoins (no changes)
+--------------------------------------------------------------------------------
 ================================================================================
 GenerateStreamingGroupBy
   Cost: 2198.11

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -249,9 +249,9 @@ define JoinPrivate {
     # Flags modify what type of join we choose.
     Flags JoinFlags
 
-    # WasReordered indicates whether reorderings of the join tree rooted at this
-    # join have already been considered.
-    WasReordered bool
+    # SkipReorderJoins indicates whether the ReorderJoins rule should match this
+    # join.
+    SkipReorderJoins bool
 }
 
 # IndexJoin represents an inner join between an input expression and a primary

--- a/pkg/sql/opt/testutils/opttester/testdata/explore-trace
+++ b/pkg/sql/opt/testutils/opttester/testdata/explore-trace
@@ -150,7 +150,21 @@ Source expression:
              └── filters
                   └── grandchild.pid = parent.pid
 
-New expression 1 of 1:
+New expression 1 of 2:
+  sort
+   └── project
+        └── inner-join (hash)
+             ├── inner-join (hash)
+             │    ├── scan grandchild
+             │    ├── scan child
+             │    └── filters
+             │         ├── grandchild.pid = child.pid
+             │         └── grandchild.cid = child.cid
+             ├── scan parent
+             └── filters
+                  └── grandchild.pid = parent.pid
+
+New expression 2 of 2:
   sort
    └── project
         └── inner-join (hash)
@@ -179,7 +193,7 @@ Source expression:
              └── filters
                   └── grandchild.pid = parent.pid
 
-New expression 1 of 5:
+New expression 1 of 6:
   sort
    └── project
         └── inner-join (hash)
@@ -193,7 +207,7 @@ New expression 1 of 5:
                   ├── grandchild.pid = child.pid
                   └── grandchild.cid = child.cid
 
-New expression 2 of 5:
+New expression 2 of 6:
   sort
    └── project
         └── inner-join (hash)
@@ -207,7 +221,7 @@ New expression 2 of 5:
                   ├── grandchild.pid = child.pid
                   └── grandchild.cid = child.cid
 
-New expression 3 of 5:
+New expression 3 of 6:
   sort
    └── project
         └── inner-join (hash)
@@ -221,7 +235,7 @@ New expression 3 of 5:
                   ├── grandchild.pid = child.pid
                   └── grandchild.cid = child.cid
 
-New expression 4 of 5:
+New expression 4 of 6:
   sort
    └── project
         └── inner-join (hash)
@@ -235,7 +249,19 @@ New expression 4 of 5:
                   ├── grandchild.pid = child.pid
                   └── grandchild.cid = child.cid
 
-New expression 5 of 5:
+New expression 5 of 6:
+  sort
+   └── project
+        └── inner-join (hash)
+             ├── inner-join (merge)
+             │    ├── scan grandchild
+             │    ├── scan child
+             │    └── filters (true)
+             ├── scan parent
+             └── filters
+                  └── grandchild.pid = parent.pid
+
+New expression 6 of 6:
   sort
    └── project
         └── inner-join (hash)

--- a/pkg/sql/opt/testutils/opttester/testdata/opt-steps
+++ b/pkg/sql/opt/testutils/opttester/testdata/opt-steps
@@ -473,6 +473,127 @@ GenerateLookupJoins (higher cost)
   -           └── variable: customers.id:5 [type=int]
   + └── filters (true)
 --------------------------------------------------------------------------------
+CommuteLeftJoin (higher cost)
+--------------------------------------------------------------------------------
+  -left-join (lookup customers)
+  +right-join (hash)
+    ├── columns: id:1(int!null) customer_id:2(int) status:3(string!null) id:5(int) name:6(string) address:7(string)
+  - ├── key columns: [2] = [5]
+  - ├── lookup columns are key
+    ├── key: (1)
+    ├── fd: (1)-->(2,3,5-7), (5)-->(6,7)
+  + ├── scan customers
+  + │    ├── columns: customers.id:5(int!null) name:6(string!null) address:7(string)
+  + │    ├── key: (5)
+  + │    └── fd: (5)-->(6,7)
+    ├── scan orders
+    │    ├── columns: orders.id:1(int!null) customer_id:2(int) status:3(string!null)
+    │    ├── check constraint expressions
+    │    │    └── in [type=bool, outer=(3), constraints=(/3: [/'cancelled' - /'cancelled'] [/'complete' - /'complete'] [/'open' - /'open']; tight)]
+    │    │         ├── variable: status:3 [type=string]
+    │    │         └── tuple [type=tuple{string, string, string}]
+    │    │              ├── const: 'cancelled' [type=string]
+    │    │              ├── const: 'complete' [type=string]
+    │    │              └── const: 'open' [type=string]
+    │    ├── key: (1)
+    │    └── fd: (1)-->(2,3)
+  - └── filters (true)
+  + └── filters
+  +      └── eq [type=bool, outer=(2,5), constraints=(/2: (/NULL - ]; /5: (/NULL - ]), fd=(2)==(5), (5)==(2)]
+  +           ├── variable: customer_id:2 [type=int]
+  +           └── variable: customers.id:5 [type=int]
+--------------------------------------------------------------------------------
+GenerateMergeJoins (higher cost)
+--------------------------------------------------------------------------------
+  -right-join (hash)
+  +left-join (merge)
+    ├── columns: id:1(int!null) customer_id:2(int) status:3(string!null) id:5(int) name:6(string) address:7(string)
+  + ├── left ordering: +2
+  + ├── right ordering: +5
+    ├── key: (1)
+    ├── fd: (1)-->(2,3,5-7), (5)-->(6,7)
+  + ├── sort
+  + │    ├── columns: orders.id:1(int!null) customer_id:2(int) status:3(string!null)
+  + │    ├── key: (1)
+  + │    ├── fd: (1)-->(2,3)
+  + │    ├── ordering: +2
+  + │    └── scan orders
+  + │         ├── columns: orders.id:1(int!null) customer_id:2(int) status:3(string!null)
+  + │         ├── check constraint expressions
+  + │         │    └── in [type=bool, outer=(3), constraints=(/3: [/'cancelled' - /'cancelled'] [/'complete' - /'complete'] [/'open' - /'open']; tight)]
+  + │         │         ├── variable: status:3 [type=string]
+  + │         │         └── tuple [type=tuple{string, string, string}]
+  + │         │              ├── const: 'cancelled' [type=string]
+  + │         │              ├── const: 'complete' [type=string]
+  + │         │              └── const: 'open' [type=string]
+  + │         ├── key: (1)
+  + │         └── fd: (1)-->(2,3)
+    ├── scan customers
+    │    ├── columns: customers.id:5(int!null) name:6(string!null) address:7(string)
+    │    ├── key: (5)
+  - │    └── fd: (5)-->(6,7)
+  - ├── scan orders
+  - │    ├── columns: orders.id:1(int!null) customer_id:2(int) status:3(string!null)
+  - │    ├── check constraint expressions
+  - │    │    └── in [type=bool, outer=(3), constraints=(/3: [/'cancelled' - /'cancelled'] [/'complete' - /'complete'] [/'open' - /'open']; tight)]
+  - │    │         ├── variable: status:3 [type=string]
+  - │    │         └── tuple [type=tuple{string, string, string}]
+  - │    │              ├── const: 'cancelled' [type=string]
+  - │    │              ├── const: 'complete' [type=string]
+  - │    │              └── const: 'open' [type=string]
+  - │    ├── key: (1)
+  - │    └── fd: (1)-->(2,3)
+  - └── filters
+  -      └── eq [type=bool, outer=(2,5), constraints=(/2: (/NULL - ]; /5: (/NULL - ]), fd=(2)==(5), (5)==(2)]
+  -           ├── variable: customer_id:2 [type=int]
+  -           └── variable: customers.id:5 [type=int]
+  + │    ├── fd: (5)-->(6,7)
+  + │    └── ordering: +5
+  + └── filters (true)
+--------------------------------------------------------------------------------
+GenerateLookupJoins (higher cost)
+--------------------------------------------------------------------------------
+  -left-join (merge)
+  +left-join (lookup customers)
+    ├── columns: id:1(int!null) customer_id:2(int) status:3(string!null) id:5(int) name:6(string) address:7(string)
+  - ├── left ordering: +2
+  - ├── right ordering: +5
+  + ├── key columns: [2] = [5]
+  + ├── lookup columns are key
+    ├── key: (1)
+    ├── fd: (1)-->(2,3,5-7), (5)-->(6,7)
+  - ├── sort
+  + ├── scan orders
+    │    ├── columns: orders.id:1(int!null) customer_id:2(int) status:3(string!null)
+  + │    ├── check constraint expressions
+  + │    │    └── in [type=bool, outer=(3), constraints=(/3: [/'cancelled' - /'cancelled'] [/'complete' - /'complete'] [/'open' - /'open']; tight)]
+  + │    │         ├── variable: status:3 [type=string]
+  + │    │         └── tuple [type=tuple{string, string, string}]
+  + │    │              ├── const: 'cancelled' [type=string]
+  + │    │              ├── const: 'complete' [type=string]
+  + │    │              └── const: 'open' [type=string]
+    │    ├── key: (1)
+  - │    ├── fd: (1)-->(2,3)
+  - │    ├── ordering: +2
+  - │    └── scan orders
+  - │         ├── columns: orders.id:1(int!null) customer_id:2(int) status:3(string!null)
+  - │         ├── check constraint expressions
+  - │         │    └── in [type=bool, outer=(3), constraints=(/3: [/'cancelled' - /'cancelled'] [/'complete' - /'complete'] [/'open' - /'open']; tight)]
+  - │         │         ├── variable: status:3 [type=string]
+  - │         │         └── tuple [type=tuple{string, string, string}]
+  - │         │              ├── const: 'cancelled' [type=string]
+  - │         │              ├── const: 'complete' [type=string]
+  - │         │              └── const: 'open' [type=string]
+  - │         ├── key: (1)
+  - │         └── fd: (1)-->(2,3)
+  - ├── scan customers
+  - │    ├── columns: customers.id:5(int!null) name:6(string!null) address:7(string)
+  - │    ├── key: (5)
+  - │    ├── fd: (5)-->(6,7)
+  - │    └── ordering: +5
+  + │    └── fd: (1)-->(2,3)
+    └── filters (true)
+--------------------------------------------------------------------------------
 GenerateMergeJoins (higher cost)
 --------------------------------------------------------------------------------
   -left-join (lookup customers)
@@ -515,6 +636,9 @@ GenerateMergeJoins (higher cost)
   + │         ├── key: (1)
   + │         └── fd: (1)-->(2,3)
     └── filters (true)
+--------------------------------------------------------------------------------
+GenerateMergeJoins (no changes)
+--------------------------------------------------------------------------------
 ================================================================================
 Final best expression
   Cost: 2168.06

--- a/pkg/sql/opt/xform/join_funcs.go
+++ b/pkg/sql/opt/xform/join_funcs.go
@@ -540,7 +540,7 @@ func (c *CustomFuncs) ShouldReorderJoins(root memo.RelExpr) bool {
 
 	// Ensure that this join expression was not added to the memo by a previous
 	// reordering, as well as that the join does not have hints.
-	return !private.WasReordered && c.NoJoinHints(private)
+	return !private.SkipReorderJoins && c.NoJoinHints(private)
 }
 
 // ReorderJoins adds alternate orderings of the given join tree to the memo. The

--- a/pkg/sql/opt/xform/join_order_builder.go
+++ b/pkg/sql/opt/xform/join_order_builder.go
@@ -721,13 +721,17 @@ func (jb *JoinOrderBuilder) addToGroup(
 		jb.f.Memo().AddSelectToGroup(selectExpr, grp)
 		return
 	}
+
+	// Set SkipReorderJoins to true in order to avoid duplicate reordering on this
+	// join.
+	newJoinPrivate := memo.JoinPrivate{SkipReorderJoins: true}
 	switch op {
 	case opt.InnerJoinOp:
 		newJoin := &memo.InnerJoinExpr{
 			Left:        left,
 			Right:       right,
 			On:          on,
-			JoinPrivate: memo.JoinPrivate{},
+			JoinPrivate: newJoinPrivate,
 		}
 		jb.f.Memo().AddInnerJoinToGroup(newJoin, grp)
 
@@ -736,7 +740,7 @@ func (jb *JoinOrderBuilder) addToGroup(
 			Left:        left,
 			Right:       right,
 			On:          on,
-			JoinPrivate: memo.JoinPrivate{},
+			JoinPrivate: newJoinPrivate,
 		}
 		jb.f.Memo().AddSemiJoinToGroup(newJoin, grp)
 
@@ -745,7 +749,7 @@ func (jb *JoinOrderBuilder) addToGroup(
 			Left:        left,
 			Right:       right,
 			On:          on,
-			JoinPrivate: memo.JoinPrivate{},
+			JoinPrivate: newJoinPrivate,
 		}
 		jb.f.Memo().AddAntiJoinToGroup(newJoin, grp)
 
@@ -754,7 +758,7 @@ func (jb *JoinOrderBuilder) addToGroup(
 			Left:        left,
 			Right:       right,
 			On:          on,
-			JoinPrivate: memo.JoinPrivate{},
+			JoinPrivate: newJoinPrivate,
 		}
 		jb.f.Memo().AddLeftJoinToGroup(newJoin, grp)
 
@@ -763,7 +767,7 @@ func (jb *JoinOrderBuilder) addToGroup(
 			Left:        left,
 			Right:       right,
 			On:          on,
-			JoinPrivate: memo.JoinPrivate{},
+			JoinPrivate: newJoinPrivate,
 		}
 		jb.f.Memo().AddFullJoinToGroup(newJoin, grp)
 
@@ -779,21 +783,25 @@ func (jb *JoinOrderBuilder) memoize(
 	op opt.Operator, left, right memo.RelExpr, on, selectFilters memo.FiltersExpr,
 ) memo.RelExpr {
 	var join memo.RelExpr
+
+	// Set SkipReorderJoins to true in order to avoid duplicate reordering on this
+	// join.
+	newJoinPrivate := &memo.JoinPrivate{SkipReorderJoins: true}
 	switch op {
 	case opt.InnerJoinOp:
-		join = jb.f.Memo().MemoizeInnerJoin(left, right, on, &memo.JoinPrivate{WasReordered: true})
+		join = jb.f.Memo().MemoizeInnerJoin(left, right, on, newJoinPrivate)
 
 	case opt.SemiJoinOp:
-		join = jb.f.Memo().MemoizeSemiJoin(left, right, on, &memo.JoinPrivate{WasReordered: true})
+		join = jb.f.Memo().MemoizeSemiJoin(left, right, on, newJoinPrivate)
 
 	case opt.AntiJoinOp:
-		join = jb.f.Memo().MemoizeAntiJoin(left, right, on, &memo.JoinPrivate{WasReordered: true})
+		join = jb.f.Memo().MemoizeAntiJoin(left, right, on, newJoinPrivate)
 
 	case opt.LeftJoinOp:
-		join = jb.f.Memo().MemoizeLeftJoin(left, right, on, &memo.JoinPrivate{WasReordered: true})
+		join = jb.f.Memo().MemoizeLeftJoin(left, right, on, newJoinPrivate)
 
 	case opt.FullJoinOp:
-		join = jb.f.Memo().MemoizeFullJoin(left, right, on, &memo.JoinPrivate{WasReordered: true})
+		join = jb.f.Memo().MemoizeFullJoin(left, right, on, newJoinPrivate)
 
 	default:
 		panic(errors.AssertionFailedf("invalid operator: %v", op))

--- a/pkg/sql/opt/xform/testdata/external/trading
+++ b/pkg/sql/opt/xform/testdata/external/trading
@@ -839,18 +839,18 @@ project
  │    │         │    ├── fd: ()-->(8), (1)-->(2-6), (2,4,5)~~>(1,3,6), (9)-->(10-16), (16)-->(9-15), (1)==(9), (9)==(1), (9,20-22)-->(18,19)
  │    │         │    ├── left-join (lookup transactiondetails@detailscardidindex)
  │    │         │    │    ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null transactiondetails.dealerid:18 isbuy:19 transactiondate:20 transactiondetails.cardid:21 quantity:22
- │    │         │    │    ├── key columns: [39 40 1] = [18 19 21]
+ │    │         │    │    ├── key columns: [43 44 1] = [18 19 21]
  │    │         │    │    ├── immutable
  │    │         │    │    ├── stats: [rows=3543333.33, distinct(1)=19000, null(1)=0, distinct(2)=13000, null(2)=0, distinct(5)=829, null(5)=0, distinct(6)=5601.15328, null(6)=0, distinct(21)=19000, null(21)=0]
  │    │         │    │    ├── key: (1,20-22)
  │    │         │    │    ├── fd: (1)-->(2-6), (2,4,5)~~>(1,3,6), (1,20-22)-->(18,19)
  │    │         │    │    ├── ordering: +1
  │    │         │    │    ├── project
- │    │         │    │    │    ├── columns: "project_const_col_@18":39!null "project_const_col_@19":40!null id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null
+ │    │         │    │    │    ├── columns: "project_const_col_@18":43!null "project_const_col_@19":44!null id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null
  │    │         │    │    │    ├── immutable
- │    │         │    │    │    ├── stats: [rows=19000, distinct(1)=19000, null(1)=0, distinct(2)=13000, null(2)=0, distinct(5)=829, null(5)=0, distinct(6)=5601.15328, null(6)=0, distinct(39)=1, null(39)=0, distinct(40)=1, null(40)=0]
+ │    │         │    │    │    ├── stats: [rows=19000, distinct(1)=19000, null(1)=0, distinct(2)=13000, null(2)=0, distinct(5)=829, null(5)=0, distinct(6)=5601.15328, null(6)=0, distinct(43)=1, null(43)=0, distinct(44)=1, null(44)=0]
  │    │         │    │    │    ├── key: (1)
- │    │         │    │    │    ├── fd: ()-->(39,40), (1)-->(2-6), (2,4,5)~~>(1,3,6)
+ │    │         │    │    │    ├── fd: ()-->(43,44), (1)-->(2-6), (2,4,5)~~>(1,3,6)
  │    │         │    │    │    ├── ordering: +1
  │    │         │    │    │    ├── select
  │    │         │    │    │    │    ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null
@@ -868,8 +868,8 @@ project
  │    │         │    │    │    │    └── filters
  │    │         │    │    │    │         └── (name:2, setname:4, number:5) > ('Shock', '7E', 248) [outer=(2,4,5), immutable, constraints=(/2/4/5: [/'Shock'/'7E'/249 - ]; tight)]
  │    │         │    │    │    └── projections
- │    │         │    │    │         ├── 1 [as="project_const_col_@18":39]
- │    │         │    │    │         └── false [as="project_const_col_@19":40]
+ │    │         │    │    │         ├── 1 [as="project_const_col_@18":43]
+ │    │         │    │    │         └── false [as="project_const_col_@19":44]
  │    │         │    │    └── filters
  │    │         │    │         └── (transactiondate:20 >= '2020-02-28 00:00:00+00:00') AND (transactiondate:20 <= '2020-03-01 00:00:00+00:00') [outer=(20), constraints=(/20: [/'2020-02-28 00:00:00+00:00' - /'2020-03-01 00:00:00+00:00']; tight)]
  │    │         │    ├── scan cardsinfo

--- a/pkg/sql/opt/xform/testdata/external/trading-mutation
+++ b/pkg/sql/opt/xform/testdata/external/trading-mutation
@@ -843,18 +843,18 @@ project
  │    │         │    ├── fd: ()-->(8), (1)-->(2-6), (2,4,5)~~>(1,3,6), (9)-->(10-16), (16)-->(9-15), (1)==(9), (9)==(1), (9,24-26)-->(22,23)
  │    │         │    ├── left-join (lookup transactiondetails@detailscardidindex)
  │    │         │    │    ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null transactiondetails.dealerid:22 isbuy:23 transactiondate:24 transactiondetails.cardid:25 quantity:26
- │    │         │    │    ├── key columns: [45 46 1] = [22 23 25]
+ │    │         │    │    ├── key columns: [49 50 1] = [22 23 25]
  │    │         │    │    ├── immutable
  │    │         │    │    ├── stats: [rows=3543333.33, distinct(1)=19000, null(1)=0, distinct(2)=13000, null(2)=0, distinct(5)=829, null(5)=0, distinct(6)=5601.15328, null(6)=0, distinct(25)=19000, null(25)=0]
  │    │         │    │    ├── key: (1,24-26)
  │    │         │    │    ├── fd: (1)-->(2-6), (2,4,5)~~>(1,3,6), (1,24-26)-->(22,23)
  │    │         │    │    ├── ordering: +1
  │    │         │    │    ├── project
- │    │         │    │    │    ├── columns: "project_const_col_@22":45!null "project_const_col_@23":46!null id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null
+ │    │         │    │    │    ├── columns: "project_const_col_@22":49!null "project_const_col_@23":50!null id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null
  │    │         │    │    │    ├── immutable
- │    │         │    │    │    ├── stats: [rows=19000, distinct(1)=19000, null(1)=0, distinct(2)=13000, null(2)=0, distinct(5)=829, null(5)=0, distinct(6)=5601.15328, null(6)=0, distinct(45)=1, null(45)=0, distinct(46)=1, null(46)=0]
+ │    │         │    │    │    ├── stats: [rows=19000, distinct(1)=19000, null(1)=0, distinct(2)=13000, null(2)=0, distinct(5)=829, null(5)=0, distinct(6)=5601.15328, null(6)=0, distinct(49)=1, null(49)=0, distinct(50)=1, null(50)=0]
  │    │         │    │    │    ├── key: (1)
- │    │         │    │    │    ├── fd: ()-->(45,46), (1)-->(2-6), (2,4,5)~~>(1,3,6)
+ │    │         │    │    │    ├── fd: ()-->(49,50), (1)-->(2-6), (2,4,5)~~>(1,3,6)
  │    │         │    │    │    ├── ordering: +1
  │    │         │    │    │    ├── select
  │    │         │    │    │    │    ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null
@@ -872,8 +872,8 @@ project
  │    │         │    │    │    │    └── filters
  │    │         │    │    │    │         └── (name:2, setname:4, number:5) > ('Shock', '7E', 248) [outer=(2,4,5), immutable, constraints=(/2/4/5: [/'Shock'/'7E'/249 - ]; tight)]
  │    │         │    │    │    └── projections
- │    │         │    │    │         ├── 1 [as="project_const_col_@22":45]
- │    │         │    │    │         └── false [as="project_const_col_@23":46]
+ │    │         │    │    │         ├── 1 [as="project_const_col_@22":49]
+ │    │         │    │    │         └── false [as="project_const_col_@23":50]
  │    │         │    │    └── filters
  │    │         │    │         └── (transactiondate:24 >= '2020-02-28 00:00:00+00:00') AND (transactiondate:24 <= '2020-03-01 00:00:00+00:00') [outer=(24), constraints=(/24: [/'2020-02-28 00:00:00+00:00' - /'2020-03-01 00:00:00+00:00']; tight)]
  │    │         │    ├── scan cardsinfo

--- a/pkg/sql/opt/xform/testdata/rules/combo
+++ b/pkg/sql/opt/xform/testdata/rules/combo
@@ -94,7 +94,19 @@ Source expression:
         ├── a:1 = x:6 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
         └── b:2 = y:7 [outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ]), fd=(2)==(7), (7)==(2)]
 
-New expression 1 of 1:
+New expression 1 of 2:
+  inner-join (hash)
+   ├── columns: a:1!null b:2!null c:3 x:6!null y:7!null z:8
+   ├── fd: (1)==(6), (6)==(1), (2)==(7), (7)==(2)
+   ├── scan abc
+   │    └── columns: a:1 b:2 c:3
+   ├── scan xyz
+   │    └── columns: x:6 y:7 z:8
+   └── filters
+        ├── a:1 = x:6 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+        └── b:2 = y:7 [outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ]), fd=(2)==(7), (7)==(2)]
+
+New expression 2 of 2:
   inner-join (hash)
    ├── columns: a:1!null b:2!null c:3 x:6!null y:7!null z:8
    ├── fd: (1)==(6), (6)==(1), (2)==(7), (7)==(2)
@@ -105,6 +117,59 @@ New expression 1 of 1:
    └── filters
         ├── a:1 = x:6 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
         └── b:2 = y:7 [outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ]), fd=(2)==(7), (7)==(2)]
+
+================================================================================
+GenerateMergeJoins
+================================================================================
+Source expression:
+  inner-join (hash)
+   ├── columns: a:1!null b:2!null c:3 x:6!null y:7!null z:8
+   ├── fd: (1)==(6), (6)==(1), (2)==(7), (7)==(2)
+   ├── scan abc
+   │    └── columns: a:1 b:2 c:3
+   ├── scan xyz
+   │    └── columns: x:6 y:7 z:8
+   └── filters
+        ├── a:1 = x:6 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+        └── b:2 = y:7 [outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ]), fd=(2)==(7), (7)==(2)]
+
+New expression 1 of 1:
+  inner-join (merge)
+   ├── columns: a:1!null b:2!null c:3 x:6!null y:7!null z:8
+   ├── left ordering: +1,+2
+   ├── right ordering: +6,+7
+   ├── fd: (1)==(6), (6)==(1), (2)==(7), (7)==(2)
+   ├── scan abc@ab
+   │    ├── columns: a:1 b:2 c:3
+   │    └── ordering: +1,+2
+   ├── scan xyz@xy
+   │    ├── columns: x:6 y:7 z:8
+   │    └── ordering: +6,+7
+   └── filters (true)
+
+================================================================================
+GenerateLookupJoins
+================================================================================
+Source expression:
+  inner-join (hash)
+   ├── columns: a:1!null b:2!null c:3 x:6!null y:7!null z:8
+   ├── fd: (1)==(6), (6)==(1), (2)==(7), (7)==(2)
+   ├── scan abc
+   │    └── columns: a:1 b:2 c:3
+   ├── scan xyz
+   │    └── columns: x:6 y:7 z:8
+   └── filters
+        ├── a:1 = x:6 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+        └── b:2 = y:7 [outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ]), fd=(2)==(7), (7)==(2)]
+
+New expression 1 of 1:
+  inner-join (lookup xyz@xy)
+   ├── columns: a:1!null b:2!null c:3 x:6!null y:7!null z:8
+   ├── key columns: [1 2] = [6 7]
+   ├── fd: (1)==(6), (6)==(1), (2)==(7), (7)==(2)
+   ├── scan abc
+   │    └── columns: a:1 b:2 c:3
+   └── filters (true)
 
 ================================================================================
 GenerateMergeJoins

--- a/pkg/sql/opt/xform/testdata/rules/groupby
+++ b/pkg/sql/opt/xform/testdata/rules/groupby
@@ -1720,7 +1720,7 @@ memo (optimized, ~4KB, required=[presentation: u:2,v:3,w:4] [ordering: +4])
 memo
 SELECT (SELECT w FROM kuvw WHERE v=1 AND x=u) FROM xyz ORDER BY x+1, x
 ----
-memo (optimized, ~25KB, required=[presentation: w:10] [ordering: +11,+1])
+memo (optimized, ~33KB, required=[presentation: w:10] [ordering: +11,+1])
  ├── G1: (project G2 G3 x)
  │    ├── [presentation: w:10] [ordering: +11,+1]
  │    │    ├── best: (sort G1)
@@ -1733,16 +1733,16 @@ memo (optimized, ~25KB, required=[presentation: w:10] [ordering: +11,+1])
  │         ├── best: (ensure-distinct-on G4="[ordering: +1]" G5 cols=(1),ordering=+1)
  │         └── cost: 1099.73
  ├── G3: (projections G6 G7)
- ├── G4: (left-join G8 G9 G10) (right-join G9 G8 G10) (merge-join G8 G9 G11 left-join,+1,+6) (lookup-join G12 G11 kuvw@uvw,keyCols=[1 12],outCols=(1,6-8)) (lookup-join G13 G10 kuvw@vw,keyCols=[13],outCols=(1,6-8)) (merge-join G9 G8 G11 right-join,+6,+1)
+ ├── G4: (left-join G8 G9 G10) (left-join G8 G9 G10) (right-join G9 G8 G10) (merge-join G8 G9 G11 left-join,+1,+6) (lookup-join G12 G11 kuvw@uvw,keyCols=[1 12],outCols=(1,6-8)) (lookup-join G13 G10 kuvw@vw,keyCols=[13],outCols=(1,6-8)) (right-join G9 G8 G10) (merge-join G8 G9 G11 left-join,+1,+6) (lookup-join G14 G11 kuvw@uvw,keyCols=[1 14],outCols=(1,6-8)) (lookup-join G15 G10 kuvw@vw,keyCols=[15],outCols=(1,6-8)) (merge-join G9 G8 G11 right-join,+6,+1) (merge-join G9 G8 G11 right-join,+6,+1)
  │    ├── [ordering: +1]
  │    │    ├── best: (merge-join G8="[ordering: +1]" G9="[ordering: +6 opt(7)]" G11 left-join,+1,+6)
  │    │    └── cost: 1069.71
  │    └── []
  │         ├── best: (merge-join G8="[ordering: +1]" G9="[ordering: +6 opt(7)]" G11 left-join,+1,+6)
  │         └── cost: 1069.71
- ├── G5: (aggregations G14)
+ ├── G5: (aggregations G16)
  ├── G6: (variable kuvw.w)
- ├── G7: (plus G15 G16)
+ ├── G7: (plus G17 G18)
  ├── G8: (scan xyz,cols=(1)) (scan xyz@xy,cols=(1)) (scan xyz@zyx,cols=(1)) (scan xyz@yy,cols=(1))
  │    ├── [ordering: +1]
  │    │    ├── best: (scan xyz@xy,cols=(1))
@@ -1750,51 +1750,65 @@ memo (optimized, ~25KB, required=[presentation: w:10] [ordering: +11,+1])
  │    └── []
  │         ├── best: (scan xyz@xy,cols=(1))
  │         └── cost: 1034.02
- ├── G9: (select G17 G18) (scan kuvw@vw,cols=(6-8),constrained)
+ ├── G9: (select G19 G20) (scan kuvw@vw,cols=(6-8),constrained)
  │    ├── [ordering: +6 opt(7)]
  │    │    ├── best: (sort G9)
  │    │    └── cost: 15.58
  │    └── []
  │         ├── best: (scan kuvw@vw,cols=(6-8),constrained)
  │         └── cost: 14.71
- ├── G10: (filters G19)
+ ├── G10: (filters G21)
  ├── G11: (filters)
- ├── G12: (project G8 G20 x)
+ ├── G12: (project G8 G22 x)
  │    ├── [ordering: +1]
- │    │    ├── best: (project G8="[ordering: +1]" G20 x)
+ │    │    ├── best: (project G8="[ordering: +1]" G22 x)
  │    │    └── cost: 1054.03
  │    └── []
- │         ├── best: (project G8 G20 x)
+ │         ├── best: (project G8 G22 x)
  │         └── cost: 1054.03
- ├── G13: (project G8 G20 x)
+ ├── G13: (project G8 G22 x)
  │    ├── [ordering: +1]
- │    │    ├── best: (project G8="[ordering: +1]" G20 x)
+ │    │    ├── best: (project G8="[ordering: +1]" G22 x)
  │    │    └── cost: 1054.03
  │    └── []
- │         ├── best: (project G8 G20 x)
+ │         ├── best: (project G8 G22 x)
  │         └── cost: 1054.03
- ├── G14: (const-agg G6)
- ├── G15: (variable x)
- ├── G16: (const 1)
- ├── G17: (scan kuvw,cols=(6-8)) (scan kuvw@uvw,cols=(6-8)) (scan kuvw@wvu,cols=(6-8)) (scan kuvw@vw,cols=(6-8)) (scan kuvw@w,cols=(6-8))
+ ├── G14: (project G8 G22 x)
+ │    ├── [ordering: +1]
+ │    │    ├── best: (project G8="[ordering: +1]" G22 x)
+ │    │    └── cost: 1054.03
+ │    └── []
+ │         ├── best: (project G8 G22 x)
+ │         └── cost: 1054.03
+ ├── G15: (project G8 G22 x)
+ │    ├── [ordering: +1]
+ │    │    ├── best: (project G8="[ordering: +1]" G22 x)
+ │    │    └── cost: 1054.03
+ │    └── []
+ │         ├── best: (project G8 G22 x)
+ │         └── cost: 1054.03
+ ├── G16: (const-agg G6)
+ ├── G17: (variable x)
+ ├── G18: (const 1)
+ ├── G19: (scan kuvw,cols=(6-8)) (scan kuvw@uvw,cols=(6-8)) (scan kuvw@wvu,cols=(6-8)) (scan kuvw@vw,cols=(6-8)) (scan kuvw@w,cols=(6-8))
  │    ├── [ordering: +6 opt(7)]
  │    │    ├── best: (scan kuvw@uvw,cols=(6-8))
  │    │    └── cost: 1074.02
  │    └── []
  │         ├── best: (scan kuvw,cols=(6-8))
  │         └── cost: 1074.02
- ├── G18: (filters G21)
- ├── G19: (eq G15 G22)
- ├── G20: (projections G16)
- ├── G21: (eq G23 G16)
- ├── G22: (variable u)
- └── G23: (variable v)
+ ├── G20: (filters G23)
+ ├── G21: (eq G17 G24)
+ ├── G22: (projections G18)
+ ├── G23: (eq G25 G18)
+ ├── G24: (variable u)
+ └── G25: (variable v)
 
 # Ensure that streaming upsert-distinct-on will be used.
 memo
 INSERT INTO xyz SELECT v, w, 1.0 FROM kuvw ON CONFLICT (x) DO NOTHING
 ----
-memo (optimized, ~19KB, required=[])
+memo (optimized, ~23KB, required=[])
  ├── G1: (insert G2 G3 xyz)
  │    └── []
  │         ├── best: (insert G2 G3 xyz)
@@ -1812,7 +1826,7 @@ memo (optimized, ~19KB, required=[])
  │         ├── best: (select G6 G7)
  │         └── cost: 2158.08
  ├── G5: (aggregations G8 G9)
- ├── G6: (left-join G10 G11 G12) (right-join G11 G10 G12) (merge-join G10 G11 G13 left-join,+7,+11) (lookup-join G10 G13 xyz,keyCols=[7],outCols=(7,8,10,11)) (lookup-join G10 G13 xyz@xy,keyCols=[7],outCols=(7,8,10,11)) (merge-join G11 G10 G13 right-join,+11,+7)
+ ├── G6: (left-join G10 G11 G12) (left-join G10 G11 G12) (right-join G11 G10 G12) (merge-join G10 G11 G13 left-join,+7,+11) (lookup-join G10 G13 xyz,keyCols=[7],outCols=(7,8,10,11)) (lookup-join G10 G13 xyz@xy,keyCols=[7],outCols=(7,8,10,11)) (right-join G11 G10 G12) (merge-join G10 G11 G13 left-join,+7,+11) (lookup-join G10 G13 xyz,keyCols=[7],outCols=(7,8,10,11)) (lookup-join G10 G13 xyz@xy,keyCols=[7],outCols=(7,8,10,11)) (merge-join G11 G10 G13 right-join,+11,+7) (merge-join G11 G10 G13 right-join,+11,+7)
  │    ├── [ordering: +7 opt(10,11)]
  │    │    ├── best: (merge-join G10="[ordering: +7 opt(10)]" G11="[ordering: +11]" G13 left-join,+7,+11)
  │    │    └── cost: 2148.06
@@ -1859,7 +1873,7 @@ memo (optimized, ~19KB, required=[])
 memo
 INSERT INTO xyz SELECT v, w, 1.0 FROM kuvw ON CONFLICT (x) DO UPDATE SET z=2.0
 ----
-memo (optimized, ~22KB, required=[])
+memo (optimized, ~27KB, required=[])
  ├── G1: (upsert G2 G3 xyz)
  │    └── []
  │         ├── best: (upsert G2 G3 xyz)
@@ -1869,17 +1883,17 @@ memo (optimized, ~22KB, required=[])
  │         ├── best: (project G4 G5 v w ?column? x y z)
  │         └── cost: 2238.09
  ├── G3: (f-k-checks)
- ├── G4: (left-join G6 G7 G8) (right-join G7 G6 G8) (lookup-join G6 G9 xyz,keyCols=[7],outCols=(7,8,10-13)) (lookup-join G10 G9 xyz,keyCols=[11],outCols=(7,8,10-13)) (merge-join G7 G6 G9 right-join,+11,+7)
+ ├── G4: (left-join G6 G7 G8) (left-join G6 G7 G8) (right-join G7 G6 G8) (lookup-join G6 G9 xyz,keyCols=[7],outCols=(7,8,10-13)) (lookup-join G10 G9 xyz,keyCols=[11],outCols=(7,8,10-13)) (right-join G7 G6 G8) (lookup-join G6 G9 xyz,keyCols=[7],outCols=(7,8,10-13)) (lookup-join G11 G9 xyz,keyCols=[11],outCols=(7,8,10-13)) (merge-join G7 G6 G9 right-join,+11,+7) (merge-join G7 G6 G9 right-join,+11,+7)
  │    └── []
  │         ├── best: (merge-join G7="[ordering: +11]" G6="[ordering: +7 opt(10)]" G9 right-join,+11,+7)
  │         └── cost: 2218.08
- ├── G5: (projections G11)
- ├── G6: (ensure-upsert-distinct-on G12 G13 cols=(7)) (ensure-upsert-distinct-on G12 G13 cols=(7),ordering=+7 opt(10))
+ ├── G5: (projections G12)
+ ├── G6: (ensure-upsert-distinct-on G13 G14 cols=(7)) (ensure-upsert-distinct-on G13 G14 cols=(7),ordering=+7 opt(10))
  │    ├── [ordering: +7 opt(10)]
- │    │    ├── best: (ensure-upsert-distinct-on G12="[ordering: +7 opt(10)]" G13 cols=(7))
+ │    │    ├── best: (ensure-upsert-distinct-on G13="[ordering: +7 opt(10)]" G14 cols=(7))
  │    │    └── cost: 1124.05
  │    └── []
- │         ├── best: (ensure-upsert-distinct-on G12="[ordering: +7 opt(10)]" G13 cols=(7),ordering=+7 opt(10))
+ │         ├── best: (ensure-upsert-distinct-on G13="[ordering: +7 opt(10)]" G14 cols=(7),ordering=+7 opt(10))
  │         └── cost: 1124.05
  ├── G7: (scan xyz,cols=(11-13)) (scan xyz@zyx,cols=(11-13))
  │    ├── [ordering: +11]
@@ -1888,40 +1902,44 @@ memo (optimized, ~22KB, required=[])
  │    └── []
  │         ├── best: (scan xyz,cols=(11-13))
  │         └── cost: 1064.02
- ├── G8: (filters G14)
+ ├── G8: (filters G15)
  ├── G9: (filters)
  ├── G10: (lookup-join G6 G9 xyz@xy,keyCols=[7],outCols=(7,8,10-12))
  │    └── []
  │         ├── best: (lookup-join G6 G9 xyz@xy,keyCols=[7],outCols=(7,8,10-12))
  │         └── cost: 7174.06
- ├── G11: (case G15 G16 G17)
- ├── G12: (project G18 G19 v w)
+ ├── G11: (lookup-join G6 G9 xyz@xy,keyCols=[7],outCols=(7,8,10-12))
+ │    └── []
+ │         ├── best: (lookup-join G6 G9 xyz@xy,keyCols=[7],outCols=(7,8,10-12))
+ │         └── cost: 7174.06
+ ├── G12: (case G16 G17 G18)
+ ├── G13: (project G19 G20 v w)
  │    ├── [ordering: +7 opt(10)]
- │    │    ├── best: (project G18="[ordering: +7]" G19 v w)
+ │    │    ├── best: (project G19="[ordering: +7]" G20 v w)
  │    │    └── cost: 1084.03
  │    └── []
- │         ├── best: (project G18 G19 v w)
+ │         ├── best: (project G19 G20 v w)
  │         └── cost: 1084.03
- ├── G13: (aggregations G20 G21)
- ├── G14: (eq G22 G23)
- ├── G15: (true)
- ├── G16: (scalar-list G24)
- ├── G17: (const 2.0)
- ├── G18: (scan kuvw,cols=(7,8)) (scan kuvw@uvw,cols=(7,8)) (scan kuvw@wvu,cols=(7,8)) (scan kuvw@vw,cols=(7,8)) (scan kuvw@w,cols=(7,8))
+ ├── G14: (aggregations G21 G22)
+ ├── G15: (eq G23 G24)
+ ├── G16: (true)
+ ├── G17: (scalar-list G25)
+ ├── G18: (const 2.0)
+ ├── G19: (scan kuvw,cols=(7,8)) (scan kuvw@uvw,cols=(7,8)) (scan kuvw@wvu,cols=(7,8)) (scan kuvw@vw,cols=(7,8)) (scan kuvw@w,cols=(7,8))
  │    ├── [ordering: +7]
  │    │    ├── best: (scan kuvw@vw,cols=(7,8))
  │    │    └── cost: 1064.02
  │    └── []
  │         ├── best: (scan kuvw,cols=(7,8))
  │         └── cost: 1064.02
- ├── G19: (projections G25)
- ├── G20: (first-agg G26)
+ ├── G20: (projections G26)
  ├── G21: (first-agg G27)
- ├── G22: (variable v)
- ├── G23: (variable x)
- ├── G24: (when G28 G27)
- ├── G25: (const 1.0)
- ├── G26: (variable w)
- ├── G27: (variable "?column?")
- ├── G28: (is G23 G29)
- └── G29: (null)
+ ├── G22: (first-agg G28)
+ ├── G23: (variable v)
+ ├── G24: (variable x)
+ ├── G25: (when G29 G28)
+ ├── G26: (const 1.0)
+ ├── G27: (variable w)
+ ├── G28: (variable "?column?")
+ ├── G29: (is G24 G30)
+ └── G30: (null)

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -180,8 +180,8 @@ inner-join (merge)
 memo expect=ReorderJoins
 SELECT * FROM abc, stu, xyz WHERE abc.a=stu.s AND stu.s=xyz.x
 ----
-memo (optimized, ~36KB, required=[presentation: a:1,b:2,c:3,s:6,t:7,u:8,x:10,y:11,z:12])
- ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (inner-join G5 G6 G7) (inner-join G6 G5 G7) (inner-join G8 G9 G7) (inner-join G9 G8 G7) (merge-join G2 G3 G10 inner-join,+1,+6) (merge-join G3 G2 G10 inner-join,+6,+1) (lookup-join G3 G10 abc@ab,keyCols=[6],outCols=(1-3,6-8,10-12)) (merge-join G5 G6 G10 inner-join,+6,+10) (merge-join G6 G5 G10 inner-join,+10,+6) (lookup-join G6 G10 stu,keyCols=[10],outCols=(1-3,6-8,10-12)) (merge-join G8 G9 G10 inner-join,+6,+10) (lookup-join G8 G10 xyz@xy,keyCols=[6],outCols=(1-3,6-8,10-12)) (merge-join G9 G8 G10 inner-join,+10,+6)
+memo (optimized, ~38KB, required=[presentation: a:1,b:2,c:3,s:6,t:7,u:8,x:10,y:11,z:12])
+ ├── G1: (inner-join G2 G3 G4) (inner-join G2 G3 G4) (inner-join G3 G2 G4) (inner-join G5 G6 G7) (inner-join G6 G5 G7) (inner-join G8 G9 G7) (inner-join G9 G8 G7) (merge-join G2 G3 G10 inner-join,+1,+6) (merge-join G2 G3 G10 inner-join,+1,+6) (merge-join G3 G2 G10 inner-join,+6,+1) (lookup-join G3 G10 abc@ab,keyCols=[6],outCols=(1-3,6-8,10-12)) (merge-join G5 G6 G10 inner-join,+6,+10) (merge-join G6 G5 G10 inner-join,+10,+6) (lookup-join G6 G10 stu,keyCols=[10],outCols=(1-3,6-8,10-12)) (merge-join G8 G9 G10 inner-join,+6,+10) (lookup-join G8 G10 xyz@xy,keyCols=[6],outCols=(1-3,6-8,10-12)) (merge-join G9 G8 G10 inner-join,+10,+6)
  │    └── [presentation: a:1,b:2,c:3,s:6,t:7,u:8,x:10,y:11,z:12]
  │         ├── best: (merge-join G5="[ordering: +6]" G6="[ordering: +(1|10)]" G10 inner-join,+6,+10)
  │         └── cost: 12992.08
@@ -192,7 +192,7 @@ memo (optimized, ~36KB, required=[presentation: a:1,b:2,c:3,s:6,t:7,u:8,x:10,y:1
  │    └── []
  │         ├── best: (scan abc,cols=(1-3))
  │         └── cost: 1074.02
- ├── G3: (inner-join G5 G9 G7) (inner-join G9 G5 G7) (merge-join G5 G9 G10 inner-join,+6,+10) (lookup-join G5 G10 xyz@xy,keyCols=[6],outCols=(6-8,10-12)) (merge-join G9 G5 G10 inner-join,+10,+6) (lookup-join G9 G10 stu,keyCols=[10],outCols=(6-8,10-12))
+ ├── G3: (inner-join G5 G9 G7) (inner-join G5 G9 G7) (inner-join G9 G5 G7) (merge-join G5 G9 G10 inner-join,+6,+10) (lookup-join G5 G10 xyz@xy,keyCols=[6],outCols=(6-8,10-12)) (merge-join G5 G9 G10 inner-join,+6,+10) (lookup-join G5 G10 xyz@xy,keyCols=[6],outCols=(6-8,10-12)) (merge-join G9 G5 G10 inner-join,+10,+6) (lookup-join G9 G10 stu,keyCols=[10],outCols=(6-8,10-12))
  │    ├── [ordering: +(6|10)]
  │    │    ├── best: (merge-join G5="[ordering: +6]" G9="[ordering: +10]" G10 inner-join,+6,+10)
  │    │    └── cost: 11888.05
@@ -308,7 +308,7 @@ JOIN child1 USING (pid1, cid1)
 JOIN parent1 USING (pid1)
 ORDER BY pid1
 ----
-memo (optimized, ~34KB, required=[presentation: pid1:1,cid1:2,gcid1:3,gca1:4,ca1:8,pa1:11] [ordering: +1])
+memo (optimized, ~37KB, required=[presentation: pid1:1,cid1:2,gcid1:3,gca1:4,ca1:8,pa1:11] [ordering: +1])
  ├── G1: (project G2 G3 pid1 cid1 gcid1 gca1 ca1 pa1)
  │    ├── [presentation: pid1:1,cid1:2,gcid1:3,gca1:4,ca1:8,pa1:11] [ordering: +1]
  │    │    ├── best: (project G2="[ordering: +(1|6|10)]" G3 pid1 cid1 gcid1 gca1 ca1 pa1)
@@ -316,7 +316,7 @@ memo (optimized, ~34KB, required=[presentation: pid1:1,cid1:2,gcid1:3,gca1:4,ca1
  │    └── []
  │         ├── best: (project G2 G3 pid1 cid1 gcid1 gca1 ca1 pa1)
  │         └── cost: 2775.07
- ├── G2: (inner-join G4 G5 G6) (inner-join G7 G8 G9) (inner-join G8 G7 G9) (inner-join G10 G11 G9) (inner-join G11 G10 G9) (inner-join G5 G4 G6) (merge-join G4 G5 G12 inner-join,+1,+10) (lookup-join G4 G12 parent1,keyCols=[1],outCols=(1-4,6-8,10,11)) (merge-join G7 G8 G12 inner-join,+1,+2,+6,+7) (merge-join G8 G7 G12 inner-join,+6,+7,+1,+2) (lookup-join G8 G12 grandchild1,keyCols=[6 7],outCols=(1-4,6-8,10,11)) (merge-join G10 G11 G12 inner-join,+6,+7,+1,+2) (merge-join G11 G10 G12 inner-join,+1,+2,+6,+7) (lookup-join G11 G12 child1,keyCols=[1 2],outCols=(1-4,6-8,10,11)) (merge-join G5 G4 G12 inner-join,+10,+1)
+ ├── G2: (inner-join G4 G5 G6) (inner-join G7 G8 G9) (inner-join G8 G7 G9) (inner-join G10 G11 G9) (inner-join G11 G10 G9) (inner-join G4 G5 G6) (inner-join G5 G4 G6) (merge-join G4 G5 G12 inner-join,+1,+10) (lookup-join G4 G12 parent1,keyCols=[1],outCols=(1-4,6-8,10,11)) (merge-join G7 G8 G12 inner-join,+1,+2,+6,+7) (merge-join G8 G7 G12 inner-join,+6,+7,+1,+2) (lookup-join G8 G12 grandchild1,keyCols=[6 7],outCols=(1-4,6-8,10,11)) (merge-join G10 G11 G12 inner-join,+6,+7,+1,+2) (merge-join G11 G10 G12 inner-join,+1,+2,+6,+7) (lookup-join G11 G12 child1,keyCols=[1 2],outCols=(1-4,6-8,10,11)) (merge-join G4 G5 G12 inner-join,+1,+10) (lookup-join G4 G12 parent1,keyCols=[1],outCols=(1-4,6-8,10,11)) (merge-join G5 G4 G12 inner-join,+10,+1)
  │    ├── [ordering: +(1|6|10)]
  │    │    ├── best: (lookup-join G4="[ordering: +(1|6)]" G12 parent1,keyCols=[1],outCols=(1-4,6-8,10,11))
  │    │    └── cost: 2774.06
@@ -324,7 +324,7 @@ memo (optimized, ~34KB, required=[presentation: pid1:1,cid1:2,gcid1:3,gca1:4,ca1
  │         ├── best: (lookup-join G4 G12 parent1,keyCols=[1],outCols=(1-4,6-8,10,11))
  │         └── cost: 2774.06
  ├── G3: (projections)
- ├── G4: (inner-join G7 G10 G9) (inner-join G10 G7 G9) (merge-join G7 G10 G12 inner-join,+1,+2,+6,+7) (lookup-join G7 G12 child1,keyCols=[1 2],outCols=(1-4,6-8)) (merge-join G10 G7 G12 inner-join,+6,+7,+1,+2) (lookup-join G10 G12 grandchild1,keyCols=[6 7],outCols=(1-4,6-8))
+ ├── G4: (inner-join G7 G10 G9) (inner-join G7 G10 G9) (inner-join G10 G7 G9) (merge-join G7 G10 G12 inner-join,+1,+2,+6,+7) (lookup-join G7 G12 child1,keyCols=[1 2],outCols=(1-4,6-8)) (merge-join G7 G10 G12 inner-join,+1,+2,+6,+7) (lookup-join G7 G12 child1,keyCols=[1 2],outCols=(1-4,6-8)) (merge-join G10 G7 G12 inner-join,+6,+7,+1,+2) (lookup-join G10 G12 grandchild1,keyCols=[6 7],outCols=(1-4,6-8))
  │    ├── [ordering: +(1|6)]
  │    │    ├── best: (merge-join G7="[ordering: +1,+2]" G10="[ordering: +6,+7]" G12 inner-join,+1,+2,+6,+7)
  │    │    └── cost: 2169.05
@@ -397,7 +397,7 @@ memo
 SELECT * FROM abc, stu, xyz, pqr WHERE a = 1
 ----
 memo (optimized, ~24KB, required=[presentation: a:1,b:2,c:3,s:6,t:7,u:8,x:10,y:11,z:12,p:15,q:16,r:17,s:18,t:19])
- ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4)
+ ├── G1: (inner-join G2 G3 G4) (inner-join G2 G3 G4) (inner-join G3 G2 G4)
  │    └── [presentation: a:1,b:2,c:3,s:6,t:7,u:8,x:10,y:11,z:12,p:15,q:16,r:17,s:18,t:19]
  │         ├── best: (inner-join G3 G2 G4)
  │         └── cost: 325035492.19
@@ -405,7 +405,7 @@ memo (optimized, ~24KB, required=[presentation: a:1,b:2,c:3,s:6,t:7,u:8,x:10,y:1
  │    └── []
  │         ├── best: (scan abc@ab,cols=(1-3),constrained)
  │         └── cost: 5.08
- ├── G3: (inner-join G7 G8 G4) (inner-join G8 G7 G4)
+ ├── G3: (inner-join G7 G8 G4) (inner-join G7 G8 G4) (inner-join G8 G7 G4)
  │    └── []
  │         ├── best: (inner-join G8 G7 G4)
  │         └── cost: 100035487.08
@@ -419,7 +419,7 @@ memo (optimized, ~24KB, required=[presentation: a:1,b:2,c:3,s:6,t:7,u:8,x:10,y:1
  │    └── []
  │         ├── best: (scan stu,cols=(6-8))
  │         └── cost: 10604.02
- ├── G8: (inner-join G10 G11 G4) (inner-join G11 G10 G4)
+ ├── G8: (inner-join G10 G11 G4) (inner-join G10 G11 G4) (inner-join G11 G10 G4)
  │    └── []
  │         ├── best: (inner-join G10 G11 G4)
  │         └── cost: 12208.05
@@ -442,8 +442,8 @@ SELECT *
 FROM stu, abc, xyz, pqr
 WHERE u = a AND a = x AND x = p
 ----
-memo (optimized, ~31KB, required=[presentation: s:1,t:2,u:3,a:5,b:6,c:7,x:10,y:11,z:12,p:15,q:16,r:17,s:18,t:19])
- ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (merge-join G2 G3 G5 inner-join,+3,+5) (merge-join G3 G2 G5 inner-join,+5,+3) (lookup-join G3 G5 stu@uts,keyCols=[5],outCols=(1-3,5-7,10-12,15-19))
+memo (optimized, ~34KB, required=[presentation: s:1,t:2,u:3,a:5,b:6,c:7,x:10,y:11,z:12,p:15,q:16,r:17,s:18,t:19])
+ ├── G1: (inner-join G2 G3 G4) (inner-join G2 G3 G4) (inner-join G3 G2 G4) (merge-join G2 G3 G5 inner-join,+3,+5) (merge-join G2 G3 G5 inner-join,+3,+5) (merge-join G3 G2 G5 inner-join,+5,+3) (lookup-join G3 G5 stu@uts,keyCols=[5],outCols=(1-3,5-7,10-12,15-19))
  │    └── [presentation: s:1,t:2,u:3,a:5,b:6,c:7,x:10,y:11,z:12,p:15,q:16,r:17,s:18,t:19]
  │         ├── best: (merge-join G2="[ordering: +3]" G3="[ordering: +(5|10|15)]" G5 inner-join,+3,+5)
  │         └── cost: 14126.11
@@ -454,7 +454,7 @@ memo (optimized, ~31KB, required=[presentation: s:1,t:2,u:3,a:5,b:6,c:7,x:10,y:1
  │    └── []
  │         ├── best: (scan stu,cols=(1-3))
  │         └── cost: 10604.02
- ├── G3: (inner-join G6 G7 G8) (inner-join G7 G6 G8) (merge-join G6 G7 G5 inner-join,+5,+10) (merge-join G7 G6 G5 inner-join,+10,+5) (lookup-join G7 G5 abc@ab,keyCols=[10],outCols=(5-7,10-12,15-19))
+ ├── G3: (inner-join G6 G7 G8) (inner-join G6 G7 G8) (inner-join G7 G6 G8) (merge-join G6 G7 G5 inner-join,+5,+10) (merge-join G6 G7 G5 inner-join,+5,+10) (merge-join G7 G6 G5 inner-join,+10,+5) (lookup-join G7 G5 abc@ab,keyCols=[10],outCols=(5-7,10-12,15-19))
  │    ├── [ordering: +(5|10|15)]
  │    │    ├── best: (merge-join G6="[ordering: +5]" G7="[ordering: +(10|15)]" G5 inner-join,+5,+10)
  │    │    └── cost: 3312.08
@@ -470,7 +470,7 @@ memo (optimized, ~31KB, required=[presentation: s:1,t:2,u:3,a:5,b:6,c:7,x:10,y:1
  │    └── []
  │         ├── best: (scan abc,cols=(5-7))
  │         └── cost: 1074.02
- ├── G7: (inner-join G10 G11 G12) (inner-join G11 G10 G12) (merge-join G10 G11 G5 inner-join,+10,+15) (lookup-join G10 G5 pqr,keyCols=[10],outCols=(10-12,15-19)) (merge-join G11 G10 G5 inner-join,+15,+10) (lookup-join G11 G5 xyz@xy,keyCols=[15],outCols=(10-12,15-19))
+ ├── G7: (inner-join G10 G11 G12) (inner-join G10 G11 G12) (inner-join G11 G10 G12) (merge-join G10 G11 G5 inner-join,+10,+15) (lookup-join G10 G5 pqr,keyCols=[10],outCols=(10-12,15-19)) (merge-join G10 G11 G5 inner-join,+10,+15) (lookup-join G10 G5 pqr,keyCols=[10],outCols=(10-12,15-19)) (merge-join G11 G10 G5 inner-join,+15,+10) (lookup-join G11 G5 xyz@xy,keyCols=[15],outCols=(10-12,15-19))
  │    ├── [ordering: +(10|15)]
  │    │    ├── best: (merge-join G10="[ordering: +10]" G11="[ordering: +15]" G5 inner-join,+10,+15)
  │    │    └── cost: 2208.05
@@ -536,7 +536,7 @@ INNER JOIN LATERAL (
 )
 ON a = v
 ----
-memo (optimized, ~13KB, required=[presentation: a:1,b:2,c:3,v:6,s:7,t:8,u:9])
+memo (optimized, ~14KB, required=[presentation: a:1,b:2,c:3,v:6,s:7,t:8,u:9])
  ├── G1: (inner-join-apply G2 G3 G4)
  │    └── [presentation: a:1,b:2,c:3,v:6,s:7,t:8,u:9]
  │         ├── best: (inner-join-apply G2 G3 G4)
@@ -545,7 +545,7 @@ memo (optimized, ~13KB, required=[presentation: a:1,b:2,c:3,v:6,s:7,t:8,u:9])
  │    └── []
  │         ├── best: (scan abc,cols=(1-3))
  │         └── cost: 1074.02
- ├── G3: (inner-join G5 G6 G7) (inner-join G6 G5 G7) (lookup-join G5 G8 stu,keyCols=[6],outCols=(6-9)) (merge-join G6 G5 G8 inner-join,+7,+6)
+ ├── G3: (inner-join G5 G6 G7) (inner-join G5 G6 G7) (inner-join G6 G5 G7) (lookup-join G5 G8 stu,keyCols=[6],outCols=(6-9)) (lookup-join G5 G8 stu,keyCols=[6],outCols=(6-9)) (merge-join G6 G5 G8 inner-join,+7,+6)
  │    └── []
  │         ├── best: (lookup-join G5 G8 stu,keyCols=[6],outCols=(6-9))
  │         └── cost: 81.44
@@ -597,7 +597,14 @@ Source expression:
    └── filters
         └── a = s
 
-New expression 1 of 1:
+New expression 1 of 2:
+  inner-join (hash)
+   ├── scan abc
+   ├── scan stu
+   └── filters
+        └── a = s
+
+New expression 2 of 2:
   inner-join (hash)
    ├── scan stu
    ├── scan abc
@@ -678,7 +685,18 @@ Source expression:
    └── filters
         └── b = y
 
-New expression 1 of 1:
+New expression 1 of 2:
+  inner-join (hash)
+   ├── inner-join (hash)
+   │    ├── scan stu
+   │    ├── scan abc
+   │    └── filters
+   │         └── s = a
+   ├── scan xyz
+   └── filters
+        └── b = y
+
+New expression 2 of 2:
   inner-join (hash)
    ├── inner-join (hash)
    │    ├── scan abc
@@ -702,7 +720,7 @@ Source expression:
    └── filters
         └── b = y
 
-New expression 1 of 3:
+New expression 1 of 4:
   inner-join (hash)
    ├── scan stu
    ├── inner-join (hash)
@@ -713,7 +731,7 @@ New expression 1 of 3:
    └── filters
         └── s = a
 
-New expression 2 of 3:
+New expression 2 of 4:
   inner-join (hash)
    ├── inner-join (hash)
    │    ├── scan abc
@@ -724,7 +742,17 @@ New expression 2 of 3:
    └── filters
         └── s = a
 
-New expression 3 of 3:
+New expression 3 of 4:
+  inner-join (hash)
+   ├── inner-join (merge)
+   │    ├── scan stu
+   │    ├── scan abc@ab
+   │    └── filters (true)
+   ├── scan xyz
+   └── filters
+        └── b = y
+
+New expression 4 of 4:
   inner-join (hash)
    ├── scan xyz
    ├── inner-join (merge)
@@ -899,7 +927,19 @@ Source expression:
         └── filters
              └── small.m = large.m
 
-New expression 1 of 1:
+New expression 1 of 2:
+  project
+   └── left-join (hash)
+        ├── scan small
+        ├── inner-join (hash)
+        │    ├── scan large
+        │    ├── scan medium
+        │    └── filters
+        │         └── large.n = medium.n
+        └── filters
+             └── small.m = large.m
+
+New expression 2 of 2:
   project
    └── left-join (hash)
         ├── scan small
@@ -926,7 +966,17 @@ Source expression:
         └── filters
              └── small.m = large.m
 
-No new expressions.
+New expression 1 of 1:
+  project
+   └── left-join (hash)
+        ├── scan small
+        ├── inner-join (hash)
+        │    ├── scan large
+        │    ├── scan medium
+        │    └── filters
+        │         └── large.n = medium.n
+        └── filters
+             └── small.m = large.m
 ----
 ----
 
@@ -962,7 +1012,21 @@ Source expression:
         ├── scan xyz
         └── filters (true)
 
-No new expressions.
+New expression 1 of 1:
+  project
+   └── inner-join (cross)
+        ├── inner-join (hash)
+        │    ├── left-join (hash)
+        │    │    ├── scan medium
+        │    │    ├── scan large
+        │    │    └── filters
+        │    │         └── large.m = medium.m
+        │    ├── scan small
+        │    └── filters
+        │         ├── medium.n = small.n
+        │         └── (small.m = large.n) OR (large.n IS NULL)
+        ├── scan xyz
+        └── filters (true)
 
 ================================================================================
 ReorderJoins
@@ -983,7 +1047,7 @@ Source expression:
         ├── scan xyz
         └── filters (true)
 
-New expression 1 of 2:
+New expression 1 of 3:
   project
    └── inner-join (cross)
         ├── select
@@ -1001,7 +1065,23 @@ New expression 1 of 2:
         ├── scan xyz
         └── filters (true)
 
-New expression 2 of 2:
+New expression 2 of 3:
+  project
+   └── inner-join (cross)
+        ├── inner-join (hash)
+        │    ├── right-join (hash)
+        │    │    ├── scan large
+        │    │    ├── scan medium
+        │    │    └── filters
+        │    │         └── large.m = medium.m
+        │    ├── scan small
+        │    └── filters
+        │         ├── medium.n = small.n
+        │         └── (small.m = large.n) OR (large.n IS NULL)
+        ├── scan xyz
+        └── filters (true)
+
+New expression 3 of 3:
   project
    └── inner-join (cross)
         ├── inner-join (hash)
@@ -1038,7 +1118,25 @@ Source expression:
         ├── scan xyz
         └── filters (true)
 
-New expression 1 of 1:
+New expression 1 of 2:
+  project
+   └── inner-join (cross)
+        ├── select
+        │    ├── right-join (hash)
+        │    │    ├── scan large
+        │    │    ├── inner-join (hash)
+        │    │    │    ├── scan medium
+        │    │    │    ├── scan small
+        │    │    │    └── filters
+        │    │    │         └── medium.n = small.n
+        │    │    └── filters
+        │    │         └── large.m = medium.m
+        │    └── filters
+        │         └── (small.m = large.n) OR (large.n IS NULL)
+        ├── scan xyz
+        └── filters (true)
+
+New expression 2 of 2:
   project
    └── inner-join (cross)
         ├── scan xyz
@@ -1079,7 +1177,18 @@ Source expression:
    └── filters
         └── b = y
 
-New expression 1 of 1:
+New expression 1 of 2:
+  full-join (hash)
+   ├── full-join (hash)
+   │    ├── scan abc
+   │    ├── scan stu
+   │    └── filters
+   │         └── s = a
+   ├── scan xyz
+   └── filters
+        └── b = y
+
+New expression 2 of 2:
   full-join (hash)
    ├── full-join (hash)
    │    ├── scan stu
@@ -1103,7 +1212,7 @@ Source expression:
    └── filters
         └── b = y
 
-New expression 1 of 3:
+New expression 1 of 4:
   full-join (hash)
    ├── full-join (hash)
    │    ├── scan abc
@@ -1114,7 +1223,7 @@ New expression 1 of 3:
    └── filters
         └── s = a
 
-New expression 2 of 3:
+New expression 2 of 4:
   full-join (hash)
    ├── scan stu
    ├── full-join (hash)
@@ -1125,7 +1234,17 @@ New expression 2 of 3:
    └── filters
         └── s = a
 
-New expression 3 of 3:
+New expression 3 of 4:
+  full-join (hash)
+   ├── full-join (merge)
+   │    ├── scan abc@ab
+   │    ├── scan stu
+   │    └── filters (true)
+   ├── scan xyz
+   └── filters
+        └── b = y
+
+New expression 4 of 4:
   full-join (hash)
    ├── scan xyz
    ├── full-join (merge)
@@ -1162,7 +1281,18 @@ Source expression:
    └── filters
         └── a = x
 
-New expression 1 of 1:
+New expression 1 of 2:
+  full-join (hash)
+   ├── scan abc
+   ├── full-join (hash)
+   │    ├── scan stu
+   │    ├── scan xyz
+   │    └── filters
+   │         └── t = y
+   └── filters
+        └── a = x
+
+New expression 2 of 2:
   full-join (hash)
    ├── scan abc
    ├── full-join (hash)
@@ -1187,7 +1317,18 @@ Source expression:
    └── filters
         └── a = x
 
-New expression 1 of 3:
+New expression 1 of 4:
+  full-join (hash)
+   ├── scan abc
+   ├── full-join (hash)
+   │    ├── scan stu
+   │    ├── scan xyz
+   │    └── filters
+   │         └── t = y
+   └── filters
+        └── a = x
+
+New expression 2 of 4:
   full-join (hash)
    ├── full-join (hash)
    │    ├── scan stu
@@ -1198,7 +1339,7 @@ New expression 1 of 3:
    └── filters
         └── a = x
 
-New expression 2 of 3:
+New expression 3 of 4:
   full-join (hash)
    ├── scan stu
    ├── full-join (hash)
@@ -1209,7 +1350,7 @@ New expression 2 of 3:
    └── filters
         └── t = y
 
-New expression 3 of 3:
+New expression 4 of 4:
   full-join (hash)
    ├── full-join (hash)
    │    ├── scan abc
@@ -1243,7 +1384,16 @@ Source expression:
    └── filters
         └── b = y
 
-No new expressions.
+New expression 1 of 1:
+  left-join (hash)
+   ├── left-join (hash)
+   │    ├── scan abc
+   │    ├── scan stu
+   │    └── filters
+   │         └── s = a
+   ├── scan xyz
+   └── filters
+        └── b = y
 
 ================================================================================
 ReorderJoins
@@ -1258,7 +1408,7 @@ Source expression:
    └── filters
         └── b = y
 
-New expression 1 of 1:
+New expression 1 of 2:
   left-join (hash)
    ├── left-join (hash)
    │    ├── scan abc
@@ -1268,6 +1418,16 @@ New expression 1 of 1:
    ├── scan stu
    └── filters
         └── s = a
+
+New expression 2 of 2:
+  left-join (hash)
+   ├── left-join (merge)
+   │    ├── scan abc@ab
+   │    ├── scan stu
+   │    └── filters (true)
+   ├── scan xyz
+   └── filters
+        └── b = y
 ----
 ----
 
@@ -1292,7 +1452,18 @@ Source expression:
    └── filters
         └── b = y
 
-New expression 1 of 1:
+New expression 1 of 2:
+  left-join (hash)
+   ├── full-join (hash)
+   │    ├── scan abc
+   │    ├── scan stu
+   │    └── filters
+   │         └── s = a
+   ├── scan xyz
+   └── filters
+        └── b = y
+
+New expression 2 of 2:
   left-join (hash)
    ├── full-join (hash)
    │    ├── scan stu
@@ -1316,7 +1487,7 @@ Source expression:
    └── filters
         └── b = y
 
-New expression 1 of 2:
+New expression 1 of 3:
   full-join (hash)
    ├── left-join (hash)
    │    ├── scan abc
@@ -1327,7 +1498,7 @@ New expression 1 of 2:
    └── filters
         └── s = a
 
-New expression 2 of 2:
+New expression 2 of 3:
   full-join (hash)
    ├── scan stu
    ├── left-join (hash)
@@ -1337,6 +1508,16 @@ New expression 2 of 2:
    │         └── b = y
    └── filters
         └── s = a
+
+New expression 3 of 3:
+  left-join (hash)
+   ├── full-join (merge)
+   │    ├── scan abc@ab
+   │    ├── scan stu
+   │    └── filters (true)
+   ├── scan xyz
+   └── filters
+        └── b = y
 ----
 ----
 
@@ -1345,8 +1526,8 @@ New expression 2 of 2:
 memo expect=ReorderJoins
 SELECT * FROM abc JOIN xyz ON a=z
 ----
-memo (optimized, ~10KB, required=[presentation: a:1,b:2,c:3,x:6,y:7,z:8])
- ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (merge-join G2 G3 G5 inner-join,+1,+8) (lookup-join G3 G5 abc@ab,keyCols=[8],outCols=(1-3,6-8))
+memo (optimized, ~11KB, required=[presentation: a:1,b:2,c:3,x:6,y:7,z:8])
+ ├── G1: (inner-join G2 G3 G4) (inner-join G2 G3 G4) (inner-join G3 G2 G4) (merge-join G2 G3 G5 inner-join,+1,+8) (merge-join G2 G3 G5 inner-join,+1,+8) (lookup-join G3 G5 abc@ab,keyCols=[8],outCols=(1-3,6-8))
  │    └── [presentation: a:1,b:2,c:3,x:6,y:7,z:8]
  │         ├── best: (inner-join G2 G3 G4)
  │         └── cost: 2187.96
@@ -1373,8 +1554,8 @@ memo (optimized, ~10KB, required=[presentation: a:1,b:2,c:3,x:6,y:7,z:8])
 memo expect=ReorderJoins
 SELECT * FROM abc FULL OUTER JOIN xyz ON a=z
 ----
-memo (optimized, ~9KB, required=[presentation: a:1,b:2,c:3,x:6,y:7,z:8])
- ├── G1: (full-join G2 G3 G4) (full-join G3 G2 G4) (merge-join G2 G3 G5 full-join,+1,+8)
+memo (optimized, ~10KB, required=[presentation: a:1,b:2,c:3,x:6,y:7,z:8])
+ ├── G1: (full-join G2 G3 G4) (full-join G2 G3 G4) (full-join G3 G2 G4) (merge-join G2 G3 G5 full-join,+1,+8) (merge-join G2 G3 G5 full-join,+1,+8)
  │    └── [presentation: a:1,b:2,c:3,x:6,y:7,z:8]
  │         ├── best: (full-join G2 G3 G4)
  │         └── cost: 2188.06
@@ -1499,7 +1680,18 @@ Source expression:
    └── filters
         └── s = x
 
-New expression 1 of 1:
+New expression 1 of 2:
+  inner-join (hash)
+   ├── inner-join (hash)
+   │    ├── scan abc
+   │    ├── scan stu
+   │    └── filters
+   │         └── s = a
+   ├── scan xyz
+   └── filters
+        └── s = x
+
+New expression 2 of 2:
   inner-join (hash)
    ├── inner-join (hash)
    │    ├── scan stu
@@ -1523,7 +1715,17 @@ Source expression:
    └── filters
         └── s = x
 
-New expression 1 of 1:
+New expression 1 of 2:
+  inner-join (hash)
+   ├── inner-join (merge)
+   │    ├── scan abc@ab
+   │    ├── scan stu
+   │    └── filters (true)
+   ├── scan xyz
+   └── filters
+        └── s = x
+
+New expression 2 of 2:
   inner-join (hash)
    ├── scan xyz
    ├── inner-join (merge)
@@ -1542,8 +1744,8 @@ New expression 1 of 1:
 memo
 SELECT * FROM abc LEFT OUTER JOIN xyz ON a=z
 ----
-memo (optimized, ~9KB, required=[presentation: a:1,b:2,c:3,x:6,y:7,z:8])
- ├── G1: (left-join G2 G3 G4) (right-join G3 G2 G4) (merge-join G2 G3 G5 left-join,+1,+8)
+memo (optimized, ~10KB, required=[presentation: a:1,b:2,c:3,x:6,y:7,z:8])
+ ├── G1: (left-join G2 G3 G4) (left-join G2 G3 G4) (right-join G3 G2 G4) (merge-join G2 G3 G5 left-join,+1,+8) (right-join G3 G2 G4) (merge-join G2 G3 G5 left-join,+1,+8)
  │    └── [presentation: a:1,b:2,c:3,x:6,y:7,z:8]
  │         ├── best: (left-join G2 G3 G4)
  │         └── cost: 2188.06
@@ -1589,8 +1791,8 @@ right-join (hash)
 memo
 SELECT * FROM abc RIGHT OUTER JOIN xyz ON a=z
 ----
-memo (optimized, ~10KB, required=[presentation: a:1,b:2,c:3,x:6,y:7,z:8])
- ├── G1: (left-join G2 G3 G4) (right-join G3 G2 G4) (lookup-join G2 G5 abc@ab,keyCols=[8],outCols=(1-3,6-8)) (merge-join G3 G2 G5 right-join,+1,+8)
+memo (optimized, ~12KB, required=[presentation: a:1,b:2,c:3,x:6,y:7,z:8])
+ ├── G1: (left-join G2 G3 G4) (left-join G2 G3 G4) (right-join G3 G2 G4) (lookup-join G2 G5 abc@ab,keyCols=[8],outCols=(1-3,6-8)) (right-join G3 G2 G4) (lookup-join G2 G5 abc@ab,keyCols=[8],outCols=(1-3,6-8)) (merge-join G3 G2 G5 right-join,+1,+8) (merge-join G3 G2 G5 right-join,+1,+8)
  │    └── [presentation: a:1,b:2,c:3,x:6,y:7,z:8]
  │         ├── best: (left-join G2 G3 G4)
  │         └── cost: 2188.06
@@ -1651,8 +1853,8 @@ inner-join (merge)
 memo
 SELECT * FROM abc JOIN xyz ON a=x
 ----
-memo (optimized, ~12KB, required=[presentation: a:1,b:2,c:3,x:6,y:7,z:8])
- ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (merge-join G2 G3 G5 inner-join,+1,+6) (lookup-join G2 G5 xyz@xy,keyCols=[1],outCols=(1-3,6-8)) (merge-join G3 G2 G5 inner-join,+6,+1) (lookup-join G3 G5 abc@ab,keyCols=[6],outCols=(1-3,6-8))
+memo (optimized, ~14KB, required=[presentation: a:1,b:2,c:3,x:6,y:7,z:8])
+ ├── G1: (inner-join G2 G3 G4) (inner-join G2 G3 G4) (inner-join G3 G2 G4) (merge-join G2 G3 G5 inner-join,+1,+6) (lookup-join G2 G5 xyz@xy,keyCols=[1],outCols=(1-3,6-8)) (merge-join G2 G3 G5 inner-join,+1,+6) (lookup-join G2 G5 xyz@xy,keyCols=[1],outCols=(1-3,6-8)) (merge-join G3 G2 G5 inner-join,+6,+1) (lookup-join G3 G5 abc@ab,keyCols=[6],outCols=(1-3,6-8))
  │    └── [presentation: a:1,b:2,c:3,x:6,y:7,z:8]
  │         ├── best: (merge-join G2="[ordering: +1]" G3="[ordering: +6]" G5 inner-join,+1,+6)
  │         └── cost: 2178.05
@@ -1754,8 +1956,8 @@ inner-join (hash)
 memo
 SELECT * FROM stu AS l JOIN stu AS r ON (l.s, l.t, l.u) = (r.s, r.t, r.u)
 ----
-memo (optimized, ~15KB, required=[presentation: s:1,t:2,u:3,s:5,t:6,u:7])
- ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (merge-join G2 G3 G5 inner-join,+1,+2,+3,+5,+6,+7) (merge-join G2 G3 G5 inner-join,+3,+2,+1,+7,+6,+5) (lookup-join G2 G5 stu,keyCols=[1 2 3],outCols=(1-3,5-7)) (lookup-join G2 G5 stu@uts,keyCols=[3 2 1],outCols=(1-3,5-7)) (merge-join G3 G2 G5 inner-join,+5,+6,+7,+1,+2,+3) (merge-join G3 G2 G5 inner-join,+7,+6,+5,+3,+2,+1) (lookup-join G3 G5 stu,keyCols=[5 6 7],outCols=(1-3,5-7)) (lookup-join G3 G5 stu@uts,keyCols=[7 6 5],outCols=(1-3,5-7))
+memo (optimized, ~18KB, required=[presentation: s:1,t:2,u:3,s:5,t:6,u:7])
+ ├── G1: (inner-join G2 G3 G4) (inner-join G2 G3 G4) (inner-join G3 G2 G4) (merge-join G2 G3 G5 inner-join,+1,+2,+3,+5,+6,+7) (merge-join G2 G3 G5 inner-join,+3,+2,+1,+7,+6,+5) (lookup-join G2 G5 stu,keyCols=[1 2 3],outCols=(1-3,5-7)) (lookup-join G2 G5 stu@uts,keyCols=[3 2 1],outCols=(1-3,5-7)) (merge-join G2 G3 G5 inner-join,+1,+2,+3,+5,+6,+7) (merge-join G2 G3 G5 inner-join,+3,+2,+1,+7,+6,+5) (lookup-join G2 G5 stu,keyCols=[1 2 3],outCols=(1-3,5-7)) (lookup-join G2 G5 stu@uts,keyCols=[3 2 1],outCols=(1-3,5-7)) (merge-join G3 G2 G5 inner-join,+5,+6,+7,+1,+2,+3) (merge-join G3 G2 G5 inner-join,+7,+6,+5,+3,+2,+1) (lookup-join G3 G5 stu,keyCols=[5 6 7],outCols=(1-3,5-7)) (lookup-join G3 G5 stu@uts,keyCols=[7 6 5],outCols=(1-3,5-7))
  │    └── [presentation: s:1,t:2,u:3,s:5,t:6,u:7]
  │         ├── best: (merge-join G2="[ordering: +1,+2,+3]" G3="[ordering: +5,+6,+7]" G5 inner-join,+1,+2,+3,+5,+6,+7)
  │         └── cost: 21408.05
@@ -1795,6 +1997,60 @@ exploretrace rule=GenerateMergeJoins
 SELECT * FROM stu AS l JOIN stu AS r ON (l.s, l.t, l.u) = (r.s, r.t, r.u)
 ----
 ----
+================================================================================
+GenerateMergeJoins
+================================================================================
+Source expression:
+  inner-join (hash)
+   ├── columns: s:1!null t:2!null u:3!null s:5!null t:6!null u:7!null
+   ├── multiplicity: left-rows(exactly-one), right-rows(exactly-one)
+   ├── key: (5-7)
+   ├── fd: (1)==(5), (5)==(1), (2)==(6), (6)==(2), (3)==(7), (7)==(3)
+   ├── scan l
+   │    ├── columns: l.s:1!null l.t:2!null l.u:3!null
+   │    └── key: (1-3)
+   ├── scan r
+   │    ├── columns: r.s:5!null r.t:6!null r.u:7!null
+   │    └── key: (5-7)
+   └── filters
+        ├── l.s:1 = r.s:5 [outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
+        ├── l.t:2 = r.t:6 [outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ]), fd=(2)==(6), (6)==(2)]
+        └── l.u:3 = r.u:7 [outer=(3,7), constraints=(/3: (/NULL - ]; /7: (/NULL - ]), fd=(3)==(7), (7)==(3)]
+
+New expression 1 of 2:
+  inner-join (merge)
+   ├── columns: s:1!null t:2!null u:3!null s:5!null t:6!null u:7!null
+   ├── left ordering: +1,+2,+3
+   ├── right ordering: +5,+6,+7
+   ├── key: (5-7)
+   ├── fd: (1)==(5), (5)==(1), (2)==(6), (6)==(2), (3)==(7), (7)==(3)
+   ├── scan l
+   │    ├── columns: l.s:1!null l.t:2!null l.u:3!null
+   │    ├── key: (1-3)
+   │    └── ordering: +1,+2,+3
+   ├── scan r
+   │    ├── columns: r.s:5!null r.t:6!null r.u:7!null
+   │    ├── key: (5-7)
+   │    └── ordering: +5,+6,+7
+   └── filters (true)
+
+New expression 2 of 2:
+  inner-join (merge)
+   ├── columns: s:1!null t:2!null u:3!null s:5!null t:6!null u:7!null
+   ├── left ordering: +3,+2,+1
+   ├── right ordering: +7,+6,+5
+   ├── key: (5-7)
+   ├── fd: (1)==(5), (5)==(1), (2)==(6), (6)==(2), (3)==(7), (7)==(3)
+   ├── scan l@uts
+   │    ├── columns: l.s:1!null l.t:2!null l.u:3!null
+   │    ├── key: (1-3)
+   │    └── ordering: +3,+2,+1
+   ├── scan r@uts
+   │    ├── columns: r.s:5!null r.t:6!null r.u:7!null
+   │    ├── key: (5-7)
+   │    └── ordering: +7,+6,+5
+   └── filters (true)
+
 ================================================================================
 GenerateMergeJoins
 ================================================================================
@@ -1962,7 +2218,7 @@ memo
 SELECT * FROM abc JOIN xyz ON a=b
 ----
 memo (optimized, ~13KB, required=[presentation: a:1,b:2,c:3,x:6,y:7,z:8])
- ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4)
+ ├── G1: (inner-join G2 G3 G4) (inner-join G2 G3 G4) (inner-join G3 G2 G4)
  │    └── [presentation: a:1,b:2,c:3,x:6,y:7,z:8]
  │         ├── best: (inner-join G3 G2 G4)
  │         └── cost: 2169.68
@@ -1999,8 +2255,8 @@ CREATE TABLE kfloat (k FLOAT PRIMARY KEY)
 memo
 SELECT * FROM abc JOIN kfloat ON a=k
 ----
-memo (optimized, ~10KB, required=[presentation: a:1,b:2,c:3,k:6])
- ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4)
+memo (optimized, ~12KB, required=[presentation: a:1,b:2,c:3,k:6])
+ ├── G1: (inner-join G2 G3 G4) (inner-join G2 G3 G4) (inner-join G3 G2 G4)
  │    └── [presentation: a:1,b:2,c:3,k:6]
  │         ├── best: (inner-join G2 G3 G4)
  │         └── cost: 12128.06
@@ -2341,6 +2597,22 @@ Source expression:
   inner-join (hash)
    ├── columns: a:1!null b:2 c:3 x:6 y:7 z:8!null
    ├── fd: (1)==(8), (8)==(1)
+   ├── scan abc
+   │    └── columns: a:1 b:2 c:3
+   ├── scan xyz
+   │    └── columns: x:6 y:7 z:8
+   └── filters
+        └── a:1 = z:8 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
+
+No new expressions.
+
+================================================================================
+GenerateLookupJoins
+================================================================================
+Source expression:
+  inner-join (hash)
+   ├── columns: a:1!null b:2 c:3 x:6 y:7 z:8!null
+   ├── fd: (1)==(8), (8)==(1)
    ├── scan xyz
    │    └── columns: x:6 y:7 z:8
    ├── scan abc
@@ -2383,6 +2655,27 @@ New expression 1 of 1:
    ├── scan xyz
    │    └── columns: x:6 y:7 z:8
    └── filters (true)
+
+================================================================================
+GenerateLookupJoins
+================================================================================
+Source expression:
+  left-join (hash)
+   ├── columns: a:1 b:2 c:3 x:6 y:7 z:8
+   ├── scan xyz
+   │    └── columns: x:6 y:7 z:8
+   ├── scan abc
+   │    └── columns: a:1 b:2 c:3
+   └── filters
+        └── a:1 = z:8 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
+
+New expression 1 of 1:
+  left-join (lookup abc@ab)
+   ├── columns: a:1 b:2 c:3 x:6 y:7 z:8
+   ├── key columns: [8] = [1]
+   ├── scan xyz
+   │    └── columns: x:6 y:7 z:8
+   └── filters (true)
 ----
 ----
 
@@ -2391,6 +2684,29 @@ exploretrace rule=GenerateLookupJoins
 SELECT * FROM abc JOIN xyz ON c=x
 ----
 ----
+================================================================================
+GenerateLookupJoins
+================================================================================
+Source expression:
+  inner-join (hash)
+   ├── columns: a:1 b:2 c:3!null x:6!null y:7 z:8
+   ├── fd: (3)==(6), (6)==(3)
+   ├── scan abc
+   │    └── columns: a:1 b:2 c:3
+   ├── scan xyz
+   │    └── columns: x:6 y:7 z:8
+   └── filters
+        └── c:3 = x:6 [outer=(3,6), constraints=(/3: (/NULL - ]; /6: (/NULL - ]), fd=(3)==(6), (6)==(3)]
+
+New expression 1 of 1:
+  inner-join (lookup xyz@xy)
+   ├── columns: a:1 b:2 c:3!null x:6!null y:7 z:8
+   ├── key columns: [3] = [6]
+   ├── fd: (3)==(6), (6)==(3)
+   ├── scan abc
+   │    └── columns: a:1 b:2 c:3
+   └── filters (true)
+
 ================================================================================
 GenerateLookupJoins
 ================================================================================
@@ -2456,6 +2772,27 @@ New expression 1 of 1:
    ├── scan abc
    │    └── columns: a:1 b:2 c:3
    └── filters (true)
+
+================================================================================
+GenerateLookupJoins
+================================================================================
+Source expression:
+  left-join (hash)
+   ├── columns: a:1 b:2 c:3 x:6 y:7 z:8
+   ├── scan abc
+   │    └── columns: a:1 b:2 c:3
+   ├── scan xyz
+   │    └── columns: x:6 y:7 z:8
+   └── filters
+        └── c:3 = x:6 [outer=(3,6), constraints=(/3: (/NULL - ]; /6: (/NULL - ]), fd=(3)==(6), (6)==(3)]
+
+New expression 1 of 1:
+  left-join (lookup xyz@xy)
+   ├── columns: a:1 b:2 c:3 x:6 y:7 z:8
+   ├── key columns: [3] = [6]
+   ├── scan abc
+   │    └── columns: a:1 b:2 c:3
+   └── filters (true)
 ----
 ----
 
@@ -2464,6 +2801,21 @@ exploretrace rule=GenerateLookupJoins
 SELECT * FROM abc RIGHT JOIN xyz ON c=x
 ----
 ----
+================================================================================
+GenerateLookupJoins
+================================================================================
+Source expression:
+  left-join (hash)
+   ├── columns: a:1 b:2 c:3 x:6 y:7 z:8
+   ├── scan xyz
+   │    └── columns: x:6 y:7 z:8
+   ├── scan abc
+   │    └── columns: a:1 b:2 c:3
+   └── filters
+        └── c:3 = x:6 [outer=(3,6), constraints=(/3: (/NULL - ]; /6: (/NULL - ]), fd=(3)==(6), (6)==(3)]
+
+No new expressions.
+
 ================================================================================
 GenerateLookupJoins
 ================================================================================
@@ -3441,7 +3793,7 @@ WHERE n.name = 'Upper West Side'
 OR n.name = 'Upper East Side'
 GROUP BY n.name, n.geom
 ----
-memo (optimized, ~28KB, required=[presentation: name:15,popn_per_sqkm:20])
+memo (optimized, ~34KB, required=[presentation: name:15,popn_per_sqkm:20])
  ├── G1: (project G2 G3 name)
  │    └── [presentation: name:15,popn_per_sqkm:20]
  │         ├── best: (project G2 G3 name)
@@ -3451,56 +3803,60 @@ memo (optimized, ~28KB, required=[presentation: name:15,popn_per_sqkm:20])
  │         ├── best: (group-by G4 G5 cols=(15,16))
  │         └── cost: 7312.23
  ├── G3: (projections G6)
- ├── G4: (inner-join G7 G8 G9) (inner-join G8 G7 G9) (lookup-join G10 G11 nyc_neighborhoods,keyCols=[13],outCols=(3,9,10,14-16)) (lookup-join G12 G9 nyc_census_blocks,keyCols=[1],outCols=(3,9,10,14-16))
+ ├── G4: (inner-join G7 G8 G9) (inner-join G7 G8 G9) (inner-join G8 G7 G9) (lookup-join G10 G11 nyc_neighborhoods,keyCols=[13],outCols=(3,9,10,14-16)) (lookup-join G12 G11 nyc_neighborhoods,keyCols=[13],outCols=(3,9,10,14-16)) (lookup-join G13 G9 nyc_census_blocks,keyCols=[1],outCols=(3,9,10,14-16))
  │    └── []
- │         ├── best: (lookup-join G12 G9 nyc_census_blocks,keyCols=[1],outCols=(3,9,10,14-16))
+ │         ├── best: (lookup-join G13 G9 nyc_census_blocks,keyCols=[1],outCols=(3,9,10,14-16))
  │         └── cost: 7305.98
- ├── G5: (aggregations G13)
- ├── G6: (div G14 G15)
+ ├── G5: (aggregations G14)
+ ├── G6: (div G15 G16)
  ├── G7: (scan c,cols=(3,9,10))
  │    └── []
  │         ├── best: (scan c,cols=(3,9,10))
  │         └── cost: 43841.24
- ├── G8: (select G16 G17)
+ ├── G8: (select G17 G18)
  │    └── []
- │         ├── best: (select G16 G17)
+ │         ├── best: (select G17 G18)
  │         └── cost: 143.36
- ├── G9: (filters G18 G19)
- ├── G10: (inverted-join G7 G20 nyc_neighborhoods@nyc_neighborhoods_geo_idx)
+ ├── G9: (filters G19 G20)
+ ├── G10: (inverted-join G7 G21 nyc_neighborhoods@nyc_neighborhoods_geo_idx)
  │    └── []
- │         ├── best: (inverted-join G7 G20 nyc_neighborhoods@nyc_neighborhoods_geo_idx)
+ │         ├── best: (inverted-join G7 G21 nyc_neighborhoods@nyc_neighborhoods_geo_idx)
  │         └── cost: 921811.54
- ├── G11: (filters G18 G19 G21)
- ├── G12: (inverted-join G8 G20 nyc_census_blocks@nyc_census_blocks_geo_idx)
+ ├── G11: (filters G19 G20 G22)
+ ├── G12: (inverted-join G7 G21 nyc_neighborhoods@nyc_neighborhoods_geo_idx)
  │    └── []
- │         ├── best: (inverted-join G8 G20 nyc_census_blocks@nyc_census_blocks_geo_idx)
+ │         ├── best: (inverted-join G7 G21 nyc_neighborhoods@nyc_neighborhoods_geo_idx)
+ │         └── cost: 921811.54
+ ├── G13: (inverted-join G8 G21 nyc_census_blocks@nyc_census_blocks_geo_idx)
+ │    └── []
+ │         ├── best: (inverted-join G8 G21 nyc_census_blocks@nyc_census_blocks_geo_idx)
  │         └── cost: 1766.17
- ├── G13: (sum G22)
- ├── G14: (variable sum)
- ├── G15: (div G23 G24)
- ├── G16: (scan n,cols=(14-16))
+ ├── G14: (sum G23)
+ ├── G15: (variable sum)
+ ├── G16: (div G24 G25)
+ ├── G17: (scan n,cols=(14-16))
  │    └── []
  │         ├── best: (scan n,cols=(14-16))
  │         └── cost: 142.05
- ├── G17: (filters G21)
- ├── G18: (function G25 st_intersects)
- ├── G19: (eq G26 G27)
- ├── G20: (filters)
- ├── G21: (or G28 G29)
- ├── G22: (variable popn_total)
- ├── G23: (function G30 st_area)
- ├── G24: (const 1e+06)
- ├── G25: (scalar-list G31 G32)
- ├── G26: (variable c.boroname)
- ├── G27: (variable n.boroname)
- ├── G28: (eq G33 G34)
- ├── G29: (eq G33 G35)
- ├── G30: (scalar-list G31)
- ├── G31: (variable n.geom)
- ├── G32: (variable c.geom)
- ├── G33: (variable name)
- ├── G34: (const 'Upper West Side')
- └── G35: (const 'Upper East Side')
+ ├── G18: (filters G22)
+ ├── G19: (function G26 st_intersects)
+ ├── G20: (eq G27 G28)
+ ├── G21: (filters)
+ ├── G22: (or G29 G30)
+ ├── G23: (variable popn_total)
+ ├── G24: (function G31 st_area)
+ ├── G25: (const 1e+06)
+ ├── G26: (scalar-list G32 G33)
+ ├── G27: (variable c.boroname)
+ ├── G28: (variable n.boroname)
+ ├── G29: (eq G34 G35)
+ ├── G30: (eq G34 G36)
+ ├── G31: (scalar-list G32)
+ ├── G32: (variable n.geom)
+ ├── G33: (variable c.geom)
+ ├── G34: (variable name)
+ ├── G35: (const 'Upper West Side')
+ └── G36: (const 'Upper East Side')
 
 opt expect=GenerateInvertedJoins
 SELECT
@@ -5101,7 +5457,7 @@ SELECT 1 FROM (VALUES (1), (1)) JOIN (VALUES (1), (1), (1)) ON true
 UNION ALL
 SELECT 1 FROM (VALUES (1), (1), (1)) JOIN (VALUES (1), (1)) ON true
 ----
-memo (optimized, ~18KB, required=[presentation: ?column?:7])
+memo (optimized, ~19KB, required=[presentation: ?column?:7])
  ├── G1: (union-all G2 G3)
  │    └── [presentation: ?column?:7]
  │         ├── best: (union-all G2 G3)
@@ -5114,12 +5470,12 @@ memo (optimized, ~18KB, required=[presentation: ?column?:7])
  │    └── []
  │         ├── best: (project G6 G5)
  │         └── cost: 0.34
- ├── G4: (inner-join G7 G8 G9) (inner-join G8 G7 G9)
+ ├── G4: (inner-join G7 G8 G9) (inner-join G7 G8 G9) (inner-join G8 G7 G9)
  │    └── []
  │         ├── best: (inner-join G8 G7 G9)
  │         └── cost: 0.21
  ├── G5: (projections G10)
- ├── G6: (inner-join G11 G12 G9) (inner-join G12 G11 G9)
+ ├── G6: (inner-join G11 G12 G9) (inner-join G11 G12 G9) (inner-join G12 G11 G9)
  │    └── []
  │         ├── best: (inner-join G11 G12 G9)
  │         └── cost: 0.21

--- a/pkg/sql/opt/xform/testdata/rules/join_order
+++ b/pkg/sql/opt/xform/testdata/rules/join_order
@@ -132,7 +132,23 @@ Source expression:
    └── filters
         └── abc.b = bx.b
 
-New expression 1 of 1:
+New expression 1 of 2:
+  inner-join (hash)
+   ├── scan bx
+   ├── inner-join (hash)
+   │    ├── scan cy
+   │    ├── inner-join (hash)
+   │    │    ├── scan dz
+   │    │    ├── scan abc
+   │    │    │    └── constraint: /10: [/1 - /1]
+   │    │    └── filters
+   │    │         └── dz.d = abc.c
+   │    └── filters
+   │         └── cy.c = dz.d
+   └── filters
+        └── abc.b = bx.b
+
+New expression 2 of 2:
   inner-join (hash)
    ├── scan bx
    ├── inner-join (hash)
@@ -166,7 +182,22 @@ Source expression:
    └── filters
         └── abc.b = bx.b
 
-New expression 1 of 3:
+New expression 1 of 4:
+  inner-join (hash)
+   ├── scan bx
+   ├── inner-join (hash)
+   │    ├── scan cy
+   │    ├── inner-join (lookup dz)
+   │    │    ├── lookup columns are key
+   │    │    ├── scan abc
+   │    │    │    └── constraint: /10: [/1 - /1]
+   │    │    └── filters (true)
+   │    └── filters
+   │         └── cy.c = dz.d
+   └── filters
+        └── abc.b = bx.b
+
+New expression 2 of 4:
   inner-join (hash)
    ├── scan bx
    ├── inner-join (hash)
@@ -181,7 +212,7 @@ New expression 1 of 3:
    └── filters
         └── abc.b = bx.b
 
-New expression 2 of 3:
+New expression 3 of 4:
   inner-join (hash)
    ├── scan bx
    ├── inner-join (hash)
@@ -197,7 +228,7 @@ New expression 2 of 3:
    └── filters
         └── abc.b = bx.b
 
-New expression 3 of 3:
+New expression 4 of 4:
   inner-join (hash)
    ├── scan bx
    ├── inner-join (hash)
@@ -230,7 +261,21 @@ Source expression:
    └── filters
         └── abc.b = bx.b
 
-New expression 1 of 3:
+New expression 1 of 4:
+  inner-join (hash)
+   ├── scan bx
+   ├── inner-join (lookup cy)
+   │    ├── lookup columns are key
+   │    ├── inner-join (lookup dz)
+   │    │    ├── lookup columns are key
+   │    │    ├── scan abc
+   │    │    │    └── constraint: /10: [/1 - /1]
+   │    │    └── filters (true)
+   │    └── filters (true)
+   └── filters
+        └── abc.b = bx.b
+
+New expression 2 of 4:
   inner-join (hash)
    ├── inner-join (lookup cy)
    │    ├── lookup columns are key
@@ -244,7 +289,7 @@ New expression 1 of 3:
    └── filters
         └── abc.b = bx.b
 
-New expression 2 of 3:
+New expression 3 of 4:
   inner-join (hash)
    ├── scan cy
    ├── inner-join (hash)
@@ -259,7 +304,7 @@ New expression 2 of 3:
    └── filters
         └── cy.c = dz.d
 
-New expression 3 of 3:
+New expression 4 of 4:
   inner-join (hash)
    ├── inner-join (hash)
    │    ├── scan bx
@@ -333,8 +378,8 @@ memo (optimized, ~23KB, required=[presentation: b:1,x:2,c:4,y:5,a:7,b:8,c:9,d:10
 memo join-limit=2
 SELECT * FROM bx, cy, abc WHERE a = 1 AND abc.b = bx.b AND abc.c = cy.c
 ----
-memo (optimized, ~35KB, required=[presentation: b:1,x:2,c:4,y:5,a:7,b:8,c:9,d:10])
- ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (inner-join G5 G6 G7) (inner-join G6 G5 G7) (merge-join G2 G3 G8 inner-join,+1,+8) (lookup-join G3 G8 bx,keyCols=[8],outCols=(1,2,4,5,7-10)) (merge-join G5 G6 G8 inner-join,+4,+9) (lookup-join G6 G8 cy,keyCols=[9],outCols=(1,2,4,5,7-10))
+memo (optimized, ~40KB, required=[presentation: b:1,x:2,c:4,y:5,a:7,b:8,c:9,d:10])
+ ├── G1: (inner-join G2 G3 G4) (inner-join G2 G3 G4) (inner-join G3 G2 G4) (inner-join G5 G6 G7) (inner-join G6 G5 G7) (merge-join G2 G3 G8 inner-join,+1,+8) (merge-join G2 G3 G8 inner-join,+1,+8) (lookup-join G3 G8 bx,keyCols=[8],outCols=(1,2,4,5,7-10)) (merge-join G5 G6 G8 inner-join,+4,+9) (lookup-join G6 G8 cy,keyCols=[9],outCols=(1,2,4,5,7-10))
  │    └── [presentation: b:1,x:2,c:4,y:5,a:7,b:8,c:9,d:10]
  │         ├── best: (lookup-join G3 G8 bx,keyCols=[8],outCols=(1,2,4,5,7-10))
  │         └── cost: 17.13
@@ -345,11 +390,11 @@ memo (optimized, ~35KB, required=[presentation: b:1,x:2,c:4,y:5,a:7,b:8,c:9,d:10
  │    └── []
  │         ├── best: (scan bx,cols=(1,2))
  │         └── cost: 1044.02
- ├── G3: (inner-join G5 G9 G7) (inner-join G9 G5 G7) (merge-join G5 G9 G8 inner-join,+4,+9) (lookup-join G10 G7 abc,keyCols=[12],outCols=(4,5,7-10)) (lookup-join G9 G8 cy,keyCols=[9],outCols=(4,5,7-10))
+ ├── G3: (inner-join G5 G9 G7) (inner-join G5 G9 G7) (inner-join G9 G5 G7) (merge-join G5 G9 G8 inner-join,+4,+9) (lookup-join G10 G7 abc,keyCols=[12],outCols=(4,5,7-10)) (merge-join G5 G9 G8 inner-join,+4,+9) (lookup-join G11 G7 abc,keyCols=[13],outCols=(4,5,7-10)) (lookup-join G9 G8 cy,keyCols=[9],outCols=(4,5,7-10))
  │    └── []
  │         ├── best: (lookup-join G9 G8 cy,keyCols=[9],outCols=(4,5,7-10))
  │         └── cost: 11.13
- ├── G4: (filters G11)
+ ├── G4: (filters G12)
  ├── G5: (scan cy,cols=(4,5))
  │    ├── [ordering: +4]
  │    │    ├── best: (scan cy,cols=(4,5))
@@ -357,39 +402,43 @@ memo (optimized, ~35KB, required=[presentation: b:1,x:2,c:4,y:5,a:7,b:8,c:9,d:10
  │    └── []
  │         ├── best: (scan cy,cols=(4,5))
  │         └── cost: 1044.02
- ├── G6: (inner-join G2 G9 G4) (inner-join G9 G2 G4) (merge-join G2 G9 G8 inner-join,+1,+8) (lookup-join G12 G4 abc,keyCols=[13],outCols=(1,2,7-10)) (lookup-join G9 G8 bx,keyCols=[8],outCols=(1,2,7-10))
+ ├── G6: (inner-join G2 G9 G4) (inner-join G9 G2 G4) (merge-join G2 G9 G8 inner-join,+1,+8) (lookup-join G13 G4 abc,keyCols=[14],outCols=(1,2,7-10)) (lookup-join G9 G8 bx,keyCols=[8],outCols=(1,2,7-10))
  │    └── []
  │         ├── best: (lookup-join G9 G8 bx,keyCols=[8],outCols=(1,2,7-10))
  │         └── cost: 11.13
- ├── G7: (filters G13)
+ ├── G7: (filters G14)
  ├── G8: (filters)
- ├── G9: (select G14 G15) (scan abc,cols=(7-10),constrained)
+ ├── G9: (select G15 G16) (scan abc,cols=(7-10),constrained)
  │    └── []
  │         ├── best: (scan abc,cols=(7-10),constrained)
  │         └── cost: 5.09
- ├── G10: (project G5 G16 c y)
+ ├── G10: (project G5 G17 c y)
  │    └── []
- │         ├── best: (project G5 G16 c y)
+ │         ├── best: (project G5 G17 c y)
  │         └── cost: 1064.03
- ├── G11: (eq G17 G18)
- ├── G12: (project G2 G16 b x)
+ ├── G11: (project G5 G17 c y)
  │    └── []
- │         ├── best: (project G2 G16 b x)
+ │         ├── best: (project G5 G17 c y)
  │         └── cost: 1064.03
- ├── G13: (eq G19 G20)
- ├── G14: (scan abc,cols=(7-10))
+ ├── G12: (eq G18 G19)
+ ├── G13: (project G2 G17 b x)
+ │    └── []
+ │         ├── best: (project G2 G17 b x)
+ │         └── cost: 1064.03
+ ├── G14: (eq G20 G21)
+ ├── G15: (scan abc,cols=(7-10))
  │    └── []
  │         ├── best: (scan abc,cols=(7-10))
  │         └── cost: 1084.02
- ├── G15: (filters G21)
- ├── G16: (projections G22)
- ├── G17: (variable abc.b)
- ├── G18: (variable bx.b)
- ├── G19: (variable abc.c)
- ├── G20: (variable cy.c)
- ├── G21: (eq G23 G22)
- ├── G22: (const 1)
- └── G23: (variable a)
+ ├── G16: (filters G22)
+ ├── G17: (projections G23)
+ ├── G18: (variable abc.b)
+ ├── G19: (variable bx.b)
+ ├── G20: (variable abc.c)
+ ├── G21: (variable cy.c)
+ ├── G22: (eq G24 G23)
+ ├── G23: (const 1)
+ └── G24: (variable a)
 
 opt join-limit=3 expect=ReorderJoins
 SELECT * FROM bx, cy, dz, abc WHERE a = 1
@@ -570,8 +619,8 @@ memo (optimized, ~24KB, required=[presentation: b:1,x:2,c:4,y:5,d:7,z:8,a:10,b:1
 memo join-limit=3
 SELECT * FROM bx, cy, dz, abc WHERE x = y AND y = z AND z = a
 ----
-memo (optimized, ~51KB, required=[presentation: b:1,x:2,c:4,y:5,d:7,z:8,a:10,b:11,c:12,d:13])
- ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (inner-join G5 G6 G7) (inner-join G6 G5 G7) (inner-join G8 G9 G7) (inner-join G9 G8 G7) (inner-join G10 G11 G12) (inner-join G11 G10 G12) (inner-join G13 G14 G12) (inner-join G14 G13 G12) (inner-join G15 G16 G12) (inner-join G16 G15 G12) (inner-join G17 G18 G12) (inner-join G18 G17 G12) (merge-join G11 G10 G19 inner-join,+10,+8) (merge-join G14 G13 G19 inner-join,+10,+8) (merge-join G16 G15 G19 inner-join,+10,+8) (lookup-join G17 G19 abc,keyCols=[8],outCols=(1,2,4,5,7,8,10-13)) (merge-join G18 G17 G19 inner-join,+10,+8)
+memo (optimized, ~53KB, required=[presentation: b:1,x:2,c:4,y:5,d:7,z:8,a:10,b:11,c:12,d:13])
+ ├── G1: (inner-join G2 G3 G4) (inner-join G2 G3 G4) (inner-join G3 G2 G4) (inner-join G5 G6 G7) (inner-join G6 G5 G7) (inner-join G8 G9 G7) (inner-join G9 G8 G7) (inner-join G10 G11 G12) (inner-join G11 G10 G12) (inner-join G13 G14 G12) (inner-join G14 G13 G12) (inner-join G15 G16 G12) (inner-join G16 G15 G12) (inner-join G17 G18 G12) (inner-join G18 G17 G12) (merge-join G11 G10 G19 inner-join,+10,+8) (merge-join G14 G13 G19 inner-join,+10,+8) (merge-join G16 G15 G19 inner-join,+10,+8) (lookup-join G17 G19 abc,keyCols=[8],outCols=(1,2,4,5,7,8,10-13)) (merge-join G18 G17 G19 inner-join,+10,+8)
  │    └── [presentation: b:1,x:2,c:4,y:5,d:7,z:8,a:10,b:11,c:12,d:13]
  │         ├── best: (inner-join G3 G2 G4)
  │         └── cost: 5494.19
@@ -582,7 +631,7 @@ memo (optimized, ~51KB, required=[presentation: b:1,x:2,c:4,y:5,d:7,z:8,a:10,b:1
  │    └── []
  │         ├── best: (scan bx,cols=(1,2))
  │         └── cost: 1044.02
- ├── G3: (inner-join G5 G9 G7) (inner-join G9 G5 G7) (inner-join G10 G14 G12) (inner-join G14 G10 G12) (inner-join G15 G18 G12) (inner-join G18 G15 G12) (merge-join G14 G10 G19 inner-join,+10,+8) (lookup-join G15 G19 abc,keyCols=[8],outCols=(4,5,7,8,10-13)) (merge-join G18 G15 G19 inner-join,+10,+8)
+ ├── G3: (inner-join G5 G9 G7) (inner-join G5 G9 G7) (inner-join G9 G5 G7) (inner-join G10 G14 G12) (inner-join G14 G10 G12) (inner-join G15 G18 G12) (inner-join G18 G15 G12) (merge-join G14 G10 G19 inner-join,+10,+8) (lookup-join G15 G19 abc,keyCols=[8],outCols=(4,5,7,8,10-13)) (merge-join G18 G15 G19 inner-join,+10,+8)
  │    └── []
  │         ├── best: (inner-join G5 G9 G7)
  │         └── cost: 3339.84
@@ -606,7 +655,7 @@ memo (optimized, ~51KB, required=[presentation: b:1,x:2,c:4,y:5,d:7,z:8,a:10,b:1
  │    └── []
  │         ├── best: (inner-join G2 G5 G4)
  │         └── cost: 2216.07
- ├── G9: (inner-join G10 G18 G12) (inner-join G18 G10 G12) (lookup-join G10 G19 abc,keyCols=[8],outCols=(7,8,10-13)) (merge-join G18 G10 G19 inner-join,+10,+8)
+ ├── G9: (inner-join G10 G18 G12) (inner-join G10 G18 G12) (inner-join G18 G10 G12) (lookup-join G10 G19 abc,keyCols=[8],outCols=(7,8,10-13)) (lookup-join G10 G19 abc,keyCols=[8],outCols=(7,8,10-13)) (merge-join G18 G10 G19 inner-join,+10,+8)
  │    └── []
  │         ├── best: (inner-join G10 G18 G12)
  │         └── cost: 2167.96
@@ -1927,65 +1976,6 @@ ABC D    refs [AD] [left]
 
 Joins Considered: 12
 --------------------------------------------------------------------------------
-----Join Tree #5----
-inner-join (hash)
- ├── anti-join (hash)
- │    ├── left-join (hash)
- │    │    ├── scan bx
- │    │    ├── scan cy
- │    │    └── filters
- │    │         └── bx.b = cy.c
- │    ├── scan abc
- │    └── filters
- │         └── bx.b = a
- ├── scan dz
- └── filters
-      └── bx.b = dz.d
-
-----Vertexes----
-A:
-scan bx
-
-D:
-scan cy
-
-B:
-scan abc
-
-C:
-scan dz
-
-----Edges----
-bx.b = cy.c [left]
-bx.b = a [anti]
-bx.b = dz.d [inner]
-
-----Joining AD----
-A D    refs [AD] [left]
-----Joining AB----
-A B    refs [AB] [anti]
-----Joining ADB----
-AB D    refs [AD] [left]
-AD B    refs [AB] [anti]
-----Joining AC----
-A C    refs [AC] [inner]
-C A    refs [AC] [inner]
-----Joining ADC----
-AC D    refs [AD] [left]
-AD C    refs [AC] [inner]
-C AD    refs [AC] [inner]
-----Joining ABC----
-AC B    refs [AB] [anti]
-AB C    refs [AC] [inner]
-C AB    refs [AC] [inner]
-----Joining ADBC----
-ABC D    refs [AD] [left]
-ADC B    refs [AB] [anti]
-ADB C    refs [AC] [inner]
-C ADB    refs [AC] [inner]
-
-Joins Considered: 16
---------------------------------------------------------------------------------
 ----Final Plan----
 semi-join (lookup dz)
  ├── lookup columns are key
@@ -2256,47 +2246,6 @@ Joins Considered: 6
 inner-join (hash)
  ├── inner-join (hash)
  │    ├── scan a1
- │    ├── scan a2
- │    └── filters
- │         └── a1.a = a2.a
- ├── distinct-on
- │    └── scan a5
- └── filters
-      └── a2.c = a5.c
-
-----Vertexes----
-C:
-scan a1
-
-A:
-scan a2
-
-B:
-distinct-on
- └── scan a5
-
-----Edges----
-a1.a = a2.a [inner]
-a2.c = a5.c [inner]
-
-----Joining CA----
-C A    refs [CA] [inner]
-A C    refs [CA] [inner]
-----Joining AB----
-A B    refs [AB] [inner]
-B A    refs [AB] [inner]
-----Joining CAB----
-C AB    refs [CA] [inner]
-AB C    refs [CA] [inner]
-CA B    refs [AB] [inner]
-B CA    refs [AB] [inner]
-
-Joins Considered: 8
---------------------------------------------------------------------------------
-----Join Tree #5----
-inner-join (hash)
- ├── inner-join (hash)
- │    ├── scan a1
  │    ├── semi-join (hash)
  │    │    ├── scan a2
  │    │    ├── scan a5
@@ -2340,7 +2289,7 @@ D CA    refs [AD] [inner]
 
 Joins Considered: 8
 --------------------------------------------------------------------------------
-----Join Tree #6----
+----Join Tree #5----
 inner-join (hash)
  ├── inner-join (hash)
  │    ├── inner-join (hash)
@@ -2413,6 +2362,274 @@ inner-join (hash)
  │    └── filters (true)
  └── filters
       └── a2.b = a3.b
+--------------------------------------------------------------------------------
+----
+----
+
+# Regression test for #59076. Do not reorder on the inner join produced by
+# CommuteSemiJoin when it matches on an already-reordered semi join. The
+# following test output should only have 6 join trees.
+reorderjoins format=hide-all
+SELECT * FROM cy
+WHERE EXISTS (SELECT 1 FROM dz WHERE z = y)
+AND EXISTS (SELECT 1 FROM bx WHERE x = y)
+AND EXISTS (SELECT 1 FROM abc WHERE a = y)
+----
+----
+--------------------------------------------------------------------------------
+----Join Tree #1----
+semi-join (hash)
+ ├── scan cy
+ ├── scan abc
+ └── filters
+      └── a = y
+
+----Vertexes----
+A:
+scan cy
+
+B:
+scan abc
+
+----Edges----
+a = y [semi]
+
+----Joining AB----
+A B    refs [AB] [semi]
+
+Joins Considered: 1
+--------------------------------------------------------------------------------
+----Join Tree #2----
+inner-join (hash)
+ ├── scan cy
+ ├── scan abc
+ └── filters
+      └── a = y
+
+----Vertexes----
+A:
+scan cy
+
+B:
+scan abc
+
+----Edges----
+a = y [inner]
+
+----Joining AB----
+A B    refs [AB] [inner]
+B A    refs [AB] [inner]
+
+Joins Considered: 2
+--------------------------------------------------------------------------------
+----Join Tree #3----
+semi-join (hash)
+ ├── semi-join (hash)
+ │    ├── scan cy
+ │    ├── scan abc
+ │    └── filters
+ │         └── a = y
+ ├── scan bx
+ └── filters
+      └── x = y
+
+----Vertexes----
+A:
+scan cy
+
+B:
+scan abc
+
+C:
+scan bx
+
+----Edges----
+a = y [semi]
+x = y [semi]
+
+----Joining AB----
+A B    refs [AB] [semi]
+----Joining AC----
+A C    refs [AC] [semi]
+----Joining ABC----
+AC B    refs [AB] [semi]
+AB C    refs [AC] [semi]
+
+Joins Considered: 4
+--------------------------------------------------------------------------------
+----Join Tree #4----
+inner-join (hash)
+ ├── semi-join (hash)
+ │    ├── scan cy
+ │    ├── scan abc
+ │    └── filters
+ │         └── a = y
+ ├── distinct-on
+ │    └── scan bx
+ └── filters
+      └── x = y
+
+----Vertexes----
+A:
+scan cy
+
+B:
+scan abc
+
+C:
+distinct-on
+ └── scan bx
+
+----Edges----
+a = y [semi]
+x = y [inner]
+
+----Joining AB----
+A B    refs [AB] [semi]
+----Joining AC----
+A C    refs [AC] [inner]
+C A    refs [AC] [inner]
+----Joining ABC----
+AC B    refs [AB] [semi]
+AB C    refs [AC] [inner]
+C AB    refs [AC] [inner]
+
+Joins Considered: 6
+--------------------------------------------------------------------------------
+----Join Tree #5----
+semi-join (hash)
+ ├── semi-join (hash)
+ │    ├── semi-join (hash)
+ │    │    ├── scan cy
+ │    │    ├── scan abc
+ │    │    └── filters
+ │    │         └── a = y
+ │    ├── scan bx
+ │    └── filters
+ │         └── x = y
+ ├── scan dz
+ └── filters
+      └── z = y
+
+----Vertexes----
+A:
+scan cy
+
+B:
+scan abc
+
+C:
+scan bx
+
+D:
+scan dz
+
+----Edges----
+a = y [semi]
+x = y [semi]
+z = y [semi]
+
+----Joining AB----
+A B    refs [AB] [semi]
+----Joining AC----
+A C    refs [AC] [semi]
+----Joining ABC----
+AC B    refs [AB] [semi]
+AB C    refs [AC] [semi]
+----Joining AD----
+A D    refs [AD] [semi]
+----Joining ABD----
+AD B    refs [AB] [semi]
+AB D    refs [AD] [semi]
+----Joining ACD----
+AD C    refs [AC] [semi]
+AC D    refs [AD] [semi]
+----Joining ABCD----
+ACD B    refs [AB] [semi]
+ABD C    refs [AC] [semi]
+ABC D    refs [AD] [semi]
+
+Joins Considered: 12
+--------------------------------------------------------------------------------
+----Join Tree #6----
+inner-join (hash)
+ ├── semi-join (hash)
+ │    ├── semi-join (hash)
+ │    │    ├── scan cy
+ │    │    ├── scan abc
+ │    │    └── filters
+ │    │         └── a = y
+ │    ├── scan bx
+ │    └── filters
+ │         └── x = y
+ ├── distinct-on
+ │    └── scan dz
+ └── filters
+      └── z = y
+
+----Vertexes----
+A:
+scan cy
+
+B:
+scan abc
+
+C:
+scan bx
+
+D:
+distinct-on
+ └── scan dz
+
+----Edges----
+a = y [semi]
+x = y [semi]
+z = y [inner]
+
+----Joining AB----
+A B    refs [AB] [semi]
+----Joining AC----
+A C    refs [AC] [semi]
+----Joining ABC----
+AC B    refs [AB] [semi]
+AB C    refs [AC] [semi]
+----Joining AD----
+A D    refs [AD] [inner]
+D A    refs [AD] [inner]
+----Joining ABD----
+AD B    refs [AB] [semi]
+AB D    refs [AD] [inner]
+D AB    refs [AD] [inner]
+----Joining ACD----
+AD C    refs [AC] [semi]
+AC D    refs [AD] [inner]
+D AC    refs [AD] [inner]
+----Joining ABCD----
+ACD B    refs [AB] [semi]
+ABD C    refs [AC] [semi]
+ABC D    refs [AD] [inner]
+D ABC    refs [AD] [inner]
+
+Joins Considered: 16
+--------------------------------------------------------------------------------
+----Final Plan----
+project
+ └── semi-join (hash)
+      ├── project
+      │    └── inner-join (hash)
+      │         ├── inner-join (hash)
+      │         │    ├── scan cy
+      │         │    ├── distinct-on
+      │         │    │    └── scan dz
+      │         │    └── filters
+      │         │         └── z = y
+      │         ├── distinct-on
+      │         │    └── scan bx
+      │         └── filters
+      │              └── x = y
+      ├── scan abc
+      └── filters
+           └── a = y
 --------------------------------------------------------------------------------
 ----
 ----

--- a/pkg/sql/opt/xform/testdata/rules/stats
+++ b/pkg/sql/opt/xform/testdata/rules/stats
@@ -14,9 +14,9 @@ Top normalization rules:
   EliminateProject   applied 1 times.
   PruneJoinLeftCols  applied 1 times.
   PruneJoinRightCols applied 1 times.
-Exploration rules applied 7 times, added 5 expressions.
+Exploration rules applied 9 times, added 8 expressions.
 Top exploration rules:
-  GenerateMergeJoins  applied 2 times, added 2 expressions.
-  GenerateLookupJoins applied 2 times, added 2 expressions.
+  GenerateMergeJoins  applied 3 times, added 3 expressions.
+  GenerateLookupJoins applied 3 times, added 3 expressions.
   GenerateIndexScans  applied 2 times, added 0 expressions.
-  ReorderJoins        applied 1 times, added 1 expressions.
+  ReorderJoins        applied 1 times, added 2 expressions.


### PR DESCRIPTION
Backport 1/1 commits from #59128.

/cc @cockroachdb/release

---

Previously, a join tree with multiple `semi-join`s could cause an
exponential blowup during optimization due to interaction between
`CommuteSemiJoin` and `ReorderJoins`. Consider the following query:
```
SELECT * FROM xy
WHERE EXISTS (SELECT 1 FROM ab WHERE b = y)
AND EXISTS (SELECT 1 FROM ab WHERE b = y)
AND EXISTS (SELECT 1 FROM ab WHERE b = y);
```
Each `semi-join` in this join tree will be reordered, producing multiple
alternate join trees each with alternate `semi-joins`. At each step, the
new `semi-join`s are added to the group of the original. Since `ReorderJoins`
only matches the first expression of a group, it will not rematch on the
new `semi-joins`.

This is where `CommuteSemiJoin` becomes relevant. `CommuteSemiJoin` matches
every `semi-join` in the memo, and produces a new join group. `ReorderJoins`
then matches this new join group, and reorders it. In a tree with multiple
`semi-join`s, the inputs of such a group may include still more `semi-join`s,
each of which will itself engage in this cycle. So, the result is an
exponential blowup of memo expressions that may occur when a join tree has
multiple `semi-join`s.

This patch modifies `JoinOrderBuilder` to keep track of expressions which were
constructed as a result of reordering. The `alreadyOrdered` map is used to
prevent `ReorderJoins` from matching on these expressions.

Note that exploration rules which replace a join with a new join group (rather
than adding to the existing one) must use the `PreventReordering` method as
`CommuteSemiJoin` now does. This will prevent exponential blowups due to
interaction between the rule and `ReorderJoins`.

Release note: None

Fixes #59076
