### PR TITLE
kvserver: remove mtc from client_replica_test

### DIFF
--- a/pkg/kv/kvserver/client_test.go
+++ b/pkg/kv/kvserver/client_test.go
@@ -1187,17 +1187,6 @@ func (m *multiTestContext) findStartKeyLocked(rangeID roachpb.RangeID) roachpb.R
 	return nil // unreached, but the compiler can't tell.
 }
 
-// restart stops and restarts all stores but leaves the engines intact,
-// so the stores should contain the same persistent storage as before.
-func (m *multiTestContext) restart() {
-	for i := range m.stores {
-		m.stopStore(i)
-	}
-	for i := range m.stores {
-		m.restartStore(i)
-	}
-}
-
 // changeReplicas performs a ChangeReplicas operation, retrying until the
 // destination store has been addded or removed. Returns the range's
 // NextReplicaID, which is the ID of the newly-added replica if this is an add.

--- a/pkg/util/hlc/hlc_test.go
+++ b/pkg/util/hlc/hlc_test.go
@@ -377,6 +377,23 @@ func TestHybridManualClock(t *testing.T) {
 	require.LessOrEqual(t, UnixNano()+10, c.Now().WallTime)
 }
 
+// TestHybridManualClockPause test the Pause() functionality of the
+// HybridManualClock.
+func TestHybridManualClockPause(t *testing.T) {
+	m := NewHybridManualClock()
+	c := NewClock(m.UnixNano, time.Nanosecond)
+	now := c.Now().WallTime
+	time.Sleep(10 * time.Millisecond)
+	require.Less(t, now, c.Now().WallTime)
+	m.Pause()
+	now = c.Now().WallTime
+	require.Equal(t, now, c.Now().WallTime)
+	time.Sleep(10 * time.Millisecond)
+	require.Equal(t, now, c.Now().WallTime)
+	m.Increment(10)
+	require.Equal(t, now+10, c.Now().WallTime)
+}
+
 func TestHLCMonotonicityCheck(t *testing.T) {
 	m := NewManualClock(100000)
 	c := NewClock(m.UnixNano, 100*time.Nanosecond)


### PR DESCRIPTION
Makes progress on #8299

This commit removes the use of multiTestContect from client_replica_test
and replaces it with testcluster.TestCluster and server.TestServer. This
one change of many to completely remove multiTestContext from CRDB.

To replace these tests we introduce a new function on hlc.HybridManualClock
to pause the clock. This allows the test to conduct specific time based
measurements, which are otherwise tricky to do when the time is moving.

Release note: None