### PR TITLE
sql: audit all usages of Query to use iterator pattern

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -958,7 +958,7 @@ func backupPlanHook(
 
 			// Include all tenants.
 			// TODO(tbg): make conditional on cluster setting.
-			tenantRows, err = p.ExecCfg().InternalExecutor.Query(
+			tenantRows, err = p.ExecCfg().InternalExecutor.QueryBuffered(
 				ctx, "backup-lookup-tenant", p.ExtendedEvalContext().Txn,
 				`SELECT id, active, info FROM system.tenants`,
 			)

--- a/pkg/jobs/deprecated.go
+++ b/pkg/jobs/deprecated.go
@@ -65,21 +65,10 @@ func (r *Registry) deprecatedMaybeAdoptJob(
 SELECT id, payload, progress IS NULL, status
 FROM system.jobs
 WHERE status IN ($1, $2, $3, $4, $5) ORDER BY created DESC`
-	it, err := r.ex.QueryIterator(
+	rows, err := r.ex.QueryBuffered(
 		ctx, "adopt-job", nil /* txn */, stmt,
 		StatusPending, StatusRunning, StatusCancelRequested, StatusPauseRequested, StatusReverting,
 	)
-	if err != nil {
-		return errors.Wrap(err, "failed querying for jobs")
-	}
-
-	// TODO(yuzefovich): use QueryBuffered method once it is added to
-	// sqlutil.InternalExecutor interface.
-	var rows []tree.Datums
-	var ok bool
-	for ok, err = it.Next(ctx); ok; ok, err = it.Next(ctx) {
-		rows = append(rows, it.Cur())
-	}
 	if err != nil {
 		return errors.Wrap(err, "failed querying for jobs")
 	}

--- a/pkg/jobs/job_scheduler.go
+++ b/pkg/jobs/job_scheduler.go
@@ -295,12 +295,7 @@ func (s *jobScheduler) executeSchedules(
 
 	// We have to make sure to close the iterator since we might return from the
 	// for loop early (before Next() returns false).
-	defer func() {
-		closeErr := it.Close()
-		if retErr == nil {
-			retErr = closeErr
-		}
-	}()
+	defer func() { retErr = errors.CombineErrors(retErr, it.Close()) }()
 
 	// The loop below might encounter an error after some schedules have been
 	// executed (i.e. previous iterations succeeded), and this is ok.

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -919,12 +919,7 @@ func (r *Registry) cleanupOldJobsPage(
 	}
 	// We have to make sure to close the iterator since we might return from the
 	// for loop early (before Next() returns false).
-	defer func() {
-		closeErr := it.Close()
-		if retErr == nil {
-			retErr = closeErr
-		}
-	}()
+	defer func() { retErr = errors.CombineErrors(retErr, it.Close()) }()
 	toDelete := tree.NewDArray(types.Int)
 	oldMicros := timeutil.ToUnixMicros(olderThan)
 

--- a/pkg/kv/kvserver/protectedts/ptstorage/storage_test.go
+++ b/pkg/kv/kvserver/protectedts/ptstorage/storage_test.go
@@ -704,6 +704,12 @@ func (ie *wrappedInternalExecutor) QueryRowExWithCols(
 	panic("not implemented")
 }
 
+func (ie *wrappedInternalExecutor) QueryBuffered(
+	ctx context.Context, opName string, txn *kv.Txn, stmt string, qargs ...interface{},
+) ([]tree.Datums, error) {
+	panic("not implemented")
+}
+
 func (ie *wrappedInternalExecutor) QueryBufferedEx(
 	ctx context.Context,
 	opName string,

--- a/pkg/migration/migrationmanager/manager.go
+++ b/pkg/migration/migrationmanager/manager.go
@@ -310,17 +310,7 @@ SELECT id, status
 	if err != nil {
 		return false, 0, errors.Wrap(err, "failed to marshal version to JSON")
 	}
-	// TODO(yuzefovich): use QueryBuffered method once it is added to
-	// sqlutil.InternalExecutor interface.
-	it, err := m.ie.QueryIterator(ctx, "migration-manager-find-jobs", txn, query, jsonMsg.String())
-	if err != nil {
-		return false, 0, err
-	}
-	var rows []tree.Datums
-	var ok bool
-	for ok, err = it.Next(ctx); ok; ok, err = it.Next(ctx) {
-		rows = append(rows, it.Cur())
-	}
+	rows, err := m.ie.QueryBuffered(ctx, "migration-manager-find-jobs", txn, query, jsonMsg.String())
 	if err != nil {
 		return false, 0, err
 	}

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -2081,19 +2081,10 @@ SELECT "descID", version, expiration FROM system.public.lease AS OF SYSTEM TIME 
 		retryOptions.Closer = m.stopper.ShouldQuiesce()
 		// The retry is required because of errors caused by node restarts. Retry 30 times.
 		if err := retry.WithMaxAttempts(ctx, retryOptions, 30, func() error {
-			it, err := m.storage.internalExecutor.QueryIterator(
+			var err error
+			rows, err = m.storage.internalExecutor.QueryBuffered(
 				ctx, "read orphaned leases", nil /*txn*/, sqlQuery,
 			)
-			if err != nil {
-				return err
-			}
-			rows = rows[:0]
-			// TODO(yuzefovich): use QueryBuffered method once it is added to
-			// sqlutil.InternalExecutor interface.
-			var ok bool
-			for ok, err = it.Next(ctx); ok; ok, err = it.Next(ctx) {
-				rows = append(rows, it.Cur())
-			}
 			return err
 		}); err != nil {
 			log.Warningf(ctx, "unable to read orphaned leases: %+v", err)

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -2223,10 +2223,13 @@ FROM
 			ro.username = u.username
 			AND option = 'VALID UNTIL';
 `
-	rows, err := p.ExtendedEvalContext().ExecCfg.InternalExecutor.Query(
+	// For some reason, using the iterator API here causes privilege_builtins
+	// logic test fail in 3node-tenant config with 'txn already encountered an
+	// error' (because of the context cancellation), so we buffer all roles
+	// first.
+	rows, err := p.ExtendedEvalContext().ExecCfg.InternalExecutor.QueryBuffered(
 		ctx, "read-roles", p.txn, query,
 	)
-
 	if err != nil {
 		return err
 	}
@@ -2259,16 +2262,21 @@ FROM
 
 func forEachRoleMembership(
 	ctx context.Context, p *planner, fn func(role, member security.SQLUsername, isAdmin bool) error,
-) error {
+) (retErr error) {
 	query := `SELECT "role", "member", "isAdmin" FROM system.role_members`
-	rows, err := p.ExtendedEvalContext().ExecCfg.InternalExecutor.Query(
+	it, err := p.ExtendedEvalContext().ExecCfg.InternalExecutor.QueryIterator(
 		ctx, "read-members", p.txn, query,
 	)
 	if err != nil {
 		return err
 	}
+	// We have to make sure to close the iterator since we might return from the
+	// for loop early (before Next() returns false).
+	defer func() { retErr = errors.CombineErrors(retErr, it.Close()) }()
 
-	for _, row := range rows {
+	var ok bool
+	for ok, err = it.Next(ctx); ok; ok, err = it.Next(ctx) {
+		row := it.Cur()
 		roleName := tree.MustBeDString(row[0])
 		memberName := tree.MustBeDString(row[1])
 		isAdmin := row[2].(*tree.DBool)
@@ -2281,7 +2289,7 @@ func forEachRoleMembership(
 			return err
 		}
 	}
-	return nil
+	return err
 }
 
 func userCanSeeDescriptor(

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -361,15 +361,16 @@ func (r *rowsIterator) Types() colinfo.ResultColumns {
 	return r.resultCols
 }
 
-// Query executes the supplied SQL statement and returns the resulting rows.
-// If no user has been previously set through SetSessionData, the statement is
-// executed as the root user.
+// QueryBuffered executes the supplied SQL statement and returns the resulting
+// rows (meaning all of them are buffered at once). If no user has been
+// previously set through SetSessionData, the statement is executed as the root
+// user.
 //
 // If txn is not nil, the statement will be executed in the respective txn.
 //
-// Query is deprecated because it may transparently execute a query as root. Use
-// QueryEx instead.
-func (ie *InternalExecutor) Query(
+// QueryBuffered is deprecated because it may transparently execute a query as
+// root. Use QueryBufferedEx instead.
+func (ie *InternalExecutor) QueryBuffered(
 	ctx context.Context, opName string, txn *kv.Txn, stmt string, qargs ...interface{},
 ) ([]tree.Datums, error) {
 	return ie.QueryBufferedEx(ctx, opName, txn, ie.maybeRootSessionDataOverride(opName), stmt, qargs...)

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -1532,7 +1532,7 @@ https://www.postgresql.org/docs/9.5/catalog-pg-depend.html`,
 // as a datum row, containing object id, sub id (column id in the case of
 // columns), comment text, and comment type (keys.FooCommentType).
 func getComments(ctx context.Context, p *planner) ([]tree.Datums, error) {
-	return p.extendedEvalCtx.ExecCfg.InternalExecutor.Query(
+	return p.extendedEvalCtx.ExecCfg.InternalExecutor.QueryBuffered(
 		ctx,
 		"select-comments",
 		p.EvalContext().Txn,

--- a/pkg/sql/scrub_constraint.go
+++ b/pkg/sql/scrub_constraint.go
@@ -98,7 +98,7 @@ func (o *sqlCheckConstraintCheckOperation) Start(params runParams) error {
 		}
 	}
 
-	rows, err := params.extendedEvalCtx.ExecCfg.InternalExecutor.Query(
+	rows, err := params.extendedEvalCtx.ExecCfg.InternalExecutor.QueryBuffered(
 		ctx, "check-constraint", params.p.txn, tree.AsStringWithFlags(sel, tree.FmtParsable),
 	)
 	if err != nil {

--- a/pkg/sql/scrub_fk.go
+++ b/pkg/sql/scrub_fk.go
@@ -74,7 +74,7 @@ func (o *sqlForeignKeyCheckOperation) Start(params runParams) error {
 		return err
 	}
 
-	rows, err := params.extendedEvalCtx.ExecCfg.InternalExecutor.Query(
+	rows, err := params.extendedEvalCtx.ExecCfg.InternalExecutor.QueryBuffered(
 		ctx, "scrub-fk", params.p.txn, checkQuery,
 	)
 	if err != nil {
@@ -93,7 +93,7 @@ func (o *sqlForeignKeyCheckOperation) Start(params runParams) error {
 		if err != nil {
 			return err
 		}
-		rows, err := params.extendedEvalCtx.ExecCfg.InternalExecutor.Query(
+		rows, err := params.extendedEvalCtx.ExecCfg.InternalExecutor.QueryBuffered(
 			ctx, "scrub-fk", params.p.txn, checkNullsQuery,
 		)
 		if err != nil {

--- a/pkg/sql/scrub_index.go
+++ b/pkg/sql/scrub_index.go
@@ -123,7 +123,7 @@ func (o *indexCheckOperation) Start(params runParams) error {
 		colNames(pkColumns), colNames(otherColumns), o.tableDesc.GetID(), o.indexDesc.ID,
 	)
 
-	rows, err := params.extendedEvalCtx.ExecCfg.InternalExecutor.Query(
+	rows, err := params.extendedEvalCtx.ExecCfg.InternalExecutor.QueryBuffered(
 		ctx, "scrub-index", params.p.txn, checkQuery,
 	)
 	if err != nil {

--- a/pkg/sql/show_create_clauses.go
+++ b/pkg/sql/show_create_clauses.go
@@ -45,12 +45,14 @@ type comment struct {
 func selectComment(ctx context.Context, p PlanHookState, tableID descpb.ID) (tc *tableComments) {
 	query := fmt.Sprintf("SELECT type, object_id, sub_id, comment FROM system.comments WHERE object_id = %d", tableID)
 
-	commentRows, err := p.ExtendedEvalContext().ExecCfg.InternalExecutor.Query(
+	it, err := p.ExtendedEvalContext().ExecCfg.InternalExecutor.QueryIterator(
 		ctx, "show-tables-with-comment", p.Txn(), query)
 	if err != nil {
 		log.VEventf(ctx, 1, "%q", err)
 	} else {
-		for _, row := range commentRows {
+		var ok bool
+		for ok, err = it.Next(ctx); ok; ok, err = it.Next(ctx) {
+			row := it.Cur()
 			commentType := int(tree.MustBeDInt(row[0]))
 			switch commentType {
 			case keys.TableCommentType, keys.ColumnCommentType, keys.IndexCommentType:
@@ -70,6 +72,10 @@ func selectComment(ctx context.Context, p PlanHookState, tableID descpb.ID) (tc 
 					tc.indexes = append(tc.indexes, comment{subID, cmt})
 				}
 			}
+		}
+		if err != nil {
+			log.VEventf(ctx, 1, "%q", err)
+			tc = nil
 		}
 	}
 

--- a/pkg/sql/show_stats.go
+++ b/pkg/sql/show_stats.go
@@ -64,7 +64,9 @@ func (p *planner) ShowTableStats(ctx context.Context, n *tree.ShowTableStats) (p
 			//  - convert column IDs to column names
 			//  - if the statistic has a histogram, we return the statistic ID as a
 			//    "handle" which can be used with SHOW HISTOGRAM.
-			rows, err := p.ExtendedEvalContext().ExecCfg.InternalExecutor.Query(
+			// TODO(yuzefovich): refactor the code to use the iterator API
+			// (currently it is not possible due to a panic-catcher below).
+			rows, err := p.ExtendedEvalContext().ExecCfg.InternalExecutor.QueryBuffered(
 				ctx,
 				"read-table-stats",
 				p.txn,

--- a/pkg/sql/sqlutil/internal_executor.go
+++ b/pkg/sql/sqlutil/internal_executor.go
@@ -84,6 +84,23 @@ type InternalExecutor interface {
 		qargs ...interface{},
 	) (tree.Datums, colinfo.ResultColumns, error)
 
+	// QueryBuffered executes the supplied SQL statement and returns the
+	// resulting rows (meaning all of them are buffered at once). If no user has
+	// been previously set through SetSessionData, the statement is executed as
+	// the root user.
+	//
+	// If txn is not nil, the statement will be executed in the respective txn.
+	//
+	// QueryBuffered is deprecated because it may transparently execute a query
+	// as root. Use QueryBufferedEx instead.
+	QueryBuffered(
+		ctx context.Context,
+		opName string,
+		txn *kv.Txn,
+		stmt string,
+		qargs ...interface{},
+	) ([]tree.Datums, error)
+
 	// QueryBufferedEx executes the supplied SQL statement and returns the
 	// resulting rows (meaning all of them are buffered at once).
 	//

--- a/pkg/sql/stats/stats_cache.go
+++ b/pkg/sql/stats/stats_cache.go
@@ -490,7 +490,7 @@ func (sc *TableStatisticsCache) parseStats(
 // type that doesn't exist) and returns the rest (with no error).
 func (sc *TableStatisticsCache) getTableStatsFromDB(
 	ctx context.Context, tableID descpb.ID,
-) (_ []*TableStatistic, retErr error) {
+) ([]*TableStatistic, error) {
 	const getTableStatisticsStmt = `
 SELECT
   "tableID",


### PR DESCRIPTION
Similarly to the previous commit (dbc8676679d21d3f61568d687e74b7c83329adb2), here we audit all usages of `Query`
method of the internal executor to take advantage of the iterator API
wherever possible (or switching to `Exec` or `QueryRow`).
`QueryBuffered` has been added to the interface too.

The only place where it would be beneficial to use the iterator pattern
but it is not done currently is for `SHOW STATISTICS` statement - in
there, we have a panic-catcher which works only on the assumption of not
updating any of the shared state (which the iterator API contradicts).
Refactoring that part is left as a TODO.

Fixes: #48595.

Release justification: low-risk update to existing functionality.

Release note: None