### PR TITLE
server: wait for SQL readiness in the `/health?ready=1` probe

### DIFF
--- a/pkg/server/drain.go
+++ b/pkg/server/drain.go
@@ -188,6 +188,7 @@ func (s *Server) drainClients(ctx context.Context, reporter func(int, redact.Saf
 	// Mark the server as draining in a way that probes to
 	// /health?ready=1 will notice.
 	s.grpc.setMode(modeDraining)
+	s.sqlServer.acceptingClients.Set(false)
 	// Wait for drainUnreadyWait. This will fail load balancer checks and
 	// delay draining so that client traffic can move off this node.
 	time.Sleep(drainWait.Get(&s.st.SV))

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -2073,6 +2073,9 @@ func (s *SQLServer) startServeSQL(
 			return err
 		}
 	}
+
+	s.acceptingClients.Set(true)
+
 	return nil
 }
 

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -70,6 +70,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/netutil"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/marusama/semaphore"
@@ -111,6 +112,10 @@ type SQLServer struct {
 	// connManager is the connection manager to use to set up additional
 	// SQL listeners in AcceptClients().
 	connManager netutil.Server
+
+	// set to true when the server has started accepting client conns.
+	// Used by health checks.
+	acceptingClients syncutil.AtomicBool
 }
 
 // sqlServerOptionalKVArgs are the arguments supplied to newSQLServer which are


### PR DESCRIPTION
(smaller version than #59191) 
Fixes #58864.
Planning to backport to v20.2.

Release note (api change): the health API now checks that the SQL
server is ready to accept clients when a readiness check is requested.