### PR TITLE
sql: handle zone config in ALTER PRIMARY KEY for REGIONAL BY ROW

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
@@ -1,6 +1,6 @@
 # LogicTest: local
 
-statement error  declared partition columns \(partition_by\) do not match first 1 columns in index being partitioned \(a\)
+statement error declared partition columns \(partition_by\) do not match first 1 columns in index being partitioned \(a\)
 CREATE TABLE t (
   pk INT PRIMARY KEY,
   partition_by int,

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
@@ -73,11 +73,12 @@ LOCALITY REGIONAL BY ROW
 statement ok
 CREATE TABLE regional_by_row_table (
   pk int PRIMARY KEY,
+  pk2 int NOT NULL,
   a int NOT NULL,
   b int NOT NULL,
   INDEX (a),
   UNIQUE (b),
-  FAMILY (pk, a, b)
+  FAMILY (pk, pk2, a, b)
 ) LOCALITY REGIONAL BY ROW
 
 # TODO(#multiregion): determine how we should display the presence of a crdb_region column
@@ -88,13 +89,14 @@ SELECT create_statement FROM [SHOW CREATE TABLE regional_by_row_table]
 ----
 CREATE TABLE public.regional_by_row_table (
   pk INT8 NOT NULL,
+  pk2 INT8 NOT NULL,
   a INT8 NOT NULL,
   b INT8 NOT NULL,
   crdb_region public.crdb_internal_region NOT NULL DEFAULT gateway_region()::public.crdb_internal_region,
   CONSTRAINT "primary" PRIMARY KEY (pk ASC),
   INDEX regional_by_row_table_a_idx (a ASC),
   UNIQUE INDEX regional_by_row_table_b_key (b ASC),
-  FAMILY fam_0_pk_a_b_crdb_region (pk, a, b, crdb_region)
+  FAMILY fam_0_pk_pk2_a_b_crdb_region (pk, pk2, a, b, crdb_region)
 ) LOCALITY REGIONAL BY ROW;
 ALTER PARTITION "ap-southeast-2" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
   num_replicas = 3,
@@ -153,51 +155,51 @@ schema_name  table_name             type   owner  estimated_row_count  locality
 public       regional_by_row_table  table  root   0                    REGIONAL BY ROW
 
 query TI
-INSERT INTO regional_by_row_table (pk, a, b) VALUES
-(1, 2, 3), (4, 5, 6)
+INSERT INTO regional_by_row_table (pk, pk2, a, b) VALUES
+(1, 1, 2, 3), (4, 4, 5, 6)
 RETURNING crdb_region, pk
 ----
 ap-southeast-2  1
 ap-southeast-2  4
 
 query TI
-INSERT INTO regional_by_row_table (crdb_region, pk, a, b) VALUES
-('ca-central-1', 7, 8, 9)
+INSERT INTO regional_by_row_table (crdb_region, pk, pk2, a, b) VALUES
+('ca-central-1', 7, 7, 8, 9)
 RETURNING crdb_region, pk
 ----
 ca-central-1  7
 
 query TI nodeidx=3
-INSERT INTO multi_region_test_db.regional_by_row_table (pk, a, b) VALUES
-(10, 11, 12)
+INSERT INTO multi_region_test_db.regional_by_row_table (pk, pk2, a, b) VALUES
+(10, 10, 11, 12)
 RETURNING crdb_region, pk
 ----
 ca-central-1  10
 
 query TI nodeidx=6
-INSERT INTO multi_region_test_db.regional_by_row_table (pk, a, b) VALUES
-(20, 21, 22)
+INSERT INTO multi_region_test_db.regional_by_row_table (pk, pk2, a, b) VALUES
+(20, 20, 21, 22)
 RETURNING crdb_region, pk
 ----
 us-east-1  20
 
 query TI
-INSERT INTO regional_by_row_table (crdb_region, pk, a, b) VALUES
-(gateway_region()::crdb_internal_region, 23, 24, 25)
+INSERT INTO regional_by_row_table (crdb_region, pk, pk2, a, b) VALUES
+(gateway_region()::crdb_internal_region, 23, 23, 24, 25)
 RETURNING crdb_region, pk
 ----
 ap-southeast-2  23
 
-query TIII
-SELECT crdb_region, pk, a, b FROM regional_by_row_table
+query TIIII
+SELECT crdb_region, pk, pk2, a, b FROM regional_by_row_table
 ORDER BY pk
 ----
-ap-southeast-2  1   2   3
-ap-southeast-2  4   5   6
-ca-central-1    7   8   9
-ca-central-1    10  11  12
-us-east-1       20  21  22
-ap-southeast-2  23  24  25
+ap-southeast-2  1   1   2   3
+ap-southeast-2  4   4   5   6
+ca-central-1    7   7   8   9
+ca-central-1    10  10  11  12
+us-east-1       20  20  21  22
+ap-southeast-2  23  23  24  25
 
 # Tests creating a index and a unique constraint on a REGIONAL BY ROW table.
 statement ok
@@ -209,7 +211,7 @@ ALTER TABLE regional_by_row_table ADD CONSTRAINT unique_b_a UNIQUE(b, a)
 # We should plan uniqueness checks for all unique indexes in
 # REGIONAL BY ROW tables.
 query T
-EXPLAIN INSERT INTO regional_by_row_table VALUES (1, 1, 1)
+EXPLAIN INSERT INTO regional_by_row_table (pk, pk2, a, b) VALUES (1, 1, 1, 1)
 ----
 distribution: local
 vectorized: true
@@ -217,13 +219,13 @@ vectorized: true
 • root
 │
 ├── • insert
-│   │ into: regional_by_row_table(pk, a, b, crdb_region)
+│   │ into: regional_by_row_table(pk, pk2, a, b, crdb_region)
 │   │
 │   └── • buffer
 │       │ label: buffer 1
 │       │
 │       └── • values
-│             size: 5 columns, 1 row
+│             size: 6 columns, 1 row
 │
 ├── • constraint-check
 │   │
@@ -231,9 +233,9 @@ vectorized: true
 │       │
 │       └── • lookup join (semi)
 │           │ table: regional_by_row_table@primary
-│           │ equality: (lookup_join_const_col_@17, column1) = (crdb_region,pk)
+│           │ equality: (lookup_join_const_col_@20, column1) = (crdb_region,pk)
 │           │ equality cols are key
-│           │ pred: column10 != crdb_region
+│           │ pred: column12 != crdb_region
 │           │
 │           └── • cross join
 │               │
@@ -249,9 +251,9 @@ vectorized: true
 │       │
 │       └── • lookup join (semi)
 │           │ table: regional_by_row_table@regional_by_row_table_b_key
-│           │ equality: (lookup_join_const_col_@26, column3) = (crdb_region,b)
+│           │ equality: (lookup_join_const_col_@30, column4) = (crdb_region,b)
 │           │ equality cols are key
-│           │ pred: (column1 != pk) OR (column10 != crdb_region)
+│           │ pred: (column1 != pk) OR (column12 != crdb_region)
 │           │
 │           └── • cross join
 │               │
@@ -267,9 +269,9 @@ vectorized: true
         │
         └── • lookup join (semi)
             │ table: regional_by_row_table@new_idx
-            │ equality: (lookup_join_const_col_@36, column2, column3) = (crdb_region,a,b)
+            │ equality: (lookup_join_const_col_@41, column3, column4) = (crdb_region,a,b)
             │ equality cols are key
-            │ pred: (column1 != pk) OR (column10 != crdb_region)
+            │ pred: (column1 != pk) OR (column12 != crdb_region)
             │
             └── • cross join
                 │
@@ -280,13 +282,14 @@ vectorized: true
                       label: buffer 1
 
 statement error pq: duplicate key value violates unique constraint "regional_by_row_table_b_key"\nDETAIL: Key \(b\)=\(3\) already exists\.
-INSERT INTO regional_by_row_table (crdb_region, pk, a, b) VALUES ('us-east-1', 2, 2, 3)
+INSERT INTO regional_by_row_table (crdb_region, pk, pk2, a, b) VALUES ('us-east-1', 2, 3, 2, 3)
 
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE regional_by_row_table]
 ----
 CREATE TABLE public.regional_by_row_table (
   pk INT8 NOT NULL,
+  pk2 INT8 NOT NULL,
   a INT8 NOT NULL,
   b INT8 NOT NULL,
   crdb_region public.crdb_internal_region NOT NULL DEFAULT gateway_region()::public.crdb_internal_region,
@@ -295,7 +298,7 @@ CREATE TABLE public.regional_by_row_table (
   UNIQUE INDEX regional_by_row_table_b_key (b ASC),
   INDEX new_idx (a ASC, b ASC),
   UNIQUE INDEX unique_b_a (b ASC, a ASC),
-  FAMILY fam_0_pk_a_b_crdb_region (pk, a, b, crdb_region)
+  FAMILY fam_0_pk_pk2_a_b_crdb_region (pk, pk2, a, b, crdb_region)
 ) LOCALITY REGIONAL BY ROW;
 ALTER PARTITION "ap-southeast-2" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
   num_replicas = 3,
@@ -376,6 +379,65 @@ regional_by_row_table_b_key  crdb_region  true
 unique_b_a                   a            false
 unique_b_a                   b            false
 unique_b_a                   crdb_region  true
+
+# Tests changing the PK of a regional by row table.
+
+# Insert a row with a conflicting pk2, and check ALTER PRIMARY KEY fails.
+statement ok
+INSERT INTO regional_by_row_table (pk, pk2, a, b) VALUES (1000, 1, 1000, 2000)
+
+# TODO(#59504): we should hide crdb_region.
+statement error Key \(crdb_region,pk2\)=\('ap-southeast-2',1\) already exists.
+ALTER TABLE regional_by_row_table ALTER PRIMARY KEY USING COLUMNS (pk2)
+
+statement ok
+DELETE FROM regional_by_row_table WHERE pk = 1000
+
+statement ok
+ALTER TABLE regional_by_row_table ALTER PRIMARY KEY USING COLUMNS (pk2)
+
+# ALTER PRIMARY KEY can change the order of ALTER PARTITION, so we need to sort them.
+query T
+SELECT
+  split_part(create_statement, ';', 1)
+FROM [SHOW CREATE TABLE regional_by_row_table]
+----
+CREATE TABLE public.regional_by_row_table (
+                            pk INT8 NOT NULL,
+                            pk2 INT8 NOT NULL,
+                            a INT8 NOT NULL,
+                            b INT8 NOT NULL,
+                            crdb_region public.crdb_internal_region NOT NULL DEFAULT gateway_region()::public.crdb_internal_region,
+                            CONSTRAINT "primary" PRIMARY KEY (pk2 ASC),
+                            UNIQUE INDEX regional_by_row_table_pk_key (pk ASC),
+                            INDEX regional_by_row_table_a_idx (a ASC),
+                            UNIQUE INDEX regional_by_row_table_b_key (b ASC),
+                            INDEX new_idx (a ASC, b ASC),
+                            UNIQUE INDEX unique_b_a (b ASC, a ASC),
+                            FAMILY fam_0_pk_pk2_a_b_crdb_region (pk, pk2, a, b, crdb_region)
+) LOCALITY REGIONAL BY ROW
+
+query TT
+SHOW ZONE CONFIGURATION FOR PARTITION "ap-southeast-2" OF INDEX regional_by_row_table@primary
+----
+PARTITION "ap-southeast-2" OF INDEX regional_by_row_table@primary  ALTER PARTITION "ap-southeast-2" OF INDEX regional_by_row_table@primary CONFIGURE ZONE USING
+                                                                   range_min_bytes = 134217728,
+                                                                   range_max_bytes = 536870912,
+                                                                   gc.ttlseconds = 90000,
+                                                                   num_replicas = 3,
+                                                                   constraints = '{+region=ap-southeast-2: 1}',
+                                                                   lease_preferences = '[[+region=ap-southeast-2]]'
+
+query TT
+SHOW ZONE CONFIGURATION FOR PARTITION "ap-southeast-2" OF INDEX regional_by_row_table@unique_b_a
+----
+PARTITION "ap-southeast-2" OF INDEX regional_by_row_table@unique_b_a  ALTER PARTITION "ap-southeast-2" OF INDEX regional_by_row_table@unique_b_a CONFIGURE ZONE USING
+                                                                      range_min_bytes = 134217728,
+                                                                      range_max_bytes = 536870912,
+                                                                      gc.ttlseconds = 90000,
+                                                                      num_replicas = 3,
+                                                                      constraints = '{+region=ap-southeast-2: 1}',
+                                                                      lease_preferences = '[[+region=ap-southeast-2]]'
 
 # Tests for REGIONAL BY TABLE AS
 statement error  cannot use column crdb_region_col which has type INT8 in REGIONAL BY ROW AS\nDETAIL:\s+REGIONAL BY ROW AS must reference a column of type crdb_internal_region.


### PR DESCRIPTION
Release note (sql change): REGIONAL BY ROW tables now preserve zone
configurations when using ALTER PRIMARY KEY.

Resolves #58339 