### PR TITLE
sql: use AOST for SHOW TABLES query

### DIFF
--- a/pkg/sql/delegate/show_tables.go
+++ b/pkg/sql/delegate/show_tables.go
@@ -72,6 +72,7 @@ LEFT JOIN crdb_internal.table_row_statistics AS s ON (s.table_id = pc.oid::INT8)
 LEFT JOIN crdb_internal.tables AS ct ON (pc.oid::int8 = ct.table_id)
 WHERE pc.relkind IN ('r', 'v', 'S', 'm') %[2]s
 ORDER BY schema_name, table_name
+AS OF SYSTEM TIME -10s
 `
 	var descJoin string
 	var comment string


### PR DESCRIPTION
SHOW TABLES requires a lookup of table stats. This lookup can experience
contention with the job that writes new stats. In multi-region clusters,
the stats-writing job can take seconds, so this is likely.

In 21.1, we likely will remove the stats from the SHOW TABLES output by
default, and introduce a WITH STATISTICS modifier.

The smaller change here is meant for backporting to 20.2

touches #58189

Release note (performance improvement): The SHOW TABLES command could
experience undesirable latency due to contention when looking up table
statistics. Now the contention is reduced.