### PR TITLE
kv/kvclient/kvcoord: skip TestNoDuplicateHeartbeatLoops

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender_server_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender_server_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
@@ -142,6 +143,7 @@ func TestHeartbeatFindsOutAboutAbortedTransaction(t *testing.T) {
 // times a heartbeat loop was started.
 func TestNoDuplicateHeartbeatLoops(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 59373, "Needs rewrite - uses tracing in illegal manner")
 	defer log.Scope(t).Close(t)
 
 	s, _, db := serverutils.StartServer(t, base.TestServerArgs{})


### PR DESCRIPTION
Refs: #59373

Reason: Needs rewrite - uses tracing in illegal manner

Generated by bin/skip-test.

Release justification: non-production code changes

Release note: None