### PR TITLE
stop: ensure Closer called exactly once

### DIFF
--- a/pkg/util/stop/stopper.go
+++ b/pkg/util/stop/stopper.go
@@ -247,12 +247,11 @@ func (s *Stopper) Recover(ctx context.Context) {
 func (s *Stopper) AddCloser(c Closer) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	select {
-	case <-s.stopped:
+	if s.mu.stopCalled {
 		c.Close()
-	default:
-		s.mu.closers = append(s.mu.closers, c)
+		return
 	}
+	s.mu.closers = append(s.mu.closers, c)
 }
 
 // WithCancelOnQuiesce returns a child context which is canceled when the


### PR DESCRIPTION
Due to a bug introduced in #59041, `AddCloser` could add a closer that
would never be called in the event that the closer was concurrently
Stop'ping. This commit fixes it.

Fixes #59368.

Release note: None
