### PR TITLE
build,bazel: delete stale references breaking bazel build

### DIFF
--- a/pkg/jobs/jobspb/BUILD.bazel
+++ b/pkg/jobs/jobspb/BUILD.bazel
@@ -41,7 +41,6 @@ go_proto_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/ccl/streamingccl",  # keep
-        "//pkg/ccl/streamingccl/streamclient",  # keep
         "//pkg/roachpb",
         "//pkg/security",  # keep
         "//pkg/sql/catalog/descpb",

--- a/pkg/sql/execinfrapb/BUILD.bazel
+++ b/pkg/sql/execinfrapb/BUILD.bazel
@@ -41,7 +41,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/base",
-        "//pkg/ccl/streamingccl/streamclient",  # keep
         "//pkg/roachpb",
         "//pkg/rpc",
         "//pkg/security",


### PR DESCRIPTION
These dependencies marked `keep` aren't actually necessary any more and
now introduce cyclic dependency errors, so remove them.

Release note: None