### PR TITLE
kv/kvserver: skip TestQuotaPool

### DIFF
--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -2191,6 +2191,7 @@ func TestReplicateAddAndRemove(t *testing.T) {
 // to constantly catch up the slower node via snapshots. See #8659.
 func TestQuotaPool(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 59382, "flaky test")
 	defer log.Scope(t).Close(t)
 
 	const quota = 10000


### PR DESCRIPTION
Refs: #59382

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes

Release note: None