### PR TITLE
build,bazel: remove references to `gofmt` in bazel build

### DIFF
--- a/pkg/sql/lex/BUILD.bazel
+++ b/pkg/sql/lex/BUILD.bazel
@@ -42,7 +42,6 @@ genrule(
     outs = ["keywords.go"],
     cmd = """
         $(location //pkg/sql/lex/allkeywords) < $(location //pkg/sql/parser:sql.y) > $@
-        gofmt -s -w $@
     """,
 )
 

--- a/pkg/sql/lexbase/BUILD.bazel
+++ b/pkg/sql/lexbase/BUILD.bazel
@@ -30,6 +30,5 @@ genrule(
     outs = ["reserved_keywords.go"],
     cmd = """
           awk -f $(location //pkg/sql/parser:reserved_keywords.awk) < $(location //pkg/sql/parser:sql.y) > $@
-          gofmt -s -w $@
     """,
 )

--- a/pkg/sql/parser/BUILD.bazel
+++ b/pkg/sql/parser/BUILD.bazel
@@ -108,7 +108,6 @@ genrule(
     cmd = """
       $(location :help-gen-test) < $< >$@
       mv -f $@.tmp $@
-      gofmt -s -w $@
     """,
     tools = [
         ":help-gen-test",
@@ -125,7 +124,6 @@ genrule(
     outs = ["help_messages.go"],
     cmd = """
       awk -f $(location :help.awk) < $(location :sql.y) > $@
-      gofmt -s -w $@
     """,
 )
 


### PR DESCRIPTION
This was cargo-culted from the `Makefile`, but isn't necessary to get
the build to succeed, and interferes with hermiticity because it
requires `gofmt` to be globally installed. It's simpler to just remove
these references entirely.

Release note: None