### PR TITLE
kvserver: teach allocator to prescribe non-voter addition/removal

### DIFF
--- a/pkg/config/zonepb/zone.go
+++ b/pkg/config/zonepb/zone.go
@@ -685,6 +685,37 @@ func (z ZoneConfig) GetSubzoneForKeySuffix(keySuffix []byte) (*Subzone, int32) {
 	return nil, -1
 }
 
+// GetNumVoters returns the number of voting replicas for the given zone config.
+//
+// This method will panic if called on a ZoneConfig with an uninitialized
+// NumReplicas attribute.
+func (z *ZoneConfig) GetNumVoters() int32 {
+	if z.NumReplicas == nil {
+		panic("NumReplicas must not be nil")
+	}
+	if z.NumVoters != nil && *z.NumVoters != 0 {
+		return *z.NumVoters
+	}
+	return *z.NumReplicas
+}
+
+// GetNumNonVoters returns the number of non-voting replicas as defined in the
+// zone config.
+//
+// This method will panic if called on a ZoneConfig with an uninitialized
+// NumReplicas attribute.
+func (z *ZoneConfig) GetNumNonVoters() int32 {
+	if z.NumReplicas == nil {
+		panic("NumReplicas must not be nil")
+	}
+	if z.NumVoters != nil && *z.NumVoters != 0 {
+		return *z.NumReplicas - *z.NumVoters
+	}
+	// `num_voters` hasn't been explicitly configured. Every replica should be a
+	// voting replica.
+	return 0
+}
+
 // SetSubzone installs subzone into the ZoneConfig, overwriting any existing
 // subzone with the same IndexID and PartitionName.
 func (z *ZoneConfig) SetSubzone(subzone Subzone) {

--- a/pkg/kv/kvserver/allocator.go
+++ b/pkg/kv/kvserver/allocator.go
@@ -49,14 +49,23 @@ const (
 	minReplicaWeight = 0.001
 
 	// Priorities for various repair operations.
+	//
+	// NB: These priorities only influence the replicateQueue's understanding of
+	// which ranges are to be dealt with before others. In other words, these
+	// priorities don't influence the relative order of actions taken on a given
+	// range. Within a given range, the ordering of the various checks inside
+	// `Allocator.computeAction` determines which repair/rebalancing actions are
+	// taken before the others.
 	finalizeAtomicReplicationChangePriority    float64 = 12002
 	removeLearnerReplicaPriority               float64 = 12001
 	addDeadReplacementVoterPriority            float64 = 12000
 	addMissingVoterPriority                    float64 = 10000
 	addDecommissioningReplacementVoterPriority float64 = 5000
 	removeDeadVoterPriority                    float64 = 1000
-	removeDecommissioningVoterPriority         float64 = 200
-	removeExtraVoterPriority                   float64 = 100
+	removeDecommissioningVoterPriority         float64 = 900
+	removeExtraVoterPriority                   float64 = 800
+	addMissingNonVoterPriority                 float64 = 700
+	removeExtraNonVoterPriority                float64 = 600
 )
 
 // MinLeaseTransferStatsDuration configures the minimum amount of time a
@@ -100,7 +109,9 @@ const (
 	_ AllocatorAction = iota
 	AllocatorNoop
 	AllocatorRemoveVoter
+	AllocatorRemoveNonVoter
 	AllocatorAddVoter
+	AllocatorAddNonVoter
 	AllocatorReplaceDeadVoter
 	AllocatorRemoveDeadVoter
 	AllocatorReplaceDecommissioningVoter
@@ -114,7 +125,9 @@ const (
 var allocatorActionNames = map[AllocatorAction]string{
 	AllocatorNoop:                        "noop",
 	AllocatorRemoveVoter:                 "remove voter",
+	AllocatorRemoveNonVoter:              "remove non-voter",
 	AllocatorAddVoter:                    "add voter",
+	AllocatorAddNonVoter:                 "add non-voter",
 	AllocatorReplaceDeadVoter:            "replace dead voter",
 	AllocatorRemoveDeadVoter:             "remove dead voter",
 	AllocatorReplaceDecommissioningVoter: "replace decommissioning voter",
@@ -262,11 +275,11 @@ func MakeAllocator(
 	}
 }
 
-// GetNeededReplicas calculates the number of replicas a range should
-// have given its zone config and the number of nodes available for
-// up-replication (i.e. not dead and not decommissioning).
-func GetNeededReplicas(zoneConfigReplicaCount int32, clusterNodes int) int {
-	numZoneReplicas := int(zoneConfigReplicaCount)
+// GetNeededVoters calculates the number of voters a range should have given its
+// zone config and the number of nodes available for up-replication (i.e. not
+// decommissioning).
+func GetNeededVoters(zoneConfigVoterCount int32, clusterNodes int) int {
+	numZoneReplicas := int(zoneConfigVoterCount)
 	need := numZoneReplicas
 
 	// Adjust the replication factor for all ranges if there are fewer
@@ -296,6 +309,23 @@ func GetNeededReplicas(zoneConfigReplicaCount int32, clusterNodes int) int {
 		need = numZoneReplicas
 	}
 
+	return need
+}
+
+// GetNeededNonVoters calculates the number of non-voters a range should have
+// given the number of voting replicas the range has and the number of nodes
+// available for up-replication.
+//
+// NB: This method assumes that we have exactly as many voters as we need, since
+// this method should only be consulted after voting replicas have been
+// upreplicated / rebalanced off of dead/decommissioning nodes.
+func GetNeededNonVoters(numVoters, zoneConfigNonVoterCount, clusterNodes int) int {
+	need := zoneConfigNonVoterCount
+	if clusterNodes-numVoters < need {
+		// We only need non-voting replicas for the nodes that do not have a voting
+		// replica.
+		need = clusterNodes - numVoters
+	}
 	return need
 }
 
@@ -357,97 +387,139 @@ func (a *Allocator) ComputeAction(
 		// removeLearnerReplicaPriority as the highest priority.
 		return AllocatorRemoveLearner, removeLearnerReplicaPriority
 	}
-	// computeAction expects to operate only on voters.
-	return a.computeAction(ctx, zone, desc.Replicas().VoterDescriptors())
+	return a.computeAction(ctx, zone, desc.Replicas().VoterDescriptors(),
+		desc.Replicas().NonVoterDescriptors())
 }
 
 func (a *Allocator) computeAction(
-	ctx context.Context, zone *zonepb.ZoneConfig, voterReplicas []roachpb.ReplicaDescriptor,
+	ctx context.Context,
+	zone *zonepb.ZoneConfig,
+	voterReplicas []roachpb.ReplicaDescriptor,
+	nonVoterReplicas []roachpb.ReplicaDescriptor,
 ) (AllocatorAction, float64) {
-	have := len(voterReplicas)
-	decommissioningReplicas := a.storePool.decommissioningReplicas(voterReplicas)
+	// NB: The ordering of the checks in this method is intentional. The order in
+	// which these actions are returned by this method determines the relative
+	// priority of the actions taken on a given range. We want this to be
+	// symmetric with regards to the priorities defined at the top of this file
+	// (which influence the replicateQueue's decision of which range it'll pick to
+	// repair/rebalance before the others).
+	//
+	// In broad strokes, we first handle all voting replica-based actions and then
+	// the actions pertaining to non-voting replicas. Within each replica set, we
+	// first handle operations that correspond to repairing/recovering the range.
+	// After that we handle rebalancing related actions, followed by removal
+	// actions.
+	haveVoters := len(voterReplicas)
+	decommissioningVoters := a.storePool.decommissioningReplicas(voterReplicas)
+	// Node count including dead nodes but excluding decommissioning/decommissioned
+	// nodes.
 	clusterNodes := a.storePool.ClusterNodeCount()
-	need := GetNeededReplicas(*zone.NumReplicas, clusterNodes)
-	desiredQuorum := computeQuorum(need)
-	quorum := computeQuorum(have)
+	neededVoters := GetNeededVoters(zone.GetNumVoters(), clusterNodes)
+	desiredQuorum := computeQuorum(neededVoters)
+	quorum := computeQuorum(haveVoters)
 
-	if have < need {
-		// Range is under-replicated, and should add an additional replica.
-		// Priority is adjusted by the difference between the current replica
-		// count and the quorum of the desired replica count.
-		priority := addMissingVoterPriority + float64(desiredQuorum-have)
+	// TODO(aayush): When haveVoters < neededVoters but we don't have quorum to
+	// actually execute the addition of a new replica, we should be returning a
+	// AllocatorRangeUnavailable.
+	if haveVoters < neededVoters {
+		// Range is under-replicated, and should add an additional voter.
+		// Priority is adjusted by the difference between the current voter
+		// count and the quorum of the desired voter count.
+		priority := addMissingVoterPriority + float64(desiredQuorum-haveVoters)
 		action := AllocatorAddVoter
-		log.VEventf(ctx, 3, "%s - missing replica need=%d, have=%d, priority=%.2f",
-			action, need, have, priority)
+		log.VEventf(ctx, 3, "%s - missing voter need=%d, have=%d, priority=%.2f",
+			action, neededVoters, haveVoters, priority)
 		return action, priority
 	}
 
-	liveVoterReplicas, deadVoterReplicas := a.storePool.liveAndDeadReplicas(voterReplicas)
+	liveVoters, deadVoters := a.storePool.liveAndDeadReplicas(voterReplicas)
 
-	if len(liveVoterReplicas) < quorum {
-		// Do not take any replacement/removal action if we do not have a quorum of live
-		// replicas. If we're correctly assessing the unavailable state of the range, we
-		// also won't be able to add replicas as we try above, but hope springs eternal.
-		log.VEventf(ctx, 1, "unable to take action - live replicas %v don't meet quorum of %d",
-			liveVoterReplicas, quorum)
+	if len(liveVoters) < quorum {
+		// Do not take any replacement/removal action if we do not have a quorum of
+		// live voters. If we're correctly assessing the unavailable state of the
+		// range, we also won't be able to add replicas as we try above, but hope
+		// springs eternal.
+		log.VEventf(ctx, 1, "unable to take action - live voters %v don't meet quorum of %d",
+			liveVoters, quorum)
 		return AllocatorRangeUnavailable, 0
 	}
 
-	if have == need && len(deadVoterReplicas) > 0 {
-		// Range has dead replica(s). We should up-replicate to add another before
+	if haveVoters == neededVoters && len(deadVoters) > 0 {
+		// Range has dead voter(s). We should up-replicate to add another before
 		// before removing the dead one. This can avoid permanent data loss in cases
 		// where the node is only temporarily dead, but we remove it from the range
 		// and lose a second node before we can up-replicate (#25392).
-		// The dead replica(s) will be down-replicated later.
+		// The dead voter(s) will be down-replicated later.
 		priority := addDeadReplacementVoterPriority
 		action := AllocatorReplaceDeadVoter
-		log.VEventf(ctx, 3, "%s - replacement for %d dead replicas priority=%.2f",
-			action, len(deadVoterReplicas), priority)
+		log.VEventf(ctx, 3, "%s - replacement for %d dead voters priority=%.2f",
+			action, len(deadVoters), priority)
 		return action, priority
 	}
 
-	if have == need && len(decommissioningReplicas) > 0 {
-		// Range has decommissioning replica(s), which should be replaced.
+	if haveVoters == neededVoters && len(decommissioningVoters) > 0 {
+		// Range has decommissioning voter(s), which should be replaced.
 		priority := addDecommissioningReplacementVoterPriority
 		action := AllocatorReplaceDecommissioningVoter
-		log.VEventf(ctx, 3, "%s - replacement for %d decommissioning replicas priority=%.2f",
-			action, len(decommissioningReplicas), priority)
+		log.VEventf(ctx, 3, "%s - replacement for %d decommissioning voters priority=%.2f",
+			action, len(decommissioningVoters), priority)
 		return action, priority
 	}
 
-	// Removal actions follow.
-	// TODO(a-robinson): There's an additional case related to dead replicas that
-	// we should handle above. If there are one or more dead replicas, have <
-	// need, and there are no available stores to up-replicate to, then we should
-	// try to remove the dead replica(s) to get down to an odd number of
-	// replicas.
-	if len(deadVoterReplicas) > 0 {
+	// Voting replica removal actions follow.
+	// TODO(aayush): There's an additional case related to dead voters that we
+	// should handle above. If there are one or more dead replicas, have < need,
+	// and there are no available stores to up-replicate to, then we should try to
+	// remove the dead replica(s) to get down to an odd number of replicas.
+	if len(deadVoters) > 0 {
 		// The range has dead replicas, which should be removed immediately.
-		priority := removeDeadVoterPriority + float64(quorum-len(liveVoterReplicas))
+		priority := removeDeadVoterPriority + float64(quorum-len(liveVoters))
 		action := AllocatorRemoveDeadVoter
 		log.VEventf(ctx, 3, "%s - dead=%d, live=%d, quorum=%d, priority=%.2f",
-			action, len(deadVoterReplicas), len(liveVoterReplicas), quorum, priority)
+			action, len(deadVoters), len(liveVoters), quorum, priority)
 		return action, priority
 	}
 
-	if len(decommissioningReplicas) > 0 {
-		// Range is over-replicated, and has a decommissioning replica which
+	if len(decommissioningVoters) > 0 {
+		// Range is over-replicated, and has a decommissioning voter which
 		// should be removed.
 		priority := removeDecommissioningVoterPriority
 		action := AllocatorRemoveDecommissioningVoter
 		log.VEventf(ctx, 3,
 			"%s - need=%d, have=%d, num_decommissioning=%d, priority=%.2f",
-			action, need, have, len(decommissioningReplicas), priority)
+			action, neededVoters, haveVoters, len(decommissioningVoters), priority)
 		return action, priority
 	}
 
-	if have > need {
-		// Range is over-replicated, and should remove a replica.
-		// Ranges with an even number of replicas get extra priority because
+	if haveVoters > neededVoters {
+		// Range is over-replicated, and should remove a voter.
+		// Ranges with an even number of voters get extra priority because
 		// they have a more fragile quorum.
-		priority := removeExtraVoterPriority - float64(have%2)
+		priority := removeExtraVoterPriority - float64(haveVoters%2)
 		action := AllocatorRemoveVoter
-		log.VEventf(ctx, 3, "%s - need=%d, have=%d, priority=%.2f", action, need, have, priority)
+		log.VEventf(ctx, 3, "%s - need=%d, have=%d, priority=%.2f", action, neededVoters, haveVoters, priority)
+		return action, priority
+	}
+
+	// Non-voting replica actions follow.
+	//
+	// Non-voting replica addition.
+	haveNonVoters := len(nonVoterReplicas)
+	neededNonVoters := GetNeededNonVoters(haveVoters, int(zone.GetNumNonVoters()), clusterNodes)
+	if haveNonVoters < neededNonVoters {
+		priority := addMissingNonVoterPriority
+		action := AllocatorAddNonVoter
+		log.VEventf(ctx, 3, "%s - missing non-voter need=%d, have=%d, priority=%.2f",
+			action, neededNonVoters, haveNonVoters, priority)
+		return action, priority
+	}
+
+	// Non-voting replica removal.
+	if haveNonVoters > neededNonVoters {
+		// Like above, the range is over-replicated but should remove a non-voter.
+		priority := removeExtraNonVoterPriority
+		action := AllocatorRemoveNonVoter
+		log.VEventf(ctx, 3, "%s - need=%d, have=%d, priority=%.2f", action, neededNonVoters, haveNonVoters, priority)
 		return action, priority
 	}
 

--- a/pkg/kv/kvserver/allocator.go
+++ b/pkg/kv/kvserver/allocator.go
@@ -362,7 +362,6 @@ func (a *Allocator) ComputeAction(
 func (a *Allocator) computeAction(
 	ctx context.Context, zone *zonepb.ZoneConfig, voterReplicas []roachpb.ReplicaDescriptor,
 ) (AllocatorAction, float64) {
-	// TODO(mrtracy): Handle non-homogeneous and mismatched attribute sets.
 	have := len(voterReplicas)
 	decommissioningReplicas := a.storePool.decommissioningReplicas(voterReplicas)
 	clusterNodes := a.storePool.ClusterNodeCount()

--- a/pkg/kv/kvserver/allocator_test.go
+++ b/pkg/kv/kvserver/allocator_test.go
@@ -4265,7 +4265,7 @@ func TestAllocatorComputeAction(t *testing.T) {
 					},
 				},
 			},
-			expectedAction: AllocatorReplaceDead,
+			expectedAction: AllocatorReplaceDeadVoter,
 		},
 		// Need five replicas, one is on a dead store.
 		{
@@ -4304,7 +4304,7 @@ func TestAllocatorComputeAction(t *testing.T) {
 					},
 				},
 			},
-			expectedAction: AllocatorReplaceDead,
+			expectedAction: AllocatorReplaceDeadVoter,
 		},
 		// Need three replicas, have two.
 		{
@@ -4328,7 +4328,7 @@ func TestAllocatorComputeAction(t *testing.T) {
 					},
 				},
 			},
-			expectedAction: AllocatorAdd,
+			expectedAction: AllocatorAddVoter,
 		},
 		// Need five replicas, have four, one is on a dead store.
 		{
@@ -4362,7 +4362,7 @@ func TestAllocatorComputeAction(t *testing.T) {
 					},
 				},
 			},
-			expectedAction: AllocatorAdd,
+			expectedAction: AllocatorAddVoter,
 		},
 		// Need five replicas, have four.
 		{
@@ -4396,7 +4396,7 @@ func TestAllocatorComputeAction(t *testing.T) {
 					},
 				},
 			},
-			expectedAction: AllocatorAdd,
+			expectedAction: AllocatorAddVoter,
 		},
 		// Need three replicas, have four, one is on a dead store.
 		{
@@ -4430,7 +4430,7 @@ func TestAllocatorComputeAction(t *testing.T) {
 					},
 				},
 			},
-			expectedAction: AllocatorRemoveDead,
+			expectedAction: AllocatorRemoveDeadVoter,
 		},
 		// Need five replicas, have six, one is on a dead store.
 		{
@@ -4474,7 +4474,7 @@ func TestAllocatorComputeAction(t *testing.T) {
 					},
 				},
 			},
-			expectedAction: AllocatorRemoveDead,
+			expectedAction: AllocatorRemoveDeadVoter,
 		},
 		// Need three replicas, have five, one is on a dead store.
 		{
@@ -4513,7 +4513,7 @@ func TestAllocatorComputeAction(t *testing.T) {
 					},
 				},
 			},
-			expectedAction: AllocatorRemoveDead,
+			expectedAction: AllocatorRemoveDeadVoter,
 		},
 		// Need three replicas, have four.
 		{
@@ -4547,7 +4547,7 @@ func TestAllocatorComputeAction(t *testing.T) {
 					},
 				},
 			},
-			expectedAction: AllocatorRemove,
+			expectedAction: AllocatorRemoveVoter,
 		},
 		// Need three replicas, have five.
 		{
@@ -4586,7 +4586,7 @@ func TestAllocatorComputeAction(t *testing.T) {
 					},
 				},
 			},
-			expectedAction: AllocatorRemove,
+			expectedAction: AllocatorRemoveVoter,
 		},
 		// Need three replicas, two are on dead stores. Should
 		// be a noop because there aren't enough live replicas for
@@ -4756,14 +4756,14 @@ func TestAllocatorComputeActionRemoveDead(t *testing.T) {
 			desc:           threeReplDesc,
 			live:           []roachpb.StoreID{1, 2},
 			dead:           []roachpb.StoreID{3},
-			expectedAction: AllocatorReplaceDead,
+			expectedAction: AllocatorReplaceDeadVoter,
 		},
 		// Needs three replicas, one is dead, but there is a replacement.
 		{
 			desc:           threeReplDesc,
 			live:           []roachpb.StoreID{1, 2, 4},
 			dead:           []roachpb.StoreID{3},
-			expectedAction: AllocatorReplaceDead,
+			expectedAction: AllocatorReplaceDeadVoter,
 		},
 		// Needs three replicas, two are dead (i.e. the range lacks a quorum).
 		{
@@ -4777,7 +4777,7 @@ func TestAllocatorComputeActionRemoveDead(t *testing.T) {
 			desc:           fourReplDesc,
 			live:           []roachpb.StoreID{1, 2, 4},
 			dead:           []roachpb.StoreID{3},
-			expectedAction: AllocatorRemoveDead,
+			expectedAction: AllocatorRemoveDeadVoter,
 		},
 		// Needs three replicas, has four, two are dead (i.e. the range lacks a quorum).
 		{
@@ -4840,7 +4840,7 @@ func TestAllocatorComputeActionDecommission(t *testing.T) {
 					},
 				},
 			},
-			expectedAction:  AllocatorReplaceDecommissioning,
+			expectedAction:  AllocatorReplaceDecommissioningVoter,
 			live:            []roachpb.StoreID{1, 2},
 			dead:            nil,
 			decommissioning: []roachpb.StoreID{3},
@@ -4870,7 +4870,7 @@ func TestAllocatorComputeActionDecommission(t *testing.T) {
 					},
 				},
 			},
-			expectedAction:  AllocatorReplaceDead,
+			expectedAction:  AllocatorReplaceDeadVoter,
 			live:            []roachpb.StoreID{1},
 			dead:            []roachpb.StoreID{2},
 			decommissioning: []roachpb.StoreID{3},
@@ -4905,7 +4905,7 @@ func TestAllocatorComputeActionDecommission(t *testing.T) {
 					},
 				},
 			},
-			expectedAction:  AllocatorRemoveDead,
+			expectedAction:  AllocatorRemoveDeadVoter,
 			live:            []roachpb.StoreID{1, 4},
 			dead:            []roachpb.StoreID{2},
 			decommissioning: []roachpb.StoreID{3},
@@ -4940,7 +4940,7 @@ func TestAllocatorComputeActionDecommission(t *testing.T) {
 					},
 				},
 			},
-			expectedAction:  AllocatorRemoveDead,
+			expectedAction:  AllocatorRemoveDeadVoter,
 			live:            []roachpb.StoreID{1, 4},
 			dead:            nil,
 			decommissioning: []roachpb.StoreID{3},
@@ -4970,7 +4970,7 @@ func TestAllocatorComputeActionDecommission(t *testing.T) {
 					},
 				},
 			},
-			expectedAction:  AllocatorReplaceDecommissioning,
+			expectedAction:  AllocatorReplaceDecommissioningVoter,
 			live:            nil,
 			dead:            nil,
 			decommissioning: []roachpb.StoreID{1, 2, 3},
@@ -5004,7 +5004,7 @@ func TestAllocatorComputeActionDecommission(t *testing.T) {
 					},
 				},
 			},
-			expectedAction:  AllocatorRemoveDecommissioning,
+			expectedAction:  AllocatorRemoveDecommissioningVoter,
 			live:            []roachpb.StoreID{4},
 			dead:            nil,
 			decommissioning: []roachpb.StoreID{1, 2, 3},
@@ -5082,7 +5082,7 @@ func TestAllocatorComputeActionDynamicNumReplicas(t *testing.T) {
 			// drop past 3, so 3 it is.
 			storeList:           []roachpb.StoreID{1, 2, 3, 4},
 			expectedNumReplicas: 3,
-			expectedAction:      AllocatorRemoveDecommissioning,
+			expectedAction:      AllocatorRemoveDecommissioningVoter,
 			live:                []roachpb.StoreID{4},
 			unavailable:         nil,
 			dead:                nil,
@@ -5092,7 +5092,7 @@ func TestAllocatorComputeActionDynamicNumReplicas(t *testing.T) {
 			// Ditto.
 			storeList:           []roachpb.StoreID{1, 2, 3},
 			expectedNumReplicas: 3,
-			expectedAction:      AllocatorReplaceDecommissioning,
+			expectedAction:      AllocatorReplaceDecommissioningVoter,
 			live:                []roachpb.StoreID{4, 5},
 			unavailable:         nil,
 			dead:                nil,
@@ -5105,7 +5105,7 @@ func TestAllocatorComputeActionDynamicNumReplicas(t *testing.T) {
 			// from the range at hand, rather than trying to replace it.
 			storeList:           []roachpb.StoreID{1, 2, 3, 4},
 			expectedNumReplicas: 3,
-			expectedAction:      AllocatorRemoveDead,
+			expectedAction:      AllocatorRemoveDeadVoter,
 			live:                []roachpb.StoreID{1, 2, 3, 5},
 			unavailable:         nil,
 			dead:                []roachpb.StoreID{4},
@@ -5118,7 +5118,7 @@ func TestAllocatorComputeActionDynamicNumReplicas(t *testing.T) {
 			// important than replacing the dead one.
 			storeList:           []roachpb.StoreID{1, 4},
 			expectedNumReplicas: 3,
-			expectedAction:      AllocatorAdd,
+			expectedAction:      AllocatorAddVoter,
 			live:                []roachpb.StoreID{1, 2, 3, 5},
 			unavailable:         nil,
 			dead:                []roachpb.StoreID{4},
@@ -5140,7 +5140,7 @@ func TestAllocatorComputeActionDynamicNumReplicas(t *testing.T) {
 			// it is and we are under-replicaed.
 			storeList:           []roachpb.StoreID{1, 2},
 			expectedNumReplicas: 3,
-			expectedAction:      AllocatorAdd,
+			expectedAction:      AllocatorAddVoter,
 			live:                []roachpb.StoreID{1, 2},
 			unavailable:         nil,
 			dead:                nil,
@@ -5160,7 +5160,7 @@ func TestAllocatorComputeActionDynamicNumReplicas(t *testing.T) {
 			// Three again, on account of avoiding the even four.
 			storeList:           []roachpb.StoreID{1, 2, 3, 4},
 			expectedNumReplicas: 3,
-			expectedAction:      AllocatorRemove,
+			expectedAction:      AllocatorRemoveVoter,
 			live:                []roachpb.StoreID{1, 2, 3, 4},
 			unavailable:         nil,
 			dead:                nil,
@@ -5214,7 +5214,7 @@ func TestAllocatorComputeActionDynamicNumReplicas(t *testing.T) {
 			// slice in these tests).
 			storeList:           []roachpb.StoreID{1, 2, 3, 4, 5},
 			expectedNumReplicas: 5,
-			expectedAction:      AllocatorReplaceDead,
+			expectedAction:      AllocatorReplaceDeadVoter,
 			live:                []roachpb.StoreID{1, 2, 3},
 			unavailable:         []roachpb.StoreID{4},
 			dead:                []roachpb.StoreID{5},
@@ -5225,7 +5225,7 @@ func TestAllocatorComputeActionDynamicNumReplicas(t *testing.T) {
 			// the most important thing is removing a decommissioning replica.
 			storeList:           []roachpb.StoreID{1, 2, 3, 4, 5},
 			expectedNumReplicas: 3,
-			expectedAction:      AllocatorRemoveDecommissioning,
+			expectedAction:      AllocatorRemoveDecommissioningVoter,
 			live:                []roachpb.StoreID{1, 2, 3},
 			unavailable:         []roachpb.StoreID{4},
 			dead:                nil,

--- a/pkg/kv/kvserver/replica_metrics.go
+++ b/pkg/kv/kvserver/replica_metrics.go
@@ -176,7 +176,7 @@ func calcRangeCounter(
 		unavailable = !desc.Replicas().CanMakeProgress(func(rDesc roachpb.ReplicaDescriptor) bool {
 			return livenessMap[rDesc.NodeID].IsLive
 		})
-		needed := GetNeededReplicas(numReplicas, clusterNodes)
+		needed := GetNeededVoters(numReplicas, clusterNodes)
 		liveVoterReplicas := calcLiveVoterReplicas(desc, livenessMap)
 		if needed > liveVoterReplicas {
 			underreplicated = true

--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -404,6 +404,9 @@ func (rq *replicateQueue) processOneChange(
 		// Requeue because either we failed to transition out of a joint state
 		// (bad) or we did and there might be more to do for that range.
 		return true, err
+	case AllocatorAddNonVoter, AllocatorRemoveNonVoter:
+		return false, errors.Errorf("allocator actions pertaining to non-voters are"+
+			" currently not supported: %v", action)
 	default:
 		return false, errors.Errorf("unknown allocator action %v", action)
 	}
@@ -478,7 +481,7 @@ func (rq *replicateQueue) addOrReplace(
 	}
 
 	clusterNodes := rq.allocator.storePool.ClusterNodeCount()
-	need := GetNeededReplicas(*zone.NumReplicas, clusterNodes)
+	need := GetNeededVoters(*zone.NumReplicas, clusterNodes)
 
 	// Only up-replicate if there are suitable allocation targets such that,
 	// either the replication goal is met, or it is possible to get to the next

--- a/pkg/kv/kvserver/store_rebalancer.go
+++ b/pkg/kv/kvserver/store_rebalancer.go
@@ -504,7 +504,7 @@ func (sr *StoreRebalancer) chooseReplicaToRebalance(
 			desc.RangeID, replWithStats.qps)
 
 		clusterNodes := sr.rq.allocator.storePool.ClusterNodeCount()
-		desiredReplicas := GetNeededReplicas(*zone.NumReplicas, clusterNodes)
+		desiredReplicas := GetNeededVoters(*zone.NumReplicas, clusterNodes)
 		targets := make([]roachpb.ReplicationTarget, 0, desiredReplicas)
 		targetReplicas := make([]roachpb.ReplicaDescriptor, 0, desiredReplicas)
 		currentReplicas := desc.Replicas().Descriptors()

--- a/pkg/roachpb/metadata_replicas.go
+++ b/pkg/roachpb/metadata_replicas.go
@@ -53,6 +53,13 @@ func ReplicaTypeLearner() *ReplicaType {
 	return &t
 }
 
+// ReplicaTypeNonVoter returns a NON_VOTER pointer suitable for use in
+// a nullable proto field.
+func ReplicaTypeNonVoter() *ReplicaType {
+	t := NON_VOTER
+	return &t
+}
+
 // ReplicaSet is a set of replicas, usually the nodes/stores on which
 // replicas of a range are stored.
 type ReplicaSet struct {


### PR DESCRIPTION
This PR adds basic logic in the allocator to spit out actions that
prescribe upreplication or downreplication of non-voting replicas based
on zone configs.

Note that this commit *does not* enable the `replicateQueue` or the
`StoreRebalancer` to actually act on these newly added
`AllocatorAction`s, not does it make the allocator smart enough to
prescribe _rebalancing_ non-voting replicas. This commit also does not
teach the allocator to rank non-voting replicas for addition or removal.

Release note: None
