### PR TITLE
[dnm] tracing: clean up use of auto collection across tasks

### DIFF
--- a/pkg/kv/kvserver/replica_application_decoder.go
+++ b/pkg/kv/kvserver/replica_application_decoder.go
@@ -151,7 +151,7 @@ func (d *replicaDecoder) createTracingSpans(ctx context.Context) {
 			} else {
 				cmd.ctx, cmd.sp = d.r.AmbientContext.Tracer.StartSpanCtx(
 					ctx,
-					"raft application",
+					opName,
 					// NB: we are lying here - we are not actually going to propagate
 					// the recording towards the root. That seems ok.
 					tracing.WithParentAndManualCollection(spanCtx),

--- a/pkg/kv/kvserver/replica_sideload_test.go
+++ b/pkg/kv/kvserver/replica_sideload_test.go
@@ -582,7 +582,11 @@ func testRaftSSTableSideloadingProposal(t *testing.T, eng storage.Engine) {
 	defer stopper.Stop(context.Background())
 	tc.Start(t, stopper)
 
-	ctx, collect, cancel := tracing.ContextWithRecordingSpan(context.Background(), "test-recording")
+	tr := tc.store.ClusterSettings().Tracer
+	tr.LinkForkedSpans()
+	ctx, collect, cancel := tracing.ContextWithRecordingSpanUsing(
+		context.Background(), tr, "test-recording",
+	)
 	defer cancel()
 
 	const (

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -8372,6 +8372,8 @@ func TestFailureToProcessCommandClearsLocalResult(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
 	tc.StartWithStoreConfig(t, stopper, cfg)
+	tr := tc.store.ClusterSettings().Tracer
+	tr.LinkForkedSpans()
 
 	key := roachpb.Key("a")
 	txn := newTransaction("test", key, 1, tc.Clock())
@@ -8402,7 +8404,7 @@ func TestFailureToProcessCommandClearsLocalResult(t *testing.T) {
 	}
 	r.mu.Unlock()
 
-	opCtx, collect, cancel := tracing.ContextWithRecordingSpan(ctx, "test-recording")
+	opCtx, collect, cancel := tracing.ContextWithRecordingSpanUsing(ctx, tr, "test-recording")
 	defer cancel()
 
 	ba = roachpb.BatchRequest{}

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -1331,7 +1331,7 @@ func (ts *TestServer) ExecutorConfig() interface{} {
 	return *ts.sqlServer.execCfg
 }
 
-// Tracer is part of the TestServerInterface
+// Tracer is part of the TestServerInterface.
 func (ts *TestServer) Tracer() interface{} {
 	return ts.node.storeCfg.AmbientCtx.Tracer
 }

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1385,6 +1385,7 @@ func (t *logicTest) newCluster(serverArgs TestServerArgs) {
 			require.Lenf(t.rootT, cfg.localities, 0, "node %d does not have a locality set", i+1)
 		}
 
+		var settings *cluster.Settings
 		if cfg.binaryVersion != (roachpb.Version{}) {
 			binaryMinSupportedVersion := cfg.binaryVersion
 			if cfg.bootstrapVersion != (roachpb.Version{}) {
@@ -1392,12 +1393,17 @@ func (t *logicTest) newCluster(serverArgs TestServerArgs) {
 				// supports at least the bootstrap version.
 				binaryMinSupportedVersion = cfg.bootstrapVersion
 			}
-			nodeParams.Settings = cluster.MakeTestingClusterSettingsWithVersions(
+			settings = cluster.MakeTestingClusterSettingsWithVersions(
 				cfg.binaryVersion,
 				binaryMinSupportedVersion,
 				false, /* initializeVersion */
 			)
+		} else {
+			settings = cluster.MakeTestingClusterSettings()
 		}
+		settings.Tracer.LinkForkedSpans()
+		nodeParams.Settings = settings
+
 		paramsPerNode[i] = nodeParams
 	}
 	params.ServerArgsPerNode = paramsPerNode

--- a/pkg/util/tracing/crdbspan.go
+++ b/pkg/util/tracing/crdbspan.go
@@ -29,8 +29,8 @@ import (
 // crdbSpan is a span for internal crdb usage. This is used to power SQL session
 // tracing.
 type crdbSpan struct {
-	traceID      uint64 // probabilistically unique.
-	spanID       uint64 // probabilistically unique.
+	traceID      uint64 // probabilistically unique
+	spanID       uint64 // probabilistically unique
 	parentSpanID uint64
 
 	operation string
@@ -64,7 +64,8 @@ type crdbSpanMu struct {
 		// children contains the list of child spans started after this Span
 		// started recording.
 		children []*crdbSpan
-		// remoteSpan contains the list of remote child spans manually imported.
+		// remoteSpan contains the list of remote child span recordings that
+		// were manually imported.
 		remoteSpans []tracingpb.RecordedSpan
 	}
 

--- a/pkg/util/tracing/span_options.go
+++ b/pkg/util/tracing/span_options.go
@@ -171,11 +171,11 @@ func (o tagsOption) apply(opts spanOptions) spanOptions {
 type followsFromOpt struct{}
 
 // WithFollowsFrom instructs StartSpan to use a FollowsFrom relationship
-// should a child span be created (i.e. should WithParentAndAutoCollection or WithParentAndManualCollection
-// be supplied as well). A WithFollowsFrom child is expected to, in the common
-// case, outlive the parent span (for example: asynchronous cleanup work),
-// whereas a "regular" child span is not (i.e. the parent span typically
-// waits for the child to Finish()).
+// should a child span be created (i.e. should WithParentAndAutoCollection or
+// WithParentAndManualCollection be supplied as well). A WithFollowsFrom child
+// is expected to, in the common case, outlive the parent span (for example:
+// asynchronous cleanup work), whereas a "regular" child span is not (i.e. the
+// parent span typically waits for the child to Finish()).
 //
 // There is no penalty for getting this wrong, but it can help external
 // trace systems visualize the traces better.

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -626,7 +626,8 @@ func (t *Tracer) VisitSpans(visitor func(*Span) error) error {
 // used in an async task that might outlive the original operation.
 //
 // Returns the new context and the new Span (if any). The Span should be
-// closed via FinishSpan.
+// closed via FinishSpan. Its recording will not be propagated automatically,
+// i.e. this becomes the responsibility of the caller as well.
 //
 // See also ChildSpan() for a "parent-child relationship".
 func ForkCtxSpan(ctx context.Context, opName string) (context.Context, *Span) {
@@ -635,7 +636,7 @@ func ForkCtxSpan(ctx context.Context, opName string) (context.Context, *Span) {
 		return ctx, nil
 	}
 	return sp.Tracer().StartSpanCtx(
-		ctx, opName, WithParentAndAutoCollection(sp), WithFollowsFrom(),
+		ctx, opName, WithParentAndManualCollection(sp.Meta()), WithFollowsFrom(),
 	)
 }
 


### PR DESCRIPTION
Just posting this so it doesn't fall off the radar.

- stop: don't auto-collect forked spans
- tracing: limit number of direct children
- tracing: use manual collection in ForkCtxSpan
