### PR TITLE
build,bazel: add new docker image, supporting scripts for bazel CI job

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -86,6 +86,20 @@ committing the change.
 
 Please follow the instructions above on updating the golang version, omitting the go-version-check.sh step.
 
+## Updating the `bazelbuilder` image
+
+The `bazelbuilder` image is used exclusively for performing builds using Bazel. Only add dependencies to the image that are necessary for performing Bazel builds. The process for updating the image is as follows:
+
+- Edit `build/bazelbuilder/Dockerfile` as desired.
+- Perform the normal sequence of steps for pushing a new Docker image (for `$TAG`, you can use the value of `date +%Y%m%d-%H%M%S`):
+```
+    docker build build/bazelbuilder
+    docker image tag $IMAGE_HASH cockroachdb/bazel:$TAG
+    docker image push cockroachdb/bazel:$TAG
+```
+- Then, update `build/teamcity-bazel.sh` with the new tag and commit all your changes.
+- Ensure the "Github CI (Optional)" job passes on your PR before merging.
+
 #  Dependencies
 
 Dependencies are managed using `go mod`. We use `go mod vendor` so that we can import and use non-Go files (e.g. protobuf files) using the [modvendor](https://github.com/goware/modvendor) script.

--- a/build/bazelbuilder/Dockerfile
+++ b/build/bazelbuilder/Dockerfile
@@ -1,0 +1,65 @@
+FROM ubuntu:xenial-20170915
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    apt-transport-https \
+    autoconf \
+    bison \
+    ca-certificates \
+    curl \
+    flex \
+    git \
+    libncurses-dev \
+    make \
+ && apt-get clean
+
+# clang-3.9 - msan, libtapi needs 3.9+
+# cmake - msan / c-deps: libroach, protobuf, et al.
+# python - msan
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    clang-3.9 \
+    cmake \
+  && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-3.9 100 \
+    --slave /usr/bin/clang++ clang++ /usr/bin/clang++-3.9
+
+# xenial installs cmake 3.5.1. We need a newer version. Run this step
+# after the llvm/cross-compile step which is exceedingly slow.
+#
+# NOTE: When upgrading cmake, bump the rebuild counters in
+# c-deps/*-rebuild to force recreating the makefiles. This prevents
+# strange build errors caused by those makefiles depending on the
+# installed version of cmake.
+RUN curl -fsSL https://github.com/Kitware/CMake/releases/download/v3.17.0/cmake-3.17.0-Linux-x86_64.tar.gz -o cmake.tar.gz \
+ && echo 'b44685227b9f9be103e305efa2075a8ccf2415807fbcf1fc192da4d36aacc9f5 cmake.tar.gz' | sha256sum -c - \
+ && tar --strip-components=1 -C /usr -xzf cmake.tar.gz \
+ && rm cmake.tar.gz
+
+RUN echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list \
+ && curl https://bazel.build/bazel-release.pub.gpg | apt-key add - \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends \
+    bazel-3.6.0
+
+# git - Upgrade to a more modern version
+RUN apt-get install dh-autoreconf libcurl4-gnutls-dev libexpat1-dev gettext libz-dev libssl-dev -y && \
+    curl -fsSL https://github.com/git/git/archive/v2.29.2.zip -o "git-2.29.2.zip" && \
+    unzip "git-2.29.2.zip" && \
+    cd git-2.29.2 && \
+    make configure && \
+    ./configure && \
+    make && \
+    make install && \
+    cd .. && \
+    rm -rf git-2.29.2.zip git-2.29.2
+
+RUN apt-get purge -y \
+    apt-transport-https \
+    flex \
+    gettext \
+ && apt-get autoremove -y
+
+RUN rm -rf /tmp/* /var/lib/apt/lists/*
+
+RUN ln -s /usr/bin/bazel-3.6.0 /usr/bin/bazel
+
+COPY bazelbuild.sh /usr/local/bin

--- a/build/bazelbuilder/bazelbuild.sh
+++ b/build/bazelbuilder/bazelbuild.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -xeuo pipefail
+
+bazel build //pkg/cmd/cockroach-short
+# Stage artifacts.
+cp $(bazel info bazel-bin)/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short /artifacts

--- a/build/teamcity-bazel.sh
+++ b/build/teamcity-bazel.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source "$(dirname "${0}")/teamcity-support.sh"
+
+tc_prepare
+
+# NB: $root is set by teamcity-support.sh.
+export TMPDIR=$root/artifacts
+mkdir -p "$TMPDIR"
+
+tc_start_block "Run Bazel build"
+docker run -i ${tty-} --rm --init \
+       --workdir="/go/src/github.com/cockroachdb/cockroach" \
+       -v "$root:/go/src/github.com/cockroachdb/cockroach:ro" \
+       -v "$TMPDIR:/artifacts" \
+       cockroachdb/bazel:20210126-114949 bazelbuild.sh
+tc_end_block "Run Bazel build"


### PR DESCRIPTION
The current Docker image at `build/builder` and supporting script at
`build/builder.sh` are technically capable of running the Bazel build,
but are deficient in certain ways. Namely they're constructed very
deliberately in service of a workflow where you mount the entire
workspace as a volume inside the Docker container, which produces
all the generated files and compiled code right in the workspace. Bazel
makes this kind of complicated (see #59224):

1. `builder.sh`'s default behavior is to mount the home directory of the
   container into `./build/builder_home`. Bazel's behavior is to keep
   all of its persistent state in the home directory, however, so
   `builder_home` ends up containing a *huge* amount of files, owned
   by `root`, which are cumbersome to clean up.

2. The `cockroachdb/builder` image is configured to make the
   "mount-the-entire-workspace" workflow described above easy.
   Specifically, it sets `autouseradd --user roach` as its entry point,
   and basic functionality in the container doesn't work unless you
   mount the entire home directory as expected. This makes it difficult
   to refactor `builder.sh` to circumvent the problem described in (1).

3. Bazel helpfully symlinks `bazel-out`, `bazel-bin`, etc. in the
   workspace, which always manifest as broken links once you step
   outside of the container. This is apparently unavoidable even if you
   solve the above problems.

It is conceivable that changes to the `build/builder/Dockerfile` and/or
`build/builder.sh` could be made to allow us to mitigate these issues,
but instead I opt to start from scratch with a `Dockerfile` specifically
for building CockroachDB with Bazel. The new image is substantially
simpler and smaller than the old one, which allows us to track
hermiticity issues in addition to simplifying deployment. We'll probably
have to make additions to this image as time goes on, but we can isolate
only the changes that are absolutely necessary instead of using our
monolithic `builder` image for absolutely everything.

Furthermore, I add a couple scripts for running the build from TeamCity.
These are in service of #59063.

Future work can include writing a new analogue to `build/builder.sh` to
simplify working with the new image in CI and dev scenarios.

Release note: None