### PR TITLE
sql: overload sequence operators to accept a regclass

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -969,15 +969,23 @@ the locality flag on node startup. Returns an error if no region is set.</p>
 <tbody>
 <tr><td><a name="currval"></a><code>currval(sequence_name: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Returns the latest value obtained with nextval for this sequence in this session.</p>
 </span></td></tr>
+<tr><td><a name="currval"></a><code>currval(sequence_name: regclass) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Returns the latest value obtained with nextval for this sequence in this session.</p>
+</span></td></tr>
 <tr><td><a name="lastval"></a><code>lastval() &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Return value most recently obtained with nextval in this session.</p>
 </span></td></tr>
 <tr><td><a name="nextval"></a><code>nextval(sequence_name: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Advances the given sequence and returns its new value.</p>
+</span></td></tr>
+<tr><td><a name="nextval"></a><code>nextval(sequence_name: regclass) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Advances the given sequence and returns its new value.</p>
 </span></td></tr>
 <tr><td><a name="pg_get_serial_sequence"></a><code>pg_get_serial_sequence(table_name: <a href="string.html">string</a>, column_name: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the name of the sequence used by the given column_name in the table table_name.</p>
 </span></td></tr>
 <tr><td><a name="setval"></a><code>setval(sequence_name: <a href="string.html">string</a>, value: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Set the given sequence’s current value. The next call to nextval will return <code>value + Increment</code></p>
 </span></td></tr>
 <tr><td><a name="setval"></a><code>setval(sequence_name: <a href="string.html">string</a>, value: <a href="int.html">int</a>, is_called: <a href="bool.html">bool</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Set the given sequence’s current value. If is_called is false, the next call to nextval will return <code>value</code>; otherwise <code>value + Increment</code>.</p>
+</span></td></tr>
+<tr><td><a name="setval"></a><code>setval(sequence_name: regclass, value: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Set the given sequence’s current value. The next call to nextval will return <code>value + Increment</code></p>
+</span></td></tr>
+<tr><td><a name="setval"></a><code>setval(sequence_name: regclass, value: <a href="int.html">int</a>, is_called: <a href="bool.html">bool</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Set the given sequence’s current value. If is_called is false, the next call to nextval will return <code>value</code>; otherwise <code>value + Increment</code>.</p>
 </span></td></tr></tbody>
 </table>
 

--- a/pkg/ccl/importccl/import_table_creation.go
+++ b/pkg/ccl/importccl/import_table_creation.go
@@ -240,6 +240,13 @@ func (so *importSequenceOperators) IncrementSequence(
 }
 
 // Implements the tree.SequenceOperators interface.
+func (so *importSequenceOperators) IncrementSequenceByID(
+	ctx context.Context, seqID int64,
+) (int64, error) {
+	return 0, errSequenceOperators
+}
+
+// Implements the tree.SequenceOperators interface.
 func (so *importSequenceOperators) GetLatestValueInSessionForSequence(
 	ctx context.Context, seqName *tree.TableName,
 ) (int64, error) {
@@ -247,8 +254,22 @@ func (so *importSequenceOperators) GetLatestValueInSessionForSequence(
 }
 
 // Implements the tree.SequenceOperators interface.
+func (so *importSequenceOperators) GetLatestValueInSessionForSequenceByID(
+	ctx context.Context, seqID int64,
+) (int64, error) {
+	return 0, errSequenceOperators
+}
+
+// Implements the tree.SequenceOperators interface.
 func (so *importSequenceOperators) SetSequenceValue(
 	ctx context.Context, seqName *tree.TableName, newVal int64, isCalled bool,
+) error {
+	return errSequenceOperators
+}
+
+// Implements the tree.SequenceOperators interface.
+func (so *importSequenceOperators) SetSequenceValueByID(
+	ctx context.Context, seqID int64, newVal int64, isCalled bool,
 ) error {
 	return errSequenceOperators
 }

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -69,6 +69,13 @@ func (so *DummySequenceOperators) IncrementSequence(
 	return 0, errors.WithStack(errSequenceOperators)
 }
 
+// IncrementSequenceByID is part of the tree.SequenceOperators interface.
+func (so *DummySequenceOperators) IncrementSequenceByID(
+	ctx context.Context, seqID int64,
+) (int64, error) {
+	return 0, errors.WithStack(errSequenceOperators)
+}
+
 // GetLatestValueInSessionForSequence implements the tree.SequenceOperators
 // interface.
 func (so *DummySequenceOperators) GetLatestValueInSessionForSequence(
@@ -77,9 +84,24 @@ func (so *DummySequenceOperators) GetLatestValueInSessionForSequence(
 	return 0, errors.WithStack(errSequenceOperators)
 }
 
+// GetLatestValueInSessionForSequenceByID implements the tree.SequenceOperators
+// interface.
+func (so *DummySequenceOperators) GetLatestValueInSessionForSequenceByID(
+	ctx context.Context, seqID int64,
+) (int64, error) {
+	return 0, errors.WithStack(errSequenceOperators)
+}
+
 // SetSequenceValue implements the tree.SequenceOperators interface.
 func (so *DummySequenceOperators) SetSequenceValue(
 	ctx context.Context, seqName *tree.TableName, newVal int64, isCalled bool,
+) error {
+	return errors.WithStack(errSequenceOperators)
+}
+
+// SetSequenceValueByID implements the tree.SequenceOperators interface.
+func (so *DummySequenceOperators) SetSequenceValueByID(
+	ctx context.Context, seqID int64, newVal int64, isCalled bool,
 ) error {
 	return errors.WithStack(errSequenceOperators)
 }

--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -58,6 +58,32 @@ SELECT lastval()
 ----
 11
 
+let $lastval_test_id
+SELECT 'lastval_test'::regclass::int
+
+query I
+SELECT nextval($lastval_test_id::regclass)
+----
+3
+
+query I
+SELECT lastval()
+----
+3
+
+let $lastval_test_2_id
+SELECT 'lastval_test_2'::regclass::int
+
+query I
+SELECT nextval($lastval_test_2_id::regclass)
+----
+12
+
+query I
+SELECT lastval()
+----
+12
+
 # SEQUENCE CREATION
 
 statement ok
@@ -223,6 +249,19 @@ SELECT currval('foo')
 ----
 2
 
+let $foo_id
+SELECT 'foo'::regclass::int
+
+query I
+SELECT nextval($foo_id::regclass)
+----
+3
+
+query I
+SELECT currval($foo_id::regclass)
+----
+3
+
 query T
 SELECT pg_sequence_parameters('foo'::regclass::oid)
 ----
@@ -263,6 +302,14 @@ SELECT nextval('baz')
 ----
 7
 
+let $baz_id
+SELECT 'baz'::regclass::int
+
+query I
+SELECT nextval($baz_id::regclass)
+----
+12
+
 query T
 SELECT pg_sequence_parameters('baz'::regclass::oid)
 ----
@@ -282,6 +329,14 @@ query I
 SELECT nextval('down_test')
 ----
 -6
+
+let $down_test_id
+SELECT 'down_test'::regclass::int
+
+query I
+SELECT nextval($down_test_id::regclass)
+----
+-7
 
 query T
 SELECT pg_sequence_parameters('down_test'::regclass::oid)
@@ -398,6 +453,25 @@ SELECT lastval()
 ----
 11
 
+let $setval_test_id
+SELECT 'setval_test'::regclass::int
+
+query I
+SELECT setval($setval_test_id::regclass, 20)
+----
+20
+
+# Calling setval doesn't affect currval or lastval; they return the last value obtained with nextval.
+query I
+SELECT currval($setval_test_id::regclass)
+----
+11
+
+query I
+SELECT nextval($setval_test_id::regclass)
+----
+21
+
 # setval doesn't let you set values outside the bounds.
 
 statement ok
@@ -454,6 +528,39 @@ SELECT nextval('setval_is_called_test')
 ----
 22
 
+let $setval_is_called_test_id
+SELECT 'setval_is_called_test'::regclass::int
+
+query I
+SELECT setval($setval_is_called_test_id::regclass, 30, false)
+----
+30
+
+query I
+SELECT nextval($setval_is_called_test_id::regclass)
+----
+30
+
+query I
+SELECT nextval($setval_is_called_test_id::regclass)
+----
+31
+
+query I
+SELECT setval($setval_is_called_test_id::regclass, 30, true)
+----
+30
+
+query I
+SELECT nextval($setval_is_called_test_id::regclass)
+----
+31
+
+query I
+SELECT nextval($setval_is_called_test_id::regclass)
+----
+32
+
 # You can use setval to reset to minvalue.
 
 statement ok
@@ -506,6 +613,12 @@ SELECT nextval('limit_test')
 
 statement error pgcode 2200H pq: nextval\(\): reached maximum value of sequence "limit_test" \(10\)
 SELECT nextval('limit_test')
+
+let $limit_test_id
+SELECT 'limit_test'::regclass::int
+
+statement error pgcode 2200H pq: nextval\(\): reached maximum value of sequence "limit_test" \(10\)
+SELECT nextval($limit_test_id::regclass)
 
 query I
 SELECT currval('limit_test')

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3182,6 +3182,23 @@ type SequenceOperators interface {
 	// `newVal` is returned. Otherwise, the next call to nextval will return
 	// `newVal + seqOpts.Increment`.
 	SetSequenceValue(ctx context.Context, seqName *TableName, newVal int64, isCalled bool) error
+
+	// IncrementSequenceByID increments the given sequence and returns the result.
+	// It returns an error if the given ID is not a sequence.
+	// Takes in a sequence ID rather than a name, unlike IncrementSequence.
+	IncrementSequenceByID(ctx context.Context, seqID int64) (int64, error)
+
+	// GetLatestValueInSessionForSequenceByID returns the value most recently obtained by
+	// nextval() for the given sequence in this session.
+	// Takes in a sequence ID rather than a name, unlike GetLatestValueInSessionForSequence.
+	GetLatestValueInSessionForSequenceByID(ctx context.Context, seqID int64) (int64, error)
+
+	// SetSequenceValueByID sets the sequence's value.
+	// If isCalled is false, the sequence is set such that the next time nextval() is called,
+	// `newVal` is returned. Otherwise, the next call to nextval will return
+	// `newVal + seqOpts.Increment`.
+	// Takes in a sequence ID rather than a name, unlike SetSequenceValue.
+	SetSequenceValueByID(ctx context.Context, seqID int64, newVal int64, isCalled bool) error
 }
 
 // TenantOperator is capable of interacting with tenant state, allowing SQL


### PR DESCRIPTION
sql: overload sequence operators to accept a regclass
  
Previously, sequence operators (nextval, setval, currval)
only accepted a string to refer to the referenced sequence.
This patch allows these operators to accept a regclass as well.
Tests were also added to verify this.
This is the first step to fix this issue:
https://github.com/cockroachdb/cockroach/issues/51090.

Release note (sql change): overload sequence operators to accept a regclass