### PR TITLE
kvserver: teach replicateQueue to handle non-voter addition/removal

### DIFF
--- a/pkg/kv/kvserver/allocator_scorer_test.go
+++ b/pkg/kv/kvserver/allocator_scorer_test.go
@@ -918,7 +918,8 @@ func TestAllocateConstraintsCheck(t *testing.T) {
 				NumReplicas: proto.Int32(tc.zoneNumReplicas),
 			}
 			analyzed := constraint.AnalyzeConstraints(
-				context.Background(), getTestStoreDesc, testStoreReplicas(tc.existing), zone)
+				context.Background(), getTestStoreDesc, testStoreReplicas(tc.existing),
+				*zone.NumReplicas, zone.Constraints)
 			for _, s := range testStores {
 				valid, necessary := allocateConstraintsCheck(s, analyzed)
 				if e, a := tc.expectedValid[s.StoreID], valid; e != a {
@@ -1052,7 +1053,7 @@ func TestRemoveConstraintsCheck(t *testing.T) {
 				NumReplicas: proto.Int32(tc.zoneNumReplicas),
 			}
 			analyzed := constraint.AnalyzeConstraints(
-				context.Background(), getTestStoreDesc, existing, zone)
+				context.Background(), getTestStoreDesc, existing, *zone.NumReplicas, zone.Constraints)
 			for storeID, expected := range tc.expected {
 				valid, necessary := removeConstraintsCheck(testStores[storeID], analyzed)
 				if e, a := expected.valid, valid; e != a {

--- a/pkg/kv/kvserver/allocator_test.go
+++ b/pkg/kv/kvserver/allocator_test.go
@@ -64,10 +64,36 @@ var simpleZoneConfig = zonepb.ZoneConfig{
 	},
 }
 
-var multiDCConfig = zonepb.ZoneConfig{
+var multiDCConfigSSD = zonepb.ZoneConfig{
 	NumReplicas: proto.Int32(2),
 	Constraints: []zonepb.ConstraintsConjunction{
 		{Constraints: []zonepb.Constraint{{Value: "ssd", Type: zonepb.Constraint_REQUIRED}}},
+	},
+}
+
+var multiDCConfigConstrainToA = zonepb.ZoneConfig{
+	NumReplicas: proto.Int32(2),
+	Constraints: []zonepb.ConstraintsConjunction{
+		{Constraints: []zonepb.Constraint{{Value: "a", Type: zonepb.Constraint_REQUIRED}}},
+	},
+}
+
+var multiDCConfigUnsatisfiableVoterConstraints = zonepb.ZoneConfig{
+	NumReplicas: proto.Int32(2),
+	VoterConstraints: []zonepb.ConstraintsConjunction{
+		{Constraints: []zonepb.Constraint{{Value: "doesNotExist", Type: zonepb.Constraint_REQUIRED}}},
+	},
+}
+
+// multiDCConfigVoterAndNonVoter prescribes that one voting replica be placed in
+// DC "a" and one non-voting replica be placed in DC "b".
+var multiDCConfigVoterAndNonVoter = zonepb.ZoneConfig{
+	NumReplicas: proto.Int32(2),
+	Constraints: []zonepb.ConstraintsConjunction{
+		{Constraints: []zonepb.Constraint{{Value: "a", Type: zonepb.Constraint_REQUIRED}}, NumReplicas: 1},
+	},
+	VoterConstraints: []zonepb.ConstraintsConjunction{
+		{Constraints: []zonepb.Constraint{{Value: "b", Type: zonepb.Constraint_REQUIRED}}},
 	},
 }
 
@@ -316,6 +342,18 @@ func createTestAllocator(
 	return stopper, g, storePool, a, manual
 }
 
+// checkReplExists checks whether the given `repl` exists on any of the
+// `stores`.
+func checkReplExists(repl roachpb.ReplicaDescriptor, stores []roachpb.StoreID) (found bool) {
+	for _, storeID := range stores {
+		if repl.StoreID == storeID {
+			found = true
+			break
+		}
+	}
+	return found
+}
+
 // mockStorePool sets up a collection of a alive and dead stores in the store
 // pool for testing purposes.
 func mockStorePool(
@@ -389,10 +427,10 @@ func TestAllocatorSimpleRetrieval(t *testing.T) {
 	stopper, g, _, a, _ := createTestAllocator(1, false /* deterministic */)
 	defer stopper.Stop(context.Background())
 	gossiputil.NewStoreGossiper(g).GossipStores(singleStore, t)
-	result, _, err := a.AllocateTarget(
+	result, _, err := a.AllocateVoter(
 		context.Background(),
 		&simpleZoneConfig,
-		[]roachpb.ReplicaDescriptor{},
+		nil /* existingVoters */, nil, /* existingNonVoters */
 	)
 	if err != nil {
 		t.Fatalf("Unable to perform allocation: %+v", err)
@@ -408,10 +446,10 @@ func TestAllocatorNoAvailableDisks(t *testing.T) {
 
 	stopper, _, _, a, _ := createTestAllocator(1, false /* deterministic */)
 	defer stopper.Stop(context.Background())
-	result, _, err := a.AllocateTarget(
+	result, _, err := a.AllocateVoter(
 		context.Background(),
 		&simpleZoneConfig,
-		[]roachpb.ReplicaDescriptor{},
+		nil /* existingVoters */, nil, /* existingNonVoters */
 	)
 	if result != nil {
 		t.Errorf("expected nil result: %+v", result)
@@ -429,21 +467,21 @@ func TestAllocatorTwoDatacenters(t *testing.T) {
 	defer stopper.Stop(context.Background())
 	gossiputil.NewStoreGossiper(g).GossipStores(multiDCStores, t)
 	ctx := context.Background()
-	result1, _, err := a.AllocateTarget(
+	result1, _, err := a.AllocateVoter(
 		ctx,
-		&multiDCConfig,
-		[]roachpb.ReplicaDescriptor{},
+		&multiDCConfigSSD,
+		nil /* existingVoters */, nil, /* existingNonVoters */
 	)
 	if err != nil {
 		t.Fatalf("Unable to perform allocation: %+v", err)
 	}
-	result2, _, err := a.AllocateTarget(
+	result2, _, err := a.AllocateVoter(
 		ctx,
-		&multiDCConfig,
+		&multiDCConfigSSD,
 		[]roachpb.ReplicaDescriptor{{
 			NodeID:  result1.Node.NodeID,
 			StoreID: result1.StoreID,
-		}},
+		}}, nil, /* existingNonVoters */
 	)
 	if err != nil {
 		t.Fatalf("Unable to perform allocation: %+v", err)
@@ -454,9 +492,9 @@ func TestAllocatorTwoDatacenters(t *testing.T) {
 		t.Errorf("Expected nodes %+v: %+v vs %+v", expected, result1.Node, result2.Node)
 	}
 	// Verify that no result is forthcoming if we already have a replica.
-	result3, _, err := a.AllocateTarget(
+	result3, _, err := a.AllocateVoter(
 		ctx,
-		&multiDCConfig,
+		&multiDCConfigSSD,
 		[]roachpb.ReplicaDescriptor{
 			{
 				NodeID:  result1.Node.NodeID,
@@ -466,7 +504,7 @@ func TestAllocatorTwoDatacenters(t *testing.T) {
 				NodeID:  result2.Node.NodeID,
 				StoreID: result2.StoreID,
 			},
-		},
+		}, nil, /* existingNonVoters */
 	)
 	if err == nil {
 		t.Errorf("expected error on allocation without available stores: %+v", result3)
@@ -480,7 +518,7 @@ func TestAllocatorExistingReplica(t *testing.T) {
 	stopper, g, _, a, _ := createTestAllocator(1, false /* deterministic */)
 	defer stopper.Stop(context.Background())
 	gossiputil.NewStoreGossiper(g).GossipStores(sameDCStores, t)
-	result, _, err := a.AllocateTarget(
+	result, _, err := a.AllocateVoter(
 		context.Background(),
 		&zonepb.ZoneConfig{
 			NumReplicas: proto.Int32(0),
@@ -498,7 +536,7 @@ func TestAllocatorExistingReplica(t *testing.T) {
 				NodeID:  2,
 				StoreID: 2,
 			},
-		},
+		}, nil, /* existingNonVoters */
 	)
 	if err != nil {
 		t.Fatalf("Unable to perform allocation: %+v", err)
@@ -599,13 +637,9 @@ func TestAllocatorMultipleStoresPerNode(t *testing.T) {
 
 	for _, tc := range testCases {
 		{
-			result, _, err := a.AllocateTarget(
-				context.Background(),
-				zonepb.EmptyCompleteZoneConfig(),
-				tc.existing,
-			)
+			result, _, err := a.AllocateVoter(context.Background(), zonepb.EmptyCompleteZoneConfig(), tc.existing, nil)
 			if e, a := tc.expectTargetAllocate, result != nil; e != a {
-				t.Errorf("AllocateTarget(%v) got target %v, err %v; expectTarget=%v",
+				t.Errorf("AllocateVoter(%v) got target %v, err %v; expectTarget=%v",
 					tc.existing, result, err, tc.expectTargetAllocate)
 			}
 		}
@@ -835,7 +869,7 @@ func TestAllocatorRebalanceTarget(t *testing.T) {
 	// We make 5 stores in this test -- 3 in the same datacenter, and 1 each in
 	// 2 other datacenters. All of our replicas are distributed within these 3
 	// datacenters. Originally, the stores that are all alone in their datacenter
-	// are fuller than the other stores. If we didn't simulate RemoveTarget in
+	// are fuller than the other stores. If we didn't simulate RemoveVoter in
 	// RebalanceTarget, we would try to choose store 2 or 3 as the target store
 	// to make a rebalance. However, we would immediately remove the replica on
 	// store 1 or 2 to retain the locality diversity.
@@ -2060,7 +2094,13 @@ func TestAllocatorLeasePreferencesMultipleStoresPerLocality(t *testing.T) {
 	}
 }
 
-func TestAllocatorRemoveTargetLocality(t *testing.T) {
+// TestAllocatorRemoveBasedOnDiversity tests that replicas that are removed on
+// the basis of diversity are such that the resulting diversity score of the
+// range (after their removal) is the highest. Additionally, it also ensures
+// that voting replica removals only consider the set of existing voters when
+// computing the diversity score, whereas non-voting replica removal considers
+// all existing replicas for its diversity calculation.
+func TestAllocatorRemoveBasedOnDiversity(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
@@ -2072,61 +2112,163 @@ func TestAllocatorRemoveTargetLocality(t *testing.T) {
 	// Given a set of existing replicas for a range, pick out the ones that should
 	// be removed purely on the basis of locality diversity.
 	testCases := []struct {
-		existing []roachpb.StoreID
-		expected []roachpb.StoreID
+		existingVoters, existingNonVoters     []roachpb.ReplicaDescriptor
+		expVoterRemovals, expNonVoterRemovals []roachpb.StoreID
 	}{
+		// NB: the `existingNonVoters` in these subtests are such that they would be
+		// expected to alter the diversity scores if they were not disregarded
+		// during voter removal.
 		{
-			[]roachpb.StoreID{1, 2, 3, 5},
-			[]roachpb.StoreID{1, 2},
+			existingVoters:    replicas(1, 2, 3, 5),
+			existingNonVoters: replicas(6, 7),
+			// 1 and 2 are in the same datacenter.
+			expVoterRemovals:    []roachpb.StoreID{1, 2},
+			expNonVoterRemovals: []roachpb.StoreID{6},
 		},
 		{
-			[]roachpb.StoreID{1, 2, 3},
-			[]roachpb.StoreID{1, 2},
+			existingVoters:      replicas(1, 2, 3),
+			existingNonVoters:   replicas(4, 6, 7),
+			expVoterRemovals:    []roachpb.StoreID{1, 2},
+			expNonVoterRemovals: []roachpb.StoreID{4},
 		},
 		{
-			[]roachpb.StoreID{1, 3, 4, 5},
-			[]roachpb.StoreID{3, 4},
+			existingVoters:      replicas(1, 3, 4, 5),
+			existingNonVoters:   replicas(2),
+			expVoterRemovals:    []roachpb.StoreID{3, 4},
+			expNonVoterRemovals: []roachpb.StoreID{2},
 		},
 		{
-			[]roachpb.StoreID{1, 3, 5, 6},
-			[]roachpb.StoreID{5, 6},
+			existingVoters:      replicas(1, 3, 5, 6),
+			existingNonVoters:   replicas(2, 7, 8),
+			expVoterRemovals:    []roachpb.StoreID{5, 6},
+			expNonVoterRemovals: []roachpb.StoreID{2, 7, 8},
 		},
 		{
-			[]roachpb.StoreID{1, 3, 5},
-			[]roachpb.StoreID{1, 3, 5},
-		},
-		{
-			[]roachpb.StoreID{1, 3, 4, 6, 7, 8},
-			[]roachpb.StoreID{3, 4, 7, 8},
+			existingVoters:      replicas(3, 4, 7, 8),
+			existingNonVoters:   replicas(2, 5, 6),
+			expVoterRemovals:    []roachpb.StoreID{3, 4, 7, 8},
+			expNonVoterRemovals: []roachpb.StoreID{5, 6},
 		},
 	}
 	for _, c := range testCases {
-		existingRepls := make([]roachpb.ReplicaDescriptor, len(c.existing))
-		for i, storeID := range c.existing {
-			existingRepls[i] = roachpb.ReplicaDescriptor{
-				NodeID:  roachpb.NodeID(storeID),
-				StoreID: storeID,
-			}
-		}
-		targetRepl, details, err := a.RemoveTarget(
+		targetVoter, details, err := a.RemoveVoter(
 			context.Background(),
 			zonepb.EmptyCompleteZoneConfig(),
-			existingRepls,
-			existingRepls,
+			c.existingVoters, /* voterCandidates */
+			c.existingVoters,
+			c.existingNonVoters,
 		)
-		if err != nil {
-			t.Fatal(err)
-		}
-		var found bool
-		for _, storeID := range c.expected {
-			if targetRepl.StoreID == storeID {
-				found = true
-				break
+		require.NoError(t, err)
+
+		require.Truef(
+			t,
+			checkReplExists(targetVoter, c.expVoterRemovals),
+			"expected RemoveVoter(%v) in %v, but got %d; details: %s",
+			c.existingVoters, c.expVoterRemovals, targetVoter.StoreID, details,
+		)
+		// Ensure that we get the same set of results if we didn't have any
+		// non-voting replicas. If non-voters were to have an impact on voters'
+		// diversity score calculations, we would fail here.
+		targetVoter, _, err = a.RemoveVoter(
+			context.Background(),
+			zonepb.EmptyCompleteZoneConfig(),
+			c.existingVoters, /* voterCandidates */
+			c.existingVoters,
+			nil, /* existingNonVoters */
+		)
+		require.NoError(t, err)
+		require.Truef(t, checkReplExists(targetVoter, c.expVoterRemovals),
+			"voter target for removal differs from expectation when non-voters are present;"+
+				" expected %v, got %d", c.expVoterRemovals, targetVoter.StoreID)
+
+		targetNonVoter, _, err := a.RemoveNonVoter(
+			context.Background(),
+			zonepb.EmptyCompleteZoneConfig(),
+			c.existingNonVoters, /* nonVoterCandidates */
+			c.existingVoters,
+			c.existingNonVoters,
+		)
+		require.NoError(t, err)
+		require.True(t, checkReplExists(targetNonVoter, c.expNonVoterRemovals))
+	}
+}
+
+// TestAllocatorConstraintsAndVoterConstraints tests that allocation of voting
+// replicas respects both the `constraints` and the `voter_constraints` and the
+// allocation of non-voting replicas respects just the `constraints`.
+func TestAllocatorConstraintsAndVoterConstraints(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testCases := []struct {
+		name                                          string
+		existingVoters, existingNonVoters             []roachpb.ReplicaDescriptor
+		stores                                        []*roachpb.StoreDescriptor
+		zone                                          *zonepb.ZoneConfig
+		expectedVoters, expectedNonVoters             []roachpb.StoreID
+		shouldVoterAllocFail, shouldNonVoterAllocFail bool
+		expError                                      string
+	}{
+		{
+			name:              "one store satisfies constraints for each type of replica",
+			stores:            multiDCStores,
+			zone:              &multiDCConfigVoterAndNonVoter,
+			expectedVoters:    []roachpb.StoreID{2},
+			expectedNonVoters: []roachpb.StoreID{1},
+		},
+		{
+			name:                    "only voter can satisfy constraints",
+			stores:                  multiDCStores,
+			zone:                    &multiDCConfigConstrainToA,
+			expectedVoters:          []roachpb.StoreID{1},
+			shouldNonVoterAllocFail: true,
+		},
+		{
+			name:                 "only non_voter can satisfy constraints",
+			stores:               multiDCStores,
+			zone:                 &multiDCConfigUnsatisfiableVoterConstraints,
+			shouldVoterAllocFail: true,
+			expectedNonVoters:    []roachpb.StoreID{1, 2},
+		},
+	}
+
+	check := func(target roachpb.StoreID, stores []roachpb.StoreID) bool {
+		for _, s := range stores {
+			if s == target {
+				return true
 			}
 		}
-		if !found {
-			t.Errorf("expected RemoveTarget(%v) in %v, but got %d; details: %s", c.existing, c.expected, targetRepl.StoreID, details)
-		}
+		return false
+	}
+
+	for i, test := range testCases {
+		t.Run(fmt.Sprintf("%d:%s", i+1, test.name), func(t *testing.T) {
+			ctx := context.Background()
+			stopper, g, _, a, _ := createTestAllocator(10, false /* deterministic */)
+			defer stopper.Stop(ctx)
+			sg := gossiputil.NewStoreGossiper(g)
+			sg.GossipStores(test.stores, t)
+
+			// Allocate the voting replica first, before the non-voter. This is the
+			// order in which we'd expect the allocator to repair a given range. See
+			// TestAllocatorComputeAction.
+			voterTarget, _, err := a.AllocateVoter(ctx, test.zone, test.existingVoters, test.existingNonVoters)
+			if test.shouldVoterAllocFail {
+				require.Errorf(t, err, "expected voter allocation to fail; got %v as a valid target instead", voterTarget)
+			} else {
+				require.NoError(t, err)
+				require.True(t, check(voterTarget.StoreID, test.expectedVoters))
+				test.existingVoters = append(test.existingVoters, replicas(voterTarget.StoreID)...)
+			}
+
+			nonVoterTarget, _, err := a.AllocateNonVoter(ctx, test.zone, test.existingVoters, test.existingNonVoters)
+			if test.shouldNonVoterAllocFail {
+				require.Errorf(t, err, "expected non-voter allocation to fail; got %v as a valid target instead", nonVoterTarget)
+			} else {
+				require.True(t, check(nonVoterTarget.StoreID, test.expectedNonVoters))
+				require.NoError(t, err)
+			}
+		})
 	}
 }
 
@@ -2192,11 +2334,7 @@ func TestAllocatorAllocateTargetLocality(t *testing.T) {
 				StoreID: storeID,
 			}
 		}
-		targetStore, details, err := a.AllocateTarget(
-			context.Background(),
-			zonepb.EmptyCompleteZoneConfig(),
-			existingRepls,
-		)
+		targetStore, details, err := a.AllocateVoter(context.Background(), zonepb.EmptyCompleteZoneConfig(), existingRepls, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -2208,7 +2346,7 @@ func TestAllocatorAllocateTargetLocality(t *testing.T) {
 			}
 		}
 		if !found {
-			t.Errorf("expected AllocateTarget(%v) in %v, but got %d; details: %s", c.existing, c.expected, targetStore.StoreID, details)
+			t.Errorf("expected AllocateVoter(%v) in %v, but got %d; details: %s", c.existing, c.expected, targetStore.StoreID, details)
 		}
 	}
 }
@@ -2524,7 +2662,9 @@ func TestAllocateCandidatesExcludeNonReadyNodes(t *testing.T) {
 		// No constraints.
 		zone := &zonepb.ZoneConfig{NumReplicas: proto.Int32(0), Constraints: nil}
 		analyzed := constraint.AnalyzeConstraints(
-			context.Background(), a.storePool.getStoreDescriptor, existingRepls, zone)
+			context.Background(), a.storePool.getStoreDescriptor, existingRepls, *zone.NumReplicas,
+			zone.Constraints)
+		checkFn := voterConstraintsCheckerForAllocation(analyzed, constraint.EmptyAnalyzedConstraints)
 
 		a.storePool.isNodeReadyForRoutineReplicaTransfer = func(_ context.Context, n roachpb.NodeID) bool {
 			for _, s := range tc.excluded {
@@ -2537,18 +2677,16 @@ func TestAllocateCandidatesExcludeNonReadyNodes(t *testing.T) {
 		}
 
 		t.Run(fmt.Sprintf("%d/allocate", testIdx), func(t *testing.T) {
-			candidates := allocateCandidates(
-				context.Background(),
+			candidates := rankedCandidateListForAllocation(context.Background(),
 				sl,
-				analyzed,
+				checkFn,
 				existingRepls,
 				a.storePool.getLocalitiesByStore(existingRepls),
 				a.storePool.isNodeReadyForRoutineReplicaTransfer,
-				a.scorerOptions(),
-			)
+				a.scorerOptions())
 
 			if !expectedStoreIDsMatch(tc.expected, candidates) {
-				t.Errorf("expected allocateCandidates(%v) = %v, but got %v",
+				t.Errorf("expected rankedCandidateListForAllocation(%v) = %v, but got %v",
 					tc.existing, tc.expected, candidates)
 			}
 		})
@@ -2571,6 +2709,88 @@ func TestAllocateCandidatesExcludeNonReadyNodes(t *testing.T) {
 				if !expectedStoreIDsMatch(tc.expected, results[i].candidates) {
 					t.Errorf("results[%d]: expected candidates %v, got %v", i, tc.expected, results[i].candidates)
 				}
+			}
+		})
+	}
+}
+
+// TestAllocatorNonVoterAllocationExcludesVoterNodes checks that when allocating
+// non-voting replicas, stores that have any existing replica (voting or
+// non-voting) are excluded from the list of candidates.
+func TestAllocatorNonVoterAllocationExcludesVoterNodes(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testCases := []struct {
+		name                              string
+		existingVoters, existingNonVoters []roachpb.ReplicaDescriptor
+		stores                            []*roachpb.StoreDescriptor
+		zone                              *zonepb.ZoneConfig
+		expected                          roachpb.StoreID
+		shouldFail                        bool
+		expError                          string
+	}{
+		{
+			name:              "voters only",
+			existingNonVoters: replicas(1, 2, 3, 4),
+			stores:            sameDCStores,
+			zone:              zonepb.EmptyCompleteZoneConfig(),
+			// Expect that that the store that doesn't have any replicas would be
+			// the one to receive a new non-voter.
+			expected: roachpb.StoreID(5),
+		},
+		{
+			name:              "non-voters only",
+			existingNonVoters: replicas(1, 2, 3, 4),
+			stores:            sameDCStores,
+			zone:              zonepb.EmptyCompleteZoneConfig(),
+			expected:          roachpb.StoreID(5),
+		},
+		{
+			name:              "mixed",
+			existingVoters:    replicas(1, 2),
+			existingNonVoters: replicas(3, 4),
+			stores:            sameDCStores,
+			zone:              zonepb.EmptyCompleteZoneConfig(),
+			expected:          roachpb.StoreID(5),
+		},
+		{
+			name: "only valid store has a voter",
+			// Place a voter on the only store that would meet the constraints of
+			// `multiDCConfigConstrainToA`.
+			existingVoters: replicas(1),
+			stores:         multiDCStores,
+			zone:           &multiDCConfigConstrainToA,
+			shouldFail:     true,
+			expError:       "0 of 2 live stores are able to take a new replica for the range",
+		},
+		{
+			name: "only valid store has a non_voter",
+			// Place a non-voter on the only store that would meet the constraints of
+			// `multiDCConfigConstrainToA`.
+			existingNonVoters: replicas(1),
+			stores:            multiDCStores,
+			zone:              &multiDCConfigConstrainToA,
+			shouldFail:        true,
+			expError:          "0 of 2 live stores are able to take a new replica for the range",
+		},
+	}
+
+	for i, test := range testCases {
+		t.Run(fmt.Sprintf("%d:%s", i+1, test.name), func(t *testing.T) {
+			ctx := context.Background()
+			stopper, g, _, a, _ := createTestAllocator(10, false /* deterministic */)
+			defer stopper.Stop(ctx)
+			sg := gossiputil.NewStoreGossiper(g)
+			sg.GossipStores(test.stores, t)
+
+			result, _, err := a.AllocateNonVoter(ctx, test.zone, test.existingVoters, test.existingNonVoters)
+			if test.shouldFail {
+				require.Error(t, err)
+				require.Regexp(t, test.expError, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, test.expected, result.StoreID)
 			}
 		})
 	}
@@ -2786,16 +3006,17 @@ func TestAllocateCandidatesNumReplicasConstraints(t *testing.T) {
 		}
 		zone := &zonepb.ZoneConfig{NumReplicas: proto.Int32(0), Constraints: tc.constraints}
 		analyzed := constraint.AnalyzeConstraints(
-			context.Background(), a.storePool.getStoreDescriptor, existingRepls, zone)
-		candidates := allocateCandidates(
-			context.Background(),
+			context.Background(), a.storePool.getStoreDescriptor, existingRepls, *zone.NumReplicas,
+			zone.Constraints)
+		checkFn := voterConstraintsCheckerForAllocation(analyzed, constraint.EmptyAnalyzedConstraints)
+
+		candidates := rankedCandidateListForAllocation(context.Background(),
 			sl,
-			analyzed,
+			checkFn,
 			existingRepls,
 			a.storePool.getLocalitiesByStore(existingRepls),
-			func(context.Context, roachpb.NodeID) bool { return true }, /* isNodeValidForRoutineReplicaTransfer */
-			a.scorerOptions(),
-		)
+			func(context.Context, roachpb.NodeID) bool { return true },
+			a.scorerOptions())
 		best := candidates.best()
 		match := true
 		if len(tc.expected) != len(best) {
@@ -2812,7 +3033,7 @@ func TestAllocateCandidatesNumReplicasConstraints(t *testing.T) {
 			}
 		}
 		if !match {
-			t.Errorf("%d: expected allocateCandidates(%v) = %v, but got %v",
+			t.Errorf("%d: expected rankedCandidateListForAllocation(%v) = %v, but got %v",
 				testIdx, tc.existing, tc.expected, candidates)
 		}
 	}
@@ -3010,18 +3231,33 @@ func TestRemoveCandidatesNumReplicasConstraints(t *testing.T) {
 				StoreID: storeID,
 			}
 		}
-		zone := &zonepb.ZoneConfig{NumReplicas: proto.Int32(0), Constraints: tc.constraints}
-		analyzed := constraint.AnalyzeConstraints(
-			context.Background(), a.storePool.getStoreDescriptor, existingRepls, zone)
-		candidates := removeCandidates(
-			sl,
-			analyzed,
+		ctx := context.Background()
+		analyzed := constraint.AnalyzeConstraints(ctx, a.storePool.getStoreDescriptor, existingRepls,
+			0 /* numReplicas */, tc.constraints)
+
+		// Check behavior in a zone config where `voter_constraints` are empty.
+		checkFn := voterConstraintsCheckerForRemoval(analyzed, constraint.EmptyAnalyzedConstraints)
+		candidates := rankedCandidateListForRemoval(sl,
+			checkFn,
 			a.storePool.getLocalitiesByStore(existingRepls),
-			a.scorerOptions(),
-		)
+			a.scorerOptions())
 		if !expectedStoreIDsMatch(tc.expected, candidates.worst()) {
-			t.Errorf("%d: expected removeCandidates(%v) = %v, but got %v",
-				testIdx, tc.existing, tc.expected, candidates)
+			t.Errorf("%d (with `constraints`): expected rankedCandidateListForRemoval(%v)"+
+				" = %v, but got %v\n for candidates %v", testIdx, tc.existing, tc.expected,
+				candidates.worst(), candidates)
+		}
+
+		// Check that we'd see the same result if the same constraints were
+		// specified as `voter_constraints`.
+		checkFn = voterConstraintsCheckerForRemoval(constraint.EmptyAnalyzedConstraints, analyzed)
+		candidates = rankedCandidateListForRemoval(sl,
+			checkFn,
+			a.storePool.getLocalitiesByStore(existingRepls),
+			a.scorerOptions())
+		if !expectedStoreIDsMatch(tc.expected, candidates.worst()) {
+			t.Errorf("%d (with `voter_constraints`): expected rankedCandidateListForRemoval(%v)"+
+				" = %v, but got %v\n for candidates %v", testIdx, tc.existing, tc.expected,
+				candidates.worst(), candidates)
 		}
 	}
 }
@@ -3807,7 +4043,8 @@ func TestRebalanceCandidatesNumReplicasConstraints(t *testing.T) {
 			NumReplicas: proto.Int32(tc.zoneNumReplicas),
 		}
 		analyzed := constraint.AnalyzeConstraints(
-			context.Background(), a.storePool.getStoreDescriptor, existingRepls, zone)
+			context.Background(), a.storePool.getStoreDescriptor, existingRepls,
+			*zone.NumReplicas, zone.Constraints)
 		results := rebalanceCandidates(
 			context.Background(),
 			sl,
@@ -4138,13 +4375,13 @@ func TestLoadBasedLeaseRebalanceScore(t *testing.T) {
 	}
 }
 
-// TestAllocatorRemoveTarget verifies that the replica chosen by RemoveTarget is
-// the one with the lowest capacity.
-func TestAllocatorRemoveTarget(t *testing.T) {
+// TestAllocatorRemoveTargetBasedOnCapacity verifies that the replica chosen by
+// RemoveVoter is the one with the lowest capacity.
+func TestAllocatorRemoveTargetBasedOnCapacity(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	// List of replicas that will be passed to RemoveTarget
+	// List of replicas that will be passed to RemoveVoter
 	replicas := []roachpb.ReplicaDescriptor{
 		{
 			StoreID:   1,
@@ -4211,17 +4448,13 @@ func TestAllocatorRemoveTarget(t *testing.T) {
 
 	// Repeat this test 10 times, it should always be either store 2 or 3.
 	for i := 0; i < 10; i++ {
-		targetRepl, _, err := a.RemoveTarget(
-			ctx,
-			zonepb.EmptyCompleteZoneConfig(),
-			replicas,
-			replicas,
-		)
+		targetRepl, _, err := a.RemoveVoter(ctx, zonepb.EmptyCompleteZoneConfig(), replicas, replicas,
+			nil)
 		if err != nil {
 			t.Fatal(err)
 		}
 		if a, e1, e2 := targetRepl, replicas[1], replicas[2]; a != e1 && a != e2 {
-			t.Fatalf("%d: RemoveTarget did not select either expected replica; expected %v or %v, got %v",
+			t.Fatalf("%d: RemoveVoter did not select either expected replica; expected %v or %v, got %v",
 				i, e1, e2, a)
 		}
 	}
@@ -5531,25 +5764,40 @@ func TestAllocatorError(t *testing.T) {
 		ae       allocatorError
 		expected string
 	}{
-		{allocatorError{constraints: nil, existingReplicas: 1, aliveStores: 1},
-			"0 of 1 live stores are able to take a new replica for the range (1 already has a replica); likely not enough nodes in cluster"},
-		{allocatorError{constraints: nil, existingReplicas: 1, aliveStores: 2, throttledStores: 1},
-			"0 of 2 live stores are able to take a new replica for the range (1 throttled, 1 already has a replica)"},
-		{allocatorError{constraints: constraint, existingReplicas: 1, aliveStores: 1},
-			`0 of 1 live stores are able to take a new replica for the range (1 already has a replica); ` +
-				`must match constraints [{+one}]`},
-		{allocatorError{constraints: constraint, existingReplicas: 1, aliveStores: 2},
-			`0 of 2 live stores are able to take a new replica for the range (1 already has a replica); ` +
-				`must match constraints [{+one}]`},
-		{allocatorError{constraints: constraints, existingReplicas: 1, aliveStores: 1},
-			`0 of 1 live stores are able to take a new replica for the range (1 already has a replica); ` +
-				`must match constraints [{+one,+two}]`},
-		{allocatorError{constraints: constraints, existingReplicas: 1, aliveStores: 2},
-			`0 of 2 live stores are able to take a new replica for the range (1 already has a replica); ` +
-				`must match constraints [{+one,+two}]`},
-		{allocatorError{constraints: constraint, existingReplicas: 1, aliveStores: 2, throttledStores: 1},
-			`0 of 2 live stores are able to take a new replica for the range (1 throttled, 1 already has a replica); ` +
-				`must match constraints [{+one}]`},
+		{allocatorError{constraints: nil, existingVoterCount: 1, aliveStores: 1},
+			"0 of 1 live stores are able to take a new replica for the range" +
+				" (1 already has a voter, 0 already have a non-voter); likely not enough nodes in cluster",
+		},
+		{allocatorError{constraints: nil, existingVoterCount: 1, aliveStores: 2, throttledStores: 1},
+			"0 of 2 live stores are able to take a new replica for the range" +
+				" (1 throttled, 1 already has a voter, 0 already have a non-voter)"},
+		{allocatorError{constraints: constraint, existingVoterCount: 1, aliveStores: 1},
+			"0 of 1 live stores are able to take a new replica for the range" +
+				" (1 already has a voter, 0 already have a non-voter);" +
+				" replicas must match constraints [{+one}];" +
+				" voting replicas must match voter_constraints []",
+		},
+		{allocatorError{constraints: constraint, existingVoterCount: 1, aliveStores: 2},
+			"0 of 2 live stores are able to take a new replica for the range" +
+				" (1 already has a voter, 0 already have a non-voter);" +
+				" replicas must match constraints [{+one}];" +
+				" voting replicas must match voter_constraints []"},
+		{allocatorError{constraints: constraints, existingVoterCount: 1, aliveStores: 1},
+			"0 of 1 live stores are able to take a new replica for the range" +
+				" (1 already has a voter, 0 already have a non-voter);" +
+				" replicas must match constraints [{+one,+two}];" +
+				" voting replicas must match voter_constraints []"},
+		{allocatorError{constraints: constraints, existingVoterCount: 1, aliveStores: 2},
+			"0 of 2 live stores are able to take a new replica for the range" +
+				" (1 already has a voter, 0 already have a non-voter);" +
+				" replicas must match constraints [{+one,+two}];" +
+				" voting replicas must match voter_constraints []"},
+		{allocatorError{constraints: constraint, existingVoterCount: 1, aliveStores: 2, throttledStores: 1},
+			"0 of 2 live stores are able to take a new replica for the range" +
+				" (1 throttled, 1 already has a voter, 0 already have a non-voter);" +
+				" replicas must match constraints [{+one}];" +
+				" voting replicas must match voter_constraints []",
+		},
 	}
 
 	for i, testCase := range testCases {
@@ -5568,22 +5816,14 @@ func TestAllocatorThrottled(t *testing.T) {
 	defer stopper.Stop(ctx)
 
 	// First test to make sure we would send the replica to purgatory.
-	_, _, err := a.AllocateTarget(
-		ctx,
-		&simpleZoneConfig,
-		[]roachpb.ReplicaDescriptor{},
-	)
+	_, _, err := a.AllocateVoter(ctx, &simpleZoneConfig, []roachpb.ReplicaDescriptor{}, nil)
 	if !errors.HasInterface(err, (*purgatoryError)(nil)) {
 		t.Fatalf("expected a purgatory error, got: %+v", err)
 	}
 
 	// Second, test the normal case in which we can allocate to the store.
 	gossiputil.NewStoreGossiper(g).GossipStores(singleStore, t)
-	result, _, err := a.AllocateTarget(
-		ctx,
-		&simpleZoneConfig,
-		[]roachpb.ReplicaDescriptor{},
-	)
+	result, _, err := a.AllocateVoter(ctx, &simpleZoneConfig, []roachpb.ReplicaDescriptor{}, nil)
 	if err != nil {
 		t.Fatalf("unable to perform allocation: %+v", err)
 	}
@@ -5600,11 +5840,7 @@ func TestAllocatorThrottled(t *testing.T) {
 	}
 	storeDetail.throttledUntil = timeutil.Now().Add(24 * time.Hour)
 	a.storePool.detailsMu.Unlock()
-	_, _, err = a.AllocateTarget(
-		ctx,
-		&simpleZoneConfig,
-		[]roachpb.ReplicaDescriptor{},
-	)
+	_, _, err = a.AllocateVoter(ctx, &simpleZoneConfig, []roachpb.ReplicaDescriptor{}, nil)
 	if errors.HasInterface(err, (*purgatoryError)(nil)) {
 		t.Fatalf("expected a non purgatory error, got: %+v", err)
 	}

--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -3496,6 +3496,9 @@ func TestStoreRangeMergeDuringShutdown(t *testing.T) {
 func verifyMerged(t *testing.T, store *kvserver.Store, lhsStartKey, rhsStartKey roachpb.RKey) {
 	t.Helper()
 	repl := store.LookupReplica(rhsStartKey)
+	if repl == nil {
+		t.Fatal("replica doesn't exist")
+	}
 	if !repl.Desc().StartKey.Equal(lhsStartKey) {
 		t.Fatalf("ranges unexpectedly unmerged expected startKey %s, but got %s", lhsStartKey, repl.Desc().StartKey)
 	}
@@ -3504,6 +3507,9 @@ func verifyMerged(t *testing.T, store *kvserver.Store, lhsStartKey, rhsStartKey 
 func verifyUnmerged(t *testing.T, store *kvserver.Store, lhsStartKey, rhsStartKey roachpb.RKey) {
 	t.Helper()
 	repl := store.LookupReplica(rhsStartKey)
+	if repl == nil {
+		t.Fatal("replica doesn't exist")
+	}
 	if repl.Desc().StartKey.Equal(lhsStartKey) {
 		t.Fatalf("ranges unexpectedly merged")
 	}

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -2494,6 +2494,13 @@ func (s *Store) relocateReplicas(
 	}
 }
 
+type relocationArgs struct {
+	targetsToAdd, targetsToRemove []roachpb.ReplicaDescriptor
+	addOp, removeOp               roachpb.ReplicaChangeType
+	relocationTargets             []roachpb.ReplicationTarget
+	targetType                    targetReplicaType
+}
+
 func (s *Store) relocateOne(
 	ctx context.Context,
 	desc *roachpb.RangeDescriptor,
@@ -2518,17 +2525,34 @@ func (s *Store) relocateOne(
 	storeList, _, _ := s.allocator.storePool.getStoreList(storeFilterNone)
 	storeMap := storeListToMap(storeList)
 
-	getTargetsToRelocate := func() (targetsToAdd, targetsToRemove []roachpb.ReplicaDescriptor,
-		addOp, removeOp roachpb.ReplicaChangeType, votersRelocated bool) {
+	getRelocationArgs := func() relocationArgs {
 		votersToAdd := subtractTargets(voterTargets, desc.Replicas().Voters().ReplicationTargets())
 		votersToRemove := subtractTargets(desc.Replicas().Voters().ReplicationTargets(), voterTargets)
 		// If there are no voters to relocate, we relocate the non-voters.
+		//
+		// NB: This means that non-voters are handled after all voters have been
+		// relocated since relocateOne is expected to be called repeatedly until
+		// there are no more replicas to relocate.
 		if len(votersToAdd) == 0 && len(votersToRemove) == 0 {
 			nonVotersToAdd := subtractTargets(nonVoterTargets, desc.Replicas().NonVoters().ReplicationTargets())
 			nonVotersToRemove := subtractTargets(desc.Replicas().NonVoters().ReplicationTargets(), nonVoterTargets)
-			return nonVotersToAdd, nonVotersToRemove, roachpb.ADD_NON_VOTER, roachpb.REMOVE_NON_VOTER, true
+			return relocationArgs{
+				targetsToAdd:      nonVotersToAdd,
+				targetsToRemove:   nonVotersToRemove,
+				addOp:             roachpb.ADD_NON_VOTER,
+				removeOp:          roachpb.REMOVE_NON_VOTER,
+				relocationTargets: nonVoterTargets,
+				targetType:        nonVoterTarget,
+			}
 		}
-		return votersToAdd, votersToRemove, roachpb.ADD_VOTER, roachpb.REMOVE_VOTER, false
+		return relocationArgs{
+			targetsToAdd:      votersToAdd,
+			targetsToRemove:   votersToRemove,
+			addOp:             roachpb.ADD_VOTER,
+			removeOp:          roachpb.REMOVE_VOTER,
+			relocationTargets: voterTargets,
+			targetType:        voterTarget,
+		}
 	}
 
 	// Compute which replica to add and/or remove, respectively. We then ask the
@@ -2540,24 +2564,22 @@ func (s *Store) relocateOne(
 	// same node, and this code doesn't do anything to specifically avoid that
 	// case (although the allocator will avoid even trying to send snapshots to
 	// such stores), so it could cause some failures.
-	targetsToAdd, targetsToRemove, addOp, removeOp, votersRelocated := getTargetsToRelocate()
-	relocationTargets := voterTargets
-	existingReplicas := desc.Replicas().VoterDescriptors()
-	if votersRelocated {
-		relocationTargets = nonVoterTargets
-		existingReplicas = desc.Replicas().NonVoterDescriptors()
-	}
+	args := getRelocationArgs()
+	existingVoters := desc.Replicas().VoterDescriptors()
+	existingNonVoters := desc.Replicas().NonVoterDescriptors()
+	existingReplicas := desc.Replicas().Descriptors()
 
 	var ops roachpb.ReplicationChanges
-	if len(targetsToAdd) > 0 {
+	if len(args.targetsToAdd) > 0 {
 		// Each iteration, pick the most desirable replica to add. However,
 		// prefer the first target because it's the one that should hold the
 		// lease in the end; it helps to add it early so that the lease doesn't
 		// have to move too much.
-		candidateTargets := targetsToAdd
-		if !votersRelocated && storeHasReplica(relocationTargets[0].StoreID, candidateTargets) {
+		candidateTargets := args.targetsToAdd
+		if args.targetType == voterTarget &&
+			storeHasReplica(args.relocationTargets[0].StoreID, candidateTargets) {
 			candidateTargets = []roachpb.ReplicaDescriptor{
-				{NodeID: relocationTargets[0].NodeID, StoreID: relocationTargets[0].StoreID},
+				{NodeID: args.relocationTargets[0].NodeID, StoreID: args.relocationTargets[0].StoreID},
 			}
 		}
 
@@ -2579,42 +2601,51 @@ func (s *Store) relocateOne(
 			ctx,
 			candidateStoreList,
 			zone,
-			existingReplicas,
-			s.allocator.scorerOptions())
-		if targetStore == nil {
-			return nil, nil, fmt.Errorf("none of the remaining relocationTargets %v are legal additions to %v",
-				targetsToAdd, desc.Replicas())
-		}
+			existingVoters,
+			existingNonVoters,
+			s.allocator.scorerOptions(),
+			args.targetType)
 
 		target := roachpb.ReplicationTarget{
 			NodeID:  targetStore.Node.NodeID,
 			StoreID: targetStore.StoreID,
 		}
-		ops = append(ops, roachpb.MakeReplicationChanges(addOp, target)...)
+		ops = append(ops, roachpb.MakeReplicationChanges(args.addOp, target)...)
+
 		// Pretend the replica is already there so that the removal logic below will
 		// take it into account when deciding which replica to remove.
-		existingReplicas = append(existingReplicas, roachpb.ReplicaDescriptor{
-			NodeID:    target.NodeID,
-			StoreID:   target.StoreID,
-			ReplicaID: desc.NextReplicaID,
-			Type:      roachpb.ReplicaTypeVoterFull(),
-		})
+		if args.targetType == nonVoterTarget {
+			existingNonVoters = append(existingNonVoters, roachpb.ReplicaDescriptor{
+				NodeID:    target.NodeID,
+				StoreID:   target.StoreID,
+				ReplicaID: desc.NextReplicaID,
+				Type:      roachpb.ReplicaTypeNonVoter(),
+			})
+		} else {
+			existingVoters = append(existingVoters, roachpb.ReplicaDescriptor{
+				NodeID:    target.NodeID,
+				StoreID:   target.StoreID,
+				ReplicaID: desc.NextReplicaID,
+				Type:      roachpb.ReplicaTypeVoterFull(),
+			})
+		}
 	}
 
 	var transferTarget *roachpb.ReplicationTarget
-	if len(targetsToRemove) > 0 {
-		// Pick a replica to remove. Note that existingReplicas may already reflect
-		// a replica we're adding in the current round. This is the right thing
-		// to do. For example, consider relocating from (s1,s2,s3) to (s1,s2,s4)
-		// where targetsToAdd will be (s4) and targetsToRemove is (s3). In this code,
-		// we'll want the allocator to see if s3 can be removed from
+	if len(args.targetsToRemove) > 0 {
+		// Pick a replica to remove. Note that existingVoters/existingNonVoters may
+		// already reflect a replica we're adding in the current round. This is the
+		// right thing to do. For example, consider relocating from (s1,s2,s3) to
+		// (s1,s2,s4) where targetsToAdd will be (s4) and targetsToRemove is (s3).
+		// In this code, we'll want the allocator to see if s3 can be removed from
 		// (s1,s2,s3,s4) which is a reasonable request; that replica set is
-		// overreplicated. If we asked it instead to remove s3 from (s1,s2,s3)
-		// it may not want to do that due to constraints.
-		targetStore, _, err := s.allocator.RemoveTarget(ctx, zone, targetsToRemove, existingReplicas)
+		// overreplicated. If we asked it instead to remove s3 from (s1,s2,s3) it
+		// may not want to do that due to constraints.
+		targetStore, _, err := s.allocator.removeTarget(ctx, zone, args.targetsToRemove, existingVoters,
+			existingNonVoters, args.targetType)
 		if err != nil {
 			return nil, nil, errors.Wrapf(err, "unable to select removal target from %v; current replicas %v",
-				targetsToRemove, existingReplicas)
+				args.targetsToRemove, existingReplicas)
 		}
 		removalTarget := roachpb.ReplicationTarget{
 			NodeID:  targetStore.NodeID,
@@ -2634,17 +2665,16 @@ func (s *Store) relocateOne(
 		}
 		curLeaseholder := b.RawResponse().Responses[0].GetLeaseInfo().Lease.Replica
 		ok := curLeaseholder.StoreID != removalTarget.StoreID
-		if !ok {
-			// Pick a replica that we can give the lease to. We sort the first
-			// target to the beginning (if it's there) because that's where the
-			// lease needs to be in the end. We also exclude the last replica if
-			// it was added by the add branch above (in which case it doesn't
-			// exist yet).
-			sortedTargetReplicas := append([]roachpb.ReplicaDescriptor(nil), existingReplicas[:len(existingReplicas)-len(ops)]...)
+		if !ok && args.targetType == voterTarget {
+			// Pick a voting replica that we can give the lease to. We sort the first
+			// target to the beginning (if it's there) because that's where the lease
+			// needs to be in the end. We also exclude the last replica if it was
+			// added by the add branch above (in which case it doesn't exist yet).
+			sortedTargetReplicas := append([]roachpb.ReplicaDescriptor(nil), existingVoters[:len(existingVoters)-len(ops)]...)
 			sort.Slice(sortedTargetReplicas, func(i, j int) bool {
 				sl := sortedTargetReplicas
 				// relocationTargets[0] goes to the front (if it's present).
-				return sl[i].StoreID == relocationTargets[0].StoreID
+				return sl[i].StoreID == args.relocationTargets[0].StoreID
 			})
 			for _, rDesc := range sortedTargetReplicas {
 				if rDesc.StoreID != curLeaseholder.StoreID {
@@ -2665,7 +2695,7 @@ func (s *Store) relocateOne(
 		// illegal).
 		if ok {
 			ops = append(ops, roachpb.MakeReplicationChanges(
-				removeOp,
+				args.removeOp,
 				removalTarget)...)
 		}
 	}


### PR DESCRIPTION
This commit primarily teaches the allocator to be able to rank
non-voting replica candidates for addition and removal. This allows us
to have the replicateQueue execute upon the allocator's actions to add
or remove non-voting replicas to a range.

Note that this commit does not deal with _rebalancing_ of non-voting
replicas, just simple additions and removals when a range is over or
under-replicated.

Release note: None