### PR TITLE
sql: Implement ALTER TABLE ... LOCALITY REGIONAL BY TABLE from GLOBAL

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/alter_table_locality
+++ b/pkg/ccl/logictestccl/testdata/logic_test/alter_table_locality
@@ -149,7 +149,7 @@ statement error unimplemented: implementation pending
 ALTER TABLE regional_by_row SET LOCALITY REGIONAL BY TABLE
 
 statement error unimplemented: implementation pending
-ALTER TABLE regional_by_row SET LOCALITY REGIONAL BY TABLE in "ap-southeast"
+ALTER TABLE regional_by_row SET LOCALITY REGIONAL BY TABLE in "ap-southeast-2"
 
 statement error unimplemented: implementation pending
 ALTER TABLE regional_by_row SET LOCALITY REGIONAL BY TABLE in PRIMARY REGION
@@ -193,14 +193,84 @@ DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE 
                               constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
                               lease_preferences = '[[+region=ca-central-1]]'
 
-statement error unimplemented: implementation pending
+statement ok
 ALTER TABLE global SET LOCALITY REGIONAL BY TABLE
 
-statement error unimplemented: implementation pending
-ALTER TABLE global SET LOCALITY REGIONAL BY TABLE in "ap-southeast"
+query TT
+SHOW CREATE TABLE global
+----
+global             CREATE TABLE public.global (
+                   i INT8 NULL,
+                   FAMILY "primary" (i, rowid)
+) LOCALITY REGIONAL BY TABLE IN PRIMARY REGION
 
-statement error unimplemented: implementation pending
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE global
+----
+DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
+                              range_min_bytes = 134217728,
+                              range_max_bytes = 536870912,
+                              gc.ttlseconds = 90000,
+                              num_replicas = 3,
+                              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                              lease_preferences = '[[+region=ca-central-1]]'
+
+# Alter back, to get back to original state
+statement ok
+ALTER TABLE global SET LOCALITY GLOBAL
+
+statement ok
+ALTER TABLE global SET LOCALITY REGIONAL BY TABLE in "ap-southeast-2"
+
+query TT
+SHOW CREATE TABLE global
+----
+global             CREATE TABLE public.global (
+                   i INT8 NULL,
+                   FAMILY "primary" (i, rowid)
+) LOCALITY REGIONAL BY TABLE IN "ap-southeast-2"
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE global
+----
+TABLE global  ALTER TABLE global CONFIGURE ZONE USING
+              range_min_bytes = 134217728,
+              range_max_bytes = 536870912,
+              gc.ttlseconds = 90000,
+              global_reads = true,
+              num_replicas = 3,
+              constraints = '{+region=ap-southeast-2: 3}',
+              lease_preferences = '[[+region=ap-southeast-2]]'
+
+# Alter back, to get back to original state
+statement ok
+ALTER TABLE global SET LOCALITY GLOBAL
+
+statement ok
 ALTER TABLE global SET LOCALITY REGIONAL BY TABLE in PRIMARY REGION
+
+query TT
+SHOW CREATE TABLE global
+----
+global                                          CREATE TABLE public.global (
+                                                i INT8 NULL,
+                                                FAMILY "primary" (i, rowid)
+) LOCALITY REGIONAL BY TABLE IN PRIMARY REGION
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE global
+----
+DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
+                              range_min_bytes = 134217728,
+                              range_max_bytes = 536870912,
+                              gc.ttlseconds = 90000,
+                              num_replicas = 3,
+                              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                              lease_preferences = '[[+region=ca-central-1]]'
+
+# Alter back, to get back to original state
+statement ok
+ALTER TABLE global SET LOCALITY GLOBAL
 
 statement ok
 ALTER TABLE global SET LOCALITY GLOBAL

--- a/pkg/sql/delegate/show_regions.go
+++ b/pkg/sql/delegate/show_regions.go
@@ -86,7 +86,7 @@ FROM [
 	WHERE dbs.name = %s
 ] r
 LEFT JOIN zones_table ON (r.region = zones_table.region)
-ORDER BY region`,
+ORDER BY "primary" DESC, "region"`,
 			zonesClause,
 			lex.EscapeSQLString(dbName),
 		)

--- a/pkg/sql/logictest/testdata/logic_test/multiregion
+++ b/pkg/sql/logictest/testdata/logic_test/multiregion
@@ -124,8 +124,8 @@ query TTBT colnames
 SHOW REGIONS FROM DATABASE
 ----
 database              region          primary  zones
-multi_region_test_db  ap-southeast-2  false    {ap-az1,ap-az2,ap-az3}
 multi_region_test_db  ca-central-1    true     {ca-az1,ca-az2,ca-az3}
+multi_region_test_db  ap-southeast-2  false    {ap-az1,ap-az2,ap-az3}
 multi_region_test_db  us-east-1       false    {us-az1,us-az2,us-az3}
 
 query TTTT colnames
@@ -354,8 +354,8 @@ query TTBT colnames
 show regions from database alter_test_db
 ----
 database       region          primary  zones
-alter_test_db  ap-southeast-2  false    {ap-az1,ap-az2,ap-az3}
 alter_test_db  ca-central-1    true     {ca-az1,ca-az2,ca-az3}
+alter_test_db  ap-southeast-2  false    {ap-az1,ap-az2,ap-az3}
 
 query TTTT colnames
 SHOW ENUMS FROM alter_test_db.public
@@ -382,8 +382,8 @@ query TTBT colnames
 show regions from database alter_test_db
 ----
 database       region          primary  zones
-alter_test_db  ap-southeast-2  false    {ap-az1,ap-az2,ap-az3}
 alter_test_db  ca-central-1    true     {ca-az1,ca-az2,ca-az3}
+alter_test_db  ap-southeast-2  false    {ap-az1,ap-az2,ap-az3}
 alter_test_db  us-east-1       false    {us-az1,us-az2,us-az3}
 
 query TTTT colnames
@@ -500,8 +500,8 @@ query TTBT colnames
 show regions from database alter_primary_region_db
 ----
 database                 region          primary  zones
-alter_primary_region_db  ap-southeast-2  false    {ap-az1,ap-az2,ap-az3}
 alter_primary_region_db  ca-central-1    true     {ca-az1,ca-az2,ca-az3}
+alter_primary_region_db  ap-southeast-2  false    {ap-az1,ap-az2,ap-az3}
 
 statement ok
 ALTER DATABASE alter_primary_region_db PRIMARY REGION "ap-southeast-2"

--- a/pkg/sql/region_util.go
+++ b/pkg/sql/region_util.go
@@ -49,20 +49,6 @@ func (s *liveClusterRegions) toStrings() []string {
 	return ret
 }
 
-// assertIsMultiRegionDatabase ensures that we're in a multi-region database, and
-// if not, returns an assertion error. Takes an "operation" string which describes
-// the operation in progress which requires database to be multi-region.
-func assertIsMultiRegionDatabase(desc *dbdesc.Immutable, operation string) error {
-	if !desc.IsMultiRegion() {
-		return errors.AssertionFailedf(
-			"invalid call to %q on a non-multi-region database. %v",
-			operation,
-			desc,
-		)
-	}
-	return nil
-}
-
 // getLiveClusterRegions returns a set of live region names in the cluster.
 // A region name is deemed active if there is at least one alive node
 // in the cluster in with locality set to a given region.

--- a/pkg/sql/sem/tree/region.go
+++ b/pkg/sql/sem/tree/region.go
@@ -53,12 +53,6 @@ type Locality struct {
 	RegionalByRowColumn Name
 }
 
-// InPrimaryRegion returns true if the table is REGIONAL BY TABLE and the table
-// region is unset (representing the primary region).
-func (node *Locality) InPrimaryRegion() bool {
-	return node.LocalityLevel == LocalityLevelTable && node.TableRegion == ""
-}
-
 // Format implements the NodeFormatter interface.
 func (node *Locality) Format(ctx *FmtCtx) {
 	ctx.WriteString("LOCALITY ")


### PR DESCRIPTION
Implements ALTER TABLE ... LOCALITY REGIONAL BY TABLE (all permutations)
from LOCALITY GLOBAL.

Release note (sql change): Implements ALTER TABLE ... LOCALITY REGIONAL
BY TABLE from LOCALITY GLOBAL.

Resolves #58343.
Also resolves #59249.