### PR TITLE
sql: add support for adding/dropping UNIQUE WITHOUT INDEX constraints

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -163,8 +163,15 @@ func (n *alterTableNode) startExec(params runParams) error {
 		switch t := cmd.(type) {
 		case *tree.AlterTableAddColumn:
 			if t.ColumnDef.Unique.WithoutIndex {
-				return pgerror.New(pgcode.FeatureNotSupported,
-					"unique constraints without an index are not yet supported",
+				// TODO(rytaft): add support for this in the future if we want to expose
+				// UNIQUE WITHOUT INDEX to users.
+				return errors.WithHint(
+					pgerror.New(
+						pgcode.FeatureNotSupported,
+						"adding a column marked as UNIQUE WITHOUT INDEX is unsupported",
+					),
+					"add the column first, then run ALTER TABLE ... ADD CONSTRAINT to add a "+
+						"UNIQUE WITHOUT INDEX constraint on the column",
 				)
 			}
 			var err error
@@ -178,10 +185,20 @@ func (n *alterTableNode) startExec(params runParams) error {
 			switch d := t.ConstraintDef.(type) {
 			case *tree.UniqueConstraintTableDef:
 				if d.WithoutIndex {
-					return pgerror.New(pgcode.FeatureNotSupported,
-						"unique constraints without an index are not yet supported",
-					)
+					if err := addUniqueWithoutIndexTableDef(
+						params.ctx,
+						params.EvalContext(),
+						params.SessionData(),
+						d,
+						n.tableDesc,
+						NonEmptyTable,
+						t.ValidationBehavior,
+					); err != nil {
+						return err
+					}
+					continue
 				}
+
 				if d.PrimaryKey {
 					// We only support "adding" a primary key when we are using the
 					// default rowid primary index or if a DROP PRIMARY KEY statement
@@ -734,10 +751,13 @@ func (n *alterTableNode) startExec(params runParams) error {
 						return pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
 							"constraint %q in the middle of being added, try again later", t.Constraint)
 					}
-					// TODO(rytaft): Call validateUniqueConstraint once supported.
-					return pgerror.New(pgcode.FeatureNotSupported,
-						"validation of unique constraints without an index are not yet supported",
-					)
+					if err := validateUniqueConstraintInTxn(
+						params.ctx, params.p.LeaseMgr(), params.EvalContext(), n.tableDesc, params.EvalContext().Txn, name,
+					); err != nil {
+						return err
+					}
+					foundUnique.Validity = descpb.ConstraintValidity_Validated
+					break
 				}
 
 				// This unique constraint is enforced by an index, so fall through to

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -232,6 +232,11 @@ func (sc *SchemaChanger) runBackfill(ctx context.Context) error {
 						constraintsToAddBeforeValidation = append(constraintsToAddBeforeValidation, *t.Constraint)
 						constraintsToValidate = append(constraintsToValidate, *t.Constraint)
 					}
+				case descpb.ConstraintToUpdate_UNIQUE_WITHOUT_INDEX:
+					if t.Constraint.UniqueWithoutIndexConstraint.Validity == descpb.ConstraintValidity_Validating {
+						constraintsToAddBeforeValidation = append(constraintsToAddBeforeValidation, *t.Constraint)
+						constraintsToValidate = append(constraintsToValidate, *t.Constraint)
+					}
 				case descpb.ConstraintToUpdate_NOT_NULL:
 					// NOT NULL constraints are always validated before they can be added
 					constraintsToAddBeforeValidation = append(constraintsToAddBeforeValidation, *t.Constraint)
@@ -419,6 +424,26 @@ func (sc *SchemaChanger) dropConstraints(
 						constraint,
 					)
 				}
+			case descpb.ConstraintToUpdate_UNIQUE_WITHOUT_INDEX:
+				found := false
+				for j, c := range scTable.UniqueWithoutIndexConstraints {
+					if c.Name == constraint.Name {
+						scTable.UniqueWithoutIndexConstraints = append(
+							scTable.UniqueWithoutIndexConstraints[:j],
+							scTable.UniqueWithoutIndexConstraints[j+1:]...,
+						)
+						found = true
+						break
+					}
+				}
+				if !found {
+					log.VEventf(
+						ctx, 2,
+						"backfiller tried to drop constraint %+v but it was not found, "+
+							"presumably due to a retry or rollback",
+						constraint,
+					)
+				}
 			}
 		}
 		if err := descsCol.WriteDescToBatch(
@@ -562,6 +587,28 @@ func (sc *SchemaChanger) addConstraints(
 						}
 					}
 				}
+			case descpb.ConstraintToUpdate_UNIQUE_WITHOUT_INDEX:
+				found := false
+				for _, c := range scTable.UniqueWithoutIndexConstraints {
+					if c.Name == constraint.Name {
+						log.VEventf(
+							ctx, 2,
+							"backfiller tried to add constraint %+v but found existing constraint %+v, "+
+								"presumably due to a retry or rollback",
+							constraint, c,
+						)
+						// Ensure the constraint on the descriptor is set to Validating, in
+						// case we're in the middle of rolling back DROP CONSTRAINT
+						c.Validity = descpb.ConstraintValidity_Validating
+						found = true
+						break
+					}
+				}
+				if !found {
+					scTable.UniqueWithoutIndexConstraints = append(
+						scTable.UniqueWithoutIndexConstraints, constraints[i].UniqueWithoutIndexConstraint,
+					)
+				}
 			}
 		}
 		if err := descsCol.WriteDescToBatch(
@@ -659,6 +706,10 @@ func (sc *SchemaChanger) validateConstraints(
 					}
 				case descpb.ConstraintToUpdate_FOREIGN_KEY:
 					if err := validateFkInTxn(ctx, sc.leaseMgr, &evalCtx.EvalContext, desc, txn, c.Name); err != nil {
+						return err
+					}
+				case descpb.ConstraintToUpdate_UNIQUE_WITHOUT_INDEX:
+					if err := validateUniqueConstraintInTxn(ctx, sc.leaseMgr, &evalCtx.EvalContext, desc, txn, c.Name); err != nil {
 						return err
 					}
 				case descpb.ConstraintToUpdate_NOT_NULL:
@@ -1867,6 +1918,16 @@ func runSchemaChangesInTxn(
 							break
 						}
 					}
+				case descpb.ConstraintToUpdate_UNIQUE_WITHOUT_INDEX:
+					for i := range tableDesc.UniqueWithoutIndexConstraints {
+						if tableDesc.UniqueWithoutIndexConstraints[i].Name == t.Constraint.Name {
+							tableDesc.UniqueWithoutIndexConstraints = append(
+								tableDesc.UniqueWithoutIndexConstraints[:i],
+								tableDesc.UniqueWithoutIndexConstraints[i+1:]...,
+							)
+							break
+						}
+					}
 				default:
 					return errors.AssertionFailedf(
 						"unsupported constraint type: %d", errors.Safe(t.Constraint.ConstraintType))
@@ -1964,6 +2025,15 @@ func runSchemaChangesInTxn(
 			//
 			// For now, just always add the FK as unvalidated.
 			constraint.ForeignKey.Validity = descpb.ConstraintValidity_Unvalidated
+		case descpb.ConstraintToUpdate_UNIQUE_WITHOUT_INDEX:
+			if constraint.UniqueWithoutIndexConstraint.Validity == descpb.ConstraintValidity_Validating {
+				if err := validateUniqueConstraintInTxn(
+					ctx, planner.Descriptors().LeaseManager(), planner.EvalContext(), tableDesc, planner.txn, constraint.Name,
+				); err != nil {
+					return err
+				}
+				constraint.UniqueWithoutIndexConstraint.Validity = descpb.ConstraintValidity_Validated
+			}
 		default:
 			return errors.AssertionFailedf(
 				"unsupported constraint type: %d", errors.Safe(constraint.ConstraintType))
@@ -2006,6 +2076,10 @@ func runSchemaChangesInTxn(
 					return err
 				}
 			}
+		case descpb.ConstraintToUpdate_UNIQUE_WITHOUT_INDEX:
+			tableDesc.UniqueWithoutIndexConstraints = append(
+				tableDesc.UniqueWithoutIndexConstraints, constraint.UniqueWithoutIndexConstraint,
+			)
 		default:
 			return errors.AssertionFailedf(
 				"unsupported constraint type: %d", errors.Safe(constraint.ConstraintType))
@@ -2099,6 +2173,55 @@ func validateFkInTxn(
 	}
 
 	return validateForeignKey(ctx, tableDesc, fk, ie, txn, evalCtx.Codec)
+}
+
+// validateUniqueConstraintInTxn validates a unique constraint within the
+// provided transaction. If the provided table descriptor version is newer than
+// the cluster version, it will be used in the InternalExecutor that performs
+// the validation query.
+//
+// TODO (lucy): The special case where the table descriptor version is the same
+// as the cluster version only happens because the query in VALIDATE CONSTRAINT
+// still runs in the user transaction instead of a step in the schema changer.
+// When that's no longer true, this function should be updated.
+//
+// It operates entirely on the current goroutine and is thus able to
+// reuse an existing kv.Txn safely.
+func validateUniqueConstraintInTxn(
+	ctx context.Context,
+	leaseMgr *lease.Manager,
+	evalCtx *tree.EvalContext,
+	tableDesc *tabledesc.Mutable,
+	txn *kv.Txn,
+	constraintName string,
+) error {
+	ie := evalCtx.InternalExecutor.(*InternalExecutor)
+	if tableDesc.Version > tableDesc.ClusterVersion.Version {
+		newTc := descs.NewCollection(evalCtx.Settings, leaseMgr, nil /* hydratedTables */)
+		// pretend that the schema has been modified.
+		if err := newTc.AddUncommittedDescriptor(tableDesc); err != nil {
+			return err
+		}
+
+		ie.tcModifier = newTc
+		defer func() {
+			ie.tcModifier = nil
+		}()
+	}
+
+	var uc *descpb.UniqueWithoutIndexConstraint
+	for i := range tableDesc.UniqueWithoutIndexConstraints {
+		def := &tableDesc.UniqueWithoutIndexConstraints[i]
+		if def.Name == constraintName {
+			uc = def
+			break
+		}
+	}
+	if uc == nil {
+		return errors.AssertionFailedf("unique constraint %s does not exist", constraintName)
+	}
+
+	return validateUniqueConstraint(ctx, tableDesc, uc, ie, txn)
 }
 
 // columnBackfillInTxn backfills columns for all mutation columns in

--- a/pkg/sql/catalog/tabledesc/structured.go
+++ b/pkg/sql/catalog/tabledesc/structured.go
@@ -3050,11 +3050,9 @@ func (desc *Mutable) DropConstraint(
 					)
 					return nil
 				}
-				// TODO(rytaft): set validity to Dropping and call AddUniqueMutation
-				// once supported.
-				return pgerror.New(pgcode.FeatureNotSupported,
-					"dropping valid unique constraints without an index is not yet supported",
-				)
+				ref.Validity = descpb.ConstraintValidity_Dropping
+				desc.AddUniqueWithoutIndexMutation(ref, descpb.DescriptorMutation_DROP)
+				return nil
 			}
 		}
 		return errors.AssertionFailedf("constraint %q not found on table %q", name, desc.Name)
@@ -3301,7 +3299,7 @@ func (desc *Mutable) MakeMutationComplete(m descpb.DescriptorMutation) error {
 			case descpb.ConstraintToUpdate_CHECK:
 				switch t.Constraint.Check.Validity {
 				case descpb.ConstraintValidity_Validating:
-					// Constraint already added, just mark it as Validated
+					// Constraint already added, just mark it as Validated.
 					for _, c := range desc.Checks {
 						if c.Name == t.Constraint.Name {
 							c.Validity = descpb.ConstraintValidity_Validated
@@ -3310,7 +3308,7 @@ func (desc *Mutable) MakeMutationComplete(m descpb.DescriptorMutation) error {
 					}
 				case descpb.ConstraintValidity_Unvalidated:
 					// add the constraint to the list of check constraints on the table
-					// descriptor
+					// descriptor.
 					desc.Checks = append(desc.Checks, &t.Constraint.Check)
 				default:
 					return errors.AssertionFailedf("invalid constraint validity state: %d", t.Constraint.Check.Validity)
@@ -3318,7 +3316,7 @@ func (desc *Mutable) MakeMutationComplete(m descpb.DescriptorMutation) error {
 			case descpb.ConstraintToUpdate_FOREIGN_KEY:
 				switch t.Constraint.ForeignKey.Validity {
 				case descpb.ConstraintValidity_Validating:
-					// Constraint already added, just mark it as Validated
+					// Constraint already added, just mark it as Validated.
 					for i := range desc.OutboundFKs {
 						fk := &desc.OutboundFKs[i]
 						if fk.Name == t.Constraint.Name {
@@ -3333,8 +3331,31 @@ func (desc *Mutable) MakeMutationComplete(m descpb.DescriptorMutation) error {
 					// TODO (tyler): Combine both of these tasks in the same place.
 					desc.OutboundFKs = append(desc.OutboundFKs, t.Constraint.ForeignKey)
 				}
+			case descpb.ConstraintToUpdate_UNIQUE_WITHOUT_INDEX:
+				switch t.Constraint.UniqueWithoutIndexConstraint.Validity {
+				case descpb.ConstraintValidity_Validating:
+					// Constraint already added, just mark it as Validated.
+					for i := range desc.UniqueWithoutIndexConstraints {
+						uc := &desc.UniqueWithoutIndexConstraints[i]
+						if uc.Name == t.Constraint.Name {
+							uc.Validity = descpb.ConstraintValidity_Validated
+							break
+						}
+					}
+				case descpb.ConstraintValidity_Unvalidated:
+					// add the constraint to the list of unique without index constraints
+					// on the table descriptor.
+					desc.UniqueWithoutIndexConstraints = append(
+						desc.UniqueWithoutIndexConstraints, t.Constraint.UniqueWithoutIndexConstraint,
+					)
+				default:
+					return errors.AssertionFailedf("invalid constraint validity state: %d",
+						t.Constraint.UniqueWithoutIndexConstraint.Validity,
+					)
+				}
 			case descpb.ConstraintToUpdate_NOT_NULL:
-				// Remove the dummy check constraint that was in place during validation
+				// Remove the dummy check constraint that was in place during
+				// validation.
 				for i, c := range desc.Checks {
 					if c.Name == t.Constraint.Check.Name {
 						desc.Checks = append(desc.Checks[:i], desc.Checks[i+1:]...)
@@ -3584,6 +3605,24 @@ func (desc *Mutable) AddForeignKeyMutation(
 				ConstraintType: descpb.ConstraintToUpdate_FOREIGN_KEY,
 				Name:           fk.Name,
 				ForeignKey:     *fk,
+			},
+		},
+		Direction: direction,
+	}
+	desc.addMutation(m)
+}
+
+// AddUniqueWithoutIndexMutation adds a unqiue without index constraint mutation
+// to desc.Mutations.
+func (desc *Mutable) AddUniqueWithoutIndexMutation(
+	uc *descpb.UniqueWithoutIndexConstraint, direction descpb.DescriptorMutation_Direction,
+) {
+	m := descpb.DescriptorMutation{
+		Descriptor_: &descpb.DescriptorMutation_Constraint{
+			Constraint: &descpb.ConstraintToUpdate{
+				ConstraintType:               descpb.ConstraintToUpdate_UNIQUE_WITHOUT_INDEX,
+				Name:                         uc.Name,
+				UniqueWithoutIndexConstraint: *uc,
 			},
 		},
 		Direction: direction,

--- a/pkg/sql/catalog/tabledesc/table.go
+++ b/pkg/sql/catalog/tabledesc/table.go
@@ -260,6 +260,9 @@ func (desc *wrapper) collectConstraintInfo(
 				"duplicate constraint name: %q", uc.Name)
 		}
 		detail := descpb.ConstraintDetail{Kind: descpb.ConstraintTypeUnique}
+		// Constraints in the Validating state are considered Unvalidated for this
+		// purpose.
+		detail.Unvalidated = uc.Validity != descpb.ConstraintValidity_Validated
 		var err error
 		detail.Columns, err = desc.NamesForColumnIDs(uc.ColumnIDs)
 		if err != nil {
@@ -276,7 +279,8 @@ func (desc *wrapper) collectConstraintInfo(
 				"duplicate constraint name: %q", fk.Name)
 		}
 		detail := descpb.ConstraintDetail{Kind: descpb.ConstraintTypeFK}
-		// Constraints in the Validating state are considered Unvalidated for this purpose
+		// Constraints in the Validating state are considered Unvalidated for this
+		// purpose.
 		detail.Unvalidated = fk.Validity != descpb.ConstraintValidity_Validated
 		var err error
 		detail.Columns, err = desc.NamesForColumnIDs(fk.OriginColumnIDs)
@@ -308,7 +312,8 @@ func (desc *wrapper) collectConstraintInfo(
 				"duplicate constraint name: %q", c.Name)
 		}
 		detail := descpb.ConstraintDetail{Kind: descpb.ConstraintTypeCheck}
-		// Constraints in the Validating state are considered Unvalidated for this purpose
+		// Constraints in the Validating state are considered Unvalidated for this
+		// purpose.
 		detail.Unvalidated = c.Validity != descpb.ConstraintValidity_Validated
 		detail.CheckConstraint = c
 		detail.Details = c.Expr

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -595,6 +595,94 @@ func (p *planner) MaybeUpgradeDependentOldForeignKeyVersionTables(
 	return nil
 }
 
+// addUniqueWithoutIndexColumnTableDef runs various checks on the given
+// ColumnTableDef before adding it as a UNIQUE WITHOUT INDEX constraint to the
+// given table descriptor.
+func addUniqueWithoutIndexColumnTableDef(
+	ctx context.Context,
+	evalCtx *tree.EvalContext,
+	sessionData *sessiondata.SessionData,
+	d *tree.ColumnTableDef,
+	desc *tabledesc.Mutable,
+	ts TableState,
+	validationBehavior tree.ValidationBehavior,
+) error {
+	if !evalCtx.Settings.Version.IsActive(ctx, clusterversion.UniqueWithoutIndexConstraints) {
+		return pgerror.Newf(pgcode.FeatureNotSupported,
+			"version %v must be finalized to use UNIQUE WITHOUT INDEX",
+			clusterversion.UniqueWithoutIndexConstraints)
+	}
+	if !sessionData.EnableUniqueWithoutIndexConstraints {
+		return pgerror.New(pgcode.FeatureNotSupported,
+			"unique constraints without an index are not yet supported",
+		)
+	}
+	// Add a unique constraint.
+	if err := ResolveUniqueWithoutIndexConstraint(
+		ctx, desc, string(d.Unique.ConstraintName), []string{string(d.Name)}, ts, validationBehavior,
+	); err != nil {
+		return err
+	}
+	return nil
+}
+
+// addUniqueWithoutIndexTableDef runs various checks on the given
+// UniqueConstraintTableDef before adding it as a UNIQUE WITHOUT INDEX
+// constraint to the given table descriptor.
+func addUniqueWithoutIndexTableDef(
+	ctx context.Context,
+	evalCtx *tree.EvalContext,
+	sessionData *sessiondata.SessionData,
+	d *tree.UniqueConstraintTableDef,
+	desc *tabledesc.Mutable,
+	ts TableState,
+	validationBehavior tree.ValidationBehavior,
+) error {
+	if !evalCtx.Settings.Version.IsActive(ctx, clusterversion.UniqueWithoutIndexConstraints) {
+		return pgerror.Newf(pgcode.FeatureNotSupported,
+			"version %v must be finalized to use UNIQUE WITHOUT INDEX",
+			clusterversion.UniqueWithoutIndexConstraints)
+	}
+	if !sessionData.EnableUniqueWithoutIndexConstraints {
+		return pgerror.New(pgcode.FeatureNotSupported,
+			"unique constraints without an index are not yet supported",
+		)
+	}
+	if len(d.Storing) > 0 {
+		return pgerror.New(pgcode.FeatureNotSupported,
+			"unique constraints without an index cannot store columns",
+		)
+	}
+	if d.Interleave != nil {
+		return pgerror.New(pgcode.FeatureNotSupported,
+			"interleaved unique constraints without an index are not supported",
+		)
+	}
+	if d.PartitionByIndex.ContainsPartitions() {
+		return pgerror.New(pgcode.FeatureNotSupported,
+			"partitioned unique constraints without an index are not supported",
+		)
+	}
+	if d.Predicate != nil {
+		// TODO(rytaft): It may be necessary to support predicates so that partial
+		// unique indexes will work correctly in multi-region deployments.
+		return pgerror.New(pgcode.FeatureNotSupported,
+			"unique constraints with a predicate but without an index are not supported",
+		)
+	}
+	// Add a unique constraint.
+	colNames := make([]string, len(d.Columns))
+	for i := range colNames {
+		colNames[i] = string(d.Columns[i].Column)
+	}
+	if err := ResolveUniqueWithoutIndexConstraint(
+		ctx, desc, string(d.Name), colNames, ts, validationBehavior,
+	); err != nil {
+		return err
+	}
+	return nil
+}
+
 // ResolveUniqueWithoutIndexConstraint looks up the columns mentioned in a
 // UNIQUE WITHOUT INDEX constraint and adds metadata representing that
 // constraint to the descriptor.
@@ -669,11 +757,7 @@ func ResolveUniqueWithoutIndexConstraint(
 	if ts == NewTable {
 		tbl.UniqueWithoutIndexConstraints = append(tbl.UniqueWithoutIndexConstraints, uc)
 	} else {
-		// TODO(rytaft): call AddUniqueConstraintMutation and remove the error
-		//  below.
-		return errors.AssertionFailedf(
-			"resolving unique constraints on existing tables not yet supported",
-		)
+		tbl.AddUniqueWithoutIndexMutation(&uc, descpb.DescriptorMutation_ADD)
 	}
 
 	return nil
@@ -2017,20 +2101,8 @@ func NewTableDesc(
 		switch d := def.(type) {
 		case *tree.ColumnTableDef:
 			if d.Unique.WithoutIndex {
-				if !evalCtx.Settings.Version.IsActive(ctx, clusterversion.UniqueWithoutIndexConstraints) {
-					return nil, pgerror.Newf(pgcode.FeatureNotSupported,
-						"version %v must be finalized to use UNIQUE WITHOUT INDEX",
-						clusterversion.UniqueWithoutIndexConstraints)
-				}
-				if !sessionData.EnableUniqueWithoutIndexConstraints {
-					return nil, pgerror.New(pgcode.FeatureNotSupported,
-						"unique constraints without an index are not yet supported",
-					)
-				}
-				// Add a unique constraint.
-				if err := ResolveUniqueWithoutIndexConstraint(
-					ctx, &desc, string(d.Unique.ConstraintName), []string{string(d.Name)}, NewTable,
-					tree.ValidationDefault,
+				if err := addUniqueWithoutIndexColumnTableDef(
+					ctx, evalCtx, sessionData, d, &desc, NewTable, tree.ValidationDefault,
 				); err != nil {
 					return nil, err
 				}
@@ -2038,45 +2110,8 @@ func NewTableDesc(
 
 		case *tree.UniqueConstraintTableDef:
 			if d.WithoutIndex {
-				if !evalCtx.Settings.Version.IsActive(ctx, clusterversion.UniqueWithoutIndexConstraints) {
-					return nil, pgerror.Newf(pgcode.FeatureNotSupported,
-						"version %v must be finalized to use UNIQUE WITHOUT INDEX",
-						clusterversion.UniqueWithoutIndexConstraints)
-				}
-				if !sessionData.EnableUniqueWithoutIndexConstraints {
-					return nil, pgerror.New(pgcode.FeatureNotSupported,
-						"unique constraints without an index are not yet supported",
-					)
-				}
-				if len(d.Storing) > 0 {
-					return nil, pgerror.New(pgcode.FeatureNotSupported,
-						"unique constraints without an index cannot store columns",
-					)
-				}
-				if d.Interleave != nil {
-					return nil, pgerror.New(pgcode.FeatureNotSupported,
-						"interleaved unique constraints without an index are not supported",
-					)
-				}
-				if d.PartitionByIndex.ContainsPartitions() {
-					return nil, pgerror.New(pgcode.FeatureNotSupported,
-						"partitioned unique constraints without an index are not supported",
-					)
-				}
-				if d.Predicate != nil {
-					// TODO(rytaft): It may be necessary to support predicates so that partial
-					// unique indexes will work correctly in multi-region deployments.
-					return nil, pgerror.New(pgcode.FeatureNotSupported,
-						"unique constraints with a predicate but without an index are not supported",
-					)
-				}
-				// Add a unique constraint.
-				colNames := make([]string, len(d.Columns))
-				for i := range colNames {
-					colNames[i] = string(d.Columns[i].Column)
-				}
-				if err := ResolveUniqueWithoutIndexConstraint(
-					ctx, &desc, string(d.Name), colNames, NewTable, tree.ValidationDefault,
+				if err := addUniqueWithoutIndexTableDef(
+					ctx, evalCtx, sessionData, d, &desc, NewTable, tree.ValidationDefault,
 				); err != nil {
 					return nil, err
 				}

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -1410,6 +1410,19 @@ ALTER TABLE t_cannot_rename_constraint_over_index RENAME CONSTRAINT "primary" TO
 
 subtest unique_without_index
 
+statement error pq: unique constraints without an index are not yet supported
+CREATE TABLE unique_without_index_error (
+  a INT UNIQUE WITHOUT INDEX
+)
+
+statement ok
+CREATE TABLE unique_without_index_error (
+  a INT
+)
+
+statement error pq: unique constraints without an index are not yet supported
+ALTER TABLE unique_without_index_error ADD CONSTRAINT a_key UNIQUE WITHOUT INDEX (a)
+
 statement ok
 SET experimental_enable_unique_without_index_constraints = true
 
@@ -1433,30 +1446,63 @@ CREATE TABLE uwi_child (
   CONSTRAINT fk_d_e FOREIGN KEY (d, e) REFERENCES unique_without_index (d, e)
 )
 
-# We don't yet support adding unique constraints without an index after a table
-# is created.
-statement error pgcode 0A000 unique constraints without an index are not yet supported
-ALTER TABLE unique_without_index ADD COLUMN d INT UNIQUE WITHOUT INDEX
+# We don't yet support adding a column marked as UNIQUE WITHOUT INDEX after a
+# table is created. (The full error message includes a hint with a workaround.)
+statement error pgcode 0A000 pq: adding a column marked as UNIQUE WITHOUT INDEX is unsupported
+ALTER TABLE unique_without_index ADD COLUMN f INT UNIQUE WITHOUT INDEX
 
-statement error pgcode 0A000 unique constraints without an index are not yet supported
-ALTER TABLE unique_without_index ADD CONSTRAINT ab UNIQUE WITHOUT INDEX (a, c) NOT VALID
+# To add a UNIQUE WITHOUT INDEX column, first add the column, then add the
+# constraint.
+statement ok
+ALTER TABLE unique_without_index ADD COLUMN f INT;
+ALTER TABLE unique_without_index ADD CONSTRAINT my_unique_f UNIQUE WITHOUT INDEX (f)
 
-# All constraints are already valid, so validation should succeed.
+# The unique constraint prevents new duplicate values.
+statement error pgcode 23505 pq: duplicate key value violates unique constraint "my_unique_f"\nDETAIL: Key \(f\)=\(1\) already exists\.
+INSERT INTO unique_without_index (f) VALUES (1), (1)
+
+# There is no unique constraint on e, yet, so this insert succeeds.
+statement ok
+INSERT INTO unique_without_index (e, f) VALUES (1, 1), (1, 2)
+
+# But trying to add a unique constraint now fails.
+statement error pgcode 23505 pq: could not create unique constraint "my_unique_e"\nDETAIL: Key \(e\)=\(1\) is duplicated\.
+ALTER TABLE unique_without_index ADD CONSTRAINT my_unique_e UNIQUE WITHOUT INDEX (e)
+
+# We can create not-valid constraints, however.
+statement ok
+ALTER TABLE unique_without_index ADD CONSTRAINT my_unique_e UNIQUE WITHOUT INDEX (e) NOT VALID;
+ALTER TABLE unique_without_index ADD CONSTRAINT my_unique_e2 UNIQUE WITHOUT INDEX (e) NOT VALID
+
+# Trying to validate one of the constraints will fail.
+statement error pgcode 23505 pq: could not create unique constraint "my_unique_e"\nDETAIL: Key \(e\)=\(1\) is duplicated\.
+ALTER TABLE unique_without_index VALIDATE CONSTRAINT my_unique_e
+
+# But after we delete a row, validation should succeed.
+statement ok
+DELETE FROM unique_without_index WHERE e = 1 AND f = 1;
+ALTER TABLE unique_without_index VALIDATE CONSTRAINT my_unique_e
+
+# All these constraints are already valid, so validation should succeed.
 statement ok
 ALTER TABLE unique_without_index VALIDATE CONSTRAINT unique_b;
 ALTER TABLE unique_without_index VALIDATE CONSTRAINT unique_a_b;
 ALTER TABLE unique_without_index VALIDATE CONSTRAINT unique_without_index_c_key
 
-query TTTTB
+query TTTTB colnames
 SHOW CONSTRAINTS FROM unique_without_index
 ----
-unique_without_index  unique_a_b                  UNIQUE  UNIQUE WITHOUT INDEX (a, b)  true
-unique_without_index  unique_b                    UNIQUE  UNIQUE WITHOUT INDEX (b)     true
-unique_without_index  unique_b_1                  UNIQUE  UNIQUE WITHOUT INDEX (b)     true
-unique_without_index  unique_c                    UNIQUE  UNIQUE WITHOUT INDEX (c)     true
-unique_without_index  unique_d                    UNIQUE  UNIQUE WITHOUT INDEX (d)     true
-unique_without_index  unique_d_e                  UNIQUE  UNIQUE WITHOUT INDEX (d, e)  true
-unique_without_index  unique_without_index_c_key  UNIQUE  UNIQUE (c ASC)               true
+table_name            constraint_name             constraint_type  details                             validated
+unique_without_index  my_unique_e                 UNIQUE           UNIQUE WITHOUT INDEX (e)            true
+unique_without_index  my_unique_e2                UNIQUE           UNIQUE WITHOUT INDEX (e) NOT VALID  false
+unique_without_index  my_unique_f                 UNIQUE           UNIQUE WITHOUT INDEX (f)            true
+unique_without_index  unique_a_b                  UNIQUE           UNIQUE WITHOUT INDEX (a, b)         true
+unique_without_index  unique_b                    UNIQUE           UNIQUE WITHOUT INDEX (b)            true
+unique_without_index  unique_b_1                  UNIQUE           UNIQUE WITHOUT INDEX (b)            true
+unique_without_index  unique_c                    UNIQUE           UNIQUE WITHOUT INDEX (c)            true
+unique_without_index  unique_d                    UNIQUE           UNIQUE WITHOUT INDEX (d)            true
+unique_without_index  unique_d_e                  UNIQUE           UNIQUE WITHOUT INDEX (d, e)         true
+unique_without_index  unique_without_index_c_key  UNIQUE           UNIQUE (c ASC)                      true
 
 statement ok
 ALTER TABLE unique_without_index RENAME COLUMN a TO aa
@@ -1473,13 +1519,16 @@ ALTER TABLE unique_without_index RENAME CONSTRAINT unique_b TO unique_b_2
 query TTTTB
 SHOW CONSTRAINTS FROM unique_without_index
 ----
-unique_without_index  unique_a_b                  UNIQUE  UNIQUE WITHOUT INDEX (aa, b)  true
-unique_without_index  unique_b_1                  UNIQUE  UNIQUE WITHOUT INDEX (b)      true
-unique_without_index  unique_b_2                  UNIQUE  UNIQUE WITHOUT INDEX (b)      true
-unique_without_index  unique_c                    UNIQUE  UNIQUE WITHOUT INDEX (c)      true
-unique_without_index  unique_d                    UNIQUE  UNIQUE WITHOUT INDEX (d)      true
-unique_without_index  unique_d_e                  UNIQUE  UNIQUE WITHOUT INDEX (d, e)   true
-unique_without_index  unique_without_index_c_key  UNIQUE  UNIQUE (c ASC)                true
+unique_without_index  my_unique_e                 UNIQUE  UNIQUE WITHOUT INDEX (e)            true
+unique_without_index  my_unique_e2                UNIQUE  UNIQUE WITHOUT INDEX (e) NOT VALID  false
+unique_without_index  my_unique_f                 UNIQUE  UNIQUE WITHOUT INDEX (f)            true
+unique_without_index  unique_a_b                  UNIQUE  UNIQUE WITHOUT INDEX (aa, b)        true
+unique_without_index  unique_b_1                  UNIQUE  UNIQUE WITHOUT INDEX (b)            true
+unique_without_index  unique_b_2                  UNIQUE  UNIQUE WITHOUT INDEX (b)            true
+unique_without_index  unique_c                    UNIQUE  UNIQUE WITHOUT INDEX (c)            true
+unique_without_index  unique_d                    UNIQUE  UNIQUE WITHOUT INDEX (d)            true
+unique_without_index  unique_d_e                  UNIQUE  UNIQUE WITHOUT INDEX (d, e)         true
+unique_without_index  unique_without_index_c_key  UNIQUE  UNIQUE (c ASC)                      true
 
 statement error pgcode 0A000 cannot drop UNIQUE constraint \"unique_without_index_c_key\"
 ALTER TABLE unique_without_index DROP CONSTRAINT unique_without_index_c_key
@@ -1487,8 +1536,25 @@ ALTER TABLE unique_without_index DROP CONSTRAINT unique_without_index_c_key
 statement error pgcode 42704 constraint \"unique_b\" does not exist
 ALTER TABLE unique_without_index DROP CONSTRAINT unique_b
 
-statement error pgcode 0A000 dropping valid unique constraints without an index is not yet supported
+# Drop a valid constraint.
+statement ok
 ALTER TABLE unique_without_index DROP CONSTRAINT unique_b_2
+
+# Drop a not-valid constraint.
+statement ok
+ALTER TABLE unique_without_index DROP CONSTRAINT my_unique_e2
+
+query TTTTB
+SHOW CONSTRAINTS FROM unique_without_index
+----
+unique_without_index  my_unique_e                 UNIQUE  UNIQUE WITHOUT INDEX (e)      true
+unique_without_index  my_unique_f                 UNIQUE  UNIQUE WITHOUT INDEX (f)      true
+unique_without_index  unique_a_b                  UNIQUE  UNIQUE WITHOUT INDEX (aa, b)  true
+unique_without_index  unique_b_1                  UNIQUE  UNIQUE WITHOUT INDEX (b)      true
+unique_without_index  unique_c                    UNIQUE  UNIQUE WITHOUT INDEX (c)      true
+unique_without_index  unique_d                    UNIQUE  UNIQUE WITHOUT INDEX (d)      true
+unique_without_index  unique_d_e                  UNIQUE  UNIQUE WITHOUT INDEX (d, e)   true
+unique_without_index  unique_without_index_c_key  UNIQUE  UNIQUE (c ASC)                true
 
 # Dropping a column in a unique constraint drops the constraint.
 statement ok
@@ -1497,6 +1563,8 @@ ALTER TABLE unique_without_index DROP COLUMN b
 query TTTTB
 SHOW CONSTRAINTS FROM unique_without_index
 ----
+unique_without_index  my_unique_e                 UNIQUE  UNIQUE WITHOUT INDEX (e)     true
+unique_without_index  my_unique_f                 UNIQUE  UNIQUE WITHOUT INDEX (f)     true
 unique_without_index  unique_c                    UNIQUE  UNIQUE WITHOUT INDEX (c)     true
 unique_without_index  unique_d                    UNIQUE  UNIQUE WITHOUT INDEX (d)     true
 unique_without_index  unique_d_e                  UNIQUE  UNIQUE WITHOUT INDEX (d, e)  true
@@ -1519,15 +1587,14 @@ ALTER TABLE unique_without_index DROP COLUMN d CASCADE
 query TTTTB
 SHOW CONSTRAINTS FROM unique_without_index
 ----
+unique_without_index  my_unique_e                 UNIQUE  UNIQUE WITHOUT INDEX (e)  true
+unique_without_index  my_unique_f                 UNIQUE  UNIQUE WITHOUT INDEX (f)  true
 unique_without_index  unique_c                    UNIQUE  UNIQUE WITHOUT INDEX (c)  true
 unique_without_index  unique_without_index_c_key  UNIQUE  UNIQUE (c ASC)            true
 
 query TTTTB
 SHOW CONSTRAINTS FROM uwi_child
 ----
-
-# TODO(rytaft): Add test cases for dropping both a valid and not-valid
-# unique constraint once supported.
 
 # Regression for #54629.
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/show_create
+++ b/pkg/sql/logictest/testdata/logic_test/show_create
@@ -46,9 +46,6 @@ statement ok
 ALTER TABLE c ADD CONSTRAINT check_b CHECK (b IN (1, 2, 3)) NOT VALID;
 ALTER TABLE c ADD CONSTRAINT fk_a FOREIGN KEY (a) REFERENCES d (d) NOT VALID;
 ALTER TABLE c ADD CONSTRAINT unique_a UNIQUE (a) NOT VALID;
-
-# TODO(rytaft): Add this to the above block once it no longer causes an error.
-statement error pgcode 0A000 unique constraints without an index are not yet supported
 ALTER TABLE c ADD CONSTRAINT unique_b UNIQUE WITHOUT INDEX (b) NOT VALID;
 
 query TT
@@ -63,7 +60,8 @@ c  CREATE TABLE public.c (
    FAMILY fam_0_a_rowid (a, rowid),
    FAMILY fam_1_b (b),
    CONSTRAINT check_b CHECK (b IN (1:::INT8, 2:::INT8, 3:::INT8)) NOT VALID,
-   CONSTRAINT unique_a_b UNIQUE WITHOUT INDEX (a, b)
+   CONSTRAINT unique_a_b UNIQUE WITHOUT INDEX (a, b),
+   CONSTRAINT unique_b UNIQUE WITHOUT INDEX (b) NOT VALID
 );
 COMMENT ON TABLE public.c IS 'table';
 COMMENT ON COLUMN public.c.a IS 'column';
@@ -73,6 +71,7 @@ statement ok
 ALTER TABLE c VALIDATE CONSTRAINT check_b;
 ALTER TABLE c VALIDATE CONSTRAINT fk_a;
 ALTER TABLE c VALIDATE CONSTRAINT unique_a;
+ALTER TABLE c VALIDATE CONSTRAINT unique_b;
 ALTER TABLE c VALIDATE CONSTRAINT unique_a_b;
 
 query TT
@@ -87,7 +86,8 @@ c  CREATE TABLE public.c (
    FAMILY fam_0_a_rowid (a, rowid),
    FAMILY fam_1_b (b),
    CONSTRAINT check_b CHECK (b IN (1:::INT8, 2:::INT8, 3:::INT8)),
-   CONSTRAINT unique_a_b UNIQUE WITHOUT INDEX (a, b)
+   CONSTRAINT unique_a_b UNIQUE WITHOUT INDEX (a, b),
+   CONSTRAINT unique_b UNIQUE WITHOUT INDEX (b)
 );
 COMMENT ON TABLE public.c IS 'table';
 COMMENT ON COLUMN public.c.a IS 'column';

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -855,6 +855,9 @@ func populateTableConstraints(
 				}
 				f.WriteString(strings.Join(colNames, ", "))
 				f.WriteByte(')')
+				if con.UniqueWithoutIndexConstraint.Validity != descpb.ConstraintValidity_Validated {
+					f.WriteString(" NOT VALID")
+				}
 			} else {
 				return errors.AssertionFailedf(
 					"Index or UniqueWithoutIndexConstraint must be non-nil for a unique constraint",

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -1692,13 +1692,11 @@ func (sc *SchemaChanger) maybeDropValidatingConstraint(
 				return nil
 			}
 		}
-		if log.V(2) {
-			log.Infof(
-				ctx,
-				"attempted to drop constraint %s, but it hadn't been added to the table descriptor yet",
-				constraint.Check.Name,
-			)
-		}
+		log.Infof(
+			ctx,
+			"attempted to drop constraint %s, but it hadn't been added to the table descriptor yet",
+			constraint.Check.Name,
+		)
 	case descpb.ConstraintToUpdate_FOREIGN_KEY:
 		for i, fk := range desc.OutboundFKs {
 			if fk.Name == constraint.ForeignKey.Name {
@@ -1706,13 +1704,28 @@ func (sc *SchemaChanger) maybeDropValidatingConstraint(
 				return nil
 			}
 		}
-		if log.V(2) {
-			log.Infof(
-				ctx,
-				"attempted to drop constraint %s, but it hadn't been added to the table descriptor yet",
-				constraint.ForeignKey.Name,
-			)
+		log.Infof(
+			ctx,
+			"attempted to drop constraint %s, but it hadn't been added to the table descriptor yet",
+			constraint.ForeignKey.Name,
+		)
+	case descpb.ConstraintToUpdate_UNIQUE_WITHOUT_INDEX:
+		if constraint.UniqueWithoutIndexConstraint.Validity == descpb.ConstraintValidity_Unvalidated {
+			return nil
 		}
+		for j, c := range desc.UniqueWithoutIndexConstraints {
+			if c.Name == constraint.UniqueWithoutIndexConstraint.Name {
+				desc.UniqueWithoutIndexConstraints = append(
+					desc.UniqueWithoutIndexConstraints[:j], desc.UniqueWithoutIndexConstraints[j+1:]...,
+				)
+				return nil
+			}
+		}
+		log.Infof(
+			ctx,
+			"attempted to drop constraint %s, but it hadn't been added to the table descriptor yet",
+			constraint.UniqueWithoutIndexConstraint.Name,
+		)
 	default:
 		return errors.AssertionFailedf("unsupported constraint type: %d", errors.Safe(constraint.ConstraintType))
 	}

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -5504,6 +5504,87 @@ CREATE TABLE t.parent (a INT PRIMARY KEY);
 	}
 }
 
+func TestTableValidityWhileAddingUniqueConstraint(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	params, _ := tests.CreateTestServerParams()
+
+	publishWriteNotification := make(chan struct{})
+	continuePublishWriteNotification := make(chan struct{})
+
+	backfillNotification := make(chan struct{})
+	continueBackfillNotification := make(chan struct{})
+
+	params.Knobs = base.TestingKnobs{
+		SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
+			RunBeforePublishWriteAndDelete: func() {
+				if publishWriteNotification != nil {
+					// Notify before the delete and write only state is published.
+					close(publishWriteNotification)
+					publishWriteNotification = nil
+					<-continuePublishWriteNotification
+				}
+			},
+			RunBeforeBackfill: func() error {
+				if backfillNotification != nil {
+					// Notify before the backfill begins.
+					close(backfillNotification)
+					backfillNotification = nil
+					<-continueBackfillNotification
+				}
+				return nil
+			},
+		},
+		// Disable backfill migrations, we still need the jobs table migration.
+		SQLMigrationManager: &sqlmigrations.MigrationManagerTestingKnobs{
+			DisableBackfillMigrations: true,
+		},
+	}
+
+	server, sqlDB, _ := serverutils.StartServer(t, params)
+	defer server.Stopper().Stop(context.Background())
+
+	if _, err := sqlDB.Exec(`
+CREATE DATABASE t;
+CREATE TABLE t.tab (a INT PRIMARY KEY, b INT, c INT);
+`); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := sqlDB.Exec(`SET experimental_enable_unique_without_index_constraints = true`); err != nil {
+		t.Fatal(err)
+	}
+
+	n1 := publishWriteNotification
+	n2 := backfillNotification
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		if _, err := sqlDB.Exec(`ALTER TABLE t.tab ADD UNIQUE WITHOUT INDEX (b), ADD UNIQUE WITHOUT INDEX (b, c)`); err != nil {
+			t.Error(err)
+		}
+		wg.Done()
+	}()
+
+	<-n1
+	if _, err := sqlDB.Query(`SHOW CONSTRAINTS FROM t.tab`); err != nil {
+		t.Fatal(err)
+	}
+	close(continuePublishWriteNotification)
+
+	<-n2
+	if _, err := sqlDB.Query(`SHOW CONSTRAINTS FROM t.tab`); err != nil {
+		t.Fatal(err)
+	}
+	close(continueBackfillNotification)
+
+	wg.Wait()
+
+	if err := sqlutils.RunScrub(sqlDB, "t", "tab"); err != nil {
+		t.Fatal(err)
+	}
+}
+
 // TestWritesWithChecksBeforeDefaultColumnBackfill tests that when a check on a
 // column being added references a different public column, writes to the public
 // column ignore the constraint before the backfill for the non-public column


### PR DESCRIPTION
This commit adds support for `ALTER TABLE ... ADD/DROP CONSTRAINT` for
`UNIQUE WITHOUT INDEX` constraints. These commands require schema changes
similar to the ones used for foreign keys and check constraints. When
adding a `UNIQUE WITHOUT INDEX` constraint, the schema change triggers
a validation query that checks that the key columns are in fact unique.
If the validation query fails, the `ALTER TABLE` command fails.

Informs #56201

There is no release note since `UNIQUE WITHOUT INDEX` is still gated behind the
`experimental_enable_unique_without_index_constraints` session variable.

Release note: None