### PR TITLE
colexec: add a cluster setting to disable disk spilling for hash agg

### DIFF
--- a/pkg/sql/colexec/BUILD.bazel
+++ b/pkg/sql/colexec/BUILD.bazel
@@ -65,6 +65,7 @@ go_library(
         "//pkg/col/coldataext",  # keep
         "//pkg/col/typeconv",
         "//pkg/server/telemetry",  # keep
+        "//pkg/settings",
         "//pkg/sql/catalog/colinfo",  # keep
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/colcontainer",

--- a/pkg/sql/colexec/external_hash_aggregator.go
+++ b/pkg/sql/colexec/external_hash_aggregator.go
@@ -11,6 +11,7 @@
 package colexec
 
 import (
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecagg"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase/colexecerror"
@@ -73,3 +74,12 @@ func NewExternalHashAggregator(
 		numRequiredActivePartitions,
 	)
 }
+
+// HashAggregationDiskSpillingEnabled is a cluster setting that allows to
+// disable hash aggregator disk spilling.
+var HashAggregationDiskSpillingEnabled = settings.RegisterBoolSetting(
+	"sql.distsql.temp_storage.hash_agg.enabled",
+	"set to false to disable hash aggregator disk spilling "+
+		"(this will improve performance, but the query might hit the memory limit)",
+	true,
+)

--- a/pkg/sql/distsql/BUILD.bazel
+++ b/pkg/sql/distsql/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//pkg/settings",
         "//pkg/sql/catalog/descs",
         "//pkg/sql/catalog/lease",
+        "//pkg/sql/colexec",
         "//pkg/sql/colflow",
         "//pkg/sql/execinfra",
         "//pkg/sql/execinfrapb",

--- a/pkg/sql/sqltelemetry/exec.go
+++ b/pkg/sql/sqltelemetry/exec.go
@@ -33,3 +33,7 @@ func VecModeCounter(mode string) telemetry.Counter {
 // CascadesLimitReached is to be incremented whenever the limit of foreign key
 // cascade for a single query is exceeded.
 var CascadesLimitReached = telemetry.GetCounterOnce("sql.exec.cascade-limit-reached")
+
+// HashAggregationDiskSpillingDisabled is to be incremented whenever the disk
+// spilling of the vectorized hash aggregator is disabled.
+var HashAggregationDiskSpillingDisabled = telemetry.GetCounterOnce("sql.exec.hash-agg-spilling-disabled")

--- a/pkg/sql/telemetry_test.go
+++ b/pkg/sql/telemetry_test.go
@@ -63,7 +63,9 @@ import (
 //    variant outputs only the names of the counters that changed; the second
 //    variant outputs the counts as well. It is necessary to use
 //    feature-allowlist before these commands to avoid test flakes (e.g. because
-//    of counters that are changed by looking up descriptors)
+//    of counters that are changed by looking up descriptors).
+//    TODO(yuzefovich): counters currently don't really work because they are
+//    reset before executing every statement by reporter.ReportDiagnostics.
 //
 //  - schema
 //

--- a/pkg/sql/testdata/telemetry/execution
+++ b/pkg/sql/testdata/telemetry/execution
@@ -15,3 +15,18 @@ feature-usage
 SET CLUSTER SETTING sql.defaults.vectorize='off'
 ----
 sql.exec.vectorized-setting.off
+
+# Test for the hash aggregation disk spilling counter. Note that it is
+# incremented only when changing the setting to `false`.
+feature-allowlist
+sql.exec.hash-agg-spilling-disabled
+----
+
+feature-counters
+SET CLUSTER SETTING sql.distsql.temp_storage.hash_agg.enabled=false
+----
+sql.exec.hash-agg-spilling-disabled  1
+
+feature-counters
+SET CLUSTER SETTING sql.distsql.temp_storage.hash_agg.enabled=true
+----


### PR DESCRIPTION
Release note (sql change): A new private cluster setting
`sql.distsql.temp_storage.hash_agg.enabled` has been added that
allows to disable the disk spilling capability of the hash aggregation
in the vectorized execution engine. It is `true` by default which incurs
some performance hit, setting it to `false` will improve the performance,
but the queries might hit an out of memory limit error.