### PR TITLE
release-20.2: sql/logictest: add a directive to skip the rest of a logictest on retry

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
@@ -3,6 +3,11 @@
 statement ok
 SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false
 
+
+# Skip the rest of the test if a retry occurs. They can happen and are fine
+# but there's no way to encapsulate that in logictests.
+skip_on_retry
+
 subtest create_and_add_fk_in_same_txn
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/skip_on_retry
+++ b/pkg/sql/logictest/testdata/logic_test/skip_on_retry
@@ -1,0 +1,24 @@
+# LogicTest: local
+
+# This test demonstrates that the skip_on_retry directive works as expected.
+# The directive applies to the entire remainder of the file.
+
+statement ok
+BEGIN; SELECT * FROM system.namespace LIMIT 1;
+
+statement error pgcode 40001 TransactionRetryWithProtoRefreshError
+SELECT crdb_internal.force_retry('1h');
+
+statement ok
+ROLLBACK;
+
+skip_on_retry
+
+subtest skip_this_subtest
+
+statement ok
+BEGIN; SELECT * FROM system.namespace LIMIT 1;
+
+statement ok
+SELECT crdb_internal.force_retry('1h');
+


### PR DESCRIPTION
Backport 1/1 commits from #58217.

Closes #58363.

/cc @cockroachdb/release

---

Some logictests, specifically schema_change_in_txn, periodically experience
completely valid serializable restarts. We don't have a way to allow the
test to proceed and retry in those cases. Instead, this allows the test to
indicate that this happening is fine and to report instead that the test has
been skipped.

Touches #53724.

Release note: None
