### PR TITLE
release-20.2: flowinfra: log headProc running message

### DIFF
--- a/pkg/sql/flowinfra/flow.go
+++ b/pkg/sql/flowinfra/flow.go
@@ -305,7 +305,7 @@ func (f *FlowBase) startInternal(
 ) error {
 	f.doneFn = doneFn
 	log.VEventf(
-		ctx, 1, "starting (%d processors, %d startables)", len(processors), len(f.startables),
+		ctx, 1, "starting (%d processors, %d startables) asynchronously", len(processors), len(f.startables),
 	)
 
 	// Only register the flow if there will be inbound stream connections that
@@ -389,6 +389,7 @@ func (f *FlowBase) Run(ctx context.Context, doneFn func()) error {
 		}
 		return err
 	}
+	log.VEventf(ctx, 1, "running %T in the flow's goroutine", headProc)
 	headProc.Run(ctx)
 	return nil
 }


### PR DESCRIPTION
Backport 1/1 commits from #59402.

/cc @cockroachdb/release

---

In `startInternal` we log that we start processors and startables.
However, in `Run` method of the flow we handle the last processor
separately, and previously we could see confusing message like
`starting (0 processors, 0 startables)` in the trace, as if nothing got started.
Now we will see a message about the head processor.

Release note: None
