### PR TITLE
storage,kv: remove Distinct from the Batch interface

### DIFF
--- a/pkg/ccl/storageccl/engineccl/encrypted_fs_test.go
+++ b/pkg/ccl/storageccl/engineccl/encrypted_fs_test.go
@@ -240,7 +240,7 @@ func TestPebbleEncryption(t *testing.T) {
 	require.Equal(t, int32(enginepbccl.EncryptionType_AES128_CTR), stats.EncryptionType)
 	t.Logf("EnvStats:\n%+v\n\n", *stats)
 
-	batch := db.NewWriteOnlyBatch()
+	batch := db.NewUnIndexedBatch(false /* supportReader */)
 	require.NoError(t, batch.PutUnversioned(roachpb.Key("a"), []byte("a")))
 	require.NoError(t, batch.Commit(true))
 	require.NoError(t, db.Flush())

--- a/pkg/kv/kvserver/abortspan/abortspan.go
+++ b/pkg/kv/kvserver/abortspan/abortspan.go
@@ -79,7 +79,7 @@ func (sc *AbortSpan) ClearData(e storage.Engine) error {
 	// NB: The abort span is a Range-ID local key which has no versions or intents.
 	iter := e.NewMVCCIterator(storage.MVCCKeyIterKind, storage.IterOptions{UpperBound: sc.max()})
 	defer iter.Close()
-	b := e.NewWriteOnlyBatch()
+	b := e.NewUnIndexedBatch(false /* supportReader */)
 	defer b.Close()
 	err := b.ClearIterRange(iter, sc.min(), sc.max())
 	if err != nil {

--- a/pkg/kv/kvserver/batcheval/cmd_conditional_put.go
+++ b/pkg/kv/kvserver/batcheval/cmd_conditional_put.go
@@ -51,15 +51,6 @@ func ConditionalPut(
 	if !args.Inline {
 		ts = h.Timestamp
 	}
-	if h.DistinctSpans {
-		if b, ok := readWriter.(storage.Batch); ok {
-			// Use the distinct batch for both blind and normal ops so that we don't
-			// accidentally flush mutations to make them visible to the distinct
-			// batch.
-			readWriter = b.Distinct()
-			defer readWriter.Close()
-		}
-	}
 
 	var expVal []byte
 	if len(args.ExpBytes) != 0 {

--- a/pkg/kv/kvserver/batcheval/cmd_init_put.go
+++ b/pkg/kv/kvserver/batcheval/cmd_init_put.go
@@ -32,15 +32,6 @@ func InitPut(
 	args := cArgs.Args.(*roachpb.InitPutRequest)
 	h := cArgs.Header
 
-	if h.DistinctSpans {
-		if b, ok := readWriter.(storage.Batch); ok {
-			// Use the distinct batch for both blind and normal ops so that we don't
-			// accidentally flush mutations to make them visible to the distinct
-			// batch.
-			readWriter = b.Distinct()
-			defer readWriter.Close()
-		}
-	}
 	var err error
 	if args.Blind {
 		err = storage.MVCCBlindInitPut(ctx, readWriter, cArgs.Stats, args.Key, h.Timestamp, args.Value, args.FailOnTombstones, h.Txn)

--- a/pkg/kv/kvserver/batcheval/cmd_put.go
+++ b/pkg/kv/kvserver/batcheval/cmd_put.go
@@ -50,15 +50,6 @@ func Put(
 	if !args.Inline {
 		ts = h.Timestamp
 	}
-	if h.DistinctSpans {
-		if b, ok := readWriter.(storage.Batch); ok {
-			// Use the distinct batch for both blind and normal ops so that we don't
-			// accidentally flush mutations to make them visible to the distinct
-			// batch.
-			readWriter = b.Distinct()
-			defer readWriter.Close()
-		}
-	}
 	var err error
 	if args.Blind {
 		err = storage.MVCCBlindPut(ctx, readWriter, ms, args.Key, ts, args.Value, h.Txn)

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -2109,12 +2109,15 @@ func (r *Replica) sendSnapshot(
 	sent := func() {
 		r.store.metrics.RangeSnapshotsGenerated.Inc(1)
 	}
+	newBatchFn := func() storage.Batch {
+		return r.store.Engine().NewUnIndexedBatch(false /* supportReader */)
+	}
 	if err := r.store.cfg.Transport.SendSnapshot(
 		ctx,
 		r.store.allocator.storePool,
 		req,
 		snap,
-		r.store.Engine().NewWriteOnlyBatch,
+		newBatchFn,
 		sent,
 	); err != nil {
 		if errors.Is(err, errMalformedSnapshot) {

--- a/pkg/kv/kvserver/replica_destroy.go
+++ b/pkg/kv/kvserver/replica_destroy.go
@@ -138,7 +138,7 @@ func (r *Replica) destroyRaftMuLocked(ctx context.Context, nextReplicaID roachpb
 	startTime := timeutil.Now()
 
 	ms := r.GetMVCCStats()
-	batch := r.Engine().NewWriteOnlyBatch()
+	batch := r.Engine().NewUnIndexedBatch(false /* supportReader */)
 	defer batch.Close()
 	clearRangeIDLocalOnly := !r.IsInitialized()
 	if err := r.preDestroyRaftMuLocked(

--- a/pkg/kv/kvserver/spanset/batch.go
+++ b/pkg/kv/kvserver/spanset/batch.go
@@ -638,12 +638,6 @@ func makeSpanSetReadWriterAt(rw storage.ReadWriter, spans *SpanSet, ts hlc.Times
 	}
 }
 
-// NewReadWriter returns an engine.ReadWriter that asserts access of the
-// underlying ReadWriter against the given SpanSet.
-func NewReadWriter(rw storage.ReadWriter, spans *SpanSet) storage.ReadWriter {
-	return makeSpanSetReadWriter(rw, spans)
-}
-
 // NewReadWriterAt returns an engine.ReadWriter that asserts access of the
 // underlying ReadWriter against the given SpanSet at a given timestamp.
 // If zero timestamp is provided, accesses are considered non-MVCC.
@@ -664,13 +658,6 @@ var _ storage.Batch = spanSetBatch{}
 
 func (s spanSetBatch) Commit(sync bool) error {
 	return s.b.Commit(sync)
-}
-
-func (s spanSetBatch) Distinct() storage.ReadWriter {
-	if s.spansOnly {
-		return NewReadWriter(s.b.Distinct(), s.spans)
-	}
-	return NewReadWriterAt(s.b.Distinct(), s.spans, s.ts)
 }
 
 func (s spanSetBatch) Empty() bool {

--- a/pkg/sql/tests/kv_test.go
+++ b/pkg/sql/tests/kv_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	kv2 "github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 )
 
@@ -259,6 +260,7 @@ func (kv *kvSQL) done() {
 }
 
 func BenchmarkKV(b *testing.B) {
+	defer log.Scope(b).Close(b)
 	for i, opFn := range []func(kvInterface, int, int) error{
 		kvInterface.Insert,
 		kvInterface.Update,

--- a/pkg/storage/bench_test.go
+++ b/pkg/storage/bench_test.go
@@ -848,7 +848,7 @@ func runClearRange(
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		batch := eng.NewWriteOnlyBatch()
+		batch := eng.NewUnIndexedBatch(false /* supportReader */)
 		if err := clearRange(eng, batch, firstKey, MVCCKeyMax); err != nil {
 			b.Fatal(err)
 		}
@@ -1007,7 +1007,7 @@ func runBatchApplyBatchRepr(
 			})
 		}
 
-		batch := eng.NewWriteOnlyBatch()
+		batch := eng.NewUnIndexedBatch(false /* supportReader */)
 		defer batch.Close() // NB: hold open so batch.Repr() doesn't get reused
 
 		for i := 0; i < batchSize; i++ {
@@ -1026,7 +1026,7 @@ func runBatchApplyBatchRepr(
 	for i := 0; i < b.N; i++ {
 		var batch Batch
 		if !indexed {
-			batch = eng.NewWriteOnlyBatch()
+			batch = eng.NewUnIndexedBatch(false /* supportReader */)
 		} else {
 			batch = eng.NewBatch()
 		}
@@ -1052,7 +1052,7 @@ func runExportToSst(
 	engine := emk(b, dir)
 	defer engine.Close()
 
-	batch := engine.NewWriteOnlyBatch()
+	batch := engine.NewUnIndexedBatch(false /* supportReader */)
 	for i := 0; i < numKeys; i++ {
 		key := make([]byte, 16)
 		key = append(key, 'a', 'a', 'a')

--- a/pkg/storage/engine_test.go
+++ b/pkg/storage/engine_test.go
@@ -967,12 +967,12 @@ func TestEngineDeleteRangeBatch(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	testEngineDeleteRange(t, func(engine Engine, start, end MVCCKey) error {
-		batch := engine.NewWriteOnlyBatch()
+		batch := engine.NewUnIndexedBatch(false /* supportReader */)
 		defer batch.Close()
 		if err := batch.ClearMVCCRange(start, end); err != nil {
 			return err
 		}
-		batch2 := engine.NewWriteOnlyBatch()
+		batch2 := engine.NewUnIndexedBatch(false /* supportReader */)
 		defer batch2.Close()
 		if err := batch2.ApplyBatchRepr(batch.Repr(), false); err != nil {
 			return err

--- a/pkg/storage/mvcc_logical_ops.go
+++ b/pkg/storage/mvcc_logical_ops.go
@@ -154,16 +154,6 @@ func (ol *OpLoggerBatch) LogicalOps() []enginepb.MVCCLogicalOp {
 	return ol.ops
 }
 
-// Distinct implements the Batch interface.
-func (ol *OpLoggerBatch) Distinct() ReadWriter {
-	if ol.distinctOpen {
-		panic("distinct batch already open")
-	}
-	ol.distinctOpen = true
-	ol.distinct.ReadWriter = ol.Batch.Distinct()
-	return &ol.distinct
-}
-
 type distinctOpLoggerBatch struct {
 	ReadWriter
 	parent *OpLoggerBatch

--- a/pkg/storage/mvcc_logical_ops_test.go
+++ b/pkg/storage/mvcc_logical_ops_test.go
@@ -56,23 +56,21 @@ func TestMVCCOpLogWriter(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			// Update the intents and write another. Use a distinct batch.
-			olDist := ol.Distinct()
+			// Update the intents and write another.
 			txn1ts.Sequence++
 			txn1ts.WriteTimestamp = hlc.Timestamp{Logical: 3}
-			if err := MVCCPut(ctx, olDist, nil, testKey1, txn1ts.ReadTimestamp, value2, txn1ts); err != nil {
+			if err := MVCCPut(ctx, ol, nil, testKey1, txn1ts.ReadTimestamp, value2, txn1ts); err != nil {
 				t.Fatal(err)
 			}
-			if err := MVCCPut(ctx, olDist, nil, localKey, txn1ts.ReadTimestamp, value2, txn1ts); err != nil {
+			if err := MVCCPut(ctx, ol, nil, localKey, txn1ts.ReadTimestamp, value2, txn1ts); err != nil {
 				t.Fatal(err)
 			}
 			// Set the txn timestamp to a larger value than the intent.
 			txn1LargerTS := makeTxn(*txn1, hlc.Timestamp{Logical: 4})
 			txn1LargerTS.WriteTimestamp = hlc.Timestamp{Logical: 4}
-			if err := MVCCPut(ctx, olDist, nil, testKey2, txn1LargerTS.ReadTimestamp, value3, txn1LargerTS); err != nil {
+			if err := MVCCPut(ctx, ol, nil, testKey2, txn1LargerTS.ReadTimestamp, value3, txn1LargerTS); err != nil {
 				t.Fatal(err)
 			}
-			olDist.Close()
 
 			// Resolve all three intent.
 			txn1CommitTS := *txn1Commit

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -821,7 +821,7 @@ func (p *Pebble) clearRange(start, end MVCCKey) error {
 // ClearIterRange implements the Engine interface.
 func (p *Pebble) ClearIterRange(iter MVCCIterator, start, end roachpb.Key) error {
 	// Write all the tombstones in one batch.
-	batch := p.NewWriteOnlyBatch()
+	batch := p.NewUnIndexedBatch(false /* supportReader */)
 	defer batch.Close()
 
 	if err := batch.ClearIterRange(iter, start, end); err != nil {
@@ -1037,7 +1037,7 @@ func (p *Pebble) GetAuxiliaryDir() string {
 
 // NewBatch implements the Engine interface.
 func (p *Pebble) NewBatch() Batch {
-	return newPebbleBatch(p.db, p.db.NewIndexedBatch())
+	return newPebbleBatch(p.db, p.db.NewIndexedBatch(), false /* unIndexedReadFromDB */)
 }
 
 // NewReadOnly implements the Engine interface.
@@ -1047,9 +1047,9 @@ func (p *Pebble) NewReadOnly() ReadWriter {
 	}
 }
 
-// NewWriteOnlyBatch implements the Engine interface.
-func (p *Pebble) NewWriteOnlyBatch() Batch {
-	return newPebbleBatch(p.db, p.db.NewBatch())
+// NewUnIndexedBatch implements the Engine interface.
+func (p *Pebble) NewUnIndexedBatch(supportReader bool) Batch {
+	return newPebbleBatch(p.db, p.db.NewBatch(), supportReader)
 }
 
 // NewSnapshot implements the Engine interface.


### PR DESCRIPTION
This was a source of confusion and the target of multiple
code todos. This optimization originated when using
RocksDB to optimize when to flush mutations across the
cgo boundary, which is irrelevant in Pebble. The use of
this was inter-twined with roachpb.Header.DistinctSpans,
due to this historical context.

This PR does nothing to the concept of
Header.DistinctSpans and is not affected by it. It
replaces Engine.NewWriteOnlyBatch with
Engine.NewUnIndexedBatch(supportReader bool). The
creator of a batch has to make the determination
whether to create an indexed-batch,
unindexed-batch(true), unindexed-batch(false). This
determination has nothing to do with
Header.DistinctSpans and is based on knowledge of
whether there will be any reads using the batch as
a Reader and whether those reads need to see the
writes added to the batch. The PR changes the
callers that create a batch, but not in a way that
changes whether they create an unindexed or indexed
Pebble batch. So it will not have any performance
impact wrt the cost of indexing a batch. See
https://github.com/cockroachdb/cockroach/pull/57661
for discussion about a possible future optimization
that may create unindexed Pebble batches more often.

There is code simplication in the interface and
implementations, since there is no more need for
parent batches. Since the decision about using
a unindexed-batch(supportReader=true) is a function
of the whole roachpb.BatchRequest, there is no
more code in cmd_put.go and friends to locally
fiddle with this decision (that fiddling was
an artifact of this being originally a write flush
optimization).

There are some performance benefits to this
cleanup. We were not reusing pebbleIterators for
BatchRequests when commands were constructing child
batches. Creating new iterators is wasteful (and
cannot benefit from future iterator seek
optimizations that rely on reuse). The following
are numbers from BenchmarkKV.

```
name                            old time/op    new time/op    delta
KV/Insert/Native/rows=1-16        90.3µs ± 4%    88.3µs ± 2%     ~     (p=0.095 n=5+5)
KV/Insert/Native/rows=10-16        135µs ± 2%     134µs ± 1%     ~     (p=0.548 n=5+5)
KV/Insert/Native/rows=100-16       505µs ± 3%     481µs ± 2%   -4.77%  (p=0.016 n=5+5)
KV/Insert/Native/rows=1000-16     4.00ms ± 3%    3.93ms ± 3%     ~     (p=0.421 n=5+5)
KV/Insert/Native/rows=10000-16    42.8ms ± 3%    40.7ms ± 5%   -4.81%  (p=0.032 n=5+5)
KV/Insert/SQL/rows=1-16            267µs ± 3%     269µs ±15%     ~     (p=0.421 n=5+5)
KV/Insert/SQL/rows=10-16           351µs ± 3%     339µs ± 2%     ~     (p=0.095 n=5+5)
KV/Insert/SQL/rows=100-16          991µs ± 2%     968µs ± 2%     ~     (p=0.056 n=5+5)
KV/Insert/SQL/rows=1000-16        6.92ms ± 2%    6.83ms ± 4%     ~     (p=0.310 n=5+5)
KV/Insert/SQL/rows=10000-16       71.9ms ± 2%    70.4ms ± 4%     ~     (p=0.222 n=5+5)
KV/Update/Native/rows=1-16         126µs ± 0%     125µs ± 2%     ~     (p=0.690 n=5+5)
KV/Update/Native/rows=10-16        264µs ± 2%     257µs ± 5%     ~     (p=0.151 n=5+5)
KV/Update/Native/rows=100-16      1.57ms ± 4%    1.52ms ± 3%     ~     (p=0.095 n=5+5)
KV/Update/Native/rows=1000-16     14.7ms ± 2%    13.7ms ± 5%   -6.73%  (p=0.008 n=5+5)
KV/Update/Native/rows=10000-16     149ms ± 4%     141ms ± 4%   -5.55%  (p=0.032 n=5+5)
KV/Update/SQL/rows=1-16            365µs ± 6%     364µs ± 3%     ~     (p=0.690 n=5+5)
KV/Update/SQL/rows=10-16           659µs ± 1%     668µs ± 3%   +1.48%  (p=0.032 n=5+5)
KV/Update/SQL/rows=100-16         2.39ms ± 2%    2.39ms ± 4%     ~     (p=0.690 n=5+5)
KV/Update/SQL/rows=1000-16        13.2ms ± 4%    12.1ms ± 5%   -7.96%  (p=0.008 n=5+5)
KV/Update/SQL/rows=10000-16        167ms ± 3%     166ms ± 3%     ~     (p=0.841 n=5+5)
KV/Delete/Native/rows=1-16        90.5µs ± 3%    89.0µs ± 2%     ~     (p=0.222 n=5+5)
KV/Delete/Native/rows=10-16        154µs ± 2%     152µs ± 3%     ~     (p=0.421 n=5+5)
KV/Delete/Native/rows=100-16       683µs ± 5%     695µs ± 2%     ~     (p=0.421 n=5+5)
KV/Delete/Native/rows=1000-16     5.79ms ± 6%    6.02ms ± 4%     ~     (p=0.095 n=5+5)
KV/Delete/Native/rows=10000-16    58.7ms ± 3%    60.2ms ± 7%     ~     (p=0.690 n=5+5)
KV/Delete/SQL/rows=1-16            261µs ± 7%     261µs ±10%     ~     (p=1.000 n=5+5)
KV/Delete/SQL/rows=10-16           353µs ± 2%     357µs ± 3%     ~     (p=0.310 n=5+5)
KV/Delete/SQL/rows=100-16         1.22ms ± 1%    1.20ms ± 3%     ~     (p=0.286 n=4+5)
KV/Delete/SQL/rows=1000-16        2.18ms ± 0%    2.20ms ± 2%     ~     (p=0.556 n=4+5)
KV/Delete/SQL/rows=10000-16       18.7ms ± 4%    18.8ms ± 3%     ~     (p=0.690 n=5+5)
KV/Scan/Native/rows=1-16          28.8µs ± 3%    27.7µs ± 5%     ~     (p=0.095 n=5+5)
KV/Scan/Native/rows=10-16         31.2µs ± 3%    30.2µs ± 5%     ~     (p=0.056 n=5+5)
KV/Scan/Native/rows=100-16        46.6µs ± 1%    46.2µs ± 5%     ~     (p=1.000 n=5+5)
KV/Scan/Native/rows=1000-16        201µs ± 1%     208µs ± 7%     ~     (p=0.095 n=5+5)
KV/Scan/Native/rows=10000-16      1.68ms ± 2%    1.71ms ± 2%     ~     (p=0.056 n=5+5)
KV/Scan/SQL/rows=1-16              191µs ± 4%     192µs ± 5%     ~     (p=0.841 n=5+5)
KV/Scan/SQL/rows=10-16             205µs ± 3%     206µs ± 4%     ~     (p=0.690 n=5+5)
KV/Scan/SQL/rows=100-16            286µs ± 4%     279µs ± 3%     ~     (p=0.222 n=5+5)
KV/Scan/SQL/rows=1000-16           902µs ± 1%     905µs ± 1%     ~     (p=0.690 n=5+5)
KV/Scan/SQL/rows=10000-16         5.49ms ± 1%    5.61ms ± 3%     ~     (p=0.222 n=5+5)

name                            old alloc/op   new alloc/op   delta
KV/Insert/Native/rows=1-16        17.0kB ± 1%    16.9kB ± 1%     ~     (p=0.548 n=5+5)
KV/Insert/Native/rows=10-16       41.3kB ± 1%    41.1kB ± 0%     ~     (p=0.095 n=5+5)
KV/Insert/Native/rows=100-16       280kB ± 1%     280kB ± 1%     ~     (p=1.000 n=5+5)
KV/Insert/Native/rows=1000-16     2.55MB ± 0%    2.55MB ± 1%     ~     (p=0.690 n=5+5)
KV/Insert/Native/rows=10000-16    34.2MB ± 3%    33.8MB ± 1%     ~     (p=0.310 n=5+5)
KV/Insert/SQL/rows=1-16           43.1kB ± 1%    43.2kB ± 1%     ~     (p=0.548 n=5+5)
KV/Insert/SQL/rows=10-16          83.1kB ± 0%    83.0kB ± 0%     ~     (p=0.690 n=5+5)
KV/Insert/SQL/rows=100-16          463kB ± 0%     462kB ± 0%     ~     (p=1.000 n=5+5)
KV/Insert/SQL/rows=1000-16        4.74MB ± 0%    4.74MB ± 0%     ~     (p=0.841 n=5+5)
KV/Insert/SQL/rows=10000-16       55.5MB ± 1%    55.6MB ± 1%     ~     (p=1.000 n=5+5)
KV/Update/Native/rows=1-16        25.0kB ± 1%    24.9kB ± 2%     ~     (p=0.548 n=5+5)
KV/Update/Native/rows=10-16       59.9kB ± 1%    57.7kB ± 1%   -3.78%  (p=0.008 n=5+5)
KV/Update/Native/rows=100-16       400kB ± 1%     381kB ± 1%   -4.86%  (p=0.008 n=5+5)
KV/Update/Native/rows=1000-16     3.71MB ± 1%    3.51MB ± 2%   -5.39%  (p=0.008 n=5+5)
KV/Update/Native/rows=10000-16    50.0MB ± 1%    47.6MB ± 1%   -4.81%  (p=0.008 n=5+5)
KV/Update/SQL/rows=1-16           66.8kB ± 0%    66.7kB ± 0%     ~     (p=0.548 n=5+5)
KV/Update/SQL/rows=10-16           141kB ± 1%     142kB ± 1%     ~     (p=0.690 n=5+5)
KV/Update/SQL/rows=100-16          634kB ± 0%     635kB ± 0%     ~     (p=0.548 n=5+5)
KV/Update/SQL/rows=1000-16        3.58MB ± 0%    3.37MB ± 0%   -5.80%  (p=0.008 n=5+5)
KV/Update/SQL/rows=10000-16        103MB ± 1%     102MB ± 0%     ~     (p=0.095 n=5+5)
KV/Delete/Native/rows=1-16        16.4kB ± 1%    16.5kB ± 1%     ~     (p=0.738 n=5+5)
KV/Delete/Native/rows=10-16       37.6kB ± 1%    37.7kB ± 1%     ~     (p=0.310 n=5+5)
KV/Delete/Native/rows=100-16       247kB ± 0%     247kB ± 1%     ~     (p=0.841 n=5+5)
KV/Delete/Native/rows=1000-16     2.24MB ± 1%    2.23MB ± 1%     ~     (p=1.000 n=5+5)
KV/Delete/Native/rows=10000-16    29.6MB ± 1%    29.7MB ± 1%     ~     (p=0.548 n=5+5)
KV/Delete/SQL/rows=1-16           46.5kB ± 1%    46.1kB ± 0%     ~     (p=0.056 n=5+5)
KV/Delete/SQL/rows=10-16          69.7kB ± 0%    70.0kB ± 1%     ~     (p=0.190 n=4+5)
KV/Delete/SQL/rows=100-16          315kB ± 0%     315kB ± 1%     ~     (p=0.548 n=5+5)
KV/Delete/SQL/rows=1000-16        1.23MB ± 0%    1.23MB ± 0%     ~     (p=0.190 n=5+4)
KV/Delete/SQL/rows=10000-16       14.5MB ± 0%    14.5MB ± 0%     ~     (p=0.690 n=5+5)
KV/Scan/Native/rows=1-16          10.2kB ± 0%    10.2kB ± 0%     ~     (p=0.222 n=5+5)
KV/Scan/Native/rows=10-16         11.6kB ± 0%    11.6kB ± 0%     ~     (p=0.698 n=4+5)
KV/Scan/Native/rows=100-16        24.2kB ± 0%    24.2kB ± 0%   -0.14%  (p=0.016 n=5+4)
KV/Scan/Native/rows=1000-16        175kB ± 0%     175kB ± 0%     ~     (p=0.968 n=5+5)
KV/Scan/Native/rows=10000-16      1.51MB ± 0%    1.51MB ± 0%     ~     (p=0.222 n=5+5)
KV/Scan/SQL/rows=1-16             31.6kB ± 0%    31.7kB ± 1%     ~     (p=0.651 n=5+5)
KV/Scan/SQL/rows=10-16            35.1kB ± 0%    35.1kB ± 1%     ~     (p=0.421 n=5+5)
KV/Scan/SQL/rows=100-16           55.5kB ± 1%    55.4kB ± 0%     ~     (p=0.421 n=5+5)
KV/Scan/SQL/rows=1000-16           261kB ± 1%     260kB ± 0%     ~     (p=0.286 n=5+4)
KV/Scan/SQL/rows=10000-16         1.48MB ± 1%    1.48MB ± 0%   -0.58%  (p=0.016 n=5+5)

name                            old allocs/op  new allocs/op  delta
KV/Insert/Native/rows=1-16           139 ± 0%       139 ± 0%     ~     (all equal)
KV/Insert/Native/rows=10-16          285 ± 0%       285 ± 0%     ~     (all equal)
KV/Insert/Native/rows=100-16       1.58k ± 0%     1.58k ± 0%     ~     (p=1.000 n=5+4)
KV/Insert/Native/rows=1000-16      14.3k ± 0%     14.3k ± 0%     ~     (p=0.611 n=5+5)
KV/Insert/Native/rows=10000-16      141k ± 0%      141k ± 0%     ~     (p=0.548 n=5+5)
KV/Insert/SQL/rows=1-16              339 ± 0%       340 ± 0%   +0.29%  (p=0.016 n=4+5)
KV/Insert/SQL/rows=10-16             553 ± 0%       554 ± 0%     ~     (p=1.000 n=5+5)
KV/Insert/SQL/rows=100-16          2.50k ± 0%     2.50k ± 0%     ~     (p=0.333 n=4+5)
KV/Insert/SQL/rows=1000-16         23.1k ± 0%     23.1k ± 0%     ~     (p=0.278 n=5+5)
KV/Insert/SQL/rows=10000-16         233k ± 0%      233k ± 0%     ~     (p=0.690 n=5+5)
KV/Update/Native/rows=1-16           201 ± 0%       201 ± 0%     ~     (all equal)
KV/Update/Native/rows=10-16          469 ± 0%       424 ± 0%   -9.59%  (p=0.000 n=5+4)
KV/Update/Native/rows=100-16       2.83k ± 0%     2.34k ± 0%  -17.39%  (p=0.016 n=5+4)
KV/Update/Native/rows=1000-16      27.7k ± 0%     22.9k ± 1%  -17.32%  (p=0.008 n=5+5)
KV/Update/Native/rows=10000-16      281k ± 0%      231k ± 0%  -17.82%  (p=0.008 n=5+5)
KV/Update/SQL/rows=1-16              586 ± 0%       586 ± 0%     ~     (p=0.881 n=5+5)
KV/Update/SQL/rows=10-16           1.05k ± 0%     1.05k ± 0%     ~     (p=1.000 n=5+5)
KV/Update/SQL/rows=100-16          3.71k ± 0%     3.72k ± 0%     ~     (p=1.000 n=5+5)
KV/Update/SQL/rows=1000-16         20.9k ± 0%     15.9k ± 0%  -23.89%  (p=0.008 n=5+5)
KV/Update/SQL/rows=10000-16         259k ± 0%      259k ± 0%     ~     (p=0.095 n=5+5)
KV/Delete/Native/rows=1-16           138 ± 0%       138 ± 0%     ~     (all equal)
KV/Delete/Native/rows=10-16          263 ± 0%       263 ± 0%     ~     (p=0.444 n=5+5)
KV/Delete/Native/rows=100-16       1.38k ± 0%     1.38k ± 0%     ~     (all equal)
KV/Delete/Native/rows=1000-16      12.3k ± 0%     12.3k ± 0%     ~     (p=1.000 n=5+5)
KV/Delete/Native/rows=10000-16      121k ± 0%      121k ± 0%     ~     (p=0.190 n=5+4)
KV/Delete/SQL/rows=1-16              347 ± 0%       346 ± 0%     ~     (p=0.143 n=4+4)
KV/Delete/SQL/rows=10-16             526 ± 0%       526 ± 0%     ~     (p=1.000 n=5+5)
KV/Delete/SQL/rows=100-16          2.10k ± 0%     2.10k ± 0%     ~     (p=0.698 n=5+4)
KV/Delete/SQL/rows=1000-16         7.56k ± 0%     7.55k ± 0%     ~     (p=0.437 n=5+5)
KV/Delete/SQL/rows=10000-16        71.1k ± 0%     71.1k ± 0%     ~     (p=1.000 n=5+5)
KV/Scan/Native/rows=1-16            77.0 ± 0%      77.0 ± 0%     ~     (all equal)
KV/Scan/Native/rows=10-16           81.0 ± 0%      81.0 ± 0%     ~     (all equal)
KV/Scan/Native/rows=100-16          85.0 ± 0%      85.0 ± 0%     ~     (all equal)
KV/Scan/Native/rows=1000-16         95.8 ± 6%      92.0 ± 0%     ~     (p=0.444 n=5+5)
KV/Scan/Native/rows=10000-16         108 ± 1%       108 ± 1%     ~     (p=0.643 n=5+5)
KV/Scan/SQL/rows=1-16                290 ± 0%       291 ± 0%     ~     (p=0.238 n=5+4)
KV/Scan/SQL/rows=10-16               364 ± 0%       364 ± 0%     ~     (p=0.921 n=5+5)
KV/Scan/SQL/rows=100-16              770 ± 0%       771 ± 0%     ~     (p=0.238 n=5+4)
KV/Scan/SQL/rows=1000-16           5.18k ± 0%     5.17k ± 0%     ~     (p=0.079 n=5+5)
KV/Scan/SQL/rows=10000-16          50.4k ± 0%     50.3k ± 0%     ~     (p=0.675 n=5+5)
```

Release note: None