### PR TITLE
storage: improvements when separated intents are allowed

### DIFF
--- a/pkg/kv/kvserver/rditer/replica_data_iter.go
+++ b/pkg/kv/kvserver/rditer/replica_data_iter.go
@@ -220,6 +220,10 @@ func MakeUserKeyRange(d *roachpb.RangeDescriptor) KeyRange {
 func NewReplicaMVCCDataIterator(
 	d *roachpb.RangeDescriptor, reader storage.Reader, seekEnd bool,
 ) *ReplicaMVCCDataIterator {
+	// TODO(sumeer): this is broken for separated intents since the upper bound
+	// is a global key, but the ranges include replicated range local keys. So
+	// it underlying iterator used by intentInterleavingIter can iterate up into
+	// the lock table which is not an MVCCKey.
 	it := reader.NewMVCCIterator(
 		storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{UpperBound: d.EndKey.AsRawKey()})
 	ri := &ReplicaMVCCDataIterator{

--- a/pkg/storage/engine_test.go
+++ b/pkg/storage/engine_test.go
@@ -1476,7 +1476,7 @@ func TestEngineFSFileNotFoundError(t *testing.T) {
 func TestSupportsPrev(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	opts := IterOptions{LowerBound: keys.MinKey, UpperBound: keys.MaxKey}
+	opts := IterOptions{LowerBound: keys.LocalMax, UpperBound: keys.MaxKey}
 	type engineTest struct {
 		engineIterSupportsPrev   bool
 		batchIterSupportsPrev    bool

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -3144,6 +3144,9 @@ func MVCCGarbageCollect(
 
 	// Bound the iterator appropriately for the set of keys we'll be garbage
 	// collecting.
+	// TODO(sumeer): this can span from local to global keys. Fix in cmd_gc.go
+	// which is already examining all the keys and can separate out the local
+	// keys to call MVCCGarbageCollect separately.
 	iter := rw.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{
 		LowerBound: keys[0].Key,
 		UpperBound: keys[len(keys)-1].Key.Next(),

--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -67,6 +67,7 @@ import (
 // - `=foo` means exactly key `foo`
 // - `+foo` means `Key(foo).Next()`
 // - `-foo` means `Key(foo).PrefixEnd()`
+// - `%foo` means `append(LocalRangePrefix, "foo")`
 //
 // Additionally, the pseudo-command `with` enables sharing
 // a group of arguments between multiple commands, for example:
@@ -1018,6 +1019,8 @@ func toKey(s string) roachpb.Key {
 		return roachpb.Key(s[1:])
 	case len(s) > 0 && s[0] == '-':
 		return roachpb.Key(s[1:]).PrefixEnd()
+	case len(s) > 0 && s[0] == '%':
+		return append(keys.LocalRangePrefix, s[1:]...)
 	default:
 		return roachpb.Key(s)
 	}

--- a/pkg/storage/mvcc_stats_test.go
+++ b/pkg/storage/mvcc_stats_test.go
@@ -1530,10 +1530,13 @@ func TestMVCCStatsRandomized(t *testing.T) {
 		max := s.rng.Int63n(5)
 		desc := fmt.Sprintf("returnKeys=%t, max=%d", returnKeys, max)
 		keyMin := roachpb.KeyMin
-		if !s.isLocalKey {
+		keyMax := roachpb.KeyMax
+		if s.isLocalKey {
+			keyMax = keys.LocalMax
+		} else {
 			keyMin = keys.LocalMax
 		}
-		if _, _, _, err := MVCCDeleteRange(ctx, s.eng, s.MS, keyMin, roachpb.KeyMax, max, s.TS, s.Txn, returnKeys); err != nil {
+		if _, _, _, err := MVCCDeleteRange(ctx, s.eng, s.MS, keyMin, keyMax, max, s.TS, s.Txn, returnKeys); err != nil {
 			return desc + ": " + err.Error()
 		}
 		return desc

--- a/pkg/storage/testdata/mvcc_histories/conditional_put_with_txn_allow_separated
+++ b/pkg/storage/testdata/mvcc_histories/conditional_put_with_txn_allow_separated
@@ -2,7 +2,7 @@ run ok
 txn_begin t=A ts=123
 ----
 >> at end:
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000123,0 min=0,0 seq=0} lock=true stat=PENDING rts=0.000000123,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=123.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=123.000000000,0 wto=false max=0,0
 
 # Write value1.
 
@@ -12,9 +12,9 @@ with t=A
   cput k=k v=v
 ----
 >> at end:
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000123,0 min=0,0 seq=1} lock=true stat=PENDING rts=0.000000123,0 wto=false max=0,0
-meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000123,0 min=0,0 seq=1} ts=0.000000123,0 del=false klen=12 vlen=6
-data: "k"/0.000000123,0 -> /BYTES/v
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=123.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=123.000000000,0 wto=false max=0,0
+meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=123.000000000,0 min=0,0 seq=1} ts=123.000000000,0 del=false klen=12 vlen=6
+data: "k"/123.000000000,0 -> /BYTES/v
 
 # Now, overwrite value1 with value2 from same txn; should see value1
 # as pre-existing value.
@@ -25,9 +25,9 @@ with t=A
   cput k=k v=v2 cond=v
 ----
 >> at end:
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000123,0 min=0,0 seq=2} lock=true stat=PENDING rts=0.000000123,0 wto=false max=0,0
-meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000123,0 min=0,0 seq=2} ts=0.000000123,0 del=false klen=12 vlen=7 ih={{1 /BYTES/v}}
-data: "k"/0.000000123,0 -> /BYTES/v2
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=123.000000000,0 min=0,0 seq=2} lock=true stat=PENDING rts=123.000000000,0 wto=false max=0,0
+meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=123.000000000,0 min=0,0 seq=2} ts=123.000000000,0 del=false klen=12 vlen=7 ih={{1 /BYTES/v}}
+data: "k"/123.000000000,0 -> /BYTES/v2
 
 # Writing value3 from a new epoch should see nil again.
 
@@ -38,9 +38,9 @@ with t=A
   cput k=k v=v3
 ----
 >> at end:
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=1 ts=0.000000123,0 min=0,0 seq=1} lock=true stat=PENDING rts=0.000000123,0 wto=false max=0,0
-meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=1 ts=0.000000123,0 min=0,0 seq=1} ts=0.000000123,0 del=false klen=12 vlen=7
-data: "k"/0.000000123,0 -> /BYTES/v3
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=1 ts=123.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=123.000000000,0 wto=false max=0,0
+meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=1 ts=123.000000000,0 min=0,0 seq=1} ts=123.000000000,0 del=false klen=12 vlen=7
+data: "k"/123.000000000,0 -> /BYTES/v3
 
 # Commit value3 at a later timestamp.
 
@@ -51,7 +51,7 @@ with t=A
   txn_remove
 ----
 >> at end:
-data: "k"/0.000000124,0 -> /BYTES/v3
+data: "k"/124.000000000,0 -> /BYTES/v3
 
 # Write value4 with an old timestamp without txn...should get a write
 # too old error.
@@ -60,9 +60,9 @@ run error
 cput k=k v=v4 cond=v3 ts=123
 ----
 >> at end:
-data: "k"/0.000000124,1 -> /BYTES/v4
-data: "k"/0.000000124,0 -> /BYTES/v3
-error: (*roachpb.WriteTooOldError:) WriteTooOldError: write at timestamp 0.000000123,0 too old; wrote at 0.000000124,1
+data: "k"/124.000000000,1 -> /BYTES/v4
+data: "k"/124.000000000,0 -> /BYTES/v3
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write at timestamp 123.000000000,0 too old; wrote at 124.000000000,1
 
 # Reset for next test
 
@@ -86,10 +86,10 @@ with t=A
   cput k=c v=cput cond=value
 ----
 >> at end:
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000002,0 min=0,0 seq=1} lock=true stat=PENDING rts=0.000000002,0 wto=false max=0,0
-meta: "c"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000002,0 min=0,0 seq=1} ts=0.000000002,0 del=false klen=12 vlen=9
-data: "c"/0.000000002,0 -> /BYTES/cput
-data: "c"/0.000000001,0 -> /BYTES/value
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=2.000000000,0 wto=false max=0,0
+meta: "c"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=1} ts=2.000000000,0 del=false klen=12 vlen=9
+data: "c"/2.000000000,0 -> /BYTES/cput
+data: "c"/1.000000000,0 -> /BYTES/value
 
 # Restart and retry cput. It should succeed.
 
@@ -100,11 +100,11 @@ with t=A
   cput k=c v=cput cond=value
 ----
 >> txn_restart ts=3 t=A
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=1 ts=0.000000003,0 min=0,0 seq=0} lock=true stat=PENDING rts=0.000000003,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=1 ts=3.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=3.000000000,0 wto=false max=0,0
 >> txn_step t=A
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=1 ts=0.000000003,0 min=0,0 seq=1} lock=true stat=PENDING rts=0.000000003,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=1 ts=3.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=3.000000000,0 wto=false max=0,0
 >> cput k=c v=cput cond=value t=A
 called PutIntent("c", _, ExistingIntentInterleaved, TDNUM(true), 00000000-0000-0000-0000-000000000002)
-meta: "c"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=1 ts=0.000000003,0 min=0,0 seq=1} ts=0.000000003,0 del=false klen=12 vlen=9
-data: "c"/0.000000003,0 -> /BYTES/cput
-data: "c"/0.000000001,0 -> /BYTES/value
+meta: "c"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=1 ts=3.000000000,0 min=0,0 seq=1} ts=3.000000000,0 del=false klen=12 vlen=9
+data: "c"/3.000000000,0 -> /BYTES/cput
+data: "c"/1.000000000,0 -> /BYTES/value

--- a/pkg/storage/testdata/mvcc_histories/empty_key
+++ b/pkg/storage/testdata/mvcc_histories/empty_key
@@ -12,15 +12,15 @@ put ts=0,1 k= v=a
 error: (*withstack.withStack:) attempted access to empty key
 
 run ok
-scan ts=0,1 k= end=a
+scan ts=0,1 k= end=%a
 ----
-scan: /Min-"a" -> <no data>
+scan: /Min-/Local/Range/"a" -> <no data>
 
 
 run error
-scan ts=0,1 k=a end=
+scan ts=0,1 k=%a end=
 ----
-scan: "a"-/Min -> <no data>
+scan: /Local/Range/"a"-/Min -> <no data>
 error: (*withstack.withStack:) attempted access to empty key
 
 run error

--- a/pkg/storage/testdata/mvcc_histories/intent_history_allow_separated
+++ b/pkg/storage/testdata/mvcc_histories/intent_history_allow_separated
@@ -7,7 +7,7 @@ with t=A
   txn_remove
 ----
 >> at end:
-data: "a"/0.000000001,0 -> /BYTES/default
+data: "a"/1.000000000,0 -> /BYTES/default
 
 ## See how the intent history evolves throughout the test.
 
@@ -25,34 +25,34 @@ with t=A
   resolve_intent
 ----
 >> txn_begin ts=2 t=A
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000002,0 min=0,0 seq=0} lock=true stat=PENDING rts=0.000000002,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=2.000000000,0 wto=false max=0,0
 >> put v=first k=a t=A
 called PutIntent("a", _, NoExistingIntent, TDNUM(true), 00000000-0000-0000-0000-000000000002)
-meta: "a"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000002,0 min=0,0 seq=0} ts=0.000000002,0 del=false klen=12 vlen=10
-data: "a"/0.000000002,0 -> /BYTES/first
-data: "a"/0.000000001,0 -> /BYTES/default
+meta: "a"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0} ts=2.000000000,0 del=false klen=12 vlen=10
+data: "a"/2.000000000,0 -> /BYTES/first
+data: "a"/1.000000000,0 -> /BYTES/default
 >> txn_step k=a t=A
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000002,0 min=0,0 seq=1} lock=true stat=PENDING rts=0.000000002,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=2.000000000,0 wto=false max=0,0
 >> put v=second k=a t=A
 called PutIntent("a", _, ExistingIntentInterleaved, TDNUM(true), 00000000-0000-0000-0000-000000000002)
-meta: "a"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000002,0 min=0,0 seq=1} ts=0.000000002,0 del=false klen=12 vlen=11 ih={{0 /BYTES/first}}
-data: "a"/0.000000002,0 -> /BYTES/second
-data: "a"/0.000000001,0 -> /BYTES/default
+meta: "a"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=1} ts=2.000000000,0 del=false klen=12 vlen=11 ih={{0 /BYTES/first}}
+data: "a"/2.000000000,0 -> /BYTES/second
+data: "a"/1.000000000,0 -> /BYTES/default
 >> txn_step n=2 k=a t=A
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000002,0 min=0,0 seq=3} lock=true stat=PENDING rts=0.000000002,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=3} lock=true stat=PENDING rts=2.000000000,0 wto=false max=0,0
 >> del k=a t=A
 called PutIntent("a", _, ExistingIntentInterleaved, TDNUM(false), 00000000-0000-0000-0000-000000000002)
-meta: "a"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000002,0 min=0,0 seq=3} ts=0.000000002,0 del=true klen=12 vlen=0 ih={{0 /BYTES/first}{1 /BYTES/second}}
-data: "a"/0.000000002,0 -> /<empty>
-data: "a"/0.000000001,0 -> /BYTES/default
+meta: "a"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=3} ts=2.000000000,0 del=true klen=12 vlen=0 ih={{0 /BYTES/first}{1 /BYTES/second}}
+data: "a"/2.000000000,0 -> /<empty>
+data: "a"/1.000000000,0 -> /BYTES/default
 >> txn_step n=6 k=a t=A
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000002,0 min=0,0 seq=9} lock=true stat=PENDING rts=0.000000002,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=9} lock=true stat=PENDING rts=2.000000000,0 wto=false max=0,0
 >> put v=first k=a t=A
 called PutIntent("a", _, ExistingIntentInterleaved, TDNUM(false), 00000000-0000-0000-0000-000000000002)
-meta: "a"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000002,0 min=0,0 seq=9} ts=0.000000002,0 del=false klen=12 vlen=10 ih={{0 /BYTES/first}{1 /BYTES/second}{3 /<empty>}}
-data: "a"/0.000000002,0 -> /BYTES/first
-data: "a"/0.000000001,0 -> /BYTES/default
+meta: "a"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=9} ts=2.000000000,0 del=false klen=12 vlen=10 ih={{0 /BYTES/first}{1 /BYTES/second}{3 /<empty>}}
+data: "a"/2.000000000,0 -> /BYTES/first
+data: "a"/1.000000000,0 -> /BYTES/default
 >> resolve_intent k=a t=A
 called ClearIntent("a", ExistingIntentInterleaved, TDNUM(false), 00000000-0000-0000-0000-000000000002)
-data: "a"/0.000000002,0 -> /BYTES/first
-data: "a"/0.000000001,0 -> /BYTES/default
+data: "a"/2.000000000,0 -> /BYTES/first
+data: "a"/1.000000000,0 -> /BYTES/default

--- a/pkg/storage/testdata/mvcc_histories/intent_with_write_tracing_allow_separated
+++ b/pkg/storage/testdata/mvcc_histories/intent_with_write_tracing_allow_separated
@@ -4,11 +4,11 @@ with t=A
   put k=k1 v=v1
 ----
 >> txn_begin ts=2 t=A
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000002,0 min=0,0 seq=0} lock=true stat=PENDING rts=0.000000002,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=2.000000000,0 wto=false max=0,0
 >> put k=k1 v=v1 t=A
 called PutIntent("k1", _, NoExistingIntent, TDNUM(true), 00000000-0000-0000-0000-000000000001)
-meta: "k1"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000002,0 min=0,0 seq=0} ts=0.000000002,0 del=false klen=12 vlen=7
-data: "k1"/0.000000002,0 -> /BYTES/v1
+meta: "k1"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0} ts=2.000000000,0 del=false klen=12 vlen=7
+data: "k1"/2.000000000,0 -> /BYTES/v1
 
 run trace ok
 with t=A
@@ -18,29 +18,29 @@ with t=A
   put k=k2 v=v2
 ----
 >> txn_advance ts=3 t=A
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000003,0 min=0,0 seq=0} lock=true stat=PENDING rts=0.000000002,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=2.000000000,0 wto=false max=0,0
 >> txn_step t=A
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000003,0 min=0,0 seq=1} lock=true stat=PENDING rts=0.000000002,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=2.000000000,0 wto=false max=0,0
 >> put k=k1 v=v1 t=A
 called PutIntent("k1", _, ExistingIntentInterleaved, TDNUM(true), 00000000-0000-0000-0000-000000000001)
-meta: "k1"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000003,0 min=0,0 seq=1} ts=0.000000003,0 del=false klen=12 vlen=7 ih={{0 /BYTES/v1}}
-data: "k1"/0.000000003,0 -> /BYTES/v1
+meta: "k1"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} ts=3.000000000,0 del=false klen=12 vlen=7 ih={{0 /BYTES/v1}}
+data: "k1"/3.000000000,0 -> /BYTES/v1
 >> put k=k2 v=v2 t=A
 called PutIntent("k2", _, NoExistingIntent, TDNUM(true), 00000000-0000-0000-0000-000000000001)
-meta: "k1"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000003,0 min=0,0 seq=1} ts=0.000000003,0 del=false klen=12 vlen=7 ih={{0 /BYTES/v1}}
-data: "k1"/0.000000003,0 -> /BYTES/v1
-meta: "k2"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000003,0 min=0,0 seq=1} ts=0.000000003,0 del=false klen=12 vlen=7
-data: "k2"/0.000000003,0 -> /BYTES/v2
+meta: "k1"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} ts=3.000000000,0 del=false klen=12 vlen=7 ih={{0 /BYTES/v1}}
+data: "k1"/3.000000000,0 -> /BYTES/v1
+meta: "k2"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} ts=3.000000000,0 del=false klen=12 vlen=7
+data: "k2"/3.000000000,0 -> /BYTES/v2
 
 run trace ok
 put k=k3 v=v3 ts=1
 ----
 >> put k=k3 v=v3 ts=1
-meta: "k1"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000003,0 min=0,0 seq=1} ts=0.000000003,0 del=false klen=12 vlen=7 ih={{0 /BYTES/v1}}
-data: "k1"/0.000000003,0 -> /BYTES/v1
-meta: "k2"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000003,0 min=0,0 seq=1} ts=0.000000003,0 del=false klen=12 vlen=7
-data: "k2"/0.000000003,0 -> /BYTES/v2
-data: "k3"/0.000000001,0 -> /BYTES/v3
+meta: "k1"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} ts=3.000000000,0 del=false klen=12 vlen=7 ih={{0 /BYTES/v1}}
+data: "k1"/3.000000000,0 -> /BYTES/v1
+meta: "k2"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} ts=3.000000000,0 del=false klen=12 vlen=7
+data: "k2"/3.000000000,0 -> /BYTES/v2
+data: "k3"/1.000000000,0 -> /BYTES/v3
 
 run trace ok
 with t=A
@@ -48,13 +48,13 @@ with t=A
 ----
 >> put k=k3 v=v33 t=A
 called PutIntent("k3", _, NoExistingIntent, TDNUM(true), 00000000-0000-0000-0000-000000000001)
-meta: "k1"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000003,0 min=0,0 seq=1} ts=0.000000003,0 del=false klen=12 vlen=7 ih={{0 /BYTES/v1}}
-data: "k1"/0.000000003,0 -> /BYTES/v1
-meta: "k2"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000003,0 min=0,0 seq=1} ts=0.000000003,0 del=false klen=12 vlen=7
-data: "k2"/0.000000003,0 -> /BYTES/v2
-meta: "k3"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000003,0 min=0,0 seq=1} ts=0.000000003,0 del=false klen=12 vlen=8
-data: "k3"/0.000000003,0 -> /BYTES/v33
-data: "k3"/0.000000001,0 -> /BYTES/v3
+meta: "k1"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} ts=3.000000000,0 del=false klen=12 vlen=7 ih={{0 /BYTES/v1}}
+data: "k1"/3.000000000,0 -> /BYTES/v1
+meta: "k2"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} ts=3.000000000,0 del=false klen=12 vlen=7
+data: "k2"/3.000000000,0 -> /BYTES/v2
+meta: "k3"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} ts=3.000000000,0 del=false klen=12 vlen=8
+data: "k3"/3.000000000,0 -> /BYTES/v33
+data: "k3"/1.000000000,0 -> /BYTES/v3
 
 # transactionDidNotUpdateMeta (TDNUM) is false below for k2 and k3 since
 # disallowSeparatedIntents=true causes mvcc.go to always set it to false to maintain
@@ -68,20 +68,20 @@ with t=A
 ----
 >> resolve_intent k=k1 t=A
 called ClearIntent("k1", ExistingIntentInterleaved, TDNUM(false), 00000000-0000-0000-0000-000000000001)
-data: "k1"/0.000000003,0 -> /BYTES/v1
-meta: "k2"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000003,0 min=0,0 seq=1} ts=0.000000003,0 del=false klen=12 vlen=7
-data: "k2"/0.000000003,0 -> /BYTES/v2
-meta: "k3"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000003,0 min=0,0 seq=1} ts=0.000000003,0 del=false klen=12 vlen=8
-data: "k3"/0.000000003,0 -> /BYTES/v33
-data: "k3"/0.000000001,0 -> /BYTES/v3
+data: "k1"/3.000000000,0 -> /BYTES/v1
+meta: "k2"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} ts=3.000000000,0 del=false klen=12 vlen=7
+data: "k2"/3.000000000,0 -> /BYTES/v2
+meta: "k3"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} ts=3.000000000,0 del=false klen=12 vlen=8
+data: "k3"/3.000000000,0 -> /BYTES/v33
+data: "k3"/1.000000000,0 -> /BYTES/v3
 >> resolve_intent k=k2 status=ABORTED t=A
 called ClearIntent("k2", ExistingIntentInterleaved, TDNUM(true), 00000000-0000-0000-0000-000000000001)
-data: "k1"/0.000000003,0 -> /BYTES/v1
-meta: "k3"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000003,0 min=0,0 seq=1} ts=0.000000003,0 del=false klen=12 vlen=8
-data: "k3"/0.000000003,0 -> /BYTES/v33
-data: "k3"/0.000000001,0 -> /BYTES/v3
+data: "k1"/3.000000000,0 -> /BYTES/v1
+meta: "k3"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} ts=3.000000000,0 del=false klen=12 vlen=8
+data: "k3"/3.000000000,0 -> /BYTES/v33
+data: "k3"/1.000000000,0 -> /BYTES/v3
 >> resolve_intent k=k3 status=ABORTED t=A
 called ClearIntent("k3", ExistingIntentInterleaved, TDNUM(true), 00000000-0000-0000-0000-000000000001)
-data: "k1"/0.000000003,0 -> /BYTES/v1
-data: "k3"/0.000000001,0 -> /BYTES/v3
+data: "k1"/3.000000000,0 -> /BYTES/v1
+data: "k3"/1.000000000,0 -> /BYTES/v3
 >> txn_remove t=A

--- a/pkg/storage/testdata/mvcc_histories/no_read_after_abort_allow_separated
+++ b/pkg/storage/testdata/mvcc_histories/no_read_after_abort_allow_separated
@@ -8,11 +8,11 @@ with t=A k=a
   txn_remove
 ----
 >> txn_begin ts=22 t=A k=a
-txn: "A" meta={id=00000000 key="a" pri=0.00000000 epo=0 ts=0.000000022,0 min=0,0 seq=0} lock=true stat=PENDING rts=0.000000022,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key="a" pri=0.00000000 epo=0 ts=22.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=22.000000000,0 wto=false max=0,0
 >> put v=cde t=A k=a
 called PutIntent("a", _, NoExistingIntent, TDNUM(true), 00000000-0000-0000-0000-000000000001)
-meta: "a"/0,0 -> txn={id=00000000 key="a" pri=0.00000000 epo=0 ts=0.000000022,0 min=0,0 seq=0} ts=0.000000022,0 del=false klen=12 vlen=8
-data: "a"/0.000000022,0 -> /BYTES/cde
+meta: "a"/0,0 -> txn={id=00000000 key="a" pri=0.00000000 epo=0 ts=22.000000000,0 min=0,0 seq=0} ts=22.000000000,0 del=false klen=12 vlen=8
+data: "a"/22.000000000,0 -> /BYTES/cde
 >> resolve_intent status=ABORTED t=A k=a
 called ClearIntent("a", ExistingIntentInterleaved, TDNUM(true), 00000000-0000-0000-0000-000000000001)
 <no data>

--- a/pkg/storage/testdata/mvcc_histories/read_after_write_allow_separated
+++ b/pkg/storage/testdata/mvcc_histories/read_after_write_allow_separated
@@ -9,16 +9,16 @@ with t=A
     resolve_intent
 ----
 >> txn_begin ts=11 t=A
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=0} lock=true stat=PENDING rts=0.000000011,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=11.000000000,0 wto=false max=0,0
 >> put v=abc k=a t=A
 called PutIntent("a", _, NoExistingIntent, TDNUM(true), 00000000-0000-0000-0000-000000000001)
-meta: "a"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=0} ts=0.000000011,0 del=false klen=12 vlen=8
-data: "a"/0.000000011,0 -> /BYTES/abc
+meta: "a"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} ts=11.000000000,0 del=false klen=12 vlen=8
+data: "a"/11.000000000,0 -> /BYTES/abc
 >> get k=a t=A
-get: "a" -> /BYTES/abc @0.000000011,0
+get: "a" -> /BYTES/abc @11.000000000,0
 >> resolve_intent k=a t=A
 called ClearIntent("a", ExistingIntentInterleaved, TDNUM(true), 00000000-0000-0000-0000-000000000001)
-data: "a"/0.000000011,0 -> /BYTES/abc
+data: "a"/11.000000000,0 -> /BYTES/abc
 
 run ok
 with t=A resolve
@@ -29,11 +29,11 @@ with t=A resolve
   txn_remove
 ----
 >> at end:
-data: "a"/0.000000011,0 -> /BYTES/abc
-data: "a/1"/0.000000011,0 -> /BYTES/eee
-data: "b"/0.000000011,0 -> /BYTES/fff
-data: "b/2"/0.000000011,0 -> /BYTES/ggg
-data: "c"/0.000000011,0 -> /BYTES/hhh
+data: "a"/11.000000000,0 -> /BYTES/abc
+data: "a/1"/11.000000000,0 -> /BYTES/eee
+data: "b"/11.000000000,0 -> /BYTES/fff
+data: "b/2"/11.000000000,0 -> /BYTES/ggg
+data: "c"/11.000000000,0 -> /BYTES/hhh
 
 # Reads previous writes, transactional.
 
@@ -42,9 +42,9 @@ with t=A
   txn_begin  ts=11
   get   k=a
 ----
-get: "a" -> /BYTES/abc @0.000000011,0
+get: "a" -> /BYTES/abc @11.000000000,0
 >> at end:
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=0} lock=true stat=PENDING rts=0.000000011,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=11.000000000,0 wto=false max=0,0
 
 run trace ok
 with t=A
@@ -57,25 +57,25 @@ with t=A
   txn_remove
 ----
 >> scan k=a end==b t=A
-scan: "a" -> /BYTES/abc @0.000000011,0
-scan: "a/1" -> /BYTES/eee @0.000000011,0
+scan: "a" -> /BYTES/abc @11.000000000,0
+scan: "a/1" -> /BYTES/eee @11.000000000,0
 >> scan k=a end=+a t=A
-scan: "a" -> /BYTES/abc @0.000000011,0
+scan: "a" -> /BYTES/abc @11.000000000,0
 >> scan k=a end=-a t=A
-scan: "a" -> /BYTES/abc @0.000000011,0
-scan: "a/1" -> /BYTES/eee @0.000000011,0
+scan: "a" -> /BYTES/abc @11.000000000,0
+scan: "a/1" -> /BYTES/eee @11.000000000,0
 >> scan k=a end=+b t=A
-scan: "a" -> /BYTES/abc @0.000000011,0
-scan: "a/1" -> /BYTES/eee @0.000000011,0
-scan: "b" -> /BYTES/fff @0.000000011,0
+scan: "a" -> /BYTES/abc @11.000000000,0
+scan: "a/1" -> /BYTES/eee @11.000000000,0
+scan: "b" -> /BYTES/fff @11.000000000,0
 >> scan k=a end==b t=A
-scan: "a" -> /BYTES/abc @0.000000011,0
-scan: "a/1" -> /BYTES/eee @0.000000011,0
+scan: "a" -> /BYTES/abc @11.000000000,0
+scan: "a/1" -> /BYTES/eee @11.000000000,0
 >> scan k=a end=-b t=A
-scan: "a" -> /BYTES/abc @0.000000011,0
-scan: "a/1" -> /BYTES/eee @0.000000011,0
-scan: "b" -> /BYTES/fff @0.000000011,0
-scan: "b/2" -> /BYTES/ggg @0.000000011,0
+scan: "a" -> /BYTES/abc @11.000000000,0
+scan: "a/1" -> /BYTES/eee @11.000000000,0
+scan: "b" -> /BYTES/fff @11.000000000,0
+scan: "b/2" -> /BYTES/ggg @11.000000000,0
 >> txn_remove t=A
 
 
@@ -87,5 +87,5 @@ with t=A k=a
   txn_remove
 ----
 >> txn_begin ts=1 t=A k=a
-txn: "A" meta={id=00000000 key="a" pri=0.00000000 epo=0 ts=0.000000001,0 min=0,0 seq=0} lock=true stat=PENDING rts=0.000000001,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key="a" pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=1.000000000,0 wto=false max=0,0
 >> txn_remove t=A k=a


### PR DESCRIPTION
- There are a number of test fixes.
- intentInterleavingIter is allocated from a pool to
  reduce allocations.
- we don't use newMVCCIteratorByCloningEngineIter when
  the underlying Reader.ConsistentIterators is true,
  since such Readers have pebbleIterators that they
  want to reuse.
- There are a couple of code todos for newly discovered
  places, which involve GC, which are incorrect when we
  turn on separated intents, since they run afoul of
  the restriction that the intentInterleavingIter cannot
  span from local to global keys with bounds being set
  once. The fix is not in this PR.

The setting for DisallowSeparatedIntents remains true.

Release note: None