### PR TITLE
kv/kvserver: skip TestClosedTimestampInactiveAfterSubsumption

### DIFF
--- a/pkg/kv/kvserver/closed_timestamp_test.go
+++ b/pkg/kv/kvserver/closed_timestamp_test.go
@@ -475,6 +475,7 @@ func TestClosedTimestampCantServeForNonTransactionalReadRequest(t *testing.T) {
 // timestamps after the subsumption time.
 func TestClosedTimestampInactiveAfterSubsumption(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 59448, "flaky test")
 	// Skipping under short because this test pauses for a few seconds in order to
 	// trigger a node liveness expiration.
 	skip.UnderShort(t)


### PR DESCRIPTION
Refs: #59448

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes

Release note: None