### PR TITLE
kv/kvserver: skip TestReplicateReAddAfterDown

### DIFF
--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -3699,6 +3699,7 @@ func TestReplicaLazyLoad(t *testing.T) {
 
 func TestReplicateReAddAfterDown(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 59453, "flaky test")
 	defer log.Scope(t).Close(t)
 
 	stickyEngineRegistry := server.NewStickyInMemEnginesRegistry()


### PR DESCRIPTION
Refs: #59453

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes

Release note: None