### PR TITLE
[repro] tracing: reproduce incorrect trace capture...

### DIFF
--- a/pkg/kv/kvserver/replica_application_decoder.go
+++ b/pkg/kv/kvserver/replica_application_decoder.go
@@ -144,7 +144,7 @@ func (d *replicaDecoder) createTracingSpans(ctx context.Context) {
 		} else if cmd.raftCmd.TraceData != nil {
 			// The proposal isn't local, and trace data is available. Extract
 			// the remote span and start a server-side span that follows from it.
-			spanCtx, err := d.r.AmbientContext.Tracer.Extract(
+			spanMeta, err := d.r.AmbientContext.Tracer.Extract(
 				opentracing.TextMap, opentracing.TextMapCarrier(cmd.raftCmd.TraceData))
 			if err != nil {
 				log.Errorf(ctx, "unable to extract trace data from raft command: %s", err)
@@ -154,7 +154,7 @@ func (d *replicaDecoder) createTracingSpans(ctx context.Context) {
 					"raft application",
 					// NB: we are lying here - we are not actually going to propagate
 					// the recording towards the root. That seems ok.
-					tracing.WithParentAndManualCollection(spanCtx),
+					tracing.WithParentAndManualCollection(spanMeta),
 					tracing.WithFollowsFrom(),
 				)
 			}

--- a/pkg/sql/opt/exec/execbuilder/testdata/autocommit_nonmetamorphic
+++ b/pkg/sql/opt/exec/execbuilder/testdata/autocommit_nonmetamorphic
@@ -110,6 +110,7 @@ WHERE message     LIKE '%r$rangeid: sending batch%'
   AND message NOT LIKE '%PushTxn%'
   AND message NOT LIKE '%QueryTxn%'
 ----
+dist sender send  r35: sending batch 2 CPut to (n1,s1):1
 dist sender send  r35: sending batch 2 CPut, 1 EndTxn to (n1,s1):1
 
 # TODO(radu): allow non-side-effecting projections.
@@ -132,6 +133,7 @@ WHERE message       LIKE '%r$rangeid: sending batch%'
   AND message   NOT LIKE '%QueryTxn%'
   AND operation NOT LIKE '%async%'
 ----
+dist sender send  r35: sending batch 2 CPut to (n1,s1):1
 dist sender send  r35: sending batch 2 CPut to (n1,s1):1
 dist sender send  r35: sending batch 1 EndTxn to (n1,s1):1
 
@@ -156,6 +158,7 @@ WHERE message       LIKE '%r$rangeid: sending batch%'
   AND message   NOT LIKE '%QueryTxn%'
   AND operation NOT LIKE '%async%'
 ----
+dist sender send  r35: sending batch 2 CPut to (n1,s1):1
 dist sender send  r35: sending batch 2 CPut to (n1,s1):1
 dist sender send  r35: sending batch 1 EndTxn to (n1,s1):1
 
@@ -192,6 +195,7 @@ WHERE message     LIKE '%r$rangeid: sending batch%'
   AND message NOT LIKE '%PushTxn%'
   AND message NOT LIKE '%QueryTxn%'
 ----
+dist sender send  r35: sending batch 2 CPut to (n1,s1):1
 dist sender send  r35: sending batch 1 Put, 1 EndTxn to (n1,s1):1
 
 # Multi-row upsert should auto-commit.
@@ -213,6 +217,7 @@ WHERE message     LIKE '%r$rangeid: sending batch%'
   AND message NOT LIKE '%PushTxn%'
   AND message NOT LIKE '%QueryTxn%'
 ----
+dist sender send  r35: sending batch 2 CPut to (n1,s1):1
 dist sender send  r35: sending batch 2 Put, 1 EndTxn to (n1,s1):1
 
 # No auto-commit inside a transaction.
@@ -261,6 +266,7 @@ WHERE message     LIKE '%r$rangeid: sending batch%'
   AND message NOT LIKE '%PushTxn%'
   AND message NOT LIKE '%QueryTxn%'
 ----
+dist sender send  r35: sending batch 2 Put to (n1,s1):1
 dist sender send  r35: sending batch 2 Put, 1 EndTxn to (n1,s1):1
 
 # TODO(radu): allow non-side-effecting projections.
@@ -283,6 +289,7 @@ WHERE message       LIKE '%r$rangeid: sending batch%'
   AND message   NOT LIKE '%QueryTxn%'
   AND operation NOT LIKE '%async%'
 ----
+dist sender send  r35: sending batch 2 Put to (n1,s1):1
 dist sender send  r35: sending batch 2 Put to (n1,s1):1
 dist sender send  r35: sending batch 1 EndTxn to (n1,s1):1
 
@@ -307,6 +314,7 @@ WHERE message       LIKE '%r$rangeid: sending batch%'
   AND message   NOT LIKE '%QueryTxn%'
   AND operation NOT LIKE '%async%'
 ----
+dist sender send  r35: sending batch 2 Put to (n1,s1):1
 dist sender send  r35: sending batch 2 Put to (n1,s1):1
 dist sender send  r35: sending batch 1 EndTxn to (n1,s1):1
 
@@ -343,6 +351,7 @@ WHERE message     LIKE '%r$rangeid: sending batch%'
   AND message NOT LIKE '%PushTxn%'
   AND message NOT LIKE '%QueryTxn%'
 ----
+dist sender send  r35: sending batch 2 Put to (n1,s1):1
 dist sender send  r35: sending batch 1 Scan to (n1,s1):1
 dist sender send  r35: sending batch 2 Put, 1 EndTxn to (n1,s1):1
 
@@ -394,6 +403,8 @@ WHERE message     LIKE '%r$rangeid: sending batch%'
   AND message NOT LIKE '%QueryTxn%'
 ----
 dist sender send  r35: sending batch 1 Scan to (n1,s1):1
+dist sender send  r35: sending batch 2 Put to (n1,s1):1
+dist sender send  r35: sending batch 1 Scan to (n1,s1):1
 dist sender send  r35: sending batch 2 Put, 1 EndTxn to (n1,s1):1
 
 # TODO(radu): allow non-side-effecting projections.
@@ -416,6 +427,8 @@ WHERE message       LIKE '%r$rangeid: sending batch%'
   AND message   NOT LIKE '%QueryTxn%'
   AND operation NOT LIKE '%async%'
 ----
+dist sender send  r35: sending batch 1 Scan to (n1,s1):1
+dist sender send  r35: sending batch 2 Put to (n1,s1):1
 dist sender send  r35: sending batch 1 Scan to (n1,s1):1
 dist sender send  r35: sending batch 2 Put to (n1,s1):1
 dist sender send  r35: sending batch 1 EndTxn to (n1,s1):1
@@ -441,6 +454,8 @@ WHERE message       LIKE '%r$rangeid: sending batch%'
   AND message   NOT LIKE '%QueryTxn%'
   AND operation NOT LIKE '%async%'
 ----
+dist sender send  r35: sending batch 1 Scan to (n1,s1):1
+dist sender send  r35: sending batch 2 Put to (n1,s1):1
 dist sender send  r35: sending batch 1 Scan to (n1,s1):1
 dist sender send  r35: sending batch 2 Put to (n1,s1):1
 dist sender send  r35: sending batch 1 EndTxn to (n1,s1):1
@@ -478,6 +493,8 @@ WHERE message     LIKE '%r$rangeid: sending batch%'
   AND message NOT LIKE '%PushTxn%'
   AND message NOT LIKE '%QueryTxn%'
 ----
+dist sender send  r35: sending batch 1 Scan to (n1,s1):1
+dist sender send  r35: sending batch 2 Put to (n1,s1):1
 dist sender send  r35: sending batch 1 DelRng, 1 EndTxn to (n1,s1):1
 
 # Multi-row delete should auto-commit.
@@ -499,6 +516,8 @@ WHERE message     LIKE '%r$rangeid: sending batch%'
   AND message NOT LIKE '%PushTxn%'
   AND message NOT LIKE '%QueryTxn%'
 ----
+dist sender send  r35: sending batch 1 Scan to (n1,s1):1
+dist sender send  r35: sending batch 2 Put to (n1,s1):1
 dist sender send  r35: sending batch 1 DelRng, 1 EndTxn to (n1,s1):1
 
 # No auto-commit inside a transaction.
@@ -547,6 +566,7 @@ WHERE message     LIKE '%r$rangeid: sending batch%'
   AND message NOT LIKE '%PushTxn%'
   AND message NOT LIKE '%QueryTxn%'
 ----
+dist sender send  r35: sending batch 1 DelRng to (n1,s1):1
 dist sender send  r35: sending batch 1 Scan to (n1,s1):1
 dist sender send  r35: sending batch 2 Del, 1 EndTxn to (n1,s1):1
 
@@ -570,6 +590,7 @@ WHERE message       LIKE '%r$rangeid: sending batch%'
   AND message   NOT LIKE '%QueryTxn%'
   AND operation NOT LIKE '%async%'
 ----
+dist sender send  r35: sending batch 1 DelRng to (n1,s1):1
 dist sender send  r35: sending batch 1 Scan to (n1,s1):1
 dist sender send  r35: sending batch 2 Del to (n1,s1):1
 dist sender send  r35: sending batch 1 EndTxn to (n1,s1):1
@@ -595,6 +616,7 @@ WHERE message       LIKE '%r$rangeid: sending batch%'
   AND message   NOT LIKE '%QueryTxn%'
   AND operation NOT LIKE '%async%'
 ----
+dist sender send  r35: sending batch 1 DelRng to (n1,s1):1
 dist sender send  r35: sending batch 1 Scan to (n1,s1):1
 dist sender send  r35: sending batch 2 Del to (n1,s1):1
 dist sender send  r35: sending batch 1 EndTxn to (n1,s1):1
@@ -644,6 +666,7 @@ WHERE message       LIKE '%r$rangeid: sending batch%'
   AND message   NOT LIKE '%QueryTxn%'
   AND operation NOT LIKE '%async%'
 ----
+dist sender send  r35: sending batch 1 DelRng to (n1,s1):1
 dist sender send  r35: sending batch 2 CPut to (n1,s1):1
 dist sender send  r35: sending batch 2 Scan to (n1,s1):1
 dist sender send  r35: sending batch 1 EndTxn to (n1,s1):1
@@ -667,6 +690,7 @@ WHERE message       LIKE '%r$rangeid: sending batch%'
   AND message   NOT LIKE '%QueryTxn%'
   AND operation NOT LIKE '%async%'
 ----
+dist sender send  r35: sending batch 1 DelRng to (n1,s1):1
 dist sender send  r35: sending batch 1 Scan to (n1,s1):1
 dist sender send  r35: sending batch 1 Put to (n1,s1):1
 dist sender send  r35: sending batch 1 Scan to (n1,s1):1
@@ -692,6 +716,7 @@ WHERE message       LIKE '%r$rangeid: sending batch%'
   AND message   NOT LIKE '%QueryTxn%'
   AND operation NOT LIKE '%async%'
 ----
+dist sender send  r35: sending batch 1 DelRng to (n1,s1):1
 dist sender send  r35: sending batch 1 Scan to (n1,s1):1
 dist sender send  r35: sending batch 1 Del to (n1,s1):1
 dist sender send  r35: sending batch 1 Scan to (n1,s1):1
@@ -719,6 +744,7 @@ WHERE message       LIKE '%r$rangeid: sending batch%'
   AND message   NOT LIKE '%QueryTxn%'
   AND operation NOT LIKE '%async%'
 ----
+dist sender send  r35: sending batch 1 DelRng to (n1,s1):1
 dist sender send  r35: sending batch 1 DelRng to (n1,s1):1
 dist sender send  r35: sending batch 1 Scan to (n1,s1):1
 dist sender send  r35: sending batch 1 Del, 1 EndTxn to (n1,s1):1
@@ -749,6 +775,7 @@ WHERE message       LIKE '%r$rangeid: sending batch%'
   AND message   NOT LIKE '%QueryTxn%'
   AND operation NOT LIKE '%async%'
 ----
+dist sender send  r35: sending batch 1 DelRng to (n1,s1):1
 dist sender send  r35: sending batch 2 CPut to (n1,s1):1
 dist sender send  r35: sending batch 2 CPut to (n1,s1):1
 dist sender send  r35: sending batch 1 EndTxn to (n1,s1):1
@@ -774,6 +801,7 @@ WHERE message       LIKE '%r$rangeid: sending batch%'
   AND message   NOT LIKE '%QueryTxn%'
   AND operation NOT LIKE '%async%'
 ----
+dist sender send  r35: sending batch 1 DelRng to (n1,s1):1
 dist sender send  r35: sending batch 2 CPut to (n1,s1):1
 dist sender send  r35: sending batch 2 CPut to (n1,s1):1
 dist sender send  r35: sending batch 1 EndTxn to (n1,s1):1

--- a/pkg/sql/opt/exec/execbuilder/testdata/tracing
+++ b/pkg/sql/opt/exec/execbuilder/testdata/tracing
@@ -1,0 +1,48 @@
+# LogicTest: local !metamorphic
+
+statement ok
+CREATE TABLE ab (a INT PRIMARY KEY, b INT, FAMILY f1 (a, b))
+
+# Get the range id.
+let $rangeid
+SELECT range_id FROM [ SHOW RANGES FROM TABLE ab ]
+
+# Populate table descriptor cache.
+query II
+SELECT * FROM ab
+----
+
+# No auto-commit inside a transaction.
+statement ok
+BEGIN
+
+statement ok
+SET TRACING=ON;
+  INSERT INTO ab VALUES (4, 4), (5, 5);
+SET TRACING=OFF
+
+# query TT
+# SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
+# WHERE message     LIKE '%r$rangeid: sending batch%'
+#   AND message NOT LIKE '%PushTxn%'
+#   AND message NOT LIKE '%QueryTxn%'
+# ----
+# dist sender send  r35: sending batch 2 CPut to (n1,s1):1
+
+statement ok
+ROLLBACK
+
+statement ok
+SET TRACING=ON;
+  INSERT INTO ab VALUES (6, 6), (7, 7) RETURNING a, b;
+SET TRACING=OFF
+
+query TT
+SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
+WHERE message     LIKE '%r$rangeid: sending batch%'
+  AND message NOT LIKE '%PushTxn%'
+  AND message NOT LIKE '%QueryTxn%'
+----
+dist sender send  r35: sending batch 2 CPut, 1 EndTxn to (n1,s1):1
+
+# dist sender send  r35: sending batch 2 CPut to (n1,s1):1

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -89,7 +89,7 @@ var tracingMode = settings.RegisterEnumSetting(
 	"trace.mode",
 	"if set to 'background', traces will be created for all operations (in"+
 		"'legacy' mode it's created when explicitly requested or when auxiliary tracers are configured)",
-	"legacy",
+	"background",
 	map[int64]string{
 		int64(modeLegacy):     "legacy",
 		int64(modeBackground): "background",


### PR DESCRIPTION
...for sessions with aborted txns.

Attempt to repro #59203. Try:
```
make test PKG=./pkg/sql/opt/exec/execbuilder TESTS=TestExecBuild/local/tracing
```

Release note: None