### PR TITLE
opt: disable CheckExpr during optsteps

### DIFF
--- a/pkg/sql/opt/memo/check_expr.go
+++ b/pkg/sql/opt/memo/check_expr.go
@@ -28,6 +28,10 @@ import (
 //
 // This function does not assume that the expression has been fully normalized.
 func (m *Memo) CheckExpr(e opt.Expr) {
+	if m.disableCheckExpr {
+		return
+	}
+
 	// Check properties.
 	switch t := e.(type) {
 	case RelExpr:

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -147,6 +147,13 @@ type Memo struct {
 
 	newGroupFn func(opt.Expr)
 
+	// disableCheckExpr disables expression validation performed by CheckExpr,
+	// if the crdb_test build tag is set. If the crdb_test build tag is not set,
+	// CheckExpr is always a no-op, so disableCheckExpr has no effect. This is
+	// set to true for the optsteps test command to prevent CheckExpr from
+	// erring with partially normalized expressions.
+	disableCheckExpr bool
+
 	// WARNING: if you add more members, add initialization code in Init (if
 	// reusing allocated data structures is desired).
 }
@@ -407,4 +414,11 @@ func (m *Memo) Detach() {
 		}
 	}
 	clearColStats(m.RootExpr())
+}
+
+// DisableCheckExpr disables expression validation performed by CheckExpr,
+// if the crdb_test build tag is set. If the crdb_test build tag is not set,
+// CheckExpr is always a no-op, so DisableCheckExpr has no effect.
+func (m *Memo) DisableCheckExpr() {
+	m.disableCheckExpr = true
 }

--- a/pkg/sql/opt/testutils/opttester/explore_trace.go
+++ b/pkg/sql/opt/testutils/opttester/explore_trace.go
@@ -64,7 +64,7 @@ func (et *exploreTracer) Next() error {
 		panic("iteration already complete")
 	}
 
-	fo, err := newForcingOptimizer(et.tester, et.steps, true /* ignoreNormRules */)
+	fo, err := newForcingOptimizer(et.tester, et.steps, true /* ignoreNormRules */, false /* disableCheckExpr */)
 	if err != nil {
 		return err
 	}
@@ -98,7 +98,7 @@ func (et *exploreTracer) Next() error {
 }
 
 func (et *exploreTracer) restrictToExpr(path []memoLoc) opt.Expr {
-	fo2, err := newForcingOptimizer(et.tester, et.steps, true /* ignoreNormRules */)
+	fo2, err := newForcingOptimizer(et.tester, et.steps, true /* ignoreNormRules */, false /* disableCheckExpr */)
 	if err != nil {
 		// We should have already built the query successfully once.
 		panic(err)

--- a/pkg/sql/opt/testutils/opttester/forcing_opt.go
+++ b/pkg/sql/opt/testutils/opttester/forcing_opt.go
@@ -55,9 +55,10 @@ type forcingOptimizer struct {
 
 // newForcingOptimizer creates a forcing optimizer that stops applying any rules
 // after <steps> rules are matched. If ignoreNormRules is true, normalization
-// rules don't count against this limit.
+// rules don't count against this limit. If disableCheckExpr is true, expression
+// validation in CheckExpr will not run.
 func newForcingOptimizer(
-	tester *OptTester, steps int, ignoreNormRules bool,
+	tester *OptTester, steps int, ignoreNormRules bool, disableCheckExpr bool,
 ) (*forcingOptimizer, error) {
 	fo := &forcingOptimizer{
 		remaining:   steps,
@@ -99,6 +100,10 @@ func newForcingOptimizer(
 	fo.o.Memo().NotifyOnNewGroup(func(expr opt.Expr) {
 		fo.groups.AddGroup(expr)
 	})
+
+	if disableCheckExpr {
+		fo.o.Memo().DisableCheckExpr()
+	}
 
 	if err := tester.buildExpr(fo.o.Factory()); err != nil {
 		return nil, err

--- a/pkg/sql/opt/testutils/opttester/opt_steps.go
+++ b/pkg/sql/opt/testutils/opttester/opt_steps.go
@@ -109,7 +109,7 @@ func (os *optSteps) Next() error {
 		panic("iteration already complete")
 	}
 
-	fo, err := newForcingOptimizer(os.tester, os.steps, false /* ignoreNormRules */)
+	fo, err := newForcingOptimizer(os.tester, os.steps, false /* ignoreNormRules */, true /* disableCheckExpr */)
 	if err != nil {
 		return err
 	}
@@ -125,7 +125,7 @@ func (os *optSteps) Next() error {
 	} else if !os.Done() {
 		// The expression is not better, so suppress the lowest cost expressions
 		// so that the changed portions of the tree will be part of the output.
-		fo2, err := newForcingOptimizer(os.tester, os.steps, false /* ignoreNormRules */)
+		fo2, err := newForcingOptimizer(os.tester, os.steps, false /* ignoreNormRules */, true /* disableCheckExpr */)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/opt/testutils/opttester/testdata/opt-steps
+++ b/pkg/sql/opt/testutils/opttester/testdata/opt-steps
@@ -879,6 +879,368 @@ Final best expression
    ├── constraint: /2/1/3: [/true/1 - /true/1]
    └── fd: ()-->(1)
 
+exec-ddl
+CREATE TABLE t (i INT)
+----
+
+# Verify that CheckExpr is not run during optsteps in order to prevent crashing
+# on a partially normalized expressions. CheckExpr would cause a crash in this
+# test because the RangeExpr in the InlineConstVar step does not have tight
+# constraints.
+optsteps
+SELECT i FROM (SELECT i FROM t WHERE i > 10 AND i < 20) AS t2 WHERE i = 5
+----
+================================================================================
+Initial expression
+  Cost: 1065.87
+================================================================================
+  select
+   ├── columns: i:1(int!null)
+   ├── fd: ()-->(1)
+   ├── project
+   │    ├── columns: i:1(int!null)
+   │    └── select
+   │         ├── columns: i:1(int!null) rowid:2(int!null) crdb_internal_mvcc_timestamp:3(decimal)
+   │         ├── key: (2)
+   │         ├── fd: (2)-->(1,3)
+   │         ├── scan t
+   │         │    ├── columns: i:1(int) rowid:2(int!null) crdb_internal_mvcc_timestamp:3(decimal)
+   │         │    ├── key: (2)
+   │         │    └── fd: (2)-->(1,3)
+   │         └── filters
+   │              └── and [type=bool, outer=(1), constraints=(/1: [/11 - /19]; tight)]
+   │                   ├── gt [type=bool]
+   │                   │    ├── variable: i:1 [type=int]
+   │                   │    └── const: 10 [type=int]
+   │                   └── lt [type=bool]
+   │                        ├── variable: i:1 [type=int]
+   │                        └── const: 20 [type=int]
+   └── filters
+        └── eq [type=bool, outer=(1), constraints=(/1: [/5 - /5]; tight), fd=()-->(1)]
+             ├── variable: i:1 [type=int]
+             └── const: 5 [type=int]
+================================================================================
+SimplifySelectFilters
+  Cost: 1070.75
+================================================================================
+   select
+    ├── columns: i:1(int!null)
+    ├── fd: ()-->(1)
+    ├── project
+    │    ├── columns: i:1(int!null)
+    │    └── select
+    │         ├── columns: i:1(int!null) rowid:2(int!null) crdb_internal_mvcc_timestamp:3(decimal)
+    │         ├── key: (2)
+    │         ├── fd: (2)-->(1,3)
+    │         ├── scan t
+    │         │    ├── columns: i:1(int) rowid:2(int!null) crdb_internal_mvcc_timestamp:3(decimal)
+    │         │    ├── key: (2)
+    │         │    └── fd: (2)-->(1,3)
+    │         └── filters
+  - │              └── and [type=bool, outer=(1), constraints=(/1: [/11 - /19]; tight)]
+  - │                   ├── gt [type=bool]
+  - │                   │    ├── variable: i:1 [type=int]
+  - │                   │    └── const: 10 [type=int]
+  - │                   └── lt [type=bool]
+  - │                        ├── variable: i:1 [type=int]
+  - │                        └── const: 20 [type=int]
+  + │              ├── gt [type=bool, outer=(1), constraints=(/1: [/11 - ]; tight)]
+  + │              │    ├── variable: i:1 [type=int]
+  + │              │    └── const: 10 [type=int]
+  + │              └── lt [type=bool, outer=(1), constraints=(/1: (/NULL - /19]; tight)]
+  + │                   ├── variable: i:1 [type=int]
+  + │                   └── const: 20 [type=int]
+    └── filters
+         └── eq [type=bool, outer=(1), constraints=(/1: [/5 - /5]; tight), fd=()-->(1)]
+              ├── variable: i:1 [type=int]
+              └── const: 5 [type=int]
+================================================================================
+ConsolidateSelectFilters
+  Cost: 1065.87
+================================================================================
+   select
+    ├── columns: i:1(int!null)
+    ├── fd: ()-->(1)
+    ├── project
+    │    ├── columns: i:1(int!null)
+    │    └── select
+    │         ├── columns: i:1(int!null) rowid:2(int!null) crdb_internal_mvcc_timestamp:3(decimal)
+    │         ├── key: (2)
+    │         ├── fd: (2)-->(1,3)
+    │         ├── scan t
+    │         │    ├── columns: i:1(int) rowid:2(int!null) crdb_internal_mvcc_timestamp:3(decimal)
+    │         │    ├── key: (2)
+    │         │    └── fd: (2)-->(1,3)
+    │         └── filters
+  - │              ├── gt [type=bool, outer=(1), constraints=(/1: [/11 - ]; tight)]
+  - │              │    ├── variable: i:1 [type=int]
+  - │              │    └── const: 10 [type=int]
+  - │              └── lt [type=bool, outer=(1), constraints=(/1: (/NULL - /19]; tight)]
+  - │                   ├── variable: i:1 [type=int]
+  - │                   └── const: 20 [type=int]
+  + │              └── range [type=bool, outer=(1), constraints=(/1: [/11 - /19]; tight)]
+  + │                   └── and [type=bool]
+  + │                        ├── gt [type=bool]
+  + │                        │    ├── variable: i:1 [type=int]
+  + │                        │    └── const: 10 [type=int]
+  + │                        └── lt [type=bool]
+  + │                             ├── variable: i:1 [type=int]
+  + │                             └── const: 20 [type=int]
+    └── filters
+         └── eq [type=bool, outer=(1), constraints=(/1: [/5 - /5]; tight), fd=()-->(1)]
+              ├── variable: i:1 [type=int]
+              └── const: 5 [type=int]
+================================================================================
+PruneSelectCols
+  Cost: 1045.87
+================================================================================
+   select
+    ├── columns: i:1(int!null)
+    ├── fd: ()-->(1)
+    ├── project
+    │    ├── columns: i:1(int!null)
+    │    └── select
+  - │         ├── columns: i:1(int!null) rowid:2(int!null) crdb_internal_mvcc_timestamp:3(decimal)
+  - │         ├── key: (2)
+  - │         ├── fd: (2)-->(1,3)
+  + │         ├── columns: i:1(int!null)
+    │         ├── scan t
+  - │         │    ├── columns: i:1(int) rowid:2(int!null) crdb_internal_mvcc_timestamp:3(decimal)
+  - │         │    ├── key: (2)
+  - │         │    └── fd: (2)-->(1,3)
+  + │         │    └── columns: i:1(int)
+    │         └── filters
+    │              └── range [type=bool, outer=(1), constraints=(/1: [/11 - /19]; tight)]
+    │                   └── and [type=bool]
+    │                        ├── gt [type=bool]
+    │                        │    ├── variable: i:1 [type=int]
+    │                        │    └── const: 10 [type=int]
+    │                        └── lt [type=bool]
+    │                             ├── variable: i:1 [type=int]
+    │                             └── const: 20 [type=int]
+    └── filters
+         └── eq [type=bool, outer=(1), constraints=(/1: [/5 - /5]; tight), fd=()-->(1)]
+              ├── variable: i:1 [type=int]
+              └── const: 5 [type=int]
+================================================================================
+EliminateProject
+  Cost: 1044.96
+================================================================================
+   select
+    ├── columns: i:1(int!null)
+    ├── fd: ()-->(1)
+  - ├── project
+  + ├── select
+    │    ├── columns: i:1(int!null)
+  - │    └── select
+  - │         ├── columns: i:1(int!null)
+  - │         ├── scan t
+  - │         │    └── columns: i:1(int)
+  - │         └── filters
+  - │              └── range [type=bool, outer=(1), constraints=(/1: [/11 - /19]; tight)]
+  - │                   └── and [type=bool]
+  - │                        ├── gt [type=bool]
+  - │                        │    ├── variable: i:1 [type=int]
+  - │                        │    └── const: 10 [type=int]
+  - │                        └── lt [type=bool]
+  - │                             ├── variable: i:1 [type=int]
+  - │                             └── const: 20 [type=int]
+  + │    ├── scan t
+  + │    │    └── columns: i:1(int)
+  + │    └── filters
+  + │         └── range [type=bool, outer=(1), constraints=(/1: [/11 - /19]; tight)]
+  + │              └── and [type=bool]
+  + │                   ├── gt [type=bool]
+  + │                   │    ├── variable: i:1 [type=int]
+  + │                   │    └── const: 10 [type=int]
+  + │                   └── lt [type=bool]
+  + │                        ├── variable: i:1 [type=int]
+  + │                        └── const: 20 [type=int]
+    └── filters
+         └── eq [type=bool, outer=(1), constraints=(/1: [/5 - /5]; tight), fd=()-->(1)]
+              ├── variable: i:1 [type=int]
+              └── const: 5 [type=int]
+================================================================================
+MergeSelects
+  Cost: 1044.05
+================================================================================
+   select
+    ├── columns: i:1(int!null)
+    ├── fd: ()-->(1)
+  - ├── select
+  - │    ├── columns: i:1(int!null)
+  - │    ├── scan t
+  - │    │    └── columns: i:1(int)
+  - │    └── filters
+  - │         └── range [type=bool, outer=(1), constraints=(/1: [/11 - /19]; tight)]
+  - │              └── and [type=bool]
+  - │                   ├── gt [type=bool]
+  - │                   │    ├── variable: i:1 [type=int]
+  - │                   │    └── const: 10 [type=int]
+  - │                   └── lt [type=bool]
+  - │                        ├── variable: i:1 [type=int]
+  - │                        └── const: 20 [type=int]
+  + ├── scan t
+  + │    └── columns: i:1(int)
+    └── filters
+  +      ├── range [type=bool, outer=(1), constraints=(/1: [/11 - /19]; tight)]
+  +      │    └── and [type=bool]
+  +      │         ├── gt [type=bool]
+  +      │         │    ├── variable: i:1 [type=int]
+  +      │         │    └── const: 10 [type=int]
+  +      │         └── lt [type=bool]
+  +      │              ├── variable: i:1 [type=int]
+  +      │              └── const: 20 [type=int]
+         └── eq [type=bool, outer=(1), constraints=(/1: [/5 - /5]; tight), fd=()-->(1)]
+              ├── variable: i:1 [type=int]
+              └── const: 5 [type=int]
+================================================================================
+InlineConstVar
+  Cost: 1044.05
+================================================================================
+   select
+    ├── columns: i:1(int!null)
+    ├── fd: ()-->(1)
+    ├── scan t
+    │    └── columns: i:1(int)
+    └── filters
+  -      ├── range [type=bool, outer=(1), constraints=(/1: [/11 - /19]; tight)]
+  +      ├── range [type=bool]
+         │    └── and [type=bool]
+         │         ├── gt [type=bool]
+  -      │         │    ├── variable: i:1 [type=int]
+  +      │         │    ├── const: 5 [type=int]
+         │         │    └── const: 10 [type=int]
+         │         └── lt [type=bool]
+  -      │              ├── variable: i:1 [type=int]
+  +      │              ├── const: 5 [type=int]
+         │              └── const: 20 [type=int]
+         └── eq [type=bool, outer=(1), constraints=(/1: [/5 - /5]; tight), fd=()-->(1)]
+              ├── variable: i:1 [type=int]
+              └── const: 5 [type=int]
+================================================================================
+FoldComparison
+  Cost: 1044.05
+================================================================================
+   select
+    ├── columns: i:1(int!null)
+  + ├── cardinality: [0 - 0]
+    ├── fd: ()-->(1)
+    ├── scan t
+    │    └── columns: i:1(int)
+    └── filters
+  -      ├── range [type=bool]
+  +      ├── range [type=bool, constraints=(contradiction; tight)]
+         │    └── and [type=bool]
+  -      │         ├── gt [type=bool]
+  -      │         │    ├── const: 5 [type=int]
+  -      │         │    └── const: 10 [type=int]
+  +      │         ├── false [type=bool]
+         │         └── lt [type=bool]
+         │              ├── const: 5 [type=int]
+         │              └── const: 20 [type=int]
+         └── eq [type=bool, outer=(1), constraints=(/1: [/5 - /5]; tight), fd=()-->(1)]
+              ├── variable: i:1 [type=int]
+              └── const: 5 [type=int]
+================================================================================
+FoldComparison
+  Cost: 1044.05
+================================================================================
+   select
+    ├── columns: i:1(int!null)
+    ├── cardinality: [0 - 0]
+    ├── fd: ()-->(1)
+    ├── scan t
+    │    └── columns: i:1(int)
+    └── filters
+         ├── range [type=bool, constraints=(contradiction; tight)]
+         │    └── and [type=bool]
+         │         ├── false [type=bool]
+  -      │         └── lt [type=bool]
+  -      │              ├── const: 5 [type=int]
+  -      │              └── const: 20 [type=int]
+  +      │         └── true [type=bool]
+         └── eq [type=bool, outer=(1), constraints=(/1: [/5 - /5]; tight), fd=()-->(1)]
+              ├── variable: i:1 [type=int]
+              └── const: 5 [type=int]
+================================================================================
+SimplifyAndTrue
+  Cost: 1044.05
+================================================================================
+   select
+    ├── columns: i:1(int!null)
+    ├── cardinality: [0 - 0]
+    ├── fd: ()-->(1)
+    ├── scan t
+    │    └── columns: i:1(int)
+    └── filters
+         ├── range [type=bool, constraints=(contradiction; tight)]
+  -      │    └── and [type=bool]
+  -      │         ├── false [type=bool]
+  -      │         └── true [type=bool]
+  +      │    └── false [type=bool]
+         └── eq [type=bool, outer=(1), constraints=(/1: [/5 - /5]; tight), fd=()-->(1)]
+              ├── variable: i:1 [type=int]
+              └── const: 5 [type=int]
+================================================================================
+SimplifyRange
+  Cost: 1044.05
+================================================================================
+   select
+    ├── columns: i:1(int!null)
+    ├── cardinality: [0 - 0]
+    ├── fd: ()-->(1)
+    ├── scan t
+    │    └── columns: i:1(int)
+    └── filters
+  -      ├── range [type=bool, constraints=(contradiction; tight)]
+  -      │    └── false [type=bool]
+  +      ├── false [type=bool, constraints=(contradiction; tight)]
+         └── eq [type=bool, outer=(1), constraints=(/1: [/5 - /5]; tight), fd=()-->(1)]
+              ├── variable: i:1 [type=int]
+              └── const: 5 [type=int]
+================================================================================
+SimplifySelectFilters
+  Cost: 1044.04
+================================================================================
+   select
+  - ├── columns: i:1(int!null)
+  + ├── columns: i:1(int)
+    ├── cardinality: [0 - 0]
+  - ├── fd: ()-->(1)
+    ├── scan t
+    │    └── columns: i:1(int)
+    └── filters
+  -      ├── false [type=bool, constraints=(contradiction; tight)]
+  -      └── eq [type=bool, outer=(1), constraints=(/1: [/5 - /5]; tight), fd=()-->(1)]
+  -           ├── variable: i:1 [type=int]
+  -           └── const: 5 [type=int]
+  +      └── false [type=bool, constraints=(contradiction; tight)]
+================================================================================
+SimplifyZeroCardinalityGroup
+  Cost: 0.01
+================================================================================
+  -select
+  - ├── columns: i:1(int)
+  +values
+  + ├── columns: i:1(int!null)
+    ├── cardinality: [0 - 0]
+  - ├── scan t
+  - │    └── columns: i:1(int)
+  - └── filters
+  -      └── false [type=bool, constraints=(contradiction; tight)]
+  + ├── key: ()
+  + └── fd: ()-->(1)
+================================================================================
+Final best expression
+  Cost: 0.01
+================================================================================
+  values
+   ├── columns: i:1(int!null)
+   ├── cardinality: [0 - 0]
+   ├── key: ()
+   └── fd: ()-->(1)
+
 optsteps split-diff
 SELECT 1
 ----


### PR DESCRIPTION
As of #57532, expression validation performed by `memo.CheckExpr` is run
during all tests. This causes problems for optsteps tests because each
step could be partially normalized. A partially normalized expression
may violate the laws that `CheckExpr` upholds, resulting in a crash.

In order to prevent these crashes, this commit disables `CheckExpr`
during optsteps tests. Disabling this validation should be safe because
optsteps is primarily used for development and debugging. There are
currently only five optsteps tests committed to the repository, outside
of optsteps's own tests.

Release note: None