### PR TITLE
storageccl: avoid rand.Int63n(0) panic in test

### DIFF
--- a/pkg/ccl/storageccl/encryption_test.go
+++ b/pkg/ccl/storageccl/encryption_test.go
@@ -191,8 +191,8 @@ func TestEncryptDecrypt(t *testing.T) {
 					r, err := decryptingReader(bytes.NewReader(ciphertext), key)
 					require.NoError(t, err)
 					for k := 0; k < reads; k++ {
-						start := rng.Int63n(int64(float64(len(plaintext)) * 1.1))
-						expected := make([]byte, rng.Int63n(int64(len(plaintext))/2))
+						start := rng.Int63n(int64(float64(len(plaintext)+1) * 1.1))
+						expected := make([]byte, rng.Int63n(int64(len(plaintext)/2+1)))
 						got := make([]byte, len(expected))
 						expectedN, expectedErr := plainReader.ReadAt(expected, start)
 						gotN, gotErr := r.(io.ReaderAt).ReadAt(got, start)


### PR DESCRIPTION
The test makes random length slices and then picks random offsets in them.
However this means if it picks a lenght 0 slice, it'll try to pick a random
offset between 0 and 0, which panics.

Instead, pick a random offset between 0 and len()+1, to avoid panics.

Release note: none.

Fixes #59417.