### PR TITLE
partitionccl: refactor implicit columns detection to CCL

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
@@ -1,6 +1,6 @@
 # LogicTest: local
 
-statement error  declared partition columns \(partition_by\) do not match first 1 columns in index being partitioned \(a\)
+statement error declared partition columns \(partition_by\) do not match first 1 columns in index being partitioned \(a\)
 CREATE TABLE t (
   pk INT PRIMARY KEY,
   partition_by int,
@@ -45,6 +45,18 @@ CREATE TABLE t (
     )
   )
 )
+
+statement ok
+CREATE TABLE t (a INT, b INT, INDEX(a))
+
+statement error cannot ALTER INDEX and change the partitioning to contain implicit columns
+ALTER INDEX t@t_a_idx PARTITION BY LIST(b) (PARTITION one VALUES IN (1))
+
+statement error cannot ALTER TABLE and change the partitioning to contain implicit columns
+ALTER TABLE t PARTITION BY LIST(b) (PARTITION one VALUES IN (1))
+
+statement ok
+DROP TABLE t
 
 statement ok
 CREATE TABLE t (
@@ -125,6 +137,22 @@ CREATE TABLE public.t (
 )
 -- Warning: Partitioned table with no zone configurations.
 
+statement error cannot ALTER TABLE PARTITION BY on table which already has implicit column partitioning
+ALTER TABLE t PARTITION BY LIST(d) (
+  PARTITION pk_implicit VALUES IN (1)
+)
+
+statement error cannot ALTER INDEX PARTITION BY on index which already has implicit column partitioning
+ALTER INDEX t@t_b_idx PARTITION BY LIST(d) (
+  PARTITION pk_implicit VALUES IN (1)
+)
+
+statement error cannot ALTER INDEX PARTITION BY on index which already has implicit column partitioning
+ALTER INDEX t@t_b_idx PARTITION BY NOTHING
+
+statement error cannot ALTER TABLE PARTITION BY on table which already has implicit column partitioning
+ALTER TABLE t PARTITION BY NOTHING
+
 query TTTTTT colnames
 SELECT
   indexrelid, indrelid, indkey, indclass, indoption, indcollation
@@ -133,11 +161,11 @@ WHERE indrelid = (SELECT oid FROM pg_class WHERE relname = 't')
 ORDER BY 1,2,3
 ----
 indexrelid  indrelid  indkey  indclass  indoption  indcollation
-969972496   57        2 3 4   0 0 0     2 2 2      0 0 0
-969972497   57        5       0         2          0
-969972501   57        1       0         2          0
-969972502   57        3       0         2          0
-969972503   57        4       0         2          0
+710236226   58        5       0         2          0
+710236227   58        2 3 4   0 0 0     2 2 2      0 0 0
+710236228   58        4       0         2          0
+710236229   58        3       0         2          0
+710236230   58        1       0         2          0
 
 query TTB colnames
 SELECT index_name, column_name, implicit FROM crdb_internal.index_columns

--- a/pkg/sql/alter_primary_key.go
+++ b/pkg/sql/alter_primary_key.go
@@ -221,8 +221,9 @@ func (p *planner) AlterPrimaryKey(
 			return err
 		}
 		if partitionBy != nil {
-			var numImplicitColumns int
-			*newPrimaryIndexDesc, numImplicitColumns, err = detectImplicitPartitionColumns(
+			*newPrimaryIndexDesc, err = CreatePartitioning(
+				ctx,
+				p.ExecCfg().Settings,
 				p.EvalContext(),
 				tableDesc,
 				*newPrimaryIndexDesc,
@@ -231,19 +232,6 @@ func (p *planner) AlterPrimaryKey(
 			if err != nil {
 				return err
 			}
-			partitioning, err := CreatePartitioning(
-				ctx,
-				p.ExecCfg().Settings,
-				p.EvalContext(),
-				tableDesc,
-				newPrimaryIndexDesc,
-				numImplicitColumns,
-				partitionBy,
-			)
-			if err != nil {
-				return err
-			}
-			newPrimaryIndexDesc.Partitioning = partitioning
 		}
 	}
 

--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -544,23 +544,12 @@ func (p *planner) configureIndexDescForNewIndexPartitioning(
 		}
 
 		if partitionBy != nil {
-			var numImplicitColumns int
-			indexDesc, numImplicitColumns, err = detectImplicitPartitionColumns(
-				p.EvalContext(),
-				tableDesc,
-				indexDesc,
-				partitionBy,
-			)
-			if err != nil {
-				return indexDesc, err
-			}
-			if indexDesc.Partitioning, err = CreatePartitioning(
+			if indexDesc, err = CreatePartitioning(
 				ctx,
 				p.ExecCfg().Settings,
 				p.EvalContext(),
 				tableDesc,
-				&indexDesc,
-				numImplicitColumns,
+				indexDesc,
 				partitionBy,
 			); err != nil {
 				return indexDesc, err

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1151,23 +1151,30 @@ func (p *planner) finalizeInterleave(
 	return nil
 }
 
-// CreatePartitioning constructs the partitioning descriptor for an index that
-// is partitioned into ranges, each addressable by zone configs.
+// CreatePartitioning returns a new index descriptor with partitioning fields
+// populated to align with the tree.PartitionBy clause.
 func CreatePartitioning(
 	ctx context.Context,
 	st *cluster.Settings,
 	evalCtx *tree.EvalContext,
 	tableDesc *tabledesc.Mutable,
-	indexDesc *descpb.IndexDescriptor,
-	numImplicitColumns int,
+	indexDesc descpb.IndexDescriptor,
 	partBy *tree.PartitionBy,
-) (descpb.PartitioningDescriptor, error) {
+) (descpb.IndexDescriptor, error) {
 	if partBy == nil {
-		// No CCL necessary if we're looking at PARTITION BY NOTHING.
-		return descpb.PartitioningDescriptor{}, nil
+		if indexDesc.Partitioning.NumImplicitColumns > 0 {
+			return indexDesc, unimplemented.Newf(
+				"ALTER ... PARTITION BY NOTHING",
+				"cannot alter to PARTITION BY NOTHING if the object has implicit column partitioning",
+			)
+		}
+		// No CCL necessary if we're looking at PARTITION BY NOTHING - we can
+		// set the partitioning to nothing.
+		indexDesc.Partitioning = descpb.PartitioningDescriptor{}
+		return indexDesc, nil
 	}
 	return CreatePartitioningCCL(
-		ctx, st, evalCtx, tableDesc, indexDesc, numImplicitColumns, partBy,
+		ctx, st, evalCtx, tableDesc, indexDesc, partBy,
 	)
 }
 
@@ -1178,11 +1185,10 @@ var CreatePartitioningCCL = func(
 	st *cluster.Settings,
 	evalCtx *tree.EvalContext,
 	tableDesc *tabledesc.Mutable,
-	indexDesc *descpb.IndexDescriptor,
-	numImplicitColumns int,
+	indexDesc descpb.IndexDescriptor,
 	partBy *tree.PartitionBy,
-) (descpb.PartitioningDescriptor, error) {
-	return descpb.PartitioningDescriptor{}, sqlerrors.NewCCLRequiredError(errors.New(
+) (descpb.IndexDescriptor, error) {
+	return descpb.IndexDescriptor{}, sqlerrors.NewCCLRequiredError(errors.New(
 		"creating or manipulating partitions requires a CCL binary"))
 }
 
@@ -1731,9 +1737,10 @@ func NewTableDesc(
 				}
 
 				if partitionBy != nil {
-					var numImplicitColumns int
 					var err error
-					idx, numImplicitColumns, err = detectImplicitPartitionColumns(
+					idx, err = CreatePartitioning(
+						ctx,
+						st,
 						evalCtx,
 						&desc,
 						idx,
@@ -1742,19 +1749,6 @@ func NewTableDesc(
 					if err != nil {
 						return nil, err
 					}
-					partitioning, err := CreatePartitioning(
-						ctx,
-						st,
-						evalCtx,
-						&desc,
-						&idx,
-						numImplicitColumns,
-						partitionBy,
-					)
-					if err != nil {
-						return nil, err
-					}
-					idx.Partitioning = partitioning
 				}
 			}
 			if d.Predicate != nil {
@@ -1817,9 +1811,10 @@ func NewTableDesc(
 				}
 
 				if partitionBy != nil {
-					var numImplicitColumns int
 					var err error
-					idx, numImplicitColumns, err = detectImplicitPartitionColumns(
+					idx, err = CreatePartitioning(
+						ctx,
+						st,
 						evalCtx,
 						&desc,
 						idx,
@@ -1828,19 +1823,6 @@ func NewTableDesc(
 					if err != nil {
 						return nil, err
 					}
-					partitioning, err := CreatePartitioning(
-						ctx,
-						st,
-						evalCtx,
-						&desc,
-						&idx,
-						numImplicitColumns,
-						partitionBy,
-					)
-					if err != nil {
-						return nil, err
-					}
-					idx.Partitioning = partitioning
 				}
 			}
 			if d.Predicate != nil {
@@ -1950,7 +1932,9 @@ func NewTableDesc(
 		}
 		// At this point, we could have PARTITION ALL BY NOTHING, so check it is != nil.
 		if partitionBy != nil {
-			newPrimaryIndex, numImplicitColumns, err := detectImplicitPartitionColumns(
+			newPrimaryIndex, err := CreatePartitioning(
+				ctx,
+				st,
 				evalCtx,
 				&desc,
 				*desc.GetPrimaryIndex().IndexDesc(),
@@ -1959,19 +1943,6 @@ func NewTableDesc(
 			if err != nil {
 				return nil, err
 			}
-			partitioning, err := CreatePartitioning(
-				ctx,
-				st,
-				evalCtx,
-				&desc,
-				&newPrimaryIndex,
-				numImplicitColumns,
-				partitionBy,
-			)
-			if err != nil {
-				return nil, err
-			}
-			newPrimaryIndex.Partitioning = partitioning
 			desc.SetPrimaryIndex(newPrimaryIndex)
 		}
 	}
@@ -2594,53 +2565,4 @@ func CreateInheritedPrivilegesFromDBDesc(
 	privs.SetOwner(user)
 
 	return privs
-}
-
-// detectImplicitPartitionColumns detects implicit partitioning columns
-// and returns a new index descriptor with the implicit columns modified
-// on the index descriptor and the number of implicit columns prepended.
-func detectImplicitPartitionColumns(
-	evalCtx *tree.EvalContext,
-	tableDesc *tabledesc.Mutable,
-	indexDesc descpb.IndexDescriptor,
-	partBy *tree.PartitionBy,
-) (descpb.IndexDescriptor, int, error) {
-	if !evalCtx.SessionData.ImplicitColumnPartitioningEnabled {
-		return indexDesc, 0, nil
-	}
-	seenImplicitColumnNames := map[string]struct{}{}
-	var implicitColumnIDs []descpb.ColumnID
-	var implicitColumns []string
-	var implicitColumnDirections []descpb.IndexDescriptor_Direction
-	// Iterate over each field in the PARTITION BY until it matches the start
-	// of the actual explicitly indexed columns.
-	for _, field := range partBy.Fields {
-		// As soon as the fields match, we have no implicit columns to add.
-		if string(field) == indexDesc.ColumnNames[0] {
-			break
-		}
-
-		col, err := tableDesc.FindActiveColumnByName(string(field))
-		if err != nil {
-			return indexDesc, 0, err
-		}
-		if _, ok := seenImplicitColumnNames[col.Name]; ok {
-			return indexDesc, 0, pgerror.Newf(
-				pgcode.InvalidObjectDefinition,
-				`found multiple definitions in partition using column "%s"`,
-				col.Name,
-			)
-		}
-		seenImplicitColumnNames[col.Name] = struct{}{}
-		implicitColumns = append(implicitColumns, col.Name)
-		implicitColumnIDs = append(implicitColumnIDs, col.ID)
-		implicitColumnDirections = append(implicitColumnDirections, descpb.IndexDescriptor_ASC)
-	}
-
-	if len(implicitColumns) > 0 {
-		indexDesc.ColumnNames = append(implicitColumns, indexDesc.ColumnNames...)
-		indexDesc.ColumnIDs = append(implicitColumnIDs, indexDesc.ColumnIDs...)
-		indexDesc.ColumnDirections = append(implicitColumnDirections, indexDesc.ColumnDirections...)
-	}
-	return indexDesc, len(implicitColumns), nil
 }


### PR DESCRIPTION
This puts the CCL features with the associated code, and determines the
implicit partitioning as part of the create partitioning function, instead
of requiring it to be passed in.

Also added some unimplemented errors to bits we have not done yet.

Release note: None

