### PR TITLE
release-20.2: pgwire: handle case where TypeHints != PreparedArguments

### DIFF
--- a/pkg/acceptance/testdata/php/test.php
+++ b/pkg/acceptance/testdata/php/test.php
@@ -21,3 +21,15 @@ $stmt = $dbh->prepare('UPDATE bank.accounts SET balance = balance + :deposit WHE
 $stmt->execute(array('account' => 1, 'deposit' => 10));
 $stmt->execute(array('account' => 2, 'deposit' => -10));
 $dbh->commit();
+
+// Regression test for #59007.
+$stmt = $dbh->prepare("insert into a_table (id, a) select ?, ?, ?, ? returning id");
+$stmt->bindValue(1, 'ed66e7c0-5c39-11eb-8992-89bd28f48e75');
+$stmt->bindValue(2, 'bugging_a');
+$stmt->bindValue(3, 'bugging_b');
+try {
+  $stmt->execute();
+  assert(false, "expected exception in execute");
+} catch (Exception $e) {
+  assert(strpos($e.getMessage(), "expected 4 arguments, got 3"));
+}

--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -53,11 +53,22 @@ func (ex *connExecutor) execPrepare(
 	// type OIDs into types.T's.
 	if parseCmd.TypeHints != nil {
 		for i := range parseCmd.TypeHints {
-			if parseCmd.TypeHints[i] == nil && types.IsOIDUserDefinedType(parseCmd.RawTypeHints[i]) {
-				var err error
-				parseCmd.TypeHints[i], err = ex.planner.ResolveTypeByOID(ctx, parseCmd.RawTypeHints[i])
-				if err != nil {
-					return retErr(err)
+			if parseCmd.TypeHints[i] == nil {
+				if i >= len(parseCmd.RawTypeHints) {
+					return retErr(
+						pgwirebase.NewProtocolViolationErrorf(
+							"expected %d arguments, got %d",
+							len(parseCmd.TypeHints),
+							len(parseCmd.RawTypeHints),
+						),
+					)
+				}
+				if types.IsOIDUserDefinedType(parseCmd.RawTypeHints[i]) {
+					var err error
+					parseCmd.TypeHints[i], err = ex.planner.ResolveTypeByOID(ctx, parseCmd.RawTypeHints[i])
+					if err != nil {
+						return retErr(err)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Backport 1/1 commits from #59450.

/cc @cockroachdb/release

---

Release note (bug fix): Fix a panic where type hints mismatching
placeholder names cause a crash.

Resolves #59007.
