### PR TITLE
Revert "ccl/storageccl: skip TestEncryptDecrypt under race"

### DIFF
--- a/pkg/ccl/storageccl/BUILD.bazel
+++ b/pkg/ccl/storageccl/BUILD.bazel
@@ -78,7 +78,6 @@ go_test(
         "//pkg/storage/enginepb",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
-        "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
         "//pkg/util/encoding",

--- a/pkg/ccl/storageccl/encryption_test.go
+++ b/pkg/ccl/storageccl/encryption_test.go
@@ -15,7 +15,6 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
@@ -24,7 +23,6 @@ import (
 
 func TestEncryptDecrypt(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	skip.UnderRaceWithIssue(t, 59417, "flaky test")
 
 	passphrase := []byte("this is a a key")
 	salt, err := GenerateSalt()


### PR DESCRIPTION
Reverts cockroachdb/cockroach#59451

David beat me to the skip and already fixed the panic in #59461.

Release note: None