### PR TITLE
backfill: fix memory accounting bug

### DIFF
--- a/pkg/sql/backfill/backfill.go
+++ b/pkg/sql/backfill/backfill.go
@@ -745,7 +745,7 @@ func (ib *IndexBackfiller) BuildIndexEntriesChunk(
 			ib.rowVals,
 			buffer,
 			false, /* includeEmpty */
-			ib.boundAccount,
+			&ib.boundAccount,
 		); err != nil {
 			return nil, nil, err
 		}

--- a/pkg/sql/rowenc/index_encoding.go
+++ b/pkg/sql/rowenc/index_encoding.go
@@ -1235,7 +1235,7 @@ func EncodeSecondaryIndexes(
 	values []tree.Datum,
 	secondaryIndexEntries []IndexEntry,
 	includeEmpty bool,
-	indexBoundAccount mon.BoundAccount,
+	indexBoundAccount *mon.BoundAccount,
 ) ([]IndexEntry, error) {
 	if len(secondaryIndexEntries) > 0 {
 		panic(errors.AssertionFailedf("length of secondaryIndexEntries was non-zero"))


### PR DESCRIPTION
While refactoring code on master I came across a small bug in the index
backfiller memory accounting logic.

This could explain the mysterious #55968.

Release note (bug fix): We were not passing in a pointer to the bound
account associated with the index backfiller. This would lead to
incorrect memory accounting.