### PR TITLE
colcontainer: don't call writeFooterAndFlush in Close after an error

### DIFF
--- a/pkg/sql/colcontainer/BUILD.bazel
+++ b/pkg/sql/colcontainer/BUILD.bazel
@@ -38,6 +38,8 @@ go_test(
         "//pkg/sql/colexecbase",
         "//pkg/sql/colmem",
         "//pkg/sql/execinfra",
+        "//pkg/sql/pgwire/pgcode",
+        "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/types",
         "//pkg/storage/fs",
         "//pkg/testutils/colcontainerutils",

--- a/pkg/sql/colcontainer/diskqueue.go
+++ b/pkg/sql/colcontainer/diskqueue.go
@@ -495,9 +495,16 @@ func (d *diskQueue) resetWriters(f fs.File) error {
 	return d.serializer.Reset(d.writer)
 }
 
-func (d *diskQueue) writeFooterAndFlush(ctx context.Context) error {
-	err := d.serializer.Finish()
-	if err != nil {
+func (d *diskQueue) writeFooterAndFlush(ctx context.Context) (err error) {
+	defer func() {
+		if err != nil {
+			// If an error occurs, set the serializer to nil to avoid any future
+			// attempts to call writeFooterAndFlush during valid operation (e.g.
+			// calling Close after an error).
+			d.serializer = nil
+		}
+	}()
+	if err := d.serializer.Finish(); err != nil {
 		return err
 	}
 	written, err := d.writer.compressAndFlush()

--- a/pkg/sql/colcontainer/diskqueue_test.go
+++ b/pkg/sql/colcontainer/diskqueue_test.go
@@ -19,6 +19,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coldatatestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/colcontainer"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils/colcontainerutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
@@ -165,6 +168,35 @@ func TestDiskQueue(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestDiskQueueCloseOnErr(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	queueCfg, cleanup := colcontainerutils.NewTestingDiskQueueCfg(t, true /* inMem */)
+	defer cleanup()
+
+	serverCfg := &execinfra.ServerConfig{}
+	serverCfg.TestingKnobs.MemoryLimitBytes = 1
+	diskMon := execinfra.NewLimitedMonitor(ctx, testDiskMonitor, serverCfg, t.Name())
+	defer diskMon.Stop(ctx)
+	diskAcc := diskMon.MakeBoundAccount()
+	defer diskAcc.Close(ctx)
+
+	typs := []*types.T{types.Int}
+	q, err := colcontainer.NewDiskQueue(ctx, typs, queueCfg, &diskAcc)
+	require.NoError(t, err)
+
+	b := coldata.NewMemBatch(typs, coldata.StandardColumnFactory)
+	b.SetLength(0)
+
+	err = q.Enqueue(ctx, b)
+	require.Error(t, err, "expected Enqueue to produce an error given a disk limit of one byte")
+	require.Equal(t, pgerror.GetPGCode(err), pgcode.DiskFull, "unexpected pg code")
+
+	// Now Close the queue, this should be successful.
+	require.NoError(t, q.Close(ctx))
 }
 
 // Flags for BenchmarkQueue.


### PR DESCRIPTION
When disk monitoring was added to the diskQueue, internal state was left
unmodified in case of an error. This would cause the diskQueue to attempt to
write to disk again on Close even if an out of disk error occured during normal
operation. This commit sets the serializer to nil after Finish has been called
so that if a subsequent call to Close happens, the diskQueue does not try to
write footer information (these files will be deleted anyway later on). When
an error doesn't happen, the diskQueue expects the serializer to be reset.

Release note (bug fix): unexpected internal errors containing stack traces that
reference a countingWriter nil pointer have now been fixed.

Closes #59421 
Closes #54552