### PR TITLE
cloudimpl: cache suffix in remote file sst wrapper

### DIFF
--- a/pkg/ccl/backupccl/backup_processor.go
+++ b/pkg/ccl/backupccl/backup_processor.go
@@ -411,7 +411,6 @@ func writeFile(
 		exportStore = localitySpecificStore
 	}
 
-	log.Infof(ctx, "delme writing file %s", file.Path)
 	if err := exportStore.WriteFile(ctx, file.Path, bytes.NewReader(data)); err != nil {
 		log.VEventf(ctx, 1, "failed to put file: %+v", err)
 		return errors.Wrap(err, "writing SST")

--- a/pkg/ccl/storageccl/import.go
+++ b/pkg/ccl/storageccl/import.go
@@ -93,6 +93,12 @@ var remoteSSTs = settings.RegisterBoolSetting(
 	true,
 )
 
+var remoteSSTSuffixCacheSize = settings.RegisterByteSizeSetting(
+	"kv.bulk_ingest.stream_external_ssts.suffix_cache_size",
+	"size of suffix of remote SSTs to download and cache before reading from remote stream",
+	64<<10,
+)
+
 // commandMetadataEstimate is an estimate of how much metadata Raft will add to
 // an AddSSTable command. It is intentionally a vast overestimate to avoid
 // embedding intricate knowledge of the Raft encoding scheme here.
@@ -333,6 +339,7 @@ func ExternalSSTReader(
 	}
 
 	var reader sstable.ReadableFile = raw
+
 	if encryption != nil {
 		r, err := decryptingReader(raw, encryption.Key)
 		if err != nil {
@@ -340,6 +347,13 @@ func ExternalSSTReader(
 			return nil, err
 		}
 		reader = r
+	} else {
+		// We only explicitly buffer the suffix of the file when not decrypting as
+		// the decrypting reader has its own internal block buffer.
+		if err := raw.readAndCacheSuffix(remoteSSTSuffixCacheSize.Get(&e.Settings().SV)); err != nil {
+			f.Close()
+			return nil, err
+		}
 	}
 
 	iter, err := storage.NewSSTIterator(reader)
@@ -359,6 +373,15 @@ type sstReader struct {
 	pos  int64
 
 	readPos int64 // readPos is used to transform Read() to ReadAt(readPos).
+
+	// This wrapper's primary purpose is reading SSTs which often perform many
+	// tiny reads in a cluster of offsets near the end of the file. If we can read
+	// the whole region once and fullfil those from a cache, we can avoid repeated
+	// RPCs.
+	cache struct {
+		pos int64
+		buf []byte
+	}
 }
 
 // Close implements io.Closer.
@@ -381,11 +404,49 @@ func (r *sstReader) Read(p []byte) (int, error) {
 	return n, err
 }
 
+// readAndCacheSuffix caches the `size` suffix of the file (which could the
+// whole file) for use by later ReadAt calls to avoid making additional RPCs.
+func (r *sstReader) readAndCacheSuffix(size int64) error {
+	if size == 0 {
+		return nil
+	}
+	r.cache.buf = nil
+	r.cache.pos = int64(r.sz) - size
+	if r.cache.pos <= 0 {
+		r.cache.pos = 0
+	}
+	reader, err := r.openAt(r.cache.pos)
+	if err != nil {
+		return err
+	}
+	defer reader.Close()
+	read, err := ioutil.ReadAll(reader)
+	if err != nil {
+		return err
+	}
+	r.cache.buf = read
+	return nil
+}
+
 // ReadAt implements io.ReaderAt by opening a Reader at an offset before reading
 // from it. Note: contrary to io.ReaderAt, ReadAt does *not* support parallel
 // calls.
 func (r *sstReader) ReadAt(p []byte, offset int64) (int, error) {
 	var read int
+	if offset >= r.cache.pos && offset < r.cache.pos+int64(len(r.cache.buf)) {
+		read += copy(p, r.cache.buf[offset-r.cache.pos:])
+		if read == len(p) {
+			return read, nil
+		}
+		// Advance offset to end of what cache read.
+		offset += int64(read)
+	}
+
+	if offset == int64(r.sz) {
+		return read, io.EOF
+	}
+
+	// Position the underlying reader at offset if needed.
 	if r.pos != offset {
 		if err := r.Close(); err != nil {
 			return 0, err
@@ -397,6 +458,7 @@ func (r *sstReader) ReadAt(p []byte, offset int64) (int, error) {
 		r.pos = offset
 		r.body = b
 	}
+
 	var err error
 	for n := 0; read < len(p); n, err = r.body.Read(p[read:]) {
 		read += n


### PR DESCRIPTION
Reading SSTs starts with multiple tiny reads in offsets near the end of the file.
If we can read that whole region once and fulfill those reads from a cached buffer,
we can avoid repeated RPCs.

Release note: none.