### PR TITLE
sql: add escape_string_warning session variable for compatibility

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -3401,6 +3401,7 @@ enable_implicit_select_for_update                     on
 enable_insert_fast_path                               on
 enable_seqscan                                        on
 enable_zigzag_join                                    on
+escape_string_warning                                 on
 experimental_enable_hash_sharded_indexes              off
 experimental_enable_implicit_column_partitioning      off
 experimental_enable_multi_column_inverted_indexes     off

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1989,6 +1989,7 @@ enable_implicit_select_for_update                     on                  NULL  
 enable_insert_fast_path                               on                  NULL      NULL        NULL        string
 enable_seqscan                                        on                  NULL      NULL        NULL        string
 enable_zigzag_join                                    on                  NULL      NULL        NULL        string
+escape_string_warning                                 on                  NULL      NULL        NULL        string
 experimental_distsql_planning                         off                 NULL      NULL        NULL        string
 experimental_enable_hash_sharded_indexes              off                 NULL      NULL        NULL        string
 experimental_enable_implicit_column_partitioning      off                 NULL      NULL        NULL        string
@@ -2065,6 +2066,7 @@ enable_implicit_select_for_update                     on                  NULL  
 enable_insert_fast_path                               on                  NULL  user     NULL      on                  on
 enable_seqscan                                        on                  NULL  user     NULL      on                  on
 enable_zigzag_join                                    on                  NULL  user     NULL      on                  on
+escape_string_warning                                 on                  NULL  user     NULL      on                  on
 experimental_distsql_planning                         off                 NULL  user     NULL      off                 off
 experimental_enable_hash_sharded_indexes              off                 NULL  user     NULL      off                 off
 experimental_enable_implicit_column_partitioning      off                 NULL  user     NULL      off                 off
@@ -2137,6 +2139,7 @@ enable_implicit_select_for_update                     NULL    NULL     NULL     
 enable_insert_fast_path                               NULL    NULL     NULL     NULL        NULL
 enable_seqscan                                        NULL    NULL     NULL     NULL        NULL
 enable_zigzag_join                                    NULL    NULL     NULL     NULL        NULL
+escape_string_warning                                 NULL    NULL     NULL     NULL        NULL
 experimental_distsql_planning                         NULL    NULL     NULL     NULL        NULL
 experimental_enable_hash_sharded_indexes              NULL    NULL     NULL     NULL        NULL
 experimental_enable_implicit_column_partitioning      NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/set
+++ b/pkg/sql/logictest/testdata/logic_test/set
@@ -142,6 +142,12 @@ statement error parameter "server_encoding" cannot be changed
 SET server_encoding = 'other'
 
 statement ok
+SET escape_string_warning = 'ON'
+
+statement ok
+SET escape_string_warning = 'off'
+
+statement ok
 SET datestyle = 'ISO'
 
 statement error invalid value for parameter "DateStyle": "other"

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -46,6 +46,7 @@ enable_implicit_select_for_update                     on
 enable_insert_fast_path                               on
 enable_seqscan                                        on
 enable_zigzag_join                                    on
+escape_string_warning                                 on
 experimental_distsql_planning                         off
 experimental_enable_hash_sharded_indexes              off
 experimental_enable_implicit_column_partitioning      off

--- a/pkg/sql/unsupported_vars.go
+++ b/pkg/sql/unsupported_vars.go
@@ -102,7 +102,7 @@ var UnsupportedVars = func(ss ...string) map[string]struct{} {
 	// "enable_seqscan",
 	"enable_sort",
 	"enable_tidscan",
-	"escape_string_warning",
+	// "escape_string_warning",
 	"exit_on_error",
 	// "extra_float_digits",
 	"force_parallel_mode",

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -918,7 +918,13 @@ var varGen = map[string]sessionVar{
 
 	// Supported for PG compatibility only.
 	// See https://www.postgresql.org/docs/10/static/runtime-config-compatible.html#GUC-STANDARD-CONFORMING-STRINGS
+	// If this gets properly implemented, we will need to re-evaluate how escape_string_warning is implemented
 	`standard_conforming_strings`: makeCompatBoolVar(`standard_conforming_strings`, true, false /* anyAllowed */),
+
+	// See https://www.postgresql.org/docs/10/runtime-config-compatible.html#GUC-ESCAPE-STRING-WARNING
+	// Supported for PG compatibility only.
+	// If this gets properly implemented, we will need to re-evaluate how standard_conforming_strings is implemented
+	`escape_string_warning`: makeCompatBoolVar(`escape_string_warning`, true, true /* anyAllowed */),
 
 	// See https://www.postgresql.org/docs/10/static/runtime-config-compatible.html#GUC-SYNCHRONIZE-SEQSCANS
 	// The default in pg is "on" but the behavior in CockroachDB is "off". As this does not affect


### PR DESCRIPTION
Relates to #22937

This makes it possible for Zabbix to successfully connect to CockroachDB.
See https://www.postgresql.org/docs/10/runtime-config-compatible.html#GUC-ESCAPE-STRING-WARNING
Release note (sql change): The escape_string_warning session variable from
PostgreSQL was added with compatibility-only support. It defaults to `ON`
and cannot be changed.