### PR TITLE
sql: Block adding a primary region to the system database

### DIFF
--- a/pkg/sql/alter_database.go
+++ b/pkg/sql/alter_database.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
@@ -391,6 +392,15 @@ func (n *alterDatabasePrimaryRegionNode) startExec(params runParams) error {
 	// To add a region, the user has to have CREATEDB privileges, or be an admin user.
 	if err := params.p.CheckRoleOption(params.ctx, roleoption.CREATEDB); err != nil {
 		return err
+	}
+
+	// Block adding a primary region to the system database. This ensures that the system
+	// database can never be made into a multi-region database.
+	if n.desc.GetID() == keys.SystemDatabaseID {
+		return pgerror.Newf(
+			pgcode.FeatureNotSupported,
+			"adding a primary region to the system database is not supported",
+		)
 	}
 
 	// There are two paths to consider here: either this is the first setting of the

--- a/pkg/sql/logictest/testdata/logic_test/multiregion
+++ b/pkg/sql/logictest/testdata/logic_test/multiregion
@@ -329,6 +329,10 @@ USE new_db
 statement error database new_db is not multi-region enabled, but table cannot_create_table_no_multiregion has locality GLOBAL set
 CREATE TABLE cannot_create_table_no_multiregion (a int) LOCALITY GLOBAL
 
+# Test adding a primary region to the system database.
+statement error adding a primary region to the system database is not supported
+ALTER DATABASE system PRIMARY REGION "ap-southeast-2"
+
 statement ok
 CREATE DATABASE alter_test_db primary region "ca-central-1"
 


### PR DESCRIPTION
Prevent users from adding a primary region to the system database, thus
preventing the system database from becoming a multi-region database.

Release note: None

Resolves #57760.