### PR TITLE
release-20.2: sql: audit all usages of QueryRow and QueryRowEx to check whether row is nil

### DIFF
--- a/pkg/cli/statement_diag.go
+++ b/pkg/cli/statement_diag.go
@@ -36,7 +36,7 @@ diagnostics can be activated from the UI or using EXPLAIN ANALYZE (DEBUG).`,
 var stmtDiagListCmd = &cobra.Command{
 	Use:   "list [options]",
 	Short: "list available bundles and outstanding activation requests",
-	Long: `List statements diagnostics that are available for download and outstanding
+	Long: `List statement diagnostics that are available for download and outstanding
 diagnostics activation requests.`,
 	Args: cobra.NoArgs,
 	RunE: MaybeDecorateGRPCError(runStmtDiagList),
@@ -138,7 +138,7 @@ func runStmtDiagList(cmd *cobra.Command, args []string) error {
 var stmtDiagDownloadCmd = &cobra.Command{
 	Use:   "download <bundle id> <file> [options]",
 	Short: "download statement diagnostics bundle into a zip file",
-	Long: `Download statements diagnostics bundle into a zip file, using an ID returned by
+	Long: `Download statement diagnostics bundle into a zip file, using an ID returned by
 the list command.`,
 	Args: cobra.ExactArgs(2),
 	RunE: MaybeDecorateGRPCError(runStmtDiagDownload),

--- a/pkg/jobs/job_scheduler.go
+++ b/pkg/jobs/job_scheduler.go
@@ -219,6 +219,9 @@ func newLoopStats(
 	if err != nil {
 		return nil, err
 	}
+	if datums == nil {
+		return nil, errors.New("failed to read scheduler stats")
+	}
 	stats := &loopStats{}
 	stats.readyToRun = int64(tree.MustBeDInt(datums[0]))
 	stats.jobsRunning = int64(tree.MustBeDInt(datums[1]))

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -355,6 +355,9 @@ func (r *Registry) Run(ctx context.Context, ex sqlutil.InternalExecutor, jobs []
 		if err != nil {
 			return errors.Wrap(err, "polling for queued jobs to complete")
 		}
+		if row == nil {
+			return errors.New("polling for queued jobs failed")
+		}
 		count := int64(tree.MustBeDInt(row[0]))
 		if log.V(3) {
 			log.Infof(ctx, "waiting for %d queued jobs to complete", count)

--- a/pkg/jobs/testutils_test.go
+++ b/pkg/jobs/testutils_test.go
@@ -169,5 +169,6 @@ RETURNING id`,
 		CreatedByScheduledJobs, scheduleID, status, payload,
 	)
 	require.NoError(t, err)
+	require.NotNil(t, datums)
 	return int64(tree.MustBeDInt(datums[0]))
 }

--- a/pkg/kv/kvserver/protectedts/ptstorage/storage.go
+++ b/pkg/kv/kvserver/protectedts/ptstorage/storage.go
@@ -171,6 +171,9 @@ func (p *storage) GetMetadata(ctx context.Context, txn *kv.Txn) (ptpb.Metadata, 
 	if err != nil {
 		return ptpb.Metadata{}, errors.Wrap(err, "failed to read metadata")
 	}
+	if row == nil {
+		return ptpb.Metadata{}, errors.New("failed to read metadata")
+	}
 	return ptpb.Metadata{
 		Version:    uint64(*row[0].(*tree.DInt)),
 		NumRecords: uint64(*row[1].(*tree.DInt)),

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -1635,7 +1635,7 @@ func (s *adminServer) getStatementBundle(ctx context.Context, id int64, w http.R
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		if row == nil {
+		if chunkRow == nil {
 			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
 			return
 		}
@@ -2399,6 +2399,9 @@ func (s *adminServer) queryTableID(
 	)
 	if err != nil {
 		return descpb.InvalidID, err
+	}
+	if row == nil {
+		return descpb.InvalidID, errors.Newf("failed to resolve %q as a table name", tableName)
 	}
 	return descpb.ID(tree.MustBeDOid(row[0]).DInt), nil
 }

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -1294,6 +1294,9 @@ func (sc *SchemaChanger) validateInvertedIndexes(
 				if err != nil {
 					return err
 				}
+				if row == nil {
+					return errors.New("failed to verify inverted index count")
+				}
 				expectedCount[i] = int64(tree.MustBeDInt(row[0]))
 				return nil
 			}); err != nil {
@@ -1374,6 +1377,9 @@ func (sc *SchemaChanger) validateForwardIndexes(
 				if err != nil {
 					return err
 				}
+				if row == nil {
+					return errors.New("failed to verify index count")
+				}
 				idxLen = int64(tree.MustBeDInt(row[0]))
 				return nil
 			}); err != nil {
@@ -1453,6 +1459,9 @@ func (sc *SchemaChanger) validateForwardIndexes(
 			cnt, err := ie.QueryRowEx(ctx, "VERIFY INDEX", txn, sessiondata.InternalExecutorOverride{}, query)
 			if err != nil {
 				return err
+			}
+			if cnt == nil {
+				return errors.New("failed to verify index")
 			}
 
 			tableRowCount = int64(tree.MustBeDInt(cnt[0]))

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -389,6 +389,9 @@ func CountLeases(
 	if err != nil {
 		return 0, err
 	}
+	if values == nil {
+		return 0, errors.New("failed to count leases")
+	}
 	count := int(tree.MustBeDInt(values[0]))
 	return count, nil
 }

--- a/pkg/sql/drop_role.go
+++ b/pkg/sql/drop_role.go
@@ -273,6 +273,9 @@ func (n *DropRoleNode) startExec(params runParams) error {
 		if err != nil {
 			return err
 		}
+		if numSchedulesRow == nil {
+			return errors.New("failed to check user schedules")
+		}
 		numSchedules := int64(tree.MustBeDInt(numSchedulesRow[0]))
 		if numSchedules > 0 {
 			return pgerror.Newf(pgcode.DependentObjectsStillExist,

--- a/pkg/sql/internal_test.go
+++ b/pkg/sql/internal_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -72,6 +73,9 @@ func TestInternalExecutor(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if row == nil {
+		t.Fatal("empty result")
+	}
 	r, ok = row[0].(*tree.DInt)
 	if !ok || *r != 99 {
 		t.Fatalf("expected a DInt == 99, got: %T:%s", r, r)
@@ -94,6 +98,9 @@ func TestInternalExecutor(t *testing.T) {
 		)
 		if err != nil {
 			return err
+		}
+		if row == nil {
+			return errors.New("empty result")
 		}
 		r, ok = row[0].(*tree.DInt)
 		if !ok || *r != 99 {

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -544,6 +544,9 @@ func evalPrivilegeCheck(
 		if err != nil {
 			return nil, err
 		}
+		if r == nil {
+			return nil, errors.AssertionFailedf("failed to evaluate privilege check")
+		}
 		switch r[0] {
 		case tree.DBoolFalse:
 			return tree.DBoolFalse, nil

--- a/pkg/sql/sqlliveness/slstorage/slstorage.go
+++ b/pkg/sql/sqlliveness/slstorage/slstorage.go
@@ -312,6 +312,12 @@ func (s *Storage) deleteExpiredSessions(ctx context.Context) {
 		}
 		return
 	}
+	if row == nil {
+		if ctx.Err() == nil {
+			log.Error(ctx, "could not delete expired sessions")
+		}
+		return
+	}
 	deleted := int64(*row[0].(*tree.DInt))
 
 	s.metrics.SessionDeletionsRuns.Inc(1)

--- a/pkg/sql/stmtdiagnostics/statement_diagnostics.go
+++ b/pkg/sql/stmtdiagnostics/statement_diagnostics.go
@@ -225,6 +225,9 @@ func (r *Registry) insertRequestInternal(ctx context.Context, fprint string) (re
 		if err != nil {
 			return err
 		}
+		if row == nil {
+			return errors.New("failed to check pending statement diagnostics")
+		}
 		count := int(*row[0].(*tree.DInt))
 		if count != 0 {
 			return errors.New("a pending request for the requested fingerprint already exists")
@@ -239,6 +242,9 @@ func (r *Registry) insertRequestInternal(ctx context.Context, fprint string) (re
 			fprint, timeutil.Now())
 		if err != nil {
 			return err
+		}
+		if row == nil {
+			return errors.New("failed to insert statement diagnostics request")
 		}
 		reqID = requestID(*row[0].(*tree.DInt))
 		return nil
@@ -391,6 +397,9 @@ func (r *Registry) insertStatementDiagnostics(
 			if err != nil {
 				return err
 			}
+			if row == nil {
+				return errors.New("failed to check completed statement diagnostics")
+			}
 			cnt := int(*row[0].(*tree.DInt))
 			if cnt == 0 {
 				// Someone else already marked the request as completed. We've traced for nothing.
@@ -426,6 +435,9 @@ func (r *Registry) insertStatementDiagnostics(
 			if err != nil {
 				return err
 			}
+			if row == nil {
+				return errors.New("failed to check statement bundle chunk")
+			}
 			chunkID := row[0].(*tree.DInt)
 			if err := bundleChunksVal.Append(chunkID); err != nil {
 				return err
@@ -445,6 +457,9 @@ func (r *Registry) insertStatementDiagnostics(
 		)
 		if err != nil {
 			return err
+		}
+		if row == nil {
+			return errors.New("failed to insert statement diagnostics")
 		}
 		diagID = stmtID(*row[0].(*tree.DInt))
 

--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -423,6 +423,9 @@ func (p *planner) reassignIndexComments(
 	if err != nil {
 		return err
 	}
+	if row == nil {
+		return errors.New("failed to update table comments")
+	}
 	if int(tree.MustBeDInt(row[0])) > 0 {
 		for old, new := range indexIDMapping {
 			if _, err := p.ExtendedEvalContext().ExecCfg.InternalExecutor.ExecEx(

--- a/pkg/sqlmigrations/migrations.go
+++ b/pkg/sqlmigrations/migrations.go
@@ -1363,6 +1363,9 @@ func updateSystemLocationData(ctx context.Context, r runner) error {
 	if err != nil {
 		return err
 	}
+	if row == nil {
+		return errors.New("failed to update system locations")
+	}
 	count := int(tree.MustBeDInt(row[0]))
 	if count != 0 {
 		return nil


### PR DESCRIPTION
Backport 1/1 commits from #59434.

/cc @cockroachdb/release

---

This commit audits all usages of `QueryRow` and `QueryRowEx` method of the
internal executor to make sure that the first return parameter (`row`) is
non-nil before it is used. Previously, in some edge cases the missing nil
checks could lead to crashes (at least, in theory).

It also does `s/statements diagnostics/statement diagnostics/g` in
several places.

Informs: #59435.

Release note: None
