### PR TITLE
sql,util: add vtable for node-local inflight span registry

### DIFF
--- a/pkg/cli/testdata/zip/partial1
+++ b/pkg/cli/testdata/zip/partial1
@@ -39,6 +39,7 @@ retrieving SQL data for crdb_internal.gossip_network... writing: debug/nodes/1/c
 retrieving SQL data for crdb_internal.gossip_nodes... writing: debug/nodes/1/crdb_internal.gossip_nodes.txt
 retrieving SQL data for crdb_internal.leases... writing: debug/nodes/1/crdb_internal.leases.txt
 retrieving SQL data for crdb_internal.node_build_info... writing: debug/nodes/1/crdb_internal.node_build_info.txt
+retrieving SQL data for crdb_internal.node_inflight_trace_spans... writing: debug/nodes/1/crdb_internal.node_inflight_trace_spans.txt
 retrieving SQL data for crdb_internal.node_metrics... writing: debug/nodes/1/crdb_internal.node_metrics.txt
 retrieving SQL data for crdb_internal.node_queries... writing: debug/nodes/1/crdb_internal.node_queries.txt
 retrieving SQL data for crdb_internal.node_runtime_info... writing: debug/nodes/1/crdb_internal.node_runtime_info.txt
@@ -118,6 +119,9 @@ writing: debug/nodes/2/crdb_internal.leases.txt.err.txt
 retrieving SQL data for crdb_internal.node_build_info... writing: debug/nodes/2/crdb_internal.node_build_info.txt
 writing: debug/nodes/2/crdb_internal.node_build_info.txt.err.txt
   ^- resulted in ...
+retrieving SQL data for crdb_internal.node_inflight_trace_spans... writing: debug/nodes/2/crdb_internal.node_inflight_trace_spans.txt
+writing: debug/nodes/2/crdb_internal.node_inflight_trace_spans.txt.err.txt
+  ^- resulted in ...
 retrieving SQL data for crdb_internal.node_metrics... writing: debug/nodes/2/crdb_internal.node_metrics.txt
 writing: debug/nodes/2/crdb_internal.node_metrics.txt.err.txt
   ^- resulted in ...
@@ -171,6 +175,7 @@ retrieving SQL data for crdb_internal.gossip_network... writing: debug/nodes/3/c
 retrieving SQL data for crdb_internal.gossip_nodes... writing: debug/nodes/3/crdb_internal.gossip_nodes.txt
 retrieving SQL data for crdb_internal.leases... writing: debug/nodes/3/crdb_internal.leases.txt
 retrieving SQL data for crdb_internal.node_build_info... writing: debug/nodes/3/crdb_internal.node_build_info.txt
+retrieving SQL data for crdb_internal.node_inflight_trace_spans... writing: debug/nodes/3/crdb_internal.node_inflight_trace_spans.txt
 retrieving SQL data for crdb_internal.node_metrics... writing: debug/nodes/3/crdb_internal.node_metrics.txt
 retrieving SQL data for crdb_internal.node_queries... writing: debug/nodes/3/crdb_internal.node_queries.txt
 retrieving SQL data for crdb_internal.node_runtime_info... writing: debug/nodes/3/crdb_internal.node_runtime_info.txt

--- a/pkg/cli/testdata/zip/partial1_excluded
+++ b/pkg/cli/testdata/zip/partial1_excluded
@@ -39,6 +39,7 @@ retrieving SQL data for crdb_internal.gossip_network... writing: debug/nodes/1/c
 retrieving SQL data for crdb_internal.gossip_nodes... writing: debug/nodes/1/crdb_internal.gossip_nodes.txt
 retrieving SQL data for crdb_internal.leases... writing: debug/nodes/1/crdb_internal.leases.txt
 retrieving SQL data for crdb_internal.node_build_info... writing: debug/nodes/1/crdb_internal.node_build_info.txt
+retrieving SQL data for crdb_internal.node_inflight_trace_spans... writing: debug/nodes/1/crdb_internal.node_inflight_trace_spans.txt
 retrieving SQL data for crdb_internal.node_metrics... writing: debug/nodes/1/crdb_internal.node_metrics.txt
 retrieving SQL data for crdb_internal.node_queries... writing: debug/nodes/1/crdb_internal.node_queries.txt
 retrieving SQL data for crdb_internal.node_runtime_info... writing: debug/nodes/1/crdb_internal.node_runtime_info.txt
@@ -105,6 +106,7 @@ retrieving SQL data for crdb_internal.gossip_network... writing: debug/nodes/3/c
 retrieving SQL data for crdb_internal.gossip_nodes... writing: debug/nodes/3/crdb_internal.gossip_nodes.txt
 retrieving SQL data for crdb_internal.leases... writing: debug/nodes/3/crdb_internal.leases.txt
 retrieving SQL data for crdb_internal.node_build_info... writing: debug/nodes/3/crdb_internal.node_build_info.txt
+retrieving SQL data for crdb_internal.node_inflight_trace_spans... writing: debug/nodes/3/crdb_internal.node_inflight_trace_spans.txt
 retrieving SQL data for crdb_internal.node_metrics... writing: debug/nodes/3/crdb_internal.node_metrics.txt
 retrieving SQL data for crdb_internal.node_queries... writing: debug/nodes/3/crdb_internal.node_queries.txt
 retrieving SQL data for crdb_internal.node_runtime_info... writing: debug/nodes/3/crdb_internal.node_runtime_info.txt

--- a/pkg/cli/testdata/zip/partial2
+++ b/pkg/cli/testdata/zip/partial2
@@ -39,6 +39,7 @@ retrieving SQL data for crdb_internal.gossip_network... writing: debug/nodes/1/c
 retrieving SQL data for crdb_internal.gossip_nodes... writing: debug/nodes/1/crdb_internal.gossip_nodes.txt
 retrieving SQL data for crdb_internal.leases... writing: debug/nodes/1/crdb_internal.leases.txt
 retrieving SQL data for crdb_internal.node_build_info... writing: debug/nodes/1/crdb_internal.node_build_info.txt
+retrieving SQL data for crdb_internal.node_inflight_trace_spans... writing: debug/nodes/1/crdb_internal.node_inflight_trace_spans.txt
 retrieving SQL data for crdb_internal.node_metrics... writing: debug/nodes/1/crdb_internal.node_metrics.txt
 retrieving SQL data for crdb_internal.node_queries... writing: debug/nodes/1/crdb_internal.node_queries.txt
 retrieving SQL data for crdb_internal.node_runtime_info... writing: debug/nodes/1/crdb_internal.node_runtime_info.txt
@@ -104,6 +105,7 @@ retrieving SQL data for crdb_internal.gossip_network... writing: debug/nodes/3/c
 retrieving SQL data for crdb_internal.gossip_nodes... writing: debug/nodes/3/crdb_internal.gossip_nodes.txt
 retrieving SQL data for crdb_internal.leases... writing: debug/nodes/3/crdb_internal.leases.txt
 retrieving SQL data for crdb_internal.node_build_info... writing: debug/nodes/3/crdb_internal.node_build_info.txt
+retrieving SQL data for crdb_internal.node_inflight_trace_spans... writing: debug/nodes/3/crdb_internal.node_inflight_trace_spans.txt
 retrieving SQL data for crdb_internal.node_metrics... writing: debug/nodes/3/crdb_internal.node_metrics.txt
 retrieving SQL data for crdb_internal.node_queries... writing: debug/nodes/3/crdb_internal.node_queries.txt
 retrieving SQL data for crdb_internal.node_runtime_info... writing: debug/nodes/3/crdb_internal.node_runtime_info.txt

--- a/pkg/cli/testdata/zip/testzip
+++ b/pkg/cli/testdata/zip/testzip
@@ -41,6 +41,7 @@ retrieving SQL data for crdb_internal.gossip_network... writing: debug/nodes/1/c
 retrieving SQL data for crdb_internal.gossip_nodes... writing: debug/nodes/1/crdb_internal.gossip_nodes.txt
 retrieving SQL data for crdb_internal.leases... writing: debug/nodes/1/crdb_internal.leases.txt
 retrieving SQL data for crdb_internal.node_build_info... writing: debug/nodes/1/crdb_internal.node_build_info.txt
+retrieving SQL data for crdb_internal.node_inflight_trace_spans... writing: debug/nodes/1/crdb_internal.node_inflight_trace_spans.txt
 retrieving SQL data for crdb_internal.node_metrics... writing: debug/nodes/1/crdb_internal.node_metrics.txt
 retrieving SQL data for crdb_internal.node_queries... writing: debug/nodes/1/crdb_internal.node_queries.txt
 retrieving SQL data for crdb_internal.node_runtime_info... writing: debug/nodes/1/crdb_internal.node_runtime_info.txt

--- a/pkg/cli/testdata/zip/unavailable
+++ b/pkg/cli/testdata/zip/unavailable
@@ -64,6 +64,7 @@ retrieving SQL data for crdb_internal.gossip_network... writing: debug/nodes/1/c
 retrieving SQL data for crdb_internal.gossip_nodes... writing: debug/nodes/1/crdb_internal.gossip_nodes.txt
 retrieving SQL data for crdb_internal.leases... writing: debug/nodes/1/crdb_internal.leases.txt
 retrieving SQL data for crdb_internal.node_build_info... writing: debug/nodes/1/crdb_internal.node_build_info.txt
+retrieving SQL data for crdb_internal.node_inflight_trace_spans... writing: debug/nodes/1/crdb_internal.node_inflight_trace_spans.txt
 retrieving SQL data for crdb_internal.node_metrics... writing: debug/nodes/1/crdb_internal.node_metrics.txt
 retrieving SQL data for crdb_internal.node_queries... writing: debug/nodes/1/crdb_internal.node_queries.txt
 retrieving SQL data for crdb_internal.node_runtime_info... writing: debug/nodes/1/crdb_internal.node_runtime_info.txt

--- a/pkg/cli/zip.go
+++ b/pkg/cli/zip.go
@@ -94,6 +94,7 @@ var debugZipTablesPerNode = []string{
 	"crdb_internal.leases",
 
 	"crdb_internal.node_build_info",
+	"crdb_internal.node_inflight_trace_spans",
 	"crdb_internal.node_metrics",
 	"crdb_internal.node_queries",
 	"crdb_internal.node_runtime_info",
@@ -106,6 +107,7 @@ var debugZipTablesPerNode = []string{
 
 // Override for the default SELECT * when dumping the table.
 var customSelectClause = map[string]string{
+	"crdb.internal.node_inflight_trace_spans": "*, WHERE duration > 10*time.Second ORDER BY trace_id ASC, duration DESC",
 	"system.jobs":       "*, to_hex(payload) AS hex_payload, to_hex(progress) AS hex_progress",
 	"system.descriptor": "*, to_hex(descriptor) AS hex_descriptor",
 }

--- a/pkg/sql/catalog/catconstants/constants.go
+++ b/pkg/sql/catalog/catconstants/constants.go
@@ -50,6 +50,7 @@ const (
 	CrdbInternalGossipLivenessTableID
 	CrdbInternalGossipNetworkTableID
 	CrdbInternalIndexColumnsTableID
+	CrdbInternalInflightTraceSpanTableID
 	CrdbInternalJobsTableID
 	CrdbInternalKVNodeStatusTableID
 	CrdbInternalKVStoreStatusTableID

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -37,6 +37,7 @@ crdb_internal  kv_node_status               table  NULL  NULL  NULL
 crdb_internal  kv_store_status              table  NULL  NULL  NULL
 crdb_internal  leases                       table  NULL  NULL  NULL
 crdb_internal  node_build_info              table  NULL  NULL  NULL
+crdb_internal  node_inflight_trace_spans    table  NULL  NULL  NULL
 crdb_internal  node_metrics                 table  NULL  NULL  NULL
 crdb_internal  node_queries                 table  NULL  NULL  NULL
 crdb_internal  node_runtime_info            table  NULL  NULL  NULL
@@ -248,6 +249,11 @@ SELECT * FROM crdb_internal.zones WHERE false
 ----
 zone_id  subzone_id  target  range_name  database_name  table_name  index_name  partition_name
 raw_config_yaml  raw_config_sql  raw_config_protobuf full_config_yaml full_config_sql
+
+query IIITTT colnames
+SELECT * FROM crdb_internal.node_inflight_trace_spans WHERE span_id < 0
+----
+trace_id  parent_span_id  span_id  start_time  duration  operation
 
 query ITTTTTTTTTTTTI colnames
 SELECT * FROM crdb_internal.ranges WHERE range_id < 0

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal_tenant
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal_tenant
@@ -48,6 +48,7 @@ crdb_internal  kv_node_status               table  NULL  NULL  NULL
 crdb_internal  kv_store_status              table  NULL  NULL  NULL
 crdb_internal  leases                       table  NULL  NULL  NULL
 crdb_internal  node_build_info              table  NULL  NULL  NULL
+crdb_internal  node_inflight_trace_spans    table  NULL  NULL  NULL
 crdb_internal  node_metrics                 table  NULL  NULL  NULL
 crdb_internal  node_queries                 table  NULL  NULL  NULL
 crdb_internal  node_runtime_info            table  NULL  NULL  NULL
@@ -259,6 +260,11 @@ SELECT * FROM crdb_internal.zones WHERE false
 ----
 zone_id  subzone_id  target  range_name  database_name  table_name  index_name  partition_name
 raw_config_yaml  raw_config_sql  raw_config_protobuf full_config_yaml full_config_sql
+
+query IIITTT colnames
+SELECT * FROM crdb_internal.node_inflight_trace_spans WHERE span_id < 0
+----
+trace_id  parent_span_id  span_id  start_time  duration  operation
 
 statement error not fully contained in tenant keyspace
 SELECT * FROM crdb_internal.ranges WHERE range_id < 0

--- a/pkg/sql/logictest/testdata/logic_test/grant_table
+++ b/pkg/sql/logictest/testdata/logic_test/grant_table
@@ -49,6 +49,7 @@ test           crdb_internal       kv_node_status                         public
 test           crdb_internal       kv_store_status                        public   SELECT
 test           crdb_internal       leases                                 public   SELECT
 test           crdb_internal       node_build_info                        public   SELECT
+test           crdb_internal       node_inflight_trace_spans              public   SELECT
 test           crdb_internal       node_metrics                           public   SELECT
 test           crdb_internal       node_queries                           public   SELECT
 test           crdb_internal       node_runtime_info                      public   SELECT

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -301,6 +301,7 @@ crdb_internal       kv_node_status
 crdb_internal       kv_store_status
 crdb_internal       leases
 crdb_internal       node_build_info
+crdb_internal       node_inflight_trace_spans
 crdb_internal       node_metrics
 crdb_internal       node_queries
 crdb_internal       node_runtime_info
@@ -461,6 +462,7 @@ kv_node_status
 kv_store_status
 leases
 node_build_info
+node_inflight_trace_spans
 node_metrics
 node_queries
 node_runtime_info
@@ -640,6 +642,7 @@ system         crdb_internal       kv_node_status                         SYSTEM
 system         crdb_internal       kv_store_status                        SYSTEM VIEW  NO                  1
 system         crdb_internal       leases                                 SYSTEM VIEW  NO                  1
 system         crdb_internal       node_build_info                        SYSTEM VIEW  NO                  1
+system         crdb_internal       node_inflight_trace_spans              SYSTEM VIEW  NO                  1
 system         crdb_internal       node_metrics                           SYSTEM VIEW  NO                  1
 system         crdb_internal       node_queries                           SYSTEM VIEW  NO                  1
 system         crdb_internal       node_runtime_info                      SYSTEM VIEW  NO                  1
@@ -1880,6 +1883,7 @@ NULL     public   system         crdb_internal       kv_node_status             
 NULL     public   system         crdb_internal       kv_store_status                        SELECT          NULL          YES
 NULL     public   system         crdb_internal       leases                                 SELECT          NULL          YES
 NULL     public   system         crdb_internal       node_build_info                        SELECT          NULL          YES
+NULL     public   system         crdb_internal       node_inflight_trace_spans              SELECT          NULL          YES
 NULL     public   system         crdb_internal       node_metrics                           SELECT          NULL          YES
 NULL     public   system         crdb_internal       node_queries                           SELECT          NULL          YES
 NULL     public   system         crdb_internal       node_runtime_info                      SELECT          NULL          YES
@@ -2265,6 +2269,7 @@ NULL     public   system         crdb_internal       kv_node_status             
 NULL     public   system         crdb_internal       kv_store_status                        SELECT          NULL          YES
 NULL     public   system         crdb_internal       leases                                 SELECT          NULL          YES
 NULL     public   system         crdb_internal       node_build_info                        SELECT          NULL          YES
+NULL     public   system         crdb_internal       node_inflight_trace_spans              SELECT          NULL          YES
 NULL     public   system         crdb_internal       node_metrics                           SELECT          NULL          YES
 NULL     public   system         crdb_internal       node_queries                           SELECT          NULL          YES
 NULL     public   system         crdb_internal       node_runtime_info                      SELECT          NULL          YES

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1047,14 +1047,14 @@ FROM pg_catalog.pg_depend
 ORDER BY objid
 ----
 classid     objid       objsubid  refclassid  refobjid   refobjsubid  deptype
-4294967214  58          0         4294967214  55         1            n
-4294967214  58          0         4294967214  55         2            n
-4294967214  58          0         4294967214  55         3            n
-4294967214  58          0         4294967214  55         4            n
-4294967212  2143281868  0         4294967214  450499961  0            n
-4294967212  2355671820  0         4294967214  0          0            n
-4294967212  3911002394  0         4294967214  0          0            n
-4294967212  4089604113  0         4294967214  450499960  0            n
+4294967213  58          0         4294967213  55         1            n
+4294967213  58          0         4294967213  55         2            n
+4294967213  58          0         4294967213  55         3            n
+4294967213  58          0         4294967213  55         4            n
+4294967211  2143281868  0         4294967213  450499961  0            n
+4294967211  2355671820  0         4294967213  0          0            n
+4294967211  3911002394  0         4294967213  0          0            n
+4294967211  4089604113  0         4294967213  450499960  0            n
 
 # Some entries in pg_depend are dependency links from the pg_constraint system
 # table to the pg_class system table. Other entries are links to pg_class when it is
@@ -1067,8 +1067,8 @@ JOIN pg_class cla ON classid=cla.oid
 JOIN pg_class refcla ON refclassid=refcla.oid
 ----
 classid     refclassid  tablename      reftablename
-4294967214  4294967214  pg_class       pg_class
-4294967212  4294967214  pg_constraint  pg_class
+4294967213  4294967213  pg_class       pg_class
+4294967211  4294967213  pg_constraint  pg_class
 
 # Some entries in pg_depend are foreign key constraints that reference an index
 # in pg_class. Other entries are table-view dependencies
@@ -1776,130 +1776,131 @@ SELECT objoid, classoid, objsubid, regexp_replace(description, e'\n.*', '') AS d
   FROM pg_catalog.pg_description
 ----
 objoid      classoid    objsubid  description
-4294967294  4294967214  0         backward inter-descriptor dependencies starting from tables accessible by current user in current database (KV scan)
-4294967292  4294967214  0         built-in functions (RAM/static)
-4294967252  4294967214  0         virtual table with database privileges
-4294967291  4294967214  0         running queries visible by current user (cluster RPC; expensive!)
-4294967289  4294967214  0         running sessions visible to current user (cluster RPC; expensive!)
-4294967288  4294967214  0         cluster settings (RAM)
-4294967290  4294967214  0         running user transactions visible by the current user (cluster RPC; expensive!)
-4294967287  4294967214  0         CREATE and ALTER statements for all tables accessible by current user in current database (KV scan)
-4294967286  4294967214  0         CREATE statements for all user defined types accessible by the current user in current database (KV scan)
-4294967285  4294967214  0         databases accessible by the current user (KV scan)
-4294967284  4294967214  0         telemetry counters (RAM; local node only)
-4294967283  4294967214  0         forward inter-descriptor dependencies starting from tables accessible by current user in current database (KV scan)
-4294967281  4294967214  0         locally known gossiped health alerts (RAM; local node only)
-4294967280  4294967214  0         locally known gossiped node liveness (RAM; local node only)
-4294967279  4294967214  0         locally known edges in the gossip network (RAM; local node only)
-4294967282  4294967214  0         locally known gossiped node details (RAM; local node only)
-4294967278  4294967214  0         index columns for all indexes accessible by current user in current database (KV scan)
-4294967253  4294967214  0         virtual table to validate descriptors
-4294967277  4294967214  0         decoded job metadata from system.jobs (KV scan)
-4294967276  4294967214  0         node details across the entire cluster (cluster RPC; expensive!)
-4294967275  4294967214  0         store details and status (cluster RPC; expensive!)
-4294967274  4294967214  0         acquired table leases (RAM; local node only)
-4294967293  4294967214  0         detailed identification strings (RAM, local node only)
-4294967270  4294967214  0         current values for metrics (RAM; local node only)
-4294967273  4294967214  0         running queries visible by current user (RAM; local node only)
-4294967265  4294967214  0         server parameters, useful to construct connection URLs (RAM, local node only)
-4294967271  4294967214  0         running sessions visible by current user (RAM; local node only)
-4294967261  4294967214  0         statement statistics (in-memory, not durable; local node only). This table is wiped periodically (by default, at least every two hours)
-4294967256  4294967214  0         finer-grained transaction statistics (in-memory, not durable; local node only). This table is wiped periodically (by default, at least every two hours)
-4294967272  4294967214  0         running user transactions visible by the current user (RAM; local node only)
-4294967255  4294967214  0         per-application transaction statistics (in-memory, not durable; local node only). This table is wiped periodically (by default, at least every two hours)
-4294967269  4294967214  0         defined partitions for all tables/indexes accessible by the current user in the current database (KV scan)
-4294967268  4294967214  0         comments for predefined virtual tables (RAM/static)
-4294967267  4294967214  0         range metadata without leaseholder details (KV join; expensive!)
-4294967264  4294967214  0         ongoing schema changes, across all descriptors accessible by current user (KV scan; expensive!)
-4294967263  4294967214  0         session trace accumulated so far (RAM)
-4294967262  4294967214  0         session variables (RAM)
-4294967260  4294967214  0         details for all columns accessible by current user in current database (KV scan)
-4294967259  4294967214  0         indexes accessible by current user in current database (KV scan)
-4294967257  4294967214  0         the latest stats for all tables accessible by current user in current database (KV scan)
-4294967258  4294967214  0         table descriptors accessible by current user, including non-public and virtual (KV scan; expensive!)
-4294967254  4294967214  0         decoded zone configurations from system.zones (KV scan)
-4294967250  4294967214  0         roles for which the current user has admin option
-4294967249  4294967214  0         roles available to the current user
-4294967248  4294967214  0         character sets available in the current database
-4294967247  4294967214  0         check constraints
-4294967246  4294967214  0         identifies which character set the available collations are
-4294967245  4294967214  0         shows the collations available in the current database
-4294967244  4294967214  0         column privilege grants (incomplete)
-4294967242  4294967214  0         columns with user defined types
-4294967243  4294967214  0         table and view columns (incomplete)
-4294967241  4294967214  0         columns usage by constraints
-4294967240  4294967214  0         roles for the current user
-4294967239  4294967214  0         column usage by indexes and key constraints
-4294967238  4294967214  0         built-in function parameters (empty - introspection not yet supported)
-4294967237  4294967214  0         foreign key constraints
-4294967236  4294967214  0         privileges granted on table or views (incomplete; see also information_schema.table_privileges; may contain excess users or roles)
-4294967235  4294967214  0         built-in functions (empty - introspection not yet supported)
-4294967233  4294967214  0         schema privileges (incomplete; may contain excess users or roles)
-4294967234  4294967214  0         database schemas (may contain schemata without permission)
-4294967231  4294967214  0         sequences
-4294967232  4294967214  0         exposes the session variables.
-4294967230  4294967214  0         index metadata and statistics (incomplete)
-4294967229  4294967214  0         table constraints
-4294967228  4294967214  0         privileges granted on table or views (incomplete; may contain excess users or roles)
-4294967227  4294967214  0         tables and views
-4294967226  4294967214  0         type privileges (incomplete; may contain excess users or roles)
-4294967224  4294967214  0         grantable privileges (incomplete)
-4294967225  4294967214  0         views (incomplete)
-4294967222  4294967214  0         aggregated built-in functions (incomplete)
-4294967221  4294967214  0         index access methods (incomplete)
-4294967220  4294967214  0         column default values
-4294967219  4294967214  0         table columns (incomplete - see also information_schema.columns)
-4294967217  4294967214  0         role membership
-4294967218  4294967214  0         authorization identifiers - differs from postgres as we do not display passwords,
-4294967216  4294967214  0         available extensions
-4294967215  4294967214  0         casts (empty - needs filling out)
-4294967214  4294967214  0         tables and relation-like objects (incomplete - see also information_schema.tables/sequences/views)
-4294967213  4294967214  0         available collations (incomplete)
-4294967212  4294967214  0         table constraints (incomplete - see also information_schema.table_constraints)
-4294967211  4294967214  0         encoding conversions (empty - unimplemented)
-4294967210  4294967214  0         available databases (incomplete)
-4294967209  4294967214  0         default ACLs (empty - unimplemented)
-4294967208  4294967214  0         dependency relationships (incomplete)
-4294967207  4294967214  0         object comments
-4294967205  4294967214  0         enum types and labels (empty - feature does not exist)
-4294967204  4294967214  0         event triggers (empty - feature does not exist)
-4294967203  4294967214  0         installed extensions (empty - feature does not exist)
-4294967202  4294967214  0         foreign data wrappers (empty - feature does not exist)
-4294967201  4294967214  0         foreign servers (empty - feature does not exist)
-4294967200  4294967214  0         foreign tables (empty  - feature does not exist)
-4294967199  4294967214  0         indexes (incomplete)
-4294967198  4294967214  0         index creation statements
-4294967197  4294967214  0         table inheritance hierarchy (empty - feature does not exist)
-4294967196  4294967214  0         available languages (empty - feature does not exist)
-4294967195  4294967214  0         locks held by active processes (empty - feature does not exist)
-4294967194  4294967214  0         available materialized views (empty - feature does not exist)
-4294967193  4294967214  0         available namespaces (incomplete; namespaces and databases are congruent in CockroachDB)
-4294967192  4294967214  0         opclass (empty - Operator classes not supported yet)
-4294967191  4294967214  0         operators (incomplete)
-4294967190  4294967214  0         prepared statements
-4294967189  4294967214  0         prepared transactions (empty - feature does not exist)
-4294967188  4294967214  0         built-in functions (incomplete)
-4294967187  4294967214  0         range types (empty - feature does not exist)
-4294967186  4294967214  0         rewrite rules (empty - feature does not exist)
-4294967185  4294967214  0         database roles
-4294967172  4294967214  0         security labels (empty - feature does not exist)
-4294967184  4294967214  0         security labels (empty)
-4294967183  4294967214  0         sequences (see also information_schema.sequences)
-4294967182  4294967214  0         session variables (incomplete)
-4294967181  4294967214  0         shared dependencies (empty - not implemented)
-4294967206  4294967214  0         shared object comments
-4294967171  4294967214  0         shared security labels (empty - feature not supported)
-4294967173  4294967214  0         backend access statistics (empty - monitoring works differently in CockroachDB)
-4294967178  4294967214  0         tables summary (see also information_schema.tables, pg_catalog.pg_class)
-4294967177  4294967214  0         available tablespaces (incomplete; concept inapplicable to CockroachDB)
-4294967176  4294967214  0         triggers (empty - feature does not exist)
-4294967175  4294967214  0         scalar types (incomplete)
-4294967180  4294967214  0         database users
-4294967179  4294967214  0         local to remote user mapping (empty - feature does not exist)
-4294967174  4294967214  0         view definitions (incomplete - see also information_schema.views)
-4294967169  4294967214  0         Shows all defined geography columns. Matches PostGIS' geography_columns functionality.
-4294967168  4294967214  0         Shows all defined geometry columns. Matches PostGIS' geometry_columns functionality.
-4294967167  4294967214  0         Shows all defined Spatial Reference Identifiers (SRIDs). Matches PostGIS' spatial_ref_sys table.
+4294967294  4294967213  0         backward inter-descriptor dependencies starting from tables accessible by current user in current database (KV scan)
+4294967292  4294967213  0         built-in functions (RAM/static)
+4294967251  4294967213  0         virtual table with database privileges
+4294967291  4294967213  0         running queries visible by current user (cluster RPC; expensive!)
+4294967289  4294967213  0         running sessions visible to current user (cluster RPC; expensive!)
+4294967288  4294967213  0         cluster settings (RAM)
+4294967290  4294967213  0         running user transactions visible by the current user (cluster RPC; expensive!)
+4294967287  4294967213  0         CREATE and ALTER statements for all tables accessible by current user in current database (KV scan)
+4294967286  4294967213  0         CREATE statements for all user defined types accessible by the current user in current database (KV scan)
+4294967285  4294967213  0         databases accessible by the current user (KV scan)
+4294967284  4294967213  0         telemetry counters (RAM; local node only)
+4294967283  4294967213  0         forward inter-descriptor dependencies starting from tables accessible by current user in current database (KV scan)
+4294967281  4294967213  0         locally known gossiped health alerts (RAM; local node only)
+4294967280  4294967213  0         locally known gossiped node liveness (RAM; local node only)
+4294967279  4294967213  0         locally known edges in the gossip network (RAM; local node only)
+4294967282  4294967213  0         locally known gossiped node details (RAM; local node only)
+4294967278  4294967213  0         index columns for all indexes accessible by current user in current database (KV scan)
+4294967252  4294967213  0         virtual table to validate descriptors
+4294967276  4294967213  0         decoded job metadata from system.jobs (KV scan)
+4294967275  4294967213  0         node details across the entire cluster (cluster RPC; expensive!)
+4294967274  4294967213  0         store details and status (cluster RPC; expensive!)
+4294967273  4294967213  0         acquired table leases (RAM; local node only)
+4294967293  4294967213  0         detailed identification strings (RAM, local node only)
+4294967277  4294967213  0         in-flight spans (RAM; local node only)
+4294967269  4294967213  0         current values for metrics (RAM; local node only)
+4294967272  4294967213  0         running queries visible by current user (RAM; local node only)
+4294967264  4294967213  0         server parameters, useful to construct connection URLs (RAM, local node only)
+4294967270  4294967213  0         running sessions visible by current user (RAM; local node only)
+4294967260  4294967213  0         statement statistics (in-memory, not durable; local node only). This table is wiped periodically (by default, at least every two hours)
+4294967255  4294967213  0         finer-grained transaction statistics (in-memory, not durable; local node only). This table is wiped periodically (by default, at least every two hours)
+4294967271  4294967213  0         running user transactions visible by the current user (RAM; local node only)
+4294967254  4294967213  0         per-application transaction statistics (in-memory, not durable; local node only). This table is wiped periodically (by default, at least every two hours)
+4294967268  4294967213  0         defined partitions for all tables/indexes accessible by the current user in the current database (KV scan)
+4294967267  4294967213  0         comments for predefined virtual tables (RAM/static)
+4294967266  4294967213  0         range metadata without leaseholder details (KV join; expensive!)
+4294967263  4294967213  0         ongoing schema changes, across all descriptors accessible by current user (KV scan; expensive!)
+4294967262  4294967213  0         session trace accumulated so far (RAM)
+4294967261  4294967213  0         session variables (RAM)
+4294967259  4294967213  0         details for all columns accessible by current user in current database (KV scan)
+4294967258  4294967213  0         indexes accessible by current user in current database (KV scan)
+4294967256  4294967213  0         the latest stats for all tables accessible by current user in current database (KV scan)
+4294967257  4294967213  0         table descriptors accessible by current user, including non-public and virtual (KV scan; expensive!)
+4294967253  4294967213  0         decoded zone configurations from system.zones (KV scan)
+4294967249  4294967213  0         roles for which the current user has admin option
+4294967248  4294967213  0         roles available to the current user
+4294967247  4294967213  0         character sets available in the current database
+4294967246  4294967213  0         check constraints
+4294967245  4294967213  0         identifies which character set the available collations are
+4294967244  4294967213  0         shows the collations available in the current database
+4294967243  4294967213  0         column privilege grants (incomplete)
+4294967241  4294967213  0         columns with user defined types
+4294967242  4294967213  0         table and view columns (incomplete)
+4294967240  4294967213  0         columns usage by constraints
+4294967239  4294967213  0         roles for the current user
+4294967238  4294967213  0         column usage by indexes and key constraints
+4294967237  4294967213  0         built-in function parameters (empty - introspection not yet supported)
+4294967236  4294967213  0         foreign key constraints
+4294967235  4294967213  0         privileges granted on table or views (incomplete; see also information_schema.table_privileges; may contain excess users or roles)
+4294967234  4294967213  0         built-in functions (empty - introspection not yet supported)
+4294967232  4294967213  0         schema privileges (incomplete; may contain excess users or roles)
+4294967233  4294967213  0         database schemas (may contain schemata without permission)
+4294967230  4294967213  0         sequences
+4294967231  4294967213  0         exposes the session variables.
+4294967229  4294967213  0         index metadata and statistics (incomplete)
+4294967228  4294967213  0         table constraints
+4294967227  4294967213  0         privileges granted on table or views (incomplete; may contain excess users or roles)
+4294967226  4294967213  0         tables and views
+4294967225  4294967213  0         type privileges (incomplete; may contain excess users or roles)
+4294967223  4294967213  0         grantable privileges (incomplete)
+4294967224  4294967213  0         views (incomplete)
+4294967221  4294967213  0         aggregated built-in functions (incomplete)
+4294967220  4294967213  0         index access methods (incomplete)
+4294967219  4294967213  0         column default values
+4294967218  4294967213  0         table columns (incomplete - see also information_schema.columns)
+4294967216  4294967213  0         role membership
+4294967217  4294967213  0         authorization identifiers - differs from postgres as we do not display passwords,
+4294967215  4294967213  0         available extensions
+4294967214  4294967213  0         casts (empty - needs filling out)
+4294967213  4294967213  0         tables and relation-like objects (incomplete - see also information_schema.tables/sequences/views)
+4294967212  4294967213  0         available collations (incomplete)
+4294967211  4294967213  0         table constraints (incomplete - see also information_schema.table_constraints)
+4294967210  4294967213  0         encoding conversions (empty - unimplemented)
+4294967209  4294967213  0         available databases (incomplete)
+4294967208  4294967213  0         default ACLs (empty - unimplemented)
+4294967207  4294967213  0         dependency relationships (incomplete)
+4294967206  4294967213  0         object comments
+4294967204  4294967213  0         enum types and labels (empty - feature does not exist)
+4294967203  4294967213  0         event triggers (empty - feature does not exist)
+4294967202  4294967213  0         installed extensions (empty - feature does not exist)
+4294967201  4294967213  0         foreign data wrappers (empty - feature does not exist)
+4294967200  4294967213  0         foreign servers (empty - feature does not exist)
+4294967199  4294967213  0         foreign tables (empty  - feature does not exist)
+4294967198  4294967213  0         indexes (incomplete)
+4294967197  4294967213  0         index creation statements
+4294967196  4294967213  0         table inheritance hierarchy (empty - feature does not exist)
+4294967195  4294967213  0         available languages (empty - feature does not exist)
+4294967194  4294967213  0         locks held by active processes (empty - feature does not exist)
+4294967193  4294967213  0         available materialized views (empty - feature does not exist)
+4294967192  4294967213  0         available namespaces (incomplete; namespaces and databases are congruent in CockroachDB)
+4294967191  4294967213  0         opclass (empty - Operator classes not supported yet)
+4294967190  4294967213  0         operators (incomplete)
+4294967189  4294967213  0         prepared statements
+4294967188  4294967213  0         prepared transactions (empty - feature does not exist)
+4294967187  4294967213  0         built-in functions (incomplete)
+4294967186  4294967213  0         range types (empty - feature does not exist)
+4294967185  4294967213  0         rewrite rules (empty - feature does not exist)
+4294967184  4294967213  0         database roles
+4294967171  4294967213  0         security labels (empty - feature does not exist)
+4294967183  4294967213  0         security labels (empty)
+4294967182  4294967213  0         sequences (see also information_schema.sequences)
+4294967181  4294967213  0         session variables (incomplete)
+4294967180  4294967213  0         shared dependencies (empty - not implemented)
+4294967205  4294967213  0         shared object comments
+4294967170  4294967213  0         shared security labels (empty - feature not supported)
+4294967172  4294967213  0         backend access statistics (empty - monitoring works differently in CockroachDB)
+4294967177  4294967213  0         tables summary (see also information_schema.tables, pg_catalog.pg_class)
+4294967176  4294967213  0         available tablespaces (incomplete; concept inapplicable to CockroachDB)
+4294967175  4294967213  0         triggers (empty - feature does not exist)
+4294967174  4294967213  0         scalar types (incomplete)
+4294967179  4294967213  0         database users
+4294967178  4294967213  0         local to remote user mapping (empty - feature does not exist)
+4294967173  4294967213  0         view definitions (incomplete - see also information_schema.views)
+4294967168  4294967213  0         Shows all defined geography columns. Matches PostGIS' geography_columns functionality.
+4294967167  4294967213  0         Shows all defined geometry columns. Matches PostGIS' geometry_columns functionality.
+4294967166  4294967213  0         Shows all defined Spatial Reference Identifiers (SRIDs). Matches PostGIS' spatial_ref_sys table.
 
 ## pg_catalog.pg_shdescription
 

--- a/pkg/sql/logictest/testdata/logic_test/table
+++ b/pkg/sql/logictest/testdata/logic_test/table
@@ -556,6 +556,7 @@ kv_node_status                         NULL
 kv_store_status                        NULL
 leases                                 NULL
 node_build_info                        NULL
+node_inflight_trace_spans              NULL
 node_metrics                           NULL
 node_queries                           NULL
 node_runtime_info                      NULL

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -129,11 +129,9 @@ func (tc *TestCluster) stopServers(ctx context.Context) {
 		// [1]: cleanupSessionTempObjects
 		tracer := tc.Server(i).Tracer().(*tracing.Tracer)
 		testutils.SucceedsSoon(tc.t, func() error {
-			var err error
-			tracer.VisitSpans(func(span *tracing.Span) {
-				err = errors.Newf("expected to find no active spans, found %s", span.Meta())
+			return tracer.VisitSpans(func(span *tracing.Span) error {
+				return errors.Newf("expected to find no active spans, found %s", span.Meta())
 			})
-			return err
 		})
 	}
 }

--- a/pkg/util/tracing/crdbspan.go
+++ b/pkg/util/tracing/crdbspan.go
@@ -246,6 +246,13 @@ func (s *crdbSpan) getRecordingLocked(m mode) tracingpb.RecordedSpan {
 		Duration:     s.mu.duration,
 	}
 
+	if rs.Duration == -1 {
+		// -1 indicates an unfinished Span. For a recording it's better to put some
+		// duration in it, otherwise tools get confused. For example, we export
+		// recordings to Jaeger, and spans with a zero duration don't look nice.
+		rs.Duration = timeutil.Now().Sub(rs.StartTime)
+	}
+
 	addTag := func(k, v string) {
 		if rs.Tags == nil {
 			rs.Tags = make(map[string]string)
@@ -257,11 +264,7 @@ func (s *crdbSpan) getRecordingLocked(m mode) tracingpb.RecordedSpan {
 	// related to Span UX improvements.
 	onlyBackgroundTracing := m == modeBackground && s.recordingType() == RecordingOff
 	if !onlyBackgroundTracing {
-		if rs.Duration == -1 {
-			// -1 indicates an unfinished Span. For a recording it's better to put some
-			// duration in it, otherwise tools get confused. For example, we export
-			// recordings to Jaeger, and spans with a zero duration don't look nice.
-			rs.Duration = timeutil.Now().Sub(rs.StartTime)
+		if s.mu.duration == -1 {
 			addTag("_unfinished", "1")
 		}
 		if s.mu.recording.recordingType.load() == RecordingVerbose {

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -605,7 +605,7 @@ func (t *Tracer) Extract(format interface{}, carrier interface{}) (*SpanMeta, er
 }
 
 // VisitSpans invokes the visitor with all active Spans.
-func (t *Tracer) VisitSpans(visitor func(*Span)) {
+func (t *Tracer) VisitSpans(visitor func(*Span) error) error {
 	t.activeSpans.Lock()
 	sl := make([]*Span, 0, len(t.activeSpans.m))
 	for sp := range t.activeSpans.m {
@@ -614,8 +614,11 @@ func (t *Tracer) VisitSpans(visitor func(*Span)) {
 	t.activeSpans.Unlock()
 
 	for _, sp := range sl {
-		visitor(sp)
+		if err := visitor(sp); err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
 // ForkCtxSpan checks if ctx has a Span open; if it does, it creates a new Span


### PR DESCRIPTION
This change adds a virtual table, `crdb_internal.node_inflight_trace_spans`
that exposes data on currently inflight spans in the current node.
The table includes information on the span IDs, parent span IDs, trace IDs,
start time, duration (measured by time of collection - start time of the
span), and the span's operation.

Part 1 of addressing #55733. Will follow up with a built-in that will
allow querying of a particular span ID to surface more detailed
recording information.


Release note (sql change): Adds a virtual table,
`crdb_internal.node_inflight_trace_spans`, which exposes span ID, parent span
ID, trace ID, start time, duration, and operation of node-local inflight spans.