### PR TITLE
opt: calculate stats for JSON fetch value operator

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
@@ -332,19 +332,15 @@ vectorized: true
               table: d@foo_inv
               spans: /{}-/{}/PrefixEnd /???-/[]
 
-
-# TODO(mgartner): It should not be required to force the index scan. It is
-# required until the statistics builder treats b->'a' = '"b"' similarly to the
-# containment operator, @>.
 query T
-EXPLAIN (VERBOSE) SELECT * from d@foo_inv where b->'a' = '"b"'
+EXPLAIN (VERBOSE) SELECT * from d where b->'a' = '"b"'
 ----
 distribution: local
 vectorized: true
 ·
 • index join
 │ columns: (a, b)
-│ estimated row count: 333 (missing stats)
+│ estimated row count: 111 (missing stats)
 │ table: d@primary
 │ key columns: a
 │
@@ -364,7 +360,7 @@ vectorized: true
 ·
 • filter
 │ columns: (a, b)
-│ estimated row count: 333 (missing stats)
+│ estimated row count: 111 (missing stats)
 │ filter: ((b->'a')->'c') = '"b"'
 │
 └── • scan
@@ -382,18 +378,15 @@ vectorized: true
 • norows
   columns: (a, b)
 
-# TODO(mgartner): It should not be required to force the index scan. It is
-# required until the statistics builder treats b->'a' = '"b"' similarly to the
-# containment operator, @>.
 query T
-EXPLAIN (VERBOSE) SELECT * from d@foo_inv where '"b"' = b->'a'
+EXPLAIN (VERBOSE) SELECT * from d where '"b"' = b->'a'
 ----
 distribution: local
 vectorized: true
 ·
 • index join
 │ columns: (a, b)
-│ estimated row count: 333 (missing stats)
+│ estimated row count: 111 (missing stats)
 │ table: d@primary
 │ key columns: a
 │

--- a/pkg/sql/opt/memo/testdata/stats/inverted-json
+++ b/pkg/sql/opt/memo/testdata/stats/inverted-json
@@ -131,6 +131,26 @@ index-join t
       │                <--- '\x3763000112640001' --- '\x3763000112640002'
       └── key: (1)
 
+# A query with the fetch val operator results in the same stats as a query with
+# the containment operator.
+opt
+SELECT * FROM t WHERE j->'c' = '"d"'
+----
+index-join t
+ ├── columns: k:1(int!null) j:2(jsonb)
+ ├── immutable
+ ├── stats: [rows=222.222222]
+ ├── key: (1)
+ ├── fd: (1)-->(2)
+ └── scan t@j_idx
+      ├── columns: k:1(int!null)
+      ├── inverted constraint: /4/1
+      │    └── spans: ["7c\x00\x01\x12d\x00\x01", "7c\x00\x01\x12d\x00\x01"]
+      ├── stats: [rows=100, distinct(4)=1, null(4)=0]
+      │   histogram(4)=  0          100           0           0
+      │                <--- '\x3763000112640001' --- '\x3763000112640002'
+      └── key: (1)
+
 # A disjunction requires scanning all entries that match either the left or the
 # right.
 opt


### PR DESCRIPTION
The statistics builder has a special case for estimating selectivity of
a filter with a JSON or ARRAY contains operator, `@>`. This commit
expands this special case to include filters with the JSON fetch value,
for example `j->'a' = '1'.

The inverted constraint generated from a query filter with a fetch value
operator (for example `j->'a' = '1'`) is equivalent to the inverted
constraint generated from the equivalent containment expression (for
example `j @> '{"a": "b"}`). Statistics are generated for inverted scans
based on the inverted constraints, so no code changes are required for
inverted scan stats.

Fixes #55319

Release note: None
