### PR TITLE
opt: index accelerate chained fetch value operators

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/inverted_index
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index
@@ -744,7 +744,15 @@ INSERT INTO f VALUES
   (2, '{"b": 2}'),
   (3, '{"b": 2, "a": 1}'),
   (4, '{"a": 1, "c": 3}'),
-  (5, '{"a": [1, 2]}')
+  (5, '{"a": [1, 2]}'),
+  (6, '{"a": {"b": 1}}'),
+  (7, '{"a": {"b": 1, "d": 2}}'),
+  (8, '{"a": {"d": 2}}'),
+  (9, '{"a": {"b": [1, 2]}}'),
+  (10, '{"a": {"b": {"c": 1}}}'),
+  (11, '{"a": {"b": {"c": 1, "d": 2}}}}'),
+  (12, '{"a": {"b": {"d": 2}}}}'),
+  (13, '{"a": {"b": {"c": [1, 2]}}}')
 
 query T
 SELECT j FROM f@i WHERE j->'a' = '1' ORDER BY k
@@ -768,6 +776,18 @@ SELECT j FROM f@i WHERE j->'a' = '1' OR j @> '{"b": 2}' ORDER BY k
 {"b": 2}
 {"a": 1, "b": 2}
 {"a": 1, "c": 3}
+
+query T
+SELECT j FROM f@i WHERE j->'a'->'b' = '1' ORDER BY k
+----
+{"a": {"b": 1}}
+{"a": {"b": 1, "d": 2}}
+
+query T
+SELECT j FROM f@i WHERE j->'a'->'b'->'c' = '1' ORDER BY k
+----
+{"a": {"b": {"c": 1}}}
+{"a": {"b": {"c": 1, "d": 2}}}
 
 subtest arrays
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
@@ -350,24 +350,23 @@ vectorized: true
       table: d@foo_inv
       spans: /"a"/"b"-/"a"/"b"/PrefixEnd
 
-# TODO(mgartner): Add support for building inverted index constraints for chained JSON
-# fetch operators.
 query T
-EXPLAIN (VERBOSE) SELECT * from d where b->'a'->'c' = '"b"'
+EXPLAIN (VERBOSE) SELECT * from d@foo_inv where b->'a'->'c' = '"b"'
 ----
 distribution: local
 vectorized: true
 ·
-• filter
+• index join
 │ columns: (a, b)
 │ estimated row count: 111 (missing stats)
-│ filter: ((b->'a')->'c') = '"b"'
+│ table: d@primary
+│ key columns: a
 │
 └── • scan
-      columns: (a, b)
-      estimated row count: 1,000 (missing stats)
-      table: d@primary
-      spans: FULL SCAN
+      columns: (a)
+      estimated row count: 111 (missing stats)
+      table: d@foo_inv
+      spans: /"a"/"c"/"b"-/"a"/"c"/"b"/PrefixEnd
 
 query T
 EXPLAIN (VERBOSE) SELECT * from d where b->(NULL::STRING) = '"b"'

--- a/pkg/sql/opt/invertedidx/json_array_test.go
+++ b/pkg/sql/opt/invertedidx/json_array_test.go
@@ -425,6 +425,33 @@ func TestTryFilterJsonOrArrayIndex(t *testing.T) {
 			ok:       false,
 		},
 		{
+			filters:  "j->'a'->'b' = '1'",
+			indexOrd: jsonOrd,
+			ok:       true,
+			tight:    true,
+			unique:   true,
+		},
+		{
+			filters:  "j->'a'->'b'->'c' = '1'",
+			indexOrd: jsonOrd,
+			ok:       true,
+			tight:    true,
+			unique:   true,
+		},
+		{
+			// Integer indexes are not yet supported.
+			filters:  "j->0->'b' = '1'",
+			indexOrd: jsonOrd,
+			ok:       false,
+		},
+		{
+			// The inner most expression is not a fetch val expression with an
+			// indexed column on the left.
+			filters:  "(j-'c')->'a'->'b' = '1'",
+			indexOrd: jsonOrd,
+			ok:       false,
+		},
+		{
 			filters:  "j->'a' = '1' AND j->'b' = '2'",
 			indexOrd: jsonOrd,
 			ok:       true,

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -1951,6 +1951,20 @@ project
       │    └── spans: ["7a\x00\x01\x12b\x00\x01", "7a\x00\x01\x12b\x00\x01"]
       └── key: (1)
 
+# Chained fetch val operators.
+opt expect=GenerateInvertedIndexScans
+SELECT k FROM b WHERE j->'a'->'b' = '"c"'
+----
+project
+ ├── columns: k:1!null
+ ├── immutable
+ ├── key: (1)
+ └── scan b@j_inv_idx
+      ├── columns: k:1!null
+      ├── inverted constraint: /6/1
+      │    └── spans: ["7a\x00\x02b\x00\x01\x12c\x00\x01", "7a\x00\x02b\x00\x01\x12c\x00\x01"]
+      └── key: (1)
+
 # Do not generate an inverted scan when the fetch val and equality operators are
 # wrapped in a NOT operator. The -> operator returns NULL if the key does not
 # exist in the JSON object, so (NOT j->'a' = '"b"') is not equivalent to the

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -1951,6 +1951,30 @@ project
       │    └── spans: ["7a\x00\x01\x12b\x00\x01", "7a\x00\x01\x12b\x00\x01"]
       └── key: (1)
 
+# Do not generate an inverted scan when the fetch val and equality operators are
+# wrapped in a NOT operator. The -> operator returns NULL if the key does not
+# exist in the JSON object, so (NOT j->'a' = '"b"') is not equivalent to the
+# inverse of the existence of the key/value pair {"a": "b"} in the inverted
+# index. See #49143 and #55316.
+opt expect-not=GenerateInvertedIndexScans
+SELECT k FROM b WHERE NOT j->'a' = '"b"'
+----
+project
+ ├── columns: k:1!null
+ ├── immutable
+ ├── key: (1)
+ └── select
+      ├── columns: k:1!null j:4
+      ├── immutable
+      ├── key: (1)
+      ├── fd: (1)-->(4)
+      ├── scan b
+      │    ├── columns: k:1!null j:4
+      │    ├── key: (1)
+      │    └── fd: (1)-->(4)
+      └── filters
+           └── (j:4->'a') != '"b"' [outer=(4), immutable]
+
 # Do not generate an inverted scan when the index of the fetch val operator is
 # not a string.
 opt expect-not=GenerateInvertedIndexScans


### PR DESCRIPTION
#### opt: add test for JSON fetch val inverse

Release note: None

#### opt: index accelerate chained fetch value operators

Prior to #55316, the optimizer generated inverted index scans on indexed
JSON columns when queries had filters with chained fetch value
operators, for example `j->'a'->'b' = '1'`. The logic that made this
possible was found to create query plans not equivalent to the query, so
it was removed. This commit restores the ability to index accelerate
chained -> operators.

Fixes #55317

Release note (performance improvement): A bug fix included in 20.2.1 for
for the JSON fetch value operator, `->`, resulted in chained `->`
operators in query filters not being index accelerated, e.g.,
`j->'a'->'b' = '1'`. Chained `->` are now index accelerated.
