### PR TITLE
opt: scan partial indexes with virtual columns in predicate

### DIFF
--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -1349,8 +1349,14 @@ func (mb *mutationBuilder) arbiterIndexesAndConstraints(
 		// If the index is a pseudo-partial index, it can always be an arbiter.
 		// Furthermore, it is the only arbiter needed because it guarantees
 		// uniqueness of its columns across all rows.
+		// TODO(mgartner): Add UPSERT tests for partial index predicates with
+		// virtual computed columns once UPSERTs of virtual columns are
+		// supported. It's not necessary for virtual column expressions to be
+		// inlined, as long as virtual column expressions are also not inlined
+		// in arbiterFilters below, so we can consider passing a boolean to
+		// buildPartialIndexPredicate to prevent unnecessary inlining.
 		predFilter, err := mb.b.buildPartialIndexPredicate(
-			tableScope, mb.parsePartialIndexPredicateExpr(idx), "index predicate",
+			tabMeta, tableScope, mb.parsePartialIndexPredicateExpr(idx), "index predicate",
 		)
 		if err != nil {
 			panic(err)
@@ -1371,8 +1377,15 @@ func (mb *mutationBuilder) arbiterIndexesAndConstraints(
 
 			// Build the arbiter filters once.
 			if arbiterFilters == nil {
+				// TODO(mgartner): Add UPSERT tests for arbiter predicates with
+				// virtual computed columns once UPSERTs of virtual columns are
+				// supported. It's not necessary for virtual column expressions
+				// to be inlined, as long as virtual column expressions are also
+				// not inlined in predFilter above, so we can consider passing a
+				// boolean to buildPartialIndexPredicate to prevent unnecessary
+				// inlining.
 				arbiterFilters, err = mb.b.buildPartialIndexPredicate(
-					tableScope, arbiterPredicate, "arbiter predicate",
+					tabMeta, tableScope, arbiterPredicate, "arbiter predicate",
 				)
 				if err != nil {
 					// The error is due to a non-immutable operator in the arbiter

--- a/pkg/sql/opt/optbuilder/testdata/delete
+++ b/pkg/sql/opt/optbuilder/testdata/delete
@@ -540,7 +540,7 @@ delete partial_index_virtual
       │    │    │         └── lower(c:8)
       │    │    └── partial index predicates
       │    │         └── secondary: filters
-      │    │              └── d:9 = 'foo'
+      │    │              └── lower(c:8) = 'foo'
       │    └── projections
       │         └── lower(c:8) [as=d:9]
       └── projections

--- a/pkg/sql/opt/optbuilder/testdata/select
+++ b/pkg/sql/opt/optbuilder/testdata/select
@@ -1414,6 +1414,41 @@ project
                 └── ((v:3 > 100) AND (v:3 < 200)) AND (u:2 > 50)
 
 exec-ddl
+CREATE TABLE partial_index_comp (
+  k INT PRIMARY KEY,
+  u INT,
+  v INT AS (u + 10) VIRTUAL,
+  w INT AS (u + 100) STORED,
+  INDEX v_idx (u) WHERE v > 0,
+  INDEX w_idx (u) WHERE w > 0
+)
+----
+
+# Inline virtual computed column expressions in partial index predicates in
+# table metadata. Do not inline stored computed column expressions.
+build
+SELECT k FROM partial_index_comp
+----
+project
+ ├── columns: k:1!null
+ └── project
+      ├── columns: v:3 k:1!null u:2 w:4 crdb_internal_mvcc_timestamp:5
+      ├── scan partial_index_comp
+      │    ├── columns: k:1!null u:2 w:4 crdb_internal_mvcc_timestamp:5
+      │    ├── computed column expressions
+      │    │    ├── v:3
+      │    │    │    └── u:2 + 10
+      │    │    └── w:4
+      │    │         └── u:2 + 100
+      │    └── partial index predicates
+      │         ├── v_idx: filters
+      │         │    └── (u:2 + 10) > 0
+      │         └── w_idx: filters
+      │              └── w:4 > 0
+      └── projections
+           └── u:2 + 10 [as=v:3]
+
+exec-ddl
 CREATE TABLE inaccessible (
     k INT PRIMARY KEY,
     "v:inaccessible" INT

--- a/pkg/sql/opt/optbuilder/testdata/update
+++ b/pkg/sql/opt/optbuilder/testdata/update
@@ -1808,7 +1808,7 @@ update partial_index_virtual
       │    │    │    │    │         └── lower(c:8)
       │    │    │    │    └── partial index predicates
       │    │    │    │         └── secondary: filters
-      │    │    │    │              └── d:9 = 'foo'
+      │    │    │    │              └── lower(c:8) = 'foo'
       │    │    │    └── projections
       │    │    │         └── lower(c:8) [as=d:9]
       │    │    └── projections
@@ -1844,7 +1844,7 @@ update partial_index_virtual
       │    │    │    │    │         └── lower(c:8)
       │    │    │    │    └── partial index predicates
       │    │    │    │         └── secondary: filters
-      │    │    │    │              └── d:9 = 'foo'
+      │    │    │    │              └── lower(c:8) = 'foo'
       │    │    │    └── projections
       │    │    │         └── lower(c:8) [as=d:9]
       │    │    └── projections

--- a/pkg/sql/opt/optbuilder/testdata/upsert
+++ b/pkg/sql/opt/optbuilder/testdata/upsert
@@ -2175,7 +2175,7 @@ insert partial_index_virtual
       │    │    │    │    │         └── lower(c:12)
       │    │    │    │    └── partial index predicates
       │    │    │    │         └── secondary: filters
-      │    │    │    │              └── d:13 = 'foo'
+      │    │    │    │              └── lower(c:12) = 'foo'
       │    │    │    └── projections
       │    │    │         └── lower(c:12) [as=d:13]
       │    │    └── filters
@@ -2245,7 +2245,7 @@ upsert partial_index_virtual
       │    │    │    │    │    │    │         └── lower(c:12)
       │    │    │    │    │    │    └── partial index predicates
       │    │    │    │    │    │         └── secondary: filters
-      │    │    │    │    │    │              └── d:13 = 'foo'
+      │    │    │    │    │    │              └── lower(c:12) = 'foo'
       │    │    │    │    │    └── projections
       │    │    │    │    │         └── lower(c:12) [as=d:13]
       │    │    │    │    └── filters
@@ -2315,7 +2315,7 @@ upsert partial_index_virtual
       │    │    │    │    │         └── lower(c:12)
       │    │    │    │    └── partial index predicates
       │    │    │    │         └── secondary: filters
-      │    │    │    │              └── d:13 = 'foo'
+      │    │    │    │              └── lower(c:12) = 'foo'
       │    │    │    └── projections
       │    │    │         └── lower(c:12) [as=d:13]
       │    │    └── filters

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -116,6 +116,16 @@ CREATE TABLE computed (
 )
 ----
 
+exec-ddl
+CREATE TABLE virtual (
+    k INT PRIMARY KEY,
+    a INT,
+    b INT,
+    c INT AS (b + 10) VIRTUAL,
+    INDEX (a) WHERE c IN (10, 20, 30)
+)
+----
+
 # --------------------------------------------------
 # GeneratePartialIndexScans
 # --------------------------------------------------
@@ -320,6 +330,58 @@ DROP INDEX idx
 exec-ddl
 DROP INDEX idx2
 ----
+
+opt
+SELECT k FROM virtual WHERE c IN (10, 20, 30)
+----
+project
+ ├── columns: k:1!null
+ ├── immutable
+ ├── key: (1)
+ └── scan virtual@secondary,partial
+      ├── columns: k:1!null
+      └── key: (1)
+
+# TODO(mgartner): The normalization of the query filter from (c = 20) to ((b +
+# 10) = 20) to (b = 10) and the lack of constraints for the partial index
+# predicate ((b + 10) IN (10, 20, 30)) prevents implication from being proven. A
+# normalization rule similar to NormalizeCmpPlusConst, but that applies to an IN
+# expression might resolve this specific issue. However, there could be many
+# more combinations of filters and predicates that make partial index
+# implication difficult or impossible.
+opt
+SELECT k FROM virtual WHERE c = 20
+----
+project
+ ├── columns: k:1!null
+ ├── key: (1)
+ └── select
+      ├── columns: k:1!null b:3!null
+      ├── key: (1)
+      ├── fd: ()-->(3)
+      ├── scan virtual
+      │    ├── columns: k:1!null b:3
+      │    ├── computed column expressions
+      │    │    └── c:4
+      │    │         └── b:3 + 10
+      │    ├── partial index predicates
+      │    │    └── secondary: filters
+      │    │         └── (b:3 + 10) IN (10, 20, 30) [outer=(3), immutable]
+      │    ├── key: (1)
+      │    └── fd: (1)-->(3)
+      └── filters
+           └── b:3 = 10 [outer=(3), constraints=(/3: [/10 - /10]; tight), fd=()-->(3)]
+
+opt
+SELECT k FROM virtual WHERE (b + 10) IN (10, 20, 30)
+----
+project
+ ├── columns: k:1!null
+ ├── immutable
+ ├── key: (1)
+ └── scan virtual@secondary,partial
+      ├── columns: k:1!null
+      └── key: (1)
 
 # --------------------------------------------------
 # GenerateConstrainedScans
@@ -1591,6 +1653,52 @@ memo (optimized, ~7KB, required=[presentation: i:1])
 exec-ddl
 DROP INDEX idx
 ----
+
+# Constrained partial index scan with a virtual computed column in the
+# predicate.
+opt
+SELECT k FROM virtual WHERE a > 10 AND a < 20 AND c IN (10, 20, 30)
+----
+project
+ ├── columns: k:1!null
+ ├── immutable
+ ├── key: (1)
+ └── scan virtual@secondary,partial
+      ├── columns: k:1!null a:2!null
+      ├── constraint: /2/1: [/11 - /19]
+      ├── key: (1)
+      └── fd: (1)-->(2)
+
+# TODO(mgartner): The normalization of the query filter from (c = 20) to ((b +
+# 10) = 20) to (b = 10) and the lack of constraints for the partial index
+# predicate ((b + 10) IN (10, 20, 30)) prevents implication from being proven. A
+# normalization rule similar to NormalizeCmpPlusConst, but that applies to an IN
+# expression might resolve this specific issue. However, there could be many
+# more combinations of filters and predicates that make partial index
+# implication difficult or impossible.
+opt
+SELECT k FROM virtual WHERE a > 10 AND a < 20 AND c = 20
+----
+project
+ ├── columns: k:1!null
+ ├── key: (1)
+ └── select
+      ├── columns: k:1!null a:2!null b:3!null
+      ├── key: (1)
+      ├── fd: ()-->(3), (1)-->(2)
+      ├── scan virtual
+      │    ├── columns: k:1!null a:2 b:3
+      │    ├── computed column expressions
+      │    │    └── c:4
+      │    │         └── b:3 + 10
+      │    ├── partial index predicates
+      │    │    └── secondary: filters
+      │    │         └── (b:3 + 10) IN (10, 20, 30) [outer=(3), immutable]
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2,3)
+      └── filters
+           ├── (a:2 > 10) AND (a:2 < 20) [outer=(2), constraints=(/2: [/11 - /19]; tight)]
+           └── b:3 = 10 [outer=(3), constraints=(/3: [/10 - /10]; tight), fd=()-->(3)]
 
 # Regression test for #55387. GenerateConstrainedScans should not reduce the
 # input filters when proving partial index implication.


### PR DESCRIPTION
This commit makes it possible for the optimizer to generate scans on
partial indexes with predicates that have references to virtual columns.
When partial index predicate expressions are added to table metadata,
virtual column expressions are inlined. This allows implication to be
proven by a query filter with virtual columns that have also been
inlined by the PushSelectIntoInlinableProject rule.

Unfortunately, this only supports query filters that have expressions
that exactly match the partial index predicate. Partial index
implication is not guaranteed to be proven for queries that imply
a partial index predicate in theory, but do not have exactly matching
expressions. For example:

    CREATE TABLE t (
      k INT PRIMARY KEY,
      a INT,
      b INT,
      c INT AS (b + 10) VIRTUAL,
      INDEX (a) WHERE c IN (10, 20, 30)
    )

    SELECT k FROM t WHERE c = 20

The virtual column in the query filter `c = 20` is inlined to
`(b + 10) = 20` and the expression is normalized to `b = 10`. The
virtual column in the partial index `c IN (10, 20, 30)` is normalized to
`(b + 10) IN (10, 20, 30)`. Implication cannot easily be proven for the
filter `b = 10` and the predicate `(b + 10) IN (10, 20, 30)`.

Release note: None