### PR TITLE
sql,ccl: add checks for implicitly partitioned unique indexes

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
@@ -408,3 +408,63 @@ CREATE TABLE public.t (
   PARTITION two VALUES FROM (2) TO (MAXVALUE)
 )
 -- Warning: Partitioned table with no zone configurations.
+
+subtest unique-checks
+
+# We should plan uniqueness checks for all implicitly partitioned unique indexes.
+query T
+EXPLAIN INSERT INTO t VALUES (1, 1, 1, 1, 1, 1, 1)
+----
+distribution: local
+vectorized: true
+·
+• root
+│
+├── • insert
+│   │ into: t(pk, pk2, partition_by, a, b, c, d)
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • values
+│             size: 7 columns, 1 row
+│
+├── • constraint-check
+│   │
+│   └── • error if rows
+│       │
+│       └── • hash join (right semi)
+│           │ equality: (pk) = (column1)
+│           │ right cols are key
+│           │ pred: column3 != partition_by
+│           │
+│           ├── • scan
+│           │     missing stats
+│           │     table: t@t_a_idx
+│           │     spans: FULL SCAN
+│           │
+│           └── • scan buffer
+│                 label: buffer 1
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │
+        └── • hash join (right semi)
+            │ equality: (b) = (column5)
+            │ right cols are key
+            │ pred: (column1 != pk) OR (column3 != partition_by)
+            │
+            ├── • scan
+            │     missing stats
+            │     table: t@t_b_key
+            │     spans: FULL SCAN
+            │
+            └── • scan buffer
+                  label: buffer 1
+
+statement ok
+INSERT INTO t VALUES (1, 1, 1, 1, 1, 1, 1), (2, 2, 2, 2, 2, 2, 2)
+
+statement error pq: duplicate key value violates unique constraint "t_b_key"\nDETAIL: Key \(b\)=\(1\) already exists\.
+UPDATE t SET b = 1 WHERE pk = 2

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
@@ -206,6 +206,82 @@ CREATE INDEX new_idx ON regional_by_row_table(a, b)
 statement ok
 ALTER TABLE regional_by_row_table ADD CONSTRAINT unique_b_a UNIQUE(b, a)
 
+# We should plan uniqueness checks for all unique indexes in
+# REGIONAL BY ROW tables.
+query T
+EXPLAIN INSERT INTO regional_by_row_table VALUES (1, 1, 1)
+----
+distribution: local
+vectorized: true
+·
+• root
+│
+├── • insert
+│   │ into: regional_by_row_table(pk, a, b, crdb_region)
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • values
+│             size: 5 columns, 1 row
+│
+├── • constraint-check
+│   │
+│   └── • error if rows
+│       │
+│       └── • lookup join (semi)
+│           │ table: regional_by_row_table@primary
+│           │ equality: (lookup_join_const_col_@17, column1) = (crdb_region,pk)
+│           │ equality cols are key
+│           │ pred: column10 != crdb_region
+│           │
+│           └── • cross join
+│               │
+│               ├── • values
+│               │     size: 1 column, 3 rows
+│               │
+│               └── • scan buffer
+│                     label: buffer 1
+│
+├── • constraint-check
+│   │
+│   └── • error if rows
+│       │
+│       └── • lookup join (semi)
+│           │ table: regional_by_row_table@regional_by_row_table_b_key
+│           │ equality: (lookup_join_const_col_@26, column3) = (crdb_region,b)
+│           │ equality cols are key
+│           │ pred: (column1 != pk) OR (column10 != crdb_region)
+│           │
+│           └── • cross join
+│               │
+│               ├── • values
+│               │     size: 1 column, 3 rows
+│               │
+│               └── • scan buffer
+│                     label: buffer 1
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │
+        └── • lookup join (semi)
+            │ table: regional_by_row_table@new_idx
+            │ equality: (lookup_join_const_col_@36, column2, column3) = (crdb_region,a,b)
+            │ equality cols are key
+            │ pred: (column1 != pk) OR (column10 != crdb_region)
+            │
+            └── • cross join
+                │
+                ├── • values
+                │     size: 1 column, 3 rows
+                │
+                └── • scan buffer
+                      label: buffer 1
+
+statement error pq: duplicate key value violates unique constraint "regional_by_row_table_b_key"\nDETAIL: Key \(b\)=\(3\) already exists\.
+INSERT INTO regional_by_row_table (crdb_region, pk, a, b) VALUES ('us-east-1', 2, 2, 3)
+
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE regional_by_row_table]
 ----


### PR DESCRIPTION
This commit teaches the optimizer that it should enforce the unique
constraints on implicitly partitioned unique indexes. Simply adding
these constraints to the optimizer catalog is sufficient to ensure
that the optimizer plans uniqueness checks for these indexes. This
commit includes a few tests to show that this works for both implicitly
partitioned tables and `REGIONAL BY ROW` tables.

Release note (sql change): The optimizer now enforces a unique constraint
on the explicit index columns for implicitly partitioned unique indexes
and unique indexes in `REGIONAL BY ROW` tables. An attempt to insert or
update a row such that the unique constraint is violated will result in
an error.