### PR TITLE
workload/cli: add --init-conns for init INSERT

### DIFF
--- a/pkg/workload/cli/run.go
+++ b/pkg/workload/cli/run.go
@@ -57,6 +57,8 @@ var sharedFlags = pflag.NewFlagSet(`shared`, pflag.ContinueOnError)
 var pprofport = sharedFlags.Int("pprofport", 33333, "Port for pprof endpoint.")
 var dataLoader = sharedFlags.String("data-loader", `INSERT`,
 	"How to load initial table data. Options are INSERT and IMPORT")
+var initConns = sharedFlags.Int("init-conns", 16,
+	"The number of connections to use during INSERT init")
 
 var displayEvery = runFlags.Duration("display-every", time.Second, "How much time between every one-line activity reports.")
 
@@ -277,10 +279,7 @@ func runInitImpl(
 	switch strings.ToLower(*dataLoader) {
 	case `insert`, `inserts`:
 		l = workloadsql.InsertsDataLoader{
-			// TODO(dan): Don't hardcode this. Similar to dbOverride, this should be
-			// hooked up to a flag directly once once more of run.go moves inside
-			// workload.
-			Concurrency: 16,
+			Concurrency: *initConns,
 		}
 	case `import`, `imports`:
 		l = workload.ImportDataLoader


### PR DESCRIPTION
Previously the number of connections when doing workload init INSERT was
hardcoded to 16.
This isn't always optimal and in case of free-tier clusters, it leads to
timeouts on the server side (because of 10s default login timeout).
This PR now allows the caller to override the default 16 by specifying a
--init-conns XX flag.

Release note: None