### PR TITLE
sql: refactor zone config setting code for multi-region

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/alter_table_locality
+++ b/pkg/ccl/logictestccl/testdata/logic_test/alter_table_locality
@@ -237,7 +237,6 @@ TABLE global  ALTER TABLE global CONFIGURE ZONE USING
               range_min_bytes = 134217728,
               range_max_bytes = 536870912,
               gc.ttlseconds = 90000,
-              global_reads = true,
               num_replicas = 3,
               constraints = '{+region=ap-southeast-2: 3}',
               lease_preferences = '[[+region=ap-southeast-2]]'
@@ -644,3 +643,35 @@ CREATE TABLE regional_by_table_in_us_east (i int) LOCALITY REGIONAL BY TABLE IN 
 
 statement error unimplemented: implementation pending
 ALTER TABLE regional_by_table_in_us_east SET LOCALITY REGIONAL BY ROW
+
+# Set a table with a gc.ttlseconds to be a non-default value, and check this is
+# the same after a change to REGIONAL BY TABLE IN PRIMARY REGION, which truncates
+# other fields.
+statement ok
+CREATE TABLE rbt_table_gc_ttl () LOCALITY REGIONAL BY TABLE IN "us-east-1"
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE rbt_table_gc_ttl
+----
+TABLE rbt_table_gc_ttl  ALTER TABLE rbt_table_gc_ttl CONFIGURE ZONE USING
+                        range_min_bytes = 134217728,
+                        range_max_bytes = 536870912,
+                        gc.ttlseconds = 90000,
+                        num_replicas = 3,
+                        constraints = '{+region=us-east-1: 3}',
+                        lease_preferences = '[[+region=us-east-1]]'
+
+statement ok
+ALTER TABLE rbt_table_gc_ttl CONFIGURE ZONE USING gc.ttlseconds = 999;
+ALTER TABLE rbt_table_gc_ttl SET LOCALITY REGIONAL BY TABLE IN PRIMARY REGION
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE rbt_table_gc_ttl
+----
+TABLE rbt_table_gc_ttl  ALTER TABLE rbt_table_gc_ttl CONFIGURE ZONE USING
+                        range_min_bytes = 134217728,
+                        range_max_bytes = 536870912,
+                        gc.ttlseconds = 999,
+                        num_replicas = 3,
+                        constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                        lease_preferences = '[[+region=ca-central-1]]'

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
@@ -98,6 +98,10 @@ CREATE TABLE public.regional_by_row_table (
   UNIQUE INDEX regional_by_row_table_b_key (b ASC),
   FAMILY fam_0_pk_pk2_a_b_crdb_region (pk, pk2, a, b, crdb_region)
 ) LOCALITY REGIONAL BY ROW;
+ALTER PARTITION "ap-southeast-2" OF INDEX multi_region_test_db.public.regional_by_row_table@primary CONFIGURE ZONE USING
+  num_replicas = 3,
+  constraints = '{+region=ap-southeast-2: 1}',
+  lease_preferences = '[[+region=ap-southeast-2]]';
 ALTER PARTITION "ap-southeast-2" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
   num_replicas = 3,
   constraints = '{+region=ap-southeast-2: 1}',
@@ -106,10 +110,10 @@ ALTER PARTITION "ap-southeast-2" OF INDEX multi_region_test_db.public.regional_b
   num_replicas = 3,
   constraints = '{+region=ap-southeast-2: 1}',
   lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX multi_region_test_db.public.regional_by_row_table@primary CONFIGURE ZONE USING
+ALTER PARTITION "ca-central-1" OF INDEX multi_region_test_db.public.regional_by_row_table@primary CONFIGURE ZONE USING
   num_replicas = 3,
-  constraints = '{+region=ap-southeast-2: 1}',
-  lease_preferences = '[[+region=ap-southeast-2]]';
+  constraints = '{+region=ca-central-1: 1}',
+  lease_preferences = '[[+region=ca-central-1]]';
 ALTER PARTITION "ca-central-1" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
   num_replicas = 3,
   constraints = '{+region=ca-central-1: 1}',
@@ -118,19 +122,15 @@ ALTER PARTITION "ca-central-1" OF INDEX multi_region_test_db.public.regional_by_
   num_replicas = 3,
   constraints = '{+region=ca-central-1: 1}',
   lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX multi_region_test_db.public.regional_by_row_table@primary CONFIGURE ZONE USING
+ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row_table@primary CONFIGURE ZONE USING
   num_replicas = 3,
-  constraints = '{+region=ca-central-1: 1}',
-  lease_preferences = '[[+region=ca-central-1]]';
+  constraints = '{+region=us-east-1: 1}',
+  lease_preferences = '[[+region=us-east-1]]';
 ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
   num_replicas = 3,
   constraints = '{+region=us-east-1: 1}',
   lease_preferences = '[[+region=us-east-1]]';
 ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
-  num_replicas = 3,
-  constraints = '{+region=us-east-1: 1}',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row_table@primary CONFIGURE ZONE USING
   num_replicas = 3,
   constraints = '{+region=us-east-1: 1}',
   lease_preferences = '[[+region=us-east-1]]'
@@ -300,6 +300,10 @@ CREATE TABLE public.regional_by_row_table (
   UNIQUE INDEX unique_b_a (b ASC, a ASC),
   FAMILY fam_0_pk_pk2_a_b_crdb_region (pk, pk2, a, b, crdb_region)
 ) LOCALITY REGIONAL BY ROW;
+ALTER PARTITION "ap-southeast-2" OF INDEX multi_region_test_db.public.regional_by_row_table@primary CONFIGURE ZONE USING
+  num_replicas = 3,
+  constraints = '{+region=ap-southeast-2: 1}',
+  lease_preferences = '[[+region=ap-southeast-2]]';
 ALTER PARTITION "ap-southeast-2" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
   num_replicas = 3,
   constraints = '{+region=ap-southeast-2: 1}',
@@ -308,10 +312,10 @@ ALTER PARTITION "ap-southeast-2" OF INDEX multi_region_test_db.public.regional_b
   num_replicas = 3,
   constraints = '{+region=ap-southeast-2: 1}',
   lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX multi_region_test_db.public.regional_by_row_table@primary CONFIGURE ZONE USING
+ALTER PARTITION "ca-central-1" OF INDEX multi_region_test_db.public.regional_by_row_table@primary CONFIGURE ZONE USING
   num_replicas = 3,
-  constraints = '{+region=ap-southeast-2: 1}',
-  lease_preferences = '[[+region=ap-southeast-2]]';
+  constraints = '{+region=ca-central-1: 1}',
+  lease_preferences = '[[+region=ca-central-1]]';
 ALTER PARTITION "ca-central-1" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
   num_replicas = 3,
   constraints = '{+region=ca-central-1: 1}',
@@ -320,19 +324,15 @@ ALTER PARTITION "ca-central-1" OF INDEX multi_region_test_db.public.regional_by_
   num_replicas = 3,
   constraints = '{+region=ca-central-1: 1}',
   lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX multi_region_test_db.public.regional_by_row_table@primary CONFIGURE ZONE USING
+ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row_table@primary CONFIGURE ZONE USING
   num_replicas = 3,
-  constraints = '{+region=ca-central-1: 1}',
-  lease_preferences = '[[+region=ca-central-1]]';
+  constraints = '{+region=us-east-1: 1}',
+  lease_preferences = '[[+region=us-east-1]]';
 ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
   num_replicas = 3,
   constraints = '{+region=us-east-1: 1}',
   lease_preferences = '[[+region=us-east-1]]';
 ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
-  num_replicas = 3,
-  constraints = '{+region=us-east-1: 1}',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row_table@primary CONFIGURE ZONE USING
   num_replicas = 3,
   constraints = '{+region=us-east-1: 1}',
   lease_preferences = '[[+region=us-east-1]]';
@@ -480,6 +480,10 @@ CREATE TABLE public.regional_by_row_table_as (
   UNIQUE INDEX regional_by_row_table_as_b_key (b ASC),
   FAMILY fam_0_pk_a_b_crdb_region_col (pk, a, b, crdb_region_col)
 ) LOCALITY REGIONAL BY ROW AS crdb_region_col;
+ALTER PARTITION "ap-southeast-2" OF INDEX multi_region_test_db.public.regional_by_row_table_as@primary CONFIGURE ZONE USING
+  num_replicas = 3,
+  constraints = '{+region=ap-southeast-2: 1}',
+  lease_preferences = '[[+region=ap-southeast-2]]';
 ALTER PARTITION "ap-southeast-2" OF INDEX multi_region_test_db.public.regional_by_row_table_as@regional_by_row_table_as_a_idx CONFIGURE ZONE USING
   num_replicas = 3,
   constraints = '{+region=ap-southeast-2: 1}',
@@ -488,10 +492,10 @@ ALTER PARTITION "ap-southeast-2" OF INDEX multi_region_test_db.public.regional_b
   num_replicas = 3,
   constraints = '{+region=ap-southeast-2: 1}',
   lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX multi_region_test_db.public.regional_by_row_table_as@primary CONFIGURE ZONE USING
+ALTER PARTITION "ca-central-1" OF INDEX multi_region_test_db.public.regional_by_row_table_as@primary CONFIGURE ZONE USING
   num_replicas = 3,
-  constraints = '{+region=ap-southeast-2: 1}',
-  lease_preferences = '[[+region=ap-southeast-2]]';
+  constraints = '{+region=ca-central-1: 1}',
+  lease_preferences = '[[+region=ca-central-1]]';
 ALTER PARTITION "ca-central-1" OF INDEX multi_region_test_db.public.regional_by_row_table_as@regional_by_row_table_as_a_idx CONFIGURE ZONE USING
   num_replicas = 3,
   constraints = '{+region=ca-central-1: 1}',
@@ -500,19 +504,15 @@ ALTER PARTITION "ca-central-1" OF INDEX multi_region_test_db.public.regional_by_
   num_replicas = 3,
   constraints = '{+region=ca-central-1: 1}',
   lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX multi_region_test_db.public.regional_by_row_table_as@primary CONFIGURE ZONE USING
+ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row_table_as@primary CONFIGURE ZONE USING
   num_replicas = 3,
-  constraints = '{+region=ca-central-1: 1}',
-  lease_preferences = '[[+region=ca-central-1]]';
+  constraints = '{+region=us-east-1: 1}',
+  lease_preferences = '[[+region=us-east-1]]';
 ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row_table_as@regional_by_row_table_as_a_idx CONFIGURE ZONE USING
   num_replicas = 3,
   constraints = '{+region=us-east-1: 1}',
   lease_preferences = '[[+region=us-east-1]]';
 ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row_table_as@regional_by_row_table_as_b_key CONFIGURE ZONE USING
-  num_replicas = 3,
-  constraints = '{+region=us-east-1: 1}',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row_table_as@primary CONFIGURE ZONE USING
   num_replicas = 3,
   constraints = '{+region=us-east-1: 1}',
   lease_preferences = '[[+region=us-east-1]]'
@@ -568,6 +568,32 @@ PARTITION "us-east-1" OF TABLE t_regional_by_row  ALTER PARTITION "us-east-1" OF
                                                   range_min_bytes = 134217728,
                                                   range_max_bytes = 536870912,
                                                   gc.ttlseconds = 90000,
+                                                  num_replicas = 3,
+                                                  constraints = '{+region=us-east-1: 3}',
+                                                  lease_preferences = '[[+region=us-east-1]]'
+
+# Test setting non-multi-region fields on tables behaves as appropriate.
+statement ok
+ALTER TABLE t_regional_by_row CONFIGURE ZONE USING gc.ttlseconds = 999
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE t_regional_by_row
+----
+TABLE t_regional_by_row  ALTER TABLE t_regional_by_row CONFIGURE ZONE USING
+                         range_min_bytes = 134217728,
+                         range_max_bytes = 536870912,
+                         gc.ttlseconds = 999,
+                         num_replicas = 3,
+                         constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                         lease_preferences = '[[+region=us-east-1]]'
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE t_regional_by_row PARTITION "us-east-1"
+----
+PARTITION "us-east-1" OF TABLE t_regional_by_row  ALTER PARTITION "us-east-1" OF TABLE t_regional_by_row CONFIGURE ZONE USING
+                                                  range_min_bytes = 134217728,
+                                                  range_max_bytes = 536870912,
+                                                  gc.ttlseconds = 999,
                                                   num_replicas = 3,
                                                   constraints = '{+region=us-east-1: 3}',
                                                   lease_preferences = '[[+region=us-east-1]]'

--- a/pkg/config/zonepb/zone.go
+++ b/pkg/config/zonepb/zone.go
@@ -531,52 +531,45 @@ func (z *ZoneConfig) InheritFromParent(parent *ZoneConfig) {
 // CopyFromZone copies over the specified fields from the other zone.
 func (z *ZoneConfig) CopyFromZone(other ZoneConfig, fieldList []tree.Name) {
 	for _, fieldName := range fieldList {
-		if fieldName == "num_replicas" {
+		switch fieldName {
+		case "num_replicas":
 			z.NumReplicas = nil
 			if other.NumReplicas != nil {
 				z.NumReplicas = proto.Int32(*other.NumReplicas)
 			}
-		}
-		if fieldName == "num_voters" {
+		case "num_voters":
 			z.NumVoters = nil
 			if other.NumVoters != nil {
 				z.NumVoters = proto.Int32(*other.NumVoters)
 			}
-		}
-		if fieldName == "range_min_bytes" {
+		case "range_min_bytes":
 			z.RangeMinBytes = nil
 			if other.RangeMinBytes != nil {
 				z.RangeMinBytes = proto.Int64(*other.RangeMinBytes)
 			}
-		}
-		if fieldName == "range_max_bytes" {
+		case "range_max_bytes":
 			z.RangeMaxBytes = nil
 			if other.RangeMaxBytes != nil {
 				z.RangeMaxBytes = proto.Int64(*other.RangeMaxBytes)
 			}
-		}
-		if fieldName == "global_reads" {
+		case "global_reads":
 			z.GlobalReads = nil
 			if other.GlobalReads != nil {
 				z.GlobalReads = proto.Bool(*other.GlobalReads)
 			}
-		}
-		if fieldName == "gc.ttlseconds" {
+		case "gc.ttlseconds":
 			z.GC = nil
 			if other.GC != nil {
 				tempGC := *other.GC
 				z.GC = &tempGC
 			}
-		}
-		if fieldName == "constraints" {
+		case "constraints":
 			z.Constraints = other.Constraints
 			z.InheritedConstraints = other.InheritedConstraints
-		}
-		if fieldName == "voter_constraints" {
+		case "voter_constraints":
 			z.VoterConstraints = other.VoterConstraints
 			z.InheritedVoterConstraints = other.InheritedVoterConstraints
-		}
-		if fieldName == "lease_preferences" {
+		case "lease_preferences":
 			z.LeasePreferences = other.LeasePreferences
 			z.InheritedLeasePreferences = other.InheritedLeasePreferences
 		}

--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -579,11 +579,13 @@ func (p *planner) configureZoneConfigForNewIndexPartitioning(
 		if err != nil {
 			return err
 		}
-		if err := p.addNewZoneConfigSubzonesForIndex(
+		if err := applyZoneConfigForMultiRegionTable(
 			ctx,
-			tableDesc,
-			indexDesc.ID,
+			p.txn,
+			p.ExecCfg(),
 			*dbDesc.RegionConfig,
+			tableDesc,
+			applyZoneConfigForMultiRegionTableOptionNewIndex(indexDesc.ID),
 		); err != nil {
 			return err
 		}

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -372,11 +372,13 @@ func (n *createTableNode) startExec(params runParams) error {
 		if err != nil {
 			return errors.Wrap(err, "error resolving database for multi-region")
 		}
-		if err := params.p.applyZoneConfigFromTableLocalityConfig(
+		if err := applyZoneConfigForMultiRegionTable(
 			params.ctx,
-			n.n.Table,
-			desc.TableDesc(),
+			params.p.txn,
+			params.p.ExecCfg(),
 			*dbDesc.RegionConfig,
+			desc,
+			applyZoneConfigForMultiRegionTableOptionTableAndIndexes,
 		); err != nil {
 			return err
 		}

--- a/pkg/sql/region_util.go
+++ b/pkg/sql/region_util.go
@@ -12,11 +12,11 @@ package sql
 
 import (
 	"context"
-	"fmt"
 	"sort"
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/dbdesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -184,46 +184,52 @@ func constraintsConjunctionForRegionalLocality(
 	}
 }
 
+var multiRegionZoneConfigFields = []tree.Name{
+	"constraints",
+	"global_reads",
+	"lease_preferences",
+	"num_replicas",
+	"voter_constraints",
+}
+
 // zoneConfigFromTableLocalityConfig generates a desired ZoneConfig based
 // on the locality config for the database.
-// This function can return a nil zonepb.ZoneConfig, meaning no table level zone
-// configuration is required.
+// Relevant multi-region configured fields swill be overwritten by the calling function
+// into an existing ZoneConfig using multiRegionZoneConfigFields.
 // TODO(#multiregion,aayushshah15): properly configure this for region survivability and leaseholder
 // preferences when new zone configuration parameters merge.
 func zoneConfigFromTableLocalityConfig(
 	localityConfig descpb.TableDescriptor_LocalityConfig,
 	regionConfig descpb.DatabaseDescriptor_RegionConfig,
-) (*zonepb.ZoneConfig, error) {
-	ret := zonepb.ZoneConfig{
-		NumReplicas: proto.Int32(zoneConfigNumReplicasFromRegionConfig(regionConfig)),
-	}
+) (zonepb.ZoneConfig, error) {
+	ret := *(zonepb.NewZoneConfig())
 
 	switch l := localityConfig.Locality.(type) {
 	case *descpb.TableDescriptor_LocalityConfig_Global_:
 		// Enable non-blocking transactions.
 		ret.GlobalReads = proto.Bool(true)
-		// Inherit constraints and leaseholders from the database.
-		ret.InheritedConstraints = true
-		ret.InheritedLeasePreferences = true
 	case *descpb.TableDescriptor_LocalityConfig_RegionalByTable_:
 		// Use the same configuration as the database and return nil here.
 		if l.RegionalByTable.Region == nil {
-			return nil, nil
+			return ret, nil
 		}
+		ret.NumReplicas = proto.Int32(zoneConfigNumReplicasFromRegionConfig(regionConfig))
 		preferredRegion := *l.RegionalByTable.Region
 		var err error
 		if ret.Constraints, err = constraintsConjunctionForRegionalLocality(preferredRegion, regionConfig); err != nil {
-			return nil, err
+			return ret, err
 		}
 		ret.LeasePreferences = []zonepb.LeasePreference{
 			{Constraints: []zonepb.Constraint{makeRequiredZoneConstraintForRegion(preferredRegion)}},
 		}
+		ret.InheritedLeasePreferences = false
+		ret.InheritedConstraints = false
 	case *descpb.TableDescriptor_LocalityConfig_RegionalByRow_:
 		// We purposely do not set anything here at table level - this should be done at
 		// partition level instead.
-		return nil, nil
+		return ret, nil
 	}
-	return &ret, nil
+	return ret, nil
 }
 
 // TODO(#multiregion): everything using this should instead use getZoneConfigRaw
@@ -259,130 +265,154 @@ func (p *planner) applyZoneConfigForMultiRegion(
 	return nil
 }
 
-func (p *planner) applyZoneConfigFromTableLocalityConfig(
-	ctx context.Context,
-	tblName tree.TableName,
-	desc *descpb.TableDescriptor,
+// applyZoneConfigForMultiRegionTableOption is an option that can be passed into
+// applyZoneConfigForMultiRegionTable.
+type applyZoneConfigForMultiRegionTableOption func(
+	zoneConfig zonepb.ZoneConfig,
 	regionConfig descpb.DatabaseDescriptor_RegionConfig,
-) error {
-	localityConfig := *desc.LocalityConfig
+	table catalog.TableDescriptor,
+) (hasNewSubzones bool, newZoneConfig zonepb.ZoneConfig, err error)
 
-	// Construct an explicit name so that CONFIGURE ZONE has the fully qualified name.
-	// Without this, the table may fail to resolve.
-	explicitTblName := tree.MakeTableNameWithSchema(
-		tblName.CatalogName,
-		tblName.SchemaName,
-		tblName.ObjectName,
-	)
-
-	// Apply zone configs for each index partition.
-	// TODO(otan): depending on what we decide for cascading zone configs, some of this
-	// code will have to change.
-	switch localityConfig.Locality.(type) {
-	case *descpb.TableDescriptor_LocalityConfig_RegionalByRow_:
+// applyZoneConfigForMultiRegionTableOptionNewIndex applies table zone configs
+// for a newly added index which requires partitioning of individual indexes.
+func applyZoneConfigForMultiRegionTableOptionNewIndex(
+	indexID descpb.IndexID,
+) applyZoneConfigForMultiRegionTableOption {
+	return func(
+		zoneConfig zonepb.ZoneConfig,
+		regionConfig descpb.DatabaseDescriptor_RegionConfig,
+		table catalog.TableDescriptor,
+	) (hasNewSubzones bool, newZoneConfig zonepb.ZoneConfig, err error) {
 		for _, region := range regionConfig.Regions {
 			zc, err := zoneConfigFromRegionConfigForPartition(region, regionConfig)
 			if err != nil {
-				return err
+				return false, zoneConfig, err
 			}
-
-			for _, idx := range desc.Indexes {
-				if err := p.applyZoneConfigForMultiRegion(
-					ctx,
-					tree.ZoneSpecifier{
-						TableOrIndex: tree.TableIndexName{
-							Table: explicitTblName,
-							Index: tree.UnrestrictedName(idx.Name),
-						},
-						Partition: tree.Name(region.Name),
-					},
-					&zc,
-					"index-multiregion-set-zone-config",
-				); err != nil {
-					return err
-				}
-			}
-
-			if err := p.applyZoneConfigForMultiRegion(
-				ctx,
-				tree.ZoneSpecifier{
-					TableOrIndex: tree.TableIndexName{
-						Table: explicitTblName,
-						Index: tree.UnrestrictedName(desc.PrimaryIndex.Name),
-					},
-					Partition: tree.Name(region.Name),
-				},
-				&zc,
-				"primary-index-multiregion-set-zone-config",
-			); err != nil {
-				return err
-			}
+			zoneConfig.SetSubzone(zonepb.Subzone{
+				IndexID:       uint32(indexID),
+				PartitionName: string(region.Name),
+				Config:        zc,
+			})
 		}
+		return true, zoneConfig, nil
 	}
+}
+
+// applyZoneConfigForMultiRegionTableOptionTableAndIndexes applies table zone configs
+// on the entire table as well as its indexes, replacing multi-region related zone
+// configuration fields.
+var applyZoneConfigForMultiRegionTableOptionTableAndIndexes = func(
+	zc zonepb.ZoneConfig,
+	regionConfig descpb.DatabaseDescriptor_RegionConfig,
+	table catalog.TableDescriptor,
+) (bool, zonepb.ZoneConfig, error) {
+	localityConfig := *table.GetLocalityConfig()
 
 	localityZoneConfig, err := zoneConfigFromTableLocalityConfig(
 		localityConfig,
 		regionConfig,
 	)
 	if err != nil {
-		return err
+		return false, zonepb.ZoneConfig{}, err
 	}
+	zc.CopyFromZone(localityZoneConfig, multiRegionZoneConfigFields)
 
-	// This means that the table doesn't need an explicit zone configuration. Drop
-	// one if it already exists and return.
-	if localityZoneConfig == nil {
-		return p.dropZoneConfigForTable(ctx, explicitTblName)
+	hasNewSubzones := table.IsLocalityRegionalByRow()
+	if hasNewSubzones {
+		// Mark the zone config as a placeholder zone config if it is currently empty and we are
+		// adding subzones.
+		// See zonepb.IsSubzonePlaceholder for why this is necessary.
+		if zc.Equal(zonepb.NewZoneConfig()) {
+			zc.NumReplicas = proto.Int32(0)
+		}
+
+		for _, region := range regionConfig.Regions {
+			subzoneConfig, err := zoneConfigFromRegionConfigForPartition(region, regionConfig)
+			if err != nil {
+				return false, zc, err
+			}
+			for _, idx := range table.NonDropIndexes() {
+				zc.SetSubzone(zonepb.Subzone{
+					IndexID:       uint32(idx.GetID()),
+					PartitionName: string(region.Name),
+					Config:        subzoneConfig,
+				})
+			}
+		}
 	}
-
-	return p.applyZoneConfigForMultiRegion(
-		ctx,
-		tree.ZoneSpecifier{TableOrIndex: tree.TableIndexName{Table: explicitTblName}},
-		localityZoneConfig,
-		"table-multiregion-set-zone-config",
-	)
+	return hasNewSubzones, zc, nil
 }
 
-// addNewZoneConfigSubzonesForIndex updates the ZoneConfig for the given index,
-// assuming a zone config already exists for the given table and that the index
-// has previously not had a subzone defined.
-func (p *planner) addNewZoneConfigSubzonesForIndex(
+// applyZoneConfigForMultiRegionTable applies zone config settings based
+// on the options provided.
+func applyZoneConfigForMultiRegionTable(
 	ctx context.Context,
-	table catalog.TableDescriptor,
-	indexID descpb.IndexID,
+	txn *kv.Txn,
+	execCfg *ExecutorConfig,
 	regionConfig descpb.DatabaseDescriptor_RegionConfig,
+	table catalog.TableDescriptor,
+	opt applyZoneConfigForMultiRegionTableOption,
 ) error {
 	tableID := table.GetID()
-	zone, err := getZoneConfigRaw(ctx, p.txn, p.ExecCfg().Codec, tableID)
+	zoneRaw, err := getZoneConfigRaw(ctx, txn, execCfg.Codec, tableID)
 	if err != nil {
 		return err
 	}
-	if zone == nil {
-		return errors.AssertionFailedf("expected zone config for table %d", tableID)
-	}
-	for _, region := range regionConfig.Regions {
-		zc, err := zoneConfigFromRegionConfigForPartition(region, regionConfig)
-		if err != nil {
-			return err
-		}
-		zone.SetSubzone(zonepb.Subzone{
-			IndexID:       uint32(indexID),
-			PartitionName: string(region.Name),
-			Config:        zc,
-		})
+	var zoneConfig zonepb.ZoneConfig
+	if zoneRaw != nil {
+		zoneConfig = *zoneRaw
 	}
 
-	if _, err = writeZoneConfig(
-		ctx,
-		p.txn,
-		tableID,
+	var hasNewSubzones bool
+	if hasNewSubzones, zoneConfig, err = opt(
+		zoneConfig,
+		regionConfig,
 		table,
-		zone,
-		p.ExecCfg(),
-		true, /* hasNewSubzones */
 	); err != nil {
 		return err
 	}
 
+	if !zoneConfig.Equal(zonepb.NewZoneConfig()) {
+		if err := zoneConfig.Validate(); err != nil {
+			return pgerror.Newf(
+				pgcode.CheckViolation,
+				"could not validate zone config: %v",
+				err,
+			)
+		}
+		if err := zoneConfig.ValidateTandemFields(); err != nil {
+			return pgerror.Newf(
+				pgcode.CheckViolation,
+				"could not validate zone config: %v",
+				err,
+			)
+		}
+
+		// If we have fields that are not the default value, write in a new zone configuration
+		// value.
+		if _, err = writeZoneConfig(
+			ctx,
+			txn,
+			tableID,
+			table,
+			&zoneConfig,
+			execCfg,
+			hasNewSubzones,
+		); err != nil {
+			return err
+		}
+	} else if zoneRaw != nil {
+		// Delete the zone configuration if it exists but the new zone config is blank.
+		if _, err = execCfg.InternalExecutor.Exec(
+			ctx,
+			"delete-zone",
+			txn,
+			"DELETE FROM system.zones WHERE id = $1",
+			tableID,
+		); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -398,25 +428,6 @@ func (p *planner) applyZoneConfigFromDatabaseRegionConfig(
 		zoneConfigFromRegionConfigForDatabase(regionConfig),
 		"database-multiregion-set-zone-config",
 	)
-}
-
-// dropZoneConfigForTable drops the zone configuration for a table if one exists.
-func (p *planner) dropZoneConfigForTable(ctx context.Context, name tree.TableName) error {
-	// TODO(#multiregion): We should check to see if the zone configuration has been updated
-	// by the user. If it has, we need to warn, and only proceed if sql_safe_updates is disabled.
-	sql := fmt.Sprintf("ALTER TABLE %s CONFIGURE ZONE DISCARD", name.String())
-	if _, err := p.ExtendedEvalContext().ExecCfg.InternalExecutor.ExecEx(
-		ctx,
-		"table-multiregion-discard-zone-config",
-		p.ExtendedEvalContext().Txn,
-		sessiondata.InternalExecutorOverride{
-			User: p.SessionData().User(),
-		},
-		sql,
-	); err != nil {
-		return err
-	}
-	return nil
 }
 
 // forEachTableWithLocalityConfigInDatabase loops through each schema and table
@@ -487,11 +498,13 @@ func (p *planner) updateZoneConfigsForAllTables(ctx context.Context, desc *dbdes
 		ctx,
 		desc,
 		func(ctx context.Context, schema string, tbName tree.TableName, tbDesc *tabledesc.Mutable) error {
-			return p.applyZoneConfigFromTableLocalityConfig(
+			return applyZoneConfigForMultiRegionTable(
 				ctx,
-				tbName,
-				tbDesc.TableDesc(),
+				p.txn,
+				p.ExecCfg(),
 				*desc.RegionConfig,
+				tbDesc,
+				applyZoneConfigForMultiRegionTableOptionTableAndIndexes,
 			)
 		},
 	)

--- a/pkg/sql/region_util_test.go
+++ b/pkg/sql/region_util_test.go
@@ -185,7 +185,7 @@ func TestZoneConfigFromTableLocalityConfig(t *testing.T) {
 		desc           string
 		localityConfig descpb.TableDescriptor_LocalityConfig
 		regionConfig   descpb.DatabaseDescriptor_RegionConfig
-		expected       *zonepb.ZoneConfig
+		expected       zonepb.ZoneConfig
 	}{
 		{
 			desc: "4-region global table with zone survival",
@@ -204,11 +204,11 @@ func TestZoneConfigFromTableLocalityConfig(t *testing.T) {
 				PrimaryRegion: "region_b",
 				SurvivalGoal:  descpb.SurvivalGoal_ZONE_FAILURE,
 			},
-			expected: &zonepb.ZoneConfig{
+			expected: zonepb.ZoneConfig{
 				GlobalReads:               proto.Bool(true),
-				NumReplicas:               proto.Int32(4),
 				InheritedConstraints:      true,
 				InheritedLeasePreferences: true,
+				InheritedVoterConstraints: true,
 			},
 		},
 		{
@@ -228,11 +228,11 @@ func TestZoneConfigFromTableLocalityConfig(t *testing.T) {
 				PrimaryRegion: "region_b",
 				SurvivalGoal:  descpb.SurvivalGoal_REGION_FAILURE,
 			},
-			expected: &zonepb.ZoneConfig{
+			expected: zonepb.ZoneConfig{
 				GlobalReads:               proto.Bool(true),
-				NumReplicas:               proto.Int32(4),
 				InheritedConstraints:      true,
 				InheritedLeasePreferences: true,
+				InheritedVoterConstraints: true,
 			},
 		},
 		{
@@ -252,7 +252,7 @@ func TestZoneConfigFromTableLocalityConfig(t *testing.T) {
 				PrimaryRegion: "region_b",
 				SurvivalGoal:  descpb.SurvivalGoal_ZONE_FAILURE,
 			},
-			expected: nil,
+			expected: *(zonepb.NewZoneConfig()),
 		},
 		{
 			desc: "4-region regional by row table with region survival",
@@ -271,7 +271,7 @@ func TestZoneConfigFromTableLocalityConfig(t *testing.T) {
 				PrimaryRegion: "region_b",
 				SurvivalGoal:  descpb.SurvivalGoal_ZONE_FAILURE,
 			},
-			expected: nil,
+			expected: *(zonepb.NewZoneConfig()),
 		},
 		{
 			desc: "4-region regional by table with zone survival on primary region",
@@ -292,7 +292,7 @@ func TestZoneConfigFromTableLocalityConfig(t *testing.T) {
 				PrimaryRegion: "region_b",
 				SurvivalGoal:  descpb.SurvivalGoal_ZONE_FAILURE,
 			},
-			expected: nil,
+			expected: *(zonepb.NewZoneConfig()),
 		},
 		{
 			desc: "4-region regional by table with regional survival on primary region",
@@ -313,7 +313,7 @@ func TestZoneConfigFromTableLocalityConfig(t *testing.T) {
 				PrimaryRegion: "region_b",
 				SurvivalGoal:  descpb.SurvivalGoal_REGION_FAILURE,
 			},
-			expected: nil,
+			expected: *(zonepb.NewZoneConfig()),
 		},
 		{
 			desc: "4-region regional by table with zone survival on non primary region",
@@ -334,7 +334,7 @@ func TestZoneConfigFromTableLocalityConfig(t *testing.T) {
 				PrimaryRegion: "region_b",
 				SurvivalGoal:  descpb.SurvivalGoal_ZONE_FAILURE,
 			},
-			expected: &zonepb.ZoneConfig{
+			expected: zonepb.ZoneConfig{
 				NumReplicas: proto.Int32(4),
 				LeasePreferences: []zonepb.LeasePreference{
 					{Constraints: []zonepb.Constraint{{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_c"}}},
@@ -342,6 +342,7 @@ func TestZoneConfigFromTableLocalityConfig(t *testing.T) {
 				Constraints: []zonepb.ConstraintsConjunction{
 					{NumReplicas: 4, Constraints: []zonepb.Constraint{{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_c"}}},
 				},
+				InheritedVoterConstraints: true,
 			},
 		},
 		{
@@ -363,7 +364,7 @@ func TestZoneConfigFromTableLocalityConfig(t *testing.T) {
 				PrimaryRegion: "region_b",
 				SurvivalGoal:  descpb.SurvivalGoal_REGION_FAILURE,
 			},
-			expected: &zonepb.ZoneConfig{
+			expected: zonepb.ZoneConfig{
 				NumReplicas: proto.Int32(4),
 				LeasePreferences: []zonepb.LeasePreference{
 					{Constraints: []zonepb.Constraint{{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_c"}}},
@@ -371,6 +372,7 @@ func TestZoneConfigFromTableLocalityConfig(t *testing.T) {
 				Constraints: []zonepb.ConstraintsConjunction{
 					{NumReplicas: 1, Constraints: []zonepb.Constraint{{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_c"}}},
 				},
+				InheritedVoterConstraints: true,
 			},
 		},
 	}


### PR DESCRIPTION
This commit refactors zone configuration code for multi-region to not
require shelling out to SQL and calling ALTER ... ZONE CONFIG. Instead,
zone configurations are done in-place. This reduces the number of SQL/KV
round trips and the need to look up the schema name of the database.

As an added bonus, added the requisite code that "merges"
non-multi-region based zone configurations. This means that, e.g.
setting gc.ttlseconds on a zone configuration carries over even after
altering localities.

Release note: None