### PR TITLE
colexec,bazel: pin the `types` dependency in generated files

### DIFF
--- a/pkg/sql/colexec/crossjoiner.eg.go
+++ b/pkg/sql/colexec/crossjoiner.eg.go
@@ -23,6 +23,7 @@ import (
 // pick up the right packages when run within the bazel sandbox.
 var (
 	_ = typeconv.DatumVecCanonicalTypeFamily
+	_ = types.BoolFamily
 )
 
 // buildFromLeftInput builds part of the output of a cross join that comes from

--- a/pkg/sql/colexec/crossjoiner_tmpl.go
+++ b/pkg/sql/colexec/crossjoiner_tmpl.go
@@ -34,6 +34,7 @@ import (
 // pick up the right packages when run within the bazel sandbox.
 var (
 	_ = typeconv.DatumVecCanonicalTypeFamily
+	_ = types.BoolFamily
 )
 
 // buildFromLeftInput builds part of the output of a cross join that comes from


### PR DESCRIPTION
This is a workaround for bazel auto-generated code. goimports does not
automatically pick up the right packages when run within the bazel
sandbox, so we have to pin it by hand.

Release note: None