### PR TITLE
storage,kv: fixes for enabling separated intents

### DIFF
--- a/pkg/ccl/storageccl/engineccl/BUILD.bazel
+++ b/pkg/ccl/storageccl/engineccl/BUILD.bazel
@@ -43,6 +43,7 @@ go_test(
         "//pkg/base",
         "//pkg/ccl/baseccl",
         "//pkg/ccl/storageccl/engineccl/enginepbccl:enginepbccl_go_proto",
+        "//pkg/keys",
         "//pkg/roachpb",
         "//pkg/settings/cluster",
         "//pkg/storage",

--- a/pkg/ccl/storageccl/engineccl/bench_test.go
+++ b/pkg/ccl/storageccl/engineccl/bench_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
@@ -153,7 +154,7 @@ func runIterate(
 		}
 		it := makeIterator(eng, startTime, endTime)
 		defer it.Close()
-		for it.SeekGE(storage.MVCCKey{}); ; it.Next() {
+		for it.SeekGE(storage.MVCCKey{Key: keys.LocalMax}); ; it.Next() {
 			if ok, err := it.Valid(); !ok {
 				if err != nil {
 					b.Fatal(err)

--- a/pkg/ccl/storageccl/export_test.go
+++ b/pkg/ccl/storageccl/export_test.go
@@ -729,6 +729,7 @@ func TestRandomKeyAndTimestampExport(t *testing.T) {
 		return keys, timestamps
 	}
 
+	localMax := keys.LocalMax
 	testWithTargetSize := func(t *testing.T, targetSize uint64) {
 		e, cleanup := mkEngine(t)
 		defer cleanup()
@@ -736,7 +737,7 @@ func TestRandomKeyAndTimestampExport(t *testing.T) {
 		numKeys := getNumKeys(t, rnd, targetSize)
 		keys, timestamps := mkData(t, e, rnd, numKeys)
 		var (
-			keyMin = roachpb.KeyMin
+			keyMin = localMax
 			keyMax = roachpb.KeyMax
 
 			tsMin = hlc.Timestamp{WallTime: 0, Logical: 0}

--- a/pkg/keys/constants.go
+++ b/pkg/keys/constants.go
@@ -53,8 +53,8 @@ var (
 	localSuffixLength = 4
 
 	// There are five types of local key data enumerated below: replicated
-	// range-ID, unreplicated range-ID, range local, range lock, and
-	// store-local keys.
+	// range-ID, unreplicated range-ID, range local, store-local, and range lock
+	// keys.
 
 	// 1. Replicated Range-ID keys
 	//
@@ -145,36 +145,10 @@ var (
 	// transaction records. The additional detail is the transaction id.
 	LocalTransactionSuffix = roachpb.RKey("txn-")
 
-	// 4. Lock table keys
+	// 4. Store local keys
 	//
-	// LocalRangeLockTablePrefix specifies the key prefix for the lock
-	// table. It is immediately followed by the LockTableSingleKeyInfix,
-	// and then the key being locked.
-	//
-	// The lock strength and txn UUID are not in the part of the key that
-	// the keys package deals with. They are in the versioned part of the
-	// key (see EngineKey.Version). This permits the storage engine to use
-	// bloom filters when searching for all locks for a lockable key.
-	//
-	// Different lock strengths may use different value types. The exclusive
-	// lock strength uses MVCCMetadata as the value type, since it does
-	// double duty as a reference to a provisional MVCC value.
-	// TODO(sumeer): remember to adjust this comment when adding locks of
-	// other strengths, or range locks.
-	LocalRangeLockTablePrefix = roachpb.Key(makeKey(localPrefix, roachpb.RKey("l")))
-	LockTableSingleKeyInfix   = []byte("k")
-	// LockTableSingleKeyStart is the inclusive start key of the key range
-	// containing single key locks.
-	LockTableSingleKeyStart = roachpb.Key(makeKey(LocalRangeLockTablePrefix, LockTableSingleKeyInfix))
-	// LockTableSingleKeyEnd is the exclusive end key of the key range
-	// containing single key locks.
-	LockTableSingleKeyEnd = roachpb.Key(
-		makeKey(LocalRangeLockTablePrefix, roachpb.Key(LockTableSingleKeyInfix).PrefixEnd()))
-
-	// 5. Store local keys
-	//
-	// localStorePrefix is the prefix identifying per-store data.
-	localStorePrefix = makeKey(localPrefix, roachpb.Key("s"))
+	// LocalStorePrefix is the prefix identifying per-store data.
+	LocalStorePrefix = makeKey(localPrefix, roachpb.Key("s"))
 	// localStoreSuggestedCompactionSuffix stores suggested compactions to
 	// be aggregated and processed on the store.
 	localStoreSuggestedCompactionSuffix = []byte("comp")
@@ -209,6 +183,32 @@ var (
 	LocalStoreCachedSettingsKeyMin = MakeStoreKey(localStoreCachedSettingsSuffix, nil)
 	// LocalStoreCachedSettingsKeyMax is the end of span of possible cached settings keys.
 	LocalStoreCachedSettingsKeyMax = LocalStoreCachedSettingsKeyMin.PrefixEnd()
+
+	// 5. Lock table keys
+	//
+	// LocalRangeLockTablePrefix specifies the key prefix for the lock
+	// table. It is immediately followed by the LockTableSingleKeyInfix,
+	// and then the key being locked.
+	//
+	// The lock strength and txn UUID are not in the part of the key that
+	// the keys package deals with. They are in the versioned part of the
+	// key (see EngineKey.Version). This permits the storage engine to use
+	// bloom filters when searching for all locks for a lockable key.
+	//
+	// Different lock strengths may use different value types. The exclusive
+	// lock strength uses MVCCMetadata as the value type, since it does
+	// double duty as a reference to a provisional MVCC value.
+	// TODO(sumeer): remember to adjust this comment when adding locks of
+	// other strengths, or range locks.
+	LocalRangeLockTablePrefix = roachpb.Key(makeKey(localPrefix, roachpb.RKey("z")))
+	LockTableSingleKeyInfix   = []byte("k")
+	// LockTableSingleKeyStart is the inclusive start key of the key range
+	// containing single key locks.
+	LockTableSingleKeyStart = roachpb.Key(makeKey(LocalRangeLockTablePrefix, LockTableSingleKeyInfix))
+	// LockTableSingleKeyEnd is the exclusive end key of the key range
+	// containing single key locks.
+	LockTableSingleKeyEnd = roachpb.Key(
+		makeKey(LocalRangeLockTablePrefix, roachpb.Key(LockTableSingleKeyInfix).PrefixEnd()))
 
 	// The global keyspace includes the meta{1,2}, system, system tenant SQL
 	// keys, and non-system tenant SQL keys.

--- a/pkg/keys/keys.go
+++ b/pkg/keys/keys.go
@@ -27,8 +27,8 @@ func makeKey(keys ...[]byte) []byte {
 // MakeStoreKey creates a store-local key based on the metadata key
 // suffix, and optional detail.
 func MakeStoreKey(suffix, detail roachpb.RKey) roachpb.Key {
-	key := make(roachpb.Key, 0, len(localStorePrefix)+len(suffix)+len(detail))
-	key = append(key, localStorePrefix...)
+	key := make(roachpb.Key, 0, len(LocalStorePrefix)+len(suffix)+len(detail))
+	key = append(key, LocalStorePrefix...)
 	key = append(key, suffix...)
 	key = append(key, detail...)
 	return key
@@ -37,11 +37,11 @@ func MakeStoreKey(suffix, detail roachpb.RKey) roachpb.Key {
 // DecodeStoreKey returns the suffix and detail portions of a local
 // store key.
 func DecodeStoreKey(key roachpb.Key) (suffix, detail roachpb.RKey, err error) {
-	if !bytes.HasPrefix(key, localStorePrefix) {
-		return nil, nil, errors.Errorf("key %s does not have %s prefix", key, localStorePrefix)
+	if !bytes.HasPrefix(key, LocalStorePrefix) {
+		return nil, nil, errors.Errorf("key %s does not have %s prefix", key, LocalStorePrefix)
 	}
 	// Cut the prefix, the Range ID, and the infix specifier.
-	key = key[len(localStorePrefix):]
+	key = key[len(LocalStorePrefix):]
 	if len(key) < localSuffixLength {
 		return nil, nil, errors.Errorf("malformed key does not contain local store suffix")
 	}
@@ -481,12 +481,6 @@ func IsLocal(k roachpb.Key) bool {
 	return bytes.HasPrefix(k, localPrefix)
 }
 
-// IsLocalStoreKey performs a cheap check that returns true iff the parameter
-// is a local store key.
-func IsLocalStoreKey(k roachpb.Key) bool {
-	return bytes.HasPrefix(k, localStorePrefix)
-}
-
 // Addr returns the address for the key, used to lookup the range containing the
 // key. In the normal case, this is simply the key's value. However, for local
 // keys, such as transaction records, the address is the inner encoded key, with
@@ -512,7 +506,7 @@ func Addr(k roachpb.Key) (roachpb.RKey, error) {
 	}
 
 	for {
-		if bytes.HasPrefix(k, localStorePrefix) {
+		if bytes.HasPrefix(k, LocalStorePrefix) {
 			return nil, errors.Errorf("store-local key %q is not addressable", k)
 		}
 		if bytes.HasPrefix(k, LocalRangeIDPrefix) {

--- a/pkg/keys/printer.go
+++ b/pkg/keys/printer.go
@@ -71,7 +71,7 @@ var (
 	// KeyDict drives the pretty-printing and pretty-scanning of the key space.
 	KeyDict = KeyComprehensionTable{
 		{Name: "/Local", start: localPrefix, end: LocalMax, Entries: []DictEntry{
-			{Name: "/Store", prefix: roachpb.Key(localStorePrefix),
+			{Name: "/Store", prefix: roachpb.Key(LocalStorePrefix),
 				ppFunc: localStoreKeyPrint, PSFunc: localStoreKeyParse},
 			{Name: "/RangeID", prefix: roachpb.Key(LocalRangeIDPrefix),
 				ppFunc: localRangeIDKeyPrint, PSFunc: localRangeIDKeyParse},
@@ -218,11 +218,11 @@ func localStoreKeyPrint(_ []encoding.Direction, key roachpb.Key) string {
 		if bytes.HasPrefix(key, v.key) {
 			if v.key.Equal(localStoreNodeTombstoneSuffix) {
 				return v.name + "/" + nodeTombstoneKeyPrint(
-					append(roachpb.Key(nil), append(localStorePrefix, key...)...),
+					append(roachpb.Key(nil), append(LocalStorePrefix, key...)...),
 				)
 			} else if v.key.Equal(localStoreCachedSettingsSuffix) {
 				return v.name + "/" + cachedSettingsKeyPrint(
-					append(roachpb.Key(nil), append(localStorePrefix, key...)...),
+					append(roachpb.Key(nil), append(LocalStorePrefix, key...)...),
 				)
 			}
 			return v.name

--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
@@ -416,6 +416,56 @@ func IsEndTxnTriggeringRetryError(
 
 const lockResolutionBatchSize = 500
 
+// iterManager provides a storage.IterAndBuf appropriate for working with a
+// span of keys that are either all local or all global keys, identified by
+// the start key of the span, that is passed to getIterAndBuf. This is to deal
+// with the constraint that a single MVCCIterator using
+// MVCCKeyAndIntentsIterKind can either iterate over local keys or global
+// keys, but not both. We don't wish to create a new iterator for each span,
+// so iterManager lazily creates a new one when needed.
+type iterManager struct {
+	reader              storage.Reader
+	globalKeyUpperBound roachpb.Key
+	iterAndBuf          storage.IterAndBuf
+
+	iter        storage.MVCCIterator
+	isLocalIter bool
+}
+
+func (im *iterManager) getIterAndBuf(key roachpb.Key) storage.IterAndBuf {
+	isLocal := keys.IsLocal(key)
+	if im.iter != nil {
+		if im.isLocalIter == isLocal {
+			return im.iterAndBuf
+		}
+		im.iterAndBuf.SwitchIter(nil /* iter */)
+		im.iter.Close()
+		im.iter = nil
+	}
+	if isLocal {
+		im.iter = im.reader.NewMVCCIterator(
+			storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{
+				UpperBound: keys.LocalMax,
+			})
+		im.isLocalIter = true
+		im.iterAndBuf.SwitchIter(im.iter)
+	} else {
+		im.iter = im.reader.NewMVCCIterator(
+			storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{
+				UpperBound: im.globalKeyUpperBound,
+			})
+		im.isLocalIter = false
+		im.iterAndBuf.SwitchIter(im.iter)
+	}
+	return im.iterAndBuf
+}
+
+func (im *iterManager) Close() {
+	im.iterAndBuf.Cleanup()
+	im.iterAndBuf = storage.IterAndBuf{}
+	im.iter = nil
+}
+
 // resolveLocalLocks synchronously resolves any locks that are local to this
 // range in the same batch and returns those lock spans. The remainder are
 // collected and returned so that they can be handed off to asynchronous
@@ -439,11 +489,12 @@ func resolveLocalLocks(
 		desc = &mergeTrigger.LeftDesc
 	}
 
-	iter := readWriter.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{
-		UpperBound: desc.EndKey.AsRawKey(),
-	})
-	iterAndBuf := storage.GetBufUsingIter(iter)
-	defer iterAndBuf.Cleanup()
+	iterManager := &iterManager{
+		reader:              readWriter,
+		globalKeyUpperBound: desc.EndKey.AsRawKey(),
+		iterAndBuf:          storage.GetBufUsingIter(nil),
+	}
+	defer iterManager.Close()
 
 	var resolveAllowance int64 = lockResolutionBatchSize
 	if args.InternalCommitTrigger != nil {
@@ -466,7 +517,8 @@ func resolveLocalLocks(
 					return nil
 				}
 				resolveMS := ms
-				ok, err := storage.MVCCResolveWriteIntentUsingIter(ctx, readWriter, iterAndBuf, resolveMS, update)
+				ok, err := storage.MVCCResolveWriteIntentUsingIter(
+					ctx, readWriter, iterManager.getIterAndBuf(span.Key), resolveMS, update)
 				if err != nil {
 					return err
 				}
@@ -483,7 +535,8 @@ func resolveLocalLocks(
 			externalLocks = append(externalLocks, outSpans...)
 			if inSpan != nil {
 				update.Span = *inSpan
-				num, resumeSpan, err := storage.MVCCResolveWriteIntentRangeUsingIter(ctx, readWriter, iterAndBuf, ms, update, resolveAllowance)
+				num, resumeSpan, err := storage.MVCCResolveWriteIntentRangeUsingIter(
+					ctx, readWriter, iterManager.getIterAndBuf(update.Span.Key), ms, update, resolveAllowance)
 				if err != nil {
 					return err
 				}

--- a/pkg/kv/kvserver/client_split_test.go
+++ b/pkg/kv/kvserver/client_split_test.go
@@ -446,13 +446,13 @@ func TestStoreRangeSplitIntents(t *testing.T) {
 	// Verify the transaction record is gone.
 	start := storage.MakeMVCCMetadataKey(keys.MakeRangeKeyPrefix(roachpb.RKeyMin))
 	end := storage.MakeMVCCMetadataKey(keys.MakeRangeKeyPrefix(roachpb.RKeyMax))
-	iter := store.Engine().NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{UpperBound: roachpb.KeyMax})
+	iter := store.Engine().NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{UpperBound: end.Key})
 
 	defer iter.Close()
 	for iter.SeekGE(start); ; iter.Next() {
 		if ok, err := iter.Valid(); err != nil {
 			t.Fatal(err)
-		} else if !ok || !iter.UnsafeKey().Less(end) {
+		} else if !ok {
 			break
 		}
 

--- a/pkg/kv/kvserver/rditer/replica_data_iter_test.go
+++ b/pkg/kv/kvserver/rditer/replica_data_iter_test.go
@@ -126,13 +126,12 @@ func createRangeData(
 }
 
 func verifyRDReplicatedOnlyMVCCIter(
-	t *testing.T,
-	desc *roachpb.RangeDescriptor,
-	readWriter storage.ReadWriter,
-	expectedKeys []storage.MVCCKey,
+	t *testing.T, desc *roachpb.RangeDescriptor, eng storage.Engine, expectedKeys []storage.MVCCKey,
 ) {
 	t.Helper()
 	verify := func(t *testing.T, useSpanSet, reverse bool) {
+		readWriter := eng.NewReadOnly()
+		defer readWriter.Close()
 		if useSpanSet {
 			var spans spanset.SpanSet
 			spans.AddNonMVCC(spanset.SpanReadOnly, roachpb.Span{
@@ -192,11 +191,10 @@ func verifyRDReplicatedOnlyMVCCIter(
 }
 
 func verifyRDEngineIter(
-	t *testing.T,
-	desc *roachpb.RangeDescriptor,
-	readWriter storage.ReadWriter,
-	expectedKeys []storage.MVCCKey,
+	t *testing.T, desc *roachpb.RangeDescriptor, eng storage.Engine, expectedKeys []storage.MVCCKey,
 ) {
+	readWriter := eng.NewReadOnly()
+	defer readWriter.Close()
 	iter := NewReplicaEngineDataIterator(desc, readWriter, false)
 	defer iter.Close()
 	i := 0

--- a/pkg/kv/kvserver/rditer/stats.go
+++ b/pkg/kv/kvserver/rditer/stats.go
@@ -22,16 +22,23 @@ import (
 func ComputeStatsForRange(
 	d *roachpb.RangeDescriptor, reader storage.Reader, nowNanos int64,
 ) (enginepb.MVCCStats, error) {
-	iter := reader.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{UpperBound: d.EndKey.AsRawKey()})
-	defer iter.Close()
-
 	ms := enginepb.MVCCStats{}
+	var err error
 	for _, keyRange := range MakeReplicatedKeyRangesExceptLockTable(d) {
-		msDelta, err := iter.ComputeStats(keyRange.Start.Key, keyRange.End.Key, nowNanos)
+		func() {
+			iter := reader.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind,
+				storage.IterOptions{UpperBound: keyRange.End.Key})
+			defer iter.Close()
+
+			var msDelta enginepb.MVCCStats
+			if msDelta, err = iter.ComputeStats(keyRange.Start.Key, keyRange.End.Key, nowNanos); err != nil {
+				return
+			}
+			ms.Add(msDelta)
+		}()
 		if err != nil {
 			return enginepb.MVCCStats{}, err
 		}
-		ms.Add(msDelta)
 	}
 	return ms, nil
 }

--- a/pkg/storage/batch_test.go
+++ b/pkg/storage/batch_test.go
@@ -110,7 +110,7 @@ func testBatchBasics(t *testing.T, writeOnly bool, commit func(e Engine, b Batch
 				{Key: mvccKey("c"), Value: appender("foo")},
 				{Key: mvccKey("d"), Value: []byte("before")},
 			}
-			kvs, err := Scan(e, roachpb.KeyMin, roachpb.KeyMax, 0)
+			kvs, err := Scan(e, localMax, roachpb.KeyMax, 0)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -126,7 +126,7 @@ func testBatchBasics(t *testing.T, writeOnly bool, commit func(e Engine, b Batch
 			}
 			if !writeOnly {
 				// Scan values from batch directly.
-				kvs, err = Scan(b, roachpb.KeyMin, roachpb.KeyMax, 0)
+				kvs, err = Scan(b, localMax, roachpb.KeyMax, 0)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -139,7 +139,7 @@ func testBatchBasics(t *testing.T, writeOnly bool, commit func(e Engine, b Batch
 			if err := commit(e, b); err != nil {
 				t.Fatal(err)
 			}
-			kvs, err = Scan(e, roachpb.KeyMin, roachpb.KeyMax, 0)
+			kvs, err = Scan(e, localMax, roachpb.KeyMax, 0)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -273,7 +273,7 @@ func TestReadOnlyBasics(t *testing.T) {
 				{Key: mvccKey("c"), Value: appender("foobar")},
 			}
 
-			kvs, err := Scan(e, roachpb.KeyMin, roachpb.KeyMax, 0)
+			kvs, err := Scan(e, localMax, roachpb.KeyMax, 0)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -723,7 +723,7 @@ func TestBatchScanWithDelete(t *testing.T) {
 			if err := b.ClearUnversioned(mvccKey("a").Key); err != nil {
 				t.Fatal(err)
 			}
-			kvs, err := Scan(b, roachpb.KeyMin, roachpb.KeyMax, 0)
+			kvs, err := Scan(b, localMax, roachpb.KeyMax, 0)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -761,7 +761,7 @@ func TestBatchScanMaxWithDeleted(t *testing.T) {
 				t.Fatal(err)
 			}
 			// A scan with max=1 should scan "b".
-			kvs, err := Scan(b, roachpb.KeyMin, roachpb.KeyMax, 1)
+			kvs, err := Scan(b, localMax, roachpb.KeyMax, 1)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -147,8 +147,25 @@ type MVCCIterator interface {
 	// and the encoded SST data specified, within the provided key range. Returns
 	// stats on skipped KVs, or an error if a collision is found.
 	CheckForKeyCollisions(sstData []byte, start, end roachpb.Key) (enginepb.MVCCStats, error)
-	// SetUpperBound installs a new upper bound for this iterator. The caller can modify
-	// the parameter after this function returns.
+	// SetUpperBound installs a new upper bound for this iterator. The caller
+	// can modify the parameter after this function returns. This must not be a
+	// nil key. When Reader.ConsistentIterators is true, prefer creating a new
+	// iterator.
+	//
+	// Due to the rare use, we are limiting this method to not switch an
+	// iterator from a global key upper-bound to a local key upper-bound (it
+	// simplifies some code in intentInterleavingIter) or vice versa. Iterator
+	// reuse already happens under-the-covers for most Reader implementations
+	// when constructing a new iterator, and that is a much cleaner solution.
+	//
+	// TODO(sumeer): this method is rarely used and is a source of complexity
+	// since intentInterleavingIter needs to fiddle with the bounds of its
+	// underlying iterators when this is called. Currently only used by
+	// pebbleBatch.ClearIterRange to modify the upper bound of the iterator it
+	// is given: this use is unprincipled and there is a comment in that code
+	// about it. The caller is already usually setting the bounds accurately,
+	// and in some cases the callee is tightening the upper bound. Remove that
+	// use case and remove this from the interface.
 	SetUpperBound(roachpb.Key)
 	// Stats returns statistics about the iterator.
 	Stats() IteratorStats
@@ -200,7 +217,9 @@ type EngineIterator interface {
 	// Value returns the current value as a byte slice.
 	// REQUIRES: latest positioning function returned valid=true.
 	Value() []byte
-	// SetUpperBound installs a new upper bound for this iterator.
+	// SetUpperBound installs a new upper bound for this iterator. When
+	// Reader.ConsistentIterators is true, prefer creating a new iterator.
+	// TODO(sumeer): remove this method.
 	SetUpperBound(roachpb.Key)
 	// GetRawIter is a low-level method only for use in the storage package,
 	// that returns the underlying pebble Iterator.
@@ -256,6 +275,23 @@ type MVCCIterKind int
 const (
 	// MVCCKeyAndIntentsIterKind specifies that intents must be seen, and appear
 	// interleaved with keys, even if they are in a separated lock table.
+	// Iterators of this kind are not allowed to span from local to global keys,
+	// since the physical layout has the separated lock table in-between the
+	// local and global keys. These iterators do strict error checking and panic
+	// if the caller seems that to be trying to violate this constraint.
+	// Specifically:
+	// - If both bounds are set they must not span from local to global.
+	// - Any bound (lower or upper), constrains the iterator for its lifetime to
+	//   one of local or global keys. The iterator will not tolerate a seek or
+	//   SetUpperBound call that violates this constraint.
+	// We could, with significant code complexity, not constrain an iterator for
+	// its lifetime, and allow a seek that specifies a global (local) key to
+	// change the constraint to global (local). This would allow reuse of the
+	// same iterator with a large global upper-bound. But a Next call on the
+	// highest local key (Prev on the lowest global key) would still not be able
+	// to transparently skip over the intermediate lock table. We deem that
+	// behavior to be more surprising and bug-prone (for the caller), than being
+	// strict.
 	MVCCKeyAndIntentsIterKind MVCCIterKind = iota
 	// MVCCKeyIterKind specifies that the caller does not need to see intents.
 	// Any interleaved intents may be seen, but no correctness properties are
@@ -271,7 +307,9 @@ const (
 // different iterators created by NewMVCCIterator, NewEngineIterator:
 // - pebbleSnapshot, because it uses an engine snapshot.
 // - pebbleReadOnly, pebbleBatch: when the IterOptions do not specify a
-//   timestamp hint.
+//   timestamp hint. Note that currently the engine state visible here is
+//   not as of the time of the Reader creation. It is the time when the
+//   first iterator is created.
 // The ConsistentIterators method returns true when this consistency is
 // guaranteed by the Reader.
 // TODO(sumeer): this partial consistency can be a source of bugs if future
@@ -597,18 +635,9 @@ type Engine interface {
 	// operations) are executed on it and caches iterators to avoid the overhead
 	// of creating multiple iterators for batched reads.
 	//
-	// All iterators created from a read-only engine with the same "Prefix"
-	// option are guaranteed to provide a consistent snapshot of the underlying
-	// engine. For instance, two prefix iterators created from a read-only
-	// engine will provide a consistent snapshot. Similarly, two non-prefix
-	// iterators created from a read-only engine will provide a consistent
-	// snapshot. However, a prefix iterator and a non-prefix iterator created
-	// from a read-only engine are not guaranteed to provide a consistent view
-	// of the underlying engine.
-	//
-	// TODO(nvanbenschoten): remove this complexity when we're fully on Pebble
-	// and can guarantee that all iterators created from a read-only engine are
-	// consistent. To do this, we will want to add an MVCCIterator.Clone method.
+	// All iterators created from a read-only engine are guaranteed to provide a
+	// consistent snapshot of the underlying engine. See the comment on the
+	// Reader interface and the Reader.ConsistentIterators method.
 	NewReadOnly() ReadWriter
 	// NewUnindexedBatch returns a new instance of a batched engine which wraps
 	// this engine. It is unindexed, in that writes to the batch are not

--- a/pkg/storage/multi_iterator_test.go
+++ b/pkg/storage/multi_iterator_test.go
@@ -127,7 +127,7 @@ func TestMultiIterator(t *testing.T) {
 				t.Run(subtest.name, func(t *testing.T) {
 					var output bytes.Buffer
 					it := MakeMultiIterator(iters)
-					for it.SeekGE(MVCCKey{Key: keys.MinKey}); ; subtest.fn(it) {
+					for it.SeekGE(MVCCKey{Key: keys.LocalMax}); ; subtest.fn(it) {
 						ok, err := it.Valid()
 						if err != nil {
 							t.Fatalf("unexpected error: %+v", err)

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -3016,10 +3016,18 @@ func GetBufUsingIter(iter MVCCIterator) IterAndBuf {
 	}
 }
 
+// SwitchIter switches to iter, and relinquishes ownership of the existing
+// iter.
+func (b *IterAndBuf) SwitchIter(iter MVCCIterator) {
+	b.iter = iter
+}
+
 // Cleanup must be called to release the resources when done.
 func (b IterAndBuf) Cleanup() {
 	b.buf.release()
-	b.iter.Close()
+	if b.iter != nil {
+		b.iter.Close()
+	}
 }
 
 // MVCCResolveWriteIntentRange commits or aborts (rolls back) the
@@ -3115,6 +3123,11 @@ func MVCCResolveWriteIntentRangeUsingIter(
 // timestamp parameter is used to compute the intent age on GC.
 //
 // Note that this method will be sorting the keys.
+//
+// REQUIRES: the keys are either all local keys, or all global keys, and
+// not a mix of the two. This is to accommodate the implementation below
+// that creates an iterator with bounds that span from the first to last
+// key (in sorted order).
 func MVCCGarbageCollect(
 	ctx context.Context,
 	rw ReadWriter,
@@ -3147,6 +3160,7 @@ func MVCCGarbageCollect(
 	// TODO(sumeer): this can span from local to global keys. Fix in cmd_gc.go
 	// which is already examining all the keys and can separate out the local
 	// keys to call MVCCGarbageCollect separately.
+	// TODO(sumeer): do we even need these coarse bounds?
 	iter := rw.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{
 		LowerBound: keys[0].Key,
 		UpperBound: keys[len(keys)-1].Key.Next(),

--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -96,7 +96,12 @@ func TestMVCCHistories(t *testing.T) {
 				if strings.Contains(path, "_disallow_separated") && !DisallowSeparatedIntents {
 					return
 				}
-				if strings.Contains(path, "_allow_separated") && DisallowSeparatedIntents {
+				if strings.Contains(path, "_allow_separated") &&
+					(DisallowSeparatedIntents || enabledSeparatedIntents) {
+					return
+				}
+				if strings.Contains(path, "_enable_separated") &&
+					(DisallowSeparatedIntents || !enabledSeparatedIntents) {
 					return
 				}
 				// We start from a clean slate in every test file.

--- a/pkg/storage/mvcc_incremental_iterator_test.go
+++ b/pkg/storage/mvcc_incremental_iterator_test.go
@@ -265,7 +265,6 @@ func TestMVCCIncrementalIteratorNextIgnoringTime(t *testing.T) {
 	ctx := context.Background()
 
 	var (
-		localMax = keys.LocalMax
 		keyMax   = roachpb.KeyMax
 		testKey1 = roachpb.Key("/db1")
 		testKey2 = roachpb.Key("/db2")
@@ -406,7 +405,6 @@ func TestMVCCIncrementalIterator(t *testing.T) {
 	ctx := context.Background()
 
 	var (
-		localMax = keys.LocalMax
 		keyMax   = roachpb.KeyMax
 		testKey1 = roachpb.Key("/db1")
 		testKey2 = roachpb.Key("/db2")
@@ -987,7 +985,7 @@ func TestMVCCIterateTimeBound(t *testing.T) {
 			var expectedKVs []MVCCKeyValue
 			iter := eng.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{UpperBound: roachpb.KeyMax})
 			defer iter.Close()
-			iter.SeekGE(MVCCKey{})
+			iter.SeekGE(MVCCKey{Key: localMax})
 			for {
 				ok, err := iter.Valid()
 				if err != nil {

--- a/pkg/storage/pebble_iterator.go
+++ b/pkg/storage/pebble_iterator.go
@@ -620,10 +620,15 @@ func findSplitKeyUsingIterator(
 
 // SetUpperBound implements the MVCCIterator interface.
 func (p *pebbleIterator) SetUpperBound(upperBound roachpb.Key) {
+	if upperBound == nil {
+		panic("SetUpperBound must not use a nil key")
+	}
 	p.curBuf = (p.curBuf + 1) % 2
 	i := p.curBuf
-	p.lowerBoundBuf[i] = append(p.lowerBoundBuf[i][:0], p.options.LowerBound...)
-	p.options.LowerBound = p.lowerBoundBuf[i]
+	if p.options.LowerBound != nil {
+		p.lowerBoundBuf[i] = append(p.lowerBoundBuf[i][:0], p.options.LowerBound...)
+		p.options.LowerBound = p.lowerBoundBuf[i]
+	}
 	p.upperBoundBuf[i] = append(p.upperBoundBuf[i][:0], upperBound...)
 	p.upperBoundBuf[i] = append(p.upperBoundBuf[i], 0x00)
 	p.options.UpperBound = p.upperBoundBuf[i]

--- a/pkg/storage/pebble_test.go
+++ b/pkg/storage/pebble_test.go
@@ -160,7 +160,11 @@ func TestPebbleIterReuse(t *testing.T) {
 	// previous iterator should get zeroed.
 	iter2 := batch.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{UpperBound: []byte{10}})
 	valuesCount = 0
-	iter2.SeekGE(MVCCKey{Key: []byte{0}})
+	// This is a peculiar test that is disregarding how local and global keys
+	// affect the behavior of MVCCIterators. This test is writing []byte{0}
+	// which precedes the localPrefix. Ignore the local and preceding keys in
+	// this seek.
+	iter2.SeekGE(MVCCKey{Key: []byte{2}})
 	for ; ; iter2.Next() {
 		ok, err := iter2.Valid()
 		if err != nil {
@@ -176,8 +180,8 @@ func TestPebbleIterReuse(t *testing.T) {
 		valuesCount++
 	}
 
-	if valuesCount != 10 {
-		t.Fatalf("expected 10 values, got %d", valuesCount)
+	if valuesCount != 8 {
+		t.Fatalf("expected 8 values, got %d", valuesCount)
 	}
 	iter2.Close()
 }

--- a/pkg/storage/testdata/intent_interleaving_iter/basic
+++ b/pkg/storage/testdata/intent_interleaving_iter/basic
@@ -563,3 +563,226 @@ prev: output: meta k=b\0c\0d ts=20.000000000,0 txn=1
 prev: output: value k=abcdefg\0 ts=20.000000000,0 v=a
 prev: output: meta k=abcdefg\0 ts=20.000000000,0 txn=1
 prev: output: .
+
+# Local and global keys with separated locks. This test exercises previously
+# buggy cases where callers were:
+# - iterating over global keys without a lower bound. Since the manufactured
+#   lower bounds on the intentIter and iter, to prevent iter iterating into
+#   the lock table, were not semantically identical, the
+#   intentInterleavingIter would detect an inconsistency and go into error
+#   state.
+# - iterating over local keys without an upper bound. We had the same issue
+#   with the manufactured bounds.
+
+define
+locks
+meta k=Lb ts=20 txn=2
+meta k=Lc ts=30 txn=4
+meta k=b ts=40 txn=5
+meta k=d ts=50 txn=6
+mvcc
+meta k=La ts=10 txn=1
+value k=La ts=10 v=a10
+value k=Lb ts=20 v=b20
+value k=Lc ts=30 v=c30
+value k=b ts=40 v=b40
+value k=d ts=50 v=d50
+----
+
+iter upper=e
+seek-ge k=a
+next
+next
+prev
+prev
+prev
+next
+----
+seek-ge "a"/0,0: output: meta k=b ts=40.000000000,0 txn=5
+next: output: value k=b ts=40.000000000,0 v=b40
+next: output: meta k=d ts=50.000000000,0 txn=6
+prev: output: value k=b ts=40.000000000,0 v=b40
+prev: output: meta k=b ts=40.000000000,0 txn=5
+prev: output: .
+next: output: meta k=b ts=40.000000000,0 txn=5
+
+iter lower=La
+seek-lt k=Ld
+prev
+prev
+next
+next
+next
+prev
+----
+seek-lt "Ld"/0,0: output: value k=Lc ts=30.000000000,0 v=c30
+prev: output: meta k=Lc ts=30.000000000,0 txn=4
+prev: output: value k=Lb ts=20.000000000,0 v=b20
+next: output: meta k=Lc ts=30.000000000,0 txn=4
+next: output: value k=Lc ts=30.000000000,0 v=c30
+next: output: .
+prev: output: value k=Lc ts=30.000000000,0 v=c30
+
+iter prefix=true
+seek-ge k=Lb
+next
+next
+seek-ge k=La
+next
+next
+seek-ge k=Laa
+seek-ge k=b
+next
+next
+seek-ge k=d
+next
+next
+seek-ge k=e
+seek-ge k=c
+----
+seek-ge "Lb"/0,0: output: meta k=Lb ts=20.000000000,0 txn=2
+next: output: value k=Lb ts=20.000000000,0 v=b20
+next: output: .
+seek-ge "La"/0,0: output: meta k=La ts=10.000000000,0 txn=1
+next: output: value k=La ts=10.000000000,0 v=a10
+next: output: .
+seek-ge "Laa"/0,0: output: .
+seek-ge "b"/0,0: output: meta k=b ts=40.000000000,0 txn=5
+next: output: value k=b ts=40.000000000,0 v=b40
+next: output: .
+seek-ge "d"/0,0: output: meta k=d ts=50.000000000,0 txn=6
+next: output: value k=d ts=50.000000000,0 v=d50
+next: output: .
+seek-ge "e"/0,0: output: .
+seek-ge "c"/0,0: output: .
+
+# The meta Sc is bogus since local store keys do not have locks, but it is
+# worthwhile for the intentInterleavingIter to work cleanly here.
+define
+locks
+meta k=Lb ts=20 txn=2
+meta k=Sc ts=30 txn=3
+meta k=d ts=40 txn=4
+mvcc
+value k=Lb ts=20 v=b20
+value k=Sc ts=30 v=c30
+value k=d ts=40 v=d40
+----
+
+# Iterator sees Sc, which it should.
+iter lower=La
+seek-ge k=La
+prev
+next
+prev
+next
+next
+next
+next
+next
+prev
+----
+seek-ge "La"/0,0: output: meta k=Lb ts=20.000000000,0 txn=2
+prev: output: .
+next: output: meta k=Lb ts=20.000000000,0 txn=2
+prev: output: .
+next: output: meta k=Lb ts=20.000000000,0 txn=2
+next: output: value k=Lb ts=20.000000000,0 v=b20
+next: output: meta k=Sc ts=30.000000000,0 txn=3
+next: output: value k=Sc ts=30.000000000,0 v=c30
+next: output: .
+prev: output: value k=Sc ts=30.000000000,0 v=c30
+
+# Iterator sees Lb, which it should.
+# error state.
+iter upper=Sd
+seek-lt k=Sd
+prev
+prev
+prev
+prev
+next
+----
+seek-lt "Sd"/0,0: output: value k=Sc ts=30.000000000,0 v=c30
+prev: output: meta k=Sc ts=30.000000000,0 txn=3
+prev: output: value k=Lb ts=20.000000000,0 v=b20
+prev: output: meta k=Lb ts=20.000000000,0 txn=2
+prev: output: .
+next: output: meta k=Lb ts=20.000000000,0 txn=2
+
+# Iterator over local keys, with upper bound equal to LocalMax. The underlying
+# iterator over the MVCC key space will stop itself when it encounters the
+# lock table keys (which are also local keys), without an error.
+iter upper=Z
+seek-ge k=Lb
+next
+next
+next
+next
+prev
+----
+seek-ge "Lb"/0,0: output: meta k=Lb ts=20.000000000,0 txn=2
+next: output: value k=Lb ts=20.000000000,0 v=b20
+next: output: meta k=Sc ts=30.000000000,0 txn=3
+next: output: value k=Sc ts=30.000000000,0 v=c30
+next: output: .
+prev: output: value k=Sc ts=30.000000000,0 v=c30
+
+# Similar to previous test, but with an upper bound less than LocalMax but
+# above the lock table key space. The result is the same
+iter upper=Yc
+seek-ge k=Lb
+next
+next
+next
+next
+prev
+----
+seek-ge "Lb"/0,0: output: meta k=Lb ts=20.000000000,0 txn=2
+next: output: value k=Lb ts=20.000000000,0 v=b20
+next: output: meta k=Sc ts=30.000000000,0 txn=3
+next: output: value k=Sc ts=30.000000000,0 v=c30
+next: output: .
+prev: output: value k=Sc ts=30.000000000,0 v=c30
+
+# Write some keys above the lock table in the local key space, which should
+# not happen in a correct system. Also note that the local store key with
+# non-zero timestamps is bogus, but harmless.
+define
+locks
+meta k=Lb ts=20 txn=2
+meta k=e ts=50 txn=3
+mvcc
+value k=Lb ts=20 v=b20
+value k=Sc ts=30 v=c30
+value k=Yd ts=40 v=d40
+value k=e ts=50 v=e50
+----
+
+# The intentInterleavingIter cannot see the Yd key, when iterating up from
+# keys below the lock table.
+iter upper=Z
+seek-ge k=Lb
+next
+next
+next
+prev
+----
+seek-ge "Lb"/0,0: output: meta k=Lb ts=20.000000000,0 txn=2
+next: output: value k=Lb ts=20.000000000,0 v=b20
+next: output: value k=Sc ts=30.000000000,0 v=c30
+next: output: .
+prev: output: value k=Sc ts=30.000000000,0 v=c30
+
+# When iterating backwards from LocalMax, we should see all the local keys,
+# except for the Yd key.
+iter upper=Z
+seek-lt k=Z
+prev
+prev
+next
+----
+seek-lt "Z"/0,0: output: value k=Sc ts=30.000000000,0 v=c30
+prev: output: value k=Lb ts=20.000000000,0 v=b20
+prev: output: meta k=Lb ts=20.000000000,0 txn=2
+next: output: value k=Lb ts=20.000000000,0 v=b20

--- a/pkg/storage/testdata/mvcc_histories/conditional_put_with_txn_enable_separated
+++ b/pkg/storage/testdata/mvcc_histories/conditional_put_with_txn_enable_separated
@@ -1,0 +1,110 @@
+run ok
+txn_begin t=A ts=123
+----
+>> at end:
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=123.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=123.000000000,0 wto=false max=0,0
+
+# Write value1.
+
+run ok
+with t=A
+  txn_step
+  cput k=k v=v
+----
+>> at end:
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=123.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=123.000000000,0 wto=false max=0,0
+meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=123.000000000,0 min=0,0 seq=1} ts=123.000000000,0 del=false klen=12 vlen=6
+data: "k"/123.000000000,0 -> /BYTES/v
+
+# Now, overwrite value1 with value2 from same txn; should see value1
+# as pre-existing value.
+
+run ok
+with t=A
+  txn_step
+  cput k=k v=v2 cond=v
+----
+>> at end:
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=123.000000000,0 min=0,0 seq=2} lock=true stat=PENDING rts=123.000000000,0 wto=false max=0,0
+meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=123.000000000,0 min=0,0 seq=2} ts=123.000000000,0 del=false klen=12 vlen=7 ih={{1 /BYTES/v}}
+data: "k"/123.000000000,0 -> /BYTES/v2
+
+# Writing value3 from a new epoch should see nil again.
+
+run ok
+with t=A
+  txn_restart
+  txn_step
+  cput k=k v=v3
+----
+>> at end:
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=1 ts=123.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=123.000000000,0 wto=false max=0,0
+meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=1 ts=123.000000000,0 min=0,0 seq=1} ts=123.000000000,0 del=false klen=12 vlen=7
+data: "k"/123.000000000,0 -> /BYTES/v3
+
+# Commit value3 at a later timestamp.
+
+run ok
+with t=A
+  txn_advance    ts=124
+  resolve_intent k=k
+  txn_remove
+----
+>> at end:
+data: "k"/124.000000000,0 -> /BYTES/v3
+
+# Write value4 with an old timestamp without txn...should get a write
+# too old error.
+
+run error
+cput k=k v=v4 cond=v3 ts=123
+----
+>> at end:
+data: "k"/124.000000000,1 -> /BYTES/v4
+data: "k"/124.000000000,0 -> /BYTES/v3
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write at timestamp 123.000000000,0 too old; wrote at 124.000000000,1
+
+# Reset for next test
+
+run ok
+clear_range k=k end=-k
+----
+>> at end:
+<no data>
+
+# From TxnCoordSenderRetries,
+# "multi-range batch with forwarded timestamp and cput and delete range"
+
+# First txn attempt
+
+run ok
+# Before txn start:
+put k=c v=value ts=1
+with t=A
+  txn_begin ts=2
+  txn_step
+  cput k=c v=cput cond=value
+----
+>> at end:
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=2.000000000,0 wto=false max=0,0
+meta: "c"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=1} ts=2.000000000,0 del=false klen=12 vlen=9
+data: "c"/2.000000000,0 -> /BYTES/cput
+data: "c"/1.000000000,0 -> /BYTES/value
+
+# Restart and retry cput. It should succeed.
+
+run trace ok
+with t=A
+  txn_restart ts=3
+  txn_step
+  cput k=c v=cput cond=value
+----
+>> txn_restart ts=3 t=A
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=1 ts=3.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=3.000000000,0 wto=false max=0,0
+>> txn_step t=A
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=1 ts=3.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=3.000000000,0 wto=false max=0,0
+>> cput k=c v=cput cond=value t=A
+called PutIntent("c", _, ExistingIntentSeparated, TDNUM(true), 00000000-0000-0000-0000-000000000002)
+meta: "c"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=1 ts=3.000000000,0 min=0,0 seq=1} ts=3.000000000,0 del=false klen=12 vlen=9
+data: "c"/3.000000000,0 -> /BYTES/cput
+data: "c"/1.000000000,0 -> /BYTES/value

--- a/pkg/storage/testdata/mvcc_histories/intent_history_enable_separated
+++ b/pkg/storage/testdata/mvcc_histories/intent_history_enable_separated
@@ -1,0 +1,58 @@
+## Write the base (default) value.
+
+run ok
+with t=A
+  txn_begin  ts=1
+  put   k=a v=default resolve
+  txn_remove
+----
+>> at end:
+data: "a"/1.000000000,0 -> /BYTES/default
+
+## See how the intent history evolves throughout the test.
+
+run trace ok
+with t=A
+  txn_begin  ts=2
+  with       k=a
+  put        v=first
+  txn_step
+  put        v=second
+  txn_step   n=2
+  del
+  txn_step   n=6
+  put        v=first
+  resolve_intent
+----
+>> txn_begin ts=2 t=A
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=2.000000000,0 wto=false max=0,0
+>> put v=first k=a t=A
+called PutIntent("a", _, NoExistingIntent, TDNUM(true), 00000000-0000-0000-0000-000000000002)
+meta: "a"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0} ts=2.000000000,0 del=false klen=12 vlen=10
+data: "a"/2.000000000,0 -> /BYTES/first
+data: "a"/1.000000000,0 -> /BYTES/default
+>> txn_step k=a t=A
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=2.000000000,0 wto=false max=0,0
+>> put v=second k=a t=A
+called PutIntent("a", _, ExistingIntentSeparated, TDNUM(true), 00000000-0000-0000-0000-000000000002)
+meta: "a"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=1} ts=2.000000000,0 del=false klen=12 vlen=11 ih={{0 /BYTES/first}}
+data: "a"/2.000000000,0 -> /BYTES/second
+data: "a"/1.000000000,0 -> /BYTES/default
+>> txn_step n=2 k=a t=A
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=3} lock=true stat=PENDING rts=2.000000000,0 wto=false max=0,0
+>> del k=a t=A
+called PutIntent("a", _, ExistingIntentSeparated, TDNUM(false), 00000000-0000-0000-0000-000000000002)
+meta: "a"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=3} ts=2.000000000,0 del=true klen=12 vlen=0 ih={{0 /BYTES/first}{1 /BYTES/second}}
+data: "a"/2.000000000,0 -> /<empty>
+data: "a"/1.000000000,0 -> /BYTES/default
+>> txn_step n=6 k=a t=A
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=9} lock=true stat=PENDING rts=2.000000000,0 wto=false max=0,0
+>> put v=first k=a t=A
+called PutIntent("a", _, ExistingIntentSeparated, TDNUM(false), 00000000-0000-0000-0000-000000000002)
+meta: "a"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=9} ts=2.000000000,0 del=false klen=12 vlen=10 ih={{0 /BYTES/first}{1 /BYTES/second}{3 /<empty>}}
+data: "a"/2.000000000,0 -> /BYTES/first
+data: "a"/1.000000000,0 -> /BYTES/default
+>> resolve_intent k=a t=A
+called ClearIntent("a", ExistingIntentSeparated, TDNUM(false), 00000000-0000-0000-0000-000000000002)
+data: "a"/2.000000000,0 -> /BYTES/first
+data: "a"/1.000000000,0 -> /BYTES/default

--- a/pkg/storage/testdata/mvcc_histories/intent_with_write_tracing_enable_separated
+++ b/pkg/storage/testdata/mvcc_histories/intent_with_write_tracing_enable_separated
@@ -1,0 +1,87 @@
+run trace ok
+with t=A
+  txn_begin ts=2
+  put k=k1 v=v1
+----
+>> txn_begin ts=2 t=A
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=2.000000000,0 wto=false max=0,0
+>> put k=k1 v=v1 t=A
+called PutIntent("k1", _, NoExistingIntent, TDNUM(true), 00000000-0000-0000-0000-000000000001)
+meta: "k1"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0} ts=2.000000000,0 del=false klen=12 vlen=7
+data: "k1"/2.000000000,0 -> /BYTES/v1
+
+run trace ok
+with t=A
+  txn_advance ts=3
+  txn_step
+  put k=k1 v=v1
+  put k=k2 v=v2
+----
+>> txn_advance ts=3 t=A
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=2.000000000,0 wto=false max=0,0
+>> txn_step t=A
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=2.000000000,0 wto=false max=0,0
+>> put k=k1 v=v1 t=A
+called PutIntent("k1", _, ExistingIntentSeparated, TDNUM(true), 00000000-0000-0000-0000-000000000001)
+meta: "k1"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} ts=3.000000000,0 del=false klen=12 vlen=7 ih={{0 /BYTES/v1}}
+data: "k1"/3.000000000,0 -> /BYTES/v1
+>> put k=k2 v=v2 t=A
+called PutIntent("k2", _, NoExistingIntent, TDNUM(true), 00000000-0000-0000-0000-000000000001)
+meta: "k1"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} ts=3.000000000,0 del=false klen=12 vlen=7 ih={{0 /BYTES/v1}}
+data: "k1"/3.000000000,0 -> /BYTES/v1
+meta: "k2"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} ts=3.000000000,0 del=false klen=12 vlen=7
+data: "k2"/3.000000000,0 -> /BYTES/v2
+
+run trace ok
+put k=k3 v=v3 ts=1
+----
+>> put k=k3 v=v3 ts=1
+meta: "k1"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} ts=3.000000000,0 del=false klen=12 vlen=7 ih={{0 /BYTES/v1}}
+data: "k1"/3.000000000,0 -> /BYTES/v1
+meta: "k2"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} ts=3.000000000,0 del=false klen=12 vlen=7
+data: "k2"/3.000000000,0 -> /BYTES/v2
+data: "k3"/1.000000000,0 -> /BYTES/v3
+
+run trace ok
+with t=A
+  put k=k3 v=v33
+----
+>> put k=k3 v=v33 t=A
+called PutIntent("k3", _, NoExistingIntent, TDNUM(true), 00000000-0000-0000-0000-000000000001)
+meta: "k1"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} ts=3.000000000,0 del=false klen=12 vlen=7 ih={{0 /BYTES/v1}}
+data: "k1"/3.000000000,0 -> /BYTES/v1
+meta: "k2"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} ts=3.000000000,0 del=false klen=12 vlen=7
+data: "k2"/3.000000000,0 -> /BYTES/v2
+meta: "k3"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} ts=3.000000000,0 del=false klen=12 vlen=8
+data: "k3"/3.000000000,0 -> /BYTES/v33
+data: "k3"/1.000000000,0 -> /BYTES/v3
+
+# transactionDidNotUpdateMeta (TDNUM) is false below for k2 and k3 since
+# disallowSeparatedIntents=true causes mvcc.go to always set it to false to maintain
+# consistency in a mixed version cluster.
+run trace ok
+with t=A
+  resolve_intent k=k1
+  resolve_intent k=k2 status=ABORTED
+  resolve_intent k=k3 status=ABORTED
+  txn_remove
+----
+>> resolve_intent k=k1 t=A
+called ClearIntent("k1", ExistingIntentSeparated, TDNUM(false), 00000000-0000-0000-0000-000000000001)
+data: "k1"/3.000000000,0 -> /BYTES/v1
+meta: "k2"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} ts=3.000000000,0 del=false klen=12 vlen=7
+data: "k2"/3.000000000,0 -> /BYTES/v2
+meta: "k3"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} ts=3.000000000,0 del=false klen=12 vlen=8
+data: "k3"/3.000000000,0 -> /BYTES/v33
+data: "k3"/1.000000000,0 -> /BYTES/v3
+>> resolve_intent k=k2 status=ABORTED t=A
+called ClearIntent("k2", ExistingIntentSeparated, TDNUM(true), 00000000-0000-0000-0000-000000000001)
+data: "k1"/3.000000000,0 -> /BYTES/v1
+meta: "k3"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} ts=3.000000000,0 del=false klen=12 vlen=8
+data: "k3"/3.000000000,0 -> /BYTES/v33
+data: "k3"/1.000000000,0 -> /BYTES/v3
+>> resolve_intent k=k3 status=ABORTED t=A
+called ClearIntent("k3", ExistingIntentSeparated, TDNUM(true), 00000000-0000-0000-0000-000000000001)
+data: "k1"/3.000000000,0 -> /BYTES/v1
+data: "k3"/1.000000000,0 -> /BYTES/v3
+>> txn_remove t=A

--- a/pkg/storage/testdata/mvcc_histories/no_read_after_abort_enable_separated
+++ b/pkg/storage/testdata/mvcc_histories/no_read_after_abort_enable_separated
@@ -1,0 +1,30 @@
+## Simple txn that aborts.
+
+run trace ok
+with t=A k=a
+  txn_begin      ts=22
+  put            v=cde
+  resolve_intent status=ABORTED
+  txn_remove
+----
+>> txn_begin ts=22 t=A k=a
+txn: "A" meta={id=00000000 key="a" pri=0.00000000 epo=0 ts=22.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=22.000000000,0 wto=false max=0,0
+>> put v=cde t=A k=a
+called PutIntent("a", _, NoExistingIntent, TDNUM(true), 00000000-0000-0000-0000-000000000001)
+meta: "a"/0,0 -> txn={id=00000000 key="a" pri=0.00000000 epo=0 ts=22.000000000,0 min=0,0 seq=0} ts=22.000000000,0 del=false klen=12 vlen=8
+data: "a"/22.000000000,0 -> /BYTES/cde
+>> resolve_intent status=ABORTED t=A k=a
+called ClearIntent("a", ExistingIntentSeparated, TDNUM(true), 00000000-0000-0000-0000-000000000001)
+<no data>
+>> txn_remove t=A k=a
+
+# Cannot read aborted value.
+
+run ok
+with t=A
+  txn_begin  ts=23
+  get   k=a
+  txn_remove
+----
+get: "a" -> <no data>
+>> at end:

--- a/pkg/storage/testdata/mvcc_histories/read_after_write_enable_separated
+++ b/pkg/storage/testdata/mvcc_histories/read_after_write_enable_separated
@@ -1,0 +1,91 @@
+## A simple txn that commits.
+
+run trace ok
+with t=A
+  txn_begin  ts=11
+  with       k=a
+    put      v=abc
+    get
+    resolve_intent
+----
+>> txn_begin ts=11 t=A
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=11.000000000,0 wto=false max=0,0
+>> put v=abc k=a t=A
+called PutIntent("a", _, NoExistingIntent, TDNUM(true), 00000000-0000-0000-0000-000000000001)
+meta: "a"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} ts=11.000000000,0 del=false klen=12 vlen=8
+data: "a"/11.000000000,0 -> /BYTES/abc
+>> get k=a t=A
+get: "a" -> /BYTES/abc @11.000000000,0
+>> resolve_intent k=a t=A
+called ClearIntent("a", ExistingIntentSeparated, TDNUM(true), 00000000-0000-0000-0000-000000000001)
+data: "a"/11.000000000,0 -> /BYTES/abc
+
+run ok
+with t=A resolve
+  put   k=a/1 v=eee
+  put   k=b   v=fff
+  put   k=b/2 v=ggg
+  put   k=c   v=hhh
+  txn_remove
+----
+>> at end:
+data: "a"/11.000000000,0 -> /BYTES/abc
+data: "a/1"/11.000000000,0 -> /BYTES/eee
+data: "b"/11.000000000,0 -> /BYTES/fff
+data: "b/2"/11.000000000,0 -> /BYTES/ggg
+data: "c"/11.000000000,0 -> /BYTES/hhh
+
+# Reads previous writes, transactional.
+
+run ok
+with t=A
+  txn_begin  ts=11
+  get   k=a
+----
+get: "a" -> /BYTES/abc @11.000000000,0
+>> at end:
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=11.000000000,0 wto=false max=0,0
+
+run trace ok
+with t=A
+  scan k=a end==b
+  scan k=a end=+a
+  scan k=a end=-a
+  scan k=a end=+b
+  scan k=a end==b
+  scan k=a end=-b
+  txn_remove
+----
+>> scan k=a end==b t=A
+scan: "a" -> /BYTES/abc @11.000000000,0
+scan: "a/1" -> /BYTES/eee @11.000000000,0
+>> scan k=a end=+a t=A
+scan: "a" -> /BYTES/abc @11.000000000,0
+>> scan k=a end=-a t=A
+scan: "a" -> /BYTES/abc @11.000000000,0
+scan: "a/1" -> /BYTES/eee @11.000000000,0
+>> scan k=a end=+b t=A
+scan: "a" -> /BYTES/abc @11.000000000,0
+scan: "a/1" -> /BYTES/eee @11.000000000,0
+scan: "b" -> /BYTES/fff @11.000000000,0
+>> scan k=a end==b t=A
+scan: "a" -> /BYTES/abc @11.000000000,0
+scan: "a/1" -> /BYTES/eee @11.000000000,0
+>> scan k=a end=-b t=A
+scan: "a" -> /BYTES/abc @11.000000000,0
+scan: "a/1" -> /BYTES/eee @11.000000000,0
+scan: "b" -> /BYTES/fff @11.000000000,0
+scan: "b/2" -> /BYTES/ggg @11.000000000,0
+>> txn_remove t=A
+
+
+## A simple txn anchored at some arbitrary key.
+
+run trace ok
+with t=A k=a
+  txn_begin ts=1
+  txn_remove
+----
+>> txn_begin ts=1 t=A k=a
+txn: "A" meta={id=00000000 key="a" pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=1.000000000,0 wto=false max=0,0
+>> txn_remove t=A k=a


### PR DESCRIPTION
The main part of this PR is a reworking of the bounds behavior
of intentInterleavingIter and a clarification of that behavior
in engine.go. The existing behavior was subtly broken in two
ways:
- iteration up from local keys without an upper bound or an
  upper bound that was a global key could cause the iterator
  to enter an error state when it found a separated intent
  without the corresponding provisional value. Similarly, the
  behavior when iterating backwards from global keys without
  a lower bound, or a lower bound that was a local key would
  encounter an error. There are additional tests that exercise
  this (the earlier tests did not construct an engine with
  both local and global keys and therefore missed this
  problem).
- even if we could fix the inconsistency from the previous
  bullet, there is a semantic concern that a caller that
  sets a global upper bound (local lower bound) and seeks
  to a local key (global key) and then iterates forward
  (backward) is expecting this iteration to seamlessly go
  from local (global) to global (local) keys, which is
  not something we can do with intentInterleavingIter since
  it would require it to transparently jump over the
  intermediate lock table.
  I didn't expect there were callers trying to do this, but
  there are: we have multiple places that have both
  local and global spans, and create an iterator with an
  upperbound that is the end of the highest global span and
  then SeekGE to the start of the smallest local span.
  They are not actually trying to go from local to global
  without an intermediate seek, but it is impossible to
  know their intention from the iterator interface. Such
  behavior is no longer allowed, since intentInterleavingIter
  is very strict about ensuring that if it is constrained to
  local (global) keys, all seek and SetUpperBound calls
  are using the same kind of key. Without such strictness
  we are at risk of introducing hard-to-find correctness
  bugs.

Additionally, we now place the lock table keys at the
end of the local key space, after the local store keys.
This is convenient for cleanly separating the two parts
of the key space that a caller iterates over using an
MVCCIterator (even though local store keys don't have
versions).

intentInterleavingIter is simpler with the above fixes:
- The compex upper-bound behavior for prefix iteration is
  ripped out. It was never needed since pebble.Iterator
  is very strict about not exposing keys that don't match
  the prefix.
- The constraint on whether the iterator is over local or
  global keys or unconstrained (only for prefix iteration
  because of the previous bullet), is computed at iterator
  construction time.

The callers mentioned above are now fixed. They now create
new iterators for each span, or lazily create a new one if
the existing iterator was constrained differently. Creating
a new iterator is usually cheap because of iterator reuse.
One exception is that pebbleSnapshot does not reuse
iterators -- I tried to add reuse there but I can't add
it directly to pebbleSnapshot itself since callers may
be expecting to the use the same snapshot in multiple
goroutines. And wrapping pebbleSnapshot for iterator reuse
in a single goroutine is complicated because the snapshot
may have been wrapped in other Reader implementations.
I suspect the iterator construction is not going to
performance critical for these snapshot use cases, but
could use a more informed opinion.

Related to the above, SetUpperBound is now deprecated for
MVCCIterator and EngineIterator.

Informs #41720

Release note: None
