### PR TITLE
sql: fix EXPLAIN ANALYZE (DEBUG)

### DIFF
--- a/pkg/cli/interactive_tests/test_explain_analyze_debug.tcl
+++ b/pkg/cli/interactive_tests/test_explain_analyze_debug.tcl
@@ -1,0 +1,34 @@
+#! /usr/bin/env expect -f
+
+source [file join [file dirname $argv0] common.tcl]
+
+start_test "Ensure that EXPLAIN ANALYZE (DEBUG) works as expected in the sql shell"
+
+start_server $argv
+
+# Spawn a sql shell.
+spawn $argv sql
+set client_spawn_id $spawn_id
+eexpect root@
+
+send "EXPLAIN ANALYZE (DEBUG) SELECT 1;\r"
+eexpect "Statement diagnostics bundle generated."
+expect {
+  "warning: pq: unexpected DataRow in simple query execution" {
+    puts "Error: unexpected DataRow in simple query execution"
+    exit 1
+  }
+  "connection lost" {
+    puts "Error: connection lost"
+    exit 1
+  }
+  "root@" {
+  }
+}
+
+interrupt
+eexpect eof
+
+end_test
+
+stop_server $argv

--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -261,12 +261,6 @@ func (ih *instrumentationHelper) Finish(
 			ih.finishCollectionDiagnostics()
 			telemetry.Inc(sqltelemetry.StatementDiagnosticsCollectedCounter)
 		}
-
-		// Handle EXPLAIN ANALYZE (DEBUG). If there was a communication error
-		// already, no point in setting any results.
-		if ih.outputMode == explainAnalyzeDebugOutput && retErr == nil {
-			retErr = setExplainBundleResult(ctx, res, bundle, cfg)
-		}
 	}
 
 	// If there was a communication error already, no point in setting any


### PR DESCRIPTION
A bug was introduced which causes EXPLAIN ANALYZE (DEBUG) to set the
result twice, confusing the pg client and resulting in a terminated
connection. This change fixes this issue and adds a cli test that
would have caught this.

Fixes #59553.

Release note (bug fix): fixed EXPLAIN ANALYZE (DEBUG) interaction with
the SQL shell.