### PR TITLE
sql: remove experimental multi-column inverted index session setting

### DIFF
--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -185,9 +185,6 @@ func MakeIndexDescriptor(
 			return nil, pgerror.New(pgcode.InvalidSQLStatementName, "inverted indexes can't be unique")
 		}
 
-		if !params.SessionData().EnableMultiColumnInvertedIndexes && len(n.Columns) > 1 {
-			return nil, pgerror.New(pgcode.FeatureNotSupported, "indexing more than one column with an inverted index is not supported")
-		}
 		indexDesc.Type = descpb.IndexDescriptor_INVERTED
 		columnDesc, _, err := tableDesc.FindColumnByName(n.Columns[len(n.Columns)-1].Column)
 		if err != nil {

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1693,9 +1693,6 @@ func NewTableDesc(
 				Version:          indexEncodingVersion,
 			}
 			if d.Inverted {
-				if !sessionData.EnableMultiColumnInvertedIndexes && len(d.Columns) > 1 {
-					return nil, pgerror.New(pgcode.FeatureNotSupported, "indexing more than one column with an inverted index is not supported")
-				}
 				idx.Type = descpb.IndexDescriptor_INVERTED
 			}
 			if d.Sharded != nil {

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -310,15 +310,6 @@ var clusterIdleInSessionTimeout = settings.RegisterDurationSetting(
 	settings.NonNegativeDuration,
 )
 
-// TODO(mgartner): remove this once multi-column inverted indexes are fully
-// supported.
-var experimentalMultiColumnInvertedIndexesMode = settings.RegisterBoolSetting(
-	"sql.defaults.experimental_multi_column_inverted_indexes.enabled",
-	"default value for experimental_enable_multi_column_inverted_indexes session setting;"+
-		"disables multi column inverted indexes by default",
-	false,
-)
-
 // TODO(rytaft): remove this once unique without index constraints are fully
 // supported.
 var experimentalUniqueWithoutIndexConstraintsMode = settings.RegisterBoolSetting(
@@ -2231,12 +2222,6 @@ func (m *sessionDataMutator) SetDisallowFullTableScans(val bool) {
 
 func (m *sessionDataMutator) SetAlterColumnTypeGeneral(val bool) {
 	m.data.AlterColumnTypeGeneralEnabled = val
-}
-
-// TODO(mgartner): remove this once multi-column inverted indexes are fully
-// supported.
-func (m *sessionDataMutator) SetMutliColumnInvertedIndexes(val bool) {
-	m.data.EnableMultiColumnInvertedIndexes = val
 }
 
 // TODO(radu): remove this once the feature is stable.

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -3403,7 +3403,6 @@ enable_seqscan                                        on
 enable_zigzag_join                                    on
 experimental_enable_hash_sharded_indexes              off
 experimental_enable_implicit_column_partitioning      off
-experimental_enable_multi_column_inverted_indexes     off
 experimental_enable_temp_tables                       off
 experimental_enable_unique_without_index_constraints  on
 experimental_enable_virtual_columns                   off

--- a/pkg/sql/logictest/testdata/logic_test/inverted_filter_json_array_dist
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_filter_json_array_dist
@@ -1,9 +1,6 @@
 # LogicTest: 5node
 
 statement ok
-SET experimental_enable_multi_column_inverted_indexes=true
-
-statement ok
 CREATE TABLE json_tab (
   a INT PRIMARY KEY,
   b JSONB,

--- a/pkg/sql/logictest/testdata/logic_test/inverted_index
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index
@@ -13,10 +13,10 @@ INSERT INTO t VALUES (1,1,1)
 statement ok
 CREATE INDEX foo ON t (b)
 
-statement error column b is of type int and thus is not indexable with an inverted index.*\nHINT.*\n.*35730
+statement error column b of type int is not allowed as the last column in an inverted index\nHINT: see the documentation for more information about inverted indexes
 CREATE INVERTED INDEX foo_inv ON t(b)
 
-statement error column b is of type int and thus is not indexable with an inverted index.*\nHINT.*\n.*35730
+statement error column b of type int is not allowed as the last column in an inverted index\nHINT: see the documentation for more information about inverted indexes
 CREATE INDEX foo_inv2 ON t USING GIN (b)
 
 statement error pq: inverted indexes can't be unique
@@ -52,9 +52,7 @@ c  CREATE TABLE public.c (
 statement ok
 CREATE INVERTED INDEX ON c("qUuX")
 
-# TODO(mgartner): This error message is unclear. It should explain that only the
-# last indexed column can be inverted.
-statement error column foo is of type jsonb and thus is not indexable with an inverted index
+statement error column foo of type jsonb is only allowed as the last column in an inverted index\nHINT: see the documentation for more information about inverted indexes
 CREATE TABLE d (
   id INT PRIMARY KEY,
   foo JSONB,
@@ -62,7 +60,7 @@ CREATE TABLE d (
   INVERTED INDEX (foo, bar)
 )
 
-statement error column foo is of type int and thus is not indexable with an inverted index.*\nHINT.*\n.*35730
+statement error column foo of type int is not allowed as the last column in an inverted index\nHINT: see the documentation for more information about inverted indexes
 CREATE TABLE d (
   id INT PRIMARY KEY,
   foo INT,

--- a/pkg/sql/logictest/testdata/logic_test/inverted_index
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index
@@ -52,7 +52,9 @@ c  CREATE TABLE public.c (
 statement ok
 CREATE INVERTED INDEX ON c("qUuX")
 
-statement error indexing more than one column with an inverted index is not supported
+# TODO(mgartner): This error message is unclear. It should explain that only the
+# last indexed column can be inverted.
+statement error column foo is of type jsonb and thus is not indexable with an inverted index
 CREATE TABLE d (
   id INT PRIMARY KEY,
   foo JSONB,

--- a/pkg/sql/logictest/testdata/logic_test/inverted_index_multi_column
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index_multi_column
@@ -1,21 +1,15 @@
 # Tests for multi-column inverted indexes.
 
 # Err if the last column is not an invertable type.
-# TODO(mgartner): This error message should explain that it's not indexable as
-# the last column.
-statement error column b is of type int and thus is not indexable with an inverted index
+statement error column b of type int is not allowed as the last column in an inverted index\nHINT: see the documentation for more information about inverted indexes
 CREATE TABLE m_err (k INT PRIMARY KEY, a INT, b INT, geom GEOMETRY, INVERTED INDEX (a, b))
 
 # Err if a non-last column is not a non-invertable type.
-# TODO(mgartner): This error message should explain that it's not indexable as
-# a non-last column.
-statement error column j is of type jsonb and thus is not indexable with an inverted index
+statement error column j of type jsonb is only allowed as the last column in an inverted index\nHINT: see the documentation for more information about inverted indexes
 CREATE TABLE m_err (k INT PRIMARY KEY, j JSON, geom GEOMETRY, INVERTED INDEX (j, geom))
 
 # Err if a non-last column is not a non-invertable type.
-# TODO(mgartner): This error message should explain that it's not indexable as
-# a non-last column.
-statement error column j is of type jsonb and thus is not indexable with an inverted index
+statement error column j of type jsonb is only allowed as the last column in an inverted index\nHINT: see the documentation for more information about inverted indexes
 CREATE TABLE m_err (k INT PRIMARY KEY, a INT, j JSON, geom GEOMETRY, INVERTED INDEX (a, j, geom))
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/inverted_index_multi_column
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index_multi_column
@@ -1,17 +1,4 @@
-# Err when experimental_enable_multi_column_inverted_index is not true.
-statement error indexing more than one column with an inverted index is not supported
-CREATE TABLE m_err (a INT, geom GEOMETRY, INVERTED INDEX (a, geom))
-
-# Err when experimental_enable_multi_column_inverted_index is not true.
-statement error indexing more than one column with an inverted index is not supported
-CREATE TABLE m_err (a INT, geom GEOMETRY);
-CREATE INVERTED INDEX m_err_idx ON m_err (a, geom);
-
-statement ok
-DROP TABLE m_err
-
-statement ok
-SET experimental_enable_multi_column_inverted_indexes=true
+# Tests for multi-column inverted indexes.
 
 # Err if the last column is not an invertable type.
 # TODO(mgartner): This error message should explain that it's not indexable as

--- a/pkg/sql/logictest/testdata/logic_test/inverted_join_multi_column
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_join_multi_column
@@ -1,5 +1,4 @@
-statement ok
-SET experimental_enable_multi_column_inverted_indexes=true
+# Tests for inverted joins with multi-column inverted indexes.
 
 statement ok
 CREATE TABLE j1 (

--- a/pkg/sql/logictest/testdata/logic_test/inverted_join_multi_column_dist
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_join_multi_column_dist
@@ -1,9 +1,6 @@
 # LogicTest: 5node-default-configs !5node-metadata
 
 statement ok
-SET experimental_enable_multi_column_inverted_indexes=true
-
-statement ok
 CREATE TABLE j1 (
   k INT PRIMARY KEY,
   j JSON

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1992,7 +1992,6 @@ enable_zigzag_join                                    on                  NULL  
 experimental_distsql_planning                         off                 NULL      NULL        NULL        string
 experimental_enable_hash_sharded_indexes              off                 NULL      NULL        NULL        string
 experimental_enable_implicit_column_partitioning      off                 NULL      NULL        NULL        string
-experimental_enable_multi_column_inverted_indexes     off                 NULL      NULL        NULL        string
 experimental_enable_temp_tables                       off                 NULL      NULL        NULL        string
 experimental_enable_unique_without_index_constraints  on                  NULL      NULL        NULL        string
 experimental_enable_virtual_columns                   off                 NULL      NULL        NULL        string
@@ -2068,7 +2067,6 @@ enable_zigzag_join                                    on                  NULL  
 experimental_distsql_planning                         off                 NULL  user     NULL      off                 off
 experimental_enable_hash_sharded_indexes              off                 NULL  user     NULL      off                 off
 experimental_enable_implicit_column_partitioning      off                 NULL  user     NULL      off                 off
-experimental_enable_multi_column_inverted_indexes     off                 NULL  user     NULL      off                 off
 experimental_enable_temp_tables                       off                 NULL  user     NULL      off                 off
 experimental_enable_unique_without_index_constraints  on                  NULL  user     NULL      off                 off
 experimental_enable_virtual_columns                   off                 NULL  user     NULL      off                 off
@@ -2140,7 +2138,6 @@ enable_zigzag_join                                    NULL    NULL     NULL     
 experimental_distsql_planning                         NULL    NULL     NULL     NULL        NULL
 experimental_enable_hash_sharded_indexes              NULL    NULL     NULL     NULL        NULL
 experimental_enable_implicit_column_partitioning      NULL    NULL     NULL     NULL        NULL
-experimental_enable_multi_column_inverted_indexes     NULL    NULL     NULL     NULL        NULL
 experimental_enable_temp_tables                       NULL    NULL     NULL     NULL        NULL
 experimental_enable_unique_without_index_constraints  NULL    NULL     NULL     NULL        NULL
 experimental_enable_virtual_columns                   NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -49,7 +49,6 @@ enable_zigzag_join                                    on
 experimental_distsql_planning                         off
 experimental_enable_hash_sharded_indexes              off
 experimental_enable_implicit_column_partitioning      off
-experimental_enable_multi_column_inverted_indexes     off
 experimental_enable_temp_tables                       off
 experimental_enable_unique_without_index_constraints  off
 experimental_enable_virtual_columns                   off

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
@@ -1126,9 +1126,6 @@ anti-join (lookup geo_table)
 subtest multi_column
 
 statement ok
-SET experimental_enable_multi_column_inverted_indexes=true
-
-statement ok
 CREATE TABLE m (
     k INT PRIMARY KEY,
     a INT,

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index_multi_column
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index_multi_column
@@ -1,9 +1,6 @@
 # LogicTest: local
 
 statement ok
-SET experimental_enable_multi_column_inverted_indexes=true
-
-statement ok
 CREATE TABLE t (
     k INT PRIMARY KEY,
     i INT,

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_join_multi_column
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_join_multi_column
@@ -1,9 +1,6 @@
 # LogicTest: local
 
 statement ok
-SET experimental_enable_multi_column_inverted_indexes=true
-
-statement ok
 CREATE TABLE j1 (
   k INT PRIMARY KEY,
   j JSON,

--- a/pkg/sql/rowexec/inverted_joiner_test.go
+++ b/pkg/sql/rowexec/inverted_joiner_test.go
@@ -200,11 +200,6 @@ func TestInvertedJoiner(t *testing.T) {
 	s, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 
-	_, err := sqlDB.Exec("SET experimental_enable_multi_column_inverted_indexes=true")
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	aFn := func(row int) tree.Datum {
 		return tree.NewDInt(tree.DInt(row))
 	}

--- a/pkg/sql/sessiondata/session_data.go
+++ b/pkg/sql/sessiondata/session_data.go
@@ -222,11 +222,6 @@ type LocalOnlySessionData struct {
 	SynchronousCommit bool
 	// EnableSeqScan is a dummy setting for the enable_seqscan var.
 	EnableSeqScan bool
-	// EnableMultiColumnInvertedIndexes indicates whether creating multi-column
-	// inverted indexes is allowed.
-	// TODO(mgartner): remove this once multi-column inverted indexes are fully
-	// supported.
-	EnableMultiColumnInvertedIndexes bool
 
 	// VirtualColumnsEnabled indicates whether we allow virtual (non-stored)
 	// computed columns.

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -1165,27 +1165,6 @@ var varGen = map[string]sessionVar{
 	},
 
 	// CockroachDB extension.
-	// TODO(mgartner): remove this once multi-column inverted indexes are fully
-	// supported.
-	`experimental_enable_multi_column_inverted_indexes`: {
-		GetStringVal: makePostgresBoolGetStringValFn(`experimental_enable_multi_column_inverted_indexes`),
-		Set: func(_ context.Context, m *sessionDataMutator, s string) error {
-			b, err := paramparse.ParseBoolVar(`experimental_enable_multi_column_inverted_indexes`, s)
-			if err != nil {
-				return err
-			}
-			m.SetMutliColumnInvertedIndexes(b)
-			return nil
-		},
-		Get: func(evalCtx *extendedEvalContext) string {
-			return formatBoolAsPostgresSetting(evalCtx.SessionData.EnableMultiColumnInvertedIndexes)
-		},
-		GlobalDefault: func(sv *settings.Values) string {
-			return formatBoolAsPostgresSetting(experimentalMultiColumnInvertedIndexesMode.Get(sv))
-		},
-	},
-
-	// CockroachDB extension.
 	`experimental_enable_virtual_columns`: {
 		GetStringVal: makePostgresBoolGetStringValFn(`experimental_enable_virtual_columns`),
 		Set: func(_ context.Context, m *sessionDataMutator, s string) error {


### PR DESCRIPTION
#### sql: remove experimental multi-column inverted index session setting

The session setting gating access to multi-column inverted indexes is
removed now that the feature is supported. Multi-column inverted indexes
add an additional indexing option for users. They will provide the
foundation to allow for partitioned inverted indexes.

Informs #43643

Release note (sql change): Multi-column inverted indexes can now be
created. The last indexed column must be inverted types such as JSON,
ARRAY, GEOMETRY, and GEOGRAPHY. All preceding columns must have types
that are indexable. These indexes may be used for queries that constrain
all index columns.

#### sql: better error messages for invalid inverted index columns

Release note: None
