### PR TITLE
sql: omit NOTICE about indexes not being partitioned for PARTITION ALL BY

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
@@ -216,7 +216,7 @@ CREATE TABLE public.t (
   PARTITION two VALUES IN (2)
 )
 
-statement ok
+query T noticetrace
 CREATE TABLE public.t (
   pk int PRIMARY KEY,
   pk2 int NOT NULL,
@@ -233,14 +233,16 @@ CREATE TABLE public.t (
   PARTITION one VALUES IN (1),
   PARTITION two VALUES IN (2)
 )
+----
 
 statement error cannot define PARTITION BY on an index if the table has a PARTITION ALL BY definition
 CREATE INDEX created_idx ON t(c) PARTITION BY LIST (d) (
   PARTITION one VALUES IN ((1))
 )
 
-statement ok
+query T noticetrace
 CREATE INDEX created_idx ON t(c)
+----
 
 statement ok
 ALTER TABLE t ADD CONSTRAINT unique_c_d UNIQUE(c, d)

--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -417,7 +417,11 @@ func (n *createIndexNode) startExec(params runParams) error {
 
 	// Warn against creating a non-partitioned index on a partitioned table,
 	// which is undesirable in most cases.
-	if n.n.PartitionByIndex == nil && n.tableDesc.GetPrimaryIndex().GetPartitioning().NumColumns > 0 {
+	// Avoid the warning if we have PARTITION ALL BY as all indexes will implicitly
+	// have relevant partitioning columns prepended at the front.
+	if n.n.PartitionByIndex == nil &&
+		n.tableDesc.GetPrimaryIndex().GetPartitioning().NumColumns > 0 &&
+		!n.tableDesc.IsPartitionAllBy() {
 		params.p.BufferClientNotice(
 			params.ctx,
 			errors.WithHint(

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -248,10 +248,12 @@ func (n *createTableNode) startExec(params runParams) error {
 
 	// Warn against creating non-partitioned indexes on a partitioned table,
 	// which is undesirable in most cases.
+	// Avoid the warning if we have PARTITION ALL BY as all indexes will implicitly
+	// have relevant partitioning columns prepended at the front.
 	if n.n.PartitionByTable.ContainsPartitions() {
 		for _, def := range n.n.Defs {
 			if d, ok := def.(*tree.IndexTableDef); ok {
-				if d.PartitionByIndex == nil {
+				if d.PartitionByIndex == nil && !n.n.PartitionByTable.All {
 					params.p.BufferClientNotice(
 						params.ctx,
 						errors.WithHint(


### PR DESCRIPTION
We previously would print a notice specifying that non-partitioned
indexes on partitioned tables may not be performant - however, this
notice does not apply for PARTITION ALL BY tables as they will be
implicitly added for all indexes.

Release note: None