### PR TITLE
vendor: bump crlfmt a78e1c207bc0 to b3eff0b87c79

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -406,8 +406,8 @@ def go_deps():
         name = "com_github_cockroachdb_crlfmt",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/cockroachdb/crlfmt",
-        sum = "h1:O4yb+RtkmDaXFlHSBpZodXaghfTd3Prdea0nk0eZCT4=",
-        version = "v0.0.0-20200116191136-a78e1c207bc0",
+        sum = "h1:4s0GWs4NXFK4JEeUc0Q1pRbL4oMbqh1DK70qeQ+viOA=",
+        version = "v0.0.0-20210128092314-b3eff0b87c79",
     )
     go_repository(
         name = "com_github_cockroachdb_datadriven",
@@ -2990,20 +2990,12 @@ def go_deps():
         version = "v0.0.0-20201020160332-67f06af15bc9",
     )
     go_repository(
-        name = "org_golang_x_sys",
-        build_file_proto_mode = "disable_global",
-        importpath = "golang.org/x/sys",
-        sum = "h1:VwygUrnw9jn88c4u8GD3rZQbqrP/tgas88tPUbBxQrk=",
-        version = "v0.0.0-20210124154548-22da62e12c0c",
-    )
-    go_repository(
         name = "org_golang_x_term",
         build_file_proto_mode = "disable_global",
         importpath = "golang.org/x/term",
         sum = "h1:/ZHdbVpdR/jk3g30/d4yUL0JU9kksj8+F/bnQUVLGDM=",
         version = "v0.0.0-20201117132131-f5c789dd3221",
     )
-
     go_repository(
         name = "org_golang_x_text",
         build_file_proto_mode = "disable_global",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -45,11 +45,19 @@ git_repository(
 load("@bazel_gazelle//:deps.bzl", "go_repository")
 
 go_repository(
+    name = "org_golang_x_sys",
+    build_file_proto_mode = "disable_global",
+    importpath = "golang.org/x/sys",
+    sum = "h1:VwygUrnw9jn88c4u8GD3rZQbqrP/tgas88tPUbBxQrk=",
+    version = "v0.0.0-20210124154548-22da62e12c0c",
+)
+
+go_repository(
     name = "org_golang_x_tools",
     build_file_proto_mode = "disable_global",
     importpath = "golang.org/x/tools",
-    sum = "h1:5xKxdl/RhlelmSPaxyVeq5PYSmJ4H14yeQT58qP1F6o=",
-    version = "v0.0.0-20210104081019-d8d6ddbec6ee",
+    sum = "h1:po9/4sTYwZU9lPhi1tOrb4hCv3qrhiQ77LZfGa2OjwY=",
+    version = "v0.1.0",
 )
 
 go_repository(

--- a/build/STRINGER.bzl
+++ b/build/STRINGER.bzl
@@ -2,11 +2,17 @@
 # within bazel sandbox.
 def stringer(src, typ, name):
    native.genrule(
-      name = name, 
+      name = name,
       srcs = [src], # Accessed below using `$<`.
       outs = [typ.lower() + "_string.go"],
+      # golang.org/x/tools executes commands via
+      # golang.org/x/sys/execabs which requires all PATH lookups to
+      # result in absolute paths. To account for this, we resolve the
+      # relative path returned by location to an absolute path.
       cmd = """
-         env PATH=`dirname $(location @go_sdk//:bin/go)` HOME=$(GENDIR) \
+         GO_REL_PATH=`dirname $(location @go_sdk//:bin/go)`
+         GO_ABS_PATH=`cd $$GO_REL_PATH && pwd`
+         env PATH=$$GO_ABS_PATH HOME=$(GENDIR) \
          $(location @org_golang_x_tools//cmd/stringer:stringer) -output=$@ -type={} $<
       """.format(typ),
       tools = [
@@ -14,4 +20,3 @@ def stringer(src, typ, name):
          "@org_golang_x_tools//cmd/stringer",
        ],
    )
-

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/cockroachdb/circuitbreaker v2.2.2-0.20190114160014-a614b14ccf63+incompatible
 	github.com/cockroachdb/cmux v0.0.0-20170110192607-30d10be49292
 	github.com/cockroachdb/cockroach-go v0.0.0-20200504194139-73ffeee90b62
-	github.com/cockroachdb/crlfmt v0.0.0-20200116191136-a78e1c207bc0
+	github.com/cockroachdb/crlfmt v0.0.0-20210128092314-b3eff0b87c79
 	github.com/cockroachdb/datadriven v1.0.1-0.20201212195501-e89bf9ee1861
 	github.com/cockroachdb/errors v1.8.2
 	github.com/cockroachdb/go-test-teamcity v0.0.0-20191211140407-cff980ad0a55
@@ -158,7 +158,7 @@ require (
 	golang.org/x/term v0.0.0-20201117132131-f5c789dd3221
 	golang.org/x/text v0.3.5
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
-	golang.org/x/tools v0.0.0-20210104081019-d8d6ddbec6ee
+	golang.org/x/tools v0.1.0
 	google.golang.org/api v0.1.0
 	google.golang.org/genproto v0.0.0-20200218151345-dad8c97a84f5 // indirect
 	google.golang.org/grpc v1.29.1

--- a/go.sum
+++ b/go.sum
@@ -139,8 +139,8 @@ github.com/cockroachdb/cmux v0.0.0-20170110192607-30d10be49292 h1:dzj1/xcivGjNPw
 github.com/cockroachdb/cmux v0.0.0-20170110192607-30d10be49292/go.mod h1:qRiX68mZX1lGBkTWyp3CLcenw9I94W2dLeRvMzcn9N4=
 github.com/cockroachdb/cockroach-go v0.0.0-20200504194139-73ffeee90b62 h1:eqJbq0A8ev6101p/zV72eOM+Z3WZkgb66S7PVJQR9wI=
 github.com/cockroachdb/cockroach-go v0.0.0-20200504194139-73ffeee90b62/go.mod h1:XGLbWH/ujMcbPbhZq52Nv6UrCghb1yGn//133kEsvDk=
-github.com/cockroachdb/crlfmt v0.0.0-20200116191136-a78e1c207bc0 h1:O4yb+RtkmDaXFlHSBpZodXaghfTd3Prdea0nk0eZCT4=
-github.com/cockroachdb/crlfmt v0.0.0-20200116191136-a78e1c207bc0/go.mod h1:uY/PY/C5c2cIFaeWGjdZSd0eptkmXiX5vd92GMZZ50M=
+github.com/cockroachdb/crlfmt v0.0.0-20210128092314-b3eff0b87c79 h1:4s0GWs4NXFK4JEeUc0Q1pRbL4oMbqh1DK70qeQ+viOA=
+github.com/cockroachdb/crlfmt v0.0.0-20210128092314-b3eff0b87c79/go.mod h1:EOI6rrXIdP+4EXwM8837kmmb6IJesf7k7W6bUu8BDOg=
 github.com/cockroachdb/datadriven v0.0.0-20200714090401-bf6692d28da5/go.mod h1:h6jFvWxBdQXxjopDMZyH2UVceIRfR84bdzbkoKrsWNo=
 github.com/cockroachdb/datadriven v1.0.0 h1:uhZrAfEayBecH2w2tZmhe20HJ7hDvrrA4x2Bg9YdZKM=
 github.com/cockroachdb/datadriven v1.0.0/go.mod h1:5Ib8Meh+jk1RlHIXej6Pzevx/NLlNvQB9pmSBZErGA4=
@@ -818,6 +818,7 @@ golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
+golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974 h1:IX6qOQeG5uLjB/hjjwjedwfjND0hgjPMMyO1RoIXQNI=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -833,6 +834,7 @@ golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190412183630-56d357773e84/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9 h1:SQFwaSi55rU7vdNs9Yr0Z324VNlrF+0wMqRXT4St8ck=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -863,6 +865,7 @@ golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200519105757-fe76b779f299/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201009025420-dfb3f7c4e634/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c h1:VwygUrnw9jn88c4u8GD3rZQbqrP/tgas88tPUbBxQrk=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221 h1:/ZHdbVpdR/jk3g30/d4yUL0JU9kksj8+F/bnQUVLGDM=
@@ -899,8 +902,9 @@ golang.org/x/tools v0.0.0-20200207183749-b753a1ba74fa/go.mod h1:TB2adYChydJhpapK
 golang.org/x/tools v0.0.0-20200410194907-79a7a3126eef/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200509030707-2212a7e161a5/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200626171337-aa94e735be7f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
-golang.org/x/tools v0.0.0-20210104081019-d8d6ddbec6ee h1:5xKxdl/RhlelmSPaxyVeq5PYSmJ4H14yeQT58qP1F6o=
-golang.org/x/tools v0.0.0-20210104081019-d8d6ddbec6ee/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
+golang.org/x/tools v0.0.0-20200923014426-f5e916c686e1/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
+golang.org/x/tools v0.1.0 h1:po9/4sTYwZU9lPhi1tOrb4hCv3qrhiQ77LZfGa2OjwY=
+golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/xerrors v0.0.0-20190410155217-1f06c39b4373/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/pkg/sql/opt/BUILD.bazel
+++ b/pkg/sql/opt/BUILD.bazel
@@ -103,9 +103,15 @@ genrule(
         ":gen-rulenames",
     ],
     outs = ["rule_name_string.go"],
+    # golang.org/x/tools executes commands via
+    # golang.org/x/sys/execabs which requires all PATH lookups to
+    # result in absolute paths. To account for this, we resolve the
+    # relative path returned by location to an absolute path.
     cmd = """
       cp $(location rule_name.go) `dirname $(location :gen-rulenames)`/rule_name.go
-      env PATH=`dirname $(location @go_sdk//:bin/go)` HOME=$(GENDIR) \
+      GO_REL_PATH=`dirname $(location @go_sdk//:bin/go)`
+      GO_ABS_PATH=`cd $$GO_REL_PATH && pwd`
+      env PATH=$$GO_ABS_PATH HOME=$(GENDIR) \
       $(location @org_golang_x_tools//cmd/stringer:stringer) -output=$@ \
       -type=RuleName `dirname $(location :gen-rulenames)`/rule_name.go $(location :gen-rulenames)
     """,

--- a/pkg/sql/schemachange/BUILD.bazel
+++ b/pkg/sql/schemachange/BUILD.bazel
@@ -50,8 +50,14 @@ genrule(
         "alter_column_type.go",
     ],
     outs = ["columnconversionkind_string.go"],
+    # golang.org/x/tools executes commands via
+    # golang.org/x/sys/execabs which requires all PATH lookups to
+    # result in absolute paths. To account for this, we resolve the
+    # relative path returned by location to an absolute path.
     cmd = """
-       env PATH=`dirname $(location @go_sdk//:bin/go)` HOME=$(GENDIR) \
+       GO_REL_PATH=`dirname $(location @go_sdk//:bin/go)`
+       GO_ABS_PATH=`cd $$GO_REL_PATH && pwd`
+       env PATH=$$GO_ABS_PATH HOME=$(GENDIR) \
        $(location @org_golang_x_tools//cmd/stringer:stringer) -output=$@ -type=ColumnConversionKind -trimprefix ColumnConversion $<
     """,
     tools = [

--- a/pkg/util/encoding/BUILD.bazel
+++ b/pkg/util/encoding/BUILD.bazel
@@ -71,9 +71,16 @@ go_test(
 #         "encoding.go",
 #     ],
 #     outs = ["type_string.go"],
+#
+#     # golang.org/x/tools executes commands via
+#     # golang.org/x/sys/execabs which requires all PATH lookups to
+#     # result in absolute paths. To account for this, we resolve the
+#     # relative path returned by location to an absolute path.
 #     cmd = """
 #        cp $(location encoding.go) `dirname $(location //pkg/util/encoding/encodingtype:encoding_type.go)`/encoding.go
-#        env PATH=`dirname $(location @go_sdk//:bin/go)` HOME=$(GENDIR) \
+#        GO_REL_PATH=`dirname $(location @go_sdk//:bin/go)`
+#        GO_ABS_PATH=`cd $$GO_REL_PATH && pwd`
+#        env PATH=$$GO_ABS_PATH HOME=$(GENDIR) \
 #        $(location @org_golang_x_tools//cmd/stringer:stringer) -output=$@ \
 #        -type=Type `dirname $(location //pkg/util/encoding/encodingtype:encoding_type.go)`/encoding.go $(location //pkg/util/encoding/encodingtype:encoding_type.go)
 #     """,


### PR DESCRIPTION
This bumps the version of cockroachdb/crlfmt, pulling in the following
changes:

  - add -srcdir option similar to goimports
  - use printer options that match gofmt when simplifying
  - Fix link to CockroachDB Go coding guidelines
  - using go module to manage dependencies
  - add simplify from gofmt -s
  - Update README with usage info
  - set default tab width to 2

Additionally, this pulls in a new version of golang.org/x/tools:

   golang/tools@d8d6ddb...v0.1.0

A manual entry for golang.org/x/sys has been added to the bazel
WORKSPACE to avoid an older version from being pulled in during `make
bazel-generate`.

Release note: None