### PR TITLE
build: add make bazel-generate to dep update instructions

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -120,6 +120,8 @@ is missing, ensure it is used in code. This can be a blank dependency, e.g.
 `import _ "golang.org/api/compute/v1"`. These changes must then be committed in the submodule directory
 (see [Working with Submodules](#working-with-submodules)).
 
+Finally, run `make bazel-generate` to regenerate `DEPS.bzl` with the updated Go dependency information.
+
 Programs can then be run using `go build ...` or `go test ...`.
 
 ### Removing a dependency


### PR DESCRIPTION
Bazel ignores the vendor directory and instead uses dependency
information generated from the go.mod file. Changes that modify the
go.mod file should typically be followed by `make bazel-generate`.

Release note: None