### PR TITLE
sql: deterministic zone config output for SHOW CREATE

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
@@ -300,6 +300,10 @@ CREATE TABLE public.regional_by_row_table (
   UNIQUE INDEX unique_b_a (b ASC, a ASC),
   FAMILY fam_0_pk_pk2_a_b_crdb_region (pk, pk2, a, b, crdb_region)
 ) LOCALITY REGIONAL BY ROW;
+ALTER PARTITION "ap-southeast-2" OF INDEX multi_region_test_db.public.regional_by_row_table@new_idx CONFIGURE ZONE USING
+  num_replicas = 3,
+  constraints = '{+region=ap-southeast-2: 1}',
+  lease_preferences = '[[+region=ap-southeast-2]]';
 ALTER PARTITION "ap-southeast-2" OF INDEX multi_region_test_db.public.regional_by_row_table@primary CONFIGURE ZONE USING
   num_replicas = 3,
   constraints = '{+region=ap-southeast-2: 1}',
@@ -312,6 +316,14 @@ ALTER PARTITION "ap-southeast-2" OF INDEX multi_region_test_db.public.regional_b
   num_replicas = 3,
   constraints = '{+region=ap-southeast-2: 1}',
   lease_preferences = '[[+region=ap-southeast-2]]';
+ALTER PARTITION "ap-southeast-2" OF INDEX multi_region_test_db.public.regional_by_row_table@unique_b_a CONFIGURE ZONE USING
+  num_replicas = 3,
+  constraints = '{+region=ap-southeast-2: 1}',
+  lease_preferences = '[[+region=ap-southeast-2]]';
+ALTER PARTITION "ca-central-1" OF INDEX multi_region_test_db.public.regional_by_row_table@new_idx CONFIGURE ZONE USING
+  num_replicas = 3,
+  constraints = '{+region=ca-central-1: 1}',
+  lease_preferences = '[[+region=ca-central-1]]';
 ALTER PARTITION "ca-central-1" OF INDEX multi_region_test_db.public.regional_by_row_table@primary CONFIGURE ZONE USING
   num_replicas = 3,
   constraints = '{+region=ca-central-1: 1}',
@@ -324,6 +336,14 @@ ALTER PARTITION "ca-central-1" OF INDEX multi_region_test_db.public.regional_by_
   num_replicas = 3,
   constraints = '{+region=ca-central-1: 1}',
   lease_preferences = '[[+region=ca-central-1]]';
+ALTER PARTITION "ca-central-1" OF INDEX multi_region_test_db.public.regional_by_row_table@unique_b_a CONFIGURE ZONE USING
+  num_replicas = 3,
+  constraints = '{+region=ca-central-1: 1}',
+  lease_preferences = '[[+region=ca-central-1]]';
+ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row_table@new_idx CONFIGURE ZONE USING
+  num_replicas = 3,
+  constraints = '{+region=us-east-1: 1}',
+  lease_preferences = '[[+region=us-east-1]]';
 ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row_table@primary CONFIGURE ZONE USING
   num_replicas = 3,
   constraints = '{+region=us-east-1: 1}',
@@ -336,26 +356,6 @@ ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row
   num_replicas = 3,
   constraints = '{+region=us-east-1: 1}',
   lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX multi_region_test_db.public.regional_by_row_table@new_idx CONFIGURE ZONE USING
-  num_replicas = 3,
-  constraints = '{+region=ap-southeast-2: 1}',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ca-central-1" OF INDEX multi_region_test_db.public.regional_by_row_table@new_idx CONFIGURE ZONE USING
-  num_replicas = 3,
-  constraints = '{+region=ca-central-1: 1}',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row_table@new_idx CONFIGURE ZONE USING
-  num_replicas = 3,
-  constraints = '{+region=us-east-1: 1}',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX multi_region_test_db.public.regional_by_row_table@unique_b_a CONFIGURE ZONE USING
-  num_replicas = 3,
-  constraints = '{+region=ap-southeast-2: 1}',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ca-central-1" OF INDEX multi_region_test_db.public.regional_by_row_table@unique_b_a CONFIGURE ZONE USING
-  num_replicas = 3,
-  constraints = '{+region=ca-central-1: 1}',
-  lease_preferences = '[[+region=ca-central-1]]';
 ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row_table@unique_b_a CONFIGURE ZONE USING
   num_replicas = 3,
   constraints = '{+region=us-east-1: 1}',

--- a/pkg/sql/delegate/show_table.go
+++ b/pkg/sql/delegate/show_table.go
@@ -24,7 +24,7 @@ func (d *delegator) delegateShowCreate(n *tree.ShowCreate) (tree.Statement, erro
 
 	const showCreateQuery = `
 WITH zone_configs AS (
-    SELECT string_agg(raw_config_sql, e';\n') FROM crdb_internal.zones
+    SELECT string_agg(raw_config_sql, e';\n' ORDER BY partition_name, index_name) FROM crdb_internal.zones
     WHERE database_name = %[1]s
     AND table_name = %[2]s
     AND raw_config_yaml IS NOT NULL


### PR DESCRIPTION
Previously, tests that depended on the order of the ALTER PARTITION
statements generated as part of SHOW CREATE would occasionally
fail. This change sorts the zone_configs CTE by the partition_name and
index_name, leading to more deterministic output.

With this in place, I was able to run the previously flaky test 500
times without failure, whereas it previously would fail after 10 or so
runs.

Fixes #59511

Release note (sql change): The SHOW CREATE statement now lists ALTER
PARTITION statements sorted by the partition name and index_name.