### PR TITLE
build,bazel: fix broken build

### DIFF
--- a/pkg/sql/colexec/crossjoiner_tmpl.go
+++ b/pkg/sql/colexec/crossjoiner_tmpl.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase/colexecerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/errors"
 )
 

--- a/pkg/sql/opt/exec/explain/BUILD.bazel
+++ b/pkg/sql/opt/exec/explain/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//pkg/roachpb",
         "//pkg/sql/catalog/colinfo",
         "//pkg/sql/catalog/descpb",
+        "//pkg/sql/inverted",  # keep
         "//pkg/sql/opt",  # keep
         "//pkg/sql/opt/cat",
         "//pkg/sql/opt/constraint",

--- a/pkg/sql/opt/memo/BUILD.bazel
+++ b/pkg/sql/opt/memo/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "//pkg/sql/opt",
         "//pkg/sql/opt/cat",
         "//pkg/sql/opt/constraint",
+        "//pkg/sql/opt/invertedexpr",  # keep
         "//pkg/sql/opt/props",
         "//pkg/sql/opt/props/physical",
         "//pkg/sql/rowenc",


### PR DESCRIPTION
Update a few dependencies and add back an import that broke the build
when it was removed in `1c71e3e7c1a1e214994c7b815b61ca8fcc22a5f6`.

Release note: None