### PR TITLE
sql: hook up multi-region DDL to new zone config attributes

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/alter_table_locality
+++ b/pkg/ccl/logictestccl/testdata/logic_test/alter_table_locality
@@ -33,16 +33,16 @@ regional_by_row  CREATE TABLE public.regional_by_row (
                  FAMILY "primary" (i, crdb_region, rowid)
 ) LOCALITY REGIONAL BY ROW;
 ALTER PARTITION "ap-southeast-2" OF INDEX alter_locality_test.public.regional_by_row@primary CONFIGURE ZONE USING
-  num_replicas = 3,
-  constraints = '{+region=ap-southeast-2: 3}',
+  num_voters = 3,
+  voter_constraints = '[+region=ap-southeast-2]',
   lease_preferences = '[[+region=ap-southeast-2]]';
 ALTER PARTITION "ca-central-1" OF INDEX alter_locality_test.public.regional_by_row@primary CONFIGURE ZONE USING
-  num_replicas = 3,
-  constraints = '{+region=ca-central-1: 3}',
+  num_voters = 3,
+  voter_constraints = '[+region=ca-central-1]',
   lease_preferences = '[[+region=ca-central-1]]';
 ALTER PARTITION "us-east-1" OF INDEX alter_locality_test.public.regional_by_row@primary CONFIGURE ZONE USING
-  num_replicas = 3,
-  constraints = '{+region=us-east-1: 3}',
+  num_voters = 3,
+  voter_constraints = '[+region=us-east-1]',
   lease_preferences = '[[+region=us-east-1]]'
 
 query TT
@@ -52,8 +52,10 @@ DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE 
                               range_min_bytes = 134217728,
                               range_max_bytes = 536870912,
                               gc.ttlseconds = 90000,
-                              num_replicas = 3,
+                              num_replicas = 5,
+                              num_voters = 3,
                               constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                              voter_constraints = '[+region=ca-central-1]',
                               lease_preferences = '[[+region=ca-central-1]]'
 
 statement ok
@@ -74,8 +76,10 @@ DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE 
                               range_min_bytes = 134217728,
                               range_max_bytes = 536870912,
                               gc.ttlseconds = 90000,
-                              num_replicas = 3,
+                              num_replicas = 5,
+                              num_voters = 3,
                               constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                              voter_constraints = '[+region=ca-central-1]',
                               lease_preferences = '[[+region=ca-central-1]]'
 
 statement ok
@@ -96,8 +100,10 @@ DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE 
                               range_min_bytes = 134217728,
                               range_max_bytes = 536870912,
                               gc.ttlseconds = 90000,
-                              num_replicas = 3,
+                              num_replicas = 5,
+                              num_voters = 3,
                               constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                              voter_constraints = '[+region=ca-central-1]',
                               lease_preferences = '[[+region=ca-central-1]]'
 
 statement ok
@@ -118,32 +124,36 @@ TABLE regional_by_table_in_us_east  ALTER TABLE regional_by_table_in_us_east CON
                                     range_min_bytes = 134217728,
                                     range_max_bytes = 536870912,
                                     gc.ttlseconds = 90000,
-                                    num_replicas = 3,
-                                    constraints = '{+region=us-east-1: 3}',
+                                    num_replicas = 5,
+                                    num_voters = 3,
+                                    constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                    voter_constraints = '[+region=us-east-1]',
                                     lease_preferences = '[[+region=us-east-1]]'
 
 statement ok
-CREATE TABLE global (i int) LOCALITY GLOBAL
+CREATE TABLE created_as_global (i int) LOCALITY GLOBAL
 
 query TT
-SHOW CREATE TABLE global
+SHOW CREATE TABLE created_as_global
 ----
-global             CREATE TABLE public.global (
+created_as_global  CREATE TABLE public.created_as_global (
                    i INT8 NULL,
                    FAMILY "primary" (i, rowid)
 ) LOCALITY GLOBAL
 
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE global
+SHOW ZONE CONFIGURATION FOR TABLE created_as_global
 ----
-TABLE global  ALTER TABLE global CONFIGURE ZONE USING
-              range_min_bytes = 134217728,
-              range_max_bytes = 536870912,
-              gc.ttlseconds = 90000,
-              global_reads = true,
-              num_replicas = 3,
-              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-              lease_preferences = '[[+region=ca-central-1]]'
+TABLE created_as_global  ALTER TABLE created_as_global CONFIGURE ZONE USING
+                         range_min_bytes = 134217728,
+                         range_max_bytes = 536870912,
+                         gc.ttlseconds = 90000,
+                         global_reads = true,
+                         num_replicas = 5,
+                         num_voters = 3,
+                         constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                         voter_constraints = '[+region=ca-central-1]',
+                         lease_preferences = '[[+region=ca-central-1]]'
 
 statement error unimplemented: implementation pending
 ALTER TABLE regional_by_row SET LOCALITY REGIONAL BY TABLE
@@ -170,16 +180,16 @@ regional_by_row  CREATE TABLE public.regional_by_row (
                  FAMILY "primary" (i, crdb_region, rowid)
 ) LOCALITY REGIONAL BY ROW;
 ALTER PARTITION "ap-southeast-2" OF INDEX alter_locality_test.public.regional_by_row@primary CONFIGURE ZONE USING
-  num_replicas = 3,
-  constraints = '{+region=ap-southeast-2: 3}',
+  num_voters = 3,
+  voter_constraints = '[+region=ap-southeast-2]',
   lease_preferences = '[[+region=ap-southeast-2]]';
 ALTER PARTITION "ca-central-1" OF INDEX alter_locality_test.public.regional_by_row@primary CONFIGURE ZONE USING
-  num_replicas = 3,
-  constraints = '{+region=ca-central-1: 3}',
+  num_voters = 3,
+  voter_constraints = '[+region=ca-central-1]',
   lease_preferences = '[[+region=ca-central-1]]';
 ALTER PARTITION "us-east-1" OF INDEX alter_locality_test.public.regional_by_row@primary CONFIGURE ZONE USING
-  num_replicas = 3,
-  constraints = '{+region=us-east-1: 3}',
+  num_voters = 3,
+  voter_constraints = '[+region=us-east-1]',
   lease_preferences = '[[+region=us-east-1]]'
 
 query TT
@@ -189,113 +199,123 @@ DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE 
                               range_min_bytes = 134217728,
                               range_max_bytes = 536870912,
                               gc.ttlseconds = 90000,
-                              num_replicas = 3,
+                              num_replicas = 5,
+                              num_voters = 3,
                               constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                              voter_constraints = '[+region=ca-central-1]',
                               lease_preferences = '[[+region=ca-central-1]]'
 
 statement ok
-ALTER TABLE global SET LOCALITY REGIONAL BY TABLE
+ALTER TABLE created_as_global SET LOCALITY REGIONAL BY TABLE
 
 query TT
-SHOW CREATE TABLE global
+SHOW CREATE TABLE created_as_global
 ----
-global             CREATE TABLE public.global (
+created_as_global             CREATE TABLE public.created_as_global (
                    i INT8 NULL,
                    FAMILY "primary" (i, rowid)
 ) LOCALITY REGIONAL BY TABLE IN PRIMARY REGION
 
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE global
+SHOW ZONE CONFIGURATION FOR TABLE created_as_global
 ----
 DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
                               range_min_bytes = 134217728,
                               range_max_bytes = 536870912,
                               gc.ttlseconds = 90000,
-                              num_replicas = 3,
+                              num_replicas = 5,
+                              num_voters = 3,
                               constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                              voter_constraints = '[+region=ca-central-1]',
                               lease_preferences = '[[+region=ca-central-1]]'
 
 # Alter back, to get back to original state
 statement ok
-ALTER TABLE global SET LOCALITY GLOBAL
+ALTER TABLE created_as_global SET LOCALITY GLOBAL
 
 statement ok
-ALTER TABLE global SET LOCALITY REGIONAL BY TABLE in "ap-southeast-2"
+ALTER TABLE created_as_global SET LOCALITY REGIONAL BY TABLE in "ap-southeast-2"
 
 query TT
-SHOW CREATE TABLE global
+SHOW CREATE TABLE created_as_global
 ----
-global             CREATE TABLE public.global (
+created_as_global             CREATE TABLE public.created_as_global (
                    i INT8 NULL,
                    FAMILY "primary" (i, rowid)
 ) LOCALITY REGIONAL BY TABLE IN "ap-southeast-2"
 
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE global
+SHOW ZONE CONFIGURATION FOR TABLE created_as_global
 ----
-TABLE global  ALTER TABLE global CONFIGURE ZONE USING
+TABLE created_as_global  ALTER TABLE created_as_global CONFIGURE ZONE USING
               range_min_bytes = 134217728,
               range_max_bytes = 536870912,
               gc.ttlseconds = 90000,
-              num_replicas = 3,
-              constraints = '{+region=ap-southeast-2: 3}',
+              num_replicas = 5,
+              num_voters = 3,
+              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+              voter_constraints = '[+region=ap-southeast-2]',
               lease_preferences = '[[+region=ap-southeast-2]]'
 
 # Alter back, to get back to original state
 statement ok
-ALTER TABLE global SET LOCALITY GLOBAL
+ALTER TABLE created_as_global SET LOCALITY GLOBAL
 
 statement ok
-ALTER TABLE global SET LOCALITY REGIONAL BY TABLE in PRIMARY REGION
+ALTER TABLE created_as_global SET LOCALITY REGIONAL BY TABLE in PRIMARY REGION
 
 query TT
-SHOW CREATE TABLE global
+SHOW CREATE TABLE created_as_global
 ----
-global                                          CREATE TABLE public.global (
+created_as_global                                          CREATE TABLE public.created_as_global (
                                                 i INT8 NULL,
                                                 FAMILY "primary" (i, rowid)
 ) LOCALITY REGIONAL BY TABLE IN PRIMARY REGION
 
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE global
+SHOW ZONE CONFIGURATION FOR TABLE created_as_global
 ----
 DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
                               range_min_bytes = 134217728,
                               range_max_bytes = 536870912,
                               gc.ttlseconds = 90000,
-                              num_replicas = 3,
+                              num_replicas = 5,
+                              num_voters = 3,
                               constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                              voter_constraints = '[+region=ca-central-1]',
                               lease_preferences = '[[+region=ca-central-1]]'
 
 # Alter back, to get back to original state
 statement ok
-ALTER TABLE global SET LOCALITY GLOBAL
+ALTER TABLE created_as_global SET LOCALITY GLOBAL
 
 statement ok
-ALTER TABLE global SET LOCALITY GLOBAL
+ALTER TABLE created_as_global SET LOCALITY GLOBAL
 
 query TT
-SHOW CREATE TABLE global
+SHOW CREATE TABLE created_as_global
 ----
-global             CREATE TABLE public.global (
+created_as_global             CREATE TABLE public.created_as_global (
                    i INT8 NULL,
                    FAMILY "primary" (i, rowid)
 ) LOCALITY GLOBAL
 
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE global
+SHOW ZONE CONFIGURATION FOR TABLE created_as_global
 ----
-TABLE global  ALTER TABLE global CONFIGURE ZONE USING
+TABLE created_as_global  ALTER TABLE created_as_global CONFIGURE ZONE USING
               range_min_bytes = 134217728,
               range_max_bytes = 536870912,
               gc.ttlseconds = 90000,
               global_reads = true,
-              num_replicas = 3,
+              num_replicas = 5,
+              num_voters = 3,
               constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+              voter_constraints = '[+region=ca-central-1]',
               lease_preferences = '[[+region=ca-central-1]]'
 
 statement error unimplemented: implementation pending
-ALTER TABLE global SET LOCALITY REGIONAL BY ROW
+ALTER TABLE created_as_global SET LOCALITY REGIONAL BY ROW
 
 statement error region "invalid-region" has not been added to database "alter_locality_test"
 ALTER TABLE regional_by_table_in_primary_region SET LOCALITY REGIONAL BY TABLE in "invalid-region"
@@ -318,8 +338,10 @@ TABLE regional_by_table_in_primary_region  ALTER TABLE regional_by_table_in_prim
                                            range_min_bytes = 134217728,
                                            range_max_bytes = 536870912,
                                            gc.ttlseconds = 90000,
-                                           num_replicas = 3,
-                                           constraints = '{+region=ap-southeast-2: 3}',
+                                           num_replicas = 5,
+                                           num_voters = 3,
+                                           constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                           voter_constraints = '[+region=ap-southeast-2]',
                                            lease_preferences = '[[+region=ap-southeast-2]]'
 
 # Alter back to original state
@@ -341,8 +363,10 @@ DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE 
                               range_min_bytes = 134217728,
                               range_max_bytes = 536870912,
                               gc.ttlseconds = 90000,
-                              num_replicas = 3,
+                              num_replicas = 5,
+                              num_voters = 3,
                               constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                              voter_constraints = '[+region=ca-central-1]',
                               lease_preferences = '[[+region=ca-central-1]]'
 
 # Alter to same state
@@ -364,8 +388,10 @@ DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE 
                               range_min_bytes = 134217728,
                               range_max_bytes = 536870912,
                               gc.ttlseconds = 90000,
-                              num_replicas = 3,
+                              num_replicas = 5,
+                              num_voters = 3,
                               constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                              voter_constraints = '[+region=ca-central-1]',
                               lease_preferences = '[[+region=ca-central-1]]'
 
 statement ok
@@ -386,8 +412,10 @@ DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE 
                               range_min_bytes = 134217728,
                               range_max_bytes = 536870912,
                               gc.ttlseconds = 90000,
-                              num_replicas = 3,
+                              num_replicas = 5,
+                              num_voters = 3,
                               constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                              voter_constraints = '[+region=ca-central-1]',
                               lease_preferences = '[[+region=ca-central-1]]'
 
 statement ok
@@ -409,8 +437,10 @@ TABLE regional_by_table_in_primary_region  ALTER TABLE regional_by_table_in_prim
                                            range_max_bytes = 536870912,
                                            gc.ttlseconds = 90000,
                                            global_reads = true,
-                                           num_replicas = 3,
+                                           num_replicas = 5,
+                                           num_voters = 3,
                                            constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                           voter_constraints = '[+region=ca-central-1]',
                                            lease_preferences = '[[+region=ca-central-1]]'
 
 # Drop the table and recreate it to get back to original state (this is required because alter table
@@ -442,8 +472,10 @@ DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE 
                               range_min_bytes = 134217728,
                               range_max_bytes = 536870912,
                               gc.ttlseconds = 90000,
-                              num_replicas = 3,
+                              num_replicas = 5,
+                              num_voters = 3,
                               constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                              voter_constraints = '[+region=ca-central-1]',
                               lease_preferences = '[[+region=ca-central-1]]'
 
 # Drop and recreate the table to get it back to the "no region" state.
@@ -471,8 +503,10 @@ TABLE regional_by_table_no_region  ALTER TABLE regional_by_table_no_region CONFI
                                    range_min_bytes = 134217728,
                                    range_max_bytes = 536870912,
                                    gc.ttlseconds = 90000,
-                                   num_replicas = 3,
-                                   constraints = '{+region=ap-southeast-2: 3}',
+                                   num_replicas = 5,
+                                   num_voters = 3,
+                                   constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                   voter_constraints = '[+region=ap-southeast-2]',
                                    lease_preferences = '[[+region=ap-southeast-2]]'
 
 # Drop and recreate the table to get it back to the "no region" state.
@@ -500,8 +534,10 @@ DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE 
                               range_min_bytes = 134217728,
                               range_max_bytes = 536870912,
                               gc.ttlseconds = 90000,
-                              num_replicas = 3,
+                              num_replicas = 5,
+                              num_voters = 3,
                               constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                              voter_constraints = '[+region=ca-central-1]',
                               lease_preferences = '[[+region=ca-central-1]]'
 
 statement ok
@@ -523,8 +559,10 @@ TABLE regional_by_table_no_region  ALTER TABLE regional_by_table_no_region CONFI
                                    range_max_bytes = 536870912,
                                    gc.ttlseconds = 90000,
                                    global_reads = true,
-                                   num_replicas = 3,
+                                   num_replicas = 5,
+                                   num_voters = 3,
                                    constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                   voter_constraints = '[+region=ca-central-1]',
                                    lease_preferences = '[[+region=ca-central-1]]'
 
 # Drop the table and recreate it to get back to original state (this is required because alter table
@@ -556,8 +594,10 @@ DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE 
                               range_min_bytes = 134217728,
                               range_max_bytes = 536870912,
                               gc.ttlseconds = 90000,
-                              num_replicas = 3,
+                              num_replicas = 5,
+                              num_voters = 3,
                               constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                              voter_constraints = '[+region=ca-central-1]',
                               lease_preferences = '[[+region=ca-central-1]]'
 
 statement ok
@@ -581,8 +621,10 @@ TABLE regional_by_table_in_us_east  ALTER TABLE regional_by_table_in_us_east CON
                                     range_min_bytes = 134217728,
                                     range_max_bytes = 536870912,
                                     gc.ttlseconds = 90000,
-                                    num_replicas = 3,
-                                    constraints = '{+region=ap-southeast-2: 3}',
+                                    num_replicas = 5,
+                                    num_voters = 3,
+                                    constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                    voter_constraints = '[+region=ap-southeast-2]',
                                     lease_preferences = '[[+region=ap-southeast-2]]'
 
 statement ok
@@ -606,8 +648,10 @@ DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE 
                               range_min_bytes = 134217728,
                               range_max_bytes = 536870912,
                               gc.ttlseconds = 90000,
-                              num_replicas = 3,
+                              num_replicas = 5,
+                              num_voters = 3,
                               constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                              voter_constraints = '[+region=ca-central-1]',
                               lease_preferences = '[[+region=ca-central-1]]'
 
 statement ok
@@ -629,8 +673,10 @@ TABLE regional_by_table_in_us_east  ALTER TABLE regional_by_table_in_us_east CON
                                     range_max_bytes = 536870912,
                                     gc.ttlseconds = 90000,
                                     global_reads = true,
-                                    num_replicas = 3,
+                                    num_replicas = 5,
+                                    num_voters = 3,
                                     constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                    voter_constraints = '[+region=ca-central-1]',
                                     lease_preferences = '[[+region=ca-central-1]]'
 
 # Drop the table and recreate it to get back to original state (this is required because alter table
@@ -645,8 +691,8 @@ statement error unimplemented: implementation pending
 ALTER TABLE regional_by_table_in_us_east SET LOCALITY REGIONAL BY ROW
 
 # Set a table with a gc.ttlseconds to be a non-default value, and check this is
-# the same after a change to REGIONAL BY TABLE IN PRIMARY REGION, which truncates
-# other fields.
+# the same after a change to REGIONAL BY TABLE IN PRIMARY REGION, which overrides
+# some other fields.
 statement ok
 CREATE TABLE rbt_table_gc_ttl () LOCALITY REGIONAL BY TABLE IN "us-east-1"
 
@@ -657,8 +703,10 @@ TABLE rbt_table_gc_ttl  ALTER TABLE rbt_table_gc_ttl CONFIGURE ZONE USING
                         range_min_bytes = 134217728,
                         range_max_bytes = 536870912,
                         gc.ttlseconds = 90000,
-                        num_replicas = 3,
-                        constraints = '{+region=us-east-1: 3}',
+                        num_replicas = 5,
+                        num_voters = 3,
+                        constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                        voter_constraints = '[+region=us-east-1]',
                         lease_preferences = '[[+region=us-east-1]]'
 
 statement ok
@@ -672,6 +720,8 @@ TABLE rbt_table_gc_ttl  ALTER TABLE rbt_table_gc_ttl CONFIGURE ZONE USING
                         range_min_bytes = 134217728,
                         range_max_bytes = 536870912,
                         gc.ttlseconds = 999,
-                        num_replicas = 3,
+                        num_replicas = 5,
+                        num_voters = 3,
                         constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                        voter_constraints = '[+region=ca-central-1]',
                         lease_preferences = '[[+region=ca-central-1]]'

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
@@ -99,40 +99,40 @@ CREATE TABLE public.regional_by_row_table (
   FAMILY fam_0_pk_pk2_a_b_crdb_region (pk, pk2, a, b, crdb_region)
 ) LOCALITY REGIONAL BY ROW;
 ALTER PARTITION "ap-southeast-2" OF INDEX multi_region_test_db.public.regional_by_row_table@primary CONFIGURE ZONE USING
-  num_replicas = 3,
-  constraints = '{+region=ap-southeast-2: 1}',
+  num_voters = 5,
+  voter_constraints = '{+region=ap-southeast-2: 2}',
   lease_preferences = '[[+region=ap-southeast-2]]';
 ALTER PARTITION "ap-southeast-2" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
-  num_replicas = 3,
-  constraints = '{+region=ap-southeast-2: 1}',
+  num_voters = 5,
+  voter_constraints = '{+region=ap-southeast-2: 2}',
   lease_preferences = '[[+region=ap-southeast-2]]';
 ALTER PARTITION "ap-southeast-2" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
-  num_replicas = 3,
-  constraints = '{+region=ap-southeast-2: 1}',
+  num_voters = 5,
+  voter_constraints = '{+region=ap-southeast-2: 2}',
   lease_preferences = '[[+region=ap-southeast-2]]';
 ALTER PARTITION "ca-central-1" OF INDEX multi_region_test_db.public.regional_by_row_table@primary CONFIGURE ZONE USING
-  num_replicas = 3,
-  constraints = '{+region=ca-central-1: 1}',
+  num_voters = 5,
+  voter_constraints = '{+region=ca-central-1: 2}',
   lease_preferences = '[[+region=ca-central-1]]';
 ALTER PARTITION "ca-central-1" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
-  num_replicas = 3,
-  constraints = '{+region=ca-central-1: 1}',
+  num_voters = 5,
+  voter_constraints = '{+region=ca-central-1: 2}',
   lease_preferences = '[[+region=ca-central-1]]';
 ALTER PARTITION "ca-central-1" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
-  num_replicas = 3,
-  constraints = '{+region=ca-central-1: 1}',
+  num_voters = 5,
+  voter_constraints = '{+region=ca-central-1: 2}',
   lease_preferences = '[[+region=ca-central-1]]';
 ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row_table@primary CONFIGURE ZONE USING
-  num_replicas = 3,
-  constraints = '{+region=us-east-1: 1}',
+  num_voters = 5,
+  voter_constraints = '{+region=us-east-1: 2}',
   lease_preferences = '[[+region=us-east-1]]';
 ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
-  num_replicas = 3,
-  constraints = '{+region=us-east-1: 1}',
+  num_voters = 5,
+  voter_constraints = '{+region=us-east-1: 2}',
   lease_preferences = '[[+region=us-east-1]]';
 ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
-  num_replicas = 3,
-  constraints = '{+region=us-east-1: 1}',
+  num_voters = 5,
+  voter_constraints = '{+region=us-east-1: 2}',
   lease_preferences = '[[+region=us-east-1]]'
 
 query TTB colnames
@@ -301,64 +301,64 @@ CREATE TABLE public.regional_by_row_table (
   FAMILY fam_0_pk_pk2_a_b_crdb_region (pk, pk2, a, b, crdb_region)
 ) LOCALITY REGIONAL BY ROW;
 ALTER PARTITION "ap-southeast-2" OF INDEX multi_region_test_db.public.regional_by_row_table@new_idx CONFIGURE ZONE USING
-  num_replicas = 3,
-  constraints = '{+region=ap-southeast-2: 1}',
+  num_voters = 5,
+  voter_constraints = '{+region=ap-southeast-2: 2}',
   lease_preferences = '[[+region=ap-southeast-2]]';
 ALTER PARTITION "ap-southeast-2" OF INDEX multi_region_test_db.public.regional_by_row_table@primary CONFIGURE ZONE USING
-  num_replicas = 3,
-  constraints = '{+region=ap-southeast-2: 1}',
+  num_voters = 5,
+  voter_constraints = '{+region=ap-southeast-2: 2}',
   lease_preferences = '[[+region=ap-southeast-2]]';
 ALTER PARTITION "ap-southeast-2" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
-  num_replicas = 3,
-  constraints = '{+region=ap-southeast-2: 1}',
+  num_voters = 5,
+  voter_constraints = '{+region=ap-southeast-2: 2}',
   lease_preferences = '[[+region=ap-southeast-2]]';
 ALTER PARTITION "ap-southeast-2" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
-  num_replicas = 3,
-  constraints = '{+region=ap-southeast-2: 1}',
+  num_voters = 5,
+  voter_constraints = '{+region=ap-southeast-2: 2}',
   lease_preferences = '[[+region=ap-southeast-2]]';
 ALTER PARTITION "ap-southeast-2" OF INDEX multi_region_test_db.public.regional_by_row_table@unique_b_a CONFIGURE ZONE USING
-  num_replicas = 3,
-  constraints = '{+region=ap-southeast-2: 1}',
+  num_voters = 5,
+  voter_constraints = '{+region=ap-southeast-2: 2}',
   lease_preferences = '[[+region=ap-southeast-2]]';
 ALTER PARTITION "ca-central-1" OF INDEX multi_region_test_db.public.regional_by_row_table@new_idx CONFIGURE ZONE USING
-  num_replicas = 3,
-  constraints = '{+region=ca-central-1: 1}',
+  num_voters = 5,
+  voter_constraints = '{+region=ca-central-1: 2}',
   lease_preferences = '[[+region=ca-central-1]]';
 ALTER PARTITION "ca-central-1" OF INDEX multi_region_test_db.public.regional_by_row_table@primary CONFIGURE ZONE USING
-  num_replicas = 3,
-  constraints = '{+region=ca-central-1: 1}',
+  num_voters = 5,
+  voter_constraints = '{+region=ca-central-1: 2}',
   lease_preferences = '[[+region=ca-central-1]]';
 ALTER PARTITION "ca-central-1" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
-  num_replicas = 3,
-  constraints = '{+region=ca-central-1: 1}',
+  num_voters = 5,
+  voter_constraints = '{+region=ca-central-1: 2}',
   lease_preferences = '[[+region=ca-central-1]]';
 ALTER PARTITION "ca-central-1" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
-  num_replicas = 3,
-  constraints = '{+region=ca-central-1: 1}',
+  num_voters = 5,
+  voter_constraints = '{+region=ca-central-1: 2}',
   lease_preferences = '[[+region=ca-central-1]]';
 ALTER PARTITION "ca-central-1" OF INDEX multi_region_test_db.public.regional_by_row_table@unique_b_a CONFIGURE ZONE USING
-  num_replicas = 3,
-  constraints = '{+region=ca-central-1: 1}',
+  num_voters = 5,
+  voter_constraints = '{+region=ca-central-1: 2}',
   lease_preferences = '[[+region=ca-central-1]]';
 ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row_table@new_idx CONFIGURE ZONE USING
-  num_replicas = 3,
-  constraints = '{+region=us-east-1: 1}',
+  num_voters = 5,
+  voter_constraints = '{+region=us-east-1: 2}',
   lease_preferences = '[[+region=us-east-1]]';
 ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row_table@primary CONFIGURE ZONE USING
-  num_replicas = 3,
-  constraints = '{+region=us-east-1: 1}',
+  num_voters = 5,
+  voter_constraints = '{+region=us-east-1: 2}',
   lease_preferences = '[[+region=us-east-1]]';
 ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
-  num_replicas = 3,
-  constraints = '{+region=us-east-1: 1}',
+  num_voters = 5,
+  voter_constraints = '{+region=us-east-1: 2}',
   lease_preferences = '[[+region=us-east-1]]';
 ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
-  num_replicas = 3,
-  constraints = '{+region=us-east-1: 1}',
+  num_voters = 5,
+  voter_constraints = '{+region=us-east-1: 2}',
   lease_preferences = '[[+region=us-east-1]]';
 ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row_table@unique_b_a CONFIGURE ZONE USING
-  num_replicas = 3,
-  constraints = '{+region=us-east-1: 1}',
+  num_voters = 5,
+  voter_constraints = '{+region=us-east-1: 2}',
   lease_preferences = '[[+region=us-east-1]]'
 
 query TTB colnames
@@ -424,8 +424,10 @@ PARTITION "ap-southeast-2" OF INDEX regional_by_row_table@primary  ALTER PARTITI
                                                                    range_min_bytes = 134217728,
                                                                    range_max_bytes = 536870912,
                                                                    gc.ttlseconds = 90000,
-                                                                   num_replicas = 3,
-                                                                   constraints = '{+region=ap-southeast-2: 1}',
+                                                                   num_replicas = 5,
+                                                                   num_voters = 5,
+                                                                   constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                                                   voter_constraints = '{+region=ap-southeast-2: 2}',
                                                                    lease_preferences = '[[+region=ap-southeast-2]]'
 
 query TT
@@ -435,8 +437,10 @@ PARTITION "ap-southeast-2" OF INDEX regional_by_row_table@unique_b_a  ALTER PART
                                                                       range_min_bytes = 134217728,
                                                                       range_max_bytes = 536870912,
                                                                       gc.ttlseconds = 90000,
-                                                                      num_replicas = 3,
-                                                                      constraints = '{+region=ap-southeast-2: 1}',
+                                                                      num_replicas = 5,
+                                                                      num_voters = 5,
+                                                                      constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                                                      voter_constraints = '{+region=ap-southeast-2: 2}',
                                                                       lease_preferences = '[[+region=ap-southeast-2]]'
 
 # Tests for REGIONAL BY TABLE AS
@@ -481,40 +485,40 @@ CREATE TABLE public.regional_by_row_table_as (
   FAMILY fam_0_pk_a_b_crdb_region_col (pk, a, b, crdb_region_col)
 ) LOCALITY REGIONAL BY ROW AS crdb_region_col;
 ALTER PARTITION "ap-southeast-2" OF INDEX multi_region_test_db.public.regional_by_row_table_as@primary CONFIGURE ZONE USING
-  num_replicas = 3,
-  constraints = '{+region=ap-southeast-2: 1}',
+  num_voters = 5,
+  voter_constraints = '{+region=ap-southeast-2: 2}',
   lease_preferences = '[[+region=ap-southeast-2]]';
 ALTER PARTITION "ap-southeast-2" OF INDEX multi_region_test_db.public.regional_by_row_table_as@regional_by_row_table_as_a_idx CONFIGURE ZONE USING
-  num_replicas = 3,
-  constraints = '{+region=ap-southeast-2: 1}',
+  num_voters = 5,
+  voter_constraints = '{+region=ap-southeast-2: 2}',
   lease_preferences = '[[+region=ap-southeast-2]]';
 ALTER PARTITION "ap-southeast-2" OF INDEX multi_region_test_db.public.regional_by_row_table_as@regional_by_row_table_as_b_key CONFIGURE ZONE USING
-  num_replicas = 3,
-  constraints = '{+region=ap-southeast-2: 1}',
+  num_voters = 5,
+  voter_constraints = '{+region=ap-southeast-2: 2}',
   lease_preferences = '[[+region=ap-southeast-2]]';
 ALTER PARTITION "ca-central-1" OF INDEX multi_region_test_db.public.regional_by_row_table_as@primary CONFIGURE ZONE USING
-  num_replicas = 3,
-  constraints = '{+region=ca-central-1: 1}',
+  num_voters = 5,
+  voter_constraints = '{+region=ca-central-1: 2}',
   lease_preferences = '[[+region=ca-central-1]]';
 ALTER PARTITION "ca-central-1" OF INDEX multi_region_test_db.public.regional_by_row_table_as@regional_by_row_table_as_a_idx CONFIGURE ZONE USING
-  num_replicas = 3,
-  constraints = '{+region=ca-central-1: 1}',
+  num_voters = 5,
+  voter_constraints = '{+region=ca-central-1: 2}',
   lease_preferences = '[[+region=ca-central-1]]';
 ALTER PARTITION "ca-central-1" OF INDEX multi_region_test_db.public.regional_by_row_table_as@regional_by_row_table_as_b_key CONFIGURE ZONE USING
-  num_replicas = 3,
-  constraints = '{+region=ca-central-1: 1}',
+  num_voters = 5,
+  voter_constraints = '{+region=ca-central-1: 2}',
   lease_preferences = '[[+region=ca-central-1]]';
 ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row_table_as@primary CONFIGURE ZONE USING
-  num_replicas = 3,
-  constraints = '{+region=us-east-1: 1}',
+  num_voters = 5,
+  voter_constraints = '{+region=us-east-1: 2}',
   lease_preferences = '[[+region=us-east-1]]';
 ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row_table_as@regional_by_row_table_as_a_idx CONFIGURE ZONE USING
-  num_replicas = 3,
-  constraints = '{+region=us-east-1: 1}',
+  num_voters = 5,
+  voter_constraints = '{+region=us-east-1: 2}',
   lease_preferences = '[[+region=us-east-1]]';
 ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row_table_as@regional_by_row_table_as_b_key CONFIGURE ZONE USING
-  num_replicas = 3,
-  constraints = '{+region=us-east-1: 1}',
+  num_voters = 5,
+  voter_constraints = '{+region=us-east-1: 2}',
   lease_preferences = '[[+region=us-east-1]]'
 
 query TI
@@ -543,8 +547,10 @@ PARTITION "us-east-1" OF TABLE t_regional_by_row  ALTER PARTITION "us-east-1" OF
                                                   range_min_bytes = 134217728,
                                                   range_max_bytes = 536870912,
                                                   gc.ttlseconds = 90000,
-                                                  num_replicas = 3,
-                                                  constraints = '{+region=us-east-1: 1}',
+                                                  num_replicas = 5,
+                                                  num_voters = 5,
+                                                  constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                                  voter_constraints = '{+region=us-east-1: 2}',
                                                   lease_preferences = '[[+region=us-east-1]]'
 
 query TT
@@ -554,8 +560,10 @@ DATABASE alter_survive_db  ALTER DATABASE alter_survive_db CONFIGURE ZONE USING
                            range_min_bytes = 134217728,
                            range_max_bytes = 536870912,
                            gc.ttlseconds = 90000,
-                           num_replicas = 3,
+                           num_replicas = 5,
+                           num_voters = 5,
                            constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                           voter_constraints = '{+region=us-east-1: 2}',
                            lease_preferences = '[[+region=us-east-1]]'
 
 statement ok
@@ -568,8 +576,10 @@ PARTITION "us-east-1" OF TABLE t_regional_by_row  ALTER PARTITION "us-east-1" OF
                                                   range_min_bytes = 134217728,
                                                   range_max_bytes = 536870912,
                                                   gc.ttlseconds = 90000,
-                                                  num_replicas = 3,
-                                                  constraints = '{+region=us-east-1: 3}',
+                                                  num_replicas = 5,
+                                                  num_voters = 3,
+                                                  constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                                  voter_constraints = '[+region=us-east-1]',
                                                   lease_preferences = '[[+region=us-east-1]]'
 
 # Test setting non-multi-region fields on tables behaves as appropriate.
@@ -583,8 +593,10 @@ TABLE t_regional_by_row  ALTER TABLE t_regional_by_row CONFIGURE ZONE USING
                          range_min_bytes = 134217728,
                          range_max_bytes = 536870912,
                          gc.ttlseconds = 999,
-                         num_replicas = 3,
+                         num_replicas = 5,
+                         num_voters = 3,
                          constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                         voter_constraints = '[+region=us-east-1]',
                          lease_preferences = '[[+region=us-east-1]]'
 
 query TT
@@ -594,6 +606,8 @@ PARTITION "us-east-1" OF TABLE t_regional_by_row  ALTER PARTITION "us-east-1" OF
                                                   range_min_bytes = 134217728,
                                                   range_max_bytes = 536870912,
                                                   gc.ttlseconds = 999,
-                                                  num_replicas = 3,
-                                                  constraints = '{+region=us-east-1: 3}',
+                                                  num_replicas = 5,
+                                                  num_voters = 3,
+                                                  constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                                  voter_constraints = '[+region=us-east-1]',
                                                   lease_preferences = '[[+region=us-east-1]]'

--- a/pkg/sql/logictest/testdata/logic_test/multiregion
+++ b/pkg/sql/logictest/testdata/logic_test/multiregion
@@ -160,7 +160,9 @@ DATABASE region_test_db  ALTER DATABASE region_test_db CONFIGURE ZONE USING
                          range_max_bytes = 536870912,
                          gc.ttlseconds = 90000,
                          num_replicas = 3,
+                         num_voters = 3,
                          constraints = '{+region=ap-southeast-2: 1}',
+                         voter_constraints = '[+region=ap-southeast-2]',
                          lease_preferences = '[[+region=ap-southeast-2]]'
 
 # copy of the previous test but using FROM instead of FOR
@@ -172,7 +174,9 @@ DATABASE region_test_db  ALTER DATABASE region_test_db CONFIGURE ZONE USING
                          range_max_bytes = 536870912,
                          gc.ttlseconds = 90000,
                          num_replicas = 3,
+                         num_voters = 3,
                          constraints = '{+region=ap-southeast-2: 1}',
+                         voter_constraints = '[+region=ap-southeast-2]',
                          lease_preferences = '[[+region=ap-southeast-2]]'
 
 query TT
@@ -182,8 +186,10 @@ DATABASE multi_region_test_db  ALTER DATABASE multi_region_test_db CONFIGURE ZON
                                range_min_bytes = 134217728,
                                range_max_bytes = 536870912,
                                gc.ttlseconds = 90000,
-                               num_replicas = 3,
+                               num_replicas = 5,
+                               num_voters = 5,
                                constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                               voter_constraints = '{+region=ca-central-1: 2}',
                                lease_preferences = '[[+region=ca-central-1]]'
 
 query TT
@@ -193,8 +199,10 @@ DATABASE multi_region_test_explicit_primary_region_db  ALTER DATABASE multi_regi
                                                        range_min_bytes = 134217728,
                                                        range_max_bytes = 536870912,
                                                        gc.ttlseconds = 90000,
-                                                       num_replicas = 3,
+                                                       num_replicas = 5,
+                                                       num_voters = 5,
                                                        constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                                       voter_constraints = '{+region=ap-southeast-2: 2}',
                                                        lease_preferences = '[[+region=ap-southeast-2]]'
 
 query TT
@@ -204,8 +212,10 @@ DATABASE multi_region_test_survive_zone_failure_db  ALTER DATABASE multi_region_
                                                     range_min_bytes = 134217728,
                                                     range_max_bytes = 536870912,
                                                     gc.ttlseconds = 90000,
-                                                    num_replicas = 3,
+                                                    num_replicas = 5,
+                                                    num_voters = 3,
                                                     constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                                    voter_constraints = '[+region=us-east-1]',
                                                     lease_preferences = '[[+region=us-east-1]]'
 
 statement error PRIMARY REGION must be specified if REGIONS are specified
@@ -238,8 +248,10 @@ DATABASE multi_region_test_db  ALTER DATABASE multi_region_test_db CONFIGURE ZON
                                range_min_bytes = 134217728,
                                range_max_bytes = 536870912,
                                gc.ttlseconds = 90000,
-                               num_replicas = 3,
+                               num_replicas = 5,
+                               num_voters = 5,
                                constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                               voter_constraints = '{+region=ca-central-1: 2}',
                                lease_preferences = '[[+region=ca-central-1]]'
 
 statement ok
@@ -260,8 +272,10 @@ DATABASE multi_region_test_db  ALTER DATABASE multi_region_test_db CONFIGURE ZON
                                range_min_bytes = 134217728,
                                range_max_bytes = 536870912,
                                gc.ttlseconds = 90000,
-                               num_replicas = 3,
+                               num_replicas = 5,
+                               num_voters = 5,
                                constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                               voter_constraints = '{+region=ca-central-1: 2}',
                                lease_preferences = '[[+region=ca-central-1]]'
 
 statement ok
@@ -279,12 +293,14 @@ query TT
 SHOW ZONE CONFIGURATION FOR TABLE "regional_us-east-1_table"
 ----
 TABLE "regional_us-east-1_table"  ALTER TABLE "regional_us-east-1_table" CONFIGURE ZONE USING
-                                 range_min_bytes = 134217728,
-                                 range_max_bytes = 536870912,
-                                 gc.ttlseconds = 90000,
-                                 num_replicas = 3,
-                                 constraints = '{+region=us-east-1: 1}',
-                                 lease_preferences = '[[+region=us-east-1]]'
+                                  range_min_bytes = 134217728,
+                                  range_max_bytes = 536870912,
+                                  gc.ttlseconds = 90000,
+                                  num_replicas = 5,
+                                  num_voters = 5,
+                                  constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                  voter_constraints = '{+region=us-east-1: 2}',
+                                  lease_preferences = '[[+region=us-east-1]]'
 
 statement error region "test4" has not been added to database "multi_region_test_db"\nHINT: available regions: ap-southeast-2, ca-central-1, us-east-1
 CREATE TABLE regional_test4_table (a int) LOCALITY REGIONAL BY TABLE IN "test4"
@@ -308,8 +324,10 @@ TABLE global_table  ALTER TABLE global_table CONFIGURE ZONE USING
                     range_max_bytes = 536870912,
                     gc.ttlseconds = 90000,
                     global_reads = true,
-                    num_replicas = 3,
+                    num_replicas = 5,
+                    num_voters = 5,
                     constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                    voter_constraints = '{+region=ca-central-1: 2}',
                     lease_preferences = '[[+region=ca-central-1]]'
 
 query TTTTIT colnames
@@ -367,12 +385,14 @@ query TT
 SHOW ZONE CONFIGURATION FOR DATABASE alter_test_db
 ----
 DATABASE alter_test_db  ALTER DATABASE alter_test_db CONFIGURE ZONE USING
-                         range_min_bytes = 134217728,
-                         range_max_bytes = 536870912,
-                         gc.ttlseconds = 90000,
-                         num_replicas = 3,
-                         constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1}',
-                         lease_preferences = '[[+region=ca-central-1]]'
+                        range_min_bytes = 134217728,
+                        range_max_bytes = 536870912,
+                        gc.ttlseconds = 90000,
+                        num_replicas = 4,
+                        num_voters = 3,
+                        constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1}',
+                        voter_constraints = '[+region=ca-central-1]',
+                        lease_preferences = '[[+region=ca-central-1]]'
 
 # Test adding a region after first region.
 statement ok
@@ -396,12 +416,14 @@ query TT
 SHOW ZONE CONFIGURATION FOR DATABASE alter_test_db
 ----
 DATABASE alter_test_db  ALTER DATABASE alter_test_db CONFIGURE ZONE USING
-                         range_min_bytes = 134217728,
-                         range_max_bytes = 536870912,
-                         gc.ttlseconds = 90000,
-                         num_replicas = 3,
-                         constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                         lease_preferences = '[[+region=ca-central-1]]'
+                        range_min_bytes = 134217728,
+                        range_max_bytes = 536870912,
+                        gc.ttlseconds = 90000,
+                        num_replicas = 5,
+                        num_voters = 3,
+                        constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                        voter_constraints = '[+region=ca-central-1]',
+                        lease_preferences = '[[+region=ca-central-1]]'
 
 # Failure testing for ADD REGION.
 statement error region "test" does not exist
@@ -447,6 +469,19 @@ schema  name  values  owner
 statement error region "test" does not exist
 ALTER DATABASE alter_primary_region_db PRIMARY REGION "test"
 
+# Since the last statement was rejected, ensure that no changes were made to the
+# database's zone configuration
+query TT
+SHOW ZONE CONFIGURATION FOR DATABASE alter_primary_region_db
+----
+RANGE default  ALTER RANGE default CONFIGURE ZONE USING
+               range_min_bytes = 134217728,
+               range_max_bytes = 536870912,
+               gc.ttlseconds = 90000,
+               num_replicas = 3,
+               constraints = '[]',
+               lease_preferences = '[]'
+
 statement ok
 ALTER DATABASE alter_primary_region_db PRIMARY REGION "ca-central-1"
 
@@ -454,12 +489,14 @@ query TT
 SHOW ZONE CONFIGURATION FOR DATABASE alter_primary_region_db
 ----
 DATABASE alter_primary_region_db  ALTER DATABASE alter_primary_region_db CONFIGURE ZONE USING
-                            range_min_bytes = 134217728,
-                            range_max_bytes = 536870912,
-                            gc.ttlseconds = 90000,
-                            num_replicas = 3,
-                            constraints = '{+region=ca-central-1: 1}',
-                            lease_preferences = '[[+region=ca-central-1]]'
+                                  range_min_bytes = 134217728,
+                                  range_max_bytes = 536870912,
+                                  gc.ttlseconds = 90000,
+                                  num_replicas = 3,
+                                  num_voters = 3,
+                                  constraints = '{+region=ca-central-1: 1}',
+                                  voter_constraints = '[+region=ca-central-1]',
+                                  lease_preferences = '[[+region=ca-central-1]]'
 
 query TTBT colnames
 show regions from database alter_primary_region_db
@@ -483,12 +520,14 @@ query TT
 SHOW ZONE CONFIGURATION FOR DATABASE alter_primary_region_db
 ----
 DATABASE alter_primary_region_db  ALTER DATABASE alter_primary_region_db CONFIGURE ZONE USING
-                            range_min_bytes = 134217728,
-                            range_max_bytes = 536870912,
-                            gc.ttlseconds = 90000,
-                            num_replicas = 3,
-                            constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1}',
-                            lease_preferences = '[[+region=ca-central-1]]'
+                                  range_min_bytes = 134217728,
+                                  range_max_bytes = 536870912,
+                                  gc.ttlseconds = 90000,
+                                  num_replicas = 4,
+                                  num_voters = 3,
+                                  constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1}',
+                                  voter_constraints = '[+region=ca-central-1]',
+                                  lease_preferences = '[[+region=ca-central-1]]'
 
 query TTTT colnames
 SHOW ENUMS FROM alter_primary_region_db.public
@@ -510,12 +549,14 @@ query TT
 SHOW ZONE CONFIGURATION FOR DATABASE alter_primary_region_db
 ----
 DATABASE alter_primary_region_db  ALTER DATABASE alter_primary_region_db CONFIGURE ZONE USING
-                            range_min_bytes = 134217728,
-                            range_max_bytes = 536870912,
-                            gc.ttlseconds = 90000,
-                            num_replicas = 3,
-                            constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1}',
-                            lease_preferences = '[[+region=ap-southeast-2]]'
+                                  range_min_bytes = 134217728,
+                                  range_max_bytes = 536870912,
+                                  gc.ttlseconds = 90000,
+                                  num_replicas = 4,
+                                  num_voters = 3,
+                                  constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1}',
+                                  voter_constraints = '[+region=ap-southeast-2]',
+                                  lease_preferences = '[[+region=ap-southeast-2]]'
 
 query TTTT colnames
 SHOW ENUMS FROM alter_primary_region_db.public
@@ -556,12 +597,14 @@ query TT
 SHOW ZONE CONFIGURATION FOR DATABASE alter_survive_db
 ----
 DATABASE alter_survive_db  ALTER DATABASE alter_survive_db CONFIGURE ZONE USING
-                                  range_min_bytes = 134217728,
-                                  range_max_bytes = 536870912,
-                                  gc.ttlseconds = 90000,
-                                  num_replicas = 3,
-                                  constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                                  lease_preferences = '[[+region=ca-central-1]]'
+                           range_min_bytes = 134217728,
+                           range_max_bytes = 536870912,
+                           gc.ttlseconds = 90000,
+                           num_replicas = 5,
+                           num_voters = 3,
+                           constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                           voter_constraints = '[+region=ca-central-1]',
+                           lease_preferences = '[[+region=ca-central-1]]'
 
 statement ok
 create table t_no_locality (i int)
@@ -573,12 +616,14 @@ DATABASE alter_survive_db  ALTER DATABASE alter_survive_db CONFIGURE ZONE USING
                            range_min_bytes = 134217728,
                            range_max_bytes = 536870912,
                            gc.ttlseconds = 90000,
-                           num_replicas = 3,
+                           num_replicas = 5,
+                           num_voters = 3,
                            constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                           voter_constraints = '[+region=ca-central-1]',
                            lease_preferences = '[[+region=ca-central-1]]'
 
 statement ok
-create table t_global (i int) locality global
+CREATE TABLE t_global (i int) LOCALITY GLOBAL
 
 query TT
 SHOW ZONE CONFIGURATION FOR TABLE t_global
@@ -588,8 +633,10 @@ TABLE t_global  ALTER TABLE t_global CONFIGURE ZONE USING
                 range_max_bytes = 536870912,
                 gc.ttlseconds = 90000,
                 global_reads = true,
-                num_replicas = 3,
+                num_replicas = 5,
+                num_voters = 3,
                 constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                voter_constraints = '[+region=ca-central-1]',
                 lease_preferences = '[[+region=ca-central-1]]'
 
 query TTTTT colnames
@@ -613,12 +660,14 @@ query TT
 SHOW ZONE CONFIGURATION FOR DATABASE alter_survive_db
 ----
 DATABASE alter_survive_db  ALTER DATABASE alter_survive_db CONFIGURE ZONE USING
-                                  range_min_bytes = 134217728,
-                                  range_max_bytes = 536870912,
-                                  gc.ttlseconds = 90000,
-                                  num_replicas = 3,
-                                  constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                                  lease_preferences = '[[+region=ca-central-1]]'
+                           range_min_bytes = 134217728,
+                           range_max_bytes = 536870912,
+                           gc.ttlseconds = 90000,
+                           num_replicas = 5,
+                           num_voters = 3,
+                           constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                           voter_constraints = '[+region=ca-central-1]',
+                           lease_preferences = '[[+region=ca-central-1]]'
 
 statement ok
 alter database alter_survive_db survive region failure
@@ -644,12 +693,14 @@ query TT
 SHOW ZONE CONFIGURATION FOR DATABASE alter_survive_db
 ----
 DATABASE alter_survive_db  ALTER DATABASE alter_survive_db CONFIGURE ZONE USING
-                                  range_min_bytes = 134217728,
-                                  range_max_bytes = 536870912,
-                                  gc.ttlseconds = 90000,
-                                  num_replicas = 3,
-                                  constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                                  lease_preferences = '[[+region=ca-central-1]]'
+                           range_min_bytes = 134217728,
+                           range_max_bytes = 536870912,
+                           gc.ttlseconds = 90000,
+                           num_replicas = 5,
+                           num_voters = 5,
+                           constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                           voter_constraints = '{+region=ca-central-1: 2}',
+                           lease_preferences = '[[+region=ca-central-1]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR TABLE t_no_locality
@@ -658,8 +709,10 @@ DATABASE alter_survive_db  ALTER DATABASE alter_survive_db CONFIGURE ZONE USING
                            range_min_bytes = 134217728,
                            range_max_bytes = 536870912,
                            gc.ttlseconds = 90000,
-                           num_replicas = 3,
+                           num_replicas = 5,
+                           num_voters = 5,
                            constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                           voter_constraints = '{+region=ca-central-1: 2}',
                            lease_preferences = '[[+region=ca-central-1]]'
 
 query TT
@@ -670,8 +723,10 @@ TABLE t_global  ALTER TABLE t_global CONFIGURE ZONE USING
                 range_max_bytes = 536870912,
                 gc.ttlseconds = 90000,
                 global_reads = true,
-                num_replicas = 3,
+                num_replicas = 5,
+                num_voters = 5,
                 constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                voter_constraints = '{+region=ca-central-1: 2}',
                 lease_preferences = '[[+region=ca-central-1]]'
 
 statement ok
@@ -701,8 +756,10 @@ DATABASE alter_survive_db  ALTER DATABASE alter_survive_db CONFIGURE ZONE USING
                            range_min_bytes = 134217728,
                            range_max_bytes = 536870912,
                            gc.ttlseconds = 90000,
-                           num_replicas = 3,
+                           num_replicas = 5,
+                           num_voters = 3,
                            constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                           voter_constraints = '[+region=ca-central-1]',
                            lease_preferences = '[[+region=ca-central-1]]'
 
 query TT
@@ -712,8 +769,10 @@ DATABASE alter_survive_db  ALTER DATABASE alter_survive_db CONFIGURE ZONE USING
                            range_min_bytes = 134217728,
                            range_max_bytes = 536870912,
                            gc.ttlseconds = 90000,
-                           num_replicas = 3,
+                           num_replicas = 5,
+                           num_voters = 3,
                            constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                           voter_constraints = '[+region=ca-central-1]',
                            lease_preferences = '[[+region=ca-central-1]]'
 
 query TT
@@ -724,8 +783,10 @@ TABLE t_global  ALTER TABLE t_global CONFIGURE ZONE USING
                 range_max_bytes = 536870912,
                 gc.ttlseconds = 90000,
                 global_reads = true,
-                num_replicas = 3,
+                num_replicas = 5,
+                num_voters = 3,
                 constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                voter_constraints = '[+region=ca-central-1]',
                 lease_preferences = '[[+region=ca-central-1]]'
 
 statement ok
@@ -745,7 +806,9 @@ DATABASE no_initial_region  ALTER DATABASE no_initial_region CONFIGURE ZONE USIN
                             range_max_bytes = 536870912,
                             gc.ttlseconds = 90000,
                             num_replicas = 3,
+                            num_voters = 3,
                             constraints = '{+region=us-east-1: 1}',
+                            voter_constraints = '[+region=us-east-1]',
                             lease_preferences = '[[+region=us-east-1]]'
 
 query T

--- a/pkg/sql/region_util.go
+++ b/pkg/sql/region_util.go
@@ -86,7 +86,7 @@ func checkLiveClusterRegion(liveClusterRegions liveClusterRegions, region descpb
 	return nil
 }
 
-func makeRequiredZoneConstraintForRegion(r descpb.RegionName) zonepb.Constraint {
+func makeRequiredConstraintForRegion(r descpb.RegionName) zonepb.Constraint {
 	return zonepb.Constraint{
 		Type:  zonepb.Constraint_REQUIRED,
 		Key:   "region",
@@ -94,89 +94,224 @@ func makeRequiredZoneConstraintForRegion(r descpb.RegionName) zonepb.Constraint 
 	}
 }
 
-// zoneConfigFromRegionConfigForDatabase generates a desired ZoneConfig based
-// on the region config.
-// TODO(#multiregion,aayushshah15): properly configure this for region survivability and leaseholder
-// preferences when new zone configuration parameters merge.
-func zoneConfigFromRegionConfigForDatabase(
+// zoneConfigForMultiRegionDatabase generates a ZoneConfig stub for a
+// multi-region database such that at least one replica (voting or non-voting)
+// is constrained to each region defined within the given `regionConfig` and
+// some voting replicas are constrained to the primary region of the database
+// depending on its prescribed survivability goal.
+//
+// For instance, for a database with 4 regions: A (primary), B, C, D and region
+// survivability. This method will generate a ZoneConfig object representing
+// the following attributes:
+// num_replicas = 5
+// num_voters = 5
+// constraints = '{"+region=A": 1,"+region=B": 1,"+region=C": 1,"+region=D": 1}'
+// voter_constraints = '{"+region=A": 2}'
+// lease_preferences = [["+region=A"]]
+//
+// See synthesizeVoterConstraints() for explanation on why `voter_constraints`
+// are set the way they are.
+func zoneConfigForMultiRegionDatabase(
 	regionConfig descpb.DatabaseDescriptor_RegionConfig,
-) *zonepb.ZoneConfig {
-	numReplicas := zoneConfigNumReplicasFromRegionConfig(regionConfig)
-	conjunctions := []zonepb.ConstraintsConjunction{}
-	for _, region := range regionConfig.Regions {
-		conjunctions = append(
-			conjunctions,
-			zonepb.ConstraintsConjunction{
-				NumReplicas: 1,
-				Constraints: []zonepb.Constraint{makeRequiredZoneConstraintForRegion(region.Name)},
-			},
-		)
+) (*zonepb.ZoneConfig, error) {
+	numVoters, numReplicas := getNumVotersAndNumReplicas(regionConfig)
+	constraints := make([]zonepb.ConstraintsConjunction, len(regionConfig.Regions))
+	for i, region := range regionConfig.Regions {
+		// Constrain at least 1 (voting or non-voting) replica per region.
+		constraints[i] = zonepb.ConstraintsConjunction{
+			NumReplicas: 1,
+			Constraints: []zonepb.Constraint{makeRequiredConstraintForRegion(region.Name)},
+		}
 	}
+
+	voterConstraints, err := synthesizeVoterConstraints(regionConfig.PrimaryRegion, regionConfig)
+	if err != nil {
+		return nil, err
+	}
+
 	return &zonepb.ZoneConfig{
 		NumReplicas: &numReplicas,
+		NumVoters:   &numVoters,
 		LeasePreferences: []zonepb.LeasePreference{
-			{Constraints: []zonepb.Constraint{makeRequiredZoneConstraintForRegion(regionConfig.PrimaryRegion)}},
+			{Constraints: []zonepb.Constraint{makeRequiredConstraintForRegion(regionConfig.PrimaryRegion)}},
 		},
-		Constraints: conjunctions,
-	}
+		VoterConstraints: voterConstraints,
+		Constraints:      constraints,
+	}, nil
 }
 
-// zoneConfigFromRegionConfigForPartition generates a desired ZoneConfig based
-// on the region config for the given partition.
-// TODO(#multiregion,aayushshah15): properly configure this for region survivability and leaseholder
-// preferences when new zone configuration parameters merge.
-func zoneConfigFromRegionConfigForPartition(
+// zoneConfigForMultiRegionPartition generates a ZoneConfig stub for a partition
+// that belongs to a regional by row table in a multi-region database.
+//
+// At the table/partition level, the only attributes that are set are
+// `num_voters`, `voter_constraints`, and `lease_preferences`. We expect that
+// the attributes `num_replicas` and `constraints` will be inherited from the
+// database level zone config.
+func zoneConfigForMultiRegionPartition(
 	partitionRegion descpb.DatabaseDescriptor_RegionConfig_Region,
 	regionConfig descpb.DatabaseDescriptor_RegionConfig,
 ) (zonepb.ZoneConfig, error) {
-	zc := zonepb.ZoneConfig{
-		NumReplicas: proto.Int32(zoneConfigNumReplicasFromRegionConfig(regionConfig)),
-		LeasePreferences: []zonepb.LeasePreference{
-			{Constraints: []zonepb.Constraint{makeRequiredZoneConstraintForRegion(partitionRegion.Name)}},
-		},
+	numVoters, _ := getNumVotersAndNumReplicas(regionConfig)
+	zc := zonepb.NewZoneConfig()
+	voterConstraints, err := synthesizeVoterConstraints(partitionRegion.Name, regionConfig)
+	if err != nil {
+		return zonepb.ZoneConfig{}, err
 	}
-	var err error
-	if zc.Constraints, err = constraintsConjunctionForRegionalLocality(
-		partitionRegion.Name,
-		regionConfig,
-	); err != nil {
-		return zc, err
+	zc.NumVoters = &numVoters
+
+	zc.InheritedVoterConstraints = false
+	zc.VoterConstraints = voterConstraints
+
+	zc.InheritedLeasePreferences = false
+	zc.LeasePreferences = []zonepb.LeasePreference{
+		{Constraints: []zonepb.Constraint{makeRequiredConstraintForRegion(partitionRegion.Name)}},
 	}
-	return zc, err
+	return *zc, err
 }
 
-// zoneConfigNumReplicasFromRegionConfig generates the number of replicas needed given a region config.
-func zoneConfigNumReplicasFromRegionConfig(
+// maxFailuresBeforeUnavailability returns the maximum number of individual
+// failures that can be tolerated, among `numVoters` voting replicas, before a
+// given range is unavailable.
+func maxFailuresBeforeUnavailability(numVoters int32) int32 {
+	return ((numVoters + 1) / 2) - 1
+}
+
+// getNumVotersAndNumReplicas computes the number of voters and the total number
+// of replicas needed for a given region config.
+func getNumVotersAndNumReplicas(
 	regionConfig descpb.DatabaseDescriptor_RegionConfig,
-) int32 {
-	// TODO(#multiregion): do we want 5 in the case of region failure?
-	numReplicas := int32(len(regionConfig.Regions))
-	if numReplicas < 3 {
-		numReplicas = 3
+) (numVoters, numReplicas int32) {
+	const numVotersForZoneSurvival = 3
+	// Under region survivability, we use 5 voting replicas to allow for a
+	// theoretical (2-2-1) voting replica configuration, where the primary region
+	// has 2 voting replicas and the next closest region has another 2. This
+	// allows for stable read/write latencies even under single node failures.
+	//
+	// TODO(aayush): Until we add allocator heuristics to coalesce voting replicas
+	// together based on their relative latencies to the leaseholder, we can't
+	// actually ensure that the region closest to the leaseholder has 2 voting
+	// replicas.
+	//
+	// Until the above TODO is addressed, the non-leaseholder voting replicas will
+	// be allowed to "float" around among the other regions in the database. They
+	// may or may not be placed geographically close to the leaseholder replica.
+	const numVotersForRegionSurvival = 5
+
+	numRegions := int32(len(regionConfig.Regions))
+	switch regionConfig.SurvivalGoal {
+	// NB: See mega-comment inside `synthesizeVoterConstraints()` for why these
+	// are set the way they are.
+	case descpb.SurvivalGoal_ZONE_FAILURE:
+		numVoters = numVotersForZoneSurvival
+		// <numVoters in the home region> + <1 replica for every other region>
+		numReplicas = (numVotersForZoneSurvival) + (numRegions - 1)
+	case descpb.SurvivalGoal_REGION_FAILURE:
+		// <(quorum - 1) voters in the home region> + <1 replica for every other
+		// region>
+		numVoters = numVotersForRegionSurvival
+		// We place the maximum concurrent replicas that can fail before a range
+		// outage in the home region, and ensure that there's at least one replica
+		// in all other regions.
+		numReplicas = maxFailuresBeforeUnavailability(numVotersForRegionSurvival) + (numRegions - 1)
+		if numReplicas < numVoters {
+			// NumReplicas cannot be less than NumVoters. If we have <= 4 regions, all
+			// replicas will be voting replicas.
+			numReplicas = numVoters
+		}
 	}
-	return numReplicas
+	return numVoters, numReplicas
 }
 
-// constraintsConjunctionForRegionalLocality generates a ConstraintsConjunction clause
-// to be set for a given locality.
-// TODO(#multiregion,aayushshah15): properly configure constraints and replicas for
-// region survivability and leaseholder preferences when new zone configuration parameters merge.
-func constraintsConjunctionForRegionalLocality(
+// synthesizeVoterConstraints generates a ConstraintsConjunction clause
+// representing the `voter_constraints` field to be set for the primary region
+// of a multi-region database or the home region of a table in such a database.
+//
+// Under zone survivability, we will constrain all voting replicas to be inside
+// the primary/home region.
+//
+// Under region survivability, we will constrain exactly <quorum - 1> voting
+// replicas in the primary/home region.
+func synthesizeVoterConstraints(
 	region descpb.RegionName, regionConfig descpb.DatabaseDescriptor_RegionConfig,
 ) ([]zonepb.ConstraintsConjunction, error) {
+	numVoters, _ := getNumVotersAndNumReplicas(regionConfig)
 	switch regionConfig.SurvivalGoal {
 	case descpb.SurvivalGoal_ZONE_FAILURE:
 		return []zonepb.ConstraintsConjunction{
 			{
-				NumReplicas: zoneConfigNumReplicasFromRegionConfig(regionConfig),
-				Constraints: []zonepb.Constraint{makeRequiredZoneConstraintForRegion(region)},
+				// We don't specify `NumReplicas` here to indicate that we want _all_
+				// voting replicas to be constrained to this one region.
+				//
+				// Constraining all voting replicas to be inside the primary/home region
+				// is necessary and sufficient to ensure zone survivability, even though
+				// it might appear that these zone configs don't seem to spell out the
+				// requirement of being resilient to zone failures. This is because, by
+				// default, the allocator (see kv/kvserver/allocator.go) will maximize
+				// survivability due to it's diversity heuristic (see
+				// Locality.DiversityScore()) by spreading the replicas of a range
+				// across nodes with the most mutual difference in their locality
+				// hierarchies.
+				//
+				// For instance, in a 2 region deployment, each with 3 AZs, this is
+				// expected to result in a configuration like the following:
+				//
+				// +---- Region A -----+      +---- Region B -----+
+				// |                   |      |                   |
+				// |   +------------+  |      |  +------------+   |
+				// |   |   VOTER    |  |      |  |            |   |
+				// |   |            |  |      |  |            |   |
+				// |   +------------+  |      |  +------------+   |
+				// |   +------------+  |      |  +------------+   |
+				// |   |   VOTER    |  |      |  |            |   |
+				// |   |            |  |      |  | NON-VOTER  |   |
+				// |   +------------+  |      |  |            |   |
+				// |   +------------+  |      |  +------------+   |
+				// |   |            |  |      |  +------------+   |
+				// |   |   VOTER    |  |      |  |            |   |
+				// |   |            |  |      |  |            |   |
+				// |   +------------+  |      |  +------------+   |
+				// +-------------------+      +-------------------+
+				//
+				Constraints: []zonepb.Constraint{makeRequiredConstraintForRegion(region)},
 			},
 		}, nil
 	case descpb.SurvivalGoal_REGION_FAILURE:
 		return []zonepb.ConstraintsConjunction{
 			{
-				NumReplicas: 1,
-				Constraints: []zonepb.Constraint{makeRequiredZoneConstraintForRegion(region)},
+				// We constrain <quorum - 1> voting replicas to the primary region and
+				// allow the rest to "float" around. This allows the allocator inside KV
+				// to make dynamic placement decisions for the voting replicas that lie
+				// outside the primary/home region.
+				//
+				// It might appear that constraining just <quorum - 1> voting replicas
+				// to the primary region leaves open the possibility of a majority
+				// quorum coalescing inside of some other region. However, similar to
+				// the case above, the diversity heuristic in the allocator prevents
+				// this from happening as it will spread the unconstrained replicas out
+				// across nodes with the most diverse locality hierarchies.
+				//
+				// For instance, in a 3 region deployment (minimum for a database with
+				// "region" survivability), each with 3 AZs, we'd expect to see a
+				// configuration like the following:
+				//
+				// +---- Region A ------+   +---- Region B -----+    +----- Region C -----+
+				// |                    |   |                   |    |                    |
+				// |   +------------+   |   |  +------------+   |    |   +------------+   |
+				// |   |   VOTER    |   |   |  |   VOTER    |   |    |   |            |   |
+				// |   |            |   |   |  |            |   |    |   |            |   |
+				// |   +------------+   |   |  +------------+   |    |   +------------+   |
+				// |   +------------+   |   |  +------------+   |    |   +------------+   |
+				// |   |            |   |   |  |   VOTER    |   |    |   |   VOTER    |   |
+				// |   |            |   |   |  |            |   |    |   |            |   |
+				// |   +------------+   |   |  +------------+   |    |   +------------+   |
+				// |   +------------+   |   |  +------------+   |    |   +------------+   |
+				// |   |   VOTER    |   |   |  |            |   |    |   |            |   |
+				// |   |            |   |   |  |            |   |    |   |            |   |
+				// |   +------------+   |   |  +------------+   |    |   +------------+   |
+				// +--------------------+   +-------------------+    +--------------------+
+				//
+				NumReplicas: maxFailuresBeforeUnavailability(numVoters),
+				Constraints: []zonepb.Constraint{makeRequiredConstraintForRegion(region)},
 			},
 		}, nil
 	default:
@@ -185,45 +320,63 @@ func constraintsConjunctionForRegionalLocality(
 }
 
 var multiRegionZoneConfigFields = []tree.Name{
-	"constraints",
 	"global_reads",
-	"lease_preferences",
 	"num_replicas",
+	"num_voters",
+	"constraints",
 	"voter_constraints",
+	"lease_preferences",
 }
 
-// zoneConfigFromTableLocalityConfig generates a desired ZoneConfig based
-// on the locality config for the database.
-// Relevant multi-region configured fields swill be overwritten by the calling function
-// into an existing ZoneConfig using multiRegionZoneConfigFields.
-// TODO(#multiregion,aayushshah15): properly configure this for region survivability and leaseholder
-// preferences when new zone configuration parameters merge.
-func zoneConfigFromTableLocalityConfig(
+// zoneConfigForMultiRegionTable generates a ZoneConfig stub for a
+// regional-by-table or global table in a multi-region database.
+//
+// At the table/partition level, the only attributes that are set are
+// `num_voters`, `voter_constraints`, and `lease_preferences`. We expect that
+// the attributes `num_replicas` and `constraints` will be inherited from the
+// database level zone config.
+//
+// This function can return a nil zonepb.ZoneConfig, meaning no table level zone
+// configuration is required.
+//
+// Relevant multi-region configured fields (as defined in
+// `multiRegionZoneConfigFields`) will be overwritten by the calling function
+// into an existing ZoneConfig.
+func zoneConfigForMultiRegionTable(
 	localityConfig descpb.TableDescriptor_LocalityConfig,
 	regionConfig descpb.DatabaseDescriptor_RegionConfig,
-) (zonepb.ZoneConfig, error) {
-	ret := *(zonepb.NewZoneConfig())
+) (*zonepb.ZoneConfig, error) {
+	// We only care about NumVoters here at the table level. NumReplicas is set at
+	// the database level, not at the table/partition level.
+	numVoters, _ := getNumVotersAndNumReplicas(regionConfig)
+	ret := zonepb.NewZoneConfig()
 
 	switch l := localityConfig.Locality.(type) {
 	case *descpb.TableDescriptor_LocalityConfig_Global_:
 		// Enable non-blocking transactions.
 		ret.GlobalReads = proto.Bool(true)
+		// Inherit voter_constraints and lease preferences from the database. We do
+		// nothing here because `NewZoneConfig()` already marks those fields as
+		// 'inherited'.
 	case *descpb.TableDescriptor_LocalityConfig_RegionalByTable_:
 		// Use the same configuration as the database and return nil here.
 		if l.RegionalByTable.Region == nil {
 			return ret, nil
 		}
-		ret.NumReplicas = proto.Int32(zoneConfigNumReplicasFromRegionConfig(regionConfig))
 		preferredRegion := *l.RegionalByTable.Region
-		var err error
-		if ret.Constraints, err = constraintsConjunctionForRegionalLocality(preferredRegion, regionConfig); err != nil {
-			return ret, err
+		voterConstraints, err := synthesizeVoterConstraints(preferredRegion, regionConfig)
+		if err != nil {
+			return nil, err
 		}
-		ret.LeasePreferences = []zonepb.LeasePreference{
-			{Constraints: []zonepb.Constraint{makeRequiredZoneConstraintForRegion(preferredRegion)}},
-		}
+		ret.NumVoters = &numVoters
+
+		ret.InheritedVoterConstraints = false
+		ret.VoterConstraints = voterConstraints
+
 		ret.InheritedLeasePreferences = false
-		ret.InheritedConstraints = false
+		ret.LeasePreferences = []zonepb.LeasePreference{
+			{Constraints: []zonepb.Constraint{makeRequiredConstraintForRegion(preferredRegion)}},
+		}
 	case *descpb.TableDescriptor_LocalityConfig_RegionalByRow_:
 		// We purposely do not set anything here at table level - this should be done at
 		// partition level instead.
@@ -284,7 +437,7 @@ func applyZoneConfigForMultiRegionTableOptionNewIndex(
 		table catalog.TableDescriptor,
 	) (hasNewSubzones bool, newZoneConfig zonepb.ZoneConfig, err error) {
 		for _, region := range regionConfig.Regions {
-			zc, err := zoneConfigFromRegionConfigForPartition(region, regionConfig)
+			zc, err := zoneConfigForMultiRegionPartition(region, regionConfig)
 			if err != nil {
 				return false, zoneConfig, err
 			}
@@ -308,14 +461,14 @@ var applyZoneConfigForMultiRegionTableOptionTableAndIndexes = func(
 ) (bool, zonepb.ZoneConfig, error) {
 	localityConfig := *table.GetLocalityConfig()
 
-	localityZoneConfig, err := zoneConfigFromTableLocalityConfig(
+	localityZoneConfig, err := zoneConfigForMultiRegionTable(
 		localityConfig,
 		regionConfig,
 	)
 	if err != nil {
 		return false, zonepb.ZoneConfig{}, err
 	}
-	zc.CopyFromZone(localityZoneConfig, multiRegionZoneConfigFields)
+	zc.CopyFromZone(*localityZoneConfig, multiRegionZoneConfigFields)
 
 	hasNewSubzones := table.IsLocalityRegionalByRow()
 	if hasNewSubzones {
@@ -327,7 +480,7 @@ var applyZoneConfigForMultiRegionTableOptionTableAndIndexes = func(
 		}
 
 		for _, region := range regionConfig.Regions {
-			subzoneConfig, err := zoneConfigFromRegionConfigForPartition(region, regionConfig)
+			subzoneConfig, err := zoneConfigForMultiRegionPartition(region, regionConfig)
 			if err != nil {
 				return false, zc, err
 			}
@@ -422,10 +575,14 @@ func (p *planner) applyZoneConfigFromDatabaseRegionConfig(
 	// Convert the partially filled zone config to re-run as a SQL command.
 	// This avoid us having to modularize planNode logic from set_zone_config
 	// and the optimizer.
+	dbZoneConfig, err := zoneConfigForMultiRegionDatabase(regionConfig)
+	if err != nil {
+		return err
+	}
 	return p.applyZoneConfigForMultiRegion(
 		ctx,
 		tree.ZoneSpecifier{Database: dbName},
-		zoneConfigFromRegionConfigForDatabase(regionConfig),
+		dbZoneConfig,
 		"database-multiregion-set-zone-config",
 	)
 }

--- a/pkg/sql/region_util_test.go
+++ b/pkg/sql/region_util_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestZoneConfigFromRegionConfigForDatabase(t *testing.T) {
+func TestZoneConfigForMultiRegionDatabase(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	testCases := []struct {
@@ -39,11 +39,28 @@ func TestZoneConfigFromRegionConfigForDatabase(t *testing.T) {
 			},
 			expected: &zonepb.ZoneConfig{
 				NumReplicas: proto.Int32(3),
+				NumVoters:   proto.Int32(3),
 				LeasePreferences: []zonepb.LeasePreference{
-					{Constraints: []zonepb.Constraint{{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_a"}}},
+					{
+						Constraints: []zonepb.Constraint{
+							{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_a"},
+						},
+					},
 				},
 				Constraints: []zonepb.ConstraintsConjunction{
-					{NumReplicas: 1, Constraints: []zonepb.Constraint{{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_a"}}},
+					{
+						NumReplicas: 1,
+						Constraints: []zonepb.Constraint{
+							{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_a"},
+						},
+					},
+				},
+				VoterConstraints: []zonepb.ConstraintsConjunction{
+					{
+						Constraints: []zonepb.Constraint{
+							{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_a"},
+						},
+					},
 				},
 			},
 		},
@@ -58,13 +75,35 @@ func TestZoneConfigFromRegionConfigForDatabase(t *testing.T) {
 				SurvivalGoal:  descpb.SurvivalGoal_ZONE_FAILURE,
 			},
 			expected: &zonepb.ZoneConfig{
-				NumReplicas: proto.Int32(3),
+				NumReplicas: proto.Int32(4),
+				NumVoters:   proto.Int32(3),
 				LeasePreferences: []zonepb.LeasePreference{
-					{Constraints: []zonepb.Constraint{{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_a"}}},
+					{
+						Constraints: []zonepb.Constraint{
+							{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_a"},
+						},
+					},
 				},
 				Constraints: []zonepb.ConstraintsConjunction{
-					{NumReplicas: 1, Constraints: []zonepb.Constraint{{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_b"}}},
-					{NumReplicas: 1, Constraints: []zonepb.Constraint{{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_a"}}},
+					{
+						NumReplicas: 1,
+						Constraints: []zonepb.Constraint{
+							{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_b"},
+						},
+					},
+					{
+						NumReplicas: 1,
+						Constraints: []zonepb.Constraint{
+							{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_a"},
+						},
+					},
+				},
+				VoterConstraints: []zonepb.ConstraintsConjunction{
+					{
+						Constraints: []zonepb.Constraint{
+							{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_a"},
+						},
+					},
 				},
 			},
 		},
@@ -80,14 +119,41 @@ func TestZoneConfigFromRegionConfigForDatabase(t *testing.T) {
 				SurvivalGoal:  descpb.SurvivalGoal_ZONE_FAILURE,
 			},
 			expected: &zonepb.ZoneConfig{
-				NumReplicas: proto.Int32(3),
+				NumReplicas: proto.Int32(5),
+				NumVoters:   proto.Int32(3),
 				LeasePreferences: []zonepb.LeasePreference{
-					{Constraints: []zonepb.Constraint{{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_b"}}},
+					{
+						Constraints: []zonepb.Constraint{
+							{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_b"},
+						},
+					},
 				},
 				Constraints: []zonepb.ConstraintsConjunction{
-					{NumReplicas: 1, Constraints: []zonepb.Constraint{{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_b"}}},
-					{NumReplicas: 1, Constraints: []zonepb.Constraint{{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_c"}}},
-					{NumReplicas: 1, Constraints: []zonepb.Constraint{{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_a"}}},
+					{
+						NumReplicas: 1,
+						Constraints: []zonepb.Constraint{
+							{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_b"},
+						},
+					},
+					{
+						NumReplicas: 1,
+						Constraints: []zonepb.Constraint{
+							{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_c"},
+						},
+					},
+					{
+						NumReplicas: 1,
+						Constraints: []zonepb.Constraint{
+							{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_a"},
+						},
+					},
+				},
+				VoterConstraints: []zonepb.ConstraintsConjunction{
+					{
+						Constraints: []zonepb.Constraint{
+							{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_b"},
+						},
+					},
 				},
 			},
 		},
@@ -103,14 +169,41 @@ func TestZoneConfigFromRegionConfigForDatabase(t *testing.T) {
 				SurvivalGoal:  descpb.SurvivalGoal_REGION_FAILURE,
 			},
 			expected: &zonepb.ZoneConfig{
-				NumReplicas: proto.Int32(3),
+				NumReplicas: proto.Int32(5),
+				NumVoters:   proto.Int32(5),
 				LeasePreferences: []zonepb.LeasePreference{
-					{Constraints: []zonepb.Constraint{{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_b"}}},
+					{
+						Constraints: []zonepb.Constraint{
+							{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_b"}},
+					},
 				},
 				Constraints: []zonepb.ConstraintsConjunction{
-					{NumReplicas: 1, Constraints: []zonepb.Constraint{{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_b"}}},
-					{NumReplicas: 1, Constraints: []zonepb.Constraint{{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_c"}}},
-					{NumReplicas: 1, Constraints: []zonepb.Constraint{{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_a"}}},
+					{
+						NumReplicas: 1,
+						Constraints: []zonepb.Constraint{
+							{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_b"},
+						},
+					},
+					{
+						NumReplicas: 1,
+						Constraints: []zonepb.Constraint{
+							{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_c"},
+						},
+					},
+					{
+						NumReplicas: 1,
+						Constraints: []zonepb.Constraint{
+							{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_a"},
+						},
+					},
+				},
+				VoterConstraints: []zonepb.ConstraintsConjunction{
+					{
+						NumReplicas: 2,
+						Constraints: []zonepb.Constraint{
+							{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_b"},
+						},
+					},
 				},
 			},
 		},
@@ -127,15 +220,47 @@ func TestZoneConfigFromRegionConfigForDatabase(t *testing.T) {
 				SurvivalGoal:  descpb.SurvivalGoal_ZONE_FAILURE,
 			},
 			expected: &zonepb.ZoneConfig{
-				NumReplicas: proto.Int32(4),
+				NumReplicas: proto.Int32(6),
+				NumVoters:   proto.Int32(3),
 				LeasePreferences: []zonepb.LeasePreference{
-					{Constraints: []zonepb.Constraint{{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_b"}}},
+					{
+						Constraints: []zonepb.Constraint{
+							{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_b"},
+						},
+					},
 				},
 				Constraints: []zonepb.ConstraintsConjunction{
-					{NumReplicas: 1, Constraints: []zonepb.Constraint{{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_b"}}},
-					{NumReplicas: 1, Constraints: []zonepb.Constraint{{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_c"}}},
-					{NumReplicas: 1, Constraints: []zonepb.Constraint{{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_a"}}},
-					{NumReplicas: 1, Constraints: []zonepb.Constraint{{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_d"}}},
+					{
+						NumReplicas: 1,
+						Constraints: []zonepb.Constraint{
+							{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_b"},
+						},
+					},
+					{
+						NumReplicas: 1,
+						Constraints: []zonepb.Constraint{
+							{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_c"},
+						},
+					},
+					{
+						NumReplicas: 1,
+						Constraints: []zonepb.Constraint{
+							{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_a"},
+						},
+					},
+					{
+						NumReplicas: 1,
+						Constraints: []zonepb.Constraint{
+							{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_d"},
+						},
+					},
+				},
+				VoterConstraints: []zonepb.ConstraintsConjunction{
+					{
+						Constraints: []zonepb.Constraint{
+							{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_b"},
+						},
+					},
 				},
 			},
 		},
@@ -152,15 +277,48 @@ func TestZoneConfigFromRegionConfigForDatabase(t *testing.T) {
 				SurvivalGoal:  descpb.SurvivalGoal_REGION_FAILURE,
 			},
 			expected: &zonepb.ZoneConfig{
-				NumReplicas: proto.Int32(4),
+				NumReplicas: proto.Int32(5),
+				NumVoters:   proto.Int32(5),
 				LeasePreferences: []zonepb.LeasePreference{
-					{Constraints: []zonepb.Constraint{{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_b"}}},
+					{
+						Constraints: []zonepb.Constraint{
+							{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_b"},
+						},
+					},
 				},
 				Constraints: []zonepb.ConstraintsConjunction{
-					{NumReplicas: 1, Constraints: []zonepb.Constraint{{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_b"}}},
-					{NumReplicas: 1, Constraints: []zonepb.Constraint{{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_c"}}},
-					{NumReplicas: 1, Constraints: []zonepb.Constraint{{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_a"}}},
-					{NumReplicas: 1, Constraints: []zonepb.Constraint{{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_d"}}},
+					{
+						NumReplicas: 1,
+						Constraints: []zonepb.Constraint{
+							{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_b"},
+						},
+					},
+					{
+						NumReplicas: 1,
+						Constraints: []zonepb.Constraint{
+							{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_c"},
+						},
+					},
+					{
+						NumReplicas: 1,
+						Constraints: []zonepb.Constraint{
+							{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_a"},
+						},
+					},
+					{
+						NumReplicas: 1,
+						Constraints: []zonepb.Constraint{
+							{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_d"},
+						},
+					},
+				},
+				VoterConstraints: []zonepb.ConstraintsConjunction{
+					{
+						NumReplicas: 2,
+						Constraints: []zonepb.Constraint{
+							{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_b"},
+						},
+					},
 				},
 			},
 		},
@@ -168,7 +326,8 @@ func TestZoneConfigFromRegionConfigForDatabase(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			res := zoneConfigFromRegionConfigForDatabase(tc.regionConfig)
+			res, err := zoneConfigForMultiRegionDatabase(tc.regionConfig)
+			require.NoError(t, err)
 			require.Equal(t, tc.expected, res)
 		})
 	}
@@ -178,7 +337,7 @@ func protoRegionName(region descpb.RegionName) *descpb.RegionName {
 	return &region
 }
 
-func TestZoneConfigFromTableLocalityConfig(t *testing.T) {
+func TestZoneConfigForMultiRegionTable(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	testCases := []struct {
@@ -326,23 +485,32 @@ func TestZoneConfigFromTableLocalityConfig(t *testing.T) {
 			},
 			regionConfig: descpb.DatabaseDescriptor_RegionConfig{
 				Regions: []descpb.DatabaseDescriptor_RegionConfig_Region{
+					{Name: "region_a"},
 					{Name: "region_b"},
 					{Name: "region_c"},
-					{Name: "region_a"},
 					{Name: "region_d"},
 				},
 				PrimaryRegion: "region_b",
 				SurvivalGoal:  descpb.SurvivalGoal_ZONE_FAILURE,
 			},
 			expected: zonepb.ZoneConfig{
-				NumReplicas: proto.Int32(4),
+				NumReplicas: nil, // Set at the database level.
+				NumVoters:   proto.Int32(3),
 				LeasePreferences: []zonepb.LeasePreference{
-					{Constraints: []zonepb.Constraint{{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_c"}}},
+					{
+						Constraints: []zonepb.Constraint{
+							{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_c"},
+						},
+					},
 				},
-				Constraints: []zonepb.ConstraintsConjunction{
-					{NumReplicas: 4, Constraints: []zonepb.Constraint{{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_c"}}},
+				InheritedConstraints: true,
+				VoterConstraints: []zonepb.ConstraintsConjunction{
+					{
+						Constraints: []zonepb.Constraint{
+							{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_c"},
+						},
+					},
 				},
-				InheritedVoterConstraints: true,
 			},
 		},
 		{
@@ -365,27 +533,37 @@ func TestZoneConfigFromTableLocalityConfig(t *testing.T) {
 				SurvivalGoal:  descpb.SurvivalGoal_REGION_FAILURE,
 			},
 			expected: zonepb.ZoneConfig{
-				NumReplicas: proto.Int32(4),
+				NumReplicas: nil, // Set at the database level.
+				NumVoters:   proto.Int32(5),
 				LeasePreferences: []zonepb.LeasePreference{
-					{Constraints: []zonepb.Constraint{{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_c"}}},
+					{
+						Constraints: []zonepb.Constraint{
+							{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_c"},
+						},
+					},
 				},
-				Constraints: []zonepb.ConstraintsConjunction{
-					{NumReplicas: 1, Constraints: []zonepb.Constraint{{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_c"}}},
+				InheritedConstraints: true,
+				VoterConstraints: []zonepb.ConstraintsConjunction{
+					{
+						NumReplicas: 2,
+						Constraints: []zonepb.Constraint{
+							{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_c"},
+						},
+					},
 				},
-				InheritedVoterConstraints: true,
 			},
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			zc, err := zoneConfigFromTableLocalityConfig(tc.localityConfig, tc.regionConfig)
+			zc, err := zoneConfigForMultiRegionTable(tc.localityConfig, tc.regionConfig)
 			require.NoError(t, err)
-			require.Equal(t, tc.expected, zc)
+			require.Equal(t, tc.expected, *zc)
 		})
 	}
 }
 
-func TestZoneConfigFromRegionConfigForPartition(t *testing.T) {
+func TestZoneConfigForMultiRegionPartition(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	testCases := []struct {
@@ -410,28 +588,20 @@ func TestZoneConfigFromRegionConfigForPartition(t *testing.T) {
 				SurvivalGoal:  descpb.SurvivalGoal_ZONE_FAILURE,
 			},
 			expected: zonepb.ZoneConfig{
-				NumReplicas: proto.Int32(4),
-				Constraints: []zonepb.ConstraintsConjunction{
+				NumReplicas:          nil, // Set at the database level.
+				NumVoters:            proto.Int32(3),
+				InheritedConstraints: true,
+				VoterConstraints: []zonepb.ConstraintsConjunction{
 					{
-						NumReplicas: 4,
 						Constraints: []zonepb.Constraint{
-							{
-								Type:  zonepb.Constraint_REQUIRED,
-								Key:   "region",
-								Value: "region_a",
-							},
+							{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_a"},
 						},
 					},
 				},
-				InheritedConstraints: false,
 				LeasePreferences: []zonepb.LeasePreference{
 					{
 						Constraints: []zonepb.Constraint{
-							{
-								Type:  zonepb.Constraint_REQUIRED,
-								Key:   "region",
-								Value: "region_a",
-							},
+							{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_a"},
 						},
 					},
 				},
@@ -453,28 +623,21 @@ func TestZoneConfigFromRegionConfigForPartition(t *testing.T) {
 				SurvivalGoal:  descpb.SurvivalGoal_REGION_FAILURE,
 			},
 			expected: zonepb.ZoneConfig{
-				NumReplicas: proto.Int32(4),
-				Constraints: []zonepb.ConstraintsConjunction{
+				NumReplicas:          nil, // Set at the database level.
+				NumVoters:            proto.Int32(5),
+				InheritedConstraints: true,
+				VoterConstraints: []zonepb.ConstraintsConjunction{
 					{
-						NumReplicas: 1,
+						NumReplicas: 2,
 						Constraints: []zonepb.Constraint{
-							{
-								Type:  zonepb.Constraint_REQUIRED,
-								Key:   "region",
-								Value: "region_a",
-							},
+							{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_a"},
 						},
 					},
 				},
-				InheritedConstraints: false,
 				LeasePreferences: []zonepb.LeasePreference{
 					{
 						Constraints: []zonepb.Constraint{
-							{
-								Type:  zonepb.Constraint_REQUIRED,
-								Key:   "region",
-								Value: "region_a",
-							},
+							{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: "region_a"},
 						},
 					},
 				},
@@ -483,7 +646,7 @@ func TestZoneConfigFromRegionConfigForPartition(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			zc, err := zoneConfigFromRegionConfigForPartition(tc.region, tc.regionConfig)
+			zc, err := zoneConfigForMultiRegionPartition(tc.region, tc.regionConfig)
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, zc)
 		})


### PR DESCRIPTION
After the introduction of #57184, we can constrain voting replicas
separately from non-voting replicas using the new attributes
`num_voters` and `voter_constraints`. This commit connects our
multi-region DDL statements to leverage these new attributes.

Broadly speaking,
- The existing `constraints` and `num_replicas` fields are set at the
database level, to be inherited by table/partition level zone configs.
- The new attributes: `num_voters` and `voter_constraints` (along with
accompanying `lease_preferences` for these voters) are set at the
table/partition level.

This brings the implementation of these DDL statements inline with the
functional specfication.

Fixes #57663

Release note: None
