### PR TITLE
parser: lowercase timespans in extract

### DIFF
--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -11453,7 +11453,7 @@ array_expr_list:
 extract_list:
   extract_arg FROM a_expr
   {
-    $$.val = tree.Exprs{tree.NewStrVal($1), $3.expr()}
+    $$.val = tree.Exprs{tree.NewStrVal(strings.ToLower($1)), $3.expr()}
   }
 | expr_list
   {


### PR DESCRIPTION
Touches #19965. Confirmed that this (relatively silly) PR gets rid of the allocations in the experiment listed in https://github.com/cockroachdb/cockroach/issues/19965#issuecomment-770060166

The `extract` builtin is kind of weird - it is actually supported by the
parser and not an ordinary builtin function that people can call without
parser support. As such, we can normalize its inputs right in the
parser.

The benefit of this is that, later, we are going to unconditionally
ToLower() the string arguments to extract - which costs an allocation.
So we can do this normalization up front to save a bunch of allocations
in queries that run `extract` over a lot of data rows.

Release note (performance improvement): improve the allocation
performance of workloads that use the `EXTRACT` builtin.