### PR TITLE
Bazel: Try-import a user-specific .bazelrc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,3 +2,5 @@
 
 build --ui_event_filters=-DEBUG
 query --ui_event_filters=-DEBUG
+
+try-import %workspace%/.bazelrc.user

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ build/Railroad.jar
 
 # Bazel generated symlinks
 /bazel-*
+
+# Per-user .bazelrc
+/.bazelrc.user


### PR DESCRIPTION
This allows users to have their own project-specific bazel flags.