### PR TITLE
builtins: add pg_total_relation_size builtin

### DIFF
--- a/pkg/ccl/importccl/import_table_creation.go
+++ b/pkg/ccl/importccl/import_table_creation.go
@@ -201,6 +201,8 @@ var (
 type importSequenceOperators struct {
 }
 
+var _ tree.SequenceOperators = &importSequenceOperators{}
+
 // GetSerialSequenceNameFromColumn is part of the tree.SequenceOperators interface.
 func (so *importSequenceOperators) GetSerialSequenceNameFromColumn(
 	ctx context.Context, tn *tree.TableName, columnName tree.Name,
@@ -258,6 +260,12 @@ func (so *importSequenceOperators) GetLatestValueInSessionForSequence(
 	ctx context.Context, seqName *tree.TableName,
 ) (int64, error) {
 	return 0, errSequenceOperators
+}
+
+func (so *importSequenceOperators) LookupTableNameByID(
+	ctx context.Context, tableID tree.ID,
+) (*tree.TableName, error) {
+	return nil, errSequenceOperators
 }
 
 // Implements the tree.SequenceOperators interface.

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -373,34 +373,6 @@ WHERE table_catalog = $1 AND table_type != 'SYSTEM VIEW';`, req.Database)
 	return &resp, nil
 }
 
-// getFullyQualifiedTableName, given a database name and a tableName that either
-// is a unqualified name or a schema-qualified name, returns a maximally
-// qualified name: either database.table if the input wasn't schema qualified,
-// or database.schema.table if it was.
-func getFullyQualifiedTableName(dbName string, tableName string) (string, error) {
-	name, err := parser.ParseQualifiedTableName(tableName)
-	if err != nil {
-		// If we got a parse error, it could be that the user passed us an unescaped
-		// table name. Quote the whole thing and try again.
-		name, err = parser.ParseQualifiedTableName(tree.NameStringP(&tableName))
-		if err != nil {
-			return "", err
-		}
-	}
-	if !name.ExplicitSchema {
-		// If the schema wasn't explicitly set, craft the qualified table name to be
-		// database.table.
-		name.SchemaName = tree.Name(dbName)
-		name.ExplicitSchema = true
-	} else {
-		// Otherwise, add the database to the beginning of the name:
-		// database.schema.table.
-		name.CatalogName = tree.Name(dbName)
-		name.ExplicitCatalog = true
-	}
-	return name.String(), nil
-}
-
 // TableDetails is an endpoint that returns columns, indices, and other
 // relevant details for the specified table.
 func (s *adminServer) TableDetails(
@@ -412,7 +384,7 @@ func (s *adminServer) TableDetails(
 		return nil, err
 	}
 
-	escQualTable, err := getFullyQualifiedTableName(req.Database, req.Table)
+	escQualTable, err := parser.GetFullyQualifiedTableName(req.Database, req.Table)
 	if err != nil {
 		return nil, err
 	}
@@ -691,7 +663,7 @@ func (s *adminServer) TableStats(
 	if err != nil {
 		return nil, err
 	}
-	escQualTable, err := getFullyQualifiedTableName(req.Database, req.Table)
+	escQualTable, err := parser.GetFullyQualifiedTableName(req.Database, req.Table)
 	if err != nil {
 		return nil, err
 	}
@@ -702,7 +674,7 @@ func (s *adminServer) TableStats(
 	}
 	tableSpan := generateTableSpan(tableID)
 
-	return s.statsForSpan(ctx, tableSpan)
+	return s.server.sqlServer.pgServer.SQLServer.StatsForSpan(ctx, tableSpan)
 }
 
 // NonTableStats is an endpoint that returns disk usage and replication
@@ -715,7 +687,7 @@ func (s *adminServer) NonTableStats(
 		return nil, err
 	}
 
-	timeSeriesStats, err := s.statsForSpan(ctx, roachpb.Span{
+	timeSeriesStats, err := s.server.sqlServer.pgServer.SQLServer.StatsForSpan(ctx, roachpb.Span{
 		Key:    keys.TimeseriesPrefix,
 		EndKey: keys.TimeseriesPrefix.PrefixEnd(),
 	})
@@ -737,7 +709,7 @@ func (s *adminServer) NonTableStats(
 		},
 	}
 	for _, span := range spansForInternalUse {
-		nonTableStats, err := s.statsForSpan(ctx, span)
+		nonTableStats, err := s.server.sqlServer.pgServer.SQLServer.StatsForSpan(ctx, span)
 		if err != nil {
 			return nil, err
 		}
@@ -758,135 +730,6 @@ func (s *adminServer) NonTableStats(
 	response.InternalUseStats.RangeCount += nonTableDescriptorRangeCount()
 
 	return &response, nil
-}
-
-func (s *adminServer) statsForSpan(
-	ctx context.Context, span roachpb.Span,
-) (*serverpb.TableStatsResponse, error) {
-	startKey, err := keys.Addr(span.Key)
-	if err != nil {
-		return nil, s.serverError(err)
-	}
-	endKey, err := keys.Addr(span.EndKey)
-	if err != nil {
-		return nil, s.serverError(err)
-	}
-
-	// Get current range descriptors for table. This is done by scanning over
-	// meta2 keys for the range. A special case occurs if we wish to include
-	// the meta1 key range itself, in which case we'll get KeyMin back and that
-	// cannot be scanned (due to range-local addressing confusion). This is
-	// handled appropriately by adjusting the bounds to grab the descriptors
-	// for all ranges (including range1, which is not only gossiped but also
-	// persisted in meta1).
-	startMetaKey := keys.RangeMetaKey(startKey)
-	if bytes.Equal(startMetaKey, roachpb.RKeyMin) {
-		// This is the special case described above. The following key instructs
-		// the code below to scan all of the addressing, i.e. grab all of the
-		// descriptors including that for r1.
-		startMetaKey = keys.RangeMetaKey(keys.MustAddr(keys.Meta2Prefix))
-	}
-
-	rangeDescKVs, err := s.server.db.Scan(ctx, startMetaKey, keys.RangeMetaKey(endKey), 0)
-	if err != nil {
-		return nil, s.serverError(err)
-	}
-
-	// This map will store the nodes we need to fan out to.
-	nodeIDs := make(map[roachpb.NodeID]struct{})
-	for _, kv := range rangeDescKVs {
-		var rng roachpb.RangeDescriptor
-		if err := kv.Value.GetProto(&rng); err != nil {
-			return nil, s.serverError(err)
-		}
-		for _, repl := range rng.Replicas().Descriptors() {
-			nodeIDs[repl.NodeID] = struct{}{}
-		}
-	}
-
-	// Construct TableStatsResponse by sending an RPC to every node involved.
-	tableStatResponse := serverpb.TableStatsResponse{
-		NodeCount: int64(len(nodeIDs)),
-		// TODO(mrtracy): The "RangeCount" returned by TableStats is more
-		// accurate than the "RangeCount" returned by TableDetails, because this
-		// method always consistently queries the meta2 key range for the table;
-		// in contrast, TableDetails uses a method on the DistSender, which
-		// queries using a range metadata cache and thus may return stale data
-		// for tables that are rapidly splitting. However, one potential
-		// *advantage* of using the DistSender is that it will populate the
-		// DistSender's range metadata cache in the case where meta2 information
-		// for this table is not already present; the query used by TableStats
-		// does not populate the DistSender cache. We should consider plumbing
-		// TableStats' meta2 query through the DistSender so that it will share
-		// the advantage of populating the cache (without the disadvantage of
-		// potentially returning stale data).
-		// See Github #5435 for some discussion.
-		RangeCount: int64(len(rangeDescKVs)),
-	}
-	type nodeResponse struct {
-		nodeID roachpb.NodeID
-		resp   *serverpb.SpanStatsResponse
-		err    error
-	}
-
-	// Send a SpanStats query to each node.
-	responses := make(chan nodeResponse, len(nodeIDs))
-	for nodeID := range nodeIDs {
-		nodeID := nodeID // avoid data race
-		if err := s.server.stopper.RunAsyncTask(
-			ctx, "server.adminServer: requesting remote stats",
-			func(ctx context.Context) {
-				// Set a generous timeout on the context for each individual query.
-				var spanResponse *serverpb.SpanStatsResponse
-				err := contextutil.RunWithTimeout(ctx, "request remote stats", 5*base.NetworkTimeout,
-					func(ctx context.Context) error {
-						client, err := s.server.status.dialNode(ctx, nodeID)
-						if err == nil {
-							req := serverpb.SpanStatsRequest{
-								StartKey: startKey,
-								EndKey:   endKey,
-								NodeID:   nodeID.String(),
-							}
-							spanResponse, err = client.SpanStats(ctx, &req)
-						}
-						return err
-					})
-
-				// Channel is buffered, can always write.
-				responses <- nodeResponse{
-					nodeID: nodeID,
-					resp:   spanResponse,
-					err:    err,
-				}
-			}); err != nil {
-			return nil, err
-		}
-	}
-	for remainingResponses := len(nodeIDs); remainingResponses > 0; remainingResponses-- {
-		select {
-		case resp := <-responses:
-			// For nodes which returned an error, note that the node's data
-			// is missing. For successful calls, aggregate statistics.
-			if resp.err != nil {
-				tableStatResponse.MissingNodes = append(
-					tableStatResponse.MissingNodes,
-					serverpb.TableStatsResponse_MissingNode{
-						NodeID:       resp.nodeID.String(),
-						ErrorMessage: resp.err.Error(),
-					},
-				)
-			} else {
-				tableStatResponse.Stats.Add(resp.resp.TotalStats)
-				tableStatResponse.ReplicaCount += int64(resp.resp.RangeCount)
-				tableStatResponse.ApproximateDiskBytes += resp.resp.ApproximateDiskBytes
-			}
-		case <-ctx.Done():
-			// Caller gave up, stop doing work.
-			return nil, ctx.Err()
-		}
-	}
-
-	return &tableStatResponse, nil
 }
 
 // Users returns a list of users, stripped of any passwords.

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -531,7 +531,7 @@ func TestRangeCount(t *testing.T) {
 
 	getRangeCountFromFullSpan := func() int64 {
 		adminServer := s.(*TestServer).Server.admin
-		stats, err := adminServer.statsForSpan(context.Background(), roachpb.Span{
+		stats, err := adminServer.StatsForSpan(context.Background(), roachpb.Span{
 			Key:    keys.LocalMax,
 			EndKey: keys.MaxKey,
 		})
@@ -1978,7 +1978,7 @@ func TestStatsforSpanOnLocalMax(t *testing.T) {
 		EndKey: keys.SystemPrefix,
 	}
 
-	_, err := adminServer.statsForSpan(context.Background(), underTest)
+	_, err := adminServer.StatsForSpan(context.Background(), underTest)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -480,6 +480,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 		RPCContext:              cfg.rpcContext,
 		LeaseManager:            leaseMgr,
 		Clock:                   cfg.clock,
+		NodeDialer:              cfg.nodeDialer,
 		DistSQLSrv:              distSQLServer,
 		NodesStatusServer:       cfg.nodesStatusServer,
 		SQLStatusServer:         cfg.sqlStatusServer,

--- a/pkg/server/serverpb/status.go
+++ b/pkg/server/serverpb/status.go
@@ -23,6 +23,8 @@ type SQLStatusServer interface {
 	ListLocalSessions(context.Context, *ListSessionsRequest) (*ListSessionsResponse, error)
 	CancelQuery(context.Context, *CancelQueryRequest) (*CancelQueryResponse, error)
 	CancelSession(context.Context, *CancelSessionRequest) (*CancelSessionResponse, error)
+
+	TableStats(ctx context.Context, req *TableStatsRequest) (*TableStatsResponse, error)
 }
 
 // OptionalNodesStatusServer is a StatusServer that is only optionally present

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -2098,6 +2098,14 @@ func (s *statusServer) CancelQuery(
 	return output, nil
 }
 
+// TableStats is an endpoint that returns disk usage and replication statistics
+// for the specified table.
+func (s *statusServer) TableStats(
+	ctx context.Context, req *serverpb.TableStatsRequest,
+) (*serverpb.TableStatsResponse, error) {
+	return s.admin.TableStats(ctx, req)
+}
+
 // SpanStats requests the total statistics stored on a node for a given key
 // span, which may include multiple ranges.
 func (s *statusServer) SpanStats(

--- a/pkg/server/tenant_status.go
+++ b/pkg/server/tenant_status.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
 )
 
 // tenantStatusServer is an implementation of a SQLStatusServer that is
@@ -29,6 +30,8 @@ import (
 type tenantStatusServer struct {
 	baseStatusServer
 }
+
+var _ serverpb.SQLStatusServer = &tenantStatusServer{}
 
 func newTenantStatusServer(
 	ambient log.AmbientContext,
@@ -89,4 +92,12 @@ func (t *tenantStatusServer) CancelSession(
 		return nil, err
 	}
 	return t.sessionRegistry.CancelSession(request.SessionID)
+}
+
+func (t *tenantStatusServer) TableStats(
+	ctx context.Context, req *serverpb.TableStatsRequest,
+) (*serverpb.TableStatsResponse, error) {
+	// TODO(jordan): this needs to be implemented to support pg_total_relation_size
+	// for multitenant clusters.
+	return nil, errors.New("TableStats unimplemented for tenant status server")
 }

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -291,7 +291,7 @@ type Metrics struct {
 // NewServer creates a new Server. Start() needs to be called before the Server
 // is used.
 func NewServer(cfg *ExecutorConfig, pool *mon.BytesMonitor) *Server {
-	return &Server{
+	s := &Server{
 		cfg:             cfg,
 		Metrics:         makeMetrics(false /*internal*/),
 		InternalMetrics: makeMetrics(true /*internal*/),
@@ -300,6 +300,8 @@ func NewServer(cfg *ExecutorConfig, pool *mon.BytesMonitor) *Server {
 		reportedStats:   sqlStats{st: cfg.Settings, apps: make(map[string]*appStats)},
 		reCache:         tree.NewRegexpCache(512),
 	}
+	cfg.SQLServer = s
+	return s
 }
 
 func makeMetrics(internal bool) Metrics {

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -39,6 +39,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/migration"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
+	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/server/status/statuspb"
@@ -741,7 +742,12 @@ type ExecutorConfig struct {
 	RPCContext        *rpc.Context
 	LeaseManager      *lease.Manager
 	Clock             *hlc.Clock
+	NodeDialer        *nodedialer.Dialer
 	DistSQLSrv        *distsql.ServerImpl
+	// SQLServer is a pointer to the Server that this config ultimately created.
+	// It's only set to non-nil once we've actually used this configuration to
+	// make a new sql server.
+	SQLServer *Server
 	// NodesStatusServer gives access to the NodesStatus service and is only
 	// available when running as a system tenant.
 	NodesStatusServer serverpb.OptionalNodesStatusServer

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -114,9 +114,27 @@ func (so *DummySequenceOperators) SetSequenceValueByID(
 	return errors.WithStack(errSequenceOperators)
 }
 
+func (so *DummySequenceOperators) LookupTableNameByID(
+	ctx context.Context, tableID tree.ID,
+) (*tree.TableName, error) {
+	return nil, errors.WithStack(errSequenceOperators)
+}
+
 // DummyEvalPlanner implements the tree.EvalPlanner interface by returning
 // errors.
 type DummyEvalPlanner struct{}
+
+func (ep *DummyEvalPlanner) LookupTableNameByID(
+	ctx context.Context, tableID tree.ID,
+) (*tree.TableName, error) {
+	return nil, errors.WithStack(errEvalPlanner)
+}
+
+func (ep *DummyEvalPlanner) AdminTableApproximateSize(
+	ctx context.Context, databaseName string, schemaQualifiedTable string,
+) (uint64, error) {
+	return 0, errors.WithStack(errEvalPlanner)
+}
 
 // UnsafeUpsertDescriptor is part of the EvalPlanner interface.
 func (ep *DummyEvalPlanner) UnsafeUpsertDescriptor(

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -255,15 +255,15 @@ SELECT * FROM crdb_internal.node_inflight_trace_spans WHERE span_id < 0
 ----
 trace_id  parent_span_id  span_id  goroutine_id  finished  start_time  duration  operation
 
-query ITTTTTTTTTTTTI colnames
+query ITTTTITTTTTTTTTI colnames
 SELECT * FROM crdb_internal.ranges WHERE range_id < 0
 ----
-range_id  start_key  start_pretty  end_key  end_pretty  database_name  table_name  index_name  replicas  replica_localities learner_replicas  split_enforced_until  lease_holder range_size
+range_id  start_key  start_pretty  end_key  end_pretty  table_id  database_name  schema_name  table_name  index_name  replicas  replica_localities  learner_replicas  split_enforced_until  lease_holder range_size
 
-query ITTTTTTTTTTT colnames
+query ITTTTITTTTTTTT colnames
 SELECT * FROM crdb_internal.ranges_no_leases WHERE range_id < 0
 ----
-range_id  start_key  start_pretty  end_key  end_pretty  database_name  table_name  index_name  replicas  replica_localities learner_replicas  split_enforced_until
+range_id  start_key  start_pretty  end_key  end_pretty  table_id  database_name  schema_name  table_name  index_name  replicas  replica_localities  learner_replicas  split_enforced_until
 
 statement ok
 INSERT INTO system.zones (id, config) VALUES

--- a/pkg/sql/logictest/testdata/logic_test/pg_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/pg_builtins
@@ -127,3 +127,14 @@ query B
 SELECT pg_table_is_visible(1010101010)
 ----
 NULL
+
+statement ok
+CREATE TABLE size_tester (a PRIMARY KEY, b) AS SELECT g,g+1 FROM generate_series(1,100) g(g)
+
+# In tests, this returns NULL because ranges don't appear properly in
+# crdb_internal.ranges in the logic test context.
+# Make sure also that a non-existent table id returns null.
+query II
+SELECT pg_total_relation_size('size_tester'::regclass), pg_total_relation_size(387438)
+----
+NULL  NULL

--- a/pkg/sql/logictest/testdata/logic_test/pg_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/pg_builtins
@@ -129,7 +129,7 @@ SELECT pg_table_is_visible(1010101010)
 NULL
 
 statement ok
-CREATE TABLE size_tester (a PRIMARY KEY, b) AS SELECT g,g+1 FROM generate_series(1,100) g(g)
+CREATE TABLE size_tester (a PRIMARY KEY, b string) AS SELECT g, 'preston' FROM generate_series(1,100) g(g)
 
 # In tests, this returns NULL because ranges don't appear properly in
 # crdb_internal.ranges in the logic test context.

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -527,6 +527,51 @@ func (p *planner) LookupTableByID(
 	return table, nil
 }
 
+// LookupTableNameByID is the inverse of ResolveTableName: given an ID, it
+// looks up the table, schema, and database name of the table descriptor with
+// that ID.
+func (p *planner) LookupTableNameByID(
+	ctx context.Context, tableID tree.ID,
+) (*tree.TableName, error) {
+	table, err := p.LookupTableByID(ctx, descpb.ID(tableID))
+	if err != nil {
+		return nil, err
+	}
+
+	schemaID := table.GetParentSchemaID()
+	flags := tree.CommonLookupFlags{AvoidCached: p.avoidCachedDescriptors}
+	schema, err := p.Descriptors().GetImmutableSchemaByID(ctx, p.txn, schemaID, flags)
+	if err != nil {
+		return nil, err
+	}
+
+	database, err := p.Descriptors().GetImmutableDatabaseByID(ctx, p.txn, table.GetParentID(), flags)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := tree.MakeTableNameWithSchema(
+		tree.Name(database.GetName()),
+		tree.Name(schema.Name),
+		tree.Name(table.GetName()))
+	return &ret, nil
+}
+
+// LookupSchemaByID looks up a database, by the given descriptor ID. Based on the
+// CommonLookupFlags, it could use or skip the Collection cache. See
+// Collection.getTableVersionByID for how it's used.
+func (p *planner) LookupDatabaseByID(
+	ctx context.Context, databaseID descpb.ID,
+) (catalog.DatabaseDescriptor, error) {
+
+	flags := tree.SchemaLookupFlags{AvoidCached: p.avoidCachedDescriptors}
+	database, err := p.Descriptors().GetImmutableDatabaseByID(ctx, p.txn, databaseID, flags)
+	if err != nil {
+		return nil, err
+	}
+	return database, nil
+}
+
 // TypeAsString enforces (not hints) that the given expression typechecks as a
 // string and returns a function that can be called to get the string value
 // during (planNode).Start.

--- a/pkg/sql/sem/builtins/pg_size_test.go
+++ b/pkg/sql/sem/builtins/pg_size_test.go
@@ -1,0 +1,53 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package builtins_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+// This test ensures that pg_table_size returns the right number. If it fails,
+// maybe you changed the key encoding?? Look out!
+func TestPGTableSize(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{})
+	defer tc.Stopper().Stop(ctx)
+
+	_, err := tc.Conns[0].ExecContext(ctx, `CREATE TABLE t(int) AS SELECT generate_series(0, 1000)`)
+	require.NoError(t, err)
+
+	row := tc.Conns[0].QueryRowContext(ctx, `SELECT 't'::regclass::int`)
+	require.NoError(t, row.Err())
+	var tableID int
+	err = row.Scan(&tableID)
+	require.NoError(t, err)
+	tablePrefix := keys.MakeSQLCodec(tc.Servers[0].Cfg.TenantID).TablePrefix(uint32(tableID))
+	require.NoError(t, tc.WaitForSplitAndInitialization(tablePrefix))
+
+	row = tc.Conns[0].QueryRowContext(ctx, `SELECT pg_total_relation_size('t'::regclass)`)
+	require.NoError(t, row.Err())
+	var actual int
+	err = row.Scan(&actual)
+	require.NoError(t, err)
+	expected := 32969
+	if actual != expected {
+		t.Errorf("expected pg_table_size(t) to be %d, found %d", expected, actual)
+	}
+}

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3030,6 +3030,8 @@ type EvalDatabase interface {
 		searchPath sessiondata.SearchPath,
 		tableID int64,
 	) (isVisible bool, exists bool, err error)
+
+	LookupTableNameByID(ctx context.Context, tableID ID) (*TableName, error)
 }
 
 // EvalPlanner is a limited planner that can be used from EvalContext.
@@ -3090,6 +3092,12 @@ type EvalPlanner interface {
 		ctx context.Context,
 		member security.SQLUsername,
 	) (map[security.SQLUsername]bool, error)
+
+	// AdminTableApproximateSize collects detailed, computationally expensive
+	// information about a table. Note: this fans out to other nodes in the
+	// database.
+	AdminTableApproximateSize(ctx context.Context, databaseName string, schemaQualifiedTable string,
+	) (uint64, error)
 }
 
 // EvalSessionAccessor is a limited interface to access session variables.

--- a/pkg/sql/size_stats.go
+++ b/pkg/sql/size_stats.go
@@ -11,9 +11,21 @@
 package sql
 
 import (
+	"bytes"
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc"
+	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
+	"github.com/cockroachdb/errors"
 )
 
 // AdminTableStats is an endpoint that returns disk usage and replication
@@ -21,10 +33,178 @@ import (
 func (p *planner) AdminTableApproximateSize(
 	ctx context.Context, databaseName string, schemaQualifiedTable string,
 ) (uint64, error) {
-	resp, err := p.execCfg.SQLStatusServer.TableStats(ctx, &serverpb.TableStatsRequest{Database: databaseName,
-		Table: schemaQualifiedTable})
-	if err != nil || resp == nil {
+	// Simply call into the SQL server that we have access to from the planner.
+	//p.execCfg.SQLServer.TableStats()
+	sessionData := p.EvalContext().SessionData
+	return p.execCfg.SQLServer.TableStats(ctx,
+		sessionData.User(),
+		sessionData.Database,
+		&serverpb.TableStatsRequest{Database: databaseName,
+			Table: schemaQualifiedTable})
+}
+
+func (s *Server) TableStats(
+	ctx context.Context,
+	username security.SQLUsername,
+	database string,
+	req *serverpb.TableStatsRequest,
+) (uint64, error) {
+	escQualTable, err := parser.GetFullyQualifiedTableName(req.Database, req.Table)
+	if err != nil {
+		return 0, err
+	}
+
+	// tenantid/1/2/hello -> world
+
+	row, err := s.cfg.InternalExecutor.QueryRowEx(
+		ctx, "admin-resolve-name", nil,
+		sessiondata.InternalExecutorOverride{User: username, Database: database},
+		"SELECT $1::regclass::oid", escQualTable,
+	)
+	if err != nil {
+		return 0, err
+	}
+	if row == nil {
+		return 0, errors.Newf("failed to resolve %q as a table name", escQualTable)
+	}
+	tableID := descpb.ID(tree.MustBeDOid(row[0]).DInt)
+	tableStartKey := s.cfg.Codec.TablePrefix(uint32(tableID))
+	tableEndKey := tableStartKey.PrefixEnd()
+	span := roachpb.Span{Key: tableStartKey, EndKey: tableEndKey}
+	resp, err := s.StatsForSpan(ctx, span)
+	if err != nil {
 		return 0, err
 	}
 	return resp.ApproximateDiskBytes, nil
+}
+
+func (s *Server) StatsForSpan(
+	ctx context.Context, span roachpb.Span,
+) (*serverpb.TableStatsResponse, error) {
+	startKey, err := keys.Addr(span.Key)
+	if err != nil {
+		return nil, err
+	}
+	endKey, err := keys.Addr(span.EndKey)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get current range descriptors for table. This is done by scanning over
+	// meta2 keys for the range. A special case occurs if we wish to include
+	// the meta1 key range itself, in which case we'll get KeyMin back and that
+	// cannot be scanned (due to range-local addressing confusion). This is
+	// handled appropriately by adjusting the bounds to grab the descriptors
+	// for all ranges (including range1, which is not only gossiped but also
+	// persisted in meta1).
+	startMetaKey := keys.RangeMetaKey(startKey)
+	if bytes.Equal(startMetaKey, roachpb.RKeyMin) {
+		// This is the special case described above. The following key instructs
+		// the code below to scan all of the addressing, i.e. grab all of the
+		// descriptors including that for r1.
+		startMetaKey = keys.RangeMetaKey(keys.MustAddr(keys.Meta2Prefix))
+	}
+
+	rangeDescKVs, err := s.cfg.DB.Scan(ctx, startMetaKey, keys.RangeMetaKey(endKey), 0)
+	if err != nil {
+		return nil, err
+	}
+
+	// This map will store the nodes we need to fan out to.
+	nodeIDs := make(map[roachpb.NodeID]struct{})
+	for _, kv := range rangeDescKVs {
+		var rng roachpb.RangeDescriptor
+		if err := kv.Value.GetProto(&rng); err != nil {
+			return nil, err
+		}
+		for _, repl := range rng.Replicas().Descriptors() {
+			nodeIDs[repl.NodeID] = struct{}{}
+		}
+	}
+
+	// Construct TableStatsResponse by sending an RPC to every node involved.
+	tableStatResponse := serverpb.TableStatsResponse{
+		NodeCount: int64(len(nodeIDs)),
+		// TODO(mrtracy): The "RangeCount" returned by TableStats is more
+		// accurate than the "RangeCount" returned by TableDetails, because this
+		// method always consistently queries the meta2 key range for the table;
+		// in contrast, TableDetails uses a method on the DistSender, which
+		// queries using a range metadata cache and thus may return stale data
+		// for tables that are rapidly splitting. However, one potential
+		// *advantage* of using the DistSender is that it will populate the
+		// DistSender's range metadata cache in the case where meta2 information
+		// for this table is not already present; the query used by TableStats
+		// does not populate the DistSender cache. We should consider plumbing
+		// TableStats' meta2 query through the DistSender so that it will share
+		// the advantage of populating the cache (without the disadvantage of
+		// potentially returning stale data).
+		// See Github #5435 for some discussion.
+		RangeCount: int64(len(rangeDescKVs)),
+	}
+	type nodeResponse struct {
+		nodeID roachpb.NodeID
+		resp   *serverpb.SpanStatsResponse
+		err    error
+	}
+
+	// Send a SpanStats query to each node.
+	responses := make(chan nodeResponse, len(nodeIDs))
+	for nodeID := range nodeIDs {
+		nodeID := nodeID // avoid data race
+		if err := s.cfg.DistSQLSrv.Stopper.RunAsyncTask(
+			ctx, "server.adminServer: requesting remote stats",
+			func(ctx context.Context) {
+				// Set a generous timeout on the context for each individual query.
+				var spanResponse *serverpb.SpanStatsResponse
+				err := contextutil.RunWithTimeout(ctx, "request remote stats", 5*base.NetworkTimeout,
+					func(ctx context.Context) error {
+						conn, err := s.cfg.NodeDialer.Dial(ctx, nodeID, rpc.DefaultClass)
+						if err != nil {
+							return err
+						}
+						client := serverpb.NewStatusClient(conn)
+						req := serverpb.SpanStatsRequest{
+							StartKey: startKey,
+							EndKey:   endKey,
+							NodeID:   nodeID.String(),
+						}
+						spanResponse, err = client.SpanStats(ctx, &req)
+						return err
+					})
+
+				// Channel is buffered, can always write.
+				responses <- nodeResponse{
+					nodeID: nodeID,
+					resp:   spanResponse,
+					err:    err,
+				}
+			}); err != nil {
+			return nil, err
+		}
+	}
+	for remainingResponses := len(nodeIDs); remainingResponses > 0; remainingResponses-- {
+		select {
+		case resp := <-responses:
+			// For nodes which returned an error, note that the node's data
+			// is missing. For successful calls, aggregate statistics.
+			if resp.err != nil {
+				tableStatResponse.MissingNodes = append(
+					tableStatResponse.MissingNodes,
+					serverpb.TableStatsResponse_MissingNode{
+						NodeID:       resp.nodeID.String(),
+						ErrorMessage: resp.err.Error(),
+					},
+				)
+			} else {
+				tableStatResponse.Stats.Add(resp.resp.TotalStats)
+				tableStatResponse.ReplicaCount += int64(resp.resp.RangeCount)
+				tableStatResponse.ApproximateDiskBytes += resp.resp.ApproximateDiskBytes
+			}
+		case <-ctx.Done():
+			// Caller gave up, stop doing work.
+			return nil, ctx.Err()
+		}
+	}
+
+	return &tableStatResponse, nil
 }

--- a/pkg/sql/size_stats.go
+++ b/pkg/sql/size_stats.go
@@ -1,0 +1,30 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
+)
+
+// AdminTableStats is an endpoint that returns disk usage and replication
+// statistics for the specified table.
+func (p *planner) AdminTableApproximateSize(
+	ctx context.Context, databaseName string, schemaQualifiedTable string,
+) (uint64, error) {
+	resp, err := p.execCfg.SQLStatusServer.TableStats(ctx, &serverpb.TableStatsRequest{Database: databaseName,
+		Table: schemaQualifiedTable})
+	if err != nil || resp == nil {
+		return 0, err
+	}
+	return resp.ApproximateDiskBytes, nil
+}


### PR DESCRIPTION
Closes #20712.

Depends on #59865.

This builtin function returns the number of bytes in a table. For
CockroachDB, this means summing up the number of bytes in the ranges of
a table.

Notably, we do not multiply the number of bytes in the table's ranges by
the number of replicas - this is left up to the user to do if desired.

Release note (sql change): add the pg_total_relation_size builtin for estimating
the amount of data in a table.
