### PR TITLE
sql/catalog/lease: remove limitation regarding dropped descriptors

### DIFF
--- a/pkg/sql/catalog/lease/BUILD.bazel
+++ b/pkg/sql/catalog/lease/BUILD.bazel
@@ -83,6 +83,7 @@ go_test(
         "//pkg/util/log/logpb",
         "//pkg/util/randutil",
         "//pkg/util/retry",
+        "//pkg/util/stop",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "//pkg/util/tracing",

--- a/pkg/sql/set_zone_config.go
+++ b/pkg/sql/set_zone_config.go
@@ -213,7 +213,10 @@ func checkPrivilegeForSetZoneConfig(ctx context.Context, p *planner, zs tree.Zon
 			return p.RequireAdminRole(ctx, "alter the system database")
 		}
 		_, dbDesc, err := p.Descriptors().GetImmutableDatabaseByName(ctx, p.txn,
-			string(zs.Database), tree.DatabaseLookupFlags{Required: true})
+			string(zs.Database), tree.DatabaseLookupFlags{
+				Required:    true,
+				AvoidCached: true,
+			})
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Prior to this change, there was an awkward limitation in the lease manager when
requests came in at a timestamp that precedes the timestamp at which a table
was dropped. There were some special cases in the descs.Collection for tables
however, they were not there for databases or schemas. This generalizes the
solution and removes the limitation.

The interaction is so subtle, I don't know that it warrants a release note.

Release note: None