### PR TITLE
sql: fix ExtraColumnIDs not being populated for implicit indexes

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
@@ -498,3 +498,48 @@ INSERT INTO t VALUES (1, 1, 1, 1, 1, 1, 1), (2, 2, 2, 2, 2, 2, 2)
 
 statement error pq: duplicate key value violates unique constraint "t_b_key"\nDETAIL: Key \(b\)=\(1\) already exists\.
 UPDATE t SET b = 1 WHERE pk = 2
+
+# Regression tests for #59583.
+statement ok
+DROP TABLE t;
+CREATE TABLE t (
+  pk INT,
+  pk2 INT NOT NULL,
+  partition_by INT,
+  x INT,
+  y INT,
+  INDEX (y)
+) PARTITION BY LIST (partition_by) (
+    PARTITION p1 VALUES IN (1)
+);
+INSERT INTO t VALUES (1,2,3,4,5),(11,12,13,14,15)
+
+query IIIII
+SELECT * FROM t@t_y_idx
+----
+1   2   3   4   5
+11  12  13  14  15
+
+statement ok
+CREATE INDEX new_idx ON t(x)
+
+query IIIII
+SELECT * FROM t@new_idx
+----
+1   2   3   4   5
+11  12  13  14  15
+
+statement ok
+ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS(pk2)
+
+query IIIII
+SELECT * FROM t@t_y_idx
+----
+1   2   3   4   5
+11  12  13  14  15
+
+query IIIII
+SELECT * FROM t@new_idx
+----
+1   2   3   4   5
+11  12  13  14  15

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -2033,6 +2033,28 @@ func NewTableDesc(
 			if err != nil {
 				return nil, err
 			}
+			// During CreatePartitioning, implicitly partitioned columns may be
+			// created. AllocateIDs which allocates ExtraColumnIDs to each index
+			// needs to be called before CreatePartitioning as CreatePartitioning
+			// requires IDs to be allocated.
+			//
+			// As such, do a post check for implicitly partitioned columns, and
+			// if they are detected, ensure each index contains the implicitly
+			// partitioned column.
+			if numImplicitCols := newPrimaryIndex.Partitioning.NumImplicitColumns; numImplicitCols > 0 {
+				for _, idx := range desc.AllIndexes() {
+					if idx.GetEncodingType() == descpb.SecondaryIndexEncoding {
+						for _, implicitPrimaryColID := range newPrimaryIndex.ColumnIDs[:numImplicitCols] {
+							if !idx.ContainsColumnID(implicitPrimaryColID) {
+								idx.IndexDesc().ExtraColumnIDs = append(
+									idx.IndexDesc().ExtraColumnIDs,
+									implicitPrimaryColID,
+								)
+							}
+						}
+					}
+				}
+			}
 			desc.SetPrimaryIndex(newPrimaryIndex)
 		}
 	}


### PR DESCRIPTION
We previously were missing ExtraColumnIDs being populated with implicit
partitioned columns on CREATE TABLE, as the logic to do this in
AllocateIDs occurs before the implicit partitioning columns are known.
This commit rectifies this.

Resolves #59583 

Release note: None