### PR TITLE
ui: fix node status names on Nodes overview table

### DIFF
--- a/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
@@ -155,6 +155,14 @@ const getBadgeTypeByNodeStatus = (
   }
 };
 
+// getLivenessStatusName truncates the prefix for status name to keep only
+// status name ("NODE_STATUS_LIVE" -> "LIVE").
+export const getLivenessStatusName = (status: LivenessStatus): string => {
+  const prefix = "NODE_STATUS_";
+  const statusKey = LivenessStatus[status];
+  return statusKey.replace(prefix, "");
+};
+
 const NodeNameColumn: React.FC<{
   record: NodeStatusRow | DecommissionedNodeStatusRow;
 }> = ({ record }) => {
@@ -322,7 +330,7 @@ export class NodeList extends React.Component<LiveNodeListProps> {
             tooltipText = getStatusDescription(record.status);
             break;
           default:
-            badgeText = LivenessStatus[record.status];
+            badgeText = getLivenessStatusName(record.status);
             tooltipText = getStatusDescription(record.status);
             break;
         }

--- a/pkg/ui/src/views/cluster/containers/nodesOverview/nodesOverview.spec.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodesOverview/nodesOverview.spec.tsx
@@ -16,6 +16,7 @@ import Long from "long";
 
 import {
   decommissionedNodesTableDataSelector,
+  getLivenessStatusName,
   liveNodesTableDataSelector,
   NodeList,
   NodeStatusRow,
@@ -25,7 +26,7 @@ import { LocalSetting } from "src/redux/localsettings";
 import { SortSetting } from "src/views/shared/components/sortabletable";
 import { connectedMount } from "src/test-utils";
 import { cockroach } from "src/js/protos";
-import { livenessByNodeIDSelector } from "src/redux/nodes";
+import { livenessByNodeIDSelector, LivenessStatus } from "src/redux/nodes";
 
 import NodeLivenessStatus = cockroach.kv.kvserver.liveness.livenesspb.NodeLivenessStatus;
 
@@ -464,6 +465,24 @@ describe("Nodes Overview page", () => {
           assert.equal(record.nodeName, expectedName);
         });
       });
+    });
+  });
+
+  describe("getLivenessStatusName", () => {
+    it("return node liveness names without prefix", () => {
+      assert.equal(
+        getLivenessStatusName(LivenessStatus.NODE_STATUS_LIVE),
+        "LIVE",
+      );
+      assert.equal(
+        getLivenessStatusName(LivenessStatus.NODE_STATUS_DECOMMISSIONED),
+        "DECOMMISSIONED",
+      );
+      assert.equal(
+        getLivenessStatusName(LivenessStatus.NODE_STATUS_DEAD),
+        "DEAD",
+      );
+      assert.equal(getLivenessStatusName(3), "LIVE");
     });
   });
 });


### PR DESCRIPTION
Before, NodeLiveness enums were named in a way that they
matched with required status names on UI (LivenessStatus.LIVE status
matched to LIVE status in Node overview table).
But Liveness Status names were renamed and it affected status names on ui.
To prevent this, prefixes of statuses are truncated to keep
status names only.

Before:
![Screen Shot 2021-02-01 at 10 37 42 AM](https://user-images.githubusercontent.com/3106437/106458294-d9fd6100-6498-11eb-9c2e-d9e2ff924686.png)


After:
![Screen Shot 2021-02-01 at 2 41 42 PM](https://user-images.githubusercontent.com/3106437/106460226-ab34ba00-649b-11eb-8b8a-c5c214ad26aa.png)
