### PR TITLE
*: prefer ctx.Done() over ShouldStop()

### DIFF
--- a/pkg/ccl/kvccl/kvtenantccl/connector.go
+++ b/pkg/ccl/kvccl/kvtenantccl/connector.go
@@ -118,10 +118,7 @@ func (connectorFactory) NewConnector(
 // cluster's ID and set Connector.rpcContext.ClusterID.
 func (c *Connector) Start(ctx context.Context) error {
 	startupC := c.startupC
-	if err := c.rpcContext.Stopper.RunAsyncTask(context.Background(), "connector", func(ctx context.Context) {
-		ctx = c.AnnotateCtx(ctx)
-		ctx, cancel := c.rpcContext.Stopper.WithCancelOnQuiesce(ctx)
-		defer cancel()
+	if err := c.rpcContext.Stopper.RunAsyncTask(c.AnnotateCtx(context.Background()), "connector", func(ctx context.Context) {
 		c.runGossipSubscription(ctx)
 	}); err != nil {
 		return err
@@ -363,8 +360,6 @@ func (c *Connector) getClient(ctx context.Context) (roachpb.InternalClient, erro
 	}
 	ch, _ := c.rpcDial.DoChan("dial", func() (interface{}, error) {
 		dialCtx := c.AnnotateCtx(context.Background())
-		dialCtx, cancel := c.rpcContext.Stopper.WithCancelOnQuiesce(dialCtx)
-		defer cancel()
 		err := c.rpcContext.Stopper.RunTaskWithErr(dialCtx, "kvtenant.Connector: dial", c.dialAddrs)
 		if err != nil {
 			return nil, err

--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -1372,7 +1372,7 @@ func (g *Gossip) manage() {
 		stallTimer.Reset(jitteredInterval(g.stallInterval))
 		for {
 			select {
-			case <-g.server.stopper.ShouldQuiesce():
+			case <-ctx.Done():
 				return
 			case c := <-g.disconnected:
 				g.doDisconnected(c)

--- a/pkg/gossip/simulation/network.go
+++ b/pkg/gossip/simulation/network.go
@@ -117,8 +117,8 @@ func (n *Network) CreateNode(defaultZoneConfig *zonepb.ZoneConfig) (*Node, error
 	node := &Node{Server: server, Listener: ln, Registry: metric.NewRegistry()}
 	node.Gossip = gossip.NewTest(0, n.RPCContext, server, n.Stopper, node.Registry, defaultZoneConfig)
 	n.Stopper.AddCloser(stop.CloserFn(server.Stop))
-	_ = n.Stopper.RunAsyncTask(context.TODO(), "node-wait-quiesce", func(context.Context) {
-		<-n.Stopper.ShouldQuiesce()
+	_ = n.Stopper.RunAsyncTask(context.TODO(), "node-wait-quiesce", func(ctx context.Context) {
+		<-ctx.Done()
 		netutil.FatalIfUnexpected(ln.Close())
 		node.Gossip.EnableSimulationCycler(false)
 	})

--- a/pkg/jobs/job_scheduler.go
+++ b/pkg/jobs/job_scheduler.go
@@ -354,7 +354,7 @@ func (s *jobScheduler) runDaemon(ctx context.Context, stopper *stop.Stopper) {
 		for timer := time.NewTimer(initialDelay); ; timer.Reset(
 			getWaitPeriod(&s.Settings.SV, s.TestingKnobs)) {
 			select {
-			case <-stopper.ShouldQuiesce():
+			case <-ctx.Done():
 				return
 			case <-timer.C:
 				if !schedulerEnabledSetting.Get(&s.Settings.SV) {

--- a/pkg/kv/kvserver/closedts/provider/provider.go
+++ b/pkg/kv/kvserver/closedts/provider/provider.go
@@ -231,7 +231,7 @@ func (p *Provider) Notify(nodeID roachpb.NodeID) chan<- ctpb.Entry {
 					return
 				}
 				handle(entry)
-			case <-p.cfg.Stopper.ShouldQuiesce():
+			case <-ctx.Done():
 				return
 			}
 		}

--- a/pkg/kv/kvserver/concurrency/lock_table_waiter_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_waiter_test.go
@@ -174,7 +174,7 @@ func TestLockTableWaiterWithTxn(t *testing.T) {
 		defer w.stopper.Stop(ctx)
 
 		go func() {
-			w.stopper.Quiesce(ctx)
+			w.stopper.Stop(ctx)
 		}()
 
 		err := w.WaitOn(ctx, makeReq(), g)
@@ -245,7 +245,7 @@ func TestLockTableWaiterWithNonTxn(t *testing.T) {
 		defer w.stopper.Stop(ctx)
 
 		go func() {
-			w.stopper.Quiesce(ctx)
+			w.stopper.Stop(ctx)
 		}()
 
 		err := w.WaitOn(ctx, makeReq(), g)

--- a/pkg/kv/kvserver/liveness/liveness.go
+++ b/pkg/kv/kvserver/liveness/liveness.go
@@ -670,8 +670,6 @@ func (nl *NodeLiveness) Start(ctx context.Context, opts NodeLivenessStartOptions
 	_ = opts.Stopper.RunAsyncTask(ctx, "liveness-hb", func(context.Context) {
 		ambient := nl.ambientCtx
 		ambient.AddLogTag("liveness-hb", nil)
-		ctx, cancel := opts.Stopper.WithCancelOnQuiesce(context.Background())
-		defer cancel()
 		ctx, sp := ambient.AnnotateCtxWithSpan(ctx, "liveness heartbeat loop")
 		defer sp.Finish()
 

--- a/pkg/kv/kvserver/protectedts/ptcache/cache.go
+++ b/pkg/kv/kvserver/protectedts/ptcache/cache.go
@@ -188,8 +188,7 @@ func (c *Cache) periodicallyRefreshProtectedtsCache(ctx context.Context) {
 
 func (c *Cache) doSingleFlightUpdate() (interface{}, error) {
 	// TODO(ajwerner): add log tags to the context.
-	ctx, cancel := c.stopper.WithCancelOnQuiesce(context.Background())
-	defer cancel()
+	ctx := context.Background()
 	return nil, c.stopper.RunTaskWithErr(ctx,
 		"refresh-protectedts-cache", c.doUpdate)
 }

--- a/pkg/kv/kvserver/rangefeed/processor.go
+++ b/pkg/kv/kvserver/rangefeed/processor.go
@@ -333,7 +333,7 @@ func (p *Processor) run(
 			return
 
 		// Exit on stopper.
-		case <-stopper.ShouldQuiesce():
+		case <-ctx.Done():
 			pErr := roachpb.NewError(&roachpb.NodeUnavailableError{})
 			p.reg.DisconnectWithErr(all, pErr)
 			return

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -1475,7 +1475,7 @@ func (r *Replica) maybeWatchForMerge(ctx context.Context, freezeStart hlc.Timest
 			})
 			if err := r.DB().Run(ctx, b); err != nil {
 				select {
-				case <-r.store.stopper.ShouldQuiesce():
+				case <-ctx.Done():
 					// The server is shutting down. The error while pushing the
 					// transaction was probably caused by the shutdown, so ignore it.
 					return

--- a/pkg/kv/kvserver/replica_consistency.go
+++ b/pkg/kv/kvserver/replica_consistency.go
@@ -502,9 +502,9 @@ func (r *Replica) checksumWait(
 ) (bool, error) {
 	// Wait
 	select {
-	case <-r.store.Stopper().ShouldQuiesce():
+	case <-ctx.Done()
 		return false,
-			errors.Errorf("store quiescing while waiting for compute checksum (ID = %s)", id)
+			errors.Errorf("context canceled while waiting for compute checksum (ID = %s)", id)
 	case <-ctx.Done():
 		return false,
 			errors.Wrapf(ctx.Err(), "while waiting for compute checksum (ID = %s)", id)

--- a/pkg/kv/kvserver/replica_consistency_test.go
+++ b/pkg/kv/kvserver/replica_consistency_test.go
@@ -111,7 +111,7 @@ func TestGetChecksumNotSuccessfulExitConditions(t *testing.T) {
 	ctx, cancel = context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 	// Next condition, node should quiesce.
-	tc.repl.store.Stopper().Quiesce(ctx)
+	tc.repl.store.Stopper().Stop(ctx)
 	rc, err = tc.repl.getChecksum(ctx, uuid.FastMakeV4())
 	if !testutils.IsError(err, "store quiescing") {
 		t.Fatal(err)

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -12515,7 +12515,7 @@ func TestProposalNotAcknowledgedOrReproposedAfterApplication(t *testing.T) {
 	}
 	log.Flush()
 
-	stopper.Quiesce(ctx)
+	stopper.Stop(ctx)
 	entries, err := log.FetchEntriesFromFiles(0, math.MaxInt64, 1,
 		regexp.MustCompile("net/trace"), log.WithFlattenedSensitiveData)
 	if err != nil {
@@ -12611,7 +12611,7 @@ func TestLaterReproposalsDoNotReuseContext(t *testing.T) {
 		t.Fatal(pErr)
 	}
 
-	stopper.Quiesce(ctx)
+	stopper.Stop(ctx)
 	// Check and see if the trace package logged an error.
 	log.Flush()
 	entries, err := log.FetchEntriesFromFiles(0, math.MaxInt64, 1,

--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -579,8 +579,6 @@ func TestTransferLeaseToLaggingNode(t *testing.T) {
 			select {
 			case <-ctx.Done():
 				return
-			case <-tc.Stopper().ShouldQuiesce():
-				return
 			case <-time.After(queryInterval):
 			}
 		}

--- a/pkg/kv/kvserver/reports/reporter.go
+++ b/pkg/kv/kvserver/reports/reporter.go
@@ -153,7 +153,7 @@ func (stats *Reporter) Start(ctx context.Context, stopper *stop.Stopper) {
 			case <-timerCh:
 				timer.Read = true
 			case <-changeCh:
-			case <-stopper.ShouldQuiesce():
+			case <-ctx.Done():
 				return
 			}
 		}

--- a/pkg/kv/kvserver/spanlatch/manager.go
+++ b/pkg/kv/kvserver/spanlatch/manager.go
@@ -402,10 +402,6 @@ func (m *Manager) waitForSignal(ctx context.Context, t *timeutil.Timer, wait, he
 		case <-ctx.Done():
 			log.VEventf(ctx, 2, "%s while acquiring latch %s, held by %s", ctx.Err(), wait, held)
 			return ctx.Err()
-		case <-m.stopper.ShouldQuiesce():
-			// While shutting down, requests may acquire
-			// latches and never release them.
-			return &roachpb.NodeUnavailableError{}
 		}
 	}
 }

--- a/pkg/kv/kvserver/store_snapshot.go
+++ b/pkg/kv/kvserver/store_snapshot.go
@@ -534,8 +534,6 @@ func (s *Store) reserveSnapshot(
 		case s.snapshotApplySem <- struct{}{}:
 		case <-ctx.Done():
 			return nil, "", ctx.Err()
-		case <-s.stopper.ShouldQuiesce():
-			return nil, "", errors.Errorf("stopped")
 		}
 	}
 

--- a/pkg/server/auto_upgrade.go
+++ b/pkg/server/auto_upgrade.go
@@ -26,9 +26,7 @@ import (
 
 // startAttemptUpgrade attempts to upgrade cluster version.
 func (s *Server) startAttemptUpgrade(ctx context.Context) {
-	ctx, cancel := s.stopper.WithCancelOnQuiesce(ctx)
 	if err := s.stopper.RunAsyncTask(ctx, "auto-upgrade", func(ctx context.Context) {
-		defer cancel()
 		retryOpts := retry.Options{
 			InitialBackoff: time.Second,
 			MaxBackoff:     30 * time.Second,
@@ -80,7 +78,6 @@ func (s *Server) startAttemptUpgrade(ctx context.Context) {
 			}
 		}
 	}); err != nil {
-		cancel()
 		log.Infof(ctx, "failed attempt to upgrade cluster version, error: %s", err)
 	}
 }

--- a/pkg/server/diagnostics/reporter.go
+++ b/pkg/server/diagnostics/reporter.go
@@ -108,7 +108,7 @@ func (r *Reporter) PeriodicallyReportDiagnostics(ctx context.Context, stopper *s
 
 			timer.Reset(addJitter(nextReport.Sub(timeutil.Now())))
 			select {
-			case <-stopper.ShouldQuiesce():
+			case <-ctx.Done():
 				return
 			case <-timer.C:
 				timer.Read = true

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -661,7 +661,7 @@ func (n *Node) startComputePeriodicMetrics(stopper *stop.Stopper, interval time.
 				if err := n.computePeriodicMetrics(ctx, tick); err != nil {
 					log.Errorf(ctx, "failed computing periodic metrics: %s", err)
 				}
-			case <-stopper.ShouldQuiesce():
+			case <-ctx.Done():
 				return
 			}
 		}

--- a/pkg/server/node_engine_health.go
+++ b/pkg/server/node_engine_health.go
@@ -39,7 +39,7 @@ func (n *Node) startAssertEngineHealth(
 				t.Read = true
 				t.Reset(10 * time.Second)
 				n.assertEngineHealth(ctx, engines, maxSyncDuration, fatalOnExceeded)
-			case <-n.stopper.ShouldQuiesce():
+			case <-ctx.Done():
 				return
 			}
 		}

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -1860,8 +1860,6 @@ func (s *statusServer) iterateNodes(
 
 	// Issue the requests concurrently.
 	sem := quotapool.NewIntPool("node status", maxConcurrentRequests)
-	ctx, cancel := s.stopper.WithCancelOnQuiesce(ctx)
-	defer cancel()
 	for nodeID := range nodeStatuses {
 		nodeID := nodeID // needed to ensure the closure below captures a copy.
 		if err := s.stopper.RunLimitedAsyncTask(

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -725,7 +725,7 @@ func StartTenant(
 
 	{
 		waitQuiesce := func(ctx context.Context) {
-			<-args.stopper.ShouldQuiesce()
+			<-ctx.Done()
 			_ = httpL.Close()
 		}
 		if err := args.stopper.RunAsyncTask(ctx, "wait-quiesce-http", waitQuiesce); err != nil {

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -1792,8 +1792,6 @@ func (m *Manager) watchForGossipUpdates(
 		gossipUpdateC := rawG.RegisterSystemConfigChannel()
 		filter := gossip.MakeSystemConfigDeltaFilter(descKeyPrefix)
 
-		ctx, cancel := s.WithCancelOnQuiesce(ctx)
-		defer cancel()
 		for {
 			select {
 			case <-gossipUpdateC:
@@ -1813,7 +1811,6 @@ func (m *Manager) watchForRangefeedUpdates(
 	}
 	distSender := db.NonTransactionalSender().(*kv.CrossRangeTxnWrapperSender).Wrapped().(*kvcoord.DistSender)
 	eventCh := make(chan *roachpb.RangeFeedEvent)
-	ctx, _ = s.WithCancelOnQuiesce(ctx)
 	if err := s.RunAsyncTask(ctx, "lease rangefeed", func(ctx context.Context) {
 
 		// Run the rangefeed in a loop in the case of failure, likely due to node

--- a/pkg/sql/distsql/inbound_test.go
+++ b/pkg/sql/distsql/inbound_test.go
@@ -148,5 +148,5 @@ func TestOutboxInboundStreamIntegration(t *testing.T) {
 
 	// Wait for outstanding tasks to complete. Specifically, we are waiting for
 	// the outbox's drain signal listener to return.
-	outboxStopper.Quiesce(ctx)
+	outboxStopper.Stop(ctx)
 }

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -98,13 +98,11 @@ func (dsp *DistSQLPlanner) initRunners(ctx context.Context) {
 	for i := 0; i < numRunners; i++ {
 		_ = dsp.stopper.RunAsyncTask(ctx, "distslq-runner", func(context.Context) {
 			runnerChan := dsp.runnerChan
-			stopChan := dsp.stopper.ShouldQuiesce()
 			for {
 				select {
 				case req := <-runnerChan:
 					req.run()
-
-				case <-stopChan:
+				case <-ctx.Done():
 					return
 				}
 			}

--- a/pkg/sql/flowinfra/flow_scheduler.go
+++ b/pkg/sql/flowinfra/flow_scheduler.go
@@ -190,7 +190,7 @@ func (fs *FlowScheduler) Start() {
 					atomic.AddInt32(&fs.atomics.numRunning, -1)
 				}
 
-			case <-fs.stopper.ShouldQuiesce():
+			case <-ctx.Done():
 				fs.mu.Lock()
 				stopped = true
 			}

--- a/pkg/sql/gcjob/gcjobnotifier/notifier.go
+++ b/pkg/sql/gcjob/gcjobnotifier/notifier.go
@@ -129,12 +129,12 @@ func (n *Notifier) Start(ctx context.Context) {
 	}
 }
 
-func (n *Notifier) run(_ context.Context) {
+func (n *Notifier) run(ctx context.Context) {
 	defer n.markStopped()
 	gossipUpdateCh := n.provider.RegisterSystemConfigChannel()
 	for {
 		select {
-		case <-n.stopper.ShouldQuiesce():
+		case <-ctx.Done():
 			return
 		case <-gossipUpdateCh:
 			n.maybeNotify()

--- a/pkg/sql/sqlliveness/slinstance/slinstance.go
+++ b/pkg/sql/sqlliveness/slinstance/slinstance.go
@@ -179,11 +179,6 @@ func (l *Instance) extendSession(ctx context.Context, s sqlliveness.Session) (bo
 }
 
 func (l *Instance) heartbeatLoop(ctx context.Context) {
-	defer func() {
-		log.Warning(ctx, "exiting heartbeat loop")
-	}()
-	ctx, cancel := l.stopper.WithCancelOnQuiesce(ctx)
-	defer cancel()
 	t := timeutil.NewTimer()
 	t.Reset(0)
 	for {

--- a/pkg/sql/sqlliveness/slstorage/slstorage.go
+++ b/pkg/sql/sqlliveness/slstorage/slstorage.go
@@ -275,8 +275,6 @@ DELETE FROM sqlliveness WHERE session_id = $1
 
 // deleteSessionsLoop is launched in start and periodically deletes sessions.
 func (s *Storage) deleteSessionsLoop(ctx context.Context) {
-	ctx, cancel := s.stopper.WithCancelOnQuiesce(ctx)
-	defer cancel()
 	t := s.newTimer()
 	t.Reset(s.gcInterval())
 	for {

--- a/pkg/sql/stats/automatic_stats.go
+++ b/pkg/sql/stats/automatic_stats.go
@@ -306,7 +306,7 @@ func (r *Refresher) Start(
 			case mut := <-r.mutations:
 				r.mutationCounts[mut.tableID] += int64(mut.rowsAffected)
 
-			case <-stopper.ShouldQuiesce():
+			case <-ctx.Done():
 				return
 			}
 		}

--- a/pkg/sql/stmtdiagnostics/statement_diagnostics.go
+++ b/pkg/sql/stmtdiagnostics/statement_diagnostics.go
@@ -102,7 +102,6 @@ func NewRegistry(
 
 // Start will start the polling loop for the Registry.
 func (r *Registry) Start(ctx context.Context, stopper *stop.Stopper) {
-	ctx, _ = stopper.WithCancelOnQuiesce(ctx)
 	// NB: The only error that should occur here would be if the server were
 	// shutting down so let's swallow it.
 	_ = stopper.RunAsyncTask(ctx, "stmt-diag-poll", r.poll)

--- a/pkg/util/stop/stopper_test.go
+++ b/pkg/util/stop/stopper_test.go
@@ -361,6 +361,7 @@ func TestStopperWithCancel(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s := stop.NewStopper()
 	ctx := context.Background()
+	defer s.Stop(ctx)
 	ctx1, _ := s.WithCancelOnQuiesce(ctx)
 	ctx3, cancel3 := s.WithCancelOnQuiesce(ctx)
 
@@ -379,12 +380,10 @@ func TestStopperWithCancel(t *testing.T) {
 		t.Fatalf("should be canceled: %v", err)
 	}
 
-	s.Quiesce(ctx)
+	s.Stop(ctx)
 	if err := ctx1.Err(); !errors.Is(err, context.Canceled) {
 		t.Fatalf("should be canceled: %v", err)
 	}
-
-	s.Stop(ctx)
 }
 
 func TestStopperWithCancelConcurrent(t *testing.T) {

--- a/pkg/util/stop/stopper_test.go
+++ b/pkg/util/stop/stopper_test.go
@@ -578,7 +578,7 @@ func TestStopperRunLimitedAsyncTaskCancelContext(t *testing.T) {
 		for i := 0; i < maxConcurrency*2; i++ {
 			if err := s.RunLimitedAsyncTask(ctx, "test", sem, true, f); err != nil {
 				if !errors.Is(err, context.Canceled) {
-					t.Fatal(err)
+					t.Error(err)
 				}
 				atomic.AddInt32(&workersCanceled, 1)
 			}


### PR DESCRIPTION
- stopper: remove unused sCancels field
- *: prefer stopper.Stop over Quiesce
- stop: use cancelable context for all tasks
- stop: avoid ShouldStop() when ctx.Done() works
