### PR TITLE
opt: fix bug with incorrect results returned by left lookup/inverted join

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/inverted_join_multi_column
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_join_multi_column
@@ -494,3 +494,27 @@ ORDER BY (lk, rk)
 3  16
 5  12
 5  16
+
+# Regression test for #59615. Ensure that invalid inverted joins are not created
+# for left and anti joins.
+statement ok
+CREATE TABLE t59615_inv (
+  x INT NOT NULL CHECK (x in (1, 3)),
+  y JSON,
+  z INT,
+  INVERTED INDEX (x, y)
+)
+
+query TITI
+SELECT * FROM (VALUES ('"a"'::jsonb), ('"b"'::jsonb)) AS u(y) LEFT JOIN t59615_inv t ON t.y @> u.y
+----
+"a"  NULL  NULL  NULL
+"b"  NULL  NULL  NULL
+
+query T
+SELECT * FROM (VALUES ('"a"'::jsonb), ('"b"'::jsonb)) AS u(y) WHERE NOT EXISTS (
+  SELECT * FROM t59615_inv t WHERE t.y @> u.y
+)
+----
+"a"
+"b"

--- a/pkg/sql/logictest/testdata/logic_test/lookup_join
+++ b/pkg/sql/logictest/testdata/logic_test/lookup_join
@@ -588,3 +588,28 @@ CREATE TABLE tab4 (
 query I
 SELECT pk FROM tab4 WHERE col0 IN (SELECT col3 FROM tab4 WHERE col4 = 495.6) AND (col3 IS NULL)
 ----
+
+# Regression test for #59615. Ensure that invalid lookup joins are not created
+# for left and anti joins.
+statement ok
+CREATE TABLE t59615 (
+  x INT NOT NULL CHECK (x in (1, 3)),
+  y INT NOT NULL,
+  z INT,
+  PRIMARY KEY (x, y)
+)
+
+# We cannot create a lookup join in this case.
+query IIII
+SELECT * FROM (VALUES (1), (2)) AS u(y) LEFT JOIN t59615 t ON u.y = t.y
+----
+1  NULL  NULL  NULL
+2  NULL  NULL  NULL
+
+query I
+SELECT * FROM (VALUES (1), (2)) AS u(y) WHERE NOT EXISTS (
+  SELECT * FROM t59615 t WHERE u.y = t.y
+)
+----
+1
+2

--- a/pkg/sql/opt/exec/execbuilder/testdata/unique
+++ b/pkg/sql/opt/exec/execbuilder/testdata/unique
@@ -805,6 +805,8 @@ vectorized: true
                               label: buffer 1
 
 # Test that we use the index when available for the ON CONFLICT checks.
+# TODO(rytaft): This plan is suboptimal because it's not safe to construct
+# a left lookup join in this case (see #59649).
 query T
 EXPLAIN (VERBOSE) INSERT INTO uniq_enum VALUES ('us-west', 'foo', 1, 1), ('us-east', 'bar', 2, 2)
 ON CONFLICT DO NOTHING
@@ -835,73 +837,53 @@ vectorized: true
 │           │ render column3: column3
 │           │ render column4: column4
 │           │
-│           └── • project
+│           └── • hash join (right anti)
 │               │ columns: (column1, column2, column3, column4)
 │               │ estimated row count: 0 (missing stats)
+│               │ equality: (i) = (column3)
+│               │
+│               ├── • scan
+│               │     columns: (i)
+│               │     estimated row count: 1,000 (missing stats)
+│               │     table: uniq_enum@primary
+│               │     spans: FULL SCAN
 │               │
 │               └── • lookup join (anti)
-│                   │ columns: ("lookup_join_const_col_@29", column1, column2, column3, column4)
-│                   │ table: uniq_enum@uniq_enum_r_s_j_key
-│                   │ equality: (lookup_join_const_col_@29, column2, column4) = (r,s,j)
+│                   │ columns: (column1, column2, column3, column4)
+│                   │ estimated row count: 0 (missing stats)
+│                   │ table: uniq_enum@primary
+│                   │ equality: (column1, column3) = (r,i)
 │                   │ equality cols are key
 │                   │
-│                   └── • cross join (inner)
-│                       │ columns: ("lookup_join_const_col_@29", column1, column2, column3, column4)
+│                   └── • lookup join (anti)
+│                       │ columns: (column1, column2, column3, column4)
 │                       │ estimated row count: 0 (missing stats)
+│                       │ table: uniq_enum@uniq_enum_r_s_j_key
+│                       │ equality: (column1, column2, column4) = (r,s,j)
+│                       │ equality cols are key
 │                       │
-│                       ├── • values
-│                       │     columns: ("lookup_join_const_col_@29")
-│                       │     size: 1 column, 3 rows
-│                       │     row 0, expr 0: 'us-east'
-│                       │     row 1, expr 0: 'us-west'
-│                       │     row 2, expr 0: 'eu-west'
-│                       │
-│                       └── • project
+│                       └── • hash join (right anti)
 │                           │ columns: (column1, column2, column3, column4)
 │                           │ estimated row count: 0 (missing stats)
+│                           │ equality: (s, j) = (column2, column4)
 │                           │
-│                           └── • lookup join (anti)
-│                               │ columns: ("lookup_join_const_col_@23", column1, column2, column3, column4)
-│                               │ table: uniq_enum@primary
-│                               │ equality: (lookup_join_const_col_@23, column3) = (r,i)
-│                               │ equality cols are key
-│                               │
-│                               └── • cross join (inner)
-│                                   │ columns: ("lookup_join_const_col_@23", column1, column2, column3, column4)
-│                                   │ estimated row count: 0 (missing stats)
-│                                   │
-│                                   ├── • values
-│                                   │     columns: ("lookup_join_const_col_@23")
-│                                   │     size: 1 column, 3 rows
-│                                   │     row 0, expr 0: 'us-east'
-│                                   │     row 1, expr 0: 'us-west'
-│                                   │     row 2, expr 0: 'eu-west'
-│                                   │
-│                                   └── • lookup join (anti)
-│                                       │ columns: (column1, column2, column3, column4)
-│                                       │ estimated row count: 0 (missing stats)
-│                                       │ table: uniq_enum@primary
-│                                       │ equality: (column1, column3) = (r,i)
-│                                       │ equality cols are key
-│                                       │
-│                                       └── • lookup join (anti)
-│                                           │ columns: (column1, column2, column3, column4)
-│                                           │ estimated row count: 0 (missing stats)
-│                                           │ table: uniq_enum@uniq_enum_r_s_j_key
-│                                           │ equality: (column1, column2, column4) = (r,s,j)
-│                                           │ equality cols are key
-│                                           │
-│                                           └── • values
-│                                                 columns: (column1, column2, column3, column4)
-│                                                 size: 4 columns, 2 rows
-│                                                 row 0, expr 0: 'us-west'
-│                                                 row 0, expr 1: 'foo'
-│                                                 row 0, expr 2: 1
-│                                                 row 0, expr 3: 1
-│                                                 row 1, expr 0: 'us-east'
-│                                                 row 1, expr 1: 'bar'
-│                                                 row 1, expr 2: 2
-│                                                 row 1, expr 3: 2
+│                           ├── • scan
+│                           │     columns: (s, j)
+│                           │     estimated row count: 1,000 (missing stats)
+│                           │     table: uniq_enum@primary
+│                           │     spans: FULL SCAN
+│                           │
+│                           └── • values
+│                                 columns: (column1, column2, column3, column4)
+│                                 size: 4 columns, 2 rows
+│                                 row 0, expr 0: 'us-west'
+│                                 row 0, expr 1: 'foo'
+│                                 row 0, expr 2: 1
+│                                 row 0, expr 3: 1
+│                                 row 1, expr 0: 'us-east'
+│                                 row 1, expr 1: 'bar'
+│                                 row 1, expr 2: 2
+│                                 row 1, expr 3: 2
 │
 ├── • constraint-check
 │   │
@@ -2313,6 +2295,8 @@ vectorized: true
                               label: buffer 1
 
 # Test that we use the index when available for the ON CONFLICT checks.
+# TODO(rytaft): This plan is suboptimal because it's not safe to construct
+# a left lookup join in this case (see #59649).
 query T
 EXPLAIN (VERBOSE) INSERT INTO uniq_enum VALUES ('us-west', 'foo', 1, 1), ('us-east', 'bar', 2, 2)
 ON CONFLICT (s, j) DO UPDATE SET i = 3
@@ -2369,38 +2353,28 @@ vectorized: true
 │                   │ render i: i
 │                   │ render j: j
 │                   │
-│                   └── • project
-│                       │ columns: (column1, column2, column3, column4, r, s, i, j)
+│                   └── • hash join (right outer)
+│                       │ columns: (r, s, i, j, column1, column2, column3, column4)
 │                       │ estimated row count: 2 (missing stats)
+│                       │ equality: (s, j) = (column2, column4)
 │                       │
-│                       └── • lookup join (left outer)
-│                           │ columns: ("lookup_join_const_col_@11", column1, column2, column3, column4, r, s, i, j)
-│                           │ table: uniq_enum@uniq_enum_r_s_j_key
-│                           │ equality: (lookup_join_const_col_@11, column2, column4) = (r,s,j)
-│                           │ equality cols are key
-│                           │
-│                           └── • cross join (inner)
-│                               │ columns: ("lookup_join_const_col_@11", column1, column2, column3, column4)
-│                               │ estimated row count: 6
-│                               │
-│                               ├── • values
-│                               │     columns: ("lookup_join_const_col_@11")
-│                               │     size: 1 column, 3 rows
-│                               │     row 0, expr 0: 'us-east'
-│                               │     row 1, expr 0: 'us-west'
-│                               │     row 2, expr 0: 'eu-west'
-│                               │
-│                               └── • values
-│                                     columns: (column1, column2, column3, column4)
-│                                     size: 4 columns, 2 rows
-│                                     row 0, expr 0: 'us-west'
-│                                     row 0, expr 1: 'foo'
-│                                     row 0, expr 2: 1
-│                                     row 0, expr 3: 1
-│                                     row 1, expr 0: 'us-east'
-│                                     row 1, expr 1: 'bar'
-│                                     row 1, expr 2: 2
-│                                     row 1, expr 3: 2
+│                       ├── • scan
+│                       │     columns: (r, s, i, j)
+│                       │     estimated row count: 1,000 (missing stats)
+│                       │     table: uniq_enum@primary
+│                       │     spans: FULL SCAN
+│                       │
+│                       └── • values
+│                             columns: (column1, column2, column3, column4)
+│                             size: 4 columns, 2 rows
+│                             row 0, expr 0: 'us-west'
+│                             row 0, expr 1: 'foo'
+│                             row 0, expr 2: 1
+│                             row 0, expr 3: 1
+│                             row 1, expr 0: 'us-east'
+│                             row 1, expr 1: 'bar'
+│                             row 1, expr 2: 2
+│                             row 1, expr 3: 2
 │
 ├── • constraint-check
 │   │

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -3122,6 +3122,58 @@ anti-join (hash)
       ├── m:1 = a:5 [outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
       └── n:2 = c:7 [outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ]), fd=(2)==(7), (7)==(2)]
 
+# Regression test for #59615. Ensure that invalid lookup joins are not created
+# for left and anti joins.
+exec-ddl
+CREATE TABLE t59615 (
+  x INT NOT NULL CHECK (x in (1, 3)),
+  y INT NOT NULL,
+  z INT,
+  PRIMARY KEY (x, y)
+)
+----
+
+opt expect-not=GenerateLookupJoins
+SELECT * FROM (VALUES (1), (2)) AS u(y) LEFT JOIN t59615 t ON u.y = t.y
+----
+right-join (hash)
+ ├── columns: y:1!null x:2 y:3 z:4
+ ├── cardinality: [2 - ]
+ ├── fd: (2,3)-->(4)
+ ├── scan t59615 [as=t]
+ │    ├── columns: x:2!null y:3!null z:4
+ │    ├── check constraint expressions
+ │    │    └── x:2 IN (1, 3) [outer=(2), constraints=(/2: [/1 - /1] [/3 - /3]; tight)]
+ │    ├── key: (2,3)
+ │    └── fd: (2,3)-->(4)
+ ├── values
+ │    ├── columns: column1:1!null
+ │    ├── cardinality: [2 - 2]
+ │    ├── (1,)
+ │    └── (2,)
+ └── filters
+      └── column1:1 = y:3 [outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+
+opt expect-not=GenerateLookupJoins
+SELECT * FROM (VALUES (1), (2)) AS u(y) WHERE NOT EXISTS (
+  SELECT * FROM t59615 t WHERE u.y = t.y
+)
+----
+anti-join (hash)
+ ├── columns: y:1!null
+ ├── cardinality: [0 - 2]
+ ├── values
+ │    ├── columns: column1:1!null
+ │    ├── cardinality: [2 - 2]
+ │    ├── (1,)
+ │    └── (2,)
+ ├── scan t59615 [as=t]
+ │    ├── columns: y:3!null
+ │    └── check constraint expressions
+ │         └── x:2 IN (1, 3) [outer=(2), constraints=(/2: [/1 - /1] [/3 - /3]; tight)]
+ └── filters
+      └── column1:1 = y:3 [outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+
 # --------------------------------------------------
 # GenerateLookupJoinsWithFilter
 # --------------------------------------------------
@@ -6078,41 +6130,29 @@ semi-join (lookup json_arr1 [as=t1])
  └── filters
       └── t1.j:8 @> t2.j:3 [outer=(3,8), immutable]
 
-# Generate an inverted anti-join on a multi-column inverted index.
-opt expect=GenerateInvertedJoinsFromSelect
+# We cannot generate an inverted anti-join in this case, due to the multiple
+# possible values for t1.i.
+opt expect-not=GenerateInvertedJoinsFromSelect
 SELECT * FROM json_arr2 AS t2
 WHERE NOT EXISTS (
   SELECT * FROM json_arr1 AS t1 WHERE t1.j @> t2.j AND t1.i IN (3, 4)
 )
 ----
-anti-join (lookup json_arr1 [as=t1])
+anti-join (cross)
  ├── columns: k:1!null l:2 j:3 a:4
- ├── key columns: [20] = [6]
- ├── lookup columns are key
  ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-4)
- ├── left-join (inverted json_arr1@j_idx [as=t1])
- │    ├── columns: t2.k:1!null l:2 t2.j:3 t2.a:4 "inverted_join_const_col_@7":19!null t1.k:20 i:21 continuation:33
- │    ├── prefix key columns: [19] = [21]
- │    ├── inverted-expr
- │    │    └── t1.j:22 @> t2.j:3
- │    ├── fd: (1)-->(2-4), (20)-->(21,33)
- │    ├── inner-join (cross)
- │    │    ├── columns: t2.k:1!null l:2 t2.j:3 t2.a:4 "inverted_join_const_col_@7":19!null
- │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
- │    │    ├── fd: (1)-->(2-4)
- │    │    ├── scan json_arr2 [as=t2]
- │    │    │    ├── columns: t2.k:1!null l:2 t2.j:3 t2.a:4
- │    │    │    ├── key: (1)
- │    │    │    └── fd: (1)-->(2-4)
- │    │    ├── values
- │    │    │    ├── columns: "inverted_join_const_col_@7":19!null
- │    │    │    ├── cardinality: [2 - 2]
- │    │    │    ├── (3,)
- │    │    │    └── (4,)
- │    │    └── filters (true)
- │    └── filters (true)
+ ├── scan json_arr2 [as=t2]
+ │    ├── columns: t2.k:1!null l:2 t2.j:3 t2.a:4
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-4)
+ ├── select
+ │    ├── columns: i:7!null t1.j:8
+ │    ├── scan json_arr1 [as=t1]
+ │    │    └── columns: i:7 t1.j:8
+ │    └── filters
+ │         └── i:7 IN (3, 4) [outer=(7), constraints=(/7: [/3 - /3] [/4 - /4]; tight)]
  └── filters
       └── t1.j:8 @> t2.j:3 [outer=(3,8), immutable]
 
@@ -6145,6 +6185,57 @@ anti-join (lookup json_arr1 [as=t1])
  │    └── filters (true)
  └── filters
       └── t1.j:8 @> t2.j:3 [outer=(3,8), immutable]
+
+# Regression test for #59615. Ensure that invalid inverted joins are not created
+# for left and anti joins.
+exec-ddl
+CREATE TABLE t59615_inv (
+  x INT NOT NULL CHECK (x in (1, 3)),
+  y JSON,
+  z INT,
+  INVERTED INDEX (x, y)
+)
+----
+
+opt expect-not=GenerateInvertedJoins
+SELECT * FROM (VALUES ('"a"'::jsonb), ('"b"'::jsonb)) AS u(y) LEFT JOIN t59615_inv t ON t.y @> u.y
+----
+right-join (cross)
+ ├── columns: y:1!null x:2 y:3 z:4
+ ├── cardinality: [2 - ]
+ ├── immutable
+ ├── scan t59615_inv [as=t]
+ │    ├── columns: x:2!null y:3 z:4
+ │    └── check constraint expressions
+ │         └── x:2 IN (1, 3) [outer=(2), constraints=(/2: [/1 - /1] [/3 - /3]; tight)]
+ ├── values
+ │    ├── columns: column1:1!null
+ │    ├── cardinality: [2 - 2]
+ │    ├── ('"a"',)
+ │    └── ('"b"',)
+ └── filters
+      └── y:3 @> column1:1 [outer=(1,3), immutable]
+
+opt expect-not=GenerateInvertedJoins
+SELECT * FROM (VALUES ('"a"'::jsonb), ('"b"'::jsonb)) AS u(y) WHERE NOT EXISTS (
+  SELECT * FROM t59615_inv t WHERE t.y @> u.y
+)
+----
+anti-join (cross)
+ ├── columns: y:1!null
+ ├── cardinality: [0 - 2]
+ ├── immutable
+ ├── values
+ │    ├── columns: column1:1!null
+ │    ├── cardinality: [2 - 2]
+ │    ├── ('"a"',)
+ │    └── ('"b"',)
+ ├── scan t59615_inv [as=t]
+ │    ├── columns: y:3
+ │    └── check constraint expressions
+ │         └── x:2 IN (1, 3) [outer=(2), constraints=(/2: [/1 - /1] [/3 - /3]; tight)]
+ └── filters
+      └── y:3 @> column1:1 [outer=(1,3), immutable]
 
 # -------------------------------------------------------
 # GenerateInvertedJoinsFromSelect + Partial Indexes


### PR DESCRIPTION
This commit fixes a bug in which incorrect results could be returned for left
and anti lookup and inverted joins. This could happen when one of the prefix
columns was constrained to more than one constant value, either due to a check
constraint or an `IN` clause. The current implementation used to support lookup
and inverted joins for this case creates a cross-join between the constant
values and the input, thus artifically increasing the size of the input to the
join. This works for inner and semi joins, but it is not correct for left or
anti joins, because non-matching input rows will be returned multiple times in
the output, which is incorrect.

This commit fixes the bug by avoiding creating lookup or inverted joins in
these cases. However, this is suboptimal for performance, and in a future
commit we should try to find a way to create left/anti inverted/lookup joins
safely for these cases.

Fixes #59615

Release note (bug fix): Fixed a bug in which incorrect results could be
returned for left and anti joins. This could happen when one of the columns on
one side of the join was constrained to multiple constant values, either due to
a check constraint or an IN clause. The bug resulted in non-matching input rows
getting returned multiple times in the output, which is incorrect. This bug
only affected previous alpha releases of 21.1, and has now been fixed.