### PR TITLE
stop: rip out expensive task tracking

### DIFF
--- a/pkg/util/stop/BUILD.bazel
+++ b/pkg/util/stop/BUILD.bazel
@@ -8,7 +8,6 @@ go_library(
     deps = [
         "//pkg/roachpb",
         "//pkg/settings",
-        "//pkg/util/caller",
         "//pkg/util/leaktest",
         "//pkg/util/log",
         "//pkg/util/log/logcrash",

--- a/pkg/util/stop/stopper_test.go
+++ b/pkg/util/stop/stopper_test.go
@@ -269,6 +269,7 @@ func TestStopperCloserConcurrent(t *testing.T) {
 func TestStopperNumTasks(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s := stop.NewStopper()
+	defer s.Stop(context.Background())
 	var tasks []chan bool
 	for i := 0; i < 3; i++ {
 		c := make(chan bool)
@@ -279,30 +280,11 @@ func TestStopperNumTasks(t *testing.T) {
 		}); err != nil {
 			t.Fatal(err)
 		}
-		tm := s.RunningTasks()
-		if numTypes, numTasks := len(tm), s.NumTasks(); numTypes != 1 || numTasks != i+1 {
-			t.Errorf("stopper should have %d running tasks, got %d / %+v", i+1, numTasks, tm)
-		}
-		m := s.RunningTasks()
-		if len(m) != 1 {
-			t.Fatalf("expected exactly one task map entry: %+v", m)
-		}
-		for _, v := range m {
-			if expNum := len(tasks); v != expNum {
-				t.Fatalf("%d: expected %d tasks, got %d", i, expNum, v)
-			}
+		if numTasks := s.NumTasks(); numTasks != i+1 {
+			t.Errorf("stopper should have %d running tasks, got %d", i+1, numTasks)
 		}
 	}
 	for i, c := range tasks {
-		m := s.RunningTasks()
-		if len(m) != 1 {
-			t.Fatalf("%d: expected exactly one task map entry: %+v", i, m)
-		}
-		for _, v := range m {
-			if expNum := len(tasks[i:]); v != expNum {
-				t.Fatalf("%d: expected %d tasks, got %d:\n%s", i, expNum, v, m)
-			}
-		}
 		// Close the channel to let the task proceed.
 		close(c)
 		expNum := len(tasks[i+1:])
@@ -313,11 +295,6 @@ func TestStopperNumTasks(t *testing.T) {
 			return nil
 		})
 	}
-	// The taskmap should've been cleared out.
-	if m := s.RunningTasks(); len(m) != 0 {
-		t.Fatalf("task map not empty: %+v", m)
-	}
-	s.Stop(context.Background())
 }
 
 // TestStopperRunTaskPanic ensures that a panic handler can recover panicking


### PR DESCRIPTION
First commit was put up for PR separately, ignore it here.

----

We are likely going to invest more in the stopper-conferred
observability in the near future as part of initiatives such as #58164,
but the task tracking that has been a part of the stopper since near
its conception has not proven to be useful in practice, while at the
same time raising concern about stopper use in hot paths.

When shutting down a running server, we don't particularly care about leaking
goroutines (as the process will end anyway). In tests, we want to ensure
goroutine hygiene, but if a test hangs during `Stop`, it is easier to look at
the stacks to find out why than to consult the task map.

Together, this left little reason to do anything more complicated than
what's left after this commit: we keep track of the running number of
tasks, and wait until this drops to zero.

With this change in, we should feel comfortable using the stopper
extensively and, for example, ensuring that any CRDB goroutine is
anchored in a Stopper task; this is the right approach for test flakes
such as in #51544 and makes sense for all of the reasons mentioned in
issue #58164 as well.

In a future change, we should make the Stopper more configurable and,
through this configurability, we could in principle bring a version of
the task map back (in debug builds) without backing it into the stopper,
though I don't anticipate that we'll want to.

Closes #52894.

Release note: None
