### PR TITLE
bazel,build: move `stringer` helper outside of /pkg

### DIFF
--- a/build/BUILD.bazel
+++ b/build/BUILD.bazel
@@ -1,0 +1,2 @@
+# Left empty intentionally, for bazel to treat this as a package and source
+# utility methods from it.

--- a/build/STRINGER.bzl
+++ b/build/STRINGER.bzl
@@ -1,11 +1,9 @@
-# Common function to create //go:generate stringer files within bazel sandbox
-
-def stringer(file, typ, name):
+# stringer lets us define the equivalent of `//go:generate stringer` files
+# within bazel sandbox.
+def stringer(src, typ, name):
    native.genrule(
       name = name, 
-      srcs = [
-          file,
-      ],
+      srcs = [src], # Accessed below using `$<`.
       outs = [typ.lower() + "_string.go"],
       cmd = """
          env PATH=`dirname $(location @go_sdk//:bin/go)` HOME=$(GENDIR) \
@@ -16,3 +14,4 @@ def stringer(file, typ, name):
          "@org_golang_x_tools//cmd/stringer",
        ],
    )
+

--- a/pkg/base/BUILD.bazel
+++ b/pkg/base/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
-load("//pkg:STRINGER.bzl", "stringer")
+load("//build:STRINGER.bzl", "stringer")
 
 go_library(
     name = "base",
@@ -68,6 +68,6 @@ go_test(
 
 stringer(
     name = "gen-clusterreplication-stringer",
-    file = "test_server_args.go",
+    src = "test_server_args.go",
     typ = "TestClusterReplicationMode",
 )

--- a/pkg/ccl/sqlproxyccl/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
-load("//pkg:STRINGER.bzl", "stringer")
+load("//build:STRINGER.bzl", "stringer")
 
 go_library(
     name = "sqlproxyccl",
@@ -62,6 +62,6 @@ go_test(
 
 stringer(
     name = "gen-errorcode-stringer",
-    file = "error.go",
+    src = "error.go",
     typ = "ErrorCode",
 )

--- a/pkg/cli/BUILD.bazel
+++ b/pkg/cli/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
-load("//pkg:STRINGER.bzl", "stringer")
+load("//build:STRINGER.bzl", "stringer")
 
 go_library(
     name = "cli",
@@ -340,6 +340,6 @@ go_test(
 
 stringer(
     name = "gen-keytype-stringer",
-    file = "flags_util.go",
+    src = "flags_util.go",
     typ = "keyType",
 )

--- a/pkg/clusterversion/BUILD.bazel
+++ b/pkg/clusterversion/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
-load("//pkg:STRINGER.bzl", "stringer")
+load("//build:STRINGER.bzl", "stringer")
 
 go_library(
     name = "clusterversion",
@@ -65,6 +65,6 @@ go_proto_library(
 
 stringer(
     name = "gen-key-stringer",
-    file = "cockroach_versions.go",
+    src = "cockroach_versions.go",
     typ = "Key",
 )

--- a/pkg/kv/kvclient/kvcoord/BUILD.bazel
+++ b/pkg/kv/kvclient/kvcoord/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
-load("//pkg:STRINGER.bzl", "stringer")
+load("//build:STRINGER.bzl", "stringer")
 
 go_library(
     name = "kvcoord",
@@ -152,6 +152,6 @@ go_test(
 
 stringer(
     name = "gen-txnstate-stringer",
-    file = "txn_coord_sender.go",
+    src = "txn_coord_sender.go",
     typ = "txnState",
 )

--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
-load("//pkg:STRINGER.bzl", "stringer")
+load("//build:STRINGER.bzl", "stringer")
 
 go_library(
     name = "kvserver",
@@ -433,6 +433,6 @@ go_proto_library(
 
 stringer(
     name = "gen-refreshraftreason-stringer",
-    file = "replica_raft.go",
+    src = "replica_raft.go",
     typ = "refreshRaftReason",
 )

--- a/pkg/roachpb/BUILD.bazel
+++ b/pkg/roachpb/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
-load("//pkg:STRINGER.bzl", "stringer")
+load("//build:STRINGER.bzl", "stringer")
 
 go_library(
     name = "roachpb",
@@ -151,13 +151,13 @@ go_proto_library(
 # Using common function for stringer to create method_string.go
 stringer(
     name = "gen-method-stringer",
-    file = "method.go",
+    src = "method.go",
     typ = "Method",
 )
 
 # Using common function for stringer to create errordetailtype_string.go
 stringer(
     name = "gen-errordetailtype-stringer",
-    file = "errors.go",
+    src = "errors.go",
     typ = "ErrorDetailType",
 )

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
-load("//pkg:STRINGER.bzl", "stringer")
+load("//build:STRINGER.bzl", "stringer")
 
 go_library(
     name = "sql",
@@ -595,24 +595,24 @@ go_test(
 
 stringer(
     name = "gen-txnevent-stringer",
-    file = "txn_state.go",
+    src = "txn_state.go",
     typ = "txnEvent",
 )
 
 stringer(
     name = "gen-txntype-stringer",
-    file = "txn_state.go",
+    src = "txn_state.go",
     typ = "txnType",
 )
 
 stringer(
     name = "gen-advancecode-stringer",
-    file = "txn_state.go",
+    src = "txn_state.go",
     typ = "advanceCode",
 )
 
 stringer(
     name = "gen-nodestatus-stringer",
-    file = "distsql_physical_planner.go",
+    src = "distsql_physical_planner.go",
     typ = "NodeStatus",
 )

--- a/pkg/sql/catalog/catalogkv/BUILD.bazel
+++ b/pkg/sql/catalog/catalogkv/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
-load("//pkg:STRINGER.bzl", "stringer")
+load("//build:STRINGER.bzl", "stringer")
 
 go_library(
     name = "catalogkv",
@@ -53,6 +53,6 @@ go_test(
 
 stringer(
     name = "gen-descriptorkind-stringer",
-    file = "catalogkv.go",
+    src = "catalogkv.go",
     typ = "DescriptorKind",
 )

--- a/pkg/sql/catalog/descpb/BUILD.bazel
+++ b/pkg/sql/catalog/descpb/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
-load("//pkg:STRINGER.bzl", "stringer")
+load("//build:STRINGER.bzl", "stringer")
 
 go_library(
     name = "descpb",
@@ -87,12 +87,12 @@ go_proto_library(
 
 stringer(
     name = "gen-privilegedescversion-stringer",
-    file = "privilege.go",
+    src = "privilege.go",
     typ = "PrivilegeDescVersion",
 )
 
 stringer(
     name = "gen-formatversion-stringer",
-    file = "structured.go",
+    src = "structured.go",
     typ = "FormatVersion",
 )

--- a/pkg/sql/colfetcher/BUILD.bazel
+++ b/pkg/sql/colfetcher/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
-load("//pkg:STRINGER.bzl", "stringer")
+load("//build:STRINGER.bzl", "stringer")
 
 go_library(
     name = "colfetcher",
@@ -42,6 +42,6 @@ go_library(
 
 stringer(
     name = "gen-fetcherstate-stringer",
-    file = "cfetcher.go",
+    src = "cfetcher.go",
     typ = "fetcherState",
 )

--- a/pkg/sql/execinfra/BUILD.bazel
+++ b/pkg/sql/execinfra/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
-load("//pkg:STRINGER.bzl", "stringer")
+load("//build:STRINGER.bzl", "stringer")
 
 go_library(
     name = "execinfra",
@@ -93,12 +93,12 @@ go_test(
 
 stringer(
     name = "gen-procstate-stringer",
-    file = "processorsbase.go",
+    src = "processorsbase.go",
     typ = "procState",
 )
 
 stringer(
     name = "gen-consumerstatus-stringer",
-    file = "base.go",
+    src = "base.go",
     typ = "ConsumerStatus",
 )

--- a/pkg/sql/opt/optgen/lang/BUILD.bazel
+++ b/pkg/sql/opt/optgen/lang/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
-load("//pkg:STRINGER.bzl", "stringer")
+load("//build:STRINGER.bzl", "stringer")
 
 go_library(
     name = "lang",
@@ -82,12 +82,12 @@ genrule(
 
 stringer(
     name = "gen-token-stringer",
-    file = "scanner.go",
+    src = "scanner.go",
     typ = "Token",
 )
 
 stringer(
     name = "gen-operator-stringer",
-    file = "operator.og.go",
+    src = "operator.og.go",
     typ = "Operator",
 )

--- a/pkg/sql/pgwire/pgwirebase/BUILD.bazel
+++ b/pkg/sql/pgwire/pgwirebase/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
-load("//pkg:STRINGER.bzl", "stringer")
+load("//build:STRINGER.bzl", "stringer")
 
 go_library(
     name = "pgwirebase",
@@ -43,36 +43,36 @@ go_library(
 
 stringer(
     name = "gen-pgnumericsign-stringer",
-    file = "encoding.go",
+    src = "encoding.go",
     typ = "PGNumericSign",
 )
 
 stringer(
     name = "gen-formatcode-stringer",
-    file = "encoding.go",
+    src = "encoding.go",
     typ = "FormatCode",
 )
 
 stringer(
     name = "gen-clientmessagetype-stringer",
-    file = "msg.go",
+    src = "msg.go",
     typ = "ClientMessageType",
 )
 
 stringer(
     name = "gen-servermessagetype-stringer",
-    file = "msg.go",
+    src = "msg.go",
     typ = "ServerMessageType",
 )
 
 stringer(
     name = "gen-servererrfieldtype-stringer",
-    file = "msg.go",
+    src = "msg.go",
     typ = "ServerErrFieldType",
 )
 
 stringer(
     name = "gen-preparetype-stringer",
-    file = "msg.go",
+    src = "msg.go",
     typ = "PrepareType",
 )

--- a/pkg/sql/privilege/BUILD.bazel
+++ b/pkg/sql/privilege/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
-load("//pkg:STRINGER.bzl", "stringer")
+load("//build:STRINGER.bzl", "stringer")
 
 go_library(
     name = "privilege",
@@ -31,6 +31,6 @@ go_test(
 
 stringer(
     name = "gen-kind-stringer",
-    file = "privilege.go",
+    src = "privilege.go",
     typ = "Kind",
 )

--- a/pkg/sql/roleoption/BUILD.bazel
+++ b/pkg/sql/roleoption/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
-load("//pkg:STRINGER.bzl", "stringer")
+load("//build:STRINGER.bzl", "stringer")
 
 go_library(
     name = "roleoption",
@@ -19,6 +19,6 @@ go_library(
 
 stringer(
     name = "gen-option-stringer",
-    file = "role_option.go",
+    src = "role_option.go",
     typ = "Option",
 )

--- a/pkg/sql/sem/tree/BUILD.bazel
+++ b/pkg/sql/sem/tree/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
-load("//pkg:STRINGER.bzl", "stringer")
+load("//build:STRINGER.bzl", "stringer")
 
 go_library(
     name = "tree",
@@ -232,12 +232,12 @@ go_test(
 
 stringer(
     name = "gen-createtypevariety-stringer",
-    file = "create.go",
+    src = "create.go",
     typ = "CreateTypeVariety",
 )
 
 stringer(
     name = "gen-statementtype-stringer",
-    file = "stmt.go",
+    src = "stmt.go",
     typ = "StatementType",
 )

--- a/pkg/util/timeutil/pgdate/BUILD.bazel
+++ b/pkg/util/timeutil/pgdate/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
-load("//pkg:STRINGER.bzl", "stringer")
+load("//build:STRINGER.bzl", "stringer")
 
 go_library(
     name = "pgdate",
@@ -44,12 +44,12 @@ go_test(
 
 stringer(
     name = "gen-field-stringer",
-    file = "fields.go",
+    src = "fields.go",
     typ = "field",
 )
 
 stringer(
     name = "gen-parsemode-stringer",
-    file = "parsing.go",
+    src = "parsing.go",
     typ = "ParseMode",
 )

--- a/pkg/workload/schemachange/BUILD.bazel
+++ b/pkg/workload/schemachange/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
-load("//pkg:STRINGER.bzl", "stringer")
+load("//build:STRINGER.bzl", "stringer")
 
 go_library(
     name = "schemachange",
@@ -9,6 +9,8 @@ go_library(
         "error_screening.go",
         "operation_generator.go",
         "schemachange.go",
+        # TODO(alanmas,irfansharif): Generate this stringer file within the
+        # sandbox as well.
         "txstatus_string.go",
         "type_resolver.go",
         ":gen-optype-stringer",  # keep
@@ -38,28 +40,6 @@ go_library(
 
 stringer(
     name = "gen-optype-stringer",
-    file = "operation_generator.go",
+    src = "operation_generator.go",
     typ = "opType",
 )
-
-# TODO (alanmas): Solve stringer issue "stringer: can't happen: constant is not an integer TxStatusInFailure"
-# Seems that we need to include github.com/jackc/pgx somehow.
-# We already tried to copy the source files over so bazel source now are enconding and encodingtype
-# but it is still failing due to the same error.
-
-# genrule(
-#     name = "gen-txstatus-stringer",
-#     srcs = [
-#         "schemachange.go",
-#     ],
-#     outs = ["txstatus_string.go"],
-#     cmd = """
-#        env PATH=`dirname $(location @go_sdk//:bin/go)` HOME=$(GENDIR) \
-#        $(location @org_golang_x_tools//cmd/stringer:stringer) -output=$@ -type TxStatus $(location @com_github_jackc_pgx//:pgx) $(location schemachange.go)
-#     """,
-#     tools = [
-#         "@go_sdk//:bin/go",
-#         "@org_golang_x_tools//cmd/stringer",
-#         "@com_github_jackc_pgx//:pgx",
-#     ],
-# )


### PR DESCRIPTION
`build` feels like a better home for bazel utilities.

Release note: None