### PR TITLE
bazel: add a .bazelignore

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,0 +1,4 @@
+artifacts
+bin
+build/builder_home
+lib


### PR DESCRIPTION
Ignore some directories that are also in the `.gitignore`.

Release note: None