### PR TITLE
opt: exclude implicit partitioning columns from UPSERT key

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
@@ -499,6 +499,87 @@ INSERT INTO t VALUES (1, 1, 1, 1, 1, 1, 1), (2, 2, 2, 2, 2, 2, 2)
 statement error pq: duplicate key value violates unique constraint "t_b_key"\nDETAIL: Key \(b\)=\(1\) already exists\.
 UPDATE t SET b = 1 WHERE pk = 2
 
+subtest upsert
+
+# The conflict columns in an upsert should only include the primary key,
+# not any implicit partitioning columns.
+query T
+EXPLAIN UPSERT INTO t VALUES (3, 3, 3, 3, 3, 3, 3)
+----
+distribution: local
+vectorized: true
+·
+• root
+│
+├── • upsert
+│   │ into: t(pk, pk2, partition_by, a, b, c, d)
+│   │ arbiter constraints: primary
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • render
+│           │
+│           └── • cross join (right outer)
+│               │
+│               ├── • filter
+│               │   │ filter: pk = 3
+│               │   │
+│               │   └── • scan
+│               │         missing stats
+│               │         table: t@primary
+│               │         spans: FULL SCAN
+│               │
+│               └── • values
+│                     size: 7 columns, 1 row
+│
+├── • constraint-check
+│   │
+│   └── • error if rows
+│       │
+│       └── • hash join (right semi)
+│           │ equality: (pk) = (upsert_pk)
+│           │ pred: column3 != partition_by
+│           │
+│           ├── • scan
+│           │     missing stats
+│           │     table: t@t_a_idx
+│           │     spans: FULL SCAN
+│           │
+│           └── • scan buffer
+│                 label: buffer 1
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │
+        └── • hash join (right semi)
+            │ equality: (b) = (column5)
+            │ pred: (upsert_pk != pk) OR (column3 != partition_by)
+            │
+            ├── • scan
+            │     missing stats
+            │     table: t@t_b_key
+            │     spans: FULL SCAN
+            │
+            └── • scan buffer
+                  label: buffer 1
+
+# One row already exists, one row is new.
+statement ok
+UPSERT INTO t VALUES (2, 4, 4, 4, 4, 4, 4), (3, 3, 3, 3, 3, 3, 3)
+
+statement error pq: duplicate key value violates unique constraint "t_b_key"\nDETAIL: Key \(b\)=\(1\) already exists\.
+UPSERT INTO t VALUES (3, 2, 2, 1, 1, 1, 1)
+
+query IIIIIII colnames,rowsort
+SELECT * from t
+----
+pk  pk2  partition_by  a  b  c  d
+1   1    1             1  1  1  1
+3   3    3             3  3  3  3
+2   4    4             4  4  4  4
+
 # Regression tests for #59583.
 statement ok
 DROP TABLE t;
@@ -514,7 +595,7 @@ CREATE TABLE t (
 );
 INSERT INTO t VALUES (1,2,3,4,5),(11,12,13,14,15)
 
-query IIIII
+query IIIII rowsort
 SELECT * FROM t@t_y_idx
 ----
 1   2   3   4   5
@@ -523,7 +604,7 @@ SELECT * FROM t@t_y_idx
 statement ok
 CREATE INDEX new_idx ON t(x)
 
-query IIIII
+query IIIII rowsort
 SELECT * FROM t@new_idx
 ----
 1   2   3   4   5
@@ -532,13 +613,13 @@ SELECT * FROM t@new_idx
 statement ok
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS(pk2)
 
-query IIIII
+query IIIII rowsort
 SELECT * FROM t@t_y_idx
 ----
 1   2   3   4   5
 11  12  13  14  15
 
-query IIIII
+query IIIII rowsort
 SELECT * FROM t@new_idx
 ----
 1   2   3   4   5

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
@@ -284,6 +284,106 @@ vectorized: true
 statement error pq: duplicate key value violates unique constraint "regional_by_row_table_b_key"\nDETAIL: Key \(b\)=\(3\) already exists\.
 INSERT INTO regional_by_row_table (crdb_region, pk, pk2, a, b) VALUES ('us-east-1', 2, 3, 2, 3)
 
+# The conflict columns in an upsert should only include the primary key,
+# not the region column.
+query T
+EXPLAIN UPSERT INTO regional_by_row_table (crdb_region, pk, pk2, a, b) VALUES ('us-east-1', 2, 3, 2, 3)
+----
+distribution: local
+vectorized: true
+·
+• root
+│
+├── • upsert
+│   │ into: regional_by_row_table(pk, pk2, a, b, crdb_region)
+│   │ arbiter constraints: primary
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • render
+│           │
+│           └── • cross join (right outer)
+│               │
+│               ├── • scan
+│               │     missing stats
+│               │     table: regional_by_row_table@primary
+│               │     spans: [/'ap-southeast-2'/2 - /'ap-southeast-2'/2] [/'ca-central-1'/2 - /'ca-central-1'/2] [/'us-east-1'/2 - /'us-east-1'/2]
+│               │
+│               └── • values
+│                     size: 5 columns, 1 row
+│
+├── • constraint-check
+│   │
+│   └── • error if rows
+│       │
+│       └── • lookup join (semi)
+│           │ table: regional_by_row_table@primary
+│           │ equality: (lookup_join_const_col_@28, upsert_pk) = (crdb_region,pk)
+│           │ equality cols are key
+│           │ pred: column1 != crdb_region
+│           │
+│           └── • cross join
+│               │
+│               ├── • scan buffer
+│               │     label: buffer 1
+│               │
+│               └── • values
+│                     size: 1 column, 3 rows
+│
+├── • constraint-check
+│   │
+│   └── • error if rows
+│       │
+│       └── • lookup join (semi)
+│           │ table: regional_by_row_table@regional_by_row_table_b_key
+│           │ equality: (lookup_join_const_col_@38, column5) = (crdb_region,b)
+│           │ equality cols are key
+│           │ pred: (upsert_pk != pk) OR (column1 != crdb_region)
+│           │
+│           └── • cross join
+│               │
+│               ├── • scan buffer
+│               │     label: buffer 1
+│               │
+│               └── • values
+│                     size: 1 column, 3 rows
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │
+        └── • lookup join (semi)
+            │ table: regional_by_row_table@new_idx
+            │ equality: (lookup_join_const_col_@49, column4, column5) = (crdb_region,a,b)
+            │ equality cols are key
+            │ pred: (upsert_pk != pk) OR (column1 != crdb_region)
+            │
+            └── • cross join
+                │
+                ├── • scan buffer
+                │     label: buffer 1
+                │
+                └── • values
+                      size: 1 column, 3 rows
+
+# One row already exists, one row is new.
+statement ok
+UPSERT INTO regional_by_row_table (crdb_region, pk, pk2, a, b) VALUES ('us-east-1', 23, 24, 25, 26), ('ca-central-1', 30, 30, 31, 32)
+
+query TIIII colnames
+SELECT crdb_region, pk, pk2, a, b FROM regional_by_row_table
+ORDER BY pk
+----
+crdb_region     pk  pk2  a   b
+ap-southeast-2  1   1    2   3
+ap-southeast-2  4   4    5   6
+ca-central-1    7   7    8   9
+ca-central-1    10  10   11  12
+us-east-1       20  20   21  22
+us-east-1       23  24   25  26
+ca-central-1    30  30   31  32
+
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE regional_by_row_table]
 ----

--- a/pkg/sql/opt/cat/index.go
+++ b/pkg/sql/opt/cat/index.go
@@ -189,6 +189,25 @@ type Index interface {
 	//
 	PartitionByListPrefixes() []tree.Datums
 
+	// ImplicitPartitioningColumnCount returns the number of implicit partitioning
+	// columns at the front of the index. For example, consider the following
+	// table:
+	//
+	// CREATE TABLE t (
+	//   x INT,
+	//   y INT,
+	//   INDEX (y) PARTITION BY LIST (x) (
+	//     PARTITION p1 VALUES IN (1)
+	//   )
+	// );
+	//
+	// In this case, the number of implicit partitioning columns in the index on
+	// y is 1, since x is implicitly added to the front of the index.
+	//
+	// The implicit partitioning columns are always a prefix of the full column
+	// list, and ImplicitPartitioningColumnCount < LaxKeyColumnCount.
+	ImplicitPartitioningColumnCount() int
+
 	// InterleaveAncestorCount returns the number of interleave ancestors for this
 	// index (or zero if this is not an interleaved index). Each ancestor is an
 	// index (usually from another table) with a key that shares a prefix with

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -1204,6 +1204,18 @@ func getIndexLaxKeyOrdinals(index cat.Index) util.FastIntSet {
 	return keyOrds
 }
 
+// getExplicitPrimaryKeyOrdinals returns the ordinals of the primary key
+// columns, excluding any implicit partitioning columns in the primary index.
+func getExplicitPrimaryKeyOrdinals(tab cat.Table) util.FastIntSet {
+	index := tab.Index(cat.PrimaryIndex)
+	skipCols := index.ImplicitPartitioningColumnCount()
+	var keyOrds util.FastIntSet
+	for i, n := skipCols, index.LaxKeyColumnCount(); i < n; i++ {
+		keyOrds.Add(index.Column(i).Ordinal())
+	}
+	return keyOrds
+}
+
 // findNotNullIndexCol finds the first not-null column in the given index and
 // returns its ordinal position in the owner table. There must always be such a
 // column, even if it turns out to be an implicit primary key column.

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -944,6 +944,11 @@ func (ti *Index) PartitionByListPrefixes() []tree.Datums {
 	return res
 }
 
+// ImplicitPartitioningColumnCount is part of the cat.Index interface.
+func (ti *Index) ImplicitPartitioningColumnCount() int {
+	return 0
+}
+
 // InterleaveAncestorCount is part of the cat.Index interface.
 func (ti *Index) InterleaveAncestorCount() int {
 	return 0

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -1337,6 +1337,11 @@ func (oi *optIndex) PartitionByListPrefixes() []tree.Datums {
 	return res
 }
 
+// ImplicitPartitioningColumnCount is part of the cat.Index interface.
+func (oi *optIndex) ImplicitPartitioningColumnCount() int {
+	return int(oi.desc.Partitioning.NumImplicitColumns)
+}
+
 // InterleaveAncestorCount is part of the cat.Index interface.
 func (oi *optIndex) InterleaveAncestorCount() int {
 	return len(oi.desc.Interleave.Ancestors)
@@ -2047,6 +2052,11 @@ func (oi *optVirtualIndex) Ordinal() int {
 // PartitionByListPrefixes is part of the cat.Index interface.
 func (oi *optVirtualIndex) PartitionByListPrefixes() []tree.Datums {
 	return nil
+}
+
+// ImplicitPartitioningColumnCount is part of the cat.Index interface.
+func (oi *optVirtualIndex) ImplicitPartitioningColumnCount() int {
+	return 0
 }
 
 // InterleaveAncestorCount is part of the cat.Index interface.


### PR DESCRIPTION
This commit teaches the optimizer that the `UPSERT` conflict columns
should only include the explicit primary key columns, not any implicit
partitioning columns.

Fixes #58943

Release note (sql change): UPSERTs on tables with an implicitly
partitioned primary index now use only the explicit primary key
columns as the conflict columns, excluding all implicit partitioning
columns. This also applies to REGIONAL BY ROW tables, ensuring that
the crdb_region column is not included in the UPSERT key.