### PR TITLE
workload: fix disabled interleave tables issue

### DIFF
--- a/pkg/ccl/workloadccl/roachmartccl/roachmart.go
+++ b/pkg/ccl/workloadccl/roachmartccl/roachmart.go
@@ -131,15 +131,19 @@ func (m *roachmart) Hooks() workload.Hooks {
 			return nil
 		},
 
+		PreCreate: func(db *gosql.DB) error {
+			if _, err := db.Exec(`SET CLUSTER SETTING sql.defaults.interleaved_tables.enabled = true`); err != nil {
+				return err
+			}
+			return nil
+		},
+
 		PreLoad: func(db *gosql.DB) error {
 			if _, err := db.Exec(zoneLocationsStmt); err != nil {
 				return err
 			}
 			if !m.partition {
 				return nil
-			}
-			if _, err := db.Exec(`SET CLUSTER SETTING sql.defaults.interleaved_tables.enabled = true`); err != nil {
-				return err
 			}
 			for _, z := range zones {
 				// We are removing the EXPERIMENTAL keyword in 2.1. For compatibility

--- a/pkg/workload/interleavedpartitioned/interleavedpartitioned.go
+++ b/pkg/workload/interleavedpartitioned/interleavedpartitioned.go
@@ -741,13 +741,16 @@ func (w *interleavedPartitioned) updateFunc(
 // Hooks implements the Hookser interface.
 func (w *interleavedPartitioned) Hooks() workload.Hooks {
 	return workload.Hooks{
+		PreCreate: func(db *gosql.DB) error {
+			if _, err := db.Exec(`SET CLUSTER SETTING sql.defaults.interleaved_tables.enabled = true`); err != nil {
+				return err
+			}
+			return nil
+		},
 		PreLoad: func(db *gosql.DB) error {
 			if _, err := db.Exec(
 				zoneLocationsStmt, w.eastZoneName, w.westZoneName, w.centralZoneName,
 			); err != nil {
-				return err
-			}
-			if _, err := db.Exec(`SET CLUSTER SETTING sql.defaults.interleaved_tables.enabled = true`); err != nil {
 				return err
 			}
 

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -88,6 +88,9 @@ type Hooks struct {
 	// Validate is called after workload flags are parsed. It should return an
 	// error if the workload configuration is invalid.
 	Validate func() error
+	// PreCreate is called before workload tables are created.
+	// Implementations should be idempotent.
+	PreCreate func(*gosql.DB) error
 	// PreLoad is called after workload tables are created and before workload
 	// data is loaded. It is not called when storing or loading a fixture.
 	// Implementations should be idempotent.

--- a/pkg/workload/workloadsql/dataload.go
+++ b/pkg/workload/workloadsql/dataload.go
@@ -55,6 +55,12 @@ func (l InsertsDataLoader) InitialDataLoad(
 		hooks = h.Hooks()
 	}
 
+	if hooks.PreCreate != nil {
+		if err := hooks.PreCreate(db); err != nil {
+			return 0, errors.Wrapf(err, "Could not precreate")
+		}
+	}
+
 	for _, table := range tables {
 		createStmt := fmt.Sprintf(`CREATE TABLE IF NOT EXISTS "%s" %s`, table.Name, table.Schema)
 		if _, err := db.ExecContext(ctx, createStmt); err != nil {


### PR DESCRIPTION
Closes #59466 
Closes #59468
Closes #59470 
Closes #59471

This commit adds a new PreCreate phase to workload.Hooks, which allows
sending arbitrary commands to the db before loading a workload schema.
It also moves enabling of interleaved tables feature to this new hook
for all affected workloads.

Release note: None