### PR TITLE
roachtest: Don't carry encryption flags in tpccbench roachtests

### DIFF
--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -746,6 +746,9 @@ func runTPCCBench(ctx context.Context, t *test, c *cluster, b tpccBenchSpec) {
 	// as well.
 	c.Put(ctx, cockroach, "./cockroach", loadNodes)
 	c.Put(ctx, workload, "./workload", loadNodes)
+	// Don't encrypt in tpccbench tests.
+	c.encryptDefault = false
+	c.encryptAtRandom = false
 	c.Start(ctx, t, append(b.startOpts(), roachNodes)...)
 
 	useHAProxy := b.Chaos


### PR DESCRIPTION
`tpccbench` tests expect encryption to never be enabled for any
node. This is usually enforced by sending `startArgsDontEncrypt`
as a start arg, but that isn't propagated for chaos-based restarts.

This change resets encryption-related flags to false in case
the cluster struct was reused.

Fixes #59426.

Release note: None.