### PR TITLE
Remove multiTestContext

### DIFF
--- a/pkg/kv/kvserver/client_metrics_test.go
+++ b/pkg/kv/kvserver/client_metrics_test.go
@@ -13,7 +13,6 @@ package kvserver_test
 import (
 	"context"
 	"fmt"
-	"sync"
 	"testing"
 	"time"
 
@@ -23,7 +22,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval/result"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -47,23 +48,15 @@ func checkGauge(t *testing.T, id string, g gaugeValuer, e int64) {
 	}
 }
 
-func verifyStats(t *testing.T, mtc *multiTestContext, storeIdxSlice ...int) {
+// verifyStats checks a sets of stats on the specified list of servers. This method
+// may produce false negatives when executed against a running server that has
+// live traffic on it.
+func verifyStats(t *testing.T, tc *testcluster.TestCluster, storeIdxSlice ...int) {
 	t.Helper()
 	var stores []*kvserver.Store
-	var wg sync.WaitGroup
-
-	mtc.mu.RLock()
-	numStores := len(mtc.stores)
-	// We need to stop the stores at the given indexes, while keeping the reference to the
-	// store objects. ComputeMVCCStats() still works on a stopped store (it needs
-	// only the engine, which is still open), and the most recent stats are still
-	// available on the stopped store object; however, no further information can
-	// be committed to the store while it is stopped, preventing any races during
-	// verification.
 	for _, storeIdx := range storeIdxSlice {
-		stores = append(stores, mtc.stores[storeIdx])
+		stores = append(stores, tc.GetFirstStoreFromServer(t, storeIdx))
 	}
-	mtc.mu.RUnlock()
 
 	// Sanity regression check for bug #4624: ensure intent count is zero.
 	// This may not be true immediately due to the asynchronous nature of
@@ -77,20 +70,6 @@ func verifyStats(t *testing.T, mtc *multiTestContext, storeIdxSlice ...int) {
 			return nil
 		})
 	}
-
-	wg.Add(numStores)
-	// We actually stop *all* of the Stores. Stopping only a few is riddled
-	// with deadlocks since operations can span nodes, but stoppers don't
-	// know about this - taking all of them down at the same time is the
-	// only sane way of guaranteeing that nothing interesting happens, at
-	// least when bringing down the nodes jeopardizes majorities.
-	for i := 0; i < numStores; i++ {
-		go func(i int) {
-			defer wg.Done()
-			mtc.stopStore(i)
-		}(i)
-	}
-	wg.Wait()
 
 	for _, s := range stores {
 		idString := s.Ident.String()
@@ -127,11 +106,6 @@ func verifyStats(t *testing.T, mtc *multiTestContext, storeIdxSlice ...int) {
 
 	if t.Failed() {
 		t.Fatalf("verifyStats failed, aborting test.")
-	}
-
-	// Restart all Stores.
-	for i := 0; i < numStores; i++ {
-		mtc.restartStore(i)
 	}
 }
 
@@ -179,13 +153,16 @@ func TestStoreResolveMetrics(t *testing.T) {
 		}
 	}
 
-	mtc := &multiTestContext{}
-	defer mtc.Stop()
-	mtc.Start(t, 1)
-
 	ctx := context.Background()
+	serv, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serv.(*server.TestServer)
+	defer s.Stopper().Stop(ctx)
+	store, err := s.Stores().GetStore(s.GetFirstStoreID())
+	require.NoError(t, err)
 
-	span := roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("b")}
+	key, err := s.ScratchRange()
+	require.NoError(t, err)
+	span := roachpb.Span{Key: key, EndKey: key.Next()}
 
 	txn := roachpb.MakeTransaction("foo", span.Key, roachpb.MinUserPriority, hlc.Timestamp{WallTime: 123}, 999)
 
@@ -195,7 +172,7 @@ func TestStoreResolveMetrics(t *testing.T) {
 
 	var ba roachpb.BatchRequest
 	{
-		repl := mtc.stores[0].LookupReplica(keys.MustAddr(span.Key))
+		repl := store.LookupReplica(keys.MustAddr(span.Key))
 		var err error
 		if ba.Replica, err = repl.GetReplicaDescriptor(); err != nil {
 			t.Fatal(err)
@@ -231,17 +208,17 @@ func TestStoreResolveMetrics(t *testing.T) {
 	add(roachpb.ABORTED, false, resolveAbortCount)
 	add(roachpb.ABORTED, true, resolvePoisonCount)
 
-	if _, pErr := mtc.senders[0].Send(ctx, ba); pErr != nil {
+	if _, pErr := store.TestSender().Send(ctx, ba); pErr != nil {
 		t.Fatal(pErr)
 	}
 
-	if exp, act := resolveCommitCount, mtc.stores[0].Metrics().ResolveCommitCount.Count(); act < exp || act > exp+50 {
+	if exp, act := resolveCommitCount, store.Metrics().ResolveCommitCount.Count(); act < exp || act > exp+50 {
 		t.Errorf("expected around %d intent commits, saw %d", exp, act)
 	}
-	if exp, act := resolveAbortCount, mtc.stores[0].Metrics().ResolveAbortCount.Count(); act < exp || act > exp+50 {
+	if exp, act := resolveAbortCount, store.Metrics().ResolveAbortCount.Count(); act < exp || act > exp+50 {
 		t.Errorf("expected around %d intent aborts, saw %d", exp, act)
 	}
-	if exp, act := resolvePoisonCount, mtc.stores[0].Metrics().ResolvePoisonCount.Count(); act < exp || act > exp+50 {
+	if exp, act := resolvePoisonCount, store.Metrics().ResolvePoisonCount.Count(); act < exp || act > exp+50 {
 		t.Errorf("expected arounc %d abort span poisonings, saw %d", exp, act)
 	}
 }
@@ -250,65 +227,69 @@ func TestStoreMetrics(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	storeCfg := kvserver.TestStoreConfig(nil /* clock */)
-	storeCfg.TestingKnobs.DisableMergeQueue = true
-	storeCfg.TestingKnobs.DisableReplicateQueue = true
-	mtc := &multiTestContext{
-		storeConfig: &storeCfg,
-		// This test was written before the multiTestContext started creating many
-		// system ranges at startup, and hasn't been update to take that into
-		// account.
-		startWithSingleRange: true,
-	}
-	defer mtc.Stop()
-	mtc.Start(t, 3)
+	ctx := context.Background()
+	tc := testcluster.StartTestCluster(t, 3,
+		base.TestClusterArgs{
+			ReplicationMode: base.ReplicationManual,
+			ServerArgs: base.TestServerArgs{
+				StoreSpecs: []base.StoreSpec{
+					{
+						InMemory: true,
+						// Specify a size to trigger the BlockCache in Pebble.
+						Size: base.SizeSpec{
+							InBytes: 1 << 20,
+						},
+					},
+				},
+				Knobs: base.TestingKnobs{
+					Store: &kvserver.StoreTestingKnobs{
+						DisableRaftLogQueue: true,
+					},
+				},
+			},
+		})
+	defer tc.Stopper().Stop(ctx)
 
-	// Flush RocksDB memtables, so that RocksDB begins using block-based tables.
+	// Flush Pebble memtables, so that Pebble begins using block-based tables.
 	// This is useful, because most of the stats we track don't apply to
 	// memtables.
-	if err := mtc.stores[0].Engine().Flush(); err != nil {
-		t.Fatal(err)
-	}
-	if err := mtc.stores[1].Engine().Flush(); err != nil {
-		t.Fatal(err)
-	}
-
-	// Disable the raft log truncation which confuses this test.
-	for _, s := range mtc.stores {
-		s.SetRaftLogQueueActive(false)
+	for i := range tc.Servers {
+		if err := tc.GetFirstStoreFromServer(t, i).Engine().Flush(); err != nil {
+			t.Fatal(err)
+		}
 	}
 
-	// Perform a split, which has special metrics handling.
-	splitArgs := adminSplitArgs(roachpb.Key("m"))
-	if _, err := kv.SendWrapped(context.Background(), mtc.stores[0].TestSender(), splitArgs); err != nil {
+	initialCount := tc.GetFirstStoreFromServer(t, 0).Metrics().ReplicaCount.Value()
+	key := tc.ScratchRange(t)
+	if _, err := tc.GetFirstStoreFromServer(t, 0).DB().Inc(ctx, key, 10); err != nil {
 		t.Fatal(err)
 	}
-
 	// Verify range count is as expected
-	checkGauge(t, "store 0", mtc.stores[0].Metrics().ReplicaCount, 2)
-
-	// Verify all stats on store0 after split.
-	verifyStats(t, mtc, 0)
+	checkGauge(t, "store 0", tc.GetFirstStoreFromServer(t, 0).Metrics().ReplicaCount, initialCount+1)
 
 	// Replicate the "right" range to the other stores.
-	replica := mtc.stores[0].LookupReplica(roachpb.RKey("z"))
-	mtc.replicateRange(replica.RangeID, 1, 2)
+	desc := tc.AddVotersOrFatal(t, key, tc.Targets(1, 2)...)
+	require.NoError(t, tc.WaitForVoters(key, tc.Targets(1, 2)...))
 
 	// Verify stats on store1 after replication.
-	verifyStats(t, mtc, 1)
+	verifyStats(t, tc, 1)
 
 	// Add some data to the "right" range.
-	dataKey := []byte("z")
-	if _, err := mtc.dbs[0].Inc(context.Background(), dataKey, 5); err != nil {
+	dataKey := key.Next()
+	if _, err := tc.GetFirstStoreFromServer(t, 0).DB().Inc(ctx, dataKey, 5); err != nil {
 		t.Fatal(err)
 	}
-	mtc.waitForValues(roachpb.Key("z"), []int64{5, 5, 5})
+	tc.WaitForValues(t, dataKey, []int64{5, 5, 5})
 
 	// Verify all stats on stores after addition.
-	verifyStats(t, mtc, 0, 1, 2)
+	// We skip verifying stats on Server[0] because there is no reliable way to
+	// do that given all if the system table activity generated by the TestCluster.
+	// We use Servers[1] and Servers[2] instead, since we can control the traffic
+	// on those servers.
+	verifyStats(t, tc, 1, 2)
 
 	// Create a transaction statement that fails. Regression test for #4969.
-	if err := mtc.dbs[0].Txn(context.Background(), func(ctx context.Context, txn *kv.Txn) error {
+	if err := tc.GetFirstStoreFromServer(t, 0).DB().Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 		b := txn.NewBatch()
 		var expVal roachpb.Value
 		expVal.SetInt(6)
@@ -319,34 +300,31 @@ func TestStoreMetrics(t *testing.T) {
 	}
 
 	// Verify stats after addition.
-	verifyStats(t, mtc, 0, 1, 2)
-	checkGauge(t, "store 0", mtc.stores[0].Metrics().ReplicaCount, 2)
+	verifyStats(t, tc, 1, 2)
+	checkGauge(t, "store 0", tc.GetFirstStoreFromServer(t, 0).Metrics().ReplicaCount, initialCount+1)
 
-	// Unreplicate range from the first store.
+	tc.TransferRangeLeaseOrFatal(t, desc, tc.Target(1))
+	tc.RemoveVotersOrFatal(t, key, tc.Target(0))
 	testutils.SucceedsSoon(t, func() error {
-		// This statement can fail if store 0 is not the leaseholder.
-		if err := mtc.transferLeaseNonFatal(context.Background(), replica.RangeID, 0, 1); err != nil {
-			t.Log(err)
+		_, err := tc.GetFirstStoreFromServer(t, 0).GetReplica(desc.RangeID)
+		if err == nil {
+			return fmt.Errorf("replica still exists on dest 0")
+		} else if errors.HasType(err, (*roachpb.RangeNotFoundError)(nil)) {
+			return nil
 		}
-		// This statement will fail if store 0 IS the leaseholder. This can happen
-		// even after the previous statement.
-		return mtc.unreplicateRangeNonFatal(replica.RangeID, 0)
+		return err
 	})
-
-	// Wait until we're sure that store 0 has successfully processed its removal.
-	require.NoError(t, mtc.waitForUnreplicated(replica.RangeID, 0))
-
-	mtc.waitForValues(roachpb.Key("z"), []int64{0, 5, 5})
+	tc.WaitForValues(t, dataKey, []int64{0, 5, 5})
 
 	// Verify range count is as expected.
-	checkGauge(t, "store 0", mtc.stores[0].Metrics().ReplicaCount, 1)
-	checkGauge(t, "store 1", mtc.stores[1].Metrics().ReplicaCount, 1)
+	checkGauge(t, "store 0", tc.GetFirstStoreFromServer(t, 0).Metrics().ReplicaCount, initialCount)
+	checkGauge(t, "store 1", tc.GetFirstStoreFromServer(t, 1).Metrics().ReplicaCount, 1)
 
 	// Verify all stats on all stores after range is removed.
-	verifyStats(t, mtc, 0, 1, 2)
+	verifyStats(t, tc, 1, 2)
 
-	verifyRocksDBStats(t, mtc.stores[0])
-	verifyRocksDBStats(t, mtc.stores[1])
+	verifyRocksDBStats(t, tc.GetFirstStoreFromServer(t, 1))
+	verifyRocksDBStats(t, tc.GetFirstStoreFromServer(t, 2))
 }
 
 // TestStoreMaxBehindNanosOnlyTracksEpochBasedLeases ensures that the metric

--- a/pkg/kv/kvserver/client_raft_helpers_test.go
+++ b/pkg/kv/kvserver/client_raft_helpers_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
@@ -130,48 +131,53 @@ func (h *unreliableRaftHandler) HandleSnapshot(
 	return h.RaftMessageHandler.HandleSnapshot(header, respStream)
 }
 
-// mtcStoreRaftMessageHandler exists to allows a store to be stopped and
+// testClusterStoreRaftMessageHandler exists to allows a store to be stopped and
 // restarted while maintaining a partition using an unreliableRaftHandler.
-type mtcStoreRaftMessageHandler struct {
-	mtc      *multiTestContext
+type testClusterStoreRaftMessageHandler struct {
+	tc       *testcluster.TestCluster
 	storeIdx int
 }
 
-func (h *mtcStoreRaftMessageHandler) HandleRaftRequest(
+func (h *testClusterStoreRaftMessageHandler) getStore() (*kvserver.Store, error) {
+	ts := h.tc.Servers[h.storeIdx]
+	return ts.Stores().GetStore(ts.GetFirstStoreID())
+}
+
+func (h *testClusterStoreRaftMessageHandler) HandleRaftRequest(
 	ctx context.Context,
 	req *kvserver.RaftMessageRequest,
 	respStream kvserver.RaftMessageResponseStream,
 ) *roachpb.Error {
-	store := h.mtc.Store(h.storeIdx)
-	if store == nil {
-		return roachpb.NewErrorf("store not found")
+	store, err := h.getStore()
+	if err != nil {
+		return roachpb.NewError(err)
 	}
 	return store.HandleRaftRequest(ctx, req, respStream)
 }
 
-func (h *mtcStoreRaftMessageHandler) HandleRaftResponse(
+func (h *testClusterStoreRaftMessageHandler) HandleRaftResponse(
 	ctx context.Context, resp *kvserver.RaftMessageResponse,
 ) error {
-	store := h.mtc.Store(h.storeIdx)
-	if store == nil {
-		return errors.New("store not found")
+	store, err := h.getStore()
+	if err != nil {
+		return err
 	}
 	return store.HandleRaftResponse(ctx, resp)
 }
 
-func (h *mtcStoreRaftMessageHandler) HandleSnapshot(
+func (h *testClusterStoreRaftMessageHandler) HandleSnapshot(
 	header *kvserver.SnapshotRequest_Header, respStream kvserver.SnapshotResponseStream,
 ) error {
-	store := h.mtc.Store(h.storeIdx)
-	if store == nil {
-		return errors.New("store not found")
+	store, err := h.getStore()
+	if err != nil {
+		return err
 	}
 	return store.HandleSnapshot(header, respStream)
 }
 
-// mtcPartitionedRange is a convenient abstraction to create a range on a node
+// testClusterPartitionedRange is a convenient abstraction to create a range on a node
 // in a multiTestContext which can be partitioned and unpartitioned.
-type mtcPartitionedRange struct {
+type testClusterPartitionedRange struct {
 	rangeID roachpb.RangeID
 	mu      struct {
 		syncutil.RWMutex
@@ -182,8 +188,9 @@ type mtcPartitionedRange struct {
 	handlers []kvserver.RaftMessageHandler
 }
 
-// setupPartitionedRange sets up an mtcPartitionedRange for the provided mtc,
-// rangeID, and node index in the mtc. The range is initially not partitioned.
+// setupPartitionedRange sets up an testClusterPartitionedRange for the provided
+// TestCluster, rangeID, and node index in the TestCluster. The range is
+// initially not partitioned.
 //
 // We're going to set up the cluster with partitioning so that we can
 // partition node p from the others. We do this by installing
@@ -205,40 +212,45 @@ type mtcPartitionedRange struct {
 // If replicaID is zero then it is resolved by looking up the replica for the
 // partitionedNode of from the current range descriptor of rangeID.
 func setupPartitionedRange(
-	mtc *multiTestContext,
+	tc *testcluster.TestCluster,
 	rangeID roachpb.RangeID,
 	replicaID roachpb.ReplicaID,
 	partitionedNode int,
 	activated bool,
 	funcs unreliableRaftHandlerFuncs,
-) (*mtcPartitionedRange, error) {
-	handlers := make([]kvserver.RaftMessageHandler, 0, len(mtc.stores))
-	for i := range mtc.stores {
-		handlers = append(handlers, &mtcStoreRaftMessageHandler{
-			mtc:      mtc,
+) (*testClusterPartitionedRange, error) {
+	handlers := make([]kvserver.RaftMessageHandler, 0, len(tc.Servers))
+	for i := range tc.Servers {
+		handlers = append(handlers, &testClusterStoreRaftMessageHandler{
+			tc:       tc,
 			storeIdx: i,
 		})
 	}
-	return setupPartitionedRangeWithHandlers(mtc, rangeID, replicaID, partitionedNode, activated, handlers, funcs)
+	return setupPartitionedRangeWithHandlers(tc, rangeID, replicaID, partitionedNode, activated, handlers, funcs)
 }
 
 func setupPartitionedRangeWithHandlers(
-	mtc *multiTestContext,
+	tc *testcluster.TestCluster,
 	rangeID roachpb.RangeID,
 	replicaID roachpb.ReplicaID,
 	partitionedNode int,
 	activated bool,
 	handlers []kvserver.RaftMessageHandler,
 	funcs unreliableRaftHandlerFuncs,
-) (*mtcPartitionedRange, error) {
-	pr := &mtcPartitionedRange{
+) (*testClusterPartitionedRange, error) {
+	pr := &testClusterPartitionedRange{
 		rangeID:  rangeID,
 		handlers: make([]kvserver.RaftMessageHandler, 0, len(handlers)),
 	}
 	pr.mu.partitioned = activated
 	pr.mu.partitionedNode = partitionedNode
 	if replicaID == 0 {
-		partRepl, err := mtc.Store(partitionedNode).GetReplica(rangeID)
+		ts := tc.Servers[partitionedNode]
+		store, err := ts.Stores().GetStore(ts.GetFirstStoreID())
+		if err != nil {
+			return nil, err
+		}
+		partRepl, err := store.GetReplica(rangeID)
 		if err != nil {
 			return nil, err
 		}
@@ -251,7 +263,7 @@ func setupPartitionedRangeWithHandlers(
 	pr.mu.partitionedReplicas = map[roachpb.ReplicaID]bool{
 		replicaID: true,
 	}
-	for i := range mtc.stores {
+	for i := range tc.Servers {
 		s := i
 		h := &unreliableRaftHandler{
 			rangeID:                    rangeID,
@@ -296,32 +308,32 @@ func setupPartitionedRangeWithHandlers(
 			}
 		}
 		pr.handlers = append(pr.handlers, h)
-		mtc.transport.Listen(mtc.stores[s].Ident.StoreID, h)
+		tc.Servers[s].RaftTransport().Listen(tc.Target(s).StoreID, h)
 	}
 	return pr, nil
 }
 
-func (pr *mtcPartitionedRange) deactivate() { pr.set(false) }
-func (pr *mtcPartitionedRange) activate()   { pr.set(true) }
-func (pr *mtcPartitionedRange) set(active bool) {
+func (pr *testClusterPartitionedRange) deactivate() { pr.set(false) }
+func (pr *testClusterPartitionedRange) activate()   { pr.set(true) }
+func (pr *testClusterPartitionedRange) set(active bool) {
 	pr.mu.Lock()
 	defer pr.mu.Unlock()
 	pr.mu.partitioned = active
 }
 
-func (pr *mtcPartitionedRange) addReplica(replicaID roachpb.ReplicaID) {
+func (pr *testClusterPartitionedRange) addReplica(replicaID roachpb.ReplicaID) {
 	pr.mu.Lock()
 	defer pr.mu.Unlock()
 	pr.mu.partitionedReplicas[replicaID] = true
 }
 
-func (pr *mtcPartitionedRange) extend(
-	mtc *multiTestContext,
+func (pr *testClusterPartitionedRange) extend(
+	tc *testcluster.TestCluster,
 	rangeID roachpb.RangeID,
 	replicaID roachpb.ReplicaID,
 	partitionedNode int,
 	activated bool,
 	funcs unreliableRaftHandlerFuncs,
-) (*mtcPartitionedRange, error) {
-	return setupPartitionedRangeWithHandlers(mtc, rangeID, replicaID, partitionedNode, activated, pr.handlers, funcs)
+) (*testClusterPartitionedRange, error) {
+	return setupPartitionedRangeWithHandlers(tc, rangeID, replicaID, partitionedNode, activated, pr.handlers, funcs)
 }

--- a/pkg/kv/kvserver/client_raft_log_queue_test.go
+++ b/pkg/kv/kvserver/client_raft_log_queue_test.go
@@ -13,15 +13,21 @@ package kvserver_test
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"math"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
 	"github.com/cockroachdb/cockroach/pkg/kv"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
 	"github.com/gogo/protobuf/proto"
+	"github.com/stretchr/testify/require"
 )
 
 // TestRaftLogQueue verifies that the raft log queue correctly truncates the
@@ -30,69 +36,78 @@ func TestRaftLogQueue(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	mtc := &multiTestContext{}
-
 	// Set maxBytes to something small so we can trigger the raft log truncation
 	// without adding 64MB of logs.
 	const maxBytes = 1 << 16
 
-	// Turn off raft elections so the raft leader won't change out from under
-	// us in this test.
-	sc := kvserver.TestStoreConfig(nil)
-	sc.DefaultZoneConfig.RangeMaxBytes = proto.Int64(maxBytes)
-	sc.RaftTickInterval = math.MaxInt32
-	sc.RaftElectionTimeoutTicks = 1000000
-	mtc.storeConfig = &sc
+	zoneConfig := zonepb.DefaultZoneConfig()
+	zoneConfig.RangeMaxBytes = proto.Int64(maxBytes)
 
-	defer mtc.Stop()
-	mtc.Start(t, 3)
+	ctx := context.Background()
+	tc := testcluster.StartTestCluster(t, 3,
+		base.TestClusterArgs{
+			ReplicationMode: base.ReplicationManual,
+			ServerArgs: base.TestServerArgs{
+				Knobs: base.TestingKnobs{
+					Server: &server.TestingKnobs{
+						DefaultZoneConfigOverride: &zoneConfig,
+					},
+				},
+				RaftConfig: base.RaftConfig{
+					// Turn off raft elections so the raft leader won't change out from under
+					// us in this test.
+					RaftTickInterval:         math.MaxInt32,
+					RaftElectionTimeoutTicks: 1000000,
+				},
+			},
+		})
+	defer tc.Stopper().Stop(ctx)
+	store := tc.GetFirstStoreFromServer(t, 0)
 
+	key := tc.ScratchRange(t)
+	tc.AddVotersOrFatal(t, key, tc.Targets(1, 2)...)
 	// Write a single value to ensure we have a leader.
-	pArgs := putArgs([]byte("key"), []byte("value"))
-	if _, err := kv.SendWrapped(context.Background(), mtc.stores[0].TestSender(), pArgs); err != nil {
+	pArgs := putArgs(key, []byte("value"))
+	if _, err := kv.SendWrapped(ctx, store.TestSender(), pArgs); err != nil {
 		t.Fatal(err)
 	}
 
 	// Get the raft leader (and ensure one exists).
-	rangeID := mtc.stores[0].LookupReplica([]byte("a")).RangeID
-	raftLeaderRepl := mtc.getRaftLeader(rangeID)
-	if raftLeaderRepl == nil {
-		t.Fatalf("could not find raft leader replica for range %d", rangeID)
-	}
+	raftLeaderRepl := tc.GetRaftLeader(t, roachpb.RKey(key))
+	require.NotNil(t, raftLeaderRepl)
 	originalIndex, err := raftLeaderRepl.GetFirstIndex()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// Disable splits since we're increasing the raft log with puts.
-	for _, store := range mtc.stores {
-		store.SetSplitQueueActive(false)
-	}
-
 	// Write a collection of values to increase the raft log.
-	value := bytes.Repeat([]byte("a"), 1000) // 1KB
+	value := bytes.Repeat(key, 1000) // 1KB
 	for size := int64(0); size < 2*maxBytes; size += int64(len(value)) {
-		pArgs = putArgs([]byte(fmt.Sprintf("key-%d", size)), value)
-		if _, err := kv.SendWrapped(context.Background(), mtc.stores[0].TestSender(), pArgs); err != nil {
+		key = key.Next()
+		pArgs = putArgs(key, value)
+		if _, err := kv.SendWrapped(ctx, store.TestSender(), pArgs); err != nil {
 			t.Fatal(err)
 		}
 	}
 
-	// Force a truncation check.
-	for _, store := range mtc.stores {
-		store.MustForceRaftLogScanAndProcess()
-	}
-
-	// Ensure that firstIndex has increased indicating that the log
-	// truncation has occurred.
-	afterTruncationIndex, err := raftLeaderRepl.GetFirstIndex()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if afterTruncationIndex <= originalIndex {
-		t.Fatalf("raft log has not been truncated yet, afterTruncationIndex:%d originalIndex:%d",
-			afterTruncationIndex, originalIndex)
-	}
+	var afterTruncationIndex uint64
+	testutils.SucceedsSoon(t, func() error {
+		// Force a truncation check.
+		for i := range tc.Servers {
+			tc.GetFirstStoreFromServer(t, i).MustForceRaftLogScanAndProcess()
+		}
+		// Ensure that firstIndex has increased indicating that the log
+		// truncation has occurred.
+		afterTruncationIndex, err = raftLeaderRepl.GetFirstIndex()
+		if err != nil {
+			return err
+		}
+		if afterTruncationIndex <= originalIndex {
+			return errors.Errorf("raft log has not been truncated yet, afterTruncationIndex:%d originalIndex:%d",
+				afterTruncationIndex, originalIndex)
+		}
+		return nil
+	})
 
 	// Force a truncation check again to ensure that attempting to truncate an
 	// already truncated log has no effect. This check, unlike in the last
@@ -101,8 +116,8 @@ func TestRaftLogQueue(t *testing.T) {
 	// GetFirstIndex, giving a false negative. Fixing this requires additional
 	// instrumentation of the queues, which was deemed to require too much work
 	// at the time of this writing.
-	for _, store := range mtc.stores {
-		store.MustForceRaftLogScanAndProcess()
+	for i := range tc.Servers {
+		tc.GetFirstStoreFromServer(t, i).MustForceRaftLogScanAndProcess()
 	}
 
 	after2ndTruncationIndex, err := raftLeaderRepl.GetFirstIndex()

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -1060,10 +1060,10 @@ func (tc *TestCluster) ToggleReplicateQueues(active bool) {
 	}
 }
 
-// readIntFromStores reads the current integer value at the given key
+// ReadIntFromStores reads the current integer value at the given key
 // from all configured engines, filling in zeros when the value is not
 // found.
-func (tc *TestCluster) readIntFromStores(key roachpb.Key) []int64 {
+func (tc *TestCluster) ReadIntFromStores(key roachpb.Key) []int64 {
 	results := make([]int64, len(tc.Servers))
 	for i, server := range tc.Servers {
 		err := server.Stores().VisitStores(func(s *kvserver.Store) error {
@@ -1094,7 +1094,7 @@ func (tc *TestCluster) readIntFromStores(key roachpb.Key) []int64 {
 func (tc *TestCluster) WaitForValues(t testing.TB, key roachpb.Key, expected []int64) {
 	t.Helper()
 	testutils.SucceedsSoon(t, func() error {
-		actual := tc.readIntFromStores(key)
+		actual := tc.ReadIntFromStores(key)
 		if !reflect.DeepEqual(expected, actual) {
 			return errors.Errorf("expected %v, got %v", expected, actual)
 		}

--- a/pkg/util/leaktest/leaktest.go
+++ b/pkg/util/leaktest/leaktest.go
@@ -94,6 +94,8 @@ var PrintLeakedStoppers = func(t testing.TB) {}
 // function to be run at the end of tests to see whether any
 // goroutines leaked.
 func AfterTest(t testing.TB) func() {
+	// Try a best effort GC to help the race tests move along.
+	runtime.GC()
 	orig := interestingGoroutines()
 	return func() {
 		t.Helper()


### PR DESCRIPTION
This pull request is broken up into two commits:

Makes progress on #8299

This change converts the last set of tests in client_metrics_test,
client_raft_test, client_raft_log_queue_test to use TestCluster instead
of multiTestContext.

Closes #8299

With all the tests converted to use TestCluster/TestServer,
we can finally remove multiTestContext and all of the dependent
code.

Release Note: None

