### PR TITLE
sql: add connect privilege on databases to allow viewing objects in vtables

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -1066,8 +1066,9 @@ func createImportingDescriptors(
 				// to the new tables being restored.
 				for _, table := range mutableTables {
 					// Collect all types used by this table.
-					dbDesc, err := descsCol.GetImmutableDatabaseByID(
+					_, dbDesc, err := descsCol.GetImmutableDatabaseByID(
 						ctx, txn, table.GetParentID(), tree.DatabaseLookupFlags{
+							Required:       true,
 							AvoidCached:    true,
 							IncludeOffline: true,
 						})
@@ -1802,8 +1803,9 @@ func (r *restoreResumer) removeExistingTypeBackReferences(
 			return typ, nil
 		}
 
-		dbDesc, err := descsCol.GetImmutableDatabaseByID(
+		_, dbDesc, err := descsCol.GetImmutableDatabaseByID(
 			ctx, txn, tbl.GetParentID(), tree.DatabaseLookupFlags{
+				Required:       true,
 				AvoidCached:    true,
 				IncludeOffline: true,
 			})

--- a/pkg/ccl/backupccl/show_test.go
+++ b/pkg/ccl/backupccl/show_test.go
@@ -349,7 +349,7 @@ GRANT UPDATE ON top_secret TO agent_bond;
 		sqlDB.Exec(t, `BACKUP DATABASE mi5 TO $1;`, showPrivs)
 
 		want := [][]string{
-			{`mi5`, `database`, `GRANT ALL ON mi5 TO admin; GRANT CREATE, DELETE, DROP, GRANT, INSERT, ` +
+			{`mi5`, `database`, `GRANT ALL ON mi5 TO admin; GRANT CONNECT, CREATE, DELETE, DROP, GRANT, INSERT, ` +
 				`SELECT, ZONECONFIG ON mi5 TO agents; GRANT ALL ON mi5 TO root; `, `root`},
 			{`locator`, `schema`, `GRANT ALL ON locator TO admin; GRANT CREATE, GRANT ON locator TO agent_bond; GRANT ALL ON locator TO m; ` +
 				`GRANT ALL ON locator TO root; `, `root`},

--- a/pkg/sql/alter_primary_key.go
+++ b/pkg/sql/alter_primary_key.go
@@ -262,7 +262,7 @@ func (p *planner) AlterPrimaryKey(
 				if as := to.RegionalByRow.As; as != nil {
 					colName = tree.Name(*as)
 				}
-				dbDesc, err := p.Descriptors().GetImmutableDatabaseByID(
+				_, dbDesc, err := p.Descriptors().GetImmutableDatabaseByID(
 					ctx,
 					p.txn,
 					tableDesc.GetParentID(),

--- a/pkg/sql/alter_table_locality.go
+++ b/pkg/sql/alter_table_locality.go
@@ -68,11 +68,11 @@ func (p *planner) AlterTableLocality(
 	}
 
 	// Ensure that the database is multi-region enabled.
-	dbDesc, err := p.Descriptors().GetImmutableDatabaseByID(
+	_, dbDesc, err := p.Descriptors().GetImmutableDatabaseByID(
 		ctx,
 		p.txn,
 		tableDesc.GetParentID(),
-		tree.DatabaseLookupFlags{},
+		tree.DatabaseLookupFlags{Required: true},
 	)
 	if err != nil {
 		return nil, err
@@ -115,8 +115,9 @@ func (n *alterTableSetLocalityNode) alterTableLocalityGlobalToRegionalByTable(
 		)
 	}
 
-	dbDesc, err := params.p.Descriptors().GetImmutableDatabaseByID(
-		params.ctx, params.p.txn, n.tableDesc.ParentID, tree.DatabaseLookupFlags{})
+	_, dbDesc, err := params.p.Descriptors().GetImmutableDatabaseByID(
+		params.ctx, params.p.txn, n.tableDesc.ParentID,
+		tree.DatabaseLookupFlags{Required: true})
 	if err != nil {
 		return err
 	}
@@ -188,8 +189,9 @@ func (n *alterTableSetLocalityNode) alterTableLocalityRegionalByTableToRegionalB
 		)
 	}
 
-	dbDesc, err := params.p.Descriptors().GetImmutableDatabaseByID(
-		params.ctx, params.p.txn, n.tableDesc.ParentID, tree.DatabaseLookupFlags{})
+	_, dbDesc, err := params.p.Descriptors().GetImmutableDatabaseByID(
+		params.ctx, params.p.txn, n.tableDesc.ParentID,
+		tree.DatabaseLookupFlags{Required: true})
 	if err != nil {
 		return err
 	}
@@ -222,6 +224,7 @@ func (n *alterTableSetLocalityNode) alterTableLocalityNonRegionalByRowToRegional
 	newLocality *tree.Locality,
 ) error {
 	enumTypeID, err := n.dbDesc.MultiRegionEnumID()
+
 	if err != nil {
 		return err
 	}
@@ -532,7 +535,8 @@ func setNewLocalityConfig(
 	descsCol *descs.Collection,
 ) error {
 	getMultiRegionTypeDesc := func() (*typedesc.Mutable, error) {
-		dbDesc, err := descsCol.GetImmutableDatabaseByID(ctx, txn, desc.GetParentID(), tree.DatabaseLookupFlags{})
+		_, dbDesc, err := descsCol.GetImmutableDatabaseByID(
+			ctx, txn, desc.GetParentID(), tree.DatabaseLookupFlags{Required: true})
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -518,8 +518,8 @@ func (p *planner) canCreateOnSchema(
 			// The caller wishes to skip this check.
 			return nil
 		}
-		dbDesc, err := p.Descriptors().GetImmutableDatabaseByID(
-			ctx, p.Txn(), dbID, tree.DatabaseLookupFlags{})
+		_, dbDesc, err := p.Descriptors().GetImmutableDatabaseByID(
+			ctx, p.Txn(), dbID, tree.DatabaseLookupFlags{Required: true})
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/catalog/descpb/privilege_test.go
+++ b/pkg/sql/catalog/descpb/privilege_test.go
@@ -129,6 +129,17 @@ func TestPrivilege(t *testing.T) {
 			},
 			privilege.Table,
 		},
+		// Ensure revoking CONNECT, CREATE, DROP, GRANT, SELECT, INSERT, DELETE, UPDATE, ZONECONFIG
+		// from a user with ALL privilege on a database leaves the user with no privileges.
+		{testUser,
+			privilege.List{privilege.ALL}, privilege.List{privilege.CONNECT, privilege.CREATE,
+				privilege.DROP, privilege.GRANT, privilege.SELECT, privilege.INSERT, privilege.DELETE,
+				privilege.UPDATE, privilege.ZONECONFIG},
+			[]UserPrivilegeString{
+				{security.AdminRoleName(), []string{"ALL"}},
+			},
+			privilege.Database,
+		},
 	}
 
 	for tcNum, tc := range testCases {
@@ -284,8 +295,8 @@ func TestValidPrivilegesForObjects(t *testing.T) {
 		objectType      privilege.ObjectType
 		validPrivileges privilege.List
 	}{
-		{privilege.Table, privilege.DBTablePrivileges},
-		{privilege.Database, privilege.DBTablePrivileges},
+		{privilege.Table, privilege.TablePrivileges},
+		{privilege.Database, privilege.DBPrivileges},
 		{privilege.Schema, privilege.SchemaPrivileges},
 		{privilege.Type, privilege.TypePrivileges},
 	}

--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -669,7 +669,9 @@ func (tc *Collection) getUserDefinedSchemaByName(
 
 		// Look up whether the schema is on the database descriptor and return early
 		// if it's not.
-		dbDesc, err := tc.GetImmutableDatabaseByID(ctx, txn, dbID, tree.DatabaseLookupFlags{})
+		_, dbDesc, err := tc.GetImmutableDatabaseByID(
+			ctx, txn, dbID, tree.DatabaseLookupFlags{Required: true},
+		)
 		if err != nil {
 			return false, nil, err
 		}
@@ -848,49 +850,48 @@ func (tc *Collection) getSchemaByName(
 
 // GetMutableDatabaseByID returns a mutable database descriptor with
 // properties according to the provided lookup flags. RequireMutable is ignored.
-// Required is ignored, and an error is always returned if no descriptor with
-// the ID exists.
 func (tc *Collection) GetMutableDatabaseByID(
 	ctx context.Context, txn *kv.Txn, dbID descpb.ID, flags tree.DatabaseLookupFlags,
-) (*dbdesc.Mutable, error) {
-	desc, err := tc.getDatabaseByID(ctx, txn, dbID, flags, true /* mutable */)
-	if err != nil {
-		return nil, err
+) (bool, *dbdesc.Mutable, error) {
+	found, desc, err := tc.getDatabaseByID(ctx, txn, dbID, flags, true /* mutable */)
+	if err != nil || !found {
+		return false, nil, err
 	}
-	return desc.(*dbdesc.Mutable), nil
+	return true, desc.(*dbdesc.Mutable), nil
 }
 
 var _ = (*Collection)(nil).GetMutableDatabaseByID
 
 // GetImmutableDatabaseByID returns an immutable database descriptor with
 // properties according to the provided lookup flags. RequireMutable is ignored.
-// Required is ignored, and an error is always returned if no descriptor with
-// the ID exists.
 func (tc *Collection) GetImmutableDatabaseByID(
 	ctx context.Context, txn *kv.Txn, dbID descpb.ID, flags tree.DatabaseLookupFlags,
-) (*dbdesc.Immutable, error) {
-	desc, err := tc.getDatabaseByID(ctx, txn, dbID, flags, false /* mutable */)
-	if err != nil {
-		return nil, err
+) (bool, *dbdesc.Immutable, error) {
+	found, desc, err := tc.getDatabaseByID(ctx, txn, dbID, flags, false /* mutable */)
+	if err != nil || !found {
+		return false, nil, err
 	}
-	return desc.(*dbdesc.Immutable), nil
+	return true, desc.(*dbdesc.Immutable), nil
 }
 
 func (tc *Collection) getDatabaseByID(
 	ctx context.Context, txn *kv.Txn, dbID descpb.ID, flags tree.DatabaseLookupFlags, mutable bool,
-) (catalog.DatabaseDescriptor, error) {
+) (bool, catalog.DatabaseDescriptor, error) {
 	desc, err := tc.getDescriptorByID(ctx, txn, dbID, flags, mutable)
 	if err != nil {
 		if errors.Is(err, catalog.ErrDescriptorNotFound) {
-			return nil, sqlerrors.NewUndefinedDatabaseError(fmt.Sprintf("[%d]", dbID))
+			if flags.Required {
+				return false, nil, sqlerrors.NewUndefinedDatabaseError(fmt.Sprintf("[%d]", dbID))
+			}
+			return false, nil, nil
 		}
-		return nil, err
+		return false, nil, err
 	}
 	db, ok := desc.(catalog.DatabaseDescriptor)
 	if !ok {
-		return nil, sqlerrors.NewUndefinedDatabaseError(fmt.Sprintf("[%d]", dbID))
+		return false, nil, sqlerrors.NewUndefinedDatabaseError(fmt.Sprintf("[%d]", dbID))
 	}
-	return db, nil
+	return true, db, nil
 }
 
 // GetMutableTableByID returns a mutable table descriptor with
@@ -1197,8 +1198,8 @@ func (tc *Collection) hydrateTypesInTableDesc(
 			if err != nil {
 				return tree.TypeName{}, nil, err
 			}
-			dbDesc, err := tc.GetImmutableDatabaseByID(ctx, txn, desc.ParentID,
-				tree.DatabaseLookupFlags{})
+			_, dbDesc, err := tc.GetImmutableDatabaseByID(ctx, txn, desc.ParentID,
+				tree.DatabaseLookupFlags{Required: true})
 			if err != nil {
 				return tree.TypeName{}, nil, err
 			}

--- a/pkg/sql/catalog/descs/collection_test.go
+++ b/pkg/sql/catalog/descs/collection_test.go
@@ -210,7 +210,7 @@ func TestAddUncommittedDescriptorAndMutableResolution(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, mut.OriginalVersion(), immByName.GetVersion())
 
-			immByID, err := descriptors.GetImmutableDatabaseByID(ctx, txn, db.GetID(), flags)
+			_, immByID, err := descriptors.GetImmutableDatabaseByID(ctx, txn, db.GetID(), flags)
 			require.NoError(t, err)
 			require.Same(t, immByName, immByID)
 
@@ -238,7 +238,7 @@ func TestAddUncommittedDescriptorAndMutableResolution(t *testing.T) {
 			require.Equal(t, db.GetVersion(), immByNameAfter.GetVersion())
 			require.Equal(t, mut.ImmutableCopy(), immByNameAfter)
 
-			immByIDAfter, err := descriptors.GetImmutableDatabaseByID(ctx, txn, db.GetID(), flags)
+			_, immByIDAfter, err := descriptors.GetImmutableDatabaseByID(ctx, txn, db.GetID(), flags)
 			require.NoError(t, err)
 			require.Same(t, immByNameAfter, immByIDAfter)
 

--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -568,11 +568,11 @@ func (p *planner) configureZoneConfigForNewIndexPartitioning(
 	}
 	// For REGIONAL BY ROW tables, correctly configure relevant zone configurations.
 	if tableDesc.IsLocalityRegionalByRow() {
-		dbDesc, err := p.Descriptors().GetImmutableDatabaseByID(
+		_, dbDesc, err := p.Descriptors().GetImmutableDatabaseByID(
 			ctx,
 			p.txn,
 			tableDesc.ParentID,
-			tree.DatabaseLookupFlags{},
+			tree.DatabaseLookupFlags{Required: true},
 		)
 		if err != nil {
 			return err

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -40,6 +40,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
+	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -364,11 +365,11 @@ func (n *createTableNode) startExec(params runParams) error {
 	}
 
 	if desc.LocalityConfig != nil {
-		dbDesc, err := params.p.Descriptors().GetImmutableDatabaseByID(
+		_, dbDesc, err := params.p.Descriptors().GetImmutableDatabaseByID(
 			params.ctx,
 			params.p.txn,
 			desc.ParentID,
-			tree.DatabaseLookupFlags{},
+			tree.DatabaseLookupFlags{Required: true},
 		)
 		if err != nil {
 			return errors.Wrap(err, "error resolving database for multi-region")
@@ -2293,7 +2294,7 @@ func newTableDesc(
 	}
 
 	regionEnumID := descpb.InvalidID
-	dbDesc, err := params.p.Descriptors().GetImmutableDatabaseByID(
+	_, dbDesc, err := params.p.Descriptors().GetImmutableDatabaseByID(
 		params.ctx, params.p.txn, parentID, tree.DatabaseLookupFlags{},
 	)
 	if err != nil {
@@ -2622,8 +2623,9 @@ func incTelemetryForNewColumn(def *tree.ColumnTableDef, desc *descpb.ColumnDescr
 	}
 }
 
-// CreateInheritedPrivilegesFromDBDesc creates privileges with the appropriate
-// owner (node for system, the restoring user otherwise.)
+// CreateInheritedPrivilegesFromDBDesc creates privileges for a
+// table (or view/sequence) with the appropriate owner (node for system,
+// the restoring user otherwise.)
 func CreateInheritedPrivilegesFromDBDesc(
 	dbDesc catalog.DatabaseDescriptor, user security.SQLUsername,
 ) *descpb.PrivilegeDescriptor {
@@ -2634,6 +2636,12 @@ func CreateInheritedPrivilegesFromDBDesc(
 	}
 
 	privs := dbDesc.GetPrivileges()
+	tablePrivBits := privilege.GetValidPrivilegesForObject(privilege.Table).ToBitField()
+	for i, u := range privs.Users {
+		// Remove privileges that are valid for databases but not for tables.
+		privs.Users[i].Privileges = u.Privileges & tablePrivBits
+	}
+
 	privs.SetOwner(user)
 
 	return privs

--- a/pkg/sql/drop_type.go
+++ b/pkg/sql/drop_type.go
@@ -194,8 +194,8 @@ func (p *planner) removeTypeBackReference(
 func (p *planner) addBackRefsFromAllTypesInTable(
 	ctx context.Context, desc *tabledesc.Mutable,
 ) error {
-	dbDesc, err := p.Descriptors().GetImmutableDatabaseByID(
-		ctx, p.txn, desc.GetParentID(), tree.DatabaseLookupFlags{})
+	_, dbDesc, err := p.Descriptors().GetImmutableDatabaseByID(
+		ctx, p.txn, desc.GetParentID(), tree.DatabaseLookupFlags{Required: true})
 	if err != nil {
 		return err
 	}
@@ -221,8 +221,8 @@ func (p *planner) addBackRefsFromAllTypesInTable(
 func (p *planner) removeBackRefsFromAllTypesInTable(
 	ctx context.Context, desc *tabledesc.Mutable,
 ) error {
-	dbDesc, err := p.Descriptors().GetImmutableDatabaseByID(
-		ctx, p.txn, desc.GetParentID(), tree.DatabaseLookupFlags{})
+	_, dbDesc, err := p.Descriptors().GetImmutableDatabaseByID(
+		ctx, p.txn, desc.GetParentID(), tree.DatabaseLookupFlags{Required: true})
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/logictest/testdata/logic_test/connect_privilege
+++ b/pkg/sql/logictest/testdata/logic_test/connect_privilege
@@ -1,0 +1,43 @@
+statement ok
+CREATE TABLE a (k STRING PRIMARY KEY, v STRING)
+
+query TTT
+SELECT schemaname, tablename, tableowner FROM pg_catalog.pg_tables WHERE tablename = 'a'
+----
+public  a  root
+
+user testuser
+
+query T noticetrace
+use test
+----
+NOTICE: CONNECT privilege will be required to connect to databases in a future release
+HINT: See: https://go.crdb.dev/issue-v/59875/v21.1
+
+query TTT
+SELECT schemaname, tablename, tableowner FROM pg_catalog.pg_tables WHERE tablename = 'a'
+----
+
+query TTT
+SELECT table_catalog, table_schema, table_name FROM information_schema.tables WHERE table_name = 'a'
+----
+
+# Granting CONNECT privilege on database test to testuser should
+# allow testuser to see table a in pg_catalog / information_schema.
+
+user root
+
+statement ok
+GRANT CONNECT ON DATABASE test TO testuser
+
+user testuser
+
+query TTT
+SELECT schemaname, tablename, tableowner FROM pg_catalog.pg_tables WHERE tablename = 'a'
+----
+public  a  root
+
+query TTT
+SELECT table_catalog, table_schema, table_name FROM information_schema.tables WHERE table_name = 'a'
+----
+test  public  a

--- a/pkg/sql/logictest/testdata/logic_test/grant_database
+++ b/pkg/sql/logictest/testdata/logic_test/grant_database
@@ -66,6 +66,7 @@ query TTT
 SHOW GRANTS ON DATABASE a
 ----
 a  admin      ALL
+a  readwrite  CONNECT
 a  readwrite  CREATE
 a  readwrite  DELETE
 a  readwrite  DROP
@@ -73,6 +74,7 @@ a  readwrite  GRANT
 a  readwrite  SELECT
 a  readwrite  ZONECONFIG
 a  root       ALL
+a  test-user  CONNECT
 a  test-user  CREATE
 a  test-user  DELETE
 a  test-user  DROP
@@ -83,12 +85,14 @@ a  test-user  ZONECONFIG
 query TTT
 SHOW GRANTS ON DATABASE a FOR readwrite, "test-user"
 ----
+a  readwrite  CONNECT
 a  readwrite  CREATE
 a  readwrite  DELETE
 a  readwrite  DROP
 a  readwrite  GRANT
 a  readwrite  SELECT
 a  readwrite  ZONECONFIG
+a  test-user  CONNECT
 a  test-user  CREATE
 a  test-user  DELETE
 a  test-user  DROP
@@ -103,6 +107,7 @@ query TTT
 SHOW GRANTS ON DATABASE a
 ----
 a  admin      ALL
+a  readwrite  CONNECT
 a  readwrite  CREATE
 a  readwrite  DELETE
 a  readwrite  DROP
@@ -110,6 +115,7 @@ a  readwrite  GRANT
 a  readwrite  SELECT
 a  readwrite  ZONECONFIG
 a  root       ALL
+a  test-user  CONNECT
 a  test-user  CREATE
 a  test-user  DELETE
 a  test-user  DROP
@@ -122,6 +128,7 @@ REVOKE ALL PRIVILEGES ON DATABASE a FROM "test-user"
 query TTT
 SHOW GRANTS ON DATABASE a FOR readwrite, "test-user"
 ----
+a  readwrite  CONNECT
 a  readwrite  CREATE
 a  readwrite  DELETE
 a  readwrite  DROP
@@ -156,3 +163,24 @@ a              public       t           test-user  ALL
 
 statement error pq: invalid privilege type USAGE for database
 GRANT USAGE ON DATABASE a TO testuser
+
+statement ok
+CREATE DATABASE b
+
+statement ok
+GRANT CREATE, CONNECT ON DATABASE b TO testuser
+
+user testuser
+
+statement ok
+CREATE TABLE b.t()
+
+# CONNECT privilege should not be inherited from DB when creating a table.
+
+query TTTTT colnames
+SHOW GRANTS ON b.t
+----
+database_name  schema_name  table_name  grantee   privilege_type
+b              public       t           admin     ALL
+b              public       t           root      ALL
+b              public       t           testuser  CREATE

--- a/pkg/sql/logictest/testdata/logic_test/privilege_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/privilege_builtins
@@ -343,7 +343,7 @@ SELECT has_database_privilege((SELECT oid FROM pg_database WHERE datname = 'syst
        has_database_privilege((SELECT oid FROM pg_database WHERE datname = 'system'), 'TEMPORARY'),
        has_database_privilege((SELECT oid FROM pg_database WHERE datname = 'system'), 'TEMP')
 ----
-false  true  false  false
+false  false  false  false
 
 query BBBB
 SELECT has_database_privilege((SELECT oid FROM pg_database WHERE datname = 'test'), 'CREATE'),
@@ -363,7 +363,7 @@ SELECT has_database_privilege('system', '  CrEaTe      '),
        has_database_privilege('system', 'TEMP'),
        has_database_privilege('system', '  CrEaTe      ,CONNECT')
 ----
-false  true  false  false  false
+false  false  false  false  false
 
 query BBBBB
 SELECT has_database_privilege('test', '  CrEaTe      '),
@@ -409,7 +409,15 @@ SELECT has_database_privilege('bar', 'test', 'CREATE'),
        has_database_privilege('bar', 'test', 'CREATE, CONNECT'),
        has_database_privilege('bar', 'test', 'CREATE, TEMP')
 ----
-true  true  true  true  true  true
+true  false  true  true  false  true
+
+statement ok
+GRANT CONNECT ON DATABASE test TO bar
+
+query B
+SELECT has_database_privilege('bar', 'test', 'CONNECT')
+----
+true
 
 query BBBBBB
 SELECT has_database_privilege('bar', 'test', 'CREATE WITH GRANT OPTION'),
@@ -419,7 +427,7 @@ SELECT has_database_privilege('bar', 'test', 'CREATE WITH GRANT OPTION'),
        has_database_privilege('bar', 'test', 'CREATE WITH GRANT OPTION, CONNECT WITH GRANT OPTION'),
        has_database_privilege('bar', 'test', 'CREATE WITH GRANT OPTION, TEMP WITH GRANT OPTION')
 ----
-false  true  false  false  false  false
+false  false  false  false  false  false
 
 
 ## has_foreign_data_wrapper_privilege

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -925,7 +925,10 @@ type oneAtATimeSchemaResolver struct {
 }
 
 func (r oneAtATimeSchemaResolver) getDatabaseByID(id descpb.ID) (*dbdesc.Immutable, error) {
-	return r.p.Descriptors().GetImmutableDatabaseByID(r.ctx, r.p.txn, id, tree.DatabaseLookupFlags{})
+	_, desc, err := r.p.Descriptors().GetImmutableDatabaseByID(
+		r.ctx, r.p.txn, id, tree.DatabaseLookupFlags{Required: true},
+	)
+	return desc, err
 }
 
 func (r oneAtATimeSchemaResolver) getTableByID(id descpb.ID) (catalog.TableDescriptor, error) {
@@ -1008,9 +1011,12 @@ func makeAllRelationsVirtualTableWithDescriptorIDIndex(
 					}
 					// Don't include tables that aren't in the current database unless
 					// they're virtual, dropped tables, or ones that the user can't see.
+					canSeeDescriptor, err := userCanSeeDescriptor(ctx, p, table, true /*allowAdding*/)
+					if err != nil {
+						return false, err
+					}
 					if (!table.IsVirtualTable() && table.GetParentID() != db.GetID()) ||
-						table.Dropped() ||
-						!userCanSeeDescriptor(ctx, p, table, true /*allowAdding*/) {
+						table.Dropped() || !canSeeDescriptor {
 						return false, nil
 					}
 					h := makeOidHasher()

--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -780,6 +780,8 @@ func parseClientProvidedSessionParameters(
 		args.ConnResultsBufferSize = connResultsBufferSize.Get(sv)
 	}
 
+	// TODO(richardjcai): When connecting to the database, we'll want to
+	// check for CONNECT privilege on the database. #59875.
 	if _, ok := args.SessionDefaults["database"]; !ok {
 		// CockroachDB-specific behavior: if no database is specified,
 		// default to "defaultdb". In PostgreSQL this would be "postgres".

--- a/pkg/sql/privilege/kind_string.go
+++ b/pkg/sql/privilege/kind_string.go
@@ -18,11 +18,12 @@ func _() {
 	_ = x[UPDATE-8]
 	_ = x[USAGE-9]
 	_ = x[ZONECONFIG-10]
+	_ = x[CONNECT-11]
 }
 
-const _Kind_name = "ALLCREATEDROPGRANTSELECTINSERTDELETEUPDATEUSAGEZONECONFIG"
+const _Kind_name = "ALLCREATEDROPGRANTSELECTINSERTDELETEUPDATEUSAGEZONECONFIGCONNECT"
 
-var _Kind_index = [...]uint8{0, 3, 9, 13, 18, 24, 30, 36, 42, 47, 57}
+var _Kind_index = [...]uint8{0, 3, 9, 13, 18, 24, 30, 36, 42, 47, 57, 64}
 
 func (i Kind) String() string {
 	i -= 1

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -226,7 +226,7 @@ func (p *planner) IsTableVisible(
 	}
 	if schemaDesc.Kind != catalog.SchemaVirtual {
 		dbID := tableDesc.GetParentID()
-		dbDesc, err := p.Descriptors().GetImmutableDatabaseByID(ctx, p.Txn(), dbID,
+		_, dbDesc, err := p.Descriptors().GetImmutableDatabaseByID(ctx, p.Txn(), dbID,
 			tree.DatabaseLookupFlags{
 				Required:    true,
 				AvoidCached: p.avoidCachedDescriptors})
@@ -257,7 +257,7 @@ func (p *planner) GetTypeDescriptor(
 		return tree.TypeName{}, nil, err
 	}
 	// Note that the value of required doesn't matter for lookups by ID.
-	dbDesc, err := p.Descriptors().GetImmutableDatabaseByID(ctx, p.txn, desc.ParentID, p.CommonLookupFlags(true /* required */))
+	_, dbDesc, err := p.Descriptors().GetImmutableDatabaseByID(ctx, p.txn, desc.ParentID, p.CommonLookupFlags(true /* required */))
 	if err != nil {
 		return tree.TypeName{}, nil, err
 	}
@@ -472,8 +472,9 @@ func (p *planner) getFullyQualifiedTableNamesFromIDs(
 func (p *planner) getQualifiedTableName(
 	ctx context.Context, desc catalog.TableDescriptor,
 ) (*tree.TableName, error) {
-	dbDesc, err := p.Descriptors().GetImmutableDatabaseByID(ctx, p.txn, desc.GetParentID(),
+	_, dbDesc, err := p.Descriptors().GetImmutableDatabaseByID(ctx, p.txn, desc.GetParentID(),
 		tree.DatabaseLookupFlags{
+			Required:       true,
 			IncludeOffline: true,
 			IncludeDropped: true,
 		})
@@ -502,9 +503,10 @@ func (p *planner) getQualifiedTableName(
 func (p *planner) getQualifiedSchemaName(
 	ctx context.Context, desc catalog.SchemaDescriptor,
 ) (*tree.ObjectNamePrefix, error) {
-	dbDesc, err := p.Descriptors().GetImmutableDatabaseByID(ctx, p.txn, desc.GetParentID(), tree.DatabaseLookupFlags{
-		Required: true,
-	})
+	_, dbDesc, err := p.Descriptors().GetImmutableDatabaseByID(ctx, p.txn, desc.GetParentID(),
+		tree.DatabaseLookupFlags{
+			Required: true,
+		})
 	if err != nil {
 		return nil, err
 	}
@@ -521,9 +523,10 @@ func (p *planner) getQualifiedSchemaName(
 func (p *planner) getQualifiedTypeName(
 	ctx context.Context, desc catalog.TypeDescriptor,
 ) (*tree.TypeName, error) {
-	dbDesc, err := p.Descriptors().GetImmutableDatabaseByID(ctx, p.txn, desc.GetParentID(), tree.DatabaseLookupFlags{
-		Required: true,
-	})
+	_, dbDesc, err := p.Descriptors().GetImmutableDatabaseByID(ctx, p.txn, desc.GetParentID(),
+		tree.DatabaseLookupFlags{
+			Required: true,
+		})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -1059,7 +1059,7 @@ func (sc *SchemaChanger) done(ctx context.Context) error {
 			return err
 		}
 
-		dbDesc, err := descsCol.GetImmutableDatabaseByID(
+		_, dbDesc, err := descsCol.GetImmutableDatabaseByID(
 			ctx,
 			txn,
 			scTable.GetParentID(),

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -521,6 +521,7 @@ func parsePrivilegeStr(arg tree.Datum, availOpts pgPrivList) (tree.Datum, error)
 // option.
 func evalPrivilegeCheck(
 	ctx *tree.EvalContext,
+	schema string,
 	infoTable string,
 	user security.SQLUsername,
 	pred string,
@@ -546,8 +547,8 @@ func evalPrivilegeCheck(
 	for _, p := range privChecks {
 		query := fmt.Sprintf(`
 			SELECT bool_or(privilege_type IN ('%s', '%s')) IS TRUE
-			FROM information_schema.%s WHERE grantee = ANY ($1) AND %s`,
-			privilege.ALL, p, infoTable, pred)
+			FROM %s.%s WHERE grantee = ANY ($1) AND %s`,
+			privilege.ALL, p, schema, infoTable, pred)
 		r, err := ctx.InternalExecutor.QueryRow(
 			ctx.Ctx(), "eval-privilege-check", ctx.Txn, query, allRoles,
 		)
@@ -1200,29 +1201,29 @@ SELECT description
 					if retNull {
 						return tree.DNull, nil
 					}
-					return evalPrivilegeCheck(ctx, "table_privileges",
-						user, pred, privilege.SELECT, withGrantOpt)
+					return evalPrivilegeCheck(ctx, "information_schema",
+						"table_privileges", user, pred, privilege.SELECT, withGrantOpt)
 				},
 				"INSERT": func(withGrantOpt bool) (tree.Datum, error) {
 					if retNull {
 						return tree.DNull, nil
 					}
-					return evalPrivilegeCheck(ctx, "table_privileges",
-						user, pred, privilege.INSERT, withGrantOpt)
+					return evalPrivilegeCheck(ctx, "information_schema",
+						"table_privileges", user, pred, privilege.INSERT, withGrantOpt)
 				},
 				"UPDATE": func(withGrantOpt bool) (tree.Datum, error) {
 					if retNull {
 						return tree.DNull, nil
 					}
-					return evalPrivilegeCheck(ctx, "table_privileges",
-						user, pred, privilege.UPDATE, withGrantOpt)
+					return evalPrivilegeCheck(ctx, "information_schema",
+						"table_privileges", user, pred, privilege.UPDATE, withGrantOpt)
 				},
 				"REFERENCES": func(withGrantOpt bool) (tree.Datum, error) {
 					if retNull {
 						return tree.DNull, nil
 					}
-					return evalPrivilegeCheck(ctx, "table_privileges",
-						user, pred, privilege.SELECT, withGrantOpt)
+					return evalPrivilegeCheck(ctx, "information_schema",
+						"table_privileges", user, pred, privilege.SELECT, withGrantOpt)
 				},
 			})
 		},
@@ -1282,29 +1283,29 @@ SELECT description
 					if retNull {
 						return tree.DNull, nil
 					}
-					return evalPrivilegeCheck(ctx, "table_privileges",
-						user, pred, privilege.SELECT, withGrantOpt)
+					return evalPrivilegeCheck(ctx, "information_schema",
+						"table_privileges", user, pred, privilege.SELECT, withGrantOpt)
 				},
 				"INSERT": func(withGrantOpt bool) (tree.Datum, error) {
 					if retNull {
 						return tree.DNull, nil
 					}
-					return evalPrivilegeCheck(ctx, "table_privileges",
-						user, pred, privilege.INSERT, withGrantOpt)
+					return evalPrivilegeCheck(ctx, "information_schema",
+						"table_privileges", user, pred, privilege.INSERT, withGrantOpt)
 				},
 				"UPDATE": func(withGrantOpt bool) (tree.Datum, error) {
 					if retNull {
 						return tree.DNull, nil
 					}
-					return evalPrivilegeCheck(ctx, "table_privileges",
-						user, pred, privilege.UPDATE, withGrantOpt)
+					return evalPrivilegeCheck(ctx, "information_schema",
+						"table_privileges", user, pred, privilege.UPDATE, withGrantOpt)
 				},
 				"REFERENCES": func(withGrantOpt bool) (tree.Datum, error) {
 					if retNull {
 						return tree.DNull, nil
 					}
-					return evalPrivilegeCheck(ctx, "table_privileges",
-						user, pred, privilege.SELECT, withGrantOpt)
+					return evalPrivilegeCheck(ctx, "information_schema",
+						"table_privileges", user, pred, privilege.SELECT, withGrantOpt)
 				},
 			})
 		},
@@ -1332,35 +1333,40 @@ SELECT description
 				}
 			}
 
-			pred := fmt.Sprintf("table_catalog = '%s'", db)
+			schemaPrivilegePred := fmt.Sprintf("table_catalog = '%s'", db)
+			databasePrivilegePred := fmt.Sprintf("database_name = '%s'", db)
 			return parsePrivilegeStr(args[1], pgPrivList{
 				"CREATE": func(withGrantOpt bool) (tree.Datum, error) {
 					if retNull {
 						return tree.DNull, nil
 					}
-					return evalPrivilegeCheck(ctx, "schema_privileges",
-						user, pred, privilege.CREATE, withGrantOpt)
+					return evalPrivilegeCheck(ctx, "crdb_internal",
+						"cluster_database_privileges", user, databasePrivilegePred,
+						privilege.CREATE, withGrantOpt)
 				},
 				"CONNECT": func(withGrantOpt bool) (tree.Datum, error) {
 					if retNull {
 						return tree.DNull, nil
 					}
-					// All users have CONNECT privileges for all databases.
-					return tree.DBoolTrue, nil
+					return evalPrivilegeCheck(ctx, "crdb_internal",
+						"cluster_database_privileges", user, databasePrivilegePred,
+						privilege.CONNECT, withGrantOpt)
 				},
 				"TEMPORARY": func(withGrantOpt bool) (tree.Datum, error) {
 					if retNull {
 						return tree.DNull, nil
 					}
-					return evalPrivilegeCheck(ctx, "schema_privileges",
-						user, pred, privilege.CREATE, withGrantOpt)
+					return evalPrivilegeCheck(ctx, "information_schema",
+						"schema_privileges", user, schemaPrivilegePred,
+						privilege.CREATE, withGrantOpt)
 				},
 				"TEMP": func(withGrantOpt bool) (tree.Datum, error) {
 					if retNull {
 						return tree.DNull, nil
 					}
-					return evalPrivilegeCheck(ctx, "schema_privileges",
-						user, pred, privilege.CREATE, withGrantOpt)
+					return evalPrivilegeCheck(ctx, "information_schema",
+						"schema_privileges", user, schemaPrivilegePred,
+						privilege.CREATE, withGrantOpt)
 				},
 			})
 		},
@@ -1504,15 +1510,17 @@ SELECT description
 					if retNull {
 						return tree.DNull, nil
 					}
-					return evalPrivilegeCheck(ctx, "schema_privileges",
-						user, pred, privilege.CREATE, withGrantOpt)
+					return evalPrivilegeCheck(ctx, "information_schema",
+						"schema_privileges", user, pred,
+						privilege.CREATE, withGrantOpt)
 				},
 				"USAGE": func(withGrantOpt bool) (tree.Datum, error) {
 					if retNull {
 						return tree.DNull, nil
 					}
-					return evalPrivilegeCheck(ctx, "schema_privileges",
-						user, pred, privilege.USAGE, withGrantOpt)
+					return evalPrivilegeCheck(ctx, "information_schema",
+						"schema_privileges", user, pred,
+						privilege.USAGE, withGrantOpt)
 				},
 			})
 		},
@@ -1557,22 +1565,25 @@ SELECT description
 					if retNull {
 						return tree.DNull, nil
 					}
-					return evalPrivilegeCheck(ctx, "table_privileges",
-						user, pred, privilege.SELECT, withGrantOpt)
+					return evalPrivilegeCheck(ctx, "information_schema",
+						"table_privileges", user, pred,
+						privilege.SELECT, withGrantOpt)
 				},
 				"SELECT": func(withGrantOpt bool) (tree.Datum, error) {
 					if retNull {
 						return tree.DNull, nil
 					}
-					return evalPrivilegeCheck(ctx, "table_privileges",
-						user, pred, privilege.SELECT, withGrantOpt)
+					return evalPrivilegeCheck(ctx, "information_schema",
+						"table_privileges", user, pred,
+						privilege.SELECT, withGrantOpt)
 				},
 				"UPDATE": func(withGrantOpt bool) (tree.Datum, error) {
 					if retNull {
 						return tree.DNull, nil
 					}
-					return evalPrivilegeCheck(ctx, "table_privileges",
-						user, pred, privilege.UPDATE, withGrantOpt)
+					return evalPrivilegeCheck(ctx, "information_schema",
+						"table_privileges", user, pred,
+						privilege.UPDATE, withGrantOpt)
 				},
 			})
 		},
@@ -1633,50 +1644,57 @@ SELECT description
 					if retNull {
 						return tree.DNull, nil
 					}
-					return evalPrivilegeCheck(ctx, "table_privileges",
-						user, pred, privilege.SELECT, withGrantOpt)
+					return evalPrivilegeCheck(ctx, "information_schema",
+						"table_privileges", user, pred,
+						privilege.SELECT, withGrantOpt)
 				},
 				"INSERT": func(withGrantOpt bool) (tree.Datum, error) {
 					if retNull {
 						return tree.DNull, nil
 					}
-					return evalPrivilegeCheck(ctx, "table_privileges",
-						user, pred, privilege.INSERT, withGrantOpt)
+					return evalPrivilegeCheck(ctx, "information_schema",
+						"table_privileges", user, pred,
+						privilege.INSERT, withGrantOpt)
 				},
 				"UPDATE": func(withGrantOpt bool) (tree.Datum, error) {
 					if retNull {
 						return tree.DNull, nil
 					}
-					return evalPrivilegeCheck(ctx, "table_privileges",
-						user, pred, privilege.UPDATE, withGrantOpt)
+					return evalPrivilegeCheck(ctx, "information_schema",
+						"table_privileges", user, pred,
+						privilege.UPDATE, withGrantOpt)
 				},
 				"DELETE": func(withGrantOpt bool) (tree.Datum, error) {
 					if retNull {
 						return tree.DNull, nil
 					}
-					return evalPrivilegeCheck(ctx, "table_privileges",
-						user, pred, privilege.DELETE, withGrantOpt)
+					return evalPrivilegeCheck(ctx, "information_schema",
+						"table_privileges", user, pred,
+						privilege.DELETE, withGrantOpt)
 				},
 				"TRUNCATE": func(withGrantOpt bool) (tree.Datum, error) {
 					if retNull {
 						return tree.DNull, nil
 					}
-					return evalPrivilegeCheck(ctx, "table_privileges",
-						user, pred, privilege.DELETE, withGrantOpt)
+					return evalPrivilegeCheck(ctx, "information_schema",
+						"table_privileges", user, pred,
+						privilege.DELETE, withGrantOpt)
 				},
 				"REFERENCES": func(withGrantOpt bool) (tree.Datum, error) {
 					if retNull {
 						return tree.DNull, nil
 					}
-					return evalPrivilegeCheck(ctx, "table_privileges",
-						user, pred, privilege.SELECT, withGrantOpt)
+					return evalPrivilegeCheck(ctx, "information_schema",
+						"table_privileges", user, pred,
+						privilege.SELECT, withGrantOpt)
 				},
 				"TRIGGER": func(withGrantOpt bool) (tree.Datum, error) {
 					if retNull {
 						return tree.DNull, nil
 					}
-					return evalPrivilegeCheck(ctx, "table_privileges",
-						user, pred, privilege.CREATE, withGrantOpt)
+					return evalPrivilegeCheck(ctx, "information_schema",
+						"table_privileges", user, pred,
+						privilege.CREATE, withGrantOpt)
 				},
 			})
 		},

--- a/pkg/sql/set_var.go
+++ b/pkg/sql/set_var.go
@@ -133,6 +133,9 @@ func (n *setVarNode) startExec(params runParams) error {
 	if n.v.RuntimeSet != nil {
 		return n.v.RuntimeSet(params.ctx, params.extendedEvalCtx, strVal)
 	}
+	if n.v.SetWithPlanner != nil {
+		return n.v.SetWithPlanner(params.ctx, params.p, strVal)
+	}
 	return n.v.Set(params.ctx, params.p.sessionDataMutator, strVal)
 }
 

--- a/pkg/sql/type_change.go
+++ b/pkg/sql/type_change.go
@@ -369,8 +369,8 @@ func (t *typeSchemaChanger) cleanupEnumValues(ctx context.Context) error {
 				member.Direction = descpb.TypeDescriptor_EnumMember_NONE
 
 				if typeDesc.Kind == descpb.TypeDescriptor_MULTIREGION_ENUM {
-					dbDesc, err := descsCol.GetMutableDatabaseByID(
-						ctx, txn, typeDesc.ParentID, tree.DatabaseLookupFlags{})
+					_, dbDesc, err := descsCol.GetMutableDatabaseByID(
+						ctx, txn, typeDesc.ParentID, tree.DatabaseLookupFlags{Required: true})
 					if err != nil {
 						return err
 					}
@@ -473,8 +473,8 @@ func (t *typeSchemaChanger) canRemoveEnumValue(
 			// be unset by default) when executing the query constructed above. This is
 			// because the enum value may be used in a view expression, which is
 			// name resolved in the context of the type's database.
-			dbDesc, err := descsCol.GetImmutableDatabaseByID(
-				ctx, txn, typeDesc.ParentID, tree.DatabaseLookupFlags{})
+			_, dbDesc, err := descsCol.GetImmutableDatabaseByID(
+				ctx, txn, typeDesc.ParentID, tree.DatabaseLookupFlags{Required: true})
 			const validationErr = "could not validate removal of enum value %q"
 			if err != nil {
 				return errors.Wrapf(err, validationErr, member.LogicalRepresentation)


### PR DESCRIPTION
sql: add CONNECT privilege for databases.

Release note (sql change): CONNECT can be granted to / revoked from users
at the database level. Ie: GRANT CONNECT ON DATABASE db TO user;

Connect allows users to view all objects in a database in information_schema
and pg_catalog. Previously, only users could only see an object in
information_schema/pg_catalog if they had any privilege (ie SELECT) on the
object.

Resolves #56020