### PR TITLE
backupccl: add logging to help detect unmarshalling failure

### DIFF
--- a/pkg/ccl/backupccl/manifest_handling.go
+++ b/pkg/ccl/backupccl/manifest_handling.go
@@ -239,7 +239,7 @@ func readBackupManifest(
 				err, "file appears encrypted -- try specifying one of \"%s\" or \"%s\"",
 				backupOptEncPassphrase, backupOptEncKMS)
 		}
-		return BackupManifest{}, err
+		return BackupManifest{}, errors.Wrapf(err, "failed to unmarshal bytes %x", descBytes)
 	}
 	for _, d := range backupManifest.Descriptors {
 		// Calls to GetTable are generally frowned upon.


### PR DESCRIPTION
We're recently seen an increased number of flakes where we are failing
to unmarshal a backup manifest. This logging should help debug this
issue.

Recent failures are:
https://github.com/cockroachdb/cockroach/issues/59685
https://github.com/cockroachdb/cockroach/issues/59685

Release note: None