### PR TITLE
kv: handle future-time operations for conflict resolution requests

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
@@ -187,7 +187,7 @@ func EndTxn(
 		return result.Result{}, roachpb.NewTransactionStatusError("could not commit in one phase as requested")
 	}
 	if args.Commit && args.Poison {
-		return result.Result{}, errors.Errorf("cannot poison during a committing EndTxn request")
+		return result.Result{}, errors.AssertionFailedf("cannot poison during a committing EndTxn request")
 	}
 
 	key := keys.TransactionKey(h.Txn.Key, h.Txn.ID)
@@ -1089,11 +1089,11 @@ func mergeTrigger(
 ) (result.Result, error) {
 	desc := rec.Desc()
 	if !bytes.Equal(desc.StartKey, merge.LeftDesc.StartKey) {
-		return result.Result{}, errors.Errorf("LHS range start keys do not match: %s != %s",
+		return result.Result{}, errors.AssertionFailedf("LHS range start keys do not match: %s != %s",
 			desc.StartKey, merge.LeftDesc.StartKey)
 	}
 	if !desc.EndKey.Less(merge.LeftDesc.EndKey) {
-		return result.Result{}, errors.Errorf("original LHS end key is not less than the post merge end key: %s >= %s",
+		return result.Result{}, errors.AssertionFailedf("original LHS end key is not less than the post merge end key: %s >= %s",
 			desc.EndKey, merge.LeftDesc.EndKey)
 	}
 

--- a/pkg/kv/kvserver/batcheval/cmd_migrate.go
+++ b/pkg/kv/kvserver/batcheval/cmd_migrate.go
@@ -71,7 +71,7 @@ func Migrate(
 
 	fn, ok := migrationRegistry[migrationVersion]
 	if !ok {
-		return result.Result{}, errors.Newf("migration for %s not found", migrationVersion)
+		return result.Result{}, errors.AssertionFailedf("migration for %s not found", migrationVersion)
 	}
 	pd, err := fn(ctx, readWriter, cArgs)
 	if err != nil {

--- a/pkg/kv/kvserver/batcheval/cmd_push_txn.go
+++ b/pkg/kv/kvserver/batcheval/cmd_push_txn.go
@@ -117,18 +117,18 @@ func PushTxn(
 		// push the transaction to. Transactions should not be pushed into the
 		// future past the leaseholder's lease expiration or their effect may
 		// not be fully reflected in a future leaseholder's timestamp cache.
-		return result.Result{}, errors.Errorf("request timestamp %s less than PushTo timestamp %s",
+		return result.Result{}, errors.AssertionFailedf("request timestamp %s less than PushTo timestamp %s",
 			h.Timestamp, args.PushTo)
 	}
 	if h.WriteTimestamp().Less(args.PusheeTxn.MinTimestamp) {
 		// This condition must hold for the timestamp cache access in
 		// SynthesizeTxnFromMeta and the timestamp cache update in
 		// Replica.updateTimestampCache to be safe.
-		return result.Result{}, errors.Errorf("request timestamp %s less than pushee txn MinTimestamp %s",
+		return result.Result{}, errors.AssertionFailedf("request timestamp %s less than pushee txn MinTimestamp %s",
 			h.Timestamp, args.PusheeTxn.MinTimestamp)
 	}
 	if !bytes.Equal(args.Key, args.PusheeTxn.Key) {
-		return result.Result{}, errors.Errorf("request key %s should match pushee txn key %s",
+		return result.Result{}, errors.AssertionFailedf("request key %s should match pushee txn key %s",
 			args.Key, args.PusheeTxn.Key)
 	}
 	key := keys.TransactionKey(args.PusheeTxn.Key, args.PusheeTxn.ID)
@@ -286,7 +286,7 @@ func PushTxn(
 		// timestamp beneath this timestamp.
 		reply.PusheeTxn.WriteTimestamp.Forward(args.PushTo)
 	default:
-		return result.Result{}, errors.Errorf("unexpected push type: %v", pushType)
+		return result.Result{}, errors.AssertionFailedf("unexpected push type: %v", pushType)
 	}
 
 	// If the transaction record was already present, persist the updates to it.

--- a/pkg/kv/kvserver/batcheval/cmd_push_txn.go
+++ b/pkg/kv/kvserver/batcheval/cmd_push_txn.go
@@ -111,27 +111,25 @@ func PushTxn(
 	if h.Txn != nil {
 		return result.Result{}, ErrTransactionUnsupported
 	}
-	if h.Timestamp.Less(args.PushTo) {
-		// Verify that the PushTxn's timestamp is not less than the timestamp that
-		// the request intends to push the transaction to. Transactions should not
-		// be pushed into the future or their effect may not be fully reflected in
-		// a future leaseholder's timestamp cache. This is analogous to how reads
-		// should not be performed at a timestamp in the future.
-		return result.Result{}, errors.Errorf("request timestamp %s less than PushTo timestamp %s", h.Timestamp, args.PushTo)
+	if h.WriteTimestamp().Less(args.PushTo) {
+		// Verify that the PushTxn's header timestamp (the one checked against
+		// the lease) is not less than the timestamp that the request intends to
+		// push the transaction to. Transactions should not be pushed into the
+		// future past the leaseholder's lease expiration or their effect may
+		// not be fully reflected in a future leaseholder's timestamp cache.
+		return result.Result{}, errors.Errorf("request timestamp %s less than PushTo timestamp %s",
+			h.Timestamp, args.PushTo)
 	}
-	if h.Timestamp.Less(args.PusheeTxn.WriteTimestamp) {
-		// This condition must hold for the timestamp cache access/update to be safe.
-		return result.Result{}, errors.Errorf("request timestamp %s less than pushee txn timestamp %s", h.Timestamp, args.PusheeTxn.WriteTimestamp)
-	}
-	now := cArgs.EvalCtx.Clock().Now()
-	// TODO(nvanbenschoten): remove this limitation. But when doing so,
-	// keep the h.Timestamp.Less(args.PushTo) check above.
-	if now.Less(h.Timestamp) {
-		// The batch's timestamp should have been used to update the clock.
-		return result.Result{}, errors.Errorf("request timestamp %s less than current clock time %s", h.Timestamp, now)
+	if h.WriteTimestamp().Less(args.PusheeTxn.MinTimestamp) {
+		// This condition must hold for the timestamp cache access in
+		// SynthesizeTxnFromMeta and the timestamp cache update in
+		// Replica.updateTimestampCache to be safe.
+		return result.Result{}, errors.Errorf("request timestamp %s less than pushee txn MinTimestamp %s",
+			h.Timestamp, args.PusheeTxn.MinTimestamp)
 	}
 	if !bytes.Equal(args.Key, args.PusheeTxn.Key) {
-		return result.Result{}, errors.Errorf("request key %s should match pushee txn key %s", args.Key, args.PusheeTxn.Key)
+		return result.Result{}, errors.Errorf("request key %s should match pushee txn key %s",
+			args.Key, args.PusheeTxn.Key)
 	}
 	key := keys.TransactionKey(args.PusheeTxn.Key, args.PusheeTxn.ID)
 
@@ -220,7 +218,7 @@ func PushTxn(
 	var reason string
 
 	switch {
-	case txnwait.IsExpired(now, &reply.PusheeTxn):
+	case txnwait.IsExpired(cArgs.EvalCtx.Clock().Now(), &reply.PusheeTxn):
 		reason = "pushee is expired"
 		// When cleaning up, actually clean up (as opposed to simply pushing
 		// the garbage in the path of future writers).

--- a/pkg/kv/kvserver/batcheval/cmd_query_intent.go
+++ b/pkg/kv/kvserver/batcheval/cmd_query_intent.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
 )
 
 func init() {
@@ -50,6 +51,24 @@ func QueryIntent(
 	h := cArgs.Header
 	reply := resp.(*roachpb.QueryIntentResponse)
 
+	ownTxn := false
+	if h.Txn != nil {
+		// Determine if the request is querying an intent in its own
+		// transaction. If not, the request is rejected as querying one
+		// transaction's intent from within another transaction is unsupported.
+		if h.Txn.ID == args.Txn.ID {
+			ownTxn = true
+		} else {
+			return result.Result{}, ErrTransactionUnsupported
+		}
+	}
+	if h.WriteTimestamp().Less(args.Txn.WriteTimestamp) {
+		// This condition must hold for the timestamp cache update in
+		// Replica.updateTimestampCache to be safe.
+		return result.Result{}, errors.Errorf("QueryIntent request timestamp %s less than txn WriteTimestamp %s",
+			h.Timestamp, args.Txn.WriteTimestamp)
+	}
+
 	// Read at the specified key at the maximum timestamp. This ensures that we
 	// see an intent if one exists, regardless of what timestamp it is written
 	// at.
@@ -65,9 +84,6 @@ func QueryIntent(
 	if err != nil {
 		return result.Result{}, err
 	}
-
-	// Determine if the request is querying an intent in its own transaction.
-	ownTxn := h.Txn != nil && h.Txn.ID == args.Txn.ID
 
 	var curIntentPushed bool
 	if intent != nil {

--- a/pkg/kv/kvserver/batcheval/cmd_query_intent.go
+++ b/pkg/kv/kvserver/batcheval/cmd_query_intent.go
@@ -65,7 +65,7 @@ func QueryIntent(
 	if h.WriteTimestamp().Less(args.Txn.WriteTimestamp) {
 		// This condition must hold for the timestamp cache update in
 		// Replica.updateTimestampCache to be safe.
-		return result.Result{}, errors.Errorf("QueryIntent request timestamp %s less than txn WriteTimestamp %s",
+		return result.Result{}, errors.AssertionFailedf("QueryIntent request timestamp %s less than txn WriteTimestamp %s",
 			h.Timestamp, args.Txn.WriteTimestamp)
 	}
 

--- a/pkg/kv/kvserver/batcheval/cmd_query_txn.go
+++ b/pkg/kv/kvserver/batcheval/cmd_query_txn.go
@@ -50,10 +50,11 @@ func QueryTxn(
 	if h.Txn != nil {
 		return result.Result{}, ErrTransactionUnsupported
 	}
-	if h.Timestamp.Less(args.Txn.WriteTimestamp) {
-		// This condition must hold for the timestamp cache access to be safe.
-		return result.Result{}, errors.Errorf("QueryTxn request timestamp %s less than txn timestamp %s",
-			h.Timestamp, args.Txn.WriteTimestamp)
+	if h.WriteTimestamp().Less(args.Txn.MinTimestamp) {
+		// This condition must hold for the timestamp cache access in
+		// SynthesizeTxnFromMeta to be safe.
+		return result.Result{}, errors.Errorf("QueryTxn request timestamp %s less than txn MinTimestamp %s",
+			h.Timestamp, args.Txn.MinTimestamp)
 	}
 	if !args.Key.Equal(args.Txn.Key) {
 		return result.Result{}, errors.Errorf("QueryTxn request key %s does not match txn key %s",

--- a/pkg/kv/kvserver/batcheval/cmd_query_txn.go
+++ b/pkg/kv/kvserver/batcheval/cmd_query_txn.go
@@ -53,11 +53,11 @@ func QueryTxn(
 	if h.WriteTimestamp().Less(args.Txn.MinTimestamp) {
 		// This condition must hold for the timestamp cache access in
 		// SynthesizeTxnFromMeta to be safe.
-		return result.Result{}, errors.Errorf("QueryTxn request timestamp %s less than txn MinTimestamp %s",
+		return result.Result{}, errors.AssertionFailedf("QueryTxn request timestamp %s less than txn MinTimestamp %s",
 			h.Timestamp, args.Txn.MinTimestamp)
 	}
 	if !args.Key.Equal(args.Txn.Key) {
-		return result.Result{}, errors.Errorf("QueryTxn request key %s does not match txn key %s",
+		return result.Result{}, errors.AssertionFailedf("QueryTxn request key %s does not match txn key %s",
 			args.Key, args.Txn.Key)
 	}
 	key := keys.TransactionKey(args.Txn.Key, args.Txn.ID)

--- a/pkg/kv/kvserver/batcheval/cmd_recover_txn.go
+++ b/pkg/kv/kvserver/batcheval/cmd_recover_txn.go
@@ -55,10 +55,12 @@ func RecoverTxn(
 	if h.Txn != nil {
 		return result.Result{}, ErrTransactionUnsupported
 	}
-	if h.Timestamp.Less(args.Txn.WriteTimestamp) {
-		// This condition must hold for the timestamp cache access/update to be safe.
-		return result.Result{}, errors.Errorf("RecoverTxn request timestamp %s less than txn timestamp %s",
-			h.Timestamp, args.Txn.WriteTimestamp)
+	if h.WriteTimestamp().Less(args.Txn.MinTimestamp) {
+		// This condition must hold for the timestamp cache access in
+		// SynthesizeTxnFromMeta and the timestamp cache update in
+		// Replica.updateTimestampCache to be safe.
+		return result.Result{}, errors.Errorf("RecoverTxn request timestamp %s less than txn MinTimestamp %s",
+			h.Timestamp, args.Txn.MinTimestamp)
 	}
 	if !args.Key.Equal(args.Txn.Key) {
 		return result.Result{}, errors.Errorf("RecoverTxn request key %s does not match txn key %s",

--- a/pkg/kv/kvserver/batcheval/cmd_recover_txn.go
+++ b/pkg/kv/kvserver/batcheval/cmd_recover_txn.go
@@ -59,11 +59,11 @@ func RecoverTxn(
 		// This condition must hold for the timestamp cache access in
 		// SynthesizeTxnFromMeta and the timestamp cache update in
 		// Replica.updateTimestampCache to be safe.
-		return result.Result{}, errors.Errorf("RecoverTxn request timestamp %s less than txn MinTimestamp %s",
+		return result.Result{}, errors.AssertionFailedf("RecoverTxn request timestamp %s less than txn MinTimestamp %s",
 			h.Timestamp, args.Txn.MinTimestamp)
 	}
 	if !args.Key.Equal(args.Txn.Key) {
-		return result.Result{}, errors.Errorf("RecoverTxn request key %s does not match txn key %s",
+		return result.Result{}, errors.AssertionFailedf("RecoverTxn request key %s does not match txn key %s",
 			args.Key, args.Txn.Key)
 	}
 	key := keys.TransactionKey(args.Txn.Key, args.Txn.ID)

--- a/pkg/kv/kvserver/batcheval/cmd_refresh_range.go
+++ b/pkg/kv/kvserver/batcheval/cmd_refresh_range.go
@@ -33,7 +33,7 @@ func RefreshRange(
 	h := cArgs.Header
 
 	if h.Txn == nil {
-		return result.Result{}, errors.Errorf("no transaction specified to %s", args.Method())
+		return result.Result{}, errors.AssertionFailedf("no transaction specified to %s", args.Method())
 	}
 
 	// We're going to refresh up to the transaction's read timestamp.

--- a/pkg/kv/kvserver/batcheval/cmd_revert_range.go
+++ b/pkg/kv/kvserver/batcheval/cmd_revert_range.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/errors"
 )
 
 func init() {
@@ -68,7 +67,7 @@ func RevertRange(
 	ctx context.Context, readWriter storage.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
 ) (result.Result, error) {
 	if cArgs.Header.Txn != nil {
-		return result.Result{}, errors.New("cannot execute RevertRange within a transaction")
+		return result.Result{}, ErrTransactionUnsupported
 	}
 	log.VEventf(ctx, 2, "RevertRange %+v", cArgs.Args)
 

--- a/pkg/kv/kvserver/batcheval/cmd_subsume.go
+++ b/pkg/kv/kvserver/batcheval/cmd_subsume.go
@@ -77,7 +77,7 @@ func Subsume(
 	desc := cArgs.EvalCtx.Desc()
 	if !bytes.Equal(desc.StartKey, args.RightDesc.StartKey) ||
 		!bytes.Equal(desc.EndKey, args.RightDesc.EndKey) {
-		return result.Result{}, errors.Errorf("RHS range bounds do not match: %s != %s",
+		return result.Result{}, errors.AssertionFailedf("RHS range bounds do not match: %s != %s",
 			args.RightDesc, desc)
 	}
 
@@ -85,7 +85,7 @@ func Subsume(
 	// of operations in the AdminMerge transaction should make it impossible for
 	// these ranges to be nonadjacent, but double check.
 	if !bytes.Equal(args.LeftDesc.EndKey, desc.StartKey) {
-		return result.Result{}, errors.Errorf("ranges are not adjacent: %s != %s",
+		return result.Result{}, errors.AssertionFailedf("ranges are not adjacent: %s != %s",
 			args.LeftDesc.EndKey, desc.StartKey)
 	}
 
@@ -97,13 +97,13 @@ func Subsume(
 	if err != nil {
 		return result.Result{}, errors.Errorf("fetching local range descriptor: %s", err)
 	} else if intent == nil {
-		return result.Result{}, errors.New("range missing intent on its local descriptor")
+		return result.Result{}, errors.AssertionFailedf("range missing intent on its local descriptor")
 	}
 	val, _, err := storage.MVCCGetAsTxn(ctx, readWriter, descKey, cArgs.Header.Timestamp, intent.Txn)
 	if err != nil {
 		return result.Result{}, errors.Errorf("fetching local range descriptor as txn: %s", err)
 	} else if val != nil {
-		return result.Result{}, errors.New("non-deletion intent on local range descriptor")
+		return result.Result{}, errors.AssertionFailedf("non-deletion intent on local range descriptor")
 	}
 
 	// We prevent followers of the RHS from being able to serve follower reads on

--- a/pkg/kv/kvserver/batcheval/transaction.go
+++ b/pkg/kv/kvserver/batcheval/transaction.go
@@ -26,7 +26,7 @@ import (
 
 // ErrTransactionUnsupported is returned when a non-transactional command is
 // evaluated in the context of a transaction.
-var ErrTransactionUnsupported = errors.New("not supported within a transaction")
+var ErrTransactionUnsupported = errors.AssertionFailedf("not supported within a transaction")
 
 // VerifyTransaction runs sanity checks verifying that the transaction in the
 // header and the request are compatible.
@@ -34,10 +34,10 @@ func VerifyTransaction(
 	h roachpb.Header, args roachpb.Request, permittedStatuses ...roachpb.TransactionStatus,
 ) error {
 	if h.Txn == nil {
-		return errors.Errorf("no transaction specified to %s", args.Method())
+		return errors.AssertionFailedf("no transaction specified to %s", args.Method())
 	}
 	if !bytes.Equal(args.Header().Key, h.Txn.Key) {
-		return errors.Errorf("request key %s should match txn key %s", args.Header().Key, h.Txn.Key)
+		return errors.AssertionFailedf("request key %s should match txn key %s", args.Header().Key, h.Txn.Key)
 	}
 	statusPermitted := false
 	for _, s := range permittedStatuses {

--- a/pkg/kv/kvserver/intentresolver/intent_resolver.go
+++ b/pkg/kv/kvserver/intentresolver/intent_resolver.go
@@ -357,8 +357,10 @@ func (ir *IntentResolver) MaybePushTransactions(
 	log.Eventf(ctx, "pushing %d transaction(s)", len(pushTxns))
 
 	// Attempt to push the transaction(s).
+	pushTo := h.Timestamp.Next()
 	b := &kv.Batch{}
 	b.Header.Timestamp = ir.clock.Now()
+	b.Header.Timestamp.Forward(pushTo)
 	for _, pushTxn := range pushTxns {
 		b.AddRawRequest(&roachpb.PushTxnRequest{
 			RequestHeader: roachpb.RequestHeader{
@@ -366,7 +368,7 @@ func (ir *IntentResolver) MaybePushTransactions(
 			},
 			PusherTxn: pusherTxn,
 			PusheeTxn: *pushTxn,
-			PushTo:    h.Timestamp.Next(),
+			PushTo:    pushTo,
 			PushType:  pushType,
 		})
 	}

--- a/pkg/kv/kvserver/kvserverpb/BUILD.bazel
+++ b/pkg/kv/kvserver/kvserverpb/BUILD.bazel
@@ -12,7 +12,10 @@ go_library(
     embed = [":kvserverpb_go_proto"],
     importpath = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb",
     visibility = ["//visibility:public"],
-    deps = ["//pkg/roachpb"],
+    deps = [
+        "//pkg/roachpb",
+        "//pkg/util/hlc",
+    ],
 )
 
 proto_library(

--- a/pkg/kv/kvserver/kvserverpb/lease_status.go
+++ b/pkg/kv/kvserver/kvserverpb/lease_status.go
@@ -10,7 +10,10 @@
 
 package kvserverpb
 
-import roachpb "github.com/cockroachdb/cockroach/pkg/roachpb"
+import (
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+)
 
 // IsValid returns whether the lease was valid at the time that the
 // lease status was computed.
@@ -21,4 +24,16 @@ func (st LeaseStatus) IsValid() bool {
 // OwnedBy returns whether the lease is owned by the given store.
 func (st LeaseStatus) OwnedBy(storeID roachpb.StoreID) bool {
 	return st.Lease.OwnedBy(storeID)
+}
+
+// Expiration returns the expiration of the lease.
+func (st LeaseStatus) Expiration() hlc.Timestamp {
+	switch st.Lease.Type() {
+	case roachpb.LeaseExpiration:
+		return st.Lease.GetExpiration()
+	case roachpb.LeaseEpoch:
+		return st.Liveness.Expiration.ToTimestamp()
+	default:
+		panic("unexpected")
+	}
 }

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -1229,8 +1229,11 @@ func (r *Replica) checkExecutionCanProceed(
 		}
 	} else {
 		// If the request is a write or a consistent read, it requires the
-		// replica serving it to hold the range lease.
-		st, shouldExtend, err = r.leaseGoodToGoRLocked(ctx, now, ba.Timestamp)
+		// replica serving it to hold the range lease. We pass the write
+		// timestamp of the request because this is the maximum timestamp that
+		// the request will operate at, ignoring the uncertainty interval, which
+		// is already accounted for in LeaseStatus's stasis period handling.
+		st, shouldExtend, err = r.leaseGoodToGoRLocked(ctx, now, ba.WriteTimestamp())
 		if err != nil {
 			// If not, can we serve this request on a follower?
 			// TODO(nvanbenschoten): once we make this check cheaper

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -1471,50 +1471,6 @@ func (r *Replica) isNewerThanSplitRLocked(split *roachpb.SplitTrigger) bool {
 		r.mu.replicaID > rightDesc.ReplicaID
 }
 
-// TODO(nvanbenschoten): move endCmds to replica_send.go.
-
-// endCmds holds necessary information to end a batch after Raft
-// command processing.
-type endCmds struct {
-	repl *Replica
-	g    *concurrency.Guard
-}
-
-// move moves the endCmds into the return value, clearing and making
-// a call to done on the receiver a no-op.
-func (ec *endCmds) move() endCmds {
-	res := *ec
-	*ec = endCmds{}
-	return res
-}
-
-// done releases the latches acquired by the command and updates
-// the timestamp cache using the final timestamp of each command.
-//
-// No-op if the receiver has been zeroed out by a call to move.
-// Idempotent and is safe to call more than once.
-func (ec *endCmds) done(
-	ctx context.Context, ba *roachpb.BatchRequest, br *roachpb.BatchResponse, pErr *roachpb.Error,
-) {
-	if ec.repl == nil {
-		// The endCmds were cleared.
-		return
-	}
-	defer ec.move() // clear
-
-	// Update the timestamp cache if the request is not being re-evaluated. Each
-	// request is considered in turn; only those marked as affecting the cache are
-	// processed.
-	ec.repl.updateTimestampCache(ctx, ba, br, pErr)
-
-	// Release the latches acquired by the request and exit lock wait-queues.
-	// Must be done AFTER the timestamp cache is updated. ec.g is only set when
-	// the Raft proposal has assumed responsibility for the request.
-	if ec.g != nil {
-		ec.repl.concMgr.FinishReq(ec.g)
-	}
-}
-
 // maybeWatchForMerge checks whether a merge of this replica into its left
 // neighbor is in its critical phase and, if so, arranges to block all requests,
 // except for read-only requests that are older than `freezeStart`, until the

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -71,7 +71,7 @@ func (r *Replica) evalAndPropose(
 	ctx context.Context,
 	ba *roachpb.BatchRequest,
 	g *concurrency.Guard,
-	lease *roachpb.Lease,
+	st kvserverpb.LeaseStatus,
 	lul hlc.Timestamp,
 ) (chan proposalResult, func(), int64, *roachpb.Error) {
 	idKey := makeIDKey()
@@ -81,13 +81,13 @@ func (r *Replica) evalAndPropose(
 	// If the request hit a server-side concurrency retry error, immediately
 	// proagate the error. Don't assume ownership of the concurrency guard.
 	if isConcurrencyRetryError(pErr) {
-		pErr = maybeAttachLease(pErr, lease)
+		pErr = maybeAttachLease(pErr, &st.Lease)
 		return nil, nil, 0, pErr
 	}
 
 	// Attach the endCmds to the proposal and assume responsibility for
 	// releasing the concurrency guard if the proposal makes it to Raft.
-	proposal.ec = endCmds{repl: r, g: g}
+	proposal.ec = endCmds{repl: r, g: g, st: st}
 
 	// Pull out proposal channel to return. proposal.doneCh may be set to
 	// nil if it is signaled in this function.
@@ -143,7 +143,7 @@ func (r *Replica) evalAndPropose(
 	}
 
 	// Attach information about the proposer to the command.
-	proposal.command.ProposerLeaseSequence = lease.Sequence
+	proposal.command.ProposerLeaseSequence = st.Lease.Sequence
 
 	// Once a command is written to the raft log, it must be loaded into memory
 	// and replayed on all replicas. If a command is too big, stop it here. If

--- a/pkg/kv/kvserver/replica_read.go
+++ b/pkg/kv/kvserver/replica_read.go
@@ -92,7 +92,7 @@ func (r *Replica) executeReadOnlyBatch(
 	}
 
 	// Otherwise, update the timestamp cache and release the concurrency guard.
-	ec, g := endCmds{repl: r, g: g}, nil
+	ec, g := endCmds{repl: r, g: g, st: st}, nil
 	ec.done(ctx, ba, br, pErr)
 
 	// Semi-synchronously process any intents that need resolving here in

--- a/pkg/kv/kvserver/replica_send.go
+++ b/pkg/kv/kvserver/replica_send.go
@@ -695,3 +695,46 @@ func (r *Replica) collectSpans(
 
 	return latchSpans, lockSpans, nil
 }
+
+// endCmds holds necessary information to end a batch after command processing,
+// either after a write request has achieved consensus and been applied to Raft
+// or after a read-only request has finished evaluation.
+type endCmds struct {
+	repl *Replica
+	g    *concurrency.Guard
+}
+
+// move moves the endCmds into the return value, clearing and making a call to
+// done on the receiver a no-op.
+func (ec *endCmds) move() endCmds {
+	res := *ec
+	*ec = endCmds{}
+	return res
+}
+
+// done releases the latches acquired by the command and updates the timestamp
+// cache using the final timestamp of each command.
+//
+// No-op if the receiver has been zeroed out by a call to move. Idempotent and
+// is safe to call more than once.
+func (ec *endCmds) done(
+	ctx context.Context, ba *roachpb.BatchRequest, br *roachpb.BatchResponse, pErr *roachpb.Error,
+) {
+	if ec.repl == nil {
+		// The endCmds were cleared.
+		return
+	}
+	defer ec.move() // clear
+
+	// Update the timestamp cache if the request is not being re-evaluated. Each
+	// request is considered in turn; only those marked as affecting the cache
+	// are processed.
+	ec.repl.updateTimestampCache(ctx, ba, br, pErr)
+
+	// Release the latches acquired by the request and exit lock wait-queues.
+	// Must be done AFTER the timestamp cache is updated. ec.g is only set when
+	// the Raft proposal has assumed responsibility for the request.
+	if ec.g != nil {
+		ec.repl.concMgr.FinishReq(ec.g)
+	}
+}

--- a/pkg/kv/kvserver/replica_write.go
+++ b/pkg/kv/kvserver/replica_write.go
@@ -114,13 +114,13 @@ func (r *Replica) executeWriteBatch(
 	// Checking the context just before proposing can help avoid ambiguous errors.
 	if err := ctx.Err(); err != nil {
 		log.VEventf(ctx, 2, "%s before proposing: %s", err, ba.Summary())
-		return nil, g, roachpb.NewError(errors.Wrap(err, "aborted before proposing"))
+		return nil, g, roachpb.NewError(errors.Wrapf(err, "aborted before proposing"))
 	}
 
 	// If the command is proposed to Raft, ownership of and responsibility for
 	// the concurrency guard will be assumed by Raft, so provide the guard to
 	// evalAndPropose.
-	ch, abandon, maxLeaseIndex, pErr := r.evalAndPropose(ctx, ba, g, &st.Lease, localUncertaintyLimit)
+	ch, abandon, maxLeaseIndex, pErr := r.evalAndPropose(ctx, ba, g, st, localUncertaintyLimit)
 	if pErr != nil {
 		if maxLeaseIndex != 0 {
 			log.Fatalf(

--- a/pkg/roachpb/api.pb.go
+++ b/pkg/roachpb/api.pb.go
@@ -74,7 +74,7 @@ func (x ReadConsistencyType) String() string {
 	return proto.EnumName(ReadConsistencyType_name, int32(x))
 }
 func (ReadConsistencyType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{0}
+	return fileDescriptor_api_30e97dda177d9566, []int{0}
 }
 
 // ScanFormat is an enumeration of the available response formats for MVCCScan
@@ -102,7 +102,7 @@ func (x ScanFormat) String() string {
 	return proto.EnumName(ScanFormat_name, int32(x))
 }
 func (ScanFormat) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{1}
+	return fileDescriptor_api_30e97dda177d9566, []int{1}
 }
 
 type ChecksumMode int32
@@ -149,7 +149,7 @@ func (x ChecksumMode) String() string {
 	return proto.EnumName(ChecksumMode_name, int32(x))
 }
 func (ChecksumMode) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{2}
+	return fileDescriptor_api_30e97dda177d9566, []int{2}
 }
 
 // PushTxnType determines what action to take when pushing a transaction.
@@ -180,7 +180,7 @@ func (x PushTxnType) String() string {
 	return proto.EnumName(PushTxnType_name, int32(x))
 }
 func (PushTxnType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{3}
+	return fileDescriptor_api_30e97dda177d9566, []int{3}
 }
 
 type ExternalStorageProvider int32
@@ -221,7 +221,7 @@ func (x ExternalStorageProvider) String() string {
 	return proto.EnumName(ExternalStorageProvider_name, int32(x))
 }
 func (ExternalStorageProvider) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{4}
+	return fileDescriptor_api_30e97dda177d9566, []int{4}
 }
 
 type MVCCFilter int32
@@ -244,7 +244,7 @@ func (x MVCCFilter) String() string {
 	return proto.EnumName(MVCCFilter_name, int32(x))
 }
 func (MVCCFilter) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{5}
+	return fileDescriptor_api_30e97dda177d9566, []int{5}
 }
 
 type ResponseHeader_ResumeReason int32
@@ -270,7 +270,7 @@ func (x ResponseHeader_ResumeReason) String() string {
 	return proto.EnumName(ResponseHeader_ResumeReason_name, int32(x))
 }
 func (ResponseHeader_ResumeReason) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{1, 0}
+	return fileDescriptor_api_30e97dda177d9566, []int{1, 0}
 }
 
 type CheckConsistencyResponse_Status int32
@@ -312,7 +312,7 @@ func (x CheckConsistencyResponse_Status) String() string {
 	return proto.EnumName(CheckConsistencyResponse_Status_name, int32(x))
 }
 func (CheckConsistencyResponse_Status) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{25, 0}
+	return fileDescriptor_api_30e97dda177d9566, []int{25, 0}
 }
 
 // RequestHeader is supplied with every storage node request.
@@ -333,7 +333,7 @@ func (m *RequestHeader) Reset()         { *m = RequestHeader{} }
 func (m *RequestHeader) String() string { return proto.CompactTextString(m) }
 func (*RequestHeader) ProtoMessage()    {}
 func (*RequestHeader) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{0}
+	return fileDescriptor_api_30e97dda177d9566, []int{0}
 }
 func (m *RequestHeader) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -399,7 +399,7 @@ func (m *ResponseHeader) Reset()         { *m = ResponseHeader{} }
 func (m *ResponseHeader) String() string { return proto.CompactTextString(m) }
 func (*ResponseHeader) ProtoMessage()    {}
 func (*ResponseHeader) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{1}
+	return fileDescriptor_api_30e97dda177d9566, []int{1}
 }
 func (m *ResponseHeader) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -439,7 +439,7 @@ func (m *GetRequest) Reset()         { *m = GetRequest{} }
 func (m *GetRequest) String() string { return proto.CompactTextString(m) }
 func (*GetRequest) ProtoMessage()    {}
 func (*GetRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{2}
+	return fileDescriptor_api_30e97dda177d9566, []int{2}
 }
 func (m *GetRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -482,7 +482,7 @@ func (m *GetResponse) Reset()         { *m = GetResponse{} }
 func (m *GetResponse) String() string { return proto.CompactTextString(m) }
 func (*GetResponse) ProtoMessage()    {}
 func (*GetResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{3}
+	return fileDescriptor_api_30e97dda177d9566, []int{3}
 }
 func (m *GetResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -525,7 +525,7 @@ func (m *PutRequest) Reset()         { *m = PutRequest{} }
 func (m *PutRequest) String() string { return proto.CompactTextString(m) }
 func (*PutRequest) ProtoMessage()    {}
 func (*PutRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{4}
+	return fileDescriptor_api_30e97dda177d9566, []int{4}
 }
 func (m *PutRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -559,7 +559,7 @@ func (m *PutResponse) Reset()         { *m = PutResponse{} }
 func (m *PutResponse) String() string { return proto.CompactTextString(m) }
 func (*PutResponse) ProtoMessage()    {}
 func (*PutResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{5}
+	return fileDescriptor_api_30e97dda177d9566, []int{5}
 }
 func (m *PutResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -648,7 +648,7 @@ func (m *ConditionalPutRequest) Reset()         { *m = ConditionalPutRequest{} }
 func (m *ConditionalPutRequest) String() string { return proto.CompactTextString(m) }
 func (*ConditionalPutRequest) ProtoMessage()    {}
 func (*ConditionalPutRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{6}
+	return fileDescriptor_api_30e97dda177d9566, []int{6}
 }
 func (m *ConditionalPutRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -683,7 +683,7 @@ func (m *ConditionalPutResponse) Reset()         { *m = ConditionalPutResponse{}
 func (m *ConditionalPutResponse) String() string { return proto.CompactTextString(m) }
 func (*ConditionalPutResponse) ProtoMessage()    {}
 func (*ConditionalPutResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{7}
+	return fileDescriptor_api_30e97dda177d9566, []int{7}
 }
 func (m *ConditionalPutResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -729,7 +729,7 @@ func (m *InitPutRequest) Reset()         { *m = InitPutRequest{} }
 func (m *InitPutRequest) String() string { return proto.CompactTextString(m) }
 func (*InitPutRequest) ProtoMessage()    {}
 func (*InitPutRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{8}
+	return fileDescriptor_api_30e97dda177d9566, []int{8}
 }
 func (m *InitPutRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -763,7 +763,7 @@ func (m *InitPutResponse) Reset()         { *m = InitPutResponse{} }
 func (m *InitPutResponse) String() string { return proto.CompactTextString(m) }
 func (*InitPutResponse) ProtoMessage()    {}
 func (*InitPutResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{9}
+	return fileDescriptor_api_30e97dda177d9566, []int{9}
 }
 func (m *InitPutResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -803,7 +803,7 @@ func (m *IncrementRequest) Reset()         { *m = IncrementRequest{} }
 func (m *IncrementRequest) String() string { return proto.CompactTextString(m) }
 func (*IncrementRequest) ProtoMessage()    {}
 func (*IncrementRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{10}
+	return fileDescriptor_api_30e97dda177d9566, []int{10}
 }
 func (m *IncrementRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -840,7 +840,7 @@ func (m *IncrementResponse) Reset()         { *m = IncrementResponse{} }
 func (m *IncrementResponse) String() string { return proto.CompactTextString(m) }
 func (*IncrementResponse) ProtoMessage()    {}
 func (*IncrementResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{11}
+	return fileDescriptor_api_30e97dda177d9566, []int{11}
 }
 func (m *IncrementResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -874,7 +874,7 @@ func (m *DeleteRequest) Reset()         { *m = DeleteRequest{} }
 func (m *DeleteRequest) String() string { return proto.CompactTextString(m) }
 func (*DeleteRequest) ProtoMessage()    {}
 func (*DeleteRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{12}
+	return fileDescriptor_api_30e97dda177d9566, []int{12}
 }
 func (m *DeleteRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -908,7 +908,7 @@ func (m *DeleteResponse) Reset()         { *m = DeleteResponse{} }
 func (m *DeleteResponse) String() string { return proto.CompactTextString(m) }
 func (*DeleteResponse) ProtoMessage()    {}
 func (*DeleteResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{13}
+	return fileDescriptor_api_30e97dda177d9566, []int{13}
 }
 func (m *DeleteResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -960,7 +960,7 @@ func (m *DeleteRangeRequest) Reset()         { *m = DeleteRangeRequest{} }
 func (m *DeleteRangeRequest) String() string { return proto.CompactTextString(m) }
 func (*DeleteRangeRequest) ProtoMessage()    {}
 func (*DeleteRangeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{14}
+	return fileDescriptor_api_30e97dda177d9566, []int{14}
 }
 func (m *DeleteRangeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -997,7 +997,7 @@ func (m *DeleteRangeResponse) Reset()         { *m = DeleteRangeResponse{} }
 func (m *DeleteRangeResponse) String() string { return proto.CompactTextString(m) }
 func (*DeleteRangeResponse) ProtoMessage()    {}
 func (*DeleteRangeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{15}
+	return fileDescriptor_api_30e97dda177d9566, []int{15}
 }
 func (m *DeleteRangeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1052,7 +1052,7 @@ func (m *ClearRangeRequest) Reset()         { *m = ClearRangeRequest{} }
 func (m *ClearRangeRequest) String() string { return proto.CompactTextString(m) }
 func (*ClearRangeRequest) ProtoMessage()    {}
 func (*ClearRangeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{16}
+	return fileDescriptor_api_30e97dda177d9566, []int{16}
 }
 func (m *ClearRangeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1086,7 +1086,7 @@ func (m *ClearRangeResponse) Reset()         { *m = ClearRangeResponse{} }
 func (m *ClearRangeResponse) String() string { return proto.CompactTextString(m) }
 func (*ClearRangeResponse) ProtoMessage()    {}
 func (*ClearRangeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{17}
+	return fileDescriptor_api_30e97dda177d9566, []int{17}
 }
 func (m *ClearRangeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1128,7 +1128,7 @@ func (m *RevertRangeRequest) Reset()         { *m = RevertRangeRequest{} }
 func (m *RevertRangeRequest) String() string { return proto.CompactTextString(m) }
 func (*RevertRangeRequest) ProtoMessage()    {}
 func (*RevertRangeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{18}
+	return fileDescriptor_api_30e97dda177d9566, []int{18}
 }
 func (m *RevertRangeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1162,7 +1162,7 @@ func (m *RevertRangeResponse) Reset()         { *m = RevertRangeResponse{} }
 func (m *RevertRangeResponse) String() string { return proto.CompactTextString(m) }
 func (*RevertRangeResponse) ProtoMessage()    {}
 func (*RevertRangeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{19}
+	return fileDescriptor_api_30e97dda177d9566, []int{19}
 }
 func (m *RevertRangeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1213,7 +1213,7 @@ func (m *ScanRequest) Reset()         { *m = ScanRequest{} }
 func (m *ScanRequest) String() string { return proto.CompactTextString(m) }
 func (*ScanRequest) ProtoMessage()    {}
 func (*ScanRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{20}
+	return fileDescriptor_api_30e97dda177d9566, []int{20}
 }
 func (m *ScanRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1265,7 +1265,7 @@ func (m *ScanResponse) Reset()         { *m = ScanResponse{} }
 func (m *ScanResponse) String() string { return proto.CompactTextString(m) }
 func (*ScanResponse) ProtoMessage()    {}
 func (*ScanResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{21}
+	return fileDescriptor_api_30e97dda177d9566, []int{21}
 }
 func (m *ScanResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1316,7 +1316,7 @@ func (m *ReverseScanRequest) Reset()         { *m = ReverseScanRequest{} }
 func (m *ReverseScanRequest) String() string { return proto.CompactTextString(m) }
 func (*ReverseScanRequest) ProtoMessage()    {}
 func (*ReverseScanRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{22}
+	return fileDescriptor_api_30e97dda177d9566, []int{22}
 }
 func (m *ReverseScanRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1368,7 +1368,7 @@ func (m *ReverseScanResponse) Reset()         { *m = ReverseScanResponse{} }
 func (m *ReverseScanResponse) String() string { return proto.CompactTextString(m) }
 func (*ReverseScanResponse) ProtoMessage()    {}
 func (*ReverseScanResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{23}
+	return fileDescriptor_api_30e97dda177d9566, []int{23}
 }
 func (m *ReverseScanResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1421,7 +1421,7 @@ func (m *CheckConsistencyRequest) Reset()         { *m = CheckConsistencyRequest
 func (m *CheckConsistencyRequest) String() string { return proto.CompactTextString(m) }
 func (*CheckConsistencyRequest) ProtoMessage()    {}
 func (*CheckConsistencyRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{24}
+	return fileDescriptor_api_30e97dda177d9566, []int{24}
 }
 func (m *CheckConsistencyRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1458,7 +1458,7 @@ func (m *CheckConsistencyResponse) Reset()         { *m = CheckConsistencyRespon
 func (m *CheckConsistencyResponse) String() string { return proto.CompactTextString(m) }
 func (*CheckConsistencyResponse) ProtoMessage()    {}
 func (*CheckConsistencyResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{25}
+	return fileDescriptor_api_30e97dda177d9566, []int{25}
 }
 func (m *CheckConsistencyResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1502,7 +1502,7 @@ func (m *CheckConsistencyResponse_Result) Reset()         { *m = CheckConsistenc
 func (m *CheckConsistencyResponse_Result) String() string { return proto.CompactTextString(m) }
 func (*CheckConsistencyResponse_Result) ProtoMessage()    {}
 func (*CheckConsistencyResponse_Result) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{25, 0}
+	return fileDescriptor_api_30e97dda177d9566, []int{25, 0}
 }
 func (m *CheckConsistencyResponse_Result) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1550,7 +1550,7 @@ func (m *RecomputeStatsRequest) Reset()         { *m = RecomputeStatsRequest{} }
 func (m *RecomputeStatsRequest) String() string { return proto.CompactTextString(m) }
 func (*RecomputeStatsRequest) ProtoMessage()    {}
 func (*RecomputeStatsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{26}
+	return fileDescriptor_api_30e97dda177d9566, []int{26}
 }
 func (m *RecomputeStatsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1586,7 +1586,7 @@ func (m *RecomputeStatsResponse) Reset()         { *m = RecomputeStatsResponse{}
 func (m *RecomputeStatsResponse) String() string { return proto.CompactTextString(m) }
 func (*RecomputeStatsResponse) ProtoMessage()    {}
 func (*RecomputeStatsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{27}
+	return fileDescriptor_api_30e97dda177d9566, []int{27}
 }
 func (m *RecomputeStatsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1697,7 +1697,7 @@ func (m *EndTxnRequest) Reset()         { *m = EndTxnRequest{} }
 func (m *EndTxnRequest) String() string { return proto.CompactTextString(m) }
 func (*EndTxnRequest) ProtoMessage()    {}
 func (*EndTxnRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{28}
+	return fileDescriptor_api_30e97dda177d9566, []int{28}
 }
 func (m *EndTxnRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1743,7 +1743,7 @@ func (m *EndTxnResponse) Reset()         { *m = EndTxnResponse{} }
 func (m *EndTxnResponse) String() string { return proto.CompactTextString(m) }
 func (*EndTxnResponse) ProtoMessage()    {}
 func (*EndTxnResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{29}
+	return fileDescriptor_api_30e97dda177d9566, []int{29}
 }
 func (m *EndTxnResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1804,7 +1804,7 @@ func (m *AdminSplitRequest) Reset()         { *m = AdminSplitRequest{} }
 func (m *AdminSplitRequest) String() string { return proto.CompactTextString(m) }
 func (*AdminSplitRequest) ProtoMessage()    {}
 func (*AdminSplitRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{30}
+	return fileDescriptor_api_30e97dda177d9566, []int{30}
 }
 func (m *AdminSplitRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1839,7 +1839,7 @@ func (m *AdminSplitResponse) Reset()         { *m = AdminSplitResponse{} }
 func (m *AdminSplitResponse) String() string { return proto.CompactTextString(m) }
 func (*AdminSplitResponse) ProtoMessage()    {}
 func (*AdminSplitResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{31}
+	return fileDescriptor_api_30e97dda177d9566, []int{31}
 }
 func (m *AdminSplitResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1878,7 +1878,7 @@ func (m *AdminUnsplitRequest) Reset()         { *m = AdminUnsplitRequest{} }
 func (m *AdminUnsplitRequest) String() string { return proto.CompactTextString(m) }
 func (*AdminUnsplitRequest) ProtoMessage()    {}
 func (*AdminUnsplitRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{32}
+	return fileDescriptor_api_30e97dda177d9566, []int{32}
 }
 func (m *AdminUnsplitRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1913,7 +1913,7 @@ func (m *AdminUnsplitResponse) Reset()         { *m = AdminUnsplitResponse{} }
 func (m *AdminUnsplitResponse) String() string { return proto.CompactTextString(m) }
 func (*AdminUnsplitResponse) ProtoMessage()    {}
 func (*AdminUnsplitResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{33}
+	return fileDescriptor_api_30e97dda177d9566, []int{33}
 }
 func (m *AdminUnsplitResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1956,7 +1956,7 @@ func (m *AdminMergeRequest) Reset()         { *m = AdminMergeRequest{} }
 func (m *AdminMergeRequest) String() string { return proto.CompactTextString(m) }
 func (*AdminMergeRequest) ProtoMessage()    {}
 func (*AdminMergeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{34}
+	return fileDescriptor_api_30e97dda177d9566, []int{34}
 }
 func (m *AdminMergeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1991,7 +1991,7 @@ func (m *AdminMergeResponse) Reset()         { *m = AdminMergeResponse{} }
 func (m *AdminMergeResponse) String() string { return proto.CompactTextString(m) }
 func (*AdminMergeResponse) ProtoMessage()    {}
 func (*AdminMergeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{35}
+	return fileDescriptor_api_30e97dda177d9566, []int{35}
 }
 func (m *AdminMergeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2029,7 +2029,7 @@ func (m *AdminTransferLeaseRequest) Reset()         { *m = AdminTransferLeaseReq
 func (m *AdminTransferLeaseRequest) String() string { return proto.CompactTextString(m) }
 func (*AdminTransferLeaseRequest) ProtoMessage()    {}
 func (*AdminTransferLeaseRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{36}
+	return fileDescriptor_api_30e97dda177d9566, []int{36}
 }
 func (m *AdminTransferLeaseRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2062,7 +2062,7 @@ func (m *AdminTransferLeaseResponse) Reset()         { *m = AdminTransferLeaseRe
 func (m *AdminTransferLeaseResponse) String() string { return proto.CompactTextString(m) }
 func (*AdminTransferLeaseResponse) ProtoMessage()    {}
 func (*AdminTransferLeaseResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{37}
+	return fileDescriptor_api_30e97dda177d9566, []int{37}
 }
 func (m *AdminTransferLeaseResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2097,7 +2097,7 @@ func (m *ReplicationChange) Reset()         { *m = ReplicationChange{} }
 func (m *ReplicationChange) String() string { return proto.CompactTextString(m) }
 func (*ReplicationChange) ProtoMessage()    {}
 func (*ReplicationChange) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{38}
+	return fileDescriptor_api_30e97dda177d9566, []int{38}
 }
 func (m *ReplicationChange) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2155,7 +2155,7 @@ func (m *AdminChangeReplicasRequest) Reset()         { *m = AdminChangeReplicasR
 func (m *AdminChangeReplicasRequest) String() string { return proto.CompactTextString(m) }
 func (*AdminChangeReplicasRequest) ProtoMessage()    {}
 func (*AdminChangeReplicasRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{39}
+	return fileDescriptor_api_30e97dda177d9566, []int{39}
 }
 func (m *AdminChangeReplicasRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2190,7 +2190,7 @@ func (m *AdminChangeReplicasResponse) Reset()         { *m = AdminChangeReplicas
 func (m *AdminChangeReplicasResponse) String() string { return proto.CompactTextString(m) }
 func (*AdminChangeReplicasResponse) ProtoMessage()    {}
 func (*AdminChangeReplicasResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{40}
+	return fileDescriptor_api_30e97dda177d9566, []int{40}
 }
 func (m *AdminChangeReplicasResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2228,7 +2228,7 @@ func (m *AdminRelocateRangeRequest) Reset()         { *m = AdminRelocateRangeReq
 func (m *AdminRelocateRangeRequest) String() string { return proto.CompactTextString(m) }
 func (*AdminRelocateRangeRequest) ProtoMessage()    {}
 func (*AdminRelocateRangeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{41}
+	return fileDescriptor_api_30e97dda177d9566, []int{41}
 }
 func (m *AdminRelocateRangeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2261,7 +2261,7 @@ func (m *AdminRelocateRangeResponse) Reset()         { *m = AdminRelocateRangeRe
 func (m *AdminRelocateRangeResponse) String() string { return proto.CompactTextString(m) }
 func (*AdminRelocateRangeResponse) ProtoMessage()    {}
 func (*AdminRelocateRangeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{42}
+	return fileDescriptor_api_30e97dda177d9566, []int{42}
 }
 func (m *AdminRelocateRangeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2303,7 +2303,7 @@ func (m *HeartbeatTxnRequest) Reset()         { *m = HeartbeatTxnRequest{} }
 func (m *HeartbeatTxnRequest) String() string { return proto.CompactTextString(m) }
 func (*HeartbeatTxnRequest) ProtoMessage()    {}
 func (*HeartbeatTxnRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{43}
+	return fileDescriptor_api_30e97dda177d9566, []int{43}
 }
 func (m *HeartbeatTxnRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2340,7 +2340,7 @@ func (m *HeartbeatTxnResponse) Reset()         { *m = HeartbeatTxnResponse{} }
 func (m *HeartbeatTxnResponse) String() string { return proto.CompactTextString(m) }
 func (*HeartbeatTxnResponse) ProtoMessage()    {}
 func (*HeartbeatTxnResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{44}
+	return fileDescriptor_api_30e97dda177d9566, []int{44}
 }
 func (m *HeartbeatTxnResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2378,7 +2378,7 @@ func (m *GCRequest) Reset()         { *m = GCRequest{} }
 func (m *GCRequest) String() string { return proto.CompactTextString(m) }
 func (*GCRequest) ProtoMessage()    {}
 func (*GCRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{45}
+	return fileDescriptor_api_30e97dda177d9566, []int{45}
 }
 func (m *GCRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2412,7 +2412,7 @@ func (m *GCRequest_GCKey) Reset()         { *m = GCRequest_GCKey{} }
 func (m *GCRequest_GCKey) String() string { return proto.CompactTextString(m) }
 func (*GCRequest_GCKey) ProtoMessage()    {}
 func (*GCRequest_GCKey) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{45, 0}
+	return fileDescriptor_api_30e97dda177d9566, []int{45, 0}
 }
 func (m *GCRequest_GCKey) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2446,7 +2446,7 @@ func (m *GCResponse) Reset()         { *m = GCResponse{} }
 func (m *GCResponse) String() string { return proto.CompactTextString(m) }
 func (*GCResponse) ProtoMessage()    {}
 func (*GCResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{46}
+	return fileDescriptor_api_30e97dda177d9566, []int{46}
 }
 func (m *GCResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2515,7 +2515,7 @@ func (m *PushTxnRequest) Reset()         { *m = PushTxnRequest{} }
 func (m *PushTxnRequest) String() string { return proto.CompactTextString(m) }
 func (*PushTxnRequest) ProtoMessage()    {}
 func (*PushTxnRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{47}
+	return fileDescriptor_api_30e97dda177d9566, []int{47}
 }
 func (m *PushTxnRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2558,7 +2558,7 @@ func (m *PushTxnResponse) Reset()         { *m = PushTxnResponse{} }
 func (m *PushTxnResponse) String() string { return proto.CompactTextString(m) }
 func (*PushTxnResponse) ProtoMessage()    {}
 func (*PushTxnResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{48}
+	return fileDescriptor_api_30e97dda177d9566, []int{48}
 }
 func (m *PushTxnResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2605,7 +2605,7 @@ func (m *RecoverTxnRequest) Reset()         { *m = RecoverTxnRequest{} }
 func (m *RecoverTxnRequest) String() string { return proto.CompactTextString(m) }
 func (*RecoverTxnRequest) ProtoMessage()    {}
 func (*RecoverTxnRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{49}
+	return fileDescriptor_api_30e97dda177d9566, []int{49}
 }
 func (m *RecoverTxnRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2641,7 +2641,7 @@ func (m *RecoverTxnResponse) Reset()         { *m = RecoverTxnResponse{} }
 func (m *RecoverTxnResponse) String() string { return proto.CompactTextString(m) }
 func (*RecoverTxnResponse) ProtoMessage()    {}
 func (*RecoverTxnResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{50}
+	return fileDescriptor_api_30e97dda177d9566, []int{50}
 }
 func (m *RecoverTxnResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2685,7 +2685,7 @@ func (m *QueryTxnRequest) Reset()         { *m = QueryTxnRequest{} }
 func (m *QueryTxnRequest) String() string { return proto.CompactTextString(m) }
 func (*QueryTxnRequest) ProtoMessage()    {}
 func (*QueryTxnRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{51}
+	return fileDescriptor_api_30e97dda177d9566, []int{51}
 }
 func (m *QueryTxnRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2729,7 +2729,7 @@ func (m *QueryTxnResponse) Reset()         { *m = QueryTxnResponse{} }
 func (m *QueryTxnResponse) String() string { return proto.CompactTextString(m) }
 func (*QueryTxnResponse) ProtoMessage()    {}
 func (*QueryTxnResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{52}
+	return fileDescriptor_api_30e97dda177d9566, []int{52}
 }
 func (m *QueryTxnResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2764,11 +2764,8 @@ type QueryIntentRequest struct {
 	// intent is a match or not is defined as whether an intent exists that could
 	// be committed by the provided transaction. If an intent is found at the
 	// specified key, the intent is only considered a match if it has the same ID,
-	// the same epoch, and a provisional commit timestamp that is equal to or less
-	// than that in the provided transaction. The TxnMeta's provisional commit
-	// timestamp is forwarded by the provisional commit timestamp of the request
-	// header transaction if the transactions are the same (i.e. a transaction is
-	// querying its own intent after successfully having refreshed).
+	// the same epoch, and a write timestamp that is equal to or less than that in
+	// the provided transaction.
 	//
 	// Additionally, the intent is only considered a match if its sequence number
 	// is equal to or greater than the expected txn's sequence number. The
@@ -2778,6 +2775,17 @@ type QueryIntentRequest struct {
 	// successfully written an intent at a larger sequence number then it must
 	// have succeeeded in writing an intent at the smaller sequence number as
 	// well.
+	//
+	// QueryIntentRequests may be issued in non-transactional BatchRequests or in
+	// transactional BatchRequests. If issued inside of a transaction, the TxnMeta
+	// must be a reference to the same transaction as the batch's transaction, or
+	// the request will be rejected. In other words, a transaction can only query
+	// its own intents. In these cases where the BatchRequest is transactional,
+	// the TxnMeta's write timestamp is forwarded by the write timestamp of the
+	// request header transaction for purposes of determining whether a matching
+	// intent is found or not (see condition above). This is useful to avoid the
+	// need to update each QueryIntentRequest when a transaction is querying its
+	// own intent after having successfully refreshed.
 	Txn enginepb.TxnMeta `protobuf:"bytes,2,opt,name=txn,proto3" json:"txn"`
 	// If true, return an IntentMissingError if a matching intent is not found.
 	// Special-cased to return a SERIALIZABLE retry error if a SERIALIZABLE
@@ -2789,7 +2797,7 @@ func (m *QueryIntentRequest) Reset()         { *m = QueryIntentRequest{} }
 func (m *QueryIntentRequest) String() string { return proto.CompactTextString(m) }
 func (*QueryIntentRequest) ProtoMessage()    {}
 func (*QueryIntentRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{53}
+	return fileDescriptor_api_30e97dda177d9566, []int{53}
 }
 func (m *QueryIntentRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2825,7 +2833,7 @@ func (m *QueryIntentResponse) Reset()         { *m = QueryIntentResponse{} }
 func (m *QueryIntentResponse) String() string { return proto.CompactTextString(m) }
 func (*QueryIntentResponse) ProtoMessage()    {}
 func (*QueryIntentResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{54}
+	return fileDescriptor_api_30e97dda177d9566, []int{54}
 }
 func (m *QueryIntentResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2872,7 +2880,7 @@ func (m *ResolveIntentRequest) Reset()         { *m = ResolveIntentRequest{} }
 func (m *ResolveIntentRequest) String() string { return proto.CompactTextString(m) }
 func (*ResolveIntentRequest) ProtoMessage()    {}
 func (*ResolveIntentRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{55}
+	return fileDescriptor_api_30e97dda177d9566, []int{55}
 }
 func (m *ResolveIntentRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2907,7 +2915,7 @@ func (m *ResolveIntentResponse) Reset()         { *m = ResolveIntentResponse{} }
 func (m *ResolveIntentResponse) String() string { return proto.CompactTextString(m) }
 func (*ResolveIntentResponse) ProtoMessage()    {}
 func (*ResolveIntentResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{56}
+	return fileDescriptor_api_30e97dda177d9566, []int{56}
 }
 func (m *ResolveIntentResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2958,7 +2966,7 @@ func (m *ResolveIntentRangeRequest) Reset()         { *m = ResolveIntentRangeReq
 func (m *ResolveIntentRangeRequest) String() string { return proto.CompactTextString(m) }
 func (*ResolveIntentRangeRequest) ProtoMessage()    {}
 func (*ResolveIntentRangeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{57}
+	return fileDescriptor_api_30e97dda177d9566, []int{57}
 }
 func (m *ResolveIntentRangeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2993,7 +3001,7 @@ func (m *ResolveIntentRangeResponse) Reset()         { *m = ResolveIntentRangeRe
 func (m *ResolveIntentRangeResponse) String() string { return proto.CompactTextString(m) }
 func (*ResolveIntentRangeResponse) ProtoMessage()    {}
 func (*ResolveIntentRangeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{58}
+	return fileDescriptor_api_30e97dda177d9566, []int{58}
 }
 func (m *ResolveIntentRangeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3030,7 +3038,7 @@ func (m *MergeRequest) Reset()         { *m = MergeRequest{} }
 func (m *MergeRequest) String() string { return proto.CompactTextString(m) }
 func (*MergeRequest) ProtoMessage()    {}
 func (*MergeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{59}
+	return fileDescriptor_api_30e97dda177d9566, []int{59}
 }
 func (m *MergeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3064,7 +3072,7 @@ func (m *MergeResponse) Reset()         { *m = MergeResponse{} }
 func (m *MergeResponse) String() string { return proto.CompactTextString(m) }
 func (*MergeResponse) ProtoMessage()    {}
 func (*MergeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{60}
+	return fileDescriptor_api_30e97dda177d9566, []int{60}
 }
 func (m *MergeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3109,7 +3117,7 @@ func (m *TruncateLogRequest) Reset()         { *m = TruncateLogRequest{} }
 func (m *TruncateLogRequest) String() string { return proto.CompactTextString(m) }
 func (*TruncateLogRequest) ProtoMessage()    {}
 func (*TruncateLogRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{61}
+	return fileDescriptor_api_30e97dda177d9566, []int{61}
 }
 func (m *TruncateLogRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3143,7 +3151,7 @@ func (m *TruncateLogResponse) Reset()         { *m = TruncateLogResponse{} }
 func (m *TruncateLogResponse) String() string { return proto.CompactTextString(m) }
 func (*TruncateLogResponse) ProtoMessage()    {}
 func (*TruncateLogResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{62}
+	return fileDescriptor_api_30e97dda177d9566, []int{62}
 }
 func (m *TruncateLogResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3187,7 +3195,7 @@ func (m *RequestLeaseRequest) Reset()         { *m = RequestLeaseRequest{} }
 func (m *RequestLeaseRequest) String() string { return proto.CompactTextString(m) }
 func (*RequestLeaseRequest) ProtoMessage()    {}
 func (*RequestLeaseRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{63}
+	return fileDescriptor_api_30e97dda177d9566, []int{63}
 }
 func (m *RequestLeaseRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3236,7 +3244,7 @@ func (m *TransferLeaseRequest) Reset()         { *m = TransferLeaseRequest{} }
 func (m *TransferLeaseRequest) String() string { return proto.CompactTextString(m) }
 func (*TransferLeaseRequest) ProtoMessage()    {}
 func (*TransferLeaseRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{64}
+	return fileDescriptor_api_30e97dda177d9566, []int{64}
 }
 func (m *TransferLeaseRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3273,7 +3281,7 @@ func (m *LeaseInfoRequest) Reset()         { *m = LeaseInfoRequest{} }
 func (m *LeaseInfoRequest) String() string { return proto.CompactTextString(m) }
 func (*LeaseInfoRequest) ProtoMessage()    {}
 func (*LeaseInfoRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{65}
+	return fileDescriptor_api_30e97dda177d9566, []int{65}
 }
 func (m *LeaseInfoRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3310,7 +3318,7 @@ func (m *LeaseInfoResponse) Reset()         { *m = LeaseInfoResponse{} }
 func (m *LeaseInfoResponse) String() string { return proto.CompactTextString(m) }
 func (*LeaseInfoResponse) ProtoMessage()    {}
 func (*LeaseInfoResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{66}
+	return fileDescriptor_api_30e97dda177d9566, []int{66}
 }
 func (m *LeaseInfoResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3345,7 +3353,7 @@ func (m *RequestLeaseResponse) Reset()         { *m = RequestLeaseResponse{} }
 func (m *RequestLeaseResponse) String() string { return proto.CompactTextString(m) }
 func (*RequestLeaseResponse) ProtoMessage()    {}
 func (*RequestLeaseResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{67}
+	return fileDescriptor_api_30e97dda177d9566, []int{67}
 }
 func (m *RequestLeaseResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3400,7 +3408,7 @@ func (m *ComputeChecksumRequest) Reset()         { *m = ComputeChecksumRequest{}
 func (m *ComputeChecksumRequest) String() string { return proto.CompactTextString(m) }
 func (*ComputeChecksumRequest) ProtoMessage()    {}
 func (*ComputeChecksumRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{68}
+	return fileDescriptor_api_30e97dda177d9566, []int{68}
 }
 func (m *ComputeChecksumRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3437,7 +3445,7 @@ func (m *ComputeChecksumResponse) Reset()         { *m = ComputeChecksumResponse
 func (m *ComputeChecksumResponse) String() string { return proto.CompactTextString(m) }
 func (*ComputeChecksumResponse) ProtoMessage()    {}
 func (*ComputeChecksumResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{69}
+	return fileDescriptor_api_30e97dda177d9566, []int{69}
 }
 func (m *ComputeChecksumResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3477,7 +3485,7 @@ func (m *ExternalStorage) Reset()         { *m = ExternalStorage{} }
 func (m *ExternalStorage) String() string { return proto.CompactTextString(m) }
 func (*ExternalStorage) ProtoMessage()    {}
 func (*ExternalStorage) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{70}
+	return fileDescriptor_api_30e97dda177d9566, []int{70}
 }
 func (m *ExternalStorage) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3511,7 +3519,7 @@ func (m *ExternalStorage_LocalFilePath) Reset()         { *m = ExternalStorage_L
 func (m *ExternalStorage_LocalFilePath) String() string { return proto.CompactTextString(m) }
 func (*ExternalStorage_LocalFilePath) ProtoMessage()    {}
 func (*ExternalStorage_LocalFilePath) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{70, 0}
+	return fileDescriptor_api_30e97dda177d9566, []int{70, 0}
 }
 func (m *ExternalStorage_LocalFilePath) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3544,7 +3552,7 @@ func (m *ExternalStorage_Http) Reset()         { *m = ExternalStorage_Http{} }
 func (m *ExternalStorage_Http) String() string { return proto.CompactTextString(m) }
 func (*ExternalStorage_Http) ProtoMessage()    {}
 func (*ExternalStorage_Http) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{70, 1}
+	return fileDescriptor_api_30e97dda177d9566, []int{70, 1}
 }
 func (m *ExternalStorage_Http) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3586,7 +3594,7 @@ func (m *ExternalStorage_S3) Reset()         { *m = ExternalStorage_S3{} }
 func (m *ExternalStorage_S3) String() string { return proto.CompactTextString(m) }
 func (*ExternalStorage_S3) ProtoMessage()    {}
 func (*ExternalStorage_S3) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{70, 2}
+	return fileDescriptor_api_30e97dda177d9566, []int{70, 2}
 }
 func (m *ExternalStorage_S3) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3625,7 +3633,7 @@ func (m *ExternalStorage_GCS) Reset()         { *m = ExternalStorage_GCS{} }
 func (m *ExternalStorage_GCS) String() string { return proto.CompactTextString(m) }
 func (*ExternalStorage_GCS) ProtoMessage()    {}
 func (*ExternalStorage_GCS) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{70, 3}
+	return fileDescriptor_api_30e97dda177d9566, []int{70, 3}
 }
 func (m *ExternalStorage_GCS) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3661,7 +3669,7 @@ func (m *ExternalStorage_Azure) Reset()         { *m = ExternalStorage_Azure{} }
 func (m *ExternalStorage_Azure) String() string { return proto.CompactTextString(m) }
 func (*ExternalStorage_Azure) ProtoMessage()    {}
 func (*ExternalStorage_Azure) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{70, 4}
+	return fileDescriptor_api_30e97dda177d9566, []int{70, 4}
 }
 func (m *ExternalStorage_Azure) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3700,7 +3708,7 @@ func (m *ExternalStorage_Workload) Reset()         { *m = ExternalStorage_Worklo
 func (m *ExternalStorage_Workload) String() string { return proto.CompactTextString(m) }
 func (*ExternalStorage_Workload) ProtoMessage()    {}
 func (*ExternalStorage_Workload) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{70, 5}
+	return fileDescriptor_api_30e97dda177d9566, []int{70, 5}
 }
 func (m *ExternalStorage_Workload) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3742,7 +3750,7 @@ func (m *ExternalStorage_FileTable) Reset()         { *m = ExternalStorage_FileT
 func (m *ExternalStorage_FileTable) String() string { return proto.CompactTextString(m) }
 func (*ExternalStorage_FileTable) ProtoMessage()    {}
 func (*ExternalStorage_FileTable) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{70, 6}
+	return fileDescriptor_api_30e97dda177d9566, []int{70, 6}
 }
 func (m *ExternalStorage_FileTable) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3782,7 +3790,7 @@ func (m *WriteBatchRequest) Reset()         { *m = WriteBatchRequest{} }
 func (m *WriteBatchRequest) String() string { return proto.CompactTextString(m) }
 func (*WriteBatchRequest) ProtoMessage()    {}
 func (*WriteBatchRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{71}
+	return fileDescriptor_api_30e97dda177d9566, []int{71}
 }
 func (m *WriteBatchRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3816,7 +3824,7 @@ func (m *WriteBatchResponse) Reset()         { *m = WriteBatchResponse{} }
 func (m *WriteBatchResponse) String() string { return proto.CompactTextString(m) }
 func (*WriteBatchResponse) ProtoMessage()    {}
 func (*WriteBatchResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{72}
+	return fileDescriptor_api_30e97dda177d9566, []int{72}
 }
 func (m *WriteBatchResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3852,7 +3860,7 @@ func (m *FileEncryptionOptions) Reset()         { *m = FileEncryptionOptions{} }
 func (m *FileEncryptionOptions) String() string { return proto.CompactTextString(m) }
 func (*FileEncryptionOptions) ProtoMessage()    {}
 func (*FileEncryptionOptions) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{73}
+	return fileDescriptor_api_30e97dda177d9566, []int{73}
 }
 func (m *FileEncryptionOptions) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3922,7 +3930,7 @@ func (m *ExportRequest) Reset()         { *m = ExportRequest{} }
 func (m *ExportRequest) String() string { return proto.CompactTextString(m) }
 func (*ExportRequest) ProtoMessage()    {}
 func (*ExportRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{74}
+	return fileDescriptor_api_30e97dda177d9566, []int{74}
 }
 func (m *ExportRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3974,7 +3982,7 @@ func (m *BulkOpSummary) Reset()         { *m = BulkOpSummary{} }
 func (m *BulkOpSummary) String() string { return proto.CompactTextString(m) }
 func (*BulkOpSummary) ProtoMessage()    {}
 func (*BulkOpSummary) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{75}
+	return fileDescriptor_api_30e97dda177d9566, []int{75}
 }
 func (m *BulkOpSummary) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4010,7 +4018,7 @@ func (m *ExportResponse) Reset()         { *m = ExportResponse{} }
 func (m *ExportResponse) String() string { return proto.CompactTextString(m) }
 func (*ExportResponse) ProtoMessage()    {}
 func (*ExportResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{76}
+	return fileDescriptor_api_30e97dda177d9566, []int{76}
 }
 func (m *ExportResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4050,7 +4058,7 @@ func (m *ExportResponse_File) Reset()         { *m = ExportResponse_File{} }
 func (m *ExportResponse_File) String() string { return proto.CompactTextString(m) }
 func (*ExportResponse_File) ProtoMessage()    {}
 func (*ExportResponse_File) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{76, 0}
+	return fileDescriptor_api_30e97dda177d9566, []int{76, 0}
 }
 func (m *ExportResponse_File) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4101,7 +4109,7 @@ func (m *ImportRequest) Reset()         { *m = ImportRequest{} }
 func (m *ImportRequest) String() string { return proto.CompactTextString(m) }
 func (*ImportRequest) ProtoMessage()    {}
 func (*ImportRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{77}
+	return fileDescriptor_api_30e97dda177d9566, []int{77}
 }
 func (m *ImportRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4136,7 +4144,7 @@ func (m *ImportRequest_File) Reset()         { *m = ImportRequest_File{} }
 func (m *ImportRequest_File) String() string { return proto.CompactTextString(m) }
 func (*ImportRequest_File) ProtoMessage()    {}
 func (*ImportRequest_File) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{77, 0}
+	return fileDescriptor_api_30e97dda177d9566, []int{77, 0}
 }
 func (m *ImportRequest_File) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4172,7 +4180,7 @@ func (m *ImportRequest_TableRekey) Reset()         { *m = ImportRequest_TableRek
 func (m *ImportRequest_TableRekey) String() string { return proto.CompactTextString(m) }
 func (*ImportRequest_TableRekey) ProtoMessage()    {}
 func (*ImportRequest_TableRekey) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{77, 1}
+	return fileDescriptor_api_30e97dda177d9566, []int{77, 1}
 }
 func (m *ImportRequest_TableRekey) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4207,7 +4215,7 @@ func (m *ImportResponse) Reset()         { *m = ImportResponse{} }
 func (m *ImportResponse) String() string { return proto.CompactTextString(m) }
 func (*ImportResponse) ProtoMessage()    {}
 func (*ImportResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{78}
+	return fileDescriptor_api_30e97dda177d9566, []int{78}
 }
 func (m *ImportResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4245,7 +4253,7 @@ func (m *AdminScatterRequest) Reset()         { *m = AdminScatterRequest{} }
 func (m *AdminScatterRequest) String() string { return proto.CompactTextString(m) }
 func (*AdminScatterRequest) ProtoMessage()    {}
 func (*AdminScatterRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{79}
+	return fileDescriptor_api_30e97dda177d9566, []int{79}
 }
 func (m *AdminScatterRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4282,7 +4290,7 @@ func (m *AdminScatterResponse) Reset()         { *m = AdminScatterResponse{} }
 func (m *AdminScatterResponse) String() string { return proto.CompactTextString(m) }
 func (*AdminScatterResponse) ProtoMessage()    {}
 func (*AdminScatterResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{80}
+	return fileDescriptor_api_30e97dda177d9566, []int{80}
 }
 func (m *AdminScatterResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4315,7 +4323,7 @@ func (m *AdminScatterResponse_Range) Reset()         { *m = AdminScatterResponse
 func (m *AdminScatterResponse_Range) String() string { return proto.CompactTextString(m) }
 func (*AdminScatterResponse_Range) ProtoMessage()    {}
 func (*AdminScatterResponse_Range) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{80, 0}
+	return fileDescriptor_api_30e97dda177d9566, []int{80, 0}
 }
 func (m *AdminScatterResponse_Range) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4360,7 +4368,7 @@ func (m *AdminVerifyProtectedTimestampRequest) Reset()         { *m = AdminVerif
 func (m *AdminVerifyProtectedTimestampRequest) String() string { return proto.CompactTextString(m) }
 func (*AdminVerifyProtectedTimestampRequest) ProtoMessage()    {}
 func (*AdminVerifyProtectedTimestampRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{81}
+	return fileDescriptor_api_30e97dda177d9566, []int{81}
 }
 func (m *AdminVerifyProtectedTimestampRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4398,7 +4406,7 @@ func (m *AdminVerifyProtectedTimestampResponse) Reset()         { *m = AdminVeri
 func (m *AdminVerifyProtectedTimestampResponse) String() string { return proto.CompactTextString(m) }
 func (*AdminVerifyProtectedTimestampResponse) ProtoMessage()    {}
 func (*AdminVerifyProtectedTimestampResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{82}
+	return fileDescriptor_api_30e97dda177d9566, []int{82}
 }
 func (m *AdminVerifyProtectedTimestampResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4451,7 +4459,7 @@ func (m *AddSSTableRequest) Reset()         { *m = AddSSTableRequest{} }
 func (m *AddSSTableRequest) String() string { return proto.CompactTextString(m) }
 func (*AddSSTableRequest) ProtoMessage()    {}
 func (*AddSSTableRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{83}
+	return fileDescriptor_api_30e97dda177d9566, []int{83}
 }
 func (m *AddSSTableRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4485,7 +4493,7 @@ func (m *AddSSTableResponse) Reset()         { *m = AddSSTableResponse{} }
 func (m *AddSSTableResponse) String() string { return proto.CompactTextString(m) }
 func (*AddSSTableResponse) ProtoMessage()    {}
 func (*AddSSTableResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{84}
+	return fileDescriptor_api_30e97dda177d9566, []int{84}
 }
 func (m *AddSSTableResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4529,7 +4537,7 @@ func (m *RefreshRequest) Reset()         { *m = RefreshRequest{} }
 func (m *RefreshRequest) String() string { return proto.CompactTextString(m) }
 func (*RefreshRequest) ProtoMessage()    {}
 func (*RefreshRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{85}
+	return fileDescriptor_api_30e97dda177d9566, []int{85}
 }
 func (m *RefreshRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4563,7 +4571,7 @@ func (m *RefreshResponse) Reset()         { *m = RefreshResponse{} }
 func (m *RefreshResponse) String() string { return proto.CompactTextString(m) }
 func (*RefreshResponse) ProtoMessage()    {}
 func (*RefreshResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{86}
+	return fileDescriptor_api_30e97dda177d9566, []int{86}
 }
 func (m *RefreshResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4602,7 +4610,7 @@ func (m *RefreshRangeRequest) Reset()         { *m = RefreshRangeRequest{} }
 func (m *RefreshRangeRequest) String() string { return proto.CompactTextString(m) }
 func (*RefreshRangeRequest) ProtoMessage()    {}
 func (*RefreshRangeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{87}
+	return fileDescriptor_api_30e97dda177d9566, []int{87}
 }
 func (m *RefreshRangeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4636,7 +4644,7 @@ func (m *RefreshRangeResponse) Reset()         { *m = RefreshRangeResponse{} }
 func (m *RefreshRangeResponse) String() string { return proto.CompactTextString(m) }
 func (*RefreshRangeResponse) ProtoMessage()    {}
 func (*RefreshRangeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{88}
+	return fileDescriptor_api_30e97dda177d9566, []int{88}
 }
 func (m *RefreshRangeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4685,7 +4693,7 @@ func (m *SubsumeRequest) Reset()         { *m = SubsumeRequest{} }
 func (m *SubsumeRequest) String() string { return proto.CompactTextString(m) }
 func (*SubsumeRequest) ProtoMessage()    {}
 func (*SubsumeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{89}
+	return fileDescriptor_api_30e97dda177d9566, []int{89}
 }
 func (m *SubsumeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4734,7 +4742,7 @@ func (m *SubsumeResponse) Reset()         { *m = SubsumeResponse{} }
 func (m *SubsumeResponse) String() string { return proto.CompactTextString(m) }
 func (*SubsumeResponse) ProtoMessage()    {}
 func (*SubsumeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{90}
+	return fileDescriptor_api_30e97dda177d9566, []int{90}
 }
 func (m *SubsumeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4769,7 +4777,7 @@ func (m *RangeStatsRequest) Reset()         { *m = RangeStatsRequest{} }
 func (m *RangeStatsRequest) String() string { return proto.CompactTextString(m) }
 func (*RangeStatsRequest) ProtoMessage()    {}
 func (*RangeStatsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{91}
+	return fileDescriptor_api_30e97dda177d9566, []int{91}
 }
 func (m *RangeStatsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4810,7 +4818,7 @@ func (m *RangeStatsResponse) Reset()         { *m = RangeStatsResponse{} }
 func (m *RangeStatsResponse) String() string { return proto.CompactTextString(m) }
 func (*RangeStatsResponse) ProtoMessage()    {}
 func (*RangeStatsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{92}
+	return fileDescriptor_api_30e97dda177d9566, []int{92}
 }
 func (m *RangeStatsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4853,7 +4861,7 @@ func (m *MigrateRequest) Reset()         { *m = MigrateRequest{} }
 func (m *MigrateRequest) String() string { return proto.CompactTextString(m) }
 func (*MigrateRequest) ProtoMessage()    {}
 func (*MigrateRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{93}
+	return fileDescriptor_api_30e97dda177d9566, []int{93}
 }
 func (m *MigrateRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4887,7 +4895,7 @@ func (m *MigrateResponse) Reset()         { *m = MigrateResponse{} }
 func (m *MigrateResponse) String() string { return proto.CompactTextString(m) }
 func (*MigrateResponse) ProtoMessage()    {}
 func (*MigrateResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{94}
+	return fileDescriptor_api_30e97dda177d9566, []int{94}
 }
 func (m *MigrateResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4971,7 +4979,7 @@ func (m *RequestUnion) Reset()         { *m = RequestUnion{} }
 func (m *RequestUnion) String() string { return proto.CompactTextString(m) }
 func (*RequestUnion) ProtoMessage()    {}
 func (*RequestUnion) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{95}
+	return fileDescriptor_api_30e97dda177d9566, []int{95}
 }
 func (m *RequestUnion) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -6452,7 +6460,7 @@ func (m *ResponseUnion) Reset()         { *m = ResponseUnion{} }
 func (m *ResponseUnion) String() string { return proto.CompactTextString(m) }
 func (*ResponseUnion) ProtoMessage()    {}
 func (*ResponseUnion) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{96}
+	return fileDescriptor_api_30e97dda177d9566, []int{96}
 }
 func (m *ResponseUnion) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -8008,7 +8016,7 @@ func (m *Header) Reset()         { *m = Header{} }
 func (m *Header) String() string { return proto.CompactTextString(m) }
 func (*Header) ProtoMessage()    {}
 func (*Header) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{97}
+	return fileDescriptor_api_30e97dda177d9566, []int{97}
 }
 func (m *Header) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -8044,7 +8052,7 @@ type BatchRequest struct {
 func (m *BatchRequest) Reset()      { *m = BatchRequest{} }
 func (*BatchRequest) ProtoMessage() {}
 func (*BatchRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{98}
+	return fileDescriptor_api_30e97dda177d9566, []int{98}
 }
 func (m *BatchRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -8081,7 +8089,7 @@ type BatchResponse struct {
 func (m *BatchResponse) Reset()      { *m = BatchResponse{} }
 func (*BatchResponse) ProtoMessage() {}
 func (*BatchResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{99}
+	return fileDescriptor_api_30e97dda177d9566, []int{99}
 }
 func (m *BatchResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -8157,7 +8165,7 @@ func (m *BatchResponse_Header) Reset()         { *m = BatchResponse_Header{} }
 func (m *BatchResponse_Header) String() string { return proto.CompactTextString(m) }
 func (*BatchResponse_Header) ProtoMessage()    {}
 func (*BatchResponse_Header) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{99, 0}
+	return fileDescriptor_api_30e97dda177d9566, []int{99, 0}
 }
 func (m *BatchResponse_Header) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -8195,7 +8203,7 @@ func (m *RangeLookupRequest) Reset()         { *m = RangeLookupRequest{} }
 func (m *RangeLookupRequest) String() string { return proto.CompactTextString(m) }
 func (*RangeLookupRequest) ProtoMessage()    {}
 func (*RangeLookupRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{100}
+	return fileDescriptor_api_30e97dda177d9566, []int{100}
 }
 func (m *RangeLookupRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -8233,7 +8241,7 @@ func (m *RangeLookupResponse) Reset()         { *m = RangeLookupResponse{} }
 func (m *RangeLookupResponse) String() string { return proto.CompactTextString(m) }
 func (*RangeLookupResponse) ProtoMessage()    {}
 func (*RangeLookupResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{101}
+	return fileDescriptor_api_30e97dda177d9566, []int{101}
 }
 func (m *RangeLookupResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -8272,7 +8280,7 @@ func (m *RangeFeedRequest) Reset()         { *m = RangeFeedRequest{} }
 func (m *RangeFeedRequest) String() string { return proto.CompactTextString(m) }
 func (*RangeFeedRequest) ProtoMessage()    {}
 func (*RangeFeedRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{102}
+	return fileDescriptor_api_30e97dda177d9566, []int{102}
 }
 func (m *RangeFeedRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -8313,7 +8321,7 @@ func (m *RangeFeedValue) Reset()         { *m = RangeFeedValue{} }
 func (m *RangeFeedValue) String() string { return proto.CompactTextString(m) }
 func (*RangeFeedValue) ProtoMessage()    {}
 func (*RangeFeedValue) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{103}
+	return fileDescriptor_api_30e97dda177d9566, []int{103}
 }
 func (m *RangeFeedValue) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -8354,7 +8362,7 @@ func (m *RangeFeedCheckpoint) Reset()         { *m = RangeFeedCheckpoint{} }
 func (m *RangeFeedCheckpoint) String() string { return proto.CompactTextString(m) }
 func (*RangeFeedCheckpoint) ProtoMessage()    {}
 func (*RangeFeedCheckpoint) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{104}
+	return fileDescriptor_api_30e97dda177d9566, []int{104}
 }
 func (m *RangeFeedCheckpoint) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -8391,7 +8399,7 @@ func (m *RangeFeedError) Reset()         { *m = RangeFeedError{} }
 func (m *RangeFeedError) String() string { return proto.CompactTextString(m) }
 func (*RangeFeedError) ProtoMessage()    {}
 func (*RangeFeedError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{105}
+	return fileDescriptor_api_30e97dda177d9566, []int{105}
 }
 func (m *RangeFeedError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -8428,7 +8436,7 @@ func (m *RangeFeedEvent) Reset()         { *m = RangeFeedEvent{} }
 func (m *RangeFeedEvent) String() string { return proto.CompactTextString(m) }
 func (*RangeFeedEvent) ProtoMessage()    {}
 func (*RangeFeedEvent) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{106}
+	return fileDescriptor_api_30e97dda177d9566, []int{106}
 }
 func (m *RangeFeedEvent) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -8472,7 +8480,7 @@ func (m *ResetQuorumRequest) Reset()         { *m = ResetQuorumRequest{} }
 func (m *ResetQuorumRequest) String() string { return proto.CompactTextString(m) }
 func (*ResetQuorumRequest) ProtoMessage()    {}
 func (*ResetQuorumRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{107}
+	return fileDescriptor_api_30e97dda177d9566, []int{107}
 }
 func (m *ResetQuorumRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -8504,7 +8512,7 @@ func (m *ResetQuorumResponse) Reset()         { *m = ResetQuorumResponse{} }
 func (m *ResetQuorumResponse) String() string { return proto.CompactTextString(m) }
 func (*ResetQuorumResponse) ProtoMessage()    {}
 func (*ResetQuorumResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{108}
+	return fileDescriptor_api_30e97dda177d9566, []int{108}
 }
 func (m *ResetQuorumResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -8545,7 +8553,7 @@ func (m *GossipSubscriptionRequest) Reset()         { *m = GossipSubscriptionReq
 func (m *GossipSubscriptionRequest) String() string { return proto.CompactTextString(m) }
 func (*GossipSubscriptionRequest) ProtoMessage()    {}
 func (*GossipSubscriptionRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{109}
+	return fileDescriptor_api_30e97dda177d9566, []int{109}
 }
 func (m *GossipSubscriptionRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -8585,7 +8593,7 @@ func (m *GossipSubscriptionEvent) Reset()         { *m = GossipSubscriptionEvent
 func (m *GossipSubscriptionEvent) String() string { return proto.CompactTextString(m) }
 func (*GossipSubscriptionEvent) ProtoMessage()    {}
 func (*GossipSubscriptionEvent) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{110}
+	return fileDescriptor_api_30e97dda177d9566, []int{110}
 }
 func (m *GossipSubscriptionEvent) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -8621,7 +8629,7 @@ func (m *JoinNodeRequest) Reset()         { *m = JoinNodeRequest{} }
 func (m *JoinNodeRequest) String() string { return proto.CompactTextString(m) }
 func (*JoinNodeRequest) ProtoMessage()    {}
 func (*JoinNodeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{111}
+	return fileDescriptor_api_30e97dda177d9566, []int{111}
 }
 func (m *JoinNodeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -8660,7 +8668,7 @@ func (m *JoinNodeResponse) Reset()         { *m = JoinNodeResponse{} }
 func (m *JoinNodeResponse) String() string { return proto.CompactTextString(m) }
 func (*JoinNodeResponse) ProtoMessage()    {}
 func (*JoinNodeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{112}
+	return fileDescriptor_api_30e97dda177d9566, []int{112}
 }
 func (m *JoinNodeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -8700,7 +8708,7 @@ type ContentionEvent struct {
 func (m *ContentionEvent) Reset()      { *m = ContentionEvent{} }
 func (*ContentionEvent) ProtoMessage() {}
 func (*ContentionEvent) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_f2b2489e6aa3dd67, []int{113}
+	return fileDescriptor_api_30e97dda177d9566, []int{113}
 }
 func (m *ContentionEvent) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -38914,9 +38922,9 @@ var (
 	ErrIntOverflowApi   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("roachpb/api.proto", fileDescriptor_api_f2b2489e6aa3dd67) }
+func init() { proto.RegisterFile("roachpb/api.proto", fileDescriptor_api_30e97dda177d9566) }
 
-var fileDescriptor_api_f2b2489e6aa3dd67 = []byte{
+var fileDescriptor_api_30e97dda177d9566 = []byte{
 	// 8182 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe4, 0xbd, 0x5d, 0x6c, 0x23, 0x59,
 	0x76, 0x1f, 0xae, 0x22, 0x29, 0x89, 0x3c, 0xa4, 0x48, 0xea, 0xaa, 0x3f, 0xd8, 0x9c, 0x99, 0x56,

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -1015,11 +1015,8 @@ message QueryIntentRequest {
   // intent is a match or not is defined as whether an intent exists that could
   // be committed by the provided transaction. If an intent is found at the
   // specified key, the intent is only considered a match if it has the same ID,
-  // the same epoch, and a provisional commit timestamp that is equal to or less
-  // than that in the provided transaction. The TxnMeta's provisional commit
-  // timestamp is forwarded by the provisional commit timestamp of the request
-  // header transaction if the transactions are the same (i.e. a transaction is
-  // querying its own intent after successfully having refreshed).
+  // the same epoch, and a write timestamp that is equal to or less than that in
+  // the provided transaction.
   //
   // Additionally, the intent is only considered a match if its sequence number
   // is equal to or greater than the expected txn's sequence number. The
@@ -1029,6 +1026,17 @@ message QueryIntentRequest {
   // successfully written an intent at a larger sequence number then it must
   // have succeeeded in writing an intent at the smaller sequence number as
   // well.
+  //
+  // QueryIntentRequests may be issued in non-transactional BatchRequests or in
+  // transactional BatchRequests. If issued inside of a transaction, the TxnMeta
+  // must be a reference to the same transaction as the batch's transaction, or
+  // the request will be rejected. In other words, a transaction can only query
+  // its own intents. In these cases where the BatchRequest is transactional,
+  // the TxnMeta's write timestamp is forwarded by the write timestamp of the
+  // request header transaction for purposes of determining whether a matching
+  // intent is found or not (see condition above). This is useful to avoid the
+  // need to update each QueryIntentRequest when a transaction is querying its
+  // own intent after having successfully refreshed.
   storage.enginepb.TxnMeta txn = 2 [(gogoproto.nullable) = false];
 
   // If true, return an IntentMissingError if a matching intent is not found.

--- a/pkg/roachpb/batch.go
+++ b/pkg/roachpb/batch.go
@@ -25,6 +25,19 @@ import (
 
 //go:generate go run -tags gen-batch gen_batch.go
 
+// WriteTimestamp returns the timestamps at which this request is writing. For
+// non-transactional requests, this is the same as the read timestamp. For
+// transactional requests, the write timestamp can be higher until commit time.
+//
+// This should only be called after SetActiveTimestamp().
+func (h Header) WriteTimestamp() hlc.Timestamp {
+	ts := h.Timestamp
+	if h.Txn != nil {
+		ts.Forward(h.Txn.WriteTimestamp)
+	}
+	return ts
+}
+
 // SetActiveTimestamp sets the correct timestamp at which the request is to be
 // carried out. For transactional requests, ba.Timestamp must be zero initially
 // and it will be set to txn.ReadTimestamp (note though this mostly impacts
@@ -70,19 +83,6 @@ func (ba BatchRequest) EarliestActiveTimestamp() hlc.Timestamp {
 		case *RevertRangeRequest:
 			ts.Backward(t.TargetTime)
 		}
-	}
-	return ts
-}
-
-// WriteTimestamp returns the timestamps at which this request is writing. For
-// non-transactional requests, this is the same as the read timestamp. For
-// transactional requests, the write timestamp can be higher until commit time.
-//
-// This should only be called after SetActiveTimestamp().
-func (ba *BatchRequest) WriteTimestamp() hlc.Timestamp {
-	ts := ba.Timestamp
-	if ba.Txn != nil {
-		ts.Forward(ba.Txn.WriteTimestamp)
 	}
 	return ts
 }


### PR DESCRIPTION
Relates to #57688.

This PR updates the following four requests types to properly handle future-time operations:
- `PushTxnRequest`
- `QueryTxnRequest`
- `QueryIntentRequest`
- `RecoverTxnRequest`

It also updates the request evaluation code to properly check that all timestamp cache updates are safe, based on the batch header timestamps of the requests. This is coupled with a stricter, more comprehensive assertion when updating the timestamp cache that all updates are performed below the expiration time of the active lease. This ensures that timestamp cache updates are not lost during non-cooperative lease change.

In doing so, the PR also updates the replica lease check to test against the batch's read or write timestamp, whichever is later. This addresses the concerns raised in https://github.com/cockroachdb/cockroach/pull/58904#pullrequestreview-572482570.