### PR TITLE
changefeedccl: Add WITH avro_schema_prefix option to changefeeds in avro format

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -1979,6 +1979,7 @@ func TestChangefeedErrors(t *testing.T) {
 	)
 
 	// Check that confluent_schema_registry is only accepted if format is avro.
+	// TODO: This should be testing it as a WITH option and check avro_schema_prefix too
 	sqlDB.ExpectErr(
 		t, `unknown sink query parameter: confluent_schema_registry`,
 		`CREATE CHANGEFEED FOR foo INTO $1`, `experimental-sql://d/?confluent_schema_registry=foo`,

--- a/pkg/ccl/changefeedccl/changefeedbase/options.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options.go
@@ -26,6 +26,7 @@ type SchemaChangePolicy string
 
 // Constants for the options.
 const (
+	OptAvroSchemaPrefix         = `avro_schema_prefix`
 	OptConfluentSchemaRegistry  = `confluent_schema_registry`
 	OptCursor                   = `cursor`
 	OptEnvelope                 = `envelope`
@@ -97,6 +98,7 @@ const (
 // ChangefeedOptionExpectValues is used to parse changefeed options using
 // PlanHookState.TypeAsStringOpts().
 var ChangefeedOptionExpectValues = map[string]sql.KVStringOptValidate{
+	OptAvroSchemaPrefix:         sql.KVStringOptRequireValue,
 	OptConfluentSchemaRegistry:  sql.KVStringOptRequireValue,
 	OptCursor:                   sql.KVStringOptRequireValue,
 	OptEnvelope:                 sql.KVStringOptRequireValue,

--- a/pkg/ccl/changefeedccl/encoder_test.go
+++ b/pkg/ccl/changefeedccl/encoder_test.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/cockroachdb/cockroach-go/crdb"
@@ -261,14 +262,16 @@ type testSchemaRegistry struct {
 	server *httptest.Server
 	mu     struct {
 		syncutil.Mutex
-		idAlloc int32
-		schemas map[int32]string
+		idAlloc  int32
+		schemas  map[int32]string
+		subjects map[string]int32
 	}
 }
 
 func makeTestSchemaRegistry() *testSchemaRegistry {
 	r := &testSchemaRegistry{}
 	r.mu.schemas = make(map[int32]string)
+	r.mu.subjects = make(map[string]int32)
 	r.server = httptest.NewServer(http.HandlerFunc(r.Register))
 	return r
 }
@@ -292,9 +295,11 @@ func (r *testSchemaRegistry) Register(hw http.ResponseWriter, hr *http.Request) 
 		}
 
 		r.mu.Lock()
+		subject := strings.Split(hr.URL.Path, "/")[2]
 		id := r.mu.idAlloc
 		r.mu.idAlloc++
 		r.mu.schemas[id] = req.Schema
+		r.mu.subjects[subject] = id
 		r.mu.Unlock()
 
 		res, err := gojson.Marshal(confluentSchemaVersionResponse{ID: id})
@@ -385,6 +390,93 @@ func TestAvroEncoder(t *testing.T) {
 	}
 
 	t.Run(`sinkless`, sinklessTest(testFn))
+	t.Run(`enterprise`, enterpriseTest(testFn))
+}
+
+func TestAvroSchemaNaming(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
+		reg := makeTestSchemaRegistry()
+		defer reg.Close()
+
+		sqlDB := sqlutils.MakeSQLRunner(db)
+		sqlDB.Exec(t, `CREATE DATABASE movr`)
+		sqlDB.Exec(t, `CREATE TABLE movr.drivers (id INT PRIMARY KEY, name STRING)`)
+		sqlDB.Exec(t,
+			`INSERT INTO movr.drivers VALUES (1, 'Alice')`,
+		)
+
+		movrFeed := feed(t, f, `CREATE CHANGEFEED FOR movr.drivers `+
+			`WITH format=$1, confluent_schema_registry=$2`,
+			changefeedbase.OptFormatAvro, reg.server.URL)
+		defer closeFeed(t, movrFeed)
+
+		assertPayloadsAvro(t, reg, movrFeed, []string{
+			`drivers: {"id":{"long":1}}->{"after":{"drivers":{"id":{"long":1},"name":{"string":"Alice"}}}}`,
+		})
+
+		assertRegisteredSubjects(t, reg, []string{
+			`drivers-key`,
+			`drivers-value`,
+		})
+
+		fqnFeed := feed(t, f, `CREATE CHANGEFEED FOR movr.drivers `+
+			`WITH format=$1, confluent_schema_registry=$2, full_table_name`,
+			changefeedbase.OptFormatAvro, reg.server.URL)
+		defer closeFeed(t, fqnFeed)
+
+		assertPayloadsAvro(t, reg, fqnFeed, []string{
+			`movr.public.drivers: {"id":{"long":1}}->{"after":{"drivers":{"id":{"long":1},"name":{"string":"Alice"}}}}`,
+		})
+
+		assertRegisteredSubjects(t, reg, []string{
+			`drivers-key`,
+			`drivers-value`,
+			`db#.schema#.drivers-key`,
+			`db#.schema#.drivers-value`,
+		})
+
+		prefixFeed := feed(t, f, `CREATE CHANGEFEED FOR movr.drivers `+
+			`WITH format=$1, confluent_schema_registry=$2, avro_schema_prefix=super`,
+			changefeedbase.OptFormatAvro, reg.server.URL)
+		defer closeFeed(t, prefixFeed)
+
+		assertPayloadsAvro(t, reg, prefixFeed, []string{
+			`drivers: {"id":{"long":1}}->{"after":{"drivers":{"id":{"long":1},"name":{"string":"Alice"}}}}`,
+		})
+
+		assertRegisteredSubjects(t, reg, []string{
+			`drivers-key`,
+			`drivers-value`,
+			`db#.schema#.drivers-key`,
+			`db#.schema#.drivers-value`,
+			`superdrivers-key`,
+			`superdrivers-value`,
+		})
+
+		prefixFQNFeed := feed(t, f, `CREATE CHANGEFEED FOR movr.drivers `+
+			`WITH format=$1, confluent_schema_registry=$2, avro_schema_prefix=super, full_table_name`,
+			changefeedbase.OptFormatAvro, reg.server.URL)
+		defer closeFeed(t, prefixFQNFeed)
+
+		assertPayloadsAvro(t, reg, prefixFQNFeed, []string{
+			`movr.public.drivers: {"id":{"long":1}}->{"after":{"drivers":{"id":{"long":1},"name":{"string":"Alice"}}}}`,
+		})
+
+		assertRegisteredSubjects(t, reg, []string{
+			`drivers-key`,
+			`drivers-value`,
+			`db#.schema#.drivers-key`,
+			`db#.schema#.drivers-value`,
+			`superdrivers-key`,
+			`superdrivers-value`,
+			`superdb#.schema#.drivers-key`,
+			`superdb#.schema#.drivers-value`,
+		})
+	}
+
 	t.Run(`enterprise`, enterpriseTest(testFn))
 }
 

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"net/url"
 	"reflect"
+	"regexp"
 	"sort"
 	"strings"
 	"testing"
@@ -144,6 +145,25 @@ func assertPayloadsAvro(
 
 	// The tests that use this aren't concerned with order, just that these are
 	// the next len(expected) messages.
+	sort.Strings(expected)
+	sort.Strings(actual)
+	if !reflect.DeepEqual(expected, actual) {
+		t.Fatalf("expected\n  %s\ngot\n  %s",
+			strings.Join(expected, "\n  "), strings.Join(actual, "\n  "))
+	}
+}
+
+func assertRegisteredSubjects(t testing.TB, reg *testSchemaRegistry, expected []string) {
+	t.Helper()
+
+	scrubIds := regexp.MustCompile(`\d+`)
+
+	actual := make([]string, 0, len(reg.mu.subjects))
+
+	for subject := range reg.mu.subjects {
+		actual = append(actual, scrubIds.ReplaceAllString(subject, "#"))
+	}
+
 	sort.Strings(expected)
 	sort.Strings(actual)
 	if !reflect.DeepEqual(expected, actual) {


### PR DESCRIPTION
The avro schema for changefeed output is registered as a subject name the same
as the table. This doesn't work if the same schema registry is being used for
multiple changefeeds on the same table, or different tables with the same name.
So now you can disambiguate with full_table_name, avro_schema_prefix, or both.

Release note (sql change): Added WITH avro_schema_prefix option
to avro changefeeds to prevent collisions in a shared schema registry

Closes https://github.com/cockroachdb/cockroach/issues/56026