### PR TITLE
pgwire: use ring.Buffer for cmdStarts mapping

### DIFF
--- a/pkg/sql/pgwire/BUILD.bazel
+++ b/pkg/sql/pgwire/BUILD.bazel
@@ -46,6 +46,7 @@ go_library(
         "//pkg/util/log/eventpb",
         "//pkg/util/metric",
         "//pkg/util/mon",
+        "//pkg/util/ring",
         "//pkg/util/stop",
         "//pkg/util/syncutil",
         "//pkg/util/timeofday",


### PR DESCRIPTION
Previously, we were using a map (that is recreated on `Flush`) to keep
track of the index in which the corresponding result in the buffer
starts for a particular CmdPos. This can be improved since the positions
are monotonically increasing sequences (possibly with gaps), and this
commit utilizes a ring.Buffer to keep track of that state.

Fixes: #30507.

Release note: None