### PR TITLE
backupccl: fix rare failure in reading backup file

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -17,7 +17,6 @@ import (
 	"io"
 	"io/ioutil"
 	"math/rand"
-	"net/http"
 	"net/url"
 	"os"
 	"path"
@@ -335,8 +334,7 @@ func TestBackupRestoreStatementResult(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		fileType := http.DetectContentType(backupManifestBytes)
-		require.Equal(t, ZipType, fileType)
+		require.True(t, isGZipped(backupManifestBytes))
 	})
 
 	sqlDB.Exec(t, "CREATE DATABASE data2")
@@ -468,8 +466,7 @@ func TestBackupRestorePartitioned(t *testing.T) {
 					if err != nil {
 						t.Fatal(err)
 					}
-					fileType := http.DetectContentType(backupPartitionBytes)
-					require.Equal(t, ZipType, fileType)
+					require.True(t, isGZipped(backupPartitionBytes))
 				}
 			}
 		}
@@ -1586,8 +1583,7 @@ func TestBackupRestoreResume(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		fileType := http.DetectContentType(backupManifestBytes)
-		if fileType == ZipType {
+		if isGZipped(backupManifestBytes) {
 			backupManifestBytes, err = decompressData(backupManifestBytes)
 			require.NoError(t, err)
 		}
@@ -3946,8 +3942,7 @@ func TestBackupRestoreChecksum(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%+v", err)
 		}
-		fileType := http.DetectContentType(backupManifestBytes)
-		if fileType == ZipType {
+		if isGZipped(backupManifestBytes) {
 			backupManifestBytes, err = decompressData(backupManifestBytes)
 			require.NoError(t, err)
 		}


### PR DESCRIPTION
BackupManifests are compresed when written to ExternalStorage. When
reading backup manifests, we check if the content type indicates that
the backup manifest is compressed (and thus needs to be decompressed).
We do this because some previous backups were not compressed, so backup
needs to be able to detect if the backup manfiest has been compressed.

However, very rarely (1 in 60000 attempts in my case), the compressed
data might be detected as "application/vnd.ms-fontobject", rather than a
gzipped file. This causes backup to not decompress the file, and thus
try to unmarshall the compressed data. The file is misdetected because
the defined sniffing algorithm in http.DetectContentType first looks at
the 35th byte to see if it matches a "magic pattern", before checking if
the data is in gzip format. And, sometimes, the 35th byte happens to
match up.

This commit updates the check so that we only check if the GZip magic
bytes header is present or not, rather than checking all possible
content types. The gzip header is not expected to conflict with the
first 6 bytes of normally generated protobuf messages that are
compressed.

Closes https://github.com/cockroachdb/cockroach/issues/59685.
Closes https://github.com/cockroachdb/cockroach/issues/54550.

Release note (bug fix): Fixes a bug where backups would fail with an
error when trying to read a backup that was written.