### PR TITLE
kvserver: improve a rangefeed test

### DIFF
--- a/pkg/kv/kvserver/replica_rangefeed_test.go
+++ b/pkg/kv/kvserver/replica_rangefeed_test.go
@@ -167,6 +167,14 @@ func TestReplicaRangefeed(t *testing.T) {
 				}
 
 				events = stream.Events()
+				var filteredEvents []*roachpb.RangeFeedEvent
+				for _, e := range events {
+					if e.Checkpoint != nil {
+						continue
+					}
+					filteredEvents = append(filteredEvents, e)
+				}
+				events = filteredEvents
 				if len(events) < len(expEvents) {
 					return errors.Errorf("too few events: %v", events)
 				}
@@ -187,10 +195,6 @@ func TestReplicaRangefeed(t *testing.T) {
 	expEvents := []*roachpb.RangeFeedEvent{
 		{Val: &roachpb.RangeFeedValue{
 			Key: roachpb.Key("b"), Value: expVal1,
-		}},
-		{Checkpoint: &roachpb.RangeFeedCheckpoint{
-			Span:       rangefeedSpan,
-			ResolvedTS: hlc.Timestamp{},
 		}},
 	}
 	checkForExpEvents(expEvents)


### PR DESCRIPTION
This test was asserting the presence of some checkpoints, and implicitly
the absence of others. That's racy, since checkpoints can come at any
time - whenever the closed timestamp is advanced, so whenever various
tickers tick. Moreover, these checkpoints are about to become a lot more
frequent, since the closed timestamp is about to start advancing
continuously, with every write, rather than discreetely on a timer as it
does now.

Release note: None