### PR TITLE
bazel: tell bazel to run go tests with `-test.v`

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,5 +2,6 @@
 
 build --ui_event_filters=-DEBUG
 query --ui_event_filters=-DEBUG
+test --test_env=GO_TEST_WRAP_TESTV=1
 
 try-import %workspace%/.bazelrc.user


### PR DESCRIPTION
This environment variable tells `rules_go` to run the tests with
`-test.v`. This results in better per-test logging, included in the
generated `test.xml`.

Release note: None