### PR TITLE
kvserver: put logscope around some tests

### DIFF
--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -3717,6 +3717,7 @@ func TestMergeQueue(t *testing.T) {
 
 func TestMergeQueueSeesNonVoters(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	type test struct {
 		name                                                   string

--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -3498,6 +3498,7 @@ func makeReplicationTargets(ids ...int) (targets []roachpb.ReplicationTarget) {
 //  (3) When a store starts up, it assigns the right tenant ID.
 func TestTenantID(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	stickyEngineRegistry := server.NewStickyInMemEnginesRegistry()
 	defer stickyEngineRegistry.CloseAllStickyInMemEngines()


### PR DESCRIPTION
Some tests were randomly missing this.

Release note: None