### PR TITLE
opt: fix panic in GenerateLookupJoin

### DIFF
--- a/pkg/sql/opt/xform/general_funcs.go
+++ b/pkg/sql/opt/xform/general_funcs.go
@@ -229,9 +229,9 @@ func (c *CustomFuncs) initIdxConstraintForIndex(
 // The values of both columns in that index are known, enabling a single value
 // constraint to be generated.
 func (c *CustomFuncs) computedColFilters(
-	tabID opt.TableID, requiredFilters, optionalFilters memo.FiltersExpr,
+	scanPrivate *memo.ScanPrivate, requiredFilters, optionalFilters memo.FiltersExpr,
 ) memo.FiltersExpr {
-	tabMeta := c.e.mem.Metadata().TableMeta(tabID)
+	tabMeta := c.e.mem.Metadata().TableMeta(scanPrivate.Table)
 	if len(tabMeta.ComputedCols) == 0 {
 		return nil
 	}
@@ -239,8 +239,8 @@ func (c *CustomFuncs) computedColFilters(
 	// Start with set of constant columns, as derived from the list of filter
 	// conditions.
 	constCols := make(map[opt.ColumnID]opt.ScalarExpr)
-	c.findConstantFilterCols(constCols, tabID, requiredFilters)
-	c.findConstantFilterCols(constCols, tabID, optionalFilters)
+	c.findConstantFilterCols(constCols, scanPrivate, requiredFilters)
+	c.findConstantFilterCols(constCols, scanPrivate, optionalFilters)
 	if len(constCols) == 0 {
 		// No constant values could be derived from filters, so assume that there
 		// are also no constant computed columns.

--- a/pkg/sql/opt/xform/general_funcs.go
+++ b/pkg/sql/opt/xform/general_funcs.go
@@ -11,11 +11,13 @@
 package xform
 
 import (
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/idxconstraint"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/norm"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/partialidx"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/errors"
 )
 
@@ -259,4 +261,65 @@ func (c *CustomFuncs) computedColFilters(
 		}
 	}
 	return computedColFilters
+}
+
+// findConstantFilterCols adds to constFilterCols mappings from table column ID
+// to the constant value of that column. It does this by iterating over the
+// given lists of filters and finding expressions that constrain columns to a
+// single constant value. For example:
+//
+//   x = 5 AND y = 'foo'
+//
+// This would add a mapping from x => 5 and y => 'foo', which constants can
+// then be used to prove that dependent computed columns are also constant.
+func (c *CustomFuncs) findConstantFilterCols(
+	constFilterCols map[opt.ColumnID]opt.ScalarExpr,
+	scanPrivate *memo.ScanPrivate,
+	filters memo.FiltersExpr,
+) {
+	tab := c.e.mem.Metadata().Table(scanPrivate.Table)
+	for i := range filters {
+		// If filter constraints are not tight, then no way to derive constant
+		// values.
+		props := filters[i].ScalarProps()
+		if !props.TightConstraints {
+			continue
+		}
+
+		// Iterate over constraint conjuncts with a single column and single
+		// span having a single key.
+		for i, n := 0, props.Constraints.Length(); i < n; i++ {
+			cons := props.Constraints.Constraint(i)
+			if cons.Columns.Count() != 1 || cons.Spans.Count() != 1 {
+				continue
+			}
+
+			// Skip columns that aren't in the scanned table.
+			colID := cons.Columns.Get(0).ID()
+			if !scanPrivate.Cols.Contains(colID) {
+				continue
+			}
+
+			// Skip columns with a data type that uses a composite key encoding.
+			// Each of these data types can have multiple distinct values that
+			// compare equal. For example, 0 == -0 for the FLOAT data type. It's
+			// not safe to treat these as constant inputs to computed columns,
+			// since the computed expression may differentiate between the
+			// different forms of the same value.
+			colTyp := tab.Column(scanPrivate.Table.ColumnOrdinal(colID)).DatumType()
+			if colinfo.HasCompositeKeyEncoding(colTyp) {
+				continue
+			}
+
+			span := cons.Spans.Get(0)
+			if !span.HasSingleKey(c.e.evalCtx) {
+				continue
+			}
+
+			datum := span.StartKey().Value(0)
+			if datum != tree.DNull {
+				constFilterCols[colID] = c.e.f.ConstructConstVal(datum, colTyp)
+			}
+		}
+	}
 }

--- a/pkg/sql/opt/xform/join_funcs.go
+++ b/pkg/sql/opt/xform/join_funcs.go
@@ -224,7 +224,7 @@ func (c *CustomFuncs) GenerateLookupJoins(
 	// Generate implicit filters from CHECK constraints and computed columns as
 	// optional filters to help generate lookup join keys.
 	optionalFilters := c.checkConstraintFilters(scanPrivate.Table)
-	computedColFilters := c.computedColFilters(scanPrivate.Table, on, optionalFilters)
+	computedColFilters := c.computedColFilters(scanPrivate, on, optionalFilters)
 	optionalFilters = append(optionalFilters, computedColFilters...)
 
 	var pkCols opt.ColList
@@ -505,7 +505,7 @@ func (c *CustomFuncs) GenerateInvertedJoins(
 				// using them here would result in a reduced set of optional
 				// filters.
 				optionalFilters = c.checkConstraintFilters(scanPrivate.Table)
-				computedColFilters := c.computedColFilters(scanPrivate.Table, on, optionalFilters)
+				computedColFilters := c.computedColFilters(scanPrivate, on, optionalFilters)
 				optionalFilters = append(optionalFilters, computedColFilters...)
 
 				eqColsAndOptionalFiltersCalculated = true

--- a/pkg/sql/opt/xform/select_funcs.go
+++ b/pkg/sql/opt/xform/select_funcs.go
@@ -13,7 +13,6 @@ package xform
 import (
 	"sort"
 
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/inverted"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
@@ -368,67 +367,6 @@ func (c *CustomFuncs) GenerateConstrainedScans(
 
 		sb.build(grp)
 	})
-}
-
-// findConstantFilterCols adds to constFilterCols mappings from table column ID
-// to the constant value of that column. It does this by iterating over the
-// given lists of filters and finding expressions that constrain columns to a
-// single constant value. For example:
-//
-//   x = 5 AND y = 'foo'
-//
-// This would add a mapping from x => 5 and y => 'foo', which constants can
-// then be used to prove that dependent computed columns are also constant.
-func (c *CustomFuncs) findConstantFilterCols(
-	constFilterCols map[opt.ColumnID]opt.ScalarExpr,
-	scanPrivate *memo.ScanPrivate,
-	filters memo.FiltersExpr,
-) {
-	tab := c.e.mem.Metadata().Table(scanPrivate.Table)
-	for i := range filters {
-		// If filter constraints are not tight, then no way to derive constant
-		// values.
-		props := filters[i].ScalarProps()
-		if !props.TightConstraints {
-			continue
-		}
-
-		// Iterate over constraint conjuncts with a single column and single
-		// span having a single key.
-		for i, n := 0, props.Constraints.Length(); i < n; i++ {
-			cons := props.Constraints.Constraint(i)
-			if cons.Columns.Count() != 1 || cons.Spans.Count() != 1 {
-				continue
-			}
-
-			// Skip columns that aren't in the scanned table.
-			colID := cons.Columns.Get(0).ID()
-			if !scanPrivate.Cols.Contains(colID) {
-				continue
-			}
-
-			// Skip columns with a data type that uses a composite key encoding.
-			// Each of these data types can have multiple distinct values that
-			// compare equal. For example, 0 == -0 for the FLOAT data type. It's
-			// not safe to treat these as constant inputs to computed columns,
-			// since the computed expression may differentiate between the
-			// different forms of the same value.
-			colTyp := tab.Column(scanPrivate.Table.ColumnOrdinal(colID)).DatumType()
-			if colinfo.HasCompositeKeyEncoding(colTyp) {
-				continue
-			}
-
-			span := cons.Spans.Get(0)
-			if !span.HasSingleKey(c.e.evalCtx) {
-				continue
-			}
-
-			datum := span.StartKey().Value(0)
-			if datum != tree.DNull {
-				constFilterCols[colID] = c.e.f.ConstructConstVal(datum, colTyp)
-			}
-		}
-	}
 }
 
 // tryFoldComputedCol tries to reduce the computed column with the given column

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -3174,6 +3174,35 @@ anti-join (hash)
  └── filters
       └── column1:1 = y:3 [outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
 
+# Regression test for #59738. findConstantFilterCols should not panic when it
+# finds constant filters for columns that are not in the index of the lookup
+# table.
+exec-ddl
+CREATE TABLE t59738_ab (a INT, b INT AS (a + 10) STORED, INDEX (a))
+----
+
+exec-ddl
+CREATE TABLE t59738_cd (c INT, d INT)
+----
+
+opt expect=GenerateLookupJoins
+SELECT * FROM t59738_cd LEFT LOOKUP JOIN t59738_ab ON a = c AND d > 5
+----
+left-join (lookup t59738_ab)
+ ├── columns: c:1 d:2 a:5 b:6
+ ├── key columns: [7] = [7]
+ ├── lookup columns are key
+ ├── left-join (lookup t59738_ab@secondary)
+ │    ├── columns: c:1 d:2 a:5 t59738_ab.rowid:7
+ │    ├── flags: force lookup join (into right side)
+ │    ├── key columns: [1] = [5]
+ │    ├── fd: (7)-->(5)
+ │    ├── scan t59738_cd
+ │    │    └── columns: c:1 d:2
+ │    └── filters
+ │         └── d:2 > 5 [outer=(2), constraints=(/2: [/6 - ]; tight)]
+ └── filters (true)
+
 # --------------------------------------------------
 # GenerateLookupJoinsWithFilter
 # --------------------------------------------------


### PR DESCRIPTION
#### opt: fix panic in GenerateLookupJoin

In #57690 a new code path was introduced from `findConstantFilterCols`
from `GenerateLookupJoins`. This new code path made it possible for the
filters passed to `findConstantFilterCols` to contain columns that are
not part of the given table. This violated the assumption that the
filter only contains columns in the given table and caused a panic. This
commit fixes the issue by neglecting constant filters for columns not in
the given table.

Fixes #59738

Release note (bug fix): A bug has been fixed that caused errors when
joining two tables when one of the tables had a computed column. This
bug was present since version 21.1.0-alpha.2 and not present in any
production releases.

#### opt: move findConstantFilterCols to general_funcs.go

Release note: None
