### PR TITLE
opt: switch checks to use CrdbTestBuild instead of RaceEnabled

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -329,17 +329,21 @@ func (b *Builder) buildRelational(e memo.RelExpr) (execPlan, error) {
 		return execPlan{}, err
 	}
 
-	// In race builds, assert that the exec plan output columns match the opt
+	// In test builds, assert that the exec plan output columns match the opt
 	// plan output columns.
-	if util.RaceEnabled {
-		optCols := e.Relational().OutputCols
-		var execCols opt.ColSet
-		ep.outputCols.ForEach(func(key, val int) {
-			execCols.Add(opt.ColumnID(key))
-		})
-		if !execCols.Equals(optCols) {
-			return execPlan{}, errors.AssertionFailedf(
-				"exec columns do not match opt columns: expected %v, got %v", optCols, execCols)
+	if util.CrdbTestBuild {
+		// TODO(sumeer): paired inverted joins produce extra columns unknown to the
+		// optimizer.
+		if e.Op() != opt.InvertedJoinOp {
+			optCols := e.Relational().OutputCols
+			var execCols opt.ColSet
+			ep.outputCols.ForEach(func(key, val int) {
+				execCols.Add(opt.ColumnID(key))
+			})
+			if !execCols.Equals(optCols) {
+				return execPlan{}, errors.AssertionFailedf(
+					"exec columns do not match opt columns: expected %v, got %v. op: %T", optCols, execCols, e)
+			}
 		}
 	}
 

--- a/pkg/sql/opt/ordering/ordering.go
+++ b/pkg/sql/opt/ordering/ordering.go
@@ -26,7 +26,7 @@ func CanProvide(expr memo.RelExpr, required *physical.OrderingChoice) bool {
 	if required.Any() {
 		return true
 	}
-	if util.RaceEnabled {
+	if util.CrdbTestBuild {
 		checkRequired(expr, required)
 	}
 	return funcMap[expr.Op()].canProvideOrdering(expr, required)
@@ -39,7 +39,7 @@ func BuildChildRequired(
 	parent memo.RelExpr, required *physical.OrderingChoice, childIdx int,
 ) physical.OrderingChoice {
 	result := funcMap[parent.Op()].buildChildReqOrdering(parent, required, childIdx)
-	if util.RaceEnabled && !result.Any() {
+	if util.CrdbTestBuild && !result.Any() {
 		checkRequired(parent.Child(childIdx).(memo.RelExpr), &result)
 	}
 	return result
@@ -66,7 +66,7 @@ func BuildProvided(expr memo.RelExpr, required *physical.OrderingChoice) opt.Ord
 	}
 	provided := funcMap[expr.Op()].buildProvidedOrdering(expr, required)
 
-	if util.RaceEnabled {
+	if util.CrdbTestBuild {
 		checkProvided(expr, required, provided)
 	}
 

--- a/pkg/sql/opt/table_meta.go
+++ b/pkg/sql/opt/table_meta.go
@@ -52,10 +52,8 @@ func (t TableID) IndexColumnID(idx cat.Index, idxOrd int) ColumnID {
 // NOTE: This method cannot do complete bounds checking, so it's up to the
 //       caller to ensure that this column is really in the given base table.
 func (t TableID) ColumnOrdinal(id ColumnID) int {
-	if util.RaceEnabled {
-		if id < t.firstColID() {
-			panic(errors.AssertionFailedf("ordinal cannot be negative"))
-		}
+	if util.CrdbTestBuild && id < t.firstColID() {
+		panic(errors.AssertionFailedf("ordinal cannot be negative"))
 	}
 	return int(id - t.firstColID())
 }

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -76,7 +76,7 @@ func ConstantWithMetamorphicTestValue(name string, defaultValue, metamorphicValu
 var rng *rand.Rand
 
 func init() {
-	if crdbTestBuild {
+	if CrdbTestBuild {
 		rng, _ = randutil.NewPseudoRand()
 		metamorphicBuild = rng.Float64() < metamorphicBuildProbability
 	}

--- a/pkg/util/crdb_test_off.go
+++ b/pkg/util/crdb_test_off.go
@@ -12,9 +12,9 @@
 
 package util
 
-// crdbTestBuild is a flag that is set to true if the binary was compiled
+// CrdbTestBuild is a flag that is set to true if the binary was compiled
 // with the 'crdb_test' build tag (which is the case for all test targets). This
 // flag can be used to enable expensive checks, test randomizations, or other
 // metamorphic-style perturbations that will not affect test results but will
 // exercise different parts of the code.
-const crdbTestBuild = false
+const CrdbTestBuild = false

--- a/pkg/util/crdb_test_on.go
+++ b/pkg/util/crdb_test_on.go
@@ -12,9 +12,9 @@
 
 package util
 
-// crdbTestBuild is a flag that is set to true if the binary was compiled
+// CrdbTestBuild is a flag that is set to true if the binary was compiled
 // with the 'crdb_test' build tag (which is the case for all test targets). This
 // flag can be used to enable expensive checks, test randomizations, or other
 // metamorphic-style perturbations that will not affect test results but will
 // exercise different parts of the code.
-const crdbTestBuild = true
+const CrdbTestBuild = true


### PR DESCRIPTION
The RaceEnabled flag is not very useful for checks; e.g. apparently
execbuilder tests aren't run routinely in race mode. These checks are
now "live" in any test build, using the crdb_test build tag.

Release note: None