### PR TITLE
cli/sql: new command-line flag `--embedded`

### DIFF
--- a/pkg/cli/README.md
+++ b/pkg/cli/README.md
@@ -66,3 +66,10 @@
     terminal: `terminalOutput && !isInteractive`
   - human runs the SQL shell but filters the output, e.g. `cockroach sql | grep XXX`
     `!terminalOutput && isInteractive`.
+
+- Be mindful of the `--embedded` flag, for use in "playground" environments.
+
+  If `sqlCtx.embeddedMode` is set, the (human) user has no control
+  over the command line and the configuration. In that case, help
+  texts about the configuration should be avoided because they are
+  non-actionable.

--- a/pkg/cli/README.md
+++ b/pkg/cli/README.md
@@ -1,0 +1,68 @@
+# CLI utility design guidelines
+
+## Guidelines for operator-level utilities
+
+- Be concise in the common case, verbose with errors.
+
+- Be flexible on input, strict on output.
+  (Accept mistakes by the user providing flags / input; but make the
+  output format specific: it is consumed by programs.)
+
+- Errors on stderr, regular output on stdout.
+
+- CLI tools other than the `debug` utilities are part of the API:
+  don't change features without release notes; use the deprecation
+  cycle to remove features or change flags; and ensure cross-version
+  compatibility (possibly via opt-in flags).
+
+## Guidelines for the SQL shell
+
+- Be mindful of the two "modes" of *output*:
+
+  - output consumed by a human. (`cliCtx.terminalOutput == true`)
+
+    In this mode, there can be explanations printed out to help
+    the human understand what they are seeing. Long
+    operations (eg workload init) should be described by an
+    explanatory message before the operation starts, so that the user
+    knows there is something to wait for.
+
+  - output consumed by scripts, automation etc. (`cliCtx.terminalOutput == false`)
+
+    In the output automation mode: output should be concise, parsable:
+    it is consumed by programs.
+
+    In the non-human case, the output is part of the public API of CockroachDB.
+    Beware of documenting changes in release notes; use the deprecation cycle
+    to remove key output aspects; ensure that users can preserve specific
+    outputs from previous version when upgrading, possibly via opt-in flags.
+
+- Be mindful of the two "modes" of *input*:
+
+  - input provided by a human: interactive use via a
+    terminal. (`cliCtx.isInteractive == true`)
+
+    In this mode, there can be explanations to suggest to the human
+    what is a good “next step” after they do something.
+
+  - input provided by scripts, automation etc., e.g. via `cockroach sql <input.sql`.
+    (`cliCtx.isInteractive == false`)
+
+    In this mode, there should *not* be guidance printed out to help a
+    human.
+
+    Also, the automated input mode is part of the public API of CockroachDB.
+    Beware of documenting changes in release notes; use the deprecation cycle
+    to remove key input aspects; ensure that users can preserve specific
+    outputs from previous version when upgrading, possibly via opt-in flags.
+
+- Beware: the two modes above are orthogonal to each other. We know
+  about real-world usage of all 4 combinations:
+
+  - fully interactive: `terminalOutput && isInteractive`
+  - fully automated: `!terminalOutput && !isInteractive`
+  - human reads a SQL script from a file but wants explanations about
+    what's going on, e.g. running `cockroach sql <foo.sql` on a
+    terminal: `terminalOutput && !isInteractive`
+  - human runs the SQL shell but filters the output, e.g. `cockroach sql | grep XXX`
+    `!terminalOutput && isInteractive`.

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -291,6 +291,23 @@ transaction state. Equivalent to --echo-sql, \unset check_syntax and
 \set prompt1 %n@%M>.`,
 	}
 
+	EmbeddedMode = FlagInfo{
+		Name: "embedded",
+		Description: `
+Simplify and reduce the SQL CLI output to make it appropriate for
+embedding in a 'playground'-type environment.
+
+This causes the shell to omit informational message about
+aspects that can only be changed with command-line flags
+or environment variables: in an embedded environment, the user
+has no control over these and the messages would thus be
+confusing.
+
+It also causes the shell to omit informational messages about
+networking details (e.g. server address), as it is assumed
+that the embedding environment will report those instead.`,
+	}
+
 	SafeUpdates = FlagInfo{
 		Name: "safe-updates",
 		Description: `

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -125,11 +125,17 @@ type cliContext struct {
 	// is, the commands executed are extremely likely to be *input* from
 	// a human user: the standard input is a terminal and `-e` was not
 	// used (the shell has a prompt).
+	//
+	// Refer to README.md to understand the general design guidelines for
+	// CLI utilities with interactive vs non-interactive input.
 	isInteractive bool
 
 	// terminalOutput indicates whether output is going to a terminal,
 	// that is, it is not going to a file, another program for automated
 	// processing, etc.: the standard output is a terminal.
+	//
+	// Refer to README.md to understand the general design guidelines for
+	// CLI utilities with terminal vs non-terminal output.
 	terminalOutput bool
 
 	// tableDisplayFormat indicates how to format result tables.

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -270,6 +270,11 @@ var sqlCtx = struct {
 	// more verbose (sets echo).
 	debugMode bool
 
+	// embeddedMode, when set, reduces the amount of informational
+	// messages printed out to exclude details that are not
+	// under user's control when the shell is run by a playground environment.
+	embeddedMode bool
+
 	// Determines whether to display server execution timings in the CLI.
 	enableServerExecutionTimings bool
 

--- a/pkg/cli/demo.go
+++ b/pkg/cli/demo.go
@@ -229,11 +229,13 @@ func checkDemoConfiguration(
 				return nil, errors.Newf("--nodes with a value different from 9 cannot be used with %s", geoFlag)
 			}
 		} else {
-			const msg = `#
-# --geo-partitioned replicas operates on a 9 node cluster.
-# The cluster size has been changed from the default to 9 nodes.`
-			fmt.Println(msg)
 			demoCtx.nodes = 9
+			printlnUnlessEmbedded(
+				// Only explain how the configuration was interpreted if the
+				// user has control over it.
+				`#
+# --geo-partitioned replicas operates on a 9 node cluster.
+# The cluster size has been changed from the default to 9 nodes.`)
 		}
 
 		// If geo-partition-replicas is requested, make sure the workload has a Partitioning step.
@@ -288,12 +290,14 @@ func runDemo(cmd *cobra.Command, gen workload.Generator) (err error) {
 # You are connected to a temporary, in-memory CockroachDB cluster of %d node%s.
 `, demoCtx.nodes, util.Pluralize(int64(demoCtx.nodes)))
 
+		// Only print details about the telemetry configuration if the
+		// user has control over it.
 		if demoCtx.disableTelemetry {
-			fmt.Println("#\n# Telemetry and automatic license acquisition disabled by configuration.")
+			printlnUnlessEmbedded("#\n# Telemetry and automatic license acquisition disabled by configuration.")
 		} else if demoCtx.disableLicenseAcquisition {
-			fmt.Println("#\n# Enterprise features disabled by OSS-only build.")
+			printlnUnlessEmbedded("#\n# Enterprise features disabled by OSS-only build.")
 		} else {
-			fmt.Println("#\n# This demo session will attempt to enable enterprise features\n" +
+			printlnUnlessEmbedded("#\n# This demo session will attempt to enable enterprise features\n" +
 				"# by acquiring a temporary license from Cockroach Labs in the background.\n" +
 				"# To disable this behavior, set the environment variable\n" +
 				"# COCKROACH_SKIP_ENABLING_DIAGNOSTIC_REPORTING=true.")
@@ -318,23 +322,28 @@ func runDemo(cmd *cobra.Command, gen workload.Generator) (err error) {
 		}
 
 		fmt.Println(`#
-# Reminder: your changes to data stored in the demo session will not be saved!
-#
-# Connection parameters:`)
+# Reminder: your changes to data stored in the demo session will not be saved!`)
+
 		var nodeList strings.Builder
 		c.listDemoNodes(&nodeList, true /* justOne */)
-		fmt.Println("#", strings.ReplaceAll(nodeList.String(), "\n", "\n# "))
+		printlnUnlessEmbedded(
+			// Only print the server details when the shell is not embedded;
+			// if embedded, the embedding platform owns the network
+			// configuration.
+			`#
+# Connection parameters:
+#`,
+			strings.ReplaceAll(strings.TrimSuffix(nodeList.String(), "\n"), "\n", "\n# "))
 
 		if !demoCtx.insecure {
-			fmt.Printf(
-				"# The user %q with password %q has been created. Use it to access the Web UI!\n#\n",
+			fmt.Printf(`#
+# The user %q with password %q has been created. Use it to access the Web UI!
+#
+`,
 				c.adminUser,
 				c.adminPassword,
 			)
 		}
-		// If we didn't launch a workload, we still need to inform the
-		// user if the license check fails. Do this asynchronously and print
-		// the final error if any.
 
 		// It's ok to do this twice (if workload setup already waited) because
 		// then the error return is guaranteed to be nil.

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -643,6 +643,7 @@ func init() {
 		durationFlag(f, &sqlCtx.repeatDelay, cliflags.Watch)
 		boolFlag(f, &sqlCtx.safeUpdates, cliflags.SafeUpdates)
 		boolFlag(f, &sqlCtx.debugMode, cliflags.CliDebugMode)
+		boolFlag(f, &sqlCtx.embeddedMode, cliflags.EmbeddedMode)
 	}
 
 	// Commands that establish a SQL connection.

--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -44,6 +44,9 @@ import (
 )
 
 const (
+	// Refer to README.md to understand the general design guidelines for
+	// help texts.
+
 	welcomeMessage = `#
 # Welcome to the CockroachDB SQL shell.
 # All statements must be terminated by a semicolon.

--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -1794,3 +1794,9 @@ func (c *cliState) serverSideParse(sql string) (helpText string, err error) {
 	}
 	return "", nil
 }
+
+func printlnUnlessEmbedded(args ...interface{}) {
+	if !sqlCtx.embeddedMode {
+		fmt.Println(args...)
+	}
+}

--- a/pkg/cli/sql_util.go
+++ b/pkg/cli/sql_util.go
@@ -281,6 +281,11 @@ func (c *sqlConn) checkServerMetadata() error {
 		// change their mind upon seeing the information.
 		return nil
 	}
+	if sqlCtx.embeddedMode {
+		// Version reporting is non-actionable if the user does
+		// not have control over how the server and client are run.
+		return nil
+	}
 
 	_, newServerVersion, newClusterID, err := c.getServerMetadata()
 	if errors.Is(err, driver.ErrBadConn) {


### PR DESCRIPTION
First commit from #59749 
Fixes #52059. 

Requested by @jseldess 

`cockroach sql --embedded`:

    #
    # Welcome to the CockroachDB SQL shell.
    # All statements must be terminated by a semicolon.
    # To exit, type: \q.
    #
    #
    # Enter \? for a brief introduction.
    #
    root@:26257/defaultdb>

`cockroach demo --embedded`:

    #
    # Welcome to the CockroachDB demo database!
    #
    # You are connected to a temporary, in-memory CockroachDB cluster of 1 node.
    #
    # Beginning initialization of the movr dataset, please wait...
    #
    # The cluster has been preloaded with the "movr" dataset
    # (MovR is a fictional vehicle sharing company).
    #
    # Reminder: your changes to data stored in the demo session will not be saved!
    #
    # The user "demo" with password "demo16754" has been created. Use it to access the Web UI!
    #
    # Enter \? for a brief introduction.
    #
    demo@127.0.0.1:26257/movr>

Release note (cli change): The SQL shell (`cockroach sql` / `demo`)
now supports a flag `--embedded`, for use with playground-style
web applications. Help text for this flag:

> Simplify/reduce the SQL CLI output to make it appropriate for
> embedding in a 'playground'-type environment.
>
> This causes the shell to omit informational message about
> aspects that can only be changed with command-line flags
> or environment variables: in an embedded environment, the user
> has no control over these and the messages would thus be
> confusing.
>
> It also causes the shell to omit informational messages about
> networking details (e.g. server address), as it is assumed
> that the embedding environment will report those instead.