### PR TITLE
[dnm] sql: explicitly background trace txns

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1624,6 +1624,7 @@ func (st *SessionTracing) StopTracing() error {
 	if st.firstTxnSpan != nil {
 		spans = append(spans, st.firstTxnSpan.GetRecording()...)
 		st.firstTxnSpan.SetVerbose(false)
+		st.firstTxnSpan.SetBackground(true)
 	}
 	st.connSpan.Finish()
 	spans = append(spans, st.connSpan.GetRecording()...)
@@ -1631,6 +1632,7 @@ func (st *SessionTracing) StopTracing() error {
 	// is not inherited by children. If we are inside of a txn, that span will
 	// continue recording, even though nobody will collect its recording again.
 	st.connSpan.SetVerbose(false)
+	st.connSpan.SetBackground(true)
 	st.ex.ctxHolder.unhijack()
 
 	var err error

--- a/pkg/sql/txn_state.go
+++ b/pkg/sql/txn_state.go
@@ -168,6 +168,8 @@ func (ts *txnState) resetForNewSQLTxn(
 		sp.SetVerbose(true)
 		ts.recordingThreshold = duration
 		ts.recordingStart = timeutil.Now()
+	} else if !alreadyRecording {
+		sp.SetBackground(true)
 	}
 
 	ts.sp = sp

--- a/pkg/util/tracing/recording.go
+++ b/pkg/util/tracing/recording.go
@@ -37,8 +37,7 @@ const (
 	// RecordingVerbose means that the Span is adding events passed in via LogKV
 	// and LogData to its recording and that derived spans will do so as well.
 	RecordingVerbose
-
-	// TODO(tbg): add RecordingBackground for always-on tracing.
+	RecordingBackground
 )
 
 type traceLogData struct {

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -570,6 +570,8 @@ func (t *Tracer) Extract(format interface{}, carrier interface{}) (*SpanMeta, er
 	var recordingType RecordingType
 	if baggage[verboseTracingBaggageKey] != "" {
 		recordingType = RecordingVerbose
+	} else {
+		recordingType = RecordingBackground
 	}
 
 	var shadowCtx opentracing.SpanContext


### PR DESCRIPTION
This experiments with the idea of introducing an explicit "background"
tracing mode that can be set only for SQL txns, as explained [here].

I tried adapting the `contention_event` logictest to keep showing me the
contention event via the `session_trace` vtable while tracing is off;
but it looks like we'd need more code changes to actually make this
stuff work than I am comfortable carrying out. I think the rough problem
is that the vtable is rendered from `SessionTracing.connSpan` (or
`firstTxnSpan`) and neither are set without explicit calls to
`StartTracing`.
But, I was able to confirm (with a debugger breakpoint) that in this
test, without tracing explicitly on, the ContentionEvent makes it to
`r.contendedQueryMetric`. It should be straightforward to set up a
test with a TestCluster asserting the same programmatically.

[here]: https://github.com/cockroachdb/cockroach/pull/59391#pullrequestreview-582170340

cc @asubiotto @andreimatei 

Release note: None
