### PR TITLE
release-20.2:  cli: support `cockroach --version`, `cockroach version --build-tag`

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -1427,10 +1427,14 @@ Flags:
   -h, --help                             help for cockroach
       --logtostderr Severity[=DEFAULT]   logs at or above this threshold go to stderr (default NONE)
       --no-color                         disable standard error log colorization
+      --version                          version for cockroach
 
 Use "cockroach [command] --help" for more information about a command.
 `
-	helpExpected := fmt.Sprintf("CockroachDB command-line interface and server.\n\n%s", expUsage)
+	helpExpected := fmt.Sprintf("CockroachDB command-line interface and server.\n\n%s",
+		// Due to a bug in spf13/cobra, 'cockroach help' does not include the --version
+		// flag. Strangely, 'cockroach --help' does, as well as usage error messages.
+		strings.ReplaceAll(expUsage, "      --version                          version for cockroach\n", ""))
 	badFlagExpected := fmt.Sprintf("%s\nError: unknown flag: --foo\n", expUsage)
 
 	testCases := []struct {

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -1250,4 +1250,12 @@ The zip command will block for the duration specified. Zero disables this featur
 		Name:        "all",
 		Description: `Cancel all outstanding requests.`,
 	}
+
+	BuildTag = FlagInfo{
+		Name: "build-tag",
+		Description: `
+When set, the command prints only the build tag for the executable,
+without any other details.
+`,
+	}
 )

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -162,6 +162,9 @@ type cliContext struct {
 	// provided this way.
 	// TODO(knz): Relax this when SCRAM is implemented.
 	allowUnencryptedClientPassword bool
+
+	// For `cockroach version --build-tag`.
+	showVersionUsingOnlyBuildTag bool
 }
 
 // cliCtx captures the command-line parameters common to most CLI utilities.
@@ -193,6 +196,7 @@ func setCliContextDefaults() {
 	cliCtx.sqlConnDBName = ""
 	cliCtx.extraConnURLOptions = nil
 	cliCtx.allowUnencryptedClientPassword = false
+	cliCtx.showVersionUsingOnlyBuildTag = false
 }
 
 // sqlCtx captures the command-line parameters of the `sql` command.

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -787,6 +787,12 @@ func init() {
 		boolFlag(f, &sqlfmtCtx.align, cliflags.SQLFmtAlign)
 	}
 
+	// version command.
+	{
+		f := versionCmd.Flags()
+		boolFlag(f, &cliCtx.showVersionUsingOnlyBuildTag, cliflags.BuildTag)
+	}
+
 	// Debug commands.
 	{
 		f := debugKeysCmd.Flags()

--- a/scripts/verify-release-binaries.sh
+++ b/scripts/verify-release-binaries.sh
@@ -40,6 +40,10 @@ function check_linux() {
   curl -s https://binaries.cockroachdb.com/cockroach-${BETA_TAG}${linux}.tgz | tar xz
   local tag=$($(dirname $0)/../build/builder.sh ./cockroach-${BETA_TAG}${linux}/cockroach version |
               grep 'Build Tag:' | awk '{print $NF}' | tr -d '\r')
+  if test -z "$tag"; then
+      # From v20.2.5 onwards.
+      tag=$($(dirname $0)/../build/builder.sh ./cockroach-${BETA_TAG}${linux}/cockroach version --build-tag | tr -d '\r')
+  fi
   rm -fr ./cockroach-${BETA_TAG}${linux}
   verify_tag "${tag}"
 
@@ -56,7 +60,11 @@ function check_darwin() {
 
   curl -s https://binaries.cockroachdb.com/cockroach-${BETA_TAG}${darwin}.tgz | tar xz
   local tag=$(./cockroach-${BETA_TAG}${darwin}/cockroach version |
-              grep 'Build Tag:' | awk '{print $NF}' | tr -d '\r')
+		  grep 'Build Tag:' | awk '{print $NF}' | tr -d '\r')
+  if test -z "$tag"; then
+      # From v20.2.5 onwards.
+      tag=$(./cockroach-${BETA_TAG}${darwin}/cockroach version | tr -d '\r')
+  fi
   rm -fr cockroach-${BETA_TAG}${darwin}
   verify_tag "${tag}"
 
@@ -69,6 +77,10 @@ function check_docker() {
   trap "rm -f docker.stderr" 0
   local tag=$(docker run --rm cockroachdb/cockroach:${BETA_TAG} version 2>docker.stderr |
               grep 'Build Tag:' | awk '{print $NF}' | tr -d '\r')
+  if test -z "$tag"; then
+      # From v20.2.5 onwards.
+      tag=$(docker run --rm cockroachdb/cockroach:${BETA_TAG} version --build-tag 2>docker.stderr | tr -d '\r')
+  fi
   if [ -z "${tag}" ]; then
       echo
       cat docker.stderr


### PR DESCRIPTION
Backport 1/1 commits from #58665.

/cc @cockroachdb/release

---
