### PR TITLE
roachtest: unskip acceptance/bank/cluster-recovery

### DIFF
--- a/pkg/cmd/roachtest/acceptance.go
+++ b/pkg/cmd/roachtest/acceptance.go
@@ -27,7 +27,6 @@ func registerAcceptance(r *testRegistry) {
 		// Sorted. Please keep it that way.
 		{
 			name: "bank/cluster-recovery", fn: runBankClusterRecovery,
-			skip: "https://github.com/cockroachdb/cockroach/issues/57342",
 		},
 		{name: "bank/node-restart", fn: runBankNodeRestart},
 		{


### PR DESCRIPTION
Fixes #57342. This looks to have been the same thing as #57798, and was
fixed by #58722.

Release note: None