### PR TITLE
changefeedccl: Use actual fully qualified name in avro schema

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -139,7 +139,7 @@ func newChangeAggregatorProcessor(
 	}
 
 	var err error
-	if ca.encoder, err = getEncoder(ca.spec.Feed.Opts); err != nil {
+	if ca.encoder, err = getEncoder(ca.spec.Feed.Opts, ca.spec.Feed.Targets); err != nil {
 		return nil, err
 	}
 
@@ -520,7 +520,7 @@ func newChangeFrontierProcessor(
 	}
 
 	var err error
-	if cf.encoder, err = getEncoder(spec.Feed.Opts); err != nil {
+	if cf.encoder, err = getEncoder(spec.Feed.Opts, spec.Feed.Targets); err != nil {
 		return nil, err
 	}
 

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -259,7 +259,7 @@ func changefeedPlanHook(
 			return err
 		}
 
-		if _, err := getEncoder(details.Opts); err != nil {
+		if _, err := getEncoder(details.Opts, details.Targets); err != nil {
 			return err
 		}
 		if isCloudStorageSink(parsedSink) {

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -15,7 +15,6 @@ import (
 	"fmt"
 	"net/url"
 	"reflect"
-	"regexp"
 	"sort"
 	"strings"
 	"testing"
@@ -156,12 +155,10 @@ func assertPayloadsAvro(
 func assertRegisteredSubjects(t testing.TB, reg *testSchemaRegistry, expected []string) {
 	t.Helper()
 
-	scrubIds := regexp.MustCompile(`\d+`)
-
 	actual := make([]string, 0, len(reg.mu.subjects))
 
 	for subject := range reg.mu.subjects {
-		actual = append(actual, scrubIds.ReplaceAllString(subject, "#"))
+		actual = append(actual, subject)
 	}
 
 	sort.Strings(expected)


### PR DESCRIPTION
In my previous PR, the full_table_name option was honored differently
in Kafka topics and Avro schemas since the schema is meant to evolve.
But freezing the schema subject to match the topic is actually important,
a feature not a bug, so now we just use the statementTimeName in the avro encoder.

Release note: None