### PR TITLE
bazel: rip out a bunch of unnecessary, broken build targets

### DIFF
--- a/pkg/sql/schemachanger/scbuild/BUILD.bazel
+++ b/pkg/sql/schemachanger/scbuild/BUILD.bazel
@@ -1,61 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
-    name = "builder",
-    srcs = ["builder.go"],
-    importpath = "github.com/cockroachdb/cockroach/pkg/sql/schemachanger/builder",
-    visibility = ["//visibility:public"],
-    deps = [
-        "//pkg/clusterversion",
-        "//pkg/sql/catalog",
-        "//pkg/sql/catalog/descpb",
-        "//pkg/sql/catalog/resolver",
-        "//pkg/sql/catalog/schemaexpr",
-        "//pkg/sql/catalog/tabledesc",
-        "//pkg/sql/parser",
-        "//pkg/sql/pgwire/pgcode",
-        "//pkg/sql/pgwire/pgerror",
-        "//pkg/sql/schemachanger/targets",
-        "//pkg/sql/sem/tree",
-        "//pkg/sql/sqlerrors",
-        "//pkg/sql/types",
-        "//pkg/util/errorutil/unimplemented",
-        "//pkg/util/protoutil",
-        "//pkg/util/sequence",
-        "@com_github_cockroachdb_errors//:errors",
-    ],
-)
-
-go_test(
-    name = "builder_test",
-    srcs = [
-        "builder_test.go",
-        "main_test.go",
-    ],
-    deps = [
-        ":builder",
-        "//pkg/base",
-        "//pkg/kv",
-        "//pkg/security",
-        "//pkg/security/securitytest",
-        "//pkg/server",
-        "//pkg/sql",
-        "//pkg/sql/catalog/descpb",
-        "//pkg/sql/catalog/resolver",
-        "//pkg/sql/parser",
-        "//pkg/sql/schemachanger/targets",
-        "//pkg/sql/sem/tree",
-        "//pkg/sql/sessiondatapb",
-        "//pkg/testutils/serverutils",
-        "//pkg/testutils/sqlutils",
-        "//pkg/testutils/testcluster",
-        "//pkg/util/leaktest",
-        "//pkg/util/randutil",
-        "@com_github_stretchr_testify//require",
-    ],
-)
-
-go_library(
     name = "scbuild",
     srcs = ["builder.go"],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scbuild",

--- a/pkg/sql/schemachanger/scexec/BUILD.bazel
+++ b/pkg/sql/schemachanger/scexec/BUILD.bazel
@@ -1,66 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
-    name = "executor",
-    srcs = ["executor.go"],
-    importpath = "github.com/cockroachdb/cockroach/pkg/sql/schemachanger/executor",
-    visibility = ["//visibility:public"],
-    deps = [
-        "//pkg/keys",
-        "//pkg/kv",
-        "//pkg/roachpb",
-        "//pkg/sql/catalog",
-        "//pkg/sql/catalog/descpb",
-        "//pkg/sql/catalog/descs",
-        "//pkg/sql/schemachanger/ops",
-        "//pkg/sql/schemachanger/targets",
-        "//pkg/sql/sem/tree",
-        "//pkg/util/log",
-        "//pkg/util/protoutil",
-        "@com_github_cockroachdb_errors//:errors",
-    ],
-)
-
-go_test(
-    name = "executor_test",
-    srcs = [
-        "executor_external_test.go",
-        "main_test.go",
-    ],
-    deps = [
-        ":executor",
-        "//pkg/base",
-        "//pkg/kv",
-        "//pkg/security",
-        "//pkg/security/securitytest",
-        "//pkg/server",
-        "//pkg/settings/cluster",
-        "//pkg/sql",
-        "//pkg/sql/catalog/descpb",
-        "//pkg/sql/catalog/descs",
-        "//pkg/sql/catalog/lease",
-        "//pkg/sql/catalog/resolver",
-        "//pkg/sql/catalog/tabledesc",
-        "//pkg/sql/parser",
-        "//pkg/sql/schemachanger/builder",
-        "//pkg/sql/schemachanger/compiler",
-        "//pkg/sql/schemachanger/ops",
-        "//pkg/sql/schemachanger/targets",
-        "//pkg/sql/sem/tree",
-        "//pkg/sql/sessiondatapb",
-        "//pkg/sql/sqlutil",
-        "//pkg/sql/types",
-        "//pkg/testutils/serverutils",
-        "//pkg/testutils/sqlutils",
-        "//pkg/testutils/testcluster",
-        "//pkg/util/leaktest",
-        "//pkg/util/randutil",
-        "//pkg/util/retry",
-        "@com_github_stretchr_testify//require",
-    ],
-)
-
-go_library(
     name = "scexec",
     srcs = [
         "executor.go",

--- a/pkg/sql/schemachanger/scjob/BUILD.bazel
+++ b/pkg/sql/schemachanger/scjob/BUILD.bazel
@@ -1,31 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
-    name = "job",
-    srcs = ["job.go"],
-    importpath = "github.com/cockroachdb/cockroach/pkg/sql/schemachanger/job",
-    visibility = ["//visibility:public"],
-    deps = [
-        "//pkg/jobs",
-        "//pkg/jobs/jobspb",
-        "//pkg/keys",
-        "//pkg/kv",
-        "//pkg/roachpb",
-        "//pkg/settings/cluster",
-        "//pkg/sql",
-        "//pkg/sql/catalog/descpb",
-        "//pkg/sql/catalog/descs",
-        "//pkg/sql/catalog/lease",
-        "//pkg/sql/schemachanger/compiler",
-        "//pkg/sql/schemachanger/executor",
-        "//pkg/sql/schemachanger/targets",
-        "//pkg/sql/sem/tree",
-        "//pkg/sql/sqlutil",
-        "//pkg/util/log/logcrash",
-    ],
-)
-
-go_library(
     name = "scjob",
     srcs = ["job.go"],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scjob",

--- a/pkg/sql/schemachanger/scop/BUILD.bazel
+++ b/pkg/sql/schemachanger/scop/BUILD.bazel
@@ -1,17 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
-    name = "ops",
-    srcs = ["ops.go"],
-    importpath = "github.com/cockroachdb/cockroach/pkg/sql/schemachanger/ops",
-    visibility = ["//visibility:public"],
-    deps = [
-        "//pkg/sql/catalog/descpb",
-        "//pkg/sql/schemachanger/targets",
-    ],
-)
-
-go_library(
     name = "scop",
     srcs = [
         "backfill.go",

--- a/pkg/sql/schemachanger/scpb/BUILD.bazel
+++ b/pkg/sql/schemachanger/scpb/BUILD.bazel
@@ -3,14 +3,6 @@ load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
-    name = "targets",
-    srcs = ["targets.go"],
-    embed = [":targets_go_proto"],
-    importpath = "github.com/cockroachdb/cockroach/pkg/sql/schemachanger/targets",
-    visibility = ["//visibility:public"],
-)
-
-go_library(
     name = "scpb",
     srcs = ["elements.go"],
     embed = [":scpb_go_proto"],

--- a/pkg/sql/schemachanger/scplan/BUILD.bazel
+++ b/pkg/sql/schemachanger/scplan/BUILD.bazel
@@ -1,39 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
-
-go_library(
-    name = "compiler",
-    srcs = [
-        "compiler.go",
-        "gen_dep_edges.go",
-        "gen_op_edges.go",
-        "graphviz.go",
-    ],
-    importpath = "github.com/cockroachdb/cockroach/pkg/sql/schemachanger/compiler",
-    visibility = ["//visibility:public"],
-    deps = [
-        "//pkg/sql/catalog/descpb",
-        "//pkg/sql/schemachanger/ops",
-        "//pkg/sql/schemachanger/targets",
-        "//pkg/util",
-        "@com_github_cockroachdb_errors//:errors",
-        "@com_github_emicklei_dot//:dot",
-    ],
-)
-
-go_test(
-    name = "compiler_test",
-    srcs = ["compiler_test.go"],
-    embed = [":compiler"],
-    deps = [
-        "//pkg/sql/catalog/descpb",
-        "//pkg/sql/schemachanger/ops",
-        "//pkg/sql/schemachanger/targets",
-        "//pkg/sql/types",
-        "//pkg/util/leaktest",
-        "@com_github_emicklei_dot//:dot",
-        "@com_github_stretchr_testify//require",
-    ],
-)
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "scplan",


### PR DESCRIPTION
Gazelle doesn't manage these build targets, and they all immediately
became stale.

Release note: None