### PR TITLE
sql: add increment_feature_counter built-in

### DIFF
--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -4675,6 +4675,25 @@ may increase either contention or retry errors, or both.`,
 		},
 	),
 
+	"crdb_internal.increment_feature_counter": makeBuiltin(
+		tree.FunctionProperties{
+			Category:     categorySystemInfo,
+			Undocumented: true,
+		},
+		tree.Overload{
+			Types:      tree.ArgTypes{{"feature", types.String}},
+			ReturnType: tree.FixedReturnType(types.Bool),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				feature := string(*args[0].(*tree.DString))
+				telemetry.Inc(sqltelemetry.HashedFeatureCounter(feature))
+				return tree.DBoolTrue, nil
+			},
+			Info: "This function can be used to report the usage of an arbitrary feature. The " +
+				"feature name is hashed for privacy purposes.",
+			Volatility: tree.VolatilityVolatile,
+		},
+	),
+
 	"num_nulls": makeBuiltin(
 		tree.FunctionProperties{
 			Category:     categoryComparison,

--- a/pkg/sql/testdata/telemetry/hashed
+++ b/pkg/sql/testdata/telemetry/hashed
@@ -1,0 +1,10 @@
+# This file contains telemetry tests for the hashed.* counter.
+
+feature-allowlist
+sql.hashed.*
+----
+
+feature-usage
+SELECT crdb_internal.increment_feature_counter('abc');
+----
+sql.hashed.ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad


### PR DESCRIPTION
I added a new built-in called crdb_internal.increment_feature_counter,
which allows incrementing an arbitrary feature counter. This is intended
to be called by our adapters for third-party tools so that we can begin
to collect telemetry on tool usage.

To avoid the risk of collecting sensitive data, the feature name is
hashed before reporting.

Release note: None