### PR TITLE
release-20.2: delegate: gate estimated_row_count on SHOW TABLES behind cluster setting

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -74,6 +74,7 @@
 <tr><td><code>sql.metrics.statement_details.threshold</code></td><td>duration</td><td><code>0s</code></td><td>minimum execution time to cause statement statistics to be collected. If configured, no transaction stats are collected.</td></tr>
 <tr><td><code>sql.metrics.transaction_details.enabled</code></td><td>boolean</td><td><code>true</code></td><td>collect per-application transaction statistics</td></tr>
 <tr><td><code>sql.notices.enabled</code></td><td>boolean</td><td><code>true</code></td><td>enable notices in the server/client protocol being sent</td></tr>
+<tr><td><code>sql.show_tables.estimated_row_count.enabled</code></td><td>boolean</td><td><code>true</code></td><td>whether the estimated_row_count is shown on SHOW TABLES. Turning this off will improve SHOW TABLES performance.</td></tr>
 <tr><td><code>sql.spatial.experimental_box2d_comparison_operators.enabled</code></td><td>boolean</td><td><code>false</code></td><td>enables the use of certain experimental box2d comparison operators</td></tr>
 <tr><td><code>sql.stats.automatic_collection.enabled</code></td><td>boolean</td><td><code>true</code></td><td>automatic statistics collection mode</td></tr>
 <tr><td><code>sql.stats.automatic_collection.fraction_stale_rows</code></td><td>float</td><td><code>0.2</code></td><td>target fraction of stale rows per table that will trigger a statistics refresh</td></tr>

--- a/pkg/sql/logictest/testdata/logic_test/show_tables
+++ b/pkg/sql/logictest/testdata/logic_test/show_tables
@@ -1,0 +1,17 @@
+# LogicTest: local
+
+statement ok
+SET CLUSTER SETTING sql.show_tables.estimated_row_count.enabled = false
+
+statement ok
+CREATE TABLE show_this_table ()
+
+query TTTT
+SHOW TABLES
+----
+public  show_this_table  table  root
+
+query TTTTT
+SHOW TABLES WITH COMMENT
+----
+public  show_this_table  table  root  ·


### PR DESCRIPTION
Refs: https://github.com/cockroachdb/cockroach/issues/58189

Release note (sql change): Introduced a cluster setting
`sql.show_tables.estimated_row_count.enabled`, which defaults to true. If
false, estimated_row_count will not display on SHOW TABLES which
improves performance.

