### PR TITLE
flowinfra: deflake a test

### DIFF
--- a/pkg/sql/flowinfra/BUILD.bazel
+++ b/pkg/sql/flowinfra/BUILD.bazel
@@ -84,7 +84,6 @@ go_test(
         "//pkg/testutils/buildutil",
         "//pkg/testutils/distsqlutils",
         "//pkg/testutils/serverutils",
-        "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
         "//pkg/util/cancelchecker",


### PR DESCRIPTION
Previously, a unit test could fail in rare circumstances when relocating
a range to a remote node, and now we will use SucceedsSoon to avoid
that. Also unskip the vectorized option.

Fixes: #59712

Release note: None