### PR TITLE
opt: add exploration rules to hoist project from under join

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/tpch_vec
+++ b/pkg/sql/logictest/testdata/logic_test/tpch_vec
@@ -965,18 +965,18 @@ EXPLAIN (VEC) SELECT s_name, s_address FROM supplier, nation WHERE s_suppkey IN 
 └ Node 1
   └ *colexec.sortOp
     └ *colexec.hashJoiner
-      ├ *rowexec.joinReader
-      │ └ *colexec.unorderedDistinct
-      │   └ *rowexec.joinReader
-      │     └ *colexec.selGTInt64Float64Op
-      │       └ *colexec.projMultFloat64Float64ConstOp
-      │         └ *colexec.hashAggregator
-      │           └ *colexec.hashJoiner
-      │             ├ *rowexec.joinReader
-      │             │ └ *colfetcher.ColBatchScan
-      │             └ *colfetcher.ColBatchScan
-      └ *colexec.selEQBytesBytesConstOp
-        └ *colfetcher.ColBatchScan
+      ├ *colexec.selEQBytesBytesConstOp
+      │ └ *colfetcher.ColBatchScan
+      └ *rowexec.joinReader
+        └ *colexec.unorderedDistinct
+          └ *rowexec.joinReader
+            └ *colexec.selGTInt64Float64Op
+              └ *colexec.projMultFloat64Float64ConstOp
+                └ *colexec.hashAggregator
+                  └ *colexec.hashJoiner
+                    ├ *rowexec.joinReader
+                    │ └ *colfetcher.ColBatchScan
+                    └ *colfetcher.ColBatchScan
 
 # Query 21
 query T

--- a/pkg/sql/opt/exec/execbuilder/testdata/virtual_columns
+++ b/pkg/sql/opt/exec/execbuilder/testdata/virtual_columns
@@ -780,7 +780,6 @@ vectorized: true
                   row 1, expr 0: 6
                   row 1, expr 1: 60
 
-# TODO(radu): this should use a lookup join instead of a merge join.
 query T
 EXPLAIN (VERBOSE) INSERT INTO t VALUES (4, 100), (6, 100), (7, 100) ON CONFLICT (a) DO UPDATE SET b = t.v
 ----
@@ -809,33 +808,22 @@ vectorized: true
         │ render b: b
         │ render v: v
         │
-        └── • merge join (right outer)
-            │ columns: (v, a, b, column8, column1, column2)
+        └── • render
+            │ columns: (v, column1, column2, column8, a, b)
             │ estimated row count: 3 (missing stats)
-            │ equality: (a) = (column1)
-            │ left cols are key
-            │ merge ordering: +"(a=column1)"
+            │ render v: CASE a IS NULL WHEN true THEN CAST(NULL AS INT8) ELSE a + b END
+            │ render column1: column1
+            │ render column2: column2
+            │ render column8: column8
+            │ render a: a
+            │ render b: b
             │
-            ├── • render
-            │   │ columns: (v, a, b)
-            │   │ ordering: +a
-            │   │ estimated row count: 1,000 (missing stats)
-            │   │ render v: a + b
-            │   │ render a: a
-            │   │ render b: b
-            │   │
-            │   └── • scan
-            │         columns: (a, b)
-            │         ordering: +a
-            │         estimated row count: 1,000 (missing stats)
-            │         table: t@primary
-            │         spans: FULL SCAN
-            │
-            └── • sort
-                │ columns: (column8, column1, column2)
-                │ ordering: +column1
-                │ estimated row count: 3
-                │ order: +column1
+            └── • lookup join (left outer)
+                │ columns: (column8, column1, column2, a, b)
+                │ estimated row count: 3 (missing stats)
+                │ table: t@primary
+                │ equality: (column1) = (a)
+                │ equality cols are key
                 │
                 └── • render
                     │ columns: (column8, column1, column2)
@@ -854,7 +842,6 @@ vectorized: true
                           row 2, expr 0: 7
                           row 2, expr 1: 100
 
-# TODO(radu): this should use a lookup join instead of a merge join.
 query T
 EXPLAIN (VERBOSE) INSERT INTO t VALUES (2, 100), (5, 100), (8, 100) ON CONFLICT (a) DO UPDATE SET b = excluded.v
 ----
@@ -883,33 +870,22 @@ vectorized: true
         │ render b: b
         │ render v: v
         │
-        └── • merge join (right outer)
-            │ columns: (v, a, b, column8, column1, column2)
+        └── • render
+            │ columns: (v, column1, column2, column8, a, b)
             │ estimated row count: 3 (missing stats)
-            │ equality: (a) = (column1)
-            │ left cols are key
-            │ merge ordering: +"(a=column1)"
+            │ render v: CASE a IS NULL WHEN true THEN CAST(NULL AS INT8) ELSE a + b END
+            │ render column1: column1
+            │ render column2: column2
+            │ render column8: column8
+            │ render a: a
+            │ render b: b
             │
-            ├── • render
-            │   │ columns: (v, a, b)
-            │   │ ordering: +a
-            │   │ estimated row count: 1,000 (missing stats)
-            │   │ render v: a + b
-            │   │ render a: a
-            │   │ render b: b
-            │   │
-            │   └── • scan
-            │         columns: (a, b)
-            │         ordering: +a
-            │         estimated row count: 1,000 (missing stats)
-            │         table: t@primary
-            │         spans: FULL SCAN
-            │
-            └── • sort
-                │ columns: (column8, column1, column2)
-                │ ordering: +column1
-                │ estimated row count: 3
-                │ order: +column1
+            └── • lookup join (left outer)
+                │ columns: (column8, column1, column2, a, b)
+                │ estimated row count: 3 (missing stats)
+                │ table: t@primary
+                │ equality: (column1) = (a)
+                │ equality cols are key
                 │
                 └── • render
                     │ columns: (column8, column1, column2)
@@ -928,7 +904,6 @@ vectorized: true
                           row 2, expr 0: 8
                           row 2, expr 1: 100
 
-# TODO(radu): this should use a lookup join instead of a merge join.
 query T
 EXPLAIN (VERBOSE) UPSERT INTO t_idx VALUES (1, 10, 100), (2, 20, 200), (3, 30, 300), (4, 40, 400)
 ----
@@ -945,35 +920,27 @@ vectorized: true
 └── • project
     │ columns: (column1, column2, column3, column11, column12, a, b, c, v, w, column2, column3, column11, column12, a)
     │
-    └── • merge join (right outer)
-        │ columns: (v, w, a, b, c, column11, column12, column1, column2, column3)
+    └── • render
+        │ columns: (v, w, column1, column2, column3, column11, column12, a, b, c)
         │ estimated row count: 4 (missing stats)
-        │ equality: (a) = (column1)
-        │ left cols are key
-        │ merge ordering: +"(a=column1)"
+        │ render v: CASE a IS NULL WHEN true THEN CAST(NULL AS INT8) ELSE a + b END
+        │ render w: CASE a IS NULL WHEN true THEN CAST(NULL AS INT8) ELSE c + 1 END
+        │ render column1: column1
+        │ render column2: column2
+        │ render column3: column3
+        │ render column11: column11
+        │ render column12: column12
+        │ render a: a
+        │ render b: b
+        │ render c: c
         │
-        ├── • render
-        │   │ columns: (v, w, a, b, c)
-        │   │ ordering: +a
-        │   │ estimated row count: 1,000 (missing stats)
-        │   │ render v: a + b
-        │   │ render w: c + 1
-        │   │ render a: a
-        │   │ render b: b
-        │   │ render c: c
-        │   │
-        │   └── • scan
-        │         columns: (a, b, c)
-        │         ordering: +a
-        │         estimated row count: 1,000 (missing stats)
-        │         table: t_idx@primary
-        │         spans: FULL SCAN
-        │
-        └── • sort
-            │ columns: (column11, column12, column1, column2, column3)
-            │ ordering: +column1
-            │ estimated row count: 4
-            │ order: +column1
+        └── • lookup join (left outer)
+            │ columns: (column11, column12, column1, column2, column3, a, b, c)
+            │ estimated row count: 4 (missing stats)
+            │ table: t_idx@primary
+            │ equality: (column1) = (a)
+            │ equality cols are key
+            │ locking strength: for update
             │
             └── • render
                 │ columns: (column11, column12, column1, column2, column3)
@@ -1000,7 +967,6 @@ vectorized: true
                       row 3, expr 1: 40
                       row 3, expr 2: 400
 
-# TODO(radu): this should use a lookup join instead of a merge join.
 query T
 EXPLAIN (VERBOSE) UPSERT INTO t_idx VALUES (3, 31, 301), (5, 50, 500) RETURNING a, v, w
 ----
@@ -1032,35 +998,26 @@ vectorized: true
         │ render v: v
         │ render w: w
         │
-        └── • merge join (right outer)
-            │ columns: (v, w, a, b, c, column11, column12, column1, column2, column3)
+        └── • render
+            │ columns: (v, w, column1, column2, column3, column11, column12, a, b, c)
             │ estimated row count: 2 (missing stats)
-            │ equality: (a) = (column1)
-            │ left cols are key
-            │ merge ordering: +"(a=column1)"
+            │ render v: CASE a IS NULL WHEN true THEN CAST(NULL AS INT8) ELSE a + b END
+            │ render w: CASE a IS NULL WHEN true THEN CAST(NULL AS INT8) ELSE c + 1 END
+            │ render column1: column1
+            │ render column2: column2
+            │ render column3: column3
+            │ render column11: column11
+            │ render column12: column12
+            │ render a: a
+            │ render b: b
+            │ render c: c
             │
-            ├── • render
-            │   │ columns: (v, w, a, b, c)
-            │   │ ordering: +a
-            │   │ estimated row count: 1,000 (missing stats)
-            │   │ render v: a + b
-            │   │ render w: c + 1
-            │   │ render a: a
-            │   │ render b: b
-            │   │ render c: c
-            │   │
-            │   └── • scan
-            │         columns: (a, b, c)
-            │         ordering: +a
-            │         estimated row count: 1,000 (missing stats)
-            │         table: t_idx@primary
-            │         spans: FULL SCAN
-            │
-            └── • sort
-                │ columns: (column11, column12, column1, column2, column3)
-                │ ordering: +column1
-                │ estimated row count: 2
-                │ order: +column1
+            └── • lookup join (left outer)
+                │ columns: (column11, column12, column1, column2, column3, a, b, c)
+                │ estimated row count: 2 (missing stats)
+                │ table: t_idx@primary
+                │ equality: (column1) = (a)
+                │ equality cols are key
                 │
                 └── • render
                     │ columns: (column11, column12, column1, column2, column3)
@@ -1149,7 +1106,6 @@ vectorized: true
                           row 2, expr 1: 70
                           row 2, expr 2: 100
 
-# TODO(radu): this should use a lookup join instead of a merge join.
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_idx VALUES (4, 10, 100), (6, 10, 100), (7, 70, 700) ON CONFLICT (a) DO UPDATE SET c = 0
 ----
@@ -1180,33 +1136,24 @@ vectorized: true
         │ render c: c
         │ render w: w
         │
-        └── • merge join (right outer)
-            │ columns: (w, a, c, column11, column12, column1, column2, column3)
+        └── • render
+            │ columns: (w, column1, column2, column3, column11, column12, a, c)
             │ estimated row count: 3 (missing stats)
-            │ equality: (a) = (column1)
-            │ left cols are key
-            │ merge ordering: +"(a=column1)"
+            │ render w: CASE a IS NULL WHEN true THEN CAST(NULL AS INT8) ELSE c + 1 END
+            │ render column1: column1
+            │ render column2: column2
+            │ render column3: column3
+            │ render column11: column11
+            │ render column12: column12
+            │ render a: a
+            │ render c: c
             │
-            ├── • render
-            │   │ columns: (w, a, c)
-            │   │ ordering: +a
-            │   │ estimated row count: 1,000 (missing stats)
-            │   │ render w: c + 1
-            │   │ render a: a
-            │   │ render c: c
-            │   │
-            │   └── • scan
-            │         columns: (a, c)
-            │         ordering: +a
-            │         estimated row count: 1,000 (missing stats)
-            │         table: t_idx@primary
-            │         spans: FULL SCAN
-            │
-            └── • sort
-                │ columns: (column11, column12, column1, column2, column3)
-                │ ordering: +column1
-                │ estimated row count: 3
-                │ order: +column1
+            └── • lookup join (left outer)
+                │ columns: (column11, column12, column1, column2, column3, a, c)
+                │ estimated row count: 3 (missing stats)
+                │ table: t_idx@primary
+                │ equality: (column1) = (a)
+                │ equality cols are key
                 │
                 └── • render
                     │ columns: (column11, column12, column1, column2, column3)
@@ -1230,7 +1177,6 @@ vectorized: true
                           row 2, expr 1: 70
                           row 2, expr 2: 700
 
-# TODO(radu): this should use a lookup join instead of a merge join.
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_idx VALUES (4, 10, 100), (6, 10, 100), (7, 70, 700) ON CONFLICT (a) DO UPDATE SET c = t_idx.w RETURNING a, b, c, v, w
 ----
@@ -1266,35 +1212,26 @@ vectorized: true
         │ render v: v
         │ render w: w
         │
-        └── • merge join (right outer)
-            │ columns: (v, w, a, b, c, column11, column12, column1, column2, column3)
+        └── • render
+            │ columns: (v, w, column1, column2, column3, column11, column12, a, b, c)
             │ estimated row count: 3 (missing stats)
-            │ equality: (a) = (column1)
-            │ left cols are key
-            │ merge ordering: +"(a=column1)"
+            │ render v: CASE a IS NULL WHEN true THEN CAST(NULL AS INT8) ELSE a + b END
+            │ render w: CASE a IS NULL WHEN true THEN CAST(NULL AS INT8) ELSE c + 1 END
+            │ render column1: column1
+            │ render column2: column2
+            │ render column3: column3
+            │ render column11: column11
+            │ render column12: column12
+            │ render a: a
+            │ render b: b
+            │ render c: c
             │
-            ├── • render
-            │   │ columns: (v, w, a, b, c)
-            │   │ ordering: +a
-            │   │ estimated row count: 1,000 (missing stats)
-            │   │ render v: a + b
-            │   │ render w: c + 1
-            │   │ render a: a
-            │   │ render b: b
-            │   │ render c: c
-            │   │
-            │   └── • scan
-            │         columns: (a, b, c)
-            │         ordering: +a
-            │         estimated row count: 1,000 (missing stats)
-            │         table: t_idx@primary
-            │         spans: FULL SCAN
-            │
-            └── • sort
-                │ columns: (column11, column12, column1, column2, column3)
-                │ ordering: +column1
-                │ estimated row count: 3
-                │ order: +column1
+            └── • lookup join (left outer)
+                │ columns: (column11, column12, column1, column2, column3, a, b, c)
+                │ estimated row count: 3 (missing stats)
+                │ table: t_idx@primary
+                │ equality: (column1) = (a)
+                │ equality cols are key
                 │
                 └── • render
                     │ columns: (column11, column12, column1, column2, column3)

--- a/pkg/sql/opt/memo/testdata/logprops/select
+++ b/pkg/sql/opt/memo/testdata/logprops/select
@@ -6,6 +6,10 @@ exec-ddl
 CREATE TABLE kuv (k INT PRIMARY KEY, u FLOAT, v STRING)
 ----
 
+exec-ddl
+CREATE TABLE ab (a INT, b INT)
+----
+
 build
 SELECT * FROM xy WHERE x=1
 ----
@@ -466,3 +470,18 @@ select
                 └── le [type=bool]
                      ├── variable: y:2 [type=int]
                      └── const: 10 [type=int]
+
+# Verify that a and b are determined to be not null.
+norm
+SELECT * FROM ab WHERE a=b
+----
+select
+ ├── columns: a:1(int!null) b:2(int!null)
+ ├── fd: (1)==(2), (2)==(1)
+ ├── scan ab
+ │    ├── columns: a:1(int) b:2(int)
+ │    └── prune: (1,2)
+ └── filters
+      └── eq [type=bool, outer=(1,2), constraints=(/1: (/NULL - ]; /2: (/NULL - ]), fd=(1)==(2), (2)==(1)]
+           ├── variable: a:1 [type=int]
+           └── variable: b:2 [type=int]

--- a/pkg/sql/opt/norm/testdata/rules/combo
+++ b/pkg/sql/opt/norm/testdata/rules/combo
@@ -3028,7 +3028,7 @@ GenerateMergeJoins
     └── projections
          └── CASE WHEN bool_or:12 THEN true WHEN bool_or:12 IS NULL THEN false ELSE CAST(NULL AS BOOL) END [as=r:10, outer=(12)]
 --------------------------------------------------------------------------------
-CommuteLeftJoin (higher cost)
+HoistProjectFromLeftJoin (higher cost)
 --------------------------------------------------------------------------------
    project
     ├── columns: r:10
@@ -3038,21 +3038,29 @@ CommuteLeftJoin (higher cost)
     │    ├── key: (1)
     │    ├── fd: (1)-->(12)
   - │    ├── left-join (merge)
-  + │    ├── right-join (hash)
-    │    │    ├── columns: x:1!null k:4 notnull:11
+  - │    │    ├── columns: x:1!null k:4 notnull:11
   - │    │    ├── left ordering: +1
   - │    │    ├── right ordering: +4
+  + │    ├── project
+  + │    │    ├── columns: notnull:11 x:1!null k:4
     │    │    ├── key: (1)
     │    │    ├── fd: (4)-->(11), (1)-->(4,11)
   - │    │    ├── scan xy
   - │    │    │    ├── columns: x:1!null
-  - │    │    │    ├── key: (1)
+  + │    │    ├── left-join (hash)
+  + │    │    │    ├── columns: x:1!null k:4 i:5
+  + │    │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
+    │    │    │    ├── key: (1)
   - │    │    │    └── ordering: +1
-    │    │    ├── project
-    │    │    │    ├── columns: notnull:11!null k:4!null
-    │    │    │    ├── key: (4)
-    │    │    │    ├── fd: (4)-->(11)
+  - │    │    ├── project
+  - │    │    │    ├── columns: notnull:11!null k:4!null
+  - │    │    │    ├── key: (4)
+  - │    │    │    ├── fd: (4)-->(11)
   - │    │    │    ├── ordering: +4
+  + │    │    │    ├── fd: (4)-->(5), (1)-->(4,5)
+  + │    │    │    ├── scan xy
+  + │    │    │    │    ├── columns: x:1!null
+  + │    │    │    │    └── key: (1)
     │    │    │    ├── select
     │    │    │    │    ├── columns: k:4!null i:5
     │    │    │    │    ├── key: (4)
@@ -3066,9 +3074,413 @@ CommuteLeftJoin (higher cost)
   + │    │    │    │    │    └── fd: (4)-->(5)
     │    │    │    │    └── filters
     │    │    │    │         └── (i:5 = 5) IS NOT false [outer=(5)]
-    │    │    │    └── projections
-    │    │    │         └── i:5 IS NOT NULL [as=notnull:11, outer=(5)]
+  - │    │    │    └── projections
+  - │    │    │         └── i:5 IS NOT NULL [as=notnull:11, outer=(5)]
   - │    │    └── filters (true)
+  + │    │    │    └── filters
+  + │    │    │         └── k:4 = x:1 [outer=(1,4), constraints=(/1: (/NULL - ]; /4: (/NULL - ]), fd=(1)==(4), (4)==(1)]
+  + │    │    └── projections
+  + │    │         └── CASE k:4 IS NULL WHEN true THEN CAST(NULL AS BOOL) ELSE i:5 IS NOT NULL END [as=notnull:11, outer=(4,5)]
+    │    └── aggregations
+    │         └── bool-or [as=bool_or:12, outer=(11)]
+    │              └── notnull:11
+    └── projections
+         └── CASE WHEN bool_or:12 THEN true WHEN bool_or:12 IS NULL THEN false ELSE CAST(NULL AS BOOL) END [as=r:10, outer=(12)]
+--------------------------------------------------------------------------------
+ReorderJoins (no changes)
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+CommuteLeftJoin (higher cost)
+--------------------------------------------------------------------------------
+   project
+    ├── columns: r:10
+    ├── group-by
+    │    ├── columns: x:1!null bool_or:12
+    │    ├── grouping columns: x:1!null
+    │    ├── key: (1)
+    │    ├── fd: (1)-->(12)
+    │    ├── project
+    │    │    ├── columns: notnull:11 x:1!null k:4
+    │    │    ├── key: (1)
+    │    │    ├── fd: (4)-->(11), (1)-->(4,11)
+  - │    │    ├── left-join (hash)
+  + │    │    ├── right-join (hash)
+    │    │    │    ├── columns: x:1!null k:4 i:5
+  - │    │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
+    │    │    │    ├── key: (1)
+    │    │    │    ├── fd: (4)-->(5), (1)-->(4,5)
+  - │    │    │    ├── scan xy
+  - │    │    │    │    ├── columns: x:1!null
+  - │    │    │    │    └── key: (1)
+    │    │    │    ├── select
+    │    │    │    │    ├── columns: k:4!null i:5
+    │    │    │    │    ├── key: (4)
+    │    │    │    │    ├── fd: (4)-->(5)
+    │    │    │    │    ├── scan a
+    │    │    │    │    │    ├── columns: k:4!null i:5
+    │    │    │    │    │    ├── key: (4)
+    │    │    │    │    │    └── fd: (4)-->(5)
+    │    │    │    │    └── filters
+    │    │    │    │         └── (i:5 = 5) IS NOT false [outer=(5)]
+  + │    │    │    ├── scan xy
+  + │    │    │    │    ├── columns: x:1!null
+  + │    │    │    │    └── key: (1)
+    │    │    │    └── filters
+    │    │    │         └── k:4 = x:1 [outer=(1,4), constraints=(/1: (/NULL - ]; /4: (/NULL - ]), fd=(1)==(4), (4)==(1)]
+    │    │    └── projections
+    │    │         └── CASE k:4 IS NULL WHEN true THEN CAST(NULL AS BOOL) ELSE i:5 IS NOT NULL END [as=notnull:11, outer=(4,5)]
+    │    └── aggregations
+    │         └── bool-or [as=bool_or:12, outer=(11)]
+    │              └── notnull:11
+    └── projections
+         └── CASE WHEN bool_or:12 THEN true WHEN bool_or:12 IS NULL THEN false ELSE CAST(NULL AS BOOL) END [as=r:10, outer=(12)]
+--------------------------------------------------------------------------------
+GenerateMergeJoins (higher cost)
+--------------------------------------------------------------------------------
+   project
+    ├── columns: r:10
+    ├── group-by
+    │    ├── columns: x:1!null bool_or:12
+    │    ├── grouping columns: x:1!null
+    │    ├── key: (1)
+    │    ├── fd: (1)-->(12)
+    │    ├── project
+    │    │    ├── columns: notnull:11 x:1!null k:4
+    │    │    ├── key: (1)
+    │    │    ├── fd: (4)-->(11), (1)-->(4,11)
+  - │    │    ├── right-join (hash)
+  + │    │    ├── left-join (merge)
+    │    │    │    ├── columns: x:1!null k:4 i:5
+  + │    │    │    ├── left ordering: +1
+  + │    │    │    ├── right ordering: +4
+    │    │    │    ├── key: (1)
+    │    │    │    ├── fd: (4)-->(5), (1)-->(4,5)
+  + │    │    │    ├── scan xy
+  + │    │    │    │    ├── columns: x:1!null
+  + │    │    │    │    ├── key: (1)
+  + │    │    │    │    └── ordering: +1
+    │    │    │    ├── select
+    │    │    │    │    ├── columns: k:4!null i:5
+    │    │    │    │    ├── key: (4)
+    │    │    │    │    ├── fd: (4)-->(5)
+  + │    │    │    │    ├── ordering: +4
+    │    │    │    │    ├── scan a
+    │    │    │    │    │    ├── columns: k:4!null i:5
+    │    │    │    │    │    ├── key: (4)
+  - │    │    │    │    │    └── fd: (4)-->(5)
+  + │    │    │    │    │    ├── fd: (4)-->(5)
+  + │    │    │    │    │    └── ordering: +4
+    │    │    │    │    └── filters
+    │    │    │    │         └── (i:5 = 5) IS NOT false [outer=(5)]
+  - │    │    │    ├── scan xy
+  - │    │    │    │    ├── columns: x:1!null
+  - │    │    │    │    └── key: (1)
+  - │    │    │    └── filters
+  - │    │    │         └── k:4 = x:1 [outer=(1,4), constraints=(/1: (/NULL - ]; /4: (/NULL - ]), fd=(1)==(4), (4)==(1)]
+  + │    │    │    └── filters (true)
+    │    │    └── projections
+    │    │         └── CASE k:4 IS NULL WHEN true THEN CAST(NULL AS BOOL) ELSE i:5 IS NOT NULL END [as=notnull:11, outer=(4,5)]
+    │    └── aggregations
+    │         └── bool-or [as=bool_or:12, outer=(11)]
+    │              └── notnull:11
+    └── projections
+         └── CASE WHEN bool_or:12 THEN true WHEN bool_or:12 IS NULL THEN false ELSE CAST(NULL AS BOOL) END [as=r:10, outer=(12)]
+--------------------------------------------------------------------------------
+GenerateLookupJoinsWithFilter (higher cost)
+--------------------------------------------------------------------------------
+   project
+    ├── columns: r:10
+    ├── group-by
+    │    ├── columns: x:1!null bool_or:12
+    │    ├── grouping columns: x:1!null
+    │    ├── key: (1)
+    │    ├── fd: (1)-->(12)
+    │    ├── project
+    │    │    ├── columns: notnull:11 x:1!null k:4
+    │    │    ├── key: (1)
+    │    │    ├── fd: (4)-->(11), (1)-->(4,11)
+  - │    │    ├── left-join (merge)
+  + │    │    ├── left-join (lookup a)
+    │    │    │    ├── columns: x:1!null k:4 i:5
+  - │    │    │    ├── left ordering: +1
+  - │    │    │    ├── right ordering: +4
+  + │    │    │    ├── key columns: [1] = [4]
+  + │    │    │    ├── lookup columns are key
+    │    │    │    ├── key: (1)
+    │    │    │    ├── fd: (4)-->(5), (1)-->(4,5)
+    │    │    │    ├── scan xy
+    │    │    │    │    ├── columns: x:1!null
+  - │    │    │    │    ├── key: (1)
+  - │    │    │    │    └── ordering: +1
+  - │    │    │    ├── select
+  - │    │    │    │    ├── columns: k:4!null i:5
+  - │    │    │    │    ├── key: (4)
+  - │    │    │    │    ├── fd: (4)-->(5)
+  - │    │    │    │    ├── ordering: +4
+  - │    │    │    │    ├── scan a
+  - │    │    │    │    │    ├── columns: k:4!null i:5
+  - │    │    │    │    │    ├── key: (4)
+  - │    │    │    │    │    ├── fd: (4)-->(5)
+  - │    │    │    │    │    └── ordering: +4
+  - │    │    │    │    └── filters
+  - │    │    │    │         └── (i:5 = 5) IS NOT false [outer=(5)]
+  - │    │    │    └── filters (true)
+  + │    │    │    │    └── key: (1)
+  + │    │    │    └── filters
+  + │    │    │         └── (i:5 = 5) IS NOT false [outer=(5)]
+    │    │    └── projections
+    │    │         └── CASE k:4 IS NULL WHEN true THEN CAST(NULL AS BOOL) ELSE i:5 IS NOT NULL END [as=notnull:11, outer=(4,5)]
+    │    └── aggregations
+    │         └── bool-or [as=bool_or:12, outer=(11)]
+    │              └── notnull:11
+    └── projections
+         └── CASE WHEN bool_or:12 THEN true WHEN bool_or:12 IS NULL THEN false ELSE CAST(NULL AS BOOL) END [as=r:10, outer=(12)]
+--------------------------------------------------------------------------------
+CommuteLeftJoin (higher cost)
+--------------------------------------------------------------------------------
+   project
+    ├── columns: r:10
+    ├── group-by
+    │    ├── columns: x:1!null bool_or:12
+    │    ├── grouping columns: x:1!null
+    │    ├── key: (1)
+    │    ├── fd: (1)-->(12)
+    │    ├── project
+    │    │    ├── columns: notnull:11 x:1!null k:4
+    │    │    ├── key: (1)
+    │    │    ├── fd: (4)-->(11), (1)-->(4,11)
+  - │    │    ├── left-join (lookup a)
+  + │    │    ├── right-join (hash)
+    │    │    │    ├── columns: x:1!null k:4 i:5
+  - │    │    │    ├── key columns: [1] = [4]
+  - │    │    │    ├── lookup columns are key
+    │    │    │    ├── key: (1)
+    │    │    │    ├── fd: (4)-->(5), (1)-->(4,5)
+  + │    │    │    ├── select
+  + │    │    │    │    ├── columns: k:4!null i:5
+  + │    │    │    │    ├── key: (4)
+  + │    │    │    │    ├── fd: (4)-->(5)
+  + │    │    │    │    ├── scan a
+  + │    │    │    │    │    ├── columns: k:4!null i:5
+  + │    │    │    │    │    ├── key: (4)
+  + │    │    │    │    │    └── fd: (4)-->(5)
+  + │    │    │    │    └── filters
+  + │    │    │    │         └── (i:5 = 5) IS NOT false [outer=(5)]
+    │    │    │    ├── scan xy
+    │    │    │    │    ├── columns: x:1!null
+    │    │    │    │    └── key: (1)
+    │    │    │    └── filters
+  - │    │    │         └── (i:5 = 5) IS NOT false [outer=(5)]
+  + │    │    │         └── k:4 = x:1 [outer=(1,4), constraints=(/1: (/NULL - ]; /4: (/NULL - ]), fd=(1)==(4), (4)==(1)]
+    │    │    └── projections
+    │    │         └── CASE k:4 IS NULL WHEN true THEN CAST(NULL AS BOOL) ELSE i:5 IS NOT NULL END [as=notnull:11, outer=(4,5)]
+    │    └── aggregations
+    │         └── bool-or [as=bool_or:12, outer=(11)]
+    │              └── notnull:11
+    └── projections
+         └── CASE WHEN bool_or:12 THEN true WHEN bool_or:12 IS NULL THEN false ELSE CAST(NULL AS BOOL) END [as=r:10, outer=(12)]
+--------------------------------------------------------------------------------
+GenerateMergeJoins (higher cost)
+--------------------------------------------------------------------------------
+   project
+    ├── columns: r:10
+    ├── group-by
+    │    ├── columns: x:1!null bool_or:12
+    │    ├── grouping columns: x:1!null
+    │    ├── key: (1)
+    │    ├── fd: (1)-->(12)
+    │    ├── project
+    │    │    ├── columns: notnull:11 x:1!null k:4
+    │    │    ├── key: (1)
+    │    │    ├── fd: (4)-->(11), (1)-->(4,11)
+  - │    │    ├── right-join (hash)
+  + │    │    ├── left-join (merge)
+    │    │    │    ├── columns: x:1!null k:4 i:5
+  + │    │    │    ├── left ordering: +1
+  + │    │    │    ├── right ordering: +4
+    │    │    │    ├── key: (1)
+    │    │    │    ├── fd: (4)-->(5), (1)-->(4,5)
+  + │    │    │    ├── scan xy
+  + │    │    │    │    ├── columns: x:1!null
+  + │    │    │    │    ├── key: (1)
+  + │    │    │    │    └── ordering: +1
+    │    │    │    ├── select
+    │    │    │    │    ├── columns: k:4!null i:5
+    │    │    │    │    ├── key: (4)
+    │    │    │    │    ├── fd: (4)-->(5)
+  + │    │    │    │    ├── ordering: +4
+    │    │    │    │    ├── scan a
+    │    │    │    │    │    ├── columns: k:4!null i:5
+    │    │    │    │    │    ├── key: (4)
+  - │    │    │    │    │    └── fd: (4)-->(5)
+  + │    │    │    │    │    ├── fd: (4)-->(5)
+  + │    │    │    │    │    └── ordering: +4
+    │    │    │    │    └── filters
+    │    │    │    │         └── (i:5 = 5) IS NOT false [outer=(5)]
+  - │    │    │    ├── scan xy
+  - │    │    │    │    ├── columns: x:1!null
+  - │    │    │    │    └── key: (1)
+  - │    │    │    └── filters
+  - │    │    │         └── k:4 = x:1 [outer=(1,4), constraints=(/1: (/NULL - ]; /4: (/NULL - ]), fd=(1)==(4), (4)==(1)]
+  + │    │    │    └── filters (true)
+    │    │    └── projections
+    │    │         └── CASE k:4 IS NULL WHEN true THEN CAST(NULL AS BOOL) ELSE i:5 IS NOT NULL END [as=notnull:11, outer=(4,5)]
+    │    └── aggregations
+    │         └── bool-or [as=bool_or:12, outer=(11)]
+    │              └── notnull:11
+    └── projections
+         └── CASE WHEN bool_or:12 THEN true WHEN bool_or:12 IS NULL THEN false ELSE CAST(NULL AS BOOL) END [as=r:10, outer=(12)]
+--------------------------------------------------------------------------------
+GenerateLookupJoinsWithFilter (higher cost)
+--------------------------------------------------------------------------------
+   project
+    ├── columns: r:10
+    ├── group-by
+    │    ├── columns: x:1!null bool_or:12
+    │    ├── grouping columns: x:1!null
+    │    ├── key: (1)
+    │    ├── fd: (1)-->(12)
+    │    ├── project
+    │    │    ├── columns: notnull:11 x:1!null k:4
+    │    │    ├── key: (1)
+    │    │    ├── fd: (4)-->(11), (1)-->(4,11)
+  - │    │    ├── left-join (merge)
+  + │    │    ├── left-join (lookup a)
+    │    │    │    ├── columns: x:1!null k:4 i:5
+  - │    │    │    ├── left ordering: +1
+  - │    │    │    ├── right ordering: +4
+  + │    │    │    ├── key columns: [1] = [4]
+  + │    │    │    ├── lookup columns are key
+    │    │    │    ├── key: (1)
+    │    │    │    ├── fd: (4)-->(5), (1)-->(4,5)
+    │    │    │    ├── scan xy
+    │    │    │    │    ├── columns: x:1!null
+  - │    │    │    │    ├── key: (1)
+  - │    │    │    │    └── ordering: +1
+  - │    │    │    ├── select
+  - │    │    │    │    ├── columns: k:4!null i:5
+  - │    │    │    │    ├── key: (4)
+  - │    │    │    │    ├── fd: (4)-->(5)
+  - │    │    │    │    ├── ordering: +4
+  - │    │    │    │    ├── scan a
+  - │    │    │    │    │    ├── columns: k:4!null i:5
+  - │    │    │    │    │    ├── key: (4)
+  - │    │    │    │    │    ├── fd: (4)-->(5)
+  - │    │    │    │    │    └── ordering: +4
+  - │    │    │    │    └── filters
+  - │    │    │    │         └── (i:5 = 5) IS NOT false [outer=(5)]
+  - │    │    │    └── filters (true)
+  + │    │    │    │    └── key: (1)
+  + │    │    │    └── filters
+  + │    │    │         └── (i:5 = 5) IS NOT false [outer=(5)]
+    │    │    └── projections
+    │    │         └── CASE k:4 IS NULL WHEN true THEN CAST(NULL AS BOOL) ELSE i:5 IS NOT NULL END [as=notnull:11, outer=(4,5)]
+    │    └── aggregations
+    │         └── bool-or [as=bool_or:12, outer=(11)]
+    │              └── notnull:11
+    └── projections
+         └── CASE WHEN bool_or:12 THEN true WHEN bool_or:12 IS NULL THEN false ELSE CAST(NULL AS BOOL) END [as=r:10, outer=(12)]
+--------------------------------------------------------------------------------
+GenerateMergeJoins (higher cost)
+--------------------------------------------------------------------------------
+   project
+    ├── columns: r:10
+    ├── group-by
+    │    ├── columns: x:1!null bool_or:12
+    │    ├── grouping columns: x:1!null
+    │    ├── key: (1)
+    │    ├── fd: (1)-->(12)
+    │    ├── project
+    │    │    ├── columns: notnull:11 x:1!null k:4
+    │    │    ├── key: (1)
+    │    │    ├── fd: (4)-->(11), (1)-->(4,11)
+  - │    │    ├── left-join (lookup a)
+  + │    │    ├── right-join (merge)
+    │    │    │    ├── columns: x:1!null k:4 i:5
+  - │    │    │    ├── key columns: [1] = [4]
+  - │    │    │    ├── lookup columns are key
+  + │    │    │    ├── left ordering: +4
+  + │    │    │    ├── right ordering: +1
+    │    │    │    ├── key: (1)
+    │    │    │    ├── fd: (4)-->(5), (1)-->(4,5)
+  + │    │    │    ├── select
+  + │    │    │    │    ├── columns: k:4!null i:5
+  + │    │    │    │    ├── key: (4)
+  + │    │    │    │    ├── fd: (4)-->(5)
+  + │    │    │    │    ├── ordering: +4
+  + │    │    │    │    ├── scan a
+  + │    │    │    │    │    ├── columns: k:4!null i:5
+  + │    │    │    │    │    ├── key: (4)
+  + │    │    │    │    │    ├── fd: (4)-->(5)
+  + │    │    │    │    │    └── ordering: +4
+  + │    │    │    │    └── filters
+  + │    │    │    │         └── (i:5 = 5) IS NOT false [outer=(5)]
+    │    │    │    ├── scan xy
+    │    │    │    │    ├── columns: x:1!null
+  - │    │    │    │    └── key: (1)
+  - │    │    │    └── filters
+  - │    │    │         └── (i:5 = 5) IS NOT false [outer=(5)]
+  + │    │    │    │    ├── key: (1)
+  + │    │    │    │    └── ordering: +1
+  + │    │    │    └── filters (true)
+    │    │    └── projections
+    │    │         └── CASE k:4 IS NULL WHEN true THEN CAST(NULL AS BOOL) ELSE i:5 IS NOT NULL END [as=notnull:11, outer=(4,5)]
+    │    └── aggregations
+    │         └── bool-or [as=bool_or:12, outer=(11)]
+    │              └── notnull:11
+    └── projections
+         └── CASE WHEN bool_or:12 THEN true WHEN bool_or:12 IS NULL THEN false ELSE CAST(NULL AS BOOL) END [as=r:10, outer=(12)]
+--------------------------------------------------------------------------------
+GenerateMergeJoins (no changes)
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+CommuteLeftJoin (higher cost)
+--------------------------------------------------------------------------------
+   project
+    ├── columns: r:10
+    ├── group-by
+    │    ├── columns: x:1!null bool_or:12
+    │    ├── grouping columns: x:1!null
+    │    ├── key: (1)
+    │    ├── fd: (1)-->(12)
+  - │    ├── project
+  - │    │    ├── columns: notnull:11 x:1!null k:4
+  + │    ├── right-join (hash)
+  + │    │    ├── columns: x:1!null k:4 notnull:11
+    │    │    ├── key: (1)
+    │    │    ├── fd: (4)-->(11), (1)-->(4,11)
+  - │    │    ├── right-join (merge)
+  - │    │    │    ├── columns: x:1!null k:4 i:5
+  - │    │    │    ├── left ordering: +4
+  - │    │    │    ├── right ordering: +1
+  - │    │    │    ├── key: (1)
+  - │    │    │    ├── fd: (4)-->(5), (1)-->(4,5)
+  + │    │    ├── project
+  + │    │    │    ├── columns: notnull:11!null k:4!null
+  + │    │    │    ├── key: (4)
+  + │    │    │    ├── fd: (4)-->(11)
+    │    │    │    ├── select
+    │    │    │    │    ├── columns: k:4!null i:5
+    │    │    │    │    ├── key: (4)
+    │    │    │    │    ├── fd: (4)-->(5)
+  - │    │    │    │    ├── ordering: +4
+    │    │    │    │    ├── scan a
+    │    │    │    │    │    ├── columns: k:4!null i:5
+    │    │    │    │    │    ├── key: (4)
+  - │    │    │    │    │    ├── fd: (4)-->(5)
+  - │    │    │    │    │    └── ordering: +4
+  + │    │    │    │    │    └── fd: (4)-->(5)
+    │    │    │    │    └── filters
+    │    │    │    │         └── (i:5 = 5) IS NOT false [outer=(5)]
+  - │    │    │    ├── scan xy
+  - │    │    │    │    ├── columns: x:1!null
+  - │    │    │    │    ├── key: (1)
+  - │    │    │    │    └── ordering: +1
+  - │    │    │    └── filters (true)
+  - │    │    └── projections
+  - │    │         └── CASE k:4 IS NULL WHEN true THEN CAST(NULL AS BOOL) ELSE i:5 IS NOT NULL END [as=notnull:11, outer=(4,5)]
+  + │    │    │    └── projections
+  + │    │    │         └── i:5 IS NOT NULL [as=notnull:11, outer=(5)]
   + │    │    ├── scan xy
   + │    │    │    ├── columns: x:1!null
   + │    │    │    └── key: (1)
@@ -3081,6 +3493,9 @@ CommuteLeftJoin (higher cost)
          └── CASE WHEN bool_or:12 THEN true WHEN bool_or:12 IS NULL THEN false ELSE CAST(NULL AS BOOL) END [as=r:10, outer=(12)]
 --------------------------------------------------------------------------------
 GenerateMergeJoins (no changes)
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+HoistProjectFromLeftJoin (no changes)
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
 GenerateMergeJoins (higher cost)

--- a/pkg/sql/opt/xform/rules/join.opt
+++ b/pkg/sql/opt/xform/rules/join.opt
@@ -57,6 +57,10 @@
 # ((Distinct(RHS*) InnerJoin LHS) will have at most 1 matching row for each row
 # in the LHS if the On conditions are simple equalities.
 #
+# Note that if the join was a result of a join reordering, the new join will not
+# be reordered again (because it inherits the the SkipReorderJoins flag in the
+# private).
+#
 # Citations: [7] (see section 2.1.1)
 [CommuteSemiJoin, Explore]
 (SemiJoin
@@ -232,4 +236,84 @@
         $indexPrivate
         (OutputCols2 $left $right)
     )
+)
+
+# HoistProjectFromInnerJoin lifts a Project from under an InnerJoin; the join
+# can then be subject to other rules, most importantly allowing it to become a
+# lookup join.
+#
+# As long as the projections are non-volatile, it is equivalent to calculate
+# them on every output row.
+#
+# Note that if the join was a result of a join reordering, the new join will not
+# be reordered again (because it inherits the the SkipReorderJoins flag in the
+# private).
+#
+# TODO(radu): we could make the rule work even when the ON condition depends on
+# a projection (by inlining the projection).
+[HoistProjectFromInnerJoin, Explore]
+(InnerJoin
+    $left:*
+    $proj:(Project
+        $right:*
+        $projections:* & ^(HasVolatileProjection $projections)
+        $passthrough:*
+    )
+    $on:* &
+        ^(ColsIntersect
+            (ProjectionCols $projections)
+            (FilterOuterCols $on)
+        )
+    $private:*
+)
+=>
+(Project
+    (InnerJoin $left $right $on $private)
+    $projections
+    (UnionCols $passthrough (OutputCols $left))
+)
+
+# HoistProjectFromLeftJoin pulls a project from under an LeftJoin; the join can
+# then be subject to other rules, most importantly allowing it to become a
+# lookup join.
+#
+# This rule is similar to HoistProjectFromInnerJoin, except that we have to
+# handle "outer" rows correctly and make sure we project NULLs, regardless of
+# the expressions. First we find a canary column from the right input which is
+# null iff the output row is a null-extended left row. Then, we wrap each
+# projection in a CASE statement which is null if the canary column is null and
+# equivalent to the original projection if the canary column is not null".
+#
+# Note that if the join was a result of a join reordering, the new join will not
+# be reordered again (because it inherits the the SkipReorderJoins flag in the
+# private).
+#
+# TODO(radu): we could make the rule work even when the ON condition depends on
+# a projection (by inlining the projection).
+#
+# TODO(radu): we could make the rule augment an input Scan with a non-null
+# column from the table.
+[HoistProjectFromLeftJoin, Explore]
+(LeftJoin
+    $left:*
+    (Project
+        $right:*
+        $projections:* & ^(HasVolatileProjection $projections)
+        $passthrough:*
+    )
+    $on:* &
+        ^(ColsIntersect
+            (ProjectionCols $projections)
+            (FilterOuterCols $on)
+        ) &
+        (FoundCanaryColumn
+            $canaryCol:(FindLeftJoinCanaryColumn $right $on)
+        )
+    $private:*
+)
+=>
+(Project
+    (LeftJoin $left $right $on $private)
+    (MakeProjectionsForOuterJoin $canaryCol $projections)
+    (UnionCols $passthrough (OutputCols $left))
 )

--- a/pkg/sql/opt/xform/testdata/external/hibernate
+++ b/pkg/sql/opt/xform/testdata/external/hibernate
@@ -1997,13 +1997,14 @@ project
  │    ├── immutable
  │    ├── key: (7)
  │    ├── fd: ()-->(1-3), (7)-->(1-3,5,6,8,21)
- │    ├── right-join (hash)
- │    │    ├── columns: order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null lineitems1_.customerid:5 lineitems1_.ordernumber:6 lineitems1_.productid:7 lineitems1_.quantity:8 li.customerid:10 li.ordernumber:11 column20:20
+ │    ├── project
+ │    │    ├── columns: column20:20 order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null lineitems1_.customerid:5 lineitems1_.ordernumber:6 lineitems1_.productid:7 lineitems1_.quantity:8 li.customerid:10 li.ordernumber:11
  │    │    ├── immutable
  │    │    ├── fd: ()-->(1-3), (7)-->(5,6,8)
- │    │    ├── project
- │    │    │    ├── columns: column20:20 li.customerid:10!null li.ordernumber:11!null
- │    │    │    ├── immutable
+ │    │    ├── right-join (hash)
+ │    │    │    ├── columns: order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null lineitems1_.customerid:5 lineitems1_.ordernumber:6 lineitems1_.productid:7 lineitems1_.quantity:8 li.customerid:10 li.ordernumber:11 li.productid:12 li.quantity:13 p.productid:15 cost:17
+ │    │    │    ├── key: (7,10,11,15)
+ │    │    │    ├── fd: ()-->(1-3), (7)-->(5,6,8), (10-12)-->(13), (15)-->(17), (12)==(15), (15)==(12)
  │    │    │    ├── inner-join (hash)
  │    │    │    │    ├── columns: li.customerid:10!null li.ordernumber:11!null li.productid:12!null li.quantity:13 p.productid:15!null cost:17
  │    │    │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
@@ -2019,29 +2020,29 @@ project
  │    │    │    │    │    └── fd: (15)-->(17)
  │    │    │    │    └── filters
  │    │    │    │         └── li.productid:12 = p.productid:15 [outer=(12,15), constraints=(/12: (/NULL - ]; /15: (/NULL - ]), fd=(12)==(15), (15)==(12)]
- │    │    │    └── projections
- │    │    │         └── li.quantity:13::INT8 * cost:17::DECIMAL [as=column20:20, outer=(13,17), immutable]
- │    │    ├── left-join (merge)
- │    │    │    ├── columns: order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null lineitems1_.customerid:5 lineitems1_.ordernumber:6 lineitems1_.productid:7 lineitems1_.quantity:8
- │    │    │    ├── left ordering: +1,+2
- │    │    │    ├── right ordering: +5,+6
- │    │    │    ├── key: (7)
- │    │    │    ├── fd: ()-->(1-3), (7)-->(5,6,8)
- │    │    │    ├── scan customerorder [as=order0_]
- │    │    │    │    ├── columns: order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null
- │    │    │    │    ├── constraint: /1/2: [/'c111'/0 - /'c111'/0]
- │    │    │    │    ├── cardinality: [0 - 1]
- │    │    │    │    ├── key: ()
- │    │    │    │    └── fd: ()-->(1-3)
- │    │    │    ├── scan lineitem [as=lineitems1_]
- │    │    │    │    ├── columns: lineitems1_.customerid:5!null lineitems1_.ordernumber:6!null lineitems1_.productid:7!null lineitems1_.quantity:8
- │    │    │    │    ├── constraint: /5/6/7: [/'c111'/0 - /'c111'/0]
+ │    │    │    ├── left-join (merge)
+ │    │    │    │    ├── columns: order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null lineitems1_.customerid:5 lineitems1_.ordernumber:6 lineitems1_.productid:7 lineitems1_.quantity:8
+ │    │    │    │    ├── left ordering: +1,+2
+ │    │    │    │    ├── right ordering: +5,+6
  │    │    │    │    ├── key: (7)
- │    │    │    │    └── fd: ()-->(5,6), (7)-->(8)
- │    │    │    └── filters (true)
- │    │    └── filters
- │    │         ├── li.customerid:10 = order0_.customerid:1 [outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
- │    │         └── li.ordernumber:11 = order0_.ordernumber:2 [outer=(2,11), constraints=(/2: (/NULL - ]; /11: (/NULL - ]), fd=(2)==(11), (11)==(2)]
+ │    │    │    │    ├── fd: ()-->(1-3), (7)-->(5,6,8)
+ │    │    │    │    ├── scan customerorder [as=order0_]
+ │    │    │    │    │    ├── columns: order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null
+ │    │    │    │    │    ├── constraint: /1/2: [/'c111'/0 - /'c111'/0]
+ │    │    │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    │    │    ├── key: ()
+ │    │    │    │    │    └── fd: ()-->(1-3)
+ │    │    │    │    ├── scan lineitem [as=lineitems1_]
+ │    │    │    │    │    ├── columns: lineitems1_.customerid:5!null lineitems1_.ordernumber:6!null lineitems1_.productid:7!null lineitems1_.quantity:8
+ │    │    │    │    │    ├── constraint: /5/6/7: [/'c111'/0 - /'c111'/0]
+ │    │    │    │    │    ├── key: (7)
+ │    │    │    │    │    └── fd: ()-->(5,6), (7)-->(8)
+ │    │    │    │    └── filters (true)
+ │    │    │    └── filters
+ │    │    │         ├── li.customerid:10 = order0_.customerid:1 [outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
+ │    │    │         └── li.ordernumber:11 = order0_.ordernumber:2 [outer=(2,11), constraints=(/2: (/NULL - ]; /11: (/NULL - ]), fd=(2)==(11), (11)==(2)]
+ │    │    └── projections
+ │    │         └── CASE li.customerid:10 IS NULL WHEN true THEN CAST(NULL AS DECIMAL) ELSE li.quantity:13::INT8 * cost:17::DECIMAL END [as=column20:20, outer=(10,13,17), immutable]
  │    └── aggregations
  │         ├── sum [as=sum:21, outer=(20)]
  │         │    └── column20:20
@@ -2292,13 +2293,14 @@ project
  │    ├── immutable
  │    ├── key: (7)
  │    ├── fd: ()-->(1-3), (7)-->(1-3,5,6,8,21)
- │    ├── right-join (hash)
- │    │    ├── columns: order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null lineitems1_.customerid:5 lineitems1_.ordernumber:6 lineitems1_.productid:7 lineitems1_.quantity:8 li.customerid:10 li.ordernumber:11 column20:20
+ │    ├── project
+ │    │    ├── columns: column20:20 order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null lineitems1_.customerid:5 lineitems1_.ordernumber:6 lineitems1_.productid:7 lineitems1_.quantity:8 li.customerid:10 li.ordernumber:11
  │    │    ├── immutable
  │    │    ├── fd: ()-->(1-3), (7)-->(5,6,8)
- │    │    ├── project
- │    │    │    ├── columns: column20:20 li.customerid:10!null li.ordernumber:11!null
- │    │    │    ├── immutable
+ │    │    ├── right-join (hash)
+ │    │    │    ├── columns: order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null lineitems1_.customerid:5 lineitems1_.ordernumber:6 lineitems1_.productid:7 lineitems1_.quantity:8 li.customerid:10 li.ordernumber:11 li.productid:12 li.quantity:13 p.productid:15 cost:17
+ │    │    │    ├── key: (7,10,11,15)
+ │    │    │    ├── fd: ()-->(1-3), (7)-->(5,6,8), (10-12)-->(13), (15)-->(17), (12)==(15), (15)==(12)
  │    │    │    ├── inner-join (hash)
  │    │    │    │    ├── columns: li.customerid:10!null li.ordernumber:11!null li.productid:12!null li.quantity:13 p.productid:15!null cost:17
  │    │    │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
@@ -2314,29 +2316,29 @@ project
  │    │    │    │    │    └── fd: (15)-->(17)
  │    │    │    │    └── filters
  │    │    │    │         └── li.productid:12 = p.productid:15 [outer=(12,15), constraints=(/12: (/NULL - ]; /15: (/NULL - ]), fd=(12)==(15), (15)==(12)]
- │    │    │    └── projections
- │    │    │         └── li.quantity:13::INT8 * cost:17::DECIMAL [as=column20:20, outer=(13,17), immutable]
- │    │    ├── left-join (merge)
- │    │    │    ├── columns: order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null lineitems1_.customerid:5 lineitems1_.ordernumber:6 lineitems1_.productid:7 lineitems1_.quantity:8
- │    │    │    ├── left ordering: +1,+2
- │    │    │    ├── right ordering: +5,+6
- │    │    │    ├── key: (7)
- │    │    │    ├── fd: ()-->(1-3), (7)-->(5,6,8)
- │    │    │    ├── scan customerorder [as=order0_]
- │    │    │    │    ├── columns: order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null
- │    │    │    │    ├── constraint: /1/2: [/'c111'/0 - /'c111'/0]
- │    │    │    │    ├── cardinality: [0 - 1]
- │    │    │    │    ├── key: ()
- │    │    │    │    └── fd: ()-->(1-3)
- │    │    │    ├── scan lineitem [as=lineitems1_]
- │    │    │    │    ├── columns: lineitems1_.customerid:5!null lineitems1_.ordernumber:6!null lineitems1_.productid:7!null lineitems1_.quantity:8
- │    │    │    │    ├── constraint: /5/6/7: [/'c111'/0 - /'c111'/0]
+ │    │    │    ├── left-join (merge)
+ │    │    │    │    ├── columns: order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null lineitems1_.customerid:5 lineitems1_.ordernumber:6 lineitems1_.productid:7 lineitems1_.quantity:8
+ │    │    │    │    ├── left ordering: +1,+2
+ │    │    │    │    ├── right ordering: +5,+6
  │    │    │    │    ├── key: (7)
- │    │    │    │    └── fd: ()-->(5,6), (7)-->(8)
- │    │    │    └── filters (true)
- │    │    └── filters
- │    │         ├── li.customerid:10 = order0_.customerid:1 [outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
- │    │         └── li.ordernumber:11 = order0_.ordernumber:2 [outer=(2,11), constraints=(/2: (/NULL - ]; /11: (/NULL - ]), fd=(2)==(11), (11)==(2)]
+ │    │    │    │    ├── fd: ()-->(1-3), (7)-->(5,6,8)
+ │    │    │    │    ├── scan customerorder [as=order0_]
+ │    │    │    │    │    ├── columns: order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null
+ │    │    │    │    │    ├── constraint: /1/2: [/'c111'/0 - /'c111'/0]
+ │    │    │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    │    │    ├── key: ()
+ │    │    │    │    │    └── fd: ()-->(1-3)
+ │    │    │    │    ├── scan lineitem [as=lineitems1_]
+ │    │    │    │    │    ├── columns: lineitems1_.customerid:5!null lineitems1_.ordernumber:6!null lineitems1_.productid:7!null lineitems1_.quantity:8
+ │    │    │    │    │    ├── constraint: /5/6/7: [/'c111'/0 - /'c111'/0]
+ │    │    │    │    │    ├── key: (7)
+ │    │    │    │    │    └── fd: ()-->(5,6), (7)-->(8)
+ │    │    │    │    └── filters (true)
+ │    │    │    └── filters
+ │    │    │         ├── li.customerid:10 = order0_.customerid:1 [outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
+ │    │    │         └── li.ordernumber:11 = order0_.ordernumber:2 [outer=(2,11), constraints=(/2: (/NULL - ]; /11: (/NULL - ]), fd=(2)==(11), (11)==(2)]
+ │    │    └── projections
+ │    │         └── CASE li.customerid:10 IS NULL WHEN true THEN CAST(NULL AS DECIMAL) ELSE li.quantity:13::INT8 * cost:17::DECIMAL END [as=column20:20, outer=(10,13,17), immutable]
  │    └── aggregations
  │         ├── sum [as=sum:21, outer=(20)]
  │         │    └── column20:20

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -6780,7 +6780,7 @@ inner-join (lookup abc@ab)
  └── filters (true)
 
 # No-op case because the right side of the InnerJoin has outer columns.
-opt expect-not=PushJoinIntoIndexJoin disable=(TryDecorrelateProject)
+opt expect-not=PushJoinIntoIndexJoin disable=(TryDecorrelateProject,HoistProjectFromInnerJoin)
 SELECT * 
 FROM stu
 INNER JOIN LATERAL (
@@ -7109,3 +7109,215 @@ union-all
       │    └── filters (true)
       └── projections
            └── 1 [as="?column?":6]
+
+# --------------------------------------------------
+# HoistProjectFromInnerJoin
+# --------------------------------------------------
+
+opt expect=HoistProjectFromInnerJoin
+SELECT * FROM small JOIN (SELECT a, a+b FROM abcd) ON a=m
+----
+project
+ ├── columns: m:1!null n:2 a:5!null "?column?":10
+ ├── immutable
+ ├── fd: (1)==(5), (5)==(1)
+ ├── inner-join (lookup abcd@secondary)
+ │    ├── columns: m:1!null n:2 a:5!null b:6
+ │    ├── key columns: [1] = [5]
+ │    ├── fd: (1)==(5), (5)==(1)
+ │    ├── scan small
+ │    │    └── columns: m:1 n:2
+ │    └── filters (true)
+ └── projections
+      └── a:5 + b:6 [as="?column?":10, outer=(5,6), immutable]
+
+# The rule works the other way too, thanks to join commuting.
+opt expect=HoistProjectFromInnerJoin
+SELECT * FROM (SELECT a, a+b FROM abcd) JOIN small ON a=m
+----
+project
+ ├── columns: a:1!null "?column?":6 m:7!null n:8
+ ├── immutable
+ ├── fd: (1)==(7), (7)==(1)
+ ├── inner-join (lookup abcd@secondary)
+ │    ├── columns: a:1!null b:2 m:7!null n:8
+ │    ├── key columns: [7] = [1]
+ │    ├── fd: (1)==(7), (7)==(1)
+ │    ├── scan small
+ │    │    └── columns: m:7 n:8
+ │    └── filters (true)
+ └── projections
+      └── a:1 + b:2 [as="?column?":6, outer=(1,2), immutable]
+
+# The rule should not fire when the ON condition uses a projection.
+# TODO(radu): we could inline the projection.
+opt expect-not=HoistProjectFromInnerJoin
+SELECT * FROM small JOIN (SELECT a, a+b FROM abcd) AS rhs(a,x) ON a=m AND x=n
+----
+inner-join (hash)
+ ├── columns: m:1!null n:2!null a:5!null x:10!null
+ ├── immutable
+ ├── fd: (1)==(5), (5)==(1), (2)==(10), (10)==(2)
+ ├── project
+ │    ├── columns: "?column?":10 a:5
+ │    ├── immutable
+ │    ├── scan abcd@secondary
+ │    │    └── columns: a:5 b:6
+ │    └── projections
+ │         └── a:5 + b:6 [as="?column?":10, outer=(5,6), immutable]
+ ├── scan small
+ │    └── columns: m:1 n:2
+ └── filters
+      ├── a:5 = m:1 [outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
+      └── "?column?":10 = n:2 [outer=(2,10), constraints=(/2: (/NULL - ]; /10: (/NULL - ]), fd=(2)==(10), (10)==(2)]
+
+# The rule should not fire when a projection is volatile.
+opt expect-not=HoistProjectFromInnerJoin
+SELECT * FROM small JOIN (SELECT a, a+b, random() FROM abcd) ON a=m
+----
+inner-join (merge)
+ ├── columns: m:1!null n:2 a:5!null "?column?":10 random:11
+ ├── left ordering: +5
+ ├── right ordering: +1
+ ├── volatile
+ ├── fd: (1)==(5), (5)==(1)
+ ├── project
+ │    ├── columns: "?column?":10 random:11 a:5
+ │    ├── volatile
+ │    ├── ordering: +5
+ │    ├── scan abcd@secondary
+ │    │    ├── columns: a:5 b:6
+ │    │    └── ordering: +5
+ │    └── projections
+ │         ├── a:5 + b:6 [as="?column?":10, outer=(5,6), immutable]
+ │         └── random() [as=random:11, volatile]
+ ├── sort
+ │    ├── columns: m:1 n:2
+ │    ├── ordering: +1
+ │    └── scan small
+ │         └── columns: m:1 n:2
+ └── filters (true)
+
+# --------------------------------------------------
+# HoistProjectFromLeftJoin
+# --------------------------------------------------
+
+# The rule should use p as the canary column.
+opt expect=HoistProjectFromLeftJoin
+SELECT * FROM small LEFT JOIN (SELECT p, p+q FROM pqr) ON p=m
+----
+project
+ ├── columns: m:1 n:2 p:5 "?column?":11
+ ├── immutable
+ ├── fd: (5)-->(11)
+ ├── left-join (lookup pqr)
+ │    ├── columns: m:1 n:2 p:5 q:6
+ │    ├── key columns: [1] = [5]
+ │    ├── lookup columns are key
+ │    ├── fd: (5)-->(6)
+ │    ├── scan small
+ │    │    └── columns: m:1 n:2
+ │    └── filters (true)
+ └── projections
+      └── CASE p:5 IS NULL WHEN true THEN CAST(NULL AS INT8) ELSE p:5 + q:6 END [as="?column?":11, outer=(5,6), immutable]
+
+# The rule should use a as the canary column, because it is null-rejected by
+# the ON condition.
+opt expect=HoistProjectFromLeftJoin
+SELECT * FROM small LEFT JOIN (SELECT a, a+b FROM abcd) ON a=m
+----
+project
+ ├── columns: m:1 n:2 a:5 "?column?":10
+ ├── immutable
+ ├── left-join (lookup abcd@secondary)
+ │    ├── columns: m:1 n:2 a:5 b:6
+ │    ├── key columns: [1] = [5]
+ │    ├── scan small
+ │    │    └── columns: m:1 n:2
+ │    └── filters (true)
+ └── projections
+      └── CASE a:5 IS NULL WHEN true THEN CAST(NULL AS INT8) ELSE a:5 + b:6 END [as="?column?":10, outer=(5,6), immutable]
+
+# The rule can use p as the canary column, because it is not-null in the right
+# input.
+opt expect=HoistProjectFromLeftJoin
+SELECT * FROM small LEFT JOIN (SELECT q, p+q FROM pqr) ON q=m
+----
+project
+ ├── columns: m:1 n:2 q:6 "?column?":11
+ ├── immutable
+ ├── left-join (lookup pqr@q)
+ │    ├── columns: m:1 n:2 p:5 q:6
+ │    ├── key columns: [1] = [6]
+ │    ├── fd: (5)-->(6)
+ │    ├── scan small
+ │    │    └── columns: m:1 n:2
+ │    └── filters (true)
+ └── projections
+      └── CASE p:5 IS NULL WHEN true THEN CAST(NULL AS INT8) ELSE p:5 + q:6 END [as="?column?":11, outer=(5,6), immutable]
+
+# We cannot find a canary column, so the rule should not fire.
+# TODO(radu): we could try adding a column to the input scan, similar to EnsureKey.
+opt expect-not=HoistProjectFromLeftJoin
+SELECT * FROM small LEFT JOIN (SELECT a, a+b FROM abcd) ON a=m OR m=1
+----
+right-join (cross)
+ ├── columns: m:1 n:2 a:5 "?column?":10
+ ├── immutable
+ ├── project
+ │    ├── columns: "?column?":10 a:5
+ │    ├── immutable
+ │    ├── scan abcd@secondary
+ │    │    └── columns: a:5 b:6
+ │    └── projections
+ │         └── a:5 + b:6 [as="?column?":10, outer=(5,6), immutable]
+ ├── scan small
+ │    └── columns: m:1 n:2
+ └── filters
+      └── (a:5 = m:1) OR (m:1 = 1) [outer=(1,5), constraints=(/1: (/NULL - ])]
+
+# The rule should not fire when the ON condition uses a projection.
+# TODO(radu): we could inline the projection.
+opt expect-not=HoistProjectFromLeftJoin
+SELECT * FROM small LEFT JOIN (SELECT a, a+b FROM abcd) AS rhs(a,x) ON a=m AND x=n
+----
+right-join (hash)
+ ├── columns: m:1 n:2 a:5 x:10
+ ├── immutable
+ ├── project
+ │    ├── columns: "?column?":10 a:5
+ │    ├── immutable
+ │    ├── scan abcd@secondary
+ │    │    └── columns: a:5 b:6
+ │    └── projections
+ │         └── a:5 + b:6 [as="?column?":10, outer=(5,6), immutable]
+ ├── scan small
+ │    └── columns: m:1 n:2
+ └── filters
+      ├── a:5 = m:1 [outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
+      └── "?column?":10 = n:2 [outer=(2,10), constraints=(/2: (/NULL - ]; /10: (/NULL - ]), fd=(2)==(10), (10)==(2)]
+
+# The rule should not fire when a projection is volatile.
+opt expect-not=HoistProjectFromLeftJoin
+SELECT * FROM small LEFT JOIN (SELECT p, p+q, random() FROM pqr) ON p=m
+----
+right-join (hash)
+ ├── columns: m:1 n:2 p:5 "?column?":11 random:12
+ ├── volatile
+ ├── fd: (5)-->(11,12)
+ ├── project
+ │    ├── columns: "?column?":11 random:12 p:5!null
+ │    ├── volatile
+ │    ├── key: (5)
+ │    ├── fd: (5)-->(11,12)
+ │    ├── scan pqr@q
+ │    │    ├── columns: p:5!null q:6
+ │    │    ├── key: (5)
+ │    │    └── fd: (5)-->(6)
+ │    └── projections
+ │         ├── p:5 + q:6 [as="?column?":11, outer=(5,6), immutable]
+ │         └── random() [as=random:12, volatile]
+ ├── scan small
+ │    └── columns: m:1 n:2
+ └── filters
+      └── p:5 = m:1 [outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]

--- a/pkg/sql/opt/xform/testdata/rules/join_order
+++ b/pkg/sql/opt/xform/testdata/rules/join_order
@@ -2244,6 +2244,47 @@ Joins Considered: 6
 --------------------------------------------------------------------------------
 ----Join Tree #4----
 inner-join (hash)
+ ├── scan abc [as=a1]
+ ├── inner-join (hash)
+ │    ├── scan abc [as=a2]
+ │    ├── distinct-on
+ │    │    └── scan abc [as=a5]
+ │    └── filters
+ │         └── a2.c = a5.c
+ └── filters
+      └── a1.a = a2.a
+
+----Vertexes----
+C:
+scan abc [as=a1]
+
+A:
+scan abc [as=a2]
+
+B:
+distinct-on
+ └── scan abc [as=a5]
+
+----Edges----
+a2.c = a5.c [inner]
+a1.a = a2.a [inner]
+
+----Joining CA----
+C A    refs [CA] [inner]
+A C    refs [CA] [inner]
+----Joining AB----
+A B    refs [AB] [inner]
+B A    refs [AB] [inner]
+----Joining CAB----
+C AB    refs [CA] [inner]
+AB C    refs [CA] [inner]
+CA B    refs [AB] [inner]
+B CA    refs [AB] [inner]
+
+Joins Considered: 8
+--------------------------------------------------------------------------------
+----Join Tree #5----
+inner-join (hash)
  ├── inner-join (hash)
  │    ├── scan abc [as=a1]
  │    ├── semi-join (hash)
@@ -2289,7 +2330,7 @@ D CA    refs [AD] [inner]
 
 Joins Considered: 8
 --------------------------------------------------------------------------------
-----Join Tree #5----
+----Join Tree #6----
 inner-join (hash)
  ├── inner-join (hash)
  │    ├── inner-join (hash)
@@ -2375,5 +2416,5 @@ WHERE EXISTS (SELECT 1 FROM dz WHERE z = y)
 AND EXISTS (SELECT 1 FROM bx WHERE x = y)
 AND EXISTS (SELECT 1 FROM abc WHERE a = y)
 ----
-Rules Applied: 149
-Groups Added: 76
+Rules Applied: 169
+Groups Added: 86

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -6733,54 +6733,56 @@ SELECT u, v FROM d WHERE (u = 1 OR v = 1) AND EXISTS (SELECT * FROM a WHERE a.u 
 ----
 project
  ├── columns: u:2 v:3
- └── inner-join (hash)
+ └── project
       ├── columns: d.u:2!null d.v:3 a.u:7!null
-      ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
       ├── fd: (2)==(7), (7)==(2)
-      ├── project
-      │    ├── columns: d.u:2 d.v:3
-      │    └── distinct-on
-      │         ├── columns: d.k:1!null d.u:2 d.v:3
-      │         ├── grouping columns: d.k:1!null
-      │         ├── key: (1)
-      │         ├── fd: (1)-->(2,3)
-      │         ├── union-all
-      │         │    ├── columns: d.k:1!null d.u:2 d.v:3
-      │         │    ├── left columns: d.k:10 d.u:11 d.v:12
-      │         │    ├── right columns: d.k:15 d.u:16 d.v:17
-      │         │    ├── index-join d
-      │         │    │    ├── columns: d.k:10!null d.u:11!null d.v:12
-      │         │    │    ├── key: (10)
-      │         │    │    ├── fd: ()-->(11), (10)-->(12)
-      │         │    │    └── scan d@u
-      │         │    │         ├── columns: d.k:10!null d.u:11!null
-      │         │    │         ├── constraint: /11/10: [/1 - /1]
-      │         │    │         ├── key: (10)
-      │         │    │         └── fd: ()-->(11)
-      │         │    └── index-join d
-      │         │         ├── columns: d.k:15!null d.u:16 d.v:17!null
-      │         │         ├── key: (15)
-      │         │         ├── fd: ()-->(17), (15)-->(16)
-      │         │         └── scan d@v
-      │         │              ├── columns: d.k:15!null d.v:17!null
-      │         │              ├── constraint: /17/15: [/1 - /1]
-      │         │              ├── key: (15)
-      │         │              └── fd: ()-->(17)
-      │         └── aggregations
-      │              ├── const-agg [as=d.u:2, outer=(2)]
-      │              │    └── d.u:2
-      │              └── const-agg [as=d.v:3, outer=(3)]
-      │                   └── d.v:3
-      ├── distinct-on
-      │    ├── columns: a.u:7
-      │    ├── grouping columns: a.u:7
-      │    ├── internal-ordering: +7
-      │    ├── key: (7)
-      │    └── scan a@u
-      │         ├── columns: a.u:7
-      │         └── ordering: +7
-      └── filters
-           └── a.u:7 = d.u:2 [outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ]), fd=(2)==(7), (7)==(2)]
+      └── inner-join (hash)
+           ├── columns: d.k:1!null d.u:2!null d.v:3 a.u:7!null
+           ├── multiplicity: left-rows(zero-or-more), right-rows(zero-or-one)
+           ├── key: (1)
+           ├── fd: (1)-->(2,3), (2)==(7), (7)==(2)
+           ├── distinct-on
+           │    ├── columns: a.u:7
+           │    ├── grouping columns: a.u:7
+           │    ├── internal-ordering: +7
+           │    ├── key: (7)
+           │    └── scan a@u
+           │         ├── columns: a.u:7
+           │         └── ordering: +7
+           ├── distinct-on
+           │    ├── columns: d.k:1!null d.u:2 d.v:3
+           │    ├── grouping columns: d.k:1!null
+           │    ├── key: (1)
+           │    ├── fd: (1)-->(2,3)
+           │    ├── union-all
+           │    │    ├── columns: d.k:1!null d.u:2 d.v:3
+           │    │    ├── left columns: d.k:10 d.u:11 d.v:12
+           │    │    ├── right columns: d.k:15 d.u:16 d.v:17
+           │    │    ├── index-join d
+           │    │    │    ├── columns: d.k:10!null d.u:11!null d.v:12
+           │    │    │    ├── key: (10)
+           │    │    │    ├── fd: ()-->(11), (10)-->(12)
+           │    │    │    └── scan d@u
+           │    │    │         ├── columns: d.k:10!null d.u:11!null
+           │    │    │         ├── constraint: /11/10: [/1 - /1]
+           │    │    │         ├── key: (10)
+           │    │    │         └── fd: ()-->(11)
+           │    │    └── index-join d
+           │    │         ├── columns: d.k:15!null d.u:16 d.v:17!null
+           │    │         ├── key: (15)
+           │    │         ├── fd: ()-->(17), (15)-->(16)
+           │    │         └── scan d@v
+           │    │              ├── columns: d.k:15!null d.v:17!null
+           │    │              ├── constraint: /17/15: [/1 - /1]
+           │    │              ├── key: (15)
+           │    │              └── fd: ()-->(17)
+           │    └── aggregations
+           │         ├── const-agg [as=d.u:2, outer=(2)]
+           │         │    └── d.u:2
+           │         └── const-agg [as=d.v:3, outer=(3)]
+           │              └── d.v:3
+           └── filters
+                └── a.u:7 = d.u:2 [outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ]), fd=(2)==(7), (7)==(2)]
 
 # Correlated subquery with references to outer columns not in the scan columns.
 opt expect=SplitDisjunctionAddKey
@@ -6790,56 +6792,58 @@ project
  ├── columns: u:2 v:3
  └── project
       ├── columns: d.u:2 d.v:3 w:4
-      └── inner-join (hash)
+      └── project
            ├── columns: d.u:2 d.v:3 w:4!null a.u:7!null
-           ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
            ├── fd: (4)==(7), (7)==(4)
-           ├── project
-           │    ├── columns: d.u:2 d.v:3 w:4
-           │    └── distinct-on
-           │         ├── columns: d.k:1!null d.u:2 d.v:3 w:4
-           │         ├── grouping columns: d.k:1!null
-           │         ├── key: (1)
-           │         ├── fd: (1)-->(2-4)
-           │         ├── union-all
-           │         │    ├── columns: d.k:1!null d.u:2 d.v:3 w:4
-           │         │    ├── left columns: d.k:10 d.u:11 d.v:12 w:13
-           │         │    ├── right columns: d.k:15 d.u:16 d.v:17 w:18
-           │         │    ├── index-join d
-           │         │    │    ├── columns: d.k:10!null d.u:11!null d.v:12 w:13
-           │         │    │    ├── key: (10)
-           │         │    │    ├── fd: ()-->(11), (10)-->(12,13)
-           │         │    │    └── scan d@u
-           │         │    │         ├── columns: d.k:10!null d.u:11!null
-           │         │    │         ├── constraint: /11/10: [/1 - /1]
-           │         │    │         ├── key: (10)
-           │         │    │         └── fd: ()-->(11)
-           │         │    └── index-join d
-           │         │         ├── columns: d.k:15!null d.u:16 d.v:17!null w:18
-           │         │         ├── key: (15)
-           │         │         ├── fd: ()-->(17), (15)-->(16,18)
-           │         │         └── scan d@v
-           │         │              ├── columns: d.k:15!null d.v:17!null
-           │         │              ├── constraint: /17/15: [/1 - /1]
-           │         │              ├── key: (15)
-           │         │              └── fd: ()-->(17)
-           │         └── aggregations
-           │              ├── const-agg [as=d.u:2, outer=(2)]
-           │              │    └── d.u:2
-           │              ├── const-agg [as=d.v:3, outer=(3)]
-           │              │    └── d.v:3
-           │              └── const-agg [as=w:4, outer=(4)]
-           │                   └── w:4
-           ├── distinct-on
-           │    ├── columns: a.u:7
-           │    ├── grouping columns: a.u:7
-           │    ├── internal-ordering: +7
-           │    ├── key: (7)
-           │    └── scan a@u
-           │         ├── columns: a.u:7
-           │         └── ordering: +7
-           └── filters
-                └── a.u:7 = w:4 [outer=(4,7), constraints=(/4: (/NULL - ]; /7: (/NULL - ]), fd=(4)==(7), (7)==(4)]
+           └── inner-join (hash)
+                ├── columns: d.k:1!null d.u:2 d.v:3 w:4!null a.u:7!null
+                ├── multiplicity: left-rows(zero-or-more), right-rows(zero-or-one)
+                ├── key: (1)
+                ├── fd: (1)-->(2-4), (4)==(7), (7)==(4)
+                ├── distinct-on
+                │    ├── columns: a.u:7
+                │    ├── grouping columns: a.u:7
+                │    ├── internal-ordering: +7
+                │    ├── key: (7)
+                │    └── scan a@u
+                │         ├── columns: a.u:7
+                │         └── ordering: +7
+                ├── distinct-on
+                │    ├── columns: d.k:1!null d.u:2 d.v:3 w:4
+                │    ├── grouping columns: d.k:1!null
+                │    ├── key: (1)
+                │    ├── fd: (1)-->(2-4)
+                │    ├── union-all
+                │    │    ├── columns: d.k:1!null d.u:2 d.v:3 w:4
+                │    │    ├── left columns: d.k:10 d.u:11 d.v:12 w:13
+                │    │    ├── right columns: d.k:15 d.u:16 d.v:17 w:18
+                │    │    ├── index-join d
+                │    │    │    ├── columns: d.k:10!null d.u:11!null d.v:12 w:13
+                │    │    │    ├── key: (10)
+                │    │    │    ├── fd: ()-->(11), (10)-->(12,13)
+                │    │    │    └── scan d@u
+                │    │    │         ├── columns: d.k:10!null d.u:11!null
+                │    │    │         ├── constraint: /11/10: [/1 - /1]
+                │    │    │         ├── key: (10)
+                │    │    │         └── fd: ()-->(11)
+                │    │    └── index-join d
+                │    │         ├── columns: d.k:15!null d.u:16 d.v:17!null w:18
+                │    │         ├── key: (15)
+                │    │         ├── fd: ()-->(17), (15)-->(16,18)
+                │    │         └── scan d@v
+                │    │              ├── columns: d.k:15!null d.v:17!null
+                │    │              ├── constraint: /17/15: [/1 - /1]
+                │    │              ├── key: (15)
+                │    │              └── fd: ()-->(17)
+                │    └── aggregations
+                │         ├── const-agg [as=d.u:2, outer=(2)]
+                │         │    └── d.u:2
+                │         ├── const-agg [as=d.v:3, outer=(3)]
+                │         │    └── d.v:3
+                │         └── const-agg [as=w:4, outer=(4)]
+                │              └── w:4
+                └── filters
+                     └── a.u:7 = w:4 [outer=(4,7), constraints=(/4: (/NULL - ]; /7: (/NULL - ]), fd=(4)==(7), (7)==(4)]
 
 # Use rowid when there is no explicit primary key.
 opt expect=SplitDisjunctionAddKey


### PR DESCRIPTION
UPSERTs with virtual columns result in plans that can't utilize lookup
joins because of a Project inside a left join.

This change adds two exploration rules that try to pull up the
Project, allowing other rules to fire on the resulting join. For inner
joins, this is a trivial transformation (as long as the ON condition
doesn't refer to a projection). For the right side of left joins (the
UPSERT case), this is more complicated: we have to find a canary
column from the right side. Fortunately, for the typical `a=b` join
condition, `a` needs to be non-NULL, so we can use such a column as
canary.

Release note: None