### PR TITLE
bulkio: Move target resolution code into backupbase package.

### DIFF
--- a/pkg/ccl/backupccl/backup_destination.go
+++ b/pkg/ccl/backupccl/backup_destination.go
@@ -166,7 +166,7 @@ func getBackupManifests(
 	for i := range backupURIs {
 		i := i
 		g.GoCtx(func(ctx context.Context) error {
-			// TODO(lucy): We may want to upgrade the table descs to the newer
+			// TODO(lucy): We may want to upgrade the table Descs to the newer
 			// foreign key representation here, in case there are backups from an
 			// older cluster. Keeping the descriptors as they are works for now
 			// since all we need to do is get the past backups' table/index spans,

--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/build"
+	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl/backupbase"
 	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
 	"github.com/cockroachdb/cockroach/pkg/featureflag"
@@ -807,7 +808,7 @@ func backupPlanHook(
 			mvccFilter = MVCCFilter_All
 		}
 
-		targetDescs, completeDBs, err := ResolveTargetsToDescriptors(ctx, p, endTime, backupStmt.Targets)
+		targetDescs, completeDBs, err := backupbase.ResolveTargetsToDescriptors(ctx, p, endTime, backupStmt.Targets)
 		if err != nil {
 			return errors.Wrap(err, "failed to resolve targets specified in the BACKUP stmt")
 		}

--- a/pkg/ccl/backupccl/backupbase/main_test.go
+++ b/pkg/ccl/backupccl/backupbase/main_test.go
@@ -1,0 +1,36 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package backupbase
+
+import (
+	"os"
+	"testing"
+
+	_ "github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
+	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+func TestMain(m *testing.M) {
+	defer utilccl.TestingEnableEnterprise()()
+	security.SetAssetLoader(securitytest.EmbeddedAssets)
+	randutil.SeedForTests()
+	serverutils.InitTestServerFactory(server.TestServerFactory)
+	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
+	os.Exit(m.Run())
+}
+
+//go:generate ../../util/leaktest/add-leaktest.sh *_test.go

--- a/pkg/ccl/backupccl/backupbase/system_schema.go
+++ b/pkg/ccl/backupccl/backupbase/system_schema.go
@@ -6,7 +6,7 @@
 //
 //     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
 
-package backupccl
+package backupbase
 
 import (
 	"context"
@@ -24,12 +24,12 @@ import (
 type clusterBackupInclusion int
 
 const (
-	// invalid indicates that no preference for cluster backup inclusion has been
+	// InvalidBackupInclusion indicates that no preference for cluster backup inclusion has been
 	// set. This is to ensure that newly added system tables have to explicitly
 	// opt-in or out of cluster backups.
-	invalid = iota
-	optInToClusterBackup
-	optOutOfClusterBackup
+	InvalidBackupInclusion = iota
+	OptInToClusterBackup
+	OptOutOfClusterBackup
 )
 
 // systemBackupConfiguration holds any configuration related to backing up
@@ -43,17 +43,17 @@ const (
 //    restore creates descriptors with the same ID as they had in the backing up
 //    cluster so there is no need to rewrite system table data.
 type systemBackupConfiguration struct {
-	includeInClusterBackup clusterBackupInclusion
-	// customRestoreFunc is responsible for restoring the data from a table that
+	IncludeInClusterBackup clusterBackupInclusion
+	// CustomRestoreFunc is responsible for restoring the data from a table that
 	// holds the restore system table data into the given system table. If none
 	// is provided then `defaultRestoreFunc` is used.
-	customRestoreFunc func(ctx context.Context, execCtx *sql.ExecutorConfig, txn *kv.Txn, systemTableName, tempTableName string) error
+	CustomRestoreFunc func(ctx context.Context, execCtx *sql.ExecutorConfig, txn *kv.Txn, systemTableName, tempTableName string) error
 }
 
-// defaultSystemTableRestoreFunc is how system table data is restored. This can
+// DefaultSystemTableRestoreFunc is how system table data is restored. This can
 // be overwritten with the system table's
-// systemBackupConfiguration.customRestoreFunc.
-func defaultSystemTableRestoreFunc(
+// systemBackupConfiguration.CustomRestoreFunc.
+func DefaultSystemTableRestoreFunc(
 	ctx context.Context,
 	execCfg *sql.ExecutorConfig,
 	txn *kv.Txn,
@@ -132,109 +132,109 @@ func settingsRestoreFunc(
 	return nil
 }
 
-// systemTableBackupConfiguration is a map from every systemTable present in the
+// SystemTableBackupConfiguration is a map from every systemTable present in the
 // cluster to a configuration struct which specifies how it should be treated by
 // backup. Every system table should have a specification defined here, enforced
 // by TestAllSystemTablesHaveBackupConfig.
-var systemTableBackupConfiguration = map[string]systemBackupConfiguration{
+var SystemTableBackupConfiguration = map[string]systemBackupConfiguration{
 	systemschema.UsersTable.GetName(): {
-		includeInClusterBackup: optInToClusterBackup,
+		IncludeInClusterBackup: OptInToClusterBackup,
 	},
 	systemschema.ZonesTable.GetName(): {
-		includeInClusterBackup: optInToClusterBackup,
+		IncludeInClusterBackup: OptInToClusterBackup,
 	},
 	systemschema.SettingsTable.GetName(): {
-		includeInClusterBackup: optInToClusterBackup,
-		customRestoreFunc:      settingsRestoreFunc,
+		IncludeInClusterBackup: OptInToClusterBackup,
+		CustomRestoreFunc:      settingsRestoreFunc,
 	},
 	systemschema.LocationsTable.GetName(): {
-		includeInClusterBackup: optInToClusterBackup,
+		IncludeInClusterBackup: OptInToClusterBackup,
 	},
 	systemschema.RoleMembersTable.GetName(): {
-		includeInClusterBackup: optInToClusterBackup,
+		IncludeInClusterBackup: OptInToClusterBackup,
 	},
 	systemschema.RoleOptionsTable.GetName(): {
-		includeInClusterBackup: optInToClusterBackup,
+		IncludeInClusterBackup: OptInToClusterBackup,
 	},
 	systemschema.UITable.GetName(): {
-		includeInClusterBackup: optInToClusterBackup,
+		IncludeInClusterBackup: OptInToClusterBackup,
 	},
 	systemschema.CommentsTable.GetName(): {
-		includeInClusterBackup: optInToClusterBackup,
+		IncludeInClusterBackup: OptInToClusterBackup,
 	},
 	systemschema.JobsTable.GetName(): {
-		includeInClusterBackup: optInToClusterBackup,
-		customRestoreFunc:      jobsRestoreFunc,
+		IncludeInClusterBackup: OptInToClusterBackup,
+		CustomRestoreFunc:      jobsRestoreFunc,
 	},
 	systemschema.ScheduledJobsTable.GetName(): {
-		includeInClusterBackup: optInToClusterBackup,
+		IncludeInClusterBackup: OptInToClusterBackup,
 	},
 	systemschema.TableStatisticsTable.GetName(): {
 		// Table statistics are backed up in the backup descriptor for now.
-		includeInClusterBackup: optOutOfClusterBackup,
+		IncludeInClusterBackup: OptOutOfClusterBackup,
 	},
 	systemschema.DescriptorTable.GetName(): {
-		includeInClusterBackup: optOutOfClusterBackup,
+		IncludeInClusterBackup: OptOutOfClusterBackup,
 	},
 	systemschema.EventLogTable.GetName(): {
-		includeInClusterBackup: optOutOfClusterBackup,
+		IncludeInClusterBackup: OptOutOfClusterBackup,
 	},
 	systemschema.LeaseTable.GetName(): {
-		includeInClusterBackup: optOutOfClusterBackup,
+		IncludeInClusterBackup: OptOutOfClusterBackup,
 	},
 	systemschema.NamespaceTable.GetName(): {
-		includeInClusterBackup: optOutOfClusterBackup,
+		IncludeInClusterBackup: OptOutOfClusterBackup,
 	},
 	systemschema.DeprecatedNamespaceTable.GetName(): {
-		includeInClusterBackup: optOutOfClusterBackup,
+		IncludeInClusterBackup: OptOutOfClusterBackup,
 	},
 	systemschema.ProtectedTimestampsMetaTable.GetName(): {
-		includeInClusterBackup: optOutOfClusterBackup,
+		IncludeInClusterBackup: OptOutOfClusterBackup,
 	},
 	systemschema.ProtectedTimestampsRecordsTable.GetName(): {
-		includeInClusterBackup: optOutOfClusterBackup,
+		IncludeInClusterBackup: OptOutOfClusterBackup,
 	},
 	systemschema.RangeEventTable.GetName(): {
-		includeInClusterBackup: optOutOfClusterBackup,
+		IncludeInClusterBackup: OptOutOfClusterBackup,
 	},
 	systemschema.ReplicationConstraintStatsTable.GetName(): {
-		includeInClusterBackup: optOutOfClusterBackup,
+		IncludeInClusterBackup: OptOutOfClusterBackup,
 	},
 	systemschema.ReplicationCriticalLocalitiesTable.GetName(): {
-		includeInClusterBackup: optOutOfClusterBackup,
+		IncludeInClusterBackup: OptOutOfClusterBackup,
 	},
 	systemschema.ReportsMetaTable.GetName(): {
-		includeInClusterBackup: optOutOfClusterBackup,
+		IncludeInClusterBackup: OptOutOfClusterBackup,
 	},
 	systemschema.ReplicationStatsTable.GetName(): {
-		includeInClusterBackup: optOutOfClusterBackup,
+		IncludeInClusterBackup: OptOutOfClusterBackup,
 	},
 	systemschema.SqllivenessTable.GetName(): {
-		includeInClusterBackup: optOutOfClusterBackup,
+		IncludeInClusterBackup: OptOutOfClusterBackup,
 	},
 	systemschema.StatementBundleChunksTable.GetName(): {
-		includeInClusterBackup: optOutOfClusterBackup,
+		IncludeInClusterBackup: OptOutOfClusterBackup,
 	},
 	systemschema.StatementDiagnosticsTable.GetName(): {
-		includeInClusterBackup: optOutOfClusterBackup,
+		IncludeInClusterBackup: OptOutOfClusterBackup,
 	},
 	systemschema.StatementDiagnosticsRequestsTable.GetName(): {
-		includeInClusterBackup: optOutOfClusterBackup,
+		IncludeInClusterBackup: OptOutOfClusterBackup,
 	},
 	systemschema.TenantsTable.GetName(): {
-		includeInClusterBackup: optOutOfClusterBackup,
+		IncludeInClusterBackup: OptOutOfClusterBackup,
 	},
 	systemschema.WebSessionsTable.GetName(): {
-		includeInClusterBackup: optOutOfClusterBackup,
+		IncludeInClusterBackup: OptOutOfClusterBackup,
 	},
 }
 
 // getSystemTablesToBackup returns a set of system table names that should be
 // included in a cluster backup.
-func getSystemTablesToIncludeInClusterBackup() map[string]struct{} {
+func GetSystemTablesToIncludeInClusterBackup() map[string]struct{} {
 	systemTablesToInclude := make(map[string]struct{})
-	for systemTableName, backupConfig := range systemTableBackupConfiguration {
-		if backupConfig.includeInClusterBackup == optInToClusterBackup {
+	for systemTableName, backupConfig := range SystemTableBackupConfiguration {
+		if backupConfig.IncludeInClusterBackup == OptInToClusterBackup {
 			systemTablesToInclude[systemTableName] = struct{}{}
 		}
 	}

--- a/pkg/ccl/backupccl/backupbase/targets.go
+++ b/pkg/ccl/backupccl/backupbase/targets.go
@@ -1,0 +1,586 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package backupbase
+
+import (
+	"context"
+	"sort"
+
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/dbdesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/errors"
+)
+
+// DescriptorsMatched is a struct containing the set of
+// descriptors matching a target descriptor (or set of targets).
+type DescriptorsMatched struct {
+	// All descriptors that match targets plus their parent databases.
+	Descs []catalog.Descriptor
+
+	// The databases from which all tables were matched (eg a.* or DATABASE a).
+	ExpandedDB []descpb.ID
+
+	// Explicitly requested DBs (e.g. DATABASE a).
+	RequestedDBs []catalog.DatabaseDescriptor
+}
+
+// CheckExpnansion determines if  matched targets are covered by the specified
+// descriptors.
+func (d DescriptorsMatched) CheckExpansions(coveredDBs []descpb.ID) error {
+	covered := make(map[descpb.ID]bool)
+	for _, i := range coveredDBs {
+		covered[i] = true
+	}
+	for _, i := range d.RequestedDBs {
+		if !covered[i.GetID()] {
+			return errors.Errorf("cannot RESTORE DATABASE from a backup of individual tables (use SHOW BACKUP to determine available tables)")
+		}
+	}
+	for _, i := range d.ExpandedDB {
+		if !covered[i] {
+			return errors.Errorf("cannot RESTORE <database>.* from a backup of individual tables (use SHOW BACKUP to determine available tables)")
+		}
+	}
+	return nil
+}
+
+// DescriptorResolver is the helper struct that enables reuse of the
+// standard name resolution algorithm.
+type DescriptorResolver struct {
+	// Map: descriptorID -> descriptor
+	DescByID map[descpb.ID]catalog.Descriptor
+	// Map: db name -> dbID
+	DbsByName map[string]descpb.ID
+	// Map: dbID -> schema name -> schemaID
+	SchemasByName map[descpb.ID]map[string]descpb.ID
+	// Map: dbID -> schema name -> obj name -> obj ID
+	ObjsByName map[descpb.ID]map[string]map[string]descpb.ID
+}
+
+// LookupSchema implements the tree.ObjectNameTargetResolver interface.
+func (r *DescriptorResolver) LookupSchema(
+	_ context.Context, dbName, scName string,
+) (bool, tree.SchemaMeta, error) {
+	dbID, ok := r.DbsByName[dbName]
+	if !ok {
+		return false, nil, nil
+	}
+	schemas := r.ObjsByName[dbID]
+	if _, ok := schemas[scName]; ok {
+		// TODO (rohany): Not sure if we want to change this to also
+		//  use the resolved schema struct.
+		if dbDesc, ok := r.DescByID[dbID].(catalog.DatabaseDescriptor); ok {
+			return true, dbDesc, nil
+		}
+	}
+	return false, nil, nil
+}
+
+// LookupObject implements the tree.ObjectNameExistingResolver interface.
+func (r *DescriptorResolver) LookupObject(
+	_ context.Context, flags tree.ObjectLookupFlags, dbName, scName, obName string,
+) (bool, tree.NameResolutionResult, error) {
+	if flags.RequireMutable {
+		panic("did not expect request for mutable descriptor")
+	}
+	dbID, ok := r.DbsByName[dbName]
+	if !ok {
+		return false, nil, nil
+	}
+	if scMap, ok := r.ObjsByName[dbID]; ok {
+		if objMap, ok := scMap[scName]; ok {
+			if objID, ok := objMap[obName]; ok {
+				return true, r.DescByID[objID], nil
+			}
+		}
+	}
+	return false, nil, nil
+}
+
+// newDescriptorResolver prepares a DescriptorResolver for the given
+// known set of descriptors.
+func NewDescriptorResolver(descs []catalog.Descriptor) (*DescriptorResolver, error) {
+	r := &DescriptorResolver{
+		DescByID:      make(map[descpb.ID]catalog.Descriptor),
+		SchemasByName: make(map[descpb.ID]map[string]descpb.ID),
+		DbsByName:     make(map[string]descpb.ID),
+		ObjsByName:    make(map[descpb.ID]map[string]map[string]descpb.ID),
+	}
+
+	// Iterate to find the databases first. We need that because we also
+	// check the ParentID for tables, and all the valid parents must be
+	// known before we start to check that.
+	for _, desc := range descs {
+		if _, isDB := desc.(catalog.DatabaseDescriptor); isDB {
+			if _, ok := r.DbsByName[desc.GetName()]; ok {
+				return nil, errors.Errorf("duplicate database name: %q used for ID %d and %d",
+					desc.GetName(), r.DbsByName[desc.GetName()], desc.GetID())
+			}
+			r.DbsByName[desc.GetName()] = desc.GetID()
+			r.ObjsByName[desc.GetID()] = make(map[string]map[string]descpb.ID)
+			r.SchemasByName[desc.GetID()] = make(map[string]descpb.ID)
+			// Always add an entry for the public schema.
+			r.ObjsByName[desc.GetID()][tree.PublicSchema] = make(map[string]descpb.ID)
+			r.SchemasByName[desc.GetID()][tree.PublicSchema] = keys.PublicSchemaID
+		}
+
+		// Incidentally, also remember all the descriptors by ID.
+		if prevDesc, ok := r.DescByID[desc.GetID()]; ok {
+			return nil, errors.Errorf("duplicate descriptor ID: %d used by %q and %q",
+				desc.GetID(), prevDesc.GetName(), desc.GetName())
+		}
+		r.DescByID[desc.GetID()] = desc
+	}
+
+	// Add all schemas to the resolver.
+	for _, desc := range descs {
+		if sc, ok := desc.(catalog.SchemaDescriptor); ok {
+			schemaMap := r.ObjsByName[sc.GetParentID()]
+			if schemaMap == nil {
+				schemaMap = make(map[string]map[string]descpb.ID)
+			}
+			schemaMap[sc.GetName()] = make(map[string]descpb.ID)
+			r.ObjsByName[sc.GetParentID()] = schemaMap
+
+			schemaNameMap := r.SchemasByName[sc.GetParentID()]
+			if schemaNameMap == nil {
+				schemaNameMap = make(map[string]descpb.ID)
+			}
+			schemaNameMap[sc.GetName()] = sc.GetID()
+			r.SchemasByName[sc.GetParentID()] = schemaNameMap
+		}
+	}
+
+	// registerDesc is a closure that registers a Descriptor into the resolver's
+	// object registry.
+	registerDesc := func(parentID descpb.ID, desc catalog.Descriptor, kind string) error {
+		parentDesc, ok := r.DescByID[parentID]
+		if !ok {
+			return errors.Errorf("%s %q has unknown ParentID %d", kind, desc.GetName(), parentID)
+		}
+		if _, ok := r.DbsByName[parentDesc.GetName()]; !ok {
+			return errors.Errorf("%s %q's ParentID %d (%q) is not a database",
+				kind, desc.GetName(), parentID, parentDesc.GetName())
+		}
+
+		// Look up what schema this descriptor belongs under.
+		schemaMap := r.ObjsByName[parentDesc.GetID()]
+		scID := desc.GetParentSchemaID()
+		var scName string
+		if scID == keys.PublicSchemaID {
+			scName = tree.PublicSchema
+		} else {
+			scDescI, ok := r.DescByID[scID]
+			if !ok {
+				return errors.Errorf("schema %d not found for desc %d", scID, desc.GetID())
+			}
+			scDesc, ok := scDescI.(catalog.SchemaDescriptor)
+			if !ok {
+				return errors.Errorf("descriptor %d is not a schema", scDescI.GetID())
+			}
+			scName = scDesc.GetName()
+		}
+
+		// Create an entry for the descriptor.
+		objMap := schemaMap[scName]
+		if objMap == nil {
+			objMap = make(map[string]descpb.ID)
+		}
+		if _, ok := objMap[desc.GetName()]; ok {
+			return errors.Errorf("duplicate %s name: %q.%q.%q used for ID %d and %d",
+				kind, parentDesc.GetName(), scName, desc.GetName(), desc.GetID(), objMap[desc.GetName()])
+		}
+		objMap[desc.GetName()] = desc.GetID()
+		r.ObjsByName[parentDesc.GetID()][scName] = objMap
+		return nil
+	}
+
+	// Now on to the remaining descriptors.
+	for _, desc := range descs {
+		if desc.Dropped() {
+			continue
+		}
+		var typeToRegister string
+		switch desc := desc.(type) {
+		case catalog.TableDescriptor:
+			if desc.IsTemporary() {
+				continue
+			}
+			typeToRegister = "table"
+		case catalog.TypeDescriptor:
+			typeToRegister = "type"
+		}
+		if typeToRegister != "" {
+			if err := registerDesc(desc.GetParentID(), desc, typeToRegister); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return r, nil
+}
+
+// descriptorsMatchingTargets returns the descriptors that match the targets. A
+// database descriptor is included in this set if it matches the targets (or the
+// session database) or if one of its tables matches the targets. All expanded
+// DBs, via either `foo.*` or `DATABASE foo` are noted, as are those explicitly
+// named as DBs (e.g. with `DATABASE foo`, not `foo.*`). These distinctions are
+// used e.g. by RESTORE.
+//
+// This is guaranteed to not return duplicates.
+func DescriptorsMatchingTargets(
+	ctx context.Context,
+	currentDatabase string,
+	searchPath sessiondata.SearchPath,
+	descriptors []catalog.Descriptor,
+	targets tree.TargetList,
+) (DescriptorsMatched, error) {
+	ret := DescriptorsMatched{}
+
+	resolver, err := NewDescriptorResolver(descriptors)
+	if err != nil {
+		return ret, err
+	}
+
+	alreadyRequestedDBs := make(map[descpb.ID]struct{})
+	alreadyExpandedDBs := make(map[descpb.ID]struct{})
+	// Process all the DATABASE requests.
+	for _, d := range targets.Databases {
+		dbID, ok := resolver.DbsByName[string(d)]
+		if !ok {
+			return ret, errors.Errorf("unknown database %q", d)
+		}
+		if _, ok := alreadyRequestedDBs[dbID]; !ok {
+			desc := resolver.DescByID[dbID]
+			ret.Descs = append(ret.Descs, desc)
+			ret.RequestedDBs = append(ret.RequestedDBs,
+				desc.(catalog.DatabaseDescriptor))
+			ret.ExpandedDB = append(ret.ExpandedDB, dbID)
+			alreadyRequestedDBs[dbID] = struct{}{}
+			alreadyExpandedDBs[dbID] = struct{}{}
+		}
+	}
+
+	alreadyRequestedSchemas := make(map[descpb.ID]struct{})
+	maybeAddSchemaDesc := func(id descpb.ID, requirePublic bool) error {
+		// Only add user defined schemas.
+		if id == keys.PublicSchemaID {
+			return nil
+		}
+		if _, ok := alreadyRequestedSchemas[id]; !ok {
+			schemaDesc := resolver.DescByID[id]
+			if err := catalog.FilterDescriptorState(
+				schemaDesc, tree.CommonLookupFlags{},
+			); err != nil {
+				if requirePublic {
+					return errors.Wrapf(err, "schema %d was expected to be PUBLIC", id)
+				}
+				// If the schema is not public, but we don't require it to be, ignore
+				// it.
+				return nil
+			}
+			alreadyRequestedSchemas[id] = struct{}{}
+			ret.Descs = append(ret.Descs, resolver.DescByID[id])
+		}
+
+		return nil
+	}
+	getSchemaIDByName := func(scName string, dbID descpb.ID) (descpb.ID, error) {
+		schemas, ok := resolver.SchemasByName[dbID]
+		if !ok {
+			return 0, errors.Newf("database with ID %d not found", dbID)
+		}
+		schemaID, ok := schemas[scName]
+		if !ok {
+			return 0, errors.Newf("schema with name %s not found in DB %d", scName, dbID)
+		}
+		return schemaID, nil
+	}
+
+	alreadyRequestedTypes := make(map[descpb.ID]struct{})
+	maybeAddTypeDesc := func(id descpb.ID) {
+		if _, ok := alreadyRequestedTypes[id]; !ok {
+			// Cross database type references have been disabled, so we don't
+			// need to request the parent database because it has already been
+			// requested by the table that holds this type.
+			alreadyRequestedTypes[id] = struct{}{}
+			ret.Descs = append(ret.Descs, resolver.DescByID[id])
+		}
+	}
+	getTypeByID := func(id descpb.ID) (catalog.TypeDescriptor, error) {
+		desc, ok := resolver.DescByID[id]
+		if !ok {
+			return nil, errors.Newf("type with ID %d not found", id)
+		}
+		typeDesc, ok := desc.(catalog.TypeDescriptor)
+		if !ok {
+			return nil, errors.Newf("descriptor %d is not a type, but a %T", id, desc)
+		}
+		return typeDesc, nil
+	}
+
+	// Process all the TABLE requests.
+	// Pulling in a table needs to pull in the underlying database too.
+	alreadyRequestedTables := make(map[descpb.ID]struct{})
+	for _, pattern := range targets.Tables {
+		var err error
+		pattern, err = pattern.NormalizeTablePattern()
+		if err != nil {
+			return ret, err
+		}
+
+		switch p := pattern.(type) {
+		case *tree.TableName:
+			// TODO: As part of work for #34240, this should not be a TableName.
+			//  Instead, it should be an UnresolvedObjectName.
+			un := p.ToUnresolvedObjectName()
+			found, prefix, descI, err := tree.ResolveExisting(ctx, un, resolver, tree.ObjectLookupFlags{}, currentDatabase, searchPath)
+			if err != nil {
+				return ret, err
+			}
+			p.ObjectNamePrefix = prefix
+			doesNotExistErr := errors.Errorf(`table %q does not exist`, tree.ErrString(p))
+			if !found {
+				return ret, doesNotExistErr
+			}
+			tableDesc, isTable := descI.(catalog.TableDescriptor)
+			// If the type assertion didn't work, then we resolved a type instead, so
+			// error out.
+			if !isTable {
+				return ret, doesNotExistErr
+			}
+
+			// Verify that the table is in the correct state.
+			if err := catalog.FilterDescriptorState(
+				tableDesc, tree.CommonLookupFlags{},
+			); err != nil {
+				// Return a does not exist error if explicitly asking for this table.
+				return ret, doesNotExistErr
+			}
+
+			// If the parent database is not requested already, request it now.
+			parentID := tableDesc.GetParentID()
+			if _, ok := alreadyRequestedDBs[parentID]; !ok {
+				parentDesc := resolver.DescByID[parentID]
+				ret.Descs = append(ret.Descs, parentDesc)
+				alreadyRequestedDBs[parentID] = struct{}{}
+			}
+			// Then request the table itself.
+			if _, ok := alreadyRequestedTables[tableDesc.GetID()]; !ok {
+				alreadyRequestedTables[tableDesc.GetID()] = struct{}{}
+				ret.Descs = append(ret.Descs, tableDesc)
+			}
+			// Since the table was directly requested, so is the schema. If the table
+			// is PUBLIC, we expect the schema to also be PUBLIC.
+			if err := maybeAddSchemaDesc(tableDesc.GetParentSchemaID(), true /* requirePublic */); err != nil {
+				return ret, err
+			}
+			// Get all the types used by this table.
+			typeIDs, err := tableDesc.GetAllReferencedTypeIDs(getTypeByID)
+			if err != nil {
+				return ret, err
+			}
+			for _, id := range typeIDs {
+				maybeAddTypeDesc(id)
+			}
+
+		case *tree.AllTablesSelector:
+			found, descI, err := p.ObjectNamePrefix.Resolve(ctx, resolver, currentDatabase, searchPath)
+			if err != nil {
+				return ret, err
+			}
+			if !found {
+				return ret, sqlerrors.NewInvalidWildcardError(tree.ErrString(p))
+			}
+			desc := descI.(catalog.DatabaseDescriptor)
+
+			// If the database is not requested already, request it now.
+			dbID := desc.GetID()
+			if _, ok := alreadyRequestedDBs[dbID]; !ok {
+				ret.Descs = append(ret.Descs, desc)
+				alreadyRequestedDBs[dbID] = struct{}{}
+			}
+
+			// Then request the expansion.
+			if _, ok := alreadyExpandedDBs[desc.GetID()]; !ok {
+				ret.ExpandedDB = append(ret.ExpandedDB, desc.GetID())
+				alreadyExpandedDBs[desc.GetID()] = struct{}{}
+			}
+
+		default:
+			return ret, errors.Errorf("unknown pattern %T: %+v", pattern, pattern)
+		}
+	}
+
+	// Then process the database expansions.
+	for dbID := range alreadyExpandedDBs {
+		for schemaName, schemas := range resolver.ObjsByName[dbID] {
+			schemaID, err := getSchemaIDByName(schemaName, dbID)
+			if err != nil {
+				return ret, err
+			}
+			if err := maybeAddSchemaDesc(schemaID, false /* requirePublic */); err != nil {
+				return ret, err
+			}
+
+			for _, id := range schemas {
+				desc := resolver.DescByID[id]
+				switch desc := desc.(type) {
+				case catalog.TableDescriptor:
+					if err := catalog.FilterDescriptorState(
+						desc, tree.CommonLookupFlags{},
+					); err != nil {
+						// Don't include this table in the expansion since it's not in a valid
+						// state. Silently fail since this table was not directly requested,
+						// but was just part of an expansion.
+						continue
+					}
+					if _, ok := alreadyRequestedTables[id]; !ok {
+						ret.Descs = append(ret.Descs, desc)
+					}
+					// If this table is a member of a user defined schema, then request the
+					// user defined schema.
+					if desc.GetParentSchemaID() != keys.PublicSchemaID {
+						// Note, that although we're processing the database expansions,
+						// since the table is in a PUBLIC state, we also expect the schema
+						// to be in a similar state.
+						if err := maybeAddSchemaDesc(desc.GetParentSchemaID(), true /* requirePublic */); err != nil {
+							return ret, err
+						}
+					}
+					// Get all the types used by this table.
+					typeIDs, err := desc.GetAllReferencedTypeIDs(getTypeByID)
+					if err != nil {
+						return ret, err
+					}
+					for _, id := range typeIDs {
+						maybeAddTypeDesc(id)
+					}
+				case catalog.TypeDescriptor:
+					maybeAddTypeDesc(desc.GetID())
+				}
+			}
+		}
+	}
+
+	return ret, nil
+}
+
+func LoadAllDescs(
+	ctx context.Context, codec keys.SQLCodec, db *kv.DB, asOf hlc.Timestamp,
+) ([]catalog.Descriptor, error) {
+	var allDescs []catalog.Descriptor
+	if err := db.Txn(
+		ctx,
+		func(ctx context.Context, txn *kv.Txn) (err error) {
+			txn.SetFixedTimestamp(ctx, asOf)
+			allDescs, err = catalogkv.GetAllDescriptors(ctx, txn, codec)
+			return err
+		}); err != nil {
+		return nil, err
+	}
+	return allDescs, nil
+}
+
+// ResolveTargetsToDescriptors performs name resolution on a set of targets and
+// returns the resulting descriptors.
+func ResolveTargetsToDescriptors(
+	ctx context.Context, p sql.PlanHookState, endTime hlc.Timestamp, targets *tree.TargetList,
+) ([]catalog.Descriptor, []descpb.ID, error) {
+	allDescs, err := LoadAllDescs(ctx, p.ExecCfg().Codec, p.ExecCfg().DB, endTime)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if targets == nil {
+		return fullClusterTargetsBackup(allDescs)
+	}
+
+	var matched DescriptorsMatched
+	if matched, err = DescriptorsMatchingTargets(ctx,
+		p.CurrentDatabase(), p.CurrentSearchPath(), allDescs, *targets); err != nil {
+		return nil, nil, err
+	}
+
+	// Ensure interleaved tables appear after their parent. Since parents must be
+	// created before their children, simply sorting by ID accomplishes this.
+	sort.Slice(matched.Descs, func(i, j int) bool { return matched.Descs[i].GetID() < matched.Descs[j].GetID() })
+	return matched.Descs, matched.ExpandedDB, nil
+}
+
+// fullClusterTargetsBackup returns the same descriptors referenced in
+// fullClusterTargets, but rather than returning the entire database
+// descriptor as the second argument, it only returns their IDs.
+func fullClusterTargetsBackup(
+	allDescs []catalog.Descriptor,
+) ([]catalog.Descriptor, []descpb.ID, error) {
+	fullClusterDescs, fullClusterDBs, err := FullClusterTargets(allDescs)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	fullClusterDBIDs := make([]descpb.ID, 0)
+	for _, desc := range fullClusterDBs {
+		fullClusterDBIDs = append(fullClusterDBIDs, desc.GetID())
+	}
+	return fullClusterDescs, fullClusterDBIDs, nil
+}
+
+// FullClusterTargets returns all of the tableDescriptors to be included in a
+// full cluster backup, and all the user databases.
+func FullClusterTargets(
+	allDescs []catalog.Descriptor,
+) ([]catalog.Descriptor, []*dbdesc.Immutable, error) {
+	fullClusterDescs := make([]catalog.Descriptor, 0, len(allDescs))
+	fullClusterDBs := make([]*dbdesc.Immutable, 0)
+
+	systemTablesToBackup := GetSystemTablesToIncludeInClusterBackup()
+
+	for _, desc := range allDescs {
+		switch desc := desc.(type) {
+		case catalog.DatabaseDescriptor:
+			dbDesc := dbdesc.NewImmutable(*desc.DatabaseDesc())
+			fullClusterDescs = append(fullClusterDescs, desc)
+			if dbDesc.GetID() != systemschema.SystemDB.GetID() {
+				// The only database that isn't being fully backed up is the system DB.
+				fullClusterDBs = append(fullClusterDBs, dbDesc)
+			}
+		case catalog.TableDescriptor:
+			if desc.GetParentID() == keys.SystemDatabaseID {
+				// Add only the system tables that we plan to include in a full cluster
+				// backup.
+				if _, ok := systemTablesToBackup[desc.GetName()]; ok {
+					fullClusterDescs = append(fullClusterDescs, desc)
+				}
+			} else {
+				// Add all user tables that are not in a DROP state.
+				if desc.GetState() != descpb.DescriptorState_DROP {
+					fullClusterDescs = append(fullClusterDescs, desc)
+				}
+			}
+		case catalog.SchemaDescriptor:
+			fullClusterDescs = append(fullClusterDescs, desc)
+		case catalog.TypeDescriptor:
+			fullClusterDescs = append(fullClusterDescs, desc)
+		}
+	}
+	return fullClusterDescs, fullClusterDBs, nil
+}

--- a/pkg/ccl/backupccl/create_scheduled_backup_test.go
+++ b/pkg/ccl/backupccl/create_scheduled_backup_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl/backupbase"
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
@@ -488,7 +489,7 @@ INSERT INTO t1 values (-1), (10), (-100);
 	}
 
 	expectedSystemTables := make([]string, 0)
-	for systemTableName := range getSystemTablesToIncludeInClusterBackup() {
+	for systemTableName := range backupbase.GetSystemTablesToIncludeInClusterBackup() {
 		expectedSystemTables = append(expectedSystemTables, systemTableName)
 	}
 

--- a/pkg/ccl/backupccl/replication_stream_planning.go
+++ b/pkg/ccl/backupccl/replication_stream_planning.go
@@ -1,0 +1,216 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package backupccl
+
+import (
+	"context"
+	"math"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/kvfeed"
+	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
+	"github.com/cockroachdb/errors"
+)
+
+// replicationStreamEval is a representation of tree.ReplicationStream, prepared
+// for evaluation
+type replicationStreamEval struct {
+	*tree.ReplicationStream
+	sinkURI func() (string, error)
+}
+
+const createStreamOp = "CREATE REPLICATION STREAM"
+
+func makeReplicationStreamEval(
+	ctx context.Context, p sql.PlanHookState, stream *tree.ReplicationStream,
+) (*replicationStreamEval, error) {
+	if err := utilccl.CheckEnterpriseEnabled(
+		p.ExecCfg().Settings, p.ExecCfg().ClusterID(),
+		p.ExecCfg().Organization(), createStreamOp); err != nil {
+		return nil, err
+	}
+
+	eval := &replicationStreamEval{ReplicationStream: stream}
+	var err error
+	eval.sinkURI, err = p.TypeAsString(ctx, stream.SinkURI, createStreamOp)
+	if err != nil {
+		return nil, err
+	}
+	return eval, nil
+}
+
+// This is a placeholder implementation for KV event sink.
+// It simply emits the key of the KV to the user connected channel.
+// TODO(yevgeniy): This implementaion needs to be replace with real one.
+type emitKeysSink struct {
+	resultsCh chan<- tree.Datums
+}
+
+var _ kvfeed.EventBufferWriter = &emitKeysSink{}
+
+func (s *emitKeysSink) AddKV(
+	ctx context.Context, kv roachpb.KeyValue, prevVal roachpb.Value, backfillTimestamp hlc.Timestamp,
+) error {
+	// TODO(yevgeniy): This is silly.   We need to buffer, etc
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case s.resultsCh <- tree.Datums{
+		tree.NewDString(kv.Key.String()),
+		tree.DNull,
+	}:
+		return nil
+	}
+}
+
+func (s *emitKeysSink) AddResolved(
+	ctx context.Context, span roachpb.Span, ts hlc.Timestamp, boundaryReached bool,
+) error {
+	// TODO(yevgeniy): This is silly.   We need to buffer, etc
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case s.resultsCh <- tree.Datums{
+		tree.NewDString(span.Key.String()),
+		tree.TimestampToDecimalDatum(ts),
+	}:
+		return nil
+	}
+}
+
+func (s *emitKeysSink) Close(ctx context.Context) {
+
+}
+
+func streamKVs(
+	ctx context.Context,
+	p sql.PlanHookState,
+	startTS hlc.Timestamp,
+	spans []roachpb.Span,
+	resultsCh chan<- tree.Datums,
+) error {
+	metrics := kvfeed.MakeMetrics("replication", base.DefaultHistogramWindowInterval())
+	// TODO(yevgeniy): Use correct memory monitor.
+	monitor := mon.NewUnlimitedMonitor(
+		context.Background(), "replication", mon.MemoryResource,
+		nil /* curCount */, nil /* maxHist */, math.MaxInt64, p.ExecCfg().Settings)
+
+	cfg := kvfeed.Config{
+		Settings:           p.ExecCfg().Settings,
+		DB:                 p.ExecCfg().DB,
+		Codec:              p.ExecCfg().Codec,
+		Clock:              p.ExecCfg().Clock,
+		Gossip:             p.ExecCfg().Gossip,
+		Spans:              spans,
+		Targets:            nil,
+		Sink:               &emitKeysSink{resultsCh: resultsCh},
+		LeaseMgr:           p.ExecCfg().LeaseManager,
+		Metrics:            &metrics,
+		MM:                 monitor,
+		WithDiff:           false,
+		NeedsInitialScan:   true,
+		InitialHighWater:   startTS,
+		SchemaChangePolicy: changefeedbase.OptSchemaChangePolicyIgnore,
+	}
+	return kvfeed.Run(ctx, cfg)
+}
+
+// doCreateReplicationStream is a plan hook implementation responsible for
+// creation of replication stream.
+func doCreateReplicationStream(
+	ctx context.Context,
+	p sql.PlanHookState,
+	eval *replicationStreamEval,
+	resultsCh chan<- tree.Datums,
+) error {
+	if err := p.RequireAdminRole(ctx, createStreamOp); err != nil {
+		return err
+	}
+
+	sinkURI, err := eval.sinkURI()
+	if err != nil {
+		return err
+	}
+
+	if sinkURI != "" {
+		return errors.AssertionFailedf("replication streaming into sink not supported")
+	}
+
+	scanStart := hlc.Timestamp{
+		WallTime: p.ExtendedEvalContext().GetStmtTimestamp().UnixNano(),
+	}
+	if eval.Options.Cursor != nil {
+		if scanStart, err = p.EvalAsOfTimestamp(ctx, tree.AsOfClause{Expr: eval.Options.Cursor}); err != nil {
+			return err
+		}
+	}
+
+	var spans []roachpb.Span
+	if eval.Targets.Tenant == (roachpb.TenantID{}) {
+		// TODO(yevgeniy): Only tenant streaming supported now; Support granular streaming.
+		return errors.AssertionFailedf("granular replication streaming not supported")
+	}
+
+	prefix := keys.MakeTenantPrefix(roachpb.MakeTenantID(eval.Targets.Tenant.ToUint64()))
+	spans = append(spans, roachpb.Span{
+		Key:    prefix,
+		EndKey: prefix.PrefixEnd(),
+	})
+
+	// TODO(yevgeniy): Implement and use replication job to stream results into sink.
+	return streamKVs(ctx, p, scanStart, spans, resultsCh)
+}
+
+// replicationStreamHeader is the header for "CREATE REPLICATION STREAM..." statements results.
+var replicationStreamHeader = colinfo.ResultColumns{
+	{Name: "kv", Typ: types.String},
+	{Name: "ts", Typ: types.Decimal},
+}
+
+// createReplicationStreamHook is a plan hook responsible for creating replication stream.
+func createReplicationStreamHook(
+	ctx context.Context, stmt tree.Statement, p sql.PlanHookState,
+) (sql.PlanHookRowFn, colinfo.ResultColumns, []sql.PlanNode, bool, error) {
+	stream, ok := stmt.(*tree.ReplicationStream)
+	if !ok {
+		return nil, nil, nil, false, nil
+	}
+	eval, err := makeReplicationStreamEval(ctx, p, stream)
+	if err != nil {
+		return nil, nil, nil, false, err
+	}
+
+	fn := func(ctx context.Context, _ []sql.PlanNode, resultsCh chan<- tree.Datums) error {
+		err := doCreateReplicationStream(ctx, p, eval, resultsCh)
+		if err != nil {
+			telemetry.Count("replication.create.failed")
+			return err
+		}
+
+		return nil
+	}
+	avoidBuffering := stream.SinkURI == nil
+	return fn, replicationStreamHeader, nil, avoidBuffering, nil
+}
+
+func init() {
+	sql.AddPlanHook(createReplicationStreamHook)
+}

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -15,6 +15,7 @@ import (
 	"math"
 
 	"github.com/cockroachdb/cockroach/pkg/build"
+	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl/backupbase"
 	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
@@ -1901,15 +1902,15 @@ func (r *restoreResumer) restoreSystemTables(
 
 		if err := db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 			txn.SetDebugName("system-restore-txn")
-			config, ok := systemTableBackupConfiguration[systemTableName]
+			config, ok := backupbase.SystemTableBackupConfiguration[systemTableName]
 			if !ok {
 				log.Warningf(ctx, "no configuration specified for table %s... skipping restoration",
 					systemTableName)
 			}
 
-			restoreFunc := defaultSystemTableRestoreFunc
-			if config.customRestoreFunc != nil {
-				restoreFunc = config.customRestoreFunc
+			restoreFunc := backupbase.DefaultSystemTableRestoreFunc
+			if config.CustomRestoreFunc != nil {
+				restoreFunc = config.CustomRestoreFunc
 				log.Eventf(ctx, "using custom restore function for table %s", systemTableName)
 			}
 

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -418,7 +418,7 @@ func allocateDescriptorRewrites(
 						return nil, err
 					}
 					// Write a schema descriptor rewrite so that we can remap all
-					// temporary table descs which were under the original session
+					// temporary table Descs which were under the original session
 					// specific pg_temp schema to point to this synthesized schema when we
 					// are performing the table rewrites.
 					descriptorRewrites[table.GetParentSchemaID()] = &jobspb.RestoreDetails_DescriptorRewrite{ID: synthesizedSchemaID}
@@ -1539,7 +1539,7 @@ func doRestorePlan(
 	}
 
 	// Ensure that no user table descriptors exist for a full cluster restore.
-	txn := p.ExecCfg().DB.NewTxn(ctx, "count-user-descs")
+	txn := p.ExecCfg().DB.NewTxn(ctx, "count-user-Descs")
 	descCount, err := catalogkv.CountUserDescriptors(ctx, txn, p.ExecCfg().Codec)
 	if err != nil {
 		return errors.Wrap(err, "looking up user descriptors during restore")

--- a/pkg/ccl/backupccl/targets.go
+++ b/pkg/ccl/backupccl/targets.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"sort"
 
+	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl/backupbase"
 	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
@@ -20,470 +21,17 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkeys"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/dbdesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/errors"
 )
 
-type descriptorsMatched struct {
-	// All descriptors that match targets plus their parent databases.
-	descs []catalog.Descriptor
-
-	// The databases from which all tables were matched (eg a.* or DATABASE a).
-	expandedDB []descpb.ID
-
-	// Explicitly requested DBs (e.g. DATABASE a).
-	requestedDBs []catalog.DatabaseDescriptor
-}
-
-func (d descriptorsMatched) checkExpansions(coveredDBs []descpb.ID) error {
-	covered := make(map[descpb.ID]bool)
-	for _, i := range coveredDBs {
-		covered[i] = true
-	}
-	for _, i := range d.requestedDBs {
-		if !covered[i.GetID()] {
-			return errors.Errorf("cannot RESTORE DATABASE from a backup of individual tables (use SHOW BACKUP to determine available tables)")
-		}
-	}
-	for _, i := range d.expandedDB {
-		if !covered[i] {
-			return errors.Errorf("cannot RESTORE <database>.* from a backup of individual tables (use SHOW BACKUP to determine available tables)")
-		}
-	}
-	return nil
-}
-
-// descriptorResolver is the helper struct that enables reuse of the
-// standard name resolution algorithm.
-type descriptorResolver struct {
-	descByID map[descpb.ID]catalog.Descriptor
-	// Map: db name -> dbID
-	dbsByName map[string]descpb.ID
-	// Map: dbID -> schema name -> schemaID
-	schemasByName map[descpb.ID]map[string]descpb.ID
-	// Map: dbID -> schema name -> obj name -> obj ID
-	objsByName map[descpb.ID]map[string]map[string]descpb.ID
-}
-
-// LookupSchema implements the tree.ObjectNameTargetResolver interface.
-func (r *descriptorResolver) LookupSchema(
-	_ context.Context, dbName, scName string,
-) (bool, tree.SchemaMeta, error) {
-	dbID, ok := r.dbsByName[dbName]
-	if !ok {
-		return false, nil, nil
-	}
-	schemas := r.objsByName[dbID]
-	if _, ok := schemas[scName]; ok {
-		// TODO (rohany): Not sure if we want to change this to also
-		//  use the resolved schema struct.
-		if dbDesc, ok := r.descByID[dbID].(catalog.DatabaseDescriptor); ok {
-			return true, dbDesc, nil
-		}
-	}
-	return false, nil, nil
-}
-
-// LookupObject implements the tree.ObjectNameExistingResolver interface.
-func (r *descriptorResolver) LookupObject(
-	_ context.Context, flags tree.ObjectLookupFlags, dbName, scName, obName string,
-) (bool, tree.NameResolutionResult, error) {
-	if flags.RequireMutable {
-		panic("did not expect request for mutable descriptor")
-	}
-	dbID, ok := r.dbsByName[dbName]
-	if !ok {
-		return false, nil, nil
-	}
-	if scMap, ok := r.objsByName[dbID]; ok {
-		if objMap, ok := scMap[scName]; ok {
-			if objID, ok := objMap[obName]; ok {
-				return true, r.descByID[objID], nil
-			}
-		}
-	}
-	return false, nil, nil
-}
-
-// newDescriptorResolver prepares a descriptorResolver for the given
-// known set of descriptors.
-func newDescriptorResolver(descs []catalog.Descriptor) (*descriptorResolver, error) {
-	r := &descriptorResolver{
-		descByID:      make(map[descpb.ID]catalog.Descriptor),
-		schemasByName: make(map[descpb.ID]map[string]descpb.ID),
-		dbsByName:     make(map[string]descpb.ID),
-		objsByName:    make(map[descpb.ID]map[string]map[string]descpb.ID),
-	}
-
-	// Iterate to find the databases first. We need that because we also
-	// check the ParentID for tables, and all the valid parents must be
-	// known before we start to check that.
-	for _, desc := range descs {
-		if _, isDB := desc.(catalog.DatabaseDescriptor); isDB {
-			if _, ok := r.dbsByName[desc.GetName()]; ok {
-				return nil, errors.Errorf("duplicate database name: %q used for ID %d and %d",
-					desc.GetName(), r.dbsByName[desc.GetName()], desc.GetID())
-			}
-			r.dbsByName[desc.GetName()] = desc.GetID()
-			r.objsByName[desc.GetID()] = make(map[string]map[string]descpb.ID)
-			r.schemasByName[desc.GetID()] = make(map[string]descpb.ID)
-			// Always add an entry for the public schema.
-			r.objsByName[desc.GetID()][tree.PublicSchema] = make(map[string]descpb.ID)
-			r.schemasByName[desc.GetID()][tree.PublicSchema] = keys.PublicSchemaID
-		}
-
-		// Incidentally, also remember all the descriptors by ID.
-		if prevDesc, ok := r.descByID[desc.GetID()]; ok {
-			return nil, errors.Errorf("duplicate descriptor ID: %d used by %q and %q",
-				desc.GetID(), prevDesc.GetName(), desc.GetName())
-		}
-		r.descByID[desc.GetID()] = desc
-	}
-
-	// Add all schemas to the resolver.
-	for _, desc := range descs {
-		if sc, ok := desc.(catalog.SchemaDescriptor); ok {
-			schemaMap := r.objsByName[sc.GetParentID()]
-			if schemaMap == nil {
-				schemaMap = make(map[string]map[string]descpb.ID)
-			}
-			schemaMap[sc.GetName()] = make(map[string]descpb.ID)
-			r.objsByName[sc.GetParentID()] = schemaMap
-
-			schemaNameMap := r.schemasByName[sc.GetParentID()]
-			if schemaNameMap == nil {
-				schemaNameMap = make(map[string]descpb.ID)
-			}
-			schemaNameMap[sc.GetName()] = sc.GetID()
-			r.schemasByName[sc.GetParentID()] = schemaNameMap
-		}
-	}
-
-	// registerDesc is a closure that registers a Descriptor into the resolver's
-	// object registry.
-	registerDesc := func(parentID descpb.ID, desc catalog.Descriptor, kind string) error {
-		parentDesc, ok := r.descByID[parentID]
-		if !ok {
-			return errors.Errorf("%s %q has unknown ParentID %d", kind, desc.GetName(), parentID)
-		}
-		if _, ok := r.dbsByName[parentDesc.GetName()]; !ok {
-			return errors.Errorf("%s %q's ParentID %d (%q) is not a database",
-				kind, desc.GetName(), parentID, parentDesc.GetName())
-		}
-
-		// Look up what schema this descriptor belongs under.
-		schemaMap := r.objsByName[parentDesc.GetID()]
-		scID := desc.GetParentSchemaID()
-		var scName string
-		if scID == keys.PublicSchemaID {
-			scName = tree.PublicSchema
-		} else {
-			scDescI, ok := r.descByID[scID]
-			if !ok {
-				return errors.Errorf("schema %d not found for desc %d", scID, desc.GetID())
-			}
-			scDesc, ok := scDescI.(catalog.SchemaDescriptor)
-			if !ok {
-				return errors.Errorf("descriptor %d is not a schema", scDescI.GetID())
-			}
-			scName = scDesc.GetName()
-		}
-
-		// Create an entry for the descriptor.
-		objMap := schemaMap[scName]
-		if objMap == nil {
-			objMap = make(map[string]descpb.ID)
-		}
-		if _, ok := objMap[desc.GetName()]; ok {
-			return errors.Errorf("duplicate %s name: %q.%q.%q used for ID %d and %d",
-				kind, parentDesc.GetName(), scName, desc.GetName(), desc.GetID(), objMap[desc.GetName()])
-		}
-		objMap[desc.GetName()] = desc.GetID()
-		r.objsByName[parentDesc.GetID()][scName] = objMap
-		return nil
-	}
-
-	// Now on to the remaining descriptors.
-	for _, desc := range descs {
-		if desc.Dropped() {
-			continue
-		}
-		var typeToRegister string
-		switch desc := desc.(type) {
-		case catalog.TableDescriptor:
-			if desc.IsTemporary() {
-				continue
-			}
-			typeToRegister = "table"
-		case catalog.TypeDescriptor:
-			typeToRegister = "type"
-		}
-		if typeToRegister != "" {
-			if err := registerDesc(desc.GetParentID(), desc, typeToRegister); err != nil {
-				return nil, err
-			}
-		}
-	}
-
-	return r, nil
-}
-
-// descriptorsMatchingTargets returns the descriptors that match the targets. A
-// database descriptor is included in this set if it matches the targets (or the
-// session database) or if one of its tables matches the targets. All expanded
-// DBs, via either `foo.*` or `DATABASE foo` are noted, as are those explicitly
-// named as DBs (e.g. with `DATABASE foo`, not `foo.*`). These distinctions are
-// used e.g. by RESTORE.
-//
-// This is guaranteed to not return duplicates.
-func descriptorsMatchingTargets(
-	ctx context.Context,
-	currentDatabase string,
-	searchPath sessiondata.SearchPath,
-	descriptors []catalog.Descriptor,
-	targets tree.TargetList,
-) (descriptorsMatched, error) {
-	ret := descriptorsMatched{}
-
-	resolver, err := newDescriptorResolver(descriptors)
-	if err != nil {
-		return ret, err
-	}
-
-	alreadyRequestedDBs := make(map[descpb.ID]struct{})
-	alreadyExpandedDBs := make(map[descpb.ID]struct{})
-	// Process all the DATABASE requests.
-	for _, d := range targets.Databases {
-		dbID, ok := resolver.dbsByName[string(d)]
-		if !ok {
-			return ret, errors.Errorf("unknown database %q", d)
-		}
-		if _, ok := alreadyRequestedDBs[dbID]; !ok {
-			desc := resolver.descByID[dbID]
-			ret.descs = append(ret.descs, desc)
-			ret.requestedDBs = append(ret.requestedDBs,
-				desc.(catalog.DatabaseDescriptor))
-			ret.expandedDB = append(ret.expandedDB, dbID)
-			alreadyRequestedDBs[dbID] = struct{}{}
-			alreadyExpandedDBs[dbID] = struct{}{}
-		}
-	}
-
-	alreadyRequestedSchemas := make(map[descpb.ID]struct{})
-	maybeAddSchemaDesc := func(id descpb.ID, requirePublic bool) error {
-		// Only add user defined schemas.
-		if id == keys.PublicSchemaID {
-			return nil
-		}
-		if _, ok := alreadyRequestedSchemas[id]; !ok {
-			schemaDesc := resolver.descByID[id]
-			if err := catalog.FilterDescriptorState(
-				schemaDesc, tree.CommonLookupFlags{},
-			); err != nil {
-				if requirePublic {
-					return errors.Wrapf(err, "schema %d was expected to be PUBLIC", id)
-				}
-				// If the schema is not public, but we don't require it to be, ignore
-				// it.
-				return nil
-			}
-			alreadyRequestedSchemas[id] = struct{}{}
-			ret.descs = append(ret.descs, resolver.descByID[id])
-		}
-
-		return nil
-	}
-	getSchemaIDByName := func(scName string, dbID descpb.ID) (descpb.ID, error) {
-		schemas, ok := resolver.schemasByName[dbID]
-		if !ok {
-			return 0, errors.Newf("database with ID %d not found", dbID)
-		}
-		schemaID, ok := schemas[scName]
-		if !ok {
-			return 0, errors.Newf("schema with name %s not found in DB %d", scName, dbID)
-		}
-		return schemaID, nil
-	}
-
-	alreadyRequestedTypes := make(map[descpb.ID]struct{})
-	maybeAddTypeDesc := func(id descpb.ID) {
-		if _, ok := alreadyRequestedTypes[id]; !ok {
-			// Cross database type references have been disabled, so we don't
-			// need to request the parent database because it has already been
-			// requested by the table that holds this type.
-			alreadyRequestedTypes[id] = struct{}{}
-			ret.descs = append(ret.descs, resolver.descByID[id])
-		}
-	}
-	getTypeByID := func(id descpb.ID) (catalog.TypeDescriptor, error) {
-		desc, ok := resolver.descByID[id]
-		if !ok {
-			return nil, errors.Newf("type with ID %d not found", id)
-		}
-		typeDesc, ok := desc.(catalog.TypeDescriptor)
-		if !ok {
-			return nil, errors.Newf("descriptor %d is not a type, but a %T", id, desc)
-		}
-		return typeDesc, nil
-	}
-
-	// Process all the TABLE requests.
-	// Pulling in a table needs to pull in the underlying database too.
-	alreadyRequestedTables := make(map[descpb.ID]struct{})
-	for _, pattern := range targets.Tables {
-		var err error
-		pattern, err = pattern.NormalizeTablePattern()
-		if err != nil {
-			return ret, err
-		}
-
-		switch p := pattern.(type) {
-		case *tree.TableName:
-			// TODO: As part of work for #34240, this should not be a TableName.
-			//  Instead, it should be an UnresolvedObjectName.
-			un := p.ToUnresolvedObjectName()
-			found, prefix, descI, err := tree.ResolveExisting(ctx, un, resolver, tree.ObjectLookupFlags{}, currentDatabase, searchPath)
-			if err != nil {
-				return ret, err
-			}
-			p.ObjectNamePrefix = prefix
-			doesNotExistErr := errors.Errorf(`table %q does not exist`, tree.ErrString(p))
-			if !found {
-				return ret, doesNotExistErr
-			}
-			tableDesc, isTable := descI.(catalog.TableDescriptor)
-			// If the type assertion didn't work, then we resolved a type instead, so
-			// error out.
-			if !isTable {
-				return ret, doesNotExistErr
-			}
-
-			// Verify that the table is in the correct state.
-			if err := catalog.FilterDescriptorState(
-				tableDesc, tree.CommonLookupFlags{},
-			); err != nil {
-				// Return a does not exist error if explicitly asking for this table.
-				return ret, doesNotExistErr
-			}
-
-			// If the parent database is not requested already, request it now.
-			parentID := tableDesc.GetParentID()
-			if _, ok := alreadyRequestedDBs[parentID]; !ok {
-				parentDesc := resolver.descByID[parentID]
-				ret.descs = append(ret.descs, parentDesc)
-				alreadyRequestedDBs[parentID] = struct{}{}
-			}
-			// Then request the table itself.
-			if _, ok := alreadyRequestedTables[tableDesc.GetID()]; !ok {
-				alreadyRequestedTables[tableDesc.GetID()] = struct{}{}
-				ret.descs = append(ret.descs, tableDesc)
-			}
-			// Since the table was directly requested, so is the schema. If the table
-			// is PUBLIC, we expect the schema to also be PUBLIC.
-			if err := maybeAddSchemaDesc(tableDesc.GetParentSchemaID(), true /* requirePublic */); err != nil {
-				return ret, err
-			}
-			// Get all the types used by this table.
-			typeIDs, err := tableDesc.GetAllReferencedTypeIDs(getTypeByID)
-			if err != nil {
-				return ret, err
-			}
-			for _, id := range typeIDs {
-				maybeAddTypeDesc(id)
-			}
-
-		case *tree.AllTablesSelector:
-			found, descI, err := p.ObjectNamePrefix.Resolve(ctx, resolver, currentDatabase, searchPath)
-			if err != nil {
-				return ret, err
-			}
-			if !found {
-				return ret, sqlerrors.NewInvalidWildcardError(tree.ErrString(p))
-			}
-			desc := descI.(catalog.DatabaseDescriptor)
-
-			// If the database is not requested already, request it now.
-			dbID := desc.GetID()
-			if _, ok := alreadyRequestedDBs[dbID]; !ok {
-				ret.descs = append(ret.descs, desc)
-				alreadyRequestedDBs[dbID] = struct{}{}
-			}
-
-			// Then request the expansion.
-			if _, ok := alreadyExpandedDBs[desc.GetID()]; !ok {
-				ret.expandedDB = append(ret.expandedDB, desc.GetID())
-				alreadyExpandedDBs[desc.GetID()] = struct{}{}
-			}
-
-		default:
-			return ret, errors.Errorf("unknown pattern %T: %+v", pattern, pattern)
-		}
-	}
-
-	// Then process the database expansions.
-	for dbID := range alreadyExpandedDBs {
-		for schemaName, schemas := range resolver.objsByName[dbID] {
-			schemaID, err := getSchemaIDByName(schemaName, dbID)
-			if err != nil {
-				return ret, err
-			}
-			if err := maybeAddSchemaDesc(schemaID, false /* requirePublic */); err != nil {
-				return ret, err
-			}
-
-			for _, id := range schemas {
-				desc := resolver.descByID[id]
-				switch desc := desc.(type) {
-				case catalog.TableDescriptor:
-					if err := catalog.FilterDescriptorState(
-						desc, tree.CommonLookupFlags{},
-					); err != nil {
-						// Don't include this table in the expansion since it's not in a valid
-						// state. Silently fail since this table was not directly requested,
-						// but was just part of an expansion.
-						continue
-					}
-					if _, ok := alreadyRequestedTables[id]; !ok {
-						ret.descs = append(ret.descs, desc)
-					}
-					// If this table is a member of a user defined schema, then request the
-					// user defined schema.
-					if desc.GetParentSchemaID() != keys.PublicSchemaID {
-						// Note, that although we're processing the database expansions,
-						// since the table is in a PUBLIC state, we also expect the schema
-						// to be in a similar state.
-						if err := maybeAddSchemaDesc(desc.GetParentSchemaID(), true /* requirePublic */); err != nil {
-							return ret, err
-						}
-					}
-					// Get all the types used by this table.
-					typeIDs, err := desc.GetAllReferencedTypeIDs(getTypeByID)
-					if err != nil {
-						return ret, err
-					}
-					for _, id := range typeIDs {
-						maybeAddTypeDesc(id)
-					}
-				case catalog.TypeDescriptor:
-					maybeAddTypeDesc(desc.GetID())
-				}
-			}
-		}
-	}
-
-	return ret, nil
-}
-
 // getRelevantDescChanges finds the changes between start and end time to the
-// SQL descriptors matching `descs` or `expandedDBs`, ordered by time. A
+// SQL descriptors matching `Descs` or `expandedDBs`, ordered by time. A
 // descriptor revision matches if it is an earlier revision of a descriptor in
-// descs (same ID) or has parentID in `expanded`. Deleted descriptors are
+// Descs (same ID) or has parentID in `expanded`. Deleted descriptors are
 // represented as nil. Fills in the `priorIDs` map in the process, which maps
 // a descriptor the ID by which it was previously known (e.g pre-TRUNCATE).
 func getRelevantDescChanges(
@@ -503,7 +51,7 @@ func getRelevantDescChanges(
 	}
 
 	// If no descriptors changed, we can just stop now and have RESTORE use the
-	// normal list of descs (i.e. as of endTime).
+	// normal list of Descs (i.e. as of endTime).
 	if len(allChanges) == 0 {
 		return nil, nil
 	}
@@ -539,7 +87,7 @@ func getRelevantDescChanges(
 	}
 
 	if !startTime.IsEmpty() {
-		starting, err := loadAllDescs(ctx, codec, db, startTime)
+		starting, err := backupbase.LoadAllDescs(ctx, codec, db, startTime)
 		if err != nil {
 			return nil, err
 		}
@@ -695,107 +243,6 @@ func ensureInterleavesIncluded(tables []catalog.TableDescriptor) error {
 	return nil
 }
 
-func loadAllDescs(
-	ctx context.Context, codec keys.SQLCodec, db *kv.DB, asOf hlc.Timestamp,
-) ([]catalog.Descriptor, error) {
-	var allDescs []catalog.Descriptor
-	if err := db.Txn(
-		ctx,
-		func(ctx context.Context, txn *kv.Txn) (err error) {
-			txn.SetFixedTimestamp(ctx, asOf)
-			allDescs, err = catalogkv.GetAllDescriptors(ctx, txn, codec)
-			return err
-		}); err != nil {
-		return nil, err
-	}
-	return allDescs, nil
-}
-
-// ResolveTargetsToDescriptors performs name resolution on a set of targets and
-// returns the resulting descriptors.
-func ResolveTargetsToDescriptors(
-	ctx context.Context, p sql.PlanHookState, endTime hlc.Timestamp, targets *tree.TargetList,
-) ([]catalog.Descriptor, []descpb.ID, error) {
-	allDescs, err := loadAllDescs(ctx, p.ExecCfg().Codec, p.ExecCfg().DB, endTime)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	if targets == nil {
-		return fullClusterTargetsBackup(allDescs)
-	}
-
-	var matched descriptorsMatched
-	if matched, err = descriptorsMatchingTargets(ctx,
-		p.CurrentDatabase(), p.CurrentSearchPath(), allDescs, *targets); err != nil {
-		return nil, nil, err
-	}
-
-	// Ensure interleaved tables appear after their parent. Since parents must be
-	// created before their children, simply sorting by ID accomplishes this.
-	sort.Slice(matched.descs, func(i, j int) bool { return matched.descs[i].GetID() < matched.descs[j].GetID() })
-	return matched.descs, matched.expandedDB, nil
-}
-
-// fullClusterTargetsBackup returns the same descriptors referenced in
-// fullClusterTargets, but rather than returning the entire database
-// descriptor as the second argument, it only returns their IDs.
-func fullClusterTargetsBackup(
-	allDescs []catalog.Descriptor,
-) ([]catalog.Descriptor, []descpb.ID, error) {
-	fullClusterDescs, fullClusterDBs, err := fullClusterTargets(allDescs)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	fullClusterDBIDs := make([]descpb.ID, 0)
-	for _, desc := range fullClusterDBs {
-		fullClusterDBIDs = append(fullClusterDBIDs, desc.GetID())
-	}
-	return fullClusterDescs, fullClusterDBIDs, nil
-}
-
-// fullClusterTargets returns all of the tableDescriptors to be included in a
-// full cluster backup, and all the user databases.
-func fullClusterTargets(
-	allDescs []catalog.Descriptor,
-) ([]catalog.Descriptor, []*dbdesc.Immutable, error) {
-	fullClusterDescs := make([]catalog.Descriptor, 0, len(allDescs))
-	fullClusterDBs := make([]*dbdesc.Immutable, 0)
-
-	systemTablesToBackup := getSystemTablesToIncludeInClusterBackup()
-
-	for _, desc := range allDescs {
-		switch desc := desc.(type) {
-		case catalog.DatabaseDescriptor:
-			dbDesc := dbdesc.NewImmutable(*desc.DatabaseDesc())
-			fullClusterDescs = append(fullClusterDescs, desc)
-			if dbDesc.GetID() != systemschema.SystemDB.GetID() {
-				// The only database that isn't being fully backed up is the system DB.
-				fullClusterDBs = append(fullClusterDBs, dbDesc)
-			}
-		case catalog.TableDescriptor:
-			if desc.GetParentID() == keys.SystemDatabaseID {
-				// Add only the system tables that we plan to include in a full cluster
-				// backup.
-				if _, ok := systemTablesToBackup[desc.GetName()]; ok {
-					fullClusterDescs = append(fullClusterDescs, desc)
-				}
-			} else {
-				// Add all user tables that are not in a DROP state.
-				if desc.GetState() != descpb.DescriptorState_DROP {
-					fullClusterDescs = append(fullClusterDescs, desc)
-				}
-			}
-		case catalog.SchemaDescriptor:
-			fullClusterDescs = append(fullClusterDescs, desc)
-		case catalog.TypeDescriptor:
-			fullClusterDescs = append(fullClusterDescs, desc)
-		}
-	}
-	return fullClusterDescs, fullClusterDBs, nil
-}
-
 func lookupDatabaseID(
 	ctx context.Context, txn *kv.Txn, codec keys.SQLCodec, name string,
 ) (descpb.ID, error) {
@@ -837,7 +284,7 @@ func CheckObjectExists(
 func fullClusterTargetsRestore(
 	allDescs []catalog.Descriptor, lastBackupManifest BackupManifest,
 ) ([]catalog.Descriptor, []catalog.DatabaseDescriptor, []descpb.TenantInfo, error) {
-	fullClusterDescs, fullClusterDBs, err := fullClusterTargets(allDescs)
+	fullClusterDescs, fullClusterDBs, err := backupbase.FullClusterTargets(allDescs)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -885,21 +332,21 @@ func selectTargets(
 		return nil, nil, nil, errors.Errorf("tenant %d not in backup", targets.Tenant.ToUint64())
 	}
 
-	matched, err := descriptorsMatchingTargets(ctx,
+	matched, err := backupbase.DescriptorsMatchingTargets(ctx,
 		p.CurrentDatabase(), p.CurrentSearchPath(), allDescs, targets)
 	if err != nil {
 		return nil, nil, nil, err
 	}
 
-	if len(matched.descs) == 0 {
+	if len(matched.Descs) == 0 {
 		return nil, nil, nil, errors.Errorf("no tables or databases matched the given targets: %s", tree.ErrString(&targets))
 	}
 
 	if lastBackupManifest.FormatVersion >= BackupFormatDescriptorTrackingVersion {
-		if err := matched.checkExpansions(lastBackupManifest.CompleteDbs); err != nil {
+		if err := matched.CheckExpansions(lastBackupManifest.CompleteDbs); err != nil {
 			return nil, nil, nil, err
 		}
 	}
 
-	return matched.descs, matched.requestedDBs, nil, nil
+	return matched.Descs, matched.RequestedDBs, nil, nil
 }

--- a/pkg/ccl/backupccl/targets_test.go
+++ b/pkg/ccl/backupccl/targets_test.go
@@ -15,6 +15,7 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl/backupbase"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
@@ -255,7 +256,7 @@ func TestDescriptorsMatchingTargets(t *testing.T) {
 			}
 			targets := stmt.AST.(*tree.Grant).Targets
 
-			matched, err := descriptorsMatchingTargets(context.Background(),
+			matched, err := backupbase.DescriptorsMatchingTargets(context.Background(),
 				test.sessionDatabase, searchPath, descriptors, targets)
 			if test.err != "" {
 				if !testutils.IsError(err, test.err) {
@@ -265,11 +266,11 @@ func TestDescriptorsMatchingTargets(t *testing.T) {
 				t.Fatal(err)
 			} else {
 				var matchedNames []string
-				for _, m := range matched.descs {
+				for _, m := range matched.Descs {
 					matchedNames = append(matchedNames, m.GetName())
 				}
 				var matchedDBNames []string
-				for _, m := range matched.requestedDBs {
+				for _, m := range matched.RequestedDBs {
 					matchedDBNames = append(matchedDBNames, m.GetName())
 				}
 				sort.Strings(test.expected)

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -17,7 +17,7 @@ import (
 	"sort"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl"
+	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl/backupbase"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
 	"github.com/cockroachdb/cockroach/pkg/docs"
@@ -186,7 +186,7 @@ func changefeedPlanHook(
 		}
 
 		// This grabs table descriptors once to get their ids.
-		targetDescs, _, err := backupccl.ResolveTargetsToDescriptors(
+		targetDescs, _, err := backupbase.ResolveTargetsToDescriptors(
 			ctx, p, statementTime, &changefeedStmt.Targets)
 		if err != nil {
 			return errors.Wrap(err, "failed to resolve targets in the CHANGEFEED stmt")


### PR DESCRIPTION
A code movement refactoring which moves methods accessible
from outside of backupccl (currently ResolveTargetsToDescriptors) into
a separate backupbase package.  Because of various dependencies,
most supporting functions, including system schema backup/restore
information are also moved into backupbase.

This is a pure code movement to avoid dependency cycles between
backupccl and changefeedccl.  Now, all cross package dependencies
live in backupbase and changefeedbase respectively.

Release Notes: None