### PR TITLE
kvserver: de-flake TestReplicateQueue{Up,Down}Replicate

### DIFF
--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -369,6 +369,7 @@ go_test(
         "//pkg/util/uuid",
         "@com_github_cenkalti_backoff//:backoff",
         "@com_github_cockroachdb_circuitbreaker//:circuitbreaker",
+        "@com_github_cockroachdb_cockroach_go//crdb",
         "@com_github_cockroachdb_datadriven//:datadriven",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_errors//oserror",

--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach-go/crdb"
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
@@ -215,18 +216,18 @@ func TestReplicateQueueUpReplicate(t *testing.T) {
 	// Now wait until the replicas have been up-replicated to the
 	// desired number.
 	testutils.SucceedsSoon(t, func() error {
-		desc, err := tc.LookupRange(testKey)
+		descriptor, err := tc.LookupRange(testKey)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if len(desc.InternalReplicas) != replicaCount {
+		if len(descriptor.InternalReplicas) != replicaCount {
 			return errors.Errorf("replica count, want %d, current %d", replicaCount, len(desc.InternalReplicas))
 		}
 		return nil
 	})
 
 	infos, err := filterRangeLog(
-		tc.Conns[0], kvserverpb.RangeLogEventType_add_voter, kvserverpb.ReasonRangeUnderReplicated,
+		tc.Conns[0], desc.RangeID, kvserverpb.RangeLogEventType_add_voter, kvserverpb.ReasonRangeUnderReplicated,
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -278,18 +279,18 @@ func TestReplicateQueueDownReplicate(t *testing.T) {
 	// Now wait until the replicas have been down-replicated back to the
 	// desired number.
 	testutils.SucceedsSoon(t, func() error {
-		desc, err := tc.LookupRange(testKey)
+		descriptor, err := tc.LookupRange(testKey)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if len(desc.InternalReplicas) != replicaCount {
+		if len(descriptor.InternalReplicas) != replicaCount {
 			return errors.Errorf("replica count, want %d, current %d", replicaCount, len(desc.InternalReplicas))
 		}
 		return nil
 	})
 
 	infos, err := filterRangeLog(
-		tc.Conns[0], kvserverpb.RangeLogEventType_remove_voter, kvserverpb.ReasonRangeOverReplicated,
+		tc.Conns[0], desc.RangeID, kvserverpb.RangeLogEventType_remove_voter, kvserverpb.ReasonRangeOverReplicated,
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -304,36 +305,48 @@ func TestReplicateQueueDownReplicate(t *testing.T) {
 func queryRangeLog(
 	conn *gosql.DB, query string, args ...interface{},
 ) ([]kvserverpb.RangeLogEvent_Info, error) {
-	rows, err := conn.Query(query, args...)
-	if err != nil {
-		return nil, err
-	}
 
-	var sl []kvserverpb.RangeLogEvent_Info
-	defer rows.Close()
-	var numEntries int
-	for rows.Next() {
-		numEntries++
-		var infoStr string
-		if err := rows.Scan(&infoStr); err != nil {
-			return nil, err
+	// The range log can get large and sees unpredictable writes, so run this in a
+	// proper txn to avoid spurious retries.
+	var events []kvserverpb.RangeLogEvent_Info
+	err := crdb.ExecuteTx(context.Background(), conn, nil, func(conn *gosql.Tx) error {
+		events = nil // reset in case of a retry
+
+		rows, err := conn.Query(query, args...)
+		if err != nil {
+			return err
 		}
-		var info kvserverpb.RangeLogEvent_Info
-		if err := json.Unmarshal([]byte(infoStr), &info); err != nil {
-			return nil, errors.Errorf("error unmarshaling info string %q: %s", infoStr, err)
+
+		defer rows.Close()
+		var numEntries int
+		for rows.Next() {
+			numEntries++
+			var infoStr string
+			if err := rows.Scan(&infoStr); err != nil {
+				return err
+			}
+			var info kvserverpb.RangeLogEvent_Info
+			if err := json.Unmarshal([]byte(infoStr), &info); err != nil {
+				return errors.Errorf("error unmarshaling info string %q: %s", infoStr, err)
+			}
+			events = append(events, info)
 		}
-		sl = append(sl, info)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return sl, nil
+		if err := rows.Err(); err != nil {
+			return err
+		}
+		return nil
+	})
+	return events, err
+
 }
 
 func filterRangeLog(
-	conn *gosql.DB, eventType kvserverpb.RangeLogEventType, reason kvserverpb.RangeLogEventReason,
+	conn *gosql.DB,
+	rangeID roachpb.RangeID,
+	eventType kvserverpb.RangeLogEventType,
+	reason kvserverpb.RangeLogEventReason,
 ) ([]kvserverpb.RangeLogEvent_Info, error) {
-	return queryRangeLog(conn, `SELECT info FROM system.rangelog WHERE "eventType" = $1 AND info LIKE concat('%', $2, '%');`, eventType.String(), reason)
+	return queryRangeLog(conn, `SELECT info FROM system.rangelog WHERE "rangeID" = $1 AND "eventType" = $2 AND info LIKE concat('%', $3, '%');`, rangeID, eventType.String(), reason)
 }
 
 func toggleReplicationQueues(tc *testcluster.TestCluster, active bool) {


### PR DESCRIPTION
Noticed this was flaky on #59423 and it flakes just the same on master.
Looking into this, we were querying the rangelog without filtering on
the rangeID, which often gives >>100 entries. This means that txn retry
errors can't automatically be retried away internally, as output is sent
to the client (us) before the txn completes. With a rangeID filter, this
shouldn't be an issue any more.

Proper retry logic is introduced on top of this, which would also fix
the issue in itself.

Release note: None
