### PR TITLE
scripts: Replace hubspot form with marketo form in release notes script

### DIFF
--- a/scripts/release-notes.py
+++ b/scripts/release-notes.py
@@ -848,18 +848,8 @@ if options.prod_release:
 if not hidedownloads:
     print("""Get future release notes emailed to you:
 
-<div class="hubspot-install-form install-form-1 clearfix">
-    <script>
-        hbspt.forms.create({
-            css: '',
-            cssClass: 'install-form',
-            portalId: '1753393',
-            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
-            formInstanceId: 1,
-            target: '.install-form-1'
-        });
-    </script>
-</div>""")
+{% include marketo.html %}
+""")
     print()
 
     print("""### Downloads


### PR DESCRIPTION
Previously, Marketing used Hubspot for the email and
form signups on our website and docs. They recently
migrated to Marketo, and so the signup in docs release
notes need to be include the right form.