### PR TITLE
kvserver: fix the log tag on split

### DIFF
--- a/pkg/kv/kvserver/store_split.go
+++ b/pkg/kv/kvserver/store_split.go
@@ -235,7 +235,8 @@ func prepareRightReplicaForSplit(
 	// Invoke the leasePostApplyLocked method to ensure we properly initialize
 	// the replica according to whether it holds the lease. This enables the
 	// txnWaitQueue.
-	rightRepl.leasePostApplyLocked(ctx,
+	rhsCtx := rightRepl.AnnotateCtx(ctx)
+	rightRepl.leasePostApplyLocked(rhsCtx,
 		rightRepl.mu.state.Lease, /* prevLease */
 		rightRepl.mu.state.Lease, /* newLease - same as prevLease */
 		nil,                      /* priorReadSum */


### PR DESCRIPTION
Make the initial lease application on the RHS after a split reflect the
fact that it's executing in the context of the RHS, not the LHS.

Release note: None