### PR TITLE
bazel: don't unconditionally run tests with `-test.v`

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,6 +2,5 @@
 
 build --ui_event_filters=-DEBUG
 query --ui_event_filters=-DEBUG
-test --test_env=GO_TEST_WRAP_TESTV=1
 
 try-import %workspace%/.bazelrc.user

--- a/.bazelrc.ci
+++ b/.bazelrc.ci
@@ -1,0 +1,6 @@
+# Bazel configuration for TeamCity. `cp` this file to `.bazelrc.user` to
+# activate these settings.
+
+# Set `-test.v` in Go tests.
+# Ref: https://github.com/bazelbuild/rules_go/pull/2456
+test --test_env=GO_TEST_WRAP_TESTV=1

--- a/build/teamcity-bazel.sh
+++ b/build/teamcity-bazel.sh
@@ -10,6 +10,9 @@ tc_prepare
 export TMPDIR=$root/artifacts
 mkdir -p "$TMPDIR"
 
+# Bazel configuration for CI.
+cp $root/.bazelrc.ci $root/.bazelrc.user
+
 tc_start_block "Run Bazel build"
 docker run -i ${tty-} --rm --init \
        --workdir="/go/src/github.com/cockroachdb/cockroach" \


### PR DESCRIPTION
In a follow-up discussion on #59736, it was determined that this was an
unacceptable UX regression for dev scenarios. Instead, turn this on only
in CI.

Release note: None