### PR TITLE
[release-20.2] vendor: Bump pebble to 045f961ab67, re-surface Fd through encryptedFile

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/cockroachdb/go-test-teamcity v0.0.0-20191211140407-cff980ad0a55
 	github.com/cockroachdb/gostdlib v1.13.0
 	github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f
-	github.com/cockroachdb/pebble v0.0.0-20201228155439-c3ef93f9a9ed
+	github.com/cockroachdb/pebble v0.0.0-20210204213345-045f961ab673
 	github.com/cockroachdb/redact v1.0.7
 	github.com/cockroachdb/returncheck v0.0.0-20200612231554-92cdbca611dd
 	github.com/cockroachdb/sentry-go v0.6.1-cockroachdb.2

--- a/go.sum
+++ b/go.sum
@@ -162,8 +162,8 @@ github.com/cockroachdb/grpc-gateway v1.14.6-0.20200519165156-52697fc4a249 h1:pZu
 github.com/cockroachdb/grpc-gateway v1.14.6-0.20200519165156-52697fc4a249/go.mod h1:UJ0EZAp832vCd54Wev9N1BMKEyvcZ5+IM0AwDrnlkEc=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f h1:o/kfcElHqOiXqcou5a3rIlMc7oJbMQkeLk0VQJ7zgqY=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
-github.com/cockroachdb/pebble v0.0.0-20201228155439-c3ef93f9a9ed h1:ftr0cgVMzdHtmUyeWGZGue2gjVrIdJm7M1DeC9MIecA=
-github.com/cockroachdb/pebble v0.0.0-20201228155439-c3ef93f9a9ed/go.mod h1:hU7vhtrqonEphNF+xt8/lHdaBprxmV1h8BOGrd9XwmQ=
+github.com/cockroachdb/pebble v0.0.0-20210204213345-045f961ab673 h1:c/WXoDH+EI68v2HQXbA1jg25jMdyvBRJjX7Yv7lmyeU=
+github.com/cockroachdb/pebble v0.0.0-20210204213345-045f961ab673/go.mod h1:hU7vhtrqonEphNF+xt8/lHdaBprxmV1h8BOGrd9XwmQ=
 github.com/cockroachdb/redact v0.0.0-20200622112456-cd282804bbd3 h1:2+dpIJzYMSbLi0587YXpi8tOJT52qCOI/1I0UNThc/I=
 github.com/cockroachdb/redact v0.0.0-20200622112456-cd282804bbd3/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/redact v1.0.6 h1:W34uRRyNR4dlZFd0MibhNELsZSgMkl52uRV/tA1xToY=

--- a/pkg/ccl/storageccl/engineccl/encrypted_fs.go
+++ b/pkg/ccl/storageccl/engineccl/encrypted_fs.go
@@ -132,7 +132,8 @@ func (fs *encryptedFS) Create(name string) (vfs.File, error) {
 		f.Close()
 		return nil, err
 	}
-	return &encryptedFile{File: f, stream: stream}, nil
+	ef := &encryptedFile{File: f, stream: stream}
+	return vfs.WithFd(f, ef), nil
 }
 
 // Link implements vfs.FS.Link.
@@ -168,7 +169,8 @@ func (fs *encryptedFS) Open(name string, opts ...vfs.OpenOption) (vfs.File, erro
 		f.Close()
 		return nil, err
 	}
-	return &encryptedFile{File: f, stream: stream}, nil
+	ef := &encryptedFile{File: f, stream: stream}
+	return vfs.WithFd(f, ef), nil
 }
 
 // Remove implements vfs.FS.Remove.


### PR DESCRIPTION
/cc @cockroachdb/release 

Change pulled in:
```
vfs: Add fdFileWrapper to re-implement Fd() method on file wrappers
```

Release note (bug fix): Re-enable some file-level performance
optimizations such as WAL preallocation and readahead that
got inadvertently disabled in a past change.

----
The encryptedFile file wrapper, used in encryption-at-rest,
hides the Fd() method on the underlying os.File if one exists.
This results in some optimizations like readahead and WAL
preallocations getting disabled.

This change resurfaces that method (using `vfs.WithFd`), and
indirectly enables those optimizations when encryption-at-rest
is used.

Release note (performance improvement): Enable some file-level
optimizations such as WAL preallocation and readahead when
encryption-at-rest is used.
