### PR TITLE
 build: teamcity-compile-builds.sh publishes built artifacts to teamcity

### DIFF
--- a/build/builder.sh
+++ b/build/builder.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 image=cockroachdb/builder
-version=20210201-231606
+version=20210205-000935
 
 function init() {
   docker build --tag="${image}" "$(dirname "${0}")/builder"

--- a/build/builder/mkrelease.sh
+++ b/build/builder/mkrelease.sh
@@ -32,6 +32,10 @@ shopt -s extglob
 cd "$(dirname "$(readlink -f "$0")")/../.."
 source build/shlib.sh
 
+# Callers can set the MKRELEASE_BUILDTYPE environment variable to configure a
+# custom build type.
+BUILDTYPE="${MKRELEASE_BUILDTYPE:-release}"
+
 case "${1-}" in
   ""|?(amd64-)linux?(-gnu))
     args=(
@@ -113,4 +117,4 @@ if [ $# -ge 1 ]; then
     shift
 fi
 
-(set -x && CGO_ENABLED=1 make BUILDTYPE=release "${args[@]}" "$@")
+(set -x && CGO_ENABLED=1 make BUILDTYPE=$BUILDTYPE "${args[@]}" "$@")

--- a/build/teamcity-compile-builds.sh
+++ b/build/teamcity-compile-builds.sh
@@ -6,4 +6,5 @@ export BUILDER_HIDE_GOPATH_SRC=1
 
 build/builder.sh go install ./pkg/cmd/compile-build
 build/builder.sh env \
-  compile-build --all
+  compile-build --all --buildtype=development
+cp cockroach.* artifacts

--- a/pkg/cmd/compile-build/main.go
+++ b/pkg/cmd/compile-build/main.go
@@ -25,6 +25,7 @@ func main() {
 	}
 
 	var compileAll = flag.Bool("all", false, "compile all supported builds (darwin, linux, windows)")
+	var buildType = flag.String("buildtype", "release", "compile with a different build type. Default: 'release'. Options: 'development', 'release'")
 	flag.Parse()
 
 	// We compile just the first supported target unless we explicitly told to
@@ -33,11 +34,15 @@ func main() {
 	if *compileAll {
 		targets = release.SupportedTargets
 	}
+	opts := []release.MakeReleaseOption{
+		release.WithMakeReleaseOptionEnv("MKRELEASE_BUILDTYPE=" + *buildType),
+	}
 
 	for _, target := range targets {
 		if err := release.MakeRelease(
 			target,
 			pkg.Dir,
+			opts...,
 		); err != nil {
 			log.Fatal(err)
 		}

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -74,6 +74,7 @@ var SupportedTargets = []SupportedTarget{
 // makeReleaseAndVerifyOptions are options for MakeRelease.
 type makeReleaseAndVerifyOptions struct {
 	args   []string
+	env    []string
 	execFn ExecFn
 }
 
@@ -110,6 +111,14 @@ func WithMakeReleaseOptionExecFn(r ExecFn) MakeReleaseOption {
 	}
 }
 
+// WithMakeReleaseOptionEnv adds an environment variable to the build.
+func WithMakeReleaseOptionEnv(env string) MakeReleaseOption {
+	return func(m makeReleaseAndVerifyOptions) makeReleaseAndVerifyOptions {
+		m.env = append(m.env, env)
+		return m
+	}
+}
+
 // MakeWorkload makes the bin/workload binary.
 func MakeWorkload(pkgDir string) error {
 	cmd := exec.Command("make", "bin/workload")
@@ -137,6 +146,9 @@ func MakeRelease(b SupportedTarget, pkgDir string, opts ...MakeReleaseOption) er
 		cmd := exec.Command("mkrelease", args...)
 		cmd.Dir = pkgDir
 		cmd.Stderr = os.Stderr
+		if len(params.env) > 0 {
+			cmd.Env = append(os.Environ(), params.env...)
+		}
 		log.Printf("%s %s", cmd.Env, cmd.Args)
 		if out, err := params.execFn(cmd); err != nil {
 			return errors.Newf("%s %s: %s\n\n%s", cmd.Env, cmd.Args, err, out)


### PR DESCRIPTION
Up until now, the binaries that the Compile Builds TC build
configuration built were labeled `Release` versions, and we don't want
to accidentally give anyone the impression these builds are official in
any way, so we add code to `mkrelease` and `pkg/cmd/compile-build` to
allow a custom `BUILDTYPE` to be set.

Release note: None