### PR TITLE
sql: show hidden columns in SHOW CREATE TABLE

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/alter_table_locality
+++ b/pkg/ccl/logictestccl/testdata/logic_test/alter_table_locality
@@ -674,9 +674,11 @@ ALTER TABLE regional_by_table_no_region SET LOCALITY REGIONAL BY TABLE in PRIMAR
 query TT
 SHOW CREATE TABLE regional_by_table_no_region
 ----
-regional_by_table_no_region  CREATE TABLE public.regional_by_table_no_region (
-                             i INT8 NULL,
-                             FAMILY "primary" (i, rowid)
+regional_by_table_no_region                     CREATE TABLE public.regional_by_table_no_region (
+                                                i INT8 NULL,
+                                                rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                                                CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
+                                                FAMILY "primary" (i, rowid)
 ) LOCALITY REGIONAL BY TABLE IN PRIMARY REGION
 
 query TT
@@ -700,6 +702,8 @@ SHOW CREATE TABLE regional_by_table_no_region
 ----
 regional_by_table_no_region  CREATE TABLE public.regional_by_table_no_region (
                              i INT8 NULL,
+                             rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                             CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
                              FAMILY "primary" (i, rowid)
 ) LOCALITY GLOBAL
 

--- a/pkg/sql/alter_column_type_test.go
+++ b/pkg/sql/alter_column_type_test.go
@@ -201,6 +201,8 @@ INSERT INTO t.test VALUES (1), (2), (3);
 	expected := [][]string{{"t.public.test",
 		`CREATE TABLE public.test (
 	x INT8 NULL,
+	rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+	CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
 	FAMILY "primary" (x, rowid)
 )`}}
 
@@ -213,6 +215,8 @@ INSERT INTO t.test VALUES (1), (2), (3);
 	expected = [][]string{{"t.public.test",
 		`CREATE TABLE public.test (
 	x STRING NULL,
+	rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+	CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
 	FAMILY "primary" (x, rowid)
 )`}}
 

--- a/pkg/sql/logictest/testdata/logic_test/alias_types
+++ b/pkg/sql/logictest/testdata/logic_test/alias_types
@@ -13,6 +13,8 @@ table_name  create_statement
 aliases     CREATE TABLE public.aliases (
             a OID NULL,
             b NAME NULL,
+            rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+            CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
             FAMILY "primary" (a, rowid),
             FAMILY fam_1_b (b)
 )

--- a/pkg/sql/logictest/testdata/logic_test/alter_column_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_column_type
@@ -260,6 +260,8 @@ SHOW CREATE TABLE t6
 t6  CREATE TABLE public.t6 (
     id INT8 NULL,
     id2 STRING NULL,
+    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+    CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
     FAMILY f1 (id, rowid),
     FAMILY f2 (id2)
 )
@@ -294,6 +296,8 @@ SHOW CREATE TABLE t8
 ----
 t8  CREATE TABLE public.t8 (
     x STRING NULL,
+    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+    CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
     FAMILY "primary" (x, rowid)
 )
 
@@ -408,6 +412,8 @@ show create table t17
 table_name  create_statement
 t17         CREATE TABLE public.t17 (
             x STRING NULL DEFAULT 'HELLO':::STRING,
+            rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+            CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
             FAMILY "primary" (x, rowid)
 )
 
@@ -479,6 +485,8 @@ show create table t24
 table_name  create_statement
 t24         CREATE TABLE public.t24 (
             x STRING NULL,
+            rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+            CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
             FAMILY "primary" (x, rowid)
 )
 

--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key
@@ -355,6 +355,7 @@ t  CREATE TABLE public.t (
    z INT8 NOT NULL,
    w INT8 NULL,
    v JSONB NULL,
+   crdb_internal_z_shard_4 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(COALESCE(CAST(z AS STRING), '':::STRING)), 4:::INT8)) STORED,
    CONSTRAINT "primary" PRIMARY KEY (y ASC),
    UNIQUE INDEX i3 (z ASC) STORING (y),
    UNIQUE INDEX t_x_key (x ASC),
@@ -508,6 +509,8 @@ t  CREATE TABLE public.t (
    x INT8 NOT NULL,
    y INT8 NOT NULL,
    z INT8 NULL,
+   crdb_internal_z_shard_5 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(COALESCE(CAST(z AS STRING), '':::STRING)), 5:::INT8)) STORED,
+   crdb_internal_y_shard_10 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(COALESCE(CAST(y AS STRING), '':::STRING)), 10:::INT8)) STORED,
    CONSTRAINT "primary" PRIMARY KEY (y ASC) USING HASH WITH BUCKET_COUNT = 10,
    UNIQUE INDEX t_x_key (x ASC),
    INDEX i1 (z ASC) USING HASH WITH BUCKET_COUNT = 5,
@@ -568,6 +571,7 @@ query TT
 SHOW CREATE t
 ----
 t  CREATE TABLE public.t (
+   crdb_internal_x_shard_5 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(COALESCE(CAST(x AS STRING), '':::STRING)), 5:::INT8)) STORED,
    x INT8 NOT NULL,
    y INT8 NOT NULL,
    z INT8 NULL,
@@ -597,6 +601,8 @@ SHOW CREATE t
 ----
 t  CREATE TABLE public.t (
    rowid INT8 NOT NULL,
+   rowid_1 INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+   CONSTRAINT "primary" PRIMARY KEY (rowid_1 ASC),
    FAMILY "primary" (rowid, rowid_1)
 )
 
@@ -608,6 +614,7 @@ SHOW CREATE t
 ----
 t  CREATE TABLE public.t (
    rowid INT8 NOT NULL,
+   rowid_1 INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
    CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
    FAMILY "primary" (rowid, rowid_1)
 )
@@ -679,6 +686,7 @@ SHOW CREATE t
 ----
 t  CREATE TABLE public.t (
    x INT8 NOT NULL,
+   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
    CONSTRAINT "primary" PRIMARY KEY (x ASC),
    FAMILY "primary" (x, rowid)
 )
@@ -695,6 +703,7 @@ SHOW CREATE t2
 t2                                    CREATE TABLE public.t2 (
                                       x INT8 NOT NULL,
                                       y INT8 NOT NULL,
+                                      rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
                                       CONSTRAINT "primary" PRIMARY KEY (x ASC, y ASC),
                                       FAMILY fam_0_x_y_rowid (x, y, rowid)
 ) INTERLEAVE IN PARENT public.t1 (x)
@@ -719,6 +728,8 @@ SHOW CREATE t
 ----
 t  CREATE TABLE public.t (
    x INT8 NOT NULL,
+   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+   crdb_internal_x_shard_4 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(COALESCE(CAST(x AS STRING), '':::STRING)), 4:::INT8)) STORED,
    CONSTRAINT "primary" PRIMARY KEY (x ASC) USING HASH WITH BUCKET_COUNT = 4,
    FAMILY "primary" (x, rowid, crdb_internal_x_shard_4)
 )
@@ -733,6 +744,7 @@ SHOW CREATE t
 ----
 t  CREATE TABLE public.t (
    x INT8 NOT NULL,
+   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
    CONSTRAINT my_pk PRIMARY KEY (x ASC),
    FAMILY "primary" (x, rowid)
 )
@@ -995,6 +1007,7 @@ SHOW CREATE t
 t  CREATE TABLE public.t (
    x INT8 NOT NULL,
    y INT8 NULL,
+   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
    CONSTRAINT "primary" PRIMARY KEY (x ASC),
    INDEX t_y_idx (y ASC),
    FAMILY fam_0_x_y_rowid (x, y, rowid)
@@ -1031,6 +1044,7 @@ SHOW CREATE t
 t  CREATE TABLE public.t (
    x INT8 NOT NULL,
    y INT8 NULL,
+   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
    CONSTRAINT "primary" PRIMARY KEY (x ASC),
    INDEX t_y_idx (y ASC),
    FAMILY fam_0_x_y_rowid (x, y, rowid)
@@ -1070,6 +1084,7 @@ SHOW CREATE t2
 t2                                    CREATE TABLE public.t2 (
                                       x INT8 NOT NULL,
                                       y INT8 NOT NULL,
+                                      rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
                                       CONSTRAINT "primary" PRIMARY KEY (x ASC, y ASC),
                                       FAMILY fam_0_x_y_rowid (x, y, rowid)
 ) INTERLEAVE IN PARENT public.t1 (x)
@@ -1140,6 +1155,7 @@ t  CREATE TABLE public.t (
    y INT8 NULL,
    z INT8 NULL,
    w INT8 NULL,
+   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
    CONSTRAINT "primary" PRIMARY KEY (x ASC),
    INDEX i1 (y ASC),
    UNIQUE INDEX i2 (z ASC),
@@ -1168,7 +1184,9 @@ query TT
 SHOW CREATE t
 ----
 t  CREATE TABLE public.t (
+   crdb_internal_x_shard_2 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(COALESCE(CAST(x AS STRING), '':::STRING)), 2:::INT8)) STORED,
    x INT8 NOT NULL,
+   crdb_internal_x_shard_3 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(COALESCE(CAST(x AS STRING), '':::STRING)), 3:::INT8)) STORED,
    CONSTRAINT "primary" PRIMARY KEY (x ASC) USING HASH WITH BUCKET_COUNT = 3,
    FAMILY "primary" (crdb_internal_x_shard_2, x, crdb_internal_x_shard_3)
 )
@@ -1184,8 +1202,10 @@ query TT
 SHOW CREATE t
 ----
 t  CREATE TABLE public.t (
+   crdb_internal_x_shard_2 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(COALESCE(CAST(x AS STRING), '':::STRING)), 2:::INT8)) STORED,
    x INT8 NOT NULL,
    y INT8 NOT NULL,
+   crdb_internal_y_shard_2 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(COALESCE(CAST(y AS STRING), '':::STRING)), 2:::INT8)) STORED,
    CONSTRAINT "primary" PRIMARY KEY (y ASC) USING HASH WITH BUCKET_COUNT = 2,
    UNIQUE INDEX t_x_key (x ASC) USING HASH WITH BUCKET_COUNT = 2,
    FAMILY fam_0_x_y_crdb_internal_x_shard_2 (x, y, crdb_internal_x_shard_2, crdb_internal_y_shard_2)

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -1127,7 +1127,9 @@ SHOW CREATE t2
 ----
 t2  CREATE TABLE public.t2 (
     y INT8 NULL,
+    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
     x INT8 NULL,
+    CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
     CONSTRAINT fk_x_ref_t1 FOREIGN KEY (x) REFERENCES public.t1(x),
     FAMILY "primary" (y, rowid, x)
 )
@@ -1145,7 +1147,9 @@ SHOW CREATE t3
 ----
 t3  CREATE TABLE public.t3 (
     y INT8 NULL,
+    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
     x INT8 NULL,
+    CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
     CONSTRAINT fk_x_ref_t1 FOREIGN KEY (x) REFERENCES public.t1(x),
     UNIQUE INDEX t3_x_key (x ASC),
     FAMILY "primary" (y, rowid, x)
@@ -1206,7 +1210,9 @@ SHOW CREATE t2
 ----
 t2  CREATE TABLE public.t2 (
     y INT8 NULL,
+    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
     x INT8 NULL,
+    CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
     CONSTRAINT fk_x_ref_t1 FOREIGN KEY (x) REFERENCES public.t1(x) NOT VALID,
     FAMILY "primary" (y, rowid, x)
 )
@@ -1228,7 +1234,9 @@ SHOW CREATE t2
 ----
 t2  CREATE TABLE public.t2 (
     y INT8 NULL,
+    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
     x INT8 NULL,
+    CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
     CONSTRAINT fk_x_ref_t1 FOREIGN KEY (x) REFERENCES public.t1(x) NOT VALID,
     FAMILY "primary" (y, rowid, x)
 )
@@ -1253,7 +1261,9 @@ SHOW CREATE t2
 ----
 t2  CREATE TABLE public.t2 (
     y INT8 NULL,
+    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
     x INT8 NULL,
+    CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
     CONSTRAINT fk_x_ref_t1 FOREIGN KEY (x) REFERENCES public.t1(x) NOT VALID,
     INDEX t2_x_idx (x ASC),
     FAMILY "primary" (y, rowid, x)
@@ -1277,7 +1287,9 @@ SHOW CREATE t2
 ----
 t2  CREATE TABLE public.t2 (
     y INT8 NULL,
+    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
     x INT8 NULL,
+    CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
     CONSTRAINT fk_x_ref_t1 FOREIGN KEY (x) REFERENCES public.t1(x),
     INDEX t2_x_idx (x ASC),
     FAMILY "primary" (y, rowid, x)
@@ -1300,6 +1312,8 @@ SHOW CREATE t2
 ----
 t2  CREATE TABLE public.t2 (
     x INT8 NULL,
+    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+    CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
     CONSTRAINT fk_x_ref_t1 FOREIGN KEY (x) REFERENCES public.t1(x),
     INDEX t2_x_idx (x ASC),
     FAMILY "primary" (x, rowid)
@@ -1327,7 +1341,9 @@ SHOW CREATE t2
 ----
 t2  CREATE TABLE public.t2 (
     y INT8 NULL,
+    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
     x INT8 NULL DEFAULT 1:::INT8,
+    CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
     CONSTRAINT fk_x_ref_t1 FOREIGN KEY (x) REFERENCES public.t1(x),
     UNIQUE INDEX t2_x_key (x ASC),
     FAMILY "primary" (y, rowid, x)

--- a/pkg/sql/logictest/testdata/logic_test/array
+++ b/pkg/sql/logictest/testdata/logic_test/array
@@ -466,6 +466,8 @@ SHOW CREATE TABLE a
 ----
 a  CREATE TABLE public.a (
    b INT8[] NULL,
+   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+   CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
    FAMILY "primary" (b, rowid)
 )
 
@@ -525,6 +527,8 @@ SHOW CREATE TABLE a
 ----
 a  CREATE TABLE public.a (
    b INT8[] NULL,
+   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+   CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
    FAMILY "primary" (b, rowid)
 )
 
@@ -596,6 +600,8 @@ SHOW CREATE TABLE a
 ----
 a  CREATE TABLE public.a (
    b INT2[] NULL,
+   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+   CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
    FAMILY "primary" (b, rowid)
 )
 

--- a/pkg/sql/logictest/testdata/logic_test/bit
+++ b/pkg/sql/logictest/testdata/logic_test/bit
@@ -21,6 +21,8 @@ bits        CREATE TABLE public.bits (
             b BIT(4) NULL,
             c VARBIT NULL,
             d VARBIT(4) NULL,
+            rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+            CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
             FAMILY "primary" (a, b, c, d, rowid)
 )
 
@@ -267,6 +269,8 @@ SELECT create_statement FROM [SHOW CREATE obitsa]
 ----
 CREATE TABLE public.obitsa (
    x VARBIT(20)[] NULL,
+   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+   CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
    FAMILY "primary" (x, rowid)
 )
 

--- a/pkg/sql/logictest/testdata/logic_test/check_constraints
+++ b/pkg/sql/logictest/testdata/logic_test/check_constraints
@@ -219,6 +219,8 @@ t7  CREATE TABLE public.t7 (
     x INT8 NULL,
     y INT8 NULL,
     z INT8 NULL,
+    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+    CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
     FAMILY "primary" (x, y, z, rowid),
     CONSTRAINT check_x CHECK (x > 0:::INT8),
     CONSTRAINT check_x_y CHECK ((x + y) > 0:::INT8),
@@ -254,6 +256,8 @@ SHOW CREATE TABLE t8
 ----
 t8  CREATE TABLE public.t8 (
     a INT8 NULL,
+    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+    CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
     FAMILY "primary" (a, rowid),
     CONSTRAINT check_a CHECK (a > 0:::INT8),
     CONSTRAINT check_a1 CHECK (a > 0:::INT8),

--- a/pkg/sql/logictest/testdata/logic_test/collatedstring
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring
@@ -217,6 +217,8 @@ SHOW CREATE TABLE t
 ----
 t  CREATE TABLE public.t (
    a STRING COLLATE en NULL,
+   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+   CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
    FAMILY "primary" (a, rowid)
 )
 
@@ -359,6 +361,8 @@ quoted_coll  CREATE TABLE public.quoted_coll (
              c STRING COLLATE en_US NULL DEFAULT 'c':::STRING COLLATE en_US,
              d STRING COLLATE en_u_ks_level1 NULL DEFAULT 'd':::STRING COLLATE en_u_ks_level1,
              e STRING COLLATE en_US NULL AS (a COLLATE en_US) STORED,
+             rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+             CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
              FAMILY "primary" (a, b, c, d, e, rowid)
 )
 
@@ -458,9 +462,11 @@ CREATE TABLE collation_name_case (s STRING COLLATE en_us_u_ks_level2);
 query TT
 SHOW CREATE TABLE collation_name_case
 ----
-collation_name_case   CREATE TABLE public.collation_name_case (
-                      s STRING COLLATE en_US_u_ks_level2 NULL,
-                      FAMILY "primary" (s, rowid)
+collation_name_case  CREATE TABLE public.collation_name_case (
+                     s STRING COLLATE en_US_u_ks_level2 NULL,
+                     rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                     CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
+                     FAMILY "primary" (s, rowid)
 )
 
 statement error invalid locale en-US-u-ks-le"vel2: language: tag is not well-formed

--- a/pkg/sql/logictest/testdata/logic_test/computed
+++ b/pkg/sql/logictest/testdata/logic_test/computed
@@ -13,6 +13,8 @@ with_no_column_refs  CREATE TABLE public.with_no_column_refs (
                      a INT8 NULL,
                      b INT8 NULL,
                      c INT8 NULL AS (3:::INT8) STORED,
+                     rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                     CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
                      FAMILY "primary" (a, b, c, rowid)
 )
 
@@ -31,6 +33,8 @@ extra_parens  CREATE TABLE public.extra_parens (
               a INT8 NULL,
               b INT8 NULL,
               c INT8 NULL AS (3:::INT8) STORED,
+              rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+              CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
               FAMILY "primary" (a, b, c, rowid)
 )
 
@@ -85,6 +89,8 @@ x  CREATE TABLE public.x (
    b INT8 NULL DEFAULT 7:::INT8,
    c INT8 NULL AS (a) STORED,
    d INT8 NULL AS (a + b) STORED,
+   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+   CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
    FAMILY "primary" (a, b, c, d, rowid)
 )
 
@@ -634,6 +640,8 @@ SHOW CREATE TABLE x
 x  CREATE TABLE public.x (
    a INT8 NULL,
    b INT8 NULL AS (a) STORED,
+   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+   CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
    FAMILY "primary" (a, b, rowid)
 )
 
@@ -657,6 +665,8 @@ SHOW CREATE TABLE x
 x  CREATE TABLE public.x (
    c INT8 NULL,
    b INT8 NULL AS (c) STORED,
+   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+   CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
    FAMILY "primary" (c, b, rowid)
 )
 
@@ -696,7 +706,9 @@ SHOW CREATE TABLE x
 x  CREATE TABLE public.x (
    a INT8 NULL,
    b INT8 NULL AS (a * 2:::INT8) STORED,
+   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
    c INT8 NOT NULL AS (a + 4:::INT8) STORED,
+   CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
    FAMILY "primary" (a, b, rowid, c)
 )
 
@@ -820,6 +832,8 @@ SHOW CREATE t42418
 ----
 t42418  CREATE TABLE public.t42418 (
         x INT8 NULL AS (1:::INT8) STORED,
+        rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
         y INT8 NULL AS (1:::INT8) STORED,
+        CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
         FAMILY "primary" (x, rowid, y)
 )

--- a/pkg/sql/logictest/testdata/logic_test/create_index
+++ b/pkg/sql/logictest/testdata/logic_test/create_index
@@ -180,6 +180,8 @@ SHOW CREATE TABLE create_index_concurrently_tbl
 ----
 create_index_concurrently_tbl  CREATE TABLE public.create_index_concurrently_tbl (
                                a INT8 NULL,
+                               rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                               CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
                                INDEX create_index_concurrently_idx (a ASC),
                                FAMILY "primary" (a, rowid)
 )
@@ -201,6 +203,8 @@ SHOW CREATE TABLE create_index_concurrently_tbl
 ----
 create_index_concurrently_tbl  CREATE TABLE public.create_index_concurrently_tbl (
                                a INT8 NULL,
+                               rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                               CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
                                FAMILY "primary" (a, rowid)
 )
 

--- a/pkg/sql/logictest/testdata/logic_test/create_statements
+++ b/pkg/sql/logictest/testdata/logic_test/create_statements
@@ -34,15 +34,21 @@ SELECT create_statement, create_nofks, alter_statements, validate_statements FRO
 create_statement  create_nofks  alter_statements  validate_statements
 CREATE TABLE public.t (
    a INT8 NULL,
+   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+   CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
    CONSTRAINT fk_a_ref_t FOREIGN KEY (a) REFERENCES public.t(rowid),
    FAMILY "primary" (a, rowid)
 )  CREATE TABLE public.t (
    a INT8 NULL,
+   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+   CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
    FAMILY "primary" (a, rowid)
 )  {"ALTER TABLE public.t ADD CONSTRAINT fk_a_ref_t FOREIGN KEY (a) REFERENCES public.t(rowid)"}  {"ALTER TABLE public.t VALIDATE CONSTRAINT fk_a_ref_t"}
 CREATE TABLE public.v (
    "'" INT8 NULL,
    s STRING NULL,
+   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+   CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
    CONSTRAINT "fk_'_ref_t" FOREIGN KEY ("'") REFERENCES public.t(rowid),
    CONSTRAINT fk_s_ref_v FOREIGN KEY (s) REFERENCES public.v(s),
    UNIQUE INDEX v_s_key (s ASC),
@@ -50,12 +56,16 @@ CREATE TABLE public.v (
 )  CREATE TABLE public.v (
    "'" INT8 NULL,
    s STRING NULL,
+   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+   CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
    UNIQUE INDEX v_s_key (s ASC),
    FAMILY "primary" ("'", s, rowid)
 )  {"ALTER TABLE public.v ADD CONSTRAINT \"fk_'_ref_t\" FOREIGN KEY (\"'\") REFERENCES public.t(rowid)","ALTER TABLE public.v ADD CONSTRAINT fk_s_ref_v FOREIGN KEY (s) REFERENCES public.v(s)"}  {"ALTER TABLE public.v VALIDATE CONSTRAINT \"fk_'_ref_t\"","ALTER TABLE public.v VALIDATE CONSTRAINT fk_s_ref_v"}
 CREATE TABLE public.c (
   a INT8 NOT NULL,
   b INT8 NULL,
+  rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+  CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
   INDEX c_a_b_idx (a ASC, b ASC),
   FAMILY fam_0_a_rowid (a, rowid),
   FAMILY fam_1_b (b)
@@ -65,6 +75,8 @@ COMMENT ON COLUMN public.c.a IS 'column';
 COMMENT ON INDEX public.c@c_a_b_idx IS 'index'  CREATE TABLE public.c (
                                                 a INT8 NOT NULL,
                                                 b INT8 NULL,
+                                                rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                                                CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
                                                 INDEX c_a_b_idx (a ASC, b ASC),
                                                 FAMILY fam_0_a_rowid (a, rowid),
                                                 FAMILY fam_1_b (b)

--- a/pkg/sql/logictest/testdata/logic_test/create_table
+++ b/pkg/sql/logictest/testdata/logic_test/create_table
@@ -68,6 +68,8 @@ SHOW CREATE t
 t  CREATE TABLE public.t (
    rowid INT8 NULL,
    rowid_1 INT8 NULL,
+   rowid_2 INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+   CONSTRAINT "primary" PRIMARY KEY (rowid_2 ASC),
    FAMILY fam_0_rowid_rowid_1_rowid_2 (rowid, rowid_1, rowid_2)
 )
 
@@ -146,6 +148,8 @@ like_none  CREATE TABLE public.like_none (
            h INT8 NULL,
            j JSONB NULL,
            k INT8 NULL,
+           rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+           CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
            FAMILY "primary" (a, b, c, h, j, k, rowid)
 )
 
@@ -162,6 +166,8 @@ like_constraints  CREATE TABLE public.like_constraints (
                   h INT8 NULL,
                   j JSONB NULL,
                   k INT8 NULL,
+                  rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                  CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
                   FAMILY "primary" (a, b, c, h, j, k, rowid),
                   CONSTRAINT check_a CHECK (a > 3:::INT8),
                   CONSTRAINT unique_k UNIQUE WITHOUT INDEX (k),
@@ -202,6 +208,8 @@ like_generated  CREATE TABLE public.like_generated (
                 h INT8 NULL,
                 j JSONB NULL,
                 k INT8 NULL,
+                rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
                 FAMILY "primary" (a, b, c, h, j, k, rowid)
 )
 
@@ -218,6 +226,8 @@ like_defaults  CREATE TABLE public.like_defaults (
                h INT8 NULL,
                j JSONB NULL,
                k INT8 NULL,
+               rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+               CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
                FAMILY "primary" (a, b, c, h, j, k, rowid)
 )
 
@@ -280,6 +290,8 @@ SHOW CREATE TABLE like_no_pk_rowid_hidden
 like_no_pk_rowid_hidden  CREATE TABLE public.like_no_pk_rowid_hidden (
                          a INT8 NULL,
                          b INT8 NULL,
+                         rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                         CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
                          FAMILY "primary" (a, b, rowid)
 )
 
@@ -306,6 +318,8 @@ like_more_specifiers  CREATE TABLE public.like_more_specifiers (
                       k INT8 NULL,
                       z DECIMAL NULL,
                       blah INT8 NULL,
+                      rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                      CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
                       INDEX like_more_specifiers_a_blah_z_idx (a ASC, blah ASC, z ASC),
                       FAMILY "primary" (a, b, c, h, j, k, z, blah, rowid)
 )
@@ -321,6 +335,9 @@ SHOW CREATE TABLE like_hash
 ----
 like_hash  CREATE TABLE public.like_hash (
            a INT8 NULL,
+           crdb_internal_a_shard_4 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(COALESCE(CAST(a AS STRING), '':::STRING)), 4:::INT8)) STORED,
+           rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+           CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
            INDEX like_hash_base_a_idx (a ASC) USING HASH WITH BUCKET_COUNT = 4,
            FAMILY "primary" (a, crdb_internal_a_shard_4, rowid)
 )

--- a/pkg/sql/logictest/testdata/logic_test/drop_index
+++ b/pkg/sql/logictest/testdata/logic_test/drop_index
@@ -282,6 +282,8 @@ SHOW CREATE fk1
 ----
 fk1  CREATE TABLE public.fk1 (
      x INT8 NULL,
+     rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+     CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
      CONSTRAINT fk1 FOREIGN KEY (x) REFERENCES public.fk2(x),
      INDEX i2 (x ASC),
      FAMILY "primary" (x, rowid)

--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -375,6 +375,8 @@ SHOW CREATE t1
 ----
 t1  CREATE TABLE public.t1 (
     x public.greeting NULL,
+    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+    CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
     INDEX i (x ASC),
     FAMILY "primary" (x, rowid)
 )
@@ -386,6 +388,8 @@ SELECT create_statement FROM crdb_internal.create_statements WHERE descriptor_na
 ----
 CREATE TABLE public.t1 (
    x public.greeting NULL,
+   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+   CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
    INDEX i (x ASC),
    FAMILY "primary" (x, rowid)
 )
@@ -489,6 +493,8 @@ enum_default  CREATE TABLE public.enum_default (
               x INT8 NULL,
               y public.greeting NULL DEFAULT 'hello':::public.greeting,
               z BOOL NULL DEFAULT 'hello':::public.greeting IS OF (public.greeting, public.greeting),
+              rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+              CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
               FAMILY fam_0_x_y_z_rowid (x, y, z, rowid)
 )
 
@@ -545,6 +551,8 @@ enum_computed  CREATE TABLE public.enum_computed (
                y public.greeting NULL AS ('hello':::public.greeting) STORED,
                z BOOL NULL AS (w = 'howdy':::public.greeting) STORED,
                w public.greeting NULL,
+               rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+               CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
                FAMILY fam_0_x_y_z_w_rowid (x, y, z, w, rowid)
 )
 
@@ -577,6 +585,8 @@ SHOW CREATE enum_checks
 ----
 enum_checks  CREATE TABLE public.enum_checks (
              x public.greeting NULL,
+             rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+             CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
              FAMILY "primary" (x, rowid),
              CONSTRAINT check_x CHECK (x = 'hello':::public.greeting),
              CONSTRAINT "check" CHECK ('hello':::public.greeting = 'hello':::public.greeting)

--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -503,6 +503,8 @@ delivery  CREATE TABLE public.delivery (
           "order" INT8 NULL,
           shipment INT8 NULL,
           item STRING NULL,
+          rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+          CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
           CONSTRAINT fk_order_ref_orders FOREIGN KEY ("order", shipment) REFERENCES public.orders(id, shipment),
           CONSTRAINT fk_item_ref_products FOREIGN KEY (item) REFERENCES public.products(upc),
           INDEX delivery_item_idx (item ASC),
@@ -816,6 +818,8 @@ refpairs  CREATE TABLE public.refpairs (
           a INT8 NULL,
           b STRING NULL,
           c INT8 NULL,
+          rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+          CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
           CONSTRAINT fk_a_ref_pairs FOREIGN KEY (a, b) REFERENCES public.pairs(src, dest) ON UPDATE RESTRICT,
           INDEX refpairs_a_b_c_idx (a ASC, b ASC, c ASC),
           FAMILY "primary" (a, b, c, rowid)
@@ -1023,6 +1027,8 @@ SHOW CREATE TABLE refers
 refers  CREATE TABLE public.refers (
         a INT8 NULL,
         b INT8 NULL,
+        rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+        CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
         CONSTRAINT fk_a_ref_referee FOREIGN KEY (a) REFERENCES public.referee(id),
         INDEX another_idx (b ASC),
         INDEX foo (a ASC),

--- a/pkg/sql/logictest/testdata/logic_test/fk-mixed-20.1-20.2
+++ b/pkg/sql/logictest/testdata/logic_test/fk-mixed-20.1-20.2
@@ -12,6 +12,8 @@ SHOW CREATE t1
 ----
 t1  CREATE TABLE public.t1 (
     x INT8 NULL,
+    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+    CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
     CONSTRAINT fk_x_ref_t2 FOREIGN KEY (x) REFERENCES public.t2(y),
     INDEX t1_auto_index_fk_x_ref_t2 (x ASC),
     FAMILY "primary" (x, rowid)

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -68,6 +68,8 @@ SELECT create_statement FROM [SHOW CREATE TABLE geom_table_negative_values]
 ----
 CREATE TABLE public.geom_table_negative_values (
    a GEOMETRY(GEOMETRY) NULL,
+   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+   CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
    FAMILY "primary" (a, rowid)
 )
 
@@ -81,6 +83,8 @@ SELECT create_statement FROM [SHOW CREATE TABLE geog_table_negative_values]
 ----
 CREATE TABLE public.geog_table_negative_values (
    a GEOGRAPHY(GEOMETRY) NULL,
+   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+   CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
    FAMILY "primary" (a, rowid)
 )
 

--- a/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
+++ b/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
@@ -9,6 +9,7 @@ query TT
 SHOW CREATE TABLE sharded_primary
 ----
 sharded_primary  CREATE TABLE public.sharded_primary (
+                 crdb_internal_a_shard_10 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(COALESCE(CAST(a AS STRING), '':::STRING)), 10:::INT8)) STORED,
                  a INT8 NOT NULL,
                  CONSTRAINT "primary" PRIMARY KEY (a ASC) USING HASH WITH BUCKET_COUNT = 10,
                  FAMILY "primary" (crdb_internal_a_shard_10, a)
@@ -42,6 +43,7 @@ SHOW CREATE TABLE sharded_primary
 ----
 sharded_primary  CREATE TABLE public.sharded_primary (
                  a INT8 NOT NULL,
+                 crdb_internal_a_shard_10 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(COALESCE(CAST(a AS STRING), '':::STRING)), 10:::INT8)) STORED,
                  CONSTRAINT "primary" PRIMARY KEY (a ASC) USING HASH WITH BUCKET_COUNT = 10,
                  FAMILY "primary" (crdb_internal_a_shard_10, a)
 )
@@ -88,6 +90,9 @@ SHOW CREATE TABLE specific_family
 specific_family  CREATE TABLE public.specific_family (
                  a INT8 NULL,
                  b INT8 NULL,
+                 crdb_internal_b_shard_10 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(COALESCE(CAST(b AS STRING), '':::STRING)), 10:::INT8)) STORED,
+                 rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                 CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
                  INDEX specific_family_b_idx (b ASC) USING HASH WITH BUCKET_COUNT = 10,
                  FAMILY a_family (a, rowid),
                  FAMILY b_family (b, crdb_internal_b_shard_10)
@@ -102,6 +107,9 @@ SHOW CREATE TABLE sharded_secondary
 ----
 sharded_secondary  CREATE TABLE public.sharded_secondary (
                    a INT8 NULL,
+                   crdb_internal_a_shard_4 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(COALESCE(CAST(a AS STRING), '':::STRING)), 4:::INT8)) STORED,
+                   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                   CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
                    INDEX sharded_secondary_a_idx (a ASC) USING HASH WITH BUCKET_COUNT = 4,
                    FAMILY "primary" (a, crdb_internal_a_shard_4, rowid)
 )
@@ -121,6 +129,9 @@ SHOW CREATE TABLE sharded_secondary
 ----
 sharded_secondary  CREATE TABLE public.sharded_secondary (
                    a INT8 NULL,
+                   crdb_internal_a_shard_4 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(COALESCE(CAST(a AS STRING), '':::STRING)), 4:::INT8)) STORED,
+                   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                   CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
                    INDEX sharded_secondary_crdb_internal_a_shard_4_a_idx (a ASC) USING HASH WITH BUCKET_COUNT = 4,
                    FAMILY "primary" (a, crdb_internal_a_shard_4, rowid)
 )
@@ -147,6 +158,9 @@ SHOW CREATE TABLE sharded_secondary
 ----
 sharded_secondary  CREATE TABLE public.sharded_secondary (
                    a INT8 NULL,
+                   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                   crdb_internal_a_shard_10 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(COALESCE(CAST(a AS STRING), '':::STRING)), 10:::INT8)) STORED,
+                   CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
                    INDEX sharded_secondary_a_idx (a ASC) USING HASH WITH BUCKET_COUNT = 10,
                    FAMILY "primary" (a, rowid, crdb_internal_a_shard_10)
 )
@@ -163,6 +177,10 @@ SHOW CREATE TABLE sharded_secondary
 ----
 sharded_secondary  CREATE TABLE public.sharded_secondary (
                    a INT8 NULL,
+                   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                   crdb_internal_a_shard_10 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(COALESCE(CAST(a AS STRING), '':::STRING)), 10:::INT8)) STORED,
+                   crdb_internal_a_shard_4 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(COALESCE(CAST(a AS STRING), '':::STRING)), 4:::INT8)) STORED,
+                   CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
                    INDEX sharded_secondary_a_idx (a ASC) USING HASH WITH BUCKET_COUNT = 10,
                    INDEX sharded_secondary_a_idx1 (a ASC) USING HASH WITH BUCKET_COUNT = 4,
                    FAMILY "primary" (a, rowid, crdb_internal_a_shard_10, crdb_internal_a_shard_4)
@@ -177,6 +195,9 @@ SHOW CREATE TABLE sharded_secondary
 ----
 sharded_secondary  CREATE TABLE public.sharded_secondary (
                    a INT8 NULL,
+                   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                   crdb_internal_a_shard_4 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(COALESCE(CAST(a AS STRING), '':::STRING)), 4:::INT8)) STORED,
+                   CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
                    INDEX sharded_secondary_a_idx1 (a ASC) USING HASH WITH BUCKET_COUNT = 4,
                    FAMILY "primary" (a, rowid, crdb_internal_a_shard_4)
 )
@@ -190,6 +211,8 @@ SHOW CREATE TABLE sharded_secondary
 ----
 sharded_secondary  CREATE TABLE public.sharded_secondary (
                    a INT8 NULL,
+                   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                   CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
                    FAMILY "primary" (a, rowid)
 )
 
@@ -231,6 +254,9 @@ SHOW CREATE TABLE sharded_secondary
 ----
 sharded_secondary  CREATE TABLE public.sharded_secondary (
                    a INT8 NULL,
+                   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                   crdb_internal_a_shard_10 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(COALESCE(CAST(a AS STRING), '':::STRING)), 10:::INT8)) STORED,
+                   CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
                    INDEX sharded_secondary_a_idx (a ASC) USING HASH WITH BUCKET_COUNT = 10,
                    INDEX sharded_secondary_a_idx1 (a ASC) USING HASH WITH BUCKET_COUNT = 10,
                    INDEX sharded_secondary_a_idx2 (a ASC) USING HASH WITH BUCKET_COUNT = 10,
@@ -252,6 +278,8 @@ SHOW CREATE TABLE sharded_primary
 ----
 sharded_primary  CREATE TABLE public.sharded_primary (
                  a INT8 NOT NULL,
+                 crdb_internal_a_shard_10 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(COALESCE(CAST(a AS STRING), '':::STRING)), 10:::INT8)) STORED,
+                 crdb_internal_a_shard_4 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(COALESCE(CAST(a AS STRING), '':::STRING)), 4:::INT8)) STORED,
                  CONSTRAINT "primary" PRIMARY KEY (a ASC) USING HASH WITH BUCKET_COUNT = 10,
                  INDEX sharded_primary_a_idx (a ASC) USING HASH WITH BUCKET_COUNT = 4,
                  FAMILY "primary" (crdb_internal_a_shard_10, a, crdb_internal_a_shard_4)
@@ -268,6 +296,7 @@ SHOW CREATE TABLE sharded_primary
 ----
 sharded_primary  CREATE TABLE public.sharded_primary (
                  a INT8 NOT NULL,
+                 crdb_internal_a_shard_10 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(COALESCE(CAST(a AS STRING), '':::STRING)), 10:::INT8)) STORED,
                  CONSTRAINT "primary" PRIMARY KEY (a ASC) USING HASH WITH BUCKET_COUNT = 10,
                  FAMILY "primary" (crdb_internal_a_shard_10, a)
 )
@@ -280,6 +309,7 @@ SHOW CREATE TABLE sharded_primary
 ----
 sharded_primary  CREATE TABLE public.sharded_primary (
                  a INT8 NOT NULL,
+                 crdb_internal_a_shard_10 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(COALESCE(CAST(a AS STRING), '':::STRING)), 10:::INT8)) STORED,
                  CONSTRAINT "primary" PRIMARY KEY (a ASC) USING HASH WITH BUCKET_COUNT = 10,
                  INDEX sharded_primary_a_idx (a ASC) USING HASH WITH BUCKET_COUNT = 10,
                  FAMILY "primary" (crdb_internal_a_shard_10, a)
@@ -358,6 +388,9 @@ SHOW CREATE TABLE column_used_on_unsharded
 ----
 column_used_on_unsharded  CREATE TABLE public.column_used_on_unsharded (
                           a INT8 NULL,
+                          crdb_internal_a_shard_10 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(COALESCE(CAST(a AS STRING), '':::STRING)), 10:::INT8)) STORED,
+                          rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                          CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
                           INDEX column_used_on_unsharded_crdb_internal_a_shard_10_idx (crdb_internal_a_shard_10 ASC),
                           FAMILY "primary" (a, crdb_internal_a_shard_10, rowid)
 )
@@ -380,6 +413,9 @@ SHOW CREATE TABLE column_used_on_unsharded_create_table
 ----
 column_used_on_unsharded_create_table  CREATE TABLE public.column_used_on_unsharded_create_table (
                                        a INT8 NULL,
+                                       crdb_internal_a_shard_10 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(COALESCE(CAST(a AS STRING), '':::STRING)), 10:::INT8)) STORED,
+                                       rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                                       CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
                                        INDEX column_used_on_unsharded_create_table_crdb_internal_a_shard_10_idx (crdb_internal_a_shard_10 ASC),
                                        FAMILY "primary" (a, crdb_internal_a_shard_10, rowid)
 )
@@ -431,8 +467,10 @@ query TT
 SHOW CREATE TABLE weird_names
 ----
 weird_names  CREATE TABLE public.weird_names (
+             "crdb_internal_I am a column with spaces_shard_12" INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(COALESCE(CAST("I am a column with spaces" AS STRING), '':::STRING)), 12:::INT8)) STORED,
              "I am a column with spaces" INT8 NOT NULL,
              "'quotes' in the column's name" INT8 NULL,
+             "crdb_internal_'quotes' in the column's name_shard_4" INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(COALESCE(CAST("'quotes' in the column's name" AS STRING), '':::STRING)), 4:::INT8)) STORED,
              CONSTRAINT "primary" PRIMARY KEY ("I am a column with spaces" ASC) USING HASH WITH BUCKET_COUNT = 12,
              INDEX foo ("'quotes' in the column's name" ASC) USING HASH WITH BUCKET_COUNT = 4,
              FAMILY "primary" ("I am a column with spaces", "'quotes' in the column's name", "crdb_internal_I am a column with spaces_shard_12", "crdb_internal_'quotes' in the column's name_shard_4")
@@ -526,6 +564,8 @@ rename_column  CREATE TABLE public.rename_column (
                c0 INT8 NOT NULL,
                c1 INT8 NOT NULL,
                c2 INT8 NULL,
+               crdb_internal_c0_c1_shard_8 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(COALESCE(CAST(c0 AS STRING), '':::STRING)) + fnv32(COALESCE(CAST(c1 AS STRING), '':::STRING)), 8:::INT8)) STORED,
+               crdb_internal_c2_shard_8 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(COALESCE(CAST(c2 AS STRING), '':::STRING)), 8:::INT8)) STORED,
                CONSTRAINT "primary" PRIMARY KEY (c0 ASC, c1 ASC) USING HASH WITH BUCKET_COUNT = 8,
                INDEX rename_column_c2_idx (c2 ASC) USING HASH WITH BUCKET_COUNT = 8,
                FAMILY "primary" (c0, c1, c2, crdb_internal_c0_c1_shard_8, crdb_internal_c2_shard_8)
@@ -548,6 +588,8 @@ rename_column  CREATE TABLE public.rename_column (
                c1 INT8 NOT NULL,
                c2 INT8 NOT NULL,
                c3 INT8 NULL,
+               crdb_internal_c1_c2_shard_8 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(COALESCE(CAST(c1 AS STRING), '':::STRING)) + fnv32(COALESCE(CAST(c2 AS STRING), '':::STRING)), 8:::INT8)) STORED,
+               crdb_internal_c3_shard_8 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(COALESCE(CAST(c3 AS STRING), '':::STRING)), 8:::INT8)) STORED,
                CONSTRAINT "primary" PRIMARY KEY (c1 ASC, c2 ASC) USING HASH WITH BUCKET_COUNT = 8,
                INDEX rename_column_c2_idx (c3 ASC) USING HASH WITH BUCKET_COUNT = 8,
                FAMILY "primary" (c1, c2, c3, crdb_internal_c1_c2_shard_8, crdb_internal_c3_shard_8)
@@ -569,6 +611,8 @@ rename_column  CREATE TABLE public.rename_column (
                c0 INT8 NOT NULL,
                c1 INT8 NOT NULL,
                c2 INT8 NULL,
+               crdb_internal_c0_c1_shard_8 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(COALESCE(CAST(c0 AS STRING), '':::STRING)) + fnv32(COALESCE(CAST(c1 AS STRING), '':::STRING)), 8:::INT8)) STORED,
+               crdb_internal_c2_shard_8 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(COALESCE(CAST(c2 AS STRING), '':::STRING)), 8:::INT8)) STORED,
                CONSTRAINT "primary" PRIMARY KEY (c0 ASC, c1 ASC) USING HASH WITH BUCKET_COUNT = 8,
                INDEX rename_column_c2_idx (c2 ASC) USING HASH WITH BUCKET_COUNT = 8,
                FAMILY "primary" (c0, c1, c2, crdb_internal_c0_c1_shard_8, crdb_internal_c2_shard_8)

--- a/pkg/sql/logictest/testdata/logic_test/hidden_columns
+++ b/pkg/sql/logictest/testdata/logic_test/hidden_columns
@@ -26,7 +26,11 @@ INSERT INTO kv VALUES (111, 222)
 query TT
 SHOW CREATE TABLE t
 ----
-t  CREATE TABLE public.t (FAMILY "primary" (x, rowid)
+t  CREATE TABLE public.t (
+   x INT8 NOT VISIBLE NULL,
+   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+   CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
+   FAMILY "primary" (x, rowid)
 )
 
 # Check that stars expand to no columns.

--- a/pkg/sql/logictest/testdata/logic_test/insert
+++ b/pkg/sql/logictest/testdata/logic_test/insert
@@ -486,6 +486,8 @@ CREATE TABLE public.sw (
    dc VARCHAR(3) COLLATE en NULL,
    ec STRING COLLATE en NULL,
    fc STRING(3) COLLATE en NULL,
+   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+   CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
    FAMILY "primary" (a, b, c, d, e, f, g, ac, bc, cc, dc, ec, fc, rowid)
 )
 
@@ -597,6 +599,8 @@ SELECT create_statement FROM [SHOW CREATE t29494]
 ----
 CREATE TABLE public.t29494 (
    x INT8 NULL,
+   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+   CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
    FAMILY "primary" (x, rowid)
 )
 
@@ -636,6 +640,8 @@ SELECT create_statement FROM [SHOW CREATE t32759]
 CREATE TABLE public.t32759 (
    x INT8 NULL,
    z INT8 NULL,
+   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+   CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
    FAMILY "primary" (x, z, rowid)
 )
 

--- a/pkg/sql/logictest/testdata/logic_test/int_size
+++ b/pkg/sql/logictest/testdata/logic_test/int_size
@@ -23,6 +23,8 @@ SHOW CREATE TABLE i4
 ----
 i4  CREATE TABLE public.i4 (
     i4 INT4 NULL,
+    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+    CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
     FAMILY "primary" (i4, rowid)
 )
 
@@ -44,6 +46,8 @@ SHOW CREATE TABLE i8
 ----
 i8  CREATE TABLE public.i8 (
     i8 INT8 NULL,
+    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+    CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
     FAMILY "primary" (i8, rowid)
 )
 
@@ -63,6 +67,8 @@ SHOW CREATE TABLE late4
 ----
 late4  CREATE TABLE public.late4 (
        a INT8 NULL,
+       rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+       CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
        FAMILY "primary" (a, rowid)
 )
 
@@ -94,6 +100,8 @@ SHOW CREATE TABLE i4_rowid
 ----
 i4_rowid  CREATE TABLE public.i4_rowid (
           a INT8 NOT NULL DEFAULT unique_rowid(),
+          rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+          CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
           FAMILY "primary" (a, rowid)
 )
 
@@ -108,6 +116,8 @@ SHOW CREATE TABLE i8_rowid
 ----
 i8_rowid  CREATE TABLE public.i8_rowid (
           a INT8 NOT NULL DEFAULT unique_rowid(),
+          rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+          CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
           FAMILY "primary" (a, rowid)
 )
 
@@ -125,6 +135,8 @@ SHOW CREATE TABLE i4_sql_sequence
 ----
 i4_sql_sequence  CREATE TABLE public.i4_sql_sequence (
                  a INT4 NOT NULL DEFAULT nextval('i4_sql_sequence_a_seq':::STRING),
+                 rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                 CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
                  FAMILY "primary" (a, rowid)
 )
 
@@ -139,6 +151,8 @@ SHOW CREATE TABLE i8_sql_sequence
 ----
 i8_sql_sequence  CREATE TABLE public.i8_sql_sequence (
                  a INT8 NOT NULL DEFAULT nextval('i8_sql_sequence_a_seq':::STRING),
+                 rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                 CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
                  FAMILY "primary" (a, rowid)
 )
 
@@ -157,6 +171,8 @@ SHOW CREATE TABLE i4_virtual_sequence
 ----
 i4_virtual_sequence  CREATE TABLE public.i4_virtual_sequence (
                      a INT8 NOT NULL DEFAULT nextval('i4_virtual_sequence_a_seq':::STRING),
+                     rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                     CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
                      FAMILY "primary" (a, rowid)
 )
 
@@ -171,5 +187,7 @@ SHOW CREATE TABLE i8_virtual_sequence
 ----
 i8_virtual_sequence  CREATE TABLE public.i8_virtual_sequence (
                      a INT8 NOT NULL DEFAULT nextval('i8_virtual_sequence_a_seq':::STRING),
+                     rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                     CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
                      FAMILY "primary" (a, rowid)
 )

--- a/pkg/sql/logictest/testdata/logic_test/inverted_index_multi_column
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index_multi_column
@@ -62,6 +62,8 @@ SELECT create_statement FROM [SHOW CREATE TABLE drop_j]
 CREATE TABLE public.drop_j (
    a INT8 NULL,
    b INT8 NULL,
+   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+   CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
    FAMILY fam_0_a_b_j_rowid (a, b, rowid)
 )
 
@@ -83,6 +85,8 @@ SELECT create_statement FROM [SHOW CREATE TABLE drop_a]
 CREATE TABLE public.drop_a (
    b INT8 NULL,
    j JSONB NULL,
+   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+   CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
    FAMILY fam_0_a_b_j_rowid (b, j, rowid)
 )
 
@@ -98,6 +102,8 @@ CREATE TABLE public.dst (
    a INT8 NULL,
    b INT8 NULL,
    j JSONB NULL,
+   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+   CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
    INVERTED INDEX src_a_j_idx (a, j),
    INVERTED INDEX src_a_b_j_idx (a, b, j),
    FAMILY "primary" (a, b, j, rowid)

--- a/pkg/sql/logictest/testdata/logic_test/multiregion
+++ b/pkg/sql/logictest/testdata/logic_test/multiregion
@@ -238,6 +238,8 @@ SELECT create_statement FROM [SHOW CREATE TABLE regional_primary_region_table]
 ----
 CREATE TABLE public.regional_primary_region_table (
                                                 a INT8 NULL,
+                                                rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                                                CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
                                                 FAMILY "primary" (a, rowid)
 ) LOCALITY REGIONAL BY TABLE IN PRIMARY REGION
 
@@ -262,6 +264,8 @@ SELECT create_statement FROM [SHOW CREATE TABLE regional_implicit_primary_region
 ----
 CREATE TABLE public.regional_implicit_primary_region_table (
                                                 a INT8 NULL,
+                                                rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                                                CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
                                                 FAMILY "primary" (a, rowid)
 ) LOCALITY REGIONAL BY TABLE IN PRIMARY REGION
 
@@ -285,8 +289,10 @@ query T
 SELECT create_statement FROM [SHOW CREATE TABLE "regional_us-east-1_table"]
 ----
 CREATE TABLE public."regional_us-east-1_table" (
-                                            a INT8 NULL,
-                                            FAMILY "primary" (a, rowid)
+                                             a INT8 NULL,
+                                             rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                                             CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
+                                             FAMILY "primary" (a, rowid)
 ) LOCALITY REGIONAL BY TABLE IN "us-east-1"
 
 query TT
@@ -313,6 +319,8 @@ SELECT create_statement FROM [SHOW CREATE TABLE global_table]
 ----
 CREATE TABLE public.global_table (
                    a INT8 NULL,
+                   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                   CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
                    FAMILY "primary" (a, rowid)
 ) LOCALITY GLOBAL
 
@@ -816,5 +824,7 @@ SELECT create_statement FROM [SHOW CREATE TABLE no_initial_region.t]
 ----
 CREATE TABLE public.t (
                                                 k INT8 NULL,
+                                                rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                                                CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
                                                 FAMILY "primary" (k, rowid)
 ) LOCALITY REGIONAL BY TABLE IN PRIMARY REGION

--- a/pkg/sql/logictest/testdata/logic_test/name_escapes
+++ b/pkg/sql/logictest/testdata/logic_test/name_escapes
@@ -59,5 +59,7 @@ SHOW CREATE TABLE ";--dontask"
               a INT8 NULL,
               b INT8 NULL,
               c INT8 NULL,
+              rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+              CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
               FAMILY "primary" (a, b, c, rowid)
 )

--- a/pkg/sql/logictest/testdata/logic_test/partial_index
+++ b/pkg/sql/logictest/testdata/logic_test/partial_index
@@ -115,6 +115,8 @@ SHOW CREATE TABLE t6
 ----
 t6  CREATE TABLE public.t6 (
     a INT8 NULL,
+    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+    CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
     INDEX t6_a_idx (a ASC) WHERE a > 0:::INT8,
     INDEX t6_a_idx1 (a ASC) WHERE a > 1:::INT8,
     INDEX t6_a_idx2 (a DESC) WHERE a > 2:::INT8,
@@ -137,6 +139,8 @@ SHOW CREATE TABLE t6
 ----
 t6  CREATE TABLE public.t6 (
     b INT8 NULL,
+    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+    CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
     INDEX t6_a_idx (b ASC) WHERE b > 0:::INT8,
     INDEX t6_a_idx1 (b ASC) WHERE b > 1:::INT8,
     INDEX t6_a_idx2 (b DESC) WHERE b > 2:::INT8,
@@ -159,6 +163,8 @@ SHOW CREATE TABLE t7
 ----
 t7  CREATE TABLE public.t7 (
     b INT8 NULL,
+    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+    CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
     INDEX t6_a_idx (b ASC) WHERE b > 0:::INT8,
     INDEX t6_a_idx1 (b ASC) WHERE b > 1:::INT8,
     INDEX t6_a_idx2 (b DESC) WHERE b > 2:::INT8,
@@ -192,6 +198,8 @@ SHOW CREATE TABLE t8
 t8  CREATE TABLE public.t8 (
     a INT8 NULL,
     b INT8 NULL,
+    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+    CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
     INDEX t8_a_idx (a ASC) WHERE b > 0:::INT8,
     FAMILY fam_0_a_b_c_rowid (a, b, rowid)
 )
@@ -211,6 +219,8 @@ SHOW CREATE TABLE t10
 t10  CREATE TABLE public.t10 (
      a INT8 NULL,
      b INT8 NULL,
+     rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+     CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
      INDEX t9_a_idx (a ASC) WHERE b > 1:::INT8,
      FAMILY "primary" (a, b, rowid)
 )
@@ -1141,6 +1151,8 @@ SHOW CREATE TABLE enum_table_show
 enum_table_show  CREATE TABLE public.enum_table_show (
                  a INT8 NULL,
                  b public.enum_type NULL,
+                 rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                 CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
                  INDEX i (a ASC) WHERE b IN ('foo':::public.enum_type, 'bar':::public.enum_type),
                  FAMILY fam_0_a_b_rowid (a, b, rowid)
 )

--- a/pkg/sql/logictest/testdata/logic_test/partial_txn_commit
+++ b/pkg/sql/logictest/testdata/logic_test/partial_txn_commit
@@ -32,5 +32,7 @@ SHOW CREATE t
 ----
 t  CREATE TABLE public.t (
    x INT8 NULL,
+   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+   CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
    FAMILY "primary" (x, rowid)
 )

--- a/pkg/sql/logictest/testdata/logic_test/rename_constraint
+++ b/pkg/sql/logictest/testdata/logic_test/rename_constraint
@@ -13,6 +13,8 @@ SELECT create_statement FROM [SHOW CREATE t]
 CREATE TABLE public.t (
    x INT8 NULL,
    y INT8 NULL,
+   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+   CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
    CONSTRAINT cf FOREIGN KEY (x) REFERENCES public.t(x),
    UNIQUE INDEX cu (x ASC),
    FAMILY "primary" (x, y, rowid),
@@ -39,6 +41,8 @@ SELECT create_statement FROM [SHOW CREATE t]
 CREATE TABLE public.t (
    x INT8 NULL,
    y INT8 NULL,
+   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+   CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
    CONSTRAINT cf2 FOREIGN KEY (x) REFERENCES public.t(x),
    UNIQUE INDEX cu2 (x ASC),
    FAMILY "primary" (x, y, rowid),
@@ -89,6 +93,8 @@ SELECT create_statement FROM [SHOW CREATE t]
 CREATE TABLE public.t (
    x INT8 NULL,
    y INT8 NULL,
+   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+   CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
    CONSTRAINT cf4 FOREIGN KEY (x) REFERENCES public.t(x),
    UNIQUE INDEX cu4 (x ASC),
    FAMILY "primary" (x, y, rowid),

--- a/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
@@ -278,7 +278,9 @@ SHOW CREATE TABLE b
 ----
 b  CREATE TABLE public.b (
    parent_id INT8 NULL,
+   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
    d INT8 NULL DEFAULT 23:::INT8,
+   CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
    CONSTRAINT fk_parent_id_ref_parent FOREIGN KEY (parent_id) REFERENCES public.parent(id),
    INDEX foo (parent_id ASC),
    UNIQUE INDEX bar (parent_id ASC),

--- a/pkg/sql/logictest/testdata/logic_test/serial
+++ b/pkg/sql/logictest/testdata/logic_test/serial
@@ -54,6 +54,8 @@ smallbig  CREATE TABLE public.smallbig (
           a INT8 NOT NULL DEFAULT unique_rowid(),
           b INT8 NOT NULL DEFAULT unique_rowid(),
           c INT8 NULL,
+          rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+          CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
           FAMILY "primary" (a, b, c, rowid)
 )
 
@@ -76,6 +78,8 @@ serials  CREATE TABLE public.serials (
          b INT8 NOT NULL DEFAULT unique_rowid(),
          c INT8 NOT NULL DEFAULT unique_rowid(),
          d INT8 NULL,
+         rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+         CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
          FAMILY "primary" (a, b, c, d, rowid)
 )
 
@@ -159,6 +163,8 @@ smallbig  CREATE TABLE public.smallbig (
           a INT8 NOT NULL DEFAULT nextval('smallbig_a_seq':::STRING),
           b INT8 NOT NULL DEFAULT nextval('smallbig_b_seq':::STRING),
           c INT8 NULL,
+          rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+          CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
           FAMILY "primary" (a, b, c, rowid)
 )
 
@@ -181,6 +187,8 @@ serials  CREATE TABLE public.serials (
          b INT8 NOT NULL DEFAULT nextval('serials_b_seq':::STRING),
          c INT8 NOT NULL DEFAULT nextval('serials_c_seq':::STRING),
          d INT8 NULL,
+         rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+         CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
          FAMILY "primary" (a, b, c, d, rowid)
 )
 
@@ -300,6 +308,8 @@ smallbig  CREATE TABLE public.smallbig (
           a INT2 NOT NULL DEFAULT nextval('smallbig_a_seq1':::STRING),
           b INT8 NOT NULL DEFAULT nextval('smallbig_b_seq1':::STRING),
           c INT8 NULL,
+          rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+          CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
           FAMILY "primary" (a, b, c, rowid)
 )
 
@@ -322,6 +332,8 @@ serials  CREATE TABLE public.serials (
          b INT4 NOT NULL DEFAULT nextval('serials_b_seq1':::STRING),
          c INT8 NOT NULL DEFAULT nextval('serials_c_seq1':::STRING),
          d INT8 NULL,
+         rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+         CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
          FAMILY "primary" (a, b, c, d, rowid)
 )
 

--- a/pkg/sql/logictest/testdata/logic_test/show_create
+++ b/pkg/sql/logictest/testdata/logic_test/show_create
@@ -30,6 +30,8 @@ table_name  create_statement
 c           CREATE TABLE public.c (
             a INT8 NOT NULL,
             b INT8 NULL,
+            rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+            CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
             INDEX c_a_b_idx (a ASC, b ASC),
             FAMILY fam_0_a_rowid (a, rowid),
             FAMILY fam_1_b (b),
@@ -54,6 +56,8 @@ SHOW CREATE c
 c  CREATE TABLE public.c (
    a INT8 NOT NULL,
    b INT8 NULL,
+   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+   CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
    CONSTRAINT fk_a FOREIGN KEY (a) REFERENCES public.d(d) NOT VALID,
    INDEX c_a_b_idx (a ASC, b ASC),
    UNIQUE INDEX unique_a (a ASC),
@@ -80,6 +84,8 @@ SHOW CREATE c
 c  CREATE TABLE public.c (
    a INT8 NOT NULL,
    b INT8 NULL,
+   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+   CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
    CONSTRAINT fk_a FOREIGN KEY (a) REFERENCES public.d(d),
    INDEX c_a_b_idx (a ASC, b ASC),
    UNIQUE INDEX unique_a (a ASC),

--- a/pkg/sql/logictest/testdata/logic_test/table
+++ b/pkg/sql/logictest/testdata/logic_test/table
@@ -481,6 +481,8 @@ SHOW CREATE TABLE test.null_default
 ----
 test.public.null_default  CREATE TABLE public.null_default (
                           ts TIMESTAMP NULL,
+                          rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                          CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
                           FAMILY "primary" (ts, rowid)
 )
 

--- a/pkg/sql/logictest/testdata/logic_test/upsert
+++ b/pkg/sql/logictest/testdata/logic_test/upsert
@@ -635,6 +635,8 @@ SELECT create_statement FROM [SHOW CREATE t29494]
 ----
 CREATE TABLE public.t29494 (
    x INT8 NULL,
+   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+   CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
    FAMILY "primary" (x, rowid)
 )
 

--- a/pkg/sql/show_create.go
+++ b/pkg/sql/show_create.go
@@ -82,8 +82,7 @@ func ShowCreateTable(
 	f.WriteString("TABLE ")
 	f.FormatNode(tn)
 	f.WriteString(" (")
-	primaryKeyIsOnVisibleColumn := false
-	for i, col := range desc.VisibleColumns() {
+	for i, col := range desc.PublicColumns() {
 		if i != 0 {
 			f.WriteString(",")
 		}
@@ -93,19 +92,15 @@ func ShowCreateTable(
 			return "", err
 		}
 		f.WriteString(colstr)
-		if desc.IsPhysicalTable() && desc.GetPrimaryIndex().GetColumnID(0) == col.GetID() {
-			// Only set primaryKeyIsOnVisibleColumn to true if the primary key
-			// is on a visible column (not rowid).
-			primaryKeyIsOnVisibleColumn = true
-		}
 	}
-	if primaryKeyIsOnVisibleColumn ||
-		(desc.IsPhysicalTable() && desc.GetPrimaryIndex().IsSharded()) {
+
+	if desc.IsPhysicalTable() {
 		f.WriteString(",\n\tCONSTRAINT ")
 		formatQuoteNames(&f.Buffer, desc.GetPrimaryIndex().GetName())
 		f.WriteString(" ")
 		f.WriteString(desc.PrimaryKeyString())
 	}
+
 	// TODO (lucy): Possibly include FKs in the mutations list here, or else
 	// exclude check mutations below, for consistency.
 	if displayOptions.FKDisplayMode != OmitFKClausesFromCreate {

--- a/pkg/sql/show_create_clauses.go
+++ b/pkg/sql/show_create_clauses.go
@@ -255,7 +255,7 @@ func showFamilyClause(desc catalog.TableDescriptor, f *tree.FmtCtx) {
 				activeColumnNames = append(activeColumnNames, fam.ColumnNames[i])
 			}
 		}
-		if len(desc.VisibleColumns()) == 0 {
+		if len(desc.PublicColumns()) == 0 {
 			f.WriteString("FAMILY ")
 		} else {
 			f.WriteString(",\n\tFAMILY ")


### PR DESCRIPTION
Release note (sql change): Hidden columns (created using NOT VISIBLE or
implicitly created via hash sharded indexes, lack of a primary key
definition or using REGIONAL BY ROW) will now display with `NOT VISIBLE`
annotations on SHOW CREATE TABLE.