### PR TITLE
*: configure the use of separated intents in a cluster

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -100,6 +100,6 @@
 <tr><td><code>trace.debug.enable</code></td><td>boolean</td><td><code>false</code></td><td>if set, traces for recent requests can be seen at https://<ui>/debug/requests</td></tr>
 <tr><td><code>trace.lightstep.token</code></td><td>string</td><td><code></code></td><td>if set, traces go to Lightstep using this token</td></tr>
 <tr><td><code>trace.zipkin.collector</code></td><td>string</td><td><code></code></td><td>if set, traces go to the given Zipkin instance (example: '127.0.0.1:9411'); ignored if trace.lightstep.token is set</td></tr>
-<tr><td><code>version</code></td><td>version</td><td><code>20.2-24</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
+<tr><td><code>version</code></td><td>version</td><td><code>20.2-26</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
 </tbody>
 </table>

--- a/pkg/ccl/storageccl/import_test.go
+++ b/pkg/ccl/storageccl/import_test.go
@@ -70,7 +70,7 @@ func slurpSSTablesLatestKey(
 ) []storage.MVCCKeyValue {
 	start, end := storage.MVCCKey{Key: keys.LocalMax}, storage.MVCCKey{Key: keys.MaxKey}
 
-	e := storage.NewDefaultInMem()
+	e := storage.NewDefaultInMemForTesting()
 	defer e.Close()
 	batch := e.NewBatch()
 	defer batch.Close()

--- a/pkg/ccl/storageccl/writebatch_test.go
+++ b/pkg/ccl/storageccl/writebatch_test.go
@@ -111,7 +111,7 @@ func TestWriteBatchMVCCStats(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	e := storage.NewDefaultInMem()
+	e := storage.NewDefaultInMemForTesting()
 	defer e.Close()
 
 	var batch storage.RocksDBBatchBuilder

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_test.go
@@ -181,7 +181,7 @@ func assertEqualKVs(
 	var prevKey roachpb.Key
 	var valueTimestampTuples []roachpb.KeyValue
 	var err error
-	for it.SeekGE(storage.MVCCKey{}); ; it.Next() {
+	for it.SeekGE(storage.MVCCKey{Key: key}); ; it.Next() {
 		if ok, err := it.Valid(); !ok {
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -235,6 +235,8 @@ const (
 	// using the replicated legacy TruncatedState. It's also used in asserting
 	// that no replicated truncated state representation is found.
 	PostTruncatedAndRangeAppliedStateMigration
+	// SeparatedIntents allows the writing of separated intents/locks.
+	SeparatedIntents
 
 	// Step (1): Add new versions here.
 )
@@ -388,6 +390,10 @@ var versionsSingleton = keyedVersions([]keyedVersion{
 	{
 		Key:     PostTruncatedAndRangeAppliedStateMigration,
 		Version: roachpb.Version{Major: 20, Minor: 2, Internal: 24},
+	},
+	{
+		Key:     SeparatedIntents,
+		Version: roachpb.Version{Major: 20, Minor: 2, Internal: 26},
 	},
 	// Step (2): Add new versions here.
 })

--- a/pkg/clusterversion/key_string.go
+++ b/pkg/clusterversion/key_string.go
@@ -40,11 +40,12 @@ func _() {
 	_ = x[LongRunningMigrations-29]
 	_ = x[TruncatedAndRangeAppliedStateMigration-30]
 	_ = x[PostTruncatedAndRangeAppliedStateMigration-31]
+	_ = x[SeparatedIntents-32]
 }
 
-const _Key_name = "NamespaceTableWithSchemasStart20_2GeospatialTypeEnumsRangefeedLeasesAlterColumnTypeGeneralAlterSystemJobsAddCreatedByColumnsAddScheduledJobsTableUserDefinedSchemasNoOriginFKIndexesNodeMembershipStatusMinPasswordLengthAbortSpanBytesAlterSystemJobsAddSqllivenessColumnsAddNewSystemSqllivenessTableMaterializedViewsBox2DTypeUpdateScheduledJobsSchemaCreateLoginPrivilegeHBAForNonTLSV20_2Start21_1EmptyArraysInInvertedIndexesUniqueWithoutIndexConstraintsVirtualComputedColumnsCPutInlineReplicaVersionsreplacedTruncatedAndRangeAppliedStateMigrationreplacedPostTruncatedAndRangeAppliedStateMigrationNewSchemaChangerLongRunningMigrationsTruncatedAndRangeAppliedStateMigrationPostTruncatedAndRangeAppliedStateMigration"
+const _Key_name = "NamespaceTableWithSchemasStart20_2GeospatialTypeEnumsRangefeedLeasesAlterColumnTypeGeneralAlterSystemJobsAddCreatedByColumnsAddScheduledJobsTableUserDefinedSchemasNoOriginFKIndexesNodeMembershipStatusMinPasswordLengthAbortSpanBytesAlterSystemJobsAddSqllivenessColumnsAddNewSystemSqllivenessTableMaterializedViewsBox2DTypeUpdateScheduledJobsSchemaCreateLoginPrivilegeHBAForNonTLSV20_2Start21_1EmptyArraysInInvertedIndexesUniqueWithoutIndexConstraintsVirtualComputedColumnsCPutInlineReplicaVersionsreplacedTruncatedAndRangeAppliedStateMigrationreplacedPostTruncatedAndRangeAppliedStateMigrationNewSchemaChangerLongRunningMigrationsTruncatedAndRangeAppliedStateMigrationPostTruncatedAndRangeAppliedStateMigrationSeparatedIntents"
 
-var _Key_index = [...]uint16{0, 25, 34, 48, 53, 68, 90, 124, 145, 163, 180, 200, 217, 231, 295, 312, 321, 346, 366, 378, 383, 392, 420, 449, 471, 481, 496, 542, 592, 608, 629, 667, 709}
+var _Key_index = [...]uint16{0, 25, 34, 48, 53, 68, 90, 124, 145, 163, 180, 200, 217, 231, 295, 312, 321, 346, 366, 378, 383, 392, 420, 449, 471, 481, 496, 542, 592, 608, 629, 667, 709, 725}
 
 func (i Key) String() string {
 	if i < 0 || i >= Key(len(_Key_index)-1) {

--- a/pkg/kv/kvserver/abortspan/abortspan_test.go
+++ b/pkg/kv/kvserver/abortspan/abortspan_test.go
@@ -45,7 +45,7 @@ var (
 func createTestAbortSpan(
 	t *testing.T, rangeID roachpb.RangeID, stopper *stop.Stopper,
 ) (*AbortSpan, storage.Engine) {
-	eng := storage.NewDefaultInMem()
+	eng := storage.NewDefaultInMemForTesting()
 	stopper.AddCloser(eng)
 	return New(rangeID), eng
 }

--- a/pkg/kv/kvserver/batch_spanset_test.go
+++ b/pkg/kv/kvserver/batch_spanset_test.go
@@ -30,7 +30,7 @@ import (
 func TestSpanSetBatchBoundaries(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	eng := storage.NewDefaultInMem()
+	eng := storage.NewDefaultInMemForTesting()
 	defer eng.Close()
 
 	var ss spanset.SpanSet
@@ -269,7 +269,7 @@ func TestSpanSetBatchBoundaries(t *testing.T) {
 func TestSpanSetBatchTimestamps(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	eng := storage.NewDefaultInMem()
+	eng := storage.NewDefaultInMemForTesting()
 	defer eng.Close()
 
 	var ss spanset.SpanSet
@@ -375,7 +375,7 @@ func TestSpanSetBatchTimestamps(t *testing.T) {
 func TestSpanSetIteratorTimestamps(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	eng := storage.NewDefaultInMem()
+	eng := storage.NewDefaultInMemForTesting()
 	defer eng.Close()
 
 	var ss spanset.SpanSet
@@ -469,7 +469,7 @@ func TestSpanSetIteratorTimestamps(t *testing.T) {
 func TestSpanSetNonMVCCBatch(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	eng := storage.NewDefaultInMem()
+	eng := storage.NewDefaultInMemForTesting()
 	defer eng.Close()
 
 	var ss spanset.SpanSet
@@ -518,7 +518,7 @@ func TestSpanSetNonMVCCBatch(t *testing.T) {
 func TestSpanSetMVCCResolveWriteIntentRangeUsingIter(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	eng := storage.NewDefaultInMem()
+	eng := storage.NewDefaultInMemForTesting()
 	defer eng.Close()
 
 	ctx := context.Background()

--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
@@ -39,7 +39,7 @@ import (
 
 // createTestPebbleEngine returns a new in-memory Pebble storage engine.
 func createTestPebbleEngine() storage.Engine {
-	return storage.NewInMem(context.Background(), roachpb.Attributes{}, 1<<20)
+	return storage.NewInMemForTesting(context.Background(), roachpb.Attributes{}, 1<<20)
 }
 
 var engineImpls = []struct {

--- a/pkg/kv/kvserver/batcheval/cmd_clear_range_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_clear_range_test.go
@@ -89,7 +89,7 @@ func TestCmdClearRangeBytesThreshold(t *testing.T) {
 	for _, test := range tests {
 		t.Run("", func(t *testing.T) {
 			ctx := context.Background()
-			eng := storage.NewDefaultInMem()
+			eng := storage.NewDefaultInMemForTesting()
 			defer eng.Close()
 
 			var stats enginepb.MVCCStats
@@ -155,7 +155,7 @@ func TestCmdClearRangeDeadline(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
-	eng := storage.NewDefaultInMem()
+	eng := storage.NewDefaultInMemForTesting()
 	defer eng.Close()
 
 	var stats enginepb.MVCCStats

--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction_test.go
@@ -872,7 +872,7 @@ func TestEndTxnUpdatesTransactionRecord(t *testing.T) {
 	}
 	for _, c := range testCases {
 		t.Run(c.name, func(t *testing.T) {
-			db := storage.NewDefaultInMem()
+			db := storage.NewDefaultInMemForTesting()
 			defer db.Close()
 			batch := db.NewBatch()
 			defer batch.Close()
@@ -974,7 +974,7 @@ func TestPartialRollbackOnEndTransaction(t *testing.T) {
 	defer TestingSetTxnAutoGC(false)()
 
 	testutils.RunTrueAndFalse(t, "withStoredTxnRecord", func(t *testing.T, storeTxnBeforeEndTxn bool) {
-		db := storage.NewDefaultInMem()
+		db := storage.NewDefaultInMemForTesting()
 		defer db.Close()
 		batch := db.NewBatch()
 		defer batch.Close()

--- a/pkg/kv/kvserver/batcheval/cmd_lease_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_lease_test.go
@@ -172,7 +172,7 @@ func TestLeaseTransferForwardsStartTime(t *testing.T) {
 
 	testutils.RunTrueAndFalse(t, "epoch", func(t *testing.T, epoch bool) {
 		ctx := context.Background()
-		db := storage.NewDefaultInMem()
+		db := storage.NewDefaultInMemForTesting()
 		defer db.Close()
 		batch := db.NewBatch()
 		defer batch.Close()

--- a/pkg/kv/kvserver/batcheval/cmd_recover_txn_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_recover_txn_test.go
@@ -42,7 +42,7 @@ func TestRecoverTxn(t *testing.T) {
 	txn.InFlightWrites = []roachpb.SequencedWrite{{Key: k2, Sequence: 0}}
 
 	testutils.RunTrueAndFalse(t, "missing write", func(t *testing.T, missingWrite bool) {
-		db := storage.NewDefaultInMem()
+		db := storage.NewDefaultInMemForTesting()
 		defer db.Close()
 
 		// Write the transaction record.
@@ -194,7 +194,7 @@ func TestRecoverTxnRecordChanged(t *testing.T) {
 	}
 	for _, c := range testCases {
 		t.Run(c.name, func(t *testing.T) {
-			db := storage.NewDefaultInMem()
+			db := storage.NewDefaultInMemForTesting()
 			defer db.Close()
 
 			// Write the modified transaction record, simulating a concurrent

--- a/pkg/kv/kvserver/batcheval/cmd_refresh_range_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_refresh_range_test.go
@@ -54,7 +54,7 @@ func TestRefreshRangeTimeBoundIterator(t *testing.T) {
 	ts3 := hlc.Timestamp{WallTime: 3}
 	ts4 := hlc.Timestamp{WallTime: 4}
 
-	db := storage.NewDefaultInMem()
+	db := storage.NewDefaultInMemForTesting()
 	defer db.Close()
 
 	// Create an sstable containing an unresolved intent.

--- a/pkg/kv/kvserver/batcheval/cmd_resolve_intent_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_resolve_intent_test.go
@@ -75,7 +75,7 @@ func TestDeclareKeysResolveIntent(t *testing.T) {
 		},
 	}
 	ctx := context.Background()
-	engine := storage.NewDefaultInMem()
+	engine := storage.NewDefaultInMemForTesting()
 	defer engine.Close()
 	testutils.RunTrueAndFalse(t, "ranged", func(t *testing.T, ranged bool) {
 		for _, test := range tests {
@@ -153,7 +153,7 @@ func TestResolveIntentAfterPartialRollback(t *testing.T) {
 	}
 
 	testutils.RunTrueAndFalse(t, "ranged", func(t *testing.T, ranged bool) {
-		db := storage.NewDefaultInMem()
+		db := storage.NewDefaultInMemForTesting()
 		defer db.Close()
 		batch := db.NewBatch()
 		defer batch.Close()

--- a/pkg/kv/kvserver/batcheval/cmd_revert_range_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_revert_range_test.go
@@ -55,12 +55,12 @@ func getStats(t *testing.T, reader storage.Reader) enginepb.MVCCStats {
 // createTestRocksDBEngine returns a new in-memory RocksDB engine with 1MB of
 // storage capacity.
 func createTestRocksDBEngine(ctx context.Context) storage.Engine {
-	return storage.NewInMem(ctx, roachpb.Attributes{}, 1<<20)
+	return storage.NewInMemForTesting(ctx, roachpb.Attributes{}, 1<<20)
 }
 
 // createTestPebbleEngine returns a new in-memory Pebble storage engine.
 func createTestPebbleEngine(ctx context.Context) storage.Engine {
-	return storage.NewInMem(ctx, roachpb.Attributes{}, 1<<20)
+	return storage.NewInMemForTesting(ctx, roachpb.Attributes{}, 1<<20)
 }
 
 var engineImpls = []struct {

--- a/pkg/kv/kvserver/batcheval/cmd_scan_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_scan_test.go
@@ -58,7 +58,7 @@ func testScanReverseScanInner(
 	k1, k2 := roachpb.Key("a"), roachpb.Key("b")
 	ts := hlc.Timestamp{WallTime: 1}
 
-	eng := storage.NewDefaultInMem()
+	eng := storage.NewDefaultInMemForTesting()
 	defer eng.Close()
 
 	// Write to k1 and k2.

--- a/pkg/kv/kvserver/batcheval/cmd_truncate_log_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_truncate_log_test.go
@@ -126,7 +126,7 @@ func runUnreplicatedTruncatedState(t *testing.T, tc unreplicatedTruncStateTest) 
 		FirstIndex: firstIndex,
 	}
 
-	eng := storage.NewDefaultInMem()
+	eng := storage.NewDefaultInMemForTesting()
 	defer eng.Close()
 
 	truncState := roachpb.RaftTruncatedState{

--- a/pkg/kv/kvserver/batcheval/intent_test.go
+++ b/pkg/kv/kvserver/batcheval/intent_test.go
@@ -119,7 +119,7 @@ func TestCollectIntentsUsesSameIterator(t *testing.T) {
 			// the request should ignore the intent and should not return any
 			// corresponding intent row.
 			testutils.RunTrueAndFalse(t, "deletion intent", func(t *testing.T, delete bool) {
-				db := &instrumentedEngine{Engine: storage.NewDefaultInMem()}
+				db := &instrumentedEngine{Engine: storage.NewDefaultInMemForTesting()}
 				defer db.Close()
 
 				// Write an intent.

--- a/pkg/kv/kvserver/batcheval/transaction_test.go
+++ b/pkg/kv/kvserver/batcheval/transaction_test.go
@@ -730,7 +730,7 @@ func TestUpdateAbortSpan(t *testing.T) {
 				skip.IgnoreLint(t, "invalid test case")
 			}
 
-			db := storage.NewDefaultInMem()
+			db := storage.NewDefaultInMemForTesting()
 			defer db.Close()
 			batch := db.NewBatch()
 			defer batch.Close()

--- a/pkg/kv/kvserver/client_test.go
+++ b/pkg/kv/kvserver/client_test.go
@@ -122,7 +122,7 @@ func createTestStoreWithOpts(
 	}
 	eng := opts.eng
 	if eng == nil {
-		eng = storage.NewDefaultInMem()
+		eng = storage.NewDefaultInMemForTesting()
 		stopper.AddCloser(eng)
 	}
 
@@ -832,7 +832,7 @@ func (m *multiTestContext) addStore(idx int) {
 	} else {
 		engineStopper := stop.NewStopper()
 		m.engineStoppers = append(m.engineStoppers, engineStopper)
-		eng = storage.NewDefaultInMem()
+		eng = storage.NewDefaultInMemForTesting()
 		engineStopper.AddCloser(eng)
 		m.engines = append(m.engines, eng)
 		needBootstrap = true

--- a/pkg/kv/kvserver/gc/gc_iterator_test.go
+++ b/pkg/kv/kvserver/gc/gc_iterator_test.go
@@ -122,7 +122,7 @@ func TestGCIterator(t *testing.T) {
 	}
 	makeTest := func(tc testCase) func(t *testing.T) {
 		return func(t *testing.T) {
-			eng := storage.NewDefaultInMem()
+			eng := storage.NewDefaultInMemForTesting()
 			defer eng.Close()
 			ds := makeLiteralDataDistribution(tc.data...)
 			ds.setupTest(t, eng, desc)

--- a/pkg/kv/kvserver/gc/gc_random_test.go
+++ b/pkg/kv/kvserver/gc/gc_random_test.go
@@ -87,7 +87,7 @@ func TestRunNewVsOld(t *testing.T) {
 		},
 	} {
 		t.Run(fmt.Sprintf("%v@%v,ttl=%v", tc.ds, tc.now, tc.ttl), func(t *testing.T) {
-			eng := storage.NewDefaultInMem()
+			eng := storage.NewDefaultInMemForTesting()
 			defer eng.Close()
 
 			tc.ds.dist(N, rng).setupTest(t, eng, *tc.ds.desc())
@@ -144,7 +144,7 @@ func BenchmarkRun(b *testing.B) {
 	}
 	makeTest := func(old bool, spec randomRunGCTestSpec) func(b *testing.B) {
 		return func(b *testing.B) {
-			eng := storage.NewDefaultInMem()
+			eng := storage.NewDefaultInMemForTesting()
 			defer eng.Close()
 			ms := spec.ds.dist(b.N, rng).setupTest(b, eng, *spec.ds.desc())
 			b.SetBytes(int64(float64(ms.Total()) / float64(b.N)))

--- a/pkg/kv/kvserver/gc_queue_test.go
+++ b/pkg/kv/kvserver/gc_queue_test.go
@@ -236,7 +236,7 @@ func (cws *cachedWriteSimulator) value(size int) roachpb.Value {
 func (cws *cachedWriteSimulator) multiKey(
 	numOps int, size int, txn *roachpb.Transaction, ms *enginepb.MVCCStats,
 ) {
-	eng := storage.NewDefaultInMem()
+	eng := storage.NewDefaultInMemForTesting()
 	defer eng.Close()
 	t, ctx := cws.t, context.Background()
 
@@ -254,7 +254,7 @@ func (cws *cachedWriteSimulator) multiKey(
 func (cws *cachedWriteSimulator) singleKeySteady(
 	qps int, duration time.Duration, size int, ms *enginepb.MVCCStats,
 ) {
-	eng := storage.NewDefaultInMem()
+	eng := storage.NewDefaultInMemForTesting()
 	defer eng.Close()
 	t, ctx := cws.t, context.Background()
 	cacheKey := fmt.Sprintf("%d-%s-%s", qps, duration, humanizeutil.IBytes(int64(size)))

--- a/pkg/kv/kvserver/rditer/replica_data_iter_test.go
+++ b/pkg/kv/kvserver/rditer/replica_data_iter_test.go
@@ -233,7 +233,7 @@ func verifyRDEngineIter(
 func TestReplicaDataIteratorEmptyRange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	eng := storage.NewDefaultInMem()
+	eng := storage.NewDefaultInMemForTesting()
 	defer eng.Close()
 
 	desc := &roachpb.RangeDescriptor{
@@ -255,7 +255,7 @@ func TestReplicaDataIteratorEmptyRange(t *testing.T) {
 func TestReplicaDataIterator(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	eng := storage.NewDefaultInMem()
+	eng := storage.NewDefaultInMemForTesting()
 	defer eng.Close()
 
 	descPre := roachpb.RangeDescriptor{

--- a/pkg/kv/kvserver/replica_evaluate_test.go
+++ b/pkg/kv/kvserver/replica_evaluate_test.go
@@ -603,7 +603,7 @@ func TestEvaluateBatch(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
-			eng := storage.NewDefaultInMem()
+			eng := storage.NewDefaultInMemForTesting()
 			defer eng.Close()
 
 			d := &data{

--- a/pkg/kv/kvserver/replica_raft_truncation_test.go
+++ b/pkg/kv/kvserver/replica_raft_truncation_test.go
@@ -46,7 +46,7 @@ func TestHandleTruncatedStateBelowRaft(t *testing.T) {
 	datadriven.Walk(t, "testdata/truncated_state_migration", func(t *testing.T, path string) {
 		const rangeID = 12
 		loader := stateloader.Make(rangeID)
-		eng := storage.NewDefaultInMem()
+		eng := storage.NewDefaultInMemForTesting()
 		defer eng.Close()
 
 		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {

--- a/pkg/kv/kvserver/replica_sideload_test.go
+++ b/pkg/kv/kvserver/replica_sideload_test.go
@@ -87,7 +87,7 @@ func TestSideloadingSideloadedStorage(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	t.Run("Mem", func(t *testing.T) {
-		eng := storage.NewDefaultInMem()
+		eng := storage.NewDefaultInMemForTesting()
 		defer eng.Close()
 		testSideloadingSideloadedStorage(t, eng)
 	})
@@ -419,7 +419,7 @@ func TestRaftSSTableSideloadingInline(t *testing.T) {
 			context.Background(), tracing.NewTracer(), "test-recording")
 		defer cancel()
 
-		eng := storage.NewDefaultInMem()
+		eng := storage.NewDefaultInMemForTesting()
 		defer eng.Close()
 		ss := newTestingSideloadStorage(t, eng)
 		ec := raftentry.NewCache(1024) // large enough
@@ -524,7 +524,7 @@ func TestRaftSSTableSideloadingSideload(t *testing.T) {
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			ctx := context.Background()
-			eng := storage.NewDefaultInMem()
+			eng := storage.NewDefaultInMemForTesting()
 			defer eng.Close()
 			sideloaded := newTestingSideloadStorage(t, eng)
 			postEnts, size, err := maybeSideloadEntriesImpl(ctx, test.preEnts, sideloaded)
@@ -561,7 +561,7 @@ func TestRaftSSTableSideloadingProposal(t *testing.T) {
 	testutils.RunTrueAndFalse(t, "InMem", func(t *testing.T, engineInMem bool) {
 		var eng storage.Engine
 		if engineInMem {
-			eng = storage.NewDefaultInMem()
+			eng = storage.NewDefaultInMemForTesting()
 		} else {
 			var cleanup func()
 			cleanup, eng = newOnDiskEngine(t)

--- a/pkg/kv/kvserver/spanset/batch.go
+++ b/pkg/kv/kvserver/spanset/batch.go
@@ -11,6 +11,8 @@
 package spanset
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
@@ -584,6 +586,7 @@ func (s spanSetWriter) PutUnversioned(key roachpb.Key, value []byte) error {
 }
 
 func (s spanSetWriter) PutIntent(
+	ctx context.Context,
 	key roachpb.Key,
 	value []byte,
 	state storage.PrecedingIntentState,
@@ -593,7 +596,7 @@ func (s spanSetWriter) PutIntent(
 	if err := s.checkAllowed(key); err != nil {
 		return 0, err
 	}
-	return s.w.PutIntent(key, value, state, txnDidNotUpdateMeta, txnUUID)
+	return s.w.PutIntent(ctx, key, value, state, txnDidNotUpdateMeta, txnUUID)
 }
 
 func (s spanSetWriter) PutEngineKey(key storage.EngineKey, value []byte) error {
@@ -604,6 +607,10 @@ func (s spanSetWriter) PutEngineKey(key storage.EngineKey, value []byte) error {
 		return err
 	}
 	return s.w.PutEngineKey(key, value)
+}
+
+func (s spanSetWriter) SafeToWriteSeparatedIntents(ctx context.Context) (bool, error) {
+	return s.w.SafeToWriteSeparatedIntents(ctx)
 }
 
 func (s spanSetWriter) LogData(data []byte) error {

--- a/pkg/kv/kvserver/stateloader/initial_test.go
+++ b/pkg/kv/kvserver/stateloader/initial_test.go
@@ -27,7 +27,7 @@ func TestSynthesizeHardState(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.Background())
-	eng := storage.NewDefaultInMem()
+	eng := storage.NewDefaultInMemForTesting()
 	stopper.AddCloser(eng)
 
 	tHS := raftpb.HardState{Term: 2, Vote: 3, Commit: 4}

--- a/pkg/kv/kvserver/store_pool_test.go
+++ b/pkg/kv/kvserver/store_pool_test.go
@@ -582,7 +582,7 @@ func TestStorePoolUpdateLocalStoreBeforeGossip(t *testing.T) {
 
 	// Create store.
 	node := roachpb.NodeDescriptor{NodeID: roachpb.NodeID(1)}
-	eng := storage.NewDefaultInMem()
+	eng := storage.NewDefaultInMemForTesting()
 	stopper.AddCloser(eng)
 	cfg := TestStoreConfig(clock)
 	cfg.Transport = NewDummyRaftTransport(cfg.Settings)

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -228,7 +228,7 @@ func createTestStoreWithoutStart(
 	// and merge queues separately to cover event-driven splits and merges.
 	cfg.TestingKnobs.DisableSplitQueue = true
 	cfg.TestingKnobs.DisableMergeQueue = true
-	eng := storage.NewDefaultInMem()
+	eng := storage.NewDefaultInMemForTesting()
 	stopper.AddCloser(eng)
 	cfg.Transport = NewDummyRaftTransport(cfg.Settings)
 	factory := &testSenderFactory{}
@@ -303,7 +303,7 @@ func TestIterateIDPrefixKeys(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
 
-	eng := storage.NewDefaultInMem()
+	eng := storage.NewDefaultInMemForTesting()
 	stopper.AddCloser(eng)
 
 	seed := randutil.NewPseudoSeed()
@@ -433,7 +433,7 @@ func TestStoreInitAndBootstrap(t *testing.T) {
 	stopper := stop.NewStopper()
 	ctx := context.Background()
 	defer stopper.Stop(ctx)
-	eng := storage.NewDefaultInMem()
+	eng := storage.NewDefaultInMemForTesting()
 	stopper.AddCloser(eng)
 	cfg.Transport = NewDummyRaftTransport(cfg.Settings)
 	factory := &testSenderFactory{}
@@ -509,7 +509,7 @@ func TestInitializeEngineErrors(t *testing.T) {
 	stopper := stop.NewStopper()
 	ctx := context.Background()
 	defer stopper.Stop(ctx)
-	eng := storage.NewDefaultInMem()
+	eng := storage.NewDefaultInMemForTesting()
 	stopper.AddCloser(eng)
 
 	// Bootstrap should fail if engine has no cluster version yet.
@@ -2822,7 +2822,7 @@ func (sp *fakeStorePool) throttle(reason throttleReason, why string, toStoreID r
 func TestSendSnapshotThrottling(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	e := storage.NewDefaultInMem()
+	e := storage.NewDefaultInMemForTesting()
 	defer e.Close()
 
 	ctx := context.Background()

--- a/pkg/kv/kvserver/stores_test.go
+++ b/pkg/kv/kvserver/stores_test.go
@@ -128,7 +128,7 @@ func TestStoresGetReplicaForRangeID(t *testing.T) {
 		rangeID := roachpb.RangeID(i)
 		replicaID := roachpb.ReplicaID(1)
 
-		memEngine := storage.NewDefaultInMem()
+		memEngine := storage.NewDefaultInMemForTesting()
 		stopper.AddCloser(memEngine)
 
 		cfg := TestStoreConfig(clock)
@@ -224,7 +224,7 @@ func createStores(count int, t *testing.T) (*hlc.ManualClock, []*Store, *Stores,
 	stores := []*Store{}
 	for i := 0; i < count; i++ {
 		cfg.Transport = NewDummyRaftTransport(cfg.Settings)
-		eng := storage.NewDefaultInMem()
+		eng := storage.NewDefaultInMemForTesting()
 		stopper.AddCloser(eng)
 		s := NewStore(context.Background(), cfg, eng, &roachpb.NodeDescriptor{NodeID: 1})
 		storeIDAlloc++
@@ -513,7 +513,7 @@ func TestStoresClusterVersionIncompatible(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			engs := []storage.Engine{storage.NewDefaultInMem()}
+			engs := []storage.Engine{storage.NewDefaultInMemForTesting()}
 			defer engs[0].Close()
 			// Configure versions and write.
 			cv := clusterversion.ClusterVersion{Version: tc.engV}

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -515,7 +515,7 @@ func (cfg *Config) CreateEngines(ctx context.Context) (Engines, error) {
 				}
 				engines = append(engines, e)
 			} else {
-				engines = append(engines, storage.NewInMem(ctx, spec.Attributes, sizeInBytes))
+				engines = append(engines, storage.NewInMem(ctx, spec.Attributes, sizeInBytes, cfg.Settings))
 			}
 		} else {
 			if spec.Size.Percent > 0 {

--- a/pkg/server/node_test.go
+++ b/pkg/server/node_test.go
@@ -59,7 +59,7 @@ func TestBootstrapCluster(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
-	e := storage.NewDefaultInMem()
+	e := storage.NewDefaultInMemForTesting()
 	defer e.Close()
 	require.NoError(t, kvserver.WriteClusterVersion(ctx, e, clusterversion.TestingClusterVersion))
 
@@ -242,7 +242,7 @@ func TestCorruptedClusterID(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	e := storage.NewDefaultInMem()
+	e := storage.NewDefaultInMemForTesting()
 	defer e.Close()
 
 	cv := clusterversion.TestingClusterVersion

--- a/pkg/server/node_tombstone_storage_test.go
+++ b/pkg/server/node_tombstone_storage_test.go
@@ -28,9 +28,9 @@ import (
 func TestNodeTombstoneStorage(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
-	eng1 := storage.NewDefaultInMem()
+	eng1 := storage.NewDefaultInMemForTesting()
 	defer eng1.Close()
-	eng2 := storage.NewDefaultInMem()
+	eng2 := storage.NewDefaultInMemForTesting()
 	defer eng2.Close()
 
 	engs := []storage.Engine{eng1, eng2}
@@ -98,7 +98,7 @@ func TestNodeTombstoneStorage(t *testing.T) {
 	require.Equal(t, time.Time{}, mustTime(s.IsDecommissioned(ctx, 3)))
 
 	// Throw an uninitialized engine in the mix. It should be skipped over.
-	eng3 := storage.NewDefaultInMem()
+	eng3 := storage.NewDefaultInMemForTesting()
 	defer eng3.Close()
 	s = &nodeTombstoneStorage{engs: []storage.Engine{eng1, eng2, eng3}}
 	// Decommission n100.

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -697,7 +697,7 @@ func TestClusterIDMismatch(t *testing.T) {
 
 	engines := make([]storage.Engine, 2)
 	for i := range engines {
-		e := storage.NewDefaultInMem()
+		e := storage.NewDefaultInMemForTesting()
 		defer e.Close()
 
 		sIdent := roachpb.StoreIdent{

--- a/pkg/server/settings_cache_test.go
+++ b/pkg/server/settings_cache_test.go
@@ -44,7 +44,7 @@ func TestCachedSettingsStoreAndLoad(t *testing.T) {
 	ctx := context.Background()
 	attrs := roachpb.Attributes{}
 	cacheSize := int64(1 << 20)
-	engine := storage.NewInMem(ctx, attrs, cacheSize)
+	engine := storage.NewInMemForTesting(ctx, attrs, cacheSize)
 	defer engine.Close()
 
 	require.NoError(t, storeCachedSettingsKVs(ctx, engine, testSettings))

--- a/pkg/server/sticky_engine.go
+++ b/pkg/server/sticky_engine.go
@@ -105,7 +105,12 @@ func (registry *stickyInMemEnginesRegistryImpl) GetOrCreateStickyInMemEngine(
 	engine := &stickyInMemEngine{
 		id:     spec.StickyInMemoryEngineID,
 		closed: false,
-		Engine: storage.NewInMem(ctx, spec.Attributes, spec.Size.InBytes),
+		// This engine will stay alive after the node dies, so we don't want the
+		// caller to pass in a *cluster.Settings from the current node. Just
+		// create a random one since that is what we like to do in tests (for
+		// better test coverage).
+		Engine: storage.NewInMem(
+			ctx, spec.Attributes, spec.Size.InBytes, storage.MakeRandomSettingsForSeparatedIntents()),
 	}
 	registry.entries[spec.StickyInMemoryEngineID] = engine
 	return engine, nil

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"math/rand"
 	"net"
 	"net/http"
 	"net/http/cookiejar"
@@ -131,6 +132,11 @@ func makeTestConfigFromParams(params base.TestServerArgs) Config {
 	st := params.Settings
 	if params.Settings == nil {
 		st = cluster.MakeClusterSettings()
+		enabledSeparated := rand.Intn(2) == 0
+		log.Infof(context.Background(),
+			"test Config is randomly setting enabledSeparated: %t",
+			enabledSeparated)
+		storage.SeparatedIntentsEnabled.Override(&st.SV, enabledSeparated)
 	}
 	st.ExternalIODir = params.ExternalIODir
 	cfg := makeTestConfig(st)

--- a/pkg/storage/BUILD.bazel
+++ b/pkg/storage/BUILD.bazel
@@ -74,6 +74,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/base",
+        "//pkg/clusterversion",
         "//pkg/keys",
         "//pkg/kv/kvserver/concurrency/lock",
         "//pkg/kv/kvserver/diskmap",

--- a/pkg/storage/bench_pebble_test.go
+++ b/pkg/storage/bench_pebble_test.go
@@ -40,6 +40,8 @@ func setupMVCCPebble(b testing.TB, dir string) Engine {
 		PebbleConfig{
 			StorageConfig: base.StorageConfig{
 				Dir: dir,
+				Settings: makeSettingsForSeparatedIntents(
+					false /* oldClusterVersion */, true /* enabled */),
 			},
 			Opts: opts,
 		})

--- a/pkg/storage/in_mem.go
+++ b/pkg/storage/in_mem.go
@@ -12,21 +12,67 @@ package storage
 
 import (
 	"context"
+	"math/rand"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
 // NewInMem allocates and returns a new, opened in-memory engine. The caller
 // must call the engine's Close method when the engine is no longer needed.
 //
 // FIXME(tschottdorf): make the signature similar to NewPebble (require a cfg).
-func NewInMem(ctx context.Context, attrs roachpb.Attributes, cacheSize int64) Engine {
-	return newPebbleInMem(ctx, attrs, cacheSize, nil /* settings */)
+func NewInMem(
+	ctx context.Context, attrs roachpb.Attributes, cacheSize int64, settings *cluster.Settings,
+) Engine {
+	return newPebbleInMem(ctx, attrs, cacheSize, settings)
 }
 
-// NewDefaultInMem allocates and returns a new, opened in-memory engine with
+// The ForTesting functions randomize the settings for separated intents. This
+// is a bit peculiar for tests outside the storage package, since they usually
+// have higher level cluster constructs, including creating a cluster.Settings
+// as part of the StoreConfig. We are ignoring what may be produced there, and
+// injecting a different cluster.Settings here. Plumbing that through for all
+// the different higher level testing constructs seems painful, and the only
+// places that actively change their behavior for separated intents will use
+// the cluster.Settings we inject here, which is used for no other purpose
+// other than configuring separated intents. So the fact that we have two
+// inconsistent cluster.Settings is harmless.
+
+// NewInMemForTesting allocates and returns a new, opened in-memory engine. The caller
+// must call the engine's Close method when the engine is no longer needed.
+func NewInMemForTesting(ctx context.Context, attrs roachpb.Attributes, cacheSize int64) Engine {
+	settings := MakeRandomSettingsForSeparatedIntents()
+	return newPebbleInMem(ctx, attrs, cacheSize, settings)
+}
+
+// NewDefaultInMemForTesting allocates and returns a new, opened in-memory engine with
 // the default configuration. The caller must call the engine's Close method
 // when the engine is no longer needed.
-func NewDefaultInMem() Engine {
-	return NewInMem(context.Background(), roachpb.Attributes{}, 1<<20)
+func NewDefaultInMemForTesting() Engine {
+	return NewInMemForTesting(context.Background(), roachpb.Attributes{}, 1<<20)
+}
+
+// MakeRandomSettingsForSeparatedIntents makes settings for which it randomly
+// picks whether the cluster understands separated intents, and if yes,
+// whether to write separated intents. Once made, these setting do not change.
+func MakeRandomSettingsForSeparatedIntents() *cluster.Settings {
+	oldClusterVersion := rand.Intn(2) == 0
+	enabledSeparated := rand.Intn(2) == 0
+	log.Infof(context.Background(),
+		"engine creation is randomly setting oldClusterVersion: %t, enabledSeparated: %t",
+		oldClusterVersion, enabledSeparated)
+	return makeSettingsForSeparatedIntents(oldClusterVersion, enabledSeparated)
+}
+
+func makeSettingsForSeparatedIntents(oldClusterVersion bool, enabled bool) *cluster.Settings {
+	version := clusterversion.ByKey(clusterversion.SeparatedIntents)
+	if oldClusterVersion {
+		version = clusterversion.ByKey(clusterversion.V20_2)
+	}
+	settings := cluster.MakeTestingClusterSettingsWithVersions(version, version, true)
+	SeparatedIntentsEnabled.Override(&settings.SV, enabled)
+	return settings
 }

--- a/pkg/storage/mvcc_incremental_iterator_test.go
+++ b/pkg/storage/mvcc_incremental_iterator_test.go
@@ -752,7 +752,7 @@ func TestMVCCIncrementalIteratorIntentDeletion(t *testing.T) {
 	txnB1 := txn(kB, ts1)
 	txnC1 := txn(kC, ts1)
 
-	db := NewInMem(ctx, roachpb.Attributes{}, 10<<20)
+	db := createTestPebbleEngine()
 	defer db.Close()
 
 	// Set up two sstables very specifically:
@@ -825,7 +825,7 @@ func TestMVCCIncrementalIteratorIntentStraddlesSStables(t *testing.T) {
 	// regular MVCCPut operation to generate these keys, which we'll later be
 	// copying into manually created sstables.
 	ctx := context.Background()
-	db1 := NewInMem(ctx, roachpb.Attributes{}, 10<<20)
+	db1 := NewInMemForTesting(ctx, roachpb.Attributes{}, 10<<20)
 	defer db1.Close()
 
 	put := func(key, value string, ts int64, txn *roachpb.Transaction) {
@@ -860,7 +860,7 @@ func TestMVCCIncrementalIteratorIntentStraddlesSStables(t *testing.T) {
 	//
 	//   SSTable 2:
 	//     b@2
-	db2 := NewInMem(ctx, roachpb.Attributes{}, 10<<20)
+	db2 := NewInMemForTesting(ctx, roachpb.Attributes{}, 10<<20)
 	defer db2.Close()
 
 	// NB: If the original intent was separated, iterating using an interleaving

--- a/pkg/storage/mvcc_stats_test.go
+++ b/pkg/storage/mvcc_stats_test.go
@@ -76,6 +76,12 @@ func assertEqLocal(t *testing.T, rw ReadWriter, debug string, ms, expMS *enginep
 	assertEqImpl(t, rw, debug, false /* globalKeys */, ms, expMS)
 }
 
+func accountForTxnDidNotUpdateMeta(t *testing.T, eng Engine) bool {
+	accountFor, err := eng.SafeToWriteSeparatedIntents(context.Background())
+	require.NoError(t, err)
+	return accountFor
+}
+
 // TestMVCCStatsDeleteCommitMovesTimestamp exercises the case in which a value
 // is written, later deleted via an intent and the deletion committed at an even
 // higher timestamp. This exercises subtleties related to the implicit push of
@@ -191,10 +197,10 @@ func TestMVCCStatsPutCommitMovesTimestamp(t *testing.T) {
 				Txn:       &txn.TxnMeta,
 			}).Size())
 			var separatedIntentCount int64
-			if !DisallowSeparatedIntents {
+			if accountForTxnDidNotUpdateMeta(t, engine) {
 				// Account for TxnDidNotUpdateMeta
 				mValSize += 2
-				if EnabledSeparatedIntents {
+				if engine.IsSeparatedIntentsEnabledForTesting() {
 					separatedIntentCount = 1
 				}
 			}
@@ -280,10 +286,10 @@ func TestMVCCStatsPutPushMovesTimestamp(t *testing.T) {
 				Txn:       &txn.TxnMeta,
 			}).Size())
 			var separatedIntentCount int64
-			if !DisallowSeparatedIntents {
+			if accountForTxnDidNotUpdateMeta(t, engine) {
 				// Account for TxnDidNotUpdateMeta
 				mValSize += 2
-				if EnabledSeparatedIntents {
+				if engine.IsSeparatedIntentsEnabledForTesting() {
 					separatedIntentCount = 1
 				}
 			}
@@ -314,7 +320,7 @@ func TestMVCCStatsPutPushMovesTimestamp(t *testing.T) {
 			); err != nil {
 				t.Fatal(err)
 			}
-			if !DisallowSeparatedIntents {
+			if accountForTxnDidNotUpdateMeta(t, engine) {
 				// Account for removal of TxnDidNotUpdateMeta
 				mValSize -= 2
 			}
@@ -382,10 +388,10 @@ func TestMVCCStatsDeleteMovesTimestamp(t *testing.T) {
 			}).Size())
 			require.EqualValues(t, mVal1Size, 46)
 			var separatedIntentCount int64
-			if !DisallowSeparatedIntents {
+			if accountForTxnDidNotUpdateMeta(t, engine) {
 				// Account for TxnDidNotUpdateMeta
 				mVal1Size += 2
-				if EnabledSeparatedIntents {
+				if engine.IsSeparatedIntentsEnabledForTesting() {
 					separatedIntentCount = 1
 				}
 			}
@@ -398,7 +404,7 @@ func TestMVCCStatsDeleteMovesTimestamp(t *testing.T) {
 				Txn:       &txn.TxnMeta,
 			}).Size())
 			require.EqualValues(t, m1ValSize, 46)
-			if !DisallowSeparatedIntents {
+			if accountForTxnDidNotUpdateMeta(t, engine) {
 				// Account for TxnDidNotUpdateMeta
 				m1ValSize += 2
 			}
@@ -512,10 +518,10 @@ func TestMVCCStatsPutMovesDeletionTimestamp(t *testing.T) {
 			}).Size())
 			require.EqualValues(t, mVal1Size, 46)
 			var separatedIntentCount int64
-			if !DisallowSeparatedIntents {
+			if accountForTxnDidNotUpdateMeta(t, engine) {
 				// Account for TxnDidNotUpdateMeta
 				mVal1Size += 2
-				if EnabledSeparatedIntents {
+				if engine.IsSeparatedIntentsEnabledForTesting() {
 					separatedIntentCount = 1
 				}
 			}
@@ -648,10 +654,10 @@ func TestMVCCStatsDelDelCommitMovesTimestamp(t *testing.T) {
 			}).Size())
 			require.EqualValues(t, mValSize, 46)
 			var separatedIntentCount int64
-			if !DisallowSeparatedIntents {
+			if accountForTxnDidNotUpdateMeta(t, engine) {
 				// Account for TxnDidNotUpdateMeta
 				mValSize += 2
-				if EnabledSeparatedIntents {
+				if engine.IsSeparatedIntentsEnabledForTesting() {
 					separatedIntentCount = 1
 				}
 			}
@@ -804,10 +810,10 @@ func TestMVCCStatsPutDelPutMovesTimestamp(t *testing.T) {
 			}).Size())
 			require.EqualValues(t, mValSize, 46)
 			var separatedIntentCount int64
-			if !DisallowSeparatedIntents {
+			if accountForTxnDidNotUpdateMeta(t, engine) {
 				// Account for TxnDidNotUpdateMeta
 				mValSize += 2
-				if EnabledSeparatedIntents {
+				if engine.IsSeparatedIntentsEnabledForTesting() {
 					separatedIntentCount = 1
 				}
 			}
@@ -1031,10 +1037,10 @@ func TestMVCCStatsPutIntentTimestampNotPutTimestamp(t *testing.T) {
 				Txn:       &txn.TxnMeta,
 			}).Size())
 			var separatedIntentCount int64
-			if !DisallowSeparatedIntents {
+			if accountForTxnDidNotUpdateMeta(t, engine) {
 				// Account for TxnDidNotUpdateMeta
 				m1ValSize += 2
-				if EnabledSeparatedIntents {
+				if engine.IsSeparatedIntentsEnabledForTesting() {
 					separatedIntentCount = 1
 				}
 			}
@@ -1227,7 +1233,7 @@ func TestMVCCStatsTxnSysPutPut(t *testing.T) {
 				Txn:       &txn.TxnMeta,
 			}).Size())
 			require.EqualValues(t, mValSize, 46)
-			if !DisallowSeparatedIntents {
+			if accountForTxnDidNotUpdateMeta(t, engine) {
 				// Account for TxnDidNotUpdateMeta
 				mValSize += 2
 			}
@@ -1320,7 +1326,7 @@ func TestMVCCStatsTxnSysPutAbort(t *testing.T) {
 				Txn:       &txn.TxnMeta,
 			}).Size())
 			require.EqualValues(t, mValSize, 46)
-			if !DisallowSeparatedIntents {
+			if accountForTxnDidNotUpdateMeta(t, engine) {
 				// Account for TxnDidNotUpdateMeta
 				mValSize += 2
 			}

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -405,6 +405,8 @@ func (l pebbleLogger) Fatalf(format string, args ...interface{}) {
 // a new Pebble instance.
 type PebbleConfig struct {
 	// StorageConfig contains storage configs for all storage engines.
+	// A non-nil cluster.Settings must be provided in the StorageConfig for a
+	// Pebble instance that will be used to write intents.
 	base.StorageConfig
 	// Pebble specific options.
 	Opts *pebble.Options
@@ -428,11 +430,13 @@ type EncryptionStatsHandler interface {
 type Pebble struct {
 	db *pebble.DB
 
-	closed        bool
-	path          string
-	auxDir        string
-	maxSize       int64
-	attrs         roachpb.Attributes
+	closed  bool
+	path    string
+	auxDir  string
+	maxSize int64
+	attrs   roachpb.Attributes
+	// settings must be non-nil if this Pebble instance will be used to write
+	// intents.
 	settings      *cluster.Settings
 	statsHandler  EncryptionStatsHandler
 	fileRegistry  *PebbleFileRegistry
@@ -446,8 +450,7 @@ type Pebble struct {
 	fs     vfs.FS
 	logger pebble.Logger
 
-	useWrappedIntentWriter bool
-	wrappedIntentWriter    intentDemuxWriter
+	wrappedIntentWriter intentDemuxWriter
 }
 
 var _ Engine = &Pebble{}
@@ -547,7 +550,7 @@ func NewPebble(ctx context.Context, cfg PebbleConfig) (*Pebble, error) {
 	}
 	p.connectEventMetrics(ctx, &cfg.Opts.EventListener)
 	p.eventListener = &cfg.Opts.EventListener
-	p.wrappedIntentWriter, p.useWrappedIntentWriter = tryWrapIntentWriter(p)
+	p.wrappedIntentWriter = wrapIntentWriter(ctx, p, cfg.Settings, true /* isLongLived */)
 
 	db, err := pebble.Open(cfg.StorageConfig.Dir, cfg.Opts)
 	if err != nil {
@@ -763,12 +766,9 @@ func (p *Pebble) ClearUnversioned(key roachpb.Key) error {
 func (p *Pebble) ClearIntent(
 	key roachpb.Key, state PrecedingIntentState, txnDidNotUpdateMeta bool, txnUUID uuid.UUID,
 ) (int, error) {
-	if p.useWrappedIntentWriter {
-		_, separatedIntentCountDelta, err :=
-			p.wrappedIntentWriter.ClearIntent(key, state, txnDidNotUpdateMeta, txnUUID, nil)
-		return separatedIntentCountDelta, err
-	}
-	return 0, p.clear(MVCCKey{Key: key})
+	_, separatedIntentCountDelta, err :=
+		p.wrappedIntentWriter.ClearIntent(key, state, txnDidNotUpdateMeta, txnUUID, nil)
+	return separatedIntentCountDelta, err
 }
 
 // ClearEngineKey implements the Engine interface.
@@ -801,11 +801,9 @@ func (p *Pebble) ClearRawRange(start, end roachpb.Key) error {
 
 // ClearMVCCRangeAndIntents implements the Engine interface.
 func (p *Pebble) ClearMVCCRangeAndIntents(start, end roachpb.Key) error {
-	if p.useWrappedIntentWriter {
-		_, err := p.wrappedIntentWriter.ClearMVCCRangeAndIntents(start, end, nil)
-		return err
-	}
-	return p.clearRange(MVCCKey{Key: start}, MVCCKey{Key: end})
+	_, err := p.wrappedIntentWriter.ClearMVCCRangeAndIntents(start, end, nil)
+	return err
+
 }
 
 // ClearMVCCRange implements the Engine interface.
@@ -854,18 +852,17 @@ func (p *Pebble) PutUnversioned(key roachpb.Key, value []byte) error {
 
 // PutIntent implements the Engine interface.
 func (p *Pebble) PutIntent(
+	ctx context.Context,
 	key roachpb.Key,
 	value []byte,
 	state PrecedingIntentState,
 	txnDidNotUpdateMeta bool,
 	txnUUID uuid.UUID,
 ) (int, error) {
-	if p.useWrappedIntentWriter {
-		_, separatedIntentCountDelta, err :=
-			p.wrappedIntentWriter.PutIntent(key, value, state, txnDidNotUpdateMeta, txnUUID, nil)
-		return separatedIntentCountDelta, err
-	}
-	return 0, p.put(MVCCKey{Key: key}, value)
+
+	_, separatedIntentCountDelta, err :=
+		p.wrappedIntentWriter.PutIntent(ctx, key, value, state, txnDidNotUpdateMeta, txnUUID, nil)
+	return separatedIntentCountDelta, err
 }
 
 // PutEngineKey implements the Engine interface.
@@ -874,6 +871,18 @@ func (p *Pebble) PutEngineKey(key EngineKey, value []byte) error {
 		return emptyKeyError()
 	}
 	return p.db.Set(key.Encode(), value, pebble.Sync)
+}
+
+// SafeToWriteSeparatedIntents implements the Engine interface.
+func (p *Pebble) SafeToWriteSeparatedIntents(ctx context.Context) (bool, error) {
+	// This is not fast. Pebble should not be used by writers that want
+	// performance. They should use pebbleBatch.
+	return p.wrappedIntentWriter.safeToWriteSeparatedIntents(ctx)
+}
+
+// IsSeparatedIntentsEnabledForTesting implements the Engine interface.
+func (p *Pebble) IsSeparatedIntentsEnabledForTesting() bool {
+	return SeparatedIntentsEnabled.Get(&p.settings.SV)
 }
 
 func (p *Pebble) put(key MVCCKey, value []byte) error {
@@ -1039,7 +1048,7 @@ func (p *Pebble) GetAuxiliaryDir() string {
 
 // NewBatch implements the Engine interface.
 func (p *Pebble) NewBatch() Batch {
-	return newPebbleBatch(p.db, p.db.NewIndexedBatch(), false /* writeOnly */)
+	return newPebbleBatch(p.db, p.db.NewIndexedBatch(), false /* writeOnly */, p.settings)
 }
 
 // NewReadOnly implements the Engine interface.
@@ -1051,7 +1060,7 @@ func (p *Pebble) NewReadOnly() ReadWriter {
 
 // NewUnindexedBatch implements the Engine interface.
 func (p *Pebble) NewUnindexedBatch(writeOnly bool) Batch {
-	return newPebbleBatch(p.db, p.db.NewBatch(), writeOnly)
+	return newPebbleBatch(p.db, p.db.NewBatch(), writeOnly, p.settings)
 }
 
 // NewSnapshot implements the Engine interface.
@@ -1435,6 +1444,7 @@ func (p *pebbleReadOnly) PutUnversioned(key roachpb.Key, value []byte) error {
 }
 
 func (p *pebbleReadOnly) PutIntent(
+	ctx context.Context,
 	key roachpb.Key,
 	value []byte,
 	state PrecedingIntentState,
@@ -1445,6 +1455,10 @@ func (p *pebbleReadOnly) PutIntent(
 }
 
 func (p *pebbleReadOnly) PutEngineKey(key EngineKey, value []byte) error {
+	panic("not implemented")
+}
+
+func (p *pebbleReadOnly) SafeToWriteSeparatedIntents(context.Context) (bool, error) {
 	panic("not implemented")
 }
 

--- a/pkg/storage/sst_writer.go
+++ b/pkg/storage/sst_writer.go
@@ -12,6 +12,7 @@ package storage
 
 import (
 	"bytes"
+	"context"
 	"io"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -142,6 +143,7 @@ func (fw *SSTWriter) PutUnversioned(key roachpb.Key, value []byte) error {
 // (according to the comparator configured during writer creation). `Close`
 // cannot have been called.
 func (fw *SSTWriter) PutIntent(
+	ctx context.Context,
 	key roachpb.Key,
 	value []byte,
 	state PrecedingIntentState,
@@ -162,6 +164,11 @@ func (fw *SSTWriter) PutEngineKey(key EngineKey, value []byte) error {
 	fw.DataSize += int64(len(key.Key)) + int64(len(value))
 	fw.scratch = key.EncodeToBuf(fw.scratch[:0])
 	return fw.fw.Set(fw.scratch, value)
+}
+
+// SafeToWriteSeparatedIntents implements the Writer interface.
+func (fw *SSTWriter) SafeToWriteSeparatedIntents(context.Context) (bool, error) {
+	return false, errors.Errorf("SSTWriter does not support SafeToWriteSeparatedIntents")
 }
 
 // put puts a kv entry into the sstable being built. An error is returned if it

--- a/pkg/storage/testdata/mvcc_histories/conditional_put_with_txn_allow_separated
+++ b/pkg/storage/testdata/mvcc_histories/conditional_put_with_txn_allow_separated
@@ -2,7 +2,7 @@ run ok
 txn_begin t=A ts=123
 ----
 >> at end:
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=123.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=123.000000000,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=123.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=123.000000000,0 wto=false gul=0,0
 
 # Write value1.
 
@@ -12,7 +12,7 @@ with t=A
   cput k=k v=v
 ----
 >> at end:
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=123.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=123.000000000,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=123.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=123.000000000,0 wto=false gul=0,0
 meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=123.000000000,0 min=0,0 seq=1} ts=123.000000000,0 del=false klen=12 vlen=6
 data: "k"/123.000000000,0 -> /BYTES/v
 
@@ -25,7 +25,7 @@ with t=A
   cput k=k v=v2 cond=v
 ----
 >> at end:
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=123.000000000,0 min=0,0 seq=2} lock=true stat=PENDING rts=123.000000000,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=123.000000000,0 min=0,0 seq=2} lock=true stat=PENDING rts=123.000000000,0 wto=false gul=0,0
 meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=123.000000000,0 min=0,0 seq=2} ts=123.000000000,0 del=false klen=12 vlen=7 ih={{1 /BYTES/v}}
 data: "k"/123.000000000,0 -> /BYTES/v2
 
@@ -38,7 +38,7 @@ with t=A
   cput k=k v=v3
 ----
 >> at end:
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=1 ts=123.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=123.000000000,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=1 ts=123.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=123.000000000,0 wto=false gul=0,0
 meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=1 ts=123.000000000,0 min=0,0 seq=1} ts=123.000000000,0 del=false klen=12 vlen=7
 data: "k"/123.000000000,0 -> /BYTES/v3
 
@@ -86,7 +86,7 @@ with t=A
   cput k=c v=cput cond=value
 ----
 >> at end:
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=2.000000000,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=2.000000000,0 wto=false gul=0,0
 meta: "c"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=1} ts=2.000000000,0 del=false klen=12 vlen=9
 data: "c"/2.000000000,0 -> /BYTES/cput
 data: "c"/1.000000000,0 -> /BYTES/value
@@ -100,9 +100,9 @@ with t=A
   cput k=c v=cput cond=value
 ----
 >> txn_restart ts=3 t=A
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=1 ts=3.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=3.000000000,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=1 ts=3.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=3.000000000,0 wto=false gul=0,0
 >> txn_step t=A
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=1 ts=3.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=3.000000000,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=1 ts=3.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=3.000000000,0 wto=false gul=0,0
 >> cput k=c v=cput cond=value t=A
 called PutIntent("c", _, ExistingIntentInterleaved, TDNUM(true), 00000000-0000-0000-0000-000000000002)
 meta: "c"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=1 ts=3.000000000,0 min=0,0 seq=1} ts=3.000000000,0 del=false klen=12 vlen=9

--- a/pkg/storage/testdata/mvcc_histories/conditional_put_with_txn_enable_separated
+++ b/pkg/storage/testdata/mvcc_histories/conditional_put_with_txn_enable_separated
@@ -2,7 +2,7 @@ run ok
 txn_begin t=A ts=123
 ----
 >> at end:
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=123.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=123.000000000,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=123.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=123.000000000,0 wto=false gul=0,0
 
 # Write value1.
 
@@ -12,7 +12,7 @@ with t=A
   cput k=k v=v
 ----
 >> at end:
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=123.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=123.000000000,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=123.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=123.000000000,0 wto=false gul=0,0
 meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=123.000000000,0 min=0,0 seq=1} ts=123.000000000,0 del=false klen=12 vlen=6
 data: "k"/123.000000000,0 -> /BYTES/v
 
@@ -25,7 +25,7 @@ with t=A
   cput k=k v=v2 cond=v
 ----
 >> at end:
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=123.000000000,0 min=0,0 seq=2} lock=true stat=PENDING rts=123.000000000,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=123.000000000,0 min=0,0 seq=2} lock=true stat=PENDING rts=123.000000000,0 wto=false gul=0,0
 meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=123.000000000,0 min=0,0 seq=2} ts=123.000000000,0 del=false klen=12 vlen=7 ih={{1 /BYTES/v}}
 data: "k"/123.000000000,0 -> /BYTES/v2
 
@@ -38,7 +38,7 @@ with t=A
   cput k=k v=v3
 ----
 >> at end:
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=1 ts=123.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=123.000000000,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=1 ts=123.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=123.000000000,0 wto=false gul=0,0
 meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=1 ts=123.000000000,0 min=0,0 seq=1} ts=123.000000000,0 del=false klen=12 vlen=7
 data: "k"/123.000000000,0 -> /BYTES/v3
 
@@ -86,7 +86,7 @@ with t=A
   cput k=c v=cput cond=value
 ----
 >> at end:
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=2.000000000,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=2.000000000,0 wto=false gul=0,0
 meta: "c"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=1} ts=2.000000000,0 del=false klen=12 vlen=9
 data: "c"/2.000000000,0 -> /BYTES/cput
 data: "c"/1.000000000,0 -> /BYTES/value
@@ -100,9 +100,9 @@ with t=A
   cput k=c v=cput cond=value
 ----
 >> txn_restart ts=3 t=A
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=1 ts=3.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=3.000000000,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=1 ts=3.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=3.000000000,0 wto=false gul=0,0
 >> txn_step t=A
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=1 ts=3.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=3.000000000,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=1 ts=3.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=3.000000000,0 wto=false gul=0,0
 >> cput k=c v=cput cond=value t=A
 called PutIntent("c", _, ExistingIntentSeparated, TDNUM(true), 00000000-0000-0000-0000-000000000002)
 meta: "c"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=1 ts=3.000000000,0 min=0,0 seq=1} ts=3.000000000,0 del=false klen=12 vlen=9

--- a/pkg/storage/testdata/mvcc_histories/intent_history_allow_separated
+++ b/pkg/storage/testdata/mvcc_histories/intent_history_allow_separated
@@ -25,28 +25,28 @@ with t=A
   resolve_intent
 ----
 >> txn_begin ts=2 t=A
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=2.000000000,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=2.000000000,0 wto=false gul=0,0
 >> put v=first k=a t=A
 called PutIntent("a", _, NoExistingIntent, TDNUM(true), 00000000-0000-0000-0000-000000000002)
 meta: "a"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0} ts=2.000000000,0 del=false klen=12 vlen=10
 data: "a"/2.000000000,0 -> /BYTES/first
 data: "a"/1.000000000,0 -> /BYTES/default
 >> txn_step k=a t=A
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=2.000000000,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=2.000000000,0 wto=false gul=0,0
 >> put v=second k=a t=A
 called PutIntent("a", _, ExistingIntentInterleaved, TDNUM(true), 00000000-0000-0000-0000-000000000002)
 meta: "a"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=1} ts=2.000000000,0 del=false klen=12 vlen=11 ih={{0 /BYTES/first}}
 data: "a"/2.000000000,0 -> /BYTES/second
 data: "a"/1.000000000,0 -> /BYTES/default
 >> txn_step n=2 k=a t=A
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=3} lock=true stat=PENDING rts=2.000000000,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=3} lock=true stat=PENDING rts=2.000000000,0 wto=false gul=0,0
 >> del k=a t=A
 called PutIntent("a", _, ExistingIntentInterleaved, TDNUM(false), 00000000-0000-0000-0000-000000000002)
 meta: "a"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=3} ts=2.000000000,0 del=true klen=12 vlen=0 ih={{0 /BYTES/first}{1 /BYTES/second}}
 data: "a"/2.000000000,0 -> /<empty>
 data: "a"/1.000000000,0 -> /BYTES/default
 >> txn_step n=6 k=a t=A
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=9} lock=true stat=PENDING rts=2.000000000,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=9} lock=true stat=PENDING rts=2.000000000,0 wto=false gul=0,0
 >> put v=first k=a t=A
 called PutIntent("a", _, ExistingIntentInterleaved, TDNUM(false), 00000000-0000-0000-0000-000000000002)
 meta: "a"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=9} ts=2.000000000,0 del=false klen=12 vlen=10 ih={{0 /BYTES/first}{1 /BYTES/second}{3 /<empty>}}

--- a/pkg/storage/testdata/mvcc_histories/intent_history_enable_separated
+++ b/pkg/storage/testdata/mvcc_histories/intent_history_enable_separated
@@ -25,28 +25,28 @@ with t=A
   resolve_intent
 ----
 >> txn_begin ts=2 t=A
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=2.000000000,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=2.000000000,0 wto=false gul=0,0
 >> put v=first k=a t=A
 called PutIntent("a", _, NoExistingIntent, TDNUM(true), 00000000-0000-0000-0000-000000000002)
 meta: "a"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0} ts=2.000000000,0 del=false klen=12 vlen=10
 data: "a"/2.000000000,0 -> /BYTES/first
 data: "a"/1.000000000,0 -> /BYTES/default
 >> txn_step k=a t=A
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=2.000000000,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=2.000000000,0 wto=false gul=0,0
 >> put v=second k=a t=A
 called PutIntent("a", _, ExistingIntentSeparated, TDNUM(true), 00000000-0000-0000-0000-000000000002)
 meta: "a"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=1} ts=2.000000000,0 del=false klen=12 vlen=11 ih={{0 /BYTES/first}}
 data: "a"/2.000000000,0 -> /BYTES/second
 data: "a"/1.000000000,0 -> /BYTES/default
 >> txn_step n=2 k=a t=A
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=3} lock=true stat=PENDING rts=2.000000000,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=3} lock=true stat=PENDING rts=2.000000000,0 wto=false gul=0,0
 >> del k=a t=A
 called PutIntent("a", _, ExistingIntentSeparated, TDNUM(false), 00000000-0000-0000-0000-000000000002)
 meta: "a"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=3} ts=2.000000000,0 del=true klen=12 vlen=0 ih={{0 /BYTES/first}{1 /BYTES/second}}
 data: "a"/2.000000000,0 -> /<empty>
 data: "a"/1.000000000,0 -> /BYTES/default
 >> txn_step n=6 k=a t=A
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=9} lock=true stat=PENDING rts=2.000000000,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=9} lock=true stat=PENDING rts=2.000000000,0 wto=false gul=0,0
 >> put v=first k=a t=A
 called PutIntent("a", _, ExistingIntentSeparated, TDNUM(false), 00000000-0000-0000-0000-000000000002)
 meta: "a"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=9} ts=2.000000000,0 del=false klen=12 vlen=10 ih={{0 /BYTES/first}{1 /BYTES/second}{3 /<empty>}}

--- a/pkg/storage/testdata/mvcc_histories/intent_with_write_tracing_allow_separated
+++ b/pkg/storage/testdata/mvcc_histories/intent_with_write_tracing_allow_separated
@@ -4,7 +4,7 @@ with t=A
   put k=k1 v=v1
 ----
 >> txn_begin ts=2 t=A
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=2.000000000,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=2.000000000,0 wto=false gul=0,0
 >> put k=k1 v=v1 t=A
 called PutIntent("k1", _, NoExistingIntent, TDNUM(true), 00000000-0000-0000-0000-000000000001)
 meta: "k1"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0} ts=2.000000000,0 del=false klen=12 vlen=7
@@ -18,9 +18,9 @@ with t=A
   put k=k2 v=v2
 ----
 >> txn_advance ts=3 t=A
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=2.000000000,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=2.000000000,0 wto=false gul=0,0
 >> txn_step t=A
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=2.000000000,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=2.000000000,0 wto=false gul=0,0
 >> put k=k1 v=v1 t=A
 called PutIntent("k1", _, ExistingIntentInterleaved, TDNUM(true), 00000000-0000-0000-0000-000000000001)
 meta: "k1"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} ts=3.000000000,0 del=false klen=12 vlen=7 ih={{0 /BYTES/v1}}

--- a/pkg/storage/testdata/mvcc_histories/intent_with_write_tracing_enable_separated
+++ b/pkg/storage/testdata/mvcc_histories/intent_with_write_tracing_enable_separated
@@ -4,7 +4,7 @@ with t=A
   put k=k1 v=v1
 ----
 >> txn_begin ts=2 t=A
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=2.000000000,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=2.000000000,0 wto=false gul=0,0
 >> put k=k1 v=v1 t=A
 called PutIntent("k1", _, NoExistingIntent, TDNUM(true), 00000000-0000-0000-0000-000000000001)
 meta: "k1"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0} ts=2.000000000,0 del=false klen=12 vlen=7
@@ -18,9 +18,9 @@ with t=A
   put k=k2 v=v2
 ----
 >> txn_advance ts=3 t=A
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=2.000000000,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=2.000000000,0 wto=false gul=0,0
 >> txn_step t=A
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=2.000000000,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=2.000000000,0 wto=false gul=0,0
 >> put k=k1 v=v1 t=A
 called PutIntent("k1", _, ExistingIntentSeparated, TDNUM(true), 00000000-0000-0000-0000-000000000001)
 meta: "k1"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} ts=3.000000000,0 del=false klen=12 vlen=7 ih={{0 /BYTES/v1}}

--- a/pkg/storage/testdata/mvcc_histories/no_read_after_abort_allow_separated
+++ b/pkg/storage/testdata/mvcc_histories/no_read_after_abort_allow_separated
@@ -8,7 +8,7 @@ with t=A k=a
   txn_remove
 ----
 >> txn_begin ts=22 t=A k=a
-txn: "A" meta={id=00000000 key="a" pri=0.00000000 epo=0 ts=22.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=22.000000000,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key="a" pri=0.00000000 epo=0 ts=22.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=22.000000000,0 wto=false gul=0,0
 >> put v=cde t=A k=a
 called PutIntent("a", _, NoExistingIntent, TDNUM(true), 00000000-0000-0000-0000-000000000001)
 meta: "a"/0,0 -> txn={id=00000000 key="a" pri=0.00000000 epo=0 ts=22.000000000,0 min=0,0 seq=0} ts=22.000000000,0 del=false klen=12 vlen=8

--- a/pkg/storage/testdata/mvcc_histories/no_read_after_abort_enable_separated
+++ b/pkg/storage/testdata/mvcc_histories/no_read_after_abort_enable_separated
@@ -8,7 +8,7 @@ with t=A k=a
   txn_remove
 ----
 >> txn_begin ts=22 t=A k=a
-txn: "A" meta={id=00000000 key="a" pri=0.00000000 epo=0 ts=22.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=22.000000000,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key="a" pri=0.00000000 epo=0 ts=22.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=22.000000000,0 wto=false gul=0,0
 >> put v=cde t=A k=a
 called PutIntent("a", _, NoExistingIntent, TDNUM(true), 00000000-0000-0000-0000-000000000001)
 meta: "a"/0,0 -> txn={id=00000000 key="a" pri=0.00000000 epo=0 ts=22.000000000,0 min=0,0 seq=0} ts=22.000000000,0 del=false klen=12 vlen=8

--- a/pkg/storage/testdata/mvcc_histories/read_after_write_allow_separated
+++ b/pkg/storage/testdata/mvcc_histories/read_after_write_allow_separated
@@ -9,7 +9,7 @@ with t=A
     resolve_intent
 ----
 >> txn_begin ts=11 t=A
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=11.000000000,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0
 >> put v=abc k=a t=A
 called PutIntent("a", _, NoExistingIntent, TDNUM(true), 00000000-0000-0000-0000-000000000001)
 meta: "a"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} ts=11.000000000,0 del=false klen=12 vlen=8
@@ -44,7 +44,7 @@ with t=A
 ----
 get: "a" -> /BYTES/abc @11.000000000,0
 >> at end:
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=11.000000000,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0
 
 run trace ok
 with t=A
@@ -87,5 +87,5 @@ with t=A k=a
   txn_remove
 ----
 >> txn_begin ts=1 t=A k=a
-txn: "A" meta={id=00000000 key="a" pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=1.000000000,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key="a" pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=1.000000000,0 wto=false gul=0,0
 >> txn_remove t=A k=a

--- a/pkg/storage/testdata/mvcc_histories/read_after_write_enable_separated
+++ b/pkg/storage/testdata/mvcc_histories/read_after_write_enable_separated
@@ -9,7 +9,7 @@ with t=A
     resolve_intent
 ----
 >> txn_begin ts=11 t=A
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=11.000000000,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0
 >> put v=abc k=a t=A
 called PutIntent("a", _, NoExistingIntent, TDNUM(true), 00000000-0000-0000-0000-000000000001)
 meta: "a"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} ts=11.000000000,0 del=false klen=12 vlen=8
@@ -44,7 +44,7 @@ with t=A
 ----
 get: "a" -> /BYTES/abc @11.000000000,0
 >> at end:
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=11.000000000,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0
 
 run trace ok
 with t=A
@@ -87,5 +87,5 @@ with t=A k=a
   txn_remove
 ----
 >> txn_begin ts=1 t=A k=a
-txn: "A" meta={id=00000000 key="a" pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=1.000000000,0 wto=false max=0,0
+txn: "A" meta={id=00000000 key="a" pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=1.000000000,0 wto=false gul=0,0
 >> txn_remove t=A k=a

--- a/pkg/testutils/colcontainerutils/diskqueuecfg.go
+++ b/pkg/testutils/colcontainerutils/diskqueuecfg.go
@@ -35,7 +35,7 @@ func NewTestingDiskQueueCfg(t testing.TB, inMem bool) (colcontainer.DiskQueueCfg
 	)
 
 	if inMem {
-		ngn := storage.NewDefaultInMem()
+		ngn := storage.NewDefaultInMemForTesting()
 		testingFS = ngn.(fs.FS)
 		if err := testingFS.MkdirAll(inMemDirName); err != nil {
 			t.Fatal(err)

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -132,7 +132,8 @@ func (ltc *LocalTestCluster) Start(t testing.TB, baseCtx *base.Config, initFacto
 	clusterID := &cfg.RPCContext.ClusterID
 	server := rpc.NewServer(cfg.RPCContext) // never started
 	ltc.Gossip = gossip.New(ambient, clusterID, nc, cfg.RPCContext, server, ltc.stopper, metric.NewRegistry(), roachpb.Locality{}, zonepb.DefaultZoneConfigRef())
-	ltc.Eng = storage.NewInMem(ambient.AnnotateCtx(context.Background()), roachpb.Attributes{}, 50<<20)
+	ltc.Eng = storage.NewInMem(ambient.AnnotateCtx(context.Background()), roachpb.Attributes{},
+		50<<20, storage.MakeRandomSettingsForSeparatedIntents())
 	ltc.stopper.AddCloser(ltc.Eng)
 
 	ltc.Stores = kvserver.NewStores(ambient, ltc.Clock)


### PR DESCRIPTION
This is done using a combination of the cluster version,
which prevents separated intents until any node is running
below the SeparatedIntents version, and then by the
storage.transaction.separated_intents.enabled cluster
setting which is on by default.

This replaces the temporary consts that were being used
previously for configuration.

The safety of transition from 20.2 to 21.1 is
discussed in:
- comments in intent_reader_writer.go (where the cluster
  setting is declared).
- the new Writer.SafeToWriteSeparatedIntents which
  gates the use of MVCCMetadata.TxnDidNotUpdateMeta
  so that replicas do not diverge across new and
  old nodes that do not understand this field.
- comments in store_snapshot.go regarding why snapshots
  exchanged between 20.2 and 21.1 nodes are fine
  even though the latter will iterate through the
  lock table key space for outgoing snapshots and
  construct ssts for deleting the lock table key
  space for incoming snapshots.

The only non-test code that cares about this configuration
lives in the storage package and accesses the config
via the optional cluster.Settings provided when
constructing a Pebble Engine.

Affected tests are in 3 categories:
- tests that had different datadriven test files for
  different configuration settings. These now iterate
  through all the configurations. This is a small
  subset of storage tests.
- tests that were adjusting their expected values
  based on the configuration settings. These now
  randomize the configuration settings.
- tests that were ignorant of the configuration
  settings. These also randomize the settings, which
  is done at different levels of abstraction depending
  on the kind of test.
  - When constructing the Engine in the test. For tests
    that directly construct an Engine or indirectly
    via LocalTestCluster or kvserver.testContext.
    This allows for manipulating both the version
    and the cluster setting.
  - When constructing cluster.Settings for
    server.TestServerFactory. This only manipulates
    the cluster setting.

Informs #41720

Release note (ops change): adds the
storage.transaction.separated_intents.enabled cluster
setting, which enables separated intents by default.