### PR TITLE
geo/wkt: add support for parsing polygons with Z and M dimensions

### DIFF
--- a/pkg/geo/wkt/lex.go
+++ b/pkg/geo/wkt/lex.go
@@ -98,6 +98,14 @@ func getKeywordToken(tokStr string) int {
 		return LINESTRINGZ
 	case "LINESTRINGZM":
 		return LINESTRINGZM
+	case "POLYGON":
+		return POLYGON
+	case "POLYGONM":
+		return POLYGONM
+	case "POLYGONZ":
+		return POLYGONZ
+	case "POLYGONZM":
+		return POLYGONZM
 	default:
 		return eof
 	}

--- a/pkg/geo/wkt/wkt.y
+++ b/pkg/geo/wkt/wkt.y
@@ -14,6 +14,33 @@ package wkt
 
 import "github.com/twpayne/go-geom"
 
+func isValidLineString(wktlex wktLexer, flatCoords []float64, stride int) bool {
+	if len(flatCoords) < 2 * stride {
+		wktlex.(*wktLex).Error("syntax error: non-empty linestring with only one point")
+		return false
+	}
+	return true
+}
+
+func isValidPolygonRing(wktlex wktLexer, flatCoords []float64, stride int) bool {
+	if len(flatCoords) < 4 * stride {
+		wktlex.(*wktLex).Error("syntax error: polygon ring doesn't have enough points")
+		return false
+	}
+	for i := 0; i < stride; i++ {
+		if flatCoords[i] != flatCoords[len(flatCoords)-stride+i] {
+			wktlex.(*wktLex).Error("syntax error: polygon ring not closed")
+			return false
+    }
+	}
+	return true
+}
+
+type geomPair struct {
+	flatCoords []float64
+	ends       []int
+}
+
 %}
 
 %union {
@@ -21,18 +48,23 @@ import "github.com/twpayne/go-geom"
 	geom      geom.T
 	coord     float64
 	coordList []float64
+	pair      geomPair
 }
 
 %token <str> POINT POINTM POINTZ POINTZM
 %token <str> LINESTRING LINESTRINGM LINESTRINGZ LINESTRINGZM
+%token <str> POLYGON POLYGONM POLYGONZ POLYGONZM
 %token <str> EMPTY
-//%token <str> POLYGON MULTIPOINT MULTILINESTRING MULTIPOLYGON GEOMETRYCOLLECTION
+//%token <str> MULTIPOINT MULTILINESTRING MULTIPOLYGON GEOMETRYCOLLECTION
 %token <coord> NUM
 
 %type <geom> geometry
-%type <geom> point linestring
+%type <geom> point linestring polygon
 %type <coordList> two_coords three_coords four_coords
 %type <coordList> two_coords_list three_coords_list four_coords_list
+%type <coordList> two_coords_line three_coords_line four_coords_line
+%type <pair> two_coords_ring three_coords_ring four_coords_ring
+%type <pair> two_coords_ring_list three_coords_ring_list four_coords_ring_list
 
 %%
 
@@ -44,8 +76,8 @@ start:
 
 geometry:
 	point
-	// TODO(ayang) have parser check that linestrings are either empty or have 2+ points
 |	linestring
+|	polygon
 
 point:
 	POINT '(' two_coords ')'
@@ -90,29 +122,47 @@ point:
 	}
 
 linestring:
-	LINESTRING '(' two_coords_list ')'
+	LINESTRING two_coords_line
 	{
-		$$ = geom.NewLineStringFlat(geom.XY, $3)
+		if !isValidLineString(wktlex, $2, 2) {
+			return 1
+		}
+		$$ = geom.NewLineStringFlat(geom.XY, $2)
 	}
-|	LINESTRING '(' three_coords_list ')'
+|	LINESTRING three_coords_line
 	{
-		$$ = geom.NewLineStringFlat(geom.XYZ, $3)
+		if !isValidLineString(wktlex, $2, 3) {
+			return 1
+		}
+		$$ = geom.NewLineStringFlat(geom.XYZ, $2)
 	}
-|	LINESTRING '(' four_coords_list ')'
+|	LINESTRING four_coords_line
 	{
-		$$ = geom.NewLineStringFlat(geom.XYZM, $3)
+		if !isValidLineString(wktlex, $2, 4) {
+			return 1
+		}
+		$$ = geom.NewLineStringFlat(geom.XYZM, $2)
 	}
-|	LINESTRINGM '(' three_coords_list ')'
+|	LINESTRINGM three_coords_line
 	{
-		$$ = geom.NewLineStringFlat(geom.XYM, $3)
+		if !isValidLineString(wktlex, $2, 3) {
+			return 1
+		}
+		$$ = geom.NewLineStringFlat(geom.XYM, $2)
 	}
-|	LINESTRINGZ '(' three_coords_list ')'
+|	LINESTRINGZ three_coords_line
 	{
-		$$ = geom.NewLineStringFlat(geom.XYZ, $3)
+		if !isValidLineString(wktlex, $2, 3) {
+			return 1
+		}
+		$$ = geom.NewLineStringFlat(geom.XYZ, $2)
 	}
-|	LINESTRINGZM '(' four_coords_list ')'
+|	LINESTRINGZM four_coords_line
 	{
-		$$ = geom.NewLineStringFlat(geom.XYZM, $3)
+		if !isValidLineString(wktlex, $2, 4) {
+			return 1
+		}
+		$$ = geom.NewLineStringFlat(geom.XYZM, $2)
 	}
 |	LINESTRING EMPTY
 	{
@@ -129,6 +179,114 @@ linestring:
 |	LINESTRINGZM EMPTY
 	{
 		$$ = geom.NewLineString(geom.XYZM)
+	}
+
+polygon:
+	POLYGON '(' two_coords_ring_list ')'
+	{
+		$$ = geom.NewPolygonFlat(geom.XY, $3.flatCoords, $3.ends)
+	}
+|	POLYGON '(' three_coords_ring_list ')'
+	{
+		$$ = geom.NewPolygonFlat(geom.XYZ, $3.flatCoords, $3.ends)
+	}
+|	POLYGON '(' four_coords_ring_list ')'
+	{
+		$$ = geom.NewPolygonFlat(geom.XYZM, $3.flatCoords, $3.ends)
+	}
+|	POLYGONM '(' three_coords_ring_list ')'
+	{
+		$$ = geom.NewPolygonFlat(geom.XYM, $3.flatCoords, $3.ends)
+	}
+|	POLYGONZ '(' three_coords_ring_list ')'
+	{
+		$$ = geom.NewPolygonFlat(geom.XYZ, $3.flatCoords, $3.ends)
+	}
+|	POLYGONZM '(' four_coords_ring_list ')'
+	{
+		$$ = geom.NewPolygonFlat(geom.XYZM, $3.flatCoords, $3.ends)
+	}
+|	POLYGON EMPTY
+	{
+		$$ = geom.NewPolygon(geom.XY)
+	}
+|	POLYGONM EMPTY
+	{
+		$$ = geom.NewPolygon(geom.XYM)
+	}
+|	POLYGONZ EMPTY
+	{
+		$$ = geom.NewPolygon(geom.XYZ)
+	}
+|	POLYGONZM EMPTY
+	{
+		$$ = geom.NewPolygon(geom.XYZM)
+	}
+
+two_coords_ring_list:
+	two_coords_ring_list ',' two_coords_ring
+	{
+		$$ = geomPair{append($1.flatCoords, $3.flatCoords...), append($1.ends, $1.ends[len($1.ends)-1] + $3.ends[0])}
+	}
+|	two_coords_ring
+
+three_coords_ring_list:
+	three_coords_ring_list ',' three_coords_ring
+	{
+		$$ = geomPair{append($1.flatCoords, $3.flatCoords...), append($1.ends, $1.ends[len($1.ends)-1] + $3.ends[0])}
+	}
+|	three_coords_ring
+
+four_coords_ring_list:
+	four_coords_ring_list ',' four_coords_ring
+	{
+		$$ = geomPair{append($1.flatCoords, $3.flatCoords...), append($1.ends, $1.ends[len($1.ends)-1] + $3.ends[0])}
+	}
+|	four_coords_ring
+
+two_coords_ring:
+	two_coords_line
+	{
+		if !isValidPolygonRing(wktlex, $1, 2) {
+			return 1
+		}
+		$$ = geomPair{$1, []int{len($1)}}
+	}
+
+three_coords_ring:
+	three_coords_line
+	{
+		if !isValidPolygonRing(wktlex, $1, 3) {
+			return 1
+		}
+		$$ = geomPair{$1, []int{len($1)}}
+	}
+
+four_coords_ring:
+	four_coords_line
+	{
+		if !isValidPolygonRing(wktlex, $1, 4) {
+			return 1
+		}
+		$$ = geomPair{$1, []int{len($1)}}
+	}
+
+two_coords_line:
+	'(' two_coords_list ')'
+	{
+		$$ = $2
+	}
+
+three_coords_line:
+	'(' three_coords_list ')'
+	{
+		$$ = $2
+	}
+
+four_coords_line:
+	'(' four_coords_list ')'
+	{
+		$$ = $2
 	}
 
 two_coords_list:

--- a/pkg/geo/wkt/wkt_test.go
+++ b/pkg/geo/wkt/wkt_test.go
@@ -105,6 +105,59 @@ func TestUnmarshal(t *testing.T) {
 			equivInputs: []string{"LINESTRING ZM EMPTY", "LINESTRINGZM EMPTY"},
 			expected:    geom.NewLineString(geom.XYZM),
 		},
+		// POLYGON tests
+		{
+			desc:        "parse 2D polygon",
+			equivInputs: []string{"POLYGON((0 0, 1 -1, 2 0, 0 0))", "POLYGON ((0 0, 1 -1, 2 0, 0 0))"},
+			expected:    geom.NewPolygonFlat(geom.XY, []float64{0, 0, 1, -1, 2, 0, 0, 0}, []int{8}),
+		},
+		{
+			desc:        "parse 2D polygon with hole",
+			equivInputs: []string{"POLYGON((0 0, 0 100, 100 100, 100 0, 0 0),(10 10, 11 11, 12 10, 10 10))"},
+			expected: geom.NewPolygonFlat(geom.XY,
+				[]float64{0, 0, 0, 100, 100, 100, 100, 0, 0, 0, 10, 10, 11, 11, 12, 10, 10, 10}, []int{10, 18}),
+		},
+		{
+			desc:        "parse 2D polygon with two holes",
+			equivInputs: []string{"POLYGON((0 0, 0 100, 100 100, 100 0, 0 0),(10 10, 11 11, 12 10, 10 10), (2 2, 4 4, 5 1, 2 2))"},
+			expected: geom.NewPolygonFlat(geom.XY,
+				[]float64{0, 0, 0, 100, 100, 100, 100, 0, 0, 0, 10, 10, 11, 11, 12, 10, 10, 10, 2, 2, 4, 4, 5, 1, 2, 2}, []int{10, 18, 26}),
+		},
+		{
+			desc:        "parse 2D+M polygon",
+			equivInputs: []string{"POLYGONM((0 0 7, 1 -1 -50, 2 0 0, 0 0 7))", "POLYGON M ((0 0 7, 1 -1 -50, 2 0 0, 0 0 7))"},
+			expected:    geom.NewPolygonFlat(geom.XYM, []float64{0, 0, 7, 1, -1, -50, 2, 0, 0, 0, 0, 7}, []int{12}),
+		},
+		{
+			desc:        "parse 3D polygon",
+			equivInputs: []string{"POLYGON((0 0 7, 1 -1 -50, 2 0 0, 0 0 7))", "POLYGON Z ((0 0 7, 1 -1 -50, 2 0 0, 0 0 7))"},
+			expected:    geom.NewPolygonFlat(geom.XYZ, []float64{0, 0, 7, 1, -1, -50, 2, 0, 0, 0, 0, 7}, []int{12}),
+		},
+		{
+			desc:        "parse 4D polygon",
+			equivInputs: []string{"POLYGON((0 0 12 7, 1 -1 12 -50, 2 0 12 0, 0 0 12 7))", "POLYGON ZM ((0 0 12 7, 1 -1 12 -50, 2 0 12 0, 0 0 12 7))"},
+			expected:    geom.NewPolygonFlat(geom.XYZM, []float64{0, 0, 12, 7, 1, -1, 12, -50, 2, 0, 12, 0, 0, 0, 12, 7}, []int{16}),
+		},
+		{
+			desc:        "parse empty 2D polygon",
+			equivInputs: []string{"POLYGON EMPTY"},
+			expected:    geom.NewPolygon(geom.XY),
+		},
+		{
+			desc:        "parse empty 2D+M polygon",
+			equivInputs: []string{"POLYGON M EMPTY", "POLYGONM EMPTY"},
+			expected:    geom.NewPolygon(geom.XYM),
+		},
+		{
+			desc:        "parse empty 3D polygon",
+			equivInputs: []string{"POLYGON Z EMPTY", "POLYGONZ EMPTY"},
+			expected:    geom.NewPolygon(geom.XYZ),
+		},
+		{
+			desc:        "parse empty 4D polygon",
+			equivInputs: []string{"POLYGON ZM EMPTY", "POLYGONZM EMPTY"},
+			expected:    geom.NewPolygon(geom.XYZM),
+		},
 	}
 
 	for _, tc := range testCases {
@@ -147,6 +200,13 @@ DOT(0 0)
 POINT(2 2.3.7)
         ^`,
 		},
+		{
+			desc:  "invalid keyword when extraneous spaces are present in ZM",
+			input: "POINT Z M (1 1 1 1)",
+			expectedErrStr: `lex error: invalid keyword at pos 8
+POINT Z M (1 1 1 1)
+        ^`,
+		},
 		// ParseError
 		{
 			desc:  "invalid point",
@@ -163,11 +223,53 @@ POINT(0, 0)
        ^`,
 		},
 		{
+			desc:  "2D linestring with not enough points",
+			input: "LINESTRING(0 0)",
+			expectedErrStr: `syntax error: non-empty linestring with only one point at pos 14
+LINESTRING(0 0)
+              ^`,
+		},
+		{
 			desc:  "linestring with mixed dimensionality",
 			input: "LINESTRING(0 0, 1 1 1)",
 			expectedErrStr: `syntax error: unexpected NUM, expecting ')' at pos 20
 LINESTRING(0 0, 1 1 1)
                     ^`,
+		},
+		{
+			desc:  "2D polygon with not enough points",
+			input: "POLYGON((0 0, 1 1, 2 0))",
+			expectedErrStr: `syntax error: polygon ring doesn't have enough points at pos 22
+POLYGON((0 0, 1 1, 2 0))
+                      ^`,
+		},
+		{
+			desc:  "2D polygon with ring that isn't closed",
+			input: "POLYGON((0 0, 1 1, 2 0, 1 -1))",
+			expectedErrStr: `syntax error: polygon ring not closed at pos 28
+POLYGON((0 0, 1 1, 2 0, 1 -1))
+                            ^`,
+		},
+		{
+			desc:  "2D polygon with empty second ring",
+			input: "POLYGON((0 0, 1 -1, 2 0, 0 0), ())",
+			expectedErrStr: `syntax error: unexpected ')', expecting NUM at pos 32
+POLYGON((0 0, 1 -1, 2 0, 0 0), ())
+                                ^`,
+		},
+		{
+			desc:  "2D polygon with EMPTY as second ring",
+			input: "POLYGON((0 0, 1 -1, 2 0, 0 0), EMPTY)",
+			expectedErrStr: `syntax error: unexpected EMPTY, expecting '(' at pos 31
+POLYGON((0 0, 1 -1, 2 0, 0 0), EMPTY)
+                               ^`,
+		},
+		{
+			desc:  "2D polygon with invalid second ring",
+			input: "POLYGON((0 0, 1 -1, 2 0, 0 0), (0.5 -0.5))",
+			expectedErrStr: `syntax error: polygon ring doesn't have enough points at pos 40
+POLYGON((0 0, 1 -1, 2 0, 0 0), (0.5 -0.5))
+                                        ^`,
 		},
 	}
 


### PR DESCRIPTION
This patch extends the capabilities of the WKT parser to include
parsing of polygons with Z and M dimensions.

Refs: #53091 

Release note: None