### PR TITLE
opt: inline virtual column filters under Projects

### DIFF
--- a/pkg/sql/opt/norm/rules/inline.opt
+++ b/pkg/sql/opt/norm/rules/inline.opt
@@ -157,6 +157,115 @@
     $passthrough
 )
 
+# InlineSelectVirtualColumns pushes Select filters referencing virtual columns
+# into a Project by inlining the virtual column expressions. This makes the
+# Select independent of the Project. Filters with virtual columns are only
+# pushed below the Project if those virtual columns are indexed by a secondary
+# index. This allows exploration rules to generate plans that use those indexes.
+# Non-indexed virtual column filters are not inlined because the virtual column
+# expression would be executed twice (once in the filter and once in the
+# projection), adding overhead without any chance of a secondary index being
+# used in the optimized plan.
+#
+# Notice that this rule is similar to PushSelectIntoInlinableProject. The key
+# difference is that PushSelectIntoInlinableProject only inlines simple
+# expressions that will add negligible overhead when computing twice.
+# Conversely, InlineSelectVirtualColumns does not discriminate by the type of
+# expression. It will inline all virtual columns that are indexed in the hopes
+# that inling will lead to a query plan that uses a virtual column index.
+#
+# Also, PushSelectIntoInlinableProject will inline filters if and only if each
+# filter is inlinable (by its definition), whereas InlineSelectVirtualColumns
+# will split the input filters into two groups: one to inline below the Project,
+# and one to leave above the Project.
+#
+# For example, consider the table and query:
+#
+#   CREATE TABLE t (
+#     a INT,
+#     b INT,
+#     v INT AS (abs(a)),
+#     w INT AS (abs(b)),
+#     INDEX (v)
+#   )
+#   SELECT * FROM t WHERE v = 5 AND w = 10
+#
+# The partially normalized expression for the SELECT query before
+# InlineSelectVirtualColumns is:
+#
+#   project
+#    ├── columns: a:1 b:2 v:3 w:4
+#    └── select
+#         ├── columns: a:1 b:2 v:3 w:4
+#         ├── project
+#         │    ├── columns: v:3 w:4 a:1 b:2
+#         │    ├── scan t
+#         │    │    └── columns: a:1 b:2
+#         │    └── projections
+#         │         ├── abs(a:1) [as=v:3]
+#         │         └── abs(b:2) [as=w:4]
+#         └── filters
+#              ├── v:3 = 5
+#              └── w:4 = 10
+#
+# InlineSelectVirtualColumns will push only the (v = 5) filter below the Project
+# as (abs(a) = 5) because v is indexed. The (w = 10) filter remains above the
+# Project.
+#
+#   project
+#    ├── columns: a:1 b:2 v:3 w:4
+#    └── select
+#         ├── columns: a:1 b:2 v:3 w:4!null
+#         ├── project
+#         │    ├── columns: v:3 w:4 a:1 b:2
+#         │    ├── select
+#         │    │    ├── columns: a:1 b:2
+#         │    │    ├── scan t
+#         │    │    │    └── columns: a:1 b:2
+#         │    │    └── filters
+#         │    │         └── abs(a:1) = 5
+#         │    └── projections
+#         │         ├── abs(a:1) [as=v:3]
+#         │         └── abs(b:2) [as=w:4]
+#         └── filters
+#              └── w:4 = 10
+#
+# This rule has no explicit priority so that it runs before
+# PushSelectIntoInlinableProject (which is low priority). It must run before
+# PushSelectIntoInlinableProject in order to match the (Select (Project (Scan)))
+# pattern which is produced by optbuilder for a filter on a table with virtual
+# columns.
+[InlineSelectVirtualColumns, Normalize]
+(Select
+    (Project
+        $scan:(Scan $scanPrivate:*)
+        $projections:*
+        $passthrough:*
+    )
+    $filters:* &
+        ^(ColsAreEmpty
+            $indexedVirtualColumns:(IndexedVirtualColumns
+                $scanPrivate
+            )
+        ) &
+        (InlineSelectVirtualColumnsSucceeded
+            $result:(TryInlineSelectVirtualColumns
+                $filters
+                $projections
+                $indexedVirtualColumns
+            )
+        )
+)
+=>
+(Select
+    (Project
+        (Select $scan (InlinedFilters $result))
+        $projections
+        $passthrough
+    )
+    (NotInlinedFilters $result)
+)
+
 # InlineProjectInProject folds an inner Project operator into an outer Project
 # that references each inner synthesized column no more than one time. If there
 # are no duplicate references, then there's no benefit to keeping the multiple

--- a/pkg/sql/opt/norm/testdata/rules/inline
+++ b/pkg/sql/opt/norm/testdata/rules/inline
@@ -14,6 +14,20 @@ exec-ddl
 CREATE TABLE b (k INT PRIMARY KEY, i INT, f FLOAT, s STRING NOT NULL, j JSON)
 ----
 
+exec-ddl
+CREATE TABLE virt (
+  k INT PRIMARY KEY,
+  i INT,
+  s STRING,
+  j JSON,
+  v STRING AS (lower(s)) VIRTUAL,
+  w STRING AS (upper(s)) VIRTUAL,
+  x JSON AS (j->'x') VIRTUAL,
+  INDEX (v),
+  INVERTED INDEX (x)
+)
+----
+
 # --------------------------------------------------
 # InlineConstVar
 # --------------------------------------------------
@@ -699,6 +713,197 @@ project
       │              │    └── 1.0
       │              └── 1.0
       └── 107
+
+# --------------------------------------------------
+# InlineSelectVirtualColumns
+# --------------------------------------------------
+
+# Inline indexed virtual columns in a Select below the Project.
+norm expect=InlineSelectVirtualColumns
+SELECT * FROM virt WHERE v = 'foo'
+----
+project
+ ├── columns: k:1!null i:2 s:3 j:4 v:5 w:6 x:7
+ ├── immutable
+ ├── key: (1)
+ ├── fd: (1)-->(2-4), (3)-->(5,6), (4)-->(7)
+ ├── select
+ │    ├── columns: k:1!null i:2 s:3 j:4
+ │    ├── immutable
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-4)
+ │    ├── scan virt
+ │    │    ├── columns: k:1!null i:2 s:3 j:4
+ │    │    ├── computed column expressions
+ │    │    │    ├── v:5
+ │    │    │    │    └── lower(s:3)
+ │    │    │    ├── w:6
+ │    │    │    │    └── upper(s:3)
+ │    │    │    └── x:7
+ │    │    │         └── j:4->'x'
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2-4)
+ │    └── filters
+ │         └── lower(s:3) = 'foo' [outer=(3), immutable]
+ └── projections
+      ├── lower(s:3) [as=v:5, outer=(3), immutable]
+      ├── upper(s:3) [as=w:6, outer=(3), immutable]
+      └── j:4->'x' [as=x:7, outer=(4), immutable]
+
+# Inline inverted-indexed virtual columns.
+norm expect=InlineSelectVirtualColumns
+SELECT * FROM virt WHERE x @> '1'
+----
+project
+ ├── columns: k:1!null i:2 s:3 j:4 v:5 w:6 x:7
+ ├── immutable
+ ├── key: (1)
+ ├── fd: (1)-->(2-4), (3)-->(5,6), (4)-->(7)
+ ├── select
+ │    ├── columns: k:1!null i:2 s:3 j:4
+ │    ├── immutable
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-4)
+ │    ├── scan virt
+ │    │    ├── columns: k:1!null i:2 s:3 j:4
+ │    │    ├── computed column expressions
+ │    │    │    ├── v:5
+ │    │    │    │    └── lower(s:3)
+ │    │    │    ├── w:6
+ │    │    │    │    └── upper(s:3)
+ │    │    │    └── x:7
+ │    │    │         └── j:4->'x'
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2-4)
+ │    └── filters
+ │         └── (j:4->'x') @> '1' [outer=(4), immutable]
+ └── projections
+      ├── lower(s:3) [as=v:5, outer=(3), immutable]
+      ├── upper(s:3) [as=w:6, outer=(3), immutable]
+      └── j:4->'x' [as=x:7, outer=(4), immutable]
+
+# Do not inline virtual columns that aren't indexed.
+norm expect-not=InlineSelectVirtualColumns
+SELECT * FROM virt WHERE w = 'FOO'
+----
+select
+ ├── columns: k:1!null i:2 s:3 j:4 v:5 w:6!null x:7
+ ├── immutable
+ ├── key: (1)
+ ├── fd: ()-->(6), (1)-->(2-4), (3)-->(5), (4)-->(7)
+ ├── project
+ │    ├── columns: v:5 w:6 x:7 k:1!null i:2 s:3 j:4
+ │    ├── immutable
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-4), (3)-->(5,6), (4)-->(7)
+ │    ├── scan virt
+ │    │    ├── columns: k:1!null i:2 s:3 j:4
+ │    │    ├── computed column expressions
+ │    │    │    ├── v:5
+ │    │    │    │    └── lower(s:3)
+ │    │    │    ├── w:6
+ │    │    │    │    └── upper(s:3)
+ │    │    │    └── x:7
+ │    │    │         └── j:4->'x'
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2-4)
+ │    └── projections
+ │         ├── lower(s:3) [as=v:5, outer=(3), immutable]
+ │         ├── upper(s:3) [as=w:6, outer=(3), immutable]
+ │         └── j:4->'x' [as=x:7, outer=(4), immutable]
+ └── filters
+      └── w:6 = 'FOO' [outer=(6), constraints=(/6: [/'FOO' - /'FOO']; tight), fd=()-->(6)]
+
+# Split the filters and inline only the indexed virtual columns.
+norm expect=InlineSelectVirtualColumns
+SELECT * FROM virt WHERE v = 'foo' AND w = 'FOO' AND i = 10
+----
+select
+ ├── columns: k:1!null i:2!null s:3 j:4 v:5 w:6!null x:7
+ ├── immutable
+ ├── key: (1)
+ ├── fd: ()-->(2,6), (1)-->(3,4), (3)-->(5), (4)-->(7)
+ ├── project
+ │    ├── columns: v:5 w:6 x:7 k:1!null i:2!null s:3 j:4
+ │    ├── immutable
+ │    ├── key: (1)
+ │    ├── fd: ()-->(2), (1)-->(3,4), (3)-->(5,6), (4)-->(7)
+ │    ├── select
+ │    │    ├── columns: k:1!null i:2!null s:3 j:4
+ │    │    ├── immutable
+ │    │    ├── key: (1)
+ │    │    ├── fd: ()-->(2), (1)-->(3,4)
+ │    │    ├── scan virt
+ │    │    │    ├── columns: k:1!null i:2 s:3 j:4
+ │    │    │    ├── computed column expressions
+ │    │    │    │    ├── v:5
+ │    │    │    │    │    └── lower(s:3)
+ │    │    │    │    ├── w:6
+ │    │    │    │    │    └── upper(s:3)
+ │    │    │    │    └── x:7
+ │    │    │    │         └── j:4->'x'
+ │    │    │    ├── key: (1)
+ │    │    │    └── fd: (1)-->(2-4)
+ │    │    └── filters
+ │    │         ├── lower(s:3) = 'foo' [outer=(3), immutable]
+ │    │         └── i:2 = 10 [outer=(2), constraints=(/2: [/10 - /10]; tight), fd=()-->(2)]
+ │    └── projections
+ │         ├── lower(s:3) [as=v:5, outer=(3), immutable]
+ │         ├── upper(s:3) [as=w:6, outer=(3), immutable]
+ │         └── j:4->'x' [as=x:7, outer=(4), immutable]
+ └── filters
+      └── w:6 = 'FOO' [outer=(6), constraints=(/6: [/'FOO' - /'FOO']; tight), fd=()-->(6)]
+
+# Do not inline correlated subqueries.
+norm expect-not=InlineSelectVirtualColumns
+SELECT * FROM virt v1
+WHERE w = 'FOO' AND EXISTS (
+  SELECT * FROM virt v2 WHERE v1.v = v2.s
+)
+----
+semi-join (hash)
+ ├── columns: k:1!null i:2 s:3 j:4 v:5 w:6!null x:7
+ ├── immutable
+ ├── key: (1)
+ ├── fd: ()-->(6), (1)-->(2-4), (3)-->(5), (4)-->(7)
+ ├── select
+ │    ├── columns: k:1!null i:2 s:3 j:4 v:5 w:6!null x:7
+ │    ├── immutable
+ │    ├── key: (1)
+ │    ├── fd: ()-->(6), (1)-->(2-4), (3)-->(5), (4)-->(7)
+ │    ├── project
+ │    │    ├── columns: v:5 w:6 x:7 k:1!null i:2 s:3 j:4
+ │    │    ├── immutable
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(2-4), (3)-->(5,6), (4)-->(7)
+ │    │    ├── scan virt
+ │    │    │    ├── columns: k:1!null i:2 s:3 j:4
+ │    │    │    ├── computed column expressions
+ │    │    │    │    ├── v:5
+ │    │    │    │    │    └── lower(s:3)
+ │    │    │    │    ├── w:6
+ │    │    │    │    │    └── upper(s:3)
+ │    │    │    │    └── x:7
+ │    │    │    │         └── j:4->'x'
+ │    │    │    ├── key: (1)
+ │    │    │    └── fd: (1)-->(2-4)
+ │    │    └── projections
+ │    │         ├── lower(s:3) [as=v:5, outer=(3), immutable]
+ │    │         ├── upper(s:3) [as=w:6, outer=(3), immutable]
+ │    │         └── j:4->'x' [as=x:7, outer=(4), immutable]
+ │    └── filters
+ │         └── w:6 = 'FOO' [outer=(6), constraints=(/6: [/'FOO' - /'FOO']; tight), fd=()-->(6)]
+ ├── scan virt
+ │    ├── columns: s:12
+ │    └── computed column expressions
+ │         ├── v:14
+ │         │    └── lower(s:12)
+ │         ├── w:15
+ │         │    └── upper(s:12)
+ │         └── x:16
+ │              └── j:13->'x'
+ └── filters
+      └── v:5 = s:12 [outer=(5,12), constraints=(/5: (/NULL - ]; /12: (/NULL - ]), fd=(5)==(12), (12)==(5)]
 
 # --------------------------------------------------
 # InlineProjectInProject

--- a/pkg/sql/opt/table_meta.go
+++ b/pkg/sql/opt/table_meta.go
@@ -172,8 +172,7 @@ func (tm *TableMeta) clearAnnotations() {
 	}
 }
 
-// IndexColumns returns the metadata IDs for the set of table columns in the
-// given index.
+// IndexColumns returns the set of table columns in the given index.
 // TODO(justin): cache this value in the table metadata.
 func (tm *TableMeta) IndexColumns(indexOrd int) ColSet {
 	index := tm.Table.Index(indexOrd)
@@ -186,9 +185,8 @@ func (tm *TableMeta) IndexColumns(indexOrd int) ColSet {
 	return indexCols
 }
 
-// IndexColumnsMapVirtual returns the metadata IDs for the set of table columns
-// in the given index. Virtual inverted index columns are mapped to their source
-// column.
+// IndexColumnsMapVirtual returns the set of table columns in the given index.
+// Virtual inverted index columns are mapped to their source column.
 func (tm *TableMeta) IndexColumnsMapVirtual(indexOrd int) ColSet {
 	index := tm.Table.Index(indexOrd)
 
@@ -204,8 +202,7 @@ func (tm *TableMeta) IndexColumnsMapVirtual(indexOrd int) ColSet {
 	return indexCols
 }
 
-// IndexKeyColumns returns the metadata IDs for the set of strict key columns in
-// the given index.
+// IndexKeyColumns returns the set of strict key columns in the given index.
 func (tm *TableMeta) IndexKeyColumns(indexOrd int) ColSet {
 	index := tm.Table.Index(indexOrd)
 
@@ -217,9 +214,8 @@ func (tm *TableMeta) IndexKeyColumns(indexOrd int) ColSet {
 	return indexCols
 }
 
-// IndexKeyColumnsMapVirtual returns the metadata IDs for the set of strict key
-// columns in the given index. Inverted index columns are mapped to their source
-// column.
+// IndexKeyColumnsMapVirtual returns the set of strict key columns in the given
+// index. Inverted index columns are mapped to their source column.
 func (tm *TableMeta) IndexKeyColumnsMapVirtual(indexOrd int) ColSet {
 	index := tm.Table.Index(indexOrd)
 
@@ -282,6 +278,18 @@ func (tm *TableMeta) PartialIndexPredicate(ord cat.IndexOrdinal) (pred ScalarExp
 // opt expressions. Use PartialIndexPredicate in all other cases.
 func (tm *TableMeta) PartialIndexPredicatesForFormattingOnly() map[cat.IndexOrdinal]ScalarExpr {
 	return tm.partialIndexPredicates
+}
+
+// VirtualComputedColumns returns the set of virtual computed table columns.
+func (tm *TableMeta) VirtualComputedColumns() ColSet {
+	var virtualCols ColSet
+	for col := range tm.ComputedCols {
+		ord := tm.MetaID.ColumnOrdinal(col)
+		if tm.Table.Column(ord).IsVirtualComputed() {
+			virtualCols.Add(col)
+		}
+	}
+	return virtualCols
 }
 
 // TableAnnotation returns the given annotation that is associated with the

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -122,7 +122,10 @@ CREATE TABLE virtual (
     a INT,
     b INT,
     c INT AS (b + 10) VIRTUAL,
-    INDEX (a) WHERE c IN (10, 20, 30)
+    s STRING,
+    lower_s STRING AS (lower(s)) VIRTUAL,
+    INDEX (a) WHERE c IN (10, 20, 30),
+    INDEX (lower_s)
 )
 ----
 
@@ -362,8 +365,10 @@ project
       ├── scan virtual
       │    ├── columns: k:1!null b:3
       │    ├── computed column expressions
-      │    │    └── c:4
-      │    │         └── b:3 + 10
+      │    │    ├── c:4
+      │    │    │    └── b:3 + 10
+      │    │    └── lower_s:6
+      │    │         └── lower(s:5)
       │    ├── partial index predicates
       │    │    └── secondary: filters
       │    │         └── (b:3 + 10) IN (10, 20, 30) [outer=(3), immutable]
@@ -1421,6 +1426,20 @@ scan with_time_index@secondary
  ├── key: (1)
  └── fd: (1)-->(2)
 
+# Test that we can constrain an index on a virtual column with a function in the
+# expression.
+opt expect=GenerateConstrainedScans
+SELECT k FROM virtual WHERE lower_s = 'foo'
+----
+project
+ ├── columns: k:1!null
+ ├── immutable
+ ├── key: (1)
+ └── scan virtual@secondary
+      ├── columns: k:1!null
+      ├── constraint: /6/1: [/'foo' - /'foo']
+      └── key: (1)
+
 # Constrained partial index scan.
 
 exec-ddl
@@ -1690,8 +1709,10 @@ project
       ├── scan virtual
       │    ├── columns: k:1!null a:2 b:3
       │    ├── computed column expressions
-      │    │    └── c:4
-      │    │         └── b:3 + 10
+      │    │    ├── c:4
+      │    │    │    └── b:3 + 10
+      │    │    └── lower_s:6
+      │    │         └── lower(s:5)
       │    ├── partial index predicates
       │    │    └── secondary: filters
       │    │         └── (b:3 + 10) IN (10, 20, 30) [outer=(3), immutable]


### PR DESCRIPTION
The InlineSelectVirtualColumns normalization rule has been added. This
rule pushes Select filters that reference virtual computed columns under
the Project that projects the virtual column. Only virtual columns that
are indexed by secondary indexes are inlined. This rule is required in
order to generate plans that use indexes with virtual columns when the
virtual column expressions are complex and therefore not inlined by
PushSelectIntoInlinableProject.

In discussions with the team we considered altering
PushSelectIntoInlinableProject to inline more expressions as long as
costly expressions are not inlined (to avoid the overhead of computing
the expression twice; once in the filter and once in the projection).
However, with a rule that only inlines indexed virtual columns, the cost
of the expression is no longer relevant. We would always choose to
inline an expensive virtual column expression if there is a chance it
will allow usage of an index on the virtual column and avoid a full
table scan.

There is no release note because virtual columns are gated behind an
experimental session setting.

Release note: None