### PR TITLE
execinfra: remove return ctx parameter from RowSource.Start

### DIFF
--- a/pkg/ccl/backupccl/backup_processor.go
+++ b/pkg/ccl/backupccl/backup_processor.go
@@ -108,12 +108,18 @@ func newBackupDataProcessor(
 }
 
 // Start is part of the RowSource interface.
-func (bp *backupDataProcessor) Start(ctx context.Context) context.Context {
+func (bp *backupDataProcessor) Start(ctx context.Context) {
 	go func() {
 		defer close(bp.progCh)
 		bp.backupErr = runBackupProcessor(ctx, bp.flowCtx, &bp.spec, bp.progCh)
 	}()
-	return bp.StartInternal(ctx, backupProcessorName)
+	ctx = bp.StartInternal(ctx, backupProcessorName)
+	// Go around "this value of ctx is never used" linter error. We do it this
+	// way instead of omitting the assignment to ctx above so that if in the
+	// future other initialization is added, the correct ctx is used.
+	// TODO(bulkio): check whether this context should be used in the closure
+	// above.
+	_ = ctx
 }
 
 // Next is part of the RowSource interface.

--- a/pkg/ccl/backupccl/restore_data_processor.go
+++ b/pkg/ccl/backupccl/restore_data_processor.go
@@ -79,9 +79,13 @@ func newRestoreDataProcessor(
 }
 
 // Start is part of the RowSource interface.
-func (rd *restoreDataProcessor) Start(ctx context.Context) context.Context {
+func (rd *restoreDataProcessor) Start(ctx context.Context) {
 	rd.input.Start(ctx)
-	return rd.StartInternal(ctx, restoreDataProcName)
+	ctx = rd.StartInternal(ctx, restoreDataProcName)
+	// Go around "this value of ctx is never used" linter error. We do it this
+	// way instead of omitting the assignment to ctx above so that if in the
+	// future other initialization is added, the correct ctx is used.
+	_ = ctx
 }
 
 // Next is part of the RowSource interface.

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -190,7 +190,7 @@ func newChangeAggregatorProcessor(
 }
 
 // Start is part of the RowSource interface.
-func (ca *changeAggregator) Start(ctx context.Context) context.Context {
+func (ca *changeAggregator) Start(ctx context.Context) {
 	ctx, ca.cancel = context.WithCancel(ctx)
 	// StartInternal called at the beginning of the function because there are
 	// early returns if errors are detected.
@@ -209,7 +209,7 @@ func (ca *changeAggregator) Start(ctx context.Context) context.Context {
 		// Early abort in the case that there is an error creating the sink.
 		ca.MoveToDraining(err)
 		ca.cancel()
-		return ctx
+		return
 	}
 
 	// This is the correct point to set up certain hooks depending on the sink
@@ -258,8 +258,6 @@ func (ca *changeAggregator) Start(ctx context.Context) context.Context {
 	}
 
 	ca.startKVFeed(ctx, kvfeedCfg)
-
-	return ctx
 }
 
 func (ca *changeAggregator) startKVFeed(ctx context.Context, kvfeedCfg kvfeed.Config) {
@@ -907,7 +905,7 @@ func newChangeFrontierProcessor(
 }
 
 // Start is part of the RowSource interface.
-func (cf *changeFrontier) Start(ctx context.Context) context.Context {
+func (cf *changeFrontier) Start(ctx context.Context) {
 	cf.input.Start(ctx)
 
 	// StartInternal called at the beginning of the function because there are
@@ -925,7 +923,7 @@ func (cf *changeFrontier) Start(ctx context.Context) context.Context {
 	if err != nil {
 		err = MarkRetryableError(err)
 		cf.MoveToDraining(err)
-		return ctx
+		return
 	}
 
 	if b, ok := cf.sink.(*bufferSink); ok {
@@ -945,7 +943,7 @@ func (cf *changeFrontier) Start(ctx context.Context) context.Context {
 		job, err := cf.flowCtx.Cfg.JobRegistry.LoadJob(ctx, cf.spec.JobID)
 		if err != nil {
 			cf.MoveToDraining(err)
-			return ctx
+			return
 		}
 		cf.jobProgressedFn = func(ctx context.Context, fn jobs.HighWaterProgressedFn) error {
 			return job.HighWaterProgressed(ctx, nil /* txn */, fn)
@@ -973,8 +971,6 @@ func (cf *changeFrontier) Start(ctx context.Context) context.Context {
 		<-ctx.Done()
 		cf.closeMetrics()
 	}()
-
-	return ctx
 }
 
 func (cf *changeFrontier) close() {

--- a/pkg/ccl/importccl/import_processor.go
+++ b/pkg/ccl/importccl/import_processor.go
@@ -99,7 +99,7 @@ func newReadImportDataProcessor(
 }
 
 // Start is part of the RowSource interface.
-func (idp *readImportDataProcessor) Start(ctx context.Context) context.Context {
+func (idp *readImportDataProcessor) Start(ctx context.Context) {
 	// We don't have to worry about this go routine leaking because next we loop over progCh
 	// which is closed only after the go routine returns.
 	go func() {
@@ -107,7 +107,13 @@ func (idp *readImportDataProcessor) Start(ctx context.Context) context.Context {
 		idp.summary, idp.importErr = runImport(ctx, idp.flowCtx, &idp.spec, idp.progCh,
 			idp.seqChunkProvider)
 	}()
-	return idp.StartInternal(ctx, readImportDataProcessorName)
+	ctx = idp.StartInternal(ctx, readImportDataProcessorName)
+	// Go around "this value of ctx is never used" linter error. We do it this
+	// way instead of omitting the assignment to ctx above so that if in the
+	// future other initialization is added, the correct ctx is used.
+	// TODO(bulkio): check whether this context should be used in the closure
+	// above.
+	_ = ctx
 }
 
 // Next is part of the RowSource interface.

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_frontier_processor.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_frontier_processor.go
@@ -87,9 +87,13 @@ func newStreamIngestionFrontierProcessor(
 }
 
 // Start is part of the RowSource interface.
-func (sf *streamIngestionFrontier) Start(ctx context.Context) context.Context {
+func (sf *streamIngestionFrontier) Start(ctx context.Context) {
 	sf.input.Start(ctx)
-	return sf.StartInternal(ctx, streamIngestionFrontierProcName)
+	ctx = sf.StartInternal(ctx, streamIngestionFrontierProcName)
+	// Go around "this value of ctx is never used" linter error. We do it this
+	// way instead of omitting the assignment to ctx above so that if in the
+	// future other initialization is added, the correct ctx is used.
+	_ = ctx
 }
 
 // Next is part of the RowSource interface.

--- a/pkg/sql/colexec/materializer.go
+++ b/pkg/sql/colexec/materializer.go
@@ -99,9 +99,8 @@ func (d *drainHelper) OutputTypes() []*types.T {
 }
 
 // Start implements the RowSource interface.
-func (d *drainHelper) Start(ctx context.Context) context.Context {
+func (d *drainHelper) Start(ctx context.Context) {
 	d.ctx = ctx
-	return ctx
 }
 
 // Next implements the RowSource interface.
@@ -233,16 +232,19 @@ func (m *Materializer) Child(nth int, verbose bool) execinfra.OpNode {
 }
 
 // Start is part of the execinfra.RowSource interface.
-func (m *Materializer) Start(ctx context.Context) context.Context {
-	ctx = m.drainHelper.Start(ctx)
+func (m *Materializer) Start(ctx context.Context) {
+	m.drainHelper.Start(ctx)
 	ctx = m.ProcessorBase.StartInternal(ctx, materializerProcName)
+	// Go around "this value of ctx is never used" linter error. We do it this
+	// way instead of omitting the assignment to ctx above so that if in the
+	// future other initialization is added, the correct ctx is used.
+	_ = ctx
 	// We can encounter an expected error during Init (e.g. an operator
 	// attempts to allocate a batch, but the memory budget limit has been
 	// reached), so we need to wrap it with a catcher.
 	if err := colexecerror.CatchVectorizedRuntimeError(m.input.Init); err != nil {
 		m.MoveToDraining(err)
 	}
-	return ctx
 }
 
 // next is the logic of Next() extracted in a separate method to be used by an

--- a/pkg/sql/execinfra/base.go
+++ b/pkg/sql/execinfra/base.go
@@ -107,9 +107,9 @@ type RowSource interface {
 	// inputs.
 	//
 	// Implementations are expected to hold on to the provided context. They may
-	// choose to derive and annotate it (Processors generally do). For convenience,
-	// the possibly updated context is returned.
-	Start(context.Context) context.Context
+	// choose to derive and annotate it (Processors generally do, and the
+	// updated context is usually available at ProcessorBase.Ctx).
+	Start(context.Context)
 
 	// Next returns the next record from the source. At most one of the return
 	// values will be non-empty. Both of them can be empty when the RowSource has
@@ -475,7 +475,7 @@ func (rc *RowChannel) OutputTypes() []*types.T {
 }
 
 // Start is part of the RowSource interface.
-func (rc *RowChannel) Start(ctx context.Context) context.Context { return ctx }
+func (rc *RowChannel) Start(ctx context.Context) {}
 
 // Next is part of the RowSource interface.
 func (rc *RowChannel) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMetadata) {

--- a/pkg/sql/execinfra/metadata_test_receiver.go
+++ b/pkg/sql/execinfra/metadata_test_receiver.go
@@ -139,9 +139,13 @@ func (mtr *MetadataTestReceiver) checkRowNumMetadata() *execinfrapb.ProducerMeta
 }
 
 // Start is part of the RowSource interface.
-func (mtr *MetadataTestReceiver) Start(ctx context.Context) context.Context {
+func (mtr *MetadataTestReceiver) Start(ctx context.Context) {
 	mtr.input.Start(ctx)
-	return mtr.StartInternal(ctx, metadataTestReceiverProcName)
+	ctx = mtr.StartInternal(ctx, metadataTestReceiverProcName)
+	// Go around "this value of ctx is never used" linter error. We do it this
+	// way instead of omitting the assignment to ctx above so that if in the
+	// future other initialization is added, the correct ctx is used.
+	_ = ctx
 }
 
 // Next is part of the RowSource interface.

--- a/pkg/sql/execinfra/metadata_test_sender.go
+++ b/pkg/sql/execinfra/metadata_test_sender.go
@@ -74,9 +74,13 @@ func NewMetadataTestSender(
 }
 
 // Start is part of the RowSource interface.
-func (mts *MetadataTestSender) Start(ctx context.Context) context.Context {
+func (mts *MetadataTestSender) Start(ctx context.Context) {
 	mts.input.Start(ctx)
-	return mts.StartInternal(ctx, metadataTestSenderProcName)
+	ctx = mts.StartInternal(ctx, metadataTestSenderProcName)
+	// Go around "this value of ctx is never used" linter error. We do it this
+	// way instead of omitting the assignment to ctx above so that if in the
+	// future other initialization is added, the correct ctx is used.
+	_ = ctx
 }
 
 // Next is part of the RowSource interface.

--- a/pkg/sql/execinfra/testutils.go
+++ b/pkg/sql/execinfra/testutils.go
@@ -54,7 +54,7 @@ func (r *RepeatableRowSource) OutputTypes() []*types.T {
 }
 
 // Start is part of the RowSource interface.
-func (r *RepeatableRowSource) Start(ctx context.Context) context.Context { return ctx }
+func (r *RepeatableRowSource) Start(ctx context.Context) {}
 
 // Next is part of the RowSource interface.
 func (r *RepeatableRowSource) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMetadata) {

--- a/pkg/sql/plan_node_to_row_source.go
+++ b/pkg/sql/plan_node_to_row_source.go
@@ -115,7 +115,7 @@ func (p *planNodeToRowSource) SetInput(ctx context.Context, input execinfra.RowS
 	})
 }
 
-func (p *planNodeToRowSource) Start(ctx context.Context) context.Context {
+func (p *planNodeToRowSource) Start(ctx context.Context) {
 	// We do not call p.StartInternal to avoid creating a span. Only the context
 	// needs to be set.
 	p.Ctx = ctx
@@ -125,10 +125,9 @@ func (p *planNodeToRowSource) Start(ctx context.Context) context.Context {
 		// This starts all of the nodes below this node.
 		if err := startExec(p.params, p.node); err != nil {
 			p.MoveToDraining(err)
-			return ctx
+			return
 		}
 	}
-	return ctx
 }
 
 func (p *planNodeToRowSource) InternalClose() bool {

--- a/pkg/sql/rowexec/aggregator.go
+++ b/pkg/sql/rowexec/aggregator.go
@@ -327,21 +327,20 @@ func newOrderedAggregator(
 }
 
 // Start is part of the RowSource interface.
-func (ag *hashAggregator) Start(ctx context.Context) context.Context {
-	return ag.start(ctx, hashAggregatorProcName)
+func (ag *hashAggregator) Start(ctx context.Context) {
+	ag.start(ctx, hashAggregatorProcName)
 }
 
 // Start is part of the RowSource interface.
-func (ag *orderedAggregator) Start(ctx context.Context) context.Context {
-	return ag.start(ctx, orderedAggregatorProcName)
+func (ag *orderedAggregator) Start(ctx context.Context) {
+	ag.start(ctx, orderedAggregatorProcName)
 }
 
-func (ag *aggregatorBase) start(ctx context.Context, procName string) context.Context {
+func (ag *aggregatorBase) start(ctx context.Context, procName string) {
 	ag.input.Start(ctx)
 	ctx = ag.StartInternal(ctx, procName)
 	ag.cancelChecker = cancelchecker.NewCancelChecker(ctx)
 	ag.runningState = aggAccumulating
-	return ctx
 }
 
 func (ag *hashAggregator) close() {

--- a/pkg/sql/rowexec/bulk_row_writer.go
+++ b/pkg/sql/rowexec/bulk_row_writer.go
@@ -75,12 +75,11 @@ func newBulkRowWriterProcessor(
 }
 
 // Start is part of the RowSource interface.
-func (sp *bulkRowWriter) Start(ctx context.Context) context.Context {
+func (sp *bulkRowWriter) Start(ctx context.Context) {
 	sp.input.Start(ctx)
 	ctx = sp.StartInternal(ctx, "bulkRowWriter")
 	err := sp.work(ctx)
 	sp.MoveToDraining(err)
-	return ctx
 }
 
 // Next is part of the RowSource interface.

--- a/pkg/sql/rowexec/countrows.go
+++ b/pkg/sql/rowexec/countrows.go
@@ -67,9 +67,13 @@ func newCountAggregator(
 	return ag, nil
 }
 
-func (ag *countAggregator) Start(ctx context.Context) context.Context {
+func (ag *countAggregator) Start(ctx context.Context) {
 	ag.input.Start(ctx)
-	return ag.StartInternal(ctx, countRowsProcName)
+	ctx = ag.StartInternal(ctx, countRowsProcName)
+	// Go around "this value of ctx is never used" linter error. We do it this
+	// way instead of omitting the assignment to ctx above so that if in the
+	// future other initialization is added, the correct ctx is used.
+	_ = ctx
 }
 
 func (ag *countAggregator) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMetadata) {

--- a/pkg/sql/rowexec/distinct.go
+++ b/pkg/sql/rowexec/distinct.go
@@ -141,15 +141,23 @@ func newDistinct(
 }
 
 // Start is part of the RowSource interface.
-func (d *distinct) Start(ctx context.Context) context.Context {
+func (d *distinct) Start(ctx context.Context) {
 	d.input.Start(ctx)
-	return d.StartInternal(ctx, distinctProcName)
+	ctx = d.StartInternal(ctx, distinctProcName)
+	// Go around "this value of ctx is never used" linter error. We do it this
+	// way instead of omitting the assignment to ctx above so that if in the
+	// future other initialization is added, the correct ctx is used.
+	_ = ctx
 }
 
 // Start is part of the RowSource interface.
-func (d *sortedDistinct) Start(ctx context.Context) context.Context {
+func (d *sortedDistinct) Start(ctx context.Context) {
 	d.input.Start(ctx)
-	return d.StartInternal(ctx, sortedDistinctProcName)
+	ctx = d.StartInternal(ctx, sortedDistinctProcName)
+	// Go around "this value of ctx is never used" linter error. We do it this
+	// way instead of omitting the assignment to ctx above so that if in the
+	// future other initialization is added, the correct ctx is used.
+	_ = ctx
 }
 
 func (d *distinct) matchLastGroupKey(row rowenc.EncDatumRow) (bool, error) {

--- a/pkg/sql/rowexec/filterer.go
+++ b/pkg/sql/rowexec/filterer.go
@@ -70,9 +70,13 @@ func newFiltererProcessor(
 }
 
 // Start is part of the RowSource interface.
-func (f *filtererProcessor) Start(ctx context.Context) context.Context {
+func (f *filtererProcessor) Start(ctx context.Context) {
 	f.input.Start(ctx)
-	return f.StartInternal(ctx, filtererProcName)
+	ctx = f.StartInternal(ctx, filtererProcName)
+	// Go around "this value of ctx is never used" linter error. We do it this
+	// way instead of omitting the assignment to ctx above so that if in the
+	// future other initialization is added, the correct ctx is used.
+	_ = ctx
 }
 
 // Next is part of the RowSource interface.

--- a/pkg/sql/rowexec/hashjoiner.go
+++ b/pkg/sql/rowexec/hashjoiner.go
@@ -157,13 +157,12 @@ func newHashJoiner(
 }
 
 // Start is part of the RowSource interface.
-func (h *hashJoiner) Start(ctx context.Context) context.Context {
+func (h *hashJoiner) Start(ctx context.Context) {
 	h.leftSource.Start(ctx)
 	h.rightSource.Start(ctx)
 	ctx = h.StartInternal(ctx, hashJoinerProcName)
 	h.cancelChecker = cancelchecker.NewCancelChecker(ctx)
 	h.runningState = hjBuilding
-	return ctx
 }
 
 // Next is part of the RowSource interface.

--- a/pkg/sql/rowexec/inverted_filterer.go
+++ b/pkg/sql/rowexec/inverted_filterer.go
@@ -287,11 +287,14 @@ func (ifr *invertedFilterer) emitRow() (
 }
 
 // Start is part of the RowSource interface.
-func (ifr *invertedFilterer) Start(ctx context.Context) context.Context {
+func (ifr *invertedFilterer) Start(ctx context.Context) {
 	ifr.input.Start(ctx)
 	ctx = ifr.StartInternal(ctx, invertedFiltererProcName)
+	// Go around "this value of ctx is never used" linter error. We do it this
+	// way instead of omitting the assignment to ctx above so that if in the
+	// future other initialization is added, the correct ctx is used.
+	_ = ctx
 	ifr.runningState = ifrReadingInput
-	return ctx
 }
 
 // ConsumerClosed is part of the RowSource interface.

--- a/pkg/sql/rowexec/inverted_joiner.go
+++ b/pkg/sql/rowexec/inverted_joiner.go
@@ -733,11 +733,14 @@ func (ij *invertedJoiner) transformToTableRow(indexRow rowenc.EncDatumRow) {
 }
 
 // Start is part of the RowSource interface.
-func (ij *invertedJoiner) Start(ctx context.Context) context.Context {
+func (ij *invertedJoiner) Start(ctx context.Context) {
 	ij.input.Start(ctx)
 	ctx = ij.StartInternal(ctx, invertedJoinerProcName)
+	// Go around "this value of ctx is never used" linter error. We do it this
+	// way instead of omitting the assignment to ctx above so that if in the
+	// future other initialization is added, the correct ctx is used.
+	_ = ctx
 	ij.runningState = ijReadingInput
-	return ctx
 }
 
 // ConsumerClosed is part of the RowSource interface.

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -699,11 +699,14 @@ func (jr *joinReader) emitRow() (
 }
 
 // Start is part of the RowSource interface.
-func (jr *joinReader) Start(ctx context.Context) context.Context {
+func (jr *joinReader) Start(ctx context.Context) {
 	jr.input.Start(ctx)
 	ctx = jr.StartInternal(ctx, joinReaderProcName)
+	// Go around "this value of ctx is never used" linter error. We do it this
+	// way instead of omitting the assignment to ctx above so that if in the
+	// future other initialization is added, the correct ctx is used.
+	_ = ctx
 	jr.runningState = jrReadingInput
-	return ctx
 }
 
 // ConsumerClosed is part of the RowSource interface.

--- a/pkg/sql/rowexec/mergejoiner.go
+++ b/pkg/sql/rowexec/mergejoiner.go
@@ -114,11 +114,10 @@ func newMergeJoiner(
 }
 
 // Start is part of the RowSource interface.
-func (m *mergeJoiner) Start(ctx context.Context) context.Context {
+func (m *mergeJoiner) Start(ctx context.Context) {
 	m.streamMerger.start(ctx)
 	ctx = m.StartInternal(ctx, mergeJoinerProcName)
 	m.cancelChecker = cancelchecker.NewCancelChecker(ctx)
-	return ctx
 }
 
 // Next is part of the Processor interface.

--- a/pkg/sql/rowexec/noop.go
+++ b/pkg/sql/rowexec/noop.go
@@ -63,9 +63,13 @@ func newNoopProcessor(
 }
 
 // Start is part of the RowSource interface.
-func (n *noopProcessor) Start(ctx context.Context) context.Context {
+func (n *noopProcessor) Start(ctx context.Context) {
 	n.input.Start(ctx)
-	return n.StartInternal(ctx, noopProcName)
+	ctx = n.StartInternal(ctx, noopProcName)
+	// Go around "this value of ctx is never used" linter error. We do it this
+	// way instead of omitting the assignment to ctx above so that if in the
+	// future other initialization is added, the correct ctx is used.
+	_ = ctx
 }
 
 // Next is part of the RowSource interface.

--- a/pkg/sql/rowexec/ordinality.go
+++ b/pkg/sql/rowexec/ordinality.go
@@ -75,9 +75,13 @@ func newOrdinalityProcessor(
 }
 
 // Start is part of the RowSource interface.
-func (o *ordinalityProcessor) Start(ctx context.Context) context.Context {
+func (o *ordinalityProcessor) Start(ctx context.Context) {
 	o.input.Start(ctx)
-	return o.StartInternal(ctx, ordinalityProcName)
+	ctx = o.StartInternal(ctx, ordinalityProcName)
+	// Go around "this value of ctx is never used" linter error. We do it this
+	// way instead of omitting the assignment to ctx above so that if in the
+	// future other initialization is added, the correct ctx is used.
+	_ = ctx
 }
 
 // Next is part of the RowSource interface.

--- a/pkg/sql/rowexec/project_set.go
+++ b/pkg/sql/rowexec/project_set.go
@@ -115,11 +115,10 @@ func newProjectSetProcessor(
 }
 
 // Start is part of the RowSource interface.
-func (ps *projectSetProcessor) Start(ctx context.Context) context.Context {
-	ctx = ps.input.Start(ctx)
+func (ps *projectSetProcessor) Start(ctx context.Context) {
+	ps.input.Start(ctx)
 	ctx = ps.StartInternal(ctx, projectSetProcName)
 	ps.cancelChecker = cancelchecker.NewCancelChecker(ctx)
-	return ctx
 }
 
 // nextInputRow returns the next row or metadata from ps.input. It also

--- a/pkg/sql/rowexec/sample_aggregator.go
+++ b/pkg/sql/rowexec/sample_aggregator.go
@@ -182,7 +182,11 @@ func (s *sampleAggregator) pushTrailingMeta(ctx context.Context) {
 // Run is part of the Processor interface.
 func (s *sampleAggregator) Run(ctx context.Context) {
 	s.input.Start(ctx)
-	s.StartInternal(ctx, sampleAggregatorProcName)
+	ctx = s.StartInternal(ctx, sampleAggregatorProcName)
+	// Go around "this value of ctx is never used" linter error. We do it this
+	// way instead of omitting the assignment to ctx above so that if in the
+	// future other initialization is added, the correct ctx is used.
+	_ = ctx
 
 	earlyExit, err := s.mainLoop(s.Ctx)
 	if err != nil {

--- a/pkg/sql/rowexec/sampler.go
+++ b/pkg/sql/rowexec/sampler.go
@@ -219,7 +219,11 @@ func (s *samplerProcessor) pushTrailingMeta(ctx context.Context) {
 // Run is part of the Processor interface.
 func (s *samplerProcessor) Run(ctx context.Context) {
 	s.input.Start(ctx)
-	s.StartInternal(ctx, samplerProcName)
+	ctx = s.StartInternal(ctx, samplerProcName)
+	// Go around "this value of ctx is never used" linter error. We do it this
+	// way instead of omitting the assignment to ctx above so that if in the
+	// future other initialization is added, the correct ctx is used.
+	_ = ctx
 
 	earlyExit, err := s.mainLoop(s.Ctx)
 	if err != nil {

--- a/pkg/sql/rowexec/scrub_tablereader.go
+++ b/pkg/sql/rowexec/scrub_tablereader.go
@@ -209,7 +209,7 @@ func (tr *scrubTableReader) prettyPrimaryKeyValues(
 }
 
 // Start is part of the RowSource interface.
-func (tr *scrubTableReader) Start(ctx context.Context) context.Context {
+func (tr *scrubTableReader) Start(ctx context.Context) {
 	if tr.FlowCtx.Txn == nil {
 		tr.MoveToDraining(errors.Errorf("scrubTableReader outside of txn"))
 	}
@@ -224,8 +224,6 @@ func (tr *scrubTableReader) Start(ctx context.Context) context.Context {
 	); err != nil {
 		tr.MoveToDraining(err)
 	}
-
-	return ctx
 }
 
 // Next is part of the RowSource interface.

--- a/pkg/sql/rowexec/sorter.go
+++ b/pkg/sql/rowexec/sorter.go
@@ -226,15 +226,18 @@ func newSortAllProcessor(
 }
 
 // Start is part of the RowSource interface.
-func (s *sortAllProcessor) Start(ctx context.Context) context.Context {
+func (s *sortAllProcessor) Start(ctx context.Context) {
 	s.input.Start(ctx)
 	ctx = s.StartInternal(ctx, sortAllProcName)
+	// Go around "this value of ctx is never used" linter error. We do it this
+	// way instead of omitting the assignment to ctx above so that if in the
+	// future other initialization is added, the correct ctx is used.
+	_ = ctx
 
 	valid, err := s.fill()
 	if !valid || err != nil {
 		s.MoveToDraining(err)
 	}
-	return ctx
 }
 
 // fill fills s.rows with the input's rows.
@@ -339,7 +342,7 @@ func newSortTopKProcessor(
 }
 
 // Start is part of the RowSource interface.
-func (s *sortTopKProcessor) Start(ctx context.Context) context.Context {
+func (s *sortTopKProcessor) Start(ctx context.Context) {
 	s.input.Start(ctx)
 	ctx = s.StartInternal(ctx, sortTopKProcName)
 
@@ -384,7 +387,6 @@ func (s *sortTopKProcessor) Start(ctx context.Context) context.Context {
 	s.rows.Sort(ctx)
 	s.i = s.rows.NewFinalIterator(ctx)
 	s.i.Rewind()
-	return ctx
 }
 
 // ConsumerClosed is part of the RowSource interface.
@@ -523,9 +525,13 @@ func (s *sortChunksProcessor) fill() (bool, error) {
 }
 
 // Start is part of the RowSource interface.
-func (s *sortChunksProcessor) Start(ctx context.Context) context.Context {
+func (s *sortChunksProcessor) Start(ctx context.Context) {
 	s.input.Start(ctx)
-	return s.StartInternal(ctx, sortChunksProcName)
+	ctx = s.StartInternal(ctx, sortChunksProcName)
+	// Go around "this value of ctx is never used" linter error. We do it this
+	// way instead of omitting the assignment to ctx above so that if in the
+	// future other initialization is added, the correct ctx is used.
+	_ = ctx
 }
 
 // Next is part of the RowSource interface.

--- a/pkg/sql/rowexec/tablereader.go
+++ b/pkg/sql/rowexec/tablereader.go
@@ -176,7 +176,7 @@ func (tr *tableReader) generateTrailingMeta(ctx context.Context) []execinfrapb.P
 }
 
 // Start is part of the RowSource interface.
-func (tr *tableReader) Start(ctx context.Context) context.Context {
+func (tr *tableReader) Start(ctx context.Context) {
 	if tr.FlowCtx.Txn == nil {
 		log.Fatalf(ctx, "tableReader outside of txn")
 	}
@@ -204,7 +204,6 @@ func (tr *tableReader) Start(ctx context.Context) context.Context {
 	if err != nil {
 		tr.MoveToDraining(err)
 	}
-	return ctx
 }
 
 // Release releases this tableReader back to the pool.

--- a/pkg/sql/rowexec/utils_test.go
+++ b/pkg/sql/rowexec/utils_test.go
@@ -103,6 +103,8 @@ type rowGeneratingSource struct {
 	maxRows int
 }
 
+var _ execinfra.RowSource = &rowGeneratingSource{}
+
 // newRowGeneratingSource creates a new rowGeneratingSource with the given fn
 // and a maximum number of rows to generate. Can be reset using Reset.
 func newRowGeneratingSource(
@@ -113,7 +115,7 @@ func newRowGeneratingSource(
 
 func (r *rowGeneratingSource) OutputTypes() []*types.T { return r.types }
 
-func (r *rowGeneratingSource) Start(ctx context.Context) context.Context { return ctx }
+func (r *rowGeneratingSource) Start(context.Context) {}
 
 func (r *rowGeneratingSource) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMetadata) {
 	if r.rowIdx > r.maxRows {

--- a/pkg/sql/rowexec/values.go
+++ b/pkg/sql/rowexec/values.go
@@ -68,7 +68,7 @@ func newValuesProcessor(
 }
 
 // Start is part of the RowSource interface.
-func (v *valuesProcessor) Start(ctx context.Context) context.Context {
+func (v *valuesProcessor) Start(ctx context.Context) {
 	ctx = v.StartInternal(ctx, valuesProcName)
 
 	// Add a bogus header to appease the StreamDecoder, which wants to receive a
@@ -79,11 +79,10 @@ func (v *valuesProcessor) Start(ctx context.Context) context.Context {
 	}
 	if err := v.sd.AddMessage(ctx, m); err != nil {
 		v.MoveToDraining(err)
-		return ctx
+		return
 	}
 
 	v.rowBuf = make(rowenc.EncDatumRow, len(v.columns))
-	return ctx
 }
 
 // Next is part of the RowSource interface.

--- a/pkg/sql/rowexec/windower.go
+++ b/pkg/sql/rowexec/windower.go
@@ -204,12 +204,11 @@ func newWindower(
 }
 
 // Start is part of the RowSource interface.
-func (w *windower) Start(ctx context.Context) context.Context {
+func (w *windower) Start(ctx context.Context) {
 	w.input.Start(ctx)
 	ctx = w.StartInternal(ctx, windowerProcName)
 	w.cancelChecker = cancelchecker.NewCancelChecker(ctx)
 	w.runningState = windowerAccumulating
-	return ctx
 }
 
 // Next is part of the RowSource interface.

--- a/pkg/sql/rowexec/zigzagjoiner.go
+++ b/pkg/sql/rowexec/zigzagjoiner.go
@@ -371,11 +371,10 @@ func valuesSpecToEncDatum(
 }
 
 // Start is part of the RowSource interface.
-func (z *zigzagJoiner) Start(ctx context.Context) context.Context {
+func (z *zigzagJoiner) Start(ctx context.Context) {
 	ctx = z.StartInternal(ctx, zigzagJoinerProcName)
 	z.cancelChecker = cancelchecker.NewCancelChecker(ctx)
 	log.VEventf(ctx, 2, "starting zigzag joiner run")
-	return ctx
 }
 
 // zigzagJoinerInfo contains all the information that needs to be

--- a/pkg/sql/rowflow/input_sync.go
+++ b/pkg/sql/rowflow/input_sync.go
@@ -279,11 +279,10 @@ func (s *orderedSynchronizer) drainSources() {
 }
 
 // Start is part of the RowSource interface.
-func (s *orderedSynchronizer) Start(ctx context.Context) context.Context {
+func (s *orderedSynchronizer) Start(ctx context.Context) {
 	for _, src := range s.sources {
 		src.src.Start(ctx)
 	}
-	return ctx
 }
 
 // Next is part of the RowSource interface.

--- a/pkg/sql/sem/tree/eval_test/eval_test.go
+++ b/pkg/sql/sem/tree/eval_test/eval_test.go
@@ -204,7 +204,7 @@ func TestEval(t *testing.T) {
 				row  rowenc.EncDatumRow
 				meta *execinfrapb.ProducerMetadata
 			)
-			ctx = mat.Start(ctx)
+			mat.Start(ctx)
 			row, meta = mat.Next()
 			if meta != nil {
 				if meta.Err != nil {

--- a/pkg/testutils/distsqlutils/row_buffer.go
+++ b/pkg/testutils/distsqlutils/row_buffer.go
@@ -163,7 +163,7 @@ func (rb *RowBuffer) OutputTypes() []*types.T {
 }
 
 // Start is part of the RowSource interface.
-func (rb *RowBuffer) Start(ctx context.Context) context.Context { return ctx }
+func (rb *RowBuffer) Start(ctx context.Context) {}
 
 // Next is part of the RowSource interface.
 //


### PR DESCRIPTION
Previously, `RowSource.Start` returned updated ctx, but it was ignored
in almost all cases which might lead to a confusion whether something is
wrong or not. Now we remove the return parameter and clarify the usage
a bit.

Release note: None