### PR TITLE
sql: improve the SHOW TABLES query to avoid reading stats when unused

### DIFF
--- a/pkg/sql/delegate/show_tables.go
+++ b/pkg/sql/delegate/show_tables.go
@@ -82,9 +82,11 @@ ORDER BY schema_name, table_name
 	var estimatedRowCountJoin string
 	if showEstimatedRowCountClusterSetting.Get(&d.evalCtx.Settings.SV) {
 		estimatedRowCount = "s.estimated_row_count AS estimated_row_count, "
-		estimatedRowCountJoin = fmt.Sprintf(
-			`LEFT JOIN %[1]s.crdb_internal.table_row_statistics AS s on (s.table_id = pc.oid::INT8)`,
-			&name.CatalogName,
+		estimatedRowCountJoin = fmt.Sprintf(`LEFT JOIN
+(
+  SELECT DISTINCT ON (table_id) table_id, estimated_row_count FROM %[1]s.crdb_internal.table_row_statistics
+) AS s ON (s.table_id = pc.oid::INT8)
+`, &name.CatalogName,
 		)
 	}
 	var descJoin string

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -359,6 +359,7 @@ vectorized: true
         │   │
         │   └── • hash join (left outer)
         │       │ equality: (column62) = (table_id)
+        │       │ right cols are key
         │       │
         │       ├── • render
         │       │   │
@@ -383,8 +384,11 @@ vectorized: true
         │       │               └── • virtual table
         │       │                     table: pg_class@primary
         │       │
-        │       └── • virtual table
-        │             table: table_row_statistics@primary
+        │       └── • distinct
+        │           │ distinct on: table_id
+        │           │
+        │           └── • virtual table
+        │                 table: table_row_statistics@primary
         │
         └── • virtual table
               table: tables@tables_database_name_idx (partial index)
@@ -409,6 +413,7 @@ vectorized: true
         │   │
         │   └── • hash join (left outer)
         │       │ equality: (column77) = (table_id)
+        │       │ right cols are key
         │       │
         │       ├── • render
         │       │   │
@@ -450,8 +455,11 @@ vectorized: true
         │       │                               └── • virtual table
         │       │                                     table: kv_catalog_comments@primary
         │       │
-        │       └── • virtual table
-        │             table: table_row_statistics@primary
+        │       └── • distinct
+        │           │ distinct on: table_id
+        │           │
+        │           └── • virtual table
+        │                 table: table_row_statistics@primary
         │
         └── • virtual table
               table: tables@tables_database_name_idx (partial index)

--- a/pkg/sql/opt/exec/execbuilder/testdata/show_tables
+++ b/pkg/sql/opt/exec/execbuilder/testdata/show_tables
@@ -1,0 +1,92 @@
+# LogicTest: local
+
+query T
+EXPLAIN SELECT schema_name, table_name, type, owner, estimated_row_count, locality FROM [SHOW TABLES]
+----
+distribution: local
+vectorized: true
+·
+• render
+│
+└── • hash join (left outer)
+    │ equality: (column80) = (table_id)
+    │
+    ├── • render
+    │   │
+    │   └── • hash join (left outer)
+    │       │ equality: (column62) = (table_id)
+    │       │ right cols are key
+    │       │
+    │       ├── • render
+    │       │   │
+    │       │   └── • hash join (right outer)
+    │       │       │ equality: (oid) = (relowner)
+    │       │       │
+    │       │       ├── • virtual table
+    │       │       │     table: pg_roles@primary
+    │       │       │
+    │       │       └── • hash join
+    │       │           │ equality: (oid) = (relnamespace)
+    │       │           │
+    │       │           ├── • filter
+    │       │           │   │ filter: nspname NOT IN ('crdb_internal', 'information_schema', __more1_10__, 'pg_extension')
+    │       │           │   │
+    │       │           │   └── • virtual table
+    │       │           │         table: pg_namespace@primary
+    │       │           │
+    │       │           └── • filter
+    │       │               │ filter: relkind IN ('S', 'm', __more1_10__, 'v')
+    │       │               │
+    │       │               └── • virtual table
+    │       │                     table: pg_class@primary
+    │       │
+    │       └── • distinct
+    │           │ distinct on: table_id
+    │           │
+    │           └── • virtual table
+    │                 table: table_row_statistics@primary
+    │
+    └── • virtual table
+          table: tables@tables_database_name_idx (partial index)
+          spans: [/'test' - /'test']
+
+# Notice that there is no join against table_row_statistics when the
+# estimated_row_count column is not used.
+
+query T
+EXPLAIN SELECT schema_name, table_name, type, owner, locality FROM [SHOW TABLES]
+----
+distribution: local
+vectorized: true
+·
+• render
+│
+└── • hash join (left outer)
+    │ equality: (column80) = (table_id)
+    │
+    ├── • render
+    │   │
+    │   └── • hash join (right outer)
+    │       │ equality: (oid) = (relowner)
+    │       │
+    │       ├── • virtual table
+    │       │     table: pg_roles@primary
+    │       │
+    │       └── • hash join
+    │           │ equality: (oid) = (relnamespace)
+    │           │
+    │           ├── • filter
+    │           │   │ filter: nspname NOT IN ('crdb_internal', 'information_schema', __more1_10__, 'pg_extension')
+    │           │   │
+    │           │   └── • virtual table
+    │           │         table: pg_namespace@primary
+    │           │
+    │           └── • filter
+    │               │ filter: relkind IN ('S', 'm', __more1_10__, 'v')
+    │               │
+    │               └── • virtual table
+    │                     table: pg_class@primary
+    │
+    └── • virtual table
+          table: tables@tables_database_name_idx (partial index)
+          spans: [/'test' - /'test']

--- a/pkg/sql/opt/exec/execbuilder/tests/local/generated_test.go
+++ b/pkg/sql/opt/exec/execbuilder/tests/local/generated_test.go
@@ -533,6 +533,13 @@ func TestExecBuild_select_index_vectorize_off(
 	runExecBuildLogicTest(t, "select_index_vectorize_off")
 }
 
+func TestExecBuild_show_tables(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runExecBuildLogicTest(t, "show_tables")
+}
+
 func TestExecBuild_show_trace(
 	t *testing.T,
 ) {


### PR DESCRIPTION
There is a distinct relationship between tables and row statistics which
was previously not stated explicitly in the query and thus, the optimizer
was unable to eliminate the join against the statistics table when the
`estimated_row_count` column was not used.

Touches #58189.
Epic: None

Release note (performance improvement): Queries which use `SHOW TABLES` but
do not utilize the `estimated_row_count` column no longer need to look up
the table statistics.