### PR TITLE
roachtest: add follower_reads variant using non-voting replicas

### DIFF
--- a/pkg/cmd/roachtest/cli.go
+++ b/pkg/cmd/roachtest/cli.go
@@ -24,7 +24,7 @@ func runCLINodeStatus(ctx context.Context, t *test, c *cluster) {
 	db := c.Conn(ctx, 1)
 	defer db.Close()
 
-	waitForFullReplication(t, db)
+	waitForFullReplication(t, db, 3)
 
 	lastWords := func(s string) []string {
 		var result []string
@@ -107,7 +107,7 @@ func runCLINodeStatus(ctx context.Context, t *test, c *cluster) {
 	c.Start(ctx, t, c.Range(1, 2))
 
 	// Wait for the cluster to come back up.
-	waitForFullReplication(t, db)
+	waitForFullReplication(t, db, 3)
 
 	waitUntil([]string{
 		"is_available is_live",

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2799,12 +2799,12 @@ func (m *monitor) wait(args ...string) error {
 
 // TODO(nvanbenschoten): this function should take a context and be responsive
 // to context cancellation.
-func waitForFullReplication(t *test, db *gosql.DB) {
+func waitForFullReplication(t *test, db *gosql.DB, numReplicas int) {
 	t.l.Printf("waiting for up-replication...")
 	tStart := timeutil.Now()
 	for ok := false; !ok; time.Sleep(time.Second) {
 		if err := db.QueryRow(
-			"SELECT min(array_length(replicas, 1)) >= 3 FROM crdb_internal.ranges",
+			"SELECT min(array_length(replicas, 1)) >= $1 FROM crdb_internal.ranges", numReplicas,
 		).Scan(&ok); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/cmd/roachtest/cluster_init.go
+++ b/pkg/cmd/roachtest/cluster_init.go
@@ -155,7 +155,7 @@ func runClusterInit(ctx context.Context, t *test, c *cluster) {
 			}
 
 			// This will only succeed if 3 nodes joined the cluster.
-			waitForFullReplication(t, dbs[0])
+			waitForFullReplication(t, dbs[0], 3)
 
 			execCLI := func(runNode int, extraArgs ...string) (string, error) {
 				args := []string{"./cockroach"}

--- a/pkg/cmd/roachtest/event_log.go
+++ b/pkg/cmd/roachtest/event_log.go
@@ -33,7 +33,7 @@ func runEventLog(ctx context.Context, t *test, c *cluster) {
 	// a node starts and contacts the cluster.
 	db := c.Conn(ctx, 1)
 	defer db.Close()
-	waitForFullReplication(t, db)
+	waitForFullReplication(t, db, 3)
 
 	err := retry.ForDuration(10*time.Second, func() error {
 		rows, err := db.Query(

--- a/pkg/cmd/roachtest/gossip.go
+++ b/pkg/cmd/roachtest/gossip.go
@@ -35,7 +35,7 @@ func registerGossip(r *testRegistry) {
 		args := startArgs("--args=--vmodule=*=1")
 		c.Put(ctx, cockroach, "./cockroach", c.All())
 		c.Start(ctx, t, c.All(), args)
-		waitForFullReplication(t, c.Conn(ctx, 1))
+		waitForFullReplication(t, c.Conn(ctx, 1), 3)
 
 		gossipNetwork := func(node int) string {
 			const query = `

--- a/pkg/cmd/roachtest/inconsistency.go
+++ b/pkg/cmd/roachtest/inconsistency.go
@@ -44,7 +44,7 @@ func runInconsistency(ctx context.Context, t *test, c *cluster) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		waitForFullReplication(t, db)
+		waitForFullReplication(t, db, 3)
 		_, db = db.Close(), nil
 	}
 

--- a/pkg/cmd/roachtest/kv.go
+++ b/pkg/cmd/roachtest/kv.go
@@ -289,7 +289,7 @@ func registerKVQuiescenceDead(r *testRegistry) {
 			db := c.Conn(ctx, 1)
 			defer db.Close()
 
-			waitForFullReplication(t, db)
+			waitForFullReplication(t, db, 3)
 
 			qps := func(f func()) float64 {
 
@@ -362,7 +362,7 @@ func registerKVGracefulDraining(r *testRegistry) {
 			db := c.Conn(ctx, 1)
 			defer db.Close()
 
-			waitForFullReplication(t, db)
+			waitForFullReplication(t, db, 3)
 
 			t.Status("initializing workload")
 
@@ -665,7 +665,7 @@ func registerKVRangeLookups(r *testRegistry) {
 				conns[i].Close()
 			}
 		}()
-		waitForFullReplication(t, conns[0])
+		waitForFullReplication(t, conns[0], 3)
 
 		m := newMonitor(ctx, c, c.Range(1, nodes))
 		m.Go(func(ctx context.Context) error {

--- a/pkg/cmd/roachtest/many_splits.go
+++ b/pkg/cmd/roachtest/many_splits.go
@@ -28,7 +28,7 @@ func runManySplits(ctx context.Context, t *test, c *cluster) {
 	defer db.Close()
 
 	// Wait for upreplication then create many ranges.
-	waitForFullReplication(t, db)
+	waitForFullReplication(t, db, 3)
 
 	m := newMonitor(ctx, c, c.All())
 	m.Go(func(ctx context.Context) error {

--- a/pkg/cmd/roachtest/network.go
+++ b/pkg/cmd/roachtest/network.go
@@ -36,7 +36,7 @@ func runNetworkSanity(ctx context.Context, t *test, origC *cluster, nodes int) {
 
 	db := c.Conn(ctx, 1) // unaffected by toxiproxy
 	defer db.Close()
-	waitForFullReplication(t, db)
+	waitForFullReplication(t, db, 3)
 
 	// NB: we're generous with latency in this test because we're checking that
 	// the upstream connections aren't affected by latency below, but the fixed
@@ -112,7 +112,7 @@ func runNetworkTPCC(ctx context.Context, t *test, origC *cluster, nodes int) {
 
 	db := c.Conn(ctx, 1)
 	defer db.Close()
-	waitForFullReplication(t, db)
+	waitForFullReplication(t, db, 3)
 
 	duration := time.Hour
 	if local {

--- a/pkg/cmd/roachtest/sysbench.go
+++ b/pkg/cmd/roachtest/sysbench.go
@@ -91,7 +91,7 @@ func runSysbench(ctx context.Context, t *test, c *cluster, opts sysbenchOptions)
 	t.Status("installing cockroach")
 	c.Put(ctx, cockroach, "./cockroach", allNodes)
 	c.Start(ctx, t, roachNodes)
-	waitForFullReplication(t, c.Conn(ctx, allNodes[0]))
+	waitForFullReplication(t, c.Conn(ctx, allNodes[0]), 3)
 
 	t.Status("installing haproxy")
 	if err := c.Install(ctx, t.l, loadNode, "haproxy"); err != nil {

--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -105,7 +105,7 @@ func setupTPCC(
 		opts.Start(ctx, t, c)
 		db := c.Conn(ctx, 1)
 		defer db.Close()
-		waitForFullReplication(t, c.Conn(ctx, crdbNodes[0]))
+		waitForFullReplication(t, c.Conn(ctx, crdbNodes[0]), 3)
 		switch opts.SetupType {
 		case usingExistingData:
 			// Do nothing.
@@ -679,7 +679,7 @@ func loadTPCCBench(
 
 	// Load the corresponding fixture.
 	t.l.Printf("restoring tpcc fixture\n")
-	waitForFullReplication(t, db)
+	waitForFullReplication(t, db, 3)
 	cmd := tpccImportCmd(b.LoadWarehouses, loadArgs)
 	if err := c.RunE(ctx, roachNodes[:1], cmd); err != nil {
 		return err

--- a/pkg/cmd/roachtest/tpcdsvec.go
+++ b/pkg/cmd/roachtest/tpcdsvec.go
@@ -112,7 +112,7 @@ func registerTPCDSVec(r *testRegistry) {
 		}
 		scatterTables(t, clusterConn, tpcdsTables)
 		t.Status("waiting for full replication")
-		waitForFullReplication(t, clusterConn)
+		waitForFullReplication(t, clusterConn, 3)
 		versionString, err := fetchCockroachVersion(ctx, c, c.Node(1)[0])
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/cmd/roachtest/tpchvec.go
+++ b/pkg/cmd/roachtest/tpchvec.go
@@ -620,7 +620,7 @@ func runTPCHVec(
 	}
 	scatterTables(t, conn, tpchTables)
 	t.Status("waiting for full replication")
-	waitForFullReplication(t, conn)
+	waitForFullReplication(t, conn, 3)
 	versionString, err := fetchCockroachVersion(ctx, c, c.Node(1)[0])
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/cmd/roachtest/ycsb.go
+++ b/pkg/cmd/roachtest/ycsb.go
@@ -43,7 +43,7 @@ func registerYCSB(r *testRegistry) {
 		c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
 		c.Put(ctx, workload, "./workload", c.Node(nodes+1))
 		c.Start(ctx, t, c.Range(1, nodes))
-		waitForFullReplication(t, c.Conn(ctx, 1))
+		waitForFullReplication(t, c.Conn(ctx, 1), 3)
 
 		t.Status("running workload")
 		m := newMonitor(ctx, c, c.Range(1, nodes))

--- a/pkg/config/zonepb/zone.go
+++ b/pkg/config/zonepb/zone.go
@@ -685,6 +685,37 @@ func (z ZoneConfig) GetSubzoneForKeySuffix(keySuffix []byte) (*Subzone, int32) {
 	return nil, -1
 }
 
+// GetNumVoters returns the number of voting replicas for the given zone config.
+//
+// This method will panic if called on a ZoneConfig with an uninitialized
+// NumReplicas attribute.
+func (z *ZoneConfig) GetNumVoters() int32 {
+	if z.NumReplicas == nil {
+		panic("NumReplicas must not be nil")
+	}
+	if z.NumVoters != nil && *z.NumVoters != 0 {
+		return *z.NumVoters
+	}
+	return *z.NumReplicas
+}
+
+// GetNumNonVoters returns the number of non-voting replicas as defined in the
+// zone config.
+//
+// This method will panic if called on a ZoneConfig with an uninitialized
+// NumReplicas attribute.
+func (z *ZoneConfig) GetNumNonVoters() int32 {
+	if z.NumReplicas == nil {
+		panic("NumReplicas must not be nil")
+	}
+	if z.NumVoters != nil && *z.NumVoters != 0 {
+		return *z.NumReplicas - *z.NumVoters
+	}
+	// `num_voters` hasn't been explicitly configured. Every replica should be a
+	// voting replica.
+	return 0
+}
+
 // SetSubzone installs subzone into the ZoneConfig, overwriting any existing
 // subzone with the same IndexID and PartitionName.
 func (z *ZoneConfig) SetSubzone(subzone Subzone) {

--- a/pkg/kv/kvserver/allocator.go
+++ b/pkg/kv/kvserver/allocator.go
@@ -362,7 +362,6 @@ func (a *Allocator) ComputeAction(
 func (a *Allocator) computeAction(
 	ctx context.Context, zone *zonepb.ZoneConfig, voterReplicas []roachpb.ReplicaDescriptor,
 ) (AllocatorAction, float64) {
-	// TODO(mrtracy): Handle non-homogeneous and mismatched attribute sets.
 	have := len(voterReplicas)
 	decommissioningReplicas := a.storePool.decommissioningReplicas(voterReplicas)
 	clusterNodes := a.storePool.ClusterNodeCount()

--- a/pkg/kv/kvserver/allocator.go
+++ b/pkg/kv/kvserver/allocator.go
@@ -49,14 +49,23 @@ const (
 	minReplicaWeight = 0.001
 
 	// Priorities for various repair operations.
+	//
+	// NB: These priorities only influence the replicateQueue's understanding of
+	// which ranges are to be dealt with before others. In other words, these
+	// priorities don't influence the relative order of actions taken on a given
+	// range. Within a given range, the ordering of the various checks inside
+	// `Allocator.computeAction` determines which repair/rebalancing actions are
+	// taken before the others.
 	finalizeAtomicReplicationChangePriority    float64 = 12002
 	removeLearnerReplicaPriority               float64 = 12001
 	addDeadReplacementVoterPriority            float64 = 12000
 	addMissingVoterPriority                    float64 = 10000
 	addDecommissioningReplacementVoterPriority float64 = 5000
 	removeDeadVoterPriority                    float64 = 1000
-	removeDecommissioningVoterPriority         float64 = 200
-	removeExtraVoterPriority                   float64 = 100
+	removeDecommissioningVoterPriority         float64 = 900
+	removeExtraVoterPriority                   float64 = 800
+	addMissingNonVoterPriority                 float64 = 700
+	removeExtraNonVoterPriority                float64 = 600
 )
 
 // MinLeaseTransferStatsDuration configures the minimum amount of time a
@@ -100,7 +109,9 @@ const (
 	_ AllocatorAction = iota
 	AllocatorNoop
 	AllocatorRemoveVoter
+	AllocatorRemoveNonVoter
 	AllocatorAddVoter
+	AllocatorAddNonVoter
 	AllocatorReplaceDeadVoter
 	AllocatorRemoveDeadVoter
 	AllocatorReplaceDecommissioningVoter
@@ -114,7 +125,9 @@ const (
 var allocatorActionNames = map[AllocatorAction]string{
 	AllocatorNoop:                        "noop",
 	AllocatorRemoveVoter:                 "remove voter",
+	AllocatorRemoveNonVoter:              "remove non-voter",
 	AllocatorAddVoter:                    "add voter",
+	AllocatorAddNonVoter:                 "add non-voter",
 	AllocatorReplaceDeadVoter:            "replace dead voter",
 	AllocatorRemoveDeadVoter:             "remove dead voter",
 	AllocatorReplaceDecommissioningVoter: "replace decommissioning voter",
@@ -262,11 +275,11 @@ func MakeAllocator(
 	}
 }
 
-// GetNeededReplicas calculates the number of replicas a range should
-// have given its zone config and the number of nodes available for
-// up-replication (i.e. not dead and not decommissioning).
-func GetNeededReplicas(zoneConfigReplicaCount int32, clusterNodes int) int {
-	numZoneReplicas := int(zoneConfigReplicaCount)
+// GetNeededVoters calculates the number of voters a range should have given its
+// zone config and the number of nodes available for up-replication (i.e. not
+// decommissioning).
+func GetNeededVoters(zoneConfigVoterCount int32, clusterNodes int) int {
+	numZoneReplicas := int(zoneConfigVoterCount)
 	need := numZoneReplicas
 
 	// Adjust the replication factor for all ranges if there are fewer
@@ -296,6 +309,27 @@ func GetNeededReplicas(zoneConfigReplicaCount int32, clusterNodes int) int {
 		need = numZoneReplicas
 	}
 
+	return need
+}
+
+// GetNeededNonVoters calculates the number of non-voters a range should have
+// given the number of voting replicas the range has and the number of nodes
+// available for up-replication.
+//
+// If `num_voters` aren't explicitly configured in the zone config, all
+// `num_replicas` replicas will be voting replicas and this method will always
+// return 0.
+//
+// NB: This method assumes that we have exactly as many voters as we need, since
+// this method should only be consulted after voting replicas have been
+// upreplicated / rebalanced off of dead/decommissioning nodes.
+func GetNeededNonVoters(numVoters, zoneConfigNonVoterCount, clusterNodes int) int {
+	need := zoneConfigNonVoterCount
+	if clusterNodes-numVoters < need {
+		// We only need non-voting replicas for the nodes that do not have a voting
+		// replica.
+		need = clusterNodes - numVoters
+	}
 	return need
 }
 
@@ -357,97 +391,141 @@ func (a *Allocator) ComputeAction(
 		// removeLearnerReplicaPriority as the highest priority.
 		return AllocatorRemoveLearner, removeLearnerReplicaPriority
 	}
-	// computeAction expects to operate only on voters.
-	return a.computeAction(ctx, zone, desc.Replicas().VoterDescriptors())
+	return a.computeAction(ctx, zone, desc.Replicas().VoterDescriptors(),
+		desc.Replicas().NonVoterDescriptors())
 }
 
 func (a *Allocator) computeAction(
-	ctx context.Context, zone *zonepb.ZoneConfig, voterReplicas []roachpb.ReplicaDescriptor,
+	ctx context.Context,
+	zone *zonepb.ZoneConfig,
+	voterReplicas []roachpb.ReplicaDescriptor,
+	nonVoterReplicas []roachpb.ReplicaDescriptor,
 ) (AllocatorAction, float64) {
-	have := len(voterReplicas)
-	decommissioningReplicas := a.storePool.decommissioningReplicas(voterReplicas)
-	clusterNodes := a.storePool.ClusterNodeCount()
-	need := GetNeededReplicas(*zone.NumReplicas, clusterNodes)
-	desiredQuorum := computeQuorum(need)
-	quorum := computeQuorum(have)
+	// NB: The ordering of the checks in this method is intentional. The order in
+	// which these actions are returned by this method determines the relative
+	// priority of the actions taken on a given range. We want this to be
+	// symmetric with regards to the priorities defined at the top of this file
+	// (which influence the replicateQueue's decision of which range it'll pick to
+	// repair/rebalance before the others).
+	//
+	// In broad strokes, we first handle all voting replica-based actions and then
+	// the actions pertaining to non-voting replicas. Within each replica set, we
+	// first handle operations that correspond to repairing/recovering the range.
+	// After that we handle rebalacing related actions, followed by removal
+	// actions.
 
-	if have < need {
-		// Range is under-replicated, and should add an additional replica.
-		// Priority is adjusted by the difference between the current replica
-		// count and the quorum of the desired replica count.
-		priority := addMissingVoterPriority + float64(desiredQuorum-have)
+	// TODO(mrtracy): Handle non-homogeneous and mismatched attribute sets.
+	haveVoters := len(voterReplicas)
+	decommissioningVoters := a.storePool.decommissioningReplicas(voterReplicas)
+	// Node count including dead nodes but excluding decommissioning/decommissioned
+	// nodes.
+	clusterNodes := a.storePool.ClusterNodeCount()
+	neededVoters := GetNeededVoters(zone.GetNumVoters(), clusterNodes)
+	desiredQuorum := computeQuorum(neededVoters)
+	quorum := computeQuorum(haveVoters)
+
+	// TODO(aayush): When haveVoters < neededVoters but we don't have quorum to
+	// actually execute the addition of a new replica, we should be returning a
+	// ALlocatorRangeUnavailable.
+	if haveVoters < neededVoters {
+		// Range is under-replicated, and should add an additional voter.
+		// Priority is adjusted by the difference between the current voter
+		// count and the quorum of the desired voter count.
+		priority := addMissingVoterPriority + float64(desiredQuorum-haveVoters)
 		action := AllocatorAddVoter
-		log.VEventf(ctx, 3, "%s - missing replica need=%d, have=%d, priority=%.2f",
-			action, need, have, priority)
+		log.VEventf(ctx, 3, "%s - missing voter need=%d, have=%d, priority=%.2f",
+			action, neededVoters, haveVoters, priority)
 		return action, priority
 	}
 
-	liveVoterReplicas, deadVoterReplicas := a.storePool.liveAndDeadReplicas(voterReplicas)
+	liveVoters, deadVoters := a.storePool.liveAndDeadReplicas(voterReplicas)
 
-	if len(liveVoterReplicas) < quorum {
-		// Do not take any replacement/removal action if we do not have a quorum of live
-		// replicas. If we're correctly assessing the unavailable state of the range, we
-		// also won't be able to add replicas as we try above, but hope springs eternal.
-		log.VEventf(ctx, 1, "unable to take action - live replicas %v don't meet quorum of %d",
-			liveVoterReplicas, quorum)
+	if len(liveVoters) < quorum {
+		// Do not take any replacement/removal action if we do not have a quorum of
+		// live voters. If we're correctly assessing the unavailable state of the
+		// range, we also won't be able to add replicas as we try above, but hope
+		// springs eternal.
+		log.VEventf(ctx, 1, "unable to take action - live voters %v don't meet quorum of %d",
+			liveVoters, quorum)
 		return AllocatorRangeUnavailable, 0
 	}
 
-	if have == need && len(deadVoterReplicas) > 0 {
-		// Range has dead replica(s). We should up-replicate to add another before
+	if haveVoters == neededVoters && len(deadVoters) > 0 {
+		// Range has dead voter(s). We should up-replicate to add another before
 		// before removing the dead one. This can avoid permanent data loss in cases
 		// where the node is only temporarily dead, but we remove it from the range
 		// and lose a second node before we can up-replicate (#25392).
-		// The dead replica(s) will be down-replicated later.
+		// The dead voter(s) will be down-replicated later.
 		priority := addDeadReplacementVoterPriority
 		action := AllocatorReplaceDeadVoter
-		log.VEventf(ctx, 3, "%s - replacement for %d dead replicas priority=%.2f",
-			action, len(deadVoterReplicas), priority)
+		log.VEventf(ctx, 3, "%s - replacement for %d dead voters priority=%.2f",
+			action, len(deadVoters), priority)
 		return action, priority
 	}
 
-	if have == need && len(decommissioningReplicas) > 0 {
-		// Range has decommissioning replica(s), which should be replaced.
+	if haveVoters == neededVoters && len(decommissioningVoters) > 0 {
+		// Range has decommissioning voter(s), which should be replaced.
 		priority := addDecommissioningReplacementVoterPriority
 		action := AllocatorReplaceDecommissioningVoter
-		log.VEventf(ctx, 3, "%s - replacement for %d decommissioning replicas priority=%.2f",
-			action, len(decommissioningReplicas), priority)
+		log.VEventf(ctx, 3, "%s - replacement for %d decommissioning voters priority=%.2f",
+			action, len(decommissioningVoters), priority)
 		return action, priority
 	}
 
-	// Removal actions follow.
-	// TODO(a-robinson): There's an additional case related to dead replicas that
-	// we should handle above. If there are one or more dead replicas, have <
-	// need, and there are no available stores to up-replicate to, then we should
-	// try to remove the dead replica(s) to get down to an odd number of
-	// replicas.
-	if len(deadVoterReplicas) > 0 {
+	// Voting replica removal actions follow.
+	// TODO(aayush): There's an additional case related to dead voters that we
+	// should handle above. If there are one or more dead replicas, have < need,
+	// and there are no available stores to up-replicate to, then we should try to
+	// remove the dead replica(s) to get down to an odd number of replicas.
+	if len(deadVoters) > 0 {
 		// The range has dead replicas, which should be removed immediately.
-		priority := removeDeadVoterPriority + float64(quorum-len(liveVoterReplicas))
+		priority := removeDeadVoterPriority + float64(quorum-len(liveVoters))
 		action := AllocatorRemoveDeadVoter
 		log.VEventf(ctx, 3, "%s - dead=%d, live=%d, quorum=%d, priority=%.2f",
-			action, len(deadVoterReplicas), len(liveVoterReplicas), quorum, priority)
+			action, len(deadVoters), len(liveVoters), quorum, priority)
 		return action, priority
 	}
 
-	if len(decommissioningReplicas) > 0 {
-		// Range is over-replicated, and has a decommissioning replica which
+	if len(decommissioningVoters) > 0 {
+		// Range is over-replicated, and has a decommissioning voter which
 		// should be removed.
 		priority := removeDecommissioningVoterPriority
 		action := AllocatorRemoveDecommissioningVoter
 		log.VEventf(ctx, 3,
 			"%s - need=%d, have=%d, num_decommissioning=%d, priority=%.2f",
-			action, need, have, len(decommissioningReplicas), priority)
+			action, neededVoters, haveVoters, len(decommissioningVoters), priority)
 		return action, priority
 	}
 
-	if have > need {
-		// Range is over-replicated, and should remove a replica.
-		// Ranges with an even number of replicas get extra priority because
+	if haveVoters > neededVoters {
+		// Range is over-replicated, and should remove a voter.
+		// Ranges with an even number of voters get extra priority because
 		// they have a more fragile quorum.
-		priority := removeExtraVoterPriority - float64(have%2)
+		priority := removeExtraVoterPriority - float64(haveVoters%2)
 		action := AllocatorRemoveVoter
-		log.VEventf(ctx, 3, "%s - need=%d, have=%d, priority=%.2f", action, need, have, priority)
+		log.VEventf(ctx, 3, "%s - need=%d, have=%d, priority=%.2f", action, neededVoters, haveVoters, priority)
+		return action, priority
+	}
+
+	// Non-voting replica actions follow.
+	//
+	// Non-voting replica addition.
+	haveNonVoters := len(nonVoterReplicas)
+	neededNonVoters := GetNeededNonVoters(haveVoters, int(zone.GetNumNonVoters()), clusterNodes)
+	if haveNonVoters < neededNonVoters {
+		priority := addMissingNonVoterPriority
+		action := AllocatorAddNonVoter
+		log.VEventf(ctx, 3, "%s - missing non-voter need=%d, have=%d, priority=%.2f",
+			action, neededNonVoters, haveNonVoters, priority)
+		return action, priority
+	}
+
+	// Non-voting replica removal.
+	if haveNonVoters > neededNonVoters {
+		// Like above, the range is over-replicated but should remove a non-voter.
+		priority := removeExtraNonVoterPriority
+		action := AllocatorRemoveNonVoter
+		log.VEventf(ctx, 3, "%s - need=%d, have=%d, priority=%.2f", action, neededNonVoters, haveNonVoters, priority)
 		return action, priority
 	}
 

--- a/pkg/kv/kvserver/allocator_scorer_test.go
+++ b/pkg/kv/kvserver/allocator_scorer_test.go
@@ -918,7 +918,8 @@ func TestAllocateConstraintsCheck(t *testing.T) {
 				NumReplicas: proto.Int32(tc.zoneNumReplicas),
 			}
 			analyzed := constraint.AnalyzeConstraints(
-				context.Background(), getTestStoreDesc, testStoreReplicas(tc.existing), zone)
+				context.Background(), getTestStoreDesc, testStoreReplicas(tc.existing),
+				int(*zone.NumReplicas), zone.Constraints)
 			for _, s := range testStores {
 				valid, necessary := allocateConstraintsCheck(s, analyzed)
 				if e, a := tc.expectedValid[s.StoreID], valid; e != a {
@@ -1052,7 +1053,7 @@ func TestRemoveConstraintsCheck(t *testing.T) {
 				NumReplicas: proto.Int32(tc.zoneNumReplicas),
 			}
 			analyzed := constraint.AnalyzeConstraints(
-				context.Background(), getTestStoreDesc, existing, zone)
+				context.Background(), getTestStoreDesc, existing, int(*zone.NumReplicas), zone.Constraints)
 			for storeID, expected := range tc.expected {
 				valid, necessary := removeConstraintsCheck(testStores[storeID], analyzed)
 				if e, a := expected.valid, valid; e != a {

--- a/pkg/kv/kvserver/allocator_test.go
+++ b/pkg/kv/kvserver/allocator_test.go
@@ -4265,7 +4265,7 @@ func TestAllocatorComputeAction(t *testing.T) {
 					},
 				},
 			},
-			expectedAction: AllocatorReplaceDead,
+			expectedAction: AllocatorReplaceDeadVoter,
 		},
 		// Need five replicas, one is on a dead store.
 		{
@@ -4304,7 +4304,7 @@ func TestAllocatorComputeAction(t *testing.T) {
 					},
 				},
 			},
-			expectedAction: AllocatorReplaceDead,
+			expectedAction: AllocatorReplaceDeadVoter,
 		},
 		// Need three replicas, have two.
 		{
@@ -4328,7 +4328,7 @@ func TestAllocatorComputeAction(t *testing.T) {
 					},
 				},
 			},
-			expectedAction: AllocatorAdd,
+			expectedAction: AllocatorAddVoter,
 		},
 		// Need five replicas, have four, one is on a dead store.
 		{
@@ -4362,7 +4362,7 @@ func TestAllocatorComputeAction(t *testing.T) {
 					},
 				},
 			},
-			expectedAction: AllocatorAdd,
+			expectedAction: AllocatorAddVoter,
 		},
 		// Need five replicas, have four.
 		{
@@ -4396,7 +4396,7 @@ func TestAllocatorComputeAction(t *testing.T) {
 					},
 				},
 			},
-			expectedAction: AllocatorAdd,
+			expectedAction: AllocatorAddVoter,
 		},
 		// Need three replicas, have four, one is on a dead store.
 		{
@@ -4430,7 +4430,7 @@ func TestAllocatorComputeAction(t *testing.T) {
 					},
 				},
 			},
-			expectedAction: AllocatorRemoveDead,
+			expectedAction: AllocatorRemoveDeadVoter,
 		},
 		// Need five replicas, have six, one is on a dead store.
 		{
@@ -4474,7 +4474,7 @@ func TestAllocatorComputeAction(t *testing.T) {
 					},
 				},
 			},
-			expectedAction: AllocatorRemoveDead,
+			expectedAction: AllocatorRemoveDeadVoter,
 		},
 		// Need three replicas, have five, one is on a dead store.
 		{
@@ -4513,7 +4513,7 @@ func TestAllocatorComputeAction(t *testing.T) {
 					},
 				},
 			},
-			expectedAction: AllocatorRemoveDead,
+			expectedAction: AllocatorRemoveDeadVoter,
 		},
 		// Need three replicas, have four.
 		{
@@ -4547,7 +4547,7 @@ func TestAllocatorComputeAction(t *testing.T) {
 					},
 				},
 			},
-			expectedAction: AllocatorRemove,
+			expectedAction: AllocatorRemoveVoter,
 		},
 		// Need three replicas, have five.
 		{
@@ -4586,7 +4586,7 @@ func TestAllocatorComputeAction(t *testing.T) {
 					},
 				},
 			},
-			expectedAction: AllocatorRemove,
+			expectedAction: AllocatorRemoveVoter,
 		},
 		// Need three replicas, two are on dead stores. Should
 		// be a noop because there aren't enough live replicas for
@@ -4756,14 +4756,14 @@ func TestAllocatorComputeActionRemoveDead(t *testing.T) {
 			desc:           threeReplDesc,
 			live:           []roachpb.StoreID{1, 2},
 			dead:           []roachpb.StoreID{3},
-			expectedAction: AllocatorReplaceDead,
+			expectedAction: AllocatorReplaceDeadVoter,
 		},
 		// Needs three replicas, one is dead, but there is a replacement.
 		{
 			desc:           threeReplDesc,
 			live:           []roachpb.StoreID{1, 2, 4},
 			dead:           []roachpb.StoreID{3},
-			expectedAction: AllocatorReplaceDead,
+			expectedAction: AllocatorReplaceDeadVoter,
 		},
 		// Needs three replicas, two are dead (i.e. the range lacks a quorum).
 		{
@@ -4777,7 +4777,7 @@ func TestAllocatorComputeActionRemoveDead(t *testing.T) {
 			desc:           fourReplDesc,
 			live:           []roachpb.StoreID{1, 2, 4},
 			dead:           []roachpb.StoreID{3},
-			expectedAction: AllocatorRemoveDead,
+			expectedAction: AllocatorRemoveDeadVoter,
 		},
 		// Needs three replicas, has four, two are dead (i.e. the range lacks a quorum).
 		{
@@ -4840,7 +4840,7 @@ func TestAllocatorComputeActionDecommission(t *testing.T) {
 					},
 				},
 			},
-			expectedAction:  AllocatorReplaceDecommissioning,
+			expectedAction:  AllocatorReplaceDecommissioningVoter,
 			live:            []roachpb.StoreID{1, 2},
 			dead:            nil,
 			decommissioning: []roachpb.StoreID{3},
@@ -4870,7 +4870,7 @@ func TestAllocatorComputeActionDecommission(t *testing.T) {
 					},
 				},
 			},
-			expectedAction:  AllocatorReplaceDead,
+			expectedAction:  AllocatorReplaceDeadVoter,
 			live:            []roachpb.StoreID{1},
 			dead:            []roachpb.StoreID{2},
 			decommissioning: []roachpb.StoreID{3},
@@ -4905,7 +4905,7 @@ func TestAllocatorComputeActionDecommission(t *testing.T) {
 					},
 				},
 			},
-			expectedAction:  AllocatorRemoveDead,
+			expectedAction:  AllocatorRemoveDeadVoter,
 			live:            []roachpb.StoreID{1, 4},
 			dead:            []roachpb.StoreID{2},
 			decommissioning: []roachpb.StoreID{3},
@@ -4940,7 +4940,7 @@ func TestAllocatorComputeActionDecommission(t *testing.T) {
 					},
 				},
 			},
-			expectedAction:  AllocatorRemoveDead,
+			expectedAction:  AllocatorRemoveDeadVoter,
 			live:            []roachpb.StoreID{1, 4},
 			dead:            nil,
 			decommissioning: []roachpb.StoreID{3},
@@ -4970,7 +4970,7 @@ func TestAllocatorComputeActionDecommission(t *testing.T) {
 					},
 				},
 			},
-			expectedAction:  AllocatorReplaceDecommissioning,
+			expectedAction:  AllocatorReplaceDecommissioningVoter,
 			live:            nil,
 			dead:            nil,
 			decommissioning: []roachpb.StoreID{1, 2, 3},
@@ -5004,7 +5004,7 @@ func TestAllocatorComputeActionDecommission(t *testing.T) {
 					},
 				},
 			},
-			expectedAction:  AllocatorRemoveDecommissioning,
+			expectedAction:  AllocatorRemoveDecommissioningVoter,
 			live:            []roachpb.StoreID{4},
 			dead:            nil,
 			decommissioning: []roachpb.StoreID{1, 2, 3},
@@ -5082,7 +5082,7 @@ func TestAllocatorComputeActionDynamicNumReplicas(t *testing.T) {
 			// drop past 3, so 3 it is.
 			storeList:           []roachpb.StoreID{1, 2, 3, 4},
 			expectedNumReplicas: 3,
-			expectedAction:      AllocatorRemoveDecommissioning,
+			expectedAction:      AllocatorRemoveDecommissioningVoter,
 			live:                []roachpb.StoreID{4},
 			unavailable:         nil,
 			dead:                nil,
@@ -5092,7 +5092,7 @@ func TestAllocatorComputeActionDynamicNumReplicas(t *testing.T) {
 			// Ditto.
 			storeList:           []roachpb.StoreID{1, 2, 3},
 			expectedNumReplicas: 3,
-			expectedAction:      AllocatorReplaceDecommissioning,
+			expectedAction:      AllocatorReplaceDecommissioningVoter,
 			live:                []roachpb.StoreID{4, 5},
 			unavailable:         nil,
 			dead:                nil,
@@ -5105,7 +5105,7 @@ func TestAllocatorComputeActionDynamicNumReplicas(t *testing.T) {
 			// from the range at hand, rather than trying to replace it.
 			storeList:           []roachpb.StoreID{1, 2, 3, 4},
 			expectedNumReplicas: 3,
-			expectedAction:      AllocatorRemoveDead,
+			expectedAction:      AllocatorRemoveDeadVoter,
 			live:                []roachpb.StoreID{1, 2, 3, 5},
 			unavailable:         nil,
 			dead:                []roachpb.StoreID{4},
@@ -5118,7 +5118,7 @@ func TestAllocatorComputeActionDynamicNumReplicas(t *testing.T) {
 			// important than replacing the dead one.
 			storeList:           []roachpb.StoreID{1, 4},
 			expectedNumReplicas: 3,
-			expectedAction:      AllocatorAdd,
+			expectedAction:      AllocatorAddVoter,
 			live:                []roachpb.StoreID{1, 2, 3, 5},
 			unavailable:         nil,
 			dead:                []roachpb.StoreID{4},
@@ -5140,7 +5140,7 @@ func TestAllocatorComputeActionDynamicNumReplicas(t *testing.T) {
 			// it is and we are under-replicaed.
 			storeList:           []roachpb.StoreID{1, 2},
 			expectedNumReplicas: 3,
-			expectedAction:      AllocatorAdd,
+			expectedAction:      AllocatorAddVoter,
 			live:                []roachpb.StoreID{1, 2},
 			unavailable:         nil,
 			dead:                nil,
@@ -5160,7 +5160,7 @@ func TestAllocatorComputeActionDynamicNumReplicas(t *testing.T) {
 			// Three again, on account of avoiding the even four.
 			storeList:           []roachpb.StoreID{1, 2, 3, 4},
 			expectedNumReplicas: 3,
-			expectedAction:      AllocatorRemove,
+			expectedAction:      AllocatorRemoveVoter,
 			live:                []roachpb.StoreID{1, 2, 3, 4},
 			unavailable:         nil,
 			dead:                nil,
@@ -5214,7 +5214,7 @@ func TestAllocatorComputeActionDynamicNumReplicas(t *testing.T) {
 			// slice in these tests).
 			storeList:           []roachpb.StoreID{1, 2, 3, 4, 5},
 			expectedNumReplicas: 5,
-			expectedAction:      AllocatorReplaceDead,
+			expectedAction:      AllocatorReplaceDeadVoter,
 			live:                []roachpb.StoreID{1, 2, 3},
 			unavailable:         []roachpb.StoreID{4},
 			dead:                []roachpb.StoreID{5},
@@ -5225,7 +5225,7 @@ func TestAllocatorComputeActionDynamicNumReplicas(t *testing.T) {
 			// the most important thing is removing a decommissioning replica.
 			storeList:           []roachpb.StoreID{1, 2, 3, 4, 5},
 			expectedNumReplicas: 3,
-			expectedAction:      AllocatorRemoveDecommissioning,
+			expectedAction:      AllocatorRemoveDecommissioningVoter,
 			live:                []roachpb.StoreID{1, 2, 3},
 			unavailable:         []roachpb.StoreID{4},
 			dead:                nil,

--- a/pkg/kv/kvserver/allocator_test.go
+++ b/pkg/kv/kvserver/allocator_test.go
@@ -389,10 +389,10 @@ func TestAllocatorSimpleRetrieval(t *testing.T) {
 	stopper, g, _, a, _ := createTestAllocator(1, false /* deterministic */)
 	defer stopper.Stop(context.Background())
 	gossiputil.NewStoreGossiper(g).GossipStores(singleStore, t)
-	result, _, err := a.AllocateTarget(
+	result, _, err := a.AllocateVoterTarget(
 		context.Background(),
 		&simpleZoneConfig,
-		[]roachpb.ReplicaDescriptor{},
+		nil /* existingVoters */, nil, /* existingNonVoters */
 	)
 	if err != nil {
 		t.Fatalf("Unable to perform allocation: %+v", err)
@@ -408,10 +408,10 @@ func TestAllocatorNoAvailableDisks(t *testing.T) {
 
 	stopper, _, _, a, _ := createTestAllocator(1, false /* deterministic */)
 	defer stopper.Stop(context.Background())
-	result, _, err := a.AllocateTarget(
+	result, _, err := a.AllocateVoterTarget(
 		context.Background(),
 		&simpleZoneConfig,
-		[]roachpb.ReplicaDescriptor{},
+		nil /* existingVoters */, nil, /* existingNonVoters */
 	)
 	if result != nil {
 		t.Errorf("expected nil result: %+v", result)
@@ -429,21 +429,21 @@ func TestAllocatorTwoDatacenters(t *testing.T) {
 	defer stopper.Stop(context.Background())
 	gossiputil.NewStoreGossiper(g).GossipStores(multiDCStores, t)
 	ctx := context.Background()
-	result1, _, err := a.AllocateTarget(
+	result1, _, err := a.AllocateVoterTarget(
 		ctx,
 		&multiDCConfig,
-		[]roachpb.ReplicaDescriptor{},
+		nil /* existingVoters */, nil, /* existingNonVoters */
 	)
 	if err != nil {
 		t.Fatalf("Unable to perform allocation: %+v", err)
 	}
-	result2, _, err := a.AllocateTarget(
+	result2, _, err := a.AllocateVoterTarget(
 		ctx,
 		&multiDCConfig,
 		[]roachpb.ReplicaDescriptor{{
 			NodeID:  result1.Node.NodeID,
 			StoreID: result1.StoreID,
-		}},
+		}}, nil, /* existingNonVoters */
 	)
 	if err != nil {
 		t.Fatalf("Unable to perform allocation: %+v", err)
@@ -454,7 +454,7 @@ func TestAllocatorTwoDatacenters(t *testing.T) {
 		t.Errorf("Expected nodes %+v: %+v vs %+v", expected, result1.Node, result2.Node)
 	}
 	// Verify that no result is forthcoming if we already have a replica.
-	result3, _, err := a.AllocateTarget(
+	result3, _, err := a.AllocateVoterTarget(
 		ctx,
 		&multiDCConfig,
 		[]roachpb.ReplicaDescriptor{
@@ -466,7 +466,7 @@ func TestAllocatorTwoDatacenters(t *testing.T) {
 				NodeID:  result2.Node.NodeID,
 				StoreID: result2.StoreID,
 			},
-		},
+		}, nil, /* existingNonVoters */
 	)
 	if err == nil {
 		t.Errorf("expected error on allocation without available stores: %+v", result3)
@@ -480,7 +480,7 @@ func TestAllocatorExistingReplica(t *testing.T) {
 	stopper, g, _, a, _ := createTestAllocator(1, false /* deterministic */)
 	defer stopper.Stop(context.Background())
 	gossiputil.NewStoreGossiper(g).GossipStores(sameDCStores, t)
-	result, _, err := a.AllocateTarget(
+	result, _, err := a.AllocateVoterTarget(
 		context.Background(),
 		&zonepb.ZoneConfig{
 			NumReplicas: proto.Int32(0),
@@ -498,7 +498,7 @@ func TestAllocatorExistingReplica(t *testing.T) {
 				NodeID:  2,
 				StoreID: 2,
 			},
-		},
+		}, nil, /* existingNonVoters */
 	)
 	if err != nil {
 		t.Fatalf("Unable to perform allocation: %+v", err)
@@ -599,13 +599,9 @@ func TestAllocatorMultipleStoresPerNode(t *testing.T) {
 
 	for _, tc := range testCases {
 		{
-			result, _, err := a.AllocateTarget(
-				context.Background(),
-				zonepb.EmptyCompleteZoneConfig(),
-				tc.existing,
-			)
+			result, _, err := a.AllocateVoterTarget(context.Background(), zonepb.EmptyCompleteZoneConfig(), tc.existing, nil)
 			if e, a := tc.expectTargetAllocate, result != nil; e != a {
-				t.Errorf("AllocateTarget(%v) got target %v, err %v; expectTarget=%v",
+				t.Errorf("AllocateVoterTarget(%v) got target %v, err %v; expectTarget=%v",
 					tc.existing, result, err, tc.expectTargetAllocate)
 			}
 		}
@@ -835,7 +831,7 @@ func TestAllocatorRebalanceTarget(t *testing.T) {
 	// We make 5 stores in this test -- 3 in the same datacenter, and 1 each in
 	// 2 other datacenters. All of our replicas are distributed within these 3
 	// datacenters. Originally, the stores that are all alone in their datacenter
-	// are fuller than the other stores. If we didn't simulate RemoveTarget in
+	// are fuller than the other stores. If we didn't simulate RemoveVoter in
 	// RebalanceTarget, we would try to choose store 2 or 3 as the target store
 	// to make a rebalance. However, we would immediately remove the replica on
 	// store 1 or 2 to retain the locality diversity.
@@ -2060,6 +2056,7 @@ func TestAllocatorLeasePreferencesMultipleStoresPerLocality(t *testing.T) {
 	}
 }
 
+// TODO(aayush): These tests should be renamed.
 func TestAllocatorRemoveTargetLocality(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -2108,11 +2105,12 @@ func TestAllocatorRemoveTargetLocality(t *testing.T) {
 				StoreID: storeID,
 			}
 		}
-		targetRepl, details, err := a.RemoveTarget(
+		targetRepl, details, err := a.RemoveVoter(
 			context.Background(),
 			zonepb.EmptyCompleteZoneConfig(),
 			existingRepls,
 			existingRepls,
+			nil, /* existingNonVoters */
 		)
 		if err != nil {
 			t.Fatal(err)
@@ -2125,7 +2123,7 @@ func TestAllocatorRemoveTargetLocality(t *testing.T) {
 			}
 		}
 		if !found {
-			t.Errorf("expected RemoveTarget(%v) in %v, but got %d; details: %s", c.existing, c.expected, targetRepl.StoreID, details)
+			t.Errorf("expected RemoveVoter(%v) in %v, but got %d; details: %s", c.existing, c.expected, targetRepl.StoreID, details)
 		}
 	}
 }
@@ -2192,11 +2190,7 @@ func TestAllocatorAllocateTargetLocality(t *testing.T) {
 				StoreID: storeID,
 			}
 		}
-		targetStore, details, err := a.AllocateTarget(
-			context.Background(),
-			zonepb.EmptyCompleteZoneConfig(),
-			existingRepls,
-		)
+		targetStore, details, err := a.AllocateVoterTarget(context.Background(), zonepb.EmptyCompleteZoneConfig(), existingRepls, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -2208,7 +2202,7 @@ func TestAllocatorAllocateTargetLocality(t *testing.T) {
 			}
 		}
 		if !found {
-			t.Errorf("expected AllocateTarget(%v) in %v, but got %d; details: %s", c.existing, c.expected, targetStore.StoreID, details)
+			t.Errorf("expected AllocateVoterTarget(%v) in %v, but got %d; details: %s", c.existing, c.expected, targetStore.StoreID, details)
 		}
 	}
 }
@@ -2524,7 +2518,8 @@ func TestAllocateCandidatesExcludeNonReadyNodes(t *testing.T) {
 		// No constraints.
 		zone := &zonepb.ZoneConfig{NumReplicas: proto.Int32(0), Constraints: nil}
 		analyzed := constraint.AnalyzeConstraints(
-			context.Background(), a.storePool.getStoreDescriptor, existingRepls, zone)
+			context.Background(), a.storePool.getStoreDescriptor, existingRepls, int(*zone.NumReplicas),
+			zone.Constraints)
 
 		a.storePool.isNodeReadyForRoutineReplicaTransfer = func(_ context.Context, n roachpb.NodeID) bool {
 			for _, s := range tc.excluded {
@@ -2541,6 +2536,8 @@ func TestAllocateCandidatesExcludeNonReadyNodes(t *testing.T) {
 				context.Background(),
 				sl,
 				analyzed,
+				constraint.EmptyAnalyzedConstraints,
+				checkVoterConstraintsForAllocation,
 				existingRepls,
 				a.storePool.getLocalitiesByStore(existingRepls),
 				a.storePool.isNodeReadyForRoutineReplicaTransfer,
@@ -2786,11 +2783,14 @@ func TestAllocateCandidatesNumReplicasConstraints(t *testing.T) {
 		}
 		zone := &zonepb.ZoneConfig{NumReplicas: proto.Int32(0), Constraints: tc.constraints}
 		analyzed := constraint.AnalyzeConstraints(
-			context.Background(), a.storePool.getStoreDescriptor, existingRepls, zone)
+			context.Background(), a.storePool.getStoreDescriptor, existingRepls, int(*zone.NumReplicas),
+			zone.Constraints)
 		candidates := allocateCandidates(
 			context.Background(),
 			sl,
 			analyzed,
+			constraint.EmptyAnalyzedConstraints,
+			checkVoterConstraintsForAllocation,
 			existingRepls,
 			a.storePool.getLocalitiesByStore(existingRepls),
 			func(context.Context, roachpb.NodeID) bool { return true }, /* isNodeValidForRoutineReplicaTransfer */
@@ -3010,18 +3010,20 @@ func TestRemoveCandidatesNumReplicasConstraints(t *testing.T) {
 				StoreID: storeID,
 			}
 		}
+		ctx := context.Background()
 		zone := &zonepb.ZoneConfig{NumReplicas: proto.Int32(0), Constraints: tc.constraints}
 		analyzed := constraint.AnalyzeConstraints(
-			context.Background(), a.storePool.getStoreDescriptor, existingRepls, zone)
-		candidates := removeCandidates(
-			sl,
-			analyzed,
-			a.storePool.getLocalitiesByStore(existingRepls),
-			a.scorerOptions(),
-		)
+			ctx, a.storePool.getStoreDescriptor, existingRepls, int(*zone.NumReplicas),
+			zone.Constraints)
+		existingVoters := roachpb.MakeReplicaSet(existingRepls).VoterDescriptors()
+		analyzedVoterConstraints := constraint.AnalyzeConstraints(
+			ctx, a.storePool.getStoreDescriptor, existingVoters, int(zone.GetNumVoters()),
+			zone.VoterConstraints)
+		candidates := rankedCandidateListForRemoval(sl, analyzed, analyzedVoterConstraints,
+			checkVoterConstraintsForRemoval, a.storePool.getLocalitiesByStore(existingRepls), a.scorerOptions())
 		if !expectedStoreIDsMatch(tc.expected, candidates.worst()) {
-			t.Errorf("%d: expected removeCandidates(%v) = %v, but got %v",
-				testIdx, tc.existing, tc.expected, candidates)
+			t.Errorf("%d: expected rankedCandidateListForRemoval(%v) = %v, but got %v\n for candidates %v",
+				testIdx, tc.existing, tc.expected, candidates.worst(), candidates)
 		}
 	}
 }
@@ -3807,7 +3809,8 @@ func TestRebalanceCandidatesNumReplicasConstraints(t *testing.T) {
 			NumReplicas: proto.Int32(tc.zoneNumReplicas),
 		}
 		analyzed := constraint.AnalyzeConstraints(
-			context.Background(), a.storePool.getStoreDescriptor, existingRepls, zone)
+			context.Background(), a.storePool.getStoreDescriptor, existingRepls,
+			int(*zone.NumReplicas), zone.Constraints)
 		results := rebalanceCandidates(
 			context.Background(),
 			sl,
@@ -4138,13 +4141,13 @@ func TestLoadBasedLeaseRebalanceScore(t *testing.T) {
 	}
 }
 
-// TestAllocatorRemoveTarget verifies that the replica chosen by RemoveTarget is
+// TestAllocatorRemoveTarget verifies that the replica chosen by RemoveVoter is
 // the one with the lowest capacity.
 func TestAllocatorRemoveTarget(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	// List of replicas that will be passed to RemoveTarget
+	// List of replicas that will be passed to RemoveVoter
 	replicas := []roachpb.ReplicaDescriptor{
 		{
 			StoreID:   1,
@@ -4211,17 +4214,13 @@ func TestAllocatorRemoveTarget(t *testing.T) {
 
 	// Repeat this test 10 times, it should always be either store 2 or 3.
 	for i := 0; i < 10; i++ {
-		targetRepl, _, err := a.RemoveTarget(
-			ctx,
-			zonepb.EmptyCompleteZoneConfig(),
-			replicas,
-			replicas,
-		)
+		targetRepl, _, err := a.RemoveVoter(ctx, zonepb.EmptyCompleteZoneConfig(), replicas, replicas,
+			nil)
 		if err != nil {
 			t.Fatal(err)
 		}
 		if a, e1, e2 := targetRepl, replicas[1], replicas[2]; a != e1 && a != e2 {
-			t.Fatalf("%d: RemoveTarget did not select either expected replica; expected %v or %v, got %v",
+			t.Fatalf("%d: RemoveVoter did not select either expected replica; expected %v or %v, got %v",
 				i, e1, e2, a)
 		}
 	}
@@ -5531,24 +5530,24 @@ func TestAllocatorError(t *testing.T) {
 		ae       allocatorError
 		expected string
 	}{
-		{allocatorError{constraints: nil, existingReplicas: 1, aliveStores: 1},
-			"0 of 1 live stores are able to take a new replica for the range (1 already has a replica); likely not enough nodes in cluster"},
-		{allocatorError{constraints: nil, existingReplicas: 1, aliveStores: 2, throttledStores: 1},
-			"0 of 2 live stores are able to take a new replica for the range (1 throttled, 1 already has a replica)"},
-		{allocatorError{constraints: constraint, existingReplicas: 1, aliveStores: 1},
-			`0 of 1 live stores are able to take a new replica for the range (1 already has a replica); ` +
+		{allocatorError{constraints: nil, existingVoterCount: 1, aliveStores: 1},
+			"0 of 1 live stores are able to take a new replica for the range (1 already has a voter); likely not enough nodes in cluster"},
+		{allocatorError{constraints: nil, existingVoterCount: 1, aliveStores: 2, throttledStores: 1},
+			"0 of 2 live stores are able to take a new replica for the range (1 throttled, 1 already has a voter)"},
+		{allocatorError{constraints: constraint, existingVoterCount: 1, aliveStores: 1},
+			`0 of 1 live stores are able to take a new replica for the range (1 already has a voter); ` +
 				`must match constraints [{+one}]`},
-		{allocatorError{constraints: constraint, existingReplicas: 1, aliveStores: 2},
-			`0 of 2 live stores are able to take a new replica for the range (1 already has a replica); ` +
+		{allocatorError{constraints: constraint, existingVoterCount: 1, aliveStores: 2},
+			`0 of 2 live stores are able to take a new replica for the range (1 already has a voter); ` +
 				`must match constraints [{+one}]`},
-		{allocatorError{constraints: constraints, existingReplicas: 1, aliveStores: 1},
-			`0 of 1 live stores are able to take a new replica for the range (1 already has a replica); ` +
+		{allocatorError{constraints: constraints, existingVoterCount: 1, aliveStores: 1},
+			`0 of 1 live stores are able to take a new replica for the range (1 already has a voter); ` +
 				`must match constraints [{+one,+two}]`},
-		{allocatorError{constraints: constraints, existingReplicas: 1, aliveStores: 2},
-			`0 of 2 live stores are able to take a new replica for the range (1 already has a replica); ` +
+		{allocatorError{constraints: constraints, existingVoterCount: 1, aliveStores: 2},
+			`0 of 2 live stores are able to take a new replica for the range (1 already has a voter); ` +
 				`must match constraints [{+one,+two}]`},
-		{allocatorError{constraints: constraint, existingReplicas: 1, aliveStores: 2, throttledStores: 1},
-			`0 of 2 live stores are able to take a new replica for the range (1 throttled, 1 already has a replica); ` +
+		{allocatorError{constraints: constraint, existingVoterCount: 1, aliveStores: 2, throttledStores: 1},
+			`0 of 2 live stores are able to take a new replica for the range (1 throttled, 1 already has a voter); ` +
 				`must match constraints [{+one}]`},
 	}
 
@@ -5568,22 +5567,14 @@ func TestAllocatorThrottled(t *testing.T) {
 	defer stopper.Stop(ctx)
 
 	// First test to make sure we would send the replica to purgatory.
-	_, _, err := a.AllocateTarget(
-		ctx,
-		&simpleZoneConfig,
-		[]roachpb.ReplicaDescriptor{},
-	)
+	_, _, err := a.AllocateVoterTarget(ctx, &simpleZoneConfig, []roachpb.ReplicaDescriptor{}, nil)
 	if !errors.HasInterface(err, (*purgatoryError)(nil)) {
 		t.Fatalf("expected a purgatory error, got: %+v", err)
 	}
 
 	// Second, test the normal case in which we can allocate to the store.
 	gossiputil.NewStoreGossiper(g).GossipStores(singleStore, t)
-	result, _, err := a.AllocateTarget(
-		ctx,
-		&simpleZoneConfig,
-		[]roachpb.ReplicaDescriptor{},
-	)
+	result, _, err := a.AllocateVoterTarget(ctx, &simpleZoneConfig, []roachpb.ReplicaDescriptor{}, nil)
 	if err != nil {
 		t.Fatalf("unable to perform allocation: %+v", err)
 	}
@@ -5600,11 +5591,7 @@ func TestAllocatorThrottled(t *testing.T) {
 	}
 	storeDetail.throttledUntil = timeutil.Now().Add(24 * time.Hour)
 	a.storePool.detailsMu.Unlock()
-	_, _, err = a.AllocateTarget(
-		ctx,
-		&simpleZoneConfig,
-		[]roachpb.ReplicaDescriptor{},
-	)
+	_, _, err = a.AllocateVoterTarget(ctx, &simpleZoneConfig, []roachpb.ReplicaDescriptor{}, nil)
 	if errors.HasInterface(err, (*purgatoryError)(nil)) {
 		t.Fatalf("expected a non purgatory error, got: %+v", err)
 	}

--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -3495,6 +3495,9 @@ func TestStoreRangeMergeDuringShutdown(t *testing.T) {
 func verifyMerged(t *testing.T, store *kvserver.Store, lhsStartKey, rhsStartKey roachpb.RKey) {
 	t.Helper()
 	repl := store.LookupReplica(rhsStartKey)
+	if repl == nil {
+		t.Fatal("replica doesn't exist")
+	}
 	if !repl.Desc().StartKey.Equal(lhsStartKey) {
 		t.Fatalf("ranges unexpectedly unmerged expected startKey %s, but got %s", lhsStartKey, repl.Desc().StartKey)
 	}
@@ -3503,6 +3506,9 @@ func verifyMerged(t *testing.T, store *kvserver.Store, lhsStartKey, rhsStartKey 
 func verifyUnmerged(t *testing.T, store *kvserver.Store, lhsStartKey, rhsStartKey roachpb.RKey) {
 	t.Helper()
 	repl := store.LookupReplica(rhsStartKey)
+	if repl == nil {
+		t.Fatal("replica doesn't exist")
+	}
 	if repl.Desc().StartKey.Equal(lhsStartKey) {
 		t.Fatalf("ranges unexpectedly merged")
 	}

--- a/pkg/kv/kvserver/constraint/analyzer.go
+++ b/pkg/kv/kvserver/constraint/analyzer.go
@@ -36,6 +36,10 @@ type AnalyzedConstraints struct {
 	Satisfies map[roachpb.StoreID][]int
 }
 
+// EmptyAnalyzedConstraints represents an empty set of constraints that are
+// satisfied by any given configuration of replicas.
+var EmptyAnalyzedConstraints = AnalyzedConstraints{}
+
 // AnalyzeConstraints processes the zone config constraints that apply to a
 // range along with the current replicas for a range, spitting back out
 // information about which constraints are satisfied by which replicas and
@@ -44,19 +48,22 @@ func AnalyzeConstraints(
 	ctx context.Context,
 	getStoreDescFn func(roachpb.StoreID) (roachpb.StoreDescriptor, bool),
 	existing []roachpb.ReplicaDescriptor,
-	zone *zonepb.ZoneConfig,
+	// TODO(aayush): !!! Just change this to an int32 to avoid all the casting the
+	// callers have to do.
+	numReplicas int,
+	constraints []zonepb.ConstraintsConjunction,
 ) AnalyzedConstraints {
 	result := AnalyzedConstraints{
-		Constraints: zone.Constraints,
+		Constraints: constraints,
 	}
 
-	if len(zone.Constraints) > 0 {
-		result.SatisfiedBy = make([][]roachpb.StoreID, len(zone.Constraints))
+	if len(constraints) > 0 {
+		result.SatisfiedBy = make([][]roachpb.StoreID, len(constraints))
 		result.Satisfies = make(map[roachpb.StoreID][]int)
 	}
 
 	var constrainedReplicas int32
-	for i, subConstraints := range zone.Constraints {
+	for i, subConstraints := range constraints {
 		constrainedReplicas += subConstraints.NumReplicas
 		for _, repl := range existing {
 			// If for some reason we don't have the store descriptor (which shouldn't
@@ -70,7 +77,7 @@ func AnalyzeConstraints(
 			}
 		}
 	}
-	if constrainedReplicas > 0 && constrainedReplicas < *zone.NumReplicas {
+	if constrainedReplicas > 0 && constrainedReplicas < int32(numReplicas) {
 		result.UnconstrainedReplicas = true
 	}
 	return result

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -2494,6 +2494,15 @@ func (s *Store) relocateReplicas(
 	}
 }
 
+type relocationArgs struct {
+	targetsToAdd, targetsToRemove []roachpb.ReplicaDescriptor
+	addOp, removeOp               roachpb.ReplicaChangeType
+	allocateFn                    chooseReplicaToAddFn
+	removeFn                      chooseReplicaToRemoveFn
+	relocationTargets             []roachpb.ReplicationTarget
+	noVotersToRelocate            bool
+}
+
 func (s *Store) relocateOne(
 	ctx context.Context,
 	desc *roachpb.RangeDescriptor,
@@ -2518,17 +2527,34 @@ func (s *Store) relocateOne(
 	storeList, _, _ := s.allocator.storePool.getStoreList(storeFilterNone)
 	storeMap := storeListToMap(storeList)
 
-	getTargetsToRelocate := func() (targetsToAdd, targetsToRemove []roachpb.ReplicaDescriptor,
-		addOp, removeOp roachpb.ReplicaChangeType, votersRelocated bool) {
+	getRelocationArgs := func() relocationArgs {
 		votersToAdd := subtractTargets(voterTargets, desc.Replicas().Voters().ReplicationTargets())
 		votersToRemove := subtractTargets(desc.Replicas().Voters().ReplicationTargets(), voterTargets)
 		// If there are no voters to relocate, we relocate the non-voters.
 		if len(votersToAdd) == 0 && len(votersToRemove) == 0 {
 			nonVotersToAdd := subtractTargets(nonVoterTargets, desc.Replicas().NonVoters().ReplicationTargets())
 			nonVotersToRemove := subtractTargets(desc.Replicas().NonVoters().ReplicationTargets(), nonVoterTargets)
-			return nonVotersToAdd, nonVotersToRemove, roachpb.ADD_NON_VOTER, roachpb.REMOVE_NON_VOTER, true
+			return relocationArgs{
+				targetsToAdd:       nonVotersToAdd,
+				targetsToRemove:    nonVotersToRemove,
+				addOp:              roachpb.ADD_NON_VOTER,
+				removeOp:           roachpb.REMOVE_NON_VOTER,
+				allocateFn:         s.allocator.allocateNonVotersFromList,
+				removeFn:           s.allocator.RemoveNonVoter,
+				relocationTargets:  nonVoterTargets,
+				noVotersToRelocate: true,
+			}
 		}
-		return votersToAdd, votersToRemove, roachpb.ADD_VOTER, roachpb.REMOVE_VOTER, false
+		return relocationArgs{
+			targetsToAdd:       votersToAdd,
+			targetsToRemove:    votersToRemove,
+			addOp:              roachpb.ADD_VOTER,
+			removeOp:           roachpb.REMOVE_VOTER,
+			allocateFn:         s.allocator.allocateVotersFromList,
+			removeFn:           s.allocator.RemoveVoter,
+			relocationTargets:  voterTargets,
+			noVotersToRelocate: false,
+		}
 	}
 
 	// Compute which replica to add and/or remove, respectively. We then ask the
@@ -2540,24 +2566,20 @@ func (s *Store) relocateOne(
 	// same node, and this code doesn't do anything to specifically avoid that
 	// case (although the allocator will avoid even trying to send snapshots to
 	// such stores), so it could cause some failures.
-	targetsToAdd, targetsToRemove, addOp, removeOp, votersRelocated := getTargetsToRelocate()
-	relocationTargets := voterTargets
-	existingReplicas := desc.Replicas().VoterDescriptors()
-	if votersRelocated {
-		relocationTargets = nonVoterTargets
-		existingReplicas = desc.Replicas().NonVoterDescriptors()
-	}
+	args := getRelocationArgs()
+	existingVoters, existingNonVoters := desc.Replicas().VoterDescriptors(), desc.Replicas().NonVoterDescriptors()
+	existingReplicas := desc.Replicas().Descriptors()
 
 	var ops roachpb.ReplicationChanges
-	if len(targetsToAdd) > 0 {
+	if len(args.targetsToAdd) > 0 {
 		// Each iteration, pick the most desirable replica to add. However,
 		// prefer the first target because it's the one that should hold the
 		// lease in the end; it helps to add it early so that the lease doesn't
 		// have to move too much.
-		candidateTargets := targetsToAdd
-		if !votersRelocated && storeHasReplica(relocationTargets[0].StoreID, candidateTargets) {
+		candidateTargets := args.targetsToAdd
+		if !args.noVotersToRelocate && storeHasReplica(args.relocationTargets[0].StoreID, candidateTargets) {
 			candidateTargets = []roachpb.ReplicaDescriptor{
-				{NodeID: relocationTargets[0].NodeID, StoreID: relocationTargets[0].StoreID},
+				{NodeID: args.relocationTargets[0].NodeID, StoreID: args.relocationTargets[0].StoreID},
 			}
 		}
 
@@ -2575,46 +2597,48 @@ func (s *Store) relocateOne(
 		}
 		candidateStoreList := makeStoreList(candidateDescs)
 
-		targetStore, _ := s.allocator.allocateTargetFromList(
-			ctx,
-			candidateStoreList,
-			zone,
-			existingReplicas,
-			s.allocator.scorerOptions())
-		if targetStore == nil {
-			return nil, nil, fmt.Errorf("none of the remaining relocationTargets %v are legal additions to %v",
-				targetsToAdd, desc.Replicas())
-		}
+		targetStore, _ := args.allocateFn(ctx, candidateStoreList, zone, existingVoters, existingNonVoters, s.allocator.scorerOptions())
 
 		target := roachpb.ReplicationTarget{
 			NodeID:  targetStore.Node.NodeID,
 			StoreID: targetStore.StoreID,
 		}
-		ops = append(ops, roachpb.MakeReplicationChanges(addOp, target)...)
+		ops = append(ops, roachpb.MakeReplicationChanges(args.addOp, target)...)
+
 		// Pretend the replica is already there so that the removal logic below will
 		// take it into account when deciding which replica to remove.
-		existingReplicas = append(existingReplicas, roachpb.ReplicaDescriptor{
-			NodeID:    target.NodeID,
-			StoreID:   target.StoreID,
-			ReplicaID: desc.NextReplicaID,
-			Type:      roachpb.ReplicaTypeVoterFull(),
-		})
+		if args.noVotersToRelocate {
+			existingNonVoters = append(existingNonVoters, roachpb.ReplicaDescriptor{
+				NodeID:    target.NodeID,
+				StoreID:   target.StoreID,
+				ReplicaID: desc.NextReplicaID,
+				Type:      roachpb.ReplicaTypeNonVoter(),
+			})
+		} else {
+			existingVoters = append(existingVoters, roachpb.ReplicaDescriptor{
+				NodeID:    target.NodeID,
+				StoreID:   target.StoreID,
+				ReplicaID: desc.NextReplicaID,
+				Type:      roachpb.ReplicaTypeVoterFull(),
+			})
+		}
 	}
 
 	var transferTarget *roachpb.ReplicationTarget
-	if len(targetsToRemove) > 0 {
-		// Pick a replica to remove. Note that existingReplicas may already reflect
-		// a replica we're adding in the current round. This is the right thing
-		// to do. For example, consider relocating from (s1,s2,s3) to (s1,s2,s4)
-		// where targetsToAdd will be (s4) and targetsToRemove is (s3). In this code,
-		// we'll want the allocator to see if s3 can be removed from
+	if len(args.targetsToRemove) > 0 {
+		// Pick a replica to remove. Note that existingVoters/existingNonVoters may
+		// already reflect a replica we're adding in the current round. This is the
+		// right thing to do. For example, consider relocating from (s1,s2,s3) to
+		// (s1,s2,s4) where targetsToAdd will be (s4) and targetsToRemove is (s3).
+		// In this code, we'll want the allocator to see if s3 can be removed from
 		// (s1,s2,s3,s4) which is a reasonable request; that replica set is
-		// overreplicated. If we asked it instead to remove s3 from (s1,s2,s3)
-		// it may not want to do that due to constraints.
-		targetStore, _, err := s.allocator.RemoveTarget(ctx, zone, targetsToRemove, existingReplicas)
+		// overreplicated. If we asked it instead to remove s3 from (s1,s2,s3) it
+		// may not want to do that due to constraints.
+		targetStore, _, err := args.removeFn(ctx, zone, args.targetsToRemove, existingVoters,
+			existingNonVoters)
 		if err != nil {
 			return nil, nil, errors.Wrapf(err, "unable to select removal target from %v; current replicas %v",
-				targetsToRemove, existingReplicas)
+				args.targetsToRemove, existingReplicas)
 		}
 		removalTarget := roachpb.ReplicationTarget{
 			NodeID:  targetStore.NodeID,
@@ -2634,17 +2658,16 @@ func (s *Store) relocateOne(
 		}
 		curLeaseholder := b.RawResponse().Responses[0].GetLeaseInfo().Lease.Replica
 		ok := curLeaseholder.StoreID != removalTarget.StoreID
-		if !ok {
-			// Pick a replica that we can give the lease to. We sort the first
-			// target to the beginning (if it's there) because that's where the
-			// lease needs to be in the end. We also exclude the last replica if
-			// it was added by the add branch above (in which case it doesn't
-			// exist yet).
-			sortedTargetReplicas := append([]roachpb.ReplicaDescriptor(nil), existingReplicas[:len(existingReplicas)-len(ops)]...)
+		if !ok && !args.noVotersToRelocate {
+			// Pick a voting replica that we can give the lease to. We sort the first
+			// target to the beginning (if it's there) because that's where the lease
+			// needs to be in the end. We also exclude the last replica if it was
+			// added by the add branch above (in which case it doesn't exist yet).
+			sortedTargetReplicas := append([]roachpb.ReplicaDescriptor(nil), existingVoters[:len(existingVoters)-len(ops)]...)
 			sort.Slice(sortedTargetReplicas, func(i, j int) bool {
 				sl := sortedTargetReplicas
 				// relocationTargets[0] goes to the front (if it's present).
-				return sl[i].StoreID == relocationTargets[0].StoreID
+				return sl[i].StoreID == args.relocationTargets[0].StoreID
 			})
 			for _, rDesc := range sortedTargetReplicas {
 				if rDesc.StoreID != curLeaseholder.StoreID {
@@ -2665,7 +2688,7 @@ func (s *Store) relocateOne(
 		// illegal).
 		if ok {
 			ops = append(ops, roachpb.MakeReplicationChanges(
-				removeOp,
+				args.removeOp,
 				removalTarget)...)
 		}
 	}

--- a/pkg/kv/kvserver/replica_metrics.go
+++ b/pkg/kv/kvserver/replica_metrics.go
@@ -176,7 +176,7 @@ func calcRangeCounter(
 		unavailable = !desc.Replicas().CanMakeProgress(func(rDesc roachpb.ReplicaDescriptor) bool {
 			return livenessMap[rDesc.NodeID].IsLive
 		})
-		needed := GetNeededReplicas(numReplicas, clusterNodes)
+		needed := GetNeededVoters(numReplicas, clusterNodes)
 		liveVoterReplicas := calcLiveVoterReplicas(desc, livenessMap)
 		if needed > liveVoterReplicas {
 			underreplicated = true

--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -120,6 +120,7 @@ func (e *quorumError) Error() string {
 func (*quorumError) purgatoryErrorMarker() {}
 
 // ReplicateQueueMetrics is the set of metrics for the replicate queue.
+// TODO(aayush): Track metrics for non-voting replicas separately here.
 type ReplicateQueueMetrics struct {
 	AddReplicaCount           *metric.Counter
 	RemoveReplicaCount        *metric.Counter
@@ -322,7 +323,9 @@ func (rq *replicateQueue) processOneChange(
 	// Avoid taking action if the range has too many dead replicas to make
 	// quorum.
 	voterReplicas := desc.Replicas().VoterDescriptors()
+	nonVoterReplicas := desc.Replicas().NonVoterDescriptors()
 	liveVoterReplicas, deadVoterReplicas := rq.allocator.storePool.liveAndDeadReplicas(voterReplicas)
+	liveNonVoterReplicas, _ := rq.allocator.storePool.liveAndDeadReplicas(nonVoterReplicas)
 
 	// NB: the replication layer ensures that the below operations don't cause
 	// unavailability; see:
@@ -345,9 +348,13 @@ func (rq *replicateQueue) processOneChange(
 		// Let the scanner requeue it again later.
 		return false, nil
 	case AllocatorAddVoter:
-		return rq.addOrReplace(ctx, repl, voterReplicas, liveVoterReplicas, -1 /* removeIdx */, dryRun)
+		return rq.addOrReplaceVoters(ctx, repl, voterReplicas, liveVoterReplicas, liveNonVoterReplicas, -1, dryRun)
+	case AllocatorAddNonVoter:
+		return rq.addNonVoter(ctx, repl, nonVoterReplicas, liveVoterReplicas, liveNonVoterReplicas, dryRun)
 	case AllocatorRemoveVoter:
-		return rq.remove(ctx, repl, voterReplicas, dryRun)
+		return rq.removeVoter(ctx, repl, voterReplicas, nonVoterReplicas, dryRun)
+	case AllocatorRemoveNonVoter:
+		return rq.removeNonVoter(ctx, repl, voterReplicas, nonVoterReplicas, dryRun)
 	case AllocatorReplaceDeadVoter:
 		if len(deadVoterReplicas) == 0 {
 			// Nothing to do.
@@ -365,7 +372,7 @@ func (rq *replicateQueue) processOneChange(
 				"dead voter %v unexpectedly not found in %v",
 				deadVoterReplicas[0], voterReplicas)
 		}
-		return rq.addOrReplace(ctx, repl, voterReplicas, liveVoterReplicas, removeIdx, dryRun)
+		return rq.addOrReplaceVoters(ctx, repl, voterReplicas, liveVoterReplicas, liveNonVoterReplicas, removeIdx, dryRun)
 	case AllocatorReplaceDecommissioningVoter:
 		decommissioningReplicas := rq.allocator.storePool.decommissioningReplicas(voterReplicas)
 		if len(decommissioningReplicas) == 0 {
@@ -384,7 +391,7 @@ func (rq *replicateQueue) processOneChange(
 				"decommissioning voter %v unexpectedly not found in %v",
 				decommissioningReplicas[0], voterReplicas)
 		}
-		return rq.addOrReplace(ctx, repl, voterReplicas, liveVoterReplicas, removeIdx, dryRun)
+		return rq.addOrReplaceVoters(ctx, repl, voterReplicas, liveVoterReplicas, liveNonVoterReplicas, removeIdx, dryRun)
 	case AllocatorRemoveDecommissioningVoter:
 		// NB: this path will only be hit when the range is over-replicated and
 		// has decommissioning replicas; in the common case we'll hit
@@ -404,51 +411,50 @@ func (rq *replicateQueue) processOneChange(
 		// Requeue because either we failed to transition out of a joint state
 		// (bad) or we did and there might be more to do for that range.
 		return true, err
-	case AllocatorAddNonVoter, AllocatorRemoveNonVoter:
-		return false, errors.Errorf("allocator actions pertaining to non-voters are"+
-			" currently not supported: %v", action)
 	default:
 		return false, errors.Errorf("unknown allocator action %v", action)
 	}
 }
 
-// addOrReplace adds or replaces a replica. If removeIdx is -1, an addition is
-// carried out. Otherwise, removeIdx must be a valid index into existingReplicas
-// and specifies which replica to replace with a new one.
+// addOrReplaceVoters adds or replaces a voting replica. If removeIdx is -1, an
+// addition is carried out. Otherwise, removeIdx must be a valid index into
+// existingVoters and specifies which voter to replace with a new one.
 //
 // The method preferably issues an atomic replica swap, but may not be able to
 // do this in all cases, such as when atomic replication changes are not
 // available, or when the range consists of a single replica. As a fall back,
 // only the addition is carried out; the removal is then a follow-up step for
 // the next scanner cycle.
-func (rq *replicateQueue) addOrReplace(
+func (rq *replicateQueue) addOrReplaceVoters(
 	ctx context.Context,
 	repl *Replica,
-	existingReplicas []roachpb.ReplicaDescriptor,
+	existingVoters []roachpb.ReplicaDescriptor,
 	liveVoterReplicas []roachpb.ReplicaDescriptor,
-	removeIdx int, // -1 for no removal
+	liveNonVoterReplicas []roachpb.ReplicaDescriptor,
+	removeIdx int,
 	dryRun bool,
 ) (requeue bool, _ error) {
-	if len(existingReplicas) == 1 {
+	if len(existingVoters) == 1 {
 		// If only one replica remains, that replica is the leaseholder and
 		// we won't be able to swap it out. Ignore the removal and simply add
 		// a replica.
 		removeIdx = -1
 	}
 
-	remainingLiveReplicas := liveVoterReplicas
+	remainingLiveVoters := liveVoterReplicas
+	remainingLiveNonVoters := liveNonVoterReplicas
 	if removeIdx >= 0 {
-		replToRemove := existingReplicas[removeIdx]
+		replToRemove := existingVoters[removeIdx]
 		for i, r := range liveVoterReplicas {
 			if r.ReplicaID == replToRemove.ReplicaID {
-				remainingLiveReplicas = append(liveVoterReplicas[:i:i], liveVoterReplicas[i+1:]...)
+				remainingLiveVoters = append(liveVoterReplicas[:i:i], liveVoterReplicas[i+1:]...)
 				break
 			}
 		}
 		// See about transferring the lease away if we're about to remove the
 		// leaseholder.
 		done, err := rq.maybeTransferLeaseAway(
-			ctx, repl, existingReplicas[removeIdx].StoreID, dryRun, nil /* canTransferLease */)
+			ctx, repl, existingVoters[removeIdx].StoreID, dryRun, nil /* canTransferLease */)
 		if err != nil {
 			return false, err
 		}
@@ -464,15 +470,11 @@ func (rq *replicateQueue) addOrReplace(
 	// there is a reason we're removing it (i.e. dead or decommissioning). If we
 	// left the replica in the slice, the allocator would not be guaranteed to
 	// pick a replica that fills the gap removeRepl leaves once it's gone.
-	newStore, details, err := rq.allocator.AllocateTarget(
-		ctx,
-		zone,
-		remainingLiveReplicas,
-	)
+	newStore, details, err := rq.allocator.AllocateVoterTarget(ctx, zone, remainingLiveVoters, remainingLiveNonVoters)
 	if err != nil {
 		return false, err
 	}
-	if removeIdx >= 0 && newStore.StoreID == existingReplicas[removeIdx].StoreID {
+	if removeIdx >= 0 && newStore.StoreID == existingVoters[removeIdx].StoreID {
 		return false, errors.AssertionFailedf("allocator suggested to replace replica on s%d with itself", newStore.StoreID)
 	}
 	newReplica := roachpb.ReplicationTarget{
@@ -481,7 +483,7 @@ func (rq *replicateQueue) addOrReplace(
 	}
 
 	clusterNodes := rq.allocator.storePool.ClusterNodeCount()
-	need := GetNeededVoters(*zone.NumReplicas, clusterNodes)
+	neededVoters := GetNeededVoters(zone.GetNumVoters(), clusterNodes)
 
 	// Only up-replicate if there are suitable allocation targets such that,
 	// either the replication goal is met, or it is possible to get to the next
@@ -490,28 +492,24 @@ func (rq *replicateQueue) addOrReplace(
 	// quorum. For example, up-replicating from 1 to 2 replicas only makes sense
 	// if it is possible to be able to go to 3 replicas.
 	//
-	// NB: If willHave > need, then always allow up-replicating as that
+	// NB: If willHave > neededVoters, then always allow up-replicating as that
 	// will be the case when up-replicating a range with a decommissioning
 	// replica.
 	//
 	// We skip this check if we're swapping a replica, since that does not
 	// change the quorum size.
-	if willHave := len(existingReplicas) + 1; removeIdx < 0 && willHave < need && willHave%2 == 0 {
+	if willHave := len(existingVoters) + 1; removeIdx < 0 && willHave < neededVoters && willHave%2 == 0 {
 		// This means we are going to up-replicate to an even replica state.
 		// Check if it is possible to go to an odd replica state beyond it.
-		oldPlusNewReplicas := append([]roachpb.ReplicaDescriptor(nil), existingReplicas...)
+		oldPlusNewReplicas := append([]roachpb.ReplicaDescriptor(nil), existingVoters...)
 		oldPlusNewReplicas = append(oldPlusNewReplicas, roachpb.ReplicaDescriptor{
 			NodeID:  newStore.Node.NodeID,
 			StoreID: newStore.StoreID,
 		})
-		_, _, err := rq.allocator.AllocateTarget(
-			ctx,
-			zone,
-			oldPlusNewReplicas,
-		)
+		_, _, err := rq.allocator.AllocateVoterTarget(ctx, zone, oldPlusNewReplicas, remainingLiveNonVoters)
 		if err != nil {
 			// It does not seem possible to go to the next odd replica state. Note
-			// that AllocateTarget returns an allocatorError (a purgatoryError)
+			// that AllocateVoterTarget returns an allocatorError (a purgatoryError)
 			// when purgatory is requested.
 			return false, errors.Wrap(err, "avoid up-replicating to fragile quorum")
 		}
@@ -520,12 +518,12 @@ func (rq *replicateQueue) addOrReplace(
 	ops := roachpb.MakeReplicationChanges(roachpb.ADD_VOTER, newReplica)
 	if removeIdx < 0 {
 		log.VEventf(ctx, 1, "adding replica %+v: %s",
-			newReplica, rangeRaftProgress(repl.RaftStatus(), existingReplicas))
+			newReplica, rangeRaftProgress(repl.RaftStatus(), existingVoters))
 	} else {
 		rq.metrics.RemoveReplicaCount.Inc(1)
-		removeReplica := existingReplicas[removeIdx]
+		removeReplica := existingVoters[removeIdx]
 		log.VEventf(ctx, 1, "replacing replica %s with %+v: %s",
-			removeReplica, newReplica, rangeRaftProgress(repl.RaftStatus(), existingReplicas))
+			removeReplica, newReplica, rangeRaftProgress(repl.RaftStatus(), existingVoters))
 		ops = append(ops,
 			roachpb.MakeReplicationChanges(roachpb.REMOVE_VOTER, roachpb.ReplicationTarget{
 				StoreID: removeReplica.StoreID,
@@ -549,17 +547,56 @@ func (rq *replicateQueue) addOrReplace(
 	return true, nil
 }
 
-// findRemoveTarget takes a list of replicas and picks one to remove, making
-// sure to not remove a newly added replica or to violate the zone configs in
-// the progress.
-func (rq *replicateQueue) findRemoveTarget(
+func (rq *replicateQueue) addNonVoter(
+	ctx context.Context,
+	repl *Replica,
+	existingReplicas, liveVoterReplicas, liveNonVoterReplicas []roachpb.ReplicaDescriptor,
+	dryRun bool,
+) (requeue bool, _ error) {
+	desc, zone := repl.DescAndZone()
+
+	newStore, details, err := rq.allocator.AllocateNonVoterTarget(ctx, zone, liveVoterReplicas, liveNonVoterReplicas)
+	if err != nil {
+		return false, err
+	}
+	newNonVoter := roachpb.ReplicationTarget{
+		NodeID:  newStore.Node.NodeID,
+		StoreID: newStore.StoreID,
+	}
+
+	ops := roachpb.MakeReplicationChanges(roachpb.ADD_NON_VOTER, newNonVoter)
+	if err := rq.changeReplicas(
+		ctx,
+		repl,
+		ops,
+		desc,
+		SnapshotRequest_RECOVERY,
+		kvserverpb.ReasonRangeUnderReplicated,
+		details,
+		dryRun,
+	); err != nil {
+		return false, err
+	}
+	// Always requeue to see if more work needs to be done.
+	return true, nil
+}
+
+// findRemoveVoter takes a list of voting replicas and picks one to remove,
+// making sure to not remove a newly added voter or to violate the zone configs
+// in the process.
+//
+// TODO(aayush): The structure around replica removal is not great. The entire
+// logic of this method should probably live inside Allocator.RemoveVoter. Doing
+// so also makes the flow of adding new replicas and removing replicas more
+// symmetric.
+func (rq *replicateQueue) findRemoveVoter(
 	ctx context.Context,
 	repl interface {
 		DescAndZone() (*roachpb.RangeDescriptor, *zonepb.ZoneConfig)
 		LastReplicaAdded() (roachpb.ReplicaID, time.Time)
 		RaftStatus() *raft.Status
 	},
-	existingReplicas []roachpb.ReplicaDescriptor,
+	existingVoters, existingNonVoters []roachpb.ReplicaDescriptor,
 ) (roachpb.ReplicaDescriptor, string, error) {
 	_, zone := repl.DescAndZone()
 	// This retry loop involves quick operations on local state, so a
@@ -587,9 +624,9 @@ func (rq *replicateQueue) findRemoveTarget(
 			// If we've lost raft leadership, we're unlikely to regain it so give up immediately.
 			return roachpb.ReplicaDescriptor{}, "", &benignError{errors.Errorf("not raft leader while range needs removal")}
 		}
-		candidates = filterUnremovableReplicas(ctx, raftStatus, existingReplicas, lastReplAdded)
+		candidates = filterUnremovableReplicas(ctx, raftStatus, existingVoters, lastReplAdded)
 		log.VEventf(ctx, 3, "filtered unremovable replicas from %v to get %v as candidates for removal: %s",
-			existingReplicas, candidates, rangeRaftProgress(raftStatus, existingReplicas))
+			existingVoters, candidates, rangeRaftProgress(raftStatus, existingVoters))
 		if len(candidates) > 0 {
 			break
 		}
@@ -617,10 +654,10 @@ func (rq *replicateQueue) findRemoveTarget(
 	if len(candidates) == 0 {
 		// If we timed out and still don't have any valid candidates, give up.
 		return roachpb.ReplicaDescriptor{}, "", &benignError{errors.Errorf("no removable replicas from range that needs a removal: %s",
-			rangeRaftProgress(repl.RaftStatus(), existingReplicas))}
+			rangeRaftProgress(repl.RaftStatus(), existingVoters))}
 	}
 
-	return rq.allocator.RemoveTarget(ctx, zone, candidates, existingReplicas)
+	return rq.allocator.RemoveVoter(ctx, zone, candidates, existingVoters, existingNonVoters)
 }
 
 // maybeTransferLeaseAway is called whenever a replica on a given store is
@@ -668,15 +705,18 @@ func (rq *replicateQueue) maybeTransferLeaseAway(
 	return transferred == transferOK, err
 }
 
-func (rq *replicateQueue) remove(
-	ctx context.Context, repl *Replica, existingReplicas []roachpb.ReplicaDescriptor, dryRun bool,
+func (rq *replicateQueue) removeVoter(
+	ctx context.Context,
+	repl *Replica,
+	existingVoters, existingNonVoters []roachpb.ReplicaDescriptor,
+	dryRun bool,
 ) (requeue bool, _ error) {
-	removeReplica, details, err := rq.findRemoveTarget(ctx, repl, existingReplicas)
+	removeVoter, details, err := rq.findRemoveVoter(ctx, repl, existingVoters, existingNonVoters)
 	if err != nil {
 		return false, err
 	}
 	done, err := rq.maybeTransferLeaseAway(
-		ctx, repl, removeReplica.StoreID, dryRun, nil /* canTransferLease */)
+		ctx, repl, removeVoter.StoreID, dryRun, nil /* canTransferLease */)
 	if err != nil {
 		return false, err
 	}
@@ -687,11 +727,11 @@ func (rq *replicateQueue) remove(
 
 	// Remove a replica.
 	rq.metrics.RemoveReplicaCount.Inc(1)
-	log.VEventf(ctx, 1, "removing replica %+v due to over-replication: %s",
-		removeReplica, rangeRaftProgress(repl.RaftStatus(), existingReplicas))
+	log.VEventf(ctx, 1, "removing voting replica %+v due to over-replication: %s",
+		removeVoter, rangeRaftProgress(repl.RaftStatus(), existingVoters))
 	target := roachpb.ReplicationTarget{
-		NodeID:  removeReplica.NodeID,
-		StoreID: removeReplica.StoreID,
+		NodeID:  removeVoter.NodeID,
+		StoreID: removeVoter.StoreID,
 	}
 	desc, _ := repl.DescAndZone()
 	if err := rq.changeReplicas(
@@ -704,6 +744,40 @@ func (rq *replicateQueue) remove(
 		details,
 		dryRun,
 	); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (rq *replicateQueue) removeNonVoter(
+	ctx context.Context,
+	repl *Replica,
+	existingVoters, existingNonVoters []roachpb.ReplicaDescriptor,
+	dryRun bool,
+) (requeue bool, _ error) {
+	rq.metrics.RemoveReplicaCount.Inc(1)
+
+	desc, zone := repl.DescAndZone()
+	removeNonVoter, details, err := rq.allocator.RemoveNonVoter(
+		ctx,
+		zone,
+		existingNonVoters,
+		existingVoters, existingNonVoters,
+	)
+	if err != nil {
+		return false, err
+	}
+
+	log.VEventf(ctx, 1, "removing non-voting replica %+v due to over-replication: %s",
+		removeNonVoter, rangeRaftProgress(repl.RaftStatus(), existingVoters))
+	target := roachpb.ReplicationTarget{
+		NodeID:  removeNonVoter.NodeID,
+		StoreID: removeNonVoter.StoreID,
+	}
+
+	if err := rq.changeReplicas(ctx, repl,
+		roachpb.MakeReplicationChanges(roachpb.REMOVE_NON_VOTER, target), desc, SnapshotRequest_UNKNOWN,
+		kvserverpb.ReasonRangeOverReplicated, details, dryRun); err != nil {
 		return false, err
 	}
 	return true, nil

--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -404,6 +404,9 @@ func (rq *replicateQueue) processOneChange(
 		// Requeue because either we failed to transition out of a joint state
 		// (bad) or we did and there might be more to do for that range.
 		return true, err
+	case AllocatorAddNonVoter, AllocatorRemoveNonVoter:
+		return false, errors.Errorf("allocator actions pertaining to non-voters are"+
+			" currently not supported: %v", action)
 	default:
 		return false, errors.Errorf("unknown allocator action %v", action)
 	}
@@ -478,7 +481,7 @@ func (rq *replicateQueue) addOrReplace(
 	}
 
 	clusterNodes := rq.allocator.storePool.ClusterNodeCount()
-	need := GetNeededReplicas(*zone.NumReplicas, clusterNodes)
+	need := GetNeededVoters(*zone.NumReplicas, clusterNodes)
 
 	// Only up-replicate if there are suitable allocation targets such that,
 	// either the replication goal is met, or it is possible to get to the next

--- a/pkg/kv/kvserver/store_rebalancer.go
+++ b/pkg/kv/kvserver/store_rebalancer.go
@@ -504,7 +504,7 @@ func (sr *StoreRebalancer) chooseReplicaToRebalance(
 			desc.RangeID, replWithStats.qps)
 
 		clusterNodes := sr.rq.allocator.storePool.ClusterNodeCount()
-		desiredReplicas := GetNeededReplicas(*zone.NumReplicas, clusterNodes)
+		desiredReplicas := GetNeededVoters(*zone.NumReplicas, clusterNodes)
 		targets := make([]roachpb.ReplicationTarget, 0, desiredReplicas)
 		targetReplicas := make([]roachpb.ReplicaDescriptor, 0, desiredReplicas)
 		currentReplicas := desc.Replicas().Descriptors()

--- a/pkg/kv/kvserver/store_rebalancer.go
+++ b/pkg/kv/kvserver/store_rebalancer.go
@@ -504,40 +504,41 @@ func (sr *StoreRebalancer) chooseReplicaToRebalance(
 			desc.RangeID, replWithStats.qps)
 
 		clusterNodes := sr.rq.allocator.storePool.ClusterNodeCount()
-		desiredReplicas := GetNeededVoters(*zone.NumReplicas, clusterNodes)
-		targets := make([]roachpb.ReplicationTarget, 0, desiredReplicas)
-		targetReplicas := make([]roachpb.ReplicaDescriptor, 0, desiredReplicas)
-		currentReplicas := desc.Replicas().Descriptors()
+		desiredVoters := GetNeededVoters(zone.GetNumVoters(), clusterNodes)
+		targets := make([]roachpb.ReplicationTarget, 0, desiredVoters)
+		targetVoters := make([]roachpb.ReplicaDescriptor, 0, desiredVoters)
+		currentVoters := desc.Replicas().VoterDescriptors()
+		currentNonVoters := desc.Replicas().NonVoterDescriptors()
 
 		// Check the range's existing diversity score, since we want to ensure we
 		// don't hurt locality diversity just to improve QPS.
 		curDiversity := rangeDiversityScore(
-			sr.rq.allocator.storePool.getLocalitiesByStore(currentReplicas))
+			sr.rq.allocator.storePool.getLocalitiesByStore(currentVoters))
 
 		// Check the existing replicas, keeping around those that aren't overloaded.
-		for i := range currentReplicas {
-			if currentReplicas[i].StoreID == localDesc.StoreID {
+		for i := range currentVoters {
+			if currentVoters[i].StoreID == localDesc.StoreID {
 				continue
 			}
 			// Keep the replica in the range if we don't know its QPS or if its QPS
 			// is below the upper threshold. Punishing stores not in our store map
 			// could cause mass evictions if the storePool gets out of sync.
-			storeDesc, ok := storeMap[currentReplicas[i].StoreID]
+			storeDesc, ok := storeMap[currentVoters[i].StoreID]
 			if !ok || storeDesc.Capacity.QueriesPerSecond < maxQPS {
 				if log.V(3) {
 					var reason redact.RedactableString
 					if ok {
 						reason = redact.Sprintf(" (qps %.2f vs max %.2f)", storeDesc.Capacity.QueriesPerSecond, maxQPS)
 					}
-					log.VEventf(ctx, 3, "keeping r%d/%d on s%d%s", desc.RangeID, currentReplicas[i].ReplicaID, currentReplicas[i].StoreID, reason)
+					log.VEventf(ctx, 3, "keeping r%d/%d on s%d%s", desc.RangeID, currentVoters[i].ReplicaID, currentVoters[i].StoreID, reason)
 				}
 				targets = append(targets, roachpb.ReplicationTarget{
-					NodeID:  currentReplicas[i].NodeID,
-					StoreID: currentReplicas[i].StoreID,
+					NodeID:  currentVoters[i].NodeID,
+					StoreID: currentVoters[i].StoreID,
 				})
-				targetReplicas = append(targetReplicas, roachpb.ReplicaDescriptor{
-					NodeID:  currentReplicas[i].NodeID,
-					StoreID: currentReplicas[i].StoreID,
+				targetVoters = append(targetVoters, roachpb.ReplicaDescriptor{
+					NodeID:  currentVoters[i].NodeID,
+					StoreID: currentVoters[i].StoreID,
 				})
 			}
 		}
@@ -545,15 +546,18 @@ func (sr *StoreRebalancer) chooseReplicaToRebalance(
 		// Then pick out which new stores to add the remaining replicas to.
 		options := sr.rq.allocator.scorerOptions()
 		options.qpsRebalanceThreshold = qpsRebalanceThreshold.Get(&sr.st.SV)
-		for len(targets) < desiredReplicas {
-			// Use the preexisting AllocateTarget logic to ensure that considerations
+		for len(targets) < desiredVoters {
+			// Use the preexisting AllocateVoterTarget logic to ensure that considerations
 			// such as zone constraints, locality diversity, and full disk come
 			// into play.
-			target, _ := sr.rq.allocator.allocateTargetFromList(
+			target, _ := sr.rq.allocator.allocateVotersFromList(
 				ctx,
 				storeList,
 				zone,
-				targetReplicas,
+				targetVoters,
+				// TODO(aayush): For now, we're not going to let the StoreRebalancer
+				// rebalance non-voting replicas. Fix this.
+				currentNonVoters,
 				options,
 			)
 			if target == nil {
@@ -571,7 +575,7 @@ func (sr *StoreRebalancer) chooseReplicaToRebalance(
 				NodeID:  target.Node.NodeID,
 				StoreID: target.StoreID,
 			})
-			targetReplicas = append(targetReplicas, roachpb.ReplicaDescriptor{
+			targetVoters = append(targetVoters, roachpb.ReplicaDescriptor{
 				NodeID:  target.Node.NodeID,
 				StoreID: target.StoreID,
 			})
@@ -584,12 +588,12 @@ func (sr *StoreRebalancer) chooseReplicaToRebalance(
 		// moving one of the other existing replicas that's on a store with less
 		// qps than the max threshold but above the mean would help in certain
 		// locality configurations.
-		if len(targets) < desiredReplicas {
+		if len(targets) < desiredVoters {
 			log.VEventf(ctx, 3, "couldn't find enough rebalance targets for r%d (%d/%d)",
-				desc.RangeID, len(targets), desiredReplicas)
+				desc.RangeID, len(targets), desiredVoters)
 			continue
 		}
-		newDiversity := rangeDiversityScore(sr.rq.allocator.storePool.getLocalitiesByStore(targetReplicas))
+		newDiversity := rangeDiversityScore(sr.rq.allocator.storePool.getLocalitiesByStore(targetVoters))
 		if newDiversity < curDiversity {
 			log.VEventf(ctx, 3,
 				"new diversity %.2f for r%d worse than current diversity %.2f; not rebalancing",

--- a/pkg/roachpb/metadata_replicas.go
+++ b/pkg/roachpb/metadata_replicas.go
@@ -53,6 +53,13 @@ func ReplicaTypeLearner() *ReplicaType {
 	return &t
 }
 
+// ReplicaTypeNonVoter returns a NON_VOTER pointer suitable for use in
+// a nullable proto field.
+func ReplicaTypeNonVoter() *ReplicaType {
+	t := NON_VOTER
+	return &t
+}
+
 // ReplicaSet is a set of replicas, usually the nodes/stores on which
 // replicas of a range are stored.
 type ReplicaSet struct {


### PR DESCRIPTION
First 3 commits from #59389, 4th commit from #59403, 5th commit 
from #59839.

This commit adds two new variants to the follower reads roachtest: one
that sets up a cluster with 3 voting replicas and 2 non-voting replicas,
and another that has 1 voting replica and 2 non-voting replicas.

Resolves #59678

Release note: None
