### PR TITLE
colmem: limit batches of dynamic size by workmem in memory footprint

### DIFF
--- a/pkg/sql/colexec/columnarizer_test.go
+++ b/pkg/sql/colexec/columnarizer_test.go
@@ -81,7 +81,10 @@ func TestColumnarizerDrainsAndClosesInput(t *testing.T) {
 	defer evalCtx.Stop(ctx)
 
 	rb := distsqlutils.NewRowBuffer([]*types.T{types.Int}, nil /* rows */, distsqlutils.RowBufferArgs{})
-	flowCtx := &execinfra.FlowCtx{EvalCtx: &evalCtx}
+	flowCtx := &execinfra.FlowCtx{
+		Cfg:     &execinfra.ServerConfig{Settings: st},
+		EvalCtx: &evalCtx,
+	}
 
 	const errMsg = "artificial error"
 	rb.Push(nil, &execinfrapb.ProducerMetadata{Err: errors.New(errMsg)})

--- a/pkg/sql/colexec/external_sort.go
+++ b/pkg/sql/colexec/external_sort.go
@@ -116,6 +116,7 @@ type externalSorter struct {
 	closerHelper
 
 	unlimitedAllocator *colmem.Allocator
+	totalMemoryLimit   int64
 	state              externalSorterState
 	inputTypes         []*types.T
 	ordering           execinfrapb.Ordering
@@ -194,19 +195,18 @@ func NewExternalSorter(
 	if maxNumberPartitions < ExternalSorterMinPartitions {
 		maxNumberPartitions = ExternalSorterMinPartitions
 	}
+	estimatedOutputBatchMemSize := colmem.EstimateBatchSizeBytes(inputTypes, coldata.BatchSize())
 	// Each disk queue will use up to BufferSizeBytes of RAM, so we reduce the
 	// memoryLimit of the partitions to sort in memory by those cache sizes. To
 	// be safe, we also estimate the size of the output batch and subtract that
 	// as well.
-	batchMemSize := colmem.EstimateBatchSizeBytes(inputTypes, coldata.BatchSize())
-	// Reserve a certain amount of memory for the partition caches.
-	memoryLimit -= int64((maxNumberPartitions * diskQueueCfg.BufferSizeBytes) + batchMemSize)
-	if memoryLimit < 1 {
+	singlePartitionSize := memoryLimit - int64(maxNumberPartitions*diskQueueCfg.BufferSizeBytes+estimatedOutputBatchMemSize)
+	if singlePartitionSize < 1 {
 		// If the memory limit is 0, the input partitioning operator will return
 		// a zero-length batch, so make it at least 1.
-		memoryLimit = 1
+		singlePartitionSize = 1
 	}
-	inputPartitioner := newInputPartitioningOperator(input, standaloneMemAccount, memoryLimit)
+	inputPartitioner := newInputPartitioningOperator(input, standaloneMemAccount, singlePartitionSize)
 	inMemSorter, err := newSorter(
 		unlimitedAllocator, newAllSpooler(unlimitedAllocator, inputPartitioner, inputTypes),
 		inputTypes, ordering.Columns,
@@ -225,14 +225,20 @@ func NewExternalSorter(
 	es := &externalSorter{
 		OneInputNode:       NewOneInputNode(inMemSorter),
 		unlimitedAllocator: unlimitedAllocator,
+		totalMemoryLimit:   memoryLimit,
 		inMemSorter:        inMemSorter,
 		inMemSorterInput:   inputPartitioner.(*inputPartitioningOperator),
 		partitionerCreator: func() colcontainer.PartitionedQueue {
 			return colcontainer.NewPartitionedDiskQueue(inputTypes, diskQueueCfg, partitionedDiskQueueSemaphore, colcontainer.PartitionerStrategyCloseOnNewPartition, diskAcc)
 		},
-		inputTypes:          inputTypes,
-		ordering:            ordering,
-		columnOrdering:      execinfrapb.ConvertToColumnOrdering(ordering),
+		inputTypes:     inputTypes,
+		ordering:       ordering,
+		columnOrdering: execinfrapb.ConvertToColumnOrdering(ordering),
+		// TODO(yuzefovich): maxNumberPartitions should also be semi-dynamically
+		// limited based on the sizes of batches. Consider a scenario when each
+		// input batch is 1 GB in size - if we don't put any limiting in place,
+		// we might try to use 16 partitions at once, which means that during
+		// merging we will be keeping 16 batches (i.e. 16GB of data) in memory.
 		maxNumberPartitions: maxNumberPartitions,
 	}
 	es.fdState.fdSemaphore = fdSemaphore
@@ -425,8 +431,11 @@ func (s *externalSorter) createMergerForPartitions(
 		)
 	}
 
+	// TODO(yuzefovich): we should calculate a more precise memory limit taking
+	// into account how many partitions are currently being merged and the
+	// average batch size in each one of them.
 	return NewOrderedSynchronizer(
-		s.unlimitedAllocator, syncInputs, s.inputTypes, s.columnOrdering,
+		s.unlimitedAllocator, s.totalMemoryLimit, syncInputs, s.inputTypes, s.columnOrdering,
 	)
 }
 

--- a/pkg/sql/colexec/hashjoiner.go
+++ b/pkg/sql/colexec/hashjoiner.go
@@ -184,6 +184,10 @@ type hashJoiner struct {
 	// ht holds the hashTable that is populated during the build phase and used
 	// during the probe phase.
 	ht *hashTable
+	// memoryLimit is the total amount of RAM available for the hash joiner.
+	// This limits the output batches (and is also the same limit for the size
+	// of the hash table).
+	memoryLimit int64
 	// output stores the resulting output batch that is constructed and returned
 	// for every input batch during the probe phase.
 	output      coldata.Batch
@@ -704,7 +708,9 @@ func (hj *hashJoiner) resetOutput(nResults int) {
 	// batch at a time. If we were to use a limited allocator, we could hit the
 	// limit here, and it would have been very hard to fall back to disk backed
 	// hash joiner because we might have already emitted partial output.
-	hj.output, _ = hj.outputUnlimitedAllocator.ResetMaybeReallocate(hj.outputTypes, hj.output, minCapacity)
+	hj.output, _ = hj.outputUnlimitedAllocator.ResetMaybeReallocate(
+		hj.outputTypes, hj.output, minCapacity, hj.memoryLimit,
+	)
 }
 
 func (hj *hashJoiner) reset(ctx context.Context) {
@@ -792,17 +798,20 @@ func MakeHashJoinerSpec(
 // buildSideAllocator should use a limited memory account and will be used for
 // the build side whereas outputUnlimitedAllocator should use an unlimited
 // memory account and will only be used when populating the output.
+// memoryLimit will limit the size of the batches produced by the hash joiner.
 func NewHashJoiner(
 	buildSideAllocator, outputUnlimitedAllocator *colmem.Allocator,
 	spec HashJoinerSpec,
 	leftSource, rightSource colexecbase.Operator,
 	initialNumBuckets uint64,
+	memoryLimit int64,
 ) ResettableOperator {
 	return &hashJoiner{
 		twoInputNode:               newTwoInputNode(leftSource, rightSource),
 		buildSideAllocator:         buildSideAllocator,
 		outputUnlimitedAllocator:   outputUnlimitedAllocator,
 		spec:                       spec,
+		memoryLimit:                memoryLimit,
 		outputTypes:                spec.joinType.MakeOutputTypes(spec.left.sourceTypes, spec.right.sourceTypes),
 		hashTableInitialNumBuckets: initialNumBuckets,
 	}

--- a/pkg/sql/colexec/hashjoiner_test.go
+++ b/pkg/sql/colexec/hashjoiner_test.go
@@ -1090,7 +1090,8 @@ func BenchmarkHashJoiner(b *testing.B) {
 										)
 										hj := NewHashJoiner(
 											testAllocator, testAllocator, hjSpec,
-											leftSource, rightSource, HashJoinerInitialNumBuckets,
+											leftSource, rightSource,
+											HashJoinerInitialNumBuckets, defaultMemoryLimit,
 										)
 										hj.Init()
 

--- a/pkg/sql/colexec/mergejoiner_exceptall.eg.go
+++ b/pkg/sql/colexec/mergejoiner_exceptall.eg.go
@@ -12701,7 +12701,9 @@ func (o *mergeJoinExceptAllOp) build(ctx context.Context) {
 }
 
 func (o *mergeJoinExceptAllOp) Next(ctx context.Context) coldata.Batch {
-	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(o.outputTypes, o.output, 1 /* minCapacity */)
+	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
+		o.outputTypes, o.output, 1 /* minCapacity */, o.memoryLimit,
+	)
 	o.bufferedGroup.helper.output = o.output
 	for {
 		switch o.state {

--- a/pkg/sql/colexec/mergejoiner_fullouter.eg.go
+++ b/pkg/sql/colexec/mergejoiner_fullouter.eg.go
@@ -13719,7 +13719,9 @@ func (o *mergeJoinFullOuterOp) build(ctx context.Context) {
 }
 
 func (o *mergeJoinFullOuterOp) Next(ctx context.Context) coldata.Batch {
-	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(o.outputTypes, o.output, 1 /* minCapacity */)
+	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
+		o.outputTypes, o.output, 1 /* minCapacity */, o.memoryLimit,
+	)
 	o.bufferedGroup.helper.output = o.output
 	for {
 		switch o.state {

--- a/pkg/sql/colexec/mergejoiner_inner.eg.go
+++ b/pkg/sql/colexec/mergejoiner_inner.eg.go
@@ -9549,7 +9549,9 @@ func (o *mergeJoinInnerOp) build(ctx context.Context) {
 }
 
 func (o *mergeJoinInnerOp) Next(ctx context.Context) coldata.Batch {
-	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(o.outputTypes, o.output, 1 /* minCapacity */)
+	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
+		o.outputTypes, o.output, 1 /* minCapacity */, o.memoryLimit,
+	)
 	o.bufferedGroup.helper.output = o.output
 	for {
 		switch o.state {

--- a/pkg/sql/colexec/mergejoiner_intersectall.eg.go
+++ b/pkg/sql/colexec/mergejoiner_intersectall.eg.go
@@ -10307,7 +10307,9 @@ func (o *mergeJoinIntersectAllOp) build(ctx context.Context) {
 }
 
 func (o *mergeJoinIntersectAllOp) Next(ctx context.Context) coldata.Batch {
-	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(o.outputTypes, o.output, 1 /* minCapacity */)
+	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
+		o.outputTypes, o.output, 1 /* minCapacity */, o.memoryLimit,
+	)
 	o.bufferedGroup.helper.output = o.output
 	for {
 		switch o.state {

--- a/pkg/sql/colexec/mergejoiner_leftanti.eg.go
+++ b/pkg/sql/colexec/mergejoiner_leftanti.eg.go
@@ -11621,7 +11621,9 @@ func (o *mergeJoinLeftAntiOp) build(ctx context.Context) {
 }
 
 func (o *mergeJoinLeftAntiOp) Next(ctx context.Context) coldata.Batch {
-	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(o.outputTypes, o.output, 1 /* minCapacity */)
+	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
+		o.outputTypes, o.output, 1 /* minCapacity */, o.memoryLimit,
+	)
 	o.bufferedGroup.helper.output = o.output
 	for {
 		switch o.state {

--- a/pkg/sql/colexec/mergejoiner_leftouter.eg.go
+++ b/pkg/sql/colexec/mergejoiner_leftouter.eg.go
@@ -11645,7 +11645,9 @@ func (o *mergeJoinLeftOuterOp) build(ctx context.Context) {
 }
 
 func (o *mergeJoinLeftOuterOp) Next(ctx context.Context) coldata.Batch {
-	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(o.outputTypes, o.output, 1 /* minCapacity */)
+	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
+		o.outputTypes, o.output, 1 /* minCapacity */, o.memoryLimit,
+	)
 	o.bufferedGroup.helper.output = o.output
 	for {
 		switch o.state {

--- a/pkg/sql/colexec/mergejoiner_leftsemi.eg.go
+++ b/pkg/sql/colexec/mergejoiner_leftsemi.eg.go
@@ -9507,7 +9507,9 @@ func (o *mergeJoinLeftSemiOp) build(ctx context.Context) {
 }
 
 func (o *mergeJoinLeftSemiOp) Next(ctx context.Context) coldata.Batch {
-	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(o.outputTypes, o.output, 1 /* minCapacity */)
+	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
+		o.outputTypes, o.output, 1 /* minCapacity */, o.memoryLimit,
+	)
 	o.bufferedGroup.helper.output = o.output
 	for {
 		switch o.state {

--- a/pkg/sql/colexec/mergejoiner_rightanti.eg.go
+++ b/pkg/sql/colexec/mergejoiner_rightanti.eg.go
@@ -11577,7 +11577,9 @@ func (o *mergeJoinRightAntiOp) build(ctx context.Context) {
 }
 
 func (o *mergeJoinRightAntiOp) Next(ctx context.Context) coldata.Batch {
-	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(o.outputTypes, o.output, 1 /* minCapacity */)
+	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
+		o.outputTypes, o.output, 1 /* minCapacity */, o.memoryLimit,
+	)
 	o.bufferedGroup.helper.output = o.output
 	for {
 		switch o.state {

--- a/pkg/sql/colexec/mergejoiner_rightouter.eg.go
+++ b/pkg/sql/colexec/mergejoiner_rightouter.eg.go
@@ -11623,7 +11623,9 @@ func (o *mergeJoinRightOuterOp) build(ctx context.Context) {
 }
 
 func (o *mergeJoinRightOuterOp) Next(ctx context.Context) coldata.Batch {
-	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(o.outputTypes, o.output, 1 /* minCapacity */)
+	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
+		o.outputTypes, o.output, 1 /* minCapacity */, o.memoryLimit,
+	)
 	o.bufferedGroup.helper.output = o.output
 	for {
 		switch o.state {

--- a/pkg/sql/colexec/mergejoiner_rightsemi.eg.go
+++ b/pkg/sql/colexec/mergejoiner_rightsemi.eg.go
@@ -9465,7 +9465,9 @@ func (o *mergeJoinRightSemiOp) build(ctx context.Context) {
 }
 
 func (o *mergeJoinRightSemiOp) Next(ctx context.Context) coldata.Batch {
-	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(o.outputTypes, o.output, 1 /* minCapacity */)
+	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
+		o.outputTypes, o.output, 1 /* minCapacity */, o.memoryLimit,
+	)
 	o.bufferedGroup.helper.output = o.output
 	for {
 		switch o.state {

--- a/pkg/sql/colexec/mergejoiner_test.go
+++ b/pkg/sql/colexec/mergejoiner_test.go
@@ -1845,7 +1845,8 @@ func TestMergeJoinCrossProduct(t *testing.T) {
 			right: hashJoinerSourceSpec{
 				eqCols: []uint32{0}, sourceTypes: typs,
 			},
-		}, leftHJSource, rightHJSource, HashJoinerInitialNumBuckets)
+		}, leftHJSource, rightHJSource, HashJoinerInitialNumBuckets, defaultMemoryLimit,
+	)
 	hj.Init()
 
 	var mjOutputTuples, hjOutputTuples tuples

--- a/pkg/sql/colexec/mergejoiner_tmpl.go
+++ b/pkg/sql/colexec/mergejoiner_tmpl.go
@@ -1210,7 +1210,9 @@ func _SOURCE_FINISHED_SWITCH(_JOIN_TYPE joinTypeInfo) { // */}}
 // */}}
 
 func (o *mergeJoin_JOIN_TYPE_STRINGOp) Next(ctx context.Context) coldata.Batch {
-	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(o.outputTypes, o.output, 1 /* minCapacity */)
+	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
+		o.outputTypes, o.output, 1 /* minCapacity */, o.memoryLimit,
+	)
 	o.bufferedGroup.helper.output = o.output
 	for {
 		switch o.state {

--- a/pkg/sql/colexec/ordered_synchronizer.eg.go
+++ b/pkg/sql/colexec/ordered_synchronizer.eg.go
@@ -31,6 +31,7 @@ import (
 // stream are assumed to be ordered according to the same set of columns.
 type OrderedSynchronizer struct {
 	allocator             *colmem.Allocator
+	memoryLimit           int64
 	inputs                []SynchronizerInput
 	ordering              colinfo.ColumnOrdering
 	typs                  []*types.T
@@ -92,14 +93,17 @@ func (o *OrderedSynchronizer) Child(nth int, verbose bool) execinfra.OpNode {
 }
 
 // NewOrderedSynchronizer creates a new OrderedSynchronizer.
+// - memoryLimit will limit the size of batches produced by the synchronizer.
 func NewOrderedSynchronizer(
 	allocator *colmem.Allocator,
+	memoryLimit int64,
 	inputs []SynchronizerInput,
 	typs []*types.T,
 	ordering colinfo.ColumnOrdering,
 ) (*OrderedSynchronizer, error) {
 	return &OrderedSynchronizer{
 		allocator:             allocator,
+		memoryLimit:           memoryLimit,
 		inputs:                inputs,
 		ordering:              ordering,
 		typs:                  typs,
@@ -255,7 +259,9 @@ func (o *OrderedSynchronizer) Next(ctx context.Context) coldata.Batch {
 
 func (o *OrderedSynchronizer) resetOutput() {
 	var reallocated bool
-	o.output, reallocated = o.allocator.ResetMaybeReallocate(o.typs, o.output, 1 /* minCapacity */)
+	o.output, reallocated = o.allocator.ResetMaybeReallocate(
+		o.typs, o.output, 1 /* minCapacity */, o.memoryLimit,
+	)
 	if reallocated {
 		o.outBoolCols = o.outBoolCols[:0]
 		o.outBytesCols = o.outBytesCols[:0]

--- a/pkg/sql/colexec/ordered_synchronizer_test.go
+++ b/pkg/sql/colexec/ordered_synchronizer_test.go
@@ -146,7 +146,7 @@ func TestOrderedSync(t *testing.T) {
 			typs[i] = types.Int
 		}
 		runTests(t, tc.sources, tc.expected, orderedVerifier, func(inputs []colexecbase.Operator) (colexecbase.Operator, error) {
-			return NewOrderedSynchronizer(testAllocator, operatorsToSynchronizerInputs(inputs), typs, tc.ordering)
+			return NewOrderedSynchronizer(testAllocator, defaultMemoryLimit, operatorsToSynchronizerInputs(inputs), typs, tc.ordering)
 		})
 	}
 }
@@ -187,7 +187,7 @@ func TestOrderedSyncRandomInput(t *testing.T) {
 		inputs[i].Op = newOpTestInput(batchSize, sources[i], typs)
 	}
 	ordering := colinfo.ColumnOrdering{{ColIdx: 0, Direction: encoding.Ascending}}
-	op, err := NewOrderedSynchronizer(testAllocator, inputs, typs, ordering)
+	op, err := NewOrderedSynchronizer(testAllocator, defaultMemoryLimit, inputs, typs, ordering)
 	require.NoError(t, err)
 	op.Init()
 	out := newOpTestOutput(op, expected)
@@ -217,7 +217,7 @@ func BenchmarkOrderedSynchronizer(b *testing.B) {
 	}
 
 	ordering := colinfo.ColumnOrdering{{ColIdx: 0, Direction: encoding.Ascending}}
-	op, err := NewOrderedSynchronizer(testAllocator, inputs, typs, ordering)
+	op, err := NewOrderedSynchronizer(testAllocator, defaultMemoryLimit, inputs, typs, ordering)
 	require.NoError(b, err)
 	op.Init()
 

--- a/pkg/sql/colexec/sort.go
+++ b/pkg/sql/colexec/sort.go
@@ -12,6 +12,7 @@ package colexec
 
 import (
 	"context"
+	"math"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase"
@@ -271,7 +272,10 @@ func (p *sortOp) Next(ctx context.Context) coldata.Batch {
 			if toEmit > coldata.BatchSize() {
 				toEmit = coldata.BatchSize()
 			}
-			p.output, _ = p.allocator.ResetMaybeReallocate(p.inputTypes, p.output, toEmit)
+			// For now, we don't enforce any footprint-based memory limit.
+			// TODO(yuzefovich): refactor this.
+			const maxBatchMemSize = math.MaxInt64
+			p.output, _ = p.allocator.ResetMaybeReallocate(p.inputTypes, p.output, toEmit, maxBatchMemSize)
 			newEmitted := p.emitted + toEmit
 			for j := 0; j < len(p.inputTypes); j++ {
 				// At this point, we have already fully sorted the input. It is ok to do

--- a/pkg/sql/colexec/sorttopk.go
+++ b/pkg/sql/colexec/sorttopk.go
@@ -13,6 +13,7 @@ package colexec
 import (
 	"container/heap"
 	"context"
+	"math"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase"
@@ -216,7 +217,10 @@ func (t *topKSorter) emit() coldata.Batch {
 	if toEmit > coldata.BatchSize() {
 		toEmit = coldata.BatchSize()
 	}
-	t.output, _ = t.allocator.ResetMaybeReallocate(t.inputTypes, t.output, toEmit)
+	// For now, we don't enforce any footprint-based memory limit.
+	// TODO(yuzefovich): refactor this.
+	const maxBatchMemSize = math.MaxInt64
+	t.output, _ = t.allocator.ResetMaybeReallocate(t.inputTypes, t.output, toEmit, maxBatchMemSize)
 	for i := range t.inputTypes {
 		vec := t.output.ColVec(i)
 		// At this point, we have already fully sorted the input. It is ok to do

--- a/pkg/sql/colfetcher/colbatch_scan.go
+++ b/pkg/sql/colfetcher/colbatch_scan.go
@@ -233,7 +233,8 @@ func NewColBatchScan(
 
 	fetcher := cFetcherPool.Get().(*cFetcher)
 	if _, _, err := initCRowFetcher(
-		flowCtx.Codec(), allocator, fetcher, table, columnIdxMap, neededColumns, spec, spec.HasSystemColumns,
+		flowCtx.Codec(), allocator, execinfra.GetWorkMemLimit(flowCtx.Cfg),
+		fetcher, table, columnIdxMap, neededColumns, spec, spec.HasSystemColumns,
 	); err != nil {
 		return nil, err
 	}
@@ -262,6 +263,7 @@ func NewColBatchScan(
 func initCRowFetcher(
 	codec keys.SQLCodec,
 	allocator *colmem.Allocator,
+	memoryLimit int64,
 	fetcher *cFetcher,
 	desc catalog.TableDescriptor,
 	colIdxMap catalog.TableColMap,
@@ -289,7 +291,7 @@ func initCRowFetcher(
 	tableArgs.InitCols(desc, spec.Visibility, withSystemColumns, virtualColumn)
 
 	if err := fetcher.Init(
-		codec, allocator, spec.Reverse, spec.LockingStrength, spec.LockingWaitPolicy, tableArgs,
+		codec, allocator, memoryLimit, spec.Reverse, spec.LockingStrength, spec.LockingWaitPolicy, tableArgs,
 	); err != nil {
 		return nil, false, err
 	}

--- a/pkg/sql/colflow/colrpc/inbox.go
+++ b/pkg/sql/colflow/colrpc/inbox.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math"
 	"time"
 
 	"github.com/apache/arrow/go/arrow/array"
@@ -327,7 +328,10 @@ func (i *Inbox) Next(ctx context.Context) coldata.Batch {
 		if err != nil {
 			colexecerror.InternalError(err)
 		}
-		i.scratch.b, _ = i.allocator.ResetMaybeReallocate(i.typs, i.scratch.b, batchLength)
+		// For now, we don't enforce any footprint-based memory limit.
+		// TODO(yuzefovich): refactor this.
+		const maxBatchMemSize = math.MaxInt64
+		i.scratch.b, _ = i.allocator.ResetMaybeReallocate(i.typs, i.scratch.b, batchLength, maxBatchMemSize)
 		if err := i.converter.ArrowToBatch(i.scratch.data, batchLength, i.scratch.b); err != nil {
 			colexecerror.InternalError(err)
 		}

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -851,7 +851,8 @@ func (s *vectorizedFlowCreator) setupInput(
 		if input.Type == execinfrapb.InputSyncSpec_ORDERED {
 			os, err := colexec.NewOrderedSynchronizer(
 				colmem.NewAllocator(ctx, s.newStreamingMemAccount(flowCtx), factory),
-				inputStreamOps, input.ColumnTypes, execinfrapb.ConvertToColumnOrdering(input.Ordering),
+				execinfra.GetWorkMemLimit(flowCtx.Cfg), inputStreamOps,
+				input.ColumnTypes, execinfrapb.ConvertToColumnOrdering(input.Ordering),
 			)
 			if err != nil {
 				return nil, nil, nil, err

--- a/pkg/sql/colmem/BUILD.bazel
+++ b/pkg/sql/colmem/BUILD.bazel
@@ -31,6 +31,9 @@ go_test(
         "//pkg/sql/execinfra",
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",
+        "//pkg/testutils/skip",
+        "//pkg/util/leaktest",
+        "//pkg/util/log",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/sql/colmem/allocator_test.go
+++ b/pkg/sql/colmem/allocator_test.go
@@ -12,6 +12,7 @@ package colmem_test
 
 import (
 	"context"
+	"math"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
@@ -22,10 +23,16 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/stretchr/testify/require"
 )
 
 func TestMaybeAppendColumn(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
 	testMemMonitor := execinfra.NewTestMemMonitor(ctx, st)
@@ -75,5 +82,86 @@ func TestMaybeAppendColumn(t *testing.T) {
 		require.Equal(t, 1, b.Width())
 		require.Equal(t, coldata.BatchSize(), b.ColVec(colIdx).Length())
 		_ = b.ColVec(colIdx).Int64()[0]
+	})
+}
+
+func TestResetMaybeReallocate(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+	testMemMonitor := execinfra.NewTestMemMonitor(ctx, st)
+	defer testMemMonitor.Stop(ctx)
+	memAcc := testMemMonitor.MakeBoundAccount()
+	defer memAcc.Close(ctx)
+	evalCtx := tree.MakeTestingEvalContext(st)
+	testColumnFactory := coldataext.NewExtendedColumnFactory(&evalCtx)
+	testAllocator := colmem.NewAllocator(ctx, &memAcc, testColumnFactory)
+
+	t.Run("ResettingBehavior", func(t *testing.T) {
+		if coldata.BatchSize() == 1 {
+			skip.IgnoreLint(t, "the test assumes coldata.BatchSize() is at least 2")
+		}
+
+		var b coldata.Batch
+		typs := []*types.T{types.Bytes}
+
+		// Allocate a new batch and modify it.
+		b, _ = testAllocator.ResetMaybeReallocate(typs, b, coldata.BatchSize(), math.MaxInt64)
+		b.SetSelection(true)
+		b.Selection()[0] = 1
+		b.ColVec(0).Bytes().Set(1, []byte("foo"))
+
+		oldBatch := b
+		b, _ = testAllocator.ResetMaybeReallocate(typs, b, coldata.BatchSize(), math.MaxInt64)
+		// We should have used the same batch, and now it should be in a "reset"
+		// state.
+		require.Equal(t, oldBatch, b)
+		require.Nil(t, b.Selection())
+		// We should be able to set in the Bytes vector using an arbitrary
+		// position since the vector should have been reset.
+		require.NotPanics(t, func() { b.ColVec(0).Bytes().Set(0, []byte("bar")) })
+	})
+
+	t.Run("LimitingByMemSize", func(t *testing.T) {
+		if coldata.BatchSize() == 1 {
+			skip.IgnoreLint(t, "the test assumes coldata.BatchSize() is at least 2")
+		}
+
+		var b coldata.Batch
+		typs := []*types.T{types.Int}
+		const minCapacity = 2
+		const maxBatchMemSize = 0
+
+		// Allocate a batch with smaller capacity.
+		smallBatch := testAllocator.NewMemBatchWithFixedCapacity(typs, minCapacity/2)
+
+		// Allocate a new batch attempting to use the batch with too small of a
+		// capacity - new batch should be allocated.
+		b, _ = testAllocator.ResetMaybeReallocate(typs, smallBatch, minCapacity, maxBatchMemSize)
+		require.NotEqual(t, smallBatch, b)
+		require.Equal(t, minCapacity, b.Capacity())
+
+		oldBatch := b
+
+		// Reset the batch and confirm that a new batch is not allocated because
+		// the old batch has enough capacity and it has reached the memory
+		// limit.
+		b, _ = testAllocator.ResetMaybeReallocate(typs, b, minCapacity, maxBatchMemSize)
+		require.Equal(t, oldBatch, b)
+		require.Equal(t, minCapacity, b.Capacity())
+
+		if coldata.BatchSize() >= minCapacity*2 {
+			// Now reset the batch with large memory limit - we should get a new
+			// batch with the double capacity.
+			//
+			// ResetMaybeReallocate truncates the capacity at
+			// coldata.BatchSize(), so we run this part of the test only when
+			// doubled capacity will not be truncated.
+			b, _ = testAllocator.ResetMaybeReallocate(typs, b, minCapacity, math.MaxInt64)
+			require.NotEqual(t, oldBatch, b)
+			require.Equal(t, 2*minCapacity, b.Capacity())
+		}
 	})
 }

--- a/pkg/sql/sem/tree/eval_test/eval_test.go
+++ b/pkg/sql/sem/tree/eval_test/eval_test.go
@@ -128,10 +128,12 @@ func TestEval(t *testing.T) {
 
 	t.Run("vectorized", func(t *testing.T) {
 		walk(t, func(t *testing.T, d *datadriven.TestData) string {
+			st := cluster.MakeTestingClusterSettings()
 			flowCtx := &execinfra.FlowCtx{
+				Cfg:     &execinfra.ServerConfig{Settings: st},
 				EvalCtx: evalCtx,
 			}
-			memMonitor := execinfra.NewTestMemMonitor(ctx, cluster.MakeTestingClusterSettings())
+			memMonitor := execinfra.NewTestMemMonitor(ctx, st)
 			defer memMonitor.Stop(ctx)
 			acc := memMonitor.MakeBoundAccount()
 			defer acc.Close(ctx)


### PR DESCRIPTION
This commit adds a minor improvement to `ResetMaybeReallocate` method so
that it reuses the old batch (without doubling the capacity and
allocating a new batch) when the old batch has enough capacity and
reached the provided limit in size. This change effectively allows us to
limit all batches flowing through the vectorized engine by `workmem`
setting in size since the main batch-producers (cfetcher and
columnarizer) use this method.

Addresses: https://github.com/cockroachlabs/support/issues/808.

Release note (sql change): Most batches of data flowing through the
vectorized execution engine will now be limited in size by
`sql.distsql.temp_storage.workmem` (64MiB by default) which should
improve the stability of CockroachDB clusters.