### PR TITLE
acceptance: add verbose logging of events from docker

### DIFF
--- a/pkg/acceptance/adapter_test.go
+++ b/pkg/acceptance/adapter_test.go
@@ -49,7 +49,6 @@ func TestDockerCSharp(t *testing.T) {
 }
 
 func TestDockerJava(t *testing.T) {
-	skip.WithIssue(t, 58955, "flaky test")
 	s := log.Scope(t)
 	defer s.Close(t)
 
@@ -70,7 +69,6 @@ func TestDockerElixir(t *testing.T) {
 }
 
 func TestDockerNodeJS(t *testing.T) {
-	skip.WithIssue(t, 58955, "flaky test")
 	s := log.Scope(t)
 	defer s.Close(t)
 
@@ -99,7 +97,6 @@ func TestDockerPHP(t *testing.T) {
 }
 
 func TestDockerPSQL(t *testing.T) {
-	skip.WithIssue(t, 58955, "flaky test")
 	s := log.Scope(t)
 	defer s.Close(t)
 

--- a/pkg/acceptance/cluster/dockercluster.go
+++ b/pkg/acceptance/cluster/dockercluster.go
@@ -538,6 +538,10 @@ func (l *DockerCluster) processEvent(ctx context.Context, event events.Message) 
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
+	// Logging everything we get from Docker in service of finding the root
+	// cause of #58955.
+	log.Infof(ctx, "processing event from Docker: %+v", event)
+
 	// If there's currently a oneshot container, ignore any die messages from
 	// it because those are expected.
 	if l.oneshot != nil && event.ID == l.oneshot.id && event.Status == eventDie {


### PR DESCRIPTION
Re-enable flaky tests and add extra logging to try to diagnose the root
cause of #58955.

Release note: None