### PR TITLE
sql: add schema_name,table_id to crdb_internal.ranges

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -2494,7 +2494,9 @@ CREATE VIEW crdb_internal.ranges AS SELECT
 	start_pretty,
 	end_key,
 	end_pretty,
+  table_id,
 	database_name,
+  schema_name,
 	table_name,
 	index_name,
 	replicas,
@@ -2512,7 +2514,9 @@ FROM crdb_internal.ranges_no_leases
 		{Name: "start_pretty", Typ: types.String},
 		{Name: "end_key", Typ: types.Bytes},
 		{Name: "end_pretty", Typ: types.String},
+		{Name: "table_id", Typ: types.Int},
 		{Name: "database_name", Typ: types.String},
+		{Name: "schema_name", Typ: types.String},
 		{Name: "table_name", Typ: types.String},
 		{Name: "index_name", Typ: types.String},
 		{Name: "replicas", Typ: types.Int2Vector},
@@ -2537,7 +2541,9 @@ CREATE TABLE crdb_internal.ranges_no_leases (
   start_pretty         STRING NOT NULL,
   end_key              BYTES NOT NULL,
   end_pretty           STRING NOT NULL,
+  table_id             INT NOT NULL,
   database_name        STRING NOT NULL,
+  schema_name          STRING NOT NULL,
   table_name           STRING NOT NULL,
   index_name           STRING NOT NULL,
   replicas             INT[] NOT NULL,
@@ -2557,13 +2563,16 @@ CREATE TABLE crdb_internal.ranges_no_leases (
 		// TODO(knz): maybe this could use internalLookupCtx.
 		dbNames := make(map[uint32]string)
 		tableNames := make(map[uint32]string)
+		schemaNames := make(map[uint32]string)
 		indexNames := make(map[uint32]map[uint32]string)
+		schemaParents := make(map[uint32]uint32)
 		parents := make(map[uint32]uint32)
 		for _, desc := range descs {
 			id := uint32(desc.GetID())
 			switch desc := desc.(type) {
 			case catalog.TableDescriptor:
 				parents[id] = uint32(desc.GetParentID())
+				schemaParents[id] = uint32(desc.GetParentSchemaID())
 				tableNames[id] = desc.GetName()
 				indexNames[id] = make(map[uint32]string)
 				for _, idx := range desc.PublicNonPrimaryIndexes() {
@@ -2571,6 +2580,8 @@ CREATE TABLE crdb_internal.ranges_no_leases (
 				}
 			case *dbdesc.Immutable:
 				dbNames[id] = desc.GetName()
+			case *schemadesc.Immutable:
+				schemaNames[id] = desc.GetName()
 			}
 		}
 		ranges, err := kvclient.ScanMetaKVs(ctx, p.txn, roachpb.Span{
@@ -2637,8 +2648,18 @@ CREATE TABLE crdb_internal.ranges_no_leases (
 				}
 			}
 
-			var dbName, tableName, indexName string
-			if _, tableID, err := p.ExecCfg().Codec.DecodeTablePrefix(desc.StartKey.AsRawKey()); err == nil {
+			var dbName, schemaName, tableName, indexName string
+			var tableID uint32
+			if _, tableID, err = p.ExecCfg().Codec.DecodeTablePrefix(desc.StartKey.AsRawKey()); err == nil {
+				schemaParent := schemaParents[tableID]
+				if schemaParent != 0 {
+					schemaName = schemaNames[schemaParent]
+				} else {
+					// This case shouldn't happen - all schema ids should be available in the
+					// schemaParents map. If it's not, just assume the name of the schema
+					// is public to avoid problems.
+					schemaName = string(tree.PublicSchemaName)
+				}
 				parent := parents[tableID]
 				if parent != 0 {
 					tableName = tableNames[tableID]
@@ -2662,7 +2683,9 @@ CREATE TABLE crdb_internal.ranges_no_leases (
 				tree.NewDString(keys.PrettyPrint(nil /* valDirs */, desc.StartKey.AsRawKey())),
 				tree.NewDBytes(tree.DBytes(desc.EndKey)),
 				tree.NewDString(keys.PrettyPrint(nil /* valDirs */, desc.EndKey.AsRawKey())),
+				tree.NewDInt(tree.DInt(tableID)),
 				tree.NewDString(dbName),
+				tree.NewDString(schemaName),
 				tree.NewDString(tableName),
 				tree.NewDString(indexName),
 				votersArr,

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -255,15 +255,15 @@ SELECT * FROM crdb_internal.node_inflight_trace_spans WHERE span_id < 0
 ----
 trace_id  parent_span_id  span_id  goroutine_id  start_time  duration  operation
 
-query ITTTTTTTTTTTTI colnames
+query ITTTTITTTTTTTTTI colnames
 SELECT * FROM crdb_internal.ranges WHERE range_id < 0
 ----
-range_id  start_key  start_pretty  end_key  end_pretty  database_name  table_name  index_name  replicas  replica_localities learner_replicas  split_enforced_until  lease_holder range_size
+range_id  start_key  start_pretty  end_key  end_pretty  table_id  database_name  schema_name  table_name  index_name  replicas  replica_localities  learner_replicas  split_enforced_until  lease_holder range_size
 
-query ITTTTTTTTTTT colnames
+query ITTTTITTTTTTTT colnames
 SELECT * FROM crdb_internal.ranges_no_leases WHERE range_id < 0
 ----
-range_id  start_key  start_pretty  end_key  end_pretty  database_name  table_name  index_name  replicas  replica_localities learner_replicas  split_enforced_until
+range_id  start_key  start_pretty  end_key  end_pretty  table_id  database_name  schema_name  table_name  index_name  replicas  replica_localities  learner_replicas  split_enforced_until
 
 statement ok
 INSERT INTO system.zones (id, config) VALUES


### PR DESCRIPTION
... and crdb_internal.ranges_no_leases

Closes #59601.

This commit adds schema_name to crdb_internal.ranges and
crdb_internal.ranges_no_leases to ensure that it's possible to
disambiguate between ranges that are contained by a table with the same
name in two different user-defined schemas.

In addition, it also adds the table_id column which allows unambiguous
lookups of ranges for a given table id. This will also enable making a
virtual index on the table_id column later, which should be a nice win
for some introspection commands.

Release note (sql change): add the schema_name and table_id columns to
the crdb_internal.ranges and crdb_internal.ranges_no_leases virtual
tables.