### PR TITLE
dev: use stdlib log package, not cockroach/pkg/util/log

### DIFF
--- a/pkg/cmd/dev/BUILD.bazel
+++ b/pkg/cmd/dev/BUILD.bazel
@@ -14,10 +14,8 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/dev",
     visibility = ["//visibility:private"],
     deps = [
-        "//pkg/util/log",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_errors//oserror",
-        "@com_github_cockroachdb_redact//:redact",
         "@com_github_spf13_cobra//:cobra",
     ],
 )

--- a/pkg/cmd/dev/build.go
+++ b/pkg/cmd/dev/build.go
@@ -17,7 +17,6 @@ import (
 	"path"
 	"strings"
 
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/errors/oserror"
 	"github.com/spf13/cobra"
@@ -72,8 +71,7 @@ func runBuild(cmd *cobra.Command, targets []string) error {
 	for _, target := range targets {
 		buildTarget, ok := buildTargetMapping[target]
 		if !ok {
-			log.Errorf(ctx, "unrecognized target: %s", target)
-			return errors.Newf("unrecognized target")
+			return errors.Newf("unrecognized target: %s", target)
 		}
 
 		args = append(args, buildTarget)
@@ -81,10 +79,10 @@ func runBuild(cmd *cobra.Command, targets []string) error {
 	if err := execute(ctx, "bazel", args...); err != nil {
 		return err
 	}
-	return symlinkBinaries(ctx, targets)
+	return symlinkBinaries(targets)
 }
 
-func symlinkBinaries(ctx context.Context, targets []string) error {
+func symlinkBinaries(targets []string) error {
 	var workspace string
 	{
 		out, err := exec.Command("bazel", "info", "workspace").Output()

--- a/pkg/cmd/dev/generate.go
+++ b/pkg/cmd/dev/generate.go
@@ -13,7 +13,6 @@ package main
 import (
 	"context"
 
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 	"github.com/spf13/cobra"
 )
@@ -62,8 +61,7 @@ func runGenerate(cmd *cobra.Command, targets []string) error {
 		case "bazel":
 			gen = generateBazel
 		default:
-			log.Errorf(ctx, "unrecognized target: %s", target)
-			return errors.Newf("unrecognized target")
+			return errors.Newf("unrecognized target: %s", target)
 		}
 
 		if err := gen(ctx, cmd); err != nil {

--- a/pkg/cmd/dev/main.go
+++ b/pkg/cmd/dev/main.go
@@ -11,11 +11,11 @@
 package main
 
 import (
-	"context"
+	"log"
 	"os"
 	"os/exec"
 
-	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -52,6 +52,9 @@ lets engineers do a few things:
 var bazel = "bazel"
 
 func init() {
+	log.SetFlags(0)
+	log.SetPrefix("")
+
 	devCmd.AddCommand(
 		benchCmd,
 		buildCmd,
@@ -67,11 +70,10 @@ func init() {
 	})
 }
 
-func runDev(ctx context.Context) error {
+func runDev() error {
 	_, err := exec.LookPath(bazel)
 	if err != nil {
-		log.Errorf(ctx, "expected to find bazel in $PATH")
-		return err
+		return errors.New("bazel not found in $PATH")
 	}
 
 	if err := devCmd.Execute(); err != nil {
@@ -81,9 +83,8 @@ func runDev(ctx context.Context) error {
 }
 
 func main() {
-	ctx := context.Background()
-	if err := runDev(ctx); err != nil {
-		log.Errorf(ctx, "%v", err)
+	if err := runDev(); err != nil {
+		log.Printf("%v", err)
 		os.Exit(1)
 	}
 }

--- a/pkg/cmd/dev/test.go
+++ b/pkg/cmd/dev/test.go
@@ -13,10 +13,10 @@ package main
 import (
 	"context"
 	"fmt"
+	"log"
 	"strings"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 	"github.com/spf13/cobra"
 )
@@ -81,11 +81,11 @@ func init() {
 
 func runTest(ctx context.Context, cmd *cobra.Command, pkgs []string) error {
 	if logicTest := mustGetFlagBool(cmd, logicFlag); logicTest {
-		return runLogicTest(ctx, cmd)
+		return runLogicTest(cmd)
 	}
 
 	if fuzzTest := mustGetFlagBool(cmd, fuzzFlag); fuzzTest {
-		return runFuzzTest(ctx, cmd, pkgs)
+		return runFuzzTest(cmd, pkgs)
 	}
 
 	return runUnitTest(ctx, cmd, pkgs)
@@ -104,7 +104,7 @@ func runUnitTest(ctx context.Context, cmd *cobra.Command, pkgs []string) error {
 		return errors.New("-show-logs unimplemented")
 	}
 
-	log.Infof(ctx, "unit test args: stress=%t  race=%t  filter=%s  timeout=%s  ignore-cache=%t  pkgs=%s",
+	log.Printf("unit test args: stress=%t  race=%t  filter=%s  timeout=%s  ignore-cache=%t  pkgs=%s",
 		stress, race, filter, timeout, ignoreCache, pkgs)
 
 	var args []string
@@ -142,19 +142,19 @@ func runUnitTest(ctx context.Context, cmd *cobra.Command, pkgs []string) error {
 	return execute(ctx, "bazel", args...)
 }
 
-func runLogicTest(ctx context.Context, cmd *cobra.Command) error {
+func runLogicTest(cmd *cobra.Command) error {
 	files := mustGetFlagString(cmd, filesFlag)
 	subtests := mustGetFlagString(cmd, subtestsFlag)
 	config := mustGetFlagString(cmd, configFlag)
 
-	log.Infof(ctx, "logic test args: files=%s  subtests=%s  config=%s",
+	log.Printf("logic test args: files=%s  subtests=%s  config=%s",
 		files, subtests, config)
 	return errors.New("--logic unimplemented")
 }
 
-func runFuzzTest(ctx context.Context, cmd *cobra.Command, pkgs []string) error {
+func runFuzzTest(cmd *cobra.Command, pkgs []string) error {
 	filter := mustGetFlagString(cmd, filterFlag)
 
-	log.Infof(ctx, "fuzz test args: filter=%s  pkgs=%s", filter, pkgs)
+	log.Printf("fuzz test args: filter=%s  pkgs=%s", filter, pkgs)
 	return errors.New("--fuzz unimplemented")
 }


### PR DESCRIPTION
We'd like to extract dev into its own repo, but that's made much more
difficult by dependencies on stuff in the main `cockroach` repo. In
preparation for that, just use the stdlib `log` package for logging.

Release note: None