### PR TITLE
opt: fix ON filter reduction in GenerateInvertedJoins

### DIFF
--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -245,6 +245,28 @@ func (n FiltersExpr) RemoveFiltersItem(search *FiltersItem) FiltersExpr {
 	panic(errors.AssertionFailedf("item to remove is not in the list: %v", search))
 }
 
+// Difference returns a new list filters containing the filters of n that are
+// not in other. If other is empty, n is returned.
+func (n FiltersExpr) Difference(other FiltersExpr) FiltersExpr {
+	if len(other) == 0 {
+		return n
+	}
+	newFilters := make(FiltersExpr, 0, len(n))
+	for i := range n {
+		found := false
+		for j := range other {
+			if n[i].Condition == other[j].Condition {
+				found = true
+				break
+			}
+		}
+		if !found {
+			newFilters = append(newFilters, n[i])
+		}
+	}
+	return newFilters
+}
+
 // RemoveCommonFilters removes the filters found in other from n.
 func (n *FiltersExpr) RemoveCommonFilters(other FiltersExpr) {
 	if len(other) == 0 {

--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -245,7 +245,7 @@ func (n FiltersExpr) RemoveFiltersItem(search *FiltersItem) FiltersExpr {
 	panic(errors.AssertionFailedf("item to remove is not in the list: %v", search))
 }
 
-// Difference returns a new list filters containing the filters of n that are
+// Difference returns a new list of filters containing the filters of n that are
 // not in other. If other is empty, n is returned.
 func (n FiltersExpr) Difference(other FiltersExpr) FiltersExpr {
 	if len(other) == 0 {
@@ -265,28 +265,6 @@ func (n FiltersExpr) Difference(other FiltersExpr) FiltersExpr {
 		}
 	}
 	return newFilters
-}
-
-// RemoveCommonFilters removes the filters found in other from n.
-func (n *FiltersExpr) RemoveCommonFilters(other FiltersExpr) {
-	if len(other) == 0 {
-		return
-	}
-	// TODO(ridwanmsharif): Faster intersection using a map
-	common := (*n)[:0]
-	for _, filter := range *n {
-		found := false
-		for _, otherFilter := range other {
-			if filter.Condition == otherFilter.Condition {
-				found = true
-				break
-			}
-		}
-		if !found {
-			common = append(common, filter)
-		}
-	}
-	*n = common
 }
 
 // OutputCols returns the set of columns constructed by the Aggregations

--- a/pkg/sql/opt/memo/extract.go
+++ b/pkg/sql/opt/memo/extract.go
@@ -257,6 +257,9 @@ func ExtractRemainingJoinFilters(on FiltersExpr, leftEq, rightEq opt.ColList) Fi
 	if len(leftEq) != len(rightEq) {
 		panic(errors.AssertionFailedf("leftEq and rightEq have different lengths"))
 	}
+	if len(leftEq) == 0 {
+		return on
+	}
 	var newFilters FiltersExpr
 	for i := range on {
 		leftVar, rightVar, ok := isVarEquality(on[i].Condition)

--- a/pkg/sql/opt/memo/extract.go
+++ b/pkg/sql/opt/memo/extract.go
@@ -252,8 +252,11 @@ func ExtractJoinEquality(
 // ExtractRemainingJoinFilters calculates the remaining ON condition after
 // removing equalities that are handled separately. The given function
 // determines if an equality is redundant. The result is empty if there are no
-// remaining conditions.
+// remaining conditions. Panics if leftEq and rightEq are not the same length.
 func ExtractRemainingJoinFilters(on FiltersExpr, leftEq, rightEq opt.ColList) FiltersExpr {
+	if len(leftEq) != len(rightEq) {
+		panic(errors.AssertionFailedf("leftEq and rightEq have different lengths"))
+	}
 	var newFilters FiltersExpr
 	for i := range on {
 		leftVar, rightVar, ok := isVarEquality(on[i].Condition)

--- a/pkg/sql/opt/xform/scan_index_iter.go
+++ b/pkg/sql/opt/xform/scan_index_iter.go
@@ -164,6 +164,11 @@ func (it *scanIndexIter) SetOriginalFilters(filters memo.FiltersExpr) {
 // index, the filters are the remaining filters after proving partial index
 // implication (see partialidx.Implicator). Otherwise, the filters are the same
 // filters that were passed to Init.
+//
+// Note that the filters argument CANNOT be mutated in the callback function
+// because these filters are used internally by scanIndexIter for partial index
+// implication while iterating over indexes. In tests the filtersMutateChecker
+// will detect a callback that mutates filters and panic.
 type enumerateIndexFunc func(idx cat.Index, filters memo.FiltersExpr, indexCols opt.ColSet, isCovering bool)
 
 // ForEach calls the given callback function for every index of the Scan

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -6036,13 +6036,12 @@ project
       │    ├── inverted-expr
       │    │    └── t1.j:20 @> t2.j:3
       │    ├── key: (18)
-      │    ├── fd: (1)-->(2,3), (18)-->(19), (2)==(19), (19)==(2), (1)==(18), (18)==(1)
+      │    ├── fd: (1)-->(2,3), (18)-->(19), (1)==(18), (18)==(1), (2)==(19), (19)==(2)
       │    ├── scan json_arr2 [as=t2]
       │    │    ├── columns: t2.k:1!null l:2 t2.j:3
       │    │    ├── key: (1)
       │    │    └── fd: (1)-->(2,3)
-      │    └── filters
-      │         └── i:19 = l:2 [outer=(2,19), constraints=(/2: (/NULL - ]; /19: (/NULL - ]), fd=(2)==(19), (19)==(2)]
+      │    └── filters (true)
       └── filters
            └── t1.j:8 @> t2.j:3 [outer=(3,8), immutable]
 
@@ -6265,6 +6264,46 @@ anti-join (cross)
  │         └── x:2 IN (1, 3) [outer=(2), constraints=(/2: [/1 - /1] [/3 - /3]; tight)]
  └── filters
       └── y:3 @> column1:1 [outer=(1,3), immutable]
+
+# Regression test for #59859. Do not panic when the ON condition has a constant
+# filter to constrain the non-inverted prefix column and a variable equality
+# filter that does not constrain the prefix column.
+exec-ddl
+CREATE TABLE t59859_a (
+  k INT PRIMARY KEY,
+  j JSON
+)
+----
+
+exec-ddl
+CREATE TABLE t59859_b (
+  k INT PRIMARY KEY,
+  i INT,
+  j JSON,
+  INVERTED INDEX (k, j)
+)
+----
+
+opt expect=GenerateInvertedJoinsFromSelect format=hide-all
+SELECT a.k, b.k
+FROM t59859_a AS a INNER INVERTED JOIN t59859_b AS b
+ON b.k = 1 AND b.j @> a.j AND b.i = a.k
+----
+project
+ └── inner-join (lookup t59859_b [as=b])
+      ├── lookup columns are key
+      ├── inner-join (inverted t59859_b@secondary [as=b])
+      │    ├── flags: force inverted join (into right side)
+      │    ├── inverted-expr
+      │    │    └── b.j @> a.j
+      │    ├── project
+      │    │    ├── scan t59859_a [as=a]
+      │    │    └── projections
+      │    │         └── 1
+      │    └── filters (true)
+      └── filters
+           ├── b.j @> a.j
+           └── i = a.k
 
 # -------------------------------------------------------
 # GenerateInvertedJoinsFromSelect + Partial Indexes


### PR DESCRIPTION
This commit fixes a bug in the logic of GenerateInvertedJoins that
removes redundant ON filters when those filters were used to constrain
non-inverted prefix columns of a multi-column inverted index. The bug
resulted in a panic in `memo.ExtractRemainingJoinFilters` when two lists
of columns of unequal lengths were passed to the function. This function
now explicitly checks for equal list lengths, which catches the bug in
existing tests even though existing tests didn't previously trigger a
panic. I've also added a regression test that panicked before the bug
fix in this commit.

The length check added to `memo.ExtractRemainingJoinFilters` also caught
a bug where the list of right equality columns was re-used for
successive iterations over inverted indexes. This prevented redundant ON
filters from being removed in some cases. An existing test's output
changed, highlighting the issue.

There is no release note because this bug only affects queries on tables with
multi-column inverted indexes. Multi-column inverted indexes have been
gated behind an experimental session setting in all previous 21.1 alpha
releases.

Fixes #59859

Release note: None