### PR TITLE
sql: close the last right side plan in apply join

### DIFF
--- a/pkg/sql/apply_join_test.go
+++ b/pkg/sql/apply_join_test.go
@@ -72,3 +72,58 @@ FROM
 		require.True(t, strings.Contains(err.Error(), "internal error"))
 	}
 }
+
+// TestApplyJoinPanic is a regression test for not closing the planNode tree in
+// the apply join that resulted in a panic that was caught by the vectorized
+// engine (#59871). At the moment of writing it's unclear why the type mismatch
+// causing the panic in the first place occurs.
+func TestApplyJoinPanic(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testClusterArgs := base.TestClusterArgs{
+		ReplicationMode: base.ReplicationAuto,
+	}
+	tc := testcluster.StartTestCluster(t, 1, testClusterArgs)
+	ctx := context.Background()
+	defer tc.Stopper().Stop(ctx)
+
+	conn := tc.Conns[0]
+
+	_, err := conn.Exec(`
+WITH
+  with_2675 AS (SELECT * FROM (VALUES ('', (SELECT ''))) AS tab_8229 (col_14424, col_14425))
+SELECT
+  (
+    SELECT
+      cte_ref_793.col_14424
+    WHERE
+      EXISTS(
+        SELECT
+          NULL
+        WHERE
+          ''
+          IN (
+              (
+                SELECT
+                  NULL
+                FROM
+                  (VALUES (NULL), ((SELECT B'101100110111011110011100101001110000111001110' FROM (VALUES (0)) AS tab_8238 (col_14434))))
+                    AS tab_8239 (col_14436)
+                ORDER BY
+                  tab_8239.col_14436 DESC
+                LIMIT
+                  1
+              ),
+              ''
+            )
+      )
+  ),
+  cte_ref_793.col_14425
+FROM
+  with_2675 AS cte_ref_793;
+`)
+	// We expect that an internal error is returned.
+	require.Error(t, err)
+	require.True(t, strings.Contains(err.Error(), "invalid datum type given"))
+}


### PR DESCRIPTION
If a panic occurs when running the right side plan in the apply join, we
might not close that plan correctly. In the row-by-row engine this
doesn't matter because the server would crash, but in the vectorized
engine we might catch the panic, and if the plan is not closed
accordingly, we could then crash since some resources (like memory
accounting) are not cleared. This is now fixed.

Fixes: #59840.

Release note: None