### PR TITLE
optbuilder: safer partial index predicate normalization

### DIFF
--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -1346,14 +1346,6 @@ func (mb *mutationBuilder) arbiterIndexesAndConstraints(
 				noRowLocking,
 				mb.b.allocScope(),
 			)
-			// If the table has any virtual computed columns, buildScan
-			// constructs a Project on top of the Scan. This is problematic when
-			// building arbiter predicates because it relies on tableScope.expr
-			// being a Scan in order to normalize the arbiter predicate. So, if
-			// tableScope.expr is a Project, we set it to its input, a Scan.
-			if proj, ok := tableScope.expr.(*memo.ProjectExpr); ok {
-				tableScope.expr = proj.Input
-			}
 		}
 
 		// Fetch the partial index predicate which was added to tabMeta in the

--- a/pkg/sql/opt/optbuilder/partial_index.go
+++ b/pkg/sql/opt/optbuilder/partial_index.go
@@ -171,25 +171,28 @@ func (b *Builder) buildPartialIndexPredicate(
 		filters,
 	)
 
-	// If the normalized relational expression is a Select, return the filters.
-	if sel, ok := selExpr.(*memo.SelectExpr); ok {
-		return sel.Filters, nil
-	}
-
-	// Otherwise, the filters may be either true or false. Check the cardinality
-	// to determine which one.
-	if selExpr.Relational().Cardinality.IsZero() {
+	switch t := selExpr.(type) {
+	case *memo.SelectExpr:
+		// If the expression remains a Select, return the normalized filters.
+		return t.Filters, nil
+	case *memo.FakeRelExpr:
+		// If the expression has been normalized to a FakeRelExpr, then the
+		// filters were normalized to true and the Select was eliminated.
+		// So, return a true filter.
+		return memo.TrueFilter, nil
+	case *memo.ValuesExpr:
+		// If the expression has been normalized to a Values expression, then
+		// the filters were normalized to false and the Select and FakeRel were
+		// eliminated. So, return a false filter.
+		if !t.Relational().Cardinality.IsZero() {
+			panic(errors.AssertionFailedf("values expression should have a cardinality of zero"))
+		}
 		return memo.FiltersExpr{b.factory.ConstructFiltersItem(memo.FalseSingleton)}, nil
+	default:
+		// Otherwise, normalization resulted in an unexpected expression type.
+		// Panic rather than return an incorrect predicate.
+		panic(errors.AssertionFailedf("unexpected expression during partial index normalization: %T", t))
 	}
-
-	// TODO(mgartner): It is a bit dangerous to assume that if the normalized
-	// expression is not a Select and the cardinality is not zero, then the
-	// filter is equivalent to True. There should only be 3 types of relation
-	// normalized relational expressions: Scan, Values, and Select. Scan
-	// indicates the filters are always true and Values indicates the filters
-	// are always false. If the expression is a Select, use its filters. If the
-	// expression is none of the three, we should probably panic.
-	return memo.TrueFilter, nil
 }
 
 // resolvePartialIndexPredicate attempts to resolve the type of expr as a

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -256,7 +256,7 @@ CREATE INDEX idx2 ON p (s) WHERE i > 0
 memo expect=GeneratePartialIndexScans
 SELECT * FROM p WHERE i > 0 AND s = 'foo'
 ----
-memo (optimized, ~13KB, required=[presentation: i:1,f:2,s:3,b:4])
+memo (optimized, ~14KB, required=[presentation: i:1,f:2,s:3,b:4])
  ├── G1: (select G2 G3) (index-join G4 p,cols=(1-4)) (index-join G5 p,cols=(1-4)) (index-join G6 p,cols=(1-4)) (index-join G7 p,cols=(1-4))
  │    └── [presentation: i:1,f:2,s:3,b:4]
  │         ├── best: (index-join G4 p,cols=(1-4))
@@ -304,7 +304,7 @@ memo (optimized, ~13KB, required=[presentation: i:1,f:2,s:3,b:4])
 memo expect-not=GeneratePartialIndexScans
 SELECT i FROM p WHERE s = 'bar'
 ----
-memo (optimized, ~7KB, required=[presentation: i:1])
+memo (optimized, ~8KB, required=[presentation: i:1])
  ├── G1: (project G2 G3 i)
  │    └── [presentation: i:1]
  │         ├── best: (project G2 G3 i)
@@ -1555,7 +1555,7 @@ CREATE INDEX idx2 ON p (i) WHERE s = 'foo'
 memo
 SELECT i FROM p WHERE i = 3 AND s = 'foo'
 ----
-memo (optimized, ~17KB, required=[presentation: i:1])
+memo (optimized, ~18KB, required=[presentation: i:1])
  ├── G1: (project G2 G3 i) (project G4 G3 i) (project G5 G3 i)
  │    └── [presentation: i:1]
  │         ├── best: (project G5 G3 i)
@@ -3403,7 +3403,7 @@ CREATE INVERTED INDEX idx2 ON pi (j) WHERE s = 'bar'
 memo expect=GenerateInvertedIndexScans
 SELECT * FROM pi WHERE j @> '{"a": "b"}' AND s = 'bar'
 ----
-memo (optimized, ~10KB, required=[presentation: k:1,s:2,j:3])
+memo (optimized, ~11KB, required=[presentation: k:1,s:2,j:3])
  ├── G1: (select G2 G3) (select G4 G5) (index-join G6 pi,cols=(1-3))
  │    └── [presentation: k:1,s:2,j:3]
  │         ├── best: (index-join G6 pi,cols=(1-3))
@@ -3451,7 +3451,7 @@ CREATE INVERTED INDEX idx ON pi (j) WHERE s IN ('foo', 'bar')
 memo expect-not=GenerateInvertedIndexScans
 SELECT * FROM pi WHERE j @> '{"a": "b"}' AND s = 'baz'
 ----
-memo (optimized, ~6KB, required=[presentation: k:1,s:2,j:3])
+memo (optimized, ~7KB, required=[presentation: k:1,s:2,j:3])
  ├── G1: (select G2 G3)
  │    └── [presentation: k:1,s:2,j:3]
  │         ├── best: (select G2 G3)
@@ -6254,7 +6254,7 @@ CREATE TABLE t (
 memo
 SELECT * FROM t WHERE a > 1 OR b > 1
 ----
-memo (optimized, ~17KB, required=[presentation: k:1,a:2,b:3,c:4])
+memo (optimized, ~18KB, required=[presentation: k:1,a:2,b:3,c:4])
  ├── G1: (select G2 G3) (index-join G4 t,cols=(1-4)) (distinct-on G5 G6 cols=(1))
  │    └── [presentation: k:1,a:2,b:3,c:4]
  │         ├── best: (select G2 G3)


### PR DESCRIPTION
#### optbuilder: eliminate redundant building of partial index predicates

This commit removes unnecessarily building partial index predicates for
each index of a table when determining arbiter indexes for an UPSERT or
INSERT ON CONFLICT statement. The partial index predicates already have
been built and added to the table metadata, so we retrieve predicates
rather than rebuilding them.

Release note: None

#### optbuilder: normalize partial index predicates with a FakeRel

Previously we normalized a partial index predicate for table metadata by
wrapping a scope's expression in a Select with the predicate as a
filter. Prior to the addition of virtual computed columns, the scope's
expression was always a Scan. With virtual columns, the expression could
be a Project. This led to issues because normalization rules could
reorder the Select and Project, making it hard to extract the normalized
filters. The previous solution of manually changing the scope's
expression from a Project to its input Scan was hacky.

Now we construct a FakeRel with the same logical properties as the
scope's expression to be used as the Select's input. This provides
consistent behavior that does not rely on the type of expression in the
scope.

Release note: None

#### optbuilder: make partial index normalization safer

We normalize a partial index predicate in table metadata by constructing
a Select with the predicate as a filter. Previously we were not explicit
about what types of expressions should result from the construction of
the Select. This led to a hard-to-detect correctness bug for INSERT ON
CONFLICT statements which was fixed in #59816.

Now we explicity require the resulting expression to be one of three
types. If the type is not one of the three, we panic, which is
preferrable to a correctness bug.

Release note: None
