### PR TITLE
sql: improve pg_table_is_visible performance

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -2847,6 +2847,8 @@ SELECT * FROM crdb_internal.check_consistency(true, ‘\x02’, ‘\x04’)</p>
 <tr><td><a name="pg_column_size"></a><code>pg_column_size(anyelement...) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Return size in bytes of the column provided as an argument</p>
 </span></td></tr>
 <tr><td><a name="pg_sleep"></a><code>pg_sleep(seconds: <a href="float.html">float</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>pg_sleep makes the current session’s process sleep until seconds seconds have elapsed. seconds is a value of type double precision, so fractional-second delays can be specified.</p>
+</span></td></tr>
+<tr><td><a name="pg_table_is_visible"></a><code>pg_table_is_visible(oid: oid) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns whether the table with the given OID belongs to one of the schemas on the search path.</p>
 </span></td></tr></tbody>
 </table>
 

--- a/pkg/bench/ddl_analysis/BUILD.bazel
+++ b/pkg/bench/ddl_analysis/BUILD.bazel
@@ -26,6 +26,7 @@ go_test(
         "drop_bench_test.go",
         "grant_revoke_bench_test.go",
         "grant_revoke_role_bench_test.go",
+        "orm_queries_bench_test.go",
         "system_bench_test.go",
         "truncate_bench_test.go",
         "validate_benchmark_data_test.go",

--- a/pkg/bench/ddl_analysis/orm_queries_bench_test.go
+++ b/pkg/bench/ddl_analysis/orm_queries_bench_test.go
@@ -1,0 +1,86 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package bench
+
+import "testing"
+
+func BenchmarkORMQueries(b *testing.B) {
+	tests := []RoundTripBenchTestCase{
+		{
+			name:  "django table introspection 1 table",
+			setup: `CREATE TABLE t1(a int primary key, b int);`,
+			stmt: `SELECT
+    a.attname AS column_name,
+    NOT (a.attnotnull OR ((t.typtype = 'd') AND t.typnotnull)) AS is_nullable,
+    pg_get_expr(ad.adbin, ad.adrelid) AS column_default
+FROM pg_attribute AS a
+LEFT JOIN pg_attrdef AS ad ON (a.attrelid = ad.adrelid) AND (a.attnum = ad.adnum)
+JOIN pg_type AS t ON a.atttypid = t.oid JOIN pg_class AS c ON a.attrelid = c.oid
+JOIN pg_namespace AS n ON c.relnamespace = n.oid
+WHERE (
+    (
+        (c.relkind IN ('f', 'm', 'p', 'r', 'v')) AND
+        (c.relname = '<target table>')
+    ) AND (n.nspname NOT IN ('pg_catalog', 'pg_toast'))
+) AND pg_table_is_visible(c.oid)`,
+		},
+
+		{
+			name: "django table introspection 4 tables",
+			setup: `CREATE TABLE t1(a int primary key, b int);
+CREATE TABLE t2(a int primary key, b int);
+CREATE TABLE t3(a int primary key, b int);
+CREATE TABLE t4(a int primary key, b int);`,
+			stmt: `SELECT
+    a.attname AS column_name,
+    NOT (a.attnotnull OR ((t.typtype = 'd') AND t.typnotnull)) AS is_nullable,
+    pg_get_expr(ad.adbin, ad.adrelid) AS column_default
+FROM pg_attribute AS a
+LEFT JOIN pg_attrdef AS ad ON (a.attrelid = ad.adrelid) AND (a.attnum = ad.adnum)
+JOIN pg_type AS t ON a.atttypid = t.oid JOIN pg_class AS c ON a.attrelid = c.oid
+JOIN pg_namespace AS n ON c.relnamespace = n.oid
+WHERE (
+    (
+        (c.relkind IN ('f', 'm', 'p', 'r', 'v')) AND
+        (c.relname = '<target table>')
+    ) AND (n.nspname NOT IN ('pg_catalog', 'pg_toast'))
+) AND pg_table_is_visible(c.oid)`,
+		},
+
+		{
+			name: "django table introspection 8 tables",
+			setup: `CREATE TABLE t1(a int primary key, b int);
+CREATE TABLE t2(a int primary key, b int);
+CREATE TABLE t3(a int primary key, b int);
+CREATE TABLE t4(a int primary key, b int);
+CREATE TABLE t5(a int primary key, b int);
+CREATE TABLE t6(a int primary key, b int);
+CREATE TABLE t7(a int primary key, b int);
+CREATE TABLE t8(a int primary key, b int);`,
+			stmt: `SELECT
+    a.attname AS column_name,
+    NOT (a.attnotnull OR ((t.typtype = 'd') AND t.typnotnull)) AS is_nullable,
+    pg_get_expr(ad.adbin, ad.adrelid) AS column_default
+FROM pg_attribute AS a
+LEFT JOIN pg_attrdef AS ad ON (a.attrelid = ad.adrelid) AND (a.attnum = ad.adnum)
+JOIN pg_type AS t ON a.atttypid = t.oid JOIN pg_class AS c ON a.attrelid = c.oid
+JOIN pg_namespace AS n ON c.relnamespace = n.oid
+WHERE (
+    (
+        (c.relkind IN ('f', 'm', 'p', 'r', 'v')) AND
+        (c.relname = '<target table>')
+    ) AND (n.nspname NOT IN ('pg_catalog', 'pg_toast'))
+) AND pg_table_is_visible(c.oid)`,
+		},
+	}
+
+	RunRoundTripBenchmark(b, tests)
+}

--- a/pkg/bench/ddl_analysis/testdata/benchmark_expectations
+++ b/pkg/bench/ddl_analysis/testdata/benchmark_expectations
@@ -68,3 +68,6 @@ min	max	benchmark
 2	2	SystemDatabaseQueries/select_system.users_without_schema_name
 1	1	SystemDatabaseQueries/select_system.users_with_empty_database_name
 1	1	SystemDatabaseQueries/select_system.users_with_schema_name
+2	2	ORMQueries/django_table_introspection_1_table
+2	2	ORMQueries/django_table_introspection_4_tables
+2	2	ORMQueries/django_table_introspection_8_tables

--- a/pkg/ccl/importccl/import_table_creation.go
+++ b/pkg/ccl/importccl/import_table_creation.go
@@ -232,6 +232,13 @@ func (so *importSequenceOperators) LookupSchema(
 	return false, nil, errSequenceOperators
 }
 
+// IsTableVisible is part of the tree.EvalDatabase interface.
+func (so *importSequenceOperators) IsTableVisible(
+	ctx context.Context, curDB string, searchPath sessiondata.SearchPath, tableID int64,
+) (bool, bool, error) {
+	return false, false, errors.WithStack(errSequenceOperators)
+}
+
 // Implements the tree.SequenceOperators interface.
 func (so *importSequenceOperators) IncrementSequence(
 	ctx context.Context, seqName *tree.TableName,

--- a/pkg/sql/faketreeeval/BUILD.bazel
+++ b/pkg/sql/faketreeeval/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//pkg/sql/pgwire/pgnotice",
         "//pkg/sql/roleoption",
         "//pkg/sql/sem/tree",
+        "//pkg/sql/sessiondata",
         "//pkg/sql/types",
         "//pkg/util/errorutil/unimplemented",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
 	"github.com/cockroachdb/cockroach/pkg/sql/roleoption"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/errors"
@@ -60,6 +61,13 @@ func (so *DummySequenceOperators) LookupSchema(
 	ctx context.Context, dbName, scName string,
 ) (bool, tree.SchemaMeta, error) {
 	return false, nil, errors.WithStack(errSequenceOperators)
+}
+
+// IsTableVisible is part of the tree.EvalDatabase interface.
+func (so *DummySequenceOperators) IsTableVisible(
+	ctx context.Context, curDB string, searchPath sessiondata.SearchPath, tableID int64,
+) (bool, bool, error) {
+	return false, false, errors.WithStack(errSequenceOperators)
 }
 
 // IncrementSequence is part of the tree.SequenceOperators interface.
@@ -167,6 +175,13 @@ func (ep *DummyEvalPlanner) LookupSchema(
 	ctx context.Context, dbName, scName string,
 ) (bool, tree.SchemaMeta, error) {
 	return false, nil, errors.WithStack(errEvalPlanner)
+}
+
+// IsTableVisible is part of the tree.EvalDatabase interface.
+func (ep *DummyEvalPlanner) IsTableVisible(
+	ctx context.Context, curDB string, searchPath sessiondata.SearchPath, tableID int64,
+) (bool, bool, error) {
+	return false, false, errors.WithStack(errEvalPlanner)
 }
 
 // ResolveTableName is part of the tree.EvalDatabase interface.

--- a/pkg/sql/logictest/testdata/logic_test/pg_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/pg_builtins
@@ -80,3 +80,50 @@ query I
 SELECT pg_column_size(NULL::int)
 ----
 NULL
+
+statement ok
+CREATE TABLE is_visible(a int primary key);
+CREATE SCHEMA other;
+CREATE TABLE other.not_visible(a int primary key);
+CREATE DATABASE db2;
+SET DATABASE = db2;
+CREATE TABLE table_in_db2(a int primary key);
+
+let $table_in_db2_id
+SELECT c.oid FROM pg_class c WHERE c.relname = 'table_in_db2';
+
+statement ok
+SET DATABASE = test;
+
+query B
+SELECT pg_table_is_visible(c.oid)
+FROM pg_class c
+WHERE c.relname = 'is_visible'
+----
+true
+
+query B
+SELECT pg_table_is_visible(c.oid)
+FROM pg_class c
+WHERE c.relname = 'pg_type'
+----
+true
+
+query B
+SELECT pg_table_is_visible(c.oid)
+FROM pg_class c
+WHERE c.relname = 'not_visible'
+----
+false
+
+# Looking up a table in a different database should return NULL.
+query B
+SELECT pg_table_is_visible($table_in_db2_id)
+----
+NULL
+
+# Looking up a non-existent OID should return NULL.
+query B
+SELECT pg_table_is_visible(1010101010)
+----
+NULL

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3021,6 +3021,15 @@ type EvalDatabase interface {
 	// LookupSchema looks up the schema with the given name in the given
 	// database.
 	LookupSchema(ctx context.Context, dbName, scName string) (found bool, scMeta SchemaMeta, err error)
+
+	// IsTableVisible checks if the table with the given ID belongs to a schema
+	// on the given sessiondata.SearchPath.
+	IsTableVisible(
+		ctx context.Context,
+		curDB string,
+		searchPath sessiondata.SearchPath,
+		tableID int64,
+	) (isVisible bool, exists bool, err error)
 }
 
 // EvalPlanner is a limited planner that can be used from EvalContext.


### PR DESCRIPTION
This is motivated by a query that Django makes in order to retrieve all
the tables visible in the current session. The query uses the
pg_table_is_visible function. Previously this was implemented by using
the internal executor to inspect the pg_catalog. This was expensive
because the internal executor does not share the same descriptor
collection as the external context, so it ended up fetching every single
table descriptor one-by-one.

Now, we avoid the internal executor and lookup the table descriptor
directly.

There are other builtins that use the internal executor that may face
the same problem. Perhaps an approach for the future is to allow builtin
functions to be implemented using user-defined scalar functions.

I added a benchmark that shows the original Django query performing a
constant number of descriptor lookups with this new implementation.

fixes #57924 

Release note (performance improvement): Improve performance of the
pg_table_is_visible builtin function.