### PR TITLE
[WIP] kvserver: remove unbounded concurency for txn record cleanup

### DIFF
--- a/pkg/kv/kvserver/intentresolver/intent_resolver.go
+++ b/pkg/kv/kvserver/intentresolver/intent_resolver.go
@@ -122,7 +122,7 @@ type IntentResolver struct {
 	stopper      *stop.Stopper
 	testingKnobs kvserverbase.IntentResolverTestingKnobs
 	ambientCtx   log.AmbientContext
-	sem          *quotapool.IntPool // semaphore to limit async goroutines
+	sem          *quotapool.IntPool // semaphore to limit async goroutines for intent resolution
 
 	rdc RangeCache
 
@@ -146,9 +146,6 @@ type IntentResolver struct {
 func setConfigDefaults(c *Config) {
 	if c.TaskLimit == 0 {
 		c.TaskLimit = defaultTaskLimit
-	}
-	if c.TaskLimit == -1 || c.TestingKnobs.ForceSyncIntentResolution {
-		c.TaskLimit = 0
 	}
 	if c.MaxGCBatchIdle == 0 {
 		c.MaxGCBatchIdle = defaultGCBatchIdle
@@ -196,12 +193,13 @@ func New(c Config) *IntentResolver {
 		gcBatchSize = c.TestingKnobs.MaxGCBatchSize
 	}
 	ir.gcBatcher = requestbatcher.New(requestbatcher.Config{
-		Name:            "intent_resolver_gc_batcher",
-		MaxMsgsPerBatch: gcBatchSize,
-		MaxWait:         c.MaxGCBatchWait,
-		MaxIdle:         c.MaxGCBatchIdle,
-		Stopper:         c.Stopper,
-		Sender:          c.DB.NonTransactionalSender(),
+		Name:                      "intent_resolver_gc_batcher",
+		MaxMsgsPerBatch:           gcBatchSize,
+		MaxWait:                   c.MaxGCBatchWait,
+		MaxIdle:                   c.MaxGCBatchIdle,
+		Stopper:                   c.Stopper,
+		Sender:                    c.DB.NonTransactionalSender(),
+		DropRequestInBackpressure: true,
 	})
 	intentResolutionBatchSize := intentResolverBatchSize
 	if c.TestingKnobs.MaxIntentResolutionBatchSize > 0 {
@@ -668,7 +666,7 @@ func (ir *IntentResolver) CleanupTxnIntentsOnGCAsync(
 }
 
 func (ir *IntentResolver) gcTxnRecord(
-	ctx context.Context, rangeID roachpb.RangeID, txn *roachpb.Transaction,
+	ctx context.Context, rangeID roachpb.RangeID, txn *roachpb.Transaction, onComplete func(error),
 ) error {
 	// We successfully resolved the intents, so we're able to GC from
 	// the txn span directly.
@@ -707,7 +705,9 @@ func (ir *IntentResolver) gcTxnRecord(
 	// always issued on behalf of the range on which this record resides which is
 	// a strong signal that it is the range which will contain the transaction
 	// record now.
-	_, err := ir.gcBatcher.Send(ctx, rangeID, &gcArgs)
+	err := ir.gcBatcher.SendAsync(ctx, rangeID, &gcArgs, func(response requestbatcher.Response) {
+		onComplete(response.Err)
+	})
 	if err != nil {
 		return errors.Wrapf(err, "could not GC completed transaction anchored at %s",
 			roachpb.Key(txn.Key))
@@ -738,21 +738,23 @@ func (ir *IntentResolver) cleanupFinishedTxnIntents(
 	if pErr := ir.ResolveIntents(ctx, txn.LocksAsLockUpdates(), opts); pErr != nil {
 		return errors.Wrapf(pErr.GoError(), "failed to resolve intents")
 	}
-	// Run transaction record GC outside of ir.sem.
-	return ir.stopper.RunAsyncTask(
-		ctx,
-		"storage.IntentResolver: cleanup txn records",
-		func(ctx context.Context) {
-			err := ir.gcTxnRecord(ctx, rangeID, txn)
-			if onComplete != nil {
-				onComplete(err)
-			}
-			if err != nil {
+	return ir.gcTxnRecord(ctx, rangeID, txn, func(err error) {
+		if onComplete != nil {
+			onComplete(err)
+		}
+		if err != nil {
+			if errors.Is(err, stop.ErrThrottled) {
+				ir.Metrics.TxnRecordCleanupDropped.Inc(1)
 				if ir.every.ShouldLog() {
-					log.Warningf(ctx, "failed to gc transaction record: %v", err)
+					log.Warningf(ctx, "Dropping request to cleanup txn record for %v", txn)
+				}
+			} else {
+				if ir.every.ShouldLog() {
+					log.Warningf(ctx, "Failed to process cleanup for txn record for %v", txn)
 				}
 			}
-		})
+		}
+	})
 }
 
 // ResolveOptions is used during intent resolution.

--- a/pkg/kv/kvserver/intentresolver/metrics.go
+++ b/pkg/kv/kvserver/intentresolver/metrics.go
@@ -20,17 +20,25 @@ var (
 		Measurement: "Intent Resolutions",
 		Unit:        metric.Unit_COUNT,
 	}
+	metaTransactionRecordCleanupDropped = metric.Metadata{
+		Name:        "intentresolver.txnrecord.dropped",
+		Help:        "Number of txn record attempts that were dropped by the intent resolver due top throttling",
+		Measurement: "Intent Resolutions",
+		Unit:        metric.Unit_COUNT,
+	}
 )
 
 // Metrics contains the metrics for the IntentResolver.
 type Metrics struct {
 	// Intent resolver metrics.
 	IntentResolverAsyncThrottled *metric.Counter
+	TxnRecordCleanupDropped      *metric.Counter
 }
 
 func makeMetrics() Metrics {
 	// Intent resolver metrics.
 	return Metrics{
 		IntentResolverAsyncThrottled: metric.NewCounter(metaIntentResolverAsyncThrottled),
+		TxnRecordCleanupDropped:      metric.NewCounter(metaTransactionRecordCleanupDropped),
 	}
 }

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1416,13 +1416,13 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 	}
 
 	s.intentResolver = intentresolver.New(intentresolver.Config{
-		Clock:                s.cfg.Clock,
-		DB:                   s.db,
-		Stopper:              stopper,
-		TaskLimit:            s.cfg.IntentResolverTaskLimit,
-		AmbientCtx:           s.cfg.AmbientCtx,
-		TestingKnobs:         s.cfg.TestingKnobs.IntentResolverKnobs,
-		RangeDescriptorCache: intentResolverRangeCache,
+		Clock:                     s.cfg.Clock,
+		DB:                        s.db,
+		Stopper:                   stopper,
+		IntentResolutionTaskLimit: s.cfg.IntentResolverTaskLimit,
+		AmbientCtx:                s.cfg.AmbientCtx,
+		TestingKnobs:              s.cfg.TestingKnobs.IntentResolverKnobs,
+		RangeDescriptorCache:      intentResolverRangeCache,
 	})
 	s.metrics.registry.AddMetricStruct(s.intentResolver.Metrics)
 

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -869,6 +869,12 @@ var charts = []sectionDescription{
 				},
 			},
 			{
+				Title: "Dropped Transaction Record Cleanup Attempts",
+				Metrics: []string{
+					"intentresolver.txnrecord.dropped",
+				},
+			},
+			{
 				Title: "Overview",
 				Metrics: []string{
 					"intents.abort-attempts",


### PR DESCRIPTION
This commit changes how we clean up transaction records in
the IntentResolver. We remove the unbounded RunAsyncTask routine
and introduce an async send method to RequestBatcher. To guarantee
that we don't have unbounded requests piling up on the RequestBatcher,
we introduce a new behavior which allows the RequestBatcher drop incoming
requests if it is overwhelmed.

Release Note: None