### PR TITLE
builtins: Check max allowed points for st_generatepoints

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -1704,9 +1704,11 @@ Bottom Left.</p>
 <p>Smaller densify_frac gives a more accurate Fréchet distance. However, the computation time and memory usage increases with the square of the number of subsegments.</p>
 <p>This function utilizes the GEOS module.</p>
 </span></td></tr>
-<tr><td><a name="st_generatepoints"></a><code>st_generatepoints(geometry: geometry, npoints: int4) &rarr; geometry</code></td><td><span class="funcdesc"><p>Generates pseudo-random points until the requested number are found within the input area. Uses system time as a seed.</p>
+<tr><td><a name="st_generatepoints"></a><code>st_generatepoints(geometry: geometry, npoints: int4) &rarr; geometry</code></td><td><span class="funcdesc"><p>Generates pseudo-random points until the requested number are found within the input area. Uses system time as a seed.
+The requested number of points must be not larger than 65336.</p>
 </span></td></tr>
-<tr><td><a name="st_generatepoints"></a><code>st_generatepoints(geometry: geometry, npoints: int4, seed: int4) &rarr; geometry</code></td><td><span class="funcdesc"><p>Generates pseudo-random points until the requested number are found within the input area.</p>
+<tr><td><a name="st_generatepoints"></a><code>st_generatepoints(geometry: geometry, npoints: int4, seed: int4) &rarr; geometry</code></td><td><span class="funcdesc"><p>Generates pseudo-random points until the requested number are found within the input area.
+The requested number of points must be not larger than 65336.</p>
 </span></td></tr>
 <tr><td><a name="st_geogfromewkb"></a><code>st_geogfromewkb(val: <a href="bytes.html">bytes</a>) &rarr; geography</code></td><td><span class="funcdesc"><p>Returns the Geography from an EWKB representation.</p>
 </span></td></tr>

--- a/pkg/geo/geomfn/generate_points_test.go
+++ b/pkg/geo/geomfn/generate_points_test.go
@@ -75,11 +75,6 @@ func TestGenerateRandomPoints(t *testing.T) {
 			geo.MustParseGeometry("SRID=4326;MULTIPOINT(0.69465779472271460548 0.92001319545446269554, 2.4417593921811042712 3.71642371685872197062, 2.79787890688424933927 3.8425013135166361522, 1.05776032659919683176 1.77173131482243051416, 1.79695770199420046254 2.42853164217679839965)"),
 		},
 		{
-			"Requires too many iterations over grid",
-			args{geo.MustParseGeometry("POLYGON((0 0,0 100,0.00001 0.00000001,0.99999 0.00000001,1 100,1 0,0 0))"), 5, 1996},
-			geo.MustParseGeometry("MULTIPOINT(0.9999990842784447497849 37.4716712014091797300352, 0.0000035681765926535594 47.1117932985884309005087, 0.000004226396968502996 32.4473691709023412954593, 0.9999921320300672045178 13.3385008252821712915193)"),
-		},
-		{
 			"Invalid Polygon",
 			args{geo.MustParseGeometry("POLYGON((-1 -1,1 -1,0 0,0 1,0 -1,0 0,-1 0,-1 -1))"), 5, 1996},
 			geo.MustParseGeometry("MULTIPOINT(-0.26747218234566871864 -0.88507288494238345322, -0.87713357493233190532 -0.97615754673482446613, -0.44243286372996359912 -0.3727648333352959753, 0.43580610882637776937 -0.55479608815084269224, -0.55844006437980153734 -0.47716362944650048128)"),
@@ -114,6 +109,16 @@ func TestGenerateRandomPoints(t *testing.T) {
 				"Polygon with zero area",
 				args{geo.MustParseGeometry("POLYGON((0 0, 1 1, 1 1, 0 0))"), 4, 1},
 				"zero area input Polygon",
+			},
+			{
+				"polygon too many points to generate",
+				args{geo.MustParseGeometry("POLYGON((1 1,1 2,2 2,2 1,1 1))"), 65337, 1996},
+				"failed to generate random points, too many points to generate: requires 65337 points, max 65336",
+			},
+			{
+				"generated area is too large",
+				args{geo.MustParseGeometry("POLYGON((0 0,0 100,0.00001 0.00000001,0.99999 0.00000001,1 100,1 0,0 0))"), 100, 1996},
+				"generating random points error: generated area is too large: 10001406, max 6533600",
 			},
 		}
 		for _, tt := range errorTestCases {

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -1970,7 +1970,8 @@ Flags shown square brackets after the geometry type have the following meaning:
 				return tree.NewDGeometry(generatedPoints), nil
 			},
 			Info: infoBuilder{
-				info: "Generates pseudo-random points until the requested number are found within the input area. Uses system time as a seed.",
+				info: `Generates pseudo-random points until the requested number are found within the input area. Uses system time as a seed.
+The requested number of points must be not larger than 65336.`,
 			}.String(),
 			Volatility: tree.VolatilityVolatile,
 		},
@@ -1991,7 +1992,8 @@ Flags shown square brackets after the geometry type have the following meaning:
 				return tree.NewDGeometry(generatedPoints), nil
 			},
 			Info: infoBuilder{
-				info: "Generates pseudo-random points until the requested number are found within the input area.",
+				info: `Generates pseudo-random points until the requested number are found within the input area.
+The requested number of points must be not larger than 65336.`,
 			}.String(),
 			Volatility: tree.VolatilityImmutable,
 		},


### PR DESCRIPTION
builtins: Check max allowed points for st_generatepoints

Previously, the number of generated points was not checked that could lead to
OOM while creating too large slices. This patch adds a validation that checks
upper bound of the given parameter (number of points to return) as well as
number of the cells to generate.

Fixes: #59452

Release note: none