### PR TITLE
release-20.2: sql: add link to deprecation docs for cross db references in the error

### DIFF
--- a/pkg/docs/docs.go
+++ b/pkg/docs/docs.go
@@ -10,12 +10,25 @@
 
 package docs
 
-import "github.com/cockroachdb/cockroach/pkg/build"
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/build"
+)
 
 // URLBase is the root URL for the version of the docs associated with this
 // binary.
 var URLBase = "https://www.cockroachlabs.com/docs/" + build.VersionPrefix()
 
+// URLReleaseNotesBase is the root URL for the release notes for the .0 patch
+// release associated with this binary.
+var URLReleaseNotesBase = fmt.Sprintf("https://www.cockroachlabs.com/docs/releases/%s.0.html",
+	build.VersionPrefix())
+
 // URL generates the URL to pageName in the version of the docs associated
 // with this binary.
 func URL(pageName string) string { return URLBase + "/" + pageName }
+
+// ReleaseNotesURL generates the URL to pageName in the .0 patch release notes
+// docs associated with this binary.
+func ReleaseNotesURL(pageName string) string { return URLReleaseNotesBase + pageName }

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -650,9 +650,11 @@ func ResolveFK(
 	}
 	if target.ParentID != tbl.ParentID {
 		if !allowCrossDatabaseFKs.Get(&evalCtx.Settings.SV) {
-			return pgerror.Newf(pgcode.InvalidForeignKey,
-				"foreign references between databases are not allowed (see the '%s' cluster setting)",
-				allowCrossDatabaseFKsSetting,
+			return errors.WithHintf(
+				pgerror.Newf(pgcode.InvalidForeignKey,
+					"foreign references between databases are not allowed (see the '%s' cluster setting)",
+					allowCrossDatabaseFKsSetting),
+				crossDBReferenceDeprecationHint(),
 			)
 		}
 	}

--- a/pkg/sql/sequence.go
+++ b/pkg/sql/sequence.go
@@ -328,9 +328,11 @@ func assignSequenceOptions(
 				}
 				if tableDesc.ParentID != sequenceParentID &&
 					!allowCrossDatabaseSeqOwner.Get(&params.p.execCfg.Settings.SV) {
-					return pgerror.Newf(pgcode.FeatureNotSupported,
-						"OWNED BY cannot refer to other databases; (see the '%s' cluster setting)",
-						allowCrossDatabaseSeqOwnerSetting,
+					return errors.WithHintf(
+						pgerror.Newf(pgcode.FeatureNotSupported,
+							"OWNED BY cannot refer to other databases; (see the '%s' cluster setting)",
+							allowCrossDatabaseSeqOwnerSetting),
+						crossDBReferenceDeprecationHint(),
 					)
 				}
 				// We only want to trigger schema changes if the owner is not what we


### PR DESCRIPTION
Backport 1/1 commits from #59551.

/cc @cockroachdb/release

---

Closes #57782

Release note (sql change): error messages for cross-database links now
include a hint directing to the user to the deprecation docs. An
example message looks like:
```
ERROR: the view cannot refer to other databases; (see the 'sql.cross_db_views.enabled' cluster setting)
SQLSTATE: 0A000
HINT: Note that cross database references will be removed in future releases. See: https://www.cockroachlabs.com/docs/releases/v21.1.0.html#deprecations
```
