### PR TITLE
opt: move fraction function from statistics code to selectivity

### DIFF
--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -2726,14 +2726,6 @@ func max(a, b float64) float64 {
 	return b
 }
 
-// fraction returns a/b if a is less than b. Otherwise returns 1.
-func fraction(a, b float64) float64 {
-	if a < b {
-		return a / b
-	}
-	return 1
-}
-
 //////////////////////////////////////////////////
 // Helper functions for selectivity calculation //
 //////////////////////////////////////////////////
@@ -3624,8 +3616,8 @@ func (sb *statisticsBuilder) selectivityFromDistinctCount(
 	}
 
 	// Calculate the selectivity of the predicate.
-	nonNullSelectivity := props.MakeSelectivity(fraction(newDistinct, oldDistinct))
-	nullSelectivity := props.MakeSelectivity(fraction(colStat.NullCount, inputColStat.NullCount))
+	nonNullSelectivity := props.MakeSelectivityFromFraction(newDistinct, oldDistinct)
+	nullSelectivity := props.MakeSelectivityFromFraction(colStat.NullCount, inputColStat.NullCount)
 	return sb.predicateSelectivity(
 		nonNullSelectivity, nullSelectivity, inputColStat.NullCount, inputRowCount,
 	)
@@ -3658,8 +3650,8 @@ func (sb *statisticsBuilder) selectivityFromHistograms(
 		oldCount := oldHist.ValuesCount()
 
 		// Calculate the selectivity of the predicate.
-		nonNullSelectivity := props.MakeSelectivity(fraction(newCount, oldCount))
-		nullSelectivity := props.MakeSelectivity(fraction(colStat.NullCount, inputColStat.NullCount))
+		nonNullSelectivity := props.MakeSelectivityFromFraction(newCount, oldCount)
+		nullSelectivity := props.MakeSelectivityFromFraction(colStat.NullCount, inputColStat.NullCount)
 		selectivity.Multiply(sb.predicateSelectivity(
 			nonNullSelectivity, nullSelectivity, inputColStat.NullCount, inputStats.RowCount,
 		))
@@ -3749,7 +3741,7 @@ func (sb *statisticsBuilder) selectivityFromEquivalency(
 
 	// The selectivity of an equality condition var1=var2 is
 	// 1/max(distinct(var1), distinct(var2)).
-	return props.MakeSelectivity(fraction(1, maxDistinctCount))
+	return props.MakeSelectivityFromFraction(1, maxDistinctCount)
 }
 
 // selectivityFromEquivalenciesSemiJoin determines the selectivity of equality
@@ -3800,7 +3792,7 @@ func (sb *statisticsBuilder) selectivityFromEquivalencySemiJoin(
 		maxDistinctCountLeft = s.RowCount
 	}
 
-	return props.MakeSelectivity(fraction(minDistinctCountRight, maxDistinctCountLeft))
+	return props.MakeSelectivityFromFraction(minDistinctCountRight, maxDistinctCountLeft)
 }
 
 func (sb *statisticsBuilder) selectivityFromInvertedJoinCondition(

--- a/pkg/sql/opt/props/selectivity.go
+++ b/pkg/sql/opt/props/selectivity.go
@@ -34,6 +34,15 @@ func MakeSelectivity(sel float64) Selectivity {
 	return Selectivity{selectivityInRange(sel)}
 }
 
+// MakeSelectivityFromFraction calculates selectivity as a fraction of a and b
+// if a is less than b and returns OneSelectivity otherwise..
+func MakeSelectivityFromFraction(a, b float64) Selectivity {
+	if a < b {
+		return MakeSelectivity(a / b)
+	}
+	return OneSelectivity
+}
+
 // AsFloat returns the private selectivity field, allowing it to be accessed
 // outside of this package.
 func (s *Selectivity) AsFloat() float64 {

--- a/pkg/sql/opt/props/selectivity_test.go
+++ b/pkg/sql/opt/props/selectivity_test.go
@@ -59,6 +59,13 @@ func TestSelectivity(t *testing.T) {
 	}
 	inf := math.MaxFloat64
 
+	// MakeSelectivityFromFraction variations.
+	test(MakeSelectivityFromFraction(1, 2), s(0.5))
+	test(MakeSelectivityFromFraction(1, 1), OneSelectivity)
+	test(MakeSelectivityFromFraction(1.5, 1), OneSelectivity)
+	test(MakeSelectivityFromFraction(1, 0), OneSelectivity)
+	test(MakeSelectivityFromFraction(0, 0), OneSelectivity)
+
 	// MinSelectivity variations.
 	test(MinSelectivity(s(0.4), s(0.5)), s(0.4))
 	test(MinSelectivity(s(0.5), s(0.4)), s(0.4))


### PR DESCRIPTION
The fraction function in the statistics builder code was only being used to
construct Selectivity, used inside the MakeSelectivity method.

This change moves the logic from the fraction function into the code for
Selectivity. It is an additional clean-up to #59413, to get rid of direct
numerical operations on Selectivity.

Fixes: #53860

Release note: None