### PR TITLE
sql: add crdb_internal.show_create_all_tables builtin

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -2300,6 +2300,9 @@ The swap_ordinate_string parameter is a 2-character string naming the ordinates 
 </span></td></tr>
 <tr><td><a name="convert_to"></a><code>convert_to(str: <a href="string.html">string</a>, enc: <a href="string.html">string</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Encode the string <code>str</code> as a byte array using encoding <code>enc</code>. Supports encodings ‘UTF8’ and ‘LATIN1’.</p>
 </span></td></tr>
+<tr><td><a name="crdb_internal.show_create_all_tables"></a><code>crdb_internal.show_create_all_tables(dbName: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns a flat log of CREATE table statements followed by
+ALTER statements to add the tables constraints for a given database.’</p>
+</span></td></tr>
 <tr><td><a name="decode"></a><code>decode(text: <a href="string.html">string</a>, format: <a href="string.html">string</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Decodes <code>data</code> using <code>format</code> (<code>hex</code> / <code>escape</code> / <code>base64</code>).</p>
 </span></td></tr>
 <tr><td><a name="difference"></a><code>difference(source: <a href="string.html">string</a>, target: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Convert two strings to their Soundex codes and then reports the number of matching code positions.</p>

--- a/pkg/sql/logictest/testdata/logic_test/show_create_all_tables_builtin
+++ b/pkg/sql/logictest/testdata/logic_test/show_create_all_tables_builtin
@@ -1,0 +1,53 @@
+query T
+SELECT crdb_internal.show_create_all_tables('d')
+----
+No tables found
+
+statement ok
+CREATE DATABASE d
+
+query T
+SELECT crdb_internal.show_create_all_tables('d')
+----
+No tables found
+
+statement ok
+CREATE TABLE d.parent (x INT, y INT,  z INT, UNIQUE (x, y, z));
+
+statement ok
+CREATE TABLE d.full_test (
+    x INT,
+    y INT,
+    z INT,
+    FOREIGN KEY (x, y, z) REFERENCES d.parent (x, y, z) MATCH FULL ON DELETE CASCADE ON UPDATE CASCADE
+  );
+
+statement ok
+CREATE VIEW d.vx AS SELECT 1
+
+statement ok
+CREATE SEQUENCE d.s
+
+query T
+SELECT crdb_internal.show_create_all_tables('d')
+----
+CREATE TABLE public.full_test (
+  x INT8 NULL,
+  y INT8 NULL,
+  z INT8 NULL,
+  FAMILY fam_0_y_x_rowid (y, x, rowid),
+  FAMILY fam_1_z (z)
+);
+CREATE TABLE public.parent (
+  x INT8 NULL,
+  y INT8 NULL,
+  z INT8 NULL,
+  UNIQUE INDEX parent_x_y_z_key (x ASC, y ASC, z ASC),
+  FAMILY fam_0_x_z_rowid (x, z, rowid),
+  FAMILY fam_1_y (y)
+);
+CREATE SEQUENCE public.s MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1;
+CREATE VIEW public.vx ("?column?") AS SELECT 1;
+ALTER TABLE public.full_test ADD CONSTRAINT fk_x_ref_parent FOREIGN KEY (x, y, z) REFERENCES public.parent(x, y, z) MATCH FULL ON DELETE CASCADE ON UPDATE CASCADE;
+-- Validate foreign key constraints. These can fail if there was unvalidated data during the dump.ALTER TABLE public.full_test VALIDATE CONSTRAINT fk_x_ref_parent;
+

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -4825,6 +4825,20 @@ the locality flag on node startup. Returns an error if no region is set.`,
 			Volatility: tree.VolatilityStable,
 		},
 	),
+
+	"crdb_internal.show_create_all_tables": makeBuiltin(
+		tree.FunctionProperties{},
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"dbName", types.String},
+			},
+			ReturnType: tree.FixedReturnType(types.String),
+			Fn:         showCreateAllTablesBuiltin,
+			Info: `Returns a flat log of CREATE table statements followed by
+ALTER statements to add the tables constraints for a given database.'`,
+			Volatility: tree.VolatilityStable,
+		},
+	),
 }
 
 var lengthImpls = func(incBitOverload bool) builtinDefinition {

--- a/pkg/sql/sem/builtins/show_create_all_tables_builtin.go
+++ b/pkg/sql/sem/builtins/show_create_all_tables_builtin.go
@@ -1,0 +1,230 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package builtins
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
+)
+
+type basicMetadata struct {
+	ID         int64
+	name       *tree.TableName
+	createStmt string
+	dependsOn  []int64
+	kind       string // "string", "table", or "view"
+	alter      []string
+	validate   []string
+	ts         string
+}
+
+type dumpTable struct {
+	schema string
+	table  string
+}
+
+func showCreateAllTablesBuiltin(evalCtx *tree.EvalContext, arg tree.Datums) (tree.Datum, error) {
+	mds, err := getDumpMetaData(evalCtx, arg)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(mds) == 0 {
+		return tree.NewDString("No tables found"), nil
+	}
+
+	byID := make(map[int64]basicMetadata)
+	for _, md := range mds {
+		byID[md.ID] = md
+	}
+
+	// First sort by name to guarantee stable output.
+	sort.Slice(mds, func(i, j int) bool {
+		return mds[i].name.String() < mds[j].name.String()
+	})
+
+	var out []string
+	for _, md := range mds {
+		out = append(out, md.createStmt+";\n")
+	}
+
+	hasRefs := false
+	for _, md := range mds {
+		for _, alter := range md.alter {
+			if !hasRefs {
+				hasRefs = true
+			}
+			out = append(out, fmt.Sprintf("%s;\n", alter))
+		}
+	}
+	if hasRefs {
+		const alterValidateMessage = `-- Validate foreign key constraints. These can fail if there was unvalidated data during the SHOW CREATE ALL TABLES`
+		out = append(out, alterValidateMessage)
+		for _, md := range mds {
+			for _, validate := range md.validate {
+				out = append(out, fmt.Sprintf("%s;\n", validate))
+
+			}
+		}
+	}
+
+	result := tree.NewDString(strings.Join(out, ""))
+	return result, nil
+}
+
+func getDumpMetaData(evalCtx *tree.EvalContext, arg tree.Datums) ([]basicMetadata, error) {
+	tsI, err := tree.MakeDTimestamp(timeutil.Now(), time.Microsecond)
+	if err != nil {
+		return nil, err
+	}
+	ts := tsI.String()
+	dbName := string(tree.MustBeDString(arg[0]))
+	dumpTables, err := getTableNames(evalCtx, dbName, ts)
+	if err != nil {
+		return nil, err
+	}
+
+	mds := make([]basicMetadata, len(dumpTables))
+	for i, dumpTable := range dumpTables {
+		basicMD, err := getBasicMetadata(evalCtx, dbName, dumpTable, ts)
+		if err != nil {
+			return nil, err
+		}
+		mds[i] = basicMD
+	}
+
+	return mds, nil
+}
+
+func getBasicMetadata(
+	evalCtx *tree.EvalContext, dbName string, table dumpTable, ts string,
+) (basicMetadata, error) {
+	tn := tree.MakeTableNameWithSchema(tree.Name(dbName), tree.Name(table.schema), tree.Name(table.table))
+	// Fetch table ID.
+	query := fmt.Sprintf(`
+		SELECT
+			schema_name,
+			descriptor_id,
+			create_nofks,
+			descriptor_type,
+			alter_statements,
+			validate_statements
+		FROM %s.crdb_internal.create_statements
+		AS OF SYSTEM TIME %s
+		WHERE database_name = $1
+      AND schema_name = $2
+			AND descriptor_name = $3
+	`, dbName, ts)
+	vals, err := evalCtx.InternalExecutor.QueryRow(evalCtx.Context, "getBasicMetadata", evalCtx.Txn, query, dbName, table.schema, table.table)
+	if err != nil {
+		return basicMetadata{}, errors.Wrap(err, "getBasicMetadata")
+	}
+
+	if len(vals) == 0 {
+		return basicMetadata{}, nil
+	}
+
+	// Check the schema to disallow dumping temp tables, views and sequences. This
+	// will only be triggered if a user explicitly specifies a temp construct as
+	// one of the arguments to the `cockroach dump` command. When no table names
+	// are specified on the CLI, we ignore temp tables at the stage where we read
+	// all table names in getTableNames.
+	schemaName := string(tree.MustBeDString(vals[0]))
+	if strings.HasPrefix(schemaName, sessiondata.PgTempSchemaName) {
+		return basicMetadata{}, errors.Newf("cannot dump temp table %s", tn.String())
+	}
+
+	idI := tree.MustBeDInt(vals[1])
+	id := int64(idI)
+
+	createStatement := string(tree.MustBeDString(vals[2]))
+
+	kind := string(tree.MustBeDString(vals[3]))
+
+	alterStatements := extractArray(vals[4])
+
+	validateStatements := extractArray(vals[5])
+
+	// Get dependencies.
+	query = fmt.Sprintf(`
+		SELECT dependson_id
+		FROM %s.crdb_internal.backward_dependencies
+		AS OF SYSTEM TIME %s
+		WHERE descriptor_id = $1
+		`, dbName, ts)
+	rows, err := evalCtx.InternalExecutor.Query(evalCtx.Context, "getBasicMetadata", evalCtx.Txn, query, id)
+	if err != nil {
+		return basicMetadata{}, err
+	}
+
+	var refs []int64
+
+	for _, row := range rows {
+		id := tree.MustBeDInt(row[0])
+		refs = append(refs, int64(id))
+	}
+
+	md := basicMetadata{
+		ID:         id,
+		name:       &tn,
+		createStmt: createStatement,
+		dependsOn:  refs,
+		kind:       kind,
+		alter:      alterStatements,
+		validate:   validateStatements,
+		ts:         ts,
+	}
+
+	return md, nil
+}
+
+func extractArray(val tree.Datum) []string {
+	arr := tree.MustBeDArray(val)
+	res := make([]string, len(arr.Array))
+	for i, v := range arr.Array {
+		res[i] = string(*v.(*tree.DString))
+	}
+	return res
+}
+
+// getTableNames retrieves all tables names in the given database. Following
+// pg_dump, we ignore all descriptors which are part of the temp schema. This
+// includes tables, views and sequences.
+func getTableNames(evalCtx *tree.EvalContext, dbName string, ts string) ([]dumpTable, error) {
+	query := fmt.Sprintf(`
+		SELECT schema_name, descriptor_name
+		FROM "".crdb_internal.create_statements
+		AS OF SYSTEM TIME %s
+		WHERE database_name = $1 AND schema_name NOT LIKE $2
+		`, ts)
+	rows, err := evalCtx.InternalExecutor.Query(evalCtx.Ctx(), "getTableNames", evalCtx.Txn, query, dbName, sessiondata.PgTempSchemaName+"%")
+	if err != nil {
+		return nil, err
+	}
+
+	var tableNames []dumpTable
+
+	for _, row := range rows {
+		schema := string(tree.MustBeDString(row[0]))
+		table := string(tree.MustBeDString(row[1]))
+
+		tableNames = append(tableNames, dumpTable{table: table, schema: schema})
+	}
+
+	return tableNames, nil
+}


### PR DESCRIPTION
sql: add crdb_internal.show_create_all_tables builtin

Making this a PR first before continuing with #53488, we can alias this builtin with SHOW CREATE ALL TABLES.

Release note (sql change): crdb_internal.show_create_all_tables is
a new builtin that takes in a database name (string) and returns
a flat log of all the CREATE TABLE statements in the database followed
by alter statements to add constraints. The output can be used
to recreate a database. This builtin was added to replace old dump logic.

Opening draft for now, need to clean up some stuff