### PR TITLE
cloudimpl: handle special char usernames in userfile

### DIFF
--- a/pkg/storage/cloudimpl/cloudimpltests/external_storage_test.go
+++ b/pkg/storage/cloudimpl/cloudimpltests/external_storage_test.go
@@ -302,7 +302,7 @@ func testListFiles(t *testing.T, storeURI, user string, ie *sql.InternalExecutor
 		for i := range in {
 			u := *uri
 			if u.Scheme == "userfile" && u.Host == "" {
-				u.Host = cloudimpl.DefaultQualifiedNamePrefix + user
+				u.Host = cloudimpl.GetDefaultQualifiedTableName(user)
 			}
 			u.Path = u.Path + "/" + in[i]
 			out[i] = u.String()

--- a/pkg/storage/cloudimpl/external_storage.go
+++ b/pkg/storage/cloudimpl/external_storage.go
@@ -215,7 +215,7 @@ func ExternalStorageConfFromURI(path, user string) (roachpb.ExternalStorage, err
 		// If the import statement does not specify a qualified table name then use
 		// the default to attempt to locate the file(s).
 		if qualifiedTableName == "" {
-			qualifiedTableName = DefaultQualifiedNamePrefix + user
+			qualifiedTableName = GetDefaultQualifiedTableName(user)
 		}
 
 		conf.Provider = roachpb.ExternalStorageProvider_FileTable


### PR DESCRIPTION
This change adds support for usernames that contain special
characters when using userfile. Usernames are used in the table name prefix for
the default target userfile operates on. For the table name to be valid
usernames with special characters need to be quoted.

Fixes: #58430

Release note (bug fix): Usernames with special characters would not work
with userfile since they were not appropriately quoted.