### PR TITLE
roachpb: use LocalUncertaintyLimit from err in readWithinUncertaintyIntervalRetryTimestamp

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
@@ -701,44 +701,63 @@ func TestTxnCoordSenderTxnUpdatedOnError(t *testing.T) {
 	plus20 := origTS.Add(20, 0).WithSynthetic(false)
 	testCases := []struct {
 		// The test's name.
-		name             string
-		pErrGen          func(txn *roachpb.Transaction) *roachpb.Error
-		expEpoch         enginepb.TxnEpoch
-		expPri           enginepb.TxnPriority
-		expTS, expOrigTS hlc.Timestamp
+		name                  string
+		pErrGen               func(txn *roachpb.Transaction) *roachpb.Error
+		expEpoch              enginepb.TxnEpoch
+		expPri                enginepb.TxnPriority
+		expWriteTS, expReadTS hlc.Timestamp
 		// Is set, we're expecting that the Transaction proto is re-initialized (as
 		// opposed to just having the epoch incremented).
 		expNewTransaction bool
-		nodeSeen          bool
 	}{
 		{
 			// No error, so nothing interesting either.
-			name:      "nil",
-			pErrGen:   func(_ *roachpb.Transaction) *roachpb.Error { return nil },
-			expEpoch:  0,
-			expPri:    1,
-			expTS:     origTS,
-			expOrigTS: origTS,
+			name:       "nil",
+			pErrGen:    func(_ *roachpb.Transaction) *roachpb.Error { return nil },
+			expEpoch:   0,
+			expPri:     1,
+			expWriteTS: origTS,
+			expReadTS:  origTS,
 		},
 		{
-			// On uncertainty error, new epoch begins and node is seen.
-			// Timestamp moves ahead of the existing write.
-			name: "ReadWithinUncertaintyIntervalError",
+			// On uncertainty error, new epoch begins. Timestamp moves ahead of
+			// the existing write and LocalUncertaintyLimit, if one exists.
+			name: "ReadWithinUncertaintyIntervalError without LocalUncertaintyLimit",
 			pErrGen: func(txn *roachpb.Transaction) *roachpb.Error {
-				const nodeID = 1
-				txn.UpdateObservedTimestamp(nodeID, plus10.UnsafeToClockTimestamp())
 				pErr := roachpb.NewErrorWithTxn(
 					roachpb.NewReadWithinUncertaintyIntervalError(
-						hlc.Timestamp{}, hlc.Timestamp{}, hlc.Timestamp{}, nil),
+						origTS,          // readTS
+						plus10,          // existingTS
+						hlc.Timestamp{}, // localUncertaintyLimit
+						txn,
+					),
 					txn)
-				pErr.OriginNode = nodeID
 				return pErr
 			},
-			expEpoch:  1,
-			expPri:    1,
-			expTS:     plus10,
-			expOrigTS: plus10,
-			nodeSeen:  true,
+			expEpoch:   1,
+			expPri:     1,
+			expWriteTS: plus10.Next(),
+			expReadTS:  plus10.Next(),
+		},
+		{
+			// On uncertainty error, new epoch begins. Timestamp moves ahead of
+			// the existing write and LocalUncertaintyLimit, if one exists.
+			name: "ReadWithinUncertaintyIntervalError with LocalUncertaintyLimit",
+			pErrGen: func(txn *roachpb.Transaction) *roachpb.Error {
+				pErr := roachpb.NewErrorWithTxn(
+					roachpb.NewReadWithinUncertaintyIntervalError(
+						origTS, // readTS
+						plus10, // existingTS
+						plus20, // localUncertaintyLimit
+						txn,
+					),
+					txn)
+				return pErr
+			},
+			expEpoch:   1,
+			expPri:     1,
+			expWriteTS: plus20,
+			expReadTS:  plus20,
 		},
 		{
 			// On abort, nothing changes but we get a new priority to use for
@@ -751,8 +770,8 @@ func TestTxnCoordSenderTxnUpdatedOnError(t *testing.T) {
 			},
 			expNewTransaction: true,
 			expPri:            10,
-			expTS:             plus20,
-			expOrigTS:         plus20,
+			expWriteTS:        plus20,
+			expReadTS:         plus20,
 		},
 		{
 			// On failed push, new epoch begins just past the pushed timestamp.
@@ -765,10 +784,10 @@ func TestTxnCoordSenderTxnUpdatedOnError(t *testing.T) {
 					},
 				}, txn)
 			},
-			expEpoch:  1,
-			expPri:    9,
-			expTS:     plus10,
-			expOrigTS: plus10,
+			expEpoch:   1,
+			expPri:     9,
+			expWriteTS: plus10,
+			expReadTS:  plus10,
 		},
 		{
 			// On retry, restart with new epoch, timestamp and priority.
@@ -778,10 +797,10 @@ func TestTxnCoordSenderTxnUpdatedOnError(t *testing.T) {
 				txn.Priority = 10
 				return roachpb.NewErrorWithTxn(&roachpb.TransactionRetryError{}, txn)
 			},
-			expEpoch:  1,
-			expPri:    10,
-			expTS:     plus10,
-			expOrigTS: plus10,
+			expEpoch:   1,
+			expPri:     10,
+			expWriteTS: plus10,
+			expReadTS:  plus10,
 		},
 	}
 
@@ -857,17 +876,13 @@ func TestTxnCoordSenderTxnUpdatedOnError(t *testing.T) {
 				t.Errorf("expected priority = %d; got %d",
 					test.expPri, proto.Priority)
 			}
-			if proto.WriteTimestamp != test.expTS {
+			if proto.WriteTimestamp != test.expWriteTS {
 				t.Errorf("expected timestamp to be %s; got %s",
-					test.expTS, proto.WriteTimestamp)
+					test.expWriteTS, proto.WriteTimestamp)
 			}
-			if proto.ReadTimestamp != test.expOrigTS {
+			if proto.ReadTimestamp != test.expReadTS {
 				t.Errorf("expected orig timestamp to be %s; got %s",
-					test.expOrigTS, proto.ReadTimestamp)
-			}
-			if ns := proto.ObservedTimestamps; (len(ns) != 0) != test.nodeSeen {
-				t.Errorf("expected nodeSeen=%t, but list of hosts is %v",
-					test.nodeSeen, ns)
+					test.expReadTS, proto.ReadTimestamp)
 			}
 		})
 	}

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -1403,8 +1403,7 @@ func PrepareTransactionForRetry(
 		// Use the priority communicated back by the server.
 		txn.Priority = errTxnPri
 	case *ReadWithinUncertaintyIntervalError:
-		txn.WriteTimestamp.Forward(
-			readWithinUncertaintyIntervalRetryTimestamp(ctx, &txn, tErr, pErr.OriginNode))
+		txn.WriteTimestamp.Forward(readWithinUncertaintyIntervalRetryTimestamp(tErr))
 	case *TransactionPushError:
 		// Increase timestamp if applicable, ensuring that we're just ahead of
 		// the pushee.
@@ -1465,8 +1464,7 @@ func CanTransactionRefresh(ctx context.Context, pErr *Error) (bool, *Transaction
 		// to the key that generated the error.
 		timestamp.Forward(writeTooOldRetryTimestamp(err))
 	case *ReadWithinUncertaintyIntervalError:
-		timestamp.Forward(
-			readWithinUncertaintyIntervalRetryTimestamp(ctx, txn, err, pErr.OriginNode))
+		timestamp.Forward(readWithinUncertaintyIntervalRetryTimestamp(err))
 	default:
 		return false, nil
 	}
@@ -1474,25 +1472,35 @@ func CanTransactionRefresh(ctx context.Context, pErr *Error) (bool, *Transaction
 }
 
 func readWithinUncertaintyIntervalRetryTimestamp(
-	ctx context.Context, txn *Transaction, err *ReadWithinUncertaintyIntervalError, origin NodeID,
+	err *ReadWithinUncertaintyIntervalError,
 ) hlc.Timestamp {
-	// If the reader encountered a newer write within the uncertainty
-	// interval, we advance the txn's timestamp just past the last observed
-	// timestamp from the node.
+	// If the reader encountered a newer write within the uncertainty interval,
+	// we advance the txn's timestamp just past the uncertain value's timestamp.
+	// This ensures that we read above the uncertain value on a retry.
+	ts := err.ExistingTimestamp.Next()
+	// In addition to advancing past the uncertainty value's timestamp, we also
+	// advance the txn's timestamp up to the local uncertainty limit on the node
+	// which hit the error. This ensures that no future read after the retry on
+	// this node (ignoring lease complications in ComputeLocalUncertaintyLimit
+	// and values with synthetic timestamps) will throw an uncertainty error,
+	// even when reading other keys.
 	//
-	// TODO(nvanbenschoten): how is this supposed to work for follower reads?
-	// This is tracked in #57685. We can now use the LocalUncertaintyLimit in
-	// place of clockTS, which handles follower reads correctly.
-	clockTS, ok := txn.GetObservedTimestamp(origin)
-	if !ok {
-		log.Fatalf(ctx,
-			"missing observed timestamp for node %d found on uncertainty restart. "+
-				"err: %s. txn: %s. Observed timestamps: %v",
-			origin, err, txn, txn.ObservedTimestamps)
-	}
-	// Also forward by the existing timestamp.
-	ts := clockTS.ToTimestamp()
-	ts.Forward(err.ExistingTimestamp.Next())
+	// Note that if the request was not able to establish a local uncertainty
+	// limit due to a missing observed timestamp (for instance, if the request
+	// was evaluated on a follower replica and the txn had never visited the
+	// leaseholder), then LocalUncertaintyLimit will be empty and the Forward
+	// will be a no-op. In this case, we could advance all the way past the
+	// global uncertainty limit, but this time would likely be in the future, so
+	// this would necessitate a commit-wait period after committing.
+	//
+	// In general, we expect the local uncertainty limit, if set, to be above
+	// the uncertainty value's timestamp. So we expect this Forward to advance
+	// ts. However, this is not always the case. The one exception is if the
+	// uncertain value had a synthetic timestamp, so it was compared against the
+	// global uncertainty limit to determine uncertainty (see IsUncertain). In
+	// such cases, we're ok advancing just past the value's timestamp. Either
+	// way, we won't see the same value in our uncertainty interval on a retry.
+	ts.Forward(err.LocalUncertaintyLimit)
 	return ts
 }
 


### PR DESCRIPTION
Fixes #57685.

This commit updates `readWithinUncertaintyIntervalRetryTimestamp` to use the the `LocalUncertaintyLimit` field from `ReadWithinUncertaintyIntervalError` in place of `ObservedTimestamps`. This addresses a bug where `ReadWithinUncertaintyIntervalErrors` thrown by follower replicas during follower reads would use meaningless observed timestamps.