### PR TITLE
kv: wait for replica initialization in closed timestamp tests

### DIFF
--- a/pkg/kv/kvserver/closed_timestamp_test.go
+++ b/pkg/kv/kvserver/closed_timestamp_test.go
@@ -1141,6 +1141,9 @@ func replsForRange(
 				return err
 			}
 			if repl != nil {
+				if !repl.IsInitialized() {
+					return errors.Errorf("%s not initialized", repl)
+				}
 				repls = append(repls, repl)
 			}
 		}

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -1187,6 +1187,15 @@ func (r *Replica) checkExecutionCanProceed(
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
+	// Has the replica been initialized?
+	// NB: this should have already been checked in Store.Send, so we don't need
+	// to handle this case particularly well, but if we do reach here (as some
+	// tests that call directly into Replica.Send have), it's better to return
+	// an error than to panic in checkSpanInRangeRLocked.
+	if !r.isInitializedRLocked() {
+		return kvserverpb.LeaseStatus{}, errors.Errorf("%s not initialized", r)
+	}
+
 	// Is the replica destroyed?
 	if _, err := r.isDestroyedRLocked(); err != nil {
 		return kvserverpb.LeaseStatus{}, err


### PR DESCRIPTION
Fixes #60288.

This commit updates tests in closed_timestamp_test.go to wait for
replica initialization before returning replicas in `replsForRange`.
This was causing flakiness on master. I bisected it back to c44b357. It
appears that that change allowed for calls directly to `Replica.Send`
(testing only) to make it deeper into replica code and eventually hit a
panic in `Replica.checkSpanInRangeRLocked`.

This commit fixes this in two ways:
1. it updates the closed timestamp tests to wait for replica
   initialization before calling directly into `Replica.Send`. Tests
   shouldn't be calling `Replica.Send` on uninitialized replicas.
2. it adds extra protection in `Replica.checkExecutionCanProceed` to throw
   an error if the replica is no initialized. This isn't strictly
   necessary, but it's cheap and limits the blast radius of getting this
   wrong elsewhere.

Release note: None