### PR TITLE
kvserver: fix up/downreplication status of non-voters in range report

### DIFF
--- a/pkg/kv/kvserver/allocator.go
+++ b/pkg/kv/kvserver/allocator.go
@@ -367,6 +367,9 @@ func GetNeededNonVoters(numVoters, zoneConfigNonVoterCount, clusterNodes int) in
 		// replica.
 		need = clusterNodes - numVoters
 	}
+	if need < 0 {
+		need = 0 // Must be non-negative.
+	}
 	return need
 }
 


### PR DESCRIPTION
This commit updates the `calcRangeCounter()` method to consider non-voting
replicas when determining whether a range is over or under-replicated.
Without this change, ranges that have any non-voting replicas would show
up as under-replicated on the DB console range report page.

Release justification: necessary for observability into non-voting replicas

Release note: None