### PR TITLE
build: cross-compile when building roachtest tools

### DIFF
--- a/build/teamcity-nightly-roachtest.sh
+++ b/build/teamcity-nightly-roachtest.sh
@@ -23,7 +23,7 @@ chmod o+rwx "${artifacts}"
 # Disable global -json flag.
 export PATH=$PATH:$(GOFLAGS=; go env GOPATH)/bin
 
-make bin/workload bin/roachtest bin/roachprod > "${artifacts}/build.txt" 2>&1 || cat "${artifacts}/build.txt"
+build/builder/mkrelease.sh amd64-linux-gnu bin/workload bin/roachtest bin/roachprod > "${artifacts}/build.txt" 2>&1 || cat "${artifacts}/build.txt"
 
 # Set up Google credentials. Note that we need this for all clouds since we upload
 # perf artifacts to Google Storage at the end.

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -174,6 +174,7 @@ func findBinaryOrLibrary(binOrLib string, name string) (string, error) {
 		dirs := []string{
 			filepath.Join(gopath, "/src/github.com/cockroachdb/cockroach/"),
 			filepath.Join(gopath, "/src/github.com/cockroachdb/cockroach", binOrLib+suffix),
+			filepath.Join(gopath, "/src/github.com/cockroachdb/cockroach", binOrLib),
 			filepath.Join(os.ExpandEnv("$PWD"), binOrLib+suffix),
 		}
 		for _, dir := range dirs {


### PR DESCRIPTION
The roachtest, workload, and roachprod tools might need to run on machines 
with older glibcs than the builder when running the roachtests.  By
using mkrelease, we ensure that theses are built using the
cross-compilation environment that supports older glibc versions. This
avoids us having to keep the builder image in line with other images
we might use for testing.

Release note: None