### PR TITLE
ccl: add support for additional sasl mechanisms (SCRAM-SHA-256 and SCRAM-SHA-512)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -144,6 +144,7 @@ require (
 	github.com/stretchr/testify v1.6.1
 	github.com/twpayne/go-geom v1.3.6
 	github.com/wadey/gocovmerge v0.0.0-20160331181800-b5bfa59ec0ad
+	github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c
 	github.com/zabawaba99/go-gitignore v0.0.0-20200117185801-39e6bddfb292
 	go.etcd.io/etcd/raft/v3 v3.0.0-20210215124703-719f6ce06fbc
 	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad

--- a/go.sum
+++ b/go.sum
@@ -741,7 +741,9 @@ github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPU
 github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=
 github.com/wadey/gocovmerge v0.0.0-20160331181800-b5bfa59ec0ad h1:W0LEBv82YCGEtcmPA3uNZBI33/qF//HAAs3MawDjRa0=
 github.com/wadey/gocovmerge v0.0.0-20160331181800-b5bfa59ec0ad/go.mod h1:Hy8o65+MXnS6EwGElrSRjUzQDLXreJlzYLlWiHtt8hM=
+github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c h1:u40Z8hqBAAQyv+vATcGgV0YCnDjqSL7/q/JyPhhJSPk=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
+github.com/xdg/stringprep v1.0.0 h1:d9X0esnoa3dFsV0FG35rAT0RIhYFlPq7MiP+DW89La0=
 github.com/xdg/stringprep v1.0.0/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=

--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "metrics.go",
         "name.go",
         "rowfetcher_cache.go",
+        "scram_client.go",
         "sink.go",
         "sink_cloudstorage.go",
         "testing_knobs.go",
@@ -92,6 +93,7 @@ go_library(
         "@com_github_google_btree//:btree",
         "@com_github_linkedin_goavro_v2//:goavro",
         "@com_github_shopify_sarama//:sarama",
+        "@com_github_xdg_scram//:scram",
     ],
 )
 

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -2081,6 +2081,14 @@ func TestChangefeedErrors(t *testing.T) {
 		t, `sasl_enabled must be enabled if a SASL password is provided`,
 		`CREATE CHANGEFEED FOR foo INTO $1`, `kafka://nope/?sasl_password=a`,
 	)
+	sqlDB.ExpectErr(
+		t, `sasl_enabled must be enabled to configure SASL mechanism`,
+		`CREATE CHANGEFEED FOR foo INTO $1`, `kafka://nope/?sasl_mechanism=SCRAM-SHA-256`,
+	)
+	sqlDB.ExpectErr(
+		t, `param sasl_mechanism must be one of SCRAM-SHA-256, SCRAM-SHA-512, or PLAIN`,
+		`CREATE CHANGEFEED FOR foo INTO $1`, `kafka://nope/?sasl_enabled=true&sasl_mechanism=unsuppported`,
+	)
 
 	// The avro format doesn't support key_in_value yet.
 	sqlDB.ExpectErr(

--- a/pkg/ccl/changefeedccl/changefeedbase/options.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options.go
@@ -93,6 +93,7 @@ const (
 	SinkParamSASLHandshake    = `sasl_handshake`
 	SinkParamSASLUser         = `sasl_user`
 	SinkParamSASLPassword     = `sasl_password`
+	SinkParamSASLMechanism    = `sasl_mechanism`
 )
 
 // ChangefeedOptionExpectValues is used to parse changefeed options using

--- a/pkg/ccl/changefeedccl/scram_client.go
+++ b/pkg/ccl/changefeedccl/scram_client.go
@@ -1,0 +1,61 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package changefeedccl
+
+import (
+	"crypto/sha256"
+	"crypto/sha512"
+
+	"github.com/Shopify/sarama"
+	"github.com/xdg/scram"
+)
+
+var (
+	// sha256ClientGenerator returns a SCRAMClient for the
+	// SCRAM-SHA-256 SASL mechanism. This can used as a
+	// SCRAMCLientGeneratorFunc when constructing a sarama SASL
+	// configuration.
+	sha256ClientGenerator = func() sarama.SCRAMClient {
+		return &scramClient{HashGeneratorFcn: sha256.New}
+	}
+
+	// sha512ClientGenerator returns a SCRAMClient for the
+	// SCRAM-SHA-512 SASL mechanism. This can used as a
+	// SCRAMCLientGeneratorFunc when constructing a sarama SASL
+	// configuration.
+	sha512ClientGenerator = func() sarama.SCRAMClient {
+		return &scramClient{HashGeneratorFcn: sha512.New}
+	}
+)
+
+type scramClient struct {
+	*scram.Client
+	*scram.ClientConversation
+	scram.HashGeneratorFcn
+}
+
+var _ sarama.SCRAMClient = &scramClient{}
+
+func (c *scramClient) Begin(userName, password, authzID string) error {
+	var err error
+	c.Client, err = c.HashGeneratorFcn.NewClient(userName, password, authzID)
+	if err != nil {
+		return err
+	}
+	c.ClientConversation = c.Client.NewConversation()
+	return nil
+}
+
+func (c *scramClient) Step(challenge string) (string, error) {
+	return c.ClientConversation.Step(challenge)
+}
+
+func (c *scramClient) Done() bool {
+	return c.ClientConversation.Done()
+}


### PR DESCRIPTION
This add support to specify the SASL mechanism for Kafka Changefeed
DSNs via the `sasl_mechanism` option. Further, we add support for
SCRAM-SHA-256 and SCRAM-SHA-512 in addition to the previously
supported PLAIN mechanism.

Release note (ccl change): Add `sasl_mechanism` parameter to Kafka
Changefeed DSNs to specify SASL mechanism. CockroachDB supports the
PLAIN, SCRAM-SHA-256, and SCRAM-SHA-512 SASL mechanisms.