### PR TITLE
catalog/tabledesc: properly wrap errors

### DIFF
--- a/pkg/sql/catalog/tabledesc/structured.go
+++ b/pkg/sql/catalog/tabledesc/structured.go
@@ -1284,7 +1284,7 @@ func (desc *wrapper) validateCrossReferences(ctx context.Context, dg catalog.Des
 		}
 
 		if err := desc.ValidateTableLocalityConfig(ctx, dg); err != nil {
-			return errors.AssertionFailedf("invalid locality config: %v", errors.Safe(err))
+			return errors.NewAssertionErrorWithWrappedErrf(err, "invalid locality config")
 		}
 	}
 


### PR DESCRIPTION
This lack of wrapping swallowing a `TransactionRetryWithProtoRefreshError`
and turning it into an assertion failure.

Release note: None