### PR TITLE
sql: Allow for multi-region database restores

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_backup
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_backup
@@ -1,0 +1,174 @@
+# LogicTest: multiregion-9node-3region-3azs
+
+query TTTT
+SHOW REGIONS
+----
+ap-southeast-2  {ap-az1,ap-az2,ap-az3}  {}  {}
+ca-central-1    {ca-az1,ca-az2,ca-az3}  {}  {}
+us-east-1       {us-az1,us-az2,us-az3}  {}  {}
+
+statement ok
+CREATE DATABASE mr_backup primary region "ca-central-1" regions "ap-southeast-2", "us-east-1"
+
+statement ok
+CREATE DATABASE mr_backup_2 primary region "ap-southeast-2" regions "ca-central-1", "us-east-1"
+
+query TT
+SHOW ZONE CONFIGURATION FOR DATABASE mr_backup
+----
+DATABASE mr_backup  ALTER DATABASE mr_backup CONFIGURE ZONE USING
+                    range_min_bytes = 134217728,
+                    range_max_bytes = 536870912,
+                    gc.ttlseconds = 90000,
+                    num_replicas = 5,
+                    num_voters = 3,
+                    constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                    voter_constraints = '[+region=ca-central-1]',
+                    lease_preferences = '[[+region=ca-central-1]]'
+
+
+query TT
+SHOW ZONE CONFIGURATION FOR DATABASE mr_backup_2
+----
+DATABASE mr_backup_2  ALTER DATABASE mr_backup_2 CONFIGURE ZONE USING
+                      range_min_bytes = 134217728,
+                      range_max_bytes = 536870912,
+                      gc.ttlseconds = 90000,
+                      num_replicas = 5,
+                      num_voters = 3,
+                      constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                      voter_constraints = '[+region=ap-southeast-2]',
+                      lease_preferences = '[[+region=ap-southeast-2]]'
+
+statement ok
+ALTER DATABASE mr_backup CONFIGURE ZONE USING gc.ttlseconds = 1;
+ALTER DATABASE mr_backup_2 CONFIGURE ZONE USING gc.ttlseconds = 1
+
+statement ok
+BACKUP DATABASE mr_backup TO 'nodelocal://self/mr_backup/';
+BACKUP DATABASE mr_backup_2 TO 'nodelocal://self/mr_backup_2/';
+BACKUP DATABASE mr_backup, mr_backup_2 TO 'nodelocal://self/mr_backup_combined/'
+
+query T
+select database_name from [show databases]
+----
+defaultdb
+mr_backup
+mr_backup_2
+postgres
+system
+test
+
+statement ok
+DROP DATABASE mr_backup;
+DROP DATABASE mr_backup_2
+
+query T
+select database_name from [show databases]
+----
+defaultdb
+postgres
+system
+test
+
+statement ok
+RESTORE DATABASE mr_backup FROM 'nodelocal://self/mr_backup/'
+
+query T
+select database_name from [show databases]
+----
+defaultdb
+mr_backup
+postgres
+system
+test
+
+query TT
+SHOW ZONE CONFIGURATION FOR DATABASE mr_backup
+----
+DATABASE mr_backup  ALTER DATABASE mr_backup CONFIGURE ZONE USING
+                    range_min_bytes = 134217728,
+                    range_max_bytes = 536870912,
+                    gc.ttlseconds = 90000,
+                    num_replicas = 5,
+                    num_voters = 3,
+                    constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                    voter_constraints = '[+region=ca-central-1]',
+                    lease_preferences = '[[+region=ca-central-1]]'
+
+statement ok
+RESTORE DATABASE mr_backup_2 FROM 'nodelocal://self/mr_backup_2/'
+
+query T
+select database_name from [show databases]
+----
+defaultdb
+mr_backup
+mr_backup_2
+postgres
+system
+test
+
+query TT
+SHOW ZONE CONFIGURATION FOR DATABASE mr_backup_2
+----
+DATABASE mr_backup_2  ALTER DATABASE mr_backup_2 CONFIGURE ZONE USING
+                      range_min_bytes = 134217728,
+                      range_max_bytes = 536870912,
+                      gc.ttlseconds = 90000,
+                      num_replicas = 5,
+                      num_voters = 3,
+                      constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                      voter_constraints = '[+region=ap-southeast-2]',
+                      lease_preferences = '[[+region=ap-southeast-2]]'
+
+statement ok
+DROP DATABASE mr_backup;
+DROP DATABASE mr_backup_2
+
+query T
+select database_name from [show databases]
+----
+defaultdb
+postgres
+system
+test
+
+statement ok
+RESTORE DATABASE mr_backup, mr_backup_2 FROM 'nodelocal://self/mr_backup_combined/'
+
+query T
+select database_name from [show databases]
+----
+defaultdb
+mr_backup
+mr_backup_2
+postgres
+system
+test
+
+query TT
+SHOW ZONE CONFIGURATION FOR DATABASE mr_backup
+----
+DATABASE mr_backup  ALTER DATABASE mr_backup CONFIGURE ZONE USING
+                    range_min_bytes = 134217728,
+                    range_max_bytes = 536870912,
+                    gc.ttlseconds = 90000,
+                    num_replicas = 5,
+                    num_voters = 3,
+                    constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                    voter_constraints = '[+region=ca-central-1]',
+                    lease_preferences = '[[+region=ca-central-1]]'
+
+query TT
+SHOW ZONE CONFIGURATION FOR DATABASE mr_backup_2
+----
+DATABASE mr_backup_2  ALTER DATABASE mr_backup_2 CONFIGURE ZONE USING
+                      range_min_bytes = 134217728,
+                      range_max_bytes = 536870912,
+                      gc.ttlseconds = 90000,
+                      num_replicas = 5,
+                      num_voters = 3,
+                      constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                      voter_constraints = '[+region=ap-southeast-2]',
+                      lease_preferences = '[[+region=ap-southeast-2]]'

--- a/pkg/sql/alter_database.go
+++ b/pkg/sql/alter_database.go
@@ -226,10 +226,13 @@ func (n *alterDatabaseAddRegionNode) startExec(params runParams) error {
 	}
 
 	// Update the database's zone configuration.
-	if err := params.p.applyZoneConfigFromDatabaseRegionConfig(
+	if err := ApplyZoneConfigFromDatabaseRegionConfig(
 		params.ctx,
-		tree.Name(n.desc.Name),
-		*n.desc.RegionConfig); err != nil {
+		n.desc.ID,
+		*n.desc.RegionConfig,
+		params.p.txn,
+		params.p.execCfg,
+	); err != nil {
 		return err
 	}
 
@@ -440,10 +443,13 @@ func (n *alterDatabasePrimaryRegionNode) switchPrimaryRegion(params runParams) e
 	}
 
 	// Update the database's zone configuration.
-	if err := params.p.applyZoneConfigFromDatabaseRegionConfig(
+	if err := ApplyZoneConfigFromDatabaseRegionConfig(
 		params.ctx,
-		tree.Name(n.desc.Name),
-		*n.desc.RegionConfig); err != nil {
+		n.desc.ID,
+		*n.desc.RegionConfig,
+		params.p.txn,
+		params.p.execCfg,
+	); err != nil {
 		return err
 	}
 
@@ -659,10 +665,13 @@ func (n *alterDatabaseSurvivalGoalNode) startExec(params runParams) error {
 	}
 
 	// Update the database's zone configuration.
-	if err := params.p.applyZoneConfigFromDatabaseRegionConfig(
+	if err := ApplyZoneConfigFromDatabaseRegionConfig(
 		params.ctx,
-		tree.Name(n.desc.Name),
-		*n.desc.RegionConfig); err != nil {
+		n.desc.ID,
+		*n.desc.RegionConfig,
+		params.p.txn,
+		params.p.execCfg,
+	); err != nil {
 		return err
 	}
 

--- a/pkg/sql/region_util.go
+++ b/pkg/sql/region_util.go
@@ -389,33 +389,33 @@ func zoneConfigForMultiRegionTable(
 	return ret, nil
 }
 
-// TODO(#59631): everything using this should instead use getZoneConfigRaw
-// and writeZoneConfig instead of calling SQL for each query.
 // This removes the requirement to only call this function after writeSchemaChange
 // is called on creation of tables, and potentially removes the need for ReadingOwnWrites
 // for some subcommands.
 // Requires some logic to "inherit" from parents.
-func (p *planner) applyZoneConfigForMultiRegion(
-	ctx context.Context, zs tree.ZoneSpecifier, zc *zonepb.ZoneConfig, desc string,
+func applyZoneConfigForMultiRegion(
+	ctx context.Context,
+	zc *zonepb.ZoneConfig,
+	targetID descpb.ID,
+	table catalog.TableDescriptor,
+	txn *kv.Txn,
+	execConfig *ExecutorConfig,
 ) error {
-	// Convert the partially filled zone config to re-run as a SQL command.
-	// This avoid us having to modularize planNode logic from set_zone_config
-	// and the optimizer.
-	sql, err := zoneConfigToSQL(&zs, zc)
-	if err != nil {
-		return err
-	}
-	if _, err := p.ExtendedEvalContext().ExecCfg.InternalExecutor.ExecEx(
+	// TODO (multiregion): Much like applyZoneConfigForMultiRegionTable we need to
+	// merge the zone config that we're writing with anything previously existing
+	// in there.
+	if _, err := writeZoneConfig(
 		ctx,
-		desc,
-		p.Txn(),
-		sessiondata.InternalExecutorOverride{
-			User: p.SessionData().User(),
-		},
-		sql,
+		txn,
+		targetID,
+		table,
+		zc,
+		execConfig,
+		true, /* hasNewSubzones */
 	); err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -612,21 +612,27 @@ func applyZoneConfigForMultiRegionTable(
 	return nil
 }
 
-func (p *planner) applyZoneConfigFromDatabaseRegionConfig(
-	ctx context.Context, dbName tree.Name, regionConfig descpb.DatabaseDescriptor_RegionConfig,
+// ApplyZoneConfigFromDatabaseRegionConfig applies a zone configuration to the
+// database using the information in the supplied RegionConfig.
+func ApplyZoneConfigFromDatabaseRegionConfig(
+	ctx context.Context,
+	dbID descpb.ID,
+	regionConfig descpb.DatabaseDescriptor_RegionConfig,
+	txn *kv.Txn,
+	execConfig *ExecutorConfig,
 ) error {
-	// Convert the partially filled zone config to re-run as a SQL command.
-	// This avoid us having to modularize planNode logic from set_zone_config
-	// and the optimizer.
+	// Build a zone config based on the RegionConfig information.
 	dbZoneConfig, err := zoneConfigForMultiRegionDatabase(regionConfig)
 	if err != nil {
 		return err
 	}
-	return p.applyZoneConfigForMultiRegion(
+	return applyZoneConfigForMultiRegion(
 		ctx,
-		tree.ZoneSpecifier{Database: dbName},
 		dbZoneConfig,
-		"database-multiregion-set-zone-config",
+		dbID,
+		nil,
+		txn,
+		execConfig,
 	)
 }
 
@@ -736,10 +742,12 @@ func (p *planner) initializeMultiRegionDatabase(ctx context.Context, desc *dbdes
 	}
 
 	// Create the database-level zone configuration.
-	if err := p.applyZoneConfigFromDatabaseRegionConfig(
+	if err := ApplyZoneConfigFromDatabaseRegionConfig(
 		ctx,
-		tree.Name(desc.Name),
-		*desc.RegionConfig); err != nil {
+		desc.ID,
+		*desc.RegionConfig,
+		p.txn,
+		p.execCfg); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Until this commit, restores of multi-region databases failed due to the
fact that the multi-region enum's type ID was changing as part of the
restore.  This commit remaps the enum ID so that the restore succeeds.

The commit also rebuilds the database-level zone configuration.  The
table level zone configurations will be handled in a follow-on PR.

Release note (sql change): Adds support for restore of multi-region
databases.