### PR TITLE
roachtest: update gopg with new expected passes

### DIFF
--- a/pkg/cmd/roachtest/gopg_blocklist.go
+++ b/pkg/cmd/roachtest/gopg_blocklist.go
@@ -26,7 +26,28 @@ var gopgBlocklists = blocklistsForVersion{
 // After a failed run, an updated version of this blocklist should be available
 // in the test log.
 
-var gopgBlockList21_1 = gopgBlockList20_2
+var gopgBlockList21_1 = blocklist{
+	"pg | BeforeQuery and AfterQuery CopyTo | is called for CopyTo with model":    "41608",
+	"pg | BeforeQuery and AfterQuery CopyTo | is called for CopyTo without model": "41608",
+	"pg | CopyFrom/CopyTo | copies corrupted data to a table":                     "41608",
+	"pg | CopyFrom/CopyTo | copies data from a table and to a table":              "41608",
+	"pg | CountEstimate | works":                                                  "17511",
+	"pg | CountEstimate | works when there are no results":                        "17511",
+	"pg | CountEstimate | works with GROUP":                                       "17511",
+	"pg | CountEstimate | works with GROUP when there are no results":             "17511",
+	"pg | Listener | is closed when DB is closed":                                 "41522",
+	"pg | Listener | listens for notifications":                                   "41522",
+	"pg | Listener | reconnects on receive error":                                 "41522",
+	"pg | Listener | returns an error on timeout":                                 "41522",
+	"pg | Listener | supports concurrent Listen and Receive":                      "41522",
+	"v10.ExampleDB_Model_postgresArrayStructTag":                                  "32552",
+	"v10.TestBigColumn":       "41608",
+	"v10.TestConversion":      "32552",
+	"v10.TestGinkgo":          "41522",
+	"v10.TestGocheck":         "17511",
+	"v10.TestReadColumnValue": "26925",
+	"v10.TestUnixSocket":      "31113",
+}
 
 var gopgBlockList20_2 = gopgBlockList20_1
 


### PR DESCRIPTION
Two tests started passing because of COPY CSV support

closes #59844 

Release note: None