### PR TITLE
geo/geomfn: fix missing free in GeneratePoints

### DIFF
--- a/pkg/geo/geos/geos.go
+++ b/pkg/geo/geos/geos.go
@@ -655,18 +655,16 @@ func PrepareGeometry(a geopb.EWKB) (PreparedGeometry, error) {
 	return PreparedGeometry(ret), nil
 }
 
-// PreparedGeomDestroy destroyed a prepared geometry.
-func PreparedGeomDestroy(a PreparedGeometry) error {
-	// Double check - since PreparedGeometry is actually a pointer to C type.
-	if a == nil {
-		return errors.New("provided PreparedGeometry is nil")
-	}
+// PreparedGeomDestroy destroys a prepared geometry.
+func PreparedGeomDestroy(a PreparedGeometry) {
 	g, err := ensureInitInternal()
 	if err != nil {
-		return err
+		panic(errors.AssertionFailedf("trying to destroy PreparedGeometry with no GEOS: %v", err))
 	}
 	ap := (*C.CR_GEOS_PreparedGeometry)(unsafe.Pointer(a))
-	return statusToError(C.CR_GEOS_PreparedGeometryDestroy(g, ap))
+	if err := statusToError(C.CR_GEOS_PreparedGeometryDestroy(g, ap)); err != nil {
+		panic(errors.AssertionFailedf("PreparedGeometryDestroy returned an error: %v", err))
+	}
 }
 
 //


### PR DESCRIPTION
Looks like I missed this in an earlier review -- we do not free a
PreparedGeometry that we created.

I've also changed the Destroy not returning to panic, as I feel as if we
are not freeing correctly something is deeply wrong in the system which
can lead to other scary errors such as OOM.

Release note: None